### PR TITLE
refactor: route flex stream launches through SpyreStream

### DIFF
--- a/torch_spyre/csrc/job_plan.cpp
+++ b/torch_spyre/csrc/job_plan.cpp
@@ -22,16 +22,16 @@
 #include <vector>
 
 #include "spyre_allocator.h"
+#include "spyre_stream.h"
 #include "util/processSpyreCodeArtifacts.h"
 
 namespace spyre {
 
 void JobPlanStepH2D::construct(LaunchContext&,
-                               flex::RuntimeStream* flex_stream) const {
-  flex::DmaParams params(host_address_, device_address_.total_size(),
-                         /*to_device=*/true, &device_address_);
+                               const SpyreStream& stream) const {
+  flex::DmaParams params(host_address_, /*to_device=*/true, &device_address_);
   params.pipeline_barrier = pipeline_barrier_;
-  flex_stream->launchOperationH2D(&params);
+  stream.launchH2D(&params);
 }
 
 void JobPlanStepH2D::write(std::ostream& os) const {
@@ -43,11 +43,10 @@ void JobPlanStepH2D::write(std::ostream& os) const {
 }
 
 void JobPlanStepD2H::construct(LaunchContext&,
-                               flex::RuntimeStream* flex_stream) const {
-  flex::DmaParams params(host_address_, device_address_.total_size(),
-                         /*to_device=*/false, &device_address_);
+                               const SpyreStream& stream) const {
+  flex::DmaParams params(host_address_, /*to_device=*/false, &device_address_);
   params.pipeline_barrier = pipeline_barrier_;
-  flex_stream->launchOperationD2H(&params);
+  stream.launchD2H(&params);
 }
 
 void JobPlanStepD2H::write(std::ostream& os) const {
@@ -59,7 +58,7 @@ void JobPlanStepD2H::write(std::ostream& os) const {
 }
 
 void JobPlanStepCompute::construct(LaunchContext& ctx,
-                                   flex::RuntimeStream* flex_stream) const {
+                                   const SpyreStream& stream) const {
   std::vector<const flex::CompositeAddress*> tensor_allocs;
   if (bind_io_addresses_) {
     for (auto& tensor : ctx.inputs_outputs) {
@@ -73,7 +72,7 @@ void JobPlanStepCompute::construct(LaunchContext& ctx,
   flex::ComputeParams params(&binary_address_, std::move(tensor_allocs), "",
                              bootstrap_addr_);
   params.pipeline_barrier = pipeline_barrier_;
-  flex_stream->launchOperationCompute(&params);
+  stream.launchCompute(&params);
 }
 
 void JobPlanStepCompute::write(std::ostream& os) const {
@@ -100,12 +99,12 @@ static int64_t composite_address_to_dmva(
 }
 
 void JobPlanStepHostCompute::construct(LaunchContext& ctx,
-                                       flex::RuntimeStream* flex_stream) const {
+                                       const SpyreStream& stream) const {
   // Helper lambda to build HostCallbackParams and launch on the stream
-  auto launch_host_callback = [this, flex_stream](auto&& callback) {
+  auto launch_host_callback = [this, &stream](auto&& callback) {
     flex::HostCallbackParams params(std::forward<decltype(callback)>(callback),
                                     nullptr, pipeline_barrier_);
-    flex_stream->launchOperationHostCallback(&params);
+    stream.launchHostCallback(&params);
   };
 
   // Case 1: input_buffer_ is provided

--- a/torch_spyre/csrc/job_plan.h
+++ b/torch_spyre/csrc/job_plan.h
@@ -293,8 +293,7 @@ class JobPlanStepH2D final : public JobPlanStep {
       : host_address_(host_address),
         device_address_(std::move(device_address)) {}
 
-  void construct(LaunchContext& ctx,
-                 const SpyreStream& stream) const override;
+  void construct(LaunchContext& ctx, const SpyreStream& stream) const override;
 
   void write(std::ostream& os) const override;
 
@@ -321,8 +320,7 @@ class JobPlanStepD2H final : public JobPlanStep {
       : device_address_(std::move(device_address)),
         host_address_(host_address) {}
 
-  void construct(LaunchContext& ctx,
-                 const SpyreStream& stream) const override;
+  void construct(LaunchContext& ctx, const SpyreStream& stream) const override;
 
   void write(std::ostream& os) const override;
 
@@ -354,8 +352,7 @@ class JobPlanStepCompute final : public JobPlanStep {
         bind_io_addresses_(bind_io_addresses),
         bootstrap_addr_(bootstrap_addr) {}
 
-  void construct(LaunchContext& ctx,
-                 const SpyreStream& stream) const override;
+  void construct(LaunchContext& ctx, const SpyreStream& stream) const override;
 
   void write(std::ostream& os) const override;
 
@@ -401,8 +398,7 @@ class JobPlanStepHostCompute final : public JobPlanStep {
         input_buffer_(input_buffer),
         ishape_(ishape) {}
 
-  void construct(LaunchContext& ctx,
-                 const SpyreStream& stream) const override;
+  void construct(LaunchContext& ctx, const SpyreStream& stream) const override;
 
   void write(std::ostream& os) const override;
 

--- a/torch_spyre/csrc/job_plan.h
+++ b/torch_spyre/csrc/job_plan.h
@@ -31,6 +31,10 @@
 
 namespace spyre {
 
+// Forward declaration: JobPlanStep::construct() submits through SpyreStream
+// rather than the raw flex::RuntimeStream handle.
+class SpyreStream;
+
 /**
  * @brief RAII wrapper for page-aligned and pinned host memory
  *
@@ -195,9 +199,9 @@ struct LaunchContext {
  * SpyreStream::Launch.
  *
  * All RuntimeOperation objects are transient: constructed inside flex when
- * construct() calls the matching RuntimeStream::launchOperationXXX(), and
- * destroyed when the stream completes the operation. No RuntimeOperation is
- * cached in the JobPlan.
+ * construct() calls the matching SpyreStream::launchXXX(), and destroyed when
+ * the stream completes the operation. No RuntimeOperation is cached in the
+ * JobPlan.
  */
 class JobPlanStep {
  public:
@@ -210,14 +214,13 @@ class JobPlanStep {
    * Called by SpyreStream during LaunchKernel. Constructs the appropriate
    * flex operation params from metadata stored during PrepareKernel and
    * runtime data from the LaunchContext, then submits them via the matching
-   * RuntimeStream::launchOperationXXX(). flex owns the RuntimeOperation
-   * lifecycle.
+   * SpyreStream::launchXXX(). flex owns the RuntimeOperation lifecycle.
    *
    * @param ctx Launch context containing composite addresses
-   * @param flex_stream Stream to launch the operation on
+   * @param stream SpyreStream to launch the operation on
    */
   virtual void construct(LaunchContext& ctx,
-                         flex::RuntimeStream* flex_stream) const = 0;
+                         const SpyreStream& stream) const = 0;
 
   /**
    * @brief Write step information to output stream
@@ -291,7 +294,7 @@ class JobPlanStepH2D final : public JobPlanStep {
         device_address_(std::move(device_address)) {}
 
   void construct(LaunchContext& ctx,
-                 flex::RuntimeStream* flex_stream) const override;
+                 const SpyreStream& stream) const override;
 
   void write(std::ostream& os) const override;
 
@@ -319,7 +322,7 @@ class JobPlanStepD2H final : public JobPlanStep {
         host_address_(host_address) {}
 
   void construct(LaunchContext& ctx,
-                 flex::RuntimeStream* flex_stream) const override;
+                 const SpyreStream& stream) const override;
 
   void write(std::ostream& os) const override;
 
@@ -352,7 +355,7 @@ class JobPlanStepCompute final : public JobPlanStep {
         bootstrap_addr_(bootstrap_addr) {}
 
   void construct(LaunchContext& ctx,
-                 flex::RuntimeStream* flex_stream) const override;
+                 const SpyreStream& stream) const override;
 
   void write(std::ostream& os) const override;
 
@@ -399,7 +402,7 @@ class JobPlanStepHostCompute final : public JobPlanStep {
         ishape_(ishape) {}
 
   void construct(LaunchContext& ctx,
-                 flex::RuntimeStream* flex_stream) const override;
+                 const SpyreStream& stream) const override;
 
   void write(std::ostream& os) const override;
 
@@ -416,8 +419,8 @@ class JobPlanStepHostCompute final : public JobPlanStep {
  * A JobPlan bundles everything needed to execute a unit of work on a stream.
  * It is produced by translating a SpyreCode's Job Execution Plan after the Job
  * Preparation Plan has been executed. flex never sees a JobPlan — SpyreStream
- * extracts the operations and submits them to RuntimeStream.launchOperation()
- * as a vector<RuntimeOperation>.
+ * translates each step into flex operation params and submits them via its
+ * typed launchXXX() methods.
  *
  * A JobPlan is self-contained: if a compute requires program correction, the
  * correction callback, the correction tensor DMA, and the device compute are

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -443,8 +443,12 @@ PYBIND11_MODULE(_C, m) {
         "        If None, uses the current stream. Defaults to None.\n\n"
         "Returns:\n"
         "    Prepared JobPlan ready for execution");
-  m.def("launch_jobplan", &spyre::launchJobPlan, py::arg("job_plan"),
-        py::arg("args"),
+  // Bind the current-stream overload (resolves the current stream internally).
+  m.def("launch_jobplan",
+        static_cast<void (*)(const spyre::JobPlan&,
+                             const std::vector<at::Tensor>&)>(
+            &spyre::launchJobPlan),
+        py::arg("job_plan"), py::arg("args"),
         "Launch a prepared JobPlan with the given tensor arguments.\n\n"
         "Args:\n"
         "    job_plan: The JobPlan to execute\n"

--- a/torch_spyre/csrc/spyre_kernel.cpp
+++ b/torch_spyre/csrc/spyre_kernel.cpp
@@ -212,10 +212,15 @@ void launchKernel(const std::string& code_dir,
   stream.executeProgramAsync(arts, args);
 }
 
+void launchJobPlan(const JobPlan& job_plan, const std::vector<at::Tensor>& args,
+                   const SpyreStream& stream) {
+  stream.launch(job_plan, args);
+}
+
 void launchJobPlan(const JobPlan& job_plan,
                    const std::vector<at::Tensor>& args) {
   auto stream = getCurrentStream(c10::Device(c10::DeviceType::PrivateUse1, -1));
-  stream.launch(job_plan, args);
+  launchJobPlan(job_plan, args, stream);
 }
 
 void clearArtifactCache() {

--- a/torch_spyre/csrc/spyre_kernel.h
+++ b/torch_spyre/csrc/spyre_kernel.h
@@ -63,6 +63,14 @@ KernelArtifacts& getOrLoadArtifacts(const std::string& code_dir,
 void launchKernel(const std::string& code_dir,
                   const std::vector<at::Tensor>& args);
 
+// Launch a JobPlan on an explicit stream. The whole plan is submitted to this
+// single stream, preserving cross-step ordering.
+void launchJobPlan(const JobPlan& job_plan, const std::vector<at::Tensor>& args,
+                   const SpyreStream& stream);
+
+// Launch a JobPlan on the calling thread's current stream. The current stream
+// is resolved exactly once here, at the public boundary, then threaded
+// explicitly into the launch path.
 void launchJobPlan(const JobPlan& job_plan,
                    const std::vector<at::Tensor>& args);
 

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -194,18 +194,15 @@ void SpyreStream::copyAsyncImpl(void* cpu_ptr,
   // Wrap dci in shared_ptr for flex API
   auto dci_ptr = dci ? std::make_shared<data_conversion_info>(*dci) : nullptr;
 
-  // Get the flex runtime stream handle
-  flex::RuntimeStream* flex_stream = resolveRuntimeHandle();
-
-  // Create and launch operation
+  // Create and launch operation through SpyreStream's typed launch methods.
   if (host2device) {
-    flex::DmaParams params(cpu_ptr, device_address->total_size(), host2device,
-                           device_address, std::move(dci_ptr));
-    flex_stream->launchOperationH2D(&params);
+    flex::DmaParams params(cpu_ptr, host2device, device_address,
+                           std::move(dci_ptr));
+    launchH2D(&params);
   } else {
-    flex::DmaParams params(cpu_ptr, device_address->total_size(), host2device,
-                           device_address, std::move(dci_ptr));
-    flex_stream->launchOperationD2H(&params);
+    flex::DmaParams params(cpu_ptr, host2device, device_address,
+                           std::move(dci_ptr));
+    launchD2H(&params);
   }
 }
 
@@ -225,9 +222,23 @@ void SpyreStream::executeProgramAsync(
   flex::ComputeParams params(&ctx->composite_addr, std::move(tensor_allocs),
                              arts.bundle_mlir_path);
 
-  // Get the flex runtime stream handle
-  flex::RuntimeStream* flex_stream = resolveRuntimeHandle();
-  flex_stream->launchOperationCompute(&params);
+  launchCompute(&params);
+}
+
+void SpyreStream::launchH2D(flex::DmaParams* params) const {
+  resolveRuntimeHandle()->launchOperationH2D(params);
+}
+
+void SpyreStream::launchD2H(flex::DmaParams* params) const {
+  resolveRuntimeHandle()->launchOperationD2H(params);
+}
+
+void SpyreStream::launchCompute(flex::ComputeParams* params) const {
+  resolveRuntimeHandle()->launchOperationCompute(params);
+}
+
+void SpyreStream::launchHostCallback(flex::HostCallbackParams* params) const {
+  resolveRuntimeHandle()->launchOperationHostCallback(params);
 }
 
 void SpyreStream::launch(const JobPlan& plan,
@@ -241,11 +252,10 @@ void SpyreStream::launch(const JobPlan& plan,
   // Create launch context with tensor arguments
   LaunchContext ctx{args};
 
-  // Each JobPlanStep builds its flex operation params and launches them on the
-  // stream in order. flex owns the RuntimeOperation lifecycle.
-  flex::RuntimeStream* flex_stream = resolveRuntimeHandle();
+  // Each JobPlanStep builds its flex operation params and launches them on
+  // this stream in order. flex owns the RuntimeOperation lifecycle.
   for (const auto& step : plan.steps) {
-    step->construct(ctx, flex_stream);
+    step->construct(ctx, *this);
   }
 }
 

--- a/torch_spyre/csrc/spyre_stream.h
+++ b/torch_spyre/csrc/spyre_stream.h
@@ -54,6 +54,14 @@ class SpyreStream {
 
   void launch(const JobPlan& plan, const std::vector<at::Tensor>& args) const;
 
+  // Typed flex operation launches. These are the single chokepoint through
+  // which torch-spyre submits work to the underlying flex stream; the raw
+  // flex::RuntimeStream handle never escapes SpyreStream.
+  void launchH2D(flex::DmaParams* params) const;
+  void launchD2H(flex::DmaParams* params) const;
+  void launchCompute(flex::ComputeParams* params) const;
+  void launchHostCallback(flex::HostCallbackParams* params) const;
+
   // Conversions
   c10::Stream unwrap() const;
 


### PR DESCRIPTION

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Submit all flex RuntimeStream work through SpyreStream rather than exposing the raw flex::RuntimeStream handle to callers.

- Add typed SpyreStream::launch{H2D,D2H,Compute,HostCallback} that forward to the private flex handle; the handle no longer escapes SpyreStream.
- Change JobPlanStep::construct() to take const SpyreStream& instead of flex::RuntimeStream*, so steps submit via SpyreStream's typed methods.
- Resolve the current stream once at the launchJobPlan boundary and thread it explicitly; add an explicit-stream launchJobPlan overload with the current-stream variant delegating to it.
- Stop deriving dma_size in torch-spyre; use the size-free flex DmaParams constructor (flex owns DMA sizing).

Depends on the flex DmaParams size-free constructor.

#### Which issue(s) this PR is related to:

Issue #2819 .

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No. Internal C++ refactor; the launch_jobplan Python API is unchanged.

#### Additional note:
