### PR TITLE
improve matmul work-division cost model

### DIFF
--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -935,15 +935,30 @@ _PT_ROWS = 8  # PT block rows per corelet
 
 # Constants for the matmul cost model (_matmul_split_cost). Each is either an
 # AIU hardware limit or a coefficient fit to measured device kernel times.
-_TARGET_PT_PASSES = 8  # per-core M that keeps the PT pipeline full = this * _PT_ROWS
+_TARGET_PT_PASSES = 5  # per-core M that keeps the PT pipeline full = this * _PT_ROWS
+_TARGET_M_TIE_PASSES = 4  # enough M lanes to keep the stationary weights fed
+_PT_EFFICIENCY_EXPONENT = 0.25
 _M_MIN = _PT_ROWS // 2  # below half a PT pass an m-split buys nothing
 _PEAK_MACS_US_CORE = (98.304e12 / 2 / 32) / 1e6  # DL16 peak / 32 cores, MACs/us/core
 _HBM_BW_GBS = 204.8  # LPDDR5 aggregate peak bandwidth
 _DTYPE_BYTES = 2  # fp16
-_PSUM_PER_ELEM_US = 1.4e-4  # per output element, per K-split ring reduction hop
+_PSUM_PER_CORE_ELEM_US = 1.0e-3
+_BMM_PSUM_PER_CORE_ELEM_US = 1.0e-4
 _COHORT_LIMIT = 8  # cores sharing a broadcast before it contends for bandwidth
-_BATCH_SPLIT_EXPONENT = 1.4  # batch-split cost grows ~ b ** this (fit to bmm sweeps)
-_TARGET_M_PENALTY_US = 50.0  # tie-break weight when per-core M under-fills PT
+_COHORT_PENALTY_EXPONENT = 0.75
+_M_LANE_UNDERUSE_PENALTY_US = 10.0  # tie-break when too few M lanes are used
+_M_TILE_UNDERFILL_TARGET = 16  # rows/core below this pay PT startup overhead
+_M_TILE_UNDERFILL_PENALTY_US = 30.0
+_TARGET_N_TILE_ELEMS = 512  # per-core N wider than this loses schedule efficiency
+_WIDE_N_TILE_PENALTY_US = 25.0  # per log2 step over _TARGET_N_TILE_ELEMS
+_CORE_UNDERUSE_PENALTY_US = (
+    150.0  # soft replacement for the old hard full-core fallback
+)
+_BMM_BATCH_SPLIT_PENALTY_US = 10.0  # true-BMM batch split cost per log2 step
+_LARGE_M_TILE_SHAPE_PENALTY_US = 20.0
+_SHARED_DOWN_N_SPLIT_PENALTY_US = 10.0
+_SHARED_NARROW_OUTPUT_REF = _TARGET_N_TILE_ELEMS * _COHORT_LIMIT
+_SHARED_N_TILE_TARGET = _TARGET_N_TILE_ELEMS // 4
 
 
 def _matmul_split_cost(
@@ -952,6 +967,7 @@ def _matmul_split_cost(
     n_axis: tuple[int, int],
     k_axis: tuple[int, int],
     max_cores: int,
+    shared_weight: bool = False,
 ) -> float:
     """Estimated kernel time in microseconds for ``[B,M,K]@[B,K,N]`` run with
     the given core split. Each axis is a ``(size, split)`` pair so a dim's size
@@ -965,38 +981,151 @@ def _matmul_split_cost(
     # Compute: per-core MACs over peak, derated when the per-core M tile is too
     # short to fill the PT pipeline. The PT array streams M in passes of
     # _PT_ROWS; below _TARGET_PT_PASSES passes its startup/drain overhead is
-    # amortised over too little work, and that overhead grows sub-linearly,
-    # hence the sqrt.
+    # amortised over too little work, and that overhead grows sub-linearly.
     m_t = M // m if m else 1
     pt_passes = max(1.0, m_t / _PT_ROWS)
-    pt_eff = min(1.0, (pt_passes / _TARGET_PT_PASSES) ** 0.5)
+    pt_eff = min(1.0, (pt_passes / _TARGET_PT_PASSES) ** _PT_EFFICIENCY_EXPONENT)
     compute_us = (B * M * N * K / cores_used) / (_PEAK_MACS_US_CORE * pt_eff)
 
     # HBM: every input operand is broadcast to the cohort of cores splitting the
     # orthogonal dim. Past _COHORT_LIMIT the broadcasts contend for the shared
     # link, so effective bandwidth falls off linearly with cohort size.
-    bytes_total = (B * M * K + B * K * N + B * M * N) * _DTYPE_BYTES
-    cohort_penalty = max(1.0, max(m, n) / _COHORT_LIMIT)
+    weight_batches = 1 if shared_weight else B
+    bytes_total = (B * M * K + weight_batches * K * N + B * M * N) * _DTYPE_BYTES
+    fanout_split = max(m, n) if shared_weight else n
+    cohort_penalty = max(
+        1.0, (fanout_split / _COHORT_LIMIT) ** _COHORT_PENALTY_EXPONENT
+    )
     hbm_us = bytes_total / (_HBM_BW_GBS * 1000) * cohort_penalty
 
-    # PSUM: a K-split spreads the reduction over k cores, costing (k-1) partial-
-    # sum hops around the ring, each touching every output element.
-    psum_us = max(0, k - 1) * (B * M * N) * _PSUM_PER_ELEM_US
+    # PSUM: a K-split spreads the reduction over k cores, costing (k-1)
+    # partial-sum hops. Charge each core's output tile rather than the whole
+    # output, so useful K-splits are not over-penalized.
+    psum_coeff = _PSUM_PER_CORE_ELEM_US if shared_weight else _BMM_PSUM_PER_CORE_ELEM_US
+    output_elems_per_core = (B * M * N) / max(1, b * m * n)
+    psum_us = max(0, k - 1) * output_elems_per_core * psum_coeff
 
-    # Tie-break: among compute-equivalent splits, penalize only M splits that
-    # make the per-core tile too short to fill the PT pipeline. Larger per-core
-    # M tiles are already compute-equivalent in this model; penalizing them
-    # incorrectly prefers M parallelism over N parallelism for wide projections.
-    if pt_passes >= _TARGET_PT_PASSES:
-        target_m_us = 0.0
-    else:
-        target_m_us = math.log2(_TARGET_PT_PASSES / pt_passes) * _TARGET_M_PENALTY_US
+    # Tie-break: among compute-equivalent splits prefer exposing enough M lanes
+    # to stream work over the stationary weight tile. PT efficiency above handles
+    # the opposite case where an M split makes each per-core tile too short.
+    target_m = max(
+        _M_MIN,
+        min(max_cores // 2, max(1, M // (_TARGET_M_TIE_PASSES * _PT_ROWS))),
+    )
+    m_lane_underuse_us = (
+        max(0.0, math.log2(target_m / max(1, m))) * _M_LANE_UNDERUSE_PENALTY_US
+    )
+    m_tile_underfill_us = (
+        max(0.0, math.log2(_M_TILE_UNDERFILL_TARGET / max(1, m_t)))
+        * _M_TILE_UNDERFILL_PENALTY_US
+    )
 
-    # Splitting batch across cores is strictly worse than tiling it in time on
-    # one core (each item is independent), so charge a super-linear b penalty.
-    batch_penalty = b**_BATCH_SPLIT_EXPONENT
+    # Very wide output tiles lose schedule efficiency in the generated kernel.
+    # Charge only the over-wide side so short-M and small/moderate-N choices
+    # are not pulled away from PT-friendly M tiles.
+    n_t = N // n if n else N
+    wide_n_us = (
+        max(0.0, math.log2(max(1, n_t) / _TARGET_N_TILE_ELEMS))
+        * _WIDE_N_TILE_PENALTY_US
+    )
 
-    return (compute_us + hbm_us + psum_us + target_m_us) * batch_penalty
+    # Once M is large enough to feed the PT, prefer tile shapes that avoid
+    # unnecessary layout/fusion fallout. For true BMMs this means avoiding
+    # splitting a tiny output dimension when the reduction dimension is much
+    # larger (value-matmul geometry: K >> N). For shared-weight projections this
+    # means avoiding very wide per-core N tiles when the whole projection is
+    # narrow enough that more N lanes are available. Both effects are expressed
+    # as ratios rather than op names or workload-specific shapes.
+    filled_m_tile_factor = 1.0 if m_t >= _M_TILE_UNDERFILL_TARGET else 0.0
+    true_bmm_value_split_us = (
+        0.0
+        if shared_weight or n <= 1
+        else filled_m_tile_factor
+        * max(0.0, math.log2(max(1, K) / max(1, N)))
+        * math.log2(n)
+        * _LARGE_M_TILE_SHAPE_PENALTY_US
+    )
+    shared_narrow_tile_us = (
+        0.0
+        if not shared_weight
+        else filled_m_tile_factor
+        * max(0.0, math.log2(_SHARED_NARROW_OUTPUT_REF / max(1, N)))
+        * max(0.0, math.log2(max(1, n_t) / _SHARED_N_TILE_TARGET))
+        * (_LARGE_M_TILE_SHAPE_PENALTY_US / 4)
+    )
+    shared_down_n_split_us = (
+        0.0
+        if not shared_weight or n <= 1
+        else max(0.0, math.log2(max(1, K) / max(1, N)))
+        * math.log2(n)
+        * _SHARED_DOWN_N_SPLIT_PENALTY_US
+    )
+    large_m_tile_shape_us = (
+        true_bmm_value_split_us + shared_narrow_tile_us + shared_down_n_split_us
+    )
+
+    # Prefer using the full core budget, but keep this soft so measured-good
+    # lower-core candidates can still win.
+    core_underuse_us = (
+        max(0.0, math.log2(max_cores / cores_used)) * _CORE_UNDERUSE_PENALTY_US
+    )
+
+    # True BMMs often need batch parallelism to avoid tiny-M underfill. Charge a
+    # small additive split overhead instead of multiplying the whole estimate.
+    batch_split_us = (
+        0.0 if shared_weight else math.log2(max(1, b)) * _BMM_BATCH_SPLIT_PENALTY_US
+    )
+
+    return (
+        compute_us
+        + hbm_us
+        + psum_us
+        + m_lane_underuse_us
+        + m_tile_underfill_us
+        + wide_n_us
+        + large_m_tile_shape_us
+        + core_underuse_us
+        + batch_split_us
+    )
+
+
+def _single_input_row_dims(
+    row_dims: list[Symbol],
+    input_tds: list[TensorDep],
+) -> list[Symbol]:
+    def _appears_in_one_input(dim: Symbol) -> bool:
+        hits = sum(
+            dim in {v for e in td.device_coords for v in e.free_symbols}
+            for td in input_tds
+        )
+        return hits == 1
+
+    return [d for d in row_dims if _appears_in_one_input(d)]
+
+
+def _pick_innermost_output_dim(
+    dims: list[Symbol],
+    output_index: Expr,
+) -> Symbol | None:
+    """Pick the row dim nearest the output's contiguous/stick dimension.
+
+    Shared 2D weights are represented as broadcast views. Their stride-0 batch
+    dimensions disappear from device coordinates, so both batch dims and the
+    true M dim can look like "LHS-only" row dims. In the output's flat host
+    index, the true M dim is the innermost row dimension: it has the smallest
+    non-zero coefficient, while batch dims have coefficients multiplied by M
+    and/or outer batch extents.
+    """
+
+    candidates: list[tuple[int, Symbol]] = []
+    for dim in dims:
+        coeff = output_index.coeff(dim)
+        if coeff == 0:
+            continue
+        candidates.append((abs(concretize_expr(coeff)), dim))
+    if not candidates:
+        return None
+    return min(candidates, key=lambda item: item[0])[1]
 
 
 def _cost_model_matmul_planner(
@@ -1029,29 +1158,31 @@ def _cost_model_matmul_planner(
     output_coord_vars = {
         v for e in output_td.device_coords[:-1] for v in e.free_symbols
     }
-    n_dims = [d for d in output_coord_vars if d in stick_vars]
-    row_dims = [d for d in output_coord_vars if d not in stick_vars]
+    ordered_output_coord_vars = [d for d in it_space_adjusted if d in output_coord_vars]
+    n_dims = [d for d in ordered_output_coord_vars if d in stick_vars]
+    row_dims = [d for d in ordered_output_coord_vars if d not in stick_vars]
     if len(n_dims) != 1 or not row_dims:
         return splits
     n_dim = n_dims[0]
 
-    def _appears_in_one_input(dim: Symbol) -> bool:
-        hits = sum(
-            dim in {v for e in td.device_coords for v in e.free_symbols}
-            for td in input_tds
-        )
-        return hits == 1
-
-    m_candidates = [d for d in row_dims if _appears_in_one_input(d)]
-    # A bmm with a SHARED 2D weight broadcasts it across the batch, so the batch
-    # dim "appears in one input" like M and m_candidates has two entries -> we
-    # decline here and the default distributor handles it. Engaging the planner
-    # for that case needs weight-rank awareness (which also fixes the B*K*N HBM
-    # term over-counting the shared weight); tracked as a follow-up.
-    if len(m_candidates) != 1:
+    m_candidates = _single_input_row_dims(row_dims, input_tds)
+    rhs_loaded_once = False
+    if len(m_candidates) == 1:
+        m_dim = m_candidates[0]
+    elif len(m_candidates) > 1:
+        m_dim = _pick_innermost_output_dim(m_candidates, output_td.dep.index)
+        if m_dim is None:
+            return splits
+        rhs_loaded_once = True
+    else:
         return splits
-    m_dim = m_candidates[0]
-    batch_dims = [d for d in row_dims if d is not m_dim]
+    batch_dims = [d for d in row_dims if d != m_dim]
+    # Folded projection matmuls have no batch dims left by this stage, but the
+    # RHS is still an unbatched weight that is loaded once. Treat them like the
+    # broadcast/shared-weight path for cost purposes while keeping true BMMs
+    # where RHS depends on batch dims on the non-shared path.
+    if not batch_dims:
+        rhs_loaded_once = True
 
     # K is the lone reduction dim (anything else this planner does not model).
     reduction = [d for d in it_space_adjusted if d not in output_coord_vars]
@@ -1090,7 +1221,12 @@ def _cost_model_matmul_planner(
                     if b_prod * mm * nn * kk > max_cores:
                         continue
                     c = _matmul_split_cost(
-                        (B_total, b_prod), (M_e, mm), (N_e, nn), (K_e, kk), max_cores
+                        (B_total, b_prod),
+                        (M_e, mm),
+                        (N_e, nn),
+                        (K_e, kk),
+                        max_cores,
+                        shared_weight=rhs_loaded_once,
                     )
                     if c < best_cost:
                         best_cost = c
@@ -1107,13 +1243,10 @@ def _cost_model_matmul_planner(
     new_splits[n_dim] = n_s
     new_splits[k_dim] = k_s
 
-    # Never trade down to fewer cores than the default distributor already found.
-    if math.prod(new_splits.values()) < math.prod(splits.values()):
-        return splits
-
     logger.debug(
         f"cost_model work_division {op.get_name()}: "
-        f"b={b_combo} m={m_s} n={n_s} k={k_s} cost={best_cost:.1f}us "
+        f"b={b_combo} m={m_s} n={n_s} k={k_s} rhs_loaded_once={rhs_loaded_once} "
+        f"cost={best_cost:.1f}us "
         f"[B={B_total} M={M_e} K={K_e} N={N_e}]"
     )
     return new_splits


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

this cost model update improves matmul performance for prefill and decode. This PR introduces 

- penalty for small per-core M tiles
- makes batch/head splitting attractive for attention matmuls
- added shared-weight BMM (3d x 2d) <-> linear matmuls vs true-BMM (3d x 3d) <-> attention matmuls, aware terms
- added term to distinguish between split-M vs split-N multicast cost based on algorithm reuse pattern

| Granite 3.3 8B | speedup vs main |
|---|---:|
| prefill | 1.07x |
| decode | 2.03x |

cc: @ani300 
#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

Part of #2149 

https://github.com/torch-spyre/torch-spyre/issues/2827

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
