### PR TITLE
ci: install regex in hw-diagnostics workflow venv

### DIFF
--- a/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
+++ b/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           source .venv/bin/activate
-          uv pip install clickhouse-connect
+          uv pip install clickhouse-connect regex
 
       - name: Install gh CLI
         run: |


### PR DESCRIPTION
## Summary

The `push-hw-diagnostics-to-clickhouse` workflow fails at the **Parse Logs** step with:

```
ModuleNotFoundError: No module named 'regex'
```

`.github/scripts/parse_hw_failures.py` uses `import regex as re` (the repo-enforced convention; `import re` is banned by a pre-commit hook), but the workflow creates a fresh `uv venv` and only installs `clickhouse-connect`. The `regex` package is never installed, so the import fails before any log is parsed.

## Fix

Add `regex` to the dependency install step:

```yaml
uv pip install clickhouse-connect regex
```

These are the only two non-stdlib imports across `parse_hw_failures.py` (`regex`) and `ingest_hw_diagnostics.py` (`clickhouse_connect`).

## Test plan

- [ ] Trigger the workflow (via `workflow_dispatch` with a known run ID) and confirm the Parse Logs step imports cleanly and produces the JSON report.