### PR TITLE
fix(cicd): disable `--parallel` flag for test_multi_spyre job to avoid conflicts with torchrun (Distributed Tests)

### DIFF
--- a/.github/actions/run-test-suite/action.yml
+++ b/.github/actions/run-test-suite/action.yml
@@ -43,6 +43,10 @@ inputs:
     description: Optional bash snippet run at the start of every attempt (e.g. topology reset)
     required: false
     default: ''
+  parallel:
+    description: Whether to pass --parallel to run_test.sh (disable for distributed torchrun tests)
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -141,7 +145,12 @@ runs:
 
           exec {FIFO_FD}>"$FIFO"
 
-          env ${_DTLOG_PREFIX} bash tests/run_test.sh "$CONFIG" --parallel ${{ inputs.extra_test_flags }} ${_SLOW_FLAG} ${_JUNIT_FLAG} \
+          _PARALLEL_FLAG=""
+          if [[ "${{ inputs.parallel }}" != "false" ]]; then
+            _PARALLEL_FLAG="--parallel"
+          fi
+
+          env ${_DTLOG_PREFIX} bash tests/run_test.sh "$CONFIG" ${_PARALLEL_FLAG} ${{ inputs.extra_test_flags }} ${_SLOW_FLAG} ${_JUNIT_FLAG} \
             >&"$FIFO_FD" 2>&1 &
           TEST_PID=$!
 

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -337,6 +337,7 @@ jobs:
           suite_name: ${{ matrix.suite.name }}
           config: tests/configs/${{ matrix.suite.config }}
           extra_test_flags: ${{ inputs.extra_test_flags }}
+          parallel: 'false'
           junit_xml_path: ${{ env.REPORT_PATH }}
           report_name: ${{ env.REPORT_NAME }}
           pre_run: |


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR passes `--parallel` as false for test-multi-spyre job to avoid conflict with `torchrun`


### Problem : no tests collected for distriubuted tests job

```bash
[torch_oot_device_tests_run_serial]   WARNING: no test IDs collected from test_barrier.py -- it will be skipped in parallel mode.
[torch_oot_device_tests_run_warning] WARNING: no test IDs collected across all files -- nothing to run.
```

### Fix (Please look at https://github.com/torch-spyre/torch-spyre/actions/runs/28078292277/job/83127181340?pr=2833)

```bash
collecting ... collected 1 item

spyreccl_backend__oot_wrapper.py::TestSpyreCCLBackendPRIVATEUSE1::test_spyreccl_device_to_backend_spyre PASSED [TAGS = platform__x86_64] [100%]  [TAGS = platform__x86_64]


- generated xml file: /home/senuser/torch-spyre/torch-spyre/test_general__shard_0.xml -
============================== 1 passed in 6.22s ===============================
# ---------------------------
# COMPLETE: RTN=0
# ---------------------------
[torch_oot_device_tests_run] Tags injected into XML: /home/senuser/torch-spyre/torch-spyre/test_general__shard_0.xml
[torch_oot_device_tests_run] Single XML shard moved to: /home/senuser/torch-spyre/torch-spyre/test_general.xml

[torch_oot_device_tests_run] Done. Overall exit code: 0
```


