### PR TITLE
feat(cicd): add report_empty_suites job to warn on zero-test matrix suites

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -417,11 +417,10 @@ jobs:
                   tree = ET.parse(xml_file)
                   root = tree.getroot()
                   # Handle both <testsuite> and <testsuites><testsuite ...> forms
-                  suites = (
-                      [root] if root.tag == "testsuite"
-                      else root.findall("testsuite")
-                  )
-                  total_tests = sum(int(s.get("tests", 0)) for s in suites)
+                  # Count <testcase> elements directly — the tests= attribute
+                  # is unreliable when pytest-xdist produced the XML (it writes
+                  # tests="0" in the suite header even when cases are present).
+                  total_tests = len(root.findall(".//testcase"))
                   if total_tests == 0:
                       empty.append(xml_file.stem)
               except ET.ParseError as e:

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -156,10 +156,9 @@ jobs:
             config: torch_spyre_tests/inductor/test_inductor_ops_pointwise_config.yaml
           - name: Inductor Ops Misc Shape A
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_shape_a_config.yaml
-            runner: spyre_pf_x4
+            runner: spyre_pf_x2
           - name: Inductor Ops Misc Shape B
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_shape_b_config.yaml
-          - name: Inductor Ops Misc Shape C
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_shape_c_config.yaml
           - name: Inductor Ops Misc Compute A
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_compute_a_config.yaml
@@ -167,7 +166,6 @@ jobs:
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_compute_b_config.yaml
           - name: Inductor Ops Misc Compute C
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_compute_c_config.yaml
-            runner: spyre_pf_x4
           - name: Inductor Ops FP8
             config: torch_spyre_tests/inductor/test_inductor_ops_fp8_config.yaml
           - name: Inductor Ops LX Planning
@@ -357,3 +355,107 @@ jobs:
           path: ${{ env.REPORT_PATH }}
           if-no-files-found: warn
           retention-days: 10
+
+  # ---------------------------------------------------------------------------
+  # Job 3: Report test suites that ran zero tests
+  #
+  # Runs after both matrix jobs (even if they fail) and checks every uploaded
+  # JUnit XML artifact for a zero-test result.  Issues ::warning:: annotations
+  # and writes a step summary table (does NOT fail the workflow).
+  # ---------------------------------------------------------------------------
+  report_empty_suites:
+    name: Report empty test suites
+    runs-on: ubuntu-latest
+    needs: [test, test_multi_spyre]
+    if: always()
+    permissions:
+      actions: read
+
+    steps:
+      - name: Download all XML artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p xml_artifacts
+          ARTIFACTS=$(gh api \
+            "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+            --jq '[.artifacts[] | select(.name | endswith(".xml")) | {id: .id, name: .name}]')
+
+          python3 <<PYEOF
+          import json, os, subprocess
+          artifacts = json.loads(r"""${ARTIFACTS}""")
+          repo = "${{ github.repository }}"
+          for a in artifacts:
+              zip_path = f"xml_artifacts/{a['name']}.zip"
+              result = subprocess.run(
+                  ["gh", "api", f"/repos/{repo}/actions/artifacts/{a['id']}/zip"],
+                  capture_output=True, check=True,
+                  env={**os.environ},
+              )
+              with open(zip_path, "wb") as f:
+                  f.write(result.stdout)
+              subprocess.run(
+                  ["unzip", "-q", "-o", zip_path, "-d", "xml_artifacts/"],
+                  check=True,
+              )
+          print(f"Downloaded {len(artifacts)} artifact(s).")
+          PYEOF
+
+      - name: Check for empty suites
+        run: |
+          python3 <<'PYEOF'
+          import os
+          import sys
+          from pathlib import Path
+          from xml.etree import ElementTree as ET
+
+          xml_dir = Path("xml_artifacts")
+          xml_files = sorted(xml_dir.glob("**/*.xml"))
+
+          empty = []
+          for xml_file in xml_files:
+              try:
+                  tree = ET.parse(xml_file)
+                  root = tree.getroot()
+                  # Handle both <testsuite> and <testsuites><testsuite ...> forms
+                  suites = (
+                      [root] if root.tag == "testsuite"
+                      else root.findall("testsuite")
+                  )
+                  total_tests = sum(int(s.get("tests", 0)) for s in suites)
+                  if total_tests == 0:
+                      empty.append(xml_file.stem)
+              except ET.ParseError as e:
+                  print(f"::warning::Could not parse {xml_file.name}: {e}")
+
+          # Build step summary
+          lines = []
+          if empty:
+              lines.append("### Empty test suites detected\n")
+              lines.append(
+                  "The following suite(s) uploaded a JUnit XML report with **0 tests**:\n"
+              )
+              lines.append("| Artifact |")
+              lines.append("|---|")
+              for name in empty:
+                  lines.append(f"| `{name}` |")
+              lines.append("")
+              lines.append(
+                  "> **Note:** This is a warning only — the workflow is not failed."
+              )
+          else:
+              lines.append("### Empty suite check: all suites ran at least one test.")
+
+          summary = "\n".join(lines)
+          print(summary)
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "")
+          if summary_path:
+              with open(summary_path, "a") as f:
+                  f.write(summary + "\n")
+
+          # Emit ::warning:: annotations for each empty suite
+          for name in empty:
+              print(f"::warning title=Empty test suite::{name} reported 0 tests collected")
+
+          sys.exit(0)
+          PYEOF

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -159,6 +159,7 @@ jobs:
             runner: spyre_pf_x2
           - name: Inductor Ops Misc Shape B
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_shape_b_config.yaml
+          - name: Inductor Ops Misc Shape C
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_shape_c_config.yaml
           - name: Inductor Ops Misc Compute A
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_compute_a_config.yaml
@@ -368,8 +369,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, test_multi_spyre]
     if: always()
-    permissions:
-      actions: read
 
     steps:
       - name: Download all XML artifacts

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -380,9 +380,9 @@ jobs:
             "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
             --jq '[.artifacts[] | select(.name | endswith(".xml")) | {id: .id, name: .name}]')
 
-          python3 <<PYEOF
+          ARTIFACTS="$ARTIFACTS" python3 <<'PYEOF'
           import json, os, subprocess
-          artifacts = json.loads(r"""${ARTIFACTS}""")
+          artifacts = json.loads(os.environ['ARTIFACTS'])
           repo = "${{ github.repository }}"
           for a in artifacts:
               zip_path = f"xml_artifacts/{a['name']}.zip"


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

- Add `report_empty_suites` job to `_test_matrix.yaml` that runs after both `test` and `test_multi_spyre` matrix jobs (even on failure)

- Downloads all JUnit XML artifacts from the current run and checks each for zero collected tests

- Emits `::warning::` annotations and a step summary table for empty suites; exits 0 so the workflow is never failed


### Flow: 

torch spyre tests run  (`run-tests`)- > check `report_empty_suites` runs -> Run Spyre unit runs


### Output 
<img width="1346" height="718" alt="image" src="https://github.com/user-attachments/assets/88b96a37-c3fb-4b43-8ce2-e273c5ec463b" /> <br><br>

Reference link: https://github.com/torch-spyre/torch-spyre/actions/runs/28084675769/job/83150801614?pr=2835

