### PR TITLE
Fix the failure of the reshape, view, zeros and other ops in CI/CD

### DIFF
--- a/tests/oot_test_config_models.py
+++ b/tests/oot_test_config_models.py
@@ -423,8 +423,11 @@ class InputsEdits(BaseModel):
                     val = test_device
                 # Handle tuples/lists from YAML (e.g., view/reshape shapes)
                 # If value is a string that looks like a tuple/list, convert it
-                elif isinstance(val, str) and (val.startswith('(') or val.startswith('[')):
+                elif isinstance(val, str) and (
+                    val.startswith("(") or val.startswith("[")
+                ):
                     import ast
+
                     try:
                         val = ast.literal_eval(val)
                     except (ValueError, SyntaxError):

--- a/tests/oot_test_config_models.py
+++ b/tests/oot_test_config_models.py
@@ -421,6 +421,18 @@ class InputsEdits(BaseModel):
                     and "cuda" in val
                 ):
                     val = test_device
+                # Handle tuples/lists from YAML (e.g., view/reshape shapes)
+                # If value is a string that looks like a tuple/list, convert it
+                elif isinstance(val, str) and (val.startswith('(') or val.startswith('[')):
+                    import ast
+                    try:
+                        val = ast.literal_eval(val)
+                    except (ValueError, SyntaxError):
+                        # If conversion fails, keep as string
+                        pass
+                # Tuples and lists are already valid Python values
+                elif isinstance(val, (tuple, list)):
+                    pass
                 cpu_args.append(val)
 
             elif isinstance(arg, InputArgPy):


### PR DESCRIPTION
#### What type of PR is this?

- [X] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

It will fix the failure of the reshape, view, zeros and other ops for all the models where value field in the yaml is instance of tuple/list. 

#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/issues/2837

#### Special notes for your reviewer:
It will correct the count of xpass and xfail of testcases in CI/CD

with this change testcases are passing in CI/CD:
```
test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_Tensor_view__25_spyre_float16 XPASS [TAGS = model__granite-3.3-8b-instruct_spyre dtype__float16 op__torch_Tensor_view platform__x86_64 constant torch.Tensor.view.1_spyre] [ 8%] [TAGS = model__granite-3.3-8b-instruct_spyre dtype__float16 op__torch_Tensor_view platform__x86_64 constant torch.Tensor.view.1_spyre]

test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_Tensor_view__28_spyre_float16 XPASS [TAGS = model__granite-3.3-8b-instruct_spyre dtype__float16 op__torch_Tensor_view platform__x86_64 constant torch.Tensor.view.2_spyre] [ 10%] [TAGS = model__granite-3.3-8b-instruct_spyre dtype__float16 op__torch_Tensor_view platform__x86_64 constant torch.Tensor.view.2_spyre]

test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_reshape__47_spyre_float16 XPASS [TAGS = model__granite-3.3-8b-instruct_spyre dtype__float16 op__torch_reshape platform__x86_64 constant torch.reshape.1_spyre][ 75%] [TAGS = model__granite-3.3-8b-instruct_spyre dtype__float16 op__torch_reshape platform__x86_64 constant torch.reshape.1_spyre]

test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_reshape__51_spyre_float16 XPASS [TAGS = model__granite-3.3-8b-instruct_spyre dtype__float16 op__torch_reshape platform__x86_64 constant torch.reshape.2_spyre][ 76%] [TAGS = model__granite-3.3-8b-instruct_spyre dtype__float16 op__torch_reshape platform__x86_64 constant torch.reshape.2_spyre]

test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_zeros__43_spyre_float16 XPASS [TAGS = model__granite-3.3-8b-instruct_spyre dtype__float16 op__torch_zeros platform__x86_64 constant torch.zeros.1_spyre] [100%] [TAGS = model__granite-3.3-8b-instruct_spyre dtype__float16 op__torch_zeros platform__x86_64 constant torch.zeros.1_spyre]
``` 

