### PR TITLE
ci: shadow runner resource-limit validation (DO NOT MERGE)

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -20,16 +20,16 @@ on:
         type: string
 
       # IMAGE selector label for runs-on. Normal runs use the standing
-      # image_spyre_backend set; the per-PR ephemeral flow passes that PR's set
+      # image_spyre_backend_shadow set; the per-PR ephemeral flow passes that PR's set
       # label (image_spyre_backend_pr_<component>_<sha12>, e.g.
       # image_spyre_backend_pr_flex_8ddcf3e155e9) so jobs land on the per-PR image
       # (the RPM is baked in -> no runtime sudo). Default keeps existing callers
       # unchanged.
       image_label:
-        description: Image scaleSetLabel to select (image_spyre_backend | image_spyre_backend_pr_<KEY>)
+        description: Image scaleSetLabel to select (image_spyre_backend_shadow | image_spyre_backend_pr_<KEY>)
         required: false
         type: string
-        default: image_spyre_backend
+        default: image_spyre_backend_shadow
 
       # Flags appended to every `bash tests/run_test.sh <config>` call for the test job
       extra_test_flags:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -70,7 +70,7 @@ on:
         description: |
           Per-PR ephemeral runner-set IMAGE label
           (image_spyre_backend_pr_<component>_<sha12>).
-          Leave empty to use the standing image_spyre_backend set.
+          Leave empty to use the standing image_spyre_backend_shadow set.
         required: false
         type: string
         default: ''
@@ -122,7 +122,7 @@ jobs:
     uses: ./.github/workflows/_test_matrix.yaml
     with:
       runner_label: linux
-      image_label: ${{ inputs.runner_label || 'image_spyre_backend' }}
+      image_label: ${{ inputs.runner_label || 'image_spyre_backend_shadow' }}
       extra_test_flags: -v
       checkout_pytorch: false
       ref: ${{ inputs.ref || '' }}

--- a/.github/workflows/model_ops_tests.yaml
+++ b/.github/workflows/model_ops_tests.yaml
@@ -33,7 +33,7 @@ jobs:
       - x86_64
       - spyre_pf_x1
       - linux
-      - image_spyre_backend
+      - image_spyre_backend_shadow
     timeout-minutes: 60
     env:
       # The CI env var is very important.

--- a/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
+++ b/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
@@ -27,7 +27,7 @@ jobs:
       - x86_64
       - spyre_pf_x0
       - linux
-      - image_spyre_backend
+      - image_spyre_backend_shadow
     timeout-minutes: 15
     if: |
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/push-to-clickhouse.yaml
+++ b/.github/workflows/push-to-clickhouse.yaml
@@ -38,7 +38,7 @@ jobs:
       - x86_64
       - spyre_pf_x0
       - linux
-      - image_spyre_backend
+      - image_spyre_backend_shadow
     timeout-minutes: 15
     # Skip if the triggering workflow was cancelled (but ingest failures are fine)
     if: |

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -45,7 +45,7 @@ on:
         description: |
           Per-PR ephemeral runner-set IMAGE label to select
           (image_spyre_backend_pr_<component>_<sha12>, e.g. image_spyre_backend_pr_flex_8ddcf3e155e9).
-          Empty = use the standing image_spyre_backend set (the RPM is then installed at
+          Empty = use the standing image_spyre_backend_shadow set (the RPM is then installed at
           runtime via rpm_names; the ephemeral flow leaves this set and rpm_names empty).
         required: false
         type: string
@@ -129,7 +129,7 @@ jobs:
     with:
       runner_label: linux
       # Per-PR ephemeral image label when provided, else the standing set.
-      image_label: ${{ inputs.runner_label || 'image_spyre_backend' }}
+      image_label: ${{ inputs.runner_label || 'image_spyre_backend_shadow' }}
       extra_test_flags: -v -m "not xfail"
       extra_test_flags_multi_spyre: -v
       checkout_pytorch: false

--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -38,7 +38,7 @@ jobs:
       - x86_64
       - spyre_pf_x1
       - linux
-      - image_spyre_backend
+      - image_spyre_backend_shadow
     timeout-minutes: 60
     env:
       # The CI env var is very important.

--- a/.github/workflows/upstream_tests_beta.yaml
+++ b/.github/workflows/upstream_tests_beta.yaml
@@ -29,7 +29,7 @@ jobs:
       - x86_64
       - spyre_pf_x1
       - linux
-      - image_spyre_backend
+      - image_spyre_backend_shadow
     timeout-minutes: 60
     env:
       # The CI env var is very important.


### PR DESCRIPTION
Throwaway PR — DO NOT MERGE. Redirects image_spyre_backend to image_spyre_backend_shadow in testing workflows to drive real CI jobs onto shadow ARC runner sets for restartPolicy/idle-timeout candidate validation (spyre-frameworks #81). Reset and force-pushed every validation cycle.

Test-With: torch-spyre/hf-adapters#87