### PR TITLE
Enable torch.max.default (no dim parameter)

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_index_norm_eager_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_index_norm_eager_config.yaml
@@ -4,7 +4,6 @@ test_suite_config:
       unlisted_test_mode: skip
       tests:
         - names:
-            - TestOps::test_max_default.*
             - TestOps::test_min_keepdim.*
             - TestOps::test_max_keepdim.*
             - TestOps::test_aminmax_keepdim.*

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_index_norm_eager_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_index_norm_eager_config.yaml
@@ -4,6 +4,7 @@ test_suite_config:
       unlisted_test_mode: skip
       tests:
         - names:
+            - TestOps::test_max_default.*
             - TestOps::test_min_keepdim.*
             - TestOps::test_max_keepdim.*
             - TestOps::test_aminmax_keepdim.*

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -765,14 +765,10 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 ),
                 "1d_int64": (unique_randn_along_dim((64,), dtype=torch.int64),),
                 "2d_int64": (unique_randn_along_dim((67, 256), dtype=torch.int64),),
+                "3d_int64": (unique_randn_along_dim((4, 8, 16), dtype=torch.int64),),
+                "1d_float32": (unique_randn_along_dim((64,), dtype=torch.float32),),
+                "2d_float32": (unique_randn_along_dim((8, 64), dtype=torch.float32),),
             },
-            "expect_fail": [
-                "1d_float16",
-                "2d_float16",
-                "3d_float16",
-                "1d_int64",
-                "2d_int64",
-            ],
         },
         # Compare with cpu for now to avoid hitting eager mode coverage issue
         ("test_max_keepdim0", "test_reduce_keepdim0_cpu"): {

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -494,28 +494,26 @@ def _(input: torch.Tensor, dim: int, keepdim: bool = False):
     return (values, indices)
 
 
-## TODO (imaihal): This needs scalar tensor support from Spyre to CPU. issues #1172
-#
-# @torch.library.custom_op("spyre::max_default_int64_fallback", mutates_args=())
-# def max_default_int64_fallback(input: torch.Tensor) -> torch.Tensor:
-#    """
-#    CPU fallback for torch.max(input) when input is int64.
-#    This custom op will be registered with a CPU fallback in fallbacks.py.
-#    Returns a 1D tensor with shape [1] containing the maximum value.
-#    """
-#    # This should never be called directly; the fallback in fallbacks.py handles it
-#    raise RuntimeError(
-#        "spyre::max_default_int64_fallback should be handled by CPU fallback registration"
-#    )
-#
-#
-# @max_default_int64_fallback.register_fake
-# def _(input: torch.Tensor):
-#    """
-#    Fake implementation for shape inference.
-#    Returns a scalar (0D) tensor matching the input dtype.
-#    """
-#    return input.new_empty([])
+@torch.library.custom_op("spyre::max_default_int64_fallback", mutates_args=())
+def max_default_int64_fallback(input: torch.Tensor) -> torch.Tensor:
+    """
+    CPU fallback for torch.max(input) when input is int64.
+    This custom op will be registered with a CPU fallback in fallbacks.py.
+    Returns a 1D tensor with shape [1] containing the maximum value.
+    """
+    # This should never be called directly; the fallback in fallbacks.py handles it
+    raise RuntimeError(
+        "spyre::max_default_int64_fallback should be handled by CPU fallback registration"
+    )
+
+
+@max_default_int64_fallback.register_fake
+def _(input: torch.Tensor):
+    """
+    Fake implementation for shape inference.
+    Returns a scalar (0D) tensor matching the input dtype.
+    """
+    return input.new_empty([])
 
 
 @torch.library.custom_op("spyre::batched_matmul", mutates_args=(), device_types="spyre")

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -609,26 +609,25 @@ def spyre__sdpa_overrideable(
     )
 
 
-## TODO(imaihal): Need to fix scalar tensor shape mismatch during Spyre-to-CPU transfer.
-## See: https://github.com/torch-spyre/torch-spyre/issues/1172
-## This will be enabled after solving this.
-# @register_spyre_decomposition([torch.ops.aten.max.default])
-# def spyre_max_default_decomp(input):
-#    """
-#    Decompose torch.max(input) with conditional CPU fallback for int64.
-#
-#    For int64 tensors, use custom op spyre::max_default_int64_fallback which has
-#    a CPU fallback registered in fallbacks.py.
-#    For other dtypes (float16, float32, etc.), use amax.
-#    """
-#    if input.dtype == torch.int64:
-#        # Use custom op with CPU fallback to avoid recursive decomposition
-#        # Returns a scalar (0D) tensor
-#        return torch.ops.spyre.max_default_int64_fallback(input)
-#    else:
-#        # Use amax for supported dtypes (can run on Spyre)
-#        # Returns a scalar (0D) tensor
-#        return torch.ops.aten.amax(input)
+@register_spyre_decomposition([torch.ops.aten.max.default])
+def spyre_max_default_decomp(input):
+    """
+    Decompose torch.max(input) with conditional CPU fallback for int64.
+
+    For int64 tensors, use custom op spyre::max_default_int64_fallback which has
+    a CPU fallback registered in fallbacks.py.
+    For other dtypes (float16, float32, etc.), use amax.
+    """
+    if input.dtype == torch.int64:
+        # Use custom op with CPU fallback to avoid recursive decomposition
+        # Returns a scalar (0D) tensor
+        return torch.ops.spyre.max_default_int64_fallback(input)
+    else:
+        # Use amax for supported dtypes (can run on Spyre)
+        # Returns a scalar (0D) tensor
+        return torch.ops.aten.amax(input)
+
+
 @register_spyre_decomposition([torch.ops.aten.max.dim])
 def spyre_max_dim_decomp(input, dim, keepdim=False):
     """


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?
This PR enables the `torch.max(input)` decomposition that was previously disabled due to scalar tensor shape mismatch issues during Spyre-to-CPU transfer. The decomposition now works correctly after fixing the underlying scalar tensor handling in issue #1172.

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

1. Decomposition (`torch_spyre/_inductor/decompositions.py`)

```python
@register_spyre_decomposition([torch.ops.aten.max.default])
def spyre_max_default_decomp(input):
    if input.dtype == torch.int64:
        # Use custom op with CPU fallback
        return torch.ops.spyre.max_default_int64_fallback(input)
    else:
        # Use amax for supported dtypes (runs on Spyre)
        return torch.ops.aten.amax(input)
```

- **INT64 tensors**: Routes to `spyre::max_default_int64_fallback` custom op with CPU fallback
- **Other dtypes** (float16, float32, etc.): Uses `torch.ops.aten.amax` which runs natively on Spyre
- Returns a scalar (0D) tensor matching PyTorch's behavior

2. Custom Op (`torch_spyre/_inductor/customops.py`)

Uncommented and enabled the `spyre::max_default_int64_fallback` custom op:
- Provides fake implementation for shape inference (returns 0D tensor)
- Actual execution handled by CPU fallback in `fallbacks.py`
- Follows the same pattern as other reduction operations

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
