### PR TITLE
test: remove xfail from test_nested_bmm_outer_Batch_inner_K_correct

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -29,7 +29,6 @@ Add new tests there using spyre_hint(num_tiles_per_dim=...) annotations.
 import sys
 import os
 
-import pytest
 import torch
 import unittest
 from unittest.mock import patch as mock_patch
@@ -1350,15 +1349,6 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
         super().setUp()
         torch.manual_seed(0xCAFE)
 
-    @pytest.mark.xfail(
-        reason=(
-            "Fails with cpu/spyre mismatch (~15-25% elements wrong). "
-            "Root cause under investigation: suspected C++ runtime or "
-            "device-level state contamination from prior flash attention "
-            "execution, or a codegen bug in nested outer-B + inner-K tiling."
-        ),
-        strict=True,
-    )
     def test_nested_bmm_outer_Batch_inner_K_correct(self):
         """bmm [B,M,K]@[B,K,N] outer B (output) + inner K (reduction) — correct."""
         from torch_spyre._inductor import spyre_hint


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Removes the `xfail` marker from
`TestCoarseTileNestedReductionE2E::test_nested_bmm_outer_Batch_inner_K_correct`.

The test was marked `xfail(strict=True)` with the note "root cause under
investigation: suspected C++ runtime or device-level state contamination from
prior flash attention execution, or a codegen bug in nested outer-B + inner-K
tiling."

The root cause was the `_tile_device_size` bug fixed in #2861: shrinking
`device_size[1]` (the row-stride dimension) to the tile row count corrupted
the hardware's inter-stick-group stride on multi-stick tensors.  The nested
outer-B + inner-K bmm test was hitting the same corruption — the output tensor
for B-tiling has `device_size[0] > 1` (sticks per row), so the inner row
dimension was being incorrectly shrunk.  The failure was order-dependent
because prior flash attention execution happened to leave the device in a state
that exposed the wrong-address reads.

Verified locally: `test_hint_flash_attention` → `test_nested_bmm_outer_Batch_inner_K_correct`
both pass in sequence.

#### Which issue(s) this PR is related to:

Follows #2861 (fix(unroll): preserve inter-stick stride in _tile_device_size).

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

No.

#### Additional note: