### PR TITLE
check CountedLoopSchedulerNode tensor budget in spyre_fuse_nodes

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1095,6 +1095,27 @@ class TestSpyreFuseNodesLoopBudget(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertIs(result[0], node)
 
+    def test_nested_loop_node_tensor_union_checked(self):
+        """Outer CountedLoopSchedulerNode's read_writes covers inner tensors.
+
+        _build_loop_group wraps inner loops first, then the outer loop.
+        FusedSchedulerNode.__init__ calls ReadWrites.merge_list on its
+        snodes, so the outer node's read_writes is already the full union
+        of all inner tensors.  This test confirms that the budget check
+        on the outer node sees all tensors from nested inner nodes.
+        """
+        sched = _make_scheduler()
+        # Simulate an outer CountedLoopSchedulerNode whose read_writes
+        # already aggregates tensors from two inner loop nodes (t1..t4).
+        # In production this aggregation is done by ReadWrites.merge_list
+        # during FusedSchedulerNode construction.
+        outer = _make_counted_loop_node(sched, ["t1", "t2", "t3", "t4"], "outer_loop")
+        # 4 unique non-intermediate tensors > max_tensors(2): must raise.
+        with self.assertRaises(RuntimeError) as ctx:
+            spyre_fuse_nodes([outer])
+        self.assertIn("outer_loop", str(ctx.exception))
+        self.assertIn("4", str(ctx.exception))
+
 
 # ===========================================================================
 # 4. generate_sdsc and compile_op_spec — symbol/affine-stride paths

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -19,9 +19,10 @@ Covers six areas, each in its own class group:
      TestIterOpSpecs, TestCodegenOpSpecListRoundtrip)
   2. coarse_tile IR pass: range rewriting, attribute stamping, nested groups
      (TestDivideRanges, TestCoarseTile, TestCoarseTileNested)
-  3. CountedLoopSchedulerNode, build_loop_scheduler_nodes, and
-     _tiled_syms_for_sched_node_at_depth
-     (TestHelpers, TestBuildLoopSchedulerNodes, TestTiledSymsForSchedNode)
+  3. CountedLoopSchedulerNode, build_loop_scheduler_nodes,
+     _tiled_syms_for_sched_node_at_depth, and spyre_fuse_nodes budget check
+     (TestHelpers, TestBuildLoopSchedulerNodes, TestTiledSymsForSchedNode,
+      TestSpyreFuseNodesLoopBudget)
   4. generate_sdsc and compile_op_spec symbol/affine-stride paths
      (TestTiledByteStride, TestGenerateSdscTiledSymbols,
       TestCompileOpSpecTwoTiledSymbols, TestCompileOpSpecSymbolMapping)
@@ -80,6 +81,7 @@ from torch_spyre._inductor.scheduler import (
     _loop_group_id,
     build_loop_scheduler_nodes,
 )
+from torch_spyre._inductor.fusion import spyre_fuse_nodes
 from torch_spyre._inductor.spyre_kernel import (
     _codegen_op_spec_list,
     _iter_op_specs,
@@ -971,6 +973,127 @@ class TestBuildLoopSchedulerNodes(unittest.TestCase):
         result, created = self._run([n1, n2])
         self.assertEqual(len(result), 1)
         self.assertEqual(created[0].loop_count, s)
+
+
+# ===========================================================================
+# 3b. spyre_fuse_nodes CountedLoopSchedulerNode budget check
+# ===========================================================================
+
+
+def _make_snode_with_tensors(scheduler, ir_op, name, tensor_names):
+    """Like _make_snode but read_writes returns named dependency mocks."""
+    snode = _make_snode(scheduler, ir_op, name)
+    deps = []
+    for tname in tensor_names:
+        dep = MagicMock()
+        dep.name = tname
+        deps.append(dep)
+    snode.read_writes.reads_and_writes.return_value = deps
+    return snode
+
+
+def _make_counted_loop_node(scheduler, tensor_names, name="loop0"):
+    """Return a fake CountedLoopSchedulerNode with the given tensor names."""
+    node = MagicMock(spec=CountedLoopSchedulerNode)
+    node.scheduler = scheduler
+    node.get_name.return_value = name
+    node.get_nodes.return_value = [node]
+    deps = []
+    for tname in tensor_names:
+        dep = MagicMock()
+        dep.name = tname
+        deps.append(dep)
+    node.read_writes = MagicMock()
+    node.read_writes.reads_and_writes.return_value = deps
+    return node
+
+
+class TestSpyreFuseNodesLoopBudget(unittest.TestCase):
+    def setUp(self):
+        # All tensor names count as non-intermediate.
+        self._patcher = patch(
+            "torch_spyre._inductor.fusion._is_non_intermediate",
+            side_effect=lambda name: True,
+        )
+        self._patcher.start()
+        # Cap the bundle at 2 tensors so overflow is easy to trigger.
+        self._max_patcher = patch(
+            "torch_spyre._inductor.fusion._max_bundle_tensors",
+            return_value=2,
+        )
+        self._max_patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+        self._max_patcher.stop()
+
+    def test_loop_node_within_budget_no_error(self):
+        """A loop node referencing <= max_tensors: passes through without error."""
+        sched = _make_scheduler()
+        loop = _make_counted_loop_node(sched, ["t1", "t2"], "loop0")
+        result = spyre_fuse_nodes([loop])
+        self.assertEqual(len(result), 1)
+        self.assertIs(result[0], loop)
+
+    def test_loop_node_exceeds_budget_raises(self):
+        """A loop node referencing > max_tensors must raise RuntimeError."""
+        sched = _make_scheduler()
+        loop = _make_counted_loop_node(sched, ["t1", "t2", "t3"], "loop0")
+        with self.assertRaises(RuntimeError) as ctx:
+            spyre_fuse_nodes([loop])
+        self.assertIn("loop0", str(ctx.exception))
+        self.assertIn("3", str(ctx.exception))
+        self.assertIn("2", str(ctx.exception))
+
+    def test_loop_node_empty_tensors_no_error(self):
+        """A loop node with no tensors (all intermediates) is fine."""
+        sched = _make_scheduler()
+        # Override: nothing is non-intermediate for this test.
+        with patch(
+            "torch_spyre._inductor.fusion._is_non_intermediate",
+            side_effect=lambda name: False,
+        ):
+            loop = _make_counted_loop_node(sched, ["t1", "t2", "t3"], "loop0")
+            result = spyre_fuse_nodes([loop])
+        self.assertEqual(len(result), 1)
+
+    def test_plain_scheduler_node_split_unaffected(self):
+        """Plain SchedulerNode tensor-budget splits still work (no regression)."""
+        sched = _make_scheduler()
+        a = _make_snode_with_tensors(sched, _make_ir_op(), "a", ["t1", "t2"])
+        b = _make_snode_with_tensors(sched, _make_ir_op(), "b", ["t3"])
+        # a fills the 2-tensor budget; b starts a new bundle.
+        result = spyre_fuse_nodes([a, b])
+        self.assertEqual(len(result), 2)
+
+    def test_loop_node_preceded_by_scheduler_nodes(self):
+        """Loop node after plain nodes: budget check on loop node itself."""
+        sched = _make_scheduler()
+        a = _make_snode_with_tensors(sched, _make_ir_op(), "a", ["t1"])
+        loop = _make_counted_loop_node(sched, ["t2", "t3", "t4"], "loop0")
+        with self.assertRaises(RuntimeError):
+            spyre_fuse_nodes([a, loop])
+
+    def test_fallback_node_exceeds_budget_no_error(self):
+        """Non-CountedLoop nodes (e.g. FallbackKernel) bypass the budget check."""
+        from torch._inductor.scheduler import FusedSchedulerNode
+
+        sched = _make_scheduler()
+        # Build a plain FusedSchedulerNode mock (not CountedLoopSchedulerNode).
+        node = MagicMock(spec=FusedSchedulerNode)
+        node.scheduler = sched
+        node.get_name.return_value = "fallback0"
+        deps = []
+        for tname in ["t1", "t2", "t3", "t4"]:
+            dep = MagicMock()
+            dep.name = tname
+            deps.append(dep)
+        node.read_writes = MagicMock()
+        node.read_writes.reads_and_writes.return_value = deps
+        # 4 tensors > max_tensors(2), but this is not a CountedLoopSchedulerNode.
+        result = spyre_fuse_nodes([node])
+        self.assertEqual(len(result), 1)
+        self.assertIs(result[0], node)
 
 
 # ===========================================================================

--- a/torch_spyre/_inductor/fusion.py
+++ b/torch_spyre/_inductor/fusion.py
@@ -22,6 +22,7 @@ from torch._inductor.ir import FallbackKernel
 from torch_spyre._inductor.logging_utils import _get_env_bool
 from .ir import FixedTiledLayout
 from .constants import SEGMENT_OFFSETS
+from .scheduler import CountedLoopSchedulerNode
 
 # TODO: Temporary hook to easily disable
 _FUSION_ENABLED = _get_env_bool("SPYRE_INDUCTOR_ENABLE_FUSION", True)
@@ -52,6 +53,12 @@ def _is_non_intermediate(name: str) -> bool:
     # bundle's non-intermediate tensor budget.
     layout = buf.maybe_get_layout()
     return isinstance(layout, FixedTiledLayout) and not layout.allocation
+
+
+def _count_non_intermediate_tensors(node: BaseSchedulerNode) -> int:
+    """Count unique non-intermediate tensors referenced by node."""
+    names = {dep.name for dep in node.read_writes.reads_and_writes()}
+    return sum(1 for name in names if _is_non_intermediate(name))
 
 
 def spyre_fuse_nodes(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
@@ -95,9 +102,19 @@ def spyre_fuse_nodes(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
                 )
 
         else:
-            # Other node types (eg Fallback nodes) force a bundle boundary.
+            # Other node types (eg Fallback nodes, CountedLoopSchedulerNode)
+            # force a bundle boundary.  For CountedLoopSchedulerNodes (atomic
+            # loop groups), verify the tensor budget since they cannot be split.
             if fused := _make_fused(cur_nodes):
                 fused_nodes.append(fused)
+            if isinstance(n, CountedLoopSchedulerNode):
+                non_intermediate = _count_non_intermediate_tensors(n)
+                if non_intermediate > max_tensors:
+                    raise RuntimeError(
+                        f"spyre_fuse_nodes: node {n.get_name()!r} references "
+                        f"{non_intermediate} non-intermediate tensors but the "
+                        f"bundle limit is {max_tensors}"
+                    )
             fused_nodes.append(n)
             cur_nodes = []
             cur_tensors = set()

--- a/torch_spyre/_inductor/fusion.py
+++ b/torch_spyre/_inductor/fusion.py
@@ -56,7 +56,15 @@ def _is_non_intermediate(name: str) -> bool:
 
 
 def _count_non_intermediate_tensors(node: BaseSchedulerNode) -> int:
-    """Count unique non-intermediate tensors referenced by node."""
+    """Count unique non-intermediate tensors referenced by node.
+
+    For a CountedLoopSchedulerNode, node.read_writes is the recursively
+    merged union of all inner nodes' read_writes (built by
+    FusedSchedulerNode.__init__ → init_group_node →
+    ReadWrites.merge_list).  Nested CountedLoopSchedulerNodes therefore
+    contribute their full tensor sets automatically; no manual recursion
+    is needed here.
+    """
     names = {dep.name for dep in node.read_writes.reads_and_writes()}
     return sum(1 for name in names if _is_non_intermediate(name))
 


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

`spyre_fuse_nodes` routes any non-`SchedulerNode` — including
`CountedLoopSchedulerNode` — to an `else` branch that forces a bundle
boundary and appends the node directly to `fused_nodes`.  Because a
`CountedLoopSchedulerNode` is an atomic loop group that must land in a
single SuperDSC bundle and cannot be split, this path never verified that
the node fit within the hardware tensor-argument budget.  A loop group
referencing more than `max_bundle_tensors` non-intermediate tensors would
silently produce an invalid bundle.

This PR adds the missing check:

- Adds `_count_non_intermediate_tensors(node)` — counts unique
  non-intermediate tensors via `node.read_writes.reads_and_writes()`.
- In the `else` branch of `spyre_fuse_nodes`, after flushing the current
  accumulator, checks whether the incoming node is a
  `CountedLoopSchedulerNode` and whether its non-intermediate tensor count
  exceeds `max_bundle_tensors`.  Raises `RuntimeError` with the node name,
  actual count, and limit if so.
- `FallbackKernel` and other non-loop node types are explicitly excluded
  from the check via `isinstance(n, CountedLoopSchedulerNode)`.

New unit tests in `TestSpyreFuseNodesLoopBudget` (6 cases):
- Loop node within budget — passes through
- Loop node over budget — raises with node name and counts in message
- Loop node with all-intermediate tensors — passes through
- `FallbackKernel`-shaped node over budget — passes through (no check)
- Plain `SchedulerNode` tensor-budget split — unaffected (regression)
- Loop node preceded by plain `SchedulerNode`s — raises

#### Which issue(s) this PR is related to:

Part of #1358 

#### Special notes for your reviewer:

The check fires in the `else` branch only, gated on
`isinstance(n, CountedLoopSchedulerNode)`.  The `SchedulerNode` branch
(tensor-budget accumulation and splitting) is untouched.

`CountedLoopSchedulerNode.read_writes` is the merged union of all inner
nodes' reads and writes, set by `FusedSchedulerNode.__init__` via
`init_group_node`, so `reads_and_writes()` gives the correct full tensor
set for the loop group.

#### Does this PR introduce a user-facing change?

Yes — compilation of a coarse-tiling loop group that references more
non-intermediate tensors than the bundle limit now raises `RuntimeError`
at compile time instead of silently producing an invalid bundle.

#### Additional note: