### PR TITLE
chore(cicd): run non-xfail tests in CI

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -31,11 +31,18 @@ on:
         type: string
         default: image_spyre_backend
 
-      # Flags appended to every `bash tests/run_test.sh <config>` call
+      # Flags appended to every `bash tests/run_test.sh <config>` call for the test job
       extra_test_flags:
-        description: Extra flags passed to run_test.sh (e.g. "-v" or "--cpu-compile -vvv -s")
+        description: Extra flags passed to run_test.sh for the test job (e.g. "-v" or "--cpu-compile -vvv -s")
         required: true
         type: string
+
+      # Flags appended to every `bash tests/run_test.sh <config>` call for the test_multi_spyre job
+      extra_test_flags_multi_spyre:
+        description: Extra flags passed to run_test.sh for the test_multi_spyre job (e.g. "-v")
+        required: false
+        type: string
+        default: ''
 
       # Whether to run checkout-pytorch (nightly only)
       checkout_pytorch:
@@ -341,7 +348,7 @@ jobs:
         with:
           suite_name: ${{ matrix.suite.name }}
           config: tests/configs/${{ matrix.suite.config }}
-          extra_test_flags: ${{ inputs.extra_test_flags }}
+          extra_test_flags: ${{ inputs.extra_test_flags_multi_spyre }}
           parallel: 'false'
           junit_xml_path: ${{ env.REPORT_PATH }}
           report_name: ${{ env.REPORT_NAME }}

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -123,7 +123,8 @@ jobs:
       runner_label: linux
       # Per-PR ephemeral image label when provided, else the standing set.
       image_label: ${{ inputs.runner_label || 'image_spyre_backend' }}
-      extra_test_flags: -v
+      extra_test_flags: -v -m "not xfail"
+      extra_test_flags_multi_spyre: -v
       checkout_pytorch: false
       ref: ${{ inputs.ref || '' }}
       repository: ${{ inputs.repository || '' }}


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

### This PR adds 

- `extra_test_flags_multi_spyre: -v` for distributed test as it is run by `torchrun` and not native `pytest` and thus `-m not xfail` does not seem to collect tests 

- `extra_test_flags: -v -m "not xfail"` for non-distributed regular torch spyre tests


`-m "not xfail"`only catches the decorator form or declared via framework config. pytest.xfail() called imperatively inside a test body still runs and results in an xfailed outcome (not a failure, but also not skipped)
E,g,

```python
def test_log_sum_exp_stability(self, execution_mode):
        """Stable log-sum-exp (``max`` + ``log`` + ``sum(exp)``), not ``torch.logsumexp``."""
        # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/453
        if execution_mode == "eager":
            pytest.xfail(reason="Max (aten::max.dim_max) operation not implemented")
```
