### PR TITLE
Assigned DL16_TO_FP32 arrangement for torch.bfloat16 to torch.float32 cast

### DIFF
--- a/tests/inductor/test_ea_bidirectional_conversion.py
+++ b/tests/inductor/test_ea_bidirectional_conversion.py
@@ -28,14 +28,15 @@ from torch_spyre._C import ElementArrangement, get_spyre_tensor_layout
 
 
 @pytest.mark.parametrize("device", ["spyre"])
-def test_fp16_to_fp32_standard_input(device):
-    """Test FP16→FP32 with STANDARD input creates DL16_TO_FP32."""
+@pytest.mark.parametrize("src_dtype", [torch.float16, torch.bfloat16])
+def test_fp16_to_fp32_standard_input(device, src_dtype):
+    """Test FP16/BF16→FP32 with STANDARD input creates DL16_TO_FP32 (#2843)."""
 
     @torch.compile
     def fn(x):
         return x.to(torch.float32)
 
-    x = torch.randn(4, 128, device=device, dtype=torch.float16)
+    x = torch.randn(4, 128, device=device, dtype=src_dtype)
     result = fn(x)
 
     # Verify output EA
@@ -47,7 +48,22 @@ def test_fp16_to_fp32_standard_input(device):
     # Note: Cannot compare tensors with non-STANDARD EA directly with CPU
     # The result has DL16_TO_FP32 EA which differs from CPU's STANDARD EA
 
-    print("✓ FP16→FP32 with STANDARD input produces DL16_TO_FP32")
+    print(f"✓ {src_dtype}→FP32 with STANDARD input produces DL16_TO_FP32")
+
+
+@pytest.mark.parametrize("device", ["spyre"])
+def test_mixed_bf16_fp32_add_rejects_ea_mismatch(device):
+    """A bf16/fp32 add must raise on EA mismatch instead of silently executing (#2843)."""
+
+    @torch.compile
+    def fn(x, y):
+        return torch.add(x, y)
+
+    x_fp32 = torch.randn(5120, dtype=torch.float32, device=device)
+    y_bf16 = torch.randn(5120, dtype=torch.bfloat16, device=device)
+
+    with pytest.raises(Exception, match="element arrangement|EA"):
+        fn(x_fp32, y_bf16)
 
 
 @pytest.mark.parametrize("device", ["spyre"])

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -502,8 +502,12 @@ def _single_arg_op_layout(
             input_ea = stl.element_arrangement
 
             # Determine output EA based on conversion direction and input EA
-            if in_layout.dtype == torch.float16 and output.dtype == torch.float32:
-                # FP16 → FP32 conversion
+            if (
+                in_layout.dtype in (torch.float16, torch.bfloat16)
+                and output.dtype == torch.float32
+            ):
+                # FP16/BF16 → FP32 conversion. Both share SEN169_FP16 physical
+                # storage and the DL16TOFP32 hardware op.
                 if input_ea == ElementArrangement.STANDARD:
                     # Case 1: STANDARD → DL16_TO_FP32 (creates staggered layout)
                     fmt = ElementArrangement.DL16_TO_FP32


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### Summary

bfloat16 -> float32 conversion incorrectly propagated ElementArrangement.STANDARD instead of ElementArrangement.DL16_TO_FP32. As a result, element arrangement mismatches could go undetected and the operation would execute without raising an error.

#### Cause

torch.float16 -> torch.float32
but did not handle:
torch.bfloat16 -> torch.float32
Both float16 and bfloat16 share SEN169_FP16 physical storage and should use ElementArrangement.DL16_TO_FP32.

#### What this PR does:

Updated the propagation rule to treat both float16 and bfloat16 identically for float32 outputs.

#### Which issue(s) this PR is related to:

Fixes #2843 

#### Does the PR introduce a user facing change?

```
import torch, torch_spyre  # noqa: F401
x_fp32 = torch.randn(5120, dtype=torch.float32).to("spyre")
y_bf16 = torch.randn(5120, dtype=torch.float16).to("spyre")
def fn(x, y):
    return torch.add(x, y)
compiled = torch.compile(fn, backend="inductor")
compiled(x_fp32, y_bf16) 
```

Before:
```
compiled(x_fp32, y_bf16)
# Executes without error
```
After:
```
Unsupported: Spyre backend does not support:
All inputs to an op must have same element arrangement,
op: add,
args: "arg0_1": ElementArrangement.STANDARD,
      "buf1": ElementArrangement.DL16_TO_FP32
```






