### PR TITLE
Reorder to preserve loops

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -3476,7 +3476,6 @@ def _make_rui_op(name, reads=(), hint_ids=()):
     """
     from torch._inductor.ir import ComputedBuffer
     from torch_spyre._inductor.propagate_hints import DimHint
-    from torch.utils._ordered_set import OrderedSet
 
     op = MagicMock(spec=ComputedBuffer)
     op.get_name.return_value = name
@@ -3514,7 +3513,6 @@ class TestReorderUnhintedInterlopers(unittest.TestCase):
 
     def _run(self, ops):
         from torch_spyre._inductor.coarse_tile import reorder_unhinted_interlopers
-        from types import SimpleNamespace
 
         graph = SimpleNamespace(operations=list(ops))
         reorder_unhinted_interlopers(graph)

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -3620,6 +3620,18 @@ class TestReorderUnhintedInterlopers(unittest.TestCase):
         c = _make_rui_op("c", hint_ids=(0,))
         self.assertEqual(self._run([a, x, b, c]), ["x", "a", "b", "c"])
 
+    def test_move_after_op_follows_run(self):
+        # [H, U(reads H), H, H, V(reads U)] — move-before blocked (x reads a);
+        # move-after should land x just after c, before d.
+        # Catches the pop-then-insert off-by-one: insert must be at run_end-1
+        # not run_end after the pop shifts indices.
+        a = _make_rui_op("a", hint_ids=(0,))
+        x = _make_rui_op("x", reads=("a",))
+        b = _make_rui_op("b", hint_ids=(0,))
+        c = _make_rui_op("c", hint_ids=(0,))
+        d = _make_rui_op("d", reads=("x",))  # unhinted, reads x — after run
+        self.assertEqual(self._run([a, x, b, c, d]), ["a", "b", "c", "x", "d"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -3599,6 +3599,14 @@ class TestReorderUnhintedInterlopers(unittest.TestCase):
         # — y's reads are not produced by any op in run_start..j-1 after x moved.
         self.assertEqual(result, ["x", "y", "a", "b"])
 
+    def test_trailing_consumer_not_error(self):
+        # Unhinted op after the run that reads run outputs — trailing consumer,
+        # not an interloper.  No hinted ops follow it so it should not raise.
+        a = _make_rui_op("a", hint_ids=(0,))
+        b = _make_rui_op("b", hint_ids=(0,))
+        x = _make_rui_op("x", reads=("a", "b"))
+        self.assertEqual(self._run([a, b, x]), ["a", "b", "x"])
+
     def test_interloper_at_start_of_list(self):
         # Unhinted op before any hinted op — no run started yet, nothing to do.
         x = _make_rui_op("x")

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -3468,11 +3468,12 @@ class TestReductionIdentityValues(unittest.TestCase):
 # ===========================================================================
 
 
-def _make_rui_op(name, reads=(), hint_ids=()):
+def _make_rui_op(name, reads=(), hint_ids=(), mutates=()):
     """Return a fake ComputedBuffer for reorder_unhinted_interlopers tests.
 
     ``reads`` is an iterable of buffer names this op reads.
     ``hint_ids`` is an iterable of hint-id integers; empty means unhinted.
+    ``mutates`` is an iterable of buffer names this op mutates in-place.
     """
     from torch._inductor.ir import ComputedBuffer
     from torch_spyre._inductor.propagate_hints import DimHint
@@ -3480,6 +3481,7 @@ def _make_rui_op(name, reads=(), hint_ids=()):
     op = MagicMock(spec=ComputedBuffer)
     op.get_name.return_value = name
     op.get_read_names.return_value = OrderedSet(reads)
+    op.get_mutation_names.return_value = list(mutates)
     if hint_ids:
         op.dim_hints = [
             DimHint(
@@ -3631,6 +3633,42 @@ class TestReorderUnhintedInterlopers(unittest.TestCase):
         c = _make_rui_op("c", hint_ids=(0,))
         d = _make_rui_op("d", reads=("x",))  # unhinted, reads x — after run
         self.assertEqual(self._run([a, x, b, c, d]), ["a", "b", "c", "x", "d"])
+
+    def test_interloper_with_unhinted_gap_before_next_hinted(self):
+        # [H, U(reads H), V(unhinted), H2] — run_end must span past V to H2.
+        # Without this fix, run_end collapses to j+1=V and move-after is a
+        # silent no-op that leaves U in place with no error.
+        a = _make_rui_op("a", hint_ids=(0,))
+        x = _make_rui_op("x", reads=("a",))  # blocked from moving before
+        v = _make_rui_op("v")  # another unhinted op (no deps)
+        a2 = _make_rui_op("a2", hint_ids=(0,))
+        # v has no deps and moves before the run; x (reads a) cannot move before
+        # but can move after a2 (run_end spans past v to a2).
+        self.assertEqual(self._run([a, x, v, a2]), ["v", "a", "a2", "x"])
+
+    def test_non_contiguous_run_multiple_interlopers(self):
+        # [H, U1(reads H), H2, U2, H3] — U1 cannot move before (reads a);
+        # move-after must span to H3 (the last same-key op), not just H2.
+        # Without the fix U1 moves to between H2 and U2, still splitting [H3].
+        # With the fix: u1 moves after c (run_end spans to c); u2 then moves
+        # before the run; result is one contiguous hinted block [a, b, c].
+        a = _make_rui_op("a", hint_ids=(0,))
+        u1 = _make_rui_op("u1", reads=("a",))
+        b = _make_rui_op("b", hint_ids=(0,))
+        u2 = _make_rui_op("u2")
+        c = _make_rui_op("c", hint_ids=(0,))
+        self.assertEqual(self._run([a, u1, b, u2, c]), ["u2", "a", "b", "c", "u1"])
+
+    def test_mutating_interloper_blocked(self):
+        # x mutates buffer 'a' produced by a hinted op; x cannot legally move
+        # before the run (would run before 'a' is produced) and b reads x so
+        # x cannot move after — should raise RuntimeError.
+        a = _make_rui_op("a", hint_ids=(0,))
+        x = _make_rui_op("x", mutates=("a",))  # mutation dep on a
+        b = _make_rui_op("b", reads=("x",), hint_ids=(0,))
+        c = _make_rui_op("c", hint_ids=(0,))
+        with self.assertRaises(RuntimeError):
+            self._run([a, x, b, c])
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -3463,5 +3463,157 @@ class TestReductionIdentityValues(unittest.TestCase):
         self.assertEqual(self._identity(BATCH_MATMUL_OP), 0)
 
 
+# ===========================================================================
+# TestReorderUnhintedInterlopers
+# ===========================================================================
+
+
+def _make_rui_op(name, reads=(), hint_ids=()):
+    """Return a fake ComputedBuffer for reorder_unhinted_interlopers tests.
+
+    ``reads`` is an iterable of buffer names this op reads.
+    ``hint_ids`` is an iterable of hint-id integers; empty means unhinted.
+    """
+    from torch._inductor.ir import ComputedBuffer
+    from torch_spyre._inductor.propagate_hints import DimHint
+    from torch.utils._ordered_set import OrderedSet
+
+    op = MagicMock(spec=ComputedBuffer)
+    op.get_name.return_value = name
+    op.get_read_names.return_value = OrderedSet(reads)
+    if hint_ids:
+        op.dim_hints = [
+            DimHint(
+                dim_names=["d0"],
+                split_count=1,
+                loop_var=None,
+                is_reduction=False,
+                hint_id=hid,
+            )
+            for hid in hint_ids
+        ]
+    else:
+        op.dim_hints = []
+    return op
+
+
+def _make_rui_non_computed(name):
+    """Return a fake non-ComputedBuffer operation.
+
+    Uses an unspec'd MagicMock so isinstance(..., ComputedBuffer) is False,
+    which causes reorder_unhinted_interlopers to treat it as an immovable
+    boundary that breaks any hint-group run.
+    """
+    op = MagicMock()
+    op.get_name.return_value = name
+    return op
+
+
+class TestReorderUnhintedInterlopers(unittest.TestCase):
+    """reorder_unhinted_interlopers moves unhinted ops out of hint-group runs."""
+
+    def _run(self, ops):
+        from torch_spyre._inductor.coarse_tile import reorder_unhinted_interlopers
+        from types import SimpleNamespace
+
+        graph = SimpleNamespace(operations=list(ops))
+        reorder_unhinted_interlopers(graph)
+        return [op.get_name() for op in graph.operations]
+
+    def test_no_ops(self):
+        self.assertEqual(self._run([]), [])
+
+    def test_all_hinted_unchanged(self):
+        a = _make_rui_op("a", hint_ids=(0,))
+        b = _make_rui_op("b", hint_ids=(0,))
+        self.assertEqual(self._run([a, b]), ["a", "b"])
+
+    def test_all_unhinted_unchanged(self):
+        a = _make_rui_op("a")
+        b = _make_rui_op("b")
+        self.assertEqual(self._run([a, b]), ["a", "b"])
+
+    def test_interloper_moved_before_run(self):
+        # [hinted, unhinted, hinted] → [unhinted, hinted, hinted]
+        # unhinted has no data deps; move before is preferred.
+        a = _make_rui_op("a", hint_ids=(0,))
+        x = _make_rui_op("x")  # interloper
+        b = _make_rui_op("b", hint_ids=(0,))
+        self.assertEqual(self._run([a, x, b]), ["x", "a", "b"])
+
+    def test_interloper_blocked_move_before_reads_hinted(self):
+        # x reads a's output → cannot move before a; try move-after.
+        a = _make_rui_op("a", hint_ids=(0,))
+        x = _make_rui_op("x", reads=("a",))
+        b = _make_rui_op("b", hint_ids=(0,))
+        self.assertEqual(self._run([a, x, b]), ["a", "b", "x"])
+
+    def test_interloper_move_after_blocked_by_hinted_reader(self):
+        # x reads a (blocks move-before) AND b reads x (blocks move-after) → error.
+        a = _make_rui_op("a", hint_ids=(0,))
+        x = _make_rui_op("x", reads=("a",))
+        b = _make_rui_op("b", reads=("x",), hint_ids=(0,))
+        c = _make_rui_op("c", hint_ids=(0,))
+        with self.assertRaises(RuntimeError):
+            self._run([a, x, b, c])
+
+    def test_interloper_blocked_both_directions(self):
+        # x reads a (blocks move-before) AND b reads x (blocks move-after) → error.
+        a = _make_rui_op("a", hint_ids=(0,))
+        x = _make_rui_op("x_out", reads=("a",))
+        b = _make_rui_op("b", reads=("x_out",), hint_ids=(0,))
+        with self.assertRaises(RuntimeError):
+            self._run([a, x, b])
+
+    def test_non_computed_buffer_breaks_run(self):
+        # A non-ComputedBuffer between two hinted ops cannot be reordered.
+        a = _make_rui_op("a", hint_ids=(0,))
+        extern = _make_rui_non_computed("extern")
+        b = _make_rui_op("b", hint_ids=(0,))
+        self.assertEqual(self._run([a, extern, b]), ["a", "extern", "b"])
+
+    def test_differently_hinted_breaks_run(self):
+        # An op with a different hint_id is not a candidate for reordering.
+        a = _make_rui_op("a", hint_ids=(0,))
+        c = _make_rui_op("c", hint_ids=(1,))
+        b = _make_rui_op("b", hint_ids=(0,))
+        self.assertEqual(self._run([a, c, b]), ["a", "c", "b"])
+
+    def test_multiple_interlopers_all_moveable_before(self):
+        # [H, U1, U2, H] with no deps → both move before.
+        a = _make_rui_op("a", hint_ids=(0,))
+        x = _make_rui_op("x")
+        y = _make_rui_op("y")
+        b = _make_rui_op("b", hint_ids=(0,))
+        self.assertEqual(self._run([a, x, y, b]), ["x", "y", "a", "b"])
+
+    def test_multiple_interlopers_second_depends_on_first(self):
+        # y reads x → x can move before, but then y reads x which is now
+        # before the run start → y can also move before (after x).
+        a = _make_rui_op("a", hint_ids=(0,))
+        x = _make_rui_op("x")
+        y = _make_rui_op("y", reads=("x",))
+        b = _make_rui_op("b", hint_ids=(0,))
+        result = self._run([a, x, y, b])
+        # x moves before, then y (reads x, which is now before run_start)
+        # — y's reads are not produced by any op in run_start..j-1 after x moved.
+        self.assertEqual(result, ["x", "y", "a", "b"])
+
+    def test_interloper_at_start_of_list(self):
+        # Unhinted op before any hinted op — no run started yet, nothing to do.
+        x = _make_rui_op("x")
+        a = _make_rui_op("a", hint_ids=(0,))
+        self.assertEqual(self._run([x, a]), ["x", "a"])
+
+    def test_move_after_multiple_trailing_hinted(self):
+        # [H, U, H, H] where U reads nothing and no one reads U:
+        # move-before is legal and preferred over move-after.
+        a = _make_rui_op("a", hint_ids=(0,))
+        x = _make_rui_op("x")
+        b = _make_rui_op("b", hint_ids=(0,))
+        c = _make_rui_op("c", hint_ids=(0,))
+        self.assertEqual(self._run([a, x, b, c]), ["x", "a", "b", "c"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -190,6 +190,10 @@ def reorder_unhinted_interlopers(graph: GraphLowering) -> None:
 
     When both directions are legal the op is moved before the run (closer
     to its original position).
+
+    Raises ``RuntimeError`` if an interloper cannot be moved in either
+    direction (data-flow dependencies anchor it between hinted ops that share
+    the same hint key).
     """
     ops = graph.operations
     i = 0

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -130,32 +130,37 @@ def _written_names(op: ComputedBuffer) -> set[str]:
     return {op.get_name()} | set(op.get_mutation_names())
 
 
+def _no_dep_conflict(op: ComputedBuffer, others: list[Operation]) -> bool:
+    """Return True if moving op past every op in others introduces no data-flow hazard.
+
+    A conflict exists if any op in others reads or mutates a buffer written by op,
+    or if op reads or mutates a buffer written by any op in others.
+    """
+    op_written = _written_names(op)
+    op_needs = op.get_read_names() | set(op.get_mutation_names())
+    for other in others:
+        if not isinstance(other, ComputedBuffer):
+            continue
+        if op_written & other.get_read_names():
+            return False
+        if _written_names(other) & op_needs:
+            return False
+    return True
+
+
 def _can_move_before(
     op: Operation,
     ops: list[Operation],
     start: int,
     end: int,
 ) -> bool:
-    """Return True if op (currently at ops[end]) can move to just before ops[start].
+    """Return True if op (at ops[end]) can move to just before ops[start].
 
-    Legal iff neither direction of data-flow is violated:
-      (a) ops[start..end-1] do not read or mutate op's written buffers, and
-      (b) op does not read or mutate any buffer written by ops[start..end-1].
+    Legal iff no data-flow conflict exists between op and ops[start..end-1].
     """
     if not isinstance(op, ComputedBuffer):
         return False
-    op_written = _written_names(op)
-    op_reads = op.get_read_names()
-    op_mutates = set(op.get_mutation_names())
-    for other in ops[start:end]:
-        if not isinstance(other, ComputedBuffer):
-            continue
-        other_written = _written_names(other)
-        if op_written & other.get_read_names():
-            return False
-        if other_written & (op_reads | op_mutates):
-            return False
-    return True
+    return _no_dep_conflict(op, ops[start:end])
 
 
 def _can_move_after(
@@ -164,25 +169,13 @@ def _can_move_after(
     start: int,
     end: int,
 ) -> bool:
-    """Return True if op (currently at ops[start]) can move to just after ops[end-1].
+    """Return True if op (at ops[start]) can move to just after ops[end-1].
 
-    Legal iff ops[start+1..end-1] do not read or mutate op's written buffers and
-    op does not read or mutate any buffer written by ops[start+1..end-1].
+    Legal iff no data-flow conflict exists between op and ops[start+1..end-1].
     """
     if not isinstance(op, ComputedBuffer):
         return False
-    op_written = _written_names(op)
-    op_reads = op.get_read_names()
-    op_mutates = set(op.get_mutation_names())
-    for other in ops[start + 1 : end]:
-        if not isinstance(other, ComputedBuffer):
-            continue
-        other_written = _written_names(other)
-        if op_written & other.get_read_names():
-            return False
-        if other_written & (op_reads | op_mutates):
-            return False
-    return True
+    return _no_dep_conflict(op, ops[start + 1 : end])
 
 
 def reorder_unhinted_interlopers(graph: GraphLowering) -> None:
@@ -191,11 +184,13 @@ def reorder_unhinted_interlopers(graph: GraphLowering) -> None:
     ``hints_to_coarse_tile_groups`` breaks a run whenever it encounters a
     ComputedBuffer with no hints (or a different hint key).  If such an op
     could legally be repositioned — either just before the current run's
-    start or just after its end — move it so the run remains unbroken.
+    start or just after the last same-key op in the remainder — move it so
+    the run remains unbroken.
 
     A move is legal when it introduces no new data-flow violation:
-    no op in the skipped range reads the moved op's output, and the
-    moved op reads no buffer produced within the skipped range.
+    no op in the skipped range reads or mutates the moved op's written
+    buffers, and the moved op reads or mutates no buffer written in the
+    skipped range.
 
     When both directions are legal the op is moved before the run (closer
     to its original position).
@@ -213,7 +208,7 @@ def reorder_unhinted_interlopers(graph: GraphLowering) -> None:
             i += 1
             continue
 
-        # Collect the maximal contiguous run of ComputedBuffer ops sharing key,
+        # Collect the maximal run of ComputedBuffer ops sharing key,
         # attempting to reorder unhinted interlopers out of the way.
         run_start = i
         j = i + 1
@@ -227,18 +222,19 @@ def reorder_unhinted_interlopers(graph: GraphLowering) -> None:
             if not isinstance(candidate, ComputedBuffer) or ckey is not None:
                 # Non-ComputedBuffer or differently-hinted op — cannot reorder.
                 break
-            # candidate is an unhinted ComputedBuffer interloper.  Find the
-            # end of the immediately-following contiguous hinted block (used
-            # as the move-after insertion point).
-            run_end = j + 1
-            while run_end < len(ops) and _hint_key(ops[run_end]) == key:
-                run_end += 1
+            # candidate is an unhinted ComputedBuffer interloper.
+            # Find the last same-key op anywhere after j (the full move-after
+            # target span).  run_end is one past that op so _can_move_after
+            # validates the entire range candidate would skip over.
+            run_end = None
+            for k in range(len(ops) - 1, j, -1):
+                if _hint_key(ops[k]) == key:
+                    run_end = k + 1
+                    break
             # If no hinted op with this key exists anywhere after j the
             # candidate is a trailing consumer, not a true interloper — end
-            # the run silently.  A trailing consumer may sit after more
-            # unhinted ops or at end-of-list; either way it cannot split a
-            # group because there is no continuation to protect.
-            if not any(_hint_key(ops[k]) == key for k in range(j + 1, len(ops))):
+            # the run silently.
+            if run_end is None:
                 break
             # Hinted ops follow: candidate genuinely splits the run.  Try to
             # move it before the run start first (preferred: stays closer to
@@ -250,20 +246,12 @@ def reorder_unhinted_interlopers(graph: GraphLowering) -> None:
                 continue
             if _can_move_after(candidate, ops, j, run_end):
                 # pop(j) shifts everything after j left by one, so the last
-                # hinted op (formerly run_end-1) is now at run_end-2 and the
-                # first non-hinted op after the block (if any) is at run_end-1.
-                # Insert at run_end-1 to land just after the last hinted op.
+                # same-key op (formerly run_end-1) is now at run_end-2.
+                # Insert at run_end-1 to land just after that last hinted op.
                 ops.insert(run_end - 1, ops.pop(j))
-                # j=run_end skips the hinted block (now at j..run_end-2) and
-                # the placed interloper (run_end-1), landing on run_end which
-                # is the original boundary op or end-of-list.
-                j = run_end
-                break
-            # The interloper cannot be moved in either direction — it has a
-            # data-flow dependency that anchors it between hinted ops that
-            # share the same loop group.  This is a graph structure violation
-            # because hinted ops with the same hint_id must form a contiguous
-            # block (validated later by _validate_contiguous).
+                # j is unchanged: ops[j] is now the next unexamined op.
+                continue
+            # The interloper cannot be moved in either direction.
             run_ops = [ops[k].get_name() for k in range(run_start, j)]
             raise RuntimeError(
                 f"Cannot reorder unhinted op '{candidate.get_name()}': "
@@ -302,9 +290,7 @@ def hints_to_coarse_tile_groups(graph: GraphLowering) -> list[tuple]:
 
     operations = graph.operations
     for op in operations:
-        if not isinstance(op, ComputedBuffer):
-            continue
-        key = frozenset(h.hint_id for h in getattr(op, "dim_hints", [])) or None
+        key = _hint_key(op)
 
         if key is not None and key == current_key:
             current_ops.append(op)

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -125,6 +125,11 @@ def _hint_key(op: Operation) -> frozenset | None:
     return frozenset(h.hint_id for h in hints) if hints else None
 
 
+def _written_names(op: ComputedBuffer) -> set[str]:
+    """Return all buffer names written by op: its output plus any mutation targets."""
+    return {op.get_name()} | set(op.get_mutation_names())
+
+
 def _can_move_before(
     op: Operation,
     ops: list[Operation],
@@ -134,19 +139,21 @@ def _can_move_before(
     """Return True if op (currently at ops[end]) can move to just before ops[start].
 
     Legal iff neither direction of data-flow is violated:
-      (a) ops[start..end-1] do not read op's output buffer, and
-      (b) op does not read any buffer produced by ops[start..end-1].
+      (a) ops[start..end-1] do not read or mutate op's written buffers, and
+      (b) op does not read or mutate any buffer written by ops[start..end-1].
     """
     if not isinstance(op, ComputedBuffer):
         return False
-    op_name = op.get_name()
+    op_written = _written_names(op)
     op_reads = op.get_read_names()
+    op_mutates = set(op.get_mutation_names())
     for other in ops[start:end]:
         if not isinstance(other, ComputedBuffer):
             continue
-        if op_name in other.get_read_names():
+        other_written = _written_names(other)
+        if op_written & other.get_read_names():
             return False
-        if other.get_name() in op_reads:
+        if other_written & (op_reads | op_mutates):
             return False
     return True
 
@@ -159,19 +166,21 @@ def _can_move_after(
 ) -> bool:
     """Return True if op (currently at ops[start]) can move to just after ops[end-1].
 
-    Legal iff ops[start+1..end-1] do not read op's output buffer and op does
-    not read any buffer produced by ops[start+1..end-1].
+    Legal iff ops[start+1..end-1] do not read or mutate op's written buffers and
+    op does not read or mutate any buffer written by ops[start+1..end-1].
     """
     if not isinstance(op, ComputedBuffer):
         return False
-    op_name = op.get_name()
+    op_written = _written_names(op)
     op_reads = op.get_read_names()
+    op_mutates = set(op.get_mutation_names())
     for other in ops[start + 1 : end]:
         if not isinstance(other, ComputedBuffer):
             continue
-        if op_name in other.get_read_names():
+        other_written = _written_names(other)
+        if op_written & other.get_read_names():
             return False
-        if other.get_name() in op_reads:
+        if other_written & (op_reads | op_mutates):
             return False
     return True
 
@@ -240,9 +249,14 @@ def reorder_unhinted_interlopers(graph: GraphLowering) -> None:
                 # j is unchanged: after the rotate, ops[j] is the next op.
                 continue
             if _can_move_after(candidate, ops, j, run_end):
-                ops.insert(run_end, ops.pop(j))
-                # All ops between j and run_end-1 have key; skip past them and
-                # the moved interloper so the outer loop doesn't revisit it.
+                # pop(j) shifts everything after j left by one, so the last
+                # hinted op (formerly run_end-1) is now at run_end-2 and the
+                # first non-hinted op after the block (if any) is at run_end-1.
+                # Insert at run_end-1 to land just after the last hinted op.
+                ops.insert(run_end - 1, ops.pop(j))
+                # j=run_end skips the hinted block (now at j..run_end-2) and
+                # the placed interloper (run_end-1), landing on run_end which
+                # is the original boundary op or end-of-list.
                 j = run_end
                 break
             # The interloper cannot be moved in either direction — it has a

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -214,22 +214,28 @@ def reorder_unhinted_interlopers(graph: GraphLowering) -> None:
             if not isinstance(candidate, ComputedBuffer) or ckey is not None:
                 # Non-ComputedBuffer or differently-hinted op — cannot reorder.
                 break
-            # candidate is an unhinted ComputedBuffer interloper.  Try to move
-            # it before the run start first (preferred: stays closer to its
-            # original position).
+            # candidate is an unhinted ComputedBuffer interloper.  Find the
+            # end of the immediately-following contiguous hinted block (used
+            # as the move-after insertion point).
+            run_end = j + 1
+            while run_end < len(ops) and _hint_key(ops[run_end]) == key:
+                run_end += 1
+            # If no hinted op with this key exists anywhere after j the
+            # candidate is a trailing consumer, not a true interloper — end
+            # the run silently.  A trailing consumer may sit after more
+            # unhinted ops or at end-of-list; either way it cannot split a
+            # group because there is no continuation to protect.
+            if not any(_hint_key(ops[k]) == key for k in range(j + 1, len(ops))):
+                break
+            # Hinted ops follow: candidate genuinely splits the run.  Try to
+            # move it before the run start first (preferred: stays closer to
+            # its original position).
             if _can_move_before(candidate, ops, run_start, j):
                 ops.insert(run_start, ops.pop(j))
                 run_start += 1
                 # j is unchanged: after the rotate, ops[j] is the next op.
                 continue
-            # Try moving after the end of the remaining run.  Find that end.
-            run_end = j + 1
-            while run_end < len(ops) and _hint_key(ops[run_end]) == key:
-                run_end += 1
-            # Only attempt move-after if there are hinted ops to skip over;
-            # if run_end == j + 1 the interloper is already at the run boundary
-            # and inserting at run_end would produce an infinite loop.
-            if run_end > j + 1 and _can_move_after(candidate, ops, j, run_end):
+            if _can_move_after(candidate, ops, j, run_end):
                 ops.insert(run_end, ops.pop(j))
                 # All ops between j and run_end-1 have key; skip past them and
                 # the moved interloper so the outer loop doesn't revisit it.

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -117,6 +117,139 @@ def _hints_levels(ops: list[Operation]) -> list[tuple]:
     return []
 
 
+def _hint_key(op: Operation) -> frozenset | None:
+    """Return the frozenset of hint_ids on op, or None if op has no hints."""
+    if not isinstance(op, ComputedBuffer):
+        return None
+    hints = getattr(op, "dim_hints", [])
+    return frozenset(h.hint_id for h in hints) if hints else None
+
+
+def _can_move_before(
+    op: Operation,
+    ops: list[Operation],
+    start: int,
+    end: int,
+) -> bool:
+    """Return True if op (currently at ops[end]) can move to just before ops[start].
+
+    Legal iff neither direction of data-flow is violated:
+      (a) ops[start..end-1] do not read op's output buffer, and
+      (b) op does not read any buffer produced by ops[start..end-1].
+    """
+    if not isinstance(op, ComputedBuffer):
+        return False
+    op_name = op.get_name()
+    op_reads = op.get_read_names()
+    for other in ops[start:end]:
+        if not isinstance(other, ComputedBuffer):
+            continue
+        if op_name in other.get_read_names():
+            return False
+        if other.get_name() in op_reads:
+            return False
+    return True
+
+
+def _can_move_after(
+    op: Operation,
+    ops: list[Operation],
+    start: int,
+    end: int,
+) -> bool:
+    """Return True if op (currently at ops[start]) can move to just after ops[end-1].
+
+    Legal iff ops[start+1..end-1] do not read op's output buffer and op does
+    not read any buffer produced by ops[start+1..end-1].
+    """
+    if not isinstance(op, ComputedBuffer):
+        return False
+    op_name = op.get_name()
+    op_reads = op.get_read_names()
+    for other in ops[start + 1 : end]:
+        if not isinstance(other, ComputedBuffer):
+            continue
+        if op_name in other.get_read_names():
+            return False
+        if other.get_name() in op_reads:
+            return False
+    return True
+
+
+def reorder_unhinted_interlopers(graph: GraphLowering) -> None:
+    """Move unhinted ComputedBuffer ops that interrupt hint-group runs.
+
+    ``hints_to_coarse_tile_groups`` breaks a run whenever it encounters a
+    ComputedBuffer with no hints (or a different hint key).  If such an op
+    could legally be repositioned — either just before the current run's
+    start or just after its end — move it so the run remains unbroken.
+
+    A move is legal when it introduces no new data-flow violation:
+    no op in the skipped range reads the moved op's output, and the
+    moved op reads no buffer produced within the skipped range.
+
+    When both directions are legal the op is moved before the run (closer
+    to its original position).
+    """
+    ops = graph.operations
+    i = 0
+    while i < len(ops):
+        op = ops[i]
+        key = _hint_key(op)
+        if key is None:
+            i += 1
+            continue
+
+        # Collect the maximal contiguous run of ComputedBuffer ops sharing key,
+        # attempting to reorder unhinted interlopers out of the way.
+        run_start = i
+        j = i + 1
+        while j < len(ops):
+            candidate = ops[j]
+            ckey = _hint_key(candidate)
+            if ckey == key:
+                j += 1
+                continue
+            # candidate does not belong to the run.
+            if not isinstance(candidate, ComputedBuffer) or ckey is not None:
+                # Non-ComputedBuffer or differently-hinted op — cannot reorder.
+                break
+            # candidate is an unhinted ComputedBuffer interloper.  Try to move
+            # it before the run start first (preferred: stays closer to its
+            # original position).
+            if _can_move_before(candidate, ops, run_start, j):
+                ops.insert(run_start, ops.pop(j))
+                run_start += 1
+                # j is unchanged: after the rotate, ops[j] is the next op.
+                continue
+            # Try moving after the end of the remaining run.  Find that end.
+            run_end = j + 1
+            while run_end < len(ops) and _hint_key(ops[run_end]) == key:
+                run_end += 1
+            # Only attempt move-after if there are hinted ops to skip over;
+            # if run_end == j + 1 the interloper is already at the run boundary
+            # and inserting at run_end would produce an infinite loop.
+            if run_end > j + 1 and _can_move_after(candidate, ops, j, run_end):
+                ops.insert(run_end, ops.pop(j))
+                # All ops between j and run_end-1 have key; skip past them and
+                # the moved interloper so the outer loop doesn't revisit it.
+                j = run_end
+                break
+            # The interloper cannot be moved in either direction — it has a
+            # data-flow dependency that anchors it between hinted ops that
+            # share the same loop group.  This is a graph structure violation
+            # because hinted ops with the same hint_id must form a contiguous
+            # block (validated later by _validate_contiguous).
+            run_ops = [ops[k].get_name() for k in range(run_start, j)]
+            raise RuntimeError(
+                f"Cannot reorder unhinted op '{candidate.get_name()}': "
+                f"data-flow deps prevent moving it before or after the "
+                f"hint-group run [{', '.join(run_ops)}] "
+                f"(hint_ids={sorted(key)})"
+            )
+        i = j
+
+
 def hints_to_coarse_tile_groups(graph: GraphLowering) -> list[tuple]:
     """Build coarse_tile() groups from op.dim_hints (set by assign_dim_hints).
 

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -270,7 +270,7 @@ def _maybe_chunk_large_tensors(graph: GraphLowering) -> None:
         chunk_large_tensors(graph)
 
 
-@_runs(hints_to_coarse_tile_groups, coarse_tile, reorder_unhinted_interlopers)
+@_runs(reorder_unhinted_interlopers, hints_to_coarse_tile_groups, coarse_tile)
 def _maybe_coarse_tile(graph: GraphLowering) -> None:
     if not config.ignore_wsr_hints:
         reorder_unhinted_interlopers(graph)

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -43,7 +43,7 @@ from .temp_passes import (
     mark_direct_unit_bmm_pass,
     mm_to_bmm_pass,
 )
-from .coarse_tile import hints_to_coarse_tile_groups
+from .coarse_tile import hints_to_coarse_tile_groups, reorder_unhinted_interlopers
 from . import config
 from .propagate_hints import (
     collect_spyre_hints,
@@ -270,9 +270,10 @@ def _maybe_chunk_large_tensors(graph: GraphLowering) -> None:
         chunk_large_tensors(graph)
 
 
-@_runs(hints_to_coarse_tile_groups, coarse_tile)
+@_runs(hints_to_coarse_tile_groups, coarse_tile, reorder_unhinted_interlopers)
 def _maybe_coarse_tile(graph: GraphLowering) -> None:
     if not config.ignore_wsr_hints:
+        reorder_unhinted_interlopers(graph)
         groups = hints_to_coarse_tile_groups(graph)
         if groups:
             coarse_tile(graph, groups=groups)


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds a `reorder_unhinted_interlopers` pre-pass that runs immediately before
`hints_to_coarse_tile_groups` in `_maybe_coarse_tile`.

`hints_to_coarse_tile_groups` walks `graph.operations` in topological order
and breaks a coarse-tile group whenever it encounters a `ComputedBuffer` with
no hints (or a different hint key).  In practice, Inductor sometimes places an
unhinted buffer (e.g. a pointwise activation or a padding buffer) in the middle
of a sequence of ops that all belong to the same hint group.  Without this
pass the group would be silently split in two, producing two separate coarse-tile
loop nests instead of one — or the run would terminate early, leaving some ops
untiled.

The new pass detects each such "interloper" and attempts to move it out of
the way using IR-level dependency checking (`ComputedBuffer.get_name()` /
`get_read_names()`):

- **Move before** the run start — preferred; op stays closer to its original
  position.
- **Move after** the run end — fallback when move-before is blocked by a
  data-flow dependency.

A move is legal iff no op in the skipped range reads the interloper's output,
and the interloper reads no buffer produced by an op in the skipped range.

If the interloper has no hinted ops following it (a trailing consumer), it is
left in place silently.  If both directions are blocked by data-flow
dependencies, `RuntimeError` is raised — the graph structure cannot be fixed
automatically.

#### Which issue(s) this PR is related to:

Part of #1358 

#### Special notes for your reviewer:

The pass runs unconditionally when `config.ignore_wsr_hints` is False (i.e.
the normal path).  It is a no-op when no hinted ops are present.

`_runs` on `_maybe_coarse_tile` is updated to include
`reorder_unhinted_interlopers` so the Inductor FX cache is correctly
invalidated when this pass changes.

#### Does this PR introduce a user-facing change?

No change to public API or model outputs.  Users may see a new `RuntimeError`
if their model produces a graph where an unhinted op is data-flow-anchored
between ops in the same hint group — this indicates a hint-annotation problem
that should be fixed upstream.

#### Additional note: