### PR TITLE
[test] Apply device-specific tensor layout in model op tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,6 +206,11 @@ def pytest_addoption(parser):
         action="store_true",
         help="Disable cuda device replacement in kwargs.",
     )
+    parser.addoption(
+        "--no-device-layout",
+        action="store_true",
+        help="Disable using device specific layout based on strides and offsets.",
+    )
 
     # NEW: inventory modes
     parser.addoption(

--- a/tests/models/runner.py
+++ b/tests/models/runner.py
@@ -81,6 +81,8 @@ def make_tensor_from_conf(
     tconf: Dict[str, Any], *, dtype: torch.dtype, seed: Optional[int]
 ) -> torch.Tensor:
     shape = list(tconf["shape"])
+    stride = list(tconf["stride"])
+    storage_offset = tconf["storage_offset"]
     init = tconf.get("init", "rand")
     init_args = dict(tconf.get("init_args", {}))
 
@@ -116,6 +118,22 @@ def make_tensor_from_conf(
             )
         else:
             raise ValueError(f"Unknown init: {init}")
+
+    # Handle custom stride/storage_offset
+    def stride_is_descending(s):
+        return all(a >= b for a, b in zip(s, s[1:]))
+
+    if (stride is not None and not stride_is_descending(stride)) or storage_offset != 0:
+        stride = stride if stride is not None else list(t.stride())
+        needed = storage_offset + (
+            sum((s - 1) * st for s, st in zip(shape, stride)) + 1 if shape else 1
+        )
+        backing = torch.empty(needed, dtype=dtype)
+        view = torch.as_strided(backing, shape, stride, storage_offset)
+        with torch.no_grad():
+            view.copy_(t)
+
+        t = view  # strided view populated with t's logical values
 
     return t
 

--- a/tests/models/test_model_ops.py
+++ b/tests/models/test_model_ops.py
@@ -133,6 +133,9 @@ class TestSpyreModelOps(TestCase):
         device_replace_disabled = bool(
             pytestconfig.getoption("--no-device-replace", default=False)
         )
+        device_layout_disabled = bool(
+            pytestconfig.getoption("--no-device-layout", default=False)
+        )
 
         method_name = self._testMethodName
 
@@ -197,15 +200,29 @@ class TestSpyreModelOps(TestCase):
             case, seed, dtype, None if device_replace_disabled else test_device
         )
 
-        def to_spyre(arg):
-            if isinstance(arg, list):
-                return [x.to(test_device) for x in arg]
-            elif isinstance(arg, torch.Tensor):
-                return arg.to(test_device)
-            else:
-                return arg
+        def tensor_to_device(tensor):
+            if device_layout_disabled or "spyre" not in str(test_device):
+                return tensor.to(test_device)
+            # import Spyre specific package when test_device is spyre
+            from torch_spyre._C import SpyreTensorLayout
 
-        test_sample = cpu_sample.transform(to_spyre)
+            size = tensor.size()
+            stride = tensor.stride()
+            dtype = tensor.dtype
+            dim_order = list(range(tensor.dim()))
+            stl = SpyreTensorLayout(size, stride, dtype, dim_order)
+            # workaround to enable monkey patch by calling to("spyre")
+            _ = torch.ones(1, dtype=torch.float16).to("spyre")
+            return tensor.to(test_device, device_layout=stl)
+
+        def to_target_device(x):
+            if torch.is_tensor(x):
+                return tensor_to_device(x)
+            if isinstance(x, list):
+                return [tensor_to_device(t) if torch.is_tensor(t) else t for t in x]
+            return x
+
+        test_sample = cpu_sample.transform(to_target_device)
 
         # run target op
         try:

--- a/tests/models/test_model_ops_v2.py
+++ b/tests/models/test_model_ops_v2.py
@@ -334,6 +334,9 @@ class TestSpyreModelOps(TestCase):
         device_replace_disabled: bool = bool(
             pytestconfig.getoption("--no-device-replace", default=False)
         )
+        device_layout_disabled: bool = bool(
+            pytestconfig.getoption("--no-device-layout", default=False)
+        )
 
         method_name = self._testMethodName
         ops_item: OpsNamedItem = op.ops_item
@@ -391,11 +394,26 @@ class TestSpyreModelOps(TestCase):
             SampleInput=SampleInput,
         )
 
+        def _tensor_to_device(tensor):
+            if device_layout_disabled or "spyre" not in str(test_device):
+                return tensor.to(test_device)
+            # import Spyre specific package when test_device is spyre
+            from torch_spyre._C import SpyreTensorLayout
+
+            size = tensor.size()
+            stride = tensor.stride()
+            dtype = tensor.dtype
+            dim_order = list(range(tensor.dim()))
+            stl = SpyreTensorLayout(size, stride, dtype, dim_order)
+            # workaround to enable monkey patch by calling to("spyre")
+            _ = torch.ones(1, dtype=torch.float16).to("spyre")
+            return tensor.to(test_device, device_layout=stl)
+
         def _to_target_device(x: Any) -> Any:
             if torch.is_tensor(x):
-                return x.to(test_device)
+                return _tensor_to_device(x)
             if isinstance(x, list):
-                return [t.to(test_device) if torch.is_tensor(t) else t for t in x]
+                return [_tensor_to_device(t) if torch.is_tensor(t) else t for t in x]
             return x
 
         test_sample: SampleInput = cpu_sample.transform(_to_target_device)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Model op tests previously moved CPU sample inputs to the Spyre device with a
plain `tensor.to(test_device)`, which discards the tensor's stride/offset
information. This PR makes the tests build a `SpyreTensorLayout` from each
tensor's size, stride, dtype, and dim order based on **eager execution**, and
pass it to `.to()` via the `device_layout` argument so the device-side layout
reflects the original tensor's strides and offsets.

A new `--no-device-layout` pytest option is added to fall back to the previous
plain `.to()` behavior, which is useful for isolating layout-related failures.

Changes:

- `tests/conftest.py`: add the `--no-device-layout` pytest option to disable
  device-specific layout based on strides and offsets.
- `tests/models/test_model_ops.py`, `tests/models/test_model_ops_v2.py`:
  read the `--no-device-layout` option; when transferring sample inputs to a
  Spyre device (and the option is not set), construct a `SpyreTensorLayout`
  from the tensor's size, stride, dtype, and dim order and pass it through
  `tensor.to(test_device, device_layout=stl)`. Otherwise keep the existing
  plain `tensor.to(test_device)` path.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#1069

#### Special notes for your reviewer:

- The Spyre-specific import (`from torch_spyre._C import SpyreTensorLayout`) is
  done lazily inside the helper so non-Spyre runs are unaffected.
- A workaround calls `torch.ones(1, dtype=torch.float16).to("spyre")` once
  before transferring with a layout, to enable the required monkey patch.
- The device-transfer helper is currently duplicated across the two test
  files; it could be factored into a shared helper in a follow-up.


#### Does this PR introduce a user-facing change?

No. This is a test-only change. (A new `--no-device-layout` pytest option is
added for developers running the test suite.)

#### Additional note:

