### PR TITLE
Enable torch.prod when dim is specified

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_compute_b_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_compute_b_config.yaml
@@ -61,4 +61,5 @@ test_suite_config:
             - TestOps::test_single_dim_reduction_invalid_dims_spyre.*
             # restickify add on padded dim tests
             - TestOps::test_restickify_add_transpose.*
+            - TestOps::test_prod.*
           mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_scalar_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_scalar_config.yaml
@@ -18,7 +18,7 @@ test_suite_config:
             # but the base method names are test_sum_keepdim0/1 from test file
             # Note: argmin and logsumexp are excluded here because their base
             # names contain "keepdim" and are covered by the keepdim shard.
-            - TestOps::test_(all_dim|any_dim|count_nonzero|cummax|cummin|cumprod|logcumsumexp|max_default|median|mode_|nanmean|nanmedian|nanquantile|nansum|prod_dim|quantile|std_|topk|conv2d|var_).*
+            - TestOps::test_(all_dim|any_dim|count_nonzero|cummax|cummin|cumprod|logcumsumexp|max_default|median|mode_|nanmean|nanmedian|nanquantile|nansum|quantile|std_|topk|conv2d|var_).*
 
           mode: mandatory_success
           tags:

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -4285,6 +4285,66 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 "3d_8x6x4": (cached_randn((2, 3, 64), dtype=torch.float16), 8, 6, 4),
             },
         },
+        # TODO: Full support for torch.prod is not yet implemented. In particular,
+        # calculating the product of all elements in the tensor is not supported yet.
+        # Once all cases are supported, similar to other reduction ops, we can
+        # simply register `prod` in the CORE_REDUCTION_OPS_DICT table.
+        ("test_prod", "test_prod_cpu"): {
+            "param_sets": {
+                "int64_dim0": (
+                    torch.randint(2, 10, (1, 2), dtype=torch.int64),
+                    0,
+                    False,
+                ),
+                "int64_dim0_keepdim": (
+                    torch.randint(2, 10, (1, 2), dtype=torch.int64),
+                    0,
+                    True,
+                ),
+                "int64_dim1": (
+                    torch.randint(2, 10, (1, 2), dtype=torch.int64),
+                    -1,
+                    False,
+                ),
+                "int64_dim1_keepdim": (
+                    torch.randint(2, 10, (1, 2), dtype=torch.int64),
+                    -1,
+                    True,
+                ),
+                "int64_dim0_2": (
+                    torch.randint(1, 2, (64, 32), dtype=torch.int64),
+                    0,
+                    False,
+                ),
+                "int64_dim0_2_keepdim": (
+                    torch.randint(1, 2, (64, 32), dtype=torch.int64),
+                    0,
+                    True,
+                ),
+                "int64_dim1_2": (
+                    torch.randint(1, 2, (64, 32), dtype=torch.int64),
+                    -1,
+                    False,
+                ),
+                "int64_dim1_2_keepdim": (
+                    torch.randint(1, 2, (64, 32), dtype=torch.int64),
+                    -1,
+                    True,
+                ),
+                "fp16_dim0": (torch.randn((128, 64), dtype=torch.float16), 0, False),
+                "fp16_dim0_keepdim": (
+                    torch.randn((128, 64), dtype=torch.float16),
+                    0,
+                    True,
+                ),
+                "fp16_dim1": (torch.randn((128, 64), dtype=torch.float16), -1, False),
+                "fp16_dim1_keepdim": (
+                    torch.randn((128, 64), dtype=torch.float16),
+                    -1,
+                    True,
+                ),
+            },
+        },
         ("test_unfold", "test_unfold_cpu"): {
             "param_sets": {
                 # 1D: Basic cases
@@ -6096,6 +6156,12 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             match="Boolean value of Tensor with more than one value is ambiguous",
         ):
             compiled(x_multi.to("spyre"))
+
+    def test_prod_cpu(self, x, dim, keepdim):
+        def fn(a):
+            return torch.prod(a, dim=dim, keepdim=keepdim)
+
+        self.compare_with_cpu(fn, x, run_eager=False)
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -4285,10 +4285,9 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 "3d_8x6x4": (cached_randn((2, 3, 64), dtype=torch.float16), 8, 6, 4),
             },
         },
-        # TODO: Full support for torch.prod is not yet implemented. In particular,
-        # calculating the product of all elements in the tensor is not supported yet.
-        # Once all cases are supported, similar to other reduction ops, we can
-        # simply register `prod` in the CORE_REDUCTION_OPS_DICT table.
+        # TODO: torch.prod(x) (reduction over all tensor elements) is not yet
+        # supported. Once support for all torch.prod forms is implemented, we
+        # can register `prod` in CORE_REDUCTION_OPS_DICT like other reduction ops.
         ("test_prod", "test_prod_cpu"): {
             "param_sets": {
                 "int64_dim0": (

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -4984,20 +4984,6 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
 
     @pytest.mark.xfail(
         reason=(
-            "Spyre compiled backend does not support torch.prod yet (stable "
-            "error signature: InductorError: AttributeError: "
-            "'UnimplementedOp' object has no attribute 'iteration_space')"
-        ),
-        strict=True,
-    )
-    def test_prod_dim0_known_xfail(self):
-        x = cached_randn((67, 256), scale=0.1)
-        self.compare_with_cpu(
-            lambda x: torch.prod(x, dim=0, keepdim=False), x, run_eager=False
-        )
-
-    @pytest.mark.xfail(
-        reason=(
             "Spyre compiled backend does not support torch.std yet (stable "
             "error signature: InductorError: TypeError: "
             "'UnimplementedOp' object is not subscriptable)"

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -17,6 +17,9 @@ IDENTITY_OP = "identity"
 RESTICKIFY_OP = "ReStickifyOpHBM"
 BATCH_MATMUL_FP8_OP = "batchmatmulfp8"
 
+# Reduction ops that cannot reduce along the stick dimension.
+REDUCTIONS_NON_STICK_DIM_ONLY = {"prod"}
+
 # Type casting operators from deeptools
 DL16TOFP32_OP = "dl16tofp32"
 FP32TODL16_OP = "fp32todl16"

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -18,6 +18,8 @@ RESTICKIFY_OP = "ReStickifyOpHBM"
 BATCH_MATMUL_FP8_OP = "batchmatmulfp8"
 
 # Reduction ops that cannot reduce along the stick dimension.
+# Native prod reduction is not currently available in the backend.
+# See backend issue #4409.
 REDUCTIONS_NON_STICK_DIM_ONLY = {"prod"}
 
 # Type casting operators from deeptools

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -83,6 +83,7 @@ SPYRE_FP32_OPS = [
     "to_dtype",
     "maximum",
     "minimum",
+    "prod",
 ]
 
 # Operations that directly handle FP8 dtypes (SEN143_FP8)

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -649,3 +649,22 @@ def dequantize_fp8_with_scale(input: torch.Tensor, scale: torch.Tensor) -> torch
 def _(input: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
     # Output is FP16 with same shape as input
     return torch.empty(input.size(), dtype=torch.float16, device=input.device)
+
+
+@torch.library.custom_op("spyre::prod_dim_int", mutates_args=(), device_types="spyre")
+def prod_dim_int_fp32(
+    input: torch.Tensor, dim: int, keepdim: bool = False
+) -> torch.Tensor:
+    pass
+
+
+@prod_dim_int_fp32.register_fake
+def _(input: torch.Tensor, dim: int, keepdim: bool = False) -> torch.Tensor:
+    if dim < 0:
+        dim += input.ndim
+    out_shape = list(input.shape)
+    if keepdim:
+        out_shape[dim] = 1
+    else:
+        out_shape = out_shape[:dim] + out_shape[dim + 1 :]
+    return torch.empty(out_shape, dtype=input.dtype, device=input.device)

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -652,13 +652,11 @@ def _(input: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
 
 
 @torch.library.custom_op("spyre::prod_dim_int", mutates_args=(), device_types="spyre")
-def prod_dim_int_fp32(
-    input: torch.Tensor, dim: int, keepdim: bool = False
-) -> torch.Tensor:
+def prod_dim_int(input: torch.Tensor, dim: int, keepdim: bool = False) -> torch.Tensor:
     pass
 
 
-@prod_dim_int_fp32.register_fake
+@prod_dim_int.register_fake
 def _(input: torch.Tensor, dim: int, keepdim: bool = False) -> torch.Tensor:
     if dim < 0:
         dim += input.ndim

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -903,6 +903,42 @@ def spyre_quantize_fp8_with_scale(
     return torch.ops.spyre.qfp8ch(x_clamped)
 
 
+@register_spyre_decomposition([torch.ops.aten.prod.dim_int])
+def spyre_prod_dim_int(
+    input: torch.Tensor, dim: int, keepdim: bool = False
+) -> torch.Tensor:
+    # Currently, restickify does not support fp32 (int64 is also converted to fp32
+    # for now, so it is unsupported as well).
+    # Use decomposition in these cases as a safe fallback, even if restickify
+    # might not be needed in the end.
+    if input.dtype != torch.float32 and input.dtype != torch.int64:
+        return torch.ops.spyre.prod_dim_int(input, dim, keepdim)
+
+    if dim < 0:
+        dim += input.ndim
+    out_shape = list(input.shape)
+    size = input.shape[dim]
+    if size == 0:
+        if keepdim:
+            out_shape[dim] = 1
+        else:
+            out_shape = out_shape[:dim] + out_shape[dim + 1 :]
+        return torch.ones(out_shape, dtype=input.dtype, device=input.device)
+
+    out_shape = out_shape[:dim] + out_shape[dim + 1 :]
+    acc = torch.ones(out_shape, dtype=input.dtype, device=input.device)
+    for i in range(size):
+        index = [slice(None)] * input.ndim
+        index[dim] = slice(i, i + 1)
+        slice_i = input[tuple(index)].squeeze(dim)
+        acc = acc * slice_i
+
+    if keepdim:
+        acc = acc.unsqueeze(dim)
+
+    return acc
+
+
 ###############################################################################################
 ##                           Register custom kernels for Spyre.                              ##
 ###############################################################################################

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -922,7 +922,6 @@ def spyre_prod_dim_int(
     for i in range(reduce_size):
         acc = acc * input.select(dim, i)
 
-
     if keepdim:
         acc = acc.unsqueeze(dim)
 

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -917,21 +917,11 @@ def spyre_prod_dim_int(
     if dim < 0:
         dim += input.ndim
     out_shape = list(input.shape)
-    size = input.shape[dim]
-    if size == 0:
-        if keepdim:
-            out_shape[dim] = 1
-        else:
-            out_shape = out_shape[:dim] + out_shape[dim + 1 :]
-        return torch.ones(out_shape, dtype=input.dtype, device=input.device)
-
-    out_shape = out_shape[:dim] + out_shape[dim + 1 :]
+    reduce_size = out_shape.pop(dim)
     acc = torch.ones(out_shape, dtype=input.dtype, device=input.device)
-    for i in range(size):
-        index = [slice(None)] * input.ndim
-        index[dim] = slice(i, i + 1)
-        slice_i = input[tuple(index)].squeeze(dim)
-        acc = acc * slice_i
+    for i in range(reduce_size):
+        acc = acc * input.select(dim, i)
+
 
     if keepdim:
         acc = acc.unsqueeze(dim)

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -1212,10 +1212,10 @@ def lower_qfp8ch(x):
     torch.ops.spyre.prod_dim_int,
     type_promotion_kind=None,
 )
-def lower_prod_dim(x, dim, keepDim=False):
+def lower_prod_dim(x, dim, keepdim=False):
     def _prod_dim_impl(x):
         kwargs = lowering._make_reduction_inner(
-            x, axis=[dim], keepdims=keepDim, dtype=x.dtype, override_return_dtype=None
+            x, axis=[dim], keepdims=keepdim, dtype=x.dtype, override_return_dtype=None
         )
         result = Reduction.create(reduction_type="prod", input_node=x, **kwargs)
         result.realize()

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -1206,3 +1206,19 @@ def lower_qfp8ch(x):
     )
     pw.realize()
     return pw
+
+
+@register_spyre_lowering(
+    torch.ops.spyre.prod_dim_int,
+    type_promotion_kind=None,
+)
+def lower_prod_dim(x, dim, keepDim=False):
+    def _prod_dim_impl(x):
+        kwargs = lowering._make_reduction_inner(
+            x, axis=[dim], keepdims=keepDim, dtype=x.dtype, override_return_dtype=None
+        )
+        result = Reduction.create(reduction_type="prod", input_node=x, **kwargs)
+        result.realize()
+        return result
+
+    return with_int64_fallback(_prod_dim_impl, x)

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -53,6 +53,7 @@ from .constants import (
     BATCH_MATMUL_OP,
     COPY_BACK_CANDIDATE_ATTR,
     ELIDED_COPY_BACK_ATTR,
+    REDUCTIONS_NON_STICK_DIM_ONLY,
     TOPK_OPS,
 )
 from .ir import FixedTiledLayout, SpyreConstantFallback
@@ -134,15 +135,8 @@ def _pick_stick_dim(stick_expr, out_coords) -> int:
 
 
 def _output_stl_from_stick_expr(
-    stick_expr,
-    output,
-    output_dep,
-    c_size,
-    c_stride,
-    reduction_type=None,
-    in_layout=None,
-    dep=None,
-) -> tuple[SpyreTensorLayout | None, int]:
+    stick_expr, output, output_dep, c_size, c_stride
+) -> SpyreTensorLayout | None:
     """If stick_expr is offset-free, build an output STL with it mapped to the right dim.
 
     Returns None if stick_expr has an offset (caller should fall back to scanning).
@@ -152,25 +146,7 @@ def _output_stl_from_stick_expr(
         return None
     out_coords = host_coordinates(output, output_dep, None)
     out_stick_dim = _pick_stick_dim(stick_expr, out_coords)
-
-    if reduction_type == "prod":
-        is_keepdim = False
-        if dep is not None:
-            reduction_vars = dep.index.free_symbols - output_dep.index.free_symbols
-            # Check if reduction_vars includes stick_expr
-            if reduction_vars & stick_expr.free_symbols:
-                return None, out_stick_dim
-        # Check if dimension is kept
-        if in_layout is not None and reduction_type is not None:
-            is_keepdim = len(output.size) == len(in_layout.size)
-        if not is_keepdim:
-            return None, out_stick_dim
-
-    if not is_stick_expr_offset_free(stick_expr, stick_size):
-        return None, out_stick_dim
-    return _make_output_stl(
-        output, output_dep, c_size, c_stride, out_stick_dim
-    ), out_stick_dim
+    return _make_output_stl(output, output_dep, c_size, c_stride, out_stick_dim)
 
 
 def _make_output_stl(
@@ -248,31 +224,27 @@ def _single_arg_op_layout(
     stick_size = get_elem_in_stick(output.dtype)
 
     if isinstance(data, Reduction):
-        x_dev_coords = device_coordinates(stl, dep, None)
-        out_coords = host_coordinates(output, output_dep, None)
+        x_dev_coords = device_coordinates(stl, dep)
         x_stick_expr = x_dev_coords[-1]
-
-        # Try to preserve input layout
-        out_stl, stick_dim = _output_stl_from_stick_expr(
-            x_stick_expr,
-            output,
-            output_dep,
-            c_size,
-            c_stride,
-            data.reduction_type,
-            in_layout,
-            dep=dep,
-        )
-        if out_stl is not None:
-            return [out_stl]
-
-        if stick_dim < 0:
-            stick_dim += len(in_layout.size)
-        # Try alternative layouts when input layout is not supported
-        in_coords = host_coordinates(in_layout, dep, None)
         reduction_var = next(
             iter(dep.index.free_symbols - output_dep.index.free_symbols), None
         )
+
+        if not (
+            data.reduction_type in REDUCTIONS_NON_STICK_DIM_ONLY
+            and reduction_var in x_stick_expr.free_symbols
+        ):
+            # Try to preserve input layout
+            out_stl = _output_stl_from_stick_expr(
+                x_stick_expr, output, output_dep, c_size, c_stride
+            )
+            if out_stl is not None:
+                return [out_stl]
+
+        # Try alternative layouts when input layout is not supported
+        in_coords = host_coordinates(in_layout, dep)
+        out_coords = host_coordinates(output, output_dep)
+        stick_dim = matching_dim(in_coords, x_stick_expr)
         layouts = []
         for in_dim in range(len(in_layout.size)):
             if in_dim == stick_dim:
@@ -373,7 +345,7 @@ def _single_arg_op_layout(
     stick_expr = in_device_coords[-1]
 
     # Try to preserve input layout, fall back to scanning all output dims
-    out_stl, _ = _output_stl_from_stick_expr(
+    out_stl = _output_stl_from_stick_expr(
         stick_expr, output, output_dep, c_size, c_stride
     )
     if out_stl is not None:

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -134,8 +134,15 @@ def _pick_stick_dim(stick_expr, out_coords) -> int:
 
 
 def _output_stl_from_stick_expr(
-    stick_expr, output, output_dep, c_size, c_stride
-) -> SpyreTensorLayout | None:
+    stick_expr,
+    output,
+    output_dep,
+    c_size,
+    c_stride,
+    reduction_type=None,
+    in_layout=None,
+    dep=None,
+) -> tuple[SpyreTensorLayout | None, int]:
     """If stick_expr is offset-free, build an output STL with it mapped to the right dim.
 
     Returns None if stick_expr has an offset (caller should fall back to scanning).
@@ -145,7 +152,25 @@ def _output_stl_from_stick_expr(
         return None
     out_coords = host_coordinates(output, output_dep, None)
     out_stick_dim = _pick_stick_dim(stick_expr, out_coords)
-    return _make_output_stl(output, output_dep, c_size, c_stride, out_stick_dim)
+
+    if reduction_type == "prod":
+        is_keepdim = False
+        if dep is not None:
+            reduction_vars = dep.index.free_symbols - output_dep.index.free_symbols
+            # Check if reduction_vars includes stick_expr
+            if reduction_vars & stick_expr.free_symbols:
+                return None, out_stick_dim
+        # Check if dimension is kept
+        if in_layout is not None and reduction_type is not None:
+            is_keepdim = len(output.size) == len(in_layout.size)
+        if not is_keepdim:
+            return None, out_stick_dim
+
+    if not is_stick_expr_offset_free(stick_expr, stick_size):
+        return None, out_stick_dim
+    return _make_output_stl(
+        output, output_dep, c_size, c_stride, out_stick_dim
+    ), out_stick_dim
 
 
 def _make_output_stl(
@@ -228,12 +253,21 @@ def _single_arg_op_layout(
         x_stick_expr = x_dev_coords[-1]
 
         # Try to preserve input layout
-        out_stl = _output_stl_from_stick_expr(
-            x_stick_expr, output, output_dep, c_size, c_stride
+        out_stl, stick_dim = _output_stl_from_stick_expr(
+            x_stick_expr,
+            output,
+            output_dep,
+            c_size,
+            c_stride,
+            data.reduction_type,
+            in_layout,
+            dep=dep,
         )
         if out_stl is not None:
             return [out_stl]
 
+        if stick_dim < 0:
+            stick_dim += len(in_layout.size)
         # Try alternative layouts when input layout is not supported
         in_coords = host_coordinates(in_layout, dep, None)
         reduction_var = next(
@@ -241,6 +275,8 @@ def _single_arg_op_layout(
         )
         layouts = []
         for in_dim in range(len(in_layout.size)):
+            if in_dim == stick_dim:
+                continue
             if concretize_expr(in_layout.size[in_dim]) % stick_size != 0:
                 # TODO: Support dimensions with size not divisible by stick_size via padding (See #1756)
                 continue
@@ -337,7 +373,7 @@ def _single_arg_op_layout(
     stick_expr = in_device_coords[-1]
 
     # Try to preserve input layout, fall back to scanning all output dims
-    out_stl = _output_stl_from_stick_expr(
+    out_stl, _ = _output_stl_from_stick_expr(
         stick_expr, output, output_dep, c_size, c_stride
     )
     if out_stl is not None:

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -230,6 +230,10 @@ def _single_arg_op_layout(
             iter(dep.index.free_symbols - output_dep.index.free_symbols), None
         )
 
+        # Do not preserve the input layout for reduction ops listed in
+        # REDUCTIONS_NON_STICK_DIM_ONLY when reducing along the stick
+        # dimension. Those reductions are currently unsupported in the backend.
+        # See backend issue #4409.
         if not (
             data.reduction_type in REDUCTIONS_NON_STICK_DIM_ONLY
             and reduction_var in x_stick_expr.free_symbols

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -224,7 +224,7 @@ def _single_arg_op_layout(
     stick_size = get_elem_in_stick(output.dtype)
 
     if isinstance(data, Reduction):
-        x_dev_coords = device_coordinates(stl, dep)
+        x_dev_coords = device_coordinates(stl, dep, None)
         x_stick_expr = x_dev_coords[-1]
         reduction_var = next(
             iter(dep.index.free_symbols - output_dep.index.free_symbols), None
@@ -242,8 +242,8 @@ def _single_arg_op_layout(
                 return [out_stl]
 
         # Try alternative layouts when input layout is not supported
-        in_coords = host_coordinates(in_layout, dep)
-        out_coords = host_coordinates(output, output_dep)
+        in_coords = host_coordinates(in_layout, dep, None)
+        out_coords = host_coordinates(output, output_dep, None)
         stick_dim = matching_dim(in_coords, x_stick_expr)
         layouts = []
         for in_dim in range(len(in_layout.size)):

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -424,7 +424,6 @@ class SpyreKernelOpsHandler(DefaultHandler):
             "welford_reduce",
             "welford_combine",
             "any",
-            "prod",
             "xor_sum",
         ]:
             return UnimplementedOp(reduction_type)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR adds support for torch.prod. Currently, it is only available when dim (and keepdim) are specified.
Calculating the product of all elements is not supported yet.

#### Which issue(s) this PR is related to:

Fixes issue #1455. Model parameter cases are addressed in this PR.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
