### PR TITLE
docs: read knowledge-graph source files via absolute paths

### DIFF
--- a/docs/source/_ext/extract_graph.py
+++ b/docs/source/_ext/extract_graph.py
@@ -745,19 +745,36 @@ def _get_git_sha(repo_root):
 
 
 def _run_file_extractor(extractor, filepath, repo_root):
-    """Run a single-file extractor and normalize its source_file paths.
+    """Run a single-file extractor and normalize the path it was handed.
 
     Extractors read their input via the path they are handed and echo it
-    back as each node's ``source_file``. We pass the absolute path so the
-    read resolves regardless of the current working directory (the docs
-    build runs from docs/source on ReadTheDocs, not the repo root), then
-    rewrite ``source_file`` to be relative to ``repo_root`` for display.
+    back as each node's ``source_file``; ``extract_config`` also bakes that
+    path into the config module node id (and the endpoints of its
+    ``reads_env`` edges). We pass the absolute path so the read resolves
+    regardless of the current working directory (the docs build runs from
+    docs/source on ReadTheDocs, not the repo root), then rewrite the absolute
+    path back to one relative to ``repo_root`` wherever it appears so node
+    ids and ``source_file`` stay stable across build environments.
     """
-    nodes, edges = extractor(str(filepath))
+    abs_path = str(filepath)
+    rel_path = str(Path(filepath).relative_to(repo_root))
+
+    nodes, edges = extractor(abs_path)
+
+    id_remap = {}
     for node in nodes:
-        src = node.get("source_file")
-        if src:
-            node["source_file"] = str(Path(src).relative_to(repo_root))
+        if node.get("source_file"):
+            node["source_file"] = node["source_file"].replace(abs_path, rel_path)
+        if abs_path in node["id"]:
+            new_id = node["id"].replace(abs_path, rel_path)
+            id_remap[node["id"]] = new_id
+            node["id"] = new_id
+
+    for edge in edges:
+        for endpoint in ("source", "target"):
+            if edge.get(endpoint) in id_remap:
+                edge[endpoint] = id_remap[edge[endpoint]]
+
     return nodes, edges
 
 
@@ -861,7 +878,7 @@ def build_graph(torch_spyre_root):
     graph = {
         "metadata": {
             "source_commit": _get_git_sha(repo_root),
-            "torch_spyre_root": str(root),
+            "torch_spyre_root": str(root.relative_to(repo_root)),
         },
         "nodes": list(seen.values()),
         "edges": valid_edges,

--- a/docs/source/_ext/extract_graph.py
+++ b/docs/source/_ext/extract_graph.py
@@ -744,6 +744,23 @@ def _get_git_sha(repo_root):
         return "unknown"
 
 
+def _run_file_extractor(extractor, filepath, repo_root):
+    """Run a single-file extractor and normalize its source_file paths.
+
+    Extractors read their input via the path they are handed and echo it
+    back as each node's ``source_file``. We pass the absolute path so the
+    read resolves regardless of the current working directory (the docs
+    build runs from docs/source on ReadTheDocs, not the repo root), then
+    rewrite ``source_file`` to be relative to ``repo_root`` for display.
+    """
+    nodes, edges = extractor(str(filepath))
+    for node in nodes:
+        src = node.get("source_file")
+        if src:
+            node["source_file"] = str(Path(src).relative_to(repo_root))
+    return nodes, edges
+
+
 def build_graph(torch_spyre_root):
     """Run all extractors and assemble the deduplicated graph."""
     root = Path(torch_spyre_root)
@@ -764,8 +781,7 @@ def build_graph(torch_spyre_root):
 
     for extractor, filepath in op_extractors:
         if filepath.exists():
-            rel = str(filepath.relative_to(repo_root))
-            n, e = extractor(rel)
+            n, e = _run_file_extractor(extractor, filepath, repo_root)
             all_nodes.extend(n)
             all_edges.extend(e)
 
@@ -787,8 +803,7 @@ def build_graph(torch_spyre_root):
 
     for filepath in class_files:
         if filepath.exists():
-            rel = str(filepath.relative_to(repo_root))
-            n, e = extract_classes(rel)
+            n, e = _run_file_extractor(extract_classes, filepath, repo_root)
             all_nodes.extend(n)
             all_edges.extend(e)
 
@@ -802,16 +817,14 @@ def build_graph(torch_spyre_root):
 
     for filepath in codegen_files:
         if filepath.exists():
-            rel = str(filepath.relative_to(repo_root))
-            n, e = extract_codegen_structures(rel)
+            n, e = _run_file_extractor(extract_codegen_structures, filepath, repo_root)
             all_nodes.extend(n)
             all_edges.extend(e)
 
     # --- Configuration / environment variables ---
     config_path = root / "_inductor" / "config.py"
     if config_path.exists():
-        rel = str(config_path.relative_to(repo_root))
-        n, e = extract_config(rel)
+        n, e = _run_file_extractor(extract_config, config_path, repo_root)
         all_nodes.extend(n)
         all_edges.extend(e)
 


### PR DESCRIPTION
The AST extractors in extract_graph.py open their input files using the path build_graph passes them, and build_graph passed a repo-root-relative path. That resolves only when Sphinx runs from the repo root. On ReadTheDocs it runs from docs/source, so every open hit FileNotFoundError and the builder-inited handler aborted the build.

Pass the extractors an absolute path so the read works from any working directory, then rewrite each node's source_file back to a repo-relative path for display.

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [x] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
