### PR TITLE
Ilp enable cloning

### DIFF
--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -469,7 +469,9 @@ class TestMeasureHBMUsageCoOptimizing(BaseTestScratchpadUsage):
         self.run_test(f, (x,))
 
 
-class TestCloneAtGraphBoundaries(BaseTestScratchpadUsage):
+class TestCloneAtGraphBoundaries(
+    BaseTestScratchpadUsage, metaclass=_ParameterizedScratchpadMeta
+):
     """End-to-end tests for clone insertion at graph input/output boundaries.
 
     The allocator now inserts clone ops on-demand inside _push_allocation rather than
@@ -482,6 +484,205 @@ class TestCloneAtGraphBoundaries(BaseTestScratchpadUsage):
     inserted clone outputs LX-eligible, so this class exercises that path
     directly.
     """
+
+    def _input_clone_when_read_by_multiple_ops(self):
+        """A graph input read by two different ops is cloned; the clone lands in LX."""
+        x = self.rand_device((64, 1024))
+
+        def fn(x):
+            # x is consumed by both exp_op and add_op → two reads → eligible for input clone
+            return torch.exp(x) + x
+
+        def assertion_fn(
+            result_with_lx,
+            n_ops_with_lx,
+            mem_usages_with_lx,
+            result_no_lx,
+            n_ops_no_lx,
+            mem_usages_no_lx,
+        ):
+            self.assertGreater(
+                n_ops_with_lx,
+                n_ops_no_lx,
+                f"Expected the input clone to add an op: {n_ops_no_lx} ops without LX, "
+                f"{n_ops_with_lx} with LX",
+            )
+            self.assertTrue(
+                any(u["location"] == "LX" for u in mem_usages_with_lx.values()),
+                "Expected at least one LX-allocated buffer after input cloning",
+            )
+            # Clone is an exact copy; LX planning must not change the numerical result.
+            self.assertTrue(
+                torch.equal(result_no_lx, result_with_lx),
+                "LX input clone changed the numerical result",
+            )
+
+        return fn, (x,), {"assertion_fn": assertion_fn}
+
+    def _output_clone_when_intermediate_is_also_graph_output(self):
+        """A buffer that is both a graph output and read inside the graph is pinned to LX;
+        a clone of it is inserted as the actual (HBM) graph output returned to the caller."""
+        x = self.rand_device((64, 1024))
+
+        def fn(x):
+            # After CSE, y = exp(x) is produced once.
+            # y is a graph output AND is read by add_op → eligible for output clone.
+            y = torch.exp(x)
+            z = y + 1  # add_op reads y
+            return y, z
+
+        def assertion_fn(
+            result_with_lx,
+            n_ops_with_lx,
+            mem_usages_with_lx,
+            result_no_lx,
+            n_ops_no_lx,
+            mem_usages_no_lx,
+        ):
+            lx_y, lx_z = result_with_lx
+            ref_y, ref_z = result_no_lx
+
+            self.assertGreater(
+                n_ops_with_lx,
+                n_ops_no_lx,
+                f"Expected the output clone to add an op: {n_ops_no_lx} ops without LX, "
+                f"{n_ops_with_lx} with LX",
+            )
+            self.assertTrue(
+                any(u["location"] == "LX" for u in mem_usages_with_lx.values()),
+                "Expected at least one LX-allocated buffer after output cloning",
+            )
+            # Clone is an exact copy; LX planning must not change the numerical result.
+            self.assertTrue(
+                torch.equal(ref_y, lx_y), "LX output clone changed result y"
+            )
+            self.assertTrue(
+                torch.equal(ref_z, lx_z), "LX output clone changed result z"
+            )
+
+        return fn, (x,), {"assertion_fn": assertion_fn}
+
+    def _input_read_at_multiple_offsets_is_correct(self):
+        """A graph input read by one op at two distinct offsets must not be
+        LX-pinned.
+
+        An LX-pinned buffer is addressed by a single base (SDSC start_address
+        = allocation["lx"]); per-access slice offsets are not folded into it.
+        Pinning ``x`` for ``x[:, 0:512] + x[:, 512:1024]`` made both reads
+        resolve to the LX base, so the op computed ``x0 + x0`` instead of
+        ``x0 + x1``. The allocator now skips such inputs (they stay in HBM,
+        where multi-offset reads work)."""
+        x = self.rand_device((64, 1024))
+
+        def fn(x):
+            # The fused add reads x at offset 0 and offset 512 -> two distinct
+            # offsets on the same buffer -> ineligible for LX pinning.
+            return x[:, 0:512] + x[:, 512:1024]
+
+        def assertion_fn(
+            result_with_lx,
+            n_ops_with_lx,
+            mem_usages_with_lx,
+            result_no_lx,
+            n_ops_no_lx,
+            mem_usages_no_lx,
+        ):
+            self.assertTrue(
+                torch.equal(result_no_lx, result_with_lx),
+                "Multi-offset input read produced wrong values under LX planning",
+            )
+
+        return fn, (x,), {"assertion_fn": assertion_fn}
+
+    def _input_feeding_reduction_is_cloned_and_correct(self):
+        """A graph input read by a reduction is LX-cloned, with the clone's
+        per-core split re-keyed correctly.
+
+        push_allocation_with_clone re-keys the consumer's op_it_space_splits
+        through the buffer's strides before assigning them to the clone. A reduction consumer's split is keyed to its
+        reduced-shape output; copied verbatim it would split the wrong axis of
+        the full-shape clone (wrong values / SDSC abort at multi-core). The
+        numerical failure only manifests when work is split across cores; here
+        (sencores=1) we assert the clone is inserted and the result is correct.
+        Multi-core numerical coverage lives in
+        tests/inductor/test_inductor_ops.py (max_sub_broadcast, aminmax,
+        softmax)."""
+        x = self.rand_device((64, 256))
+
+        def fn(x):
+            # x feeds the max reduction (and the sub) -> reduction consumer.
+            return x - torch.unsqueeze(torch.max(x, dim=1).values, dim=1)
+
+        def assertion_fn(
+            result_with_lx,
+            n_ops_with_lx,
+            mem_usages_with_lx,
+            result_no_lx,
+            n_ops_no_lx,
+            mem_usages_no_lx,
+        ):
+            self.assertGreater(
+                n_ops_with_lx,
+                n_ops_no_lx,
+                "Expected a boundary clone for the reduction-fed input, but the op "
+                f"count did not grow ({n_ops_no_lx} -> {n_ops_with_lx})",
+            )
+            self.assertTrue(
+                any(u["location"] == "LX" for u in mem_usages_with_lx.values()),
+                "Expected at least one LX-allocated buffer for the reduction input",
+            )
+            self.assertTrue(
+                torch.equal(result_no_lx, result_with_lx),
+                "Reduction-fed input changed result under LX planning",
+            )
+
+        return fn, (x,), {"assertion_fn": assertion_fn}
+
+    def _input_read_partially_is_correct(self):
+        """A graph input read only over a sub-extent (a slice) must not be
+        LX-pinned.
+
+        Strided partial reads of a multi-dim LX buffer mis-address against the
+        single LX base. Pinning ``x`` for ``add(x[:, :, 0:64].clone(),
+        x[:, :, 0:64])`` produced wrong values; the allocator now leaves such
+        inputs in HBM, where partial reads work."""
+        x = self.rand_device((3, 3, 192))
+
+        def fn(x):
+            s = x[:, :, 0:64]  # partial inner-dim slice -> sub-extent read
+            return torch.add(s.clone(), s)
+
+        def assertion_fn(
+            result_with_lx,
+            n_ops_with_lx,
+            mem_usages_with_lx,
+            result_no_lx,
+            n_ops_no_lx,
+            mem_usages_no_lx,
+        ):
+            self.assertTrue(
+                torch.equal(result_no_lx, result_with_lx),
+                "Partial input read produced wrong values under LX planning",
+            )
+
+        return fn, (x,), {"assertion_fn": assertion_fn}
+
+    parameter_axes = {
+        "solver_method": ("greedy", "bestfit", "firstfit", "cpsat"),
+        "sencores": (1, 32),
+        "co_optimization": (False, True),
+    }
+
+    parameter_models = (
+        ("multiple_ops_read", _input_clone_when_read_by_multiple_ops),
+        (
+            "output_is_intermediate",
+            _output_clone_when_intermediate_is_also_graph_output,
+        ),
+        ("multiple_offset_input_read", _input_read_at_multiple_offsets_is_correct),
+        ("input_reduction", _input_feeding_reduction_is_cloned_and_correct),
+        ("partial_input_read", _input_read_partially_is_correct),
+    )
 
     def _compile_and_inspect(
         self,
@@ -520,276 +721,36 @@ class TestCloneAtGraphBoundaries(BaseTestScratchpadUsage):
         n_ops = n_ops_captured[0] if n_ops_captured else 0
         return result, n_ops, mem_usages
 
-    def test_input_clone_when_read_by_multiple_ops(self):
-        """A graph input read by two different ops is cloned; the clone lands in LX."""
-        x = self.rand_device((64, 1024))
-
-        def fn(x):
-            # x is consumed by both exp_op and add_op → two reads → eligible for input clone
-            return torch.exp(x) + x
-
-        with ts_inductor_config.patch(lx_planning=False):
-            ref_result, n_ops_no_lx, _ = self._compile_and_inspect(fn, (x,))
-
-        torch.compiler.reset()
-
-        with ts_inductor_config.patch(lx_planning=True):
-            result, n_ops_with_lx, mem_usages = self._compile_and_inspect(fn, (x,))
-
-        self.assertGreater(
-            n_ops_with_lx,
-            n_ops_no_lx,
-            f"Expected the input clone to add an op: {n_ops_no_lx} ops without LX, "
-            f"{n_ops_with_lx} with LX",
-        )
-        self.assertTrue(
-            any(u["location"] == "LX" for u in mem_usages.values()),
-            "Expected at least one LX-allocated buffer after input cloning",
-        )
-        # Clone is an exact copy; LX planning must not change the numerical result.
-        self.assertTrue(
-            torch.equal(ref_result, result),
-            "LX input clone changed the numerical result",
-        )
-
-    # TODO: Update to expected pass on PR2907
-    @unittest.skipUnless(
-        _HAS_ORTOOLS, "joint CP-SAT boundary-clone xfail needs ortools"
-    )
-    @unittest.expectedFailure
-    def test_input_clone_unsupported_under_joint_cpsat(self):
-        """Boundary clone insertion is not yet supported by the joint CP-SAT
-        allocator (``layout_solver="cpsat"`` with ``co_optimizing_lx_planning``).
-
-        The joint allocator builds CoreDivisionBuffers only for graph *ops*:
-        graph inputs are never candidates (so an input read by multiple ops is
-        never cloned into LX) and graph outputs carry a "graph output" residency
-        reason (never pinned, so no output clone). The op count therefore does
-        not grow. This is an *expected failure* until the CP-SAT path grows
-        boundary-clone support; the greedy and placement-only CP-SAT paths handle
-        it (see ``test_input_clone_when_read_by_multiple_ops``).
-
-        Skipped without ortools: the allocator would then fall back to greedy,
-        which *does* clone, making the assertion pass (an unexpected success).
-        """
-        x = self.rand_device((64, 1024))
-
-        def fn(x):
-            # x read by both exp and add -> eligible for an input clone.
-            return torch.exp(x) + x
-
-        with ts_inductor_config.patch(lx_planning=False):
-            _, n_ops_no_lx, _ = self._compile_and_inspect(fn, (x,))
-
-        torch.compiler.reset()
-
+    def run_case(self, params: dict, factory: Callable) -> None:
+        """Run ``factory``'s model for correctness under this combo, applying
+        the combo's config at the test-case level (the inherited setUp only
+        applies invariants)."""
         with ts_inductor_config.patch(
-            lx_planning=True,
-            layout_solver="cpsat",
-            co_optimizing_lx_planning=True,
+            layout_solver=params["solver_method"],
+            sencores=params["sencores"],
+            co_optimizing_lx_planning=params["co_optimization"],
         ):
-            _, n_ops_with_lx, _ = self._compile_and_inspect(fn, (x,))
+            model, args, kwargs = factory(self)
+            torch.compiler.reset()
+            with ts_inductor_config.patch(lx_planning=True):
+                result_with_lx, n_ops_with_lx, mem_usages_with_lx = (
+                    self._compile_and_inspect(model, args)
+                )
+            torch.compiler.reset()
+            with ts_inductor_config.patch(lx_planning=False):
+                result_no_lx, n_ops_no_lx, mem_usages_no_lx = self._compile_and_inspect(
+                    model, args
+                )
 
-        # Holds on the greedy / placement-only paths (see the sibling test); the
-        # joint CP-SAT path inserts no boundary clone -> fails -> expected failure.
-        self.assertGreater(
-            n_ops_with_lx,
-            n_ops_no_lx,
-            "joint CP-SAT unexpectedly inserted a boundary clone "
-            f"({n_ops_no_lx} -> {n_ops_with_lx} ops)",
-        )
-
-    # TODO: Update to expected pass on PR2907
-    @unittest.skipUnless(
-        _HAS_ORTOOLS, "joint CP-SAT boundary-clone xfail needs ortools"
-    )
-    @unittest.expectedFailure
-    def test_output_clone_unsupported_under_joint_cpsat(self):
-        """Output boundary clone insertion is not yet supported by the joint
-        CP-SAT allocator (``layout_solver="cpsat"`` with
-        ``co_optimizing_lx_planning``).
-
-        Output-side counterpart to
-        ``test_input_clone_unsupported_under_joint_cpsat``. The joint allocator
-        builds CoreDivisionBuffers only for graph *ops* and tags graph outputs
-        with a "graph output" residency reason, so a buffer that is both a graph
-        output and read inside the graph is never pinned and no output clone is
-        inserted. The op count therefore does not grow. This is an *expected
-        failure* until the CP-SAT path grows boundary-clone support; the greedy
-        and placement-only CP-SAT paths handle it (see
-        ``test_output_clone_when_intermediate_is_also_graph_output``).
-
-        Skipped without ortools: the allocator would then fall back to greedy,
-        which *does* clone, making the assertion pass (an unexpected success).
-        """
-        x = self.rand_device((64, 1024))
-
-        def fn(x):
-            # y = exp(x) is both a graph output and read by add_op -> eligible
-            # for an output clone on the greedy / placement-only paths.
-            y = torch.exp(x)
-            z = y + 1
-            return y, z
-
-        with ts_inductor_config.patch(lx_planning=False):
-            _, n_ops_no_lx, _ = self._compile_and_inspect(fn, (x,))
-
-        torch.compiler.reset()
-
-        with ts_inductor_config.patch(
-            lx_planning=True,
-            layout_solver="cpsat",
-            co_optimizing_lx_planning=True,
-        ):
-            _, n_ops_with_lx, _ = self._compile_and_inspect(fn, (x,))
-
-        # Holds on the greedy / placement-only paths (see the sibling test); the
-        # joint CP-SAT path inserts no boundary clone -> fails -> expected failure.
-        self.assertGreater(
-            n_ops_with_lx,
-            n_ops_no_lx,
-            "joint CP-SAT unexpectedly inserted a boundary clone "
-            f"({n_ops_no_lx} -> {n_ops_with_lx} ops)",
-        )
-
-    def test_output_clone_when_intermediate_is_also_graph_output(self):
-        """A buffer that is both a graph output and read inside the graph is pinned to LX;
-        a clone of it is inserted as the actual (HBM) graph output returned to the caller."""
-        x = self.rand_device((64, 1024))
-
-        def fn(x):
-            # After CSE, y = exp(x) is produced once.
-            # y is a graph output AND is read by add_op → eligible for output clone.
-            y = torch.exp(x)
-            z = y + 1  # add_op reads y
-            return y, z
-
-        with ts_inductor_config.patch(lx_planning=False):
-            (ref_y, ref_z), n_ops_no_lx, _ = self._compile_and_inspect(fn, (x,))
-
-        torch.compiler.reset()
-
-        with ts_inductor_config.patch(lx_planning=True):
-            (result_y, result_z), n_ops_with_lx, mem_usages = self._compile_and_inspect(
-                fn, (x,)
+            assertion_fn = kwargs["assertion_fn"]
+            assertion_fn(
+                result_with_lx,
+                n_ops_with_lx,
+                mem_usages_with_lx,
+                result_no_lx,
+                n_ops_no_lx,
+                mem_usages_no_lx,
             )
-
-        self.assertGreater(
-            n_ops_with_lx,
-            n_ops_no_lx,
-            f"Expected the output clone to add an op: {n_ops_no_lx} ops without LX, "
-            f"{n_ops_with_lx} with LX",
-        )
-        self.assertTrue(
-            any(u["location"] == "LX" for u in mem_usages.values()),
-            "Expected at least one LX-allocated buffer after output cloning",
-        )
-        # Clone is an exact copy; LX planning must not change the numerical result.
-        self.assertTrue(
-            torch.equal(ref_y, result_y), "LX output clone changed result y"
-        )
-        self.assertTrue(
-            torch.equal(ref_z, result_z), "LX output clone changed result z"
-        )
-
-    def test_input_read_at_multiple_offsets_is_correct(self):
-        """A graph input read by one op at two distinct offsets must not be
-        LX-pinned.
-
-        An LX-pinned buffer is addressed by a single base (SDSC start_address
-        = allocation["lx"]); per-access slice offsets are not folded into it.
-        Pinning ``x`` for ``x[:, 0:512] + x[:, 512:1024]`` made both reads
-        resolve to the LX base, so the op computed ``x0 + x0`` instead of
-        ``x0 + x1``. The allocator now skips such inputs (they stay in HBM,
-        where multi-offset reads work)."""
-        x = self.rand_device((64, 1024))
-
-        def fn(x):
-            # The fused add reads x at offset 0 and offset 512 -> two distinct
-            # offsets on the same buffer -> ineligible for LX pinning.
-            return x[:, 0:512] + x[:, 512:1024]
-
-        with ts_inductor_config.patch(lx_planning=False):
-            ref, _, _ = self._compile_and_inspect(fn, (x,))
-
-        torch.compiler.reset()
-
-        with ts_inductor_config.patch(lx_planning=True):
-            result, _, _ = self._compile_and_inspect(fn, (x,))
-
-        self.assertTrue(
-            torch.equal(ref, result),
-            "Multi-offset input read produced wrong values under LX planning",
-        )
-
-    def test_input_feeding_reduction_is_cloned_and_correct(self):
-        """A graph input read by a reduction is LX-cloned, with the clone's
-        per-core split re-keyed correctly.
-
-        push_allocation_with_clone re-keys the consumer's op_it_space_splits
-        through the buffer's strides before assigning them to the clone. A reduction consumer's split is keyed to its
-        reduced-shape output; copied verbatim it would split the wrong axis of
-        the full-shape clone (wrong values / SDSC abort at multi-core). The
-        numerical failure only manifests when work is split across cores; here
-        (sencores=1) we assert the clone is inserted and the result is correct.
-        Multi-core numerical coverage lives in
-        tests/inductor/test_inductor_ops.py (max_sub_broadcast, aminmax,
-        softmax)."""
-        x = self.rand_device((64, 256))
-
-        def fn(x):
-            # x feeds the max reduction (and the sub) -> reduction consumer.
-            return x - torch.unsqueeze(torch.max(x, dim=1).values, dim=1)
-
-        with ts_inductor_config.patch(lx_planning=False):
-            ref, n_ops_no_lx, _ = self._compile_and_inspect(fn, (x,))
-
-        torch.compiler.reset()
-
-        with ts_inductor_config.patch(lx_planning=True):
-            result, n_ops_with_lx, mem_usages = self._compile_and_inspect(fn, (x,))
-
-        self.assertGreater(
-            n_ops_with_lx,
-            n_ops_no_lx,
-            "Expected a boundary clone for the reduction-fed input, but the op "
-            f"count did not grow ({n_ops_no_lx} -> {n_ops_with_lx})",
-        )
-        self.assertTrue(
-            any(u["location"] == "LX" for u in mem_usages.values()),
-            "Expected at least one LX-allocated buffer for the reduction input",
-        )
-        self.assertTrue(
-            torch.equal(ref, result),
-            "Reduction-fed input changed result under LX planning",
-        )
-
-    def test_input_read_partially_is_correct(self):
-        """A graph input read only over a sub-extent (a slice) must not be
-        LX-pinned.
-
-        Strided partial reads of a multi-dim LX buffer mis-address against the
-        single LX base. Pinning ``x`` for ``add(x[:, :, 0:64].clone(),
-        x[:, :, 0:64])`` produced wrong values; the allocator now leaves such
-        inputs in HBM, where partial reads work."""
-        x = self.rand_device((3, 3, 192))
-
-        def fn(x):
-            s = x[:, :, 0:64]  # partial inner-dim slice -> sub-extent read
-            return torch.add(s.clone(), s)
-
-        with ts_inductor_config.patch(lx_planning=False):
-            ref, _, _ = self._compile_and_inspect(fn, (x,))
-
-        torch.compiler.reset()
-
-        with ts_inductor_config.patch(lx_planning=True):
-            result, _, _ = self._compile_and_inspect(fn, (x,))
-
-        self.assertTrue(
-            torch.equal(ref, result),
-            "Partial input read produced wrong values under LX planning",
-        )
 
 
 # TODO: Remove hard coded core division. This test exists to check for

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -51,6 +51,7 @@ from torch_spyre._inductor.scratchpad.plan_solver import (
     LifetimeBoundBuffer,
     MemoryPlanSolver,
     SolveError,
+    BufferType,
 )
 from torch_spyre._inductor.scratchpad.firstfit_bestfit_solver import (
     BestFitLayoutSolver,
@@ -356,6 +357,8 @@ class ScratchpadAllocator:
             out_ten_layout = graph.get_buffer(buf_name).get_layout().device_layout
             out_size = info["size_per_core"]
             for input_buf in info["op_inputs"]:
+                if input_buf not in mem_usage or not lifetimes[input_buf]:
+                    continue
                 in_end = lifetimes[input_buf][-1]  # inclusive last use
                 in_ten_layout = graph.get_buffer(input_buf).get_layout().device_layout
                 in_size = mem_usage[input_buf]["size_per_core"]
@@ -1330,8 +1333,11 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             p.apply_pass(graph)
         buffers = self._generate_cd_buffers(graph, self._division_map(graph))
         allocation = self.layout_planning.plan_layout(buffers)
-        self._push_allocation(graph, allocation)
+        # the divisions must be committed such that any buffer clones can correctly
+        # pull the selected core division from the dependent buffers when
+        # the graph is updated with clones in ``_push_allocation``
         self._commit_divisions(graph, allocation)
+        self._push_allocation(graph, allocation)
         for p in self.post_optimization_passes:
             p.apply_pass(graph)
 
@@ -1496,6 +1502,12 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             out_start = lifetimes[buf_name][0]
             out_ten_layout = out_layout.device_layout
             for input_buf in info["op_inputs"]:
+                # Graph inputs / constants now appear in ``op_inputs`` but are not
+                # solver buffers, so they can't be in-place aliasing parents (the
+                # solver's ``_assert_in_place_relationships`` would fail to resolve
+                # them). Skip them, matching the base allocator's guard.
+                if input_buf not in mem_usage or not lifetimes[input_buf]:
+                    continue
                 in_layout = graph.get_buffer(input_buf).layout
                 if not hasattr(in_layout, "device_layout"):
                     continue
@@ -1590,7 +1602,12 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             return "extern kernel user"
         if name in mutated_buffers:
             return "mutation target"
-        if name in graph_output_names:
+        # A graph output normally can't reside (the value must land back in HBM),
+        # but with boundary cloning on it is pinned via an output clone that still
+        # writes HBM once; that unavoidable write cancels from the CP-SAT
+        # differential spill cost (``Boundary.Output`` in ``spill_cost``), so allow
+        # residency then.
+        if name in graph_output_names and not clone_at_graph_boundaries():
             return "graph output"
         if buffer_not_read_in_full(graph, name):
             return "partial/offset read"
@@ -1617,18 +1634,47 @@ class CoOptimizingAllocator(ScratchpadAllocator):
         mem_usage = mem_usage_by_buf(graph)
         in_place = {} if in_place is None else in_place
         op_by_name = {op.name: op for op in graph.operations}
+        graph_output_names = set(graph.get_output_names())
 
-        # Caches the candidate-invariant view prep (``_prepare_per_core_view``)
-        # keyed by (op, dep, buf), so a parent read by several consumers prepares
-        # its write-view once and each op's sympy work is reused across divisions.
         prep_cache: dict = {}
         buffers: list[CoreDivisionBuffer] = []
-        # Residency for every buffer up front: ``_cd_parent_matches`` consults the
-        # same map so it never matches against a never-resident parent. Computed
-        # before the loop because a parent can appear later than its consumer.
         residency_by_buf = self._residency_by_buf(
             graph, mem_usage, op_by_name, lifetimes
         )
+
+        input_clone_matches: dict[str, dict[str, list[tuple[int, int]]]] = {}
+        if clone_at_graph_boundaries():
+            buffer_users = get_buffer_users(graph)
+            for input_name in self._eligible_clone_inputs(graph, lifetimes):
+                consumers = [op for op in buffer_users.get(input_name, [])]
+                divs, matches = self._clone_divisions_and_matches(
+                    input_name, consumers, divisions, prep_cache
+                )
+                # No division matched any consumer -> the clone has no valid core
+                # division and could never reside, so don't hand an unplaceable
+                # buffer to the solver (it would trip the >=1-division invariant).
+                # The input simply stays in HBM, as it would uncloned.
+                if not divs:
+                    continue
+                input_clone_matches[input_name] = matches
+                residency_by_buf[input_name] = None
+                dev_layout = graph.get_buffer(input_name).layout.device_layout
+                size = math.prod(dev_layout.device_size[:-1]) * 128
+                buffers.append(
+                    CoreDivisionBuffer(
+                        input_name,
+                        size,
+                        lifetimes[input_name],
+                        first_use_is_read=True,
+                        in_place_parents=[],
+                        core_divisions=divs,
+                        parents=[],
+                        cd_parent_matches={},
+                        residency_reason=None,
+                        boundary=BufferType.Input,
+                    )
+                )
+
         for output_name, info in mem_usage.items():
             uses = lifetimes[output_name]
 
@@ -1638,7 +1684,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             buf_divisions = divisions[output_name]
             parents = in_place.get(output_name, [])
             size = info["size"]  # total footprint; solver divides per chosen cd
-            parent_proj = info["op_inputs"]
+            parent_proj = info["op_inputs"].copy()
             cd_parent_matches = self._cd_parent_matches(
                 op,
                 buf_divisions,
@@ -1648,6 +1694,12 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                 prep_cache,
                 residency_by_buf,
             )
+
+            for input_name in parent_proj:
+                if input_name in input_clone_matches:
+                    cd_parent_matches[input_name] = input_clone_matches[input_name][
+                        output_name
+                    ]
 
             buffers.append(
                 CoreDivisionBuffer(
@@ -1660,9 +1712,11 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                     parents=parent_proj,
                     cd_parent_matches=cd_parent_matches,
                     residency_reason=residency_reason,
+                    boundary=BufferType.Output
+                    if output_name in graph_output_names
+                    else BufferType.Intermediate,
                 )
             )
-
         return buffers
 
     def _is_frame_changing_clone(self, op: Operation, buf_name: str) -> bool:
@@ -1686,6 +1740,102 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                 read_syms |= set(r.index.free_symbols)
         # A write-only free symbol means the clone expands (broadcasts) that dim.
         return bool(set(write.index.free_symbols) - read_syms)
+
+    def _eligible_clone_inputs(
+        self, graph: GraphLowering, lifetimes: dict[str, list[int]]
+    ) -> list[str]:
+        """Graph inputs eligible to be cloned into LX, applying the same
+        correctness guards as the placement path's input loop.
+
+        The core division is deferred to the solver as clones can be assigned any core
+        division provided a valid core division satisfies all children. This
+        constraint is enforced by ensuring that each child matches that of
+        the parent.
+        """
+        eligible: list[str] = []
+        for input_name in graph.graph_input_names:
+            uses = lifetimes[input_name]
+            if len(uses) <= 1:
+                continue
+            if not GraphEditor.all_uses_are_rewritable(graph, uses):
+                continue
+            if buffer_not_read_in_full(graph, input_name):
+                continue
+            if _would_produce_lx_back_gap(graph, input_name, uses):
+                continue
+            eligible.append(input_name)
+        return eligible
+
+    def _clone_divisions_and_matches(
+        self,
+        input_name: str,
+        consumers: list[Operation],
+        divisions: dict[str, list[CoreDivision]],
+        prep_cache: dict,
+    ) -> tuple[list[CoreDivision], dict[str, list[tuple[int, int]]]]:
+        """Determine the core divisions which are applicable to the clone
+        node based on the read per core views of the clone's consumers and
+        equivalent core count (to cover the broadcasting case)
+
+        The applicable core divisions are found and returned as a list of
+        ``CoreDivision`` objects. The mapping such that the clone output
+        per core view matches a given op's read per core view is returned
+        where the mapping exists for each consumer. When solved the parent
+        output per core view must match that of all consumers to be placed.
+        This forces correctness at solve time rather than pre-pruning by
+        finding the intersection of core divisions.
+        """
+        clone_divs: list[CoreDivision] = []
+        clone_views: list[tuple] = []  # parallel: the view each clone div reproduces
+        matches: dict[str, list[tuple[int, int]]] = {}
+        for consumer in consumers:
+            cname = consumer.get_name()
+            consumer_divs = divisions[cname]
+            rw = op_read_writes(consumer)
+            read_dep = next(
+                (r for r in rw.reads if r.name == input_name and hasattr(r, "index")),
+                None,
+            )
+            write = next((w for w in rw.writes if hasattr(w, "index")), None)
+            if read_dep is None or write is None:
+                matches[cname] = []
+                continue
+            iter_space = iteration_space_from_op(consumer)
+            views = self._views_for_divs(
+                consumer, read_dep, input_name, consumer_divs, prep_cache
+            )
+            pairs: list[tuple[int, int]] = []
+            for j, (view, _, repr_ok) in enumerate(views):
+                if not repr_ok:
+                    continue
+                k = next((idx for idx, v in enumerate(clone_views) if v == view), None)
+                if k is None:
+                    cd = consumer_divs[j]
+                    per_sym = apply_splits_from_index_coeff(
+                        (cd.output_splits, cd.reduction_splits),
+                        write.index,
+                        read_dep.index,
+                        iter_space,
+                    )
+                    clone_out, _ = splits_by_index_coeff(
+                        per_sym, read_dep.index, read_dep.index
+                    )
+                    k = len(clone_divs)
+                    clone_divs.append(
+                        CoreDivision(
+                            output_splits=clone_out, reduction_splits={}
+                        )  # a clone op cannot have a division split
+                    )
+                    clone_views.append(view)
+                if clone_divs[k].cores_used == consumer_divs[j].cores_used:
+                    pairs.append((k, j))
+            matches[cname] = pairs
+        # An empty ``clone_divs`` means no consumer matched the clone under any
+        # division, so it has no valid core division. Return it empty rather than
+        # fabricating a whole-buffer fallback that no consumer matches: the caller
+        # drops such a clone (it can never reside), keeping it out of the solver's
+        # >=1-division invariant.
+        return clone_divs, matches
 
     def _cd_parent_matches(
         self,
@@ -1718,22 +1868,18 @@ class CoOptimizingAllocator(ScratchpadAllocator):
         matches: dict[str, list[tuple[int, int]]] = {}
         consumer_reads = op_read_writes(consumer_op).reads
         for parent in parent_names:
-            # A never-resident producer always reads from HBM, so its division
-            # can't constrain the consumer -- skip the match (and the write-index
-            # lookup below, undefined for StarDep writers). A missing entry
-            # defaults to non-resident (sentinel reason), never None.
+            if parent not in op_by_name:
+                continue
             if residency_by_buf.get(parent, "not in graph") is not None:
                 continue
             parent_divs = divisions[parent]
             parent_op = op_by_name[parent]
+            # Frame-changing (broadcasting) clone barrier: the output reads its
+            # input in a different frame (e.g. GQA broadcasting K/V over the
+            # query-group axis), so a per-core slice can't be produced
+            # core-locally. The single-frame view comparison misses this; keep
+            # it in HBM (the broadcast read is globally correct).
             if self._is_frame_changing_clone(parent_op, parent):
-                # A clone whose output has a dimension its input lacks
-                # broadcasts that dim (e.g. GQA broadcasting K/V over the
-                # query-group axis): the per-core write of the output reads the
-                # input in a different frame, so a per-core slice of the output
-                # cannot be produced core-locally. Like restickify, this is a
-                # cross-frame barrier the single-frame view comparison misses;
-                # keep the output in HBM (broadcast read is globally correct).
                 continue
             write_dep = next(
                 (
@@ -1750,17 +1896,14 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             if write_dep is None or read_dep is None:
                 continue
 
-            # Producer view per candidate on its own output ``parent``. ``None``
-            # marks a candidate that cannot host a readable residency: a
-            # partial-reduction write, an unrepresentable slicing of ``parent``,
-            # or a matmul output split across more than one device dim. The SDSC
+            # Producer view per candidate; ``None`` marks one that can't host a
+            # readable residency: a partial-reduction write, an unrepresentable
+            # slicing, or a matmul output split across >1 device dim. The SDSC
             # for a matmul carries only the primary split, so a multi-dim-split
-            # matmul output (e.g. M-split x N-stick-split) cannot be coherently
-            # LX-pinned even when producer/consumer views match -- a consumer
-            # reads per-core LX holding only a fragment (wholesale-wrong). The
-            # broadcast-operand case is already handled by the equal-``cores_used``
-            # requirement on matched pairs below. (Mirrors #2745's
-            # ``get_ncores_for_buffers`` matmul guard for the greedy path.)
+            # output (M-split x N-stick-split) can't be coherently LX-pinned even
+            # when views match -- a consumer would read per-core LX holding only
+            # a fragment. (Mirrors #2745's ``get_ncores_for_buffers`` matmul
+            # guard for the greedy path.)
             parent_is_matmul = _is_matmul_op(parent_op)
             prod_views: list[Optional[tuple]] = [
                 view
@@ -1774,9 +1917,6 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                     parent_op, write_dep, parent, parent_divs, prep_cache
                 )
             ]
-            # Consumer read-views: same unrepresentable guard. A clean empty view
-            # (the split doesn't slice ``parent`` -> reads it whole) is
-            # representable and legitimately matches a whole-buffer producer.
             cons_views: list[Optional[tuple]] = [
                 view if repr_ok else None
                 for view, _partial, repr_ok in self._views_for_divs(
@@ -1784,13 +1924,12 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                 )
             ]
 
-            # A matched pair needs equal per-core slicing of ``parent`` AND equal
-            # *total* core count. Equal views alone aren't enough: a producer on N
-            # and consumer on M>N cores can share an identical (possibly empty)
-            # slicing while the consumer's extra cores -- split on a broadcast axis
-            # -- hold no copy and would read a stale/partial LX buffer. The joint
-            # solver re-divides per buffer and can hit this, hence the gate; a
-            # rejected pair just falls back to HBM.
+            # A matched pair needs equal per-core slicing AND equal total core
+            # count: equal views alone aren't enough, since a producer on N and
+            # consumer on M>N cores can share a slicing while the consumer's
+            # extra (broadcast-axis) cores hold no copy and would read stale LX.
+            # The joint solver re-divides per buffer and can hit this; a rejected
+            # pair just falls back to HBM.
             pairs = [
                 (i, j)
                 for i, pv in enumerate(prod_views)

--- a/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
+++ b/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
@@ -36,14 +36,20 @@ constraint model over :class:`CoreDivisionBuffer`s:
   legally share an offset; the single-tick-overlap invariant
   (``_assert_in_place_relationships``) makes this exact (``_add_no_overlap_2d``).
 * **Objective** (two-phase lexicographic, in ``_run``). *Residency is the hard
-  priority.* Phase 1 minimizes total **HBM transfer traffic** -- spilling a
-  buffer forces each consumer to re-read it from HBM, so a spill costs
-  ``num_consumers * size`` -- putting as much in LX as possible and choosing
-  whatever division serves that (even no split, if that is what lets a buffer
-  match its consumers and reside). Phase 2 then *holds that residency optimum*
-  and maximizes total core usage (``sum_b cores_b``) so every buffer -- resident
-  or spilled, the latter free of the slicing gate -- takes its most parallel
-  division, which the allocator commits. Parallelism never costs a spill.
+  priority.* Phase 1 minimizes total **HBM transfer traffic** via
+  ``spill_cost(b) * (1 - in_buffer)`` -- the *differential* traffic a spill adds
+  over residency (resident buffers contribute 0). An intermediate costs
+  ``(num_consumers + 1) * size`` (the producer's HBM write, which residency turns
+  into a free LX write, plus one re-read per consumer); a graph input drops the
+  producer write it never had and the clone-in read residency cannot avoid
+  (``(num_consumers - 1) * size``); a graph output drops its unavoidable
+  write-out (``num_consumers * size``). Phase 1 puts as much in LX as possible
+  and chooses whatever division serves that (even no split, if that is what lets
+  a buffer match its consumers and reside). Phase 2 then *holds that residency
+  optimum* and maximizes total core usage (``sum_b cores_b``) so every buffer --
+  resident or spilled, the latter free of the slicing gate -- takes its most
+  parallel division, which the allocator commits. Parallelism never costs a
+  spill.
 
 After the solve, ``_justify`` slides each in-place-merged placement unit down to
 the lowest free address, squeezing out float gaps without raising the peak.
@@ -74,6 +80,7 @@ from torch_spyre._inductor.scratchpad.plan_solver import (
     MemoryPlanSolver,
     _assert_in_place_relationships,
     SolveError,
+    BufferType,
 )
 
 __all__ = ["CpSatLayoutSolver"]
@@ -210,7 +217,10 @@ class CpSatLayoutSolver(MemoryPlanSolver[CoreDivisionBuffer]):
         # Solve on copies so we never mutate the caller's buffers.
         working = {
             b.name: _CoreDivisionBufferWithCpVars(
-                replace(b, size=int(np.ceil(b.size / self.alignment))),
+                replace(
+                    b,
+                    size=int(np.ceil(b.size / self.alignment)),
+                ),
                 model,
                 self._capacity_units,
             )
@@ -253,29 +263,14 @@ class CpSatLayoutSolver(MemoryPlanSolver[CoreDivisionBuffer]):
 
         # TODO: Update objective to a maxmin optimization to optimize overall
         # throughput.
+        def spill_cost(sb: "_CoreDivisionBufferWithCpVars") -> int:
+            reads = len(children_of.get(sb.name, [])) + sb.buffer.unallocated_reads
+            if sb.buffer.boundary == BufferType.Input and reads > 0:
+                reads -= 1
+            writes = 1 if sb.buffer.boundary == BufferType.Intermediate else 0
+            return (reads + writes) * sb.buffer.size
 
-        # Two-phase lexicographic objective: residency is the hard priority and
-        # core division is chosen only in service of it.
-        #
-        # Phase 1 -- residency: put as much in LX as possible by minimizing HBM
-        # transfer traffic. Spilling a buffer forces each of its consumers to
-        # re-read it from HBM, so a spill costs ``num_consumers * size``. The
-        # division is whatever maximizes residency -- even no split at all, if
-        # that is what lets a buffer match its consumers and reside.
-        #
-        # ``unallocated_reads`` adds the consumers the solver never sees as
-        # candidates (filtered-out ops, graph outputs): they still read the
-        # buffer from LX when it resides, so they count toward its spill cost.
-        # It is 0 on the joint path, leaving this weight equal to the candidate
-        # consumer count there.
-        def _spill_weight(sb: "_CoreDivisionBufferWithCpVars") -> int:
-            return len(children_of.get(sb.name, [])) + sb.buffer.unallocated_reads
-
-        hbm_terms = [
-            weight * (1 - sb.in_buffer)
-            for sb in tensors.values()
-            if (weight := _spill_weight(sb) * sb.buffer.size)
-        ]
+        hbm_terms = [spill_cost(sb) * (1 - sb.in_buffer) for sb in tensors.values()]
         if hbm_terms:
             model.minimize(sum(hbm_terms))
             if solver.Solve(model) not in (cp_model.OPTIMAL, cp_model.FEASIBLE):

--- a/torch_spyre/_inductor/scratchpad/plan_solver.py
+++ b/torch_spyre/_inductor/scratchpad/plan_solver.py
@@ -19,12 +19,19 @@ from typing import Generic, Optional, TypeVar
 from abc import ABC, abstractmethod
 import math
 from torch_spyre._inductor.logging_utils import get_inductor_logger
+from enum import Enum
 
 logger = get_inductor_logger("scratchpad.plan_solver")
 
 
 class SolveError(Exception):
     """Raised when a solver is unable to find a solution"""
+
+
+class BufferType(Enum):
+    Intermediate = 0
+    Input = 1
+    Output = 2
 
 
 @dataclass
@@ -144,6 +151,7 @@ class CoreDivisionBuffer(LifetimeBoundBuffer):
     # residency gate are unchanged there.
     # TODO: Drop this and make other solvers use the placement = False flag
     unallocated_reads: int = 0
+    boundary: BufferType = BufferType.Intermediate
 
     @property
     def residency_allowed(self) -> bool:

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -126,7 +126,6 @@ def mem_usage_by_buf(
     num_cores_per_op = get_ncores_for_buffers(graph, cache)
     mem_usage: dict = {}
 
-    buf_names = {op.name for op in graph.operations}
     for op in graph.operations:
         buf_name = op.name
         buf = graph.get_buffer(buf_name)
@@ -142,7 +141,7 @@ def mem_usage_by_buf(
                 # below carries validity, so no arithmetic on num_cores here.
                 "size_per_core": -1,
                 "core_div_mismatch": num_cores < 0,
-                "op_inputs": [dep.name for dep in rw.reads if dep.name in buf_names],
+                "op_inputs": [dep.name for dep in rw.reads],
             }
             continue
         dev_layout = layout.device_layout
@@ -153,7 +152,7 @@ def mem_usage_by_buf(
             "size": dev_size,
             "size_per_core": dev_size // num_cores,
             "core_div_mismatch": num_cores < 0,
-            "op_inputs": [dep.name for dep in rw.reads if dep.name in buf_names],
+            "op_inputs": [dep.name for dep in rw.reads],
         }
 
     return mem_usage


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [X] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
This PR is a follow up to #2684. In the original PR, input and output cloning was not supported in an attempt to limit scope. Despite being omitted, node cloning remains a relevant and import optimization to reduce load on DDR memory induced by loading arguments into compute graphs when they are accessed multiple times.

`test_scratchpad_use.py` has been refactored to leverage data driven test definitions to cover all configurations for scratchpad planning. The inputs and assertions are unchanged.

#### Which issue(s) this PR is related to:
None. Follow up to #2684. 

#### Special notes for your reviewer:
None.

#### Does this PR introduce a user-facing change?
None.

#### Additional note:
None.
