### PR TITLE
docs: fix reference drift in env vars, downcast warning, runtime, and ops table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Test sub-suites:
 | `LX_PLANNING=1` | Enable LX scratchpad memory planning |
 | `TORCH_LOGS="+inductor"` | Verbose Inductor logging |
 | `TORCH_COMPILE_DEBUG=1` | Dump Inductor debug artifacts |
-| `TORCH_SPYRE_DOWNCAST_WARN=0` | Suppress float32→float16 warnings |
+| `TORCH_SPYRE_DOWNCAST_WARN=0` | Suppress int64→int32 downcast warnings |
 
 ## Spyre Hardware Basics
 

--- a/docs/source/api/torch_spyre.rst
+++ b/docs/source/api/torch_spyre.rst
@@ -437,11 +437,11 @@ Warnings
 
 .. function:: torch_spyre._C.get_downcast_warning() -> bool
 
-   Returns whether float32 → float16 downcast warnings are enabled.
+   Returns whether int64 → int32 downcast warnings are enabled.
 
 .. function:: torch_spyre._C.set_downcast_warning(enabled)
 
-   Enable or disable float32 → float16 downcast warnings.
+   Enable or disable int64 → int32 downcast warnings.
 
    :param bool enabled: ``True`` to enable warnings, ``False`` to suppress.
 
@@ -476,7 +476,7 @@ Environment Variables
    * - ``TORCH_SPYRE_DEBUG=1``
      - Enable C++ debug logging and ``-O0`` builds
    * - ``TORCH_SPYRE_DOWNCAST_WARN=0``
-     - Suppress float32 → float16 downcast warnings
+     - Suppress int64 → int32 downcast warnings
    * - ``SPYRE_INDUCTOR_LOG=1``
      - Enable Spyre Inductor logging
    * - ``SPYRE_INDUCTOR_LOG_LEVEL=DEBUG``

--- a/docs/source/api/torch_spyre.rst
+++ b/docs/source/api/torch_spyre.rst
@@ -478,15 +478,15 @@ Environment Variables
    * - ``TORCH_SPYRE_DOWNCAST_WARN=0``
      - Suppress int64 → int32 downcast warnings
    * - ``SPYRE_INDUCTOR_LOG=1``
-     - *Deprecated* -- use ``TORCH_LOGS='spyre.inductor:INFO'``. Enable Spyre
+     - *Deprecated*. Use ``TORCH_LOGS='spyre.inductor:INFO'``. Enables Spyre
        Inductor logging
    * - ``SPYRE_INDUCTOR_LOG_LEVEL=DEBUG``
-     - *Deprecated* -- set the level in ``TORCH_LOGS`` (e.g.
-       ``spyre.inductor:DEBUG``). Spyre Inductor log verbosity (DEBUG, INFO,
-       WARNING, ERROR)
+     - *Deprecated*. Set the level in ``TORCH_LOGS`` (e.g.
+       ``spyre.inductor:DEBUG``). Sets Spyre Inductor log verbosity (DEBUG,
+       INFO, WARNING, ERROR)
    * - ``SPYRE_LOG_FILE=path``
-     - *Deprecated* -- mapped to the top-level ``spyre`` logger file handler.
-       Redirect Spyre Inductor logs to a file
+     - *Deprecated*. Mapped to the top-level ``spyre`` logger file handler.
+       Redirects Spyre Inductor logs to a file
    * - ``TORCH_SENDNN_LOG``
      - SendNN library logging level (default: ``CRITICAL``)
    * - ``DT_DEEPRT_VERBOSE``
@@ -537,7 +537,7 @@ Environment Variables
    * - ``MIN_DEFAULT_GRANULARITY``
      - Minimum default granularity for work division (default ``4``)
    * - ``SPYRE_INDUCTOR_IGNORE_HINTS``
-     - Ignore ``spyre_hint`` annotations -- both ``work_div={...}``
+     - Ignore ``spyre_hint`` annotations: both ``work_div={...}``
        work-division hints and hint-based working-set reduction (default
        ``0``)
 

--- a/docs/source/api/torch_spyre.rst
+++ b/docs/source/api/torch_spyre.rst
@@ -531,7 +531,9 @@ Environment Variables
    * - ``MIN_DEFAULT_GRANULARITY``
      - Minimum default granularity for work division (default ``4``)
    * - ``SPYRE_INDUCTOR_IGNORE_HINTS``
-     - Ignore ``spyre_hint(work_div={...})`` annotations (default ``0``)
+     - Ignore ``spyre_hint`` annotations -- both ``work_div={...}``
+       work-division hints and hint-based working-set reduction (default
+       ``0``)
 
 **Device enumeration** (``torch_spyre/csrc/spyre_device_enum.cpp``):
 

--- a/docs/source/api/torch_spyre.rst
+++ b/docs/source/api/torch_spyre.rst
@@ -507,6 +507,8 @@ Environment Variables
        ``scratchpad_planning`` pass)
    * - ``CO_OPTIMIZING_LX_PLANNING``
      - Use the co-optimizing LX allocator strategy (default ``0``)
+   * - ``SPYRE_INDUCTOR_MEMORY_PLAN``
+     - Enable HBM / device-buffer memory planning (default ``1``)
    * - ``CHUNK_LARGE_TENSORS``
      - Run the ``chunk_large_tensors`` pass to split tensors that exceed
        the per-core span (default ``0``)

--- a/docs/source/api/torch_spyre.rst
+++ b/docs/source/api/torch_spyre.rst
@@ -478,11 +478,15 @@ Environment Variables
    * - ``TORCH_SPYRE_DOWNCAST_WARN=0``
      - Suppress int64 → int32 downcast warnings
    * - ``SPYRE_INDUCTOR_LOG=1``
-     - Enable Spyre Inductor logging
+     - *Deprecated* -- use ``TORCH_LOGS='spyre.inductor:INFO'``. Enable Spyre
+       Inductor logging
    * - ``SPYRE_INDUCTOR_LOG_LEVEL=DEBUG``
-     - Set Spyre Inductor log verbosity (DEBUG, INFO, WARNING, ERROR)
+     - *Deprecated* -- set the level in ``TORCH_LOGS`` (e.g.
+       ``spyre.inductor:DEBUG``). Spyre Inductor log verbosity (DEBUG, INFO,
+       WARNING, ERROR)
    * - ``SPYRE_LOG_FILE=path``
-     - Redirect Spyre Inductor logs to a file
+     - *Deprecated* -- mapped to the top-level ``spyre`` logger file handler.
+       Redirect Spyre Inductor logs to a file
    * - ``TORCH_SENDNN_LOG``
      - SendNN library logging level (default: ``CRITICAL``)
    * - ``DT_DEEPRT_VERBOSE``

--- a/docs/source/getting_started/key_concepts.md
+++ b/docs/source/getting_started/key_concepts.md
@@ -294,7 +294,7 @@ Spyre's default compute dtype is `torch.float16`, so tensors created
 without an explicit dtype are fp16. The dtype that is silently narrowed
 with a warning is **int64**: Spyre has no 64-bit integer type, so int64
 tensors are down-cast to int32, which can change values outside the
-32-bit range. The warning is emitted once by default; set
+32-bit range. The warning is emitted once by default. Set
 `TORCH_SPYRE_DOWNCAST_WARN=0` (or call
 `torch.spyre.set_downcast_warning(False)`) to suppress it. float32,
 bfloat16, fp8 variants, and other dtypes are supported in the runtime
@@ -344,7 +344,7 @@ Constraints that show up as compile-time errors or unexpected behavior:
 | **Indivisible reduction dims** | Some reduction dimensions cannot be split across cores; work distribution honors this. |
 | **Static shapes** | Dynamic shapes are work-in-progress. Shape-polymorphic models may recompile per shape. |
 | **Per-core memory span (256 MB)** | Each core's contiguous device-memory footprint must fit within 256 MB of addressable range. Separate from the 2 MB LX scratchpad capacity. |
-| **fp16 default** | int64 is down-cast to int32 with a warning; set `TORCH_SPYRE_DOWNCAST_WARN=0` to suppress. |
+| **fp16 default** | int64 is down-cast to int32 with a warning. Set `TORCH_SPYRE_DOWNCAST_WARN=0` to suppress. |
 | **`SENCORES=32`** | Default core count; lowering it for debugging changes work-division decisions. |
 
 ---

--- a/docs/source/getting_started/key_concepts.md
+++ b/docs/source/getting_started/key_concepts.md
@@ -290,13 +290,16 @@ For the full pipeline reference, see
 
 ## 8. Dtype defaults and casting
 
-Spyre's default compute dtype is `torch.float16`. fp32 inputs are
-down-cast to fp16 before reaching the device. This is correct for most
-inference workloads but can surprise users coming from CPU or GPU
-training paths. Down-cast warnings are emitted by default; set
-`TORCH_SPYRE_DOWNCAST_WARN=0` to suppress them. bfloat16, fp8 variants,
-and integer dtypes are supported in the runtime but have narrower op
-coverage on the compiled path.
+Spyre's default compute dtype is `torch.float16`, so tensors created
+without an explicit dtype are fp16. The dtype that is silently narrowed
+with a warning is **int64**: Spyre has no 64-bit integer type, so int64
+tensors are down-cast to int32, which can change values outside the
+32-bit range. The warning is emitted once by default; set
+`TORCH_SPYRE_DOWNCAST_WARN=0` (or call
+`torch.spyre.set_downcast_warning(False)`) to suppress it. float32,
+bfloat16, fp8 variants, and other dtypes are supported in the runtime
+but have narrower op coverage on the compiled path, where explicit
+fp32↔fp16 cast ops handle conversions.
 
 If your model has a numerically sensitive layer, check the
 [supported operations](../user_guide/supported_operations.md) matrix
@@ -341,7 +344,7 @@ Constraints that show up as compile-time errors or unexpected behavior:
 | **Indivisible reduction dims** | Some reduction dimensions cannot be split across cores; work distribution honors this. |
 | **Static shapes** | Dynamic shapes are work-in-progress. Shape-polymorphic models may recompile per shape. |
 | **Per-core memory span (256 MB)** | Each core's contiguous device-memory footprint must fit within 256 MB of addressable range. Separate from the 2 MB LX scratchpad capacity. |
-| **fp16 default** | fp32 is down-cast to fp16 with a warning; set `TORCH_SPYRE_DOWNCAST_WARN=0` to suppress. |
+| **fp16 default** | int64 is down-cast to int32 with a warning; set `TORCH_SPYRE_DOWNCAST_WARN=0` to suppress. |
 | **`SENCORES=32`** | Default core count; lowering it for debugging changes work-division decisions. |
 
 ---

--- a/docs/source/runtime/index.md
+++ b/docs/source/runtime/index.md
@@ -58,7 +58,7 @@ The count itself comes from `flex::getNumDevices`.
 |------|---------------|
 | `csrc/module.cpp` | pybind11 entry point for the `_C` extension module. Device registration itself happens in `torch_spyre/__init__.py::_autoload()`. |
 | `csrc/spyre_tensor_impl.cpp` | `SpyreTensorImpl`, the device tensor backing store. |
-| `csrc/spyre_mem.cpp` | Device memory allocation and DMA, including graph-free DMA and FlexAllocator support. |
+| `csrc/spyre_mem.cpp` | Device tensor factory ops (`spyre_empty*`, `resize_`) and host↔device copy: builds the `DataConversionInfo` (DCI) descriptors via `generate_dci` that drive `copyAsync` transfers between host memory and LPDDR5. |
 | `csrc/spyre_allocator.cpp` | `SpyreAllocator`, which bridges PyTorch's `c10::Allocator` to `flex::FlexAllocator`. |
 | `csrc/spyre_storage_impl.cpp` | `SpyreStorageImpl`, the storage object backing `SpyreTensorImpl`. |
 | `csrc/spyre_views.cpp` | Tensor view and striding support on device, including `_reshape_alias`. |
@@ -246,9 +246,9 @@ Cross-card collective communication is exposed through the standard PyTorch
 
 Torch-Spyre registers a `c10d::Backend` named `spyreccl`. The class is
 `SpyreCCLBackend` in `csrc/distributed/spyre_ccl.{cpp,hpp}`, registered with the
-process-group machinery via `createSpyreCCLBackend` (called from
-`torch_spyre/__init__.py:237` when the user invokes
-`init_process_group(backend="spyreccl")`). The constant
+process-group machinery via `createSpyreCCLBackend`, wired up in
+`_create_spyre_ccl_backend` in `torch_spyre/__init__.py` when the user invokes
+`init_process_group(backend="spyreccl")`. The constant
 `DISTRIBUTED_BACKEND_NAME = "spyreccl"` is defined in `torch_spyre/constants.py`.
 
 Standard usage looks like any other PyTorch distributed setup:

--- a/docs/source/user_guide/profiling/environment_variables.md
+++ b/docs/source/user_guide/profiling/environment_variables.md
@@ -15,7 +15,7 @@ Debug-oriented variables (`TORCH_SPYRE_DEBUG`, `TORCH_COMPILE_DEBUG`,
 | `SPYRE_INDUCTOR_LOG_LEVEL=DEBUG` | Set Spyre Inductor log verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
 | `SPYRE_LOG_FILE=path/to/file.log` | Redirect Spyre Inductor log output to a file |
 | `TORCH_LOGS="+inductor"` | Verbose PyTorch Inductor logging |
-| `TORCH_SPYRE_DOWNCAST_WARN=0` | Suppress `float32 → float16` downcast warnings |
+| `TORCH_SPYRE_DOWNCAST_WARN=0` | Suppress `int64 → int32` downcast warnings |
 
 ## Compiler configuration
 

--- a/docs/source/user_guide/profiling/environment_variables.md
+++ b/docs/source/user_guide/profiling/environment_variables.md
@@ -11,9 +11,10 @@ Debug-oriented variables (`TORCH_SPYRE_DEBUG`, `TORCH_COMPILE_DEBUG`,
 
 | Variable | Effect |
 |---|---|
-| `SPYRE_INDUCTOR_LOG=1` | Enable Spyre-specific Inductor logging |
-| `SPYRE_INDUCTOR_LOG_LEVEL=DEBUG` | Set Spyre Inductor log verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
-| `SPYRE_LOG_FILE=path/to/file.log` | Redirect Spyre Inductor log output to a file |
+| `SPYRE_INDUCTOR_LOG=1` | *Deprecated* — use `TORCH_LOGS="spyre.inductor:INFO"`. Enable Spyre-specific Inductor logging |
+| `SPYRE_INDUCTOR_LOG_LEVEL=DEBUG` | *Deprecated* — set the level in `TORCH_LOGS` (e.g. `spyre.inductor:DEBUG`). Spyre Inductor log verbosity |
+| `SPYRE_LOG_FILE=path/to/file.log` | *Deprecated* — mapped to the top-level `spyre` logger file handler. Redirect Spyre Inductor log output to a file |
+| `TORCH_LOGS="spyre.inductor:DEBUG"` | Preferred logging control; accepts `spyre.*` namespaces (`spyre`, `spyre.inductor`, `spyre.inductor.codegen`, …) |
 | `TORCH_LOGS="+inductor"` | Verbose PyTorch Inductor logging |
 | `TORCH_SPYRE_DOWNCAST_WARN=0` | Suppress `int64 → int32` downcast warnings |
 

--- a/docs/source/user_guide/profiling/environment_variables.md
+++ b/docs/source/user_guide/profiling/environment_variables.md
@@ -11,10 +11,10 @@ Debug-oriented variables (`TORCH_SPYRE_DEBUG`, `TORCH_COMPILE_DEBUG`,
 
 | Variable | Effect |
 |---|---|
-| `SPYRE_INDUCTOR_LOG=1` | *Deprecated* — use `TORCH_LOGS="spyre.inductor:INFO"`. Enable Spyre-specific Inductor logging |
-| `SPYRE_INDUCTOR_LOG_LEVEL=DEBUG` | *Deprecated* — set the level in `TORCH_LOGS` (e.g. `spyre.inductor:DEBUG`). Spyre Inductor log verbosity |
-| `SPYRE_LOG_FILE=path/to/file.log` | *Deprecated* — mapped to the top-level `spyre` logger file handler. Redirect Spyre Inductor log output to a file |
-| `TORCH_LOGS="spyre.inductor:DEBUG"` | Preferred logging control; accepts `spyre.*` namespaces (`spyre`, `spyre.inductor`, `spyre.inductor.codegen`, …) |
+| `SPYRE_INDUCTOR_LOG=1` | *Deprecated*. Use `TORCH_LOGS="spyre.inductor:INFO"`. Enables Spyre-specific Inductor logging |
+| `SPYRE_INDUCTOR_LOG_LEVEL=DEBUG` | *Deprecated*. Set the level in `TORCH_LOGS` (e.g. `spyre.inductor:DEBUG`). Sets Spyre Inductor log verbosity |
+| `SPYRE_LOG_FILE=path/to/file.log` | *Deprecated*. Mapped to the top-level `spyre` logger file handler. Redirects Spyre Inductor log output to a file |
+| `TORCH_LOGS="spyre.inductor:DEBUG"` | Preferred logging control. Accepts `spyre.*` namespaces (`spyre`, `spyre.inductor`, `spyre.inductor.codegen`, and so on) |
 | `TORCH_LOGS="+inductor"` | Verbose PyTorch Inductor logging |
 | `TORCH_SPYRE_DOWNCAST_WARN=0` | Suppress `int64 → int32` downcast warnings |
 

--- a/docs/source/user_guide/running_models.md
+++ b/docs/source/user_guide/running_models.md
@@ -43,11 +43,11 @@ Valid values: 1–32 (default: 32). See
 
 ## Examples
 
-Full working examples are listed in the [Examples](examples/index.md)
-page — single-op scripts (`tensor_allocate.py`, `softmax.py`, `gelu.py`,
-`mean.py`, `mul.py`, `softplus.py`, `spyre_hints.py`) plus a
+Full working examples are listed on the [Examples](examples/index.md)
+page. It has single-op scripts (`tensor_allocate.py`, `softmax.py`,
+`gelu.py`, `mean.py`, `mul.py`, `softplus.py`, `spyre_hints.py`) and a
 `distributed/` set covering the collective ops (allgather, allreduce,
-broadcast, gather, reduce, barrier). The scripts live under
+broadcast, gather, reduce, barrier). The scripts are under
 [examples/](https://github.com/torch-spyre/torch-spyre/tree/main/docs/source/user_guide/examples).
 
 ## Troubleshooting

--- a/docs/source/user_guide/running_models.md
+++ b/docs/source/user_guide/running_models.md
@@ -43,12 +43,12 @@ Valid values: 1–32 (default: 32). See
 
 ## Examples
 
-Full working examples are in the
-[examples/](https://github.com/torch-spyre/torch-spyre/tree/main/docs/source/user_guide/examples)
-directory:
-
-- `tensor_allocate.py` — tensor creation and allocation
-- `softmax.py` — running softmax on Spyre
+Full working examples are listed in the [Examples](examples/index.md)
+page — single-op scripts (`tensor_allocate.py`, `softmax.py`, `gelu.py`,
+`mean.py`, `mul.py`, `softplus.py`, `spyre_hints.py`) plus a
+`distributed/` set covering the collective ops (allgather, allreduce,
+broadcast, gather, reduce, barrier). The scripts live under
+[examples/](https://github.com/torch-spyre/torch-spyre/tree/main/docs/source/user_guide/examples).
 
 ## Troubleshooting
 

--- a/docs/source/user_guide/supported_operations.md
+++ b/docs/source/user_guide/supported_operations.md
@@ -70,9 +70,9 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.max` | Y | Y | Spyre | `max.dim` via custom decomposition |
 | `torch.min` | Y | Y | Spyre | `min.dim` via custom decomposition (fp16) |
 | `torch.topk` | | Y | Spyre | Custom decomposition + custom ops (`spyre::topkvalue`, `spyre::topkindex`) |
-| `torch.linalg.vector_norm` | Y | Y | Spyre | |
+| `torch.linalg.vector_norm` | | Y | Spyre | Compiled only; eager path registered but disabled (misroutes `ord`) |
 | **View Ops** [^views] | | | | |
-| `torch.reshape` / `torch.view` | | Y | Spyre | Includes `_reshape_alias` lowering |
+| `torch.reshape` / `torch.view` | | Y | Spyre | Includes `_reshape_alias` (a C++ device view, not an Inductor lowering) |
 | `torch.transpose` | | Y | Spyre | |
 | `torch.t` | Y | Y | Spyre | View op |
 | `torch.permute` | Y | Y | Spyre | |
@@ -83,7 +83,7 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.flatten` | | Y | Spyre | Compiled only (lowers via `reshape`) |
 | `torch.cat` | Y | Y | Spyre | |
 | `torch.stack` | Y | | Spyre | Eager only |
-| `torch.repeat` | Y | Y | Spyre | |
+| `torch.repeat` | | Y | Spyre | Compiled only; `repeat.out` is available as a CPU fallback |
 | `torch.unbind` | Y | Y | Spyre | |
 | `torch.Tensor.unfold` | Y | Y | Spyre | View op |
 | `torch.split` | | Y | Spyre | Compiled only (lowers via `aten.slice`) |

--- a/docs/source/user_guide/supported_operations.md
+++ b/docs/source/user_guide/supported_operations.md
@@ -70,7 +70,7 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.max` | Y | Y | Spyre | `max.dim` via custom decomposition |
 | `torch.min` | Y | Y | Spyre | `min.dim` via custom decomposition (fp16) |
 | `torch.topk` | | Y | Spyre | Custom decomposition + custom ops (`spyre::topkvalue`, `spyre::topkindex`) |
-| `torch.linalg.vector_norm` | | Y | Spyre | Compiled only; eager path registered but disabled (misroutes `ord`) |
+| `torch.linalg.vector_norm` | | Y | Spyre | Compiled only. Eager path registered but disabled (misroutes `ord`) |
 | **View Ops** [^views] | | | | |
 | `torch.reshape` / `torch.view` | | Y | Spyre | Includes `_reshape_alias` (a C++ device view, not an Inductor lowering) |
 | `torch.transpose` | | Y | Spyre | |
@@ -83,7 +83,7 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.flatten` | | Y | Spyre | Compiled only (lowers via `reshape`) |
 | `torch.cat` | Y | Y | Spyre | |
 | `torch.stack` | Y | | Spyre | Eager only |
-| `torch.repeat` | | Y | Spyre | Compiled only; `repeat.out` is available as a CPU fallback |
+| `torch.repeat` | | Y | Spyre | Compiled only. `repeat.out` is available as a CPU fallback |
 | `torch.unbind` | Y | Y | Spyre | |
 | `torch.Tensor.unfold` | Y | Y | Spyre | View op |
 | `torch.split` | | Y | Spyre | Compiled only (lowers via `aten.slice`) |


### PR DESCRIPTION
Low-risk reference corrections where docs drifted from code.

- **Downcast warning dtype.** `TORCH_SPYRE_DOWNCAST_WARN` and the `get/set_downcast_warning` APIs were described as warning on float32 to float16 downcasts. The type map in `types_mapping.h` keeps float32 as fp32 on the device and only int64 maps to int32 with the allowlisted warning. Corrected the env-var tables, the API reference, the key-concepts dtype section, and the CLAUDE.md env-var table.
- **IGNORE_HINTS.** Since #2896, `SPYRE_INDUCTOR_IGNORE_HINTS` drives both `ignore_work_division_hints` and `ignore_wsr_hints`. Noted that it also disables hint-based working-set reduction.
- **MEMORY_PLAN.** Added `SPYRE_INDUCTOR_MEMORY_PLAN` (`config.py` `hbm_planning`, default on) to the Inductor config table.
- **Logging vars.** `SPYRE_INDUCTOR_LOG`, `SPYRE_INDUCTOR_LOG_LEVEL`, and `SPYRE_LOG_FILE` emit DeprecationWarning in `logging_config.py`, which parses `TORCH_LOGS` for the `spyre.*` namespaces. Marked them deprecated and pointed readers at `TORCH_LOGS`.
- **Runtime.** Corrected the `spyre_mem.cpp` description (it holds the device tensor factory ops and the host-to-device DCI copy path, not 'graph-free DMA' or FlexAllocator) and replaced the stale `__init__.py:237` line number for the CCL backend with the `_create_spyre_ccl_backend` name.
- **Supported ops.** Blanked the eager cells for `vector_norm` (disabled, misroutes ord) and `repeat` (no native eager kernel), corrected the `_reshape_alias` note (a C++ view, not a lowering), and pointed the running-models examples list at the canonical Examples index.