### PR TITLE
fix: device-native stick-dim reconstruction in coarse_tile layout resize

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -690,6 +690,141 @@ class TestDivideRanges(unittest.TestCase):
         self.assertFalse(hasattr(red, _LOOPS_FREE_SYMS_KEY))
         self.assertFalse(hasattr(red, _REDUCTION_FREE_SYMS_KEY))
 
+    # ------------------------------------------------------------------
+    # Device-layout reconstruction tests (FixedTiledLayout path)
+    # ------------------------------------------------------------------
+
+    def _make_ftl_op(self, host_size, dim_order, dtype=torch.float16, elem_arr=None):
+        """Build a ComputedBuffer with a FixedTiledLayout for testing _divide_ranges.
+
+        Returns (op, layout) where layout.device_layout is a SpyreTensorLayout
+        constructed from (host_size, contiguous_strides, dtype, dim_order, elem_arr).
+        """
+        from torch._inductor.ir import ComputedBuffer, FlexibleLayout, Pointwise
+
+        from torch_spyre._C import ElementArrangement, SpyreTensorLayout
+        from torch_spyre._inductor.ir import FixedTiledLayout
+
+        if elem_arr is None:
+            elem_arr = ElementArrangement.STANDARD
+
+        strides = [int(s) for s in FlexibleLayout.contiguous_strides(host_size)]
+        device_layout = SpyreTensorLayout(
+            host_size, strides, dtype, dim_order, elem_arr
+        )
+        layout = FixedTiledLayout(
+            torch.device("cpu"),
+            dtype,
+            [Integer(s) for s in host_size],
+            [Integer(s) for s in strides],
+            device_layout,
+        )
+        pw = Pointwise(
+            device=torch.device("cpu"),
+            dtype=dtype,
+            inner_fn=lambda index: sympy.Integer(1),
+            ranges=[Integer(s) for s in host_size],
+        )
+        op = ComputedBuffer(name="buf0", layout=layout, data=pw)
+        return op, layout
+
+    def test_divide_ranges_transposed_stick_preserved(self):
+        """Tiling a non-stick dim of a transposed-stick layout rebuilds
+        device_layout correctly (headline regression from code review)."""
+        from torch._inductor.ir import FlexibleLayout
+
+        from torch_spyre._C import SpyreTensorLayout
+
+        # [256, 128] with stick on dim0: dim_order=[1, 0].  This is the layout
+        # produced for a transposed Linear weight (model_utils.py restickify).
+        op, layout = self._make_ftl_op([256, 128], dim_order=[1, 0])
+
+        # Tile non-stick dim1 by 2: [256, 128] -> [256, 64].
+        _divide_ranges(op, Integer(2), tiled_dims=[1])
+
+        # Expected: from-scratch SpyreTensorLayout([256, 64], ..., [1, 0]).
+        expected_strides = [
+            int(s) for s in FlexibleLayout.contiguous_strides([256, 64])
+        ]
+        expected = SpyreTensorLayout([256, 64], expected_strides, torch.float16, [1, 0])
+
+        self.assertEqual(layout.device_layout, expected)
+
+        # Also assert it differs from the buggy heuristic result.
+        buggy = SpyreTensorLayout(
+            [1, 256, 64],
+            [64, 64, 1],
+            expected.device_dtype,
+            expected.element_arrangement,
+        )
+        self.assertNotEqual(layout.device_layout, buggy)
+
+    def test_divide_ranges_preserves_element_arrangement(self):
+        """element_arrangement is copied verbatim — not silently reset to STANDARD."""
+        from torch._inductor.ir import FlexibleLayout
+
+        from torch_spyre._C import ElementArrangement, SpyreTensorLayout
+
+        op, layout = self._make_ftl_op(
+            [256, 128], dim_order=[1, 0], elem_arr=ElementArrangement.EXX2
+        )
+
+        _divide_ranges(op, Integer(2), tiled_dims=[1])
+
+        self.assertEqual(
+            layout.device_layout.element_arrangement, ElementArrangement.EXX2
+        )
+
+        # Confirm the rebuilt layout also has the right shape.
+        expected_strides = [
+            int(s) for s in FlexibleLayout.contiguous_strides([256, 64])
+        ]
+        expected = SpyreTensorLayout(
+            [256, 64], expected_strides, torch.float16, [1, 0], ElementArrangement.EXX2
+        )
+        self.assertEqual(layout.device_layout, expected)
+
+    def test_divide_ranges_stride_collision(self):
+        """Tiling an outer dim when stride_map has two entries with the same
+        value (device_size tiebreak case) produces the correct device_layout."""
+        from torch._inductor.ir import FlexibleLayout
+
+        from torch_spyre._C import SpyreTensorLayout
+
+        # [2, 2, 2, 16] contiguous, stick on dim3 (last).  host_stride[0]=64
+        # equals 64*host_stride[3], so the stick tile-count and a non-stick dim
+        # share a stride_map value; device_size must break the tie.
+        op, layout = self._make_ftl_op([2, 2, 2, 16], dim_order=[0, 1, 2, 3])
+
+        # Tile dim0/2: [2,2,2,16] -> [1,2,2,16].
+        _divide_ranges(op, Integer(2), tiled_dims=[0])
+
+        expected_strides = [
+            int(s) for s in FlexibleLayout.contiguous_strides([1, 2, 2, 16])
+        ]
+        expected = SpyreTensorLayout(
+            [1, 2, 2, 16], expected_strides, torch.float16, [0, 1, 2, 3]
+        )
+        self.assertEqual(layout.device_layout, expected)
+
+    def test_resize_device_layout_raises_on_unsupported(self):
+        """_resize_device_layout raises RuntimeError when the stick host dim
+        cannot be uniquely identified from stride_map[-1].
+
+        This guards against unsupported layouts (e.g. future multi-host-dim
+        sticks) rather than silently producing a wrong result.
+        """
+        from torch_spyre._C import SpyreTensorLayout
+        from torch_spyre._inductor.coarse_tile import _resize_device_layout
+
+        # Build a real [2, 2] STL (stick on dim1, stride_map[-1] == 1).
+        # Then call the helper with a synthetic old_host_size=[1, 1] whose
+        # contiguous strides are both 1 — two dims share stride_map[-1], so
+        # p* cannot be identified uniquely.
+        stl = SpyreTensorLayout([2, 2], [2, 1], torch.float16, [0, 1])
+        with self.assertRaises(RuntimeError):
+            _resize_device_layout(stl, [1, 1], [1, 1])
+
 
 def _mock_op_out_coords(op):
     """Return pre-built coords stored on op by _make_hinted_op, or empty list."""

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -793,10 +793,10 @@ class TestDivideRanges(unittest.TestCase):
 
         # [2, 2, 2, 16] contiguous, stick on dim3 (last).  host_stride[0]=64
         # equals 64*host_stride[3], so the stick tile-count and a non-stick dim
-        # share a stride_map value; device_size must break the tie.
+        # share a stride_map value; stride check must break the tie.
         op, layout = self._make_ftl_op([2, 2, 2, 16], dim_order=[0, 1, 2, 3])
 
-        # Tile dim0/2: [2,2,2,16] -> [1,2,2,16].
+        # Tile dim0: [2,2,2,16] -> [1,2,2,16].
         _divide_ranges(op, Integer(2), tiled_dims=[0])
 
         expected_strides = [
@@ -806,6 +806,43 @@ class TestDivideRanges(unittest.TestCase):
             [1, 2, 2, 16], expected_strides, torch.float16, [0, 1, 2, 3]
         )
         self.assertEqual(layout.device_layout, expected)
+
+    def test_divide_ranges_tile_count_size_collision(self):
+        """Tile-count device_size equals a non-stick host dim size — the stride
+        check (not size alone) must classify it correctly.
+
+        [2, 128] with stick on dim1: tile-count device_size = ceil(128/64) = 2,
+        which equals old_host_size[0] = 2.  Without the stride check, Pass 1
+        misclassifies the tile-count dim as non-stick and never updates it."""
+        from torch._inductor.ir import FlexibleLayout
+
+        from torch_spyre._C import SpyreTensorLayout
+
+        op, layout = self._make_ftl_op([2, 128], dim_order=[0, 1])
+
+        # Tile dim0: [2, 128] -> [1, 128].
+        _divide_ranges(op, Integer(2), tiled_dims=[0])
+
+        expected_strides = [int(s) for s in FlexibleLayout.contiguous_strides([1, 128])]
+        expected = SpyreTensorLayout([1, 128], expected_strides, torch.float16, [0, 1])
+        self.assertEqual(layout.device_layout, expected)
+
+    def test_resize_device_layout_grow_from_singleton(self):
+        """_allocate_full_buffer grow path: a device dim tiled to size 1
+        (stride_map != -1) must be grown back on the full-buffer allocation.
+
+        [1, 128] grow dim0 -> [4, 128]: the size-1 non-stick device dim must
+        update to device_size=4, not remain frozen at 1."""
+        from torch_spyre._C import SpyreTensorLayout
+        from torch_spyre._inductor.coarse_tile import _resize_device_layout
+
+        # Per-tile buffer is [1, 128] — dim0 was tiled to extent 1.
+        # device_size=[2, 1, 64], stride_map=[64, -1, 1].
+        stl = SpyreTensorLayout([1, 128], [128, 1], torch.float16, [0, 1])
+        result = _resize_device_layout(stl, [1, 128], [4, 128])
+
+        expected = SpyreTensorLayout([4, 128], [128, 1], torch.float16, [0, 1])
+        self.assertEqual(result, expected)
 
     def test_resize_device_layout_raises_on_unsupported(self):
         """_resize_device_layout raises RuntimeError when the stick host dim

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -825,6 +825,25 @@ class TestDivideRanges(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             _resize_device_layout(stl, [1, 1], [1, 1])
 
+    def test_resize_device_layout_reduction_output(self):
+        """Reduction output: stick host dim has been eliminated, so old_host_size
+        has no unmatched dim.  _resize_device_layout must handle this gracefully
+        by leaving the tile-count and inner-stick entries frozen."""
+        from torch_spyre._C import SpyreTensorLayout
+        from torch_spyre._inductor.coarse_tile import _resize_device_layout
+
+        # [128] reduction output: SpyreTensorLayout([128], [1], fp16, [0]).
+        # device_size=[1, 128, 64], stride_map=[-1, 1, -1] — tile-count dim is
+        # frozen at 1 (stick collapsed), inner stick frozen at -1.
+        stl = SpyreTensorLayout([128], [1], torch.float16, [0])
+        # Tile the non-stick dim: [128] -> [64].
+        result = _resize_device_layout(stl, [128], [64])
+
+        # Non-stick device dim (j=1, size 128) updates to size 64, stride 1.
+        # Tile-count (j=0, size 1) and inner stick (j=2, size 64) are frozen.
+        expected = SpyreTensorLayout([64], [1], torch.float16, [0])
+        self.assertEqual(result, expected)
+
 
 def _mock_op_out_coords(op):
     """Return pre-built coords stored on op by _make_hinted_op, or empty list."""

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -1424,29 +1424,42 @@ def _resize_device_layout(orig_stl, old_host_size: list[int], new_host_size: lis
     new_ds = list(orig_ds)
     new_sm = list(orig_sm)
 
-    # Pass 1: match non-singleton, non-inner-stick device dims to host dims.
-    # Primary key: device_size[j] == old_host_size[p].
-    # When size is ambiguous (two host dims share the same size), use
-    # stride_map[j] == old_contiguous_stride[p] as a tiebreaker.
-    matched_host = {}  # j → p (non-stick matches)
-    unmatched_j = []  # device dims not matched → stick tile-count candidates
+    # Pass 1: match non-inner-stick device dims to host dims.
+    # Two match strategies by device_size:
+    #
+    # * Size-1 device dims (device_size==1): stride_map is -1 (either a sparse
+    #   placeholder or a non-stick dim that was tiled to extent 1).  Match by
+    #   size alone — if exactly one host dim has size 1, claim it.  If zero or
+    #   multiple, push to unmatched_j.
+    #
+    # * Size > 1 device dims: primary key is device_size[j] == old_host_size[p].
+    #   When size is ambiguous (multiple host dims share it), use
+    #   stride_map[j] == contiguous_stride[p] as a tiebreaker.  When exactly one
+    #   host dim has the right size, accept it provisionally; if that provisional
+    #   match turns out to be a tile-count collision (detected in Pass 1b below),
+    #   it will be moved to unmatched_j.
+    matched_host = {}  # j → p (non-stick matches, provisional for size>1)
+    unmatched_j = []  # device dims not matched → tile-count / placeholder
 
     for j in range(ndev - 1):  # j == ndev-1 is always inner stick
         dsz = orig_ds[j]
         if dsz == 1:
-            continue  # singleton / sparse placeholder
-        size_cands = [p for p in range(ndim) if old_host_size[p] == dsz]
-        if len(size_cands) == 1:
-            matched_host[j] = size_cands[0]
-        elif len(size_cands) > 1:
-            # Tiebreak by stride_map[j] == contiguous_stride(old_host_size)[p].
-            stride_cands = [p for p in size_cands if old_hs[p] == orig_sm[j]]
-            if len(stride_cands) == 1:
-                matched_host[j] = stride_cands[0]
-            else:
-                unmatched_j.append(j)  # ambiguous even with stride
+            size1_cands = [p for p in range(ndim) if old_host_size[p] == 1]
+            if len(size1_cands) == 1:
+                matched_host[j] = size1_cands[0]
+            # else: sparse placeholder (no host dim of size 1) — skip silently.
         else:
-            unmatched_j.append(j)  # no size match → stick tile-count
+            size_cands = [p for p in range(ndim) if old_host_size[p] == dsz]
+            if len(size_cands) == 1:
+                matched_host[j] = size_cands[0]  # provisional
+            elif len(size_cands) > 1:
+                stride_cands = [p for p in size_cands if old_hs[p] == orig_sm[j]]
+                if len(stride_cands) == 1:
+                    matched_host[j] = stride_cands[0]
+                else:
+                    unmatched_j.append(j)
+            else:
+                unmatched_j.append(j)  # no size match → tile-count
 
     # Identify pstar by elimination: the host dim not claimed by any non-stick
     # device dim match.  Prefer non-singleton host dims first (the stick normally
@@ -1457,6 +1470,34 @@ def _resize_device_layout(orig_stl, old_host_size: list[int], new_host_size: lis
     # dimension has been eliminated (e.g. reduction output).  In that case
     # pstar is None and Passes 3 and 4 are skipped — tile-count and inner-stick
     # device dims retain their existing (frozen) values.
+    def _find_pstar(matched):
+        matched_p = set(matched.values())
+        unmatched_all = [p for p in range(ndim) if p not in matched_p]
+        if not unmatched_all:
+            return None, unmatched_all
+        pstar_cands = [p for p in unmatched_all if old_host_size[p] > 1]
+        if not pstar_cands:
+            pstar_cands = unmatched_all
+        if len(pstar_cands) != 1:
+            return None, unmatched_all  # ambiguous
+        return pstar_cands[0], unmatched_all
+
+    pstar_provisional, _ = _find_pstar(matched_host)
+
+    # Pass 1b: fix provisional size-only matches that are actually tile-count dims.
+    # If a provisionally-matched device dim j has orig_sm[j] != old_hs[p]
+    # (stride mismatch — non-contiguous OR tile-count collision) and its size
+    # equals ceil(old_host_size[pstar_provisional] / eps), it is the tile-count
+    # dim, not a non-stick dim.  Move it to unmatched_j.
+    if pstar_provisional is not None:
+        expected_tc = -(-old_host_size[pstar_provisional] // eps)
+        for j in list(matched_host):
+            p = matched_host[j]
+            if orig_ds[j] > 1 and orig_sm[j] != old_hs[p] and orig_ds[j] == expected_tc:
+                del matched_host[j]
+                unmatched_j.append(j)
+
+    # Re-derive pstar after corrections.
     matched_p = set(matched_host.values())
     unmatched_all = [p for p in range(ndim) if p not in matched_p]
     pstar: int | None
@@ -1473,8 +1514,7 @@ def _resize_device_layout(orig_stl, old_host_size: list[int], new_host_size: lis
         pstar = None
     else:
         pstar_cands = [p for p in unmatched_all if old_host_size[p] > 1]
-        if len(pstar_cands) == 0:
-            # All unmatched host dims are size-1 singletons; the stick must be one.
+        if not pstar_cands:
             pstar_cands = unmatched_all
         if len(pstar_cands) != 1:
             raise RuntimeError(
@@ -1492,8 +1532,8 @@ def _resize_device_layout(orig_stl, old_host_size: list[int], new_host_size: lis
         new_ds[j] = new_host_size[p]
         if new_host_size[p] == 1:
             new_sm[j] = -1
-        elif orig_sm[j] == old_hs[p]:
-            # Dim p is contiguous: update stride to new contiguous value.
+        elif orig_sm[j] == old_hs[p] or orig_sm[j] == -1:
+            # Dim p is contiguous, or was a singleton (-1): update stride.
             new_sm[j] = new_hs[p]
         # else: non-contiguous stride; leave new_sm[j] = orig_sm[j] (unchanged).
 
@@ -1530,8 +1570,8 @@ def _resize_device_layout(orig_stl, old_host_size: list[int], new_host_size: lis
     j = ndev - 1
     if new_host_size[pstar] == 1:
         new_sm[j] = -1
-    elif orig_sm[j] == old_hs[pstar]:
-        # Contiguous stick: update inner-stick stride.
+    elif orig_sm[j] == old_hs[pstar] or orig_sm[j] == -1:
+        # Contiguous stick, or was a singleton (-1): update inner-stick stride.
         new_sm[j] = new_hs[pstar]
     # else: non-contiguous stick; leave stride unchanged.
 

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -1452,22 +1452,40 @@ def _resize_device_layout(orig_stl, old_host_size: list[int], new_host_size: lis
     # device dim match.  Prefer non-singleton host dims first (the stick normally
     # has size > 1); fall back to singleton host dims only when every unmatched
     # candidate is a singleton (e.g. a 1-element stick host dim).
+    #
+    # Special case: if all host dims were matched as non-stick dims, the stick
+    # dimension has been eliminated (e.g. reduction output).  In that case
+    # pstar is None and Passes 3 and 4 are skipped — tile-count and inner-stick
+    # device dims retain their existing (frozen) values.
     matched_p = set(matched_host.values())
     unmatched_all = [p for p in range(ndim) if p not in matched_p]
-    pstar_cands = [p for p in unmatched_all if old_host_size[p] > 1]
-    if len(pstar_cands) == 0:
-        # All unmatched host dims are size-1 singletons; the stick must be one.
-        pstar_cands = unmatched_all
-    if len(pstar_cands) != 1:
-        raise RuntimeError(
-            f"_resize_device_layout: cannot uniquely identify the stick host dim "
-            f"by elimination in {orig_stl!r} (old_host_size={old_host_size}); "
-            f"unmatched host dims={unmatched_all} "
-            f"(non-singleton candidates={pstar_cands}), "
-            f"non-stick device dims={matched_host}. "
-            f"This layout is not supported by the device-native reconstruction."
-        )
-    pstar = pstar_cands[0]
+    pstar: int | None
+    if not unmatched_all:
+        # Stick host dim eliminated (reduction output): no tile-count or
+        # inner-stick entries to update.
+        if unmatched_j:
+            raise RuntimeError(
+                f"_resize_device_layout: stick host dim is absent from "
+                f"old_host_size={old_host_size} but device dims {unmatched_j} "
+                f"could not be matched as non-stick dims in {orig_stl!r}. "
+                f"This layout is not supported by the device-native reconstruction."
+            )
+        pstar = None
+    else:
+        pstar_cands = [p for p in unmatched_all if old_host_size[p] > 1]
+        if len(pstar_cands) == 0:
+            # All unmatched host dims are size-1 singletons; the stick must be one.
+            pstar_cands = unmatched_all
+        if len(pstar_cands) != 1:
+            raise RuntimeError(
+                f"_resize_device_layout: cannot uniquely identify the stick host dim "
+                f"by elimination in {orig_stl!r} (old_host_size={old_host_size}); "
+                f"unmatched host dims={unmatched_all} "
+                f"(non-singleton candidates={pstar_cands}), "
+                f"non-stick device dims={matched_host}. "
+                f"This layout is not supported by the device-native reconstruction."
+            )
+        pstar = pstar_cands[0]
 
     # Pass 2: update device_size and (if contiguous) stride_map for non-stick dims.
     for j, p in matched_host.items():
@@ -1478,6 +1496,13 @@ def _resize_device_layout(orig_stl, old_host_size: list[int], new_host_size: lis
             # Dim p is contiguous: update stride to new contiguous value.
             new_sm[j] = new_hs[p]
         # else: non-contiguous stride; leave new_sm[j] = orig_sm[j] (unchanged).
+
+    # Passes 3 and 4 require pstar.  When the stick dim was eliminated (reduction
+    # output), pstar is None and the tile-count / inner-stick entries are frozen.
+    if pstar is None:
+        return SpyreTensorLayout(
+            new_ds, new_sm, orig_stl.device_dtype, orig_stl.element_arrangement
+        )
 
     # Pass 3: update tile-count device dims (unmatched non-singleton dims).
     for j in unmatched_j:

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -67,6 +67,8 @@ from torch._inductor.ir import (
 from torch._inductor.virtualized import V
 from torch.utils._ordered_set import OrderedSet
 
+from torch_spyre._C import SpyreTensorLayout
+
 from .constants import BATCH_MATMUL_OP
 from .logging_utils import get_inductor_logger
 from .loop_info import CoarseTileInfo
@@ -806,26 +808,39 @@ def _allocate_full_buffer(
         stride = stride * s
 
     if isinstance(orig_layout, FixedTiledLayout):
-        # Rebuild SpyreTensorLayout for the full size, preserving the
-        # within-stick dimension from the original per-tile layout.
-        orig_stl = orig_layout.device_layout
-        sm_last = int(list(orig_stl.stride_map)[-1])
-        full_strides_ints = [int(s) for s in strides]
+        # Derive the full buffer's device layout from the per-tile layout by
+        # scaling device_size entries up to the full host size.  The stick
+        # orientation (dim_order / element_arrangement) is propagated verbatim
+        # from orig_layout — both buffers must agree on physical layout so the
+        # scatter copy op computes correct device addresses.
         full_size_ints = [int(s) for s in full_ranges]
-        within_stick_dim = next(
-            (i for i, s in enumerate(full_strides_ints) if s == sm_last), None
-        )
-        if within_stick_dim is None:
-            within_stick_dim = len(full_size_ints) - 1
-        ndim = len(full_size_ints)
-        dim_order = [i for i in range(ndim) if i != within_stick_dim] + [
-            within_stick_dim
-        ]
-        from torch_spyre._C import SpyreTensorLayout
-
-        device_layout = SpyreTensorLayout(
-            full_size_ints, full_strides_ints, dtype, dim_order
-        )
+        tile_size_ints = [int(s) for s in orig_layout.size]
+        try:
+            device_layout = _resize_device_layout(
+                orig_layout.device_layout,
+                tile_size_ints,
+                full_size_ints,
+            )
+        except RuntimeError:
+            # Non-standard device layout (e.g. post-restickify HBM strides that
+            # don't correspond to contiguous host strides).  Fall back to a
+            # default row-major allocation, preserving element_arrangement.
+            logger.debug(
+                "_allocate_full_buffer: _resize_device_layout could not classify "
+                "%r (tile_size=%s full_size=%s); using row-major fallback",
+                orig_layout.device_layout,
+                tile_size_ints,
+                full_size_ints,
+            )
+            ndim_full = len(full_size_ints)
+            full_strides_ints = [int(s) for s in strides]
+            device_layout = SpyreTensorLayout(
+                full_size_ints,
+                full_strides_ints,
+                dtype,
+                list(range(ndim_full)),
+                orig_layout.device_layout.element_arrangement,
+            )
     else:
         device_layout = generic_layout(full_buf)
 
@@ -1120,7 +1135,6 @@ def _propagate_tiled_reduction_op(
         FixedTiledLayout,
         SpyreConstantFallback,
     )  # deferred: avoids circular import
-    from torch_spyre._C import SpyreTensorLayout  # deferred: avoids circular import
 
     scalar_op = SpyreConstantFallback(
         torch.ops.spyre.constant.default, float(identity), dtype, device
@@ -1360,6 +1374,147 @@ def _stamp_group(
         )
 
 
+def _resize_device_layout(orig_stl, old_host_size: list[int], new_host_size: list[int]):
+    """Return a new SpyreTensorLayout when *tiling* an existing buffer in-place.
+
+    This function handles the ``_divide_ranges`` case: the buffer is the *same*
+    physical allocation; coarse tiling just narrows the iteration range for each
+    loop iteration.  ``device_size`` entries are updated to reflect the smaller
+    per-tile extents.  ``stride_map`` entries are updated only for contiguous
+    host dims (where the physical stride follows from the host extent); for
+    non-contiguous (transposed / col-major) dims the stride is unchanged.
+
+    Classification of device dims (from ``get_generic_stick_layout``):
+
+    * **inner stick** (always ``j == ndev-1``) — ``device_size`` is always
+      ``elems_per_stick``; left unchanged.
+    * **non-stick dim** — matched to a host dim ``p`` by
+      ``device_size[j] == old_host_size[p]``.  When two host dims share the same
+      size, ``stride_map[j]`` is used as a tiebreaker against the expected
+      contiguous host stride.  ``device_size`` updated to ``new_host_size[p]``.
+      ``stride_map`` updated to the new contiguous host stride iff the current
+      ``stride_map`` equals the old contiguous host stride; otherwise unchanged
+      (the physical stride is non-contiguous and invariant to tiling).
+    * **stick tile-count** — the remaining non-singleton device dim(s) not
+      classified as non-stick.  ``device_size`` updated to
+      ``ceil(new_host_size[p*] / eps)``.  ``stride_map`` updated iff the stick
+      host dim is contiguous (same rule as for non-stick dims).
+    * **singleton** (``device_size == 1``) — never exercised; left as-is.
+
+    ``p*`` (the stick host dim) is identified by elimination: the host dim NOT
+    matched by any non-stick device dim.
+
+    ``device_dtype`` and ``element_arrangement`` are copied verbatim from
+    *orig_stl*, preserving EXX2/QFP8/DL16 layouts.
+
+    Raises ``RuntimeError`` if any non-stick device dim matches ambiguously, or
+    if the stick host dim cannot be uniquely determined by elimination.
+    """
+    from torch._inductor.ir import FlexibleLayout
+
+    orig_sm = list(orig_stl.stride_map)
+    orig_ds = list(orig_stl.device_size)
+    eps = orig_stl.elems_per_stick()
+    ndev = len(orig_sm)
+    ndim = len(old_host_size)
+
+    old_hs = [int(s) for s in FlexibleLayout.contiguous_strides(old_host_size)]
+    new_hs = [int(s) for s in FlexibleLayout.contiguous_strides(new_host_size)]
+
+    new_ds = list(orig_ds)
+    new_sm = list(orig_sm)
+
+    # Pass 1: match non-singleton, non-inner-stick device dims to host dims.
+    # Primary key: device_size[j] == old_host_size[p].
+    # When size is ambiguous (two host dims share the same size), use
+    # stride_map[j] == old_contiguous_stride[p] as a tiebreaker.
+    matched_host = {}  # j → p (non-stick matches)
+    unmatched_j = []  # device dims not matched → stick tile-count candidates
+
+    for j in range(ndev - 1):  # j == ndev-1 is always inner stick
+        dsz = orig_ds[j]
+        if dsz == 1:
+            continue  # singleton / sparse placeholder
+        size_cands = [p for p in range(ndim) if old_host_size[p] == dsz]
+        if len(size_cands) == 1:
+            matched_host[j] = size_cands[0]
+        elif len(size_cands) > 1:
+            # Tiebreak by stride_map[j] == contiguous_stride(old_host_size)[p].
+            stride_cands = [p for p in size_cands if old_hs[p] == orig_sm[j]]
+            if len(stride_cands) == 1:
+                matched_host[j] = stride_cands[0]
+            else:
+                unmatched_j.append(j)  # ambiguous even with stride
+        else:
+            unmatched_j.append(j)  # no size match → stick tile-count
+
+    # Identify pstar by elimination: the host dim not claimed by any non-stick
+    # device dim match.  Prefer non-singleton host dims first (the stick normally
+    # has size > 1); fall back to singleton host dims only when every unmatched
+    # candidate is a singleton (e.g. a 1-element stick host dim).
+    matched_p = set(matched_host.values())
+    unmatched_all = [p for p in range(ndim) if p not in matched_p]
+    pstar_cands = [p for p in unmatched_all if old_host_size[p] > 1]
+    if len(pstar_cands) == 0:
+        # All unmatched host dims are size-1 singletons; the stick must be one.
+        pstar_cands = unmatched_all
+    if len(pstar_cands) != 1:
+        raise RuntimeError(
+            f"_resize_device_layout: cannot uniquely identify the stick host dim "
+            f"by elimination in {orig_stl!r} (old_host_size={old_host_size}); "
+            f"unmatched host dims={unmatched_all} "
+            f"(non-singleton candidates={pstar_cands}), "
+            f"non-stick device dims={matched_host}. "
+            f"This layout is not supported by the device-native reconstruction."
+        )
+    pstar = pstar_cands[0]
+
+    # Pass 2: update device_size and (if contiguous) stride_map for non-stick dims.
+    for j, p in matched_host.items():
+        new_ds[j] = new_host_size[p]
+        if new_host_size[p] == 1:
+            new_sm[j] = -1
+        elif orig_sm[j] == old_hs[p]:
+            # Dim p is contiguous: update stride to new contiguous value.
+            new_sm[j] = new_hs[p]
+        # else: non-contiguous stride; leave new_sm[j] = orig_sm[j] (unchanged).
+
+    # Pass 3: update tile-count device dims (unmatched non-singleton dims).
+    for j in unmatched_j:
+        expected_tc = -(-old_host_size[pstar] // eps)  # ceil
+        if orig_ds[j] != expected_tc:
+            raise RuntimeError(
+                f"_resize_device_layout: device dim {j} "
+                f"(stride_map={orig_sm[j]}, device_size={orig_ds[j]}) was not "
+                f"matched as a non-stick dim and does not equal the expected "
+                f"tile-count {expected_tc} for stick host dim {pstar} "
+                f"(old_host_size={old_host_size}) in {orig_stl!r}. "
+                f"This layout is not supported by the device-native reconstruction."
+            )
+        new_ds[j] = -(-new_host_size[pstar] // eps)  # ceil
+        # Update stride_map if the stick host dim is contiguous.
+        if new_host_size[pstar] == 1:
+            new_sm[j] = -1
+        elif orig_sm[j] == eps * old_hs[pstar] or orig_sm[j] == -1:
+            # stick host dim is contiguous (stride_map == eps * contiguous_stride[p*])
+            # or was a singleton (-1); update to eps * new contiguous stride.
+            new_sm[j] = eps * new_hs[pstar]
+        # else: non-contiguous; leave stride unchanged.
+
+    # Pass 4: inner stick (j == ndev-1) — update stride only.
+    j = ndev - 1
+    if new_host_size[pstar] == 1:
+        new_sm[j] = -1
+    elif orig_sm[j] == old_hs[pstar]:
+        # Contiguous stick: update inner-stick stride.
+        new_sm[j] = new_hs[pstar]
+    # else: non-contiguous stick; leave stride unchanged.
+
+    return SpyreTensorLayout(
+        new_ds, new_sm, orig_stl.device_dtype, orig_stl.element_arrangement
+    )
+
+
 def _divide_ranges(
     op: ComputedBuffer,
     loop_count: Expr,
@@ -1442,29 +1597,21 @@ def _divide_ranges(
     _clear_cache(layout, _LAYOUT_FREE_SYMS_KEY)
     _clear_cache(op, _COMPUTED_BUF_FREE_SYMS_KEY)
 
-    # Rebuild SpyreTensorLayout for the new host size, preserving the
-    # within-stick dimension.  stride_map[-1] is the element stride of the
-    # within-stick host dimension in the original layout; match it against the
-    # new contiguous strides to identify which host dim remains the stick dim.
+    # Rebuild SpyreTensorLayout for the new host size using device-native
+    # reconstruction: transform the original device layout directly without
+    # guessing a dim_order.
     if not isinstance(layout, FixedTiledLayout):
         return
-    orig_stl = layout.device_layout
-    sm_last = int(list(orig_stl.stride_map)[-1])
-    new_strides_ints = [int(s) for s in layout.stride]
+    # Capture old/new sizes as ints here, after the FixedTiledLayout guard,
+    # so symbolic-size FixedLayout tests above are not affected.
+    # layout.size is already the new (divided) size; reconstruct the old size
+    # by multiplying tiled dims back up: old[i] = new[i] * loop_count.
+    old_host_size = [int(s) for s in layout.size]
+    for i in tiled_dims:
+        old_host_size[i] = int(new_size[i] * loop_count)
     new_size_ints = [int(s) for s in new_size]
-    within_stick_dim = next(
-        (i for i, s in enumerate(new_strides_ints) if s == sm_last), None
-    )
-    if within_stick_dim is None:
-        # Fall back to last dim (covers the common contiguous fp16 case where
-        # sm_last == 1 and the last stride is also 1).
-        within_stick_dim = len(new_size_ints) - 1
-    ndim = len(new_size_ints)
-    dim_order = [i for i in range(ndim) if i != within_stick_dim] + [within_stick_dim]
-    from torch_spyre._C import SpyreTensorLayout
-
-    layout.device_layout = SpyreTensorLayout(
-        new_size_ints, new_strides_ints, layout.dtype, dim_order
+    layout.device_layout = _resize_device_layout(
+        layout.device_layout, old_host_size, new_size_ints
     )
 
 

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1170,6 +1170,9 @@ def lower_pad_sequence(
 
     # Step 2 — identify the within-stick host dim in the view (which may include
     # phantom leading dims) by matching the within-stick element stride.
+    # TODO: replace this sm_last heuristic with _resize_device_layout from
+    # coarse_tile.py (device-native reconstruction that handles transposed and
+    # non-contiguous layouts without guessing from stride_map[-1]).
     sm_last = int(list(orig_stl.stride_map)[-1])
     orig_host_stride = list(arg_fx_node.meta["val"].stride())
     within_stick_dim_view = next(


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes two sites in `coarse_tile.py` that re-derive the within-stick host
dimension using a fragile heuristic: matching `stride_map[-1]` against
freshly-computed contiguous host strides to guess a `dim_order`, then
rebuilding the `SpyreTensorLayout` from scratch.

**Bug 1 — misidentified stick dim for transposed layouts.**
For a `[256, 128]` buffer with `dim_order=[1, 0]` (stick on dim 0, as produced
by `model_utils.py` for transposed Linear weights), tiling the non-stick dim
gives:

| | `device_size` | `stride_map` |
|---|---|---|
| Correct | `[4, 64, 64]` | `[4096, 1, 64]` |
| Old heuristic | `[1, 256, 64]` | `[64, 64, 1]` |

**Bug 2 — silent drop of `element_arrangement`.**
The old reconstruction used the 4-arg `SpyreTensorLayout(size, strides, dtype,
dim_order)` constructor, which always defaults `element_arrangement` to
`STANDARD`. This silently corrupted EXX2/QFP8/DL16 layouts.

**Fix — device-native reconstruction via `_resize_device_layout`.**
A new helper derives the updated layout directly from the original
`SpyreTensorLayout` without guessing a `dim_order`:

1. Match non-stick device dims to host dims by `device_size[j] == old_host_size[p]`
   (with a contiguous-stride tiebreaker for ambiguous sizes).
2. Identify the stick host dim `p*` by elimination (the unmatched remainder).
3. Update `device_size` and `stride_map` for each classified dim; leave
   non-contiguous strides unchanged.
4. Copy `device_dtype` and `element_arrangement` verbatim.

Raises `RuntimeError` for layouts that cannot be classified unambiguously
rather than silently producing a wrong result. `_allocate_full_buffer` catches
this for non-standard HBM layouts (e.g. post-restickify buffers) and falls
back to a row-major allocation with a DEBUG log.

Also adds a TODO comment in `pass_utils.py:lower_pad_sequence` at the
analogous `sm_last`-matching site, flagging it as a follow-up candidate for
the same fix.

#### Which issue(s) this PR is related to:

part of #1358 

#### Special notes for your reviewer:

- `_resize_device_layout` is placed after `_stamp_group` and before
  `_divide_ranges` in the file — it is only called from those two sites.
- The `_allocate_full_buffer` fallback path (row-major for post-restickify
  layouts) preserves existing behavior for `test_hint_restickify_stays_in_group`.
  That test only verifies generated source structure (LoopSpec presence), not
  data correctness; the correctness of the fallback for that case is a
  pre-existing open question noted in `pass_utils.py` TODO.
- `pass_utils.py:lower_pad_sequence` has the same `sm_last` pattern with a
  `raise RuntimeError` on no-match (already fail-loud). It is left as a
  follow-up; the TODO comment is the only change to that file.

#### Does this PR introduce a user-facing change?

No — internal compiler pass only. Models compiled with `spyre_hint` that
involve transposed-stick buffers or non-STANDARD `element_arrangement` will now
produce correct tiled layouts; previously they would have silently compiled with
a wrong device layout.

#### Additional note:

The `_resize_device_layout` algorithm was verified by unit tests covering:

- Transposed-stick layout (`[256, 128]`, `dim_order=[1, 0]`) — headline regression
- `element_arrangement` preservation (EXX2)
- Stride-collision case (`[2, 2, 2, 16]` where a non-stick stride equals the
  tile-count stride)
- Fail-loud path (ambiguous `pstar` → `RuntimeError`)