### PR TITLE
[FEAT] Adopt FillDMA for all PyTorch fill APIs

### DIFF
--- a/torch_spyre/_C.pyi
+++ b/torch_spyre/_C.pyi
@@ -21,6 +21,7 @@ __all__: list[str] = [
     "as_strided_with_layout",
     "empty_with_layout",
     "copy_tensor",
+    "fill_tensor",
     "encode_constant",
     "free_runtime",
     "get_device_dtype",
@@ -287,6 +288,16 @@ def copy_tensor(
 
     Args:
         self or dst: one of that must be on spyre device
+    """
+    ...
+
+def fill_tensor(self: torch.Tensor, value: float) -> torch.Tensor:
+    """
+    Fill a spyre tensor with a scalar value using device-side FillDMA.
+
+    Args:
+        self: the spyre tensor to fill (in-place)
+        value: the fill value (converted to the tensor's dtype pattern)
     """
     ...
 

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -339,6 +339,11 @@ PYBIND11_MODULE(_C, m) {
         "Copy tensor between host and device using DMA", py::arg("self"),
         py::arg("dst"), py::arg("non_blocking") = false);
 
+  // Device-side fill using FillDMA (no host buffer or H2D copy)
+  m.def("fill_tensor", &spyre::spyre_fill_tensor,
+        "Fill a spyre tensor with a scalar value using device-side FillDMA",
+        py::arg("self"), py::arg("value"));
+
   // Stream management functions
   m.def("get_stream_from_pool", &spyre::getStreamFromPool, py::arg("device"),
         py::arg("priority") = 0,

--- a/torch_spyre/csrc/module.h
+++ b/torch_spyre/csrc/module.h
@@ -52,6 +52,7 @@ class GlobalRuntime {
 };
 bool get_downcast_warn_enabled();
 bool is_supported_dtype(c10::ScalarType dtype);
+DataFormats get_device_dtype(c10::ScalarType torch_dtype);
 
 int device_count();
 void startRuntime();

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -769,6 +769,28 @@ const at::Tensor& spyre_resize_(
   return self;
 }
 
+at::Tensor spyre_fill_tensor(const at::Tensor& self, double value) {
+  TORCH_CHECK(self.is_privateuseone(), "spyre_fill_tensor: tensor must be on spyre device");
+  TORCH_CHECK(self.numel() > 0, "spyre_fill_tensor: cannot fill empty tensor");
+
+  // Get the device allocation (CompositeAddress) from the spyre tensor
+  auto* spyre_impl = static_cast<SpyreTensorImpl*>(self.unsafeGetTensorImpl());
+  auto& storage = spyre_impl->storage();
+  auto* ctx = static_cast<SharedOwnerCtx*>(storage.data_ptr().get_context());
+
+  // Map torch dtype to DataFormats for the fill pattern conversion
+  DataFormats dtype = get_device_dtype(self.scalar_type());
+
+  // Construct FillParams and launch via SpyreStream
+  flex::FillParams params(&ctx->composite_addr, ctx->composite_addr.total_size(),
+                          flex::RuntimeOperationFill::valueToFillPattern(value, dtype),
+                          /*use_dmai=*/true);
+  SpyreStream stream;
+  stream.launchFill(&params);
+
+  return self;
+}
+
 TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
   m.impl("empty.memory_format", TORCH_FN(spyre_empty));
   m.impl("empty_strided", TORCH_FN(spyre_empty_strided));

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -770,7 +770,8 @@ const at::Tensor& spyre_resize_(
 }
 
 at::Tensor spyre_fill_tensor(const at::Tensor& self, double value) {
-  TORCH_CHECK(self.is_privateuseone(), "spyre_fill_tensor: tensor must be on spyre device");
+  TORCH_CHECK(self.is_privateuseone(),
+              "spyre_fill_tensor: tensor must be on spyre device");
   TORCH_CHECK(self.numel() > 0, "spyre_fill_tensor: cannot fill empty tensor");
 
   // Get the device allocation (CompositeAddress) from the spyre tensor
@@ -782,9 +783,10 @@ at::Tensor spyre_fill_tensor(const at::Tensor& self, double value) {
   DataFormats dtype = get_device_dtype(self.scalar_type());
 
   // Construct FillParams and launch via SpyreStream
-  flex::FillParams params(&ctx->composite_addr, ctx->composite_addr.total_size(),
-                          flex::RuntimeOperationFill::valueToFillPattern(value, dtype),
-                          /*use_dmai=*/true);
+  flex::FillParams params(
+      &ctx->composite_addr, ctx->composite_addr.total_size(),
+      flex::RuntimeOperationFill::valueToFillPattern(value, dtype),
+      /*use_dmai=*/true);
   SpyreStream stream;
   stream.launchFill(&params);
 

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -779,16 +779,13 @@ at::Tensor spyre_fill_tensor(const at::Tensor& self, double value) {
   auto& storage = spyre_impl->storage();
   auto* ctx = static_cast<SharedOwnerCtx*>(storage.data_ptr().get_context());
 
-  // Map torch dtype to DataFormats for the fill pattern conversion
+  // Map torch dtype to DataFormats for the value->pattern conversion, which
+  // fillAsync performs internally.
   DataFormats dtype = get_device_dtype(self.scalar_type());
 
-  // Construct FillParams and launch via SpyreStream
-  flex::FillParams params(
-      &ctx->composite_addr, ctx->composite_addr.total_size(),
-      flex::RuntimeOperationFill::valueToFillPattern(value, dtype),
-      /*use_dmai=*/true);
+  // Launch a device-side MEMORY_FILL DMA via the typed fillAsync overload.
   SpyreStream stream;
-  stream.launchFill(&params);
+  stream.fillAsync(&ctx->composite_addr, value, dtype, /*use_dmai=*/true);
 
   return self;
 }

--- a/torch_spyre/csrc/spyre_mem.h
+++ b/torch_spyre/csrc/spyre_mem.h
@@ -32,6 +32,19 @@ at::Tensor spyre_empty_strided(c10::IntArrayRef size, c10::IntArrayRef stride,
 at::Tensor spyre_copy_from(const at::Tensor& self, const at::Tensor& dst,
                            bool non_blocking);
 
+/**
+ * Fill a spyre tensor with a scalar value using device-side FillDMA.
+ *
+ * Uses flex::RuntimeStream::fillAsync() to perform the fill entirely
+ * on-device without allocating a host buffer or performing an H2D DMA.
+ *
+ * @param self The spyre tensor to fill (in-place)
+ * @param value The fill value as a double (converted to the correct hardware
+ *              pattern based on the tensor's dtype)
+ * @return The filled tensor (same as self)
+ */
+at::Tensor spyre_fill_tensor(const at::Tensor& self, double value);
+
 class SpyreTensorLayout;
 at::Tensor spyre_empty_with_layout(c10::IntArrayRef size,
                                    c10::IntArrayRef stride,

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -226,6 +226,10 @@ void SpyreStream::launchHostCallback(flex::HostCallbackParams* params) const {
   resolveRuntimeHandle()->launchOperationHostCallback(params);
 }
 
+void SpyreStream::launchFill(flex::FillParams* params) const {
+  resolveRuntimeHandle()->launchOperationFill(params);
+}
+
 void SpyreStream::launch(const JobPlan& plan,
                          const std::vector<at::Tensor>& args) const {
   // Validate all tensors are on Spyre device

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -226,8 +226,9 @@ void SpyreStream::launchHostCallback(flex::HostCallbackParams* params) const {
   resolveRuntimeHandle()->launchOperationHostCallback(params);
 }
 
-void SpyreStream::launchFill(flex::FillParams* params) const {
-  resolveRuntimeHandle()->launchOperationFill(params);
+void SpyreStream::fillAsync(const flex::CompositeAddress* dst, double value,
+                            DataFormats dtype, bool use_dmai) const {
+  resolveRuntimeHandle()->fillAsync(dst, value, dtype, use_dmai);
 }
 
 void SpyreStream::launch(const JobPlan& plan,

--- a/torch_spyre/csrc/spyre_stream.h
+++ b/torch_spyre/csrc/spyre_stream.h
@@ -59,7 +59,11 @@ class SpyreStream {
   void launchD2H(flex::DmaParams* params) const;
   void launchCompute(flex::ComputeParams* params) const;
   void launchHostCallback(flex::HostCallbackParams* params) const;
-  void launchFill(flex::FillParams* params) const;
+  // Device-side MEMORY_FILL DMA. Routes through the typed
+  // flex::RuntimeStream::fillAsync overload, which performs the value->pattern
+  // conversion internally (no FillParams construction here).
+  void fillAsync(const flex::CompositeAddress* dst, double value,
+                 DataFormats dtype, bool use_dmai) const;
 
   // Conversions
   c10::Stream unwrap() const;

--- a/torch_spyre/csrc/spyre_stream.h
+++ b/torch_spyre/csrc/spyre_stream.h
@@ -59,6 +59,7 @@ class SpyreStream {
   void launchD2H(flex::DmaParams* params) const;
   void launchCompute(flex::ComputeParams* params) const;
   void launchHostCallback(flex::HostCallbackParams* params) const;
+  void launchFill(flex::FillParams* params) const;
 
   // Conversions
   c10::Stream unwrap() const;

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -129,8 +129,7 @@ register_torch_compile_kernel(
 def spyre__fill_scalar(
     self: torch.Tensor, other: int | float | bool | complex
 ) -> torch.Tensor:
-    tmp = torch.ones(self.size(), dtype=self.dtype) * other
-    self.copy_(tmp)
+    torch_spyre._C.fill_tensor(self, float(other))
     return self
 
 
@@ -149,12 +148,8 @@ def spyre__normal_(self, mean=0.0, std=1.0, *, generator=None):
 
 @torch.library.register_kernel("aten::zero_", ["spyre"])  # type:ignore
 def spyre__zero_(self: torch.Tensor) -> torch.Tensor:
-    """Zero out the tensor in-place."""
-    # Create zeros on CPU
-    tmp = torch.zeros(self.size(), dtype=self.dtype, device="cpu")
-    # Copy to device
-    self.copy_(tmp)
-    # TODO: Can we zero out tensors in-place without copy
+    """Zero out the tensor in-place using device-side FillDMA."""
+    torch_spyre._C.fill_tensor(self, 0.0)
     return self
 
 

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -133,6 +133,39 @@ def spyre__fill_scalar(
     return self
 
 
+@torch.library.register_kernel("aten::full", ["spyre"])  # type:ignore
+def spyre_full(
+    size: list | tuple,
+    fill_value: int | float | bool | complex,
+    *,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
+) -> torch.Tensor:
+    assert layout in (torch.strided, None), f"doesn't support layout={layout}"
+    assert not pin_memory, f"doesn't support pin_memory={pin_memory}"
+    t = torch.empty(size, dtype=dtype, device=device)
+    torch_spyre._C.fill_tensor(t, float(fill_value))
+    return t
+
+
+@torch.library.register_kernel("aten::ones", ["spyre"])  # type:ignore
+def spyre_ones(
+    size: list | tuple,
+    *,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
+) -> torch.Tensor:
+    assert layout in (torch.strided, None), f"doesn't support layout={layout}"
+    assert not pin_memory, f"doesn't support pin_memory={pin_memory}"
+    t = torch.empty(size, dtype=dtype, device=device)
+    torch_spyre._C.fill_tensor(t, 1.0)
+    return t
+
+
 @torch.library.register_kernel("aten::normal_", ["spyre"])  # type:ignore
 def spyre__normal_(self, mean=0.0, std=1.0, *, generator=None):
     # "normal_" generates a random tensor, thus copying

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -129,6 +129,8 @@ register_torch_compile_kernel(
 def spyre__fill_scalar(
     self: torch.Tensor, other: int | float | bool | complex
 ) -> torch.Tensor:
+    if isinstance(other, complex):
+        raise TypeError("spyre fill_ does not support complex fill values")
     torch_spyre._C.fill_tensor(self, float(other))
     return self
 
@@ -145,6 +147,8 @@ def spyre_full(
 ) -> torch.Tensor:
     assert layout in (torch.strided, None), f"doesn't support layout={layout}"
     assert not pin_memory, f"doesn't support pin_memory={pin_memory}"
+    if isinstance(fill_value, complex):
+        raise TypeError("spyre full does not support complex fill values")
     t = torch.empty(size, dtype=dtype, device=device)
     torch_spyre._C.fill_tensor(t, float(fill_value))
     return t


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Replaces the CPU-allocate + H2D-copy path with a device-side `MEMORY_FILL`
DMA (FillDMA) for the PyTorch fill APIs: `fill_`, `zero_`, `torch.full`,
`torch.zeros`, and `torch.ones`.

Previously these ops materialized the fill pattern in a host buffer and then
transferred it to the device with an H2D copy (e.g. `torch.ones(...) * other`
followed by `self.copy_(tmp)`). This PR eliminates the host buffer allocation
and the DMA transfer entirely — the hardware writes the 32-bit fill pattern
directly into device memory.

Additionally, `torch.full` and `torch.ones` are now registered as **eager**
kernels (`empty` + `fill_tensor`) instead of being routed through
`torch.compile` into an SBF compute kernel.

#### Which issue(s) this PR is related to:

Issue #1978.

#### Special notes for your reviewer:


- `spyre_fill_tensor()` guards against non-spyre tensors and empty tensors
  (`numel() == 0`) via `TORCH_CHECK`.
- The fill value is passed as a `double` and converted to the correct
  hardware pattern based on the tensor's dtype through
  `RuntimeOperationFill::valueToFillPattern(value, dtype)`.
- `torch.full` / `torch.ones` kernels assert `layout in (torch.strided, None)`
  and reject `pin_memory`, matching the supported eager semantics.

#### Does this PR introduce a user-facing change?


No behavioral change for users. Fill operations produce the same results but
now execute via a device-side DMA instead of a host round-trip, avoiding a
host buffer allocation and an H2D copy per fill. `torch.full` and
`torch.ones` no longer trigger a `torch.compile` path.

#### Additional note:

This depends on a PR in Flex.