### PR TITLE
enable symbolic args by default

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -3287,6 +3287,10 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         self.assertEqual(
             mlir.count("!sdscbundle.input_arg<index>"), 2
         )  # param + extract
+        # Both sdsc_execute ops reference the canonical extracted name %arg_0
+        execute_lines = [ln for ln in mlir.splitlines() if "sdsc_execute" in ln]
+        self.assertEqual(execute_lines[0].split("(")[1].split(")")[0], "%arg_0")
+        self.assertEqual(execute_lines[1].split("(")[1].split(")")[0], "%arg_0")
 
     def test_pool_offset_constants_deduped(self):
         """Pool symbols with the same offset share one arith.addi SSA variable."""

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1516,9 +1516,7 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
         )
         self.assertEqual(len(symbols), 2)
         self.assertEqual(symbols[0], 0)  # kernel sentinel = arg_index = 0
-        self.assertEqual(
-            symbols[1], 0 + 128
-        )  # core-1 derived = sentinel + per-core stride
+        self.assertEqual(symbols[1], 128)  # core-1 derived = sentinel + per-core stride
         # affine_strides[0] = [{s: stride}] (one level, one tensor)
         self.assertIn(s, affine_strides[0][0])
 

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1388,8 +1388,9 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
 
     def test_tiled_tensor_base_address_registered(self):
         s = Symbol("s")
-        start = 0x2000
-        sdsc_spec = _make_sdsc_spec(s, start_address=start)
+        # On the symbolic path start_address is set to arg_index (0) as a sentinel.
+        # The raw base stored in symbols[] is the sentinel, not a real HBM address.
+        sdsc_spec = _make_sdsc_spec(s, start_address=0)
         symbols: list[int] = []
         generate_sdsc(
             0,
@@ -1400,7 +1401,7 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             use_symbols=True,
         )
         self.assertEqual(len(symbols), 1)
-        self.assertEqual(symbols[0], start)
+        self.assertEqual(symbols[0], 0)  # kernel sentinel = arg_index = 0
 
     def test_tiled_tensor_json_stores_symbol_id(self):
         s = Symbol("s")
@@ -1473,6 +1474,9 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
     def test_multi_core_tiled_per_core_symbols(self):
         s = Symbol("s")
         core_id = Symbol("core_id")
+        # On the symbolic path start_address = arg_index (0) as a sentinel; the
+        # loop unroller advances it by tile_offset_bytes for later tiles.  For tile 0
+        # start_address == arg_index == 0.
         tensor = SDSCArgs(
             layout="A",
             dim_order=[s],
@@ -1481,8 +1485,8 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             strides={s: 128},
             offsets={s: 0},
             max_dim_sizes={s: -1},
-            allocation={"hbm": 0x1000},
-            start_address=0x1000,
+            allocation={"hbm": 0},
+            start_address=0,
             backGap={},
             arg_index=0,
         )
@@ -1511,8 +1515,10 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             use_symbols=True,
         )
         self.assertEqual(len(symbols), 2)
-        self.assertEqual(symbols[0], 0x1000)
-        self.assertEqual(symbols[1], 0x1000 + 128)
+        self.assertEqual(symbols[0], 0)  # kernel sentinel = arg_index = 0
+        self.assertEqual(
+            symbols[1], 0 + 128
+        )  # core-1 derived = sentinel + per-core stride
         # affine_strides[0] = [{s: stride}] (one level, one tensor)
         self.assertIn(s, affine_strides[0][0])
 
@@ -3367,6 +3373,7 @@ class TestSymbolKind(unittest.TestCase):
 
         # Mirror the existing TestGenerateSdscTiledSymbols multi-core test but
         # with arg_index=0 to exercise the kernel/kernel_derived kind path.
+        # Use sym-path sentinel convention: start_address = arg_index = 0 for tile 0.
         tensor = SDSCArgs(
             layout="A",
             dim_order=[s],
@@ -3375,8 +3382,8 @@ class TestSymbolKind(unittest.TestCase):
             strides={s: 128},
             offsets={s: 0},
             max_dim_sizes={s: -1},
-            allocation={"hbm": 0x1000},
-            start_address=0x1000,
+            allocation={"hbm": 0},
+            start_address=0,
             backGap={},
             arg_index=0,  # kernel arg → kinds should be kernel + kernel_derived
         )

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -324,6 +324,7 @@ def _make_sdsc_spec(
         allocation=allocation,
         start_address=start_address,
         backGap={},
+        arg_index=0,
     )
     return SDSCSpec(
         opfunc="add",
@@ -1483,6 +1484,7 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             allocation={"hbm": 0x1000},
             start_address=0x1000,
             backGap={},
+            arg_index=0,
         )
         sdsc_spec = SDSCSpec(
             opfunc="add",

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -3162,35 +3162,32 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         self.assertIn("sdsc_execute () {sdsc_filename=", mlir)
 
     def test_multi_sdsc_two_tensor_args_snapshot(self):
-        """Two tensor args on first op; remaining ops use arith.constant symbols."""
+        """Two tensor args shared across multiple SDSCs emit exactly two input_arg params.
+
+        Simulates a bundle where every SDSC operates on the same two logical
+        kernel tensors (arg_index 0 and 1) but at different per-SDSC addresses.
+        Only two function parameters should be emitted — one per unique arg_index.
+        """
         op0 = self._make_op_spec_with_hbm_args("op0", [0, 1])
         ops_rest = [_make_minimal_op_spec(f"op{i}") for i in range(1, 5)]
         call_count = [0]
-        # sym values: first two are tensor args, rest are intermediates
-        sym_values = [
-            0x400000000,
-            0x800000000,  # op0: tensor args
-            0x0,
-            0x400000000,
-            0x800000000,  # op1
-            0x800000000,
-            0xC00000000,  # op2
-            0xC00000000,
-            0x1000000000,  # op3
-            0xC00000000,
-            0x1000000000,
-            0x1400000000,  # op4
+        # Each SDSC registers 2 kernel-arg symbols for arg_index 0 and 1 at
+        # different per-SDSC addresses (simulating different tile slices).
+        sdsc_addr_pairs = [
+            (0x400000000, 0x800000000),
+            (0x400010000, 0x800010000),
+            (0x400020000, 0x800020000),
+            (0x400030000, 0x800030000),
+            (0x400040000, 0x800040000),
         ]
-        sym_counts = [2, 3, 2, 2, 3]
 
         def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             i = call_count[0]
             call_count[0] += 1
-            n = sym_counts[i]
-            start = sum(sym_counts[:i])
-            local_ids = [-(symbol_id_offset + j + 1) for j in range(n)]
-            for v in sym_values[start : start + n]:
-                symbols.append(v)
+            a0, a1 = sdsc_addr_pairs[i]
+            local_ids = [-(symbol_id_offset + 1), -(symbol_id_offset + 2)]
+            symbols.append(a0)
+            symbols.append(a1)
             json_out = {
                 f"{idx}_{op_spec.op}": {
                     "numCoresUsed_": 1,
@@ -3204,37 +3201,26 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                                             "data_": {"[0, 0, 0]": str(local_ids[j])}
                                         },
                                     }
-                                    for j in range(n)
+                                    for j in range(2)
                                 ]
                             }
                         }
                     ],
                 }
             }
-            # All symbols are kernel args; use the running symbol index as arg_index
-            # so each unique value produces a distinct input_arg param.
-            sym_start = sum(sym_counts[:i])
-            symbol_kind_flags = [SymbolKind.kernel(sym_start + j) for j in range(n)]
-            return (
-                json_out,
-                sym_values[start : start + n],
-                [{} for _ in range(n)],
-                symbol_kind_flags,
-            )
+            # Both tensors have the same arg_index across all SDSCs.
+            kinds = [SymbolKind.kernel(0), SymbolKind.kernel(1)]
+            return json_out, [a0, a1], [{}, {}], kinds
 
         mlir = self._bundle([op0] + ops_rest, symbolic_args=True, fake_compile=fake)
 
-        # 12 symbols with 6 unique values → 6 unique params
-        # Param names derive from arg_index (= symbol position in sym_values list)
+        # 10 symbols across 5 SDSCs but only 2 unique arg_indices → 2 params
         self.assertIn("%arg_0_base_addr: !sdscbundle.input_arg<index>", mlir)
         self.assertIn("%arg_1_base_addr: !sdscbundle.input_arg<index>", mlir)
-        # There are exactly 6 input_arg params (each appears twice: param + extract)
-        self.assertEqual(mlir.count("!sdscbundle.input_arg<index>"), 6 * 2)
+        # Exactly 2 input_arg params (each appears twice: param + extract)
+        self.assertEqual(mlir.count("!sdscbundle.input_arg<index>"), 2 * 2)
         # First sdsc_execute uses first two extracted names
         self.assertIn("sdscbundle.sdsc_execute (%arg_0, %arg_1)", mlir)
-        # Duplicate addresses reuse existing extracted SSA names
-        self.assertNotIn("arith.constant", mlir)
-        self.assertNotIn("%pool:", mlir)
 
     def test_same_kernel_arg_across_sdsc_deduped(self):
         """The same kernel arg address appearing in two SDSCs maps to one input_arg param."""
@@ -3259,6 +3245,42 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         execute_lines = [ln for ln in mlir.splitlines() if "sdsc_execute" in ln]
         self.assertEqual(execute_lines[0].split("(")[1].split(")")[0], "%arg_0")
         self.assertEqual(execute_lines[1].split("(")[1].split(")")[0], "%arg_0")
+
+    def test_same_arg_index_different_addresses_deduped(self):
+        """Two SDSCs with the same arg_index but different addresses emit one param.
+
+        Simulates a tiled kernel where each SDSC operates on a different slice
+        of the same tensor (arg_index=0 at addr0 in op0, addr1 in op1).  The
+        function signature must not repeat %arg_0_base_addr.
+        """
+        a = _make_minimal_op_spec("a")
+        b = _make_minimal_op_spec("b")
+        addr0 = 0x400000000
+        addr1 = 0x400010000  # different address, same logical arg_index=0
+        addrs = [addr0, addr1]
+        call_count = [0]
+
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+            i = call_count[0]
+            call_count[0] += 1
+            sym_id = -(symbol_id_offset + 1)
+            symbols.append(addrs[i])
+            return (
+                _make_tiled_json(idx, sym_id),
+                [addrs[i]],
+                [{}],
+                [SymbolKind.kernel(0)],
+            )
+
+        mlir = self._bundle([a, b], symbolic_args=True, fake_compile=fake)
+
+        # Only one input_arg param — no duplicate %arg_0_base_addr
+        self.assertEqual(
+            mlir.count("%arg_0_base_addr: !sdscbundle.input_arg<index>"), 1
+        )
+        self.assertEqual(
+            mlir.count("!sdscbundle.input_arg<index>"), 2
+        )  # param + extract
 
     def test_pool_offset_constants_deduped(self):
         """Pool symbols with the same offset share one arith.addi SSA variable."""

--- a/tests/inductor/test_codegen.py
+++ b/tests/inductor/test_codegen.py
@@ -210,8 +210,9 @@ class TestSpyreConfig(InductorTestCase):
         """An inplace op (x *= 2) must not pass the same tensor twice to .run().
 
         With symbolic args, the MLIR bundle emits one input_arg param per unique
-        tensor.  Passing arg0_1 twice causes a "Number of inputs mismatches"
-        error in processComputeOnHostCommand at launch time.
+        tensor.  Passing arg0_1 twice would cause a "Number of inputs mismatches"
+        error at launch time.  This test verifies the generated .run() call
+        contains no duplicate tensor arguments.
         """
 
         def fn(x):

--- a/tests/inductor/test_codegen.py
+++ b/tests/inductor/test_codegen.py
@@ -206,7 +206,6 @@ class TestSpyreConfig(InductorTestCase):
             )
         self.assertIn("symbolic stick dim", str(cm.exception))
 
-
     def test_inplace_op_run_call_deduplicates_args(self):
         """An inplace op (x *= 2) must not pass the same tensor twice to .run().
 

--- a/tests/inductor/test_codegen.py
+++ b/tests/inductor/test_codegen.py
@@ -207,6 +207,36 @@ class TestSpyreConfig(InductorTestCase):
         self.assertIn("symbolic stick dim", str(cm.exception))
 
 
+    def test_inplace_op_run_call_deduplicates_args(self):
+        """An inplace op (x *= 2) must not pass the same tensor twice to .run().
+
+        With symbolic args, the MLIR bundle emits one input_arg param per unique
+        tensor.  Passing arg0_1 twice causes a "Number of inputs mismatches"
+        error in processComputeOnHostCommand at launch time.
+        """
+
+        def fn(x):
+            x *= 2
+            return x
+
+        x = torch.randn((4, 128), dtype=torch.float16, device="spyre")
+        cfn = torch.compile(fn)
+        _, source_codes = run_and_get_code(cfn, x)
+        code = source_codes[0]
+        # Find the .run(...) call for the fused kernel
+        run_lines = [ln.strip() for ln in code.splitlines() if ".run(" in ln]
+        self.assertTrue(run_lines, "No .run(...) call found in generated code")
+        for line in run_lines:
+            # Extract the argument list between the outermost parentheses
+            args_str = line[line.index("(") + 1 : line.rindex(")")]
+            args = [a.strip() for a in args_str.split(",")]
+            self.assertEqual(
+                len(args),
+                len(set(args)),
+                f"Duplicate args in .run() call: {line}",
+            )
+
+
 class TestResolveSdscSize(InductorTestCase):
     """Unit tests for superdsc._resolve_sdsc_size."""
 

--- a/tests/test_launch_jobplan.py
+++ b/tests/test_launch_jobplan.py
@@ -53,18 +53,27 @@ def _run_compiled_op(op_name: str, symbolic_args: bool) -> None:
 
     cpu_result = op_fn(*inputs)
 
-    old_val = os.environ.get("DUMP_SPYRE_CODE")
+    old_dump = os.environ.get("DUMP_SPYRE_CODE")
+    old_sym = os.environ.get("BUNDLE_SYMBOLIC_ARGS")
     try:
         os.environ["DUMP_SPYRE_CODE"] = "1"
+        # Keep the C++ prepare_kernel env var in sync with the Python config
+        # patch: prepare_kernel reads BUNDLE_SYMBOLIC_ARGS directly from the
+        # process environment, so patching only the Python config is insufficient.
+        os.environ["BUNDLE_SYMBOLIC_ARGS"] = "1" if symbolic_args else "0"
         with _spyre_config.patch(bundle_symbolic_args=symbolic_args):  # type: ignore[attr-defined]
             compiled_fn = torch.compile(op_fn, backend="inductor")
             spyre_inputs = tuple(inp.to("spyre") for inp in inputs)
             spyre_result = compiled_fn(*spyre_inputs).cpu()
     finally:
-        if old_val is None:
+        if old_dump is None:
             os.environ.pop("DUMP_SPYRE_CODE", None)
         else:
-            os.environ["DUMP_SPYRE_CODE"] = old_val
+            os.environ["DUMP_SPYRE_CODE"] = old_dump
+        if old_sym is None:
+            os.environ.pop("BUNDLE_SYMBOLIC_ARGS", None)
+        else:
+            os.environ["BUNDLE_SYMBOLIC_ARGS"] = old_sym
 
     torch.testing.assert_close(
         spyre_result, cpu_result, atol=0.1, rtol=0.1, equal_nan=True
@@ -72,22 +81,28 @@ def _run_compiled_op(op_name: str, symbolic_args: bool) -> None:
 
 
 class TestLaunchJobPlan(TestCase):
-    """Test suite for JobPlan-backed compiled op execution."""
+    """Test suite for JobPlan-backed compiled op execution.
+
+    Each op is exercised twice: once with symbolic_args=True (the default since
+    BUNDLE_SYMBOLIC_ARGS=1 was made the process default) and once with
+    symbolic_args=False (the non-default override path, retained as a regression
+    guard for users who explicitly disable symbolic args).
+    """
 
     def test_abs_matches_cpu_no_symbols(self):
-        """Run compiled abs op without symbolic args and compare to CPU."""
+        """abs with symbolic_args=False (non-default override path)."""
         _run_compiled_op("abs", symbolic_args=False)
 
     def test_abs_matches_cpu_with_symbols(self):
-        """Run compiled abs op with symbolic args and compare to CPU."""
+        """abs with symbolic_args=True (default path)."""
         _run_compiled_op("abs", symbolic_args=True)
 
     def test_mul_matches_cpu_no_symbols(self):
-        """Run compiled mul op without symbolic args and compare to CPU."""
+        """mul with symbolic_args=False (non-default override path)."""
         _run_compiled_op("mul", symbolic_args=False)
 
     def test_mul_matches_cpu_with_symbols(self):
-        """Run compiled mul op with symbolic args and compare to CPU."""
+        """mul with symbolic_args=True (default path)."""
         _run_compiled_op("mul", symbolic_args=True)
 
 

--- a/torch_spyre/__init__.py
+++ b/torch_spyre/__init__.py
@@ -346,8 +346,11 @@ def _autoload():
     os.environ.setdefault("DT_DEEPRT_VERBOSE", "-1")
     os.environ.setdefault("DTLOG_LEVEL", "error")
 
-    # Enable spyre code with fake addresses by default
+    # Enable spyre code with symbolic args by default
     os.environ.setdefault("DUMP_SPYRE_CODE", "1")
+    os.environ.setdefault("BUNDLE_SYMBOLIC_ARGS", "1")
+    # Enable CB split workaround
+    os.environ.setdefault("DXP_SPLIT_CORRECTION_CB", "1")
 
 
 if not profiler.is_available():

--- a/torch_spyre/__init__.py
+++ b/torch_spyre/__init__.py
@@ -346,9 +346,8 @@ def _autoload():
     os.environ.setdefault("DT_DEEPRT_VERBOSE", "-1")
     os.environ.setdefault("DTLOG_LEVEL", "error")
 
-    # Enable spyre code with symbolic args by default
+    # Enable spyre code with fake addresses by default
     os.environ.setdefault("DUMP_SPYRE_CODE", "1")
-    os.environ.setdefault("BUNDLE_SYMBOLIC_ARGS", "1")
     # Enable CB split workaround
     os.environ.setdefault("DXP_SPLIT_CORRECTION_CB", "1")
 

--- a/torch_spyre/__init__.py
+++ b/torch_spyre/__init__.py
@@ -349,8 +349,6 @@ def _autoload():
     # Enable spyre code with symbolic args by default
     os.environ.setdefault("DUMP_SPYRE_CODE", "1")
     os.environ.setdefault("BUNDLE_SYMBOLIC_ARGS", "1")
-    # Enable CB split workaround
-    os.environ.setdefault("DXP_SPLIT_CORRECTION_CB", "1")
 
 
 if not profiler.is_available():

--- a/torch_spyre/__init__.py
+++ b/torch_spyre/__init__.py
@@ -346,8 +346,9 @@ def _autoload():
     os.environ.setdefault("DT_DEEPRT_VERBOSE", "-1")
     os.environ.setdefault("DTLOG_LEVEL", "error")
 
-    # Enable spyre code with fake addresses by default
+    # Enable spyre code with symbolic args by default
     os.environ.setdefault("DUMP_SPYRE_CODE", "1")
+    os.environ.setdefault("BUNDLE_SYMBOLIC_ARGS", "1")
     # Enable CB split workaround
     os.environ.setdefault("DXP_SPLIT_CORRECTION_CB", "1")
 

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -175,6 +175,9 @@ def generate_bundle(
                     kernel_arg_sym_indices.append(i)
                 else:
                     kernel_dup_canonical[i] = seen_kernel_arg_index[ai]
+        # Sort by arg_index so the function signature matches the positional order
+        # that call_kernel passes tensors to .run().
+        kernel_arg_sym_indices.sort(key=lambda idx: symbol_kinds[idx].arg_index)
 
     with open(os.path.join(output_dir, "bundle.mlir"), "w") as f:
         logger.info(f"Generating {f.name}")

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -226,8 +226,12 @@ def generate_bundle(
 
         # Emit one declaration per symbol (symbolic_args path):
         #   - "kernel"          → skipped; already a function param + extract op above
-        #   - "kernel_derived"  → arith.addi %arg_{arg_index}, <per_core_offset>
-        #                         deduped by (arg_index, offset) pair
+        #   - "kernel_slice"    → arith.addi %arg_{arg_index}, <slice_offset_bytes>
+        #                         deduped by (arg_index, slice_offset) pair;
+        #                         produces the SSA "sliced base" that per-core offsets
+        #                         and sdsc_execute args reference for sliced tensors
+        #   - "kernel_derived"  → arith.addi <sliced_base_ssa>, <per_core_offset>
+        #                         deduped by (sliced_base_ssa, per_core_offset)
         #   - "pool"            → arith.addi %pool, <pool_offset>
         #                         deduped by pool offset value
         #   - anything else     → arith.constant (non-symbolic path)
@@ -242,15 +246,17 @@ def generate_bundle(
         for dup_idx, canon_idx in kernel_dup_canonical.items():
             if canon_idx in kernel_sym_to_arg_idx:
                 kernel_sym_to_arg_idx[dup_idx] = kernel_sym_to_arg_idx[canon_idx]
-        # sym_canonical[sym_idx] → canonical SSA name for derived/pool symbols (deduped).
-        # Also pre-populate duplicate kernel sym_idx entries with their canonical extracted name.
+        # sym_canonical[sym_idx] → canonical SSA name for derived/pool/slice symbols.
+        # Pre-populate duplicate kernel sym_idx entries with their canonical extracted name.
         sym_canonical: dict[int, str] = {
             dup_idx: f"%arg_{kernel_sym_to_arg_idx[dup_idx]}"
             for dup_idx in kernel_dup_canonical
             if dup_idx in kernel_sym_to_arg_idx
         }
-        # derived_addi_emitted[(arg_index, offset)] → SSA name already emitted
-        derived_addi_emitted: dict[tuple[int, int], str] = {}
+        # slice_addi_emitted[(arg_index, slice_offset)] → SSA name for sliced base
+        slice_addi_emitted: dict[tuple[int, int], str] = {}
+        # derived_addi_emitted[(sliced_base_ssa, per_core_offset)] → SSA name
+        derived_addi_emitted: dict[tuple[str, int], str] = {}
         # pool_addi_emitted[pool_offset_value] → SSA name already emitted
         pool_addi_emitted: dict[int, str] = {}
 
@@ -258,22 +264,51 @@ def generate_bundle(
             if sym_idx in kernel_arg_sym_set:
                 continue  # replaced by function parameter + extract op (or duplicate)
             sk: SymbolKind | None = symbol_kinds[sym_idx] if symbol_kinds else None
-            if sk is not None and sk.is_derived:
-                base_ai = kernel_sym_to_arg_idx.get(sk.base_sym_idx)
-                if base_ai is not None:
-                    key = (base_ai, sk.offset)
-                    if key not in derived_addi_emitted:
-                        offset_ssa = f"%arg_{base_ai}_core_offset_{sk.offset}"
-                        addi_ssa = f"%arg_{base_ai}_core_{sk.offset}"
+            if sk is not None and sk.kind == "kernel_slice":
+                ai = sk.arg_index
+                sl = sk.offset  # slice offset in bytes
+                key = (ai, sl)
+                if key not in slice_addi_emitted:
+                    slice_offset_ssa = f"%arg_{ai}_slice_offset_{sl}"
+                    sliced_base_ssa = f"%arg_{ai}_slice_{sl}"
+                    f.write(f"\t\t{slice_offset_ssa} = arith.constant {sl} : index\n")
+                    f.write(
+                        f"\t\t{sliced_base_ssa} = arith.addi"
+                        f" %arg_{ai}, {slice_offset_ssa} : index\n"
+                    )
+                    slice_addi_emitted[key] = sliced_base_ssa
+                sym_canonical[sym_idx] = slice_addi_emitted[key]
+            elif sk is not None and sk.is_derived:
+                # Resolve the SSA name of the sliced base that this core offset builds on.
+                base_sym_idx = sk.base_sym_idx
+                if base_sym_idx in sym_canonical:
+                    sliced_base_ssa = sym_canonical[base_sym_idx]
+                elif base_sym_idx in kernel_arg_sym_indices:
+                    # slice_offset == 0: sliced base == raw arg extract (%arg_N)
+                    ai = symbol_kinds[base_sym_idx].arg_index
+                    sliced_base_ssa = f"%arg_{ai}"
+                elif base_sym_idx in kernel_dup_canonical:
+                    canon = kernel_dup_canonical[base_sym_idx]
+                    ai = kernel_sym_to_arg_idx.get(
+                        canon, symbol_kinds[base_sym_idx].arg_index
+                    )
+                    sliced_base_ssa = f"%arg_{ai}"
+                else:
+                    sliced_base_ssa = None
+                if sliced_base_ssa is not None:
+                    key_d = (sliced_base_ssa, sk.offset)
+                    if key_d not in derived_addi_emitted:
+                        offset_ssa = f"%{sliced_base_ssa[1:]}_core_offset_{sk.offset}"
+                        addi_ssa = f"%{sliced_base_ssa[1:]}_core_{sk.offset}"
                         f.write(
                             f"\t\t{offset_ssa} = arith.constant {sk.offset} : index\n"
                         )
                         f.write(
                             f"\t\t{addi_ssa} = arith.addi"
-                            f" %arg_{base_ai}, {offset_ssa} : index\n"
+                            f" {sliced_base_ssa}, {offset_ssa} : index\n"
                         )
-                        derived_addi_emitted[key] = addi_ssa
-                    sym_canonical[sym_idx] = derived_addi_emitted[key]
+                        derived_addi_emitted[key_d] = addi_ssa
+                    sym_canonical[sym_idx] = derived_addi_emitted[key_d]
                 else:
                     f.write(
                         f"\t\t%sym_{sym_idx + 1} = arith.constant {value} : index\n"

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -33,15 +33,18 @@ logger = get_inductor_logger("sdsc_compile")
 # Types
 # ---------------------------------------------------------------------------
 
-# Compiled SDSC entry: (json_dict, base_symbol_values, affine_strides, symbol_kinds)
-#   base_symbol_values: list[int] of base HBM byte offsets for this SDSC,
-#                       one per registered symbol ID
-#   affine_strides:     list[list[dict]] — per tensor, per loop-nesting level
-#                       (outermost first).  Each inner dict maps
-#                       tiled_sym -> stride_bytes for that level's symbols.
-#                       [{} for _ in tiled_symbols] for non-tiled / lx tensors
-#                       (one empty dict per level, preserving the level count).
-#   symbol_kinds:       list[SymbolKind] parallel to base_symbol_values
+# Compiled SDSC entry: (json_dict, symbol_values, affine_strides, symbol_kinds)
+#   symbol_values:  list[int] of registered symbol values for this SDSC,
+#                   one per symbol ID.  Values are HBM byte addresses for
+#                   derived/pool symbols; arg_index sentinels for kernel
+#                   symbols on the symbolic-args path.  Only len() is used
+#                   by bundle.py; individual values are resolved via symbols[].
+#   affine_strides: list[list[dict]] — per tensor, per loop-nesting level
+#                   (outermost first).  Each inner dict maps
+#                   tiled_sym -> stride_bytes for that level's symbols.
+#                   [{} for _ in tiled_symbols] for non-tiled / lx tensors
+#                   (one empty dict per level, preserving the level count).
+#   symbol_kinds:   list[SymbolKind] parallel to symbol_values
 _CompiledEntry = tuple[Any, list[int], list[list[dict]], list[SymbolKind]]
 
 
@@ -80,7 +83,7 @@ def generate_bundle(
     and produce ``scf.for`` loops in the generated ``bundle.mlir``.
 
     ``symbolic_args`` controls the function signature of ``@sdsc_bundle``.
-    When ``False`` (default), ``sdsc_execute`` has no operands.
+    When ``False`` (non-default override), ``sdsc_execute`` has no operands.
     When ``True``, addresses are emitted as ``!sdscbundle.input_arg<index>``
     parameters; this also forces ``use_symbols=True`` implicitly.  When
     ``None``, the value is read from ``config.bundle_symbolic_args``.

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -156,23 +156,25 @@ def generate_bundle(
     # Determine whether a pool parameter is needed (any pool symbol present).
     has_pool = symbolic_args and use_symbols and any(sk.is_pool for sk in symbol_kinds)
     # Indices of kernel-base symbols that become input_arg parameters.
-    # Deduplicated by address value: multiple SDSCs may register the same kernel arg
-    # address independently (no cross-SDSC dedup in generate_sdsc), so we keep only
-    # the first sym_idx for each unique address and map subsequent duplicates to it.
-    # kernel_arg_sym_indices: list of sym_idx values, one per unique kernel arg address.
+    # Deduplicated by arg_index: multiple SDSCs operating on different slices of
+    # the same logical tensor arg share one function parameter (the first-seen
+    # sym_idx, which corresponds to core-0 / the lowest address).  Dedup by
+    # address alone is insufficient — different slices have different addresses
+    # but the same arg_index and must map to one %arg_{ai}_base_addr param.
+    # kernel_arg_sym_indices: list of sym_idx values, one per unique arg_index.
     # kernel_dup_canonical: maps duplicate kernel sym_idx → canonical sym_idx.
     kernel_arg_sym_indices: list[int] = []
     kernel_dup_canonical: dict[int, int] = {}  # duplicate sym_idx → canonical sym_idx
     if symbolic_args and use_symbols:
-        seen_kernel_addr: dict[int, int] = {}  # address → canonical sym_idx
+        seen_kernel_arg_index: dict[int, int] = {}  # arg_index → canonical sym_idx
         for i, kind_i in enumerate(symbol_kinds):
             if kind_i.kind == "kernel":
-                addr = symbols[i]
-                if addr not in seen_kernel_addr:
-                    seen_kernel_addr[addr] = i
+                ai = kind_i.arg_index
+                if ai not in seen_kernel_arg_index:
+                    seen_kernel_arg_index[ai] = i
                     kernel_arg_sym_indices.append(i)
                 else:
-                    kernel_dup_canonical[i] = seen_kernel_addr[addr]
+                    kernel_dup_canonical[i] = seen_kernel_arg_index[ai]
 
     with open(os.path.join(output_dir, "bundle.mlir"), "w") as f:
         logger.info(f"Generating {f.name}")

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -548,7 +548,15 @@ def generate_sdsc(
             if tensor.arg_index >= 0:
                 # Kernel tensors: register the raw base address first so bundle.py
                 # can emit the input_arg function parameter.
-                raw_base = tensor.start_address
+                #
+                # On the symbolic path, tensor.start_address = arg_index + tile_offset_bytes,
+                # where tile_offset_bytes is the per-tile byte advance added by the loop
+                # unroller.  We always register the raw kernel symbol keyed by arg_index so
+                # that bundle.py emits exactly one !sdscbundle.input_arg parameter per logical
+                # tensor, regardless of how many tiles reference it.
+                raw_base = (
+                    tensor.arg_index
+                )  # raw sentinel; large HBM addr on nosym path
                 offset_as_symbol(
                     raw_base, SymbolKind.kernel(arg_index=tensor.arg_index)
                 )
@@ -558,17 +566,32 @@ def generate_sdsc(
                 # registered already by an earlier tensor in this SDSC, in which case
                 # the offset_as_symbol call above was a no-op.
                 kernel_sym_idx = abs(local_symbols[("kernel", tensor.arg_index)]) - 1
+                # tile_offset_bytes: on the symbolic path the loop unroller advances
+                # arg.allocation['hbm'] by i*stride for tile i, so start_address encodes
+                # arg_index + tile_offset.  On the nosym path start_address is the real
+                # HBM address and arg_index is a small integer — we skip this calculation
+                # by only accounting for the difference when it is non-negative and less
+                # than the start address (i.e. start_address ≥ arg_index always holds on
+                # both paths, but on nosym the difference would be the full HBM address).
+                # We detect the sym path via start_address == arg_index + non_negative_offset
+                # where the full difference is the tile_offset_bytes (could be 0 for tile 0).
+                tile_offset_bytes = tensor.start_address - tensor.arg_index
+                # total_slice_offset: combine the loop-unroll tile offset with any
+                # device-coordinate compile-time slice offset (e.g. from z0+3 expressions).
+                # This is the total compile-time offset above the raw %arg_N base that the
+                # sliced-base SSA value represents in bundle.mlir.
+                total_slice_offset = tile_offset_bytes + slice_offset_bytes
                 # sliced_base_sym_idx: the symbols[] index that per-core derived symbols
-                # reference.  When slice_offset_bytes == 0 the kernel sym IS the sliced
-                # base; otherwise a separate kernel_slice sym is registered next.
-                if slice_offset_bytes > 0:
+                # reference.  When total_slice_offset == 0 the kernel sym IS the sliced
+                # base; otherwise a kernel_slice sym is registered for the combined offset.
+                if total_slice_offset > 0:
                     offset_as_symbol(
                         core0_addr,
                         SymbolKind.kernel_slice(
-                            arg_index=tensor.arg_index, offset=slice_offset_bytes
+                            arg_index=tensor.arg_index, offset=total_slice_offset
                         ),
                     )
-                    slice_key = ("kernel_slice", tensor.arg_index, slice_offset_bytes)
+                    slice_key = ("kernel_slice", tensor.arg_index, total_slice_offset)
                     sliced_base_sym_idx = abs(local_symbols[slice_key]) - 1
                 else:
                     sliced_base_sym_idx = kernel_sym_idx
@@ -673,14 +696,17 @@ def generate_sdsc(
                 if is_pool_tensor:
                     key = ("pool", addr)
                 elif c == 0:
-                    # c==0: either ("kernel", arg_index) when no slice offset,
-                    # or ("kernel_slice", arg_index, offset_bytes) when a
-                    # compile-time offset was added.  Multiple slices of the same
-                    # arg at different offsets are distinguished by offset_bytes.
+                    # c==0: either ("kernel", arg_index) when no total slice offset,
+                    # or ("kernel_slice", arg_index, offset_bytes) when a compile-time
+                    # offset was added.  total_slice_offset combines the loop-unroll
+                    # tile offset (tensor.start_address - tensor.arg_index on sym path)
+                    # with any device-coordinate slice offset from tensor.offsets.
                     slice_offset_bytes = sum(tensor.offsets.values()) * nb
+                    tile_offset_bytes = tensor.start_address - tensor.arg_index
+                    total_slice_offset = tile_offset_bytes + slice_offset_bytes
                     key = (
-                        ("kernel_slice", tensor.arg_index, slice_offset_bytes)
-                        if slice_offset_bytes > 0
+                        ("kernel_slice", tensor.arg_index, total_slice_offset)
+                        if total_slice_offset > 0
                         else ("kernel", tensor.arg_index)
                     )
                 else:
@@ -689,6 +715,8 @@ def generate_sdsc(
                     # one address), no derived symbol was registered — reuse the
                     # sliced-base key used for c==0.
                     slice_offset_bytes = sum(tensor.offsets.values()) * nb
+                    tile_offset_bytes = tensor.start_address - tensor.arg_index
+                    total_slice_offset = tile_offset_bytes + slice_offset_bytes
                     core0_addr_lookup = (
                         tensor.start_address
                         + core_idx_to_slice_offset(
@@ -698,8 +726,8 @@ def generate_sdsc(
                     )
                     if addr == core0_addr_lookup:
                         key = (
-                            ("kernel_slice", tensor.arg_index, slice_offset_bytes)
-                            if slice_offset_bytes > 0
+                            ("kernel_slice", tensor.arg_index, total_slice_offset)
+                            if total_slice_offset > 0
                             else ("kernel", tensor.arg_index)
                         )
                     else:

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -463,10 +463,16 @@ def generate_sdsc(
     # For tiled tensors the base is the iteration-0 address (tiled dims contribute 0);
     # for non-tiled tensors it is the full per-core address (as before).
     #
-    # Keys: plain int for kernel tensors (the sentinel arg_index value on the
-    # symbolic path, or a real HBM address on the non-symbolic path); a tuple
-    # ("pool", int) for pool-allocated tensors.  The tuple namespace prevents
-    # collision between kernel sentinel 0 (arg_index=0) and pool offset 0.
+    # Keys use explicit namespacing to prevent any possibility of collision:
+    #   ("kernel", arg_index)       — raw HBM base for kernel tensor arg_index
+    #   ("kernel_slice", arg_index) — sliced base (raw + compile-time offset)
+    #   int addr                    — per-core derived address (c>0 kernel tensors,
+    #                                 always large HBM byte addresses)
+    #   ("pool", int offset)        — pool-allocated tensor compile-time offset
+    #
+    # On the symbolic path, kernel sentinels are arg_index integers (0, 1, 2...).
+    # Keying by ("kernel", arg_index) rather than the sentinel value itself ensures
+    # no collision with pool offset 0 or any future sentinel scheme.
     #
     # NOTE: no cross-SDSC deduplication — each call to offset_as_symbol within
     # this SDSC gets its own sequential ID and appends to symbols.  Two SDSCs
@@ -498,9 +504,16 @@ def generate_sdsc(
     if use_symbols:
 
         def offset_as_symbol(s, kind: SymbolKind):
-            # Pool tensors use a ("pool", offset) key to avoid colliding with
-            # kernel sentinel values (e.g. arg_index=0 sentinel 0 == pool offset 0).
-            key = ("pool", s) if kind.is_pool else s
+            if kind.is_pool:
+                key = ("pool", s)
+            elif kind.kind == "kernel":
+                key = ("kernel", kind.arg_index)
+            elif kind.kind == "kernel_slice":
+                key = ("kernel_slice", kind.arg_index)
+            else:
+                # kernel_derived: s is a large per-core HBM byte address,
+                # distinct from pool offsets and sentinel values.
+                key = s
             if key not in local_symbols:
                 # Address symbols start after dim symbols in the ID counter.
                 local_symbols[key] = -(
@@ -628,7 +641,7 @@ def generate_sdsc(
 
         def _start_addr_data(tensor):
             # All per-core addresses were already registered by the per-tensor loop
-            # above. Look them up directly rather than re-computing SymbolKind.
+            # above. Look them up using the same key scheme as offset_as_symbol.
             if "lx" in tensor.allocation:
                 return {
                     f"[{c}, 0, 0]": str(tensor.start_address)
@@ -636,26 +649,49 @@ def generate_sdsc(
                 }
             nb = num_bytes(tensor.data_format)
             is_pool_tensor = tensor.arg_index < 0 and "pool" in tensor.allocation
-            core0_addr = (
-                tensor.start_address
-                + core_idx_to_slice_offset(
-                    tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
-                )
-                * nb
-            )
             result = {}
             for c in range(sdsc_spec.num_cores):
-                addr = tensor.start_address + core_idx_to_slice_offset(
-                    tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
-                ) * nb
+                addr = (
+                    tensor.start_address
+                    + core_idx_to_slice_offset(
+                        tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
+                    )
+                    * nb
+                )
                 if is_pool_tensor:
                     key = ("pool", addr)
-                elif c > 0 and addr == core0_addr:
-                    # c>0 kernel tensors where addr==core0_addr were not registered
-                    # separately; fall back to the core-0 address entry.
-                    key = core0_addr
+                elif c == 0:
+                    # c==0: either ("kernel", arg_index) when no slice offset,
+                    # or ("kernel_slice", arg_index, offset_bytes) when a
+                    # compile-time offset was added.  Multiple slices of the same
+                    # arg at different offsets are distinguished by offset_bytes.
+                    slice_offset_bytes = sum(tensor.offsets.values()) * nb
+                    key = (
+                        ("kernel_slice", tensor.arg_index, slice_offset_bytes)
+                        if slice_offset_bytes > 0
+                        else ("kernel", tensor.arg_index)
+                    )
                 else:
-                    key = addr
+                    # c>0: per-core derived address (large HBM byte value).
+                    # When addr == core0_addr (non-split tensor, all cores share
+                    # one address), no derived symbol was registered — reuse the
+                    # sliced-base key used for c==0.
+                    slice_offset_bytes = sum(tensor.offsets.values()) * nb
+                    core0_addr_lookup = (
+                        tensor.start_address
+                        + core_idx_to_slice_offset(
+                            tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
+                        )
+                        * nb
+                    )
+                    if addr == core0_addr_lookup:
+                        key = (
+                            ("kernel_slice", tensor.arg_index, slice_offset_bytes)
+                            if slice_offset_bytes > 0
+                            else ("kernel", tensor.arg_index)
+                        )
+                    else:
+                        key = addr
                 result[f"[{c}, 0, 0]"] = str(local_symbols[key])
             return result
 

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -479,7 +479,7 @@ def generate_sdsc(
     # that happen to share a base address will emit two separate arith.constant
     # declarations in bundle.mlir.  This keeps symbol IDs contiguous with the
     # symbols list indices: symbols[abs(id)-1] is always the value for id.
-    local_symbols: dict = {}
+    local_symbols: dict[tuple | int, int] = {}
     # Parallel to local_symbols (insertion order): one SymbolKind per registered symbol.
     local_symbol_kind: list[SymbolKind] = []
 
@@ -684,6 +684,23 @@ def generate_sdsc(
                 }
             nb = num_bytes(tensor.data_format)
             is_pool_tensor = tensor.arg_index < 0 and "pool" in tensor.allocation
+            # Hoist per-tensor compile-time offset computation so it is not
+            # duplicated across the c==0 and c>0 branches.
+            slice_offset_bytes = sum(tensor.offsets.values()) * nb
+            tile_offset_bytes = tensor.start_address - tensor.arg_index
+            total_slice_offset = tile_offset_bytes + slice_offset_bytes
+            c0_slice_key: tuple | int = (
+                ("kernel_slice", tensor.arg_index, total_slice_offset)
+                if total_slice_offset > 0
+                else ("kernel", tensor.arg_index)
+            )
+            core0_addr_lookup = (
+                tensor.start_address
+                + core_idx_to_slice_offset(
+                    tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
+                )
+                * nb
+            )
             result = {}
             for c in range(sdsc_spec.num_cores):
                 addr = (
@@ -694,44 +711,14 @@ def generate_sdsc(
                     * nb
                 )
                 if is_pool_tensor:
-                    key = ("pool", addr)
+                    key: tuple | int = ("pool", addr)
                 elif c == 0:
-                    # c==0: either ("kernel", arg_index) when no total slice offset,
-                    # or ("kernel_slice", arg_index, offset_bytes) when a compile-time
-                    # offset was added.  total_slice_offset combines the loop-unroll
-                    # tile offset (tensor.start_address - tensor.arg_index on sym path)
-                    # with any device-coordinate slice offset from tensor.offsets.
-                    slice_offset_bytes = sum(tensor.offsets.values()) * nb
-                    tile_offset_bytes = tensor.start_address - tensor.arg_index
-                    total_slice_offset = tile_offset_bytes + slice_offset_bytes
-                    key = (
-                        ("kernel_slice", tensor.arg_index, total_slice_offset)
-                        if total_slice_offset > 0
-                        else ("kernel", tensor.arg_index)
-                    )
+                    key = c0_slice_key
                 else:
-                    # c>0: per-core derived address (large HBM byte value).
-                    # When addr == core0_addr (non-split tensor, all cores share
-                    # one address), no derived symbol was registered — reuse the
-                    # sliced-base key used for c==0.
-                    slice_offset_bytes = sum(tensor.offsets.values()) * nb
-                    tile_offset_bytes = tensor.start_address - tensor.arg_index
-                    total_slice_offset = tile_offset_bytes + slice_offset_bytes
-                    core0_addr_lookup = (
-                        tensor.start_address
-                        + core_idx_to_slice_offset(
-                            tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
-                        )
-                        * nb
-                    )
-                    if addr == core0_addr_lookup:
-                        key = (
-                            ("kernel_slice", tensor.arg_index, total_slice_offset)
-                            if total_slice_offset > 0
-                            else ("kernel", tensor.arg_index)
-                        )
-                    else:
-                        key = addr
+                    # c>0: per-core derived address.  When addr == core0_addr
+                    # (non-split tensor, all cores share one address) no derived
+                    # symbol was registered — reuse the c==0 sliced-base key.
+                    key = c0_slice_key if addr == core0_addr_lookup else addr
                 result[f"[{c}, 0, 0]"] = str(local_symbols[key])
             return result
 

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -676,23 +676,24 @@ def generate_sdsc(
                 }
             nb = num_bytes(tensor.data_format)
             is_pool_tensor = tensor.arg_index < 0 and "pool" in tensor.allocation
-            # Hoist per-tensor compile-time offset computation so it is not
+            # Hoist kernel-tensor compile-time offsets so they are not
             # duplicated across the c==0 and c>0 branches.
-            slice_offset_bytes = sum(tensor.offsets.values()) * nb
-            tile_offset_bytes = tensor.start_address - tensor.arg_index
-            total_slice_offset = tile_offset_bytes + slice_offset_bytes
-            c0_slice_key: tuple | int = (
-                ("kernel_slice", tensor.arg_index, total_slice_offset)
-                if total_slice_offset > 0
-                else ("kernel", tensor.arg_index)
-            )
-            core0_addr_lookup = (
-                tensor.start_address
-                + core_idx_to_slice_offset(
-                    tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
+            if not is_pool_tensor:
+                slice_offset_bytes = sum(tensor.offsets.values()) * nb
+                tile_offset_bytes = tensor.start_address - tensor.arg_index
+                total_slice_offset = tile_offset_bytes + slice_offset_bytes
+                c0_slice_key: tuple | int = (
+                    ("kernel_slice", tensor.arg_index, total_slice_offset)
+                    if total_slice_offset > 0
+                    else ("kernel", tensor.arg_index)
                 )
-                * nb
-            )
+                core0_addr_lookup = (
+                    tensor.start_address
+                    + core_idx_to_slice_offset(
+                        tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
+                    )
+                    * nb
+                )
             result = {}
             for c in range(sdsc_spec.num_cores):
                 addr = (

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -606,6 +606,11 @@ def generate_sdsc(
                         if tensor.arg_index < 0:
                             offset_as_symbol(addr, SymbolKind.pool())
                         elif addr != core0_addr:
+                            # Only register a derived symbol when the core has a
+                            # distinct address from core 0.  When addr == core0_addr
+                            # (e.g. a non-split tensor where all cores share one
+                            # address) the sliced-base symbol already covers it and
+                            # we must not create a duplicate registration.
                             offset_as_symbol(
                                 addr,
                                 _derived_kind(

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -458,17 +458,22 @@ def generate_sdsc(
             symbols.append(0)  # placeholder: dim symbols have no HBM byte value
     n_dim_syms = len(dim_symbol_kinds)
 
-    # local_symbols maps base HBM byte offset -> globally-unique negative symbol id.
+    # local_symbols maps address key -> globally-unique negative symbol id.
     # symbol_id_offset ensures ids are unique across all SDSCs in the bundle.
     # For tiled tensors the base is the iteration-0 address (tiled dims contribute 0);
     # for non-tiled tensors it is the full per-core address (as before).
+    #
+    # Keys: plain int for kernel tensors (the sentinel arg_index value on the
+    # symbolic path, or a real HBM address on the non-symbolic path); a tuple
+    # ("pool", int) for pool-allocated tensors.  The tuple namespace prevents
+    # collision between kernel sentinel 0 (arg_index=0) and pool offset 0.
     #
     # NOTE: no cross-SDSC deduplication — each call to offset_as_symbol within
     # this SDSC gets its own sequential ID and appends to symbols.  Two SDSCs
     # that happen to share a base address will emit two separate arith.constant
     # declarations in bundle.mlir.  This keeps symbol IDs contiguous with the
     # symbols list indices: symbols[abs(id)-1] is always the value for id.
-    local_symbols: dict[int, int] = {}
+    local_symbols: dict = {}
     # Parallel to local_symbols (insertion order): one SymbolKind per registered symbol.
     local_symbol_kind: list[SymbolKind] = []
 
@@ -493,14 +498,17 @@ def generate_sdsc(
     if use_symbols:
 
         def offset_as_symbol(s, kind: SymbolKind):
-            if s not in local_symbols:
+            # Pool tensors use a ("pool", offset) key to avoid colliding with
+            # kernel sentinel values (e.g. arg_index=0 sentinel 0 == pool offset 0).
+            key = ("pool", s) if kind.is_pool else s
+            if key not in local_symbols:
                 # Address symbols start after dim symbols in the ID counter.
-                local_symbols[s] = -(
+                local_symbols[key] = -(
                     symbol_id_offset + n_dim_syms + len(local_symbols) + 1
                 )
                 symbols.append(s)
                 local_symbol_kind.append(kind)
-            return local_symbols[s]
+            return local_symbols[key]
 
         # Compute per-tensor, per-level affine strides and register base addresses.
         # affine_strides[i] is a list of dicts, one per loop-nesting level
@@ -627,6 +635,7 @@ def generate_sdsc(
                     for c in range(sdsc_spec.num_cores)
                 }
             nb = num_bytes(tensor.data_format)
+            is_pool_tensor = tensor.arg_index < 0 and "pool" in tensor.allocation
             core0_addr = (
                 tensor.start_address
                 + core_idx_to_slice_offset(
@@ -639,10 +648,15 @@ def generate_sdsc(
                 addr = tensor.start_address + core_idx_to_slice_offset(
                     tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
                 ) * nb
-                # c>0 kernel tensors where addr==core0_addr were not registered
-                # separately; fall back to the core-0 address entry.
-                lookup = addr if addr != core0_addr or c == 0 else core0_addr
-                result[f"[{c}, 0, 0]"] = str(local_symbols[lookup])
+                if is_pool_tensor:
+                    key = ("pool", addr)
+                elif c > 0 and addr == core0_addr:
+                    # c>0 kernel tensors where addr==core0_addr were not registered
+                    # separately; fall back to the core-0 address entry.
+                    key = core0_addr
+                else:
+                    key = addr
+                result[f"[{c}, 0, 0]"] = str(local_symbols[key])
             return result
 
     else:

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -23,14 +23,23 @@ from sympy import Symbol
 class SymbolKind:
     """Classifies a symbol registered in the bundle symbol table.
 
-    Three variants (constructed via class methods):
-      - ``kernel(arg_index)``:               base HBM address of a kernel tensor arg;
+    Four variants (constructed via class methods):
+      - ``kernel(arg_index)``:               raw HBM base address of a kernel tensor arg;
                                              emitted as a ``!sdscbundle.input_arg`` param
-                                             named ``%arg_{arg_index}``.
-      - ``kernel_derived(idx, off, arg_i)``: per-core derived address = base + offset;
-                                             emitted as ``arith.addi %arg_{arg_i}, off``.
+                                             named ``%arg_{arg_index}``.  Value =
+                                             ``tensor.start_address``.
+      - ``kernel_slice(arg_i, slice_off)``:  sliced base = raw base + compile-time slice
+                                             offset (from device_coordinates like ``z0+3``).
+                                             Emitted as ``arith.addi %arg_{arg_i},
+                                             {slice_off}``.  ``slice_off`` is in bytes.
+                                             Only present when ``slice_off > 0``;
+                                             when ``slice_off == 0`` the ``kernel`` symbol
+                                             itself serves as the sliced base.
+      - ``kernel_derived(idx, off, arg_i)``: per-core derived address = sliced_base + offset;
+                                             emitted as ``arith.addi <sliced_base_ssa>, off``.
                                              ``base_sym_idx`` is the 0-based index into the
-                                             global ``symbols`` list of the kernel base symbol.
+                                             global ``symbols`` list of the sliced-base symbol
+                                             (either a ``kernel`` or ``kernel_slice`` entry).
       - ``pool()``:                          pool-allocated tensor address;
                                              emitted as ``arith.addi %pool, value``.
       - ``dimension(gran, max, sym)``:       dynamic iteration-space dim size from
@@ -51,6 +60,10 @@ class SymbolKind:
     @classmethod
     def kernel(cls, arg_index: int) -> "SymbolKind":
         return cls(kind="kernel", arg_index=arg_index)
+
+    @classmethod
+    def kernel_slice(cls, arg_index: int, offset: int) -> "SymbolKind":
+        return cls(kind="kernel_slice", arg_index=arg_index, offset=offset)
 
     @classmethod
     def kernel_derived(
@@ -459,22 +472,20 @@ def generate_sdsc(
     # Parallel to local_symbols (insertion order): one SymbolKind per registered symbol.
     local_symbol_kind: list[SymbolKind] = []
 
-    def _per_core_kind(
-        c: int, arg_index: int, core0_addr: int, addr: int, base_sym_idx: int
+    def _derived_kind(
+        arg_index: int,
+        core0_addr: int,
+        addr: int,
+        sliced_base_sym_idx: int,
     ) -> SymbolKind:
-        """Return the SymbolKind for a per-core HBM address.
+        """Return the SymbolKind for a per-core (c>0) HBM address.
 
-        Core 0 of a kernel arg (arg_index >= 0) is the input_arg base; subsequent
-        cores are derived from it.  ``base_sym_idx`` is the 0-based index into the
-        global ``symbols`` list where the core-0 symbol was (or will be) registered.
-        Pool tensors (arg_index < 0) always use SymbolKind.pool().
+        Core 0 is handled by the caller (either ``kernel`` or ``kernel_slice``).
+        ``sliced_base_sym_idx`` is the 0-based index in ``symbols`` of the
+        sliced-base symbol (``kernel`` or ``kernel_slice``) for this tensor.
         """
-        if arg_index < 0:
-            return SymbolKind.pool()
-        if c == 0:
-            return SymbolKind.kernel(arg_index=arg_index)
         return SymbolKind.kernel_derived(
-            base_sym_idx=base_sym_idx,
+            base_sym_idx=sliced_base_sym_idx,
             offset=addr - core0_addr,
             arg_index=arg_index,
         )
@@ -501,13 +512,41 @@ def generate_sdsc(
             if "lx" in tensor.allocation:
                 affine_strides.append([{} for _ in tiled_symbols])
                 continue
-            core0_addr = tensor.start_address + core_idx_to_slice_offset(
-                tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
-            ) * num_bytes(tensor.data_format)
-            # 0-based index in global symbols[] where this tensor's core-0 address will
-            # be registered. Offset by n_dim_syms because dim symbols occupy the first
-            # n_dim_syms slots in this SDSC's range of the shared counter.
-            base_sym_idx = symbol_id_offset + n_dim_syms + len(local_symbols)
+            nb = num_bytes(tensor.data_format)
+            slice_offset_bytes = sum(tensor.offsets.values()) * nb
+            # core0_addr: compile-time address for core 0 including the tensor's
+            # slice offset (device_coordinate constant terms, e.g. z0+3 → 3 rows).
+            core0_addr = (
+                tensor.start_address
+                + core_idx_to_slice_offset(
+                    tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
+                )
+                * nb
+            )
+            if tensor.arg_index >= 0:
+                # Kernel tensors: register the raw base address first so bundle.py
+                # can emit the input_arg function parameter.
+                raw_base = tensor.start_address
+                offset_as_symbol(
+                    raw_base, SymbolKind.kernel(arg_index=tensor.arg_index)
+                )
+                # sliced_base_sym_idx: the symbols[] index that per-core derived symbols
+                # reference.  When slice_offset_bytes == 0 the kernel sym IS the sliced
+                # base; otherwise a separate kernel_slice sym is registered next.
+                if slice_offset_bytes > 0:
+                    sliced_base_sym_idx = symbol_id_offset + n_dim_syms + len(local_symbols)
+                    offset_as_symbol(
+                        core0_addr,
+                        SymbolKind.kernel_slice(
+                            arg_index=tensor.arg_index, offset=slice_offset_bytes
+                        ),
+                    )
+                else:
+                    # kernel sym already registered; its index is one before current len.
+                    sliced_base_sym_idx = symbol_id_offset + n_dim_syms + len(local_symbols) - 1
+            else:
+                # Pool tensor: no raw-base or slice symbol needed.
+                sliced_base_sym_idx = -1
             # Build per-level strides: for each level, collect the symbols at that
             # level that tile this tensor (i.e. appear in tensor.strides).
             per_level_strides: list[dict] = []
@@ -524,29 +563,59 @@ def generate_sdsc(
             if not any_tiled:
                 # Non-tiled HBM: register per-core addresses.
                 for c in range(sdsc_spec.num_cores):
-                    addr = tensor.start_address + core_idx_to_slice_offset(
-                        tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
-                    ) * num_bytes(tensor.data_format)
-                    offset_as_symbol(
-                        addr,
-                        _per_core_kind(
-                            c, tensor.arg_index, core0_addr, addr, base_sym_idx
-                        ),
+                    addr = (
+                        tensor.start_address
+                        + core_idx_to_slice_offset(
+                            tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
+                        )
+                        * nb
                     )
+                    if c == 0:
+                        if tensor.arg_index < 0:
+                            offset_as_symbol(addr, SymbolKind.pool())
+                        # kernel / kernel_slice already registered above; skip c==0
+                    else:
+                        if tensor.arg_index < 0:
+                            offset_as_symbol(addr, SymbolKind.pool())
+                        elif addr != core0_addr:
+                            offset_as_symbol(
+                                addr,
+                                _derived_kind(
+                                    tensor.arg_index,
+                                    core0_addr,
+                                    addr,
+                                    sliced_base_sym_idx,
+                                ),
+                            )
                 affine_strides.append([{} for _ in tiled_symbols])
             else:
                 # Tiled HBM: symbol value = per-core iter-0 base address.
                 # The affine map adds loop_var * tile_stride on top at runtime.
                 for c in range(sdsc_spec.num_cores):
-                    addr = tensor.start_address + core_idx_to_slice_offset(
-                        tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
-                    ) * num_bytes(tensor.data_format)
-                    offset_as_symbol(
-                        addr,
-                        _per_core_kind(
-                            c, tensor.arg_index, core0_addr, addr, base_sym_idx
-                        ),
+                    addr = (
+                        tensor.start_address
+                        + core_idx_to_slice_offset(
+                            tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
+                        )
+                        * nb
                     )
+                    if c == 0:
+                        if tensor.arg_index < 0:
+                            offset_as_symbol(addr, SymbolKind.pool())
+                        # kernel / kernel_slice already registered above; skip c==0
+                    else:
+                        if tensor.arg_index < 0:
+                            offset_as_symbol(addr, SymbolKind.pool())
+                        elif addr != core0_addr:
+                            offset_as_symbol(
+                                addr,
+                                _derived_kind(
+                                    tensor.arg_index,
+                                    core0_addr,
+                                    addr,
+                                    sliced_base_sym_idx,
+                                ),
+                            )
                 affine_strides.append(per_level_strides)
 
         def _start_addr_data(tensor):
@@ -557,12 +626,23 @@ def generate_sdsc(
                     f"[{c}, 0, 0]": str(tensor.start_address)
                     for c in range(sdsc_spec.num_cores)
                 }
+            nb = num_bytes(tensor.data_format)
+            core0_addr = (
+                tensor.start_address
+                + core_idx_to_slice_offset(
+                    tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
+                )
+                * nb
+            )
             result = {}
             for c in range(sdsc_spec.num_cores):
                 addr = tensor.start_address + core_idx_to_slice_offset(
                     tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
-                ) * num_bytes(tensor.data_format)
-                result[f"[{c}, 0, 0]"] = str(local_symbols[addr])
+                ) * nb
+                # c>0 kernel tensors where addr==core0_addr were not registered
+                # separately; fall back to the core-0 address entry.
+                lookup = addr if addr != core0_addr or c == 0 else core0_addr
+                result[f"[{c}, 0, 0]"] = str(local_symbols[lookup])
             return result
 
     else:

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -504,12 +504,13 @@ def generate_sdsc(
     if use_symbols:
 
         def offset_as_symbol(s, kind: SymbolKind):
+            key: tuple | int
             if kind.is_pool:
                 key = ("pool", s)
             elif kind.kind == "kernel":
                 key = ("kernel", kind.arg_index)
             elif kind.kind == "kernel_slice":
-                key = ("kernel_slice", kind.arg_index)
+                key = ("kernel_slice", kind.arg_index, kind.offset)
             else:
                 # kernel_derived: s is a large per-core HBM byte address,
                 # distinct from pool offsets and sentinel values.
@@ -551,20 +552,26 @@ def generate_sdsc(
                 offset_as_symbol(
                     raw_base, SymbolKind.kernel(arg_index=tensor.arg_index)
                 )
+                # Derive the 0-based symbols[] index of the kernel symbol from its
+                # registered ID.  Must be looked up (not inferred from current
+                # len(local_symbols)) because the same arg_index may have been
+                # registered already by an earlier tensor in this SDSC, in which case
+                # the offset_as_symbol call above was a no-op.
+                kernel_sym_idx = abs(local_symbols[("kernel", tensor.arg_index)]) - 1
                 # sliced_base_sym_idx: the symbols[] index that per-core derived symbols
                 # reference.  When slice_offset_bytes == 0 the kernel sym IS the sliced
                 # base; otherwise a separate kernel_slice sym is registered next.
                 if slice_offset_bytes > 0:
-                    sliced_base_sym_idx = symbol_id_offset + n_dim_syms + len(local_symbols)
                     offset_as_symbol(
                         core0_addr,
                         SymbolKind.kernel_slice(
                             arg_index=tensor.arg_index, offset=slice_offset_bytes
                         ),
                     )
+                    slice_key = ("kernel_slice", tensor.arg_index, slice_offset_bytes)
+                    sliced_base_sym_idx = abs(local_symbols[slice_key]) - 1
                 else:
-                    # kernel sym already registered; its index is one before current len.
-                    sliced_base_sym_idx = symbol_id_offset + n_dim_syms + len(local_symbols) - 1
+                    sliced_base_sym_idx = kernel_sym_idx
             else:
                 # Pool tensor: no raw-base or slice symbol needed.
                 sliced_base_sym_idx = -1

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -554,9 +554,7 @@ def generate_sdsc(
                 # unroller.  We always register the raw kernel symbol keyed by arg_index so
                 # that bundle.py emits exactly one !sdscbundle.input_arg parameter per logical
                 # tensor, regardless of how many tiles reference it.
-                raw_base = (
-                    tensor.arg_index
-                )  # raw sentinel; large HBM addr on nosym path
+                raw_base = tensor.arg_index  # sentinel value for this arg
                 offset_as_symbol(
                     raw_base, SymbolKind.kernel(arg_index=tensor.arg_index)
                 )
@@ -566,15 +564,9 @@ def generate_sdsc(
                 # registered already by an earlier tensor in this SDSC, in which case
                 # the offset_as_symbol call above was a no-op.
                 kernel_sym_idx = abs(local_symbols[("kernel", tensor.arg_index)]) - 1
-                # tile_offset_bytes: on the symbolic path the loop unroller advances
-                # arg.allocation['hbm'] by i*stride for tile i, so start_address encodes
-                # arg_index + tile_offset.  On the nosym path start_address is the real
-                # HBM address and arg_index is a small integer — we skip this calculation
-                # by only accounting for the difference when it is non-negative and less
-                # than the start address (i.e. start_address ≥ arg_index always holds on
-                # both paths, but on nosym the difference would be the full HBM address).
-                # We detect the sym path via start_address == arg_index + non_negative_offset
-                # where the full difference is the tile_offset_bytes (could be 0 for tile 0).
+                # tile_offset_bytes: the loop unroller advances arg.allocation['hbm']
+                # by i*stride for tile i, so start_address = arg_index + tile_offset.
+                # tile_offset_bytes == 0 for tile 0, positive for later tiles.
                 tile_offset_bytes = tensor.start_address - tensor.arg_index
                 # total_slice_offset: combine the loop-unroll tile offset with any
                 # device-coordinate compile-time slice offset (e.g. from z0+3 expressions).

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -79,19 +79,18 @@ core_id_k_fast_emission: bool = (
 )
 
 # When True, HBM tensor addresses are emitted as runtime symbols (%sym_N
-# constants) in bundle.mlir and resolved via affine.apply for tiled loops.
+# constants) in bundle.mlir.
 # Requires backend compiler support for the sdscbundle symbol table.
 # Independent of bundle_symbolic_args: you can have symbols in the SDSC JSON
 # without exposing them as function arguments (staged adoption).
 bundle_hbm_symbols: bool = os.environ.get("BUNDLE_HBM_SYMBOLS", "1") == "1"
 
-# When False (default), HBM tensor addresses are baked as concrete integers
+# When False, HBM tensor addresses are baked as concrete integers
 # into the SDSC JSON and bundle.mlir emits sdsc_execute with no operands.
 # When True, addresses are emitted as runtime symbols with
-# !sdscbundle.input_arg<index> parameters, input_arg_extract ops, and
-# affine.apply indirection for tiled loops.
+# !sdscbundle.input_arg<index> parameters and input_arg_extract ops.
 # Requires bundle_hbm_symbols=True to have any effect.
-bundle_symbolic_args: bool = os.environ.get("BUNDLE_SYMBOLIC_ARGS", "0") == "1"
+bundle_symbolic_args: bool = os.environ.get("BUNDLE_SYMBOLIC_ARGS", "1") == "1"
 
 # When True (default), LoopSpec nodes are fully unrolled into flat OpSpecs
 # before generate_bundle runs.  Set to False to pass LoopSpecs through intact

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -90,7 +90,7 @@ bundle_hbm_symbols: bool = os.environ.get("BUNDLE_HBM_SYMBOLS", "1") == "1"
 # When True, addresses are emitted as runtime symbols with
 # !sdscbundle.input_arg<index> parameters and input_arg_extract ops.
 # Requires bundle_hbm_symbols=True to have any effect.
-bundle_symbolic_args: bool = os.environ.get("BUNDLE_SYMBOLIC_ARGS", "0") == "1"
+bundle_symbolic_args: bool = os.environ.get("BUNDLE_SYMBOLIC_ARGS", "1") == "1"
 
 # When True (default), LoopSpec nodes are fully unrolled into flat OpSpecs
 # before generate_bundle runs.  Set to False to pass LoopSpecs through intact

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -90,7 +90,7 @@ bundle_hbm_symbols: bool = os.environ.get("BUNDLE_HBM_SYMBOLS", "1") == "1"
 # When True, addresses are emitted as runtime symbols with
 # !sdscbundle.input_arg<index> parameters and input_arg_extract ops.
 # Requires bundle_hbm_symbols=True to have any effect.
-bundle_symbolic_args: bool = os.environ.get("BUNDLE_SYMBOLIC_ARGS", "1") == "1"
+bundle_symbolic_args: bool = os.environ.get("BUNDLE_SYMBOLIC_ARGS", "0") == "1"
 
 # When True (default), LoopSpec nodes are fully unrolled into flat OpSpecs
 # before generate_bundle runs.  Set to False to pass LoopSpecs through intact

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -925,12 +925,23 @@ class SpyreKernel(Kernel[CSEVariable]):
         buf.writeline("]")
         return buf.getvalue()
 
+    def _kernel_uses_pool(self) -> bool:
+        """Return True if any op in this kernel references a pool-allocated tensor."""
+        from torch_spyre._inductor.op_spec import TensorArg
+
+        return any(
+            "pool" in arg.allocation
+            for op in _iter_op_specs(self.op_specs)
+            for arg in op.args
+            if isinstance(arg, TensorArg)
+        )
+
     def call_kernel(self, name: str, node=None):
         """Codegen a call to this kernel"""
         wrapper = V.graph.wrapper_code
         call_args = []
 
-        if getattr(V.graph, "pool_size", 0) > 0:
+        if self._kernel_uses_pool():
             call_args.append("_pool")
 
         # Add remaining kernel arguments, deduplicating tensors that appear as

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -923,8 +923,16 @@ class SpyreKernel(Kernel[CSEVariable]):
         if getattr(V.graph, "pool_size", 0) > 0:
             call_args.append("_pool")
 
-        # Add remaining kernel arguments
-        call_args.extend(self.args.python_argdefs()[1])
+        # Add remaining kernel arguments, deduplicating tensors that appear as
+        # both input and output (e.g. in-place ops like x *= 2).  With symbolic
+        # args the MLIR bundle emits one !sdscbundle.input_arg<index> per unique
+        # arg_index; passing the same tensor twice would cause a runtime
+        # "Number of inputs mismatches" error in processComputeOnHostCommand.
+        seen: set[str] = set()
+        for arg in self.args.python_argdefs()[1]:
+            if arg not in seen:
+                seen.add(arg)
+                call_args.append(arg)
 
         call_args_str = ", ".join(call_args)
         wrapper.writeline(f"{name}.run({call_args_str})")

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -30,6 +30,7 @@ from torch._inductor.ops_handler import DefaultHandler, StoreMode
 from torch._inductor.utils import IndentedBuffer, sympy_index_symbol, sympy_subs
 from torch._inductor.virtualized import V
 
+
 from .constants import (
     SPYRE_FP32_OPS,
     BATCH_MATMUL_OP,

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -40,6 +40,7 @@ from .constants import (
     SEGMENT_OFFSETS,
     SHARED_WEIGHT_UNIT_BMM_INFO_KEY,
 )
+from . import config as _spyre_config
 from .errors import Unsupported
 from .ir import FixedTiledLayout
 from .pass_utils import (
@@ -903,11 +904,19 @@ class SpyreKernel(Kernel[CSEVariable]):
 
         for name, tensor_arg in self.spyre_kernel_args:
             tensor_arg.arg_index = actuals.index(name)
-            tensor_arg.allocation["hbm"] = SEGMENT_OFFSETS[
-                tensor_arg.arg_index + 1
-                if has_pool_allocations
-                else tensor_arg.arg_index
-            ]
+            if _spyre_config.bundle_symbolic_args:
+                # On the symbolic path the HBM address is provided at runtime
+                # via input_arg_extract; start_address is never used as a
+                # literal address.  Use the arg_index itself as a small,
+                # positive, human-readable sentinel that is clearly not a
+                # real HBM address (which are O(16 GB) apart).
+                tensor_arg.allocation["hbm"] = tensor_arg.arg_index
+            else:
+                tensor_arg.allocation["hbm"] = SEGMENT_OFFSETS[
+                    tensor_arg.arg_index + 1
+                    if has_pool_allocations
+                    else tensor_arg.arg_index
+                ]
 
         buf = IndentedBuffer()
         buf.writeline("[")


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Makes `BUNDLE_SYMBOLIC_ARGS=1` the default, so HBM tensor addresses are
no longer baked as compile-time constants but instead extracted at
runtime via `!sdscbundle.input_arg` parameters in the MLIR bundle.
This enables program correction for kernel arguments, which eliminates 
the dependency on a 1:1 mapping between kernel arguments and segments.

Along the way, several correctness bugs in the symbolic-args codepath
were found and fixed:

**1. Duplicate `%arg_N_base_addr` parameter (dedup by address → dedup by arg\_index)**
(`bundle.py`)

When multiple SDSCs operated on different slices of the same logical
tensor, each registered the same `arg_index` at a different per-slice
address.  The old dedup keyed on address, so every slice became a
separate `!sdscbundle.input_arg` parameter — MLIR rejects duplicate
function parameter names.  Fix: dedup by `arg_index`; the first-seen
sym\_idx becomes the canonical parameter for that logical tensor.
Also sort `kernel_arg_sym_indices` by `arg_index` so the function
signature order matches the positional order `call_kernel` uses when
passing tensors to `.run()`.

**2. `DtException: Number of inputs mismatches` for in-place ops**
(`spyre_kernel.py`)

`call_kernel` extended the `.run(...)` call with the full
`python_argdefs()` list, which includes the same buffer name in both
input and output slots for in-place ops (e.g. `x *= 2`).  The MLIR
bundle emits one parameter per unique `arg_index`, so a duplicate name
caused an argument-count mismatch at launch.  Fix: deduplicate
`call_args` in `call_kernel`, preserving first-occurrence order.

**3. Wrong results from `%pool` arg passed to kernels that have no pool**
(`spyre_kernel.py`)

`call_kernel` unconditionally prepended `_pool` to the argument list
whenever `V.graph.pool_size > 0`, even for kernels whose `op_specs`
contain no pool-allocated tensors.  The bundle MLIR only emits a
`%pool_base_addr` parameter when `has_pool=True`, so passing an extra
argument caused a `Number of inputs mismatches` error for coarse-tile,
restickify, and LX-planning kernels.  Fix: replace the graph-level
`pool_size` check with `_kernel_uses_pool()`, a per-kernel scan of
`op_specs`.

**4. Compile-time slice offset silently lost for split/view tensors**
(`compute_ops.py`)

On the symbolic path, `generate_sdsc` was folding the per-tensor slice
offset (from device-coordinate constants like `z0+3`) directly into the
`kernel` symbol value.  At runtime, `input_arg_extract` provides only
the raw tensor base address, so the slice offset was discarded and
writes landed at the wrong memory location.  Fix: introduce
`SymbolKind.kernel_slice(arg_index, slice_offset_bytes)`.  The `kernel`
symbol stores the raw base (becomes the `!sdscbundle.input_arg`
parameter); when `slice_offset_bytes > 0` a `kernel_slice` symbol is
registered and emitted as `arith.addi %arg_N, <offset>`.  Per-core
derived symbols build on top of the per-tile sliced base.

**5. Per-tile offset ignored for coarse-tile loop unrolling**
(`compute_ops.py`)

When `unroll.py` unrolls a loop over tiles, it advances
`arg.allocation['hbm']` by `i * stride` for tile `i`, encoding the
per-tile byte offset into `start_address`.  The old code registered all
tiles under the same `("kernel", arg_index)` key, so tiles 1–3 all
referenced tile 0's `%arg_N` with no per-tile advance — every unrolled
`sdsc_execute` read from the same base address.  Fix: extract
`tile_offset_bytes = start_address - arg_index` and combine it with any
device-coordinate slice offset into `total_slice_offset`.  When
`total_slice_offset > 0`, a `kernel_slice` symbol is registered so
bundle.py emits `%arg_0_slice_16384 = arith.addi %arg_0, 16384` etc.

**6. kernel/pool key collision when `arg_index == 0` and pool offset `== 0`**
(`compute_ops.py`)

Kernel sentinels on the symbolic path are `arg_index` integers starting
at 0; pool offsets also start at 0.  Both mapped to integer key `0` in
`local_symbols`, so pool addresses silently aliased to kernel addresses.
Fix: use a fully-namespaced key scheme: `("kernel", ai)`, `("kernel_slice", ai, off)`,
raw `int` for derived addresses, and `("pool", off)` for pool offsets.

**7. `sliced_base_sym_idx` wrong when multiple slices share an `arg_index`**
(`compute_ops.py`)

Two tensors sharing an `arg_index` but having different slice offsets
both mapped to `("kernel_slice", arg_index)`, causing the second slice
to reuse the first's symbol.  Fix: include the slice offset in the key:
`("kernel_slice", arg_index, offset_bytes)`.

**8. Out-of-order `input_arg` parameters when arg_indices are not sequential**
(`bundle.py`)

When multiple SDSCs shared tensor args, kernel symbols were registered
in SDSC-processing order rather than `arg_index` order, causing the
function parameter list to be out of order (e.g. `%arg_3_base_addr`
before `%arg_2_base_addr`).  Fix: sort `kernel_arg_sym_indices` by
`arg_index` after dedup.

**9. `BUNDLE_SYMBOLIC_ARGS` env var not synced with Python config in tests**
(`test_launch_jobplan.py`)

`prepare_kernel` in the C++ layer reads `BUNDLE_SYMBOLIC_ARGS` directly
from the process environment at `JobPlan` build time.  Patching only the
Python config with `_spyre_config.patch(bundle_symbolic_args=False)` left
the C++ side still reading the default `"1"`, so it built a `JobPlan`
with `bind_io_addresses_=false` while the MLIR was generated without any
`input_arg` parameters, producing wrong results.  Fix: also set
`BUNDLE_SYMBOLIC_ARGS` in the environment to match, restoring it on exit.

**10. Sentinel values updated: `SEGMENT_OFFSETS` → `arg_index`**
(`spyre_kernel.py`)

`SEGMENT_OFFSETS` are O(16 GB) integers that served as compile-time HBM
address placeholders on the symbolic path.  They were misleading (they
looked like real HBM addresses) and unnecessary (the runtime overwrites
them anyway).  Use `arg_index` (0, 1, 2, …) as the sentinel: small,
unambiguous, and directly encoding what they represent.

#### Which issue(s) this PR is related to:

<!-- separate tracking issues exist for each fix above -->

Fixes #827. 

#### Special notes for your reviewer:

The key invariant enforced by this PR: **any access to `SEGMENT_OFFSETS`
values as tensor addresses on the symbolic path is a bug.**  On the sym
path `tensor.start_address` is always `arg_index + tile_offset_bytes`
(small integers), never a real HBM address.

#### Does this PR introduce a user-facing change?

Yes — `BUNDLE_SYMBOLIC_ARGS=1` is now the default.  Users who need the
previous behavior (addresses baked at compile time) can set
`BUNDLE_SYMBOLIC_ARGS=0` explicitly.

#### Additional note:
