### PR TITLE
feat(test framework): add per-file result summary and failed test list at end of run

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,0 +1,137 @@
+name: integration-tests
+
+# ---------------------------------------------------------------------------
+# Triggered by commits in upstream dependant repos (deeptools, flex, etc.) via
+# workflow_dispatch.  Runs the full test matrix against a specified
+# torch-spyre ref so regressions from upstream changes are caught early.
+#
+# Example caller pattern from an upstream repo's workflow:
+#
+#   gh workflow run integration-tests.yaml \
+#     --repo <org>/torch-spyre \
+#     -f triggering_repo=<repo link to deeptools/flex> \
+#     -f triggering_sha=${{ github.sha }} \
+#     -f rpm_location=... \
+#     -f rpm_names=...
+# ---------------------------------------------------------------------------
+on:
+  workflow_dispatch:
+    inputs:
+      # ---- Upstream provenance ----------------
+      triggering_repo:
+        description: Name of the upstream repo that triggered this run (e.g. "deeptools", "flex")
+        required: false
+        type: string
+        default: ''
+      triggering_sha:
+        description: Commit SHA in the upstream repo that triggered this run
+        required: false
+        type: string
+        default: ''
+
+      # ---- torch-spyre ref to test ----------
+      ref:
+        description: Branch, tag, or SHA of torch-spyre to check out and test
+        required: false
+        type: string
+        default: ''
+      repository:
+        description: Full clone URL of a torch-spyre fork (e.g. "https://github.com/myuser/torch-spyre.git"); leave empty for the base repo
+        required: false
+        type: string
+        default: ''
+
+      # ---- RPM / image overrides ------------------
+      rpm_location:
+        description: Artifactory location for RPM download
+        required: false
+        type: string
+        default: ''
+      rpm_names:
+        description: Space-separated list of RPM names to download and install
+        required: false
+        type: string
+        default: ''
+      build_torch_spyre:
+        description: Whether to re-build torch-spyre after installing the RPM
+        required: false
+        type: boolean
+        default: true
+      runner_label:
+        description: |
+          Per-PR ephemeral runner-set IMAGE label
+          (image_spyre_backend_pr_<component>_<sha12>).
+          Leave empty to use the standing image_spyre_backend set.
+        required: false
+        type: string
+        default: ''
+
+concurrency:
+  group: integration-tests-${{ inputs.triggering_repo }}-${{ inputs.triggering_sha || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Print a summary of what triggered this run so it is tracked
+  # ---------------------------------------------------------------------------
+  provenance:
+    name: Log upstream dependant tool regression trigger
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show trigger info
+        run: |
+          {
+            echo "## Integration test triggered by upstream change"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Upstream repo   | ${{ inputs.triggering_repo || '(not specified)' }} |"
+            echo "| Upstream commit | ${{ inputs.triggering_sha || '(not specified)' }} |"
+            echo "| torch-spyre ref | ${{ inputs.ref || github.sha }} |"
+            echo "| RPM names       | ${{ inputs.rpm_names || '(none)' }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # Run the full test matrix currently same as "run-tests" job in
+  # torch_spyre_tests.yaml
+  # ---------------------------------------------------------------------------
+  run-tests:
+    needs: provenance
+    uses: ./.github/workflows/_test_matrix.yaml
+    with:
+      runner_label: linux
+      image_label: ${{ inputs.runner_label || 'image_spyre_backend' }}
+      extra_test_flags: -v
+      checkout_pytorch: false
+      ref: ${{ inputs.ref || '' }}
+      repository: ${{ inputs.repository || '' }}
+      rpm_location: ${{ inputs.rpm_location || '' }}
+      rpm_names: ${{ inputs.rpm_names || '' }}
+      build_torch_spyre: ${{ inputs.build_torch_spyre == true }}
+
+  # ----------------------------------------------------------------------------------
+  # Fan-in gate job which is similar to run-spyre-unit-tests in torch_spyre_tests.yaml
+  # so callers can poll a single stable job name for pass/fail.
+  # ----------------------------------------------------------------------------------
+  integration-test-result:
+    name: Integration test result
+    runs-on: ubuntu-latest
+    needs: run-tests
+    if: always()
+    steps:
+      - name: Evaluate test results
+        run: |
+          RESULT="${{ needs.run-tests.result }}"
+          echo "run-tests result: ${RESULT}"
+
+          if [[ "${RESULT}" == "success" ]]; then
+            echo "All integration test suites passed."
+            exit 0
+          fi
+
+          echo "One or more integration test suites failed or were cancelled."
+          exit 1

--- a/tests/oot_framework/run_test.sh
+++ b/tests/oot_framework/run_test.sh
@@ -1452,6 +1452,30 @@ _add_suite_counts() {
 }
 
 # ---------------------------------------------------------------------------
+# Per-file result tracking — always collected (not just multi-config).
+# _FILE_SUMMARY_LABELS[i]  : display name (basename of original test file)
+# _FILE_SUMMARY_STATUS[i]  : PASS | FAIL | SIGNAL | NOTEST | ERROR
+# _FILE_SUMMARY_COUNTS[i]  : "passed failed error skipped xfailed xpassed time"
+# _ALL_FAILED_TESTS[]      : accumulated failed test node IDs, one per entry
+# ---------------------------------------------------------------------------
+_FILE_SUMMARY_LABELS=()
+_FILE_SUMMARY_STATUS=()
+_FILE_SUMMARY_COUNTS=()
+_ALL_FAILED_TESTS=()
+
+# _extract_failed_tests <output_file>
+# Prints one failed test node ID per line from pytest short summary section.
+_extract_failed_tests() {
+    local _f="$1"
+    [[ -f "$_f" ]] || return
+    grep -E '^FAILED ' "$_f" \
+        | sed 's/^FAILED //' \
+        | sed 's/ -.*//' \
+        | sed 's/^\[TAGS[^]]*\] //' \
+        | sed 's/__oot_wrapper//'
+}
+
+# ---------------------------------------------------------------------------
 # _parse_pytest_summary_line <output_file>
 #
 # Reads the captured pytest output file, finds the terminal summary line
@@ -1647,6 +1671,9 @@ _run_xdist_fallback() {
             echo "[torch_oot_device_tests_run]          Install with: pip install pytest-xdist" >&2
             echo "[torch_oot_device_tests_run]          Skipping remaining tests in: $_orig" >&2
             [[ $OVERALL_EXIT -eq 0 ]] && OVERALL_EXIT=1
+            _FILE_SUMMARY_LABELS+=("$(basename "$_orig") [signal/no-xdist]")
+            _FILE_SUMMARY_STATUS+=("SIGNAL")
+            _FILE_SUMMARY_COUNTS+=("0 0 0 0 0 0 0")
             return
         fi
     fi
@@ -1665,10 +1692,32 @@ _run_xdist_fallback() {
         echo "[torch_oot_device_tests_run] WARNING: xdist fallback subshell exited abnormally for $_orig" >&2
     fi
 
-    # Accumulate per-suite counts from xdist output (multi-config only).
-    if [[ ${#YAML_CONFIGS[@]} -ge 2 && -n "$_suite_lbl" && -f "$_xdist_out_tmp" ]]; then
+    # Track per-file results and collect failed test names from xdist run.
+    _xdist_display="$(basename "$_orig")"
+    if [[ -f "$_xdist_out_tmp" ]]; then
         read -r _sp _sf _se _ss _sxf _sxp _st <<< "$(_parse_pytest_summary_line "$_xdist_out_tmp")"
-        _add_suite_counts "$_suite_lbl" "${_sp:-0}" "${_sf:-0}" "${_se:-0}" "${_ss:-0}" "${_sxf:-0}" "${_sxp:-0}" "${_st:-0}"
+        # Accumulate per-suite counts (multi-config).
+        if [[ ${#YAML_CONFIGS[@]} -ge 2 && -n "$_suite_lbl" ]]; then
+            _add_suite_counts "$_suite_lbl" "${_sp:-0}" "${_sf:-0}" "${_se:-0}" "${_ss:-0}" "${_sxf:-0}" "${_sxp:-0}" "${_st:-0}"
+        fi
+        # Record per-file result for end-of-run summary.
+        case $_xexit in
+            0) _xfstatus="PASS" ;;
+            1) _xfstatus="FAIL" ;;
+            5) _xfstatus="NOTEST" ;;
+            *) _xfstatus="SIGNAL" ;;
+        esac
+        _FILE_SUMMARY_LABELS+=("${_xdist_display} [xdist]")
+        _FILE_SUMMARY_STATUS+=("$_xfstatus")
+        _FILE_SUMMARY_COUNTS+=("${_sp:-0} ${_sf:-0} ${_se:-0} ${_ss:-0} ${_sxf:-0} ${_sxp:-0} ${_st:-0}")
+        # Collect failed test names.
+        while IFS= read -r _fn; do
+            [[ -n "$_fn" ]] && _ALL_FAILED_TESTS+=("$_fn")
+        done < <(_extract_failed_tests "$_xdist_out_tmp")
+    else
+        _FILE_SUMMARY_LABELS+=("${_xdist_display} [signal]")
+        _FILE_SUMMARY_STATUS+=("SIGNAL")
+        _FILE_SUMMARY_COUNTS+=("0 0 0 0 0 0 0")
     fi
     rm -f "$_xdist_out_tmp"
 
@@ -1886,22 +1935,27 @@ _run_parallel_across_cards() {
     local -a _card_exit_files=()
     local -a _card_shard_list_files=()
     local -a _card_counts_files=()
+    local -a _card_summary_files=()
 
     for (( _k=0; _k<_n_cards; _k++ )); do
         local _card_exit_tmp="/tmp/_spyre_card_exit_${$}_${_k}.tmp"
         local _card_shard_list="/tmp/_spyre_card_shards_${$}_${_k}.tmp"
         local _card_counts_file="/tmp/_spyre_card_counts_${$}_${_k}.tmp"
+        local _card_summary_file="/tmp/_spyre_card_summary_${$}_${_k}.tmp"
         _card_exit_files+=("$_card_exit_tmp")
         _card_shard_list_files+=("$_card_shard_list")
         _card_counts_files+=("$_card_counts_file")
+        _card_summary_files+=("$_card_summary_file")
         : > "$_card_shard_list"
         : > "$_card_counts_file"
+        : > "$_card_summary_file"
 
         local _subshell_card="$_k"
         local _subshell_id_file="${_card_id_files[$_k]}"
         local _subshell_exit_tmp="$_card_exit_tmp"
         local _subshell_shard_list="$_card_shard_list"
         local _subshell_counts_file="$_card_counts_file"
+        local _subshell_summary_file="$_card_summary_file"
 
         (
             set +euo pipefail
@@ -2002,11 +2056,29 @@ _run_parallel_across_cards() {
                     echo "[torch_oot_device_tests_run] ERROR: pytest subshell exited abnormally for $original_file" >&2
                 fi
 
-                # Accumulate per-suite counts (multi-config only, clean runs).
-                if [[ ${#YAML_CONFIGS[@]} -ge 2 && -f "$_par_out_tmp" && $_exit -lt 128 ]]; then
-                    _p_suite_label="${_FILE_YAML_LABEL[$_fidx]:-unknown}"
+                # Track per-file results and collect failed test names.
+                _p_file_display="$(basename "$original_file")"
+                if [[ -f "$_par_out_tmp" && $_exit -lt 128 ]]; then
                     read -r _sp _sf _se _ss _sxf _sxp _st <<< "$(_parse_pytest_summary_line "$_par_out_tmp")"
-                    echo "${_p_suite_label} ${_sp:-0} ${_sf:-0} ${_se:-0} ${_ss:-0} ${_sxf:-0} ${_sxp:-0} ${_st:-0}" >> "$_subshell_counts_file"
+                    # Accumulate per-suite counts (multi-config).
+                    if [[ ${#YAML_CONFIGS[@]} -ge 2 ]]; then
+                        _p_suite_label="${_FILE_YAML_LABEL[$_fidx]:-unknown}"
+                        echo "${_p_suite_label} ${_sp:-0} ${_sf:-0} ${_se:-0} ${_ss:-0} ${_sxf:-0} ${_sxp:-0} ${_st:-0}" >> "$_subshell_counts_file"
+                    fi
+                    # Record per-file result for end-of-run summary.
+                    case $_exit in
+                        0) _pfstatus="PASS" ;;
+                        1) _pfstatus="FAIL" ;;
+                        5) _pfstatus="NOTEST" ;;
+                        *) _pfstatus="ERROR" ;;
+                    esac
+                    echo "FILE_RESULT ${_p_file_display} ${_pfstatus} ${_sp:-0} ${_sf:-0} ${_se:-0} ${_ss:-0} ${_sxf:-0} ${_sxp:-0} ${_st:-0}" >> "$_subshell_summary_file"
+                    # Collect failed test names.
+                    while IFS= read -r _pfn; do
+                        [[ -n "$_pfn" ]] && echo "FAILED_TEST ${_pfn}" >> "$_subshell_summary_file"
+                    done < <(_extract_failed_tests "$_par_out_tmp")
+                elif [[ $_exit -ge 128 ]]; then
+                    echo "FILE_RESULT ${_p_file_display} SIGNAL 0 0 0 0 0 0 0" >> "$_subshell_summary_file"
                 fi
                 rm -f "$_par_out_tmp"
 
@@ -2069,7 +2141,22 @@ _run_parallel_across_cards() {
 
     # -----------------------------------------------------------------------
     # Step 4: wait for all card subshells; collect exit codes and XML shards.
+    #
+    # Per-file results are aggregated across cards: a single test file may have
+    # its tests split round-robin across N cards, so each card writes its own
+    # FILE_RESULT entry.  The associative arrays below accumulate those slices
+    # and produce one consolidated row per file in the final summary.
     # -----------------------------------------------------------------------
+    local -A _par_agg_p=()
+    local -A _par_agg_f=()
+    local -A _par_agg_e=()
+    local -A _par_agg_s=()
+    local -A _par_agg_xf=()
+    local -A _par_agg_xp=()
+    local -A _par_agg_t=()
+    local -A _par_agg_status=()
+    local -a _par_agg_order=()
+
     echo "[torch_oot_device_tests_run] Waiting for all card jobs to finish..."
     for (( _k=0; _k<_n_cards; _k++ )); do
         wait "${_card_pids[$_k]}" || true
@@ -2111,7 +2198,66 @@ _run_parallel_across_cards() {
             rm -f "$_counts_file"
         fi
 
+        # Read per-file results and failed test names written by the card subshell.
+        # FILE_RESULT entries are accumulated into _par_agg_* rather than written
+        # directly to _FILE_SUMMARY_* so that slices from different cards for the
+        # same file are merged into one consolidated row.
+        local _summary_file="${_card_summary_files[$_k]}"
+        if [[ -f "$_summary_file" ]]; then
+            while IFS= read -r _sline; do
+                [[ -z "$_sline" ]] && continue
+                _stype="${_sline%% *}"
+                _srest="${_sline#* }"
+                if [[ "$_stype" == "FILE_RESULT" ]]; then
+                    read -r _slbl _sstatus _sp _sf _se _ss _sxf _sxp _st <<< "$_srest"
+                    _slbl="${_slbl:-unknown}"
+                    # First time we see this file: initialise aggregation slots.
+                    if [[ -z "${_par_agg_status[$_slbl]+set}" ]]; then
+                        _par_agg_order+=("$_slbl")
+                        _par_agg_p[$_slbl]=0
+                        _par_agg_f[$_slbl]=0
+                        _par_agg_e[$_slbl]=0
+                        _par_agg_s[$_slbl]=0
+                        _par_agg_xf[$_slbl]=0
+                        _par_agg_xp[$_slbl]=0
+                        _par_agg_t[$_slbl]="0"
+                        _par_agg_status[$_slbl]="NOTEST"
+                    fi
+                    # Sum counts across card slices.
+                    _par_agg_p[$_slbl]=$(( ${_par_agg_p[$_slbl]} + ${_sp:-0} ))
+                    _par_agg_f[$_slbl]=$(( ${_par_agg_f[$_slbl]} + ${_sf:-0} ))
+                    _par_agg_e[$_slbl]=$(( ${_par_agg_e[$_slbl]} + ${_se:-0} ))
+                    _par_agg_s[$_slbl]=$(( ${_par_agg_s[$_slbl]} + ${_ss:-0} ))
+                    _par_agg_xf[$_slbl]=$(( ${_par_agg_xf[$_slbl]} + ${_sxf:-0} ))
+                    _par_agg_xp[$_slbl]=$(( ${_par_agg_xp[$_slbl]} + ${_sxp:-0} ))
+                    _par_agg_t[$_slbl]=$(python3 -c "print('%.2f' % (${_par_agg_t[$_slbl]:-0} + ${_st:-0}))" 2>/dev/null || echo "${_par_agg_t[$_slbl]}")
+                    # Merge status: SIGNAL > FAIL > ERROR > PASS > NOTEST
+                    case "$_sstatus" in
+                        SIGNAL) _par_agg_status[$_slbl]="SIGNAL" ;;
+                        FAIL)   [[ "${_par_agg_status[$_slbl]}" != "SIGNAL" ]] && \
+                                    _par_agg_status[$_slbl]="FAIL" ;;
+                        ERROR)  [[ "${_par_agg_status[$_slbl]}" != "SIGNAL" && \
+                                    "${_par_agg_status[$_slbl]}" != "FAIL" ]] && \
+                                    _par_agg_status[$_slbl]="ERROR" ;;
+                        PASS)   [[ "${_par_agg_status[$_slbl]}" == "NOTEST" ]] && \
+                                    _par_agg_status[$_slbl]="PASS" ;;
+                    esac
+                elif [[ "$_stype" == "FAILED_TEST" ]]; then
+                    _ALL_FAILED_TESTS+=("$_srest")
+                fi
+            done < "$_summary_file"
+            rm -f "$_summary_file"
+        fi
+
         rm -f "${_card_id_files[$_k]}"
+    done
+
+    # Populate _FILE_SUMMARY_* from the aggregated per-file results (one row per
+    # unique file, counts summed across all card slices).
+    for _slbl in "${_par_agg_order[@]+"${_par_agg_order[@]}"}"; do
+        _FILE_SUMMARY_LABELS+=("$_slbl")
+        _FILE_SUMMARY_STATUS+=("${_par_agg_status[$_slbl]}")
+        _FILE_SUMMARY_COUNTS+=("${_par_agg_p[$_slbl]} ${_par_agg_f[$_slbl]} ${_par_agg_e[$_slbl]} ${_par_agg_s[$_slbl]} ${_par_agg_xf[$_slbl]} ${_par_agg_xp[$_slbl]} ${_par_agg_t[$_slbl]}")
     done
 }
 
@@ -2246,11 +2392,29 @@ for i in "${!RUN_FILES[@]}"; do
         echo "[torch_oot_device_tests_run] ERROR: pytest subshell exited abnormally (segfault or signal?) for $original_file" >&2
     fi
 
-    # Accumulate per-suite counts from pytest terminal output (multi-config only).
-    if [[ ${#YAML_CONFIGS[@]} -ge 2 && -f "$_OUT_TMP" && $_exit -lt 128 ]]; then
-        _suite_label="${_FILE_YAML_LABEL[$i]:-unknown}"
+    # Track per-file results and collect failed test names (always).
+    _file_display="$(basename "$original_file")"
+    if [[ -f "$_OUT_TMP" && $_exit -lt 128 ]]; then
         read -r _sp _sf _se _ss _sxf _sxp _st <<< "$(_parse_pytest_summary_line "$_OUT_TMP")"
-        _add_suite_counts "$_suite_label" "${_sp:-0}" "${_sf:-0}" "${_se:-0}" "${_ss:-0}" "${_sxf:-0}" "${_sxp:-0}" "${_st:-0}"
+        # Accumulate per-suite counts (multi-config).
+        if [[ ${#YAML_CONFIGS[@]} -ge 2 ]]; then
+            _suite_label="${_FILE_YAML_LABEL[$i]:-unknown}"
+            _add_suite_counts "$_suite_label" "${_sp:-0}" "${_sf:-0}" "${_se:-0}" "${_ss:-0}" "${_sxf:-0}" "${_sxp:-0}" "${_st:-0}"
+        fi
+        # Record per-file result for end-of-run summary.
+        case $_exit in
+            0) _fstatus="PASS" ;;
+            1) _fstatus="FAIL" ;;
+            5) _fstatus="NOTEST" ;;
+            *) _fstatus="ERROR" ;;
+        esac
+        _FILE_SUMMARY_LABELS+=("$_file_display")
+        _FILE_SUMMARY_STATUS+=("$_fstatus")
+        _FILE_SUMMARY_COUNTS+=("${_sp:-0} ${_sf:-0} ${_se:-0} ${_ss:-0} ${_sxf:-0} ${_sxp:-0} ${_st:-0}")
+        # Collect failed test names.
+        while IFS= read -r _fn; do
+            [[ -n "$_fn" ]] && _ALL_FAILED_TESTS+=("$_fn")
+        done < <(_extract_failed_tests "$_OUT_TMP")
     fi
     rm -f "$_OUT_TMP"
 
@@ -2401,6 +2565,58 @@ if [[ ${#YAML_CONFIGS[@]} -ge 2 ]]; then
             printf "  %-52s  %s\n" "$_lbl" "$_summary"
         done
     fi
+    echo "========================================================================"
+fi
+
+# ---------------------------------------------------------------------------
+# Per-file result summary — always printed.
+# ---------------------------------------------------------------------------
+echo ""
+echo "========================================================================"
+echo "[torch_oot_device_tests_run] Per-file result summary:"
+echo "========================================================================"
+if [[ ${#_FILE_SUMMARY_LABELS[@]} -eq 0 ]]; then
+    echo "  (no file results recorded)"
+else
+    for _fi in "${!_FILE_SUMMARY_LABELS[@]}"; do
+        _flbl="${_FILE_SUMMARY_LABELS[$_fi]}"
+        _fstat="${_FILE_SUMMARY_STATUS[$_fi]}"
+        read -r _fp _ff _fe _fs _fxf _fxp _ft <<< "${_FILE_SUMMARY_COUNTS[$_fi]}"
+        _fparts=()
+        [[ "${_fp:-0}"  -gt 0 ]] && _fparts+=("${_fp} passed")
+        [[ "${_ff:-0}"  -gt 0 ]] && _fparts+=("${_ff} failed")
+        [[ "${_fe:-0}"  -gt 0 ]] && _fparts+=("${_fe} error")
+        [[ "${_fs:-0}"  -gt 0 ]] && _fparts+=("${_fs} skipped")
+        [[ "${_fxf:-0}" -gt 0 ]] && _fparts+=("${_fxf} xfailed")
+        [[ "${_fxp:-0}" -gt 0 ]] && _fparts+=("${_fxp} xpassed")
+        if [[ ${#_fparts[@]} -eq 0 ]]; then
+            case "$_fstat" in
+                NOTEST) _fsummary="no tests collected" ;;
+                SIGNAL) _fsummary="signal/crash (see above)" ;;
+                *)      _fsummary="0 tests" ;;
+            esac
+        else
+            _fsummary="$(IFS=', '; echo "${_fparts[*]}")"
+            if [[ -n "${_ft:-}" && "$_ft" != "0" ]]; then
+                _fsummary="${_fsummary} in ${_ft}s"
+            fi
+        fi
+        printf "  %-8s  %-52s  %s\n" "$_fstat" "$_flbl" "$_fsummary"
+    done
+fi
+echo "========================================================================"
+
+# ---------------------------------------------------------------------------
+# Failed test names — printed when any failures were recorded.
+# ---------------------------------------------------------------------------
+if [[ ${#_ALL_FAILED_TESTS[@]} -gt 0 ]]; then
+    echo ""
+    echo "========================================================================"
+    echo "[torch_oot_device_tests_run] Failed tests (${#_ALL_FAILED_TESTS[@]}):"
+    echo "========================================================================"
+    for _failed in "${_ALL_FAILED_TESTS[@]}"; do
+        echo "  $_failed"
+    done
     echo "========================================================================"
 fi
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

This PR adds per-file result summary and failed test list at end of run

### Sample Output with 2 test files on this PR 

<img width="1462" height="714" alt="image" src="https://github.com/user-attachments/assets/9f68b658-3a81-4219-a7f8-c4decd449dbe" /> <br><br>

### Multiple cards output into a single test file summary
<img width="1824" height="200" alt="image" src="https://github.com/user-attachments/assets/e4a4efc3-f21e-42d8-a1c0-3f6df716b873" />

### Output with `make tests` (listing the specific failed tests at the end ) 

<img width="1690" height="1958" alt="image" src="https://github.com/user-attachments/assets/7adb13e6-39f8-4179-9d4e-af250eff58e2" /> <br><br>

### Complete Logs: 
[make_output_28th_june_v2.log](https://github.com/user-attachments/files/29429043/make_output_28th_june_v2.log)
