### PR TITLE
fix(memory_planning): sort pool allocation order deterministically

### DIFF
--- a/torch_spyre/_inductor/memory_planning.py
+++ b/torch_spyre/_inductor/memory_planning.py
@@ -233,7 +233,12 @@ def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
     live_ranges = _compute_live_ranges(nodes, intermediates)
 
     # Sort by start step so the allocator processes tensors in execution order.
-    sorted_bufs = sorted(live_ranges.items(), key=lambda kv: kv[1][0])
+    # Tie-break on (end_step, name) for determinism:
+    def _alloc_sort_key(item: tuple[str, tuple[int, int]]) -> tuple[int, int, str]:
+        name, (start, end) = item
+        return (start, end, name)
+
+    sorted_bufs = sorted(live_ranges.items(), key=_alloc_sort_key)
 
     allocator = Allocator(SEGMENT_SIZE)
 


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does

Fixes the nondeterminism of pool addresses in op specs, which sometimes varied from run to run.

The nondeterminism was because `live_ranges` in `memory_planning` is built by iterating a set, so its key order is non-deterministic.   Sorting by `start_step` alone left pool offsets varying when buffers shared a step.  

**Solution**: Add `end_step` and `name` as tie-break keys.  Op specs and sdscs produced are now identical when running coarse tile e2e tests.



