### PR TITLE
[test] Improve conv2d test stability with Xavier initialization for op-level tests

### DIFF
--- a/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506.yaml
+++ b/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506.yaml
@@ -139,14 +139,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 3, 14, 14]
                           stride: [588, 196, 14, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                       - value: (14, 14)
                       - value: (0, 0)

--- a/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506_spyre.yaml
+++ b/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506_spyre.yaml
@@ -137,14 +137,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 3, 14, 14]
                           stride: [588, 196, 14, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                       - value: (14, 14)
                       - value: (0, 0)

--- a/tests/resource/models/Mistral-Small-3.2-24B-Instruct-2506.yaml
+++ b/tests/resource/models/Mistral-Small-3.2-24B-Instruct-2506.yaml
@@ -58,14 +58,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 3, 14, 14]
           stride: [588, 196, 14, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - value: null
       - value: (14, 14)
       - value: (0, 0)

--- a/tests/resource/models/Mistral-Small-3.2-24B-Instruct-2506_spyre.yaml
+++ b/tests/resource/models/Mistral-Small-3.2-24B-Instruct-2506_spyre.yaml
@@ -55,14 +55,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 3, 14, 14]
           stride: [588, 196, 14, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - value: null
       - value: (14, 14)
       - value: (0, 0)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

This is a follow-up of https://github.com/torch-spyre/torch-spyre/pull/2610 to improve the numerical stability of conv2d tests under op-level tests.
In https://github.com/torch-spyre/torch-spyre/issues/2658, even when we translated this `conv2d` to `matmul`, we got a failure with `rand` and a success with `xavier`.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#2658
#2610

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

cc @michihirohorie, @umacdevi