### PR TITLE
Fix log-level propagation

### DIFF
--- a/torch_spyre/logging_config.py
+++ b/torch_spyre/logging_config.py
@@ -199,6 +199,27 @@ def _resolve_config() -> Dict[str, LogLevel]:
     torch_logs_config = _parse_torch_logs()
     config.update(torch_logs_config)
 
+    # When a user explicitly configures a parent component, propagate that
+    # level to any more-specific defaults that would otherwise shadow it.
+    # For example, TORCH_LOGS='+spyre.inductor' should override the default
+    # WARNING entry for 'spyre.inductor.codegen' so that child loggers like
+    # 'spyre.inductor.codegen.superdsc' resolve to the user-specified level.
+    explicit_sources = {
+        "TORCH_LOGS",
+        "legacy:SPYRE_INDUCTOR_LOG",
+        "legacy:TORCH_SPYRE_DEBUG",
+    }
+    for component in list(config):
+        if _config_source.get(component, "default") not in explicit_sources:
+            # Check if a less-specific ancestor was explicitly configured
+            parts = component.split(".")
+            for i in range(len(parts) - 1, 0, -1):
+                parent = ".".join(parts[:i])
+                if _config_source.get(parent, "default") in explicit_sources:
+                    config[component] = config[parent]
+                    _config_source[component] = _config_source[parent]
+                    break
+
     for component in config:
         if component not in _config_source:
             _config_source[component] = "default"


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
Setting log levels had no effect on loggers in files like superdsc.py and unroll.py. Their log output was silently suppressed regardless of the user's configuration. This PR fixes this by propagating the log level to all children (i.e., spyre.inductor -> spyre.inductor.codegen). 


#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
