### PR TITLE
chore: add @ani300 as code owner for runtime paths

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,16 +12,16 @@
 *  @mudhakar @raghukiran1224 @viji560 @tehbone @svaidy @elpidatz
 
 # torch_spyre top-level files (runtime infrastructure)
-/torch_spyre/*       @JRosenkranz @thoangtrvn
+/torch_spyre/*       @JRosenkranz @thoangtrvn @ani300
 
 # Inductor / compiler backend
 /torch_spyre/_inductor/  @dgrove-oss @avery-blanchard @cyang49 @marnold-ibm @tardieu
 
 # Device, execution, memory, and C++ runtime
-/torch_spyre/device/     @JRosenkranz @thoangtrvn
-/torch_spyre/execution/  @JRosenkranz @thoangtrvn
-/torch_spyre/memory/     @JRosenkranz @thoangtrvn
-/torch_spyre/csrc/       @JRosenkranz @thoangtrvn
+/torch_spyre/device/     @JRosenkranz @thoangtrvn @ani300
+/torch_spyre/execution/  @JRosenkranz @thoangtrvn @ani300
+/torch_spyre/memory/     @JRosenkranz @thoangtrvn @ani300
+/torch_spyre/csrc/       @JRosenkranz @thoangtrvn @ani300
 
 # Distributed / collective communication (spyre_ccl)
 /torch_spyre/csrc/distributed/  @jjhursey @JRosenkranz @thoangtrvn


### PR DESCRIPTION
Adds `@ani300` as a code owner for the runtime paths.

- `/torch_spyre/*` (top-level runtime infrastructure)
- `/torch_spyre/device/`
- `/torch_spyre/execution/`
- `/torch_spyre/memory/`
- `/torch_spyre/csrc/`

`/torch_spyre/csrc/distributed/` is intentionally left unchanged.

#### What type of PR is this?
- [x] cleanup