### PR TITLE
Enable --skip-slow flag for large_matmul tests on Z platform in lx_planning config

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_ops_lx_planning_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_ops_lx_planning_config.yaml
@@ -13,7 +13,15 @@ test_suite_config:
       # than enumerating each LxPlanningTwoOpPointwiseAdditionTest:: and
       # LxPlanningTwoOpReductionTest:: test name explicitly.
       unlisted_test_mode: mandatory_success
-      # tests:
+      tests:
+        - names:
+            - LxPlanningTwoOpPointwiseAdditionTest.*::test_large_matmul.*
+            - LxPlanningTwoOpReductionTest.*::test_large_matmul.*
+          mode: mandatory_success
+          tags:
+            - ops__inductor-matmul
+            - slow__plat_s390x
+      # Additional tests (commented out):
       #     ##########################################################################################
       #     # The following tests are failing in the CICD currently -- hence moving these to xfail now
       #     # Commented tests are passing now as per latest main (was failing previously in the CI)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [X] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
This PR enables the --skip-slow flag to properly skip time-consuming test_large_matmul tests on Z platform (s390x). Previously, the lx_planning test configuration lacked the necessary platform-specific slow tags, causing these tests to run even when --skip-slow was specified, resulting in unnecessarily long test execution times.

#### Testing:
Verified on s390x platform that test_large_matmul tests are now properly skipped with --skip-slow flag while other matmul tests continue to run normally.


1. Without --skip-slow:
```
bash tests/run_test.sh tests/configs/torch_spyre_tests/inductor/test_ops_lx_planning_config.yaml --collect-on
ly 2>&1 | grep "test_large_matmul"
```
returns
```
<TestCaseFunction test_large_matmul_matmul_2d_M2048_K2048_N65536_lx_planning_pointwise_spyre>
<TestCaseFunction test_large_matmul_matmul_2d_M2048_K2048_N65536_lx_planning_reduction_spyre>
```
          
2. With --skip-slow:
```
(torch-spyre) [senuser@834b93b9c114 torch-spyre]$ bash tests/run_test.sh tests/configs/torch_spyre_tests/inductor/test_ops_lx_planning_config.yaml --skip-slow --collect-only 2>&1 | grep "test_large_matmul"
```
returns nothing confirming that the large matmul tests are skipped.