### PR TITLE
inductor: add LX planner extension to enable all-to-all and all-gather on-chip

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_lx_relayout_dldsc_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_lx_relayout_dldsc_config.yaml
@@ -1,0 +1,4 @@
+test_suite_config:
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_lx_relayout_dldsc.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -111,9 +111,19 @@ def _bmm_op_spec(op: str) -> OpSpec:
     )
 
 
-@pytest.mark.parametrize("op", [BATCH_MATMUL_OP, BATCH_MATMUL_FP8_OP])
-@pytest.mark.parametrize("reduction_contiguous", [False, True])
-def test_planner_and_sdsc_use_the_same_mapping(monkeypatch, op, reduction_contiguous):
+@pytest.mark.parametrize(
+    "op,reduction_contiguous,gather_contiguous",
+    [
+        (BATCH_MATMUL_OP, False, False),
+        (BATCH_MATMUL_OP, True, False),
+        (BATCH_MATMUL_FP8_OP, False, False),
+        (BATCH_MATMUL_FP8_OP, True, False),
+        (BATCH_MATMUL_OP, True, True),
+    ],
+)
+def test_planner_and_sdsc_use_the_same_mapping(
+    monkeypatch, op, reduction_contiguous, gather_contiguous
+):
     class FakeReduction:
         def __init__(self, reduction_type):
             self.reduction_type = reduction_type
@@ -137,6 +147,8 @@ def test_planner_and_sdsc_use_the_same_mapping(monkeypatch, op, reduction_contig
 
     op_spec = _bmm_op_spec(op)
     dims = tuple(op_spec.iteration_space)
+    gather_dim = dims[1] if gather_contiguous else None
+    op_spec.gather_dim = gather_dim
     splits = dict(zip(dims, (2, 4, 4)))
     monkeypatch.setattr(
         pass_utils_module, "apply_splits_from_index_coeff", lambda *_: splits
@@ -155,6 +167,7 @@ def test_planner_and_sdsc_use_the_same_mapping(monkeypatch, op, reduction_contig
         num_stick=0,
         num_stick_stride=0,
         is_matmul=pass_utils_module._is_matmul_op(FakeComputedBuffer(op)),
+        gather_dim=gather_dim,
     )
     planner_view, _, representable = pass_utils_module._per_core_view_from_prep(
         prep, ({1: 2, 2: 4}, {3: 4})
@@ -167,3 +180,8 @@ def test_planner_and_sdsc_use_the_same_mapping(monkeypatch, op, reduction_contig
     }
     assert representable
     assert dict(planner_view.core_to_slot) == sdsc_output_mapping
+    if gather_dim is not None:
+        core_id = sympy.Symbol("core_id")
+        assert [
+            int(sdsc_output_mapping[1].subs(core_id, core)) for core in range(4)
+        ] == list(range(4))

--- a/tests/inductor/test_lx_relayout_dldsc.py
+++ b/tests/inductor/test_lx_relayout_dldsc.py
@@ -74,6 +74,21 @@ def _all_gather_plan() -> LXRelayoutPlan:
     )
 
 
+def _granite_mlp_all_to_all_plan() -> LXRelayoutPlan:
+    producer_map = {str(core): {"0": core // 8, "1": core % 8} for core in range(32)}
+    consumer_map = {str(core): {"0": core, "1": 0} for core in range(32)}
+    return LXRelayoutPlan(
+        source_name="buf_mlp",
+        consumer_name="pointwise",
+        source_core_id_to_device_slice=producer_map,
+        destination_core_id_to_device_slice=consumer_map,
+        source_device_dim_splits={"0": 4, "1": 8},
+        destination_device_dim_splits={"0": 32, "1": 1},
+        destination_size_ratio=1,
+        destination_lx_address=0x44000,
+    )
+
+
 def _overlap(lhs, rhs):
     return lhs.address < rhs.address + rhs.size and rhs.address < lhs.address + lhs.size
 
@@ -166,6 +181,82 @@ def test_all_to_all_geometry_and_emission():
     assert args[0].name == args[1].name == plan.destination_name
 
 
+def test_dense_common_refinement_geometries():
+    producer_8x4 = {str(core): {"0": core // 4, "1": core % 4} for core in range(32)}
+    partition_4x8 = {str(core): {"0": core // 8, "1": core % 8} for core in range(32)}
+    partition_32x1 = {str(core): {"0": core, "1": 0} for core in range(32)}
+
+    assert (
+        _destination_size_ratio(
+            producer_8x4,
+            {"0": 8, "1": 4},
+            partition_4x8,
+            {"0": 4, "1": 8},
+        )
+        == 1
+    )
+    assert (
+        _destination_size_ratio(
+            partition_4x8,
+            {"0": 4, "1": 8},
+            partition_32x1,
+            {"0": 32, "1": 1},
+        )
+        == 1
+    )
+
+    incomplete_partition = {
+        str(core): {"0": core // 8, "1": core % 8} for core in range(32)
+    }
+    assert (
+        _destination_size_ratio(
+            incomplete_partition,
+            {"0": 8, "1": 8},
+            partition_32x1,
+            {"0": 32, "1": 1},
+        )
+        is None
+    )
+
+
+def test_granite_mlp_common_refinement_emits_standard_shuffle():
+    m = Symbol("m")
+    n = Symbol("n")
+    plan = _granite_mlp_all_to_all_plan()
+    source_arg = TensorArg(
+        is_input=True,
+        arg_index=-1,
+        device_dtype=DataFormats.SEN169_FP16,
+        device_size=[512, 200, 64],
+        device_coordinates=[m, floor(n / 64), Mod(n, 64)],
+        allocation={"lx": 0x24000},
+        name=plan.source_name,
+    )
+    consumer_spec = OpSpec(
+        op="silu",
+        is_reduction=False,
+        iteration_space={m: (Integer(512), 32), n: (Integer(12800), 1)},
+        args=[source_arg],
+        op_info={},
+    )
+
+    result = _materialize_explicit_lx_shuffle(source_arg, consumer_spec, plan)
+
+    assert result is not None
+    shuffle_spec, consumer_arg = result
+    root, allocations = _compile_shuffle(shuffle_spec)
+    assert root["numCoresUsed_"] == 32
+    assert consumer_arg.name == plan.destination_name
+    assert consumer_arg.allocation == {"lx": plan.destination_lx_address}
+
+    producer_geometry = allocations[0]["coordinates_"]["coreIdToWkSlice_"]
+    consumer_geometry = allocations[1]["coordinates_"]["coreIdToWkSlice_"]
+    assert producer_geometry["0"] == {"mb": 0, "out": 0}
+    assert producer_geometry["31"] == {"mb": 3, "out": 7}
+    assert consumer_geometry["0"] == {"mb": 0, "out": 0}
+    assert consumer_geometry["31"] == {"mb": 31, "out": 0}
+
+
 def test_expanding_geometry_is_allocated_atomically_or_falls_back():
     graph = _DummyGraph("producer", "independent_1", "independent_2", "consumer")
     # GraphEditor may insert operations without updating GraphLowering's buffer map.
@@ -241,6 +332,68 @@ def test_relayout_keeps_producer_inputs_live_through_shuffle(monkeypatch):
 
     assert producer_input.uses == [0, 1, 2]
     assert producer_child.in_place_parents == []
+
+
+def test_partial_relayout_fallback_keeps_complete_pairs():
+    complete_plan = replace(
+        _all_gather_plan(), source_name="complete", consumer_name="consumer_a"
+    )
+    incomplete_plan = replace(
+        _all_gather_plan(), source_name="incomplete", consumer_name="consumer_b"
+    )
+    complete_source = LifetimeBoundBuffer("complete", size=128, uses=[0, 1])
+    complete_destination = LifetimeBoundBuffer(
+        complete_plan.destination_name, size=128, uses=[1, 2]
+    )
+    incomplete_source = LifetimeBoundBuffer("incomplete", size=128, uses=[2, 3])
+    incomplete_destination = LifetimeBoundBuffer(
+        incomplete_plan.destination_name, size=128, uses=[3, 4]
+    )
+    dependent = LifetimeBoundBuffer(
+        "dependent",
+        size=128,
+        uses=[3, 4],
+        in_place_parents=["incomplete"],
+    )
+    buffers = [
+        complete_source,
+        complete_destination,
+        incomplete_source,
+        incomplete_destination,
+        dependent,
+    ]
+
+    class _PartialLayout:
+        spill_reasons = {}
+
+        def plan_layout(self, planned_buffers, log_lx_usage=False):
+            del log_lx_usage
+            addresses = {
+                "complete": 0,
+                complete_plan.destination_name: 256,
+                "incomplete": 512,
+                incomplete_plan.destination_name: None,
+                "dependent": 640,
+            }
+            for buffer in planned_buffers:
+                buffer.address = addresses[buffer.name]
+            return list(planned_buffers)
+
+    allocator = ScratchpadAllocator(GreedyLayoutSolver(1536 * 1024))
+    allocator._lx_relayout_plans_by_source = {
+        "complete": complete_plan,
+        "incomplete": incomplete_plan,
+    }
+    allocation = allocator._plan_layout_with_atomic_relayouts(_PartialLayout(), buffers)
+    by_name = {buffer.name: buffer for buffer in allocation}
+
+    assert by_name["complete"].address == 0
+    assert by_name[complete_plan.destination_name].address == 256
+    assert by_name["incomplete"].address is None
+    assert by_name[incomplete_plan.destination_name].address is None
+    assert by_name["dependent"].address == 640
+    assert by_name["dependent"].in_place_parents == []
+    assert allocator._lx_relayout_plans_by_source == {"complete": complete_plan}
 
 
 def test_planned_restickify_source_is_eligible_for_lx_reuse(monkeypatch):

--- a/tests/inductor/test_lx_relayout_dldsc.py
+++ b/tests/inductor/test_lx_relayout_dldsc.py
@@ -224,6 +224,9 @@ def test_relayout_keeps_producer_inputs_live_through_shuffle(monkeypatch):
     plan = _all_gather_plan()
     producer_input = LifetimeBoundBuffer("producer_input", size=128, uses=[0, 1])
     source = LifetimeBoundBuffer("buf_k", size=128, uses=[1, 2])
+    producer_child = LifetimeBoundBuffer(
+        "producer_child", size=128, uses=[1, 2], in_place_parents=["producer_input"]
+    )
     allocator = ScratchpadAllocator(GreedyLayoutSolver(1536 * 1024))
     allocator._lx_relayout_plans_by_source = {"buf_k": plan}
     monkeypatch.setattr(
@@ -232,9 +235,12 @@ def test_relayout_keeps_producer_inputs_live_through_shuffle(monkeypatch):
         lambda _: SimpleNamespace(reads=[SimpleNamespace(name="producer_input")]),
     )
 
-    allocator._append_lx_relayout_destinations(graph, [producer_input, source])
+    allocator._append_lx_relayout_destinations(
+        graph, [producer_input, source, producer_child]
+    )
 
     assert producer_input.uses == [0, 1, 2]
+    assert producer_child.in_place_parents == []
 
 
 def test_planned_restickify_source_is_eligible_for_lx_reuse(monkeypatch):

--- a/tests/inductor/test_lx_relayout_dldsc.py
+++ b/tests/inductor/test_lx_relayout_dldsc.py
@@ -237,6 +237,41 @@ def test_relayout_keeps_producer_inputs_live_through_shuffle(monkeypatch):
     assert producer_input.uses == [0, 1, 2]
 
 
+def test_planned_restickify_source_is_eligible_for_lx_reuse(monkeypatch):
+    class _MutationLayout:
+        pass
+
+    class _ComputedBuffer:
+        def __init__(self, name, layout=None):
+            self.name = name
+            self.layout = SimpleNamespace() if layout is None else layout
+
+        def get_name(self):
+            return self.name
+
+    allocator = ScratchpadAllocator(GreedyLayoutSolver(1536 * 1024))
+    allocator._lx_relayout_plans_by_source = {"buf_k": _all_gather_plan()}
+    source = _ComputedBuffer("buf_k")
+    unrelated = _ComputedBuffer("unrelated")
+    mutated_source = _ComputedBuffer("buf_k", _MutationLayout())
+    monkeypatch.setattr(allocator_module, "ComputedBuffer", _ComputedBuffer)
+    monkeypatch.setattr(
+        allocator_module,
+        "MutationLayoutSHOULDREMOVE",
+        _MutationLayout,
+    )
+    monkeypatch.setattr(
+        allocator_module.config,
+        "allow_all_ops_in_lx_planning",
+        False,
+    )
+    monkeypatch.setattr(allocator, "_get_op_name", lambda _: "restickify")
+
+    assert allocator._op_output_good_for_lx_reuse(source)
+    assert not allocator._op_output_good_for_lx_reuse(unrelated)
+    assert not allocator._op_output_good_for_lx_reuse(mutated_source)
+
+
 def test_all_gather_emits_standard_shuffle_fold_geometry():
     h = Symbol("h")
     lq = Symbol("lq")

--- a/tests/inductor/test_lx_relayout_dldsc.py
+++ b/tests/inductor/test_lx_relayout_dldsc.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 
 from sympy import Integer, Mod, Symbol, floor
 
+import torch_spyre._inductor.lx_relayout as lx_relayout_module
 import torch_spyre._inductor.scratchpad.allocator as allocator_module
 
 from torch_spyre._C import DataFormats
@@ -24,11 +25,14 @@ from torch_spyre._inductor.codegen.superdsc import compile_op_spec
 from torch_spyre._inductor.constants import BATCH_MATMUL_OP
 from torch_spyre._inductor.lx_relayout import (
     LX_RELAYOUT_ATTR,
+    LXCollectiveKind,
     LXRelayoutPlan,
+    _classify_lx_relayout,
     _destination_size_ratio,
+    collect_lx_relayout_plans,
 )
 from torch_spyre._inductor.op_spec import OpSpec, TensorArg
-from torch_spyre._inductor.pass_utils import copy_fx_custom_meta
+from torch_spyre._inductor.pass_utils import PerCoreView, copy_fx_custom_meta
 from torch_spyre._inductor.propagate_hints import get_gather_dim
 from torch_spyre._inductor.scratchpad.allocator import ScratchpadAllocator
 from torch_spyre._inductor.scratchpad.firstfit_bestfit_solver import (
@@ -70,6 +74,7 @@ def _all_gather_plan() -> LXRelayoutPlan:
         destination_core_id_to_device_slice=consumer_map,
         source_device_dim_splits={"0": 4, "1": 8},
         destination_device_dim_splits={"0": 4, "1": 1},
+        collective_kind=LXCollectiveKind.ALL_GATHER,
         destination_size_ratio=8,
     )
 
@@ -84,6 +89,23 @@ def _granite_mlp_all_to_all_plan() -> LXRelayoutPlan:
         destination_core_id_to_device_slice=consumer_map,
         source_device_dim_splits={"0": 4, "1": 8},
         destination_device_dim_splits={"0": 32, "1": 1},
+        collective_kind=LXCollectiveKind.ALL_TO_ALL,
+        destination_size_ratio=1,
+        destination_lx_address=0x44000,
+    )
+
+
+def _broadcast_plan() -> LXRelayoutPlan:
+    producer_map = {"0": {}}
+    consumer_map = {str(core): {} for core in range(32)}
+    return LXRelayoutPlan(
+        source_name="broadcast_source",
+        consumer_name="consumer",
+        source_core_id_to_device_slice=producer_map,
+        destination_core_id_to_device_slice=consumer_map,
+        source_device_dim_splits={},
+        destination_device_dim_splits={},
+        collective_kind=LXCollectiveKind.BROADCAST,
         destination_size_ratio=1,
         destination_lx_address=0x44000,
     )
@@ -118,21 +140,25 @@ def test_gather_dim_hint_survives_metadata_copy():
 def test_all_to_all_geometry_and_emission():
     producer_map = {"0": {"0": 0}, "1": {"0": 1}}
     consumer_map = {"0": {"0": 1}, "1": {"0": 0}}
-    shuffle = _destination_size_ratio(
+    all_to_all = _classify_lx_relayout(
         producer_map,
         {"0": 2},
         consumer_map,
         {"0": 2},
     )
-    all_gather = _destination_size_ratio(
+    all_gather = _classify_lx_relayout(
         {"0": {"0": 0}, "1": {"0": 1}},
         {"0": 2},
         {"0": {"0": 0}, "1": {"0": 0}},
         {"0": 1},
     )
 
-    assert shuffle == 1
-    assert all_gather == 2
+    assert all_to_all is not None
+    assert all_to_all.collective_kind is LXCollectiveKind.ALL_TO_ALL
+    assert all_to_all.destination_size_ratio == 1
+    assert all_gather is not None
+    assert all_gather.collective_kind is LXCollectiveKind.ALL_GATHER
+    assert all_gather.destination_size_ratio == 2
 
     x = Symbol("x")
     plan = LXRelayoutPlan(
@@ -142,6 +168,7 @@ def test_all_to_all_geometry_and_emission():
         destination_core_id_to_device_slice=consumer_map,
         source_device_dim_splits={"0": 2},
         destination_device_dim_splits={"0": 2},
+        collective_kind=LXCollectiveKind.ALL_TO_ALL,
         destination_size_ratio=1,
         destination_lx_address=0x44000,
     )
@@ -179,6 +206,147 @@ def test_all_to_all_geometry_and_emission():
     )
     assert len(prefix) == 1
     assert args[0].name == args[1].name == plan.destination_name
+
+
+def test_broadcast_geometry_requires_one_physical_source_owner():
+    producer_map = {"0": {}}
+    consumer_map = {str(core): {} for core in range(32)}
+
+    classification = _classify_lx_relayout(
+        producer_map,
+        {},
+        consumer_map,
+        {},
+    )
+
+    assert classification is not None
+    assert classification.collective_kind is LXCollectiveKind.BROADCAST
+    assert classification.destination_size_ratio == 1
+
+    # Repeated producer owners would falsely claim the value already exists on
+    # every core. They are neither a partition nor a valid broadcast source.
+    padded_producer_map = {str(core): {} for core in range(32)}
+    assert (
+        _classify_lx_relayout(
+            padded_producer_map,
+            {},
+            consumer_map,
+            {},
+        )
+        is None
+    )
+
+    # Multiple independently replicated source shards are multicast cohorts,
+    # which are not yet supported by this planner.
+    multicast_producer_map = {"0": {"0": 0}, "1": {"0": 1}}
+    multicast_consumer_map = {
+        str(core): {"0": 0 if core < 16 else 1} for core in range(32)
+    }
+    assert (
+        _classify_lx_relayout(
+            multicast_producer_map,
+            {"0": 2},
+            multicast_consumer_map,
+            {"0": 2},
+        )
+        is None
+    )
+
+
+def test_planner_keeps_equal_view_edge_when_core_counts_require_broadcast(monkeypatch):
+    class _FakePointwise:
+        pass
+
+    class _FakeBuffer:
+        def __init__(self, name):
+            self.name = name
+            self.data = _FakePointwise()
+
+        def get_name(self):
+            return self.name
+
+    class _FakeDep:
+        def __init__(self, name):
+            self.name = name
+
+    producer = _FakeBuffer("broadcast_source")
+    consumer = _FakeBuffer("consumer")
+    source_write = _FakeDep(producer.name)
+    source_read = _FakeDep(producer.name)
+    consumer_write = _FakeDep(consumer.name)
+    graph = SimpleNamespace(operations=[producer, consumer])
+    whole_buffer_view = PerCoreView(work_slice_dims=(), core_to_slot=())
+
+    def read_writes(op):
+        if op is producer:
+            return SimpleNamespace(reads=[], writes=[source_write])
+        return SimpleNamespace(reads=[source_read], writes=[consumer_write])
+
+    monkeypatch.setattr(lx_relayout_module.config, "lx_planner_relayout", True)
+    monkeypatch.setattr(lx_relayout_module, "ComputedBuffer", _FakeBuffer)
+    monkeypatch.setattr(lx_relayout_module, "Pointwise", _FakePointwise)
+    monkeypatch.setattr(lx_relayout_module, "MemoryDep", _FakeDep)
+    monkeypatch.setattr(lx_relayout_module, "op_read_writes", read_writes)
+    monkeypatch.setattr(lx_relayout_module, "_is_matmul_op", lambda _: False)
+    monkeypatch.setattr(
+        lx_relayout_module,
+        "_per_core_view_on_buf",
+        lambda *_: (whole_buffer_view, False, True),
+    )
+    monkeypatch.setattr(
+        lx_relayout_module,
+        "_op_num_cores",
+        lambda op: 1 if op is producer else 32,
+    )
+
+    plans = collect_lx_relayout_plans(graph)
+
+    assert len(plans) == 1
+    plan = plans[0]
+    assert plan.collective_kind is LXCollectiveKind.BROADCAST
+    assert plan.source_core_id_to_device_slice == {"0": {}}
+    assert len(plan.destination_core_id_to_device_slice) == 32
+    assert all(
+        not per_core for per_core in plan.destination_core_id_to_device_slice.values()
+    )
+
+
+def test_broadcast_emits_one_to_all_standard_shuffle():
+    m = Symbol("m")
+    n = Symbol("n")
+    plan = _broadcast_plan()
+    source_arg = TensorArg(
+        is_input=True,
+        arg_index=-1,
+        device_dtype=DataFormats.SEN169_FP16,
+        device_size=[2, 64],
+        device_coordinates=[floor(n / 64), Mod(n, 64)],
+        allocation={"lx": 0x24000},
+        name=plan.source_name,
+    )
+    consumer_spec = OpSpec(
+        op="add",
+        is_reduction=False,
+        iteration_space={m: (Integer(32), 32), n: (Integer(128), 1)},
+        args=[source_arg, source_arg],
+        op_info={},
+    )
+
+    result = _materialize_explicit_lx_shuffle(source_arg, consumer_spec, plan)
+
+    assert result is not None
+    shuffle_spec, consumer_arg = result
+    assert shuffle_spec.op == "shuffle"
+    assert shuffle_spec.num_cores_override == 32
+    assert consumer_arg.allocation == {"lx": plan.destination_lx_address}
+    root, allocations = _compile_shuffle(shuffle_spec)
+    assert root["numCoresUsed_"] == 32
+
+    producer_geometry = allocations[0]["coordinates_"]["coreIdToWkSlice_"]
+    consumer_geometry = allocations[1]["coordinates_"]["coreIdToWkSlice_"]
+    assert producer_geometry == {"0": {"out": 0}}
+    assert len(consumer_geometry) == 32
+    assert all(per_core == {"out": 0} for per_core in consumer_geometry.values())
 
 
 def test_dense_common_refinement_geometries():
@@ -308,6 +476,41 @@ def test_expanding_geometry_is_allocated_atomically_or_falls_back():
     assert by_name["scores"].address is not None
     fallback_allocator._record_successful_lx_relayouts(graph, allocation)
     assert not hasattr(graph.operations[3], LX_RELAYOUT_ATTR)
+
+
+def test_broadcast_destination_is_full_sized_and_disjoint():
+    graph = _DummyGraph("producer", "consumer")
+    plan = _broadcast_plan()
+    source = LifetimeBoundBuffer(plan.source_name, size=128 * 1024, uses=[0, 1])
+    consumer_output = LifetimeBoundBuffer(
+        "consumer_output",
+        size=128 * 1024,
+        uses=[1, 2],
+        in_place_parents=[plan.source_name],
+    )
+    allocator = ScratchpadAllocator(GreedyLayoutSolver(384 * 1024))
+    allocator._lx_relayout_plans_by_source = {plan.source_name: plan}
+    buffers = [source, consumer_output]
+
+    allocator._append_lx_relayout_destinations(graph, buffers)
+
+    destination = {buffer.name: buffer for buffer in buffers}[plan.destination_name]
+    assert destination.size == source.size
+    assert source.uses == [0, 1]
+    assert destination.uses == [1, 2]
+    assert consumer_output.uses == [2, 3]
+    assert consumer_output.in_place_parents == []
+
+    layout_planning = allocator._layout_planner_for_buffers(buffers)
+    allocation = allocator._plan_layout_with_atomic_relayouts(layout_planning, buffers)
+    by_name = {buffer.name: buffer for buffer in allocation}
+    assert all(buffer.address is not None for buffer in allocation)
+    assert not _overlap(by_name[plan.source_name], by_name[plan.destination_name])
+
+    allocator._record_successful_lx_relayouts(graph, allocation)
+    recorded = getattr(graph.operations[1], LX_RELAYOUT_ATTR)[plan.source_name]
+    assert recorded.collective_kind is LXCollectiveKind.BROADCAST
+    assert recorded.destination_lx_address == destination.address
 
 
 def test_relayout_keeps_producer_inputs_live_through_shuffle(monkeypatch):

--- a/tests/inductor/test_lx_relayout_dldsc.py
+++ b/tests/inductor/test_lx_relayout_dldsc.py
@@ -1,0 +1,311 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+from sympy import Integer, Mod, Symbol, floor
+
+import torch_spyre._inductor.scratchpad.allocator as allocator_module
+
+from torch_spyre._C import DataFormats
+from torch_spyre._inductor.codegen.superdsc import compile_op_spec
+from torch_spyre._inductor.constants import BATCH_MATMUL_OP
+from torch_spyre._inductor.lx_relayout import (
+    LX_RELAYOUT_ATTR,
+    LXRelayoutPlan,
+    _destination_size_ratio,
+)
+from torch_spyre._inductor.op_spec import OpSpec, TensorArg
+from torch_spyre._inductor.pass_utils import copy_fx_custom_meta
+from torch_spyre._inductor.propagate_hints import get_gather_dim
+from torch_spyre._inductor.scratchpad.allocator import ScratchpadAllocator
+from torch_spyre._inductor.scratchpad.firstfit_bestfit_solver import (
+    FirstFitLayoutSolver,
+)
+from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
+from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
+from torch_spyre._inductor.spyre_kernel import (
+    _materialize_explicit_lx_shuffle,
+    _materialize_lx_relayout_inputs,
+    simplify_op_spec,
+)
+
+
+class _DummyOp:
+    def __init__(self, name):
+        self.name = name
+
+    def get_name(self):
+        return self.name
+
+
+class _DummyGraph:
+    def __init__(self, *names):
+        self.operations = [_DummyOp(name) for name in names]
+        self.name_to_buffer = {op.name: op for op in self.operations}
+
+    def try_get_buffer(self, name):
+        return self.name_to_buffer.get(name)
+
+
+def _all_gather_plan() -> LXRelayoutPlan:
+    producer_map = {str(core): {"0": core // 8, "1": core % 8} for core in range(32)}
+    consumer_map = {str(core): {"0": core // 8, "1": 0} for core in range(32)}
+    return LXRelayoutPlan(
+        source_name="buf_k",
+        consumer_name="consumer",
+        source_core_id_to_device_slice=producer_map,
+        destination_core_id_to_device_slice=consumer_map,
+        source_device_dim_splits={"0": 4, "1": 8},
+        destination_device_dim_splits={"0": 4, "1": 1},
+        destination_size_ratio=8,
+    )
+
+
+def _overlap(lhs, rhs):
+    return lhs.address < rhs.address + rhs.size and rhs.address < lhs.address + lhs.size
+
+
+def _compile_shuffle(shuffle_spec):
+    simplify_op_spec(shuffle_spec)
+    sdsc, *_ = compile_op_spec(0, shuffle_spec, [])
+    root = next(iter(sdsc.values()))
+    shuffle_dsc = next(iter(root["dscs_"][0].values()))
+    allocations = [
+        row for row in shuffle_dsc["scheduleTree_"] if row["nodeType_"] == "allocate"
+    ]
+    return root, allocations
+
+
+def test_gather_dim_hint_survives_metadata_copy():
+    src = SimpleNamespace(meta={"custom": {"_hint_1": {"gather_dim": "Lq"}}})
+    dst = SimpleNamespace(meta={"custom": {"_hint_2": {"work_div": {"H": 4}}}})
+    copy_fx_custom_meta(src, dst)
+
+    lq = Symbol("lq")
+    op = SimpleNamespace(origins=[dst], work_div_loop_info={lq: ["Lq"]})
+    assert get_gather_dim(op) == lq
+    assert set(dst.meta["custom"]) == {"_hint_1", "_hint_2"}
+
+
+def test_all_to_all_geometry_and_emission():
+    producer_map = {"0": {"0": 0}, "1": {"0": 1}}
+    consumer_map = {"0": {"0": 1}, "1": {"0": 0}}
+    shuffle = _destination_size_ratio(
+        producer_map,
+        {"0": 2},
+        consumer_map,
+        {"0": 2},
+    )
+    all_gather = _destination_size_ratio(
+        {"0": {"0": 0}, "1": {"0": 1}},
+        {"0": 2},
+        {"0": {"0": 0}, "1": {"0": 0}},
+        {"0": 1},
+    )
+
+    assert shuffle == 1
+    assert all_gather == 2
+
+    x = Symbol("x")
+    plan = LXRelayoutPlan(
+        source_name="buf_x",
+        consumer_name="consumer",
+        source_core_id_to_device_slice=producer_map,
+        destination_core_id_to_device_slice=consumer_map,
+        source_device_dim_splits={"0": 2},
+        destination_device_dim_splits={"0": 2},
+        destination_size_ratio=1,
+        destination_lx_address=0x44000,
+    )
+    source_arg = TensorArg(
+        is_input=True,
+        arg_index=-1,
+        device_dtype=DataFormats.SEN169_FP16,
+        device_size=[2, 64],
+        device_coordinates=[floor(x / 64), Mod(x, 64)],
+        allocation={"lx": 0x24000},
+        name="buf_x",
+    )
+    consumer_spec = OpSpec(
+        op="neg",
+        is_reduction=False,
+        iteration_space={x: (Integer(128), 2)},
+        args=[source_arg],
+        op_info={},
+    )
+
+    result = _materialize_explicit_lx_shuffle(source_arg, consumer_spec, plan)
+    assert result is not None
+    _, allocations = _compile_shuffle(result[0])
+    assert allocations[0]["coordinates_"]["coreIdToWkSlice_"]["0"] == {"out": 0}
+    assert allocations[1]["coordinates_"]["coreIdToWkSlice_"]["0"] == {"out": 1}
+
+    node = SimpleNamespace(**{LX_RELAYOUT_ATTR: {"buf_x": plan}})
+    current_node = SimpleNamespace(get_nodes=lambda: [SimpleNamespace(node=node)])
+    args = [source_arg, source_arg]
+    prefix = _materialize_lx_relayout_inputs(
+        current_node,
+        args,
+        [(0, source_arg), (1, source_arg)],
+        consumer_spec,
+    )
+    assert len(prefix) == 1
+    assert args[0].name == args[1].name == plan.destination_name
+
+
+def test_expanding_geometry_is_allocated_atomically_or_falls_back():
+    graph = _DummyGraph("producer", "independent_1", "independent_2", "consumer")
+    # GraphEditor may insert operations without updating GraphLowering's buffer map.
+    graph.name_to_buffer.pop("consumer")
+    plan = _all_gather_plan()
+    source = LifetimeBoundBuffer("buf_k", size=128 * 1024, uses=[0, 3])
+    consumer_output = LifetimeBoundBuffer(
+        "scores", size=512 * 1024, uses=[3, 4], in_place_parents=["buf_k"]
+    )
+    barred = LifetimeBoundBuffer(
+        "barred", size=128, uses=[0, 4], residency_reason="op not allowed"
+    )
+    allocator = ScratchpadAllocator(GreedyLayoutSolver(1536 * 1024))
+    allocator._lx_relayout_plans_by_source = {"buf_k": plan}
+    buffers = [barred, source, consumer_output]
+    allocator._append_lx_relayout_destinations(graph, buffers)
+
+    destination = {buffer.name: buffer for buffer in buffers}[plan.destination_name]
+    assert destination.size == 1024 * 1024
+    assert source.uses == [0, 3]
+    assert destination.uses == [3, 4]
+    assert consumer_output.uses == [4, 5]
+    assert consumer_output.in_place_parents == []
+    layout_planning = allocator._layout_planner_for_buffers(buffers)
+    assert isinstance(layout_planning, FirstFitLayoutSolver)
+    allocation = allocator._plan_layout_with_atomic_relayouts(layout_planning, buffers)
+    by_name = {buffer.name: buffer for buffer in allocation}
+    assert by_name["barred"].address is None
+    assert by_name["barred"].residency_reason == "op not allowed"
+    assert all(
+        buffer.address is not None for buffer in allocation if buffer.name != "barred"
+    )
+    assert not _overlap(by_name["buf_k"], by_name[plan.destination_name])
+    assert _overlap(by_name["buf_k"], by_name["scores"])
+    allocator._record_successful_lx_relayouts(graph, allocation)
+    recorded = getattr(graph.operations[3], LX_RELAYOUT_ATTR)["buf_k"]
+    assert recorded.destination_lx_address == by_name[plan.destination_name].address
+
+    for buffer in buffers:
+        buffer.address = None
+    fallback_allocator = ScratchpadAllocator(GreedyLayoutSolver(1024 * 1024))
+    fallback_allocator._lx_relayout_plans_by_source = {"buf_k": plan}
+    allocation = fallback_allocator._plan_layout_with_atomic_relayouts(
+        FirstFitLayoutSolver(1024 * 1024), buffers
+    )
+    by_name = {buffer.name: buffer for buffer in allocation}
+    assert by_name["buf_k"].address is None
+    assert by_name[plan.destination_name].address is None
+    assert by_name["scores"].address is not None
+    fallback_allocator._record_successful_lx_relayouts(graph, allocation)
+    assert not hasattr(graph.operations[3], LX_RELAYOUT_ATTR)
+
+
+def test_relayout_keeps_producer_inputs_live_through_shuffle(monkeypatch):
+    graph = _DummyGraph("producer_input", "buf_k", "consumer")
+    plan = _all_gather_plan()
+    producer_input = LifetimeBoundBuffer("producer_input", size=128, uses=[0, 1])
+    source = LifetimeBoundBuffer("buf_k", size=128, uses=[1, 2])
+    allocator = ScratchpadAllocator(GreedyLayoutSolver(1536 * 1024))
+    allocator._lx_relayout_plans_by_source = {"buf_k": plan}
+    monkeypatch.setattr(
+        allocator_module,
+        "op_read_writes",
+        lambda _: SimpleNamespace(reads=[SimpleNamespace(name="producer_input")]),
+    )
+
+    allocator._append_lx_relayout_destinations(graph, [producer_input, source])
+
+    assert producer_input.uses == [0, 1, 2]
+
+
+def test_all_gather_emits_standard_shuffle_fold_geometry():
+    h = Symbol("h")
+    lq = Symbol("lq")
+    lk = Symbol("lk")
+    d = Symbol("d")
+    plan = _all_gather_plan()
+    plan = replace(plan, destination_lx_address=0x44000)
+    source_arg = TensorArg(
+        is_input=True,
+        arg_index=-1,
+        device_dtype=DataFormats.SEN169_FP16,
+        device_size=[4, 4096, 2, 64],
+        device_coordinates=[h, lk, floor(d / 64), Mod(d, 64)],
+        allocation={"lx": 0x24000},
+        name="buf_k",
+    )
+    consumer_spec = OpSpec(
+        op=BATCH_MATMUL_OP,
+        is_reduction=True,
+        iteration_space={
+            h: (Integer(4), 4),
+            lq: (Integer(512), 8),
+            lk: (Integer(4096), 1),
+            d: (Integer(128), 1),
+        },
+        args=[source_arg],
+        op_info={},
+        gather_dim=lq,
+    )
+
+    result = _materialize_explicit_lx_shuffle(
+        source_arg,
+        consumer_spec,
+        plan,
+    )
+    assert result is not None
+    shuffle_spec, consumer_arg = result
+    assert shuffle_spec.gather_dim is None
+    assert shuffle_spec.replicas_contiguous
+    assert consumer_arg.allocation == {"lx": 0x44000}
+    assert shuffle_spec.num_cores_override == 32
+    root, allocations = _compile_shuffle(shuffle_spec)
+
+    head_dim = next(
+        dim for dim, splits in root["numWkSlicesPerDim_"].items() if splits == 4
+    )
+    assert [root["coreIdToWkSlice_"][str(core)][head_dim] for core in range(32)] == [
+        head for head in range(4) for _ in range(8)
+    ]
+
+    input_map = allocations[0]["coordinates_"]["coreIdToWkSlice_"]
+    output_map = allocations[1]["coordinates_"]["coreIdToWkSlice_"]
+    assert len(input_map) == len(output_map) == 32
+    assert input_map["0"] != input_map["4"]
+    assert output_map["0"] == output_map["4"]
+
+    input_out = allocations[0]["coordinates_"]["coordInfo"]["out"]["folds"]
+    output_out = allocations[1]["coordinates_"]["coordInfo"]["out"]["folds"]
+    assert (
+        input_out["dim_prop_attr"][0]["factor_"],
+        input_out["dim_prop_func"][0]["Affine"]["alpha_"],
+    ) == (8, 512)
+    assert (
+        output_out["dim_prop_attr"][0]["factor_"],
+        output_out["dim_prop_func"][0]["Affine"]["alpha_"],
+    ) == (1, 4096)
+
+    stick_folds = allocations[0]["coordinates_"]["coordInfo"]["in"]["folds"]
+    assert (
+        stick_folds["dim_prop_attr"][1]["factor_"],
+        stick_folds["dim_prop_func"][1]["Affine"]["alpha_"],
+    ) == (1, 0)

--- a/tests/inductor/test_scratchpad_solver.py
+++ b/tests/inductor/test_scratchpad_solver.py
@@ -510,6 +510,18 @@ class ScoreOrderingTests:
         self.assertEqual(by_name["child"], 0)  # child reuses parent's slot
         self.assertIsNone(by_name["plain"])
 
+    def test_failed_inplace_reuse_does_not_overlap_live_parent(self):
+        parent = LifetimeBoundBuffer("parent", 20, [0, 4])
+        blocker = LifetimeBoundBuffer("blocker", 5, [5, 8])
+        child = LifetimeBoundBuffer("child", 10, [4, 8], in_place_parents=["parent"])
+
+        result = self.solve([parent, blocker, child], size=30)
+        by_name = {buffer.name: buffer.address for buffer in result}
+
+        self.assertEqual(by_name["parent"], 0)
+        self.assertEqual(by_name["blocker"], 0)
+        self.assertEqual(by_name["child"], 20)
+
     def test_write_first_buffer_placed_before_read_only(self):
         # Identical span (5) and use count (2). `writer`'s first use is a write
         # (first_use_is_read=False), so pinning it also saves the more expensive

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -221,6 +221,13 @@ def add_constant(kwargs, name, value) -> int:
     return index
 
 
+def _per_core_coord_size(sdsc_spec, tensor, dim) -> int:
+    if tensor.scales[dim] != 1:
+        return 1
+    splits = tensor.core_splits.get(dim, sdsc_spec.work_slices[dim])
+    return sdsc_spec.iteration_space[dim] // splits
+
+
 def gen_coord_info_value(
     size: int,
     nsplits: int,
@@ -1135,11 +1142,14 @@ def generate_sdsc(
                                     "coordinates_": {
                                         "coordInfo": {
                                             str(dim): gen_coord_info_value(
-                                                size=sdsc_spec.iteration_space[dim]
-                                                // sdsc_spec.work_slices[dim]
-                                                if (tensor.scales[dim] == 1)
-                                                else 1,
-                                                nsplits=sdsc_spec.work_slices[dim]
+                                                size=_per_core_coord_size(
+                                                    sdsc_spec, tensor, dim
+                                                ),
+                                                nsplits=(
+                                                    tensor.core_splits.get(
+                                                        dim, sdsc_spec.work_slices[dim]
+                                                    )
+                                                )
                                                 if (tensor.scales[dim] == 1)
                                                 else 1,
                                                 elems_per_stick=tensor.data_format.elems_per_stick(),
@@ -1156,7 +1166,8 @@ def generate_sdsc(
                                                 "dim_order"
                                             ]
                                         },
-                                        "coreIdToWkSlice_": {},
+                                        "coreIdToWkSlice_": tensor.allocation_core_id_to_wk_slice
+                                        or {},
                                     },
                                 }
                                 for i, tensor in enumerate(sdsc_spec.args)

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -72,6 +72,8 @@ class SDSCArgs:
     is_index_tensor: bool = False
     related_value_tensor_idx: int = -1
     per_tile_fixed: bool = False
+    allocation_core_id_to_wk_slice: dict[str, dict[str, int]] | None = None
+    core_splits: dict[Symbol, int] = dataclasses.field(default_factory=dict)
 
     def __str__(self) -> str:
         scales = ", ".join(f"{k}={v}" for k, v in self.scales.items())
@@ -269,6 +271,68 @@ def _get_device_dim_order(
     return dim_order, stick_dim
 
 
+def _device_dim_to_sdsc_dim(
+    arg: TensorArg,
+    dim_order: list[Symbol],
+    stride_dim_order: list[Symbol],
+    mb_sym: Symbol | None,
+) -> dict[str, Symbol]:
+    result: dict[str, Symbol] = {}
+    for dim in dim_order:
+        if dim is mb_sym:
+            continue
+        stride_idx = stride_dim_order.index(dim)
+        device_dim = len(arg.device_coordinates) - stride_idx - 2
+        if device_dim >= 0:
+            result[str(device_dim)] = dim
+    return result
+
+
+def _map_core_id_to_wk_slice_dims(
+    core_id_to_device_slice: dict[str, dict[str, int]] | None,
+    device_dim_to_sdsc_dim: dict[str, Symbol],
+    dim_order: list[Symbol],
+) -> dict[str, dict[str, int]] | None:
+    if core_id_to_device_slice is None:
+        return None
+
+    layout_dim_labels = [str(dim) for dim in dim_order]
+    result: dict[str, dict[str, int]] = {}
+    for core, per_device_dim in core_id_to_device_slice.items():
+        per_dim = {dim: 0 for dim in layout_dim_labels}
+        for device_dim, slot in per_device_dim.items():
+            dim = device_dim_to_sdsc_dim.get(str(device_dim))
+            if dim is None:
+                if int(slot) != 0:
+                    raise ValueError(
+                        f"allocation uses unmapped device dimension {device_dim}"
+                    )
+                continue
+            per_dim[str(dim)] = int(slot)
+        result[str(core)] = per_dim
+    return result
+
+
+def _map_device_dim_splits(
+    device_dim_splits: dict[str, int] | None,
+    device_dim_to_sdsc_dim: dict[str, Symbol],
+) -> dict[Symbol, int]:
+    if device_dim_splits is None:
+        return {}
+
+    result: dict[Symbol, int] = {}
+    for device_dim, split in device_dim_splits.items():
+        dim = device_dim_to_sdsc_dim.get(str(device_dim))
+        if dim is None:
+            if int(split) != 1:
+                raise ValueError(
+                    f"allocation split uses unmapped device dimension {device_dim}"
+                )
+            continue
+        result[dim] = int(split)
+    return result
+
+
 def _get_layout_label(
     layouts: dict,
     dim_order: list,
@@ -447,6 +511,9 @@ def _create_sdsc_tensors(
         stride_dim_order = [
             d for d in dim_order if d not in reduced_dims
         ] + reduced_dims
+        device_dim_to_sdsc_dim = _device_dim_to_sdsc_dim(
+            arg, dim_order, stride_dim_order, mb_sym
+        )
 
         for dim in dim_order:
             stride_idx = stride_dim_order.index(dim)
@@ -503,8 +570,18 @@ def _create_sdsc_tensors(
             offsets[mb_sym] = 0
             max_dim_sizes[mb_sym] = -1
 
+        if (
+            arg.allocation_core_id_to_device_slice is not None
+            or arg.allocation_device_dim_splits is not None
+        ) and "lx" not in arg.allocation:
+            raise ValueError("explicit allocation distribution requires LX storage")
+
         effective_stick = op_stick_dim if stick_dim is None else stick_dim
-        layout_labels = MATMUL_LAYOUT_LABELS if not use_op_dims else LAYOUT_LABELS
+        layout_labels = (
+            (MATMUL_LAYOUT_LABELS if not use_op_dims else LAYOUT_LABELS)
+            if op_spec.layout_labels_override is None
+            else op_spec.layout_labels_override
+        )
 
         if has_indirect_access:
             label = get_indirect_layout_label(
@@ -564,6 +641,15 @@ def _create_sdsc_tensors(
                 is_index_tensor=is_idx_tensor,
                 related_value_tensor_idx=related_val_idx,
                 per_tile_fixed=arg.per_tile_fixed,
+                allocation_core_id_to_wk_slice=_map_core_id_to_wk_slice_dims(
+                    arg.allocation_core_id_to_device_slice,
+                    device_dim_to_sdsc_dim,
+                    dim_order,
+                ),
+                core_splits=_map_device_dim_splits(
+                    arg.allocation_device_dim_splits,
+                    device_dim_to_sdsc_dim,
+                ),
             )
         )
 
@@ -710,7 +796,11 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
     }
     has_indirect_access = bool(index_tensor_indices)
 
-    dim_labels = _get_op_dim_labels(ndim, is_matmul)
+    dim_labels = (
+        _get_op_dim_labels(ndim, is_matmul)
+        if op_spec.dim_labels_override is None
+        else op_spec.dim_labels_override
+    )
     symbol_mapping = {
         sym: Symbol(dim_labels[i]) for i, sym in enumerate(op_spec.iteration_space)
     }
@@ -741,7 +831,12 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
         symbol_mapping[dim]: value[-1] if not has_indirect_access else 1
         for dim, value in op_spec.iteration_space.items()
     }
-    num_cores = math.prod(dim_splits.values())
+    logical_core_count = math.prod(dim_splits.values())
+    num_cores = (
+        logical_core_count
+        if op_spec.num_cores_override is None
+        else op_spec.num_cores_override
+    )
 
     work_slices = {
         symbol_mapping[sym]: wk_slice if not has_indirect_access else 1
@@ -865,19 +960,29 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
     # can add unit axes to either mapping independently.
     mapping_dims = tuple(sdsc_iteration_space)
     mapping_splits = tuple(int(dim_splits[dim]) for dim in mapping_dims)
-    # Generic reductions do not yet define the same physical cohort contract as
-    # matmul partial sums.
-    contiguous_dim = (
-        len(mapping_splits) - 1
-        if is_matmul and _spyre_config.core_id_k_fast_emission
-        else None
-    )
+    gather_dim = symbol_mapping.get(op_spec.gather_dim)
+    contiguous_dim: int | None
+    if (
+        gather_dim is not None
+        and gather_dim in mapping_dims
+        and dim_splits[gather_dim] > 1
+    ):
+        contiguous_dim = mapping_dims.index(gather_dim)
+    else:
+        # Generic reductions do not yet define the same physical cohort contract
+        # as matmul partial sums.
+        contiguous_dim = (
+            len(mapping_splits) - 1
+            if is_matmul and _spyre_config.core_id_k_fast_emission
+            else None
+        )
     # TODO: Choose the mapping before LX planning and pass it through to codegen.
     core_id_to_work_slice = core_to_slice_mapping(
         mapping_dims,
         mapping_splits,
         num_cores,
         contiguous_dim=contiguous_dim,
+        replicas_contiguous=op_spec.replicas_contiguous,
     )
 
     # Collect index tensor indices for indirect access

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -29,6 +29,10 @@ global_stick_optimizer: bool = os.environ.get("GLOBAL_STICK_OPTIMIZER", "1") == 
 
 allow_all_ops_in_lx_planning: bool = False
 
+# Opt-in extension to LX planning: materialize compatible producer and
+# consumer per-core views as an explicit S1 -> SHUFFLE -> S2 sequence in LX.
+lx_planner_relayout: bool = os.environ.get("SPYRE_LX_PLANNER_RELAYOUT", "0") == "1"
+
 dxp_lx_frac_avail: float = float(os.environ.get("DXP_LX_FRAC_AVAIL", "0.2"))
 
 sencores: int = int(os.getenv("SENCORES", "32"))

--- a/torch_spyre/_inductor/core_mapping.py
+++ b/torch_spyre/_inductor/core_mapping.py
@@ -28,11 +28,13 @@ def core_to_slice_mapping(
     num_cores: int,
     *,
     contiguous_dim: int | None = None,
+    replicas_contiguous: bool = False,
 ) -> dict[str, Expr]:
     """Return the logical work slice assigned to each physical core.
 
     By default dimensions vary in iteration-space order. ``contiguous_dim``
     moves one caller-selected dimension first so its participants are adjacent.
+    ``replicas_contiguous`` packs repeated copies of each logical slice together.
     """
 
     dims = tuple(dims)
@@ -53,6 +55,11 @@ def core_to_slice_mapping(
         dim_order.insert(0, contiguous_dim)
 
     core_id: Expr = Symbol("core_id")
+    if replicas_contiguous:
+        replicas = num_cores // logical_cores
+        if replicas > 1:
+            core_id = floor(core_id / Integer(replicas))
+
     stride = Integer(1)
     result: dict[str, Expr] = {}
     for dim in dim_order:

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -610,14 +610,21 @@ def spyre__sdpa_overrideable(
                     tiles={"max_seqlen_kv": max(1, max_seqlen_kv // kv_block_size)}
                 ):
                     with spyre_hint(
-                        work_div={"num_heads": 4, "max_seqlen_q": 8, "max_seqlen_kv": 8}
+                        work_div={
+                            "num_heads": 4,
+                            "max_seqlen_q": 8,
+                            "max_seqlen_kv": 8,
+                        },
+                        gather_dim="max_seqlen_q",
                     ):
-                        scaled_keys = (
-                            key * scaling_factor
-                        )  # batch_size, num_heads, max_seqlen_kv, head_dim
-                        keys_T = scaled_keys.transpose(
-                            -1, -2
-                        )  # batch_size, num_heads, head_dim, max_seqlen_kv
+                        with spyre_hint(gather_dim="max_seqlen_kv"):
+                            scaled_keys = (
+                                key * scaling_factor
+                            )  # batch_size, num_heads, max_seqlen_kv, head_dim
+                            keys_T = scaled_keys.transpose(
+                                -1, -2
+                            )  # batch_size, num_heads, head_dim, max_seqlen_kv
+
                         scores = torch.matmul(
                             query * scaling_factor, keys_T
                         )  # batch_size, num_heads, max_seqlen_q, max_seqlen_kv

--- a/torch_spyre/_inductor/lx_relayout.py
+++ b/torch_spyre/_inductor/lx_relayout.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import dataclasses
 import math
+from enum import StrEnum
 
 import sympy
 from torch._inductor.dependencies import MemoryDep
@@ -41,6 +42,20 @@ from torch_spyre._inductor.scratchpad.utils import _op_num_cores, _op_short_name
 
 LX_RELAYOUT_ATTR = "_spyre_lx_relayout_inputs"
 LX_RELAYOUT_DESTINATION_PREFIX = "__spyre_lx_relayout_destination__"
+
+
+class LXCollectiveKind(StrEnum):
+    """Logical communication classes lowered through the physical SHUFFLE op."""
+
+    ALL_TO_ALL = "all_to_all"
+    ALL_GATHER = "all_gather"
+    BROADCAST = "broadcast"
+
+
+@dataclasses.dataclass(frozen=True)
+class _LXRelayoutClassification:
+    collective_kind: LXCollectiveKind
+    destination_size_ratio: int
 
 
 def make_lx_relayout_destination_name(source_name: str) -> str:
@@ -61,6 +76,7 @@ class LXRelayoutPlan:
     destination_core_id_to_device_slice: dict[str, dict[str, int]]
     source_device_dim_splits: dict[str, int]
     destination_device_dim_splits: dict[str, int]
+    collective_kind: LXCollectiveKind
     destination_size_ratio: int
     destination_lx_address: int | None = None
 
@@ -77,15 +93,17 @@ def _intervals_overlap(
     )
 
 
-def _destination_size_ratio(
+def _classify_lx_relayout(
     producer_map: dict[str, dict[str, int]],
     producer_splits: dict[str, int],
     consumer_map: dict[str, dict[str, int]],
     consumer_splits: dict[str, int],
-) -> int | None:
-    """Return S2:S1 per-core size ratio for exact uniform shuffle geometry."""
+) -> _LXRelayoutClassification | None:
+    """Classify exact, uniform geometry supported by the LX relayout path."""
 
-    if producer_map.keys() != consumer_map.keys():
+    producer_cores = set(producer_map)
+    consumer_cores = set(consumer_map)
+    if not producer_cores or not consumer_cores:
         return None
 
     def slice_count(core_map: dict[str, dict[str, int]]) -> int:
@@ -129,18 +147,61 @@ def _destination_size_ratio(
     consumer_is_partitioned = slice_count(consumer_map) == len(
         consumer_map
     ) and math.prod(consumer_splits.values()) == len(consumer_map)
-    if transfer_count == 0 or not covers_all_cores or not uniform:
-        return None
-    if producer_is_partitioned and consumer_is_partitioned:
-        return 1
     if (
-        producer_is_partitioned
+        transfer_count == 0
+        or not covers_all_cores
+        or not uniform
+        or not producer_cores.issubset(consumer_cores)
+    ):
+        return None
+
+    same_participants = producer_cores == consumer_cores
+    if same_participants and producer_is_partitioned and consumer_is_partitioned:
+        return _LXRelayoutClassification(LXCollectiveKind.ALL_TO_ALL, 1)
+
+    # A broadcast has one physical source owner and replicates that complete
+    # source slice to every participating consumer core. Keep this source map
+    # sparse: padding it with repeated owners would falsely claim that the
+    # value was already resident on every core.
+    producer_slice_count = slice_count(producer_map)
+    consumer_slice_count = slice_count(consumer_map)
+    if (
+        len(producer_map) == 1
+        and producer_is_partitioned
+        and producer_slice_count == 1
+        and not consumer_is_partitioned
+        and consumer_slice_count == 1
+        and max_fanout == len(consumer_map)
+        and max_fanin == 1
+    ):
+        return _LXRelayoutClassification(LXCollectiveKind.BROADCAST, 1)
+
+    if (
+        same_participants
+        and producer_is_partitioned
         and not consumer_is_partitioned
         and max_fanout > 1
         and max_fanin > 1
     ):
-        return max_fanin
+        return _LXRelayoutClassification(LXCollectiveKind.ALL_GATHER, max_fanin)
     return None
+
+
+def _destination_size_ratio(
+    producer_map: dict[str, dict[str, int]],
+    producer_splits: dict[str, int],
+    consumer_map: dict[str, dict[str, int]],
+    consumer_splits: dict[str, int],
+) -> int | None:
+    """Return S2:S1 per-core size ratio for supported relayout geometry."""
+
+    classification = _classify_lx_relayout(
+        producer_map,
+        producer_splits,
+        consumer_map,
+        consumer_splits,
+    )
+    return None if classification is None else classification.destination_size_ratio
 
 
 def _single_write_dep(op: ComputedBuffer, buf_name: str) -> MemoryDep | None:
@@ -287,11 +348,14 @@ def collect_lx_relayout_plans(
             )
             if consumer_has_partial or not consumer_representable:
                 continue
-            if producer_view == consumer_view:
-                continue
 
             producer_core_count = _op_num_cores(producer)
             consumer_core_count = _op_num_cores(consumer)
+            if (
+                producer_view == consumer_view
+                and producer_core_count == consumer_core_count
+            ):
+                continue
             producer_core_slices = _core_id_to_device_slice(
                 producer_view, producer_core_count
             )
@@ -315,13 +379,13 @@ def collect_lx_relayout_plans(
             consumer_core_slices, consumer_work_slice_dims = _dense_view(
                 consumer_core_slices, consumer_work_slice_dims, relayout_dims
             )
-            destination_size_ratio = _destination_size_ratio(
+            classification = _classify_lx_relayout(
                 producer_core_slices,
                 producer_work_slice_dims,
                 consumer_core_slices,
                 consumer_work_slice_dims,
             )
-            if destination_size_ratio is None:
+            if classification is None:
                 continue
 
             if is_matmul_consumer and (
@@ -338,7 +402,8 @@ def collect_lx_relayout_plans(
                     destination_core_id_to_device_slice=consumer_core_slices,
                     source_device_dim_splits=producer_work_slice_dims,
                     destination_device_dim_splits=consumer_work_slice_dims,
-                    destination_size_ratio=destination_size_ratio,
+                    collective_kind=classification.collective_kind,
+                    destination_size_ratio=classification.destination_size_ratio,
                 )
             )
 

--- a/torch_spyre/_inductor/lx_relayout.py
+++ b/torch_spyre/_inductor/lx_relayout.py
@@ -23,6 +23,7 @@ S1 -> SHUFFLE -> S2 sequence.
 from __future__ import annotations
 
 import dataclasses
+import math
 
 import sympy
 from torch._inductor.dependencies import MemoryDep
@@ -122,16 +123,15 @@ def _destination_size_ratio(
     covers_all_cores = (
         min(fanout_values, default=0) > 0 and min(fanin_values, default=0) > 0
     )
-    producer_is_partitioned = slice_count(producer_map) == len(producer_map)
-    consumer_is_partitioned = slice_count(consumer_map) == len(consumer_map)
+    producer_is_partitioned = slice_count(producer_map) == len(
+        producer_map
+    ) and math.prod(producer_splits.values()) == len(producer_map)
+    consumer_is_partitioned = slice_count(consumer_map) == len(
+        consumer_map
+    ) and math.prod(consumer_splits.values()) == len(consumer_map)
     if transfer_count == 0 or not covers_all_cores or not uniform:
         return None
-    if (
-        producer_is_partitioned
-        and consumer_is_partitioned
-        and max_fanout <= 1
-        and max_fanin <= 1
-    ):
+    if producer_is_partitioned and consumer_is_partitioned:
         return 1
     if (
         producer_is_partitioned

--- a/torch_spyre/_inductor/lx_relayout.py
+++ b/torch_spyre/_inductor/lx_relayout.py
@@ -1,0 +1,354 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Plan LX relayouts from producer and consumer per-core views.
+
+The regular LX planner handles same-core scratchpad persistence. This module
+finds edges where a producer and consumer use different per-core views of the
+same tensor. Accepted edges are materialized as an explicit, frontend-allocated
+S1 -> SHUFFLE -> S2 sequence.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import sympy
+from torch._inductor.dependencies import MemoryDep
+from torch._inductor.graph import GraphLowering
+from torch._inductor.ir import ComputedBuffer, Operation, Pointwise
+
+from torch_spyre._inductor import config
+from torch_spyre._inductor.pass_utils import (
+    PerCoreView,
+    _is_matmul_op,
+    _per_core_view_on_buf,
+    op_read_writes,
+)
+from torch_spyre._inductor.scratchpad.utils import _op_num_cores, _op_short_name
+
+LX_RELAYOUT_ATTR = "_spyre_lx_relayout_inputs"
+LX_RELAYOUT_DESTINATION_PREFIX = "__spyre_lx_relayout_destination__"
+
+
+def make_lx_relayout_destination_name(source_name: str) -> str:
+    return f"{LX_RELAYOUT_DESTINATION_PREFIX}:{source_name}"
+
+
+def is_lx_relayout_destination(name: str) -> bool:
+    return name.startswith(f"{LX_RELAYOUT_DESTINATION_PREFIX}:")
+
+
+@dataclasses.dataclass(frozen=True)
+class LXRelayoutPlan:
+    """Names and exact per-core geometry for one LX shuffle."""
+
+    source_name: str
+    consumer_name: str
+    source_core_id_to_device_slice: dict[str, dict[str, int]]
+    destination_core_id_to_device_slice: dict[str, dict[str, int]]
+    source_device_dim_splits: dict[str, int]
+    destination_device_dim_splits: dict[str, int]
+    destination_size_ratio: int
+    destination_lx_address: int | None = None
+
+    @property
+    def destination_name(self) -> str:
+        return make_lx_relayout_destination_name(self.source_name)
+
+
+def _intervals_overlap(
+    lhs_slot: int, lhs_split: int, rhs_slot: int, rhs_split: int
+) -> bool:
+    return lhs_slot * rhs_split < (rhs_slot + 1) * lhs_split and (
+        rhs_slot * lhs_split < (lhs_slot + 1) * rhs_split
+    )
+
+
+def _destination_size_ratio(
+    producer_map: dict[str, dict[str, int]],
+    producer_splits: dict[str, int],
+    consumer_map: dict[str, dict[str, int]],
+    consumer_splits: dict[str, int],
+) -> int | None:
+    """Return S2:S1 per-core size ratio for exact uniform shuffle geometry."""
+
+    if producer_map.keys() != consumer_map.keys():
+        return None
+
+    def slice_count(core_map: dict[str, dict[str, int]]) -> int:
+        return len(
+            {
+                tuple(sorted((dim, int(slot)) for dim, slot in per_core.items()))
+                for per_core in core_map.values()
+            }
+        )
+
+    fanout = {core: 0 for core in producer_map}
+    fanin = {core: 0 for core in consumer_map}
+    transfer_count = 0
+    dims = set(producer_splits) | set(consumer_splits)
+    for producer_core, producer_slice in producer_map.items():
+        for consumer_core, consumer_slice in consumer_map.items():
+            if all(
+                _intervals_overlap(
+                    int(producer_slice.get(dim, 0)),
+                    int(producer_splits.get(dim, 1)),
+                    int(consumer_slice.get(dim, 0)),
+                    int(consumer_splits.get(dim, 1)),
+                )
+                for dim in dims
+            ):
+                fanout[producer_core] += 1
+                fanin[consumer_core] += 1
+                transfer_count += 1
+
+    fanout_values = set(fanout.values())
+    fanin_values = set(fanin.values())
+    uniform = len(fanout_values) == 1 and len(fanin_values) == 1
+    max_fanout = max(fanout_values, default=0)
+    max_fanin = max(fanin_values, default=0)
+    covers_all_cores = (
+        min(fanout_values, default=0) > 0 and min(fanin_values, default=0) > 0
+    )
+    producer_is_partitioned = slice_count(producer_map) == len(producer_map)
+    consumer_is_partitioned = slice_count(consumer_map) == len(consumer_map)
+    if transfer_count == 0 or not covers_all_cores or not uniform:
+        return None
+    if (
+        producer_is_partitioned
+        and consumer_is_partitioned
+        and max_fanout <= 1
+        and max_fanin <= 1
+    ):
+        return 1
+    if (
+        producer_is_partitioned
+        and not consumer_is_partitioned
+        and max_fanout > 1
+        and max_fanin > 1
+    ):
+        return max_fanin
+    return None
+
+
+def _single_write_dep(op: ComputedBuffer, buf_name: str) -> MemoryDep | None:
+    matches = [
+        dep
+        for dep in op_read_writes(op).writes
+        if isinstance(dep, MemoryDep) and dep.name == buf_name
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _operations_by_name(graph: GraphLowering) -> dict[str, Operation]:
+    """Index the current graph, including operations inserted by graph editing."""
+
+    return {op.get_name(): op for op in graph.operations}
+
+
+def _restickify_reads_computed_input(
+    operations: dict[str, Operation], op: Operation
+) -> bool:
+    if _op_short_name(op) != "restickify":
+        return False
+    return any(
+        isinstance(operations.get(dep.name), ComputedBuffer)
+        for dep in op_read_writes(op).reads
+        if isinstance(dep, MemoryDep)
+    )
+
+
+def _matmul_operand_source_good_for_lx_relayout(
+    operations: dict[str, Operation], op: Operation
+) -> bool:
+    """Exclude graph-input and weight restickifies from activation relayout."""
+
+    return _op_short_name(op) != "restickify" or _restickify_reads_computed_input(
+        operations, op
+    )
+
+
+def _core_id_to_device_slice(
+    view: PerCoreView,
+    core_count: int,
+) -> dict[str, dict[str, int]] | None:
+    """Return ownership as ``core -> device-dim -> slice-index``."""
+
+    core_id = sympy.Symbol("core_id")
+    expr_by_dim = {int(dim): expr for dim, expr in view.core_to_slot}
+    split_dims = {int(dim): int(split) for dim, split in view.work_slice_dims}
+    result: dict[str, dict[str, int]] = {}
+
+    for core in range(core_count):
+        per_core: dict[str, int] = {}
+        for dim, split in split_dims.items():
+            expr = sympy.sympify(expr_by_dim.get(dim, 0))
+            slot = sympy.simplify(expr.subs(core_id, core))
+            if getattr(slot, "free_symbols", None):
+                return None
+            try:
+                slot_int = int(slot)
+            except TypeError:
+                return None
+            if slot_int < 0 or slot_int >= split:
+                return None
+            per_core[str(dim)] = slot_int
+        result[str(core)] = per_core
+
+    return result
+
+
+def _work_slice_dims(view: PerCoreView) -> dict[str, int]:
+    return {str(int(dim)): int(split) for dim, split in view.work_slice_dims}
+
+
+def _dense_view(
+    core_map: dict[str, dict[str, int]],
+    splits: dict[str, int],
+    dims: set[str],
+) -> tuple[dict[str, dict[str, int]], dict[str, int]]:
+    ordered_dims = sorted(dims, key=int)
+    dense_map = {
+        core: {dim: int(per_core.get(dim, 0)) for dim in ordered_dims}
+        for core, per_core in core_map.items()
+    }
+    dense_splits = {dim: int(splits.get(dim, 1)) for dim in ordered_dims}
+    return dense_map, dense_splits
+
+
+def clear_lx_relayout_metadata(graph: GraphLowering) -> None:
+    for op in graph.operations:
+        if hasattr(op, LX_RELAYOUT_ATTR):
+            delattr(op, LX_RELAYOUT_ATTR)
+
+
+def collect_lx_relayout_plans(
+    graph: GraphLowering, cache: dict | None = None
+) -> list[LXRelayoutPlan]:
+    """Plan bounded LX relayouts from producer and consumer coordinates.
+
+    Only records movement for single-writer, single-reader intermediates whose
+    producer output is final (not K-split partials) and whose producer and
+    consumer PerCoreViews differ.  Same-view edges remain owned by the existing
+    LX planner.
+    """
+
+    if not config.lx_planner_relayout:
+        return []
+
+    operations = _operations_by_name(graph)
+    read_counts: dict[str, int] = {}
+    for op in graph.operations:
+        for dep in op_read_writes(op).reads:
+            if isinstance(dep, MemoryDep):
+                read_counts[dep.name] = read_counts.get(dep.name, 0) + 1
+    plans: list[LXRelayoutPlan] = []
+
+    for consumer in graph.operations:
+        if not isinstance(consumer, ComputedBuffer):
+            continue
+        is_matmul_consumer = _is_matmul_op(consumer)
+        if not is_matmul_consumer and not isinstance(consumer.data, Pointwise):
+            continue
+        reads = (
+            dep for dep in op_read_writes(consumer).reads if isinstance(dep, MemoryDep)
+        )
+        for read_index, dep in enumerate(reads):
+            if read_counts.get(dep.name, 0) != 1:
+                continue
+            producer = operations.get(dep.name)
+            if not isinstance(producer, ComputedBuffer) or producer is consumer:
+                continue
+
+            write_dep = _single_write_dep(producer, dep.name)
+            if write_dep is None:
+                continue
+
+            producer_view, producer_has_partial, producer_representable = (
+                _per_core_view_on_buf(producer, write_dep, dep.name, cache)
+            )
+            if producer_has_partial or not producer_representable:
+                continue
+
+            consumer_view, consumer_has_partial, consumer_representable = (
+                _per_core_view_on_buf(consumer, dep, dep.name, cache)
+            )
+            if consumer_has_partial or not consumer_representable:
+                continue
+            if producer_view == consumer_view:
+                continue
+
+            producer_core_count = _op_num_cores(producer)
+            consumer_core_count = _op_num_cores(consumer)
+            producer_core_slices = _core_id_to_device_slice(
+                producer_view, producer_core_count
+            )
+            if producer_core_slices is None:
+                continue
+
+            consumer_work_slice_dims = _work_slice_dims(consumer_view)
+            consumer_core_slices = _core_id_to_device_slice(
+                consumer_view, consumer_core_count
+            )
+            if consumer_core_slices is None:
+                continue
+
+            producer_work_slice_dims = _work_slice_dims(producer_view)
+            relayout_dims = set(producer_work_slice_dims) | set(
+                consumer_work_slice_dims
+            )
+            producer_core_slices, producer_work_slice_dims = _dense_view(
+                producer_core_slices, producer_work_slice_dims, relayout_dims
+            )
+            consumer_core_slices, consumer_work_slice_dims = _dense_view(
+                consumer_core_slices, consumer_work_slice_dims, relayout_dims
+            )
+            destination_size_ratio = _destination_size_ratio(
+                producer_core_slices,
+                producer_work_slice_dims,
+                consumer_core_slices,
+                consumer_work_slice_dims,
+            )
+            if destination_size_ratio is None:
+                continue
+
+            if is_matmul_consumer and (
+                not _matmul_operand_source_good_for_lx_relayout(operations, producer)
+                or read_index not in (0, 1)
+            ):
+                continue
+
+            plans.append(
+                LXRelayoutPlan(
+                    source_name=dep.name,
+                    consumer_name=consumer.get_name(),
+                    source_core_id_to_device_slice=producer_core_slices,
+                    destination_core_id_to_device_slice=consumer_core_slices,
+                    source_device_dim_splits=producer_work_slice_dims,
+                    destination_device_dim_splits=consumer_work_slice_dims,
+                    destination_size_ratio=destination_size_ratio,
+                )
+            )
+
+    return plans
+
+
+def record_lx_relayout_plan(graph: GraphLowering, plan: LXRelayoutPlan) -> None:
+    """Stamp a relayout plan after the source buffer is placed in LX."""
+
+    consumer = _operations_by_name(graph)[plan.consumer_name]
+    plans = getattr(consumer, LX_RELAYOUT_ATTR, {})
+    plans[plan.source_name] = plan
+    setattr(consumer, LX_RELAYOUT_ATTR, plans)

--- a/torch_spyre/_inductor/op_spec.py
+++ b/torch_spyre/_inductor/op_spec.py
@@ -116,6 +116,11 @@ class TensorArg:
         device_coordinates: The sympy Exprs that describe how elements in the Tensor are accessed.
                 Free variables in device_coordinates refer to entries in the OpSpec's iteration_space.
         allocation: If present, the offset in scratchpad memory assigned to the Tensor.
+        allocation_core_id_to_device_slice: Optional physical ownership of an
+                LX allocation. Keys are device-dimension indices; SuperDSC
+                codegen maps them to SDSC dimensions using the tensor layout.
+        allocation_device_dim_splits: Optional allocation fold geometry keyed
+                by the same device-dimension indices.
     """
 
     is_input: bool
@@ -126,6 +131,8 @@ class TensorArg:
     allocation: Any
     per_tile_fixed: bool = False
     name: str | None = None
+    allocation_core_id_to_device_slice: dict[str, dict[str, int]] | None = None
+    allocation_device_dim_splits: dict[str, int] | None = None
 
 
 @dataclasses.dataclass
@@ -168,6 +175,13 @@ class OpSpec:
         default_factory=dict
     )
     debug_handle: DebugHandle | None = None
+    # Explicit communication ops can repeat a logical work slice across more
+    # participating cores than the op's logical work split implies.
+    num_cores_override: int | None = None
+    dim_labels_override: list[str] | None = None
+    layout_labels_override: list[str] | None = None
+    gather_dim: Symbol | None = None
+    replicas_contiguous: bool = False
 
 
 @dataclasses.dataclass

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -43,6 +43,7 @@ from .constants import ELIDED_COPY_BACK_ATTR, MATMUL_REDUCTION_OPS
 from .ir import FixedTiledLayout, SpyreConstantFallback
 from .logging_utils import get_inductor_logger
 from .loop_info import copy_op_metadata
+from .propagate_hints import get_gather_dim
 from .views import compute_coordinates, matching_dim
 
 # PyTorch's default lower bound for size symbols (sizes 0/1 are specialised).
@@ -1072,7 +1073,9 @@ def copy_fx_custom_meta(src: "torch.fx.Node", dst: "torch.fx.Node") -> None:
     so that custom metadata (including spyre hints) is not silently dropped.
     """
     if "custom" in src.meta:
-        dst.meta["custom"] = src.meta["custom"]
+        custom = dict(dst.meta.get("custom") or {})
+        custom.update(src.meta["custom"])
+        dst.meta["custom"] = custom
 
 
 def replace_computed_buffer_body(
@@ -1389,6 +1392,7 @@ class _ViewPrep(NamedTuple):
     num_stick: int
     num_stick_stride: int
     is_matmul: bool
+    gather_dim: "sympy.Symbol | None"
 
 
 def _prepare_per_core_view(
@@ -1455,6 +1459,7 @@ def _prepare_per_core_view(
         num_stick=num_stick,
         num_stick_stride=num_stick_stride,
         is_matmul=_is_matmul_op(op),
+        gather_dim=get_gather_dim(op),
     )
 
 
@@ -1580,11 +1585,16 @@ def _per_core_view_from_prep(
     num_cores = int(math.prod(per_sym.values()))
     iter_symbols = tuple(iter_space)
     dim_splits = tuple(int(per_sym[sym]) for sym in iter_symbols)
-    contiguous_dim = (
-        len(dim_splits) - 1
-        if prep.is_matmul and config.core_id_k_fast_emission
-        else None
-    )
+    gather_dim = prep.gather_dim
+    contiguous_dim: int | None
+    if gather_dim is not None and per_sym.get(gather_dim, 1) > 1:
+        contiguous_dim = iter_symbols.index(gather_dim)
+    else:
+        contiguous_dim = (
+            len(dim_splits) - 1
+            if prep.is_matmul and config.core_id_k_fast_emission
+            else None
+        )
     core_to_slot_by_name = core_to_slice_mapping(
         iter_symbols,
         dim_splits,

--- a/torch_spyre/_inductor/propagate_hints.py
+++ b/torch_spyre/_inductor/propagate_hints.py
@@ -114,6 +114,19 @@ def get_op_hints(op: Operation) -> dict[int, dict[str, Any]]:
     return hints
 
 
+def get_gather_dim(op: Operation) -> sympy.Symbol | None:
+    """Resolve an op's named gather dimension to its loop symbol."""
+
+    loop_dims = getattr(op, "work_div_loop_info", {})
+    for _, hint in sorted(get_op_hints(op).items(), reverse=True):
+        name = hint.get("gather_dim")
+        if name is not None:
+            return next(
+                (sym for sym, names in loop_dims.items() if name in names), None
+            )
+    return None
+
+
 def log_new_nodes(node: torch.fx.Node):
     if (
         node.graph.owning_module is not None

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -558,7 +558,10 @@ def _assign_dim_hints_impl(operations: list[Operation]) -> None:
             continue
 
         assert dp is not None  # guaranteed by op_hints check above
-        if any(hint_dict.get("work_div") for hint_dict in op_hints.values()):
+        if any(
+            hint_dict.get("work_div") or hint_dict.get("gather_dim")
+            for hint_dict in op_hints.values()
+        ):
             op.work_div_loop_info = {  # type: ignore[attr-defined]
                 sym: list(names) for sym, names in dp.loop_var_dims.items()
             }

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -334,8 +334,12 @@ class ScratchpadAllocator:
             return False
         if isinstance(op.layout, MutationLayoutSHOULDREMOVE):
             return False
-        return config.allow_all_ops_in_lx_planning or (
-            self._get_op_name(op) in OP_OUTPUT_GOOD_FOR_LX_REUSE
+        # A collected relayout plan is an eligibility contract for its exact source.
+        is_lx_relayout_source = op.get_name() in self._lx_relayout_plans_by_source
+        return (
+            config.allow_all_ops_in_lx_planning
+            or self._get_op_name(op) in OP_OUTPUT_GOOD_FOR_LX_REUSE
+            or is_lx_relayout_source
         )
 
     @staticmethod

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -818,6 +818,14 @@ class ScratchpadAllocator:
                         producer_input.uses = sorted(
                             {*producer_input.uses, shuffle_use}
                         )
+                        # The input now stays live past its original in-place
+                        # handoff, so its storage cannot be reused there.
+                        for child in buffers:
+                            child.in_place_parents = [
+                                parent
+                                for parent in child.in_place_parents
+                                if parent != producer_input.name
+                            ]
 
             # The original graph models the consumer as reading S1 directly,
             # so S1's liveness extends through the consumer compute. The

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -15,7 +15,9 @@
 import logging
 import math
 import time
-from collections.abc import Sequence
+from bisect import bisect_right
+from collections.abc import Iterator, Sequence
+from dataclasses import replace
 from typing import Any, Optional
 
 import sympy
@@ -70,6 +72,7 @@ from torch_spyre._inductor.scratchpad.utils import (
     calculate_liveness,
     get_buffer_users,
     ops_in_offset_mutation_component,
+    _op_short_name,
     get_op_pointwise_inputs,
     buffer_not_read_in_full,
     get_ncores_for_buffers,
@@ -81,6 +84,13 @@ from torch_spyre._inductor.scratchpad.graph_editor import GraphEditor
 
 from torch_spyre._inductor import config
 from torch_spyre._inductor.logging_utils import get_inductor_logger
+from torch_spyre._inductor.lx_relayout import (
+    LXRelayoutPlan,
+    clear_lx_relayout_metadata,
+    collect_lx_relayout_plans,
+    is_lx_relayout_destination,
+    record_lx_relayout_plan,
+)
 from torch_spyre._inductor.pass_utils import _is_matmul_op
 
 logger = get_inductor_logger("scratchpad.allocator")
@@ -137,6 +147,8 @@ class ScratchpadAllocator:
         self.pre_optimization_passes = pre_optimization_passes
         self.post_optimization_passes = post_optimization_passes
         self.layout_planning: Optional[MemoryPlanSolver] = layout_planning
+        self._last_layout_planning: MemoryPlanSolver = layout_planning
+        self._lx_relayout_plans_by_source: dict[str, LXRelayoutPlan] = {}
 
     def plan_allocation(self, graph: GraphLowering):
         """Run pre-passes, assign LX addresses to eligible buffers, then run post-passes.
@@ -171,15 +183,113 @@ class ScratchpadAllocator:
 
     def _prepare_buffers(self, graph: GraphLowering) -> Sequence[Any]:
         """Buffers to hand the solver. Base: fixed-division LifetimeBoundBuffers."""
-        return self._generate_buffers(graph)
+        return self._prepare_lifetime_buffers(graph)
+
+    def _prepare_lifetime_buffers(
+        self,
+        graph: GraphLowering,
+        cache: Optional[dict] = None,
+        timings: Optional[dict[str, float]] = None,
+        lifetimes: Optional[dict[str, list[int]]] = None,
+    ) -> list[LifetimeBoundBuffer]:
+        """Build fixed-division buffers plus any valid relayout destinations."""
+        self._lx_relayout_plans_by_source = {
+            plan.source_name: plan for plan in collect_lx_relayout_plans(graph, cache)
+        }
+        buffers = self._generate_buffers(graph, cache, timings, lifetimes)
+        self._append_lx_relayout_destinations(graph, buffers)
+        return buffers
 
     def _solve(self, buffers: Sequence[Any]) -> Sequence[Any]:
         """Assign LX addresses. Base: placement-only ``plan_layout``."""
-        assert self.layout_planning is not None
-        return self.layout_planning.plan_layout(buffers, log_lx_usage=True)
+        layout_planning = self._layout_planner_for_buffers(buffers)
+        return self._plan_layout_with_atomic_relayouts(
+            layout_planning, buffers, log_lx_usage=True
+        )
 
     def _post_solve(self, graph: GraphLowering, allocation: Sequence[Any]) -> None:
-        """Hook run after the solve, before reasons/push. Base: nothing to commit."""
+        """Record only relayouts whose source and destination both landed in LX."""
+        self._record_successful_lx_relayouts(graph, allocation)
+
+    def _layout_planner_for_buffers(
+        self, buffers: Sequence[LifetimeBoundBuffer]
+    ) -> MemoryPlanSolver:
+        assert self.layout_planning is not None
+        if isinstance(self.layout_planning, GreedyLayoutSolver) and any(
+            is_lx_relayout_destination(buffer.name) for buffer in buffers
+        ):
+            # Greedy cannot repack earlier allocations when the larger S2 view
+            # becomes live. Use a whole-lifetime solver only when S2 exists.
+            return FirstFitLayoutSolver(
+                self.layout_planning.limit, self.layout_planning.alignment
+            )
+        return self.layout_planning
+
+    def _plan_layout_with_atomic_relayouts(
+        self,
+        layout_planning: MemoryPlanSolver,
+        buffers: Sequence[LifetimeBoundBuffer],
+        *,
+        log_lx_usage: bool = False,
+    ) -> list[LifetimeBoundBuffer]:
+        """Place complete S1/S2 pairs or fall back without reserving either."""
+        allocation = layout_planning.plan_layout(buffers, log_lx_usage=log_lx_usage)
+        self._last_layout_planning = layout_planning
+        if not self._lx_relayout_plans_by_source:
+            return allocation
+
+        complete_relayouts = list(self._iter_complete_lx_relayouts(allocation))
+        if len(complete_relayouts) == len(self._lx_relayout_plans_by_source):
+            return allocation
+
+        # Replanning can move every buffer, so fall back every relayout pair
+        # atomically rather than retaining a partially allocated pair.
+        removed_names = set(self._lx_relayout_plans_by_source)
+        removed_names.update(
+            plan.destination_name for plan in self._lx_relayout_plans_by_source.values()
+        )
+        remaining = [buffer for buffer in buffers if buffer.name not in removed_names]
+        for buffer in remaining:
+            buffer.address = None
+            buffer.in_place_parents = [
+                parent
+                for parent in buffer.in_place_parents
+                if parent not in removed_names
+            ]
+
+        assert self.layout_planning is not None
+        replanned = self.layout_planning.plan_layout(
+            remaining, log_lx_usage=log_lx_usage
+        )
+        self._last_layout_planning = self.layout_planning
+        replanned_by_name = {buffer.name: buffer for buffer in replanned}
+        for buffer in allocation:
+            if buffer.name in removed_names:
+                buffer.address = None
+        return [replanned_by_name.get(buffer.name, buffer) for buffer in allocation]
+
+    def _iter_complete_lx_relayouts(
+        self, allocation: Sequence[LifetimeBoundBuffer]
+    ) -> Iterator[tuple[LXRelayoutPlan, int]]:
+        """Yield relayouts whose source and destination are allocated disjointly."""
+        by_name = {buffer.name: buffer for buffer in allocation}
+        for source_name, plan in self._lx_relayout_plans_by_source.items():
+            source = by_name.get(source_name)
+            destination = by_name.get(plan.destination_name)
+            if (
+                source is None
+                or source.address is None
+                or destination is None
+                or destination.address is None
+            ):
+                continue
+            source_address = source.address
+            destination_address = destination.address
+            if source_address < destination_address + destination.size and (
+                destination_address < source_address + source.size
+            ):
+                continue
+            yield plan, destination_address
 
     def _record_reject_reasons(self, allocation: Sequence[Any]) -> None:
         """Stamp ``reject_reasons`` for spilled buffers. Base: from the solver's
@@ -194,8 +304,7 @@ class ScratchpadAllocator:
         spilled without a reason there simply did not fit once the higher-value
         buffers were placed.
         """
-        assert self.layout_planning is not None
-        solver_reasons = self.layout_planning.spill_reasons
+        solver_reasons = self._last_layout_planning.spill_reasons
         for b in allocation:
             if b.address is None:
                 self.reject_reasons[b.name] = solver_reasons.get(
@@ -206,6 +315,19 @@ class ScratchpadAllocator:
 
     def _get_op_name(self, op: Any) -> str:
         return _op_short_name(op)
+
+    def _record_successful_lx_relayouts(
+        self,
+        graph: GraphLowering,
+        allocation: Sequence[LifetimeBoundBuffer],
+    ) -> None:
+        """Commit relayout metadata only after all required LX storage exists."""
+        clear_lx_relayout_metadata(graph)
+        for plan, destination_address in self._iter_complete_lx_relayouts(allocation):
+            record_lx_relayout_plan(
+                graph,
+                replace(plan, destination_lx_address=destination_address),
+            )
 
     def _op_output_good_for_lx_reuse(self, op: Any) -> bool:
         if not isinstance(op, ComputedBuffer):
@@ -586,9 +708,18 @@ class ScratchpadAllocator:
         t0 = time.perf_counter()
         if lifetimes is None:
             lifetimes = calculate_liveness(graph)
-        ncores, ncores_reasons = get_ncores_for_buffers(graph)
+        planned_sources = set(self._lx_relayout_plans_by_source)
+        ncores, ncores_reasons = get_ncores_for_buffers(
+            graph,
+            cache,
+            planned_relayout_sources=planned_sources,
+        )
         t1 = time.perf_counter()
-        mem_usage = mem_usage_by_buf(graph, cache)
+        mem_usage = mem_usage_by_buf(
+            graph,
+            cache,
+            planned_relayout_sources=planned_sources,
+        )
         t2 = time.perf_counter()
         if timings is not None:
             timings["residency"] += t1 - t0
@@ -614,6 +745,110 @@ class ScratchpadAllocator:
             ncores=ncores,
             ncores_reasons=ncores_reasons,
         )
+
+    def _append_lx_relayout_destinations(
+        self,
+        graph: GraphLowering,
+        buffers: list[LifetimeBoundBuffer],
+    ) -> None:
+        """Add post-shuffle views and their transfer steps to LX liveness."""
+        by_name = {buffer.name: buffer for buffer in buffers}
+        op_index = {op.get_name(): index for index, op in enumerate(graph.operations)}
+        entries: list[tuple[LifetimeBoundBuffer, LXRelayoutPlan, int]] = []
+        invalid_sources: set[str] = set()
+        for source_name, plan in self._lx_relayout_plans_by_source.items():
+            source = by_name.get(source_name)
+            consumer_use = op_index.get(plan.consumer_name)
+            if source is None or source.residency_reason is not None:
+                invalid_sources.add(source_name)
+                continue
+            if (
+                consumer_use is None
+                or consumer_use not in source.uses
+                or not any(use < consumer_use for use in source.uses)
+            ):
+                source.residency_reason = (
+                    "core div mismatch: relayout transfer could not be scheduled"
+                )
+                invalid_sources.add(source_name)
+                continue
+            entries.append((source, plan, consumer_use))
+
+        if invalid_sources:
+            # Keep every declarative buffer and its residency reason. Only drop
+            # the synthetic relayout plan when its source cannot be placed or
+            # its transfer lifetime cannot be modeled.
+            for source_name in invalid_sources:
+                self._lx_relayout_plans_by_source.pop(source_name, None)
+
+        if not entries:
+            return
+
+        # Insert one synthetic lifetime step immediately before each consumer
+        # that needs a SHUFFLE. Existing solvers then see S1 and S2 live together
+        # during the transfer and keep their addresses disjoint without any
+        # relayout-specific placement rules.
+        boundaries = sorted({consumer_use for _, _, consumer_use in entries})
+        transfer_time = {
+            consumer_use: consumer_use + rank
+            for rank, consumer_use in enumerate(boundaries)
+        }
+        for buffer in buffers:
+            buffer.uses = [use + bisect_right(boundaries, use) for use in buffer.uses]
+
+        for source, plan, original_consumer_use in entries:
+            consumer_use = original_consumer_use + bisect_right(
+                boundaries, original_consumer_use
+            )
+            shuffle_use = transfer_time[original_consumer_use]
+
+            # The backend may execute the final producer data movement and the
+            # inserted SHUFFLE in one bundle. Keep any LX-resident producer
+            # inputs live through the transfer boundary so S2 cannot reuse
+            # their storage before S1 is fully materialized.
+            producer = graph.try_get_buffer(source.name)
+            if producer is not None:
+                for dep in op_read_writes(producer).reads:
+                    producer_input = by_name.get(dep.name)
+                    if producer_input is not None:
+                        producer_input.uses = sorted(
+                            {*producer_input.uses, shuffle_use}
+                        )
+
+            # The original graph models the consumer as reading S1 directly,
+            # so S1's liveness extends through the consumer compute. The
+            # materialized schedule is instead:
+            #
+            #     produce S1 -> SHUFFLE S1 into S2 -> compute from S2
+            #
+            # Both views are accessed at the synthetic SHUFFLE step. S1 can be
+            # released before consumer compute while S2 remains live through it.
+            source_uses = [use for use in source.uses if use != consumer_use]
+            source.uses = sorted({*source_uses, shuffle_use})
+            destination_size = round_up_to_alignment(
+                source.size * plan.destination_size_ratio,
+                _LX_ALLOCATION_GRANULARITY_BYTES,
+            )
+            destination = LifetimeBoundBuffer(
+                plan.destination_name,
+                destination_size,
+                [shuffle_use, consumer_use],
+                first_use_is_read=False,
+            )
+            for child in buffers:
+                if source.name in child.in_place_parents:
+                    # This relation was validated against S1's layout and size;
+                    # it is not valid for the materialized S2 view. Normal
+                    # liveness can still reuse S1 after the SHUFFLE boundary.
+                    child.in_place_parents = [
+                        parent
+                        for parent in child.in_place_parents
+                        if parent != source.name
+                    ]
+            # Keep the synthetic destination adjacent to its source for readable
+            # plans. Placement order does not affect correctness because their
+            # lifetimes overlap at ``shuffle_use``.
+            buffers.insert(buffers.index(source), destination)
 
     def _log_lx_pinning(self, graph: GraphLowering) -> None:
         """Log the final LX pinning decision for every op in the graph."""
@@ -652,7 +887,7 @@ class ScratchpadAllocator:
         graph_editor = GraphEditor(graph)
 
         for b in buffers:
-            if b.address is None:
+            if b.address is None or is_lx_relayout_destination(b.name):
                 continue
 
             buf = graph.get_buffer(b.name)
@@ -703,30 +938,6 @@ def _fixed_core_division(op: Operation) -> CoreDivision:
     """
     seed: tuple[dict, dict] = getattr(op, "op_it_space_splits", None) or ({}, {})
     return CoreDivision(output_splits=dict(seed[0]), reduction_splits=dict(seed[1]))
-
-
-def _op_short_name(op: Any) -> str:
-    """Resolve an op's short name from its ``origin_node`` target, falling back
-    to each fused fx node in ``op.origins``; ``"None"`` when unresolvable.
-
-    ``origin_node`` is tried first (independent of ``origins``, which may be
-    empty), so a plain op still resolves; the ``origins`` fallback recovers a
-    fused op like bmm+permute, whose ``origin_node`` target has no resolvable
-    name and would otherwise resolve to ``"None"`` and be wrongly rejected as
-    "op not allowed". Module-level so ``ScratchpadAllocator._get_op_name``
-    delegates to one implementation.
-    """
-    name = None
-    for fx_node in (getattr(op, "origin_node", None), *getattr(op, "origins", ())):
-        target = getattr(fx_node, "target", None)
-        name = (
-            getattr(target, "_opname", None)
-            or getattr(target, "__name__", None)
-            or getattr(target, "name", None)
-        )
-        if name is not None:
-            break
-    return name if name is not None else "None"
 
 
 DEFAULT_VARIANT_CAP = 6
@@ -1181,14 +1392,14 @@ class StrategyBCoOptimizingAllocator(ScratchpadAllocator):
         # the clone (changes the (op, splits, dep) cache key), so on any op-count
         # change both are stale and we rebuild from scratch (cache=lifetimes=None).
         clone_inserted = len(graph.operations) != n_ops_before_clone
-        buffers = self._generate_buffers(
+        buffers = self._prepare_lifetime_buffers(
             graph,
             cache=None if clone_inserted else search_cache,
             lifetimes=None if clone_inserted else search_lifetimes,
         )
-        assert self.layout_planning is not None
-        allocation = self.layout_planning.plan_layout(buffers, log_lx_usage=True)
-        self._record_spill_reasons(allocation)
+        allocation = self._solve(buffers)
+        self._post_solve(graph, allocation)
+        self._record_reject_reasons(allocation)
         self._push_allocation(graph, allocation)
         self._log_lx_pinning(graph)
         for p in self.post_optimization_passes:
@@ -1297,9 +1508,9 @@ class StrategyBCoOptimizingAllocator(ScratchpadAllocator):
         `residency` / `mem_usage` sub-step seconds into it. `lifetimes`
         (split-invariant) is forwarded to avoid recomputing it per leaf.
         """
-        buffers = self._generate_buffers(graph, cache, timings, lifetimes)
-        assert self.layout_planning is not None
-        allocation = self.layout_planning.plan_layout(buffers)
+        buffers = self._prepare_lifetime_buffers(graph, cache, timings, lifetimes)
+        layout_planning = self._layout_planner_for_buffers(buffers)
+        allocation = self._plan_layout_with_atomic_relayouts(layout_planning, buffers)
         pinned_names = {b.name for b in allocation if b.address is not None}
 
         return sum(
@@ -1336,6 +1547,15 @@ class CoOptimizingAllocator(ScratchpadAllocator):
         self.layout_planning: Optional[CoreDivisionLayoutSolver] = layout_planning
 
     def _prepare_buffers(self, graph: GraphLowering) -> Sequence[Any]:
+        if config.lx_planner_relayout:
+            relayout_buffers = self._prepare_lifetime_buffers(graph)
+            if self._lx_relayout_plans_by_source:
+                # Relayout geometry is derived from the committed divisions, so
+                # keep those divisions fixed for this placement-only solve.
+                return relayout_buffers
+        else:
+            self._lx_relayout_plans_by_source = {}
+
         in_place = self._determine_in_place_division_invariant(graph)
         buffers = self._build_cd_bound_buffers(
             graph, in_place, self._division_map(graph)
@@ -1343,16 +1563,26 @@ class CoOptimizingAllocator(ScratchpadAllocator):
         return buffers
 
     def _solve(self, buffers: Sequence[Any]) -> Sequence[Any]:
+        if self._lx_relayout_plans_by_source:
+            return super()._solve(buffers)
         assert self.layout_planning is not None
         return self.layout_planning.plan_layout_and_core_divisions(buffers)
 
     def _post_solve(self, graph: GraphLowering, allocation: Sequence[Any]) -> None:
+        if self._lx_relayout_plans_by_source:
+            super()._post_solve(graph, allocation)
+            return
+
+        clear_lx_relayout_metadata(graph)
         # The divisions must be committed such that any buffer clones can correctly
         # pull the selected core division from the dependent buffers when the graph
         # is updated with clones in ``_push_allocation``.
         self._commit_divisions(graph, allocation)
 
     def _record_reject_reasons(self, allocation: Sequence[Any]) -> None:
+        if self._lx_relayout_plans_by_source:
+            super()._record_reject_reasons(allocation)
+            return
         # Surface the solver's per-buffer spill causes so the LX-pinning debug
         # log reports why each buffer landed in HBM, on par with the other
         # allocators. ``getattr`` because only ``CpSatLayoutSolver`` exposes it.
@@ -1923,13 +2153,13 @@ def select_allocator() -> ScratchpadAllocator:
     the allocators themselves take an explicit solver and never inspect config:
 
     * ``layout_solver == "cpsat"`` with ``co_optimizing_lx_planning`` -> joint
-      core-division + LX placement via :class:`CoOptimizingAllocator`. Falls back
-      to placement-only greedy :class:`ScratchpadAllocator` when ortools is absent.
+      core-division + LX placement via :class:`CoOptimizingAllocator`. Graphs with
+      an actual relayout candidate use placement-only CP-SAT on their committed
+      divisions. Falls back to placement-only greedy when ortools is absent.
     * ``layout_solver == "cpsat"`` without co-optimization -> placement-only
       :class:`ScratchpadAllocator` driven by the CP-SAT solver, placing buffers on
-      each op's pre-determined core division (the buffers are converted to
-      trivial ``CoreDivisionBuffer``s). Falls back to greedy when ortools is
-      absent.
+      each op's pre-determined core division. Falls back to greedy when ortools
+      is absent.
     * ``co_optimizing_lx_planning`` (non-cpsat solver) -> gap-based
       co-optimization via :class:`StrategyBCoOptimizingAllocator`.
     * otherwise -> placement-only :class:`ScratchpadAllocator` with the configured

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -242,6 +242,36 @@ class ScratchpadAllocator:
         if len(complete_relayouts) == len(self._lx_relayout_plans_by_source):
             return allocation
 
+        complete_sources = {plan.source_name for plan, _ in complete_relayouts}
+        if complete_sources:
+            # First-fit may realize a useful subset even when a larger later
+            # relayout cannot fit. Preserve every complete S1/S2 pair and drop
+            # only incomplete pairs; their sources fall back to HBM. Replanning
+            # here could move the already-complete pairs and lose that maximal
+            # subset.
+            incomplete_sources = (
+                set(self._lx_relayout_plans_by_source) - complete_sources
+            )
+            removed_names = set(incomplete_sources)
+            removed_names.update(
+                self._lx_relayout_plans_by_source[source_name].destination_name
+                for source_name in incomplete_sources
+            )
+            for buffer in allocation:
+                if buffer.name in removed_names:
+                    buffer.address = None
+                buffer.in_place_parents = [
+                    parent
+                    for parent in buffer.in_place_parents
+                    if parent not in removed_names
+                ]
+            self._lx_relayout_plans_by_source = {
+                source_name: plan
+                for source_name, plan in self._lx_relayout_plans_by_source.items()
+                if source_name in complete_sources
+            }
+            return list(allocation)
+
         # Replanning can move every buffer, so fall back every relayout pair
         # atomically rather than retaining a partially allocated pair.
         removed_names = set(self._lx_relayout_plans_by_source)

--- a/torch_spyre/_inductor/scratchpad/firstfit_bestfit_solver.py
+++ b/torch_spyre/_inductor/scratchpad/firstfit_bestfit_solver.py
@@ -126,16 +126,19 @@ class FirstFitLayoutSolver(MemoryPlanSolver):
         self,
         buffer: LifetimeBoundBuffer,
         placed: list[LifetimeBoundBuffer],
+        *,
+        reuse_in_place_parents: bool = True,
     ) -> list[Gap]:
         """Build free gaps for buffer, annotated with valid in-place parent addresses.
 
         Pass 1: subtract address intervals of all already-placed buffers that overlap
-        buffer's lifetime, except declared in-place parents (their slots are candidates
-        for reuse, not conflicts).
+        buffer's lifetime. During the in-place attempt, declared parents are kept as
+        reuse candidates rather than conflicts. During ordinary fallback placement,
+        they are conflicts like every other live buffer.
         Pass 2: for each remaining gap, record which declared parents fit entirely within it.
         """
         gaps: list[Gap] = [Gap(0, self.limit)]
-        parent_names = set(buffer.in_place_parents)
+        parent_names = set(buffer.in_place_parents) if reuse_in_place_parents else set()
 
         for other in placed:
             if other.address is None:
@@ -225,6 +228,15 @@ class FirstFitLayoutSolver(MemoryPlanSolver):
                 buffer.address = names_to_addresses[parent]
                 names_to_addresses[buffer.name] = buffer.address
             else:
+                # Exact parent-slot reuse was not legal, usually because a third
+                # live buffer occupies part of that slot. Rebuild the ordinary
+                # gaps with the parent treated as a conflict; otherwise a shifted
+                # placement can partially overlap the still-live parent.
+                gaps = self._build_gaps(
+                    buffer,
+                    placed,
+                    reuse_in_place_parents=False,
+                )
                 gap = self._pick_gap(gaps, buffer.size)
                 if gap is not None:
                     buffer.address = round_up_to_alignment(gap.start, self.alignment)

--- a/torch_spyre/_inductor/scratchpad/graph_editor.py
+++ b/torch_spyre/_inductor/scratchpad/graph_editor.py
@@ -17,6 +17,7 @@ from torch._inductor.graph import GraphLowering
 from torch._inductor.ops_handler import WrapperHandler
 from torch_spyre._inductor.pass_utils import (
     apply_splits_from_index_coeff,
+    copy_fx_custom_meta,
     copy_op_metadata,
     iteration_space_from_op,
     splits_by_index_coeff,
@@ -144,6 +145,9 @@ class GraphEditor:
         new_fx_node = self.fx_graph.create_node(
             "call_function", self.clone_aten_op, (buf_fx,)
         )
+        hint_source = buffer_users[0] if input else buffer
+        for origin in hint_source.origins:
+            copy_fx_custom_meta(origin, new_fx_node)
         for user in old_users:
             user.args = tuple(new_fx_node if ar is buf_fx else ar for ar in user.args)
         self.lowering.orig_gm.recompile()

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -106,6 +106,7 @@ def calculate_liveness(graph: GraphLowering) -> dict[str, list[int]]:
 def mem_usage_by_buf(
     graph: GraphLowering,
     cache: Optional[dict] = None,
+    planned_relayout_sources: Optional[set[str]] = None,
 ) -> dict:
     """
     Get a summary of memory usage of each operation.
@@ -116,7 +117,11 @@ def mem_usage_by_buf(
     """
     # The mismatch reasons are surfaced by the residency path; here only the
     # per-buffer core count (with -1 marking a mismatch) drives mem_usage.
-    num_cores_per_op, _ = get_ncores_for_buffers(graph, cache)
+    num_cores_per_op, _ = get_ncores_for_buffers(
+        graph,
+        cache,
+        planned_relayout_sources=planned_relayout_sources,
+    )
     mem_usage: dict = {}
 
     for op in graph.operations:
@@ -333,6 +338,21 @@ def get_buffer_users(graph: GraphLowering) -> dict[str, list[Operation]]:
     return buf_users_read_and_write
 
 
+def _op_short_name(op: Any) -> str:
+    """Resolve an op's short name, including fused operations."""
+
+    for fx_node in (getattr(op, "origin_node", None), *getattr(op, "origins", ())):
+        target = getattr(fx_node, "target", None)
+        name = (
+            getattr(target, "_opname", None)
+            or getattr(target, "__name__", None)
+            or getattr(target, "name", None)
+        )
+        if name is not None:
+            return str(name)
+    return "None"
+
+
 def _get_buffer_user_deps(
     graph: GraphLowering,
 ) -> dict[str, list[tuple[Operation, MemoryDep]]]:
@@ -365,7 +385,9 @@ def _op_num_cores(op: Operation) -> int:
 
 
 def get_ncores_for_buffers(
-    graph: GraphLowering, cache: Optional[dict] = None
+    graph: GraphLowering,
+    cache: Optional[dict] = None,
+    planned_relayout_sources: Optional[set[str]] = None,
 ) -> tuple[dict[str, int], dict[str, str]]:
     """
     Return ``(num_cores, mismatch_reasons)``, where ``num_cores`` maps each
@@ -382,6 +404,7 @@ def get_ncores_for_buffers(
     mismatch_reasons_cache: dict[str, str] = {}
     using_multicore = config.sencores > 1
     buf_user_deps = _get_buffer_user_deps(graph)
+    planned_relayout_sources = planned_relayout_sources or set()
     for buf_name, users in buf_user_deps.items():
         # this dict includes graph input and output
         if using_multicore and len(users) > 1:
@@ -441,8 +464,13 @@ def get_ncores_for_buffers(
                     )
                     break
             if mismatch_reason is not None:
-                num_cores = -1
-                mismatch_reasons_cache[buf_name] = mismatch_reason
+                if buf_name in planned_relayout_sources and writer_cores is not None:
+                    # The allocator has accepted this mismatch as an explicit
+                    # relayout edge, so size the source from its writer view.
+                    num_cores = writer_cores
+                else:
+                    num_cores = -1
+                    mismatch_reasons_cache[buf_name] = mismatch_reason
             elif writer_cores is not None:
                 num_cores = writer_cores
             else:

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -442,8 +442,10 @@ def get_ncores_for_buffers(
                     # An LX (per-core scratchpad) buffer would then live on
                     # view_cores cores but be read by op_cores; the cores without
                     # a local copy read stale scratchpad -> wrong results. There is
-                    # no single-base LX broadcast, so treat it as a core-division
-                    # mismatch and keep the buffer in HBM (correct, just unpinned).
+                    # ordinary same-base LX reuse cannot broadcast, so treat it
+                    # as a core-division mismatch. An explicit relayout plan may
+                    # accept that mismatch below and materialize a separate,
+                    # allocator-reserved destination copy on every consumer core.
                     # This is not writer-relative: it catches broadcast reads even
                     # when the buffer has no in-graph writer (a graph input cloned
                     # into LX) or when a producer's view happens to match the

--- a/torch_spyre/_inductor/split_multi_ops.py
+++ b/torch_spyre/_inductor/split_multi_ops.py
@@ -25,7 +25,7 @@ from torch._inductor.virtualized import V
 from torch.utils._ordered_set import OrderedSet
 from .logging_utils import get_inductor_logger
 from .errors import Unsupported
-from .pass_utils import replace_computed_buffer_body
+from .pass_utils import copy_fx_custom_meta, replace_computed_buffer_body
 from .constants import is_ea_compatible
 from torch_spyre._C import SpyreTensorLayout, ElementArrangement
 from torch_spyre.constants import DEVICE_NAME
@@ -516,6 +516,7 @@ def _make_intermediate_bufs(
 
         with gl.graph.inserting_before(orig_node):
             new_node = gl.graph.create_node("call_function", target, args, clean_kw)
+        copy_fx_custom_meta(orig_node, new_node)
 
         # Propagate metadata for shape inference
         if input_nodes and "val" in input_nodes[0].meta:

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -48,7 +48,7 @@ from .constants import (
 from . import config as _spyre_config
 from .errors import Unsupported
 from .ir import FixedTiledLayout
-from .lx_relayout import LX_RELAYOUT_ATTR, LXRelayoutPlan
+from .lx_relayout import LX_RELAYOUT_ATTR, LXCollectiveKind, LXRelayoutPlan
 from .pass_utils import (
     concretize_expr,
     concretize_index,
@@ -94,8 +94,16 @@ def _materialize_explicit_lx_shuffle(
     """Build one standard bounded S1 -> SHUFFLE -> S2 operation."""
     destination_address = plan.destination_lx_address
     destination_name = plan.destination_name
-    producer_map = plan.source_core_id_to_device_slice
-    consumer_map = plan.destination_core_id_to_device_slice
+    producer_map = {
+        core: dict(per_core)
+        for core, per_core in plan.source_core_id_to_device_slice.items()
+    }
+    consumer_map = {
+        core: dict(per_core)
+        for core, per_core in plan.destination_core_id_to_device_slice.items()
+    }
+    source_device_dim_splits = dict(plan.source_device_dim_splits)
+    destination_device_dim_splits = dict(plan.destination_device_dim_splits)
     participant_count = len(consumer_map)
     if "lx" not in source_arg.allocation or destination_address is None:
         return None
@@ -124,6 +132,26 @@ def _materialize_explicit_lx_shuffle(
     if not shuffle_iteration_space:
         return None
 
+    # A whole-buffer broadcast has no logically split tensor dimension, but
+    # the backend allocation contract still needs one unit-fold dimension to
+    # carry the sparse source owner and replicated destination owners. Anchor
+    # that physical metadata on the last non-stick device dimension without
+    # changing the logical communication geometry recorded in the plan.
+    if (
+        plan.collective_kind is LXCollectiveKind.BROADCAST
+        and not source_device_dim_splits
+        and not destination_device_dim_splits
+        and not any(producer_map.values())
+        and not any(consumer_map.values())
+    ):
+        if len(source_arg.device_coordinates) < 2:
+            return None
+        anchor_dim = str(len(source_arg.device_coordinates) - 2)
+        source_device_dim_splits[anchor_dim] = 1
+        destination_device_dim_splits[anchor_dim] = 1
+        producer_map = {core: {anchor_dim: 0} for core in producer_map}
+        consumer_map = {core: {anchor_dim: 0} for core in consumer_map}
+
     def splits_by_symbol(
         device_dim_splits: dict[str, int],
     ) -> dict[sympy.Symbol, int] | None:
@@ -147,8 +175,8 @@ def _materialize_explicit_lx_shuffle(
             splits_by_symbol[symbol] = split
         return splits_by_symbol
 
-    source_splits = splits_by_symbol(plan.source_device_dim_splits)
-    destination_splits = splits_by_symbol(plan.destination_device_dim_splits)
+    source_splits = splits_by_symbol(source_device_dim_splits)
+    destination_splits = splits_by_symbol(destination_device_dim_splits)
     if source_splits is None or destination_splits is None:
         return None
 
@@ -163,7 +191,7 @@ def _materialize_explicit_lx_shuffle(
         name=plan.source_name,
         allocation=dict(source_arg.allocation),
         allocation_core_id_to_device_slice=producer_map,
-        allocation_device_dim_splits=dict(plan.source_device_dim_splits),
+        allocation_device_dim_splits=source_device_dim_splits,
     )
     destination_input = replace(
         source_arg,
@@ -177,7 +205,7 @@ def _materialize_explicit_lx_shuffle(
         destination_input,
         is_input=False,
         allocation_core_id_to_device_slice=consumer_map,
-        allocation_device_dim_splits=dict(plan.destination_device_dim_splits),
+        allocation_device_dim_splits=destination_device_dim_splits,
     )
     shuffle = OpSpec(
         op="shuffle",

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass, field
-from typing import Any, Callable, Self, Sequence, Tuple, Union
 from abc import ABC
+from dataclasses import dataclass, field, replace
+import logging
+from typing import Any, Callable, Self, Sequence, Tuple, Union
 
 import torch
 import sympy
@@ -35,7 +36,11 @@ from .constants import (
     SPYRE_FP32_OPS,
     BATCH_MATMUL_OP,
     BATCH_MATMUL_FP8_OP,
+    INPUT_DIM_LABELS,
     IDENTITY_OP,
+    LAYOUT_LABELS,
+    MATMUL_DIM_LABELS,
+    OUTPUT_DIM_LABELS,
     RESTICKIFY_OP,
     SEGMENT_OFFSETS,
     SHARED_WEIGHT_UNIT_BMM_INFO_KEY,
@@ -43,6 +48,7 @@ from .constants import (
 from . import config as _spyre_config
 from .errors import Unsupported
 from .ir import FixedTiledLayout
+from .lx_relayout import LX_RELAYOUT_ATTR, LXRelayoutPlan
 from .pass_utils import (
     concretize_expr,
     concretize_index,
@@ -62,10 +68,172 @@ from .op_spec import (
     UnimplementedOp as OpSpecUnimplementedOp,
     format_op_spec_list,
 )
+from .propagate_hints import get_gather_dim
 from torch_spyre._inductor.provenance import build_debug_handle
-import logging
 
 logger = get_inductor_logger("spyre_kernel")
+
+
+def _current_node_lx_relayout_inputs(
+    current_node,
+) -> dict[str, LXRelayoutPlan]:
+    return {
+        source_name: plan
+        for scheduler_node in current_node.get_nodes()
+        for source_name, plan in getattr(
+            scheduler_node.node, LX_RELAYOUT_ATTR, {}
+        ).items()
+    }
+
+
+def _materialize_explicit_lx_shuffle(
+    source_arg: TensorArg,
+    consumer_spec: OpSpec,
+    plan: LXRelayoutPlan,
+) -> tuple[OpSpec, TensorArg] | None:
+    """Build one standard bounded S1 -> SHUFFLE -> S2 operation."""
+    destination_address = plan.destination_lx_address
+    destination_name = plan.destination_name
+    producer_map = plan.source_core_id_to_device_slice
+    consumer_map = plan.destination_core_id_to_device_slice
+    participant_count = len(consumer_map)
+    if "lx" not in source_arg.allocation or destination_address is None:
+        return None
+
+    used_symbols = {
+        symbol
+        for coordinate in source_arg.device_coordinates
+        for symbol in coordinate.free_symbols
+    }
+    consumer_is_matmul = consumer_spec.op in (
+        BATCH_MATMUL_OP,
+        BATCH_MATMUL_FP8_OP,
+    )
+    consumer_symbols = list(consumer_spec.iteration_space)
+    consumer_labels = (
+        MATMUL_DIM_LABELS[-len(consumer_symbols) :]
+        if consumer_is_matmul
+        else INPUT_DIM_LABELS[: len(consumer_symbols) - 1] + OUTPUT_DIM_LABELS[:1]
+    )
+    symbol_to_label = dict(zip(consumer_symbols, consumer_labels))
+    shuffle_iteration_space = {
+        symbol: value
+        for symbol, value in consumer_spec.iteration_space.items()
+        if symbol in used_symbols
+    }
+    if not shuffle_iteration_space:
+        return None
+
+    def splits_by_symbol(
+        device_dim_splits: dict[str, int],
+    ) -> dict[sympy.Symbol, int] | None:
+        splits_by_symbol: dict[sympy.Symbol, int] = {}
+        for device_dim, split in device_dim_splits.items():
+            index = int(device_dim)
+            if index < 0 or index >= len(source_arg.device_coordinates):
+                return None
+            symbols = [
+                symbol
+                for symbol in source_arg.device_coordinates[index].free_symbols
+                if symbol in symbol_to_label
+            ]
+            if len(symbols) != 1:
+                if split == 1:
+                    continue
+                return None
+            symbol = symbols[0]
+            if symbol in splits_by_symbol and splits_by_symbol[symbol] != split:
+                return None
+            splits_by_symbol[symbol] = split
+        return splits_by_symbol
+
+    source_splits = splits_by_symbol(plan.source_device_dim_splits)
+    destination_splits = splits_by_symbol(plan.destination_device_dim_splits)
+    if source_splits is None or destination_splits is None:
+        return None
+
+    shuffle_iteration_space = {
+        symbol: (extent, destination_splits.get(symbol, 1))
+        for symbol, (extent, _) in shuffle_iteration_space.items()
+    }
+
+    source = replace(
+        source_arg,
+        is_input=True,
+        name=plan.source_name,
+        allocation=dict(source_arg.allocation),
+        allocation_core_id_to_device_slice=producer_map,
+        allocation_device_dim_splits=dict(plan.source_device_dim_splits),
+    )
+    destination_input = replace(
+        source_arg,
+        is_input=True,
+        name=destination_name,
+        allocation={"lx": destination_address},
+        allocation_core_id_to_device_slice=None,
+        allocation_device_dim_splits=None,
+    )
+    destination_output = replace(
+        destination_input,
+        is_input=False,
+        allocation_core_id_to_device_slice=consumer_map,
+        allocation_device_dim_splits=dict(plan.destination_device_dim_splits),
+    )
+    shuffle = OpSpec(
+        op="shuffle",
+        is_reduction=False,
+        iteration_space=shuffle_iteration_space,
+        args=[source, destination_output],
+        op_info={},
+        symbolic_dim_bounds=dict(consumer_spec.symbolic_dim_bounds),
+        num_cores_override=participant_count,
+        dim_labels_override=[
+            symbol_to_label[symbol] for symbol in shuffle_iteration_space
+        ],
+        layout_labels_override=(
+            ["KERNEL", *LAYOUT_LABELS] if consumer_is_matmul else LAYOUT_LABELS
+        ),
+        gather_dim=(
+            consumer_spec.gather_dim
+            if consumer_spec.gather_dim in shuffle_iteration_space
+            else None
+        ),
+        replicas_contiguous=consumer_spec.gather_dim is not None,
+    )
+    return shuffle, destination_input
+
+
+def _materialize_lx_relayout_inputs(
+    current_node,
+    args: list[TensorArg],
+    tensor_args: Sequence[tuple[int, Any]],
+    consumer_spec: OpSpec,
+) -> list[OpSpec]:
+    """Materialize every planned consumer input before its compute row."""
+
+    plans = _current_node_lx_relayout_inputs(current_node)
+    prefix_specs: list[OpSpec] = []
+    destinations: dict[str, TensorArg] = {}
+    for arg_index, tensor in tensor_args:
+        plan = plans.get(tensor.name)
+        if plan is None:
+            continue
+        destination_arg = destinations.get(plan.source_name)
+        if destination_arg is None:
+            materialized = _materialize_explicit_lx_shuffle(
+                args[arg_index],
+                consumer_spec,
+                plan,
+            )
+            if materialized is None:
+                raise Unsupported(
+                    f"cannot materialize LX shuffle for {plan.source_name}"
+                )
+            shuffle_spec, destination_arg = materialized
+            prefix_specs.append(shuffle_spec)
+            destinations[plan.source_name] = destination_arg
+        args[arg_index] = destination_arg
+    return prefix_specs
 
 
 class RValue(ABC):
@@ -713,6 +881,7 @@ class SpyreKernel(Kernel[CSEVariable]):
             tiled_symbols=tiled_syms,
             symbolic_dim_bounds=symbolic_dim_bounds,
             debug_handle=debug_handle,
+            gather_dim=get_gather_dim(ir_node),
         )
 
     def remove_kernel_local_buffers(self) -> None:
@@ -795,6 +964,7 @@ class SpyreKernel(Kernel[CSEVariable]):
         elif isinstance(value, PointwiseOp):
             # Pointwise compute ops
             args: list[TensorArg] = []
+            tensor_args: list[tuple[int, TensorAccess]] = []
             indirect_syms = _indirect_syms_used(value, self.indirect_vars)
             if indirect_syms:
                 args += [
@@ -809,16 +979,24 @@ class SpyreKernel(Kernel[CSEVariable]):
                 ]
             for input in value.arguments:
                 if isinstance(input, TensorAccess):
+                    tensor_args.append((len(args), input))
                     args.append(self.create_tensor_arg(True, input.name, input))
                 else:
                     raise Unsupported(f"unexpected argument {input} to {value.op}")
             args.append(self.create_tensor_arg(False, real_dst_name, dst))
             op_info.update(value.op_info)
-            self.op_specs.append(
-                self.create_op_spec(
-                    value.op, False, args, op_info, self.indirect_var_names()
+            consumer_spec = self.create_op_spec(
+                value.op, False, args, op_info, self.indirect_var_names()
+            )
+            self.op_specs.extend(
+                _materialize_lx_relayout_inputs(
+                    self.current_node,
+                    args,
+                    tensor_args,
+                    consumer_spec,
                 )
             )
+            self.op_specs.append(consumer_spec)
         elif isinstance(value, TensorAccess):
             # Reshapes, transposes, and other dataops.
             if self.indirect_vars:
@@ -909,7 +1087,16 @@ class SpyreKernel(Kernel[CSEVariable]):
                 self.create_tensor_arg(True, y.name, y),
                 self.create_tensor_arg(False, real_dst_name, dst),
             ]
-            self.op_specs.append(self.create_op_spec(value.op, True, args, op_info))
+            consumer_spec = self.create_op_spec(value.op, True, args, op_info)
+            self.op_specs.extend(
+                _materialize_lx_relayout_inputs(
+                    self.current_node,
+                    args,
+                    [(0, x), (1, y)],
+                    consumer_spec,
+                )
+            )
+            self.op_specs.append(consumer_spec)
         else:
             # All other reductions have exactly one input which is a tensor
             if (not len(value.arguments) == 1) or (
@@ -1122,6 +1309,20 @@ def _codegen_op_spec_list(specs, buf: IndentedBuffer, sympy_str) -> None:
                 buf.writeline(
                     f"symbolic_dim_bounds={_serialize_value(op_spec.symbolic_dim_bounds)},"
                 )
+                if op_spec.num_cores_override is not None:
+                    buf.writeline(f"num_cores_override={op_spec.num_cores_override},")
+                if op_spec.dim_labels_override is not None:
+                    buf.writeline(
+                        f"dim_labels_override={op_spec.dim_labels_override!r},"
+                    )
+                if op_spec.layout_labels_override is not None:
+                    buf.writeline(
+                        f"layout_labels_override={op_spec.layout_labels_override!r},"
+                    )
+                if op_spec.gather_dim is not None:
+                    buf.writeline(f"gather_dim={sympy_str(op_spec.gather_dim)},")
+                if op_spec.replicas_contiguous:
+                    buf.writeline("replicas_contiguous=True,")
                 if op_spec.debug_handle is not None:
                     # Source-to-kernel provenance must survive the OpSpec ->
                     # generated-source -> exec round-trip. DebugHandle/SourceLoc
@@ -1149,6 +1350,16 @@ def _codegen_op_spec_list(specs, buf: IndentedBuffer, sympy_str) -> None:
                                 buf.writeline("per_tile_fixed=True,")
                             if arg.name is not None:
                                 buf.writeline(f"name={arg.name!r},")
+                            if arg.allocation_core_id_to_device_slice is not None:
+                                buf.writeline(
+                                    "allocation_core_id_to_device_slice="
+                                    f"{arg.allocation_core_id_to_device_slice!r},"
+                                )
+                            if arg.allocation_device_dim_splits is not None:
+                                buf.writeline(
+                                    "allocation_device_dim_splits="
+                                    f"{arg.allocation_device_dim_splits!r},"
+                                )
                         buf.writeline("),")
                 buf.writeline("]")
             buf.writeline("),")


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### Replacement progress

This PR is being superseded by a smaller replacement stack. The original branch remains available for history; review fixes are going into the replacements.

- [x] Extract the independent failed-in-place-reuse fix into #3438.
- [x] Recut planner, atomic S1/S2 allocation, scheduler revalidation, codegen, and HBM fallback as #3439.
- [x] Reject unmaterializable and mixed direct/relayout reads before allocation instead of failing after commit.
- [x] Carry resolved iteration geometry in the plan and rebind/revalidate it after scheduling.
- [x] Remove the duplicate planning pass, reuse liveness, remove the dead dependency-identity check, and make nonzero unmapped device dimensions fail loudly.
- [x] Add the relayout-mismatch sizing assertion and `core` CI label.
- [x] Remap ownership through `align_tensors()` splits/fusions, add a synthetic-dimension regression, and document `SPYRE_LX_PLANNER_RELAYOUT`.
- [x] Split grouped gather/core-ordering support into #3440.
- [x] Add direct replica-contiguous mapping coverage, gather-hint typo validation, and cloned-hint round-trip coverage.
- [x] Keep model-specific Granite policy out of the generic PRs; the measured prototype is archived on [`ah/granite-p09-prototype`](https://github.com/AdnanHoque/torch-spyre/tree/ah/granite-p09-prototype) without a PR.
- [x] Rebase all replacement branches on current `main` and cryptographically sign every commit.
- [x] Rerun full CI on the replacement heads; the prior missing-header blocker is resolved.
- [x] Clear the retained Work Division numeric DXP gate for #3439/#3440; all other checks in the prior matrix passed.
- [x] Restack #3440 on the exact signed #3439 history.
- [x] Retarget #3440 after #3439 is accepted.
- [x] Complete the focused review of the supporting DeepTools branch; its DXP fixture is 10/10.
- [x] Open the supporting DeepTools PR after team review.
- [x] Close this PR after the replacement stack is accepted.

Review answers:

- Grouped/subset fan-in is intentional in #3440; it is not restricted to a full-buffer MPI-style all-gather.
- The remaining `ValueError` checks protect internal plan/OpSpec invariants. Unsupported user geometry is rejected before allocation and takes the normal fallback path.
- #3439 retains a focused numeric device test, while #3440 contains only the minimal structural tests for its extension.

#### What this PR does:

Adds the LX planner and codegen path for on-chip all-to-all, all-gather, and broadcast relayouts. When producer and consumer core views differ, Torch:

- records their per-core LX ownership;
- classifies the logical communication as `all_to_all`, `all_gather`, or `broadcast`;
- allocates the source and destination views atomically;
- emits an explicit bounded SHUFFLE before the consumer; and
- falls back without reserving either LX view when the relayout cannot be placed.

The logical collective kind is deliberately separate from the backend op: all supported movement classes currently lower through the standard SHUFFLE primitive.

Broadcast keeps one physical source owner and materializes one full-sized destination copy on every participating consumer core. It does not pad the producer map with fake replicated owners. A unit-fold allocation coordinate is added only at SHUFFLE materialization for whole-buffer broadcasts. Multi-source multicast cohorts remain unsupported and are rejected by the classifier.

All-gather placement is explicit: the caller names the dimension whose participants must be adjacent. In the replacement stack, #3440 implements and honors this contract but does not add unconditional SDPA or model-specific policy.

#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/issues/2787
https://github.com/torch-spyre/torch-spyre/issues/3049
https://github.com/torch-spyre/torch-spyre/issues/3331

#### Special notes for your reviewer:

- #3266 is merged and provides the shared Torch/DXP usable-LX reservation contract.
- #3268 is merged and provides the shared physical core-mapping implementation.
- Backend PR #4408 is merged and provides relayout sizing support.
- DXP coordinate/ownership materialization follow-up is staged separately.

#### Does this PR introduce a user-facing change?

No. The relayout path is opt-in via `SPYRE_LX_PLANNER_RELAYOUT=1`.