### PR TITLE
Use Create and Destroy Methods of RuntimeOperationParams

### DIFF
--- a/torch_spyre/csrc/job_plan.cpp
+++ b/torch_spyre/csrc/job_plan.cpp
@@ -29,9 +29,12 @@ namespace spyre {
 
 void JobPlanStepH2D::construct(LaunchContext&,
                                const SpyreStream& stream) const {
-  flex::DmaParams params(host_address_, /*to_device=*/true, &device_address_);
-  params.pipeline_barrier = pipeline_barrier_;
-  stream.launchH2D(&params);
+  auto* params =
+      flex::createDmaParams(host_address_, device_address_.total_size(),
+                            /*to_device=*/true, &device_address_);
+  params->pipeline_barrier = pipeline_barrier_;
+  stream.launchH2D(params);
+  flex::destroyDmaParams(params);
 }
 
 void JobPlanStepH2D::write(std::ostream& os) const {
@@ -44,9 +47,12 @@ void JobPlanStepH2D::write(std::ostream& os) const {
 
 void JobPlanStepD2H::construct(LaunchContext&,
                                const SpyreStream& stream) const {
-  flex::DmaParams params(host_address_, /*to_device=*/false, &device_address_);
-  params.pipeline_barrier = pipeline_barrier_;
-  stream.launchD2H(&params);
+  auto* params =
+      flex::createDmaParams(host_address_, device_address_.total_size(),
+                            /*to_device=*/false, &device_address_);
+  params->pipeline_barrier = pipeline_barrier_;
+  stream.launchD2H(params);
+  flex::destroyDmaParams(params);
 }
 
 void JobPlanStepD2H::write(std::ostream& os) const {
@@ -69,10 +75,11 @@ void JobPlanStepCompute::construct(LaunchContext& ctx,
       tensor_allocs.push_back(address);
     }
   }
-  flex::ComputeParams params(&program_address_, std::move(tensor_allocs), "",
-                             bootstrap_offset_);
-  params.pipeline_barrier = pipeline_barrier_;
-  stream.launchCompute(&params);
+  auto* params = flex::createComputeParams(
+      &program_address_, std::move(tensor_allocs), "", bootstrap_offset_);
+  params->pipeline_barrier = pipeline_barrier_;
+  stream.launchCompute(params);
+  flex::destroyComputeParams(params);
 }
 
 void JobPlanStepCompute::write(std::ostream& os) const {
@@ -102,9 +109,10 @@ void JobPlanStepHostCompute::construct(LaunchContext& ctx,
                                        const SpyreStream& stream) const {
   // Helper lambda to build HostCallbackParams and launch on the stream
   auto launch_host_callback = [this, &stream](auto&& callback) {
-    flex::HostCallbackParams params(std::forward<decltype(callback)>(callback),
-                                    nullptr, pipeline_barrier_);
-    stream.launchHostCallback(&params);
+    auto* params = flex::createHostCallbackParams(
+        std::forward<decltype(callback)>(callback), nullptr, pipeline_barrier_);
+    stream.launchHostCallback(params);
+    flex::destroyHostCallbackParams(params);
   };
 
   // Case 1: input_buffer_ is provided

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -196,13 +196,17 @@ void SpyreStream::copyAsyncImpl(void* cpu_ptr,
 
   // Create and launch operation through SpyreStream's typed launch methods.
   if (host2device) {
-    flex::DmaParams params(cpu_ptr, host2device, device_address,
-                           std::move(dci_ptr));
-    launchH2D(&params);
+    auto* params =
+        flex::createDmaParams(cpu_ptr, device_address->total_size(),
+                              host2device, device_address, std::move(dci_ptr));
+    launchH2D(params);
+    flex::destroyDmaParams(params);
   } else {
-    flex::DmaParams params(cpu_ptr, host2device, device_address,
-                           std::move(dci_ptr));
-    launchD2H(&params);
+    auto* params =
+        flex::createDmaParams(cpu_ptr, device_address->total_size(),
+                              host2device, device_address, std::move(dci_ptr));
+    launchD2H(params);
+    flex::destroyDmaParams(params);
   }
 }
 
@@ -219,10 +223,10 @@ void SpyreStream::executeProgramAsync(
 
   // Program
   auto* ctx = static_cast<SharedOwnerCtx*>(arts.device_alloc.get_context());
-  flex::ComputeParams params(&ctx->composite_addr, std::move(tensor_allocs),
-                             arts.bundle_mlir_path);
-
-  launchCompute(&params);
+  auto* params = flex::createComputeParams(
+      &ctx->composite_addr, std::move(tensor_allocs), arts.bundle_mlir_path);
+  launchCompute(params);
+  flex::destroyComputeParams(params);
 }
 
 void SpyreStream::launchH2D(flex::DmaParams* params) const {


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:
Instead of instantiating the `RuntimeOperationParams` classes directly, this PR switches to using the intended create and destroy methods.

This PR can be merged without and dependencies on flex.

#### Which issue(s) this PR is related to:
Flex 1270

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No

#### Additional note:
