### PR TITLE
feat(coarse_tile): enable stick-dim reduction tiling

### DIFF
--- a/docs/source/compiler/coarse_tiling_loops.md
+++ b/docs/source/compiler/coarse_tiling_loops.md
@@ -632,7 +632,7 @@ existing storage in-place.  The full buffer's address is encoded in the
 unified treatment that always inserted a copy would handle all three cases
 correctly but waste a copy op here.
 
-#### Reduction tiling: Stage 1 (non-stick reduction dims)
+#### Reduction tiling: stick and non-stick reduction dims
 
 When a `Reduction` op has a non-empty `loop_tiled_reduction_dims`
 (i.e. the hint named a reduction dimension), `_propagate_tiled_reduction_op`
@@ -701,21 +701,21 @@ Identity values and combine operators by `reduction_type`:
 Before running propagation, the pass calls `_validate_reduction_tiling(op)`,
 which raises `RuntimeError` for configurations not yet implemented:
 
-- **Stick-dim reduction** — if the tiled reduction index corresponds to the
-  within-stick dimension of the primary input (detected via
-  `device_coordinates`), except for `BATCH_MATMUL_OP` whose tile output is
-  always a full `[M, N]` matrix.
 - **Mixed output+reduction at the same nesting level** — `loop_tiled_dims[i]`
   and `loop_tiled_reduction_dims[i]` are both non-empty for some level `i`.
 - **Multiple reduction indices at one level** — `len(loop_tiled_reduction_dims[i]) > 1`.
 
+Stick-dim reduction tiling is fully supported: tiling the innermost (stick)
+dimension of the input (e.g. `x.sum(dim=-1)` on a `[B, D]` tensor where D
+maps to the stick, or K-tiling for `BATCH_MATMUL_OP`) uses the same
+fill-initialize + per-tile combine pattern.  The output accumulator for a
+scalar stick-dim reduction has shape `data.ranges` (e.g. `[B]`) — the stick
+dim has been collapsed — and `_resize_device_layout` handles this "stick
+eliminated" case correctly.
+
 Nested tiling where outer level(s) tile output dims and the innermost level
 tiles a reduction dim (e.g. outer-B + inner-K for bmm) is fully supported
 and handled by the two-buffer pattern described above.
-
-**Not yet implemented:** Stick-dim reduction tiling (except `BATCH_MATMUL_OP`)
-requires handling column-vector output addressing when the tiling dimension is
-the innermost (stick) dimension of the input.
 
 ## Layer 2 — `CountedLoopSchedulerNode`
 

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1123,6 +1123,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
             with spyre_hint(num_tiles_per_dim={"D": 4}):
                 return x.sum(dim=-1)
 
+        # atol=0.05: fp16 sum over 512 elements scaled by 0.1 accumulates ~0.05 error.
         compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=0.05, rtol=0.05)
 
     def test_hint_tiled_reduction_matmul_loopspec(self):

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1070,8 +1070,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
 
     Stick-dim reduction tiling (dim=-1 on a [..., D] tensor where D maps to
     the stick) is now supported.  The loopspec tests run without hardware via
-    mock_patch + run_and_get_code.  The correctness tests require a Spyre
-    device and are skipped until issue #2748 is resolved.
+    mock_patch + run_and_get_code.
     """
 
     def setUp(self):
@@ -1106,9 +1105,6 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         self.assertIn("LoopSpec(", src, "Expected LoopSpec for D-tiled sum")
         self.assertIn("sympify('4')", src, "Expected loop count 4")
 
-    @pytest.mark.skip(
-        "Issue #2748: DtException from DCC on operand dominance failure with fake symbols"
-    )
     def test_hint_tiled_reduction_sum_correct(self):
         """x.sum(dim=-1) tiled over D (4 tiles) produces correct results."""
         from torch_spyre._inductor import spyre_hint
@@ -1207,9 +1203,6 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         self.assertIn("LoopSpec(", src, "Expected LoopSpec for D-tiled amax")
         self.assertIn("sympify('4')", src, "Expected loop count 4")
 
-    @pytest.mark.skip(
-        "Issue #2748: DtException from DCC on operand dominance failure with fake symbols"
-    )
     def test_hint_tiled_reduction_max_correct(self):
         """x.amax(dim=-1) tiled over D (4 tiles) produces correct results."""
         from torch_spyre._inductor import spyre_hint
@@ -1254,9 +1247,6 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         self.assertIn("LoopSpec(", src, "Expected LoopSpec for D-tiled amin")
         self.assertIn("sympify('4')", src, "Expected loop count 4")
 
-    @pytest.mark.skip(
-        "Issue #2748: DtException from DCC on operand dominance failure with fake symbols"
-    )
     def test_hint_tiled_reduction_min_correct(self):
         """x.amin(dim=-1) tiled over D (4 tiles) produces correct results."""
         from torch_spyre._inductor import spyre_hint

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1068,23 +1068,18 @@ class TestNamedDimsHint(InductorTestCase):
 class TestCoarseTileReductionE2E(InductorTestCase):
     """E2E tests for coarse-tiling a reduction dimension.
 
-    Stage 1 supports tiling reductions over non-stick dimensions only.
-    Tiling a reduction over the stick dimension (dim=-1 on a [..., D] tensor
-    where D maps to the stick) raises RuntimeError — deferred to Stage 2.
-
-    The tests below verify that the appropriate error is raised for stick-dim
-    reduction tiling, and that LoopSpec is still emitted up to the point where
-    validation fires.
+    Stick-dim reduction tiling (dim=-1 on a [..., D] tensor where D maps to
+    the stick) is now supported.  The loopspec tests run without hardware via
+    mock_patch + run_and_get_code.  The correctness tests require a Spyre
+    device and are skipped until issue #2748 is resolved.
     """
-
-    _STAGE2_MSG = "stick-dim reduction tiling is not yet implemented — Stage 2"
 
     def setUp(self):
         super().setUp()
         torch.manual_seed(0xAFFE)
 
     def test_hint_tiled_reduction_sum_loopspec(self):
-        """x.sum(dim=-1) tiled over D raises: stick-dim reduction not yet supported."""
+        """x.sum(dim=-1) tiled over D produces a LoopSpec with count 4."""
         from torch_spyre._inductor import spyre_hint
 
         B, D = 64, 512
@@ -1098,16 +1093,28 @@ class TestCoarseTileReductionE2E(InductorTestCase):
             with spyre_hint(num_tiles_per_dim={"D": 4}):
                 return x.sum(dim=-1)
 
-        with self.assertRaisesRegex(Exception, self._STAGE2_MSG):
-            torch.compile(fn)(x_dev)
+        cfn = torch.compile(fn)
+        with (
+            mock_patch(_LAUNCH_KERNEL),
+            mock_patch(_LAUNCH_JOBPLAN),
+            mock_patch(_PREPARE_KERNEL),
+            mock_patch("subprocess.run"),
+        ):
+            _, source_codes = run_and_get_code(cfn, x_dev)
+        self.assertTrue(len(source_codes) > 0)
+        src = source_codes[0]
+        self.assertIn("LoopSpec(", src, "Expected LoopSpec for D-tiled sum")
+        self.assertIn("sympify('4')", src, "Expected loop count 4")
 
-    def test_hint_tiled_reduction_sum_rejects(self):
-        """x.sum(dim=-1) with D hint rejects at compile time with Stage 2 error."""
+    @pytest.mark.skip(
+        "Issue #2748: DtException from DCC on operand dominance failure with fake symbols"
+    )
+    def test_hint_tiled_reduction_sum_correct(self):
+        """x.sum(dim=-1) tiled over D (4 tiles) produces correct results."""
         from torch_spyre._inductor import spyre_hint
 
         B, D = 64, 512
         x = torch.randn(B, D, dtype=torch.float16) * 0.1
-        x_dev = x.to("spyre")
         _declare_tensor_dim("B", B)
         _declare_tensor_dim("D", D)
 
@@ -1116,8 +1123,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
             with spyre_hint(num_tiles_per_dim={"D": 4}):
                 return x.sum(dim=-1)
 
-        with self.assertRaisesRegex(Exception, self._STAGE2_MSG):
-            torch.compile(fn)(x_dev)
+        compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=0.05, rtol=0.05)
 
     def test_hint_tiled_reduction_matmul_loopspec(self):
         """torch.matmul tiled over K produces a LoopSpec with count 4."""
@@ -1173,7 +1179,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         )
 
     def test_hint_tiled_reduction_max_loopspec(self):
-        """x.amax(dim=-1) tiled over D raises: stick-dim reduction not yet supported."""
+        """x.amax(dim=-1) tiled over D produces a LoopSpec with count 4."""
         from torch_spyre._inductor import spyre_hint
 
         B, D = 64, 512
@@ -1187,16 +1193,28 @@ class TestCoarseTileReductionE2E(InductorTestCase):
             with spyre_hint(num_tiles_per_dim={"D": 4}):
                 return x.amax(dim=-1)
 
-        with self.assertRaisesRegex(Exception, self._STAGE2_MSG):
-            torch.compile(fn)(x_dev)
+        cfn = torch.compile(fn)
+        with (
+            mock_patch(_LAUNCH_KERNEL),
+            mock_patch(_LAUNCH_JOBPLAN),
+            mock_patch(_PREPARE_KERNEL),
+            mock_patch("subprocess.run"),
+        ):
+            _, source_codes = run_and_get_code(cfn, x_dev)
+        self.assertTrue(len(source_codes) > 0)
+        src = source_codes[0]
+        self.assertIn("LoopSpec(", src, "Expected LoopSpec for D-tiled amax")
+        self.assertIn("sympify('4')", src, "Expected loop count 4")
 
-    def test_hint_tiled_reduction_max_rejects(self):
-        """x.amax(dim=-1) with D hint rejects at compile time with Stage 2 error."""
+    @pytest.mark.skip(
+        "Issue #2748: DtException from DCC on operand dominance failure with fake symbols"
+    )
+    def test_hint_tiled_reduction_max_correct(self):
+        """x.amax(dim=-1) tiled over D (4 tiles) produces correct results."""
         from torch_spyre._inductor import spyre_hint
 
         B, D = 64, 512
         x = torch.randn(B, D, dtype=torch.float16)
-        x_dev = x.to("spyre")
         _declare_tensor_dim("B", B)
         _declare_tensor_dim("D", D)
 
@@ -1205,11 +1223,10 @@ class TestCoarseTileReductionE2E(InductorTestCase):
             with spyre_hint(num_tiles_per_dim={"D": 4}):
                 return x.amax(dim=-1)
 
-        with self.assertRaisesRegex(Exception, self._STAGE2_MSG):
-            torch.compile(fn)(x_dev)
+        compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=1e-3, rtol=1e-3)
 
     def test_hint_tiled_reduction_min_loopspec(self):
-        """x.amin(dim=-1) tiled over D raises: stick-dim reduction not yet supported."""
+        """x.amin(dim=-1) tiled over D produces a LoopSpec with count 4."""
         from torch_spyre._inductor import spyre_hint
 
         B, D = 64, 512
@@ -1223,16 +1240,28 @@ class TestCoarseTileReductionE2E(InductorTestCase):
             with spyre_hint(num_tiles_per_dim={"D": 4}):
                 return x.amin(dim=-1)
 
-        with self.assertRaisesRegex(Exception, self._STAGE2_MSG):
-            torch.compile(fn)(x_dev)
+        cfn = torch.compile(fn)
+        with (
+            mock_patch(_LAUNCH_KERNEL),
+            mock_patch(_LAUNCH_JOBPLAN),
+            mock_patch(_PREPARE_KERNEL),
+            mock_patch("subprocess.run"),
+        ):
+            _, source_codes = run_and_get_code(cfn, x_dev)
+        self.assertTrue(len(source_codes) > 0)
+        src = source_codes[0]
+        self.assertIn("LoopSpec(", src, "Expected LoopSpec for D-tiled amin")
+        self.assertIn("sympify('4')", src, "Expected loop count 4")
 
-    def test_hint_tiled_reduction_min_rejects(self):
-        """x.amin(dim=-1) with D hint rejects at compile time with Stage 2 error."""
+    @pytest.mark.skip(
+        "Issue #2748: DtException from DCC on operand dominance failure with fake symbols"
+    )
+    def test_hint_tiled_reduction_min_correct(self):
+        """x.amin(dim=-1) tiled over D (4 tiles) produces correct results."""
         from torch_spyre._inductor import spyre_hint
 
         B, D = 64, 512
         x = torch.randn(B, D, dtype=torch.float16)
-        x_dev = x.to("spyre")
         _declare_tensor_dim("B", B)
         _declare_tensor_dim("D", D)
 
@@ -1241,8 +1270,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
             with spyre_hint(num_tiles_per_dim={"D": 4}):
                 return x.amin(dim=-1)
 
-        with self.assertRaisesRegex(Exception, self._STAGE2_MSG):
-            torch.compile(fn)(x_dev)
+        compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=1e-3, rtol=1e-3)
 
 
 class TestCoarseTileReductionDim0E2E(InductorTestCase):

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -2961,26 +2961,25 @@ class TestValidateReductionTiling(unittest.TestCase):
         ):
             _validate_reduction_tiling(op)
 
-    def test_batchmatmul_k_tiling_allowed(self):
-        """BATCH_MATMUL_OP tiling on the stick (K) dim is allowed — no Stage 2 error."""
+    def test_stick_dim_reduction_tiling_allowed(self):
+        """Tiling a reduction over the stick dimension is now supported."""
         from torch._inductor.ir import ComputedBuffer, Reduction
         from torch_spyre._inductor.coarse_tile import _validate_reduction_tiling
-        from torch_spyre._inductor.constants import BATCH_MATMUL_OP
 
         data = MagicMock(spec=Reduction)
-        data.ranges = [Integer(64), Integer(32)]  # [M, N]
-        data.reduction_ranges = [Integer(512)]  # [K]
-        data.reduction_type = BATCH_MATMUL_OP
+        data.ranges = [Integer(64)]  # [B] output
+        data.reduction_ranges = [Integer(512)]  # [D] stick dim
+        data.reduction_type = "sum"
         op = MagicMock(spec=ComputedBuffer)
         op.data = data
-        op.get_name.return_value = "test_matmul"
+        op.get_name.return_value = "test_sum"
         op.loop_info = CoarseTileInfo(
             loop_group_id=(0,),
             loop_count=[Integer(4)],
             loop_tiled_dims=[[]],
             loop_tiled_reduction_dims=[[0]],
         )
-        # Must not raise: BATCH_MATMUL_OP is exempt from the stick-dim guard.
+        # Must not raise: stick-dim reduction tiling is now supported.
         _validate_reduction_tiling(op)
 
 

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -615,47 +615,8 @@ def insert_tiling_propagation(
             _propagate_tiled_op(op, operations)
 
 
-def _reduction_tiling_is_on_stick_dim(op: ComputedBuffer, red_dim_idx: int) -> bool:
-    """Return True if red_dim_idx in reduction_ranges corresponds to the stick dim.
-
-    Uses device_coordinates to find the within-stick coordinate for the primary
-    input, then checks whether the reduction symbol for red_dim_idx appears in
-    that coordinate's free symbols — the same technique used in propagate_layouts.
-    """
-    from .ir import FixedTiledLayout
-    from .pass_utils import device_coordinates
-
-    data = op.data
-    assert isinstance(data, Reduction)
-    try:
-        rw = op.get_read_writes()
-        out_dep = next(iter(rw.writes))
-    except (StopIteration, AttributeError, TypeError):
-        # StopIteration: mocked ops in unit tests have empty rw.writes.
-        # AttributeError/TypeError: guard against partially constructed mocks.
-        return False
-    out_syms = set(out_dep.index.free_symbols)
-    in_dep = next((d for d in rw.reads if hasattr(d, "index")), None)
-    if in_dep is None:
-        return False
-    # reduction_syms: symbols in in_dep.ranges that are absent from the output index,
-    # in dep.ranges order (which matches reduction_ranges order).
-    reduction_syms = [s for s in in_dep.ranges if s not in out_syms]
-    if red_dim_idx >= len(reduction_syms):
-        return False
-    red_sym = reduction_syms[red_dim_idx]
-
-    in_buf = V.graph.get_buffer(in_dep.name)
-    if in_buf is None or not isinstance(in_buf.layout, FixedTiledLayout):
-        return False
-    # device_coordinates[-1] is the within-stick coordinate expression.
-    # If red_sym appears in its free symbols, the reduction is on the stick dim.
-    stick_coord = device_coordinates(in_buf.layout.device_layout, in_dep, None)[-1]
-    return red_sym in stick_coord.free_symbols
-
-
 def _validate_reduction_tiling(op: ComputedBuffer) -> None:
-    """Raise RuntimeError for Reduction tiling configurations not yet implemented.
+    """Raise RuntimeError for unsupported Reduction tiling configurations.
 
     Supported:
       - A single level that tiles only a non-stick reduction dim.
@@ -1467,9 +1428,9 @@ def _stamp_group(
                     # NOTE: _divide_reduction_ranges mutates data.reduction_ranges
                     # before _validate_reduction_tiling runs in the later
                     # insert_tiling_propagation pass.  If validation raises (e.g.
-                    # stick-dim tiling, Stage 2), the mutated ranges are never
-                    # observed: the RuntimeError propagates uncaught through the
-                    # pass runner and aborts compilation.
+                    # mixed output+reduction at one level), the mutated ranges are
+                    # never observed: the RuntimeError propagates uncaught through
+                    # the pass runner and aborts compilation.
                     _divide_reduction_ranges(
                         op, count, [rpos] if rpos is not None else []
                     )

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -659,14 +659,12 @@ def _validate_reduction_tiling(op: ComputedBuffer) -> None:
 
     Supported:
       - A single level that tiles only a non-stick reduction dim.
-      - A single level that tiles the K (reduction) dim of a BATCH_MATMUL_OP.
-        K is the stick dim for operand x, but each tile's output is a full
-        [M, N] matrix so no partial-stick sparsity occurs.
+      - A single level that tiles the stick (innermost) reduction dim, including
+        the K dim of BATCH_MATMUL_OP and scalar reductions over dim=-1.
       - Multiple nesting levels where outer level(s) tile output dims and the
         innermost level tiles a reduction dim (e.g. outer M + inner K for mm).
 
     Deferred (raises RuntimeError):
-      - Reduction tiling on the stick dimension (except BATCH_MATMUL_OP above).
       - Mixed output+reduction tiling at the same nesting level.
       - Multiple reduction range indices tiled at one level.
     """
@@ -700,17 +698,6 @@ def _validate_reduction_tiling(op: ComputedBuffer) -> None:
                 f"reduction dims {red_dims} (tiling more than one reduction "
                 "dim per level is not yet implemented — Stage 2)."
             )
-        for red_dim_idx in red_dims:
-            if (
-                data.reduction_type != BATCH_MATMUL_OP
-                and _reduction_tiling_is_on_stick_dim(op, red_dim_idx)
-            ):
-                raise RuntimeError(
-                    f"coarse_tile: op {op.get_name()!r} level {i} tiles "
-                    f"reduction dim {red_dim_idx} which is the stick dimension "
-                    "of the primary input (stick-dim reduction tiling is not "
-                    "yet implemented — Stage 2)."
-                )
 
 
 def _propagate_tiled_op(


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [x] documentation
- [ ] cleanup

#### What this PR does:

Removes the Stage 2 guard in `_validate_reduction_tiling` that blocked
coarse-tiling a reduction op over the stick dimension (dim=-1).  Previously,
tiling `x.sum(dim=-1)`, `x.amax(dim=-1)`, or `x.amin(dim=-1)` over the D
dimension of a `[B, D]` tensor raised:

```
RuntimeError: stick-dim reduction tiling is not yet implemented — Stage 2
```

Three earlier PRs fixed the root causes that had made stick-dim reduction
tiling produce wrong results:

- **#2859** — `_byte_stride_for_arg` was using host `stride_map` instead of
  `prod(device_size[d+1:])` for HBM address advances, producing
  addresses that were off by a factor of `C/64` for row-tiling and `R` for
  col-tiling.
- **#2861** — `_tile_device_size` wrongly shrank `device_size[d]` when an
  outer dimension with `device_size[d'] > 1` was present, corrupting the
  inter-stick-group row stride for multi-stick tensors.
- **#2912** — `_resize_device_layout` misidentified the stick dimension via
  a fragile `stride_map[-1]` heuristic, and a sub-fix explicitly added
  handling for reduction-output buffers where the stick dimension has been
  collapsed (i.e. `old_host_size` no longer contains a stick-dim entry).

With those fixes in place, the existing fill-initialize + per-tile combine
machinery in `_propagate_tiled_reduction_op` handles stick-dim reductions
correctly without any additional changes.

**Tests added** (`TestCoarseTileReductionE2E`):

- `test_hint_tiled_reduction_{sum,max,min}_loopspec` — LoopSpec tests that
  compile `x.{sum,amax,amin}(dim=-1)` with `num_tiles_per_dim={"D": 4}` and
  verify a `LoopSpec(count=4)` is emitted.  These run without hardware today
  via `mock_patch` + `run_and_get_code`.
- `test_hint_tiled_reduction_{sum,max,min}_correct` — `compare_with_cpu`
  correctness tests (currently skipped pending #2748); manually verified
  passing against a local dxp_standalone build with the #2748 fix.

**Documentation** (`docs/source/compiler/coarse_tiling_loops.md`): updated
the section heading and "Not yet implemented" note to reflect that stick-dim
reductions are now fully supported.

#### Which issue(s) this PR is related to:

Part of #1358 

#### Special notes for your reviewer:

The only code change is removing the 10-line `for red_dim_idx in red_dims`
block (lines 567–577 in the pre-PR file) from `_validate_reduction_tiling`
and updating its docstring.  No changes to the propagation logic itself —
the three earlier PRs made it correct.

The six tests previously in `TestCoarseTileReductionE2E` that asserted
`assertRaisesRegex` for the Stage 2 message are replaced by the six new
tests described above.

#### Does this PR introduce a user-facing change?

Yes: `spyre_hint(num_tiles_per_dim={"D": N})` on operations that reduce
over the stick dimension (e.g. `x.sum(dim=-1)`) no longer raises a
`RuntimeError`.  Users can now tile stick-dim reductions the same way as
any other reduction dimension.

#### Additional note:

`_reduction_tiling_is_on_stick_dim` and its call site in
`_validate_reduction_tiling` are now dead code and have been removed along
with the guard.  `BATCH_MATMUL_OP` no longer needs a special exemption in
the validation path (it was only needed to carve out an exception to the
now-removed guard).