### PR TITLE
Move tiled_symbols from LoopSpec to per-op per-level on OpSpec

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -871,6 +871,69 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         result = torch.compile(fn)(Q_dev, V_dev).cpu()
         torch.testing.assert_close(result, ref, atol=0.02, rtol=0.1)
 
+    def test_hint_h_tiling_elementwise_loopspec(self):
+        """H-tiling on BHLD (B=1 unit-size) selects the H iteration symbol, not Lq.
+
+        Regression test for the host-range-index → iteration-space-key mapping in
+        create_op_spec: loop_tiled_dims stores host-range indices which include
+        unit-size dimensions that the iteration space skips.  Without the mapping,
+        index 1 (H in BHLD with B=1) maps to the 2nd iteration-space key (Lq)
+        rather than the 1st (H), producing wrong per-tile stride advances.
+        """
+        from torch_spyre._inductor import spyre_hint
+
+        B, H, Lq, D = 1, 8, 256, 64
+
+        Q = torch.randn(B, H, Lq, D, dtype=torch.float16)
+        V = torch.randn(B, H, Lq, D, dtype=torch.float16)
+        Q_dev = Q.to("spyre")
+        V_dev = V.to("spyre")
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("H", H)
+        _declare_tensor_dim("Lq", Lq)
+        _declare_tensor_dim("D", D)
+        _name_tensor_dims(Q_dev, ["B", "H", "Lq", "D"])
+        _name_tensor_dims(V_dev, ["B", "H", "Lq", "D"])
+
+        def fn(q, v):
+            with spyre_hint(num_tiles_per_dim={"H": 2}):
+                return q * v
+
+        cfn = torch.compile(fn)
+        with (
+            mock_patch(_LAUNCH_KERNEL),
+            mock_patch(_LAUNCH_JOBPLAN),
+            mock_patch(_PREPARE_KERNEL),
+            mock_patch("subprocess.run"),
+        ):
+            _, source_codes = run_and_get_code(cfn, Q_dev, V_dev)
+
+        self.assertTrue(len(source_codes) > 0)
+        src = source_codes[0]
+        self.assertIn("LoopSpec(", src, "Expected LoopSpec for H-tiled elementwise")
+        self.assertIn("sympify('2')", src, "Expected loop count 2 for H/2 tiles")
+        # The tiled symbol must be the H iteration-space symbol.  When B=1 is
+        # present as a unit-size host dim, incorrect host→it mapping would
+        # select the Lq symbol (index 1 in iteration space) instead of H
+        # (index 0, the first non-unit dim).  We check that tiled_symbols
+        # contains exactly one symbol and that it is NOT the Lq symbol.
+        # Both Q and V have iteration-space keys [H_sym, Lq_sym, D_sym].
+        # The H symbol is always the first key (index 0).
+        import regex as re  # noqa: F401
+
+        tiled_syms_matches = re.findall(r"tiled_symbols=\[(\[.*?\])\]", src, re.DOTALL)
+        self.assertTrue(
+            tiled_syms_matches,
+            "Expected tiled_symbols=[[...]] in generated OpSpec source",
+        )
+        # Each match is the inner list literal; it must be non-empty (H is tiled).
+        for match in tiled_syms_matches:
+            self.assertNotEqual(
+                match,
+                "[]",
+                "tiled_symbols inner list should not be empty for tiled op",
+            )
+
     def test_hint_row_tiling_multi_stick_pointwise_correct(self):
         """Row-tiling a multi-stick pointwise chain produces correct output.
 

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -28,6 +28,7 @@ Add new tests there using spyre_hint(num_tiles_per_dim=...) annotations.
 
 import sys
 import os
+import regex as re
 
 import pytest
 import torch
@@ -912,26 +913,26 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         src = source_codes[0]
         self.assertIn("LoopSpec(", src, "Expected LoopSpec for H-tiled elementwise")
         self.assertIn("sympify('2')", src, "Expected loop count 2 for H/2 tiles")
-        # The tiled symbol must be the H iteration-space symbol.  When B=1 is
-        # present as a unit-size host dim, incorrect host→it mapping would
-        # select the Lq symbol (index 1 in iteration space) instead of H
-        # (index 0, the first non-unit dim).  We check that tiled_symbols
-        # contains exactly one symbol and that it is NOT the Lq symbol.
-        # Both Q and V have iteration-space keys [H_sym, Lq_sym, D_sym].
-        # The H symbol is always the first key (index 0).
-        import regex as re  # noqa: F401
-
+        # The tiled symbol must be the H iteration-space symbol (c0 — the first
+        # non-unit dim after skipping B=1), NOT the Lq symbol (c1).
+        # With an incorrect host-range→iteration-space mapping, host index 1 (H)
+        # would select c1 (Lq) instead of c0 (H), advancing per-tile strides by
+        # the wrong amount.
         tiled_syms_matches = re.findall(r"tiled_symbols=\[(\[.*?\])\]", src, re.DOTALL)
         self.assertTrue(
             tiled_syms_matches,
             "Expected tiled_symbols=[[...]] in generated OpSpec source",
         )
-        # Each match is the inner list literal; it must be non-empty (H is tiled).
         for match in tiled_syms_matches:
-            self.assertNotEqual(
+            self.assertIn(
+                "c0",
                 match,
-                "[]",
-                "tiled_symbols inner list should not be empty for tiled op",
+                f"tiled_symbols should contain the H symbol (c0), got: {match}",
+            )
+            self.assertNotIn(
+                "c1",
+                match,
+                f"tiled_symbols should NOT contain the Lq symbol (c1), got: {match}",
             )
 
     def test_hint_row_tiling_multi_stick_pointwise_correct(self):

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -374,7 +374,7 @@ def _make_tiled_op_spec() -> OpSpec:
         iteration_space={c0: (Integer(128), 1)},
         args=[tensor_in, tensor_out],
         op_info={},
-        tiled_symbols=[c0],
+        tiled_symbols=[[c0]],
     )
 
 
@@ -1376,12 +1376,14 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             sdsc_spec,
             symbols,
             symbol_id_offset=0,
-            tiled_symbols=[s],
+            tiled_symbols=[[s]],
             use_symbols=True,
         )
+        # affine_strides[tensor_idx] is list[dict] (per level, outermost first).
+        # With one tiling level, affine_strides[0] = [{s: stride}].
         self.assertEqual(len(affine_strides), 1)
-        self.assertIn(s, affine_strides[0])
-        self.assertEqual(affine_strides[0][s], 64 * 128 * 2)
+        self.assertIn(s, affine_strides[0][0])
+        self.assertEqual(affine_strides[0][0][s], 64 * 128 * 2)
 
     def test_tiled_tensor_base_address_registered(self):
         s = Symbol("s")
@@ -1393,7 +1395,7 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             sdsc_spec,
             symbols,
             symbol_id_offset=0,
-            tiled_symbols=[s],
+            tiled_symbols=[[s]],
             use_symbols=True,
         )
         self.assertEqual(len(symbols), 1)
@@ -1408,7 +1410,7 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             sdsc_spec,
             symbols,
             symbol_id_offset=0,
-            tiled_symbols=[s],
+            tiled_symbols=[[s]],
             use_symbols=True,
         )
         top_val = next(iter(sdsc_json.values()))
@@ -1428,7 +1430,7 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbol_id_offset=0,
             tiled_symbols=[],
         )
-        self.assertEqual(affine_strides, [{}])
+        self.assertEqual(affine_strides, [[]])
 
     def test_lx_tensor_not_in_symbols(self):
         s = Symbol("s")
@@ -1442,11 +1444,12 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             sdsc_spec,
             symbols,
             symbol_id_offset=0,
-            tiled_symbols=[s],
+            tiled_symbols=[[s]],
         )
         self.assertEqual(symbols, [])
         self.assertEqual(local_sym_values, [])
-        self.assertEqual(affine_strides, [{}])
+        # lx tensor: one level of tiled_symbols, but lx allocation is always non-tiled.
+        self.assertEqual(affine_strides, [[{}]])
 
     def test_symbol_id_offset_applied(self):
         s = Symbol("s")
@@ -1457,7 +1460,7 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             sdsc_spec,
             symbols,
             symbol_id_offset=5,
-            tiled_symbols=[s],
+            tiled_symbols=[[s]],
             use_symbols=True,
         )
         top_val = next(iter(sdsc_json.values()))
@@ -1502,13 +1505,14 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             sdsc_spec,
             symbols,
             symbol_id_offset=0,
-            tiled_symbols=[s],
+            tiled_symbols=[[s]],
             use_symbols=True,
         )
         self.assertEqual(len(symbols), 2)
         self.assertEqual(symbols[0], 0x1000)
         self.assertEqual(symbols[1], 0x1000 + 128)
-        self.assertIn(s, affine_strides[0])
+        # affine_strides[0] = [{s: stride}] (one level, one tensor)
+        self.assertIn(s, affine_strides[0][0])
 
 
 class TestCompileOpSpecTwoTiledSymbols(unittest.TestCase):
@@ -1543,25 +1547,34 @@ class TestCompileOpSpecTwoTiledSymbols(unittest.TestCase):
             },
             args=[tensor_in, tensor_out],
             op_info={},
-            tiled_symbols=[c0, c1],
+            tiled_symbols=[[c0, c1]],
         )
 
     def test_two_tiled_symbols_produce_two_stride_entries(self):
         op_spec = self._make_3d_op_spec()
         symbols: list[int] = []
         _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
-        hbm_strides = [d for d in affine_strides if len(d) > 0]
+        # affine_strides[tensor_idx] = list[dict] (per level, outermost first).
+        # Both tensors have one tiling level with two symbols.
+        # Find tensors with non-empty strides at any level.
+        hbm_strides = [
+            per_level
+            for per_level in affine_strides
+            if any(len(d) > 0 for d in per_level)
+        ]
         self.assertGreater(len(hbm_strides), 0)
-        for tensor_strides in hbm_strides:
-            self.assertEqual(len(tensor_strides), 2)
+        for per_level in hbm_strides:
+            total_strides = sum(len(d) for d in per_level)
+            self.assertEqual(total_strides, 2)
 
     def test_two_tiled_symbols_strides_are_positive(self):
         op_spec = self._make_3d_op_spec()
         symbols: list[int] = []
         _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
-        for tensor_strides in affine_strides:
-            for sym, stride in tensor_strides.items():
-                self.assertGreater(stride, 0)
+        for per_level in affine_strides:
+            for level_strides in per_level:
+                for sym, stride in level_strides.items():
+                    self.assertGreater(stride, 0)
 
 
 class TestCompileOpSpecSymbolMapping(unittest.TestCase):
@@ -1569,7 +1582,11 @@ class TestCompileOpSpecSymbolMapping(unittest.TestCase):
         op_spec = _make_tiled_op_spec()
         symbols: list[int] = []
         _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
-        has_strides = any(len(d) > 0 for d in affine_strides)
+        # affine_strides[tensor_idx] = list[dict] (per level, outermost first).
+        has_strides = any(
+            any(len(level_d) > 0 for level_d in per_level)
+            for per_level in affine_strides
+        )
         self.assertTrue(
             has_strides,
             f"Expected non-empty affine_strides; got {affine_strides}.",
@@ -1923,10 +1940,11 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
         def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000)
-            return _make_tiled_json(idx, sym_id), [0x1000], [{s: stride}], []
+            # affine_strides: list[list[dict]] — one tensor, one level, one stride.
+            return _make_tiled_json(idx, sym_id), [0x1000], [[{s: stride}]], []
 
         op = _make_minimal_op_spec("a")
-        op.tiled_symbols = [s]
+        op.tiled_symbols = [[s]]
         loop = LoopSpec(count=Integer(4), body=[op])
         mlir = self._bundle([loop], fake_compile)
 
@@ -1943,7 +1961,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
         def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x2000)
-            return _make_tiled_json(idx, sym_id), [0x2000], [{}], []
+            return _make_tiled_json(idx, sym_id), [0x2000], [[{}]], []
 
         op = _make_minimal_op_spec("b")
         loop = LoopSpec(count=Integer(2), body=[op])
@@ -1961,10 +1979,10 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
         def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x3000)
-            return _make_tiled_json(idx, sym_id), [0x3000], [{s: stride}], []
+            return _make_tiled_json(idx, sym_id), [0x3000], [[{s: stride}]], []
 
         op = _make_minimal_op_spec("c")
-        op.tiled_symbols = [s]
+        op.tiled_symbols = [[s]]
         loop = LoopSpec(count=Integer(4), body=[op])
         mlir = self._bundle([loop], fake_compile)
 
@@ -1978,10 +1996,10 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
         def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x4000)
-            return _make_tiled_json(idx, sym_id), [0x4000], [{s: 512}], []
+            return _make_tiled_json(idx, sym_id), [0x4000], [[{s: 512}]], []
 
         op = _make_minimal_op_spec("d")
-        op.tiled_symbols = [s]
+        op.tiled_symbols = [[s]]
         loop = LoopSpec(count=Integer(4), body=[op])
         mlir = self._bundle([loop], fake_compile)
 
@@ -1997,10 +2015,10 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
         def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000)
-            return _make_tiled_json(idx, sym_id), [0x1000], [{s: 256}], []
+            return _make_tiled_json(idx, sym_id), [0x1000], [[{s: 256}]], []
 
         op = _make_minimal_op_spec("a")
-        op.tiled_symbols = [s]
+        op.tiled_symbols = [[s]]
         loop = LoopSpec(count=Integer(4), body=[op])
         mlir = self._bundle([loop], fake_compile)
 
@@ -2050,10 +2068,12 @@ class TestGenerateBundleNestedTiling(unittest.TestCase):
         def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000)
+            # per_level_strides: outermost-first. Level 0 (outer) has s0 stride,
+            # level 1 (inner) has s1 stride.  One tensor, two levels.
             return (
                 _make_tiled_json(idx, sym_id),
                 [0x1000],
-                [{s0: outer_stride, s1: inner_stride}],
+                [[{s0: outer_stride}, {s1: inner_stride}]],
                 [],
             )
 
@@ -2163,7 +2183,8 @@ class TestGenerateBundleUnrollPath(unittest.TestCase):
         def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000)
-            return _make_tiled_json(idx, sym_id), [0x1000], [{s: 256}], []
+            # One tensor, one level (the enclosing loop), one stride.
+            return _make_tiled_json(idx, sym_id), [0x1000], [[{s: 256}]], []
 
         op = _make_minimal_op_spec("a")
         loop = LoopSpec(count=Integer(4), body=[op])
@@ -2177,7 +2198,7 @@ class TestGenerateBundleUnrollPath(unittest.TestCase):
         def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x2000)
-            return _make_tiled_json(idx, sym_id), [0x2000], [{}], []
+            return _make_tiled_json(idx, sym_id), [0x2000], [[{}]], []
 
         op = _make_minimal_op_spec("b")
         loop = LoopSpec(count=Integer(4), body=[op])
@@ -2193,7 +2214,7 @@ class TestGenerateBundleUnrollPath(unittest.TestCase):
         def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000)
-            return _make_tiled_json(idx, sym_id), [0x1000], [{s: 256}], []
+            return _make_tiled_json(idx, sym_id), [0x1000], [[{s: 256}]], []
 
         op = _make_minimal_op_spec("a")
         loop = LoopSpec(count=Integer(4), body=[op])
@@ -2238,10 +2259,18 @@ class TestGenerateBundleUnrollPath(unittest.TestCase):
             call_count[0] += 1
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000 * (i + 1))
-            if i == 0:  # bmm: tiled on inner K var only
-                return _make_tiled_json(idx, sym_id), [0x1000], [{c_k: k_stride}], []
-            else:  # combine: accum_buf not tiled on K
-                return _make_tiled_json(idx, sym_id), [0x2000], [{}], []
+            if i == 0:
+                # bmm: tiled on inner K var only (level 1 in outer>inner nesting).
+                # per_level_strides: outermost first — outer has no K stride, inner has it.
+                return (
+                    _make_tiled_json(idx, sym_id),
+                    [0x1000],
+                    [[{}, {c_k: k_stride}]],
+                    [],
+                )
+            else:
+                # combine: accum_buf not tiled on K at any level.
+                return _make_tiled_json(idx, sym_id), [0x2000], [[{}, {}]], []
 
         return fake
 
@@ -2330,14 +2359,23 @@ class TestGenerateBundleUnrollPath(unittest.TestCase):
             call_count[0] += 1
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000 * (i + 1))
-            if i == 0:  # fill: per_tile_fixed output, not tiled
-                return _make_tiled_json(idx, sym_id), [0x1000], [{}], []
-            elif i == 1:  # bmm: K-input tiled on inner K
-                return _make_tiled_json(idx, sym_id), [0x2000], [{c_k: k_stride}], []
-            elif i == 2:  # combine: per_tile_fixed accum_tile, not tiled
-                return _make_tiled_json(idx, sym_id), [0x3000], [{}], []
-            else:  # copy: accum_full advances per outer B-tile
-                return _make_tiled_json(idx, sym_id), [0x4000], [{c_b: b_stride}], []
+            if i == 0:
+                # fill: inside outer loop only, not tiled.
+                return _make_tiled_json(idx, sym_id), [0x1000], [[{}]], []
+            elif i == 1:
+                # bmm: inside outer>inner; K-input tiled at inner level (level 1).
+                return (
+                    _make_tiled_json(idx, sym_id),
+                    [0x2000],
+                    [[{}, {c_k: k_stride}]],
+                    [],
+                )
+            elif i == 2:
+                # combine: inside outer>inner, per_tile_fixed accum_tile, not tiled.
+                return _make_tiled_json(idx, sym_id), [0x3000], [[{}, {}]], []
+            else:
+                # copy: inside outer loop only; accum_full tiled at outer level (level 0).
+                return _make_tiled_json(idx, sym_id), [0x4000], [[{c_b: b_stride}]], []
 
         return fake
 
@@ -2459,11 +2497,12 @@ class TestGenerateBundleUnrollPath(unittest.TestCase):
             sid1 = -(symbol_id_offset + 2)
             symbols.append(0x1000)
             symbols.append(0x2000)
-            # tensor 0 tiled, tensor 1 not tiled
+            # tensor 0: tiled at the enclosing loop level (level 0).
+            # tensor 1: not tiled.
             return (
                 _make_two_tensor_json(idx, sid0, sid1),
                 [0x1000, 0x2000],
-                [{s: 256}, {}],
+                [[{s: 256}], [{}]],
                 [],
             )
 
@@ -2945,48 +2984,6 @@ class TestValidateReductionTiling(unittest.TestCase):
         _validate_reduction_tiling(op)
 
 
-class TestTiledSymsForSchedNode(unittest.TestCase):
-    """Regression test for _tiled_syms_for_sched_node_at_depth.
-
-    loop_tiled_dims stores host-range indices (e.g. 1 for H in [B=1,H,Lq,D])
-    but the iteration space skips unit-size dims (B=1 dropped), so H is at
-    iteration-space index 0.  The function must map between the two.
-    """
-
-    def test_unit_batch_dim_skipped(self):
-        """[B=1,H=8,Lq=256,D=64] with loop_tiled_dims=[[1]] must return H (c0).
-
-        Without the fix, index 1 is used directly and returns c1 (Lq) instead.
-        """
-        from torch_spyre._inductor.scheduler import _tiled_syms_for_sched_node_at_depth
-        from torch._inductor.scheduler import SchedulerNode
-
-        host_ranges = [1, 8, 256, 64]
-        non_unit = [r for r in host_ranges if r != 1]
-        it_syms = [Symbol(f"c{i}") for i in range(len(non_unit))]
-        it_space = {s: Integer(r) for s, r in zip(it_syms, non_unit)}
-
-        ir_op = MagicMock()
-        ir_op.data.ranges = [Integer(r) for r in host_ranges]
-        ir_op.loop_info = CoarseTileInfo(
-            loop_group_id=(0,),
-            loop_count=[Integer(4)],
-            loop_tiled_dims=[[1]],
-        )
-
-        snode = MagicMock(spec=SchedulerNode)
-        snode.node = ir_op
-
-        with patch(
-            "torch_spyre._inductor.scheduler.iteration_space",
-            return_value=it_space,
-        ):
-            result = _tiled_syms_for_sched_node_at_depth(snode, 0)
-
-        self.assertEqual(len(result), 1)
-        self.assertEqual(str(result[0]), "c0")  # H, not c1 (Lq)
-
-
 class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
@@ -3381,7 +3378,7 @@ class TestSymbolKind(unittest.TestCase):
             sdsc_spec,
             symbols,
             symbol_id_offset=0,
-            tiled_symbols=[s],
+            tiled_symbols=[[s]],
             use_symbols=True,
         )
         self.assertEqual(len(kinds), 2)

--- a/tests/inductor/test_unroll_loop_specs.py
+++ b/tests/inductor/test_unroll_loop_specs.py
@@ -94,7 +94,8 @@ def _make_op_spec(
     hbm_base: int = _HBM_BASE,
     include_lx: bool = False,
 ) -> OpSpec:
-    tiled_syms = tiled_syms or []
+    # tiled_syms are all in the same (innermost) loop level.
+    level_syms = list(tiled_syms) if tiled_syms else []
     args = [_make_hbm_tensor_arg(hbm_base)]
     if include_lx:
         args.append(_make_lx_tensor_arg())
@@ -117,7 +118,7 @@ def _make_op_spec(
         },
         args=args,
         op_info={},
-        tiled_symbols=list(tiled_syms),
+        tiled_symbols=[level_syms] if level_syms else [],
     )
 
 
@@ -274,7 +275,7 @@ class TestUnrollLoopSpecs(unittest.TestCase):
             },
             args=[arg0, arg1],
             op_info={},
-            tiled_symbols=[_C_ROW],
+            tiled_symbols=[[_C_ROW]],
         )
         loop = LoopSpec(count=Integer(2), body=[op])
         result = unroll_loop_specs([loop])
@@ -379,7 +380,12 @@ class TestNestedReductionUnroll(unittest.TestCase):
         )
 
     def _make_bmm_op(self) -> OpSpec:
-        """Model bmm partial result: reads k_input, writes pool scratch."""
+        """Model bmm partial result: reads k_input, writes pool scratch.
+
+        tiled_symbols: innermost-first.
+          [0] = inner K-loop symbols: [c_k]
+          [1] = outer B-loop symbols: [c_b]
+        """
         return OpSpec(
             op="batchmatmul",
             is_reduction=True,
@@ -391,13 +397,16 @@ class TestNestedReductionUnroll(unittest.TestCase):
             },
             args=[self._make_k_input_arg(), self._make_pool_scratch()],
             op_info={},
-            tiled_symbols=[self._C_B, self._C_K],
+            tiled_symbols=[[self._C_K], [self._C_B]],
         )
 
     def _make_combine_op(self) -> OpSpec:
         """Model combine (add): reads pool + accum_buf, writes accum_buf.
 
         Output-only iteration space: no K symbol.
+        tiled_symbols: innermost-first.
+          [0] = inner K-loop symbols: [] (K doesn't tile combine — no c_k in iteration_space)
+          [1] = outer B-loop symbols: [c_b]
         """
         return OpSpec(
             op="add",
@@ -413,7 +422,7 @@ class TestNestedReductionUnroll(unittest.TestCase):
                 self._make_accum_arg(),  # output: accum_buf (write)
             ],
             op_info={},
-            tiled_symbols=[self._C_B],
+            tiled_symbols=[[], [self._C_B]],
         )
 
     # ------------------------------------------------------------------
@@ -429,10 +438,7 @@ class TestNestedReductionUnroll(unittest.TestCase):
     def test_combine_accum_fixed_across_k_iterations(self):
         bmm = self._make_bmm_op()
         combine = self._make_combine_op()
-        # Inner K-loop: LoopSpec explicitly carries the K symbol.
-        inner = LoopSpec(
-            count=Integer(4), body=[bmm, combine], tiled_symbols=[self._C_K]
-        )
+        inner = LoopSpec(count=Integer(4), body=[bmm, combine])
         result = unroll_loop_specs([inner])
 
         self.assertEqual(len(result), 8, f"Expected 4*2=8 ops, got {len(result)}")
@@ -457,9 +463,7 @@ class TestNestedReductionUnroll(unittest.TestCase):
     def test_pool_scratch_fixed_across_k_iterations(self):
         bmm = self._make_bmm_op()
         combine = self._make_combine_op()
-        inner = LoopSpec(
-            count=Integer(4), body=[bmm, combine], tiled_symbols=[self._C_K]
-        )
+        inner = LoopSpec(count=Integer(4), body=[bmm, combine])
         result = unroll_loop_specs([inner])
 
         for op_copy in result:
@@ -485,9 +489,7 @@ class TestNestedReductionUnroll(unittest.TestCase):
         K_TILE_BYTES = (128 // 64) * (64 * 64) * 2  # 16384
         bmm = self._make_bmm_op()
         combine = self._make_combine_op()
-        inner = LoopSpec(
-            count=Integer(4), body=[bmm, combine], tiled_symbols=[self._C_K]
-        )
+        inner = LoopSpec(count=Integer(4), body=[bmm, combine])
         result = unroll_loop_specs([inner])
 
         bmm_copies = result[::2]  # every other op is a bmm copy
@@ -526,6 +528,8 @@ class TestNestedReductionUnroll(unittest.TestCase):
         B_TILE_BYTES = 2 * 64 * 2  # 256
 
         fill_accum = self._make_accum_arg()
+        # fill is only inside the outer B-loop (not the inner K-loop).
+        # tiled_symbols[0] = innermost (outer B-loop here) = [c_b]
         fill_op = OpSpec(
             op="identity",
             is_reduction=False,
@@ -535,18 +539,14 @@ class TestNestedReductionUnroll(unittest.TestCase):
             },
             args=[fill_accum],
             op_info={},
-            tiled_symbols=[self._C_B],
+            tiled_symbols=[[self._C_B]],
         )
 
         bmm = self._make_bmm_op()
         combine = self._make_combine_op()
 
-        inner = LoopSpec(
-            count=Integer(4), body=[bmm, combine], tiled_symbols=[self._C_K]
-        )
-        outer = LoopSpec(
-            count=Integer(2), body=[fill_op, inner], tiled_symbols=[self._C_B]
-        )
+        inner = LoopSpec(count=Integer(4), body=[bmm, combine])
+        outer = LoopSpec(count=Integer(2), body=[fill_op, inner])
         result = unroll_loop_specs([outer])
 
         # Expected flat layout: 2 × (1 fill + 4 × (1 bmm + 1 combine)) = 18 ops
@@ -658,7 +658,11 @@ class TestNestedReductionTileAccum(unittest.TestCase):
         )
 
     def _make_copy_op(self) -> OpSpec:
-        """Copy: accum_tile → accum_full after inner K-loop."""
+        """Copy: accum_tile → accum_full after inner K-loop.
+
+        Inside the outer B-loop only (not the inner K-loop).
+        tiled_symbols[0] = innermost (outer B-loop here) = [c_b]
+        """
         return OpSpec(
             op="copy",
             is_reduction=False,
@@ -672,7 +676,7 @@ class TestNestedReductionTileAccum(unittest.TestCase):
                 self._make_accum_full_arg(),  # output: advances per outer B-tile
             ],
             op_info={},
-            tiled_symbols=[],
+            tiled_symbols=[[self._C_B]],
         )
 
     def _make_nested_loop(self) -> LoopSpec:
@@ -698,6 +702,8 @@ class TestNestedReductionTileAccum(unittest.TestCase):
             allocation={"hbm": 0x2000000000},
             per_tile_fixed=True,
         )
+        # bmm_partial is inside the inner K-loop only (not the outer B-loop).
+        # tiled_symbols[0] = innermost = [c_k]
         bmm_partial = OpSpec(
             op="matmul",
             is_reduction=True,
@@ -708,8 +714,9 @@ class TestNestedReductionTileAccum(unittest.TestCase):
             },
             args=[bmm_input, bmm_output],
             op_info={},
-            tiled_symbols=[self._C_K],
+            tiled_symbols=[[self._C_K]],
         )
+        # combine_op is inside the inner K-loop; no K tiling (c_k not in iteration_space).
         combine_op = OpSpec(
             op="add",
             is_reduction=False,
@@ -719,17 +726,12 @@ class TestNestedReductionTileAccum(unittest.TestCase):
             },
             args=[self._make_accum_tile_arg(), self._make_accum_tile_arg()],
             op_info={},
-            tiled_symbols=[],
+            tiled_symbols=[[]],
         )
-        inner = LoopSpec(
-            count=Integer(4),
-            body=[bmm_partial, combine_op],
-            tiled_symbols=[self._C_K],
-        )
+        inner = LoopSpec(count=Integer(4), body=[bmm_partial, combine_op])
         return LoopSpec(
             count=Integer(2),
             body=[self._make_fill_op(), inner, self._make_copy_op()],
-            tiled_symbols=[self._C_B],
         )
 
     def test_accum_tile_fixed_accum_full_advances(self):
@@ -882,7 +884,7 @@ class TestDeviceStrideFormula(unittest.TestCase):
             },
             args=[arg],
             op_info={},
-            tiled_symbols=[c_row],
+            tiled_symbols=[[c_row]],
         )
         loop = LoopSpec(count=Integer(4), body=[op])
         result = unroll_loop_specs([loop])
@@ -1212,7 +1214,7 @@ class TestTileDeviceSize(unittest.TestCase):
             },
             args=[arg],
             op_info={},
-            tiled_symbols=[c0],
+            tiled_symbols=[[c0]],
         )
         loop = LoopSpec(count=Integer(COUNT), body=[op])
         result = unroll_loop_specs([loop])

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -424,9 +424,11 @@ def _collect_affine_maps(
                 for level_idx, level_strides in enumerate(per_level_strides):
                     if not level_strides:
                         continue
-                    if level_idx >= len(loop_var_depth):
-                        # Level not enclosed by any loop (e.g. non-tiled op).
-                        continue
+                    assert level_idx < len(loop_var_depth), (
+                        f"affine_strides has {len(per_level_strides)} levels but "
+                        f"only {len(loop_var_depth)} enclosing loop(s); "
+                        "create_op_spec built more tiled_syms levels than LoopSpec ancestors"
+                    )
                     lv = loop_var_depth[level_idx]
                     for stride in level_strides.values():
                         stride_vals.append(stride)

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -36,11 +36,12 @@ logger = get_inductor_logger("sdsc_compile")
 # Compiled SDSC entry: (json_dict, base_symbol_values, affine_strides, symbol_kinds)
 #   base_symbol_values: list[int] of base HBM byte offsets for this SDSC,
 #                       one per registered symbol ID
-#   affine_strides:     list[dict] parallel to SDSCSpec.args —
-#                       {tiled_sym: stride_bytes} for tiled HBM tensors,
-#                       empty dict for non-tiled / lx tensors
+#   affine_strides:     list[list[dict]] — per tensor, per loop-nesting level
+#                       (outermost first).  Each inner dict maps
+#                       tiled_sym -> stride_bytes for that level's symbols.
+#                       All-empty for non-tiled / lx tensors.
 #   symbol_kinds:       list[SymbolKind] parallel to base_symbol_values
-_CompiledEntry = tuple[Any, list[int], list[dict], list[SymbolKind]]
+_CompiledEntry = tuple[Any, list[int], list[list[dict]], list[SymbolKind]]
 
 
 # ---------------------------------------------------------------------------
@@ -125,13 +126,16 @@ def generate_bundle(
     _collect_loop_bounds(specs_list, loop_bounds)
 
     # Affine map deduplication: stride_key -> map index (0-based).
-    # A stride_key is a tuple of (stride,) values — one per tiled loop variable
-    # that advances this tensor.  For a single-level loop with one tiled sym the
-    # key is (stride_bytes,).
+    # A stride_key is a tuple of stride values in outermost-first level order.
+    # Strides from each level are appended in level order; within a level, in
+    # symbol dict insertion order.  The corresponding loop-var indices are built
+    # from the explicit level index, so each stride is mapped to the correct
+    # loop variable regardless of nesting depth.
     #
     # affine_map_loop_var_indices: parallel to compiled, per op a list of
     # per-tensor loop-var index lists.  Each inner list records which positions
-    # in the enclosing loop_vars list correspond to the strides in stride_key.
+    # in the enclosing loop_vars list correspond to the strides in stride_key,
+    # one entry per non-zero stride in outermost-first level order.
     # _emit_specs uses this to pass only the relevant loop vars to affine.apply.
     affine_map_index: dict[tuple, int] = {}
     affine_map_loop_var_indices: list[list[list[int]]] = []
@@ -392,7 +396,13 @@ def _collect_affine_maps(
     entry per OpSpec to ``loop_var_indices_out``.  Each entry is a list of
     per-tensor index lists: ``loop_var_indices_out[op_idx][tensor_idx]`` is
     the list of loop-var positions (into the enclosing ``loop_vars`` list at
-    emit time) that correspond to the strides in the tensor's stride_key.
+    emit time) that correspond to the strides in the tensor's stride_key,
+    in outermost-first level order.
+
+    ``affine_strides[tensor_idx]`` is a list of dicts, one per loop-nesting
+    level (outermost first).  We iterate over levels explicitly and use
+    ``loop_var_depth[level_idx]`` to find the correct loop variable for each
+    level's strides — no counting from the end.
     """
     for entry in specs:
         if isinstance(entry, LoopSpec):
@@ -406,22 +416,27 @@ def _collect_affine_maps(
         elif isinstance(entry, OpSpec):
             _, _, affine_strides, _ = next(compiled_iter)
             per_tensor_lv_indices: list[list[int]] = []
-            for tensor_strides in affine_strides:
-                if not tensor_strides:
+            for per_level_strides in affine_strides:
+                # per_level_strides is list[dict], one dict per level (outermost first).
+                # Build stride_key and lv_indices by iterating levels explicitly.
+                stride_vals: list[int] = []
+                lv_idxs: list[int] = []
+                for level_idx, level_strides in enumerate(per_level_strides):
+                    if not level_strides:
+                        continue
+                    if level_idx >= len(loop_var_depth):
+                        # Level not enclosed by any loop (e.g. non-tiled op).
+                        continue
+                    lv = loop_var_depth[level_idx]
+                    for stride in level_strides.values():
+                        stride_vals.append(stride)
+                        lv_idxs.append(lv)
+                if not stride_vals:
                     per_tensor_lv_indices.append([])
                     continue
-                # Build stride key from the tiled symbols present in this tensor,
-                # in the order they appear in affine_strides dict.
-                stride_key = tuple(tensor_strides.values())
+                stride_key = tuple(stride_vals)
                 if stride_key not in affine_map_index:
                     affine_map_index[stride_key] = len(affine_map_index)
-                # Record which loop-var positions (in the enclosing loop_vars
-                # list) correspond to each stride entry.  tiled_symbols is
-                # ordered outermost-first (see spyre_kernel.py), so a K-only
-                # tiled op at nesting depth 2 has stride_key length 1 and we
-                # want the innermost loop var — hence we take the *last*
-                # len(stride_key) entries of loop_var_depth.
-                lv_idxs = list(loop_var_depth[-len(stride_key) :])
                 per_tensor_lv_indices.append(lv_idxs)
             loop_var_indices_out.append(per_tensor_lv_indices)
 
@@ -522,23 +537,31 @@ def _emit_specs(
 
             # Build affine.apply ops for tiled tensors, tracking which
             # symbol IDs have been upgraded to per-iteration %addr_N names.
+            # affine_strides[tensor_idx] is list[dict] (per level, outermost first).
             sym_id_to_operand: dict[int, str] = {}
-            for tensor_idx, tensor_strides in enumerate(affine_strides):
-                if not tensor_strides:
+            for tensor_idx, per_level_strides in enumerate(affine_strides):
+                # Flatten per-level strides to build the stride_key in the same
+                # outermost-first order used by _collect_affine_maps.
+                flat_strides: list[int] = [
+                    stride
+                    for level_strides in per_level_strides
+                    for stride in level_strides.values()
+                ]
+                if not flat_strides:
                     continue
                 num_cores = _sdsc_num_cores(sdsc_json)
                 for c in range(num_cores):
                     base_sym_id = _get_tensor_core_sym_id(sdsc_json, tensor_idx, c)
                     if base_sym_id is None or base_sym_id in sym_id_to_operand:
                         continue
-                    stride_key = tuple(tensor_strides.values())
+                    stride_key = tuple(flat_strides)
                     map_idx = affine_map_index[stride_key]
                     addr_name = f"%addr_{addr_counter[0]}"
                     addr_counter[0] += 1
                     base_addr_name = _resolve_sym(base_sym_id)
-                    # Select only the loop vars that correspond to the strides
-                    # for this tensor (may be a subset of all enclosing loop vars
-                    # when the op is not tiled on every enclosing loop level).
+                    # lv_indices[tensor_idx] was built by _collect_affine_maps using
+                    # explicit level indexing — each entry is the loop_vars position
+                    # for the corresponding stride in stride_key.
                     lv_indices = per_tensor_lv_indices[tensor_idx]
                     apply_loop_vars = [loop_vars[i] for i in lv_indices]
                     loop_var_str = ", ".join(apply_loop_vars)

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -39,7 +39,8 @@ logger = get_inductor_logger("sdsc_compile")
 #   affine_strides:     list[list[dict]] — per tensor, per loop-nesting level
 #                       (outermost first).  Each inner dict maps
 #                       tiled_sym -> stride_bytes for that level's symbols.
-#                       All-empty for non-tiled / lx tensors.
+#                       [{} for _ in tiled_symbols] for non-tiled / lx tensors
+#                       (one empty dict per level, preserving the level count).
 #   symbol_kinds:       list[SymbolKind] parallel to base_symbol_values
 _CompiledEntry = tuple[Any, list[int], list[list[dict]], list[SymbolKind]]
 

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -396,10 +396,13 @@ def generate_sdsc(
     - ``sdsc_json``: the JSON dict to write to ``sdsc_N.json``
     - ``base_symbol_values``: list of HBM byte offsets registered in ``symbols``;
       empty when ``use_symbols=False``
-    - ``affine_strides``: list (parallel to ``sdsc_spec.args``) of dicts
-      ``{tiled_sym: stride_bytes}`` for tiled HBM tensors; always empty when
-      ``use_symbols=False``.  Used by ``bundle.py`` to emit ``affine.apply``
-      ops inside ``scf.for`` loops.
+    - ``affine_strides``: list (parallel to ``sdsc_spec.args``) of per-level
+      stride lists.  Each element is a list of dicts, one per loop-nesting level
+      (outermost first), where each dict maps ``tiled_sym -> stride_bytes`` for
+      that level's tiled symbols.  Always ``[[]] * len(sdsc_spec.args)`` when
+      ``use_symbols=False``.  Used by ``bundle.py`` to emit ``affine.apply`` ops
+      inside ``scf.for`` loops, with one stride per level mapped to the correct
+      loop variable.
     - ``symbol_kinds``: list of ``SymbolKind`` parallel to ``base_symbol_values``;
       empty when ``use_symbols=False``.  Classifies each symbol as a kernel base
       address, per-core derived address, or pool-allocated address.
@@ -412,6 +415,7 @@ def generate_sdsc(
     IDs in the JSON and their values appended to ``symbols``, enabling
     ``affine.apply`` address computation in ``bundle.mlir`` for tiled loops.
     """
+    # tiled_symbols is list[list[Symbol]], outermost-first per nesting level.
     if tiled_symbols is None:
         tiled_symbols = []
 
@@ -487,13 +491,15 @@ def generate_sdsc(
                 local_symbol_kind.append(kind)
             return local_symbols[s]
 
-        # Compute per-tensor affine strides and register base addresses in symbols.
-        # affine_strides[i] is {tiled_sym: stride_bytes} for tensor i (empty if
-        # non-tiled/lx).
-        affine_strides: list[dict] = []
+        # Compute per-tensor, per-level affine strides and register base addresses.
+        # affine_strides[i] is a list of dicts, one per loop-nesting level
+        # (outermost first), where each dict maps tiled_sym -> stride_bytes for
+        # the symbols at that level that advance tensor i.  Empty list of dicts
+        # (i.e. [{}] * n_levels or []) for non-tiled / lx tensors.
+        affine_strides: list[list[dict]] = []
         for tensor in sdsc_spec.args:
             if "lx" in tensor.allocation:
-                affine_strides.append({})
+                affine_strides.append([{} for _ in tiled_symbols])
                 continue
             core0_addr = tensor.start_address + core_idx_to_slice_offset(
                 tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
@@ -502,8 +508,20 @@ def generate_sdsc(
             # be registered. Offset by n_dim_syms because dim symbols occupy the first
             # n_dim_syms slots in this SDSC's range of the shared counter.
             base_sym_idx = symbol_id_offset + n_dim_syms + len(local_symbols)
-            tensor_tiled = [s for s in tiled_symbols if s in tensor.strides]
-            if not tensor_tiled:
+            # Build per-level strides: for each level, collect the symbols at that
+            # level that tile this tensor (i.e. appear in tensor.strides).
+            per_level_strides: list[dict] = []
+            any_tiled = False
+            for level_syms in tiled_symbols:
+                tensor_tiled_at_level = [s for s in level_syms if s in tensor.strides]
+                strides_for_level: dict = {}
+                for s in tensor_tiled_at_level:
+                    strides_for_level[s] = _tiled_byte_stride(
+                        tensor, s, sdsc_spec.iteration_space
+                    )
+                    any_tiled = True
+                per_level_strides.append(strides_for_level)
+            if not any_tiled:
                 # Non-tiled HBM: register per-core addresses.
                 for c in range(sdsc_spec.num_cores):
                     addr = tensor.start_address + core_idx_to_slice_offset(
@@ -515,15 +533,10 @@ def generate_sdsc(
                             c, tensor.arg_index, core0_addr, addr, base_sym_idx
                         ),
                     )
-                affine_strides.append({})
+                affine_strides.append([{} for _ in tiled_symbols])
             else:
                 # Tiled HBM: symbol value = per-core iter-0 base address.
                 # The affine map adds loop_var * tile_stride on top at runtime.
-                strides_for_tensor = {}
-                for s in tensor_tiled:
-                    strides_for_tensor[s] = _tiled_byte_stride(
-                        tensor, s, sdsc_spec.iteration_space
-                    )
                 for c in range(sdsc_spec.num_cores):
                     addr = tensor.start_address + core_idx_to_slice_offset(
                         tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
@@ -534,7 +547,7 @@ def generate_sdsc(
                             c, tensor.arg_index, core0_addr, addr, base_sym_idx
                         ),
                     )
-                affine_strides.append(strides_for_tensor)
+                affine_strides.append(per_level_strides)
 
         def _start_addr_data(tensor):
             # All per-core addresses were already registered by the per-tensor loop
@@ -555,7 +568,7 @@ def generate_sdsc(
     else:
         # use_symbols=False: bake concrete HBM addresses directly into the JSON.
         # symbols and local_symbols are not modified.
-        affine_strides = [{} for _ in sdsc_spec.args]
+        affine_strides = [[{} for _ in tiled_symbols] for _ in sdsc_spec.args]
 
         def _start_addr_data(tensor):
             if "lx" in tensor.allocation:

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -889,19 +889,21 @@ def compile_op_spec(
     symbols: list[int],
     symbol_id_offset: int = 0,
     use_symbols: bool = False,
-) -> tuple[Any, list[int], list[dict], list[SymbolKind]]:
+) -> tuple[Any, list[int], list[list[dict]], list[SymbolKind]]:
     sdsc_spec, symbol_mapping = parse_op_spec(op_spec)
     logger.debug("%s", sdsc_spec)
-    # Translate tiled_symbols from OpSpec's inductor symbols to the renamed
-    # SDSC symbols via the same mapping used to build sdsc_spec.
-    tiled_symbols = [
-        symbol_mapping[s] for s in op_spec.tiled_symbols if s in symbol_mapping
+    # Translate tiled_symbols from OpSpec's per-level inductor symbols (innermost-
+    # first) to the renamed SDSC symbols via the same mapping used to build
+    # sdsc_spec.  generate_sdsc expects outermost-first, so reverse.
+    tiled_symbols_per_level = [
+        [symbol_mapping[s] for s in level if s in symbol_mapping]
+        for level in reversed(op_spec.tiled_symbols)
     ]
     return generate_sdsc(
         idx,
         sdsc_spec,
         symbols,
         symbol_id_offset,
-        tiled_symbols=tiled_symbols,
+        tiled_symbols=tiled_symbols_per_level,
         use_symbols=use_symbols,
     )

--- a/torch_spyre/_inductor/codegen/unroll.py
+++ b/torch_spyre/_inductor/codegen/unroll.py
@@ -31,8 +31,12 @@ analysis):
 - ``per_tile_fixed=False``: address advances per iteration regardless of
   allocation type (hbm, pool, or lx).
 
-After unrolling, ``tiled_symbols`` is cleared on every copy so
-``generate_bundle`` treats the ops as plain non-tiled entries.
+Each ``OpSpec`` carries ``tiled_symbols: list[list[Symbol]]``, a per-level
+list of iteration-space symbols with index 0 = innermost enclosing loop.
+The unroller reads ``tiled_symbols[0]`` for each op independently, so ops
+with different iteration-space layouts in the same loop are each advanced by
+the correct stride.  After processing a level, ``tiled_symbols[0]`` is
+popped, leaving outer-level entries intact for subsequent unrolling passes.
 
 Nested ``LoopSpec`` nodes (e.g. outer K=2 / inner M=4) are unrolled
 innermost-first, yielding K×M flat copies with correct combined addresses.
@@ -147,10 +151,10 @@ def _arg_byte_strides_for_syms(
 ) -> list[dict[Symbol, int]]:
     """Return per-arg byte strides for the given tiled symbols.
 
-    ``tiled_syms`` is the list of symbols tiled by the enclosing LoopSpec being
-    unrolled.  This is passed explicitly rather than read from
-    ``op_spec.tiled_symbols`` so that outer-loop unrolling still works after
-    inner-loop unrolling has already cleared ``tiled_symbols`` on each copy.
+    ``tiled_syms`` is ``op_spec.tiled_symbols[0]`` — the innermost-level
+    symbols for this specific op.  Using per-op symbols (rather than a shared
+    loop-level list) ensures ops with different iteration-space layouts in
+    the same loop are each advanced by the correct stride.
     """
     result: list[dict[Symbol, int]] = []
     for arg in op_spec.args:
@@ -179,9 +183,15 @@ def _unroll_one(loop: LoopSpec) -> list:
 
     Nested ``LoopSpec`` nodes are unrolled innermost-first: inner loops are
     fully flattened before the outer loop iterates over them.  Each level
-    independently computes per-iteration byte strides from its own
-    ``tiled_symbols`` and ``iteration_space``, so strides accumulate
-    correctly across nesting depths without explicit offset propagation.
+    independently computes per-iteration byte strides from each OpSpec's own
+    ``tiled_symbols``, so ops with different iteration-space layouts in the
+    same loop are each advanced by the correct stride.
+
+    ``tiled_symbols`` stores one sublist per nesting level, innermost first.
+    Each unrolling pass consumes ``tiled_symbols[0]`` for its level and pops
+    it from the list, leaving outer-level sublists intact for subsequent
+    passes.  There is no shared per-LoopSpec symbol list: each op is advanced
+    using only its own iteration-space symbols for the current level.
     """
     # --- Recursively unroll any nested LoopSpecs in body first. ----------
     flat_body: list[OpSpec] = []
@@ -200,43 +210,38 @@ def _unroll_one(loop: LoopSpec) -> list:
         )
     count = int(count_expr)
 
-    # --- Determine which symbols this loop level tiles. ------------------
-    # If loop.tiled_symbols is populated (new path), use it directly.
-    # Otherwise fall back to reading tiled_symbols from the first OpSpec
-    # in the body (works for the single-level non-nested case).
-    if loop.tiled_symbols:
-        this_level_syms: list[Symbol] = loop.tiled_symbols
-    else:
-        this_level_syms = next(
-            (list(e.tiled_symbols) for e in flat_body if isinstance(e, OpSpec)),
-            [],
-        )
-
     # --- Pre-compute per-arg byte strides and tile device_sizes once. ----
+    # tiled_symbols is stored innermost-first.  This loop level consumes
+    # tiled_symbols[0] from each op, leaving outer-level entries intact.
     strides_per_op: list[list[dict[Symbol, int]]] = []
     tile_sizes_per_op: list[list[list[int] | None]] = []
+    op_syms_per_entry: list[list[Symbol]] = []
     for entry in flat_body:
         if isinstance(entry, OpSpec):
-            arg_strides = _arg_byte_strides_for_syms(entry, this_level_syms)
+            # Innermost level is tiled_symbols[0]; empty list if no tiling here.
+            op_syms = list(entry.tiled_symbols[0]) if entry.tiled_symbols else []
+            op_syms_per_entry.append(op_syms)
+            arg_strides = _arg_byte_strides_for_syms(entry, op_syms)
             strides_per_op.append(arg_strides)
             tile_sizes: list[list[int] | None] = []
             for arg, strides in zip(entry.args, arg_strides):
                 if strides:
                     tile_sizes.append(
-                        _tile_device_size(arg, this_level_syms, entry.iteration_space)
+                        _tile_device_size(arg, op_syms, entry.iteration_space)
                     )
                 else:
                     tile_sizes.append(None)
             tile_sizes_per_op.append(tile_sizes)
         else:
+            op_syms_per_entry.append([])
             strides_per_op.append([])
             tile_sizes_per_op.append([])
 
     # --- Emit count copies, advancing addresses per iteration. -----------
     result: list = []
     for i in range(count):
-        for entry, arg_strides, tile_sizes in zip(
-            flat_body, strides_per_op, tile_sizes_per_op
+        for entry, op_syms, arg_strides, tile_sizes in zip(
+            flat_body, op_syms_per_entry, strides_per_op, tile_sizes_per_op
         ):
             if not isinstance(entry, OpSpec):
                 result.append(copy.deepcopy(entry))
@@ -247,9 +252,7 @@ def _unroll_one(loop: LoopSpec) -> list:
             for arg, strides, tile_size in zip(op_copy.args, arg_strides, tile_sizes):
                 if not strides:
                     continue
-                iter_offset = sum(
-                    i * strides[s] for s in this_level_syms if s in strides
-                )
+                iter_offset = sum(i * strides[s] for s in op_syms if s in strides)
                 if iter_offset:
                     arg.allocation = dict(arg.allocation)
                     # Advance whichever allocation key is present (hbm, pool, lx).
@@ -262,8 +265,11 @@ def _unroll_one(loop: LoopSpec) -> list:
                 if tile_size is not None:
                     arg.device_size = tile_size
 
-            # Clear tiled_symbols: addresses are now concrete.
-            op_copy.tiled_symbols = []
+            # Pop the innermost level: addresses are now concrete for it.
+            # Outer-level entries (indices 1+) remain for subsequent unrolling.
+            op_copy.tiled_symbols = (
+                op_copy.tiled_symbols[1:] if op_copy.tiled_symbols else []
+            )
             result.append(op_copy)
 
     logger.debug(

--- a/torch_spyre/_inductor/op_spec.py
+++ b/torch_spyre/_inductor/op_spec.py
@@ -73,10 +73,15 @@ class OpSpec:
         iteration_space: The iteration space of the operation. The values are tuples of (range, work_division).
         args: The input and output arguments to the operation.
         op_info: A dictionary of auxiliary information whose content is operation-specific.
-        tiled_symbols: Iteration-space symbols divided by the enclosing loop's count.
-            Empty for ops that are not inside a LoopSpec.  The runtime computes the
-            per-iteration tensor base offset for symbol ``s`` as
-            ``loop_var * iteration_space[s].range``.
+        tiled_symbols: Per-loop-level iteration-space symbols, innermost first.
+            ``tiled_symbols[0]`` lists the symbols tiled by the innermost enclosing
+            loop; ``tiled_symbols[1]`` lists those tiled by the next-outer loop; etc.
+            Empty for ops not inside any loop.
+            The unroller reads ``tiled_symbols[0]`` at each level and removes it
+            from the list after processing, leaving outer-level entries intact.
+            The bundle path (compile_op_spec / generate_sdsc) reverses this list to
+            outermost-first and builds per-level affine.apply stride maps, mapping
+            each level's strides to the correct loop variable by explicit index.
     """
 
     op: str
@@ -84,7 +89,7 @@ class OpSpec:
     iteration_space: dict[Symbol, tuple[Expr, int]]
     args: Sequence[TensorArg]
     op_info: dict[str, Any]
-    tiled_symbols: list[Symbol] = dataclasses.field(default_factory=list)
+    tiled_symbols: list[list[Symbol]] = dataclasses.field(default_factory=list)
     # Maps PyTorch symbol name (e.g. 's97') -> (max, granularity) bounds.
     # Populated by compute_symbolic_bounds during
     # create_op_spec; empty for concrete dims.
@@ -106,18 +111,18 @@ class LoopSpec:
         count: Trip count of the loop. May be a symbolic shape expression.
         body: The operations to execute each iteration. Each element may be
             an OpSpec, UnimplementedOp, or a nested LoopSpec.
-        tiled_symbols: The iteration-space symbols divided by ``count`` at
-            *this* loop level.  Used by the unroller to advance HBM base
-            addresses by exactly the right stride for each nesting level.
-            Empty for LoopSpecs that do not carry per-level tiling info
-            (legacy path; falls back to OpSpec.tiled_symbols).
+
+    Each OpSpec in the body carries its own ``tiled_symbols`` list identifying
+    which of its iteration-space symbols are tiled by the loop that directly
+    contains it.  The unroller reads these per-op symbols rather than a shared
+    list, so ops with different iteration-space layouts in the same loop are
+    each advanced by the correct stride.
     """
 
     count: Expr
     # list[OpSpec | UnimplementedOp | LoopSpec], typed as Any to accommodate
     # the two distinct UnimplementedOp types (op_spec vs spyre_kernel).
     body: list[Any]
-    tiled_symbols: list[Symbol] = dataclasses.field(default_factory=list)
 
 
 def spyre_constant_tensor(const_val, device, dtype=torch.float16):

--- a/torch_spyre/_inductor/op_spec.py
+++ b/torch_spyre/_inductor/op_spec.py
@@ -77,6 +77,11 @@ class OpSpec:
             ``tiled_symbols[0]`` lists the symbols tiled by the innermost enclosing
             loop; ``tiled_symbols[1]`` lists those tiled by the next-outer loop; etc.
             Empty for ops not inside any loop.
+            **Invariant:** every enclosing loop level must have an entry, even if
+            empty (``[]``).  An empty entry means the op is loop-invariant at that
+            level.  This keeps level indices aligned with nesting depth so that
+            ``compile_op_spec``'s reversal maps each level to the correct
+            ``loop_var_depth`` index in ``_collect_affine_maps``.
             The unroller reads ``tiled_symbols[0]`` at each level and removes it
             from the list after processing, leaving outer-level entries intact.
             The bundle path (compile_op_spec / generate_sdsc) reverses this list to

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -40,87 +40,6 @@ from .op_spec import LoopSpec
 logger = get_inductor_logger("scheduler")
 
 
-def _find_leaf_sched_node(node: BaseSchedulerNode):
-    """Recursively find the first leaf SchedulerNode inside a (possibly nested) node."""
-    for snode in node.get_nodes():
-        if isinstance(snode, SchedulerNode):
-            return snode
-        result = _find_leaf_sched_node(snode)
-        if result is not None:
-            return result
-    return None
-
-
-def _tiled_syms_for_sched_node_at_depth(sched_node: SchedulerNode, depth: int) -> list:
-    """Return the OpSpec iteration-space symbols tiled at ``depth``.
-
-    Uses ``loop_tiled_dims[depth]`` and ``loop_tiled_reduction_dims[depth]``
-    from the IR node and the SchedulerNode's ``iteration_space`` (which
-    produces the same symbols as ``create_op_spec`` uses to build
-    ``OpSpec.tiled_symbols``).
-
-    ``loop_tiled_dims`` stores *host-range* dimension indices (indices into
-    ``op.data.ranges``), which include unit-size batch dimensions that are
-    skipped in the iteration space.  We must map host-range indices to
-    iteration-space key indices by walking ``op.data.ranges`` and counting
-    only the non-unit entries.
-
-    For reduction-dimension tiling (``loop_tiled_reduction_dims``), the
-    reduction symbols follow the output symbols in the iteration space key
-    list (the scheduler produces keys from reads.ranges for Reduction nodes,
-    which has output dims first then reduction dims).  The offset is the
-    number of non-unit output-dim ranges; indices in
-    ``loop_tiled_reduction_dims`` are 0-based into the reduction portion.
-    """
-    ir_op = sched_node.node
-    if ir_op is None:
-        return []
-    loop_info = getattr(ir_op, "loop_info", None)
-    if loop_info is None:
-        return []
-    raw = loop_info.loop_tiled_dims
-    raw_rdims = getattr(loop_info, "loop_tiled_reduction_dims", [])
-    if not raw and not raw_rdims:
-        return []
-    dims_per_level: list[list[int]] = raw if raw else [[] for _ in raw_rdims]
-    rdims_per_level: list[list[int]] = raw_rdims if raw_rdims else [[] for _ in raw]
-    if depth >= len(dims_per_level):
-        return []
-    it_space = iteration_space(sched_node)
-    keys = list(it_space.keys())
-
-    # Build a map from host-range index → iteration-space key index.
-    # loop_tiled_dims is only stamped on ComputedBuffer ops (Pointwise/Reduction),
-    # so data.ranges is always present here.  The iteration space simply omits
-    # unit-size dims, so we walk ranges and count only non-unit entries.
-    host_to_it: dict[int, int] = {}
-    it_idx = 0
-    for host_idx, r in enumerate(ir_op.data.ranges):
-        if int(r) != 1:
-            host_to_it[host_idx] = it_idx
-            it_idx += 1
-
-    result = []
-    for d in dims_per_level[depth]:
-        mapped = host_to_it.get(d)
-        if mapped is not None and mapped < len(keys):
-            result.append(keys[mapped])
-
-    # Map reduction-dimension indices to iteration-space symbols.  For
-    # Reduction nodes the iteration space (from reads.ranges) has output-dim
-    # symbols first, then reduction-dim symbols.  The offset is the count of
-    # non-unit output-dim ranges.
-    rdims_at_depth = rdims_per_level[depth] if depth < len(rdims_per_level) else []
-    if rdims_at_depth:
-        n_output_syms = sum(1 for r in ir_op.data.ranges if int(r) != 1)
-        for rd in rdims_at_depth:
-            sym_idx = n_output_syms + rd
-            if sym_idx < len(keys):
-                result.append(keys[sym_idx])
-
-    return result
-
-
 class CountedLoopSchedulerNode(FusedSchedulerNode):
     """A group of SchedulerNodes to be executed inside a counted outer loop.
 
@@ -436,19 +355,7 @@ class SuperDSCScheduling(BaseScheduling):
                         ]
                         snode.codegen(index_vars)
 
-        # Compute per-level tiled symbols for the outer (depth=0) LoopSpec.
-        # Find a leaf SchedulerNode to read loop_tiled_dims + iteration_space.
-        outer_tiled_syms: list = []
-        for inner in inner_nodes:
-            ref = _find_leaf_sched_node(inner)
-            if ref is not None:
-                outer_tiled_syms = _tiled_syms_for_sched_node_at_depth(ref, 0)
-                break
-
-        kernel.wrap_op_specs_in_loop(
-            node.loop_count,
-            tiled_symbols=outer_tiled_syms,
-        )
+        kernel.wrap_op_specs_in_loop(node.loop_count)
 
         with V.set_kernel_handler(kernel):
             src_code = kernel.codegen_kernel()
@@ -503,24 +410,10 @@ class SuperDSCScheduling(BaseScheduling):
                     ]
                     snode.codegen(index_vars)
 
-        # Determine this level's tiled symbols using the IR's loop_tiled_dims[depth].
-        ref_sched_node = _find_leaf_sched_node(node)
-        level_syms = (
-            _tiled_syms_for_sched_node_at_depth(ref_sched_node, depth)
-            if ref_sched_node is not None
-            else []
-        )
-
         # Wrap only the newly-added op_specs entries in this inner LoopSpec.
         body = kernel.op_specs[body_start:]
         kernel.op_specs = kernel.op_specs[:body_start]
-        kernel.op_specs.append(
-            LoopSpec(
-                count=node.loop_count,
-                body=body,
-                tiled_symbols=level_syms,
-            )
-        )
+        kernel.op_specs.append(LoopSpec(count=node.loop_count, body=body))
 
     def define_kernel(self, src_code, node_schedule, kernel):
         """

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -582,6 +582,11 @@ class SpyreKernel(Kernel[CSEVariable]):
         raw_tiled_red_dims: list[list[int]] = (
             li.loop_tiled_reduction_dims if li is not None else []
         )
+        # CoarseTileInfo always constructs loop_tiled_dims and
+        # loop_tiled_reduction_dims with the same length (one sublist per
+        # nesting level), so max() is just a safety net; in practice both
+        # lists have the same length and the per-level loop below never
+        # silently drops an entry from the shorter one.
         n_levels = max(len(raw_tiled_dims), len(raw_tiled_red_dims))
         it_space_keys = list(it_space.keys())
 

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -590,46 +590,53 @@ class SpyreKernel(Kernel[CSEVariable]):
         n_levels = max(len(raw_tiled_dims), len(raw_tiled_red_dims))
         it_space_keys = list(it_space.keys())
 
-        # Build host-range-index → iteration-space-key-index map by walking
-        # data.ranges and counting only non-unit entries.
-        host_to_it: dict[int, int] = {}
-        if hasattr(ir_node, "data") and hasattr(ir_node.data, "ranges"):
-            it_idx = 0
-            for host_idx, r in enumerate(ir_node.data.ranges):
-                if int(r) != 1:
-                    host_to_it[host_idx] = it_idx
-                    it_idx += 1
-        else:
-            # Fallback: identity mapping (no unit-size dims to skip).
-            host_to_it = {i: i for i in range(len(it_space_keys))}
+        # host_to_it and n_output_it_syms call int() on data.ranges entries,
+        # which throws on symbolic dimensions.  They are only needed when this
+        # op is inside a tiling loop, so skip the computation for non-tiled ops.
+        tiled_syms: list[list] = []
+        if n_levels > 0:
+            # Build host-range-index → iteration-space-key-index map by walking
+            # data.ranges and counting only non-unit entries.  loop_tiled_dims
+            # stores *host-range* indices which include unit-size dims that the
+            # iteration space skips; this mapping corrects for that.
+            host_to_it: dict[int, int] = {}
+            if hasattr(ir_node, "data") and hasattr(ir_node.data, "ranges"):
+                it_idx = 0
+                for host_idx, r in enumerate(ir_node.data.ranges):
+                    if int(r) != 1:
+                        host_to_it[host_idx] = it_idx
+                        it_idx += 1
+            else:
+                # Fallback: identity mapping (no unit-size dims to skip).
+                host_to_it = {i: i for i in range(len(it_space_keys))}
 
-        # For reduction dims: offset is the number of non-unit output-dim ranges.
-        n_output_it_syms = sum(
-            1
-            for r in (
-                ir_node.data.ranges
-                if hasattr(ir_node, "data") and hasattr(ir_node.data, "ranges")
-                else []
+            # For reduction dims: offset is the number of non-unit output-dim ranges.
+            n_output_it_syms = sum(
+                1
+                for r in (
+                    ir_node.data.ranges
+                    if hasattr(ir_node, "data") and hasattr(ir_node.data, "ranges")
+                    else []
+                )
+                if int(r) != 1
             )
-            if int(r) != 1
-        )
 
-        tiled_syms_per_level_outermost: list[list] = []
-        for lvl in range(n_levels):
-            level_syms: list = []
-            if lvl < len(raw_tiled_dims):
-                for d in raw_tiled_dims[lvl]:
-                    mapped = host_to_it.get(d)
-                    if mapped is not None and mapped < len(it_space_keys):
-                        level_syms.append(it_space_keys[mapped])
-            if lvl < len(raw_tiled_red_dims):
-                for r in raw_tiled_red_dims[lvl]:
-                    sym_idx = n_output_it_syms + r
-                    if sym_idx < len(it_space_keys):
-                        level_syms.append(it_space_keys[sym_idx])
-            tiled_syms_per_level_outermost.append(level_syms)
-        # Reverse so index 0 = innermost level.
-        tiled_syms = list(reversed(tiled_syms_per_level_outermost))
+            tiled_syms_per_level_outermost: list[list] = []
+            for lvl in range(n_levels):
+                level_syms: list = []
+                if lvl < len(raw_tiled_dims):
+                    for d in raw_tiled_dims[lvl]:
+                        mapped = host_to_it.get(d)
+                        if mapped is not None and mapped < len(it_space_keys):
+                            level_syms.append(it_space_keys[mapped])
+                if lvl < len(raw_tiled_red_dims):
+                    for r in raw_tiled_red_dims[lvl]:
+                        sym_idx = n_output_it_syms + r
+                        if sym_idx < len(it_space_keys):
+                            level_syms.append(it_space_keys[sym_idx])
+                tiled_syms_per_level_outermost.append(level_syms)
+            # Reverse so index 0 = innermost level.
+            tiled_syms = list(reversed(tiled_syms_per_level_outermost))
 
         # Collect (max, granularity) bounds for any symbolic iteration-space
         # dims. These are passed through OpSpec so SDSC codegen can emit

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -568,34 +568,63 @@ class SpyreKernel(Kernel[CSEVariable]):
             op, it_space_extended, args, op_info
         )
 
-        # If this op is inside a coarse-tiling loop, identify which iteration-space
-        # symbols are tiled by the enclosing loop(s).  loop_tiled_dims is a
-        # list[list[int]] (nested multi-level, outermost first).  Flatten all
-        # levels so that tiled_symbols covers every loop variable from outermost
-        # to innermost — matching the loop_vars ordering in bundle.py _emit_specs.
+        # Build per-level tiled_symbols (innermost first) for this op.
+        # loop_tiled_dims / loop_tiled_reduction_dims are lists of per-level
+        # dim-index lists, outermost first — so we build outermost-first then
+        # reverse to get innermost-first for tiled_symbols storage.
+        #
+        # IMPORTANT: loop_tiled_dims stores *host-range* indices (indices into
+        # op.data.ranges), but the iteration space skips unit-size dims.  We
+        # must map host-range index → iteration-space key index before looking
+        # up symbols.
         li = getattr(ir_node, "loop_info", None)
         raw_tiled_dims: list[list[int]] = li.loop_tiled_dims if li is not None else []
         raw_tiled_red_dims: list[list[int]] = (
             li.loop_tiled_reduction_dims if li is not None else []
         )
-        all_tiled_dims = [d for level in raw_tiled_dims for d in level]
-        all_tiled_red_dims = [d for level in raw_tiled_red_dims for d in level]
+        n_levels = max(len(raw_tiled_dims), len(raw_tiled_red_dims))
         it_space_keys = list(it_space.keys())
-        tiled_syms = [
-            it_space_keys[i] for i in all_tiled_dims if i < len(it_space_keys)
-        ]
-        # For reduction ops tiled over a reduction dimension, it_space (from
-        # reads.ranges) has output-dim symbols first, then reduction-dim symbols.
-        # loop_tiled_reduction_dims indices are 0-based into the reduction portion,
-        # so offset them by the number of output-space symbols.
-        if all_tiled_red_dims:
-            write_dep = next(iter(self.current_node.read_writes.writes), None)
-            n_output_syms = len(write_dep.ranges) if write_dep is not None else 0
-            tiled_syms += [
-                it_space_keys[n_output_syms + r]
-                for r in all_tiled_red_dims
-                if n_output_syms + r < len(it_space_keys)
-            ]
+
+        # Build host-range-index → iteration-space-key-index map by walking
+        # data.ranges and counting only non-unit entries.
+        host_to_it: dict[int, int] = {}
+        if hasattr(ir_node, "data") and hasattr(ir_node.data, "ranges"):
+            it_idx = 0
+            for host_idx, r in enumerate(ir_node.data.ranges):
+                if int(r) != 1:
+                    host_to_it[host_idx] = it_idx
+                    it_idx += 1
+        else:
+            # Fallback: identity mapping (no unit-size dims to skip).
+            host_to_it = {i: i for i in range(len(it_space_keys))}
+
+        # For reduction dims: offset is the number of non-unit output-dim ranges.
+        n_output_it_syms = sum(
+            1
+            for r in (
+                ir_node.data.ranges
+                if hasattr(ir_node, "data") and hasattr(ir_node.data, "ranges")
+                else []
+            )
+            if int(r) != 1
+        )
+
+        tiled_syms_per_level_outermost: list[list] = []
+        for lvl in range(n_levels):
+            level_syms: list = []
+            if lvl < len(raw_tiled_dims):
+                for d in raw_tiled_dims[lvl]:
+                    mapped = host_to_it.get(d)
+                    if mapped is not None and mapped < len(it_space_keys):
+                        level_syms.append(it_space_keys[mapped])
+            if lvl < len(raw_tiled_red_dims):
+                for r in raw_tiled_red_dims[lvl]:
+                    sym_idx = n_output_it_syms + r
+                    if sym_idx < len(it_space_keys):
+                        level_syms.append(it_space_keys[sym_idx])
+            tiled_syms_per_level_outermost.append(level_syms)
+        # Reverse so index 0 = innermost level.
+        tiled_syms = list(reversed(tiled_syms_per_level_outermost))
 
         # Collect (max, granularity) bounds for any symbolic iteration-space
         # dims. These are passed through OpSpec so SDSC codegen can emit
@@ -821,18 +850,10 @@ class SpyreKernel(Kernel[CSEVariable]):
             ]
             self.op_specs.append(self.create_op_spec(value.op, True, args, op_info))
 
-    def wrap_op_specs_in_loop(
-        self, count: sympy.Expr, tiled_symbols: list | None = None
-    ) -> None:
+    def wrap_op_specs_in_loop(self, count: sympy.Expr) -> None:
         """Replace the current op_specs list with a single LoopSpec of the given count."""
         body = self.op_specs
-        self.op_specs = [
-            LoopSpec(
-                count=count,
-                body=body,
-                tiled_symbols=tiled_symbols if tiled_symbols is not None else [],
-            )
-        ]
+        self.op_specs = [LoopSpec(count=count, body=body)]
 
     def codegen_kernel(self):
         """Codegen the body of this kernel by pretty printing its list of OpSpecs"""
@@ -935,12 +956,6 @@ def _codegen_op_spec_list(specs, buf: IndentedBuffer, sympy_str) -> None:
                 with buf.indent():
                     _codegen_op_spec_list(op_spec.body, buf, sympy_str)
                 buf.writeline("],")
-                if op_spec.tiled_symbols:
-                    buf.writeline(
-                        "tiled_symbols=["
-                        + ", ".join(sympy_str(s) for s in op_spec.tiled_symbols)
-                        + "],"
-                    )
             buf.writeline("),")
         elif isinstance(op_spec, (UnimplementedOp, OpSpecUnimplementedOp)):
             if logger.isEnabledFor(logging.DEBUG):
@@ -975,7 +990,10 @@ def _codegen_op_spec_list(specs, buf: IndentedBuffer, sympy_str) -> None:
                 if op_spec.tiled_symbols:
                     buf.writeline(
                         "tiled_symbols=["
-                        + ", ".join(sympy_str(s) for s in op_spec.tiled_symbols)
+                        + ", ".join(
+                            "[" + ", ".join(sympy_str(s) for s in level) + "]"
+                            for level in op_spec.tiled_symbols
+                        )
                         + "],"
                     )
                 buf.writeline(


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Eliminates `LoopSpec.tiled_symbols` and restructures `OpSpec.tiled_symbols`
from a flat `list[Symbol]` to `list[list[Symbol]]` (per nesting level,
innermost first).

**Motivation:** `LoopSpec.tiled_symbols` held a single flat symbol list
derived from one representative op and applied to all ops in the loop body.
This is incorrect when ops in the same loop have different iteration-space
layouts — for example, when one op has a unit-size batch dimension that
another does not.  The correct iteration-space symbol for a given host-range
dimension differs per op, so each op must carry its own per-level symbol list.

**Design:**
- `OpSpec.tiled_symbols[0]` = symbols tiled by the innermost enclosing loop;
  `[1]` = next-outer level; etc.  Empty for non-tiled ops.
- The unroller reads `tiled_symbols[0]` per op and pops it after each level,
  so each op advances by its own correct stride regardless of what other ops
  in the same loop do.
- The bundle/affine-map path (`compile_op_spec` / `generate_sdsc`) receives
  the list reversed to outermost-first.  `affine_strides` is restructured to
  `list[list[dict]]` (per tensor, per level), and `_collect_affine_maps` uses
  an explicit `loop_var_depth[level_idx]` lookup instead of the previous
  count-from-end heuristic.
- `spyre_kernel.py` now builds `tiled_symbols` via a host-range-index →
  iteration-space-key mapping that correctly skips unit-size dimensions (the
  previous scheduler-side helper `_tiled_syms_for_sched_node_at_depth` did
  this mapping but was only used for `LoopSpec.tiled_symbols`; the per-op
  codegen path in `create_op_spec` was missing it, causing wrong symbols to
  be selected when unit-size batch dims were present).

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
-->

Part of #1358 

#### Special notes for your reviewer:

The semantic invariant: `OpSpec.tiled_symbols` is always stored
innermost-first (index 0 = innermost loop).  `compile_op_spec` reverses it
to outermost-first before passing to `generate_sdsc`.  The unroller always
consumes `[0]` and pops, so after full unrolling `tiled_symbols` is empty on
all flat ops.

`LoopSpec` no longer has a `tiled_symbols` field at all.  The docstring on
`LoopSpec` explains that each op in the body carries its own symbols.

The bug that caused the two `TestCoarseTileSpyreHints` e2e test failures
(`test_hint_h_tiling_elementwise`, `test_hint_flash_attention`) was that
`create_op_spec` in `spyre_kernel.py` used `loop_tiled_dims[lvl][i]`
directly as an iteration-space key index, but `loop_tiled_dims` stores
*host-range* indices which include unit-size dimensions that the iteration
space skips.  The fix applies the same `host_to_it` mapping that
`_tiled_syms_for_sched_node_at_depth` (now deleted) had been doing for the
`LoopSpec` path.

#### Does this PR introduce a user-facing change?

No.  Internal compiler IR restructuring only; no change to supported ops,
dtypes, or device behavior.

#### Additional note:

Passes `tests/inductor/test_coarse_tiling.py` (186 tests),
`tests/inductor/test_unroll_loop_specs.py` (33 tests), and
`tests/inductor/test_coarse_tile_e2e.py` (29 passed, 9 skipped).