### PR TITLE
doc: document WrapperHandler wrapping pattern for compiler passes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,18 @@ See `docs/source/` for detailed architecture documentation:
 - `docs/source/compiler/adding_operations.md` — how to add new operations
 - `docs/source/compiler/work_division_planning.md` — multi-core work division
 
+## Compiler Pass Conventions
+
+**Modifying `ComputedBuffer.inner_fn`: wrap, never reconstruct.**
+Use a `WrapperHandler` subclass (see `WrapperHandler` in
+`torch._inductor.ops_handler`) to intercept specific ops and install it
+with `V.set_ops_handler(handler)` inside the original `inner_fn`. Do NOT
+rebuild `inner_fn` from scratch by re-creating index expressions — those
+expressions are symbolic and become stale as soon as the pass runs,
+causing silent wrong-code bugs (see issue #2797). Canonical examples of the
+correct pattern: `NameSwapHandler` in `insert_restickify.py`,
+`_SplitOpsHandler`/`_IntermediateOpHandler` in `split_multi_ops.py`.
+
 ## Skills
 
 Task-specific guidance is available in `.claude/skills/`. These cover:

--- a/docs/source/compiler/adding_operations.md
+++ b/docs/source/compiler/adding_operations.md
@@ -66,3 +66,33 @@ unsupported cases to a CPU fallback. The pattern is:
 Canonical examples are `spyre::max_dim_int64_fallback` and
 `spyre::min_dim_int64_fallback`, which fall back to CPU for int64 reductions
 while the fp16/fp32 cases run natively on Spyre via decomposition.
+
+## Modifying existing kernels: wrap, never reconstruct
+
+When a compiler pass needs to alter how an existing `ComputedBuffer` computes
+its values, always wrap the original `inner_fn` using a `WrapperHandler`
+subclass — never attempt to rebuild `inner_fn` from scratch.
+
+**Why:** `inner_fn` index expressions are symbolic; they are bound to the
+specific `sympy` objects created during lowering. Rebuilding the function from
+scratch produces fresh symbolic expressions that are structurally similar but
+not the same objects, causing silent wrong-code bugs that are hard to detect
+(see issue [#2797](https://github.com/torch-spyre/torch-spyre/issues/2797)).
+
+**Correct pattern:**
+
+```python
+class _MyHandler(WrapperHandler):
+    def load(self, name, index):
+        # intercept specific loads; delegate everything else
+        return super().load(self._name_map.get(name, name), index)
+
+def new_inner_fn(*args, _orig=orig_inner):
+    with V.set_ops_handler(_MyHandler(V.ops, ...)):
+        return _orig(*args)
+```
+
+Canonical implementations: `NameSwapHandler` in
+[insert_restickify.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/insert_restickify.py),
+`_SplitOpsHandler` and `_IntermediateOpHandler` in
+[split_multi_ops.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/split_multi_ops.py).

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -67,6 +67,10 @@ class NameSwapHandler(WrapperHandler):
     """
     Wrapper to patch a node's inner_fn to use new buffer names after inserting
     nodes upstream that change the input buffers.
+
+    This is the canonical example of the correct WrapperHandler wrapping
+    pattern for compiler passes. See CLAUDE.md "Compiler Pass Conventions"
+    and issue #2797.
     """
 
     def __init__(self, inner, name_map: dict[str, str]):

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1022,6 +1022,8 @@ def replace_computed_buffer_body(
 
     Returns the replacement ComputedBuffer.
     """
+    # Always wrap the original inner_fn via WrapperHandler; never rebuild
+    # index expressions from scratch (they go stale — see issue #2797).
     new_buf = ComputedBuffer(
         name=op.get_name(),
         layout=op.layout,


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [ ] feature
- [x] documentation
- [ ] cleanup

#### What this PR does:

Establishes and propagates the **"wrap, never reconstruct"** rule for
modifying `ComputedBuffer.inner_fn` in compiler passes.

Rebuilding `inner_fn` from scratch is dangerous: the index expressions
inside it are symbolic `sympy` objects bound at lowering time. A fresh
reconstruction produces structurally identical but distinct objects that
become stale as soon as the pass runs, yielding silent wrong-code bugs
(see #2797). The correct approach is to wrap the original `inner_fn`
using a `WrapperHandler` subclass installed via `V.set_ops_handler()`.

This pattern was introduced concretely in #2956
(`_SplitOpsHandler`/`_IntermediateOpHandler`). This PR documents it in
four places so neither human contributors nor coding agents can miss it:

1. **`CLAUDE.md`** — new "Compiler Pass Conventions" section, loaded
   automatically into every coding-agent context window.
2. **`torch_spyre/_inductor/pass_utils.py`** — comment on
   `replace_computed_buffer_body`, the utility every pass calls when
   patching a `ComputedBuffer`, making the rule visible at the point of
   use.
3. **`torch_spyre/_inductor/insert_restickify.py`** — extended
   `NameSwapHandler` docstring, annotating it as the canonical reference
   implementation of the correct wrapping pattern.
4. **`docs/source/compiler/adding_operations.md`** — new section
   "Modifying existing kernels: wrap, never reconstruct" for human
   developers reading before writing a new pass.

#### Which issue(s) this PR is related to:

#2797
#2956 (introduces the pattern this PR documents)

#### Special notes for your reviewer:

This is a documentation-only change — no behavioral differences. It is
filed as a standalone PR because it touches `CLAUDE.md` and
`docs/source/`, which have different code owners than the compiler pass
files changed in #2956.

#### Does this PR introduce a user-facing change?

No.

#### Additional note:

The pre-commit `clang-format` hook currently fails with
`InvalidManifestError: Type tag 'metal' is not recognized` on this
machine (a pre-existing env issue unrelated to this PR). The hooks that
apply to this change — `ruff`, `ruff format`, `PyMarkdown`, `mypy`, and
`signoff-commit` — all passed.