### PR TITLE
fix(logging): show all hint dims in coarse_tile_groups scopes= line

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -3875,5 +3875,112 @@ class TestReorderUnhintedInterlopers(unittest.TestCase):
             self._run([a, x, b, c])
 
 
+# ===========================================================================
+# TestHintsToCoarseTileGroupsLogging
+# ===========================================================================
+
+
+def _make_htctg_op(name, hints):
+    """Return a fake ComputedBuffer for hints_to_coarse_tile_groups logging tests.
+
+    hints: list of (hint_id, dim_names, split_count, loop_var) tuples.
+    loop_var may be None to simulate an op that is broadcast on that dim.
+    """
+    from torch._inductor.ir import ComputedBuffer
+    from torch_spyre._inductor.propagate_hints import DimHint
+
+    op = MagicMock(spec=ComputedBuffer)
+    op.get_name.return_value = name
+    op.get_operation_name.return_value = name
+    op.origins = []
+    op.dim_hints = [
+        DimHint(
+            dim_names=dim_names,
+            split_count=split_count,
+            loop_var=loop_var,
+            is_reduction=False,
+            hint_id=hint_id,
+        )
+        for hint_id, dim_names, split_count, loop_var in hints
+    ]
+    return op
+
+
+def _run_htctg_and_capture_log(ops):
+    """Run hints_to_coarse_tile_groups with INFO logging and return the log text."""
+    import logging
+    import logging.handlers
+    from types import SimpleNamespace
+    from torch_spyre._inductor.coarse_tile import hints_to_coarse_tile_groups
+    import torch_spyre._inductor.coarse_tile as coarse_tile_mod
+
+    graph = SimpleNamespace(operations=list(ops))
+
+    # Temporarily force the module-level hints_logger to INFO so the logging
+    # block inside hints_to_coarse_tile_groups actually runs.
+    original_level = coarse_tile_mod.hints_logger.level
+    coarse_tile_mod.hints_logger.setLevel(logging.INFO)
+
+    handler = logging.handlers.MemoryHandler(capacity=1000, flushLevel=logging.CRITICAL)
+    coarse_tile_mod.hints_logger.addHandler(handler)
+    try:
+        hints_to_coarse_tile_groups(graph)
+        handler.flush()
+        return "\n".join(r.getMessage() for r in handler.buffer)
+    finally:
+        coarse_tile_mod.hints_logger.removeHandler(handler)
+        coarse_tile_mod.hints_logger.setLevel(original_level)
+
+
+class TestHintsToCoarseTileGroupsLogging(unittest.TestCase):
+    """The scopes= log line must list all hint dims, not just those with
+    loop_var set on the first op in the group.
+
+    Regression test for a bug where group_ops[0] had loop_var=None for a hint
+    (e.g. a restickify op that doesn't iterate over Lq), causing that hint to
+    be absent from group_levels and therefore omitted from the scopes= line.
+    """
+
+    def test_scopes_includes_all_hints_when_first_op_is_broadcast_on_second_hint(self):
+        """When group_ops[0] has loop_var=None for hint 2 (Lq), the scopes= line
+        must still include Lq — not just H."""
+        import sympy
+
+        h_sym = sympy.Symbol("c0")
+        lq_sym = sympy.Symbol("c1")
+
+        # op0: iterates over H only — loop_var=None for Lq (broadcast, like restickify)
+        op0 = _make_htctg_op(
+            "op0",
+            [
+                (1, ["H"], 8, h_sym),  # hint_id=1, H, has loop_var
+                (2, ["Lq"], 4, None),  # hint_id=2, Lq, loop_var=None → broadcast
+            ],
+        )
+        # op1: iterates over both H and Lq
+        op1 = _make_htctg_op(
+            "op1",
+            [
+                (1, ["H"], 8, h_sym),
+                (2, ["Lq"], 4, lq_sym),
+            ],
+        )
+
+        log_output = _run_htctg_and_capture_log([op0, op1])
+
+        # Find the scopes= line specifically
+        scopes_line = next(
+            (ln for ln in log_output.splitlines() if "scopes=" in ln), ""
+        )
+        self.assertIn("H", scopes_line, f"scopes= must mention H; got: {scopes_line!r}")
+        self.assertIn(
+            "Lq",
+            scopes_line,
+            f"scopes= must mention Lq even though op0 is broadcast on Lq "
+            f"(loop_var=None for hint_id=2 on group_ops[0]); "
+            f"got: {scopes_line!r}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -73,7 +73,7 @@ from .constants import BATCH_MATMUL_OP
 from .errors import Unsupported
 from .logging_utils import get_inductor_logger
 from .loop_info import CoarseTileInfo
-from .propagate_hints import DimHint, get_op_hints
+from .propagate_hints import DimHint
 from .pass_utils import op_out_coords
 from .span_overflow_hint_analysis import plan_span_overflow_tile
 from .ir import FixedTiledLayout
@@ -337,13 +337,21 @@ def hints_to_coarse_tile_groups(graph: GraphLowering) -> list[tuple]:
         # Pre-compute hint descriptions per group — get_op_hints is called once per
         # group rather than once per op in the group.
         group_hint_descs: dict[int, str] = {}
-        for g_idx, (group_ops, group_levels) in enumerate(groups):
-            spec_op = group_ops[0]
-            op_hints = get_op_hints(spec_op)
+        for g_idx, (group_ops, _group_levels) in enumerate(groups):
+            # Collect all DimHints across the group, keyed by hint_id.
+            # Prefer a hint whose loop_var is not None (op actually iterates
+            # that dim) over a broadcast hint (loop_var=None), so that the
+            # representative name/count reflects a real iteration.
+            best: dict[int, "DimHint"] = {}
+            for gop in group_ops:
+                for h in getattr(gop, "dim_hints", []):
+                    if h.hint_id not in best or best[h.hint_id].loop_var is None:
+                        best[h.hint_id] = h
             descs = [
-                f"hint_{hint_id}={op_hints[hint_id]}"
-                for hint_id, *_ in group_levels
-                if hint_id in op_hints
+                f"hint_{h.hint_id}={{'tiles': {{"
+                + ", ".join(f"'{n}': {h.split_count}" for n in h.dim_names)
+                + "}}"
+                for h in sorted(best.values(), key=lambda x: x.hint_id)
             ]
             group_hint_descs[g_idx] = ", ".join(descs)
 


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes a logging-only bug in `hints_to_coarse_tile_groups` where the
`scopes=` summary line omitted hint dimensions whose `loop_var` was
`None` on the first op in the group (`group_ops[0]`).

**Root cause.** The group description was built by iterating over
`group_levels` (from `_hints_levels`) and looking up each `hint_id` in
`get_op_hints(group_ops[0])`.  `_hints_levels` only includes hints
where `loop_var is not None` on the first op with any non-None
loop_var.  When `group_ops[0]` is a restickify op — which is broadcast
on Lq and therefore has `loop_var=None` for the Lq hint — the Lq hint
is absent from `group_levels` and never appears in the `scopes=` line.

**Example from the field** (flash-attention variant with `H` and `Lq`
hints, restickify op first in the group):

```
# Before
group 0 scopes=[hint_1={'tiles': {'H': 8}}]:
    buf18  aten=['spyre.restickify.default']  tiles=['Hx8']
    buf3   aten=['spyre.batched_matmul.default']  tiles=['Hx8', 'Lqx4']
    ...

# After
group 0 scopes=[hint_1={'tiles': {'H': 8}}, hint_2={'tiles': {'Lq': 4}}]:
    buf18  aten=['spyre.restickify.default']  tiles=['Hx8']
    buf3   aten=['spyre.batched_matmul.default']  tiles=['Hx8', 'Lqx4']
    ...
```

**Fix.** Replace the `get_op_hints` + `group_levels` approach with a
direct scan of `dim_hints` across all ops in the group, preferring a
hint entry whose `loop_var` is not `None` (a real iteration) over a
broadcast entry when both exist for the same `hint_id`.  The
description is then built from `dim_hints` fields directly, without
requiring FX `origins` metadata.

This is a pure logging change — no effect on tiling behaviour or
codegen.

#### Which issue(s) this PR is related to:

<!--
None yet.
-->

Part of #1358 

#### Special notes for your reviewer:

The `_run_htctg_and_capture_log` test helper temporarily raises the
`hints_logger` level to INFO and attaches a `MemoryHandler` to capture
log output without touching the environment or global logging config.
The `import logging.handlers` is deferred inside the helper so it
doesn't pollute the module-level import block.

#### Does this PR introduce a user-facing change?

No behaviour change.  The `SPYRE_INDUCTOR_LOG=1` debug output now
correctly lists all tiled dimensions in the `scopes=` summary line,
making it easier to diagnose coarse-tiling configuration.

#### Additional note: