### PR TITLE
Prevent pinning tensors with a backGap in LX

### DIFF
--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -34,6 +34,7 @@ from torch._inductor.dependencies import ReadWrites
 from torch_spyre._inductor.pass_utils import (
     apply_splits_from_index_coeff,
     concretize_expr,
+    device_coordinates,
     iteration_space_from_op,
     splits_by_index_coeff,
 )
@@ -66,6 +67,51 @@ from torch_spyre._inductor.logging_utils import get_inductor_logger
 from torch_spyre._inductor.pass_utils import _is_matmul_op
 
 logger = get_inductor_logger("scratchpad.allocator")
+
+
+def _would_produce_lx_back_gap(
+    graph: GraphLowering,
+    buf_name: str,
+    uses: list[int],
+) -> bool:
+    """Return True if pinning this buffer to LX would produce a backGapCore_.
+
+    A backGap fires in superdsc when device_size[d] > it_dim_size for any
+    device dimension d, where it_dim_size is the iteration range of the loop
+    symbol that indexes that dimension.  Hardware can apply backGap to HBM
+    but not to LX tensors, so any such buffer must stay in HBM.
+
+    ``uses`` is the liveness list from lifetimes: for a computed output this
+    includes the writer (index 0) and all readers; for a graph input only readers.
+    """
+    buf = graph.get_buffer(buf_name)
+    stl = buf.layout.device_layout
+    device_size = stl.device_size
+
+    for use_idx in uses:
+        op = graph.operations[use_idx]
+        rw = op.get_read_writes()
+        for dep in rw.reads | rw.writes:
+            if dep.name != buf_name:
+                continue
+            try:
+                coords = device_coordinates(stl, dep, None)
+            except Exception:
+                continue
+            for d, coord_expr in enumerate(coords[:-1]):  # skip stick dim
+                syms = coord_expr.free_symbols
+                if not syms:
+                    # Constant coordinate on a non-unit dimension: normalize_coordinates
+                    # injects a synthetic z variable with range=1, so it_dim_size=1
+                    # and the backGap condition fires whenever device_size[d] > 1.
+                    if device_size[d] > 1:
+                        return True
+                    continue
+                sym = next(iter(syms))
+                it_dim_size = int(dep.ranges[sym])
+                if device_size[d] > it_dim_size:
+                    return True
+    return False
 
 
 class ScratchpadAllocator(ABC):
@@ -180,6 +226,9 @@ class ScratchpadAllocator(ABC):
             if output_name in graph_output_names and not cloning_allowed:
                 self.reject_reasons[output_name] = "graph output (no clone)"
                 continue  # we can only allocate graph outputs if we're allowed to clone
+            if _would_produce_lx_back_gap(graph, output_name, uses):
+                self.reject_reasons[output_name] = "lx back gap"
+                continue
             buffers.append(
                 LifetimeBoundBuffer(
                     output_name,
@@ -205,6 +254,9 @@ class ScratchpadAllocator(ABC):
                 num_cores = ncores.get(input_name, -1)
                 if num_cores < 0:
                     continue  # core division mismatch across consumers
+                if _would_produce_lx_back_gap(graph, input_name, uses):
+                    self.reject_reasons[input_name] = "lx back gap"
+                    continue
                 buf = graph.get_buffer(input_name)
                 dev_layout = buf.layout.device_layout
                 dev_size = math.prod(dev_layout.device_size[:-1]) * 128

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -74,15 +74,11 @@ def _would_produce_lx_back_gap(
     buf_name: str,
     uses: list[int],
 ) -> bool:
-    """Return True if pinning this buffer to LX would produce a backGapCore_.
+    """Check if pinning a buffer to LX would produce a backGapCore_.
 
-    A backGap fires in superdsc when device_size[d] > it_dim_size for any
-    device dimension d, where it_dim_size is the iteration range of the loop
-    symbol that indexes that dimension.  Hardware can apply backGap to HBM
-    but not to LX tensors, so any such buffer must stay in HBM.
-
-    ``uses`` is the liveness list from lifetimes: for a computed output this
-    includes the writer (index 0) and all readers; for a graph input only readers.
+    A backGap fires when device_size[d] > it_dim_size for any device dimension d.
+    The backend supports backGap for HBM but not for LX, so buffers triggering
+    this condition must stay in HBM.
     """
     buf = graph.get_buffer(buf_name)
     stl = buf.layout.device_layout
@@ -98,12 +94,9 @@ def _would_produce_lx_back_gap(
                 coords = device_coordinates(stl, dep, None)
             except Exception:
                 continue
-            for d, coord_expr in enumerate(coords[:-1]):  # skip stick dim
+            for d, coord_expr in enumerate(coords[:-1]):
                 syms = coord_expr.free_symbols
                 if not syms:
-                    # Constant coordinate on a non-unit dimension: normalize_coordinates
-                    # injects a synthetic z variable with range=1, so it_dim_size=1
-                    # and the backGap condition fires whenever device_size[d] > 1.
                     if device_size[d] > 1:
                         return True
                     continue


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

When a tensor's device_size exceeds its iteration range, a backGapCore_ is produced in the
SDSC. The backend currently only supports backGap for HBM, not LX. 
We need to prevent these tensors from being pinned in LX for now.

Add `_would_produce_lx_back_gap()` predicate that checks if LX-pinning would
trigger device_size[d] > it_dim_size for any dimension d. Tensors matching
this condition stay in HBM.

Fixes accuracy failures in kernels where LX tensors had backGap.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
