### PR TITLE
docs(coarse_tile): sync coarse_tiling_loops.md with current implementation

### DIFF
--- a/docs/source/compiler/coarse_tiling_loops.md
+++ b/docs/source/compiler/coarse_tiling_loops.md
@@ -32,6 +32,8 @@ what constraints forced each choice — see the companion RFC
 - [Design Overview](#design-overview)
 - [Small Example](#small-example)
 - [Layer 1 — IR pass & `coarse_tile()` API](#layer-1--pre-scheduling-ir-pass)
+  - [`reorder_unhinted_interlopers`](#reorder_unhinted_interlopers-pre-grouping-pass)
+  - [Groups derivation and placement](#groups-derivation-and-placement-in-custompreschedlingpasses)
 - [Layer 2 — `CountedLoopSchedulerNode`](#layer-2--countedloopschedulernode)
 - [Layer 3 — `LoopSpec` & codegen](#layer-3--loopspec-and-codegen)
 - [Key files](#key-files)
@@ -99,8 +101,8 @@ name_tensor_dims(b, ["A", "B"])
 name_tensor_dims(c, ["A", "B"])
 
 def f(a, b, c):
-    with spyre_hint(slices={"A": 2}):     # outer loop: 2 iterations over rows
-        with spyre_hint(slices={"B": 4}): # inner loop: 4 iterations over cols
+    with spyre_hint(num_tiles_per_dim={"A": 2}):     # outer loop: 2 iterations over rows
+        with spyre_hint(num_tiles_per_dim={"B": 4}): # inner loop: 4 iterations over cols
             y = a + b
             z = y * c
             return z
@@ -115,7 +117,8 @@ within the tile.
 
 This example is the canonical small example tested by
 `test_hint_nested_loop_with_scratchpad` in
-`tests/inductor/test_coarse_tile_e2e.py`.
+`tests/inductor/test_coarse_tile_e2e.py`.  (`slices=` also works — it is a
+deprecated alias for `num_tiles_per_dim=`.)
 
 ### What the coarse-tiling pass stamps
 
@@ -202,7 +205,7 @@ Key points:
 
 The Python wrapper emitted by `codegen_kernel()` contains both ops inside a
 single nested `LoopSpec`.  Below is the actual output produced by running the e2e test
-`test_hint_nested_loop_with_scratchpad` (which uses `spyre_hint(slices=...)` /
+`test_hint_nested_loop_with_scratchpad` (which uses `spyre_hint(num_tiles_per_dim=...)` /
 `declare_tensor_dim` / `name_tensor_dims` with `allow_all_ops_in_lx_planning=True`;
 concrete HBM addresses replaced with symbolic names for readability):
 
@@ -464,15 +467,17 @@ object.__setattr__(data, "ranges", ranges)
 
 ```python
 def coarse_tile(
-    operations: list[Operation],
+    graph: GraphLowering,
     groups: list[tuple],
 ) -> None:
 ```
 
 `groups` is a pre-computed list of group tuples produced by
 `hints_to_coarse_tile_groups`.  Each `ops` list must be a contiguous
-sub-sequence of `operations`; a gap indicates a data-flow dependency
-crossing the group boundary and raises `RuntimeError`.
+sub-sequence of `graph.operations`; a gap indicates a data-flow dependency
+crossing the group boundary and raises `RuntimeError`.  The full
+`GraphLowering` is required (not just the operations list) because
+`insert_tiling_propagation` calls `V.graph` APIs to allocate new buffers.
 
 Each group tuple has the form:
 
@@ -501,9 +506,88 @@ representation; it is built by `_hints_levels()` inside
 `hints_to_coarse_tile_groups` in `coarse_tile.py` before `coarse_tile()`
 stamps each op.
 
+### `reorder_unhinted_interlopers`: pre-grouping pass
+
+Before `hints_to_coarse_tile_groups` walks the operation list,
+`reorder_unhinted_interlopers` reorders any unhinted `ComputedBuffer` that
+would otherwise break a contiguous run of same-hint ops into two separate groups.
+
+#### Why it is needed
+
+`hints_to_coarse_tile_groups` collects consecutive same-key ops into a group and
+stops as soon as the key changes.  An unhinted op sandwiched between two
+same-key ops would split what should be one group into two.  This pass attempts
+to move ("reorder") such interlopers either before or after the run so the run
+becomes contiguous.
+
+#### Algorithm invariants enforced by the pass
+
+The algorithm is a two-cursor scan.  The outer cursor `i` starts at the first
+op of each new candidate run.  The inner cursor `j` walks forward, absorbing
+same-key ops.  When it encounters an unhinted `ComputedBuffer` interloper it
+applies one of three outcomes:
+
+1. **Move before** (`_can_move_before` returns `True`): `ops.insert(run_start,
+   ops.pop(j))`.  `run_start` is incremented by 1 to skip past the newly
+   inserted op; `j` stays pointing at the next candidate.
+2. **Move after** (`_can_move_after` returns `True`): `ops.insert(run_end - 1,
+   ops.pop(j))`.  `run_end` is one past the *last* same-key op in the remainder
+   (found by a backward scan), not merely the next one.  This ensures the entire
+   remaining run is covered when later interlopers would otherwise still split it.
+   After `pop(j)` shifts everything left, the insertion at `run_end - 1` lands
+   just after the last hinted op.
+3. **Neither** (both checks fail): raises `RuntimeError` with the op name and the
+   hint group it is blocking.
+
+When **both** directions are legal, the op is moved **before** the run (closer
+to its original position).
+
+#### Legality check: `_no_dep_conflict`
+
+A move is legal when it introduces no new data-flow hazard between the interloper
+and every op in the skipped range.  `_no_dep_conflict` checks four conditions:
+
+- **RAW** (read-after-write): the interloper reads a buffer written by an op in
+  the range (would observe a stale value after reordering).
+- **WAW** (write-after-write): the interloper writes a buffer also written by an
+  op in the range (order of writes matters; both directions are conservatively
+  flagged).
+- Symmetric versions: an op in the range reads or mutates a buffer written by the
+  interloper.
+
+`_no_dep_conflict` includes `op.get_mutation_names()` on both sides so that WAW
+hazards through mutation aliases are detected.  The WAW check is deliberately
+conservative: two ops mutating the same buffer cannot be safely reordered in
+either direction.
+
+#### Non-`ComputedBuffer` ops are hard stops
+
+If the inner cursor `j` reaches an op that is not a `ComputedBuffer`, or a
+`ComputedBuffer` whose hint key is different from the current run's key and
+is non-`None` (i.e., it belongs to a *different* hint group), the scan stops
+immediately.  Such ops cannot be moved by this pass.
+
+#### Trailing consumer pattern
+
+If no same-key op exists after position `j` (i.e. the unhinted op is after the
+last hinted op in this group), `run_end` is `None` and the scan ends silently.
+The unhinted op is not an interloper in this case — it is a trailing consumer.
+
+#### Key invariant summary
+
+| Invariant | How it is enforced |
+|---|---|
+| Every interloper is moved before or after the run | `RuntimeError` if neither direction is legal |
+| Move-before uses the run start (not last position) | `run_start` used as insertion target |
+| Move-after uses the last same-key op (not just the next) | Backward scan for `run_end` |
+| WAW hazards are treated as conflicts in both directions | `get_mutation_names()` included in both `op_written` and `op_needs` |
+| Non-`ComputedBuffer` ops are not moved | Type check in `_can_move_before` / `_can_move_after` |
+| Only unhinted `ComputedBuffer`s are candidates | `ckey is not None` triggers hard stop |
+
 ### Groups derivation and placement in `CustomPreSchedulingPasses`
 
-Groups are derived automatically from `spyre_hint(slices=...)` annotations
+Groups are derived automatically from `spyre_hint(num_tiles_per_dim=...)` annotations
+(`slices=` and `tiles=` are deprecated aliases that still work)
 via `hints_to_coarse_tile_groups` (in `torch_spyre/_inductor/coarse_tile.py`),
 which is a no-op when no hints are present.  `CustomPreSchedulingPasses`
 maintains a `self.passes` list of uniform `Callable[[GraphLowering], None]`
@@ -513,18 +597,26 @@ wrapped in private helpers tagged with `@_runs(...)` for cache-key purposes:
 ```python
 self.passes = [
     deadcode_elimination,
+    # Tensor Layout (Stickification)
+    split_multi_ops,
     propagate_spyre_tensor_layouts,
+    validate_ops,
     optimize_restickify_locations,
     finalize_layouts,
     insert_restickify,
     insert_bmm_padding,
+    #
     dedup_and_promote_constants,
+    # Working Set Reduction
     _maybe_chunk_large_tensors,   # config-gated
     propagate_named_dims,
     assign_dim_hints,
-    _maybe_coarse_tile,           # calls hints_to_coarse_tile_groups + coarse_tile
+    _maybe_coarse_tile,           # reorder_unhinted_interlopers + hints_to_coarse_tile_groups
+                                  # + span_overflow_groups + coarse_tile
+    # Core Division
     span_reduction,
     _distribute_work,             # calls cost_model_matmul_division + work_distribution
+    # LX Planning
     _maybe_scratchpad_planning,   # config-gated; calls scratchpad_planning
 ]
 ```
@@ -1136,7 +1228,7 @@ When backend support lands, `unroll_loops` will be flipped to default
 | File | Role |
 |---|---|
 | `torch_spyre/_inductor/loop_info.py` | Layer 1: `CoarseTileInfo` dataclass; `copy_op_metadata` |
-| `torch_spyre/_inductor/coarse_tile.py` | Layer 1: `coarse_tile()` stamps `loop_info` and rewrites ranges; `insert_tiling_propagation` handles the data perimeter |
+| `torch_spyre/_inductor/coarse_tile.py` | Layer 1: `reorder_unhinted_interlopers()` reorders interlopers before grouping; `coarse_tile()` stamps `loop_info` and rewrites ranges; `insert_tiling_propagation` handles the data perimeter |
 | `torch_spyre/_inductor/scheduler.py` | Layer 2: `CountedLoopSchedulerNode`, `build_loop_scheduler_nodes`, `_codegen_counted_loop` |
 | `torch_spyre/_inductor/op_spec.py` | Layer 3: `LoopSpec` and `OpSpec` dataclasses |
 | `torch_spyre/_inductor/spyre_kernel.py` | Layer 3: serializes `LoopSpec` tree in `codegen_kernel()`; `wrap_op_specs_in_loop()` |
@@ -1152,11 +1244,20 @@ When backend support lands, `unroll_loops` will be flipped to default
 
 ## Invariants and failure modes
 
+**Pre-grouping contiguity** (`reorder_unhinted_interlopers`): before
+`hints_to_coarse_tile_groups` runs, every unhinted `ComputedBuffer` that
+sits between two same-hint ops is moved to just before or just after the
+run.  If a data-flow dependency prevents both directions, a `RuntimeError`
+is raised.  This ensures that all same-hint ops are contiguous in
+`graph.operations` before grouping begins.
+
 **Contiguity invariant**: all `SchedulerNode`s sharing a
 `loop_info.loop_group_id` must be contiguous after the scheduler's
-topological sort.  If the tiling pass stamps ops that have a data dependency
-crossing the group boundary, the post-fusion pass will detect a non-contiguous
-run and raise a `RuntimeError`.
+topological sort.  `_stamp_group` enforces this at stamp time via
+`_validate_contiguous`, which raises `RuntimeError` if the ops are not
+a contiguous slice of the operation list.  The post-fusion pass
+(`build_loop_scheduler_nodes`) also asserts this by processing a contiguous
+run — a non-contiguous run indicates a bug in the tiling pass.
 
 **Consistent `loop_count`**: all ops sharing a `loop_group_id` must agree on
 `loop_info.loop_count` at every depth level.  The post-fusion pass asserts

--- a/docs/source/compiler/coarse_tiling_loops.md
+++ b/docs/source/compiler/coarse_tiling_loops.md
@@ -33,7 +33,7 @@ what constraints forced each choice — see the companion RFC
 - [Small Example](#small-example)
 - [Layer 1 — IR pass & `coarse_tile()` API](#layer-1--pre-scheduling-ir-pass)
   - [`reorder_unhinted_interlopers`](#reorder_unhinted_interlopers-pre-grouping-pass)
-  - [Groups derivation and placement](#groups-derivation-and-placement-in-custompreschedlingpasses)
+  - [Groups derivation and placement](#groups-derivation-and-placement-in-custompreschedulingpasses)
 - [Layer 2 — `CountedLoopSchedulerNode`](#layer-2--countedloopschedulernode)
 - [Layer 3 — `LoopSpec` & codegen](#layer-3--loopspec-and-codegen)
 - [Key files](#key-files)

--- a/docs/source/compiler/span_overflow_hint_analysis.md
+++ b/docs/source/compiler/span_overflow_hint_analysis.md
@@ -82,7 +82,8 @@ if not config.ignore_wsr_hints:
 if not config.ignore_span_overflow_hints:
     groups += span_overflow_groups(graph)
 if groups:
-    groups.sort(key=graph_order)
+    op_order = {id(op): idx for idx, op in enumerate(graph.operations)}
+    groups.sort(key=lambda group: op_order.get(id(group[0][0]), len(op_order)))
     coarse_tile(graph, groups=groups)
 ```
 

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -30,8 +30,8 @@ to innermost.  For a single-level group this is a 1-element list ``[K]``.
 
 Entry point::
 
-    groups = hints_to_coarse_tile_groups(operations)
-    coarse_tile(operations, groups)
+    groups = hints_to_coarse_tile_groups(graph)
+    coarse_tile(graph, groups)
 
 ``groups`` is a list of ``(ops, levels)`` tuples where ``levels`` is a list of
 ``(hint_id, count, is_reduction_level)`` triples, outermost first.  Each op


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [x] documentation
- [ ] cleanup

#### What this PR does:

Several gaps had accumulated since the last synch of coarse-tiling doc:

- Pass list in CustomPreSchedulingPasses was missing split_multi_ops and validate_ops; _maybe_coarse_tile comment only named two of its four callees.
- reorder_unhinted_interlopers was entirely undocumented: no section, no invariant table, not mentioned in the Invariants section.
- coarse_tile() API signature showed the old (operations, groups) form; the parameter was renamed to graph: GraphLowering when the pass was refactored to need V.graph for buffer allocation.
- Example code and prose used the deprecated slices= keyword; canonical name is num_tiles_per_dim=.
- groups.sort() snippet in span_overflow_hint_analysis.md referenced a non-existent graph_order alias; inline the actual op_order dict idiom.
- Module docstring in coarse_tile.py had the stale entry-point example.

Also adds the reorder_unhinted_interlopers section (algorithm, legality check _no_dep_conflict including WAW treatment, hard-stop and trailing- consumer rules, key invariant summary table) and updates the Invariants section to name _validate_contiguous as the stamp-time enforcement point.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

Part of #1358 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
