### PR TITLE
fix(inductor): skip non-surviving stick expr to prevent phantom rank+1 in multi-arg pointwise (#2961)

### DIFF
--- a/tests/inductor/test_multi_arg_pointwise_broadcast_rank.py
+++ b/tests/inductor/test_multi_arg_pointwise_broadcast_rank.py
@@ -1,0 +1,64 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import torch
+
+from utils_inductor import compare_with_cpu
+
+
+class TestMultiArgPointwiseBroadcastRank(unittest.TestCase):
+    """Regression tests for #2961.
+
+    PR #2948 removed the ``!= 0`` filter on ``stick_exprs`` in
+    ``_multi_arg_pointwise_layouts``, letting broadcast/constant (stick expr 0)
+    inputs flow into ``_pick_stick_dim``. When such an expr does not survive to
+    any output dim, ``_pick_stick_dim`` returns ``-1`` and
+    ``_compute_dim_order(-1, ...)`` appended a phantom trailing dimension,
+    raising the rank by one (rank-6 -> rank-7) and tripping the C++ dim_map cap
+    ("Unsupported tensor rank: 7") in spyre_tensor_impl.cpp.
+
+    The fix skips non-surviving (-1) stick exprs in the multi-arg pointwise
+    else-branch so the layout search falls through to valid candidates instead
+    of synthesizing an invalid rank-7 layout.
+    """
+
+    def setUp(self):
+        super().setUp()
+        torch.manual_seed(0xAFFE)
+
+    def test_multi_arg_pointwise_broadcast_rank_regression(self):
+        a, b, c, d, e = 2, 3, 4, 5, 64
+
+        def fn(w, x, y, z):
+            t = w + x
+            t = t.view(1, a, b, d, e)
+            t = t.unsqueeze(2) + y.unsqueeze(3)
+            return t + z
+
+        w = torch.randn(1, a, b * d * e, dtype=torch.float16) * 0.1
+        x = torch.randn(1, a, b * d * e, dtype=torch.float16) * 0.1
+        y = torch.randn(1, a, c, d, e, dtype=torch.float16) * 0.1
+        # z broadcasts along dims 3,4,5 -> its stick expr does not survive to
+        # any output dim, which is the (#2961) rank-7 trigger under compile.
+        z = torch.randn(1, a, c, 1, 1, 1, dtype=torch.float16) * 0.1
+
+        # Only the compiled path exercises the inductor layout propagation that
+        # produced the rank-7 SpyreTensorLayout; assert it compiles, returns the
+        # correct rank-6 shape, and matches CPU.
+        compare_with_cpu(fn, w, x, y, z, run_eager=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/inductor/test_propagate_named_dims.py
+++ b/tests/inductor/test_propagate_named_dims.py
@@ -545,7 +545,6 @@ def test_permute_matmul():
     )
 
 
-@pytest.mark.skip(reason="Issue #2961")
 def test_view_reshape_a():
     """View/reshape with shared name for equal-size dims (A==D, both called AD).
 
@@ -585,7 +584,6 @@ def test_view_reshape_a():
     )
 
 
-@pytest.mark.skip(reason="Issue #2961")
 def test_view_reshape_b():
     """View/reshape with all unique dim sizes.
 
@@ -846,7 +844,6 @@ def test_permuted_intermediate_then_pointwise():
     )
 
 
-@pytest.mark.skip(reason="Issue #2961")
 def test_view_reshape_a_distinct_names():
     """Like test_view_reshape_a but with distinct names A/D for the equal-size dims.
 

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -675,7 +675,19 @@ def _multi_arg_pointwise_layouts(
         }
         # Sort stick exprs for determinism
         for stick_expr in sorted(offset_free_stick_exprs, key=iter_var_id):
-            _try_stick_dim(_pick_stick_dim(stick_expr, out_coords))
+            stick_dim = _pick_stick_dim(stick_expr, out_coords)
+            # A stick expr that does not survive to any output dim
+            # (_pick_stick_dim -> -1) must NOT be handed to _try_stick_dim:
+            # _compute_dim_order(-1, ...) would append a phantom trailing dim,
+            # raising the rank by one (rank-6 -> rank-7) and tripping the C++
+            # dim_map cap in spyre_tensor_impl.cpp. These non-surviving -1s are
+            # exactly the broadcast/constant (0) stick exprs that PR #2948
+            # re-admitted by dropping the `!= 0` filter. Skip them; the
+            # alt_stick_dim fallback and the Unsupported raise below correctly
+            # handle the "no surviving candidate" case. (#2961)
+            if stick_dim == -1:
+                continue
+            _try_stick_dim(stick_dim)
 
     # Try alternative layouts if no valid layouts found
     if not results:


### PR DESCRIPTION
## Summary

Fixes the `Unsupported tensor rank: 7` compile regression tracked in #2961, which broke the **Qwen3-0.6B model E2E** (regressed 2026-06-24 → 2026-07-01) and any multi-arg pointwise graph with a non-surviving broadcast/constant operand.

The fix is a 14-line guard in `_multi_arg_pointwise_layouts` plus un-skipping the 3 tests #2948 disabled and a new active `torch.compile`-level regression test.

Closes #2961.

## The bug

The Spyre device supports a **maximum tensor rank of 6** — the C++ `dim_map` switch in `torch_spyre/csrc/spyre_tensor_impl.cpp:76` throws `Unsupported tensor rank` on anything higher. On current `main`, compiling Qwen3-0.6B fails at:

```
torch_spyre/_inductor/propagate_layouts.py:1067  propagate_spyre_tensor_layouts
torch_spyre/_inductor/propagate_layouts.py:786    compute_layouts
torch_spyre/_inductor/propagate_layouts.py:678    _multi_arg_pointwise_layouts
    _try_stick_dim(_pick_stick_dim(stick_expr, out_coords))
torch_spyre/_inductor/propagate_layouts.py:657    _try_stick_dim
E   torch._inductor.exc.InductorError: RuntimeError: Unsupported tensor rank: 7
```

## Root cause

PR #2948 ("Allow 0 as stick expression in output STL for pointwise") removed the `!= 0` filter on `stick_exprs` in `_multi_arg_pointwise_layouts`, letting **broadcast/constant operands** (whose stick expression is `0`) flow into `_pick_stick_dim`.

When such an operand **does not survive to any output dimension**, `_pick_stick_dim` returns the sentinel `-1`. That `-1` was passed straight into `_compute_dim_order(-1, size, coords)`:

```python
dim_order  = [d for d in range(len(size)) if d != stick_dim and coords[d] != 0]  # keeps ALL real dims (none == -1)
dim_order += [d for d in range(len(size)) if d != stick_dim and coords[d] == 0]
dim_order += [stick_dim]                                                         # appends a phantom -1
```

Because no real dimension index equals `-1`, the filters keep **every** real dim, and then a phantom entry is appended → `dim_order` is **one longer than the input rank** → a rank-6 layout becomes rank-7 → the C++ cap rejects it.

The #2948 author hit this at the time (commit message: *"Disable tests that trigger 7 tensors in c++ STL constructor"*) and worked around it by adding `@pytest.mark.skip(reason="Issue #2961")` to three `test_view_reshape_*` tests. Because those reproducing tests were skipped, **CI and nightly stayed green while a target model was broken.**

## The fix

Skip non-surviving (`-1`) stick dims in the multi-arg-pointwise else-branch loop, so the search falls through to valid candidates instead of synthesizing an invalid rank-7 layout:

```python
for stick_expr in sorted(offset_free_stick_exprs, key=iter_var_id):
    stick_dim = _pick_stick_dim(stick_expr, out_coords)
    # A stick expr that does not survive to any output dim (_pick_stick_dim -> -1)
    # must NOT be handed to _try_stick_dim: _compute_dim_order(-1, ...) would append
    # a phantom trailing dim, raising rank 6 -> 7 and tripping the C++ dim_map cap.
    # These non-surviving -1s are exactly the broadcast/constant (0) stick exprs that
    # PR #2948 re-admitted by dropping the `!= 0` filter. Skip them; the alt_stick_dim
    # fallback and the Unsupported raise below handle "no surviving candidate". (#2961)
    if stick_dim == -1:
        continue
    _try_stick_dim(stick_dim)
```

## Why this is the right fix

1. **Fixes the root cause, not the symptom.** The invalid state is "a non-surviving stick expr became a layout candidate." We stop it at the exact site #2948 introduced it. No rank clamp to 6, no blanket re-add of the `!= 0` filter — both would mask the problem.
2. **Preserves #2948's intent.** A broadcast/constant `0`-stick that *does* legitimately map to a real output dim still returns a `>= 0` index and is still tried as a candidate. Only the *non-surviving* ones are skipped.
3. **Doesn't touch shared helpers.** `_compute_dim_order` and the two *legitimate* `-1` sentinel paths (the `elif not stick_exprs: _try_stick_dim(-1)` all-broadcast branch and the reduction path) are left untouched — a `_compute_dim_order`-level fix was considered and rejected precisely because it would have risked those paths.
4. **Skipped candidates degrade safely.** The function already has an `alt_stick_dim` fallback loop and a clean `Unsupported` raise if nothing works — so skipping a bad candidate yields a valid layout or a *catchable* error, never an invalid rank-7 tensor deep in lowering.

## Tests

- **Un-skips** the 3 `test_view_reshape_*` tests in `tests/inductor/test_propagate_named_dims.py` that #2948 disabled with `Issue #2961`.
- **Adds** `tests/inductor/test_multi_arg_pointwise_broadcast_rank.py` — a new active `torch.compile`-level regression test encoding the minimal (model-free) repro, so this class of bug can't hide behind a skip again.

## Verification (on pod `rganti-spyre-main-hdr`)

| Check | Result |
|---|---|
| Minimal `torch.compile` repro | **PASS** → rank-6 `(1, 2, 4, 3, 5, 64)`, no error |
| 3 un-skipped `test_view_reshape_*` | **4 passed** |
| New regression test | **PASS** |
| **Qwen3-0.6B E2E** | **PASS** — load 10.2s, gen 85.0s |
| Inductor regression slice (`test_propagate_named_dims` + `test_inductor_ops`) | **1921 passed, 0 failed** |

## Note on behavior

If *every* offset-free stick expr in the else-branch resolves to `-1`, the loop now adds no results and control falls into the existing `if not results:` alt_stick_dim fallback; if that also finds nothing, a clean `Unsupported` is raised. This is the intended outcome — a catchable `Unsupported` instead of an invalid rank-7 tensor that trips the C++ cap deep in lowering.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
