### PR TITLE
fix(views): raise Unsupported when var appears in multiple Mod expressions

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -4643,8 +4643,14 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
         )
 
-    # Consider deleting — superseded by Group 10 structured tests (_flash_v4_fn)
-    @pytest.mark.skip
+    @pytest.mark.skip(
+        reason="propagate_named_dims bug: view+transpose produces index with var in two Mod "
+        "expressions that compute_coordinates cannot handle. "
+        "Root cause: find_repeat_vars skips len(mods)!=1 case silently; "
+        "compute_coordinates then produces coord=0 for num_heads dim. "
+        "Error (with PR#3034 fix): variable d2 (range 8192) appears in multiple Mod "
+        "expressions [Mod((d2//256), 32), Mod(d2, 256)] and cannot be mapped to coordinates."
+    )
     def test_hint_flash_attention_v4(self):
         """This test attempts to replicate the standalone test_granite_attn.py with views
         but the flash logic is inlined rather than relying on decompositions.py

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -254,6 +254,14 @@ def compute_coordinates(
         # compute index({var=1}) and index({var=var_ranges[var]})
         step = term.xreplace({var: 1})
         limit = term.xreplace({var: range_val})
+
+        mods_with_var = [m for m in term.atoms(sympy.Mod) if m.has(var)]
+        if len(mods_with_var) > 1:
+            raise Unsupported(
+                f"variable {var} (range {range_val}) appears in multiple Mod "
+                f"expressions {mods_with_var} and cannot be mapped to coordinates."
+            )
+
         add_term(var=var, step=step, limit=limit)
 
     # NOTE: indirect_access_subs substitution is NOT applied here. It is deferred to

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -35,6 +35,11 @@ def find_repeat_vars(index_exprs, var_ranges):
                 if m.has(var):
                     mods.append(m)
             if len(mods) != 1:
+                if len(mods) > 1:
+                    raise Unsupported(
+                        f"variable {var} (range {var_range}) appears in multiple Mod "
+                        f"expressions {mods} and cannot be mapped to coordinates."
+                    )
                 continue
             node = mods[0]
             base, modulus = node.args


### PR DESCRIPTION

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

When an index variable appears in more than one Mod expression (e.g. a view+transpose that fuses H*D into a single loop var d2, then accesses it as both Mod(d2, D) and Mod(d2//D, H)), compute_coordinates cannot correctly invert the index and silently produces 0 for the affected coordinate. 

There are now 3 instances of this error propagating downstream and creating difficult to debug crashes (sometimes in propagate_named_dims, others backend errors) so this change is needed to avoid round 4.

Two raises added:
  - `find_repeat_vars`: raises when a var appears in >1 Mod expressions instead of silently skipping it
  - `compute_coordinates`: raises in the linear path before add_term produces a wrong coordinate

Both raises produce the same clear Unsupported message identifying the variable, its range, and the conflicting Mod expressions.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

Granite passes:

```
### Instruction:
Provide a list of instructions for preparing chicken soup.

### Response:

1. Gather ingredients: 1<|end_of_text|>
```
