### PR TITLE
[test] Build tensor-spec kwargs in resolved_kwargs() so modules taking forward kwargs work

### DIFF
--- a/tests/oot_framework/oot_test_common_methods_invocations.py
+++ b/tests/oot_framework/oot_test_common_methods_invocations.py
@@ -70,13 +70,15 @@ def create_module_inputs_func_from_yaml(item: Any) -> Callable:
 
                     # Build forward inputs for this invocation
                     if hasattr(forward_spec, "build_cpu_args"):
+                        fwd_seed = None if seed is None else seed + 10000 + i * 1000
                         forward_args = forward_spec.build_cpu_args(
-                            seed=(None if seed is None else seed + 10000 + i * 1000),
+                            seed=fwd_seed,
                             op_name=item.name,
                             test_device=test_device,
                         )
                         forward_kwargs = forward_spec.resolved_kwargs(
-                            test_device=test_device
+                            test_device=test_device,
+                            seed=fwd_seed,
                         )
                     else:
                         forward_args = []
@@ -172,12 +174,15 @@ def create_module_inputs_func_from_config(config: Any) -> Callable:
             if isinstance(forward_spec, list):
                 for i, spec in enumerate(forward_spec):
                     if spec.has_inputs():
+                        fwd_seed = None if seed is None else seed + 10000 + i * 1000
                         forward_args = spec.build_cpu_args(
-                            seed=(None if seed is None else seed + 10000 + i * 1000),
+                            seed=fwd_seed,
                             op_name=module_info.name,
                             test_device=test_device,
                         )
-                        forward_kwargs = spec.resolved_kwargs(test_device=test_device)
+                        forward_kwargs = spec.resolved_kwargs(
+                            test_device=test_device, seed=fwd_seed
+                        )
                     else:
                         forward_args = []
                         forward_kwargs = {}
@@ -192,13 +197,14 @@ def create_module_inputs_func_from_config(config: Any) -> Callable:
             # Handle single forward_inputs (backward compatibility)
             else:
                 if forward_spec.has_inputs():
+                    fwd_seed = None if seed is None else seed + 10000
                     forward_args = forward_spec.build_cpu_args(
-                        seed=(None if seed is None else seed + 10000),
+                        seed=fwd_seed,
                         op_name=module_info.name,
                         test_device=test_device,
                     )
                     forward_kwargs = forward_spec.resolved_kwargs(
-                        test_device=test_device
+                        test_device=test_device, seed=fwd_seed
                     )
                 else:
                     forward_args = []

--- a/tests/oot_framework/oot_test_config_models.py
+++ b/tests/oot_framework/oot_test_config_models.py
@@ -494,10 +494,19 @@ class InputsEdits(BaseModel):
         self,
         *,
         test_device: Optional[torch.device] = None,
+        seed: Optional[int] = None,
     ) -> Dict[str, Any]:
-        """Return kwargs with dtype strings resolved to torch.dtype objects.
+        """Return kwargs with tensor specs built and dtype strings resolved.
 
-        Resolution order for each string value:
+        A kwarg value may itself be a tensor spec — a dict carrying one of
+        ``tensor`` / ``tensor_list`` / ``config_path`` / ``value`` / ``py`` — just
+        like a positional arg. Those are built into real tensors/objects here via
+        the same ``_parse_input_arg`` path used for positional args. Modules such
+        as attention/rotary layers receive ``hidden_states`` / ``position_ids`` /
+        ``position_embeddings`` as kwargs, so without this they would arrive as
+        raw dicts (``'dict' object has no attribute 'shape'``).
+
+        For plain (non-spec) string values the resolution order is:
         1. dtype alias ("float16" / "torch.float16") -> torch.dtype via DTYPE_STR_MAP
         2. device key with "cuda:*" value            -> test_device
         3. ast.literal_eval fallback                 -> Python literal (tuple, int, etc.)
@@ -507,8 +516,37 @@ class InputsEdits(BaseModel):
         """
         import ast as _ast
 
+        # Tensor-spec dicts carry exactly one of these keys; anything else is a
+        # plain scalar/dtype/device value handled by the string branch below.
+        _SPEC_KEYS = {"tensor", "tensor_list", "config_path", "py"}
+
         out: Dict[str, Any] = {}
-        for k, v in self.kwargs.items():
+        for i, (k, v) in enumerate(self.kwargs.items()):
+            # Build tensor/tensor_list/config/py specs into real objects, mirroring
+            # build_cpu_args() for positional args. Use a per-key seed offset so
+            # distinct kwargs don't share identical random data.
+            if isinstance(v, dict) and (set(v.keys()) & _SPEC_KEYS):
+                arg = _parse_input_arg(v)
+                inp_seed = None if seed is None else seed + 500000 + i * 131
+                if isinstance(arg, InputArgTensor):
+                    out[k] = arg.tensor.build(seed=inp_seed)
+                elif isinstance(arg, InputArgTensorList):
+                    out[k] = [
+                        spec.build(
+                            seed=(None if inp_seed is None else inp_seed + j * 7)
+                        )
+                        for j, spec in enumerate(arg.tensor_list)
+                    ]
+                elif isinstance(arg, InputArgConfig):
+                    import importlib
+
+                    module_path, _, cls_name = arg.config_path.rpartition(".")
+                    config_cls = getattr(importlib.import_module(module_path), cls_name)
+                    out[k] = config_cls(**arg.config_kwargs)
+                elif isinstance(arg, InputArgPy):
+                    out[k] = _eval_py_literal(arg.py)
+                continue
+
             if isinstance(v, str):
                 # 1. dtype resolution
                 bare = v.removeprefix("torch.")


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

`InputsEdits.resolved_kwargs()` only performed dtype/device/literal resolution on kwarg values. When a kwarg value was itself a **tensor spec** — a dict carrying `tensor`, `tensor_list`, `config_path`, or `py` — it was passed through **as a raw dict** and never built into an actual tensor/object.

This was asymmetric with the positional-args path: `build_cpu_args()` builds tensors from the same spec dicts (via `_parse_input_arg` → `InputTensorSpec.build()`), but `resolved_kwargs()` did not. As a result, any module/op whose forward takes tensors as **keyword arguments** (e.g. [`GraniteRotaryEmbedding`](https://github.com/torch-spyre/hf-adapters/blob/main/tests/configs/module_tests/granite_3_3_8b_instruct_spyre.yaml#L18), `GraniteAttention`, `GraniteDecoderLayer`, which take `hidden_states` / [`position_ids`](https://github.com/torch-spyre/hf-adapters/blob/main/tests/configs/module_tests/granite_3_3_8b_instruct_spyre.yaml#L35-L44) / `position_embeddings` as kwargs) received Python dicts where tensors were expected and crashed in the **CPU eager forward** with:

```
AttributeError: 'dict' object has no attribute 'shape'
```

Because this failed before any Spyre compilation, it masqueraded as a module/compiler problem when it was really a test-input construction bug.

This PR:

- **`oot_test_config_models.py`** — `resolved_kwargs()` now detects kwarg values that are tensor specs (dicts containing one of `tensor` / `tensor_list` / `config_path` / `py`) and builds them into real tensors/objects via the same `_parse_input_arg` + `InputTensorSpec.build()` path used by `build_cpu_args()`. A new optional `seed` argument is threaded through so kwarg tensors are deterministic, with a per-key seed offset so distinct kwargs don't share identical random data. Plain scalar/dtype/device/literal values keep their existing resolution behavior.
- **`oot_test_common_methods_invocations.py`** — the forward-input call sites now pass the forward seed (`seed=fwd_seed`) into `resolved_kwargs()`, matching the seed already used for `build_cpu_args()`. `seed` defaults to `None`, so all other call sites (e.g. constructor kwargs) remain unchanged and backward compatible.

#### Which issue(s) this PR is related to:

<!-- Fixes #<issue number> — link the resolved_kwargs tensor-build bug issue here -->

Fixes #3039

#### Special notes for your reviewer:

- The `seed` parameter on `resolved_kwargs()` is optional (defaults to `None`), so existing callers that don't pass it are unaffected; only the forward-input call sites were updated to propagate it.
- Config-object kwargs (`config_path`) and `py` literals are also built now, not just tensors — consistent with the positional-args path.
- Scope is limited to the two files listed; no YAML configs are modified.

#### Does this PR introduce a user-facing change?

#### Additional note:

`resolved_kwargs()` now mirrors `build_cpu_args()`, removing the positional-vs-keyword asymmetry in how forward inputs are constructed.
