### PR TITLE
Enforce clone layout when called directly from a custom lowering

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -5457,6 +5457,56 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         # for bool tensors.  Disable eager mode for all dtypes.
         self.compare_with_cpu(lambda a: torch.clone(a).contiguous(), x, run_eager=False)
 
+    def test_clone_lowering(self):
+        """Calling the Spyre clone lowering directly (no aten.clone FX node)
+        must still yield clone's standard row-major layout, matching a real
+        aten.clone on the same input.
+        """
+        from torch_spyre._inductor.lowering import (
+            clone as spyre_clone_lowering,
+            register_spyre_lowering,
+            spyre_lowerings,
+        )
+        import torch._inductor.lowering as inductor_lowering
+        from torch._inductor.utils import fresh_cache
+
+        lib = torch.library.Library("spyre_test", "FRAGMENT")  # noqa: TOR901
+        lib.define("clone_identity(Tensor x) -> Tensor")
+        op = torch.ops.spyre_test.clone_identity.default
+        lib.impl("clone_identity", lambda x: x.clone(), "CPU")
+        lib.impl("clone_identity", lambda x: torch.empty_like(x), "Meta")
+
+        @register_spyre_lowering(op, type_promotion_kind=None)
+        def _lower_clone_identity(x):
+            return spyre_clone_lowering(x)
+
+        def fn(a):
+            return torch.ops.spyre_test.clone_identity(a.permute(1, 0))
+
+        def ref_fn(a):
+            return a.permute(1, 0).clone()
+
+        try:
+            x_cpu = cached_randn((128, 192))
+            expected = fn(x_cpu)
+
+            # fresh_cache() prevents a cached graph from masking a regression.
+            with fresh_cache():
+                out = torch.compile(fn, backend="inductor")(x_cpu.to("spyre"))
+                ref = torch.compile(ref_fn, backend="inductor")(x_cpu.to("spyre"))
+
+            torch.testing.assert_close(out.cpu(), expected, atol=1e-3, rtol=1e-3)
+
+            out_layout = out.device_tensor_layout()
+            ref_layout = ref.device_tensor_layout()
+            self.assertIsNotNone(out_layout)
+            self.assertEqual(list(out_layout.device_size), list(ref_layout.device_size))
+            self.assertEqual(list(out_layout.stride_map), list(ref_layout.stride_map))
+        finally:
+            spyre_lowerings.pop(op, None)
+            inductor_lowering.lowerings.pop(op, None)
+            lib._destroy()
+
     def test_permute(self, input_dims, dims):
         self.compare_with_cpu(
             lambda input: torch.permute(input, dims),

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -35,6 +35,7 @@ from torch_spyre.ops.fallbacks import fallback_ops
 from .ir import SpyreReduction, SpyreConstantFallback, SpyreEmptyFallback
 from torch_spyre._C import get_elem_in_stick
 from torch._inductor.virtualized import V
+from torch.utils._ordered_set import OrderedSet
 from .errors import Unsupported
 import threading
 from .logging_utils import get_inductor_logger
@@ -250,6 +251,35 @@ def ensure_default_handler(op_name):
 def eager_fallback(op, *args, **kwargs):
     handler = lowering.fallback_handler(op, add_to_fallback_set=False)
     return handler(*args, **kwargs)
+
+
+def _ensure_synthetic_origin(result, target, args: tuple) -> None:
+    """Give a lowering result a synthetic ``target`` origin FX node, so Spyre
+    layout passes (which key off ``op.data.origins[].target``) recognize it even
+    when the lowering was called directly, without an FX node of its own. No-op
+    if a ``target`` origin already exists.
+    """
+
+    def _realized_buffer(node):
+        while not isinstance(node, StorageBox):
+            node = node.data
+        return node.data
+
+    origins = getattr(_realized_buffer(result), "origins", None)
+    if origins and any(o.target == target for o in origins):
+        return
+
+    fx_graph = V.graph.graph
+    first_compute_node = next(n for n in fx_graph.nodes if n.op != "placeholder")
+    with fx_graph.inserting_before(first_compute_node):
+        fx_node = fx_graph.create_node("call_function", target, args)
+
+    # Realize so the origin lands on a stable ComputedBuffer, not a Pointwise.
+    result.realize()
+    buf = _realized_buffer(result)
+    # buf.data is a frozen Loops; override its origins via object.__setattr__.
+    object.__setattr__(buf.data, "origins", OrderedSet([fx_node]))
+    buf.origins = OrderedSet([fx_node])
 
 
 # TODO:This is just place holder now; Real implementation will follow
@@ -756,10 +786,16 @@ def lower_clamp(x, min=None, max=None):
 
 @register_spyre_lowering(torch.ops.aten.clone.default, type_promotion_kind=None)
 def clone(x, *, memory_format=None):
-    from torch._inductor.ir import FlexibleLayout, get_stride_order
-    from torch._inductor.lowering import clone as clone_lowering
+    result = lowering.clone(x, memory_format=memory_format)
 
-    result = clone_lowering(x, memory_format=memory_format)
+    # A clone called directly from another lowering has no aten.clone FX node,
+    # so it inherits the caller's origin and the layout pass skips clone's
+    # layout propagation enforcement. Inject a synthetic clone origin so it fires.
+    args: tuple = ()
+    if isinstance(x, ir.IRNode) and (n := x.get_origin_node()) is not None:
+        args = (n,)
+    _ensure_synthetic_origin(result, torch.ops.aten.clone.default, args)
+
     # Upstream Inductor ignores memory_format (TODO in clone lowering).
     # The output gets a FlexibleLayout whose stride order is inferred from
     # the input's strides via ComputedBuffer.get_fill_order(). When the
@@ -769,8 +805,8 @@ def clone(x, *, memory_format=None):
     # Fix: freeze the layout to the requested stride order so that
     # decide_layout() respects the memory_format contract.
     if memory_format is not None and memory_format != torch.preserve_format:
-        stride_order = get_stride_order(
-            FlexibleLayout.stride_ordered_for_memory_format(
+        stride_order = ir.get_stride_order(
+            ir.FlexibleLayout.stride_ordered_for_memory_format(
                 result.get_size(), memory_format
             )
         )
@@ -1018,7 +1054,7 @@ def lower_constant_pad_nd(input, pad, value=0, align_to_stick=False):
         offsets.append(pad_left)
 
     if not dims:
-        return clone(cropped_input)
+        return lowering.clone(cropped_input)
 
     dtype = input.get_dtype()
     device = input.get_device()
@@ -1073,7 +1109,7 @@ def to_dtype(x, dst_dtype):
     src_dtype = x.get_dtype()
 
     if src_dtype == dst_dtype:
-        return clone(x)
+        return lowering.clone(x)
 
     # Check if conversion is supported by backend
     if DtypeOpTable.get_operator(src_dtype, dst_dtype) is None:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

The `aten.clone` lowering relies on the layout propagation pass (`propagate_layouts.py`) to enforce clone's standard row-major (generic stick) device layout. That pass recognizes a clone by its origin FX node's target (`aten.clone.default`).

This works for ordinary PyTorch programs and for fx-graph-devel custom decompositions, where a real `aten.clone` FX node drives the lowering. But when the clone lowering is called **directly from another custom lowering**, there is no `aten.clone` FX node: the result inherits the *caller's* origin, so the layout pass never treats it as a clone and the row-major contract is silently dropped.

This PR:

- Injects a synthetic `aten.clone.default` origin FX node when the clone lowering runs without one, so the layout pass fires regardless of how the lowering was reached (same technique as `lower_pad_sequence`).
- Routes the two pure-copy nested callers (`constant_pad_nd` with no padding, `to_dtype` with matching dtype) to the upstream clone lowering, since they must not acquire clone's contract.
- Adds `test_clone_lowering` covering the direct-call path.


#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

The test uses `fresh_cache()` to isolate its two compiles from the on-disk Inductor cache; without it a cached graph would mask a regression in the layout comparison. Verified as a real guard: it fails without the fix (`device_size [3, 128, 64]` vs the correct `[2, 192, 64]`) and passes with it.


#### Does this PR introduce a user-facing change?

No.

#### Additional note:

No new custom lowering currently calls the Spyre `clone` directly (the two former callers were rerouted to upstream clone), so `_ensure_synthetic_origin` is a safety net for future direct callers, covered by the new test.
