### PR TITLE
Dist: Use SetSpyreDeviceAddressBorrowed for CompositeAddr

### DIFF
--- a/torch_spyre/csrc/distributed/spyre_ccl.cpp
+++ b/torch_spyre/csrc/distributed/spyre_ccl.cpp
@@ -348,10 +348,12 @@ void SpyreCCLBackend::prepare_tensor(const at::Tensor& input_tensor,
   spyre_comms::TensorInfo tensor_info = getTensorInfo(input_tensor);
   *output_tensor =
       spyre_comms::Tensor(tensor_info, input_tensor.storage().data_ptr().get());
-  // Update the data pointer on the object since it was eagerly allocated
+  // Update the data pointer on the object since it was eagerly allocated.
+  // composite_addr is a member of SharedOwnerCtx which is owned by the tensor's
+  // DataPtr; use the borrowing setter so spyre-comms never tries to delete it.
   auto* ctx = static_cast<spyre::SharedOwnerCtx*>(
       input_tensor.storage().data_ptr().get_context());
-  output_tensor->SetSpyreDeviceAddress(&ctx->composite_addr);
+  output_tensor->SetSpyreDeviceAddressBorrowed(&ctx->composite_addr);
 }
 
 /**


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Spyre Comms prefers to use a shared pointer to the CompositeAddress internally. An API change in Spyre Comms to accommodate this inadvertently caused the memory to be freed once Spyre Comms was done instead of allowing Torch Spyre to continue to manage the lifecycle of the CompositeAddress.

#### Which issue(s) this PR is related to:

No issue was filed, but CI/CD raised the issue.

#### Special notes for your reviewer:

Requires a Spyre Comms fix to make its way into the CI/CD image.

#### Does this PR introduce a user-facing change?

No.

#### Additional note:
