### PR TITLE
Fix stale view indexing for per-tile coarse-tiled scratch buffers

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -86,6 +86,7 @@ from torch_spyre._inductor.spyre_kernel import (
     _codegen_op_spec_list,
     _iter_op_specs,
     _preserve_shared_weight_unit_bmm_dim,
+    _retile_per_tile_view_index,
 )
 from torch_spyre._inductor.temp_passes import (
     _mark_static_unit_batch_bmm,
@@ -448,6 +449,50 @@ class TestCoarseTileInfo(unittest.TestCase):
         self.assertEqual(info.loop_group_id, (0, 0))
         self.assertEqual(info.loop_count, [Integer(4), Integer(2)])
         self.assertEqual(info.loop_tiled_dims, [[0], [1]])
+
+
+class TestRetilePerTileViewIndex(unittest.TestCase):
+    def _layout(self):
+        return SimpleNamespace(
+            size=[1, 4, 512],
+            stride=[2048, 512, 1],
+            per_tile_fixed=True,
+        )
+
+    def _node(self):
+        return SimpleNamespace(
+            name="buf",
+            loop_info=CoarseTileInfo(
+                loop_group_id=(0,),
+                loop_count=[Integer(4)],
+                loop_tiled_dims=[[2]],
+            ),
+        )
+
+    def test_rewrites_full_stride_to_tile_stride(self):
+        c0, c1 = sympy.symbols("c0 c1")
+
+        result = _retile_per_tile_view_index(
+            2048 * c0 + c1,
+            self._layout(),
+            self._node(),
+            {c0: Integer(4), c1: Integer(512)},
+        )
+
+        self.assertEqual(simplify(result - (512 * c0 + c1)), 0)
+
+    def test_mixed_loop_variable_terms_are_not_rewritten(self):
+        c0, c1, c2 = sympy.symbols("c0 c1 c2")
+        index = c0 * c1 + 128 * c0 + c2
+
+        result = _retile_per_tile_view_index(
+            index,
+            self._layout(),
+            self._node(),
+            {c0: Integer(4), c1: Integer(512), c2: Integer(128)},
+        )
+
+        self.assertEqual(simplify(result - index), 0)
 
 
 # ===========================================================================

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -79,6 +79,92 @@ class TensorAccess(RValue):
     layout: FixedTiledLayout
 
 
+def _retile_per_tile_view_index(
+    index: sympy.Expr,
+    layout: FixedTiledLayout,
+    ir_node: Any,
+    it_space: dict[sympy.Symbol, sympy.Expr],
+) -> sympy.Expr:
+    """Repair full-stride view indexes after output-dim coarse tiling.
+
+    A ReinterpretView over a buffer can keep the original full-tensor host
+    strides even after coarse tiling shrinks the underlying scratch buffer.
+    When the load reaches this backend, the base layout is already per-tile
+    sized, so convert coefficients that still match the pre-tile stride back
+    to the current per-tile stride.
+    """
+    if not getattr(layout, "per_tile_fixed", False):
+        return index
+
+    loop_info = getattr(ir_node, "loop_info", None)
+    if loop_info is None:
+        return index
+
+    tiled_counts: dict[int, sympy.Expr] = {}
+    for count, dims in zip(loop_info.loop_count, loop_info.loop_tiled_dims):
+        for dim in dims:
+            if 0 <= dim < len(layout.size):
+                tiled_counts[dim] = tiled_counts.get(dim, sympy.S.One) * count
+
+    if not tiled_counts:
+        return index
+
+    loop_vars = index.free_symbols.intersection(it_space.keys())
+    if not loop_vars:
+        return index
+
+    replacements = {var: sympy.S.Zero for var in loop_vars}
+    offset = index.xreplace(replacements)
+    adjusted_index = offset
+    changed = False
+
+    for var in sorted(loop_vars, key=str):
+        other_vars = {other: sympy.S.Zero for other in loop_vars if other != var}
+        term = sympy.expand(index.xreplace(other_vars) - offset)
+        coeff = term.coeff(var)
+        remainder = sympy.simplify(term - coeff * var)
+        if remainder != 0:
+            adjusted_index += term
+            continue
+
+        var_range = concretize_expr(it_space[var])
+        candidates: list[sympy.Expr] = []
+        for host_dim, (size, stride) in enumerate(zip(layout.size, layout.stride)):
+            if concretize_expr(size) != var_range:
+                continue
+
+            factor = sympy.S.One
+            for tiled_dim, count in tiled_counts.items():
+                if tiled_dim > host_dim:
+                    factor *= count
+
+            if factor == 1:
+                continue
+
+            expected_full_stride = sympy.simplify(stride * factor)
+            if sympy.simplify(coeff - expected_full_stride) == 0:
+                candidates.append(stride)
+
+        if len(candidates) == 1:
+            adjusted_index += candidates[0] * var
+            changed = True
+        else:
+            adjusted_index += term
+
+    if changed:
+        logger.debug(
+            "retile_per_tile_view_index: node=%s size=%s stride=%s %s -> %s",
+            getattr(ir_node, "name", None),
+            list(layout.size),
+            list(layout.stride),
+            index,
+            adjusted_index,
+        )
+        return sympy.simplify(adjusted_index)
+
+    return index
+
+
 def _preserve_shared_weight_unit_bmm_dim(
     op: str,
     it_space: dict[sympy.Symbol, tuple[sympy.Expr, int]],
@@ -706,6 +792,9 @@ class SpyreKernel(Kernel[CSEVariable]):
                 f"device_size={list(layout.device_layout.device_size)}"
             )
 
+        index = _retile_per_tile_view_index(
+            index, layout, self.current_node.node, iteration_space(self.current_node)
+        )
         return TensorAccess(name, index, layout)
 
     def store(

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -115,17 +115,39 @@ def _retile_per_tile_view_index(
 
     replacements = {var: sympy.S.Zero for var in loop_vars}
     offset = index.xreplace(replacements)
+    projection_terms: dict[sympy.Symbol, sympy.Expr] = {}
+    for var in sorted(loop_vars, key=str):
+        other_vars = {other: sympy.S.Zero for other in loop_vars if other != var}
+        projection_terms[var] = sympy.expand(index.xreplace(other_vars) - offset)
+
+    residual = sympy.simplify(index - offset - sum(projection_terms.values()))
+    if residual != 0:
+        logger.warning(
+            "retile_per_tile_view_index: refusing rewrite for node=%s index=%s "
+            "because it has mixed loop-variable residual %s",
+            getattr(ir_node, "name", None),
+            index,
+            residual,
+        )
+        return index
+
     adjusted_index = offset
     changed = False
 
     for var in sorted(loop_vars, key=str):
-        other_vars = {other: sympy.S.Zero for other in loop_vars if other != var}
-        term = sympy.expand(index.xreplace(other_vars) - offset)
+        term = projection_terms[var]
         coeff = term.coeff(var)
         remainder = sympy.simplify(term - coeff * var)
         if remainder != 0:
-            adjusted_index += term
-            continue
+            logger.warning(
+                "retile_per_tile_view_index: refusing rewrite for node=%s index=%s "
+                "because projection for %s is non-affine: %s",
+                getattr(ir_node, "name", None),
+                index,
+                var,
+                term,
+            )
+            return index
 
         var_range = concretize_expr(it_space[var])
         candidates: list[sympy.Expr] = []


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR fixes a correctness/layout issue when coarse tiling is applied along an output dimension and an inside-loop view, such as `unsqueeze`, reads from a retiled scratch buffer.

In the failing flash-attention-style repro, coarse tiling correctly shrinks sparse intermediates from the full `Lq` extent to the per-tile extent, e.g.

```text
[1, 4, 2048] -> [1, 4, 512]
```

However, a `ReinterpretView` created by `unsqueeze` can still emit an index using the original full-tensor stride:

```text
2048*c0 + c1
```

When that stale index is interpreted against the retiled per-tile buffer layout, `compute_coordinates()` maps the full-stride factor into an extra device dimension. For `Lq=2048` and `q_block_size=512`, the generated wrapper previously contained:

```python
device_size=[1, 512, 4, 4, 64]
```

The extra `4` is the number of `Lq` tiles, not a real tensor dimension. The same issue appears as an extra `2` for `Lq=1024`, `q_block_size=512`.

This PR repairs the load index in `SpyreKernel.load()` for per-tile scratch buffers: if the load index coefficient still matches a pre-coarse-tiling full stride, it is rewritten back to the current per-tile stride before device-coordinate conversion.

Example repairs observed in debug logs:

```text
2048*c0 + c1 -> 512*c0 + c1
1024*c0 + c1 -> 512*c0 + c1
```

After the fix, the generated wrapper uses the expected device sizes:

```python
device_size=[1, 512, 4, 64]
device_size=[1, 512, 32, 64]
```

instead of:

```python
device_size=[1, 512, 4, 4, 64]
device_size=[1, 512, 32, 2, 64]
```
Generated wrapper artifacts were inspected to confirm the bad extra tile-count dimension is gone.

#### Which issue(s) this PR is related to:

Fixes #3003 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No

#### Additional note:
