### PR TITLE
Merge bundle_hbm_symbols and bundle_symbolic_args

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1603,7 +1603,7 @@ class TestCompileOpSpecSymbolMapping(unittest.TestCase):
         loop = LoopSpec(count=Integer(4), body=[op_spec])
         tmpdir = tempfile.mkdtemp()
         generate_bundle(
-            "test_kernel", tmpdir, [loop], unroll_loops=False, symbolic_args=True
+            "test_kernel", tmpdir, [loop], unroll_loops=False, use_symbols=True
         )
 
         with open(os.path.join(tmpdir, "bundle.mlir")) as f:
@@ -1935,7 +1935,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
                 self.tmpdir,
                 specs,
                 unroll_loops=False,
-                symbolic_args=True,
+                use_symbols=True,
             )
         return _read_mlir(self.tmpdir)
 
@@ -2064,7 +2064,7 @@ class TestGenerateBundleNestedTiling(unittest.TestCase):
                 self.tmpdir,
                 specs,
                 unroll_loops=False,
-                symbolic_args=True,
+                use_symbols=True,
             )
         return _read_mlir(self.tmpdir)
 
@@ -2177,7 +2177,7 @@ class TestGenerateBundleUnrollPath(unittest.TestCase):
                 self.tmpdir,
                 specs,
                 unroll_loops=False,
-                symbolic_args=True,
+                use_symbols=True,
             )
         return _read_mlir(self.tmpdir)
 
@@ -2998,7 +2998,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
 
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
-    def _bundle(self, specs, symbolic_args=False, fake_compile=None):
+    def _bundle(self, specs, use_symbols=False, fake_compile=None):
         if fake_compile is None:
             fake_compile = _fake_compile_op_spec
         with patch(
@@ -3010,7 +3010,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 self.tmpdir,
                 specs,
                 unroll_loops=False,
-                symbolic_args=symbolic_args,
+                use_symbols=use_symbols,
             )
         return _read_mlir(self.tmpdir)
 
@@ -3038,7 +3038,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
 
     def test_signature_accepts_symbolic_args_param(self):
         a = _make_minimal_op_spec("a")
-        mlir = self._bundle([a], symbolic_args=False)
+        mlir = self._bundle([a], use_symbols=False)
         self.assertIn("sdsc_execute", mlir)
 
     def test_func_signature_has_params_for_tensor_args(self):
@@ -3075,7 +3075,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 [SymbolKind.kernel(arg.arg_index) for arg in op_spec.args],
             )
 
-        mlir = self._bundle([a], symbolic_args=True, fake_compile=fake)
+        mlir = self._bundle([a], use_symbols=True, fake_compile=fake)
 
         self.assertIn(
             "func.func @sdsc_bundle("
@@ -3109,7 +3109,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 [SymbolKind.kernel(0)],
             )
 
-        mlir = self._bundle([a], symbolic_args=True, fake_compile=fake)
+        mlir = self._bundle([a], use_symbols=True, fake_compile=fake)
 
         self.assertIn("sdscbundle.sdsc_execute (%arg_0)", mlir)
         self.assertNotIn("sdsc_execute (%sym_0_1)", mlir)
@@ -3148,7 +3148,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
             )  # op_b has pool allocation
             return _make_tiled_json(idx, sym_id), [values[i]], [{}], [kind]
 
-        mlir = self._bundle([op_a, op_b], symbolic_args=True, fake_compile=fake)
+        mlir = self._bundle([op_a, op_b], use_symbols=True, fake_compile=fake)
 
         # First sym → parameter (kernel tensor arg)
         self.assertIn("%arg_0_base_addr: !sdscbundle.input_arg<index>", mlir)
@@ -3159,9 +3159,9 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
 
     def test_symbolic_args_false_no_params(self):
         a = self._make_op_spec_with_hbm_args("a", [0])
-        # When symbolic_args=False, use_symbols=False: no symbols registered,
+        # When use_symbols=False: no symbols registered,
         # sdsc_execute has no operands.
-        mlir = self._bundle([a], symbolic_args=False)
+        mlir = self._bundle([a], use_symbols=False)
         self.assertIn("func.func @sdsc_bundle()", mlir)
         self.assertNotIn("input_arg", mlir)
         self.assertNotIn("%sym_", mlir)
@@ -3218,7 +3218,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
             kinds = [SymbolKind.kernel(0), SymbolKind.kernel(1)]
             return json_out, [a0, a1], [{}, {}], kinds
 
-        mlir = self._bundle([op0] + ops_rest, symbolic_args=True, fake_compile=fake)
+        mlir = self._bundle([op0] + ops_rest, use_symbols=True, fake_compile=fake)
 
         # 10 symbols across 5 SDSCs but only 2 unique arg_indices → 2 params
         self.assertIn("%arg_0_base_addr: !sdscbundle.input_arg<index>", mlir)
@@ -3242,7 +3242,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
             symbols.append(base)
             return _make_tiled_json(idx, sym_id), [base], [{}], [SymbolKind.kernel(0)]
 
-        mlir = self._bundle([a, b], symbolic_args=True, fake_compile=fake)
+        mlir = self._bundle([a, b], use_symbols=True, fake_compile=fake)
 
         # Only one input_arg param (deduped cross-SDSC)
         self.assertIn("%arg_0_base_addr: !sdscbundle.input_arg<index>", mlir)
@@ -3278,7 +3278,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 [SymbolKind.kernel(0)],
             )
 
-        mlir = self._bundle([a, b], symbolic_args=True, fake_compile=fake)
+        mlir = self._bundle([a, b], use_symbols=True, fake_compile=fake)
 
         # Only one input_arg param — no duplicate %arg_0_base_addr
         self.assertEqual(
@@ -3314,7 +3314,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 [SymbolKind.pool()],
             )
 
-        mlir = self._bundle([a, b, c], symbolic_args=True, fake_compile=fake)
+        mlir = self._bundle([a, b, c], use_symbols=True, fake_compile=fake)
 
         # Exactly two arith.constant / arith.addi pairs (offsets 0 and 2048)
         self.assertEqual(mlir.count("arith.constant 0 : index"), 1)
@@ -3457,7 +3457,7 @@ class TestSymbolKind(unittest.TestCase):
                 self.tmpdir,
                 [a, b],
                 unroll_loops=False,
-                symbolic_args=True,
+                use_symbols=True,
             )
         mlir = _read_mlir(self.tmpdir)
 

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -68,7 +68,7 @@ def generate_bundle(
     ``use_symbols`` controls whether HBM tensor addresses are emitted as
     runtime symbols (``%sym_N`` constants) in ``bundle.mlir``.
     When ``None`` (the default) the value is
-    read from ``config.bundle_hbm_symbols``.
+    read from ``config.bundle_symbolic_args``.
 
     ``unroll_loops`` controls whether ``LoopSpec`` nodes are fully unrolled
     into flat ``OpSpec`` nodes before bundle generation.  When ``None`` (the

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -59,7 +59,6 @@ def generate_bundle(
     specs: Sequence,
     use_symbols: bool | None = None,
     unroll_loops: bool | None = None,
-    symbolic_args: bool | None = None,
 ):
     """Output the SDSC Bundle for the OpSpecs in output_dir.
 
@@ -67,8 +66,8 @@ def generate_bundle(
     entries are supported).
 
     ``use_symbols`` controls whether HBM tensor addresses are emitted as
-    runtime symbols (``%sym_N`` constants) in ``bundle.mlir`` with
-    ``affine.apply`` indirection.  When ``None`` (the default) the value is
+    runtime symbols (``%sym_N`` constants) in ``bundle.mlir``.
+    When ``None`` (the default) the value is
     read from ``config.bundle_hbm_symbols``.
 
     ``unroll_loops`` controls whether ``LoopSpec`` nodes are fully unrolled
@@ -81,22 +80,11 @@ def generate_bundle(
     independent ``OpSpec`` with concrete per-iteration HBM addresses baked in.
     When ``unroll_loops=False``, ``LoopSpec`` entries are passed through intact
     and produce ``scf.for`` loops in the generated ``bundle.mlir``.
-
-    ``symbolic_args`` controls the function signature of ``@sdsc_bundle``.
-    When ``False`` (non-default override), ``sdsc_execute`` has no operands.
-    When ``True``, addresses are emitted as ``!sdscbundle.input_arg<index>``
-    parameters; this also forces ``use_symbols=True`` implicitly.  When
-    ``None``, the value is read from ``config.bundle_symbolic_args``.
     """
     if use_symbols is None:
-        use_symbols = _spyre_config.bundle_hbm_symbols
+        use_symbols = _spyre_config.bundle_symbolic_args
     if unroll_loops is None:
         unroll_loops = _spyre_config.unroll_loops
-    if symbolic_args is None:
-        symbolic_args = _spyre_config.bundle_symbolic_args
-    # symbolic_args requires symbol emission — if it is set, ensure use_symbols is too.
-    if symbolic_args:
-        use_symbols = True
 
     specs_list: list = unroll_loop_specs(list(specs)) if unroll_loops else list(specs)
 
@@ -150,14 +138,14 @@ def generate_bundle(
     compiled_iter = iter(compiled)
     addr_counter = [0]
 
-    # Build a per-symbol kind list from compiled entries (symbolic_args path only).
+    # Build a per-symbol kind list from compiled entries (use_symbols path only).
     symbol_kinds: list[SymbolKind] = []
-    if symbolic_args and use_symbols:
+    if use_symbols:
         for _, _, _, local_kinds in compiled:
             symbol_kinds.extend(local_kinds)
 
     # Determine whether a pool parameter is needed (any pool symbol present).
-    has_pool = symbolic_args and use_symbols and any(sk.is_pool for sk in symbol_kinds)
+    has_pool = use_symbols and any(sk.is_pool for sk in symbol_kinds)
     # Indices of kernel-base symbols that become input_arg parameters.
     # Deduplicated by arg_index: multiple SDSCs operating on different slices of
     # the same logical tensor arg share one function parameter (the first-seen
@@ -168,7 +156,7 @@ def generate_bundle(
     # kernel_dup_canonical: maps duplicate kernel sym_idx → canonical sym_idx.
     kernel_arg_sym_indices: list[int] = []
     kernel_dup_canonical: dict[int, int] = {}  # duplicate sym_idx → canonical sym_idx
-    if symbolic_args and use_symbols:
+    if use_symbols:
         seen_kernel_arg_index: dict[int, int] = {}  # arg_index → canonical sym_idx
         for i, kind_i in enumerate(symbol_kinds):
             if kind_i.kind == "kernel":
@@ -196,12 +184,12 @@ def generate_bundle(
 
         f.write("module {\n")
 
-        # Function signature when symbolic_args is active:
+        # Function signature when use_symbols is active:
         #   - optional leading %pool_base_addr param for pool-allocated tensors
         #   - one !sdscbundle.input_arg<index> param per kernel tensor arg, with a
         #     descriptive formal name %arg_{arg_index}_base_addr; the short form
         #     %arg_{arg_index} is used in the body after input_arg_extract
-        if symbolic_args and use_symbols and (has_pool or kernel_arg_sym_indices):
+        if use_symbols and (has_pool or kernel_arg_sym_indices):
             params = []
             if has_pool:
                 params.append("%pool_base_addr: !sdscbundle.input_arg<index>")
@@ -230,7 +218,7 @@ def generate_bundle(
             for lb_idx, lb in enumerate(loop_bounds):
                 f.write(f"\t\t%loop_bound_{lb_idx} = {_mlir_count_value(lb)}\n")
 
-        # Emit one declaration per symbol (symbolic_args path):
+        # Emit one declaration per symbol (use_symbols path):
         #   - "kernel"          → skipped; already a function param + extract op above
         #   - "kernel_slice"    → arith.addi %arg_{arg_index}, <slice_offset_bytes>
         #                         deduped by (arg_index, slice_offset) pair;
@@ -350,7 +338,6 @@ def generate_bundle(
             f,
             indent=2,
             use_symbols=use_symbols,
-            symbolic_args=symbolic_args,
             kernel_sym_to_arg_idx=kernel_sym_to_arg_idx,
             sym_canonical=sym_canonical,
         )
@@ -513,7 +500,6 @@ def _emit_specs(
     f,
     indent: int,
     use_symbols: bool = False,
-    symbolic_args: bool = False,
     kernel_sym_to_arg_idx: dict | None = None,
     sym_canonical: dict | None = None,
 ) -> None:
@@ -532,7 +518,7 @@ def _emit_specs(
     def _resolve_sym(sid: int) -> str:
         # sid is a negative symbol ID; abs(sid)-1 is the 0-based index into symbols[].
         sym_idx = abs(sid) - 1
-        if symbolic_args:
+        if use_symbols:
             if sym_idx in kernel_arg_sym_to_name:
                 return kernel_arg_sym_to_name[sym_idx]
             if sym_idx in sym_canonical:
@@ -560,7 +546,6 @@ def _emit_specs(
                 f,
                 indent + 1,
                 use_symbols=use_symbols,
-                symbolic_args=symbolic_args,
                 kernel_sym_to_arg_idx=kernel_sym_to_arg_idx,
                 sym_canonical=sym_canonical,
             )

--- a/torch_spyre/_inductor/codegen/unroll.py
+++ b/torch_spyre/_inductor/codegen/unroll.py
@@ -14,9 +14,11 @@
 
 """Loop unrolling for coarse-tiling LoopSpec trees.
 
-When ``bundle_hbm_symbols=False`` the backend compiler does not support
-``scf.for`` loops in ``bundle.mlir``.  This module provides
-``unroll_loop_specs``, which fully unrolls a ``list[OpSpec | LoopSpec]`` tree
+This module implements full loop unrolling to enable exeuction
+of programs containing ``LoopSpec`` nodes while the backend compiler support
+for  ``scf.for`` loops in ``bundle.mlir`` is under development.
+
+When ``unroll_loop_specs`` a ``list[OpSpec | LoopSpec]`` tree will be fully unrolled
 into a flat list of ``OpSpec`` entries with concrete per-iteration addresses
 baked into each ``TensorArg.allocation`` derived from ``device_coordinates``
 and ``device_size`` — so args with different tile sizes or layouts each get

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -78,18 +78,11 @@ core_id_k_fast_emission: bool = (
     os.environ.get("SPYRE_CORE_ID_K_FAST_EMISSION", "1") == "1"
 )
 
-# When True, HBM tensor addresses are emitted as runtime symbols (%sym_N
-# constants) in bundle.mlir.
-# Requires backend compiler support for the sdscbundle symbol table.
-# Independent of bundle_symbolic_args: you can have symbols in the SDSC JSON
-# without exposing them as function arguments (staged adoption).
-bundle_hbm_symbols: bool = os.environ.get("BUNDLE_HBM_SYMBOLS", "1") == "1"
-
+# When True (default), HBM tensor addresses are emitted as runtime symbols
+# with !sdscbundle.input_arg<index> parameters and input_arg_extract ops
+# in the bundle.mlir.
 # When False, HBM tensor addresses are baked as concrete integers
 # into the SDSC JSON and bundle.mlir emits sdsc_execute with no operands.
-# When True, addresses are emitted as runtime symbols with
-# !sdscbundle.input_arg<index> parameters and input_arg_extract ops.
-# Requires bundle_hbm_symbols=True to have any effect.
 bundle_symbolic_args: bool = os.environ.get("BUNDLE_SYMBOLIC_ARGS", "1") == "1"
 
 # When True (default), LoopSpec nodes are fully unrolled into flat OpSpecs


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Merges the two configs/envvars that were used for staged adoption of symbolic arguments into a single config/envvar and consolidates conditional tests in SDSC codegen accordingly.

#### Which issue(s) this PR is related to:

Fixes #3036.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

It eliminates the temporary "fake symbol" codegen configuration of `BUNDLE_HBM_SYMBOLS=1` and 
`"BUNDLE_SYMBOLIC_ARGS=0`.  This was never intended for long term usage, so user impact is minimal.

Compiling with no symbols is still possible via `"BUNDLE_SYMBOLIC_ARGS=0`.  If set, the old `BUNDLE_HBM_SYMBOLS`
envar will simply be ignored (and the config where BSA was 1 and BHS was 0 was always invalid).

#### Additional note:
