### PR TITLE
Updating the SDSC Bundle Directory Name to Avoid Truncation

### DIFF
--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -17,8 +17,7 @@ from collections.abc import Sequence
 import os
 import subprocess
 import torch
-import hashlib
-import time
+import uuid
 
 from torch._inductor.async_compile import AsyncCompile
 from torch._inductor.runtime.runtime_utils import cache_dir
@@ -38,7 +37,7 @@ logger = get_inductor_logger("sdsc_compile")
 def get_output_dir(kernel_name: str):
     spyre_dir = os.path.join(cache_dir(), "inductor-spyre")
     os.makedirs(spyre_dir, exist_ok=True)
-    digest = hashlib.sha1(str(time.time_ns()).encode()).hexdigest()[:8]
+    digest = uuid.uuid4().hex[:8]
     kernel_output_dir = tempfile.mkdtemp(
         dir=spyre_dir, prefix=f"{digest}_{kernel_name}_"
     )

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -39,7 +39,9 @@ def get_output_dir(kernel_name: str):
     spyre_dir = os.path.join(cache_dir(), "inductor-spyre")
     os.makedirs(spyre_dir, exist_ok=True)
     digest = hashlib.sha1(str(time.time_ns()).encode()).hexdigest()[:8]
-    kernel_output_dir = tempfile.mkdtemp(dir=spyre_dir, prefix=f"{digest}_{kernel_name}_")
+    kernel_output_dir = tempfile.mkdtemp(
+        dir=spyre_dir, prefix=f"{digest}_{kernel_name}_"
+    )
     return kernel_output_dir
 
 

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -17,6 +17,8 @@ from collections.abc import Sequence
 import os
 import subprocess
 import torch
+import hashlib
+import time
 
 from torch._inductor.async_compile import AsyncCompile
 from torch._inductor.runtime.runtime_utils import cache_dir
@@ -36,7 +38,8 @@ logger = get_inductor_logger("sdsc_compile")
 def get_output_dir(kernel_name: str):
     spyre_dir = os.path.join(cache_dir(), "inductor-spyre")
     os.makedirs(spyre_dir, exist_ok=True)
-    kernel_output_dir = tempfile.mkdtemp(dir=spyre_dir, prefix=f"{kernel_name}_")
+    digest = hashlib.sha1(str(time.time_ns()).encode()).hexdigest()[:8]
+    kernel_output_dir = tempfile.mkdtemp(dir=spyre_dir, prefix=f"{digest}_{kernel_name}_")
     return kernel_output_dir
 
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
Updating the SDSC Bundle Directory Name to include a prefix digest in order to avoid the name truncation in performance scripts and get the PT Active Utilization counter in the post processed profiler traces using aiu-trace-analyzer.
<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:
https://github.com/torch-spyre/torch-spyre/issues/3059
https://github.com/torch-spyre/torch-spyre/issues/2437
<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
