### PR TITLE
inductor/pass_utils: extend iteration_space to include reduction dims, skip StarDep

### DIFF
--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -724,8 +724,13 @@ def iteration_space(n: SchedulerNode) -> dict[sympy.Symbol, sympy.Expr]:
         # The iteration space of a Pointwise is that of its output
         return next(iter(n.read_writes.writes)).ranges.copy()
     elif isinstance(n.node.data, Reduction):
-        # The iteration space of a Reduction is that of its input
-        return next(iter(n.read_writes.reads)).ranges.copy()
+        # Output dims from the write dep; reduction dims appended from read deps.
+        result = next(iter(n.read_writes.writes)).ranges.copy()
+        for dep in n.read_writes.reads:
+            for sym, size in dep.ranges.items():
+                if sym not in result:
+                    result[sym] = size
+        return result
     else:
         raise Unsupported("Unexpected node type")
 
@@ -737,7 +742,13 @@ def iteration_space_from_op(op: ComputedBuffer) -> dict[sympy.Symbol, sympy.Expr
     if isinstance(op.data, Pointwise):
         return next(iter(rw.writes)).ranges.copy()
     elif isinstance(op.data, Reduction):
-        return next(iter(rw.reads)).ranges.copy()
+        # Output dims from write dep; reduction dims appended from read deps.
+        result = next(iter(rw.writes)).ranges.copy()
+        for dep in rw.reads:
+            for sym, size in dep.ranges.items():
+                if sym not in result:
+                    result[sym] = size
+        return result
     else:
         raise Unsupported("Unexpected node type")
 

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -31,7 +31,7 @@ from torch._inductor.ir import (
     Reduction,
 )
 from torch._inductor.scheduler import SchedulerNode
-from torch._inductor.dependencies import MemoryDep, ReadWrites
+from torch._inductor.dependencies import MemoryDep, ReadWrites, StarDep
 from torch._inductor.virtualized import V
 from torch_spyre._C import SpyreTensorLayout, get_elem_in_stick
 from torch_spyre._inductor.errors import Unsupported
@@ -727,6 +727,8 @@ def iteration_space(n: SchedulerNode) -> dict[sympy.Symbol, sympy.Expr]:
         # Output dims from the write dep; reduction dims appended from read deps.
         result = next(iter(n.read_writes.writes)).ranges.copy()
         for dep in n.read_writes.reads:
+            if isinstance(dep, StarDep):
+                continue
             for sym, size in dep.ranges.items():
                 if sym not in result:
                     result[sym] = size
@@ -745,6 +747,8 @@ def iteration_space_from_op(op: ComputedBuffer) -> dict[sympy.Symbol, sympy.Expr
         # Output dims from write dep; reduction dims appended from read deps.
         result = next(iter(rw.writes)).ranges.copy()
         for dep in rw.reads:
+            if isinstance(dep, StarDep):
+                continue
             for sym, size in dep.ranges.items():
                 if sym not in result:
                     result[sym] = size


### PR DESCRIPTION
iteration_space() and iteration_space_from_op() previously returned
only the output dims of a Reduction node by reading from a single read
dep (next(iter(reads))). This missed all reduction dims (e.g. kH, kW
for avgpool; K for matmul), making the iteration space incomplete for
any multi-dim reduction.

Two commits:

    extend iteration_space (2faab17): Start from the write dep
    (output dims), then append any symbols from read deps that are not
    already present. The if-not-in guard deduplicates correctly because
    Inductor shares sympy symbols across all tensor accesses in a
    Reduction's inner_fn.

    skip StarDep (bcc126c): StarDep entries (produced by extern
    kernels such as mm/bmm) have no .ranges attribute. Without the
    guard, iterating over all read deps crashes on any Reduction whose
    inputs include a StarDep.

The second commit is a direct fix for a crash introduced by the first —
they are not independent and must land together.


Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
