### PR TITLE
Adding support for topk operator for all value of k and also run inputs with less than stick size

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1185,7 +1185,21 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                     -1,
                 ),
                 # "2d_k4_dim0_lessthanstick": (unique_randn_along_dim((8, 32), dim=0), 4, 0),
-                # "2d_k4_dim_minusone_lessthanstick": (unique_randn_along_dim((1, 32), dim=-1), 4, -1),
+                "2d_k4_dim_minusone_11x32": (
+                    unique_randn_along_dim((11, 32), dim=-1),
+                    4,
+                    -1,
+                ),
+                "2d_k4_dim_minusone_1x32": (
+                    unique_randn_along_dim((1, 32), dim=-1),
+                    4,
+                    -1,
+                ),
+                "2d_k6_dim_minusone_11x32": (
+                    unique_randn_along_dim((11, 32), dim=-1),
+                    6,
+                    -1,
+                ),
             },
         },
         ("test_reduce_keepdim0", "test_reduce_keepdim0_cpu"): {

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -628,8 +628,18 @@ def _create_sdsc_tensors(
         # Step 3: Handle missing stick dimension — skip for index tensors.
         if op_stick_dim is None:
             if not (has_indirect_access and i in index_tensor_indices):
-                stick_dim = next(d for d in dims if d not in op_dim_order)
-                dim_order = dim_order + [stick_dim]
+                if _is_topk(op_spec.op):
+                    # When mb=1, Inductor drops mb from iteration_space so the
+                    # k-dimension gets the "mb" label.  The generic next() search
+                    # would find Symbol("mb") again (already in dim_order for the
+                    # output tensor), producing [mb, mb].  Use the injected
+                    # Symbol("x") instead — it is the true stick for topk in this
+                    # degenerate case and is never already in dim_order.
+                    stick_dim = Symbol("x")
+                else:
+                    stick_dim = next(d for d in dims if d not in op_dim_order)
+                if stick_dim not in dim_order:
+                    dim_order = dim_order + [stick_dim]
 
         if op_spec.op == "layernormscale" and len(sdsc_args) == 0:
             reduced_dims = [stick_dim]
@@ -726,6 +736,21 @@ def _create_sdsc_tensors(
                 max_dim_sizes[mb_sym] = 1
             else:
                 max_dim_sizes[mb_sym] = -1
+
+        if (
+            _is_topk(op_spec.op)
+            and op_stick_dim is not None
+            and op_stick_dim not in dim_order
+        ):
+            # When mb=1 the stick/mb dim (Symbol("x")) has trivial range and is absent
+            # from device_coordinates, so _get_device_dim_order omits it.  Append it
+            # after the stride loop so the layout dim_order, scale_, and coordInfo include
+            # the "x" dim that the backend requires for topkvalue/topkindex.
+            dim_order = dim_order + [op_stick_dim]
+            scales[op_stick_dim] = 1
+            strides[op_stick_dim] = _calculate_device_stride(0, arg.device_size)
+            offsets[op_stick_dim] = 0
+            max_dim_sizes[op_stick_dim] = -1
 
         effective_stick = [op_stick_dim if stick_dim is None else stick_dim]
         layout_labels = MATMUL_LAYOUT_LABELS if not use_op_dims else LAYOUT_LABELS
@@ -1072,6 +1097,17 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
             # restate the invariant so the index is well-typed.
             assert op_spec.node_output_ranges is not None
             sdsc_iteration_space[stick_sym] = int(op_spec.node_output_ranges[1])
+        elif _is_topk(op_spec.op):
+            # When mb=1 the mb symbol has trivial range and is absent from iteration_space,
+            # so _get_topk_symbol_mapping omits Symbol("x") and sdsc_iteration_space lacks it.
+            # Inject it with value 1 so _extend_topk_mb_to_padded can round it up to 64.
+            # Also inject into dim_splits and work_slices so the core/slice mapping is correct.
+            stick_sym = Symbol("x")
+            op_dim_order = [d for d in op_dim_order if d != stick_sym] + [stick_sym]
+            if stick_sym not in sdsc_iteration_space:
+                sdsc_iteration_space[stick_sym] = 1
+                dim_splits[stick_sym] = 1
+                work_slices[stick_sym] = 1
         else:
             stick_sym = Symbol(INPUT_DIM_LABELS[ndim])
             sdsc_iteration_space[stick_sym] = op_spec.args[

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -332,8 +332,6 @@ def spyre_topk(
     k: int,
     dim: Optional[int] = -1,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    if k > 4:
-        raise Unsupported("Topk is not supported for this config")
     return torch.ops.spyre.topkvalue(input, k, dim), torch.ops.spyre.topkindex(
         input, k, dim
     )

--- a/torch_spyre/_inductor/optimize_restickify.py
+++ b/torch_spyre/_inductor/optimize_restickify.py
@@ -56,6 +56,7 @@ class EdgeCostMap:
         target_layouts: list,
         target_dep: "MemoryDep",
         op,
+        strict_stl: "SpyreTensorLayout | None" = None,
     ):
         self.dep = dep
         self._op = op
@@ -64,6 +65,10 @@ class EdgeCostMap:
         self._target_dep = target_dep
         self._dep_layout = V.graph.get_buffer(dep.name).get_layout()
         self._target_dep_layout = V.graph.get_buffer(target_dep.name).get_layout()
+        # When set, bypass stick_compatible and treat any in_stl != strict_stl as
+        # requiring a restickify to strict_stl.  Used for topk where size-1 mb
+        # produces a constant device coordinate that fools stick_compatible.
+        self._strict_stl = strict_stl
 
         # _cost and _layout are parallel maps.
         # _cost stores the cost for a given in/target layout pair
@@ -91,6 +96,14 @@ class EdgeCostMap:
           INFEASIBLE         — restickify needed but compute_restickify_target_layout returned None
           SpyreTensorLayout  — feasible restickify target layout
         """
+        if self._strict_stl is not None:
+            if in_stl == self._strict_stl:
+                self._cost[in_stl][target_stl] = 0.0
+                self._layout[in_stl][target_stl] = None
+            else:
+                self._cost[in_stl][target_stl] = float(math.prod(in_stl.device_size))
+                self._layout[in_stl][target_stl] = self._strict_stl
+            return
         needed, tgt = compute_restickify_needed(
             in_stl, self._dep_layout, self.dep, target_stl, self._target_dep, self._op
         )
@@ -225,10 +238,17 @@ class FixedInOutNode(RestickNodeCost):
         )
 
     @classmethod
-    def from_args(cls, args, out_stl, req_stls, op):
+    def from_args(cls, args, out_stl, req_stls, op, bypass_stick_compat=False):
         assert req_stls, "FixedInOutNode.from_args: req_stls is empty"
         edge_costs = [
-            EdgeCostMap(arg.dep, arg.layouts, [req], arg.dep, op)
+            EdgeCostMap(
+                arg.dep,
+                arg.layouts,
+                [req],
+                arg.dep,
+                op,
+                strict_stl=req if bypass_stick_compat else None,
+            )
             for arg, req in zip(args, req_stls)
         ]
         return cls(edge_costs, required_out_stl=out_stl, required_in_stls=req_stls)

--- a/torch_spyre/_inductor/padding.py
+++ b/torch_spyre/_inductor/padding.py
@@ -54,17 +54,20 @@ from torch._inductor.ir import (
 )
 from torch._inductor.virtualized import V
 
-from .constants import BATCH_MATMUL_OP, BATCH_MATMUL_FP8_OP
+from .constants import BATCH_MATMUL_OP, BATCH_MATMUL_FP8_OP, TOPK_OPS
 from .ir import FixedTiledLayout
 from .logging_utils import get_inductor_logger
 from .pass_utils import (
     concretize_expr,
+    device_coordinates,
     find_reduction_var,
-    identify_matmul_inputs,
     host_coordinates,
+    identify_matmul_inputs,
     lower_pad_sequence,
     replace_computed_buffer_body,
 )
+from .errors import Unsupported
+from .views import matching_dim
 from torch_spyre._C import get_elem_in_stick
 
 logger = get_inductor_logger("padding")
@@ -113,6 +116,42 @@ def _find_arg_fx_node(arg_name: str) -> torch.fx.Node:
     if not candidates:
         raise RuntimeError(f"no FX node found for buffer {arg_name!r}")
     return candidates[0]
+
+
+def _pad_dim_and_relocate(
+    op: ComputedBuffer,
+    cur_buf: Buffer,
+    cur_fx_node,
+    dim: int,
+    orig_size: int,
+    pad: int,
+    device,
+    dtype,
+    anchor_fx_node,
+    orig_stl,
+    operations: list[Operation],
+) -> tuple[Buffer, object, list]:
+    """Pad one dimension of cur_buf and relocate the new ops before op.
+
+    Returns (padded_buf, new_fx_node, new_ops) for the padded buffer.
+    """
+    padded_size = [concretize_expr(s) for s in cur_buf.get_size()]
+    padded_size[dim] = orig_size + pad
+    padded_buf, new_ops = lower_pad_sequence(
+        cur_fx_node,
+        padded_size=padded_size,
+        device=device,
+        dtype=dtype,
+        dim=dim,
+        insert_before=anchor_fx_node,
+        orig_stl=orig_stl,
+    )
+    for new_op in new_ops:
+        operations.remove(new_op)
+    op_idx = operations.index(op)
+    for i, new_op in enumerate(new_ops):
+        operations.insert(op_idx + i, new_op)
+    return padded_buf, _find_arg_fx_node(padded_buf.get_name()), new_ops
 
 
 def _rebuild_matmul(
@@ -263,41 +302,22 @@ def insert_bmm_padding(graph: GraphLowering) -> None:
         # minimising their live range.
         matmul_fx_node = next(iter(op.origins))
 
-        # --- Pad y only ---
-        # y's K dimension is y's row (mb) dimension.  Padding it to K_padded
-        # ensures rows K..K_padded-1 of y are zero-filled so the hardware
-        # accumulates no contribution from those rows.
-        # lower_pad_sequence builds the padded buffer at K_padded host size;
-        # reduction_ranges is NOT changed.  superdsc._extend_matmul_k_to_padded
-        # widens sdsc_iteration_space[K] to K_padded at SDSC codegen time,
-        # reading K_padded from y's device_layout.device_size.
         y_size = [concretize_expr(s) for s in y_buf.get_size()]
-        if y_host_k_dim is None:
-            y_k_dim = len(y_size) - 2
-        else:
-            y_k_dim = y_host_k_dim
-        y_padded_size = list(y_size)
-        y_padded_size[y_k_dim] = k_padded
+        y_k_dim = y_host_k_dim if y_host_k_dim is not None else len(y_size) - 2
         y_fx_node = _find_arg_fx_node(y_name)
-
-        y_orig_stl = y_buf.get_layout().device_layout
-        y_padded_buf, y_new_ops = lower_pad_sequence(
+        y_padded_buf, _, y_new_ops = _pad_dim_and_relocate(
+            op,
+            y_buf,
             y_fx_node,
-            padded_size=y_padded_size,
-            device=device,
-            dtype=dtype,
-            dim=y_k_dim,
-            insert_before=matmul_fx_node,
-            orig_stl=y_orig_stl,
+            y_k_dim,
+            y_size[y_k_dim],
+            pad,
+            device,
+            dtype,
+            matmul_fx_node,
+            y_buf.get_layout().device_layout,
+            operations,
         )
-
-        # --- Relocate new ops before the matmul ---
-        # run_node appended them at the end of operations; move before op.
-        for new_op in y_new_ops:
-            operations.remove(new_op)
-        op_idx = operations.index(op)
-        for i, new_op in enumerate(y_new_ops):
-            operations.insert(op_idx + i, new_op)
 
         # When coarse-tiling runs pre-stickification, the consuming matmul
         # already carries loop_info.  The padding ops must inherit it so they
@@ -311,3 +331,172 @@ def insert_bmm_padding(graph: GraphLowering) -> None:
         # x is left entirely untouched: the original inner_fn's x loader is
         # preserved as-is.  Only y's loader is replaced with the padded buffer.
         _rebuild_matmul(op, y_padded_buf, operations)
+
+
+def _rebuild_topk(
+    op: ComputedBuffer,
+    x_padded_buf: Buffer,
+    mb_dim: int,
+    operations: list[Operation],
+) -> ComputedBuffer:
+    """Rebuild the topk ComputedBuffer so its inner_fn reads from the padded input.
+
+    Only the loader changes; reduction_ranges and ranges are unchanged.
+    mb_dim is the host dimension of the padded (mb/row) dim in the input.
+    """
+    reduction = op.data
+    assert isinstance(reduction, Reduction)
+    x_padded_loader = x_padded_buf.make_loader()
+    if mb_dim == 0:
+        # dim=-1 lowering: inner_fn(index, rindex) = loader([index[0], rindex[0]])
+        def new_inner_fn(index, rindex, _loader=x_padded_loader):
+            return _loader([index[0], rindex[0]])
+    else:
+        # dim=0 lowering: inner_fn(index, rindex) = loader([rindex[0], index[1]])
+        def new_inner_fn(index, rindex, _loader=x_padded_loader):
+            return _loader([rindex[0], index[1]])
+
+    object.__setattr__(reduction, "inner_fn", new_inner_fn)
+    return replace_computed_buffer_body(
+        op, reduction, operations, pass_name="insert_topk_padding"
+    )
+
+
+def insert_topk_padding(graph: GraphLowering) -> None:
+    """Pad the topk input's mb and n_in dimensions to stick boundaries.
+
+    Must run before optimize_restickify_locations so that the restickify
+    feasibility check (host_size[new_stick_dim] % stick_size == 0) sees the
+    padded mb size rather than the original unaligned size.
+
+    For dim=-1 with input [mb, n_in]: pads dim=0 (mb) and dim=1 (n_in).
+    For dim=0 with input [n_in, mb]: pads dim=1 (mb) and dim=0 (n_in).
+
+    Both dimensions must be stick-aligned: mb because it becomes the stick
+    dim after restickify, n_in because the topk backend sweeps full sticks
+    along the reduction axis (N_.out_ must be a multiple of stick_size).
+
+    The padded rows/cols are zero-filled so they contribute -inf (topkvalue)
+    or dummy indices (topkindex) that never surface in the top-k output.
+    ranges stays at the original mb; the mb->mb_padded and n_in->n_in_padded
+    extensions happen at SDSC codegen time via _extend_topk_mb_to_padded in
+    superdsc.py (n_in is handled by _get_padded_iteration_space).
+    """
+    operations = graph.operations
+    for op in list(operations):
+        if not isinstance(op, ComputedBuffer):
+            continue
+        reduction = op.data
+        if not isinstance(reduction, Reduction):
+            continue
+        if reduction.reduction_type not in TOPK_OPS:
+            continue
+
+        rw = op.get_read_writes()
+        reads = [r for r in rw.reads if hasattr(r, "name")]
+        if len(reads) != 1:
+            continue
+
+        x_dep = reads[0]
+        x_buf = V.graph.get_buffer(x_dep.name)
+        if x_buf is None:
+            continue
+        layout = x_buf.get_layout()
+
+        # insert_topk_padding runs before finalize_layouts so the buffer layout
+        # is still a plain FixedLayout.  The candidate STLs assigned by
+        # propagate_spyre_tensor_layouts are on the buffer object itself.
+        if isinstance(layout, FixedTiledLayout):
+            x_orig_stl = layout.device_layout
+        elif hasattr(x_buf, "layouts") and x_buf.layouts:
+            x_orig_stl = x_buf.layouts[0]
+        else:
+            continue
+
+        dtype = x_buf.get_dtype()
+        x_size = [concretize_expr(s) for s in x_buf.get_size()]
+
+        # Identify the mb (surviving/row) dimension: the host dim that is NOT
+        # the reduction dim.  The reduction dim is the one whose coordinate has
+        # free symbols that are absent from the output host coordinates.
+        # Using the reduction dim as the anchor (rather than searching for the
+        # mb coord directly) correctly handles the degenerate case where mb has
+        # size 1: its coordinate is the constant 0 with no free symbols and
+        # would be missed by a free-symbol search.
+        write_dep = next(iter(rw.writes))
+        out_coords = host_coordinates(op.get_layout(), write_dep, None)
+        x_coords = host_coordinates(layout, x_dep, None)
+        reduction_dim: int | None = None
+        for i, coord in enumerate(x_coords):
+            if len(coord.free_symbols) > 0 and matching_dim(out_coords, coord) is None:
+                reduction_dim = i
+                break
+
+        if reduction_dim is None:
+            logger.warning(
+                "insert_topk_padding: could not identify reduction dim for %s, skipping",
+                op.get_name(),
+            )
+            continue
+
+        mb_dim = 1 - reduction_dim
+        n_in_dim = reduction_dim
+        mb_size = x_size[mb_dim]
+        n_in_size = x_size[n_in_dim]
+        mb_pad = compute_padding(mb_size, dtype)
+        n_in_pad = compute_padding(n_in_size, dtype)
+
+        # Topk requires the input stick to be on the mb (surviving) dimension.
+        # If mb is not already the stick, a ReStickifyOpHBM will be inserted
+        # downstream.  ReStickifyOpHBM does not support FP32; reject early so
+        # the fused kernel falls back to CPU cleanly.
+        x_dev_coords = device_coordinates(x_orig_stl, x_dep, None)
+        stick_vars = x_dev_coords[-1].free_symbols
+        mb_vars = x_coords[mb_dim].free_symbols
+        mb_is_stick = bool(stick_vars & mb_vars)
+        if not mb_is_stick and dtype == torch.float32:
+            raise Unsupported(
+                f"topk on float32 requires ReStickifyOpHBM to move the stick to "
+                f"the mb dimension, but ReStickifyOpHBM does not support float32 "
+                f"(input shape {x_size}, mb_dim={mb_dim})"
+            )
+
+        if mb_pad == 0 and n_in_pad == 0:
+            continue
+
+        device = x_buf.get_device()
+        topk_fx_node = next(iter(op.origins))
+
+        cur_buf = x_buf
+        cur_fx_node = _find_arg_fx_node(x_dep.name)
+        cur_stl = x_orig_stl
+
+        for dim, orig_size, pad in [
+            (mb_dim, mb_size, mb_pad),
+            (n_in_dim, n_in_size, n_in_pad),
+        ]:
+            if pad == 0:
+                continue
+            logger.debug(
+                "insert_topk_padding: padding %s dim=%d size %d -> %d",
+                op.get_name(),
+                dim,
+                orig_size,
+                orig_size + pad,
+            )
+            cur_buf, cur_fx_node, _ = _pad_dim_and_relocate(
+                op,
+                cur_buf,
+                cur_fx_node,
+                dim,
+                orig_size,
+                pad,
+                device,
+                dtype,
+                topk_fx_node,
+                cur_stl,
+                operations,
+            )
+            cur_stl = cur_buf.get_layout().device_layout
+
+        _rebuild_topk(op, cur_buf, mb_dim, operations)

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1185,6 +1185,11 @@ def replace_computed_buffer_body(
 
     op_idx = operations.index(op)
     operations[op_idx] = new_buf
+
+    # Keep V.graph.name_to_buffer in sync so get_buffer() returns the new object.
+    if op.get_name() in V.graph.name_to_buffer:
+        V.graph.name_to_buffer[op.get_name()] = new_buf
+
     return new_buf
 
 

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -38,7 +38,7 @@ from torch._inductor.scheduler import BaseSchedulerNode
 from .logging_utils import get_inductor_logger
 from .provenance import SpyreGraphTransformObserver, reset_provenance_warnings
 
-from .padding import insert_bmm_padding
+from .padding import insert_bmm_padding, insert_topk_padding
 from .temp_passes import (
     bmm_unflatten_pass,
     decompose_addmm,
@@ -442,6 +442,8 @@ class CustomPreSchedulingPasses:
             split_multi_ops,
             propagate_spyre_tensor_layouts,
             validate_ops,
+            insert_topk_padding,
+            propagate_spyre_tensor_layouts,
             optimize_restickify_locations,
             finalize_layouts,
             insert_restickify,

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -1161,8 +1161,13 @@ def _topk_layouts(
     x_coords = host_coordinates(x.layout, x.dep, None)
     out_coords = host_coordinates(output, output_dep, None)
 
-    # Reduction var: in x's index but absent from output's.
-    reduction_var = find_reduction_var(x.dep, output_dep)
+    # Reduction coordinate: in x's host coords but absent from output's host coords.
+    reduction_coord = next(
+        c
+        for c in x_coords
+        if len(c.free_symbols) > 0 and matching_dim(out_coords, c) is None
+    )
+    reduction_dim = matching_dim(x_coords, reduction_coord)
 
     # Coords that survive the reduction into the output.
     surviving_coords = [
@@ -1171,21 +1176,33 @@ def _topk_layouts(
         if len(c.free_symbols) > 0 and matching_dim(out_coords, c) is not None
     ]
 
+    # The output mb dimension is the one that is NOT the k (output-size)
+    # dimension.  For the non-degenerate case (mb > 1) it corresponds to a
+    # surviving coord; for mb == 1 surviving_coords is empty so we derive the
+    # mb output dim as the complement of the k dim (the only output dim whose
+    # coord has free symbols).
+    if surviving_coords:
+        mb_out_dim = matching_dim(out_coords, surviving_coords[0])
+    else:
+        # mb is size-1: its input coord is constant, so no surviving coord.
+        # The k output dim is the only one with free symbols; mb is the other.
+        k_out_dims = [i for i, c in enumerate(out_coords) if len(c.free_symbols) > 0]
+        if len(k_out_dims) == 1:
+            mb_out_dim = 1 - k_out_dims[0]
+        else:
+            mb_out_dim = None
+
     # Collect candidate output stick dims. A valid input stick passes through;
-    # a stick on the reduction var requires a restickify, so every surviving
-    # coord becomes a candidate.
+    # a stick on the reduction dim requires a restickify to the mb output dim.
     out_stick_dims: set[int | None] = set()
     for stl in x.layouts:
         x_stick_expr = device_coordinates(stl, x.dep, None)[-1]
-        if reduction_var in x_stick_expr.free_symbols:
-            for c in surviving_coords:
-                out_stick_dims.add(matching_dim(out_coords, c))
+        if matching_dim(x_coords, x_stick_expr) == reduction_dim:
+            out_stick_dims.add(mb_out_dim)
         else:
             out_stick_dims.add(matching_dim(out_coords, x_stick_expr))
 
     # Build one output STL per candidate stick dim.
-    # Note: the stick dim STL will never be added so will never be
-    #       selected as a candidate output STL
     c_size = [concretize_expr(s) for s in output.size]
     c_stride = [concretize_expr(s) for s in output.stride]
     results: list[SpyreTensorLayout] = []
@@ -1197,7 +1214,20 @@ def _topk_layouts(
             out_dim_order += [out_stick_dim]
         results.append(SpyreTensorLayout(c_size, c_stride, output.dtype, out_dim_order))
 
-    op.restick_cost_fn = AllSameNode.from_args(args, results, output_dep, op)
+    # Topk requires the input stick to be on the mb (surviving) dimension.  Use
+    # bypass_stick_compat=True so that stick_compatible()'s false-positive for
+    # size-1 mb (constant device coordinate) does not suppress the restickify.
+    # The required input STL has stick on the input mb (non-reduction) dimension.
+    x_size = [concretize_expr(s) for s in x.layout.size]
+    x_stride = [concretize_expr(s) for s in x.layout.stride]
+    assert reduction_dim is not None
+    mb_in_dim = 1 - reduction_dim
+    req_in_dim_order = [d for d in range(len(x_size)) if d != mb_in_dim] + [mb_in_dim]
+    req_in_stl = SpyreTensorLayout(x_size, x_stride, x.layout.dtype, req_in_dim_order)
+    req_out_stl = results[0]
+    op.restick_cost_fn = FixedInOutNode.from_args(
+        [args[0]], req_out_stl, [req_in_stl], op, bypass_stick_compat=True
+    )
     return results
 
 
@@ -1798,9 +1828,28 @@ def propagate_spyre_tensor_layouts(
                         op._restickify_plan = (target_name, target_stl, alt_stl)
                         target_stl = alt_stl
                 op.layouts = [target_stl]
-                op.restick_cost_fn = AllSameNode.from_args(
-                    args, [target_stl], output_dep, op
-                )
+                if isinstance(op.data, Reduction) and isinstance(
+                    target_layout, FixedLayout
+                ):
+                    # Reductions (e.g. matmul) have fixed per-input stick
+                    # requirements that differ from the output stick.
+                    # AllSameNode would incorrectly require all inputs to be
+                    # stick-compatible with the output, so use compute_layouts
+                    # to get the proper cost function (e.g. FixedInOutNode).
+                    compute_layouts(op, target_layout, output_dep, args)
+                    # If an alternative mutation STL was selected above,
+                    # target_stl is now alt_stl. The FixedInOutNode installed
+                    # by compute_layouts derived required_out_stl from
+                    # target_layout, which may differ. Align it with the
+                    # forced output so cost() does not return INF for the
+                    # sole candidate layout.
+                    if isinstance(op.restick_cost_fn, FixedInOutNode):
+                        op.restick_cost_fn.required_out_stl = target_stl
+                    op.layouts = [target_stl]
+                else:
+                    op.restick_cost_fn = AllSameNode.from_args(
+                        args, [target_stl], output_dep, op
+                    )
                 continue
             op.decide_layout()
             rw = op.get_read_writes()

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -1514,6 +1514,70 @@ def divide_pointwise_op(
     pass_fn(op, args, max_cores)
 
 
+# Maximum k rows that the topk hardware op can process per core.
+_TOPK_MAX_K_PER_CORE = 4
+
+
+def _divide_topk_op(
+    op: ComputedBuffer,
+    args: list[SchedNodeArg],
+    max_cores: int,
+) -> None:
+    """Apply multi-core work division for topk ops where k > _TOPK_MAX_K_PER_CORE.
+
+    The topk backend processes at most _TOPK_MAX_K_PER_CORE output rows per
+    core.  When k exceeds this limit the k dimension must be split across
+    cores, with each core computing k/num_cores output rows.
+
+    The required number of cores is the smallest divisor of k for which
+    k / divisor <= _TOPK_MAX_K_PER_CORE, capped at max_cores.  If no such
+    divisor exists, Unsupported is raised to trigger the fallback path.
+    """
+    input_tds, output_td = collect_tensor_deps(op, args)
+
+    it_space = iteration_space_from_op(op)
+
+    # Identify the k symbol: the only non-stick output dimension.
+    it_space_adjusted, _ = adjust_it_space_for_sticks(it_space, input_tds + [output_td])
+    output_dims, _ = prioritize_dimensions(output_td, it_space_adjusted)
+    if not output_dims:
+        return
+
+    # For topk the only non-stick output dim is k (mb is the stick dim).
+    k_sym = output_dims[0]
+    k_val = concretize_expr(it_space[k_sym])
+
+    if k_val <= _TOPK_MAX_K_PER_CORE:
+        return
+
+    # Find the smallest divisor of k such that k/divisor <= _TOPK_MAX_K_PER_CORE,
+    # capped at max_cores.
+    required_cores = None
+    for d in sorted(divisors(k_val)):
+        if d > 1 and k_val // d <= _TOPK_MAX_K_PER_CORE and d <= max_cores:
+            required_cores = d
+            break
+
+    if required_cores is None:
+        raise Unsupported(
+            f"topk: k={k_val} cannot be split across at most {max_cores} cores "
+            f"such that k_per_core <= {_TOPK_MAX_K_PER_CORE}; "
+            f"no valid divisor exists in [2, {max_cores}]"
+        )
+
+    splits = {sym: 1 for sym in it_space}
+    splits[k_sym] = required_cores
+    apply_splits(op, splits, output_td)
+
+    logger.debug(
+        "_divide_topk_op %s: k=%d, cores=%d, k_per_core=%d",
+        op.get_name(),
+        k_val,
+        required_cores,
+        k_val // required_cores,
+    )
+
+
 def divide_reduction_op(
     op: ComputedBuffer,
     args: list[SchedNodeArg],
@@ -1522,14 +1586,13 @@ def divide_reduction_op(
 ) -> None:
     red: Reduction = op.data
 
-    # Currently we support Topk for k<=4, which can be handled efficiently on single core
-    # TODO: Modification will be required to enable Topk for k>4
     if red.reduction_type in TOPK_OPS:
-        if not config.ignore_work_division_hints and _has_work_div_hint(op):
-            logger.warning(
-                f"work_division_hint: {op.get_name()} ignores work_div hint "
-                f"because TOPK reductions run single-core."
-            )
+        # Topk requires at most _TOPK_MAX_K_PER_CORE output rows per core.
+        # For k <= _TOPK_MAX_K_PER_CORE a single core suffices; for larger k
+        # the k dimension must be split across cores.  Work distribution passes
+        # (span_reduction, work_distribution) are not applicable to topk so we
+        # handle the split here directly.
+        _divide_topk_op(op, args, max_cores)
         return
 
     pass_fn(op, args, max_cores)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
This PR adds comprehensive support to torch.topk operations with input dimension less than stick size and also support all value of k on Spyre.

torch.topk
core_division.py: split topk operation across k value
torch.topk genereate sdsc (torch_spyre/_inductor/codegen/superdsc.py)
Added padding for topk. (torch_spyre/_inductor/padding.py, torch_spyre/_inductor/propagate_layouts.py)
Enhanced Test Coverage (tests/inductor/test_inductor_ops.py)
Added comprehensive test cases for torch.topk

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:
https://github.com/torch-spyre/torch-spyre/issues/452
<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
