### PR TITLE
inductor: use _sizes[0] to split output/reduction index vars in scheduler

### DIFF
--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -319,8 +319,8 @@ class SuperDSCScheduling(BaseScheduling):
                 var_ranges = iteration_space(node)
                 vars = list(var_ranges.keys())
                 index_vars = [
-                    vars[: len(node._body.iter_vars)],
-                    vars[len(node._body.iter_vars) :],
+                    vars[: len(node._sizes[0])],
+                    vars[len(node._sizes[0]) :],
                 ]
                 node.codegen(index_vars)
 
@@ -373,8 +373,8 @@ class SuperDSCScheduling(BaseScheduling):
                         var_ranges = iteration_space(snode)
                         vs = list(var_ranges.keys())
                         index_vars = [
-                            vs[: len(snode._body.iter_vars)],
-                            vs[len(snode._body.iter_vars) :],
+                            vs[: len(snode._sizes[0])],
+                            vs[len(snode._sizes[0]) :],
                         ]
                         snode.codegen(index_vars)
 
@@ -429,8 +429,8 @@ class SuperDSCScheduling(BaseScheduling):
                     var_ranges = iteration_space(snode)
                     vs = list(var_ranges.keys())
                     index_vars = [
-                        vs[: len(snode._body.iter_vars)],
-                        vs[len(snode._body.iter_vars) :],
+                        vs[: len(snode._sizes[0])],
+                        vs[len(snode._sizes[0]) :],
                     ]
                     snode.codegen(index_vars)
 


### PR DESCRIPTION
 _body.iter_vars is the wrong source for splitting the output/reduction boundary in index_vars. node._sizes[0] is the canonical list of output-range sizes and correctly separates output dims from reduction dims for all Reduction nodes.

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
