### PR TITLE
inductor: guard it_space_orig lookup with .get() for pool reduction dims

### DIFF
--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -124,7 +124,7 @@ def _effective_size(v: Symbol, it_space: dict[Symbol, Expr], meta: SymbolMeta) -
     """
     if v in meta:
         return meta[v][0]
-    return concretize_expr(it_space[v])
+    return concretize_expr(it_space.get(v, 1))
 
 
 def _valid_divisor_basis(
@@ -136,10 +136,14 @@ def _valid_divisor_basis(
     ``n | granularity`` ensures ``R / n`` stays integer for every admissible
     runtime value ``R = granularity * k``. For concrete dims, it is just the
     concretized size.
+
+    Absent dims (e.g. pool reduction dims ki/kj stripped from the
+    work-division iteration space) return 1 — no valid split beyond 1,
+    matching the hardware constraint that pool window dims are never split.
     """
     if v in meta:
         return meta[v][1]
-    return concretize_expr(it_space[v])
+    return concretize_expr(it_space.get(v, 1))
 
 
 def core_split(size: int, max_cores: int) -> int:


### PR DESCRIPTION
ki/kj appear as free symbols in a tensor's device coordinates but are absent from it_space_orig because pool reduction dims are stripped from the work-division iteration space. it_space[v] raises KeyError; .get(v, 1) treats absent dims as size-1 (no contribution to span).


Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
