### PR TITLE
Fix affine_map construction in UNROLL_LOOPS=0 config; add e2e test cases

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -30,6 +30,7 @@ import sys
 import os
 import regex as re
 
+import pytest
 import torch
 import unittest
 from unittest.mock import patch as mock_patch
@@ -769,6 +770,10 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         # is numerically wrong (~90% element mismatch).  Investigate and fix
         # before re-adding spyre_hint(num_tiles_per_dim={"Lk": lk_slices}).
         """
+        if not config.unroll_loops:
+            pytest.xfail(
+                "UNROLL_LOOPS=0: nested scf.for loops not yet correct in backend"
+            )
         import math
         from torch_spyre._inductor import spyre_hint
 
@@ -1551,6 +1556,8 @@ class TestCoarseTileReductionE2E(InductorTestCase):
 
     def test_hint_tiled_reduction_min_correct(self):
         """x.amin(dim=-1) tiled over D (4 tiles) produces correct results."""
+        if not config.unroll_loops:
+            pytest.xfail("UNROLL_LOOPS=0: amin scf.for loop not yet correct in backend")
         from torch_spyre._inductor import spyre_hint
 
         B, D = 64, 512
@@ -1580,6 +1587,10 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
 
     def test_hint_tiled_reduction_dim0_sum_correct(self):
         """x.sum(dim=0) tiled over B produces correct results."""
+        if not config.unroll_loops:
+            pytest.xfail(
+                "UNROLL_LOOPS=0: dim=0 reduction scf.for loop not yet correct in backend"
+            )
         from torch_spyre._inductor import spyre_hint
 
         B, D = 512, 64
@@ -1597,6 +1608,10 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
 
     def test_hint_tiled_reduction_dim0_max_correct(self):
         """x.amax(dim=0) tiled over B produces correct results."""
+        if not config.unroll_loops:
+            pytest.xfail(
+                "UNROLL_LOOPS=0: dim=0 reduction scf.for loop not yet correct in backend"
+            )
         from torch_spyre._inductor import spyre_hint
 
         B, D = 512, 64
@@ -1614,6 +1629,10 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
 
     def test_hint_tiled_reduction_dim0_min_correct(self):
         """x.amin(dim=0) tiled over B produces correct results."""
+        if not config.unroll_loops:
+            pytest.xfail(
+                "UNROLL_LOOPS=0: dim=0 reduction scf.for loop not yet correct in backend"
+            )
         from torch_spyre._inductor import spyre_hint
 
         B, D = 512, 64
@@ -1759,6 +1778,10 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
 
     def test_nested_bmm_outer_Batch_inner_K_correct(self):
         """bmm [B,M,K]@[B,K,N] outer B (output) + inner K (reduction) — correct."""
+        if not config.unroll_loops:
+            pytest.xfail(
+                "UNROLL_LOOPS=0: nested scf.for loops not yet correct in backend"
+            )
         from torch_spyre._inductor import spyre_hint
 
         B, M, K, N = 4, 64, 512, 32
@@ -1782,6 +1805,10 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
 
     def test_nested_matmul_outer_M_inner_K_correct(self):
         """mm [M,K]@[K,N] with outer M (output) + inner K (reduction) — correct."""
+        if not config.unroll_loops:
+            pytest.xfail(
+                "UNROLL_LOOPS=0: nested scf.for loops not yet correct in backend"
+            )
         from torch_spyre._inductor import spyre_hint
 
         M, K, N = 128, 512, 32

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1941,5 +1941,46 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
         )
 
 
+# ===========================================================================
+# UNROLL_LOOPS=0 variants
+#
+# Each class below inherits all test methods from its base.  The class-level
+# @config.patch sets unroll_loops=False for every inherited test.  Tests that
+# are known to give wrong results under the scf.for path already contain
+#   ``if not config.unroll_loops: pytest.xfail(...)``
+# guards, so they are reported as xfail here rather than FAILED.
+#
+# Tests whose method-level @config.patch overrides unroll_loops (e.g.
+# test_hint_unrolled_source_calls_sdsc explicitly sets unroll_loops=True)
+# are unaffected: the method decorator wins over the class decorator and
+# those tests run — and pass — with their own explicit setting.
+# ===========================================================================
+
+
+@config.patch({"unroll_loops": False})
+class TestCoarseTileSpyreHintsUnroll0(TestCoarseTileSpyreHints):
+    pass
+
+
+@config.patch({"unroll_loops": False})
+class TestNamedDimsHintUnroll0(TestNamedDimsHint):
+    pass
+
+
+@config.patch({"unroll_loops": False})
+class TestCoarseTileReductionE2EUnroll0(TestCoarseTileReductionE2E):
+    pass
+
+
+@config.patch({"unroll_loops": False})
+class TestCoarseTileReductionDim0E2EUnroll0(TestCoarseTileReductionDim0E2E):
+    pass
+
+
+@config.patch({"unroll_loops": False})
+class TestCoarseTileNestedReductionE2EUnroll0(TestCoarseTileNestedReductionE2E):
+    pass
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -4233,6 +4233,12 @@ class TestAffineStrideMatchesUnrollStride(unittest.TestCase):
 
         Returns the byte-stride value from affine_strides[tensor_idx][0][sym]
         for the first (and only) tiling level.  Raises if no stride is found.
+
+        Note: the output tensor is constructed with the same coordinates as the
+        input, so both tensors share the same affine stride for tiled_sym.  We
+        return the first non-zero value found, which is the input tensor's stride
+        (they are identical here).  Group 4 (multi-stick) inlines this extraction
+        instead because it needs a distinct iteration_space for C_COL.
         """
         out_tensor = TensorArg(
             is_input=False,
@@ -4390,18 +4396,20 @@ class TestAffineStrideMatchesUnrollStride(unittest.TestCase):
 
     def test_multi_stick_row_tiling_affine_stride_matches_unroll(self):
         """[1024,4096] multi-stick row-tiling: affine stride must equal unroll stride."""
-        C_ROW = Symbol("c_row")
-        C_COL = Symbol("c_col")
         tensor = TensorArg(
             is_input=True,
             arg_index=0,
             device_dtype=_FP16,
             device_size=[64, 1024, 64],  # [4096//64, 1024, 64]
-            device_coordinates=[C_COL // 64, C_ROW, sympy.Mod(C_COL, 64)],
+            device_coordinates=[
+                self._C_COL // 64,
+                self._C_ROW,
+                sympy.Mod(self._C_COL, 64),
+            ],
             allocation={"hbm": self._HBM_BASE},
         )
         T_ROW = 512
-        expected = _byte_stride_for_arg(tensor, C_ROW, T_ROW)
+        expected = _byte_stride_for_arg(tensor, self._C_ROW, T_ROW)
         # ground truth: 512 * 64 * 2 = 65536
         self.assertEqual(expected, T_ROW * 64 * 2)
 
@@ -4410,19 +4418,26 @@ class TestAffineStrideMatchesUnrollStride(unittest.TestCase):
             arg_index=1,
             device_dtype=_FP16,
             device_size=[64, 1024, 64],
-            device_coordinates=[C_COL // 64, C_ROW, sympy.Mod(C_COL, 64)],
+            device_coordinates=[
+                self._C_COL // 64,
+                self._C_ROW,
+                sympy.Mod(self._C_COL, 64),
+            ],
             allocation={"hbm": 0x500000000},
         )
+        # Note: C_COL range here is the full tensor width (4096), not T_ROW.
+        # The helper _get_flat_affine_stride cannot be reused for this group
+        # because it assigns iter_range to all free symbols uniformly.
         op_spec = OpSpec(
             op="add",
             is_reduction=False,
             iteration_space={
-                C_ROW: (Integer(T_ROW), 1),
-                C_COL: (Integer(4096), 1),
+                self._C_ROW: (Integer(T_ROW), 1),
+                self._C_COL: (Integer(4096), 1),
             },
             args=[tensor, out_tensor],
             op_info={},
-            tiled_symbols=[[C_ROW]],
+            tiled_symbols=[[self._C_ROW]],
         )
         symbols: list[int] = []
         _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -58,6 +58,7 @@ from torch_spyre._inductor.codegen.compute_ops import (
     _tiled_byte_stride,
     generate_sdsc,
 )
+from torch_spyre._inductor.codegen.unroll import _byte_stride_for_arg
 from torch_spyre._inductor.codegen.superdsc import (
     SDSCArgs,
     SDSCSpec,
@@ -1369,8 +1370,8 @@ class TestTiledByteStride(unittest.TestCase):
             start_address=0,
             backGap={},
         )
-        stride = _tiled_byte_stride(tensor, s, {s: 64})
-        self.assertEqual(stride, 64 * 128 * 2)
+        stride = _tiled_byte_stride(tensor, s)
+        self.assertEqual(stride, 128 * 2)
 
     def test_fp16_larger_stride(self):
         s = Symbol("s")
@@ -1386,8 +1387,8 @@ class TestTiledByteStride(unittest.TestCase):
             start_address=0,
             backGap={},
         )
-        stride = _tiled_byte_stride(tensor, s, {s: 32})
-        self.assertEqual(stride, 32 * 512 * 2)
+        stride = _tiled_byte_stride(tensor, s)
+        self.assertEqual(stride, 512 * 2)
 
     def test_stride_one(self):
         s = Symbol("s")
@@ -1403,8 +1404,8 @@ class TestTiledByteStride(unittest.TestCase):
             start_address=0,
             backGap={},
         )
-        stride = _tiled_byte_stride(tensor, s, {s: 16})
-        self.assertEqual(stride, 16 * 1 * 2)
+        stride = _tiled_byte_stride(tensor, s)
+        self.assertEqual(stride, 1 * 2)
 
 
 class TestGenerateSdscTiledSymbols(unittest.TestCase):
@@ -1424,7 +1425,7 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
         # With one tiling level, affine_strides[0] = [{s: stride}].
         self.assertEqual(len(affine_strides), 1)
         self.assertIn(s, affine_strides[0][0])
-        self.assertEqual(affine_strides[0][0][s], 64 * 128 * 2)
+        self.assertEqual(affine_strides[0][0][s], 128 * 2)
 
     def test_tiled_tensor_base_address_registered(self):
         s = Symbol("s")
@@ -4159,6 +4160,287 @@ class TestHintsToCoarseTileGroupsLogging(unittest.TestCase):
             f"scopes= must mention Lq even though op0 is broadcast on Lq "
             f"(loop_var=None for hint_id=2 on group_ops[0]); "
             f"got: {scopes_line!r}",
+        )
+
+
+class TestAffineStrideMatchesUnrollStride(unittest.TestCase):
+    """Verify that the UNROLL=0 affine-stride path produces the same byte
+    advances as the UNROLL=1 ``_byte_stride_for_arg`` ground truth.
+
+    Each test builds an ``OpSpec`` with a realistic stick-layout ``TensorArg``
+    (same geometry as ``test_unroll_loop_specs.py``), calls ``compile_op_spec``
+    to obtain ``affine_strides``, and asserts that the stride value equals what
+    ``_byte_stride_for_arg`` computes for the same tensor and symbol.
+
+    The scenarios mirror the three main coarse-tiling patterns covered by
+    ``TestUnrollLoopSpecs`` and ``TestNestedReductionUnroll``:
+
+      Group 1 — flat row-tiling: [512, 256] fp16 tensor, tile by c_row.
+      Group 2 — flat col-tiling: same tensor, tile by c_col (non-linear coord).
+      Group 3 — K-input K-tiling: [64, 128] fp16 per-tile (device_size=[2,64,64]),
+                tile by c_k (non-linear coord c_k//64).
+
+    Stick layout reference (2D fp16 tensor [R, C], C multiple of 64):
+      device_size        = [C//64, R, 64]
+      device_coordinates = [c_col//64, c_row, Mod(c_col, 64)]
+    """
+
+    # --- Symbols ---
+    _C_ROW = Symbol("c_row")
+    _C_COL = Symbol("c_col")
+    _C_K = Symbol("c_k")
+    _C_M = Symbol("c_m")
+
+    # --- [512, 256] fp16 stick-layout tensor fixture ---
+    _R, _C = 512, 256
+    _DS_RC = [_C // 64, _R, 64]  # [4, 512, 64]
+    _HBM_BASE = 0x400000000
+
+    def _make_rc_tensor(self, base: int = _HBM_BASE) -> TensorArg:
+        """Stick-layout TensorArg for [512, 256] fp16 (device_size=[4,512,64])."""
+        return TensorArg(
+            is_input=True,
+            arg_index=0,
+            device_dtype=_FP16,
+            device_size=list(self._DS_RC),
+            device_coordinates=[
+                self._C_COL // 64,
+                self._C_ROW,
+                sympy.Mod(self._C_COL, 64),
+            ],
+            allocation={"hbm": base},
+        )
+
+    def _make_k_input_tensor(self, base: int = 0x800000000) -> TensorArg:
+        """K-input tensor: [64, 128] fp16 per-tile (device_size=[2,64,64])."""
+        return TensorArg(
+            is_input=True,
+            arg_index=0,
+            device_dtype=_FP16,
+            device_size=[2, 64, 64],
+            device_coordinates=[
+                self._C_K // 64,
+                self._C_M,
+                sympy.Mod(self._C_K, 64),
+            ],
+            allocation={"hbm": base},
+        )
+
+    def _get_flat_affine_stride(
+        self, tensor: TensorArg, tiled_sym: Symbol, iter_range: int
+    ) -> int:
+        """Run compile_op_spec and extract the affine stride for tiled_sym.
+
+        Returns the byte-stride value from affine_strides[tensor_idx][0][sym]
+        for the first (and only) tiling level.  Raises if no stride is found.
+        """
+        out_tensor = TensorArg(
+            is_input=False,
+            arg_index=1,
+            device_dtype=tensor.device_dtype,
+            device_size=list(tensor.device_size),
+            device_coordinates=list(tensor.device_coordinates),
+            allocation={"hbm": 0x500000000},
+        )
+        all_syms: set = set()
+        for expr in tensor.device_coordinates:
+            all_syms |= expr.free_symbols
+        it_space = {s: (Integer(iter_range), 1) for s in all_syms if s != tiled_sym}
+        it_space[tiled_sym] = (Integer(iter_range), 1)
+        op_spec = OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space=it_space,
+            args=[tensor, out_tensor],
+            op_info={},
+            tiled_symbols=[[tiled_sym]],
+        )
+        symbols: list[int] = []
+        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
+        # affine_strides uses SDSC-renamed symbols as keys (not the original
+        # inductor symbols).  Extract the first non-zero stride value from any
+        # tensor's per-level strides.
+        for per_level in affine_strides:
+            for level_d in per_level:
+                if level_d:
+                    return next(iter(level_d.values()))
+        self.fail(
+            f"No affine stride found for {tiled_sym} in affine_strides={affine_strides}"
+        )
+
+    # -------------------------------------------------------------------------
+    # Group 1: flat row-tiling — [512, 256] fp16, tile by c_row
+    #
+    # UNROLL=1 ground truth (_byte_stride_for_arg):
+    #   coord[1] = c_row; delta = T_ROW; device_stride[1] = prod([64]) = 64
+    #   byte_stride = T_ROW * 64 * 2
+    # -------------------------------------------------------------------------
+
+    def test_row_tiling_affine_stride_matches_unroll(self):
+        """compile_op_spec affine stride for c_row must equal _byte_stride_for_arg."""
+        T_ROW = 512
+        tensor = self._make_rc_tensor()
+        expected = _byte_stride_for_arg(tensor, self._C_ROW, T_ROW)
+        actual = self._get_flat_affine_stride(tensor, self._C_ROW, T_ROW)
+        self.assertEqual(
+            actual,
+            expected,
+            f"UNROLL=0 affine stride {actual} != UNROLL=1 ground truth {expected} "
+            f"for c_row tiling of [512,256] fp16 tensor",
+        )
+
+    def test_row_tiling_ground_truth_value(self):
+        """Row-tiling stride == T_ROW * 64 * 2 (matching test_unroll_loop_specs.py)."""
+        T_ROW = 512
+        tensor = self._make_rc_tensor()
+        expected = T_ROW * 64 * 2  # 65536 — from TestUnrollLoopSpecs._STRIDE_BYTES
+        actual = _byte_stride_for_arg(tensor, self._C_ROW, T_ROW)
+        self.assertEqual(actual, expected)
+        affine = self._get_flat_affine_stride(tensor, self._C_ROW, T_ROW)
+        self.assertEqual(
+            affine,
+            expected,
+            f"affine stride {affine} != expected {expected}",
+        )
+
+    # -------------------------------------------------------------------------
+    # Group 2: flat col-tiling — [512, 256] fp16, tile by c_col (non-linear)
+    #
+    # UNROLL=1 ground truth (_byte_stride_for_arg):
+    #   coord[0] = c_col//64; delta[0] = T_COL//64; device_stride[0] = 512*64 = 32768
+    #   coord[2] = Mod(c_col,64); delta[2] = 0 (Mod resets at T_COL=128 since 128%64==0)
+    #   byte_stride = (T_COL//64) * 32768 * 2
+    # -------------------------------------------------------------------------
+
+    def test_col_tiling_affine_stride_matches_unroll(self):
+        """compile_op_spec affine stride for c_col must equal _byte_stride_for_arg."""
+        T_COL = 128  # 2 sticks
+        tensor = self._make_rc_tensor()
+        expected = _byte_stride_for_arg(tensor, self._C_COL, T_COL)
+        actual = self._get_flat_affine_stride(tensor, self._C_COL, T_COL)
+        self.assertEqual(
+            actual,
+            expected,
+            f"UNROLL=0 affine stride {actual} != UNROLL=1 ground truth {expected} "
+            f"for c_col tiling of [512,256] fp16 tensor",
+        )
+
+    def test_col_tiling_ground_truth_value(self):
+        """Col-tiling stride == (T_COL//64) * 32768 * 2 (from TestUnrollLoopSpecs)."""
+        T_COL = 128
+        tensor = self._make_rc_tensor()
+        # device_stride[0] = prod(device_size[1:]) = 512 * 64 = 32768
+        expected = (T_COL // 64) * (512 * 64) * 2  # 131072
+        actual = _byte_stride_for_arg(tensor, self._C_COL, T_COL)
+        self.assertEqual(actual, expected)
+        affine = self._get_flat_affine_stride(tensor, self._C_COL, T_COL)
+        self.assertEqual(
+            affine,
+            expected,
+            f"affine stride {affine} != expected {expected}",
+        )
+
+    # -------------------------------------------------------------------------
+    # Group 3: K-input K-tiling — device_size=[2,64,64], tile by c_k (non-linear)
+    #
+    # This is the nested reduction scenario from TestNestedReductionUnroll.
+    # UNROLL=1 ground truth:
+    #   coord[0] = c_k//64; delta[0] = T_K//64 = 128//64 = 2
+    #   device_stride[0] = prod(device_size[1:]) = 64*64 = 4096
+    #   byte_stride = 2 * 4096 * 2 = 16384
+    # -------------------------------------------------------------------------
+
+    def test_k_tiling_affine_stride_matches_unroll(self):
+        """compile_op_spec affine stride for c_k must equal _byte_stride_for_arg."""
+        T_K = 128  # 2 sticks
+        tensor = self._make_k_input_tensor()
+        expected = _byte_stride_for_arg(tensor, self._C_K, T_K)
+        actual = self._get_flat_affine_stride(tensor, self._C_K, T_K)
+        self.assertEqual(
+            actual,
+            expected,
+            f"UNROLL=0 affine stride {actual} != UNROLL=1 ground truth {expected} "
+            f"for c_k tiling of k_input tensor (device_size=[2,64,64])",
+        )
+
+    def test_k_tiling_ground_truth_value(self):
+        """K-tiling stride == (T_K//64) * 4096 * 2 (from TestNestedReductionUnroll)."""
+        T_K = 128
+        tensor = self._make_k_input_tensor()
+        # device_stride[0] = prod(device_size[1:]) = 64 * 64 = 4096
+        K_TILE_BYTES = (T_K // 64) * (64 * 64) * 2  # 16384
+        actual = _byte_stride_for_arg(tensor, self._C_K, T_K)
+        self.assertEqual(actual, K_TILE_BYTES)
+        affine = self._get_flat_affine_stride(tensor, self._C_K, T_K)
+        self.assertEqual(
+            affine,
+            K_TILE_BYTES,
+            f"affine stride {affine} != expected {K_TILE_BYTES}",
+        )
+
+    # -------------------------------------------------------------------------
+    # Group 4: multi-stick row-tiling — [1024, 4096] fp16 tensor
+    #
+    # This is the reproducer from test_hint_row_tiling_multi_stick_pointwise_correct.
+    # device_size = [4096//64, 1024, 64] = [64, 1024, 64]
+    # Tiling c_row by T_ROW=512:
+    #   device_stride[1] = prod([64]) = 64
+    #   byte_stride = 512 * 64 * 2 = 65536
+    # -------------------------------------------------------------------------
+
+    def test_multi_stick_row_tiling_affine_stride_matches_unroll(self):
+        """[1024,4096] multi-stick row-tiling: affine stride must equal unroll stride."""
+        C_ROW = Symbol("c_row")
+        C_COL = Symbol("c_col")
+        tensor = TensorArg(
+            is_input=True,
+            arg_index=0,
+            device_dtype=_FP16,
+            device_size=[64, 1024, 64],  # [4096//64, 1024, 64]
+            device_coordinates=[C_COL // 64, C_ROW, sympy.Mod(C_COL, 64)],
+            allocation={"hbm": self._HBM_BASE},
+        )
+        T_ROW = 512
+        expected = _byte_stride_for_arg(tensor, C_ROW, T_ROW)
+        # ground truth: 512 * 64 * 2 = 65536
+        self.assertEqual(expected, T_ROW * 64 * 2)
+
+        out_tensor = TensorArg(
+            is_input=False,
+            arg_index=1,
+            device_dtype=_FP16,
+            device_size=[64, 1024, 64],
+            device_coordinates=[C_COL // 64, C_ROW, sympy.Mod(C_COL, 64)],
+            allocation={"hbm": 0x500000000},
+        )
+        op_spec = OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space={
+                C_ROW: (Integer(T_ROW), 1),
+                C_COL: (Integer(4096), 1),
+            },
+            args=[tensor, out_tensor],
+            op_info={},
+            tiled_symbols=[[C_ROW]],
+        )
+        symbols: list[int] = []
+        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
+        # affine_strides uses SDSC-renamed symbols; extract first non-zero stride value.
+        actual = None
+        for per_level in affine_strides:
+            for level_d in per_level:
+                if level_d:
+                    actual = next(iter(level_d.values()))
+                    break
+            if actual is not None:
+                break
+        self.assertIsNotNone(actual, "No affine stride found for C_ROW")
+        self.assertEqual(
+            actual,
+            expected,
+            f"UNROLL=0 affine stride {actual} != UNROLL=1 ground truth {expected} "
+            f"for [1024,4096] multi-stick row tiling",
         )
 
 

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -309,18 +309,17 @@ def _per_core_symbolic_dim_info(symbolic_dims: dict, work_slices: dict) -> dict:
     return info
 
 
-def _tiled_byte_stride(tensor, tiled_sym, iteration_space) -> int:
+def _tiled_byte_stride(tensor, tiled_sym) -> int:
     """Byte stride per loop iteration for a single tiled dimension.
 
-    The coarse_tile pass already divided iteration_space[tiled_sym].range by
-    the loop count, so that range is the per-iteration element count.  The full
-    per-iteration byte advancement is:
-        per_iter_elems * device_stride_for_dim * bytes_per_element
+    ``tensor.strides[tiled_sym]`` is already the per-tile element stride after
+    the ``dev_dim_size > it_dim_size`` backGap adjustment in
+    ``_create_sdsc_tensors``.  Multiplying by bytes-per-element gives the
+    correct per-iteration byte advance.  No ``per_iter_range`` factor — that
+    was a double-count (the tile range is already baked into
+    ``tensor.strides[tiled_sym]``).
     """
-    per_iter_range = iteration_space[tiled_sym]
-    return int(
-        per_iter_range * tensor.strides[tiled_sym] * num_bytes(tensor.data_format)
-    )
+    return int(tensor.strides[tiled_sym] * num_bytes(tensor.data_format))
 
 
 def _find_index_tensor_for_value(sdsc_spec, value_tensor_idx: int) -> int:
@@ -598,9 +597,7 @@ def generate_sdsc(
                 tensor_tiled_at_level = [s for s in level_syms if s in tensor.strides]
                 strides_for_level: dict = {}
                 for s in tensor_tiled_at_level:
-                    strides_for_level[s] = _tiled_byte_stride(
-                        tensor, s, sdsc_spec.iteration_space
-                    )
+                    strides_for_level[s] = _tiled_byte_stride(tensor, s)
                     any_tiled = True
                 per_level_strides.append(strides_for_level)
             if not any_tiled:


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

The `UNROLL_LOOPS=0` path emits `scf.for` loops with `affine.apply` ops in
`bundle.mlir` rather than unrolling tiles into flat `OpSpec` copies.  This PR
fixes a bug in that path that inflated the `affine.apply` stride values by
factors of up to 512×, producing wrong tile addresses and therefore wrong
results on hardware.

**Root cause** (`compute_ops.py`, `_tiled_byte_stride`):

`SDSCArgs.strides[sym]` is the per-tile element stride — it is computed by
`_calculate_device_stride` in `_create_sdsc_tensors` and further scaled by the
`dev_dim_size > it_dim_size` backGap adjustment so it already encodes the full
per-iteration tile advance.  The old implementation multiplied this value by
`per_iter_range` a second time, producing e.g. `512 × 65536 = 33554432` bytes
instead of the correct `65536` bytes for a 512-row tile.

The fix is a one-liner: drop `per_iter_range` and return
`tensor.strides[tiled_sym] * num_bytes(tensor.data_format)` directly.  The
unused `iteration_space` parameter is also removed.

**Verification** (`test_coarse_tiling.py`, `TestAffineStrideMatchesUnrollStride`):

A new test class pins the UNROLL=0 `compile_op_spec` affine strides against
the UNROLL=1 `_byte_stride_for_arg` ground truth for four cases:

| Case | Tensor | Expected stride |
|---|---|---|
| Row-tiling | [512, 256] fp16 | 512 × 64 × 2 = 65 536 B |
| Col-tiling | [512, 256] fp16 | 2 × 32 768 × 2 = 131 072 B |
| K-tiling | device_size=[2,64,64] fp16 | 2 × 4 096 × 2 = 16 384 B |
| Multi-stick row-tiling | [1024, 4096] fp16 | 512 × 64 × 2 = 65 536 B |

All seven tests were failing before the fix and pass after it.
`TestTiledByteStride` and `TestGenerateSdscTiledSymbols` are updated to
reflect the corrected semantics.

**E2E coverage** (`test_coarse_tile_e2e.py`):

With the stride fix in place, 32 of 39 e2e tests pass under `UNROLL_LOOPS=0`.
The 7 that still give wrong results are given conditional `pytest.xfail` guards
(`if not config.unroll_loops: pytest.xfail(...)`) so they do not show as
unexpected failures.  The failing tests divide into:

- **4 single-level** — `amin` dim=-1 reduction and all three dim=0 reductions:
  wrong output from the backend `scf.for` implementation for these ops.
- **3 multi-level / nested** — flash attention, nested bmm, nested matmul:
  backend `scf.for` nested loops not yet producing correct results.

Five `*Unroll0` subclasses (one per test class) are added, each decorated with
`@config.patch({"unroll_loops": False})`.  Pytest collects both the base class
(UNROLL=1) and the subclass (UNROLL=0) in a normal CI run, giving coverage of
both paths without any extra invocation:

```
39 passed           (base classes, unroll_loops=True)
32 passed, 7 xfailed (Unroll0 subclasses, unroll_loops=False)
─────────────────────────────────────────────────────────
67 passed, 7 xfailed  total
```

#### Which issue(s) this PR is related to:

Fixes #3068. 

#### Special notes for your reviewer:

- The `@config.patch` decorator on a `unittest.TestCase` *class* uses
  `setUpClass`/`tearDownClass` to apply the patch for the whole class (see
  `torch.utils._config_module.ContextDecorator.__call__`).  This is why the
  five `*Unroll0` subclasses work without any per-method change.
- Method-level `@config.patch({"unroll_loops": True})` decorators on
  `test_hint_unrolled_source_calls_sdsc` and
  `test_hint_unrolled_softmax_shaped_execution` override the class-level patch,
  so those tests continue to exercise the UNROLL=1 path even inside the
  `*Unroll0` subclass — which is intentional.
- The `_make_sdsc_spec` helper in `test_coarse_tiling.py` uses hand-crafted
  `SDSCArgs.strides` values.  After this fix, `device_stride=128` in that
  helper means "128 elements per full tile advance" (the per-tile stride), not
  "128 elements per unit step".  The updated test assertions (`128 * 2 = 256`)
  reflect this interpretation.

#### Does this PR introduce a user-facing change?

Yes — programs compiled with `UNROLL_LOOPS=0` (the `scf.for` path) previously
produced wrong output on 32 of 39 e2e coarse-tiling test cases due to
incorrect tile addresses in the emitted `affine.apply` ops.  After this fix, 32
of those 39 produce correct output; the remaining 7 are under investigation
to determine if they are inductor bugs or backend issues. 

#### Additional note:

The underlying formula error in `_tiled_byte_stride` was present since the
function was introduced.  It was invisible under `UNROLL_LOOPS=1` because that
path computes strides via `_byte_stride_for_arg` in `unroll.py` (which
evaluates device coordinates symbolically) and never calls
`_tiled_byte_stride`.