### PR TITLE
fix(oot test framework): place built forward inputs on the module's test device

### DIFF
--- a/tests/oot_framework/oot_test_config_models.py
+++ b/tests/oot_framework/oot_test_config_models.py
@@ -392,6 +392,29 @@ def _parse_input_arg(raw: Any) -> InputArg:
     )
 
 
+def _move_to_test_device(obj: Any, test_device: Optional[torch.device]) -> Any:
+    """Move built tensors (or lists of tensors) to the target test device.
+
+    Tensor specs are always built on CPU for reproducible seeded random data
+    (see ``InputTensorSpec.build``). The module under test, however, is moved to
+    ``test_device`` by the upstream ``test_forward`` harness via ``m.to(device)``,
+    so its parameters/buffers live on the device. Forward inputs must therefore
+    be placed on the same device or ``F.linear`` (and Spyre decompositions) raise
+    a device-mismatch error. Upstream torch builds sample inputs directly on the
+    device; we build on CPU then relocate here.
+
+    ``test_device`` is None only for CPU-target runs, where the tensors already
+    live on the correct device and no move is needed.
+    """
+    if test_device is None:
+        return obj
+    if isinstance(obj, torch.Tensor):
+        return obj.to(test_device)
+    if isinstance(obj, list):
+        return [_move_to_test_device(item, test_device) for item in obj]
+    return obj
+
+
 class InputsEdits(BaseModel):
     """
     Per-test input specification (edits.inputs).
@@ -427,14 +450,15 @@ class InputsEdits(BaseModel):
             inp_seed = None if seed is None else seed + i * 1000
 
             if isinstance(arg, InputArgTensor):
-                cpu_args.append(arg.tensor.build(seed=inp_seed))
+                t = arg.tensor.build(seed=inp_seed)
+                cpu_args.append(_move_to_test_device(t, test_device))
 
             elif isinstance(arg, InputArgTensorList):
                 lst = [
                     spec.build(seed=(None if seed is None else seed + i * 1000 + j * 7))
                     for j, spec in enumerate(arg.tensor_list)
                 ]
-                cpu_args.append(lst)
+                cpu_args.append(_move_to_test_device(lst, test_device))
 
             elif isinstance(arg, InputArgConfig):
                 import importlib
@@ -530,14 +554,16 @@ class InputsEdits(BaseModel):
                 arg = _parse_input_arg(v)
                 inp_seed = None if seed is None else seed + 500000 + i * 131
                 if isinstance(arg, InputArgTensor):
-                    out[k] = arg.tensor.build(seed=inp_seed)
+                    t = arg.tensor.build(seed=inp_seed)
+                    out[k] = _move_to_test_device(t, test_device)
                 elif isinstance(arg, InputArgTensorList):
-                    out[k] = [
+                    lst = [
                         spec.build(
                             seed=(None if inp_seed is None else inp_seed + j * 7)
                         )
                         for j, spec in enumerate(arg.tensor_list)
                     ]
+                    out[k] = _move_to_test_device(lst, test_device)
                 elif isinstance(arg, InputArgConfig):
                     import importlib
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

`InputsEdits.build_cpu_args` / `resolved_kwargs` build tensor inputs on CPU for
reproducible seeded random data. The upstream `test_forward` harness, however,
moves the module under test to the test device via `m.to(device)`, so its
parameters and buffers live on that device. When the module then runs its
forward against the CPU-built inputs, it fails with a device mismatch, e.g.:

```
RuntimeError: Spyre decomposition function called with inputs being on a
different device! Args devices: args_device=[device(type='cpu'),
device(type='spyre', index=0)]
```

This PR adds a `_move_to_test_device` helper and applies it to every built
tensor / tensor-list arg (positional args and kwargs) so forward inputs are
relocated to the same device as the module. This matches upstream torch, which
builds sample inputs directly on the device. The move is skipped when
`test_device` is None (CPU-target runs), where the tensors already live on the
correct device.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

https://github.com/torch-spyre/torch-spyre/issues/2987
https://github.com/torch-spyre/hf-adapters/pull/124

#### Special notes for your reviewer:

- Builds on https://github.com/torch-spyre/torch-spyre/issues/3012 — that PR made module
  construction succeed and the forward actually run, which is what exposed this
  device-placement mismatch.
- Config args (`InputArgConfig`) are intentionally not relocated: they produce a
  `PretrainedConfig`, not a tensor, so `_move_to_test_device` passes them through
  unchanged.
- Verified with the hf-adapters module-config flow: running the Granite 3.3 MLP
  module test on the Spyre device no longer raises the CPU-vs-spyre device
  mismatch; the module forward runs with inputs on the module's device.

#### Does this PR introduce a user-facing change?

#### Additional note:
