### PR TITLE
Fix incorrect SuperDSC backGap assignment for GQA-style folded views under coarse tiling.

### DIFF
--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -246,6 +246,11 @@ class TestCoordinates(TestCase):
             tensors[0]["coordinates"],
             [p0, p1, sympy.floor(p2 / 64), sympy.Mod(p2, 64)],
         )
+        self.assertEqual(tensors[1]["size"], [1024, 2, 2, 64])
+        self.assertEqual(
+            tensors[1]["coordinates"],
+            [p1, sympy.floor(p2 / 64), p0, sympy.Mod(p2, 64)],
+        )
 
     def test_align_tensors_coalesces_repeated_constant_gap_dims(self):
         iteration_space = {p0: (2, 1), p1: (3, 1), p2: (5, 1), p3: (128, 1)}

--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -27,7 +27,7 @@ from torch_spyre._inductor.propagate_layouts import (
     PropArg,
     _check_supported_input_sticks,
 )
-from torch_spyre._inductor.views import compute_coordinates
+from torch_spyre._inductor.views import align_tensors, compute_coordinates
 from torch.utils._sympy.functions import ModularIndexing
 
 p0, p1, p2, p3, p4, p5 = sympy.symbols("p0 p1 p2 p3 p4 p5", integer=True)
@@ -211,6 +211,66 @@ class TestCoordinates(TestCase):
             5760 * p0 + 384 * p1 + p2 + 128,
         )
         self.assertEqual(cx, [p1, p2 // 64 + 2, p0, p2 % 64])
+
+    def test_align_tensors_coalesces_constant_gap_dims(self):
+        iteration_space = {p0: (2, 1), p1: (1024, 1), p2: (128, 1)}
+        new_iteration_space, tensors = align_tensors(
+            iteration_space,
+            [
+                {
+                    "size": [8, 1024, 2, 1, 64],
+                    "coordinates": [
+                        4 * p0,
+                        p1,
+                        sympy.floor(p2 / 64),
+                        sympy.S.Zero,
+                        sympy.Mod(p2, 64),
+                    ],
+                },
+                {
+                    "size": [1024, 1, 2, 2, 64],
+                    "coordinates": [
+                        p1,
+                        sympy.S.Zero,
+                        sympy.floor(p2 / 64),
+                        p0,
+                        sympy.Mod(p2, 64),
+                    ],
+                },
+            ],
+        )
+
+        self.assertEqual(new_iteration_space, iteration_space)
+        self.assertEqual(tensors[0]["size"], [2, 4096, 2, 64])
+        self.assertEqual(
+            tensors[0]["coordinates"],
+            [p0, p1, sympy.floor(p2 / 64), sympy.Mod(p2, 64)],
+        )
+
+    def test_align_tensors_coalesces_repeated_constant_gap_dims(self):
+        iteration_space = {p0: (2, 1), p1: (3, 1), p2: (5, 1), p3: (128, 1)}
+        new_iteration_space, tensors = align_tensors(
+            iteration_space,
+            [
+                {
+                    "size": [8, 15, 5, 1, 64],
+                    "coordinates": [
+                        4 * p0,
+                        5 * p1,
+                        p2,
+                        sympy.S.Zero,
+                        sympy.Mod(p3, 64),
+                    ],
+                },
+            ],
+        )
+
+        self.assertEqual(new_iteration_space, iteration_space)
+        self.assertEqual(tensors[0]["size"], [1, 2, 12, 25, 64])
+        self.assertEqual(
+            tensors[0]["coordinates"],
+            [sympy.floor(p3 / 64), p0, p1, p2, sympy.Mod(p3, 64)],
+        )
 
 
 class TestUnrepresentableStickCandidates(TestCase):

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -709,6 +709,51 @@ def align_tensors(
         )
         new_tensors.append({"size": size, "coordinates": coordinates})
 
+    def _exact_div(a, b):
+        a = sympy.sympify(a)
+        b = sympy.sympify(b)
+        if isinstance(a, sympy.Integer) and isinstance(b, sympy.Integer):
+            if int(a) % int(b) != 0:
+                return None
+            return sympy.Integer(int(a) // int(b))
+        q = sympy.simplify(a / b)
+        return q if q.is_integer else None
+
+    def _coalesce_constant_gap_dims(tensor):
+        """Fold zero-coordinate physical gap dims into adjacent logical dims."""
+        size = tensor["size"]
+        coordinates = tensor["coordinates"]
+        i = 0
+        while i + 2 < len(size) - 1:
+            # A term like 4*c0 is normalized as [c0, 0], with the size-4
+            # zero-coordinate dim carrying only physical stride.  For row-major
+            # coordinates, [A, G, B] with coords [a, 0, b] is equivalent to
+            # [A/G, B*G] with coords [a, b], when A is divisible by G.
+            gap_coord = coordinates[i + 1]
+            gap_size = size[i + 1]
+            if gap_coord != 0 or _concretize_for_cmp(gap_size) <= 1:
+                i += 1
+                continue
+
+            outer_coord = coordinates[i]
+            inner_coord = coordinates[i + 2]
+            if not outer_coord.free_symbols or not inner_coord.free_symbols:
+                i += 1
+                continue
+
+            outer_size = _exact_div(size[i], gap_size)
+            if outer_size is None:
+                i += 1
+                continue
+
+            size[i] = outer_size
+            size[i + 2] = sympy.simplify(size[i + 2] * gap_size)
+            del size[i + 1]
+            del coordinates[i + 1]
+
+    for tensor in new_tensors:
+        _coalesce_constant_gap_dims(tensor)
+
     # decide desired rank for all tensors
     rank = 0
     for i, t in enumerate(new_tensors):


### PR DESCRIPTION
Fix gap-dim alignment for folded views

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

## Summary

Here’s an updated PR description you can paste:

## Summary

This PR fixes two coarse-tiling address correctness issues found while debugging Flash Attention GQA on torch-spyre.

### 1. Fix folded-view gap-dim alignment

The first issue was caused by folded views where `align_tensors()` inserted a physical gap dimension with `coords=0`. That gap dimension could later receive `backGap` assignment in the wrong physical position, causing incorrect address calculations after view/fold transformations.

This PR generalizes the alignment logic to coalesce zero-coordinate physical gap dimensions when they are exactly foldable into neighboring dimensions. This avoids assigning `backGap` to a synthetic gap dimension that does not correspond to a real logical coordinate.


### 2. Fix preserved-loop affine strides for `per_tile_fixed` tensors

A second issue appeared when running with `UNROLL_LOOPS=0`. The unrolled path correctly treats `per_tile_fixed=True` tensors as tile-local scratch and keeps their allocation fixed across loop iterations. However, the preserved-loop symbolic-address path still generated affine address advances for those tensors.

That produced bundle MLIR like:

```mlir
%addr = affine.apply #map(%i_0)[%pool_addr_0]
```

for a pool scratch tensor that should have stayed at `%pool_addr_0`.

~~This PR threads `per_tile_fixed` as codegen-side metadata from `OpSpec` into `generate_sdsc()` and suppresses affine tile strides for those arg indices while still registering their base address normally. `per_tile_fixed` is intentionally not added to `SDSCArgs`, since it is not an SDSC tensor field.~~

Issue 2 is addressed in #3228 


#### Which issue(s) this PR is related to:

Fixes #3098

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
