### PR TITLE
fix(UNROLL_LOOPS=0): correct pool address advancement in reduction-dim tiling

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1764,10 +1764,6 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
 
     def test_nested_bmm_outer_Batch_inner_K_correct(self):
         """bmm [B,M,K]@[B,K,N] outer B (output) + inner K (reduction) — correct."""
-        if not config.unroll_loops:
-            pytest.xfail(
-                "UNROLL_LOOPS=0: nested scf.for loops not yet correct in backend"
-            )
         from torch_spyre._inductor import spyre_hint
 
         B, M, K, N = 4, 64, 512, 32
@@ -1791,10 +1787,6 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
 
     def test_nested_matmul_outer_M_inner_K_correct(self):
         """mm [M,K]@[K,N] with outer M (output) + inner K (reduction) — correct."""
-        if not config.unroll_loops:
-            pytest.xfail(
-                "UNROLL_LOOPS=0: nested scf.for loops not yet correct in backend"
-            )
         from torch_spyre._inductor import spyre_hint
 
         M, K, N = 128, 512, 32

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1556,8 +1556,6 @@ class TestCoarseTileReductionE2E(InductorTestCase):
 
     def test_hint_tiled_reduction_min_correct(self):
         """x.amin(dim=-1) tiled over D (4 tiles) produces correct results."""
-        if not config.unroll_loops:
-            pytest.xfail("UNROLL_LOOPS=0: amin scf.for loop not yet correct in backend")
         from torch_spyre._inductor import spyre_hint
 
         B, D = 64, 512
@@ -1587,10 +1585,6 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
 
     def test_hint_tiled_reduction_dim0_sum_correct(self):
         """x.sum(dim=0) tiled over B produces correct results."""
-        if not config.unroll_loops:
-            pytest.xfail(
-                "UNROLL_LOOPS=0: dim=0 reduction scf.for loop not yet correct in backend"
-            )
         from torch_spyre._inductor import spyre_hint
 
         B, D = 512, 64
@@ -1608,10 +1602,6 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
 
     def test_hint_tiled_reduction_dim0_max_correct(self):
         """x.amax(dim=0) tiled over B produces correct results."""
-        if not config.unroll_loops:
-            pytest.xfail(
-                "UNROLL_LOOPS=0: dim=0 reduction scf.for loop not yet correct in backend"
-            )
         from torch_spyre._inductor import spyre_hint
 
         B, D = 512, 64
@@ -1629,10 +1619,6 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
 
     def test_hint_tiled_reduction_dim0_min_correct(self):
         """x.amin(dim=0) tiled over B produces correct results."""
-        if not config.unroll_loops:
-            pytest.xfail(
-                "UNROLL_LOOPS=0: dim=0 reduction scf.for loop not yet correct in backend"
-            )
         from torch_spyre._inductor import spyre_hint
 
         B, D = 512, 64

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -312,12 +312,12 @@ def _per_core_symbolic_dim_info(symbolic_dims: dict, work_slices: dict) -> dict:
 def _tiled_byte_stride(tensor, tiled_sym) -> int:
     """Byte stride per loop iteration for a single tiled dimension.
 
-    ``tensor.strides[tiled_sym]`` is already the per-tile element stride after
-    the ``dev_dim_size > it_dim_size`` backGap adjustment in
-    ``_create_sdsc_tensors``.  Multiplying by bytes-per-element gives the
-    correct per-iteration byte advance.  No ``per_iter_range`` factor — that
-    was a double-count (the tile range is already baked into
-    ``tensor.strides[tiled_sym]``).
+    ``tensor.strides[tiled_sym]`` is already the per-tile element stride
+    (``_create_sdsc_tensors`` receives the per-tile iteration space, since
+    ``coarse_tile.py`` has already divided the op ranges by ``loop_count``
+    before ``create_op_spec`` runs).  Multiplying by bytes-per-element
+    gives the correct per-iteration byte advance for the ``affine.apply``
+    in the ``scf.for`` loop body.
     """
     return int(tensor.strides[tiled_sym] * num_bytes(tensor.data_format))
 
@@ -591,10 +591,18 @@ def generate_sdsc(
                 sliced_base_sym_idx = -1
             # Build per-level strides: for each level, collect the symbols at that
             # level that tile this tensor (i.e. appear in tensor.strides).
+            # Exclude symbols whose scale is negative: those are reduced dimensions
+            # whose stride describes element layout within one tile, not the advance
+            # between tiles.  Tiling by a reduction-dim symbol would incorrectly
+            # advance the base address of a pool output past its single allocated slot.
             per_level_strides: list[dict] = []
             any_tiled = False
             for level_syms in tiled_symbols:
-                tensor_tiled_at_level = [s for s in level_syms if s in tensor.strides]
+                tensor_tiled_at_level = [
+                    s
+                    for s in level_syms
+                    if s in tensor.strides and tensor.scales.get(s, 1) > 0
+                ]
                 strides_for_level: dict = {}
                 for s in tensor_tiled_at_level:
                     strides_for_level[s] = _tiled_byte_stride(tensor, s)


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug

#### What this PR does:

Fixes a silent wrong-result bug in the `UNROLL_LOOPS=0` (`scf.for`) codegen
path for tiled reductions.

**Root cause.**  Reduction operations with a coarse-tiled reduction dimension
use a 3-SDSC pattern: `sdsc_0` (identity init), `sdsc_1` (partial reduction),
`sdsc_2` (combiner).  `sdsc_1` writes its per-tile partial result into a pool
buffer; `sdsc_2` reads from that same buffer and accumulates into the output.
The pool buffer is a single working slot — reused on every loop iteration.

In `generate_sdsc` (`compute_ops.py`), the filter that decides which tiled
symbols produce an `affine.apply` base-address advance was:

```python
tensor_tiled_at_level = [s for s in level_syms if s in tensor.strides]
```

For the pool output tensor of `sdsc_1`, the reduction-dimension symbol (e.g.
`D_sym` for `amin(dim=-1)`, `B_sym` for `sum(dim=0)`) is present in
`tensor.strides`.  This is because `_create_sdsc_tensors` appends reduced dims
to `dim_order` and computes strides for all dims — those strides describe
element layout *within* one tile, not advancement *between* tiles.

The bug: the pool output's base address was incorrectly advanced per `scf.for`
iteration (`pool+0`, `pool+8192`, `pool+16384`, `pool+24576`), while `sdsc_2`
always read from the fixed base `pool+0`.  Only the first tile's partial result
was ever visible to the combiner; tiles 1–N wrote to addresses that were never
read, silently discarding their contributions.

**Fix.**  `SDSCArgs.scales` already encodes the semantics: `scales[dim] < 0`
marks a reduced dimension.  Adding `tensor.scales.get(s, 1) > 0` to the filter
excludes reduced-dimension symbols from `affine.apply` generation, leaving the
pool as a single reused working buffer:

```python
tensor_tiled_at_level = [
    s
    for s in level_syms
    if s in tensor.strides and tensor.scales.get(s, 1) > 0
]
```

This fix is correct for HBM tensors too: a non-pool output tensor tiled over an
output dimension still has `scales[dim] > 0` and continues to advance normally.

**Scope.**  The `UNROLL_LOOPS=1` path is unaffected — it unrolls the loop at
compile time into separate SDSCs with baked-in per-tile addresses and never
calls the `affine.apply` path.

**Tests.**  Six `pytest.xfail` guards are removed across two commits:

| Test | Reduction |
|---|---|
| `test_hint_tiled_reduction_min_correct` | `amin(dim=-1)`, tiled over D |
| `test_hint_tiled_reduction_dim0_sum_correct` | `sum(dim=0)`, tiled over B |
| `test_hint_tiled_reduction_dim0_max_correct` | `amax(dim=0)`, tiled over B |
| `test_hint_tiled_reduction_dim0_min_correct` | `amin(dim=0)`, tiled over B |
| `test_nested_bmm_outer_Batch_inner_K_correct` | nested outer-B + inner-K |
| `test_nested_matmul_outer_M_inner_K_correct` | nested outer-M + inner-K |

All six tests (and their `*Unroll0` subclass variants) now pass under both
`UNROLL_LOOPS=0` and `UNROLL_LOOPS=1`.  The `test_hint_flash_attention` xfail
is retained — that test still produces ~74% element mismatch under
`UNROLL_LOOPS=0` and requires separate investigation.

Local results after both commits:

| Config | Passed | Xfailed |
|---|---|---|
| `UNROLL_LOOPS=0` | 80 | 2 (`test_hint_flash_attention` ×2) |
| `UNROLL_LOOPS=1` (default) | 81 | 1 (`test_hint_flash_attention` in Unroll0 subclass) |
| `test_coarse_tiling.py` unit tests | 207 | 0 |

#### Which issue(s) this PR is related to:

<!-- none filed yet -->

#### Special notes for your reviewer:

The fix is a one-line predicate addition.  The important invariant to verify:
`SDSCArgs.scales[sym]` is negative if and only if `sym` is a reduction
dimension symbol — this holds by construction in `compile_op_spec`
(`superdsc.py`), which copies scales directly from the op spec.

The `_tiled_byte_stride` docstring is also updated to reflect the current
understanding of how per-tile strides are constructed (the old comment
referenced a now-removed `per_iter_range` factor).

#### Does this PR introduce a user-facing change?

Yes — `amin`, `amax`, and `sum` with a tiled reduction dimension now produce
correct results under `UNROLL_LOOPS=0`.  Previously all three silently returned
wrong values (only the first tile contributed to the reduction).

#### Additional note:

`UNROLL_LOOPS=1` (the current default) was not affected by this bug.  The
`UNROLL_LOOPS=0` path (`scf.for` emission) is the target steady state once all
cases are verified; `UNROLL_LOOPS=1` and `unroll.py` are scheduled for removal.