### PR TITLE
fix(layout): skip unrepresentable candidate sticks instead of aborting

### DIFF
--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -16,6 +16,17 @@ import sympy
 
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
+from torch._inductor.dependencies import MemoryDep
+from torch_spyre._C import SpyreTensorLayout
+from torch_spyre._inductor.errors import Unsupported
+from torch_spyre._inductor.pass_utils import (
+    device_coordinates,
+    try_device_coordinates,
+)
+from torch_spyre._inductor.propagate_layouts import (
+    PropArg,
+    _check_supported_input_sticks,
+)
 from torch_spyre._inductor.views import compute_coordinates
 from torch.utils._sympy.functions import ModularIndexing
 
@@ -200,6 +211,64 @@ class TestCoordinates(TestCase):
             5760 * p0 + 384 * p1 + p2 + 128,
         )
         self.assertEqual(cx, [p1, p2 // 64 + 2, p0, p2 % 64])
+
+
+class TestUnrepresentableStickCandidates(TestCase):
+    """Cover the skip-unrepresentable-candidate behavior added for the
+    ``floor(var/N)`` cross-stick crash (transpose feeding a matmul).
+
+    A candidate device layout can have a stick expression the backend cannot
+    represent (e.g. ``floor(d2/128)``). ``device_coordinates`` raises
+    ``Unsupported`` on such sticks; the enumeration sites use
+    ``try_device_coordinates`` to skip them instead of aborting the compile
+    when another candidate is valid.
+    """
+
+    def _dtype(self):
+        # Device data format for fp16 (SEN169_FP16); read off a scratch STL so
+        # the test does not hard-code the enum value.
+        return SpyreTensorLayout([1, 1], torch.float16).device_dtype
+
+    def _traced_scenario(self):
+        """The exact (dep, unrepresentable STL, representable STL) triple from
+        the Granite SDPA linear-projection failure.
+
+        dep index ``4096*d0 + d2`` over ranges {d0:512, d1:4096, d2:4096}:
+          * bad  STL -> stick expr ``floor(d2/128)`` (cross-stick, unrepresentable)
+          * good STL -> stick expr ``d2`` (bare var, representable)
+        """
+        dev = self._dtype()
+        d0, d1, d2 = sympy.symbols("d0 d1 d2", integer=True, nonnegative=True)
+        dep = MemoryDep("buf", 4096 * d0 + d2, (d0, d1, d2), (512, 4096, 4096))
+        bad = SpyreTensorLayout([512, 128, 1, 1, 64], [4096, 1, 8192, -1, 128], dev)
+        good = SpyreTensorLayout([512, 1, 1, 64], [4096, -1, -1, 1], dev)
+        return dep, bad, good
+
+    def test_device_coordinates_raises_try_returns_none(self):
+        dep, bad, good = self._traced_scenario()
+        # The strict variant raises on the unrepresentable stick ...
+        with self.assertRaises(Unsupported):
+            device_coordinates(bad, dep, None)
+        # ... while the non-raising variant returns None for it.
+        self.assertIsNone(try_device_coordinates(bad, dep, None))
+        # A representable candidate still returns coordinates from both.
+        self.assertIsNotNone(try_device_coordinates(good, dep, None))
+        d2 = sympy.Symbol("d2", integer=True, nonnegative=True)
+        self.assertEqual(device_coordinates(good, dep, None)[-1].free_symbols, {d2})
+
+    def test_check_supported_input_sticks_tolerates_mixed_list(self):
+        # arg with one unrepresentable candidate and one valid one: the guard
+        # must not raise (it previously aborted the whole compile).
+        dep, bad, good = self._traced_scenario()
+        arg = PropArg(dep, None, [bad, good])
+        _check_supported_input_sticks([arg], "batchmatmul")  # must not raise
+
+    def test_check_supported_input_sticks_all_unrepresentable(self):
+        # When every candidate is unrepresentable the guard still does not
+        # raise here (the hard failure comes later, from layout selection).
+        dep, bad, _ = self._traced_scenario()
+        arg = PropArg(dep, None, [bad])
+        _check_supported_input_sticks([arg], "batchmatmul")  # must not raise
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1010,9 +1010,13 @@ def compute_restickify_needed(
     if idc is None or out_idc is None:
         # One of the layouts has a stick expression the backend cannot
         # represent (e.g. floor(var/N) from a cross-stick access). Such a
-        # candidate can never be a feasible restickify source/target, so report
-        # it as infeasible (the cost model maps this to INF and the beam search
-        # discards it) rather than aborting the whole pass.
+        # candidate can never be a feasible restickify source/target.
+        #
+        # Return (True, None): the (needed=True, tgt=None) pair is the
+        # "infeasible restickify" signal on this function's contract. The beam
+        # search maps it to INF cost and discards the candidate — see
+        # EdgeCostMap._compute_and_cache_cost in optimize_restickify.py. This is
+        # preferable to aborting the whole pass when another candidate is valid.
         return True, None
     assert idc, "device_coordinates returned empty list for input"
     assert out_idc, "device_coordinates returned empty list for output"

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -705,6 +705,26 @@ def device_coordinates(
     return coords
 
 
+def try_device_coordinates(
+    stl: SpyreTensorLayout,
+    dep: MemoryDep,
+    indirect_sizes: "dict[sympy.Symbol, int] | None",
+) -> list[sympy.Expr] | None:
+    """Like ``device_coordinates`` but returns ``None`` instead of raising when
+    the layout's stick expression is one the backend cannot represent.
+
+    Intended for callers that *enumerate* candidate layouts (e.g. matmul input
+    layout selection) and want to skip an unrepresentable candidate rather than
+    abort the whole compile. Callers that have already committed to a single
+    layout should keep using ``device_coordinates`` so an unrepresentable stick
+    remains a hard error.
+    """
+    try:
+        return device_coordinates(stl, dep, indirect_sizes)
+    except Unsupported:
+        return None
+
+
 def iter_var_id(stick_expr) -> int:
     """Iteration variable index from a stick expr: Mod(d2,64) -> 2, d2 -> 2.
     Returns -1 for constant-zero (scalar/broadcast, no real stick).
@@ -985,8 +1005,15 @@ def compute_restickify_needed(
     ind_names, _, ind_sizes = indirect_info_from_op(op)
     if in_dep.name in ind_names:
         return False, None
-    idc = device_coordinates(in_stl, in_dep, ind_sizes)
-    out_idc = device_coordinates(out_stl, out_dep, ind_sizes)
+    idc = try_device_coordinates(in_stl, in_dep, ind_sizes)
+    out_idc = try_device_coordinates(out_stl, out_dep, ind_sizes)
+    if idc is None or out_idc is None:
+        # One of the layouts has a stick expression the backend cannot
+        # represent (e.g. floor(var/N) from a cross-stick access). Such a
+        # candidate can never be a feasible restickify source/target, so report
+        # it as infeasible (the cost model maps this to INF and the beam search
+        # discards it) rather than aborting the whole pass.
+        return True, None
     assert idc, "device_coordinates returned empty list for input"
     assert out_idc, "device_coordinates returned empty list for output"
     # Input stick with an offset always needs restickify to remove the offset.

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -204,6 +204,7 @@ def _check_supported_input_sticks(args: list[PropArg], op_label: str) -> None:
     the layout after — which is not yet implemented.
     """
     for i, arg in enumerate(args):
+        representable = 0
         for stl in arg.layouts:
             coords = try_device_coordinates(stl, arg.dep, None)
             if coords is None:
@@ -212,6 +213,7 @@ def _check_supported_input_sticks(args: list[PropArg], op_label: str) -> None:
                 # access). It is not a usable candidate, so skip it rather than
                 # aborting — another candidate for this input may be valid.
                 continue
+            representable += 1
             stick_expr = coords[-1]
             if not is_stick_expr_offset_free(stick_expr, stl.elems_per_stick()):
                 raise Unsupported(
@@ -219,6 +221,20 @@ def _check_supported_input_sticks(args: list[PropArg], op_label: str) -> None:
                     f"{stick_expr!r} (likely from slicing the stick dimension); "
                     f"this op requires a fixed input layout and double-restickify is not yet supported"
                 )
+        if arg.layouts and representable == 0:
+            # Every candidate layout for this input was unrepresentable. This
+            # is not fatal here, but the downstream layout selection will fail
+            # (find_stick_compatible_input_layout raises "cannot restickify any
+            # input layout"). Log the more specific cause so that error is
+            # easier to diagnose.
+            logger.warning(
+                "%s: all %d candidate layout(s) of input arg%d have "
+                "unrepresentable stick expressions; downstream layout "
+                "selection is expected to fail for this op.",
+                op_label,
+                len(arg.layouts),
+                i,
+            )
 
 
 def _rescale_stl_for_dtype(

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -66,6 +66,7 @@ from .pass_utils import (
     identify_matmul_inputs,
     host_coordinates,
     device_coordinates,
+    try_device_coordinates,
     indirect_info_from_op,
     is_stick_expr_offset_free,
     iter_var_id,
@@ -204,7 +205,14 @@ def _check_supported_input_sticks(args: list[PropArg], op_label: str) -> None:
     """
     for i, arg in enumerate(args):
         for stl in arg.layouts:
-            stick_expr = device_coordinates(stl, arg.dep, None)[-1]
+            coords = try_device_coordinates(stl, arg.dep, None)
+            if coords is None:
+                # This candidate layout has a stick expression the backend
+                # cannot represent (e.g. floor(var/N) from a cross-stick
+                # access). It is not a usable candidate, so skip it rather than
+                # aborting — another candidate for this input may be valid.
+                continue
+            stick_expr = coords[-1]
             if not is_stick_expr_offset_free(stick_expr, stl.elems_per_stick()):
                 raise Unsupported(
                     f"{op_label}: input arg{i} has stick expression with offset "
@@ -586,19 +594,26 @@ def find_stick_compatible_input_layout(
     2. Else return the first layout that can be restickified to put reduction_var on the stick.
     3. Else raise Unsupported.
     """
-    arg_dev_coords = [device_coordinates(stl, arg.dep, None) for stl in arg.layouts]
+    # Skip candidates whose stick expression the backend cannot represent
+    # (e.g. floor(var/N) from a cross-stick access); they are not usable inputs
+    # and another candidate may work.
+    candidates = [
+        (stl, coords)
+        for stl in arg.layouts
+        if (coords := try_device_coordinates(stl, arg.dep, None)) is not None
+    ]
 
     # Pass 1: already stick-compatible.
     # stick_compatible() checks cross-tensor compatibility; here we only need
     # to know if this input's stick coord already carries the target loop variable.
-    for stl, dev_coords in zip(arg.layouts, arg_dev_coords):
+    for stl, dev_coords in candidates:
         if reduction_var in dev_coords[-1].free_symbols:
             return stl
 
     # Pass 2: can be restickified — find the resolvable device coord for reduction_var
     # and use it as target_stick_expr for compute_restickify_target_layout.
     arg_host_coords = host_coordinates(arg.layout, arg.dep, None)
-    for stl, dev_coords in zip(arg.layouts, arg_dev_coords):
+    for stl, dev_coords in candidates:
         target_stick_expr = _dev_coord_for_var(
             dev_coords, arg_host_coords, reduction_var
         )


### PR DESCRIPTION
## Problem

During layout propagation and restickify cost estimation, matmul input-layout selection and the beam-search cost model enumerate **all** candidate device layouts for each input. Some candidates carry a stick expression the backend cannot represent — e.g. `floor(var/N)` from a cross-stick access, as produced by a transpose feeding a matmul.

`device_coordinates` raises `Unsupported` on such sticks. Because the enumeration sites call it while merely *inspecting* candidates, a single unrepresentable candidate aborted the **entire compile** — even when another candidate for the same input was perfectly valid.

Concretely this surfaced as:
```
Unsupported: Spyre backend does not support: Unexpected stick expression
floor(d2/128): expected Mod(var, 64), a bare variable, 0, or any of those
with a constant offset
```
when compiling graphs where a transpose feeds a matmul (e.g. the linear projections around `scaled_dot_product_attention` in Granite). The failing candidate was a *non-preferred* alternative layout (candidate #1 of 3); candidate #0 was valid.

## Fix

Add `try_device_coordinates`, a non-raising variant of `device_coordinates` that returns `None` for unrepresentable sticks, and use it at the three enumeration sites:

- **`_check_supported_input_sticks`** — skip the candidate. Its guard only means to reject *offset* sticks among representable candidates, not to abort on unrepresentable ones.
- **`find_stick_compatible_input_layout`** — filter candidates up front so both the stick-compatible and restickifiable passes ignore bad ones.
- **`compute_restickify_needed`** — treat an unrepresentable in/out layout as an infeasible restickify (the cost model maps this to `INF`, so the beam search discards it).

Callers that have already committed to a single layout keep using `device_coordinates`, so an unrepresentable stick there remains a hard error (no loss of a real correctness gate).

## Effect

Unblocks `torch.compile` of graphs with transpose→matmul patterns; verified end-to-end on Granite-3.3-8b (`run_granite_fms.sh`), where the layout passes now complete and the pipeline proceeds to backend codegen.

## Test plan

- [x] `pre-commit run` (ruff, ruff-format, mypy, import-regex) passes on both files
- [x] Granite-3.3-8b e2e no longer aborts in `propagate_spyre_tensor_layouts` / `optimize_restickify_locations`