### PR TITLE
Pad restickify inputs/outputs for unaligned dims

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -7172,11 +7172,11 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         """Test that offset-stick slice mutation raises Unsupported when no alt dim is divisible by stick_size."""
 
         def fn(x, y):
-            x[:, 32:96].copy_(y)
+            x[32:96].copy_(y)
             return x.clone()
 
-        x = torch.randn(63, 128, dtype=torch.float16, device="spyre")
-        y = torch.randn(63, 64, dtype=torch.float16, device="spyre")
+        x = torch.randn(128, dtype=torch.float16, device="spyre")
+        y = torch.randn(64, dtype=torch.float16, device="spyre")
 
         compiled = torch.compile(fn, backend="inductor", fullgraph=True, dynamic=False)
         with pytest.raises(Exception) as exc_info:

--- a/tests/inductor/test_inductor_transpose_edge.py
+++ b/tests/inductor/test_inductor_transpose_edge.py
@@ -195,10 +195,11 @@ class TestTransposeEdge:
         assert torch.allclose(slice1.cpu(), y_cpu[:2, :16, :8, :4])
 
     # --- Materialized copy after transpose (#1859) ---
-    @pytest.mark.xfail(
-        reason="Issue #1859: dxp_standalone SIGABRT on transpose+clone bundle generation.",
-    )
     def test_transpose_then_clone(self, execution_mode):
+        if execution_mode == "eager":
+            pytest.xfail(
+                "Issue #1859: dxp_standalone SIGABRT on transpose+clone bundle generation."
+            )
         x = cached_randn((72, 91), dtype=torch.float16)
         _compare_mode(execution_mode, lambda t: t.transpose(0, 1).clone(), x)
 

--- a/tests/inductor/test_provenance_integration.py
+++ b/tests/inductor/test_provenance_integration.py
@@ -76,7 +76,6 @@ def _assert_handles_survive_real_compile(monkeypatch, model, expect_rewrite):
     module, and (d) a fused handle carries that line among its constituents.
     """
     from torch_spyre.constants import DEVICE_NAME
-    import torch_spyre._inductor.insert_restickify as restickify
     import torch_spyre._inductor.pass_utils as pass_utils
     import torch_spyre._inductor.provenance as prov
     import torch_spyre._inductor.spyre_kernel as sk
@@ -107,7 +106,6 @@ def _assert_handles_survive_real_compile(monkeypatch, model, expect_rewrite):
     monkeypatch.setattr(prov, "build_debug_handle", _collect)
     monkeypatch.setattr(sk, "build_debug_handle", _collect)
     monkeypatch.setattr(pass_utils, "preserve_provenance", _preserve)
-    monkeypatch.setattr(restickify, "preserve_provenance", _preserve)
     monkeypatch.setattr(
         prov.SpyreGraphTransformObserver,
         "__enter__",

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -22,6 +22,7 @@
 # Shapes use multiples of 64 (stick size = 64 fp16 elements) to ensure
 # stick-aligned inputs that exercise the restickify path rather than fallback.
 
+import itertools
 import math
 
 import pytest
@@ -33,11 +34,23 @@ from torch.spyre import SpyreTensorLayout
 
 import torch_spyre._inductor.optimize_restickify as _optimize_restickify
 from torch._inductor.exc import InductorError
+from torch_spyre._inductor import config
 from utils_inductor import _compile_and_run, compare_with_cpu
 
 DEVICE = torch.device("spyre")
 S = 128  # must be a multiple of 64
 T = 64  # side length for 4D tests (all dims equal)
+
+
+@pytest.fixture(autouse=True)
+def _seed_rng():
+    """Pin the RNG before every test so the ``torch.randn`` inputs do not depend
+    on prior tests' draws.  A few tolerance-based tests reduce (e.g. p.sum())
+    over their inputs, and allclose's rtol*|ref| slack collapses when that
+    reduction lands near zero, so an unlucky order-dependent draw could flake.
+    A fixed seed makes the draws reproducible regardless of run order; the
+    exact-ramp (_arange) tests draw no RNG and are unaffected."""
+    torch.manual_seed(42)
 
 
 # -------- Helpers ---------- #
@@ -64,6 +77,47 @@ def _compile_and_run_plan_capture(fn, *args):
         spyre_result = _compile_and_run(fn, args, DEVICE)
 
     return spyre_result, captured.get("plan", {})
+
+
+def _strict_size1_input_arm(fn, x, expected_arm):
+    """Run ``fn`` (a size-1 new-stick / output-elided restickify), assert the
+    result matches CPU bit-exactly, AND assert _pad_restickify_input took the
+    expected buffer-materialisation arm.
+
+    ``expected_arm`` is ``"producer"`` (the input is a compute op whose output
+    buffer we own and tag in place) or ``"clone"`` (the input is a graph input we
+    cannot re-allocate, so an identity clone is materialised and tagged).  The
+    arm assertion guards against the read being optimised away: if a future
+    Inductor folded a graph-input transpose to a no-op (so no restickify read of
+    the input survived), the clone arm would not fire and this test would fail
+    loudly rather than silently validate nothing.
+
+    ``_pad_restickify_input`` materialises the input inline, branching on whether
+    the input buffer is a ``ComputedBuffer`` (producer) or a graph input (clone);
+    the wrapper below classifies each call the same way to record which arm ran.
+    """
+    from torch._inductor.ir import ComputedBuffer
+
+    import torch_spyre._inductor.padding as _padding
+
+    arms = []
+    orig = _padding._pad_restickify_input
+
+    def capturing(op, graph):
+        _in_dep, in_buf, _in_layout = _padding._restickify_input(op, graph)
+        arms.append("producer" if isinstance(in_buf, ComputedBuffer) else "clone")
+        return orig(op, graph)
+
+    with patch.object(_padding, "_pad_restickify_input", capturing):
+        spyre = _compile_and_run(fn, (x,), DEVICE)
+    cpu = fn(x)
+    assert torch.equal(spyre.cpu(), cpu), (
+        f"\nMISMATCH shape={tuple(x.shape)}\n cpu   =\n{cpu}\n spyre =\n{spyre.cpu()}\n"
+    )
+    assert expected_arm in arms, (
+        f"expected _pad_restickify_input {expected_arm!r} arm to fire, saw "
+        f"{arms}; the restickify input read may have been optimised away"
+    )
 
 
 def _compare(
@@ -112,6 +166,37 @@ def _make_2d_tensors(s1, s2):
     X = torch.randn((s2, s1), dtype=torch.float16)
     Y = torch.randn((s2, s1), dtype=torch.float16)
     return A, B, X, Y
+
+
+def _arange(*shape, base=0, span=1000):
+    """A distinct-value ramp that is EXACT in fp16.
+
+    Build the ramp in int64 and take the modulo BEFORE casting: fp16 cannot
+    represent integers above 2048 exactly (``torch.arange`` itself overflows to
+    inf past ~65504), and odd integers in (1024, 2048] are not representable, so
+    a direct fp16 arange — or any band reaching past 1023 — silently rounds and
+    turns the oracle's exact-equality check into a lie.
+
+    ``base + span`` must stay <= 1024 so every value lands on an exact fp16
+    integer (ULP < 1); a misplaced stick then shows up as a wrong value, never a
+    rounding artifact.  ``base`` lets a second argument occupy a disjoint band
+    from the first, so a swapped element is caught even between two cat inputs.
+    """
+    assert base + span <= 1024, f"band [{base}, {base + span}) exceeds fp16-exact 1024"
+    n = 1
+    for s in shape:
+        n *= s
+    ramp = (torch.arange(n, dtype=torch.int64) % span) + base
+    return ramp.to(torch.float16).reshape(shape)
+
+
+def _strict(fn, *args):
+    spyre = _compile_and_run(fn, args, DEVICE)
+    cpu = fn(*args)
+    shapes = [tuple(a.shape) for a in args]
+    assert torch.equal(spyre.cpu(), cpu), (
+        f"\nMISMATCH shapes={shapes}\n cpu   =\n{cpu}\n spyre =\n{spyre.cpu()}\n"
+    )
 
 
 # -------- Pointwise tests ----------
@@ -914,6 +999,949 @@ def test_sparse_dense_pointwise():
         _compare(lambda a, b: a.amin(-1) + b, a, b)
 
 
+# ------- Restickify padding: strided input raises Unsupported ---------
+
+
+def test_pad_restickify_strided_input_raises():
+    """A strided-read input to transpose+clone must raise, not silently corrupt
+    output.
+
+    ``x[:, :, ::2, :]`` reads dim -2 with step 2, so its coordinate is ``2*d``.
+    Codegen carries only a contiguous tail, so a strided read is unpaddable and
+    the compiler must fail loudly rather than return wrong data.  (A *narrowing*
+    slice, by contrast, is now padded -- see the OFFSET_STICK_OK cases.)
+    """
+    x = torch.randn((2, 2, 128, 128), dtype=torch.float16)
+    with pytest.raises(
+        RuntimeError,
+        match="strided input on host dim",
+    ):
+        _compile_and_run(
+            lambda x: x[:, :, ::2, :].transpose(-2, -1).clone(), (x,), DEVICE
+        )
+
+
+def test_pad_restickify_strided_producer_raises():
+    """A strided read fed by a *producer* must also raise, not miscompile.
+
+    Same geometry as test_pad_restickify_strided_input_raises, but the ``+ 1``
+    makes the strided tensor a produced (internal) buffer rather than a bare
+    graph input, exercising the other input path.  The strided read is equally
+    unpaddable, so this path must also fail loudly rather than return wrong
+    data.
+    """
+    x = torch.randn((2, 2, 128, 128), dtype=torch.float16)
+    with pytest.raises(
+        RuntimeError,
+        match="strided input on host dim",
+    ):
+        _compile_and_run(
+            lambda x: (x + 1)[:, :, ::2, :].transpose(-2, -1).clone(), (x,), DEVICE
+        )
+
+
+# ------- Restickify padding: sliced-transpose stick expr classification -------
+
+
+# Sliced transposes that ARE valid and must compile correctly, spanning the
+# range of slice placements and extents on the becomes-stick dim.  Codegen reads
+# a whole-stick window from the slice base -- [slice_start, slice_start +
+# round_up_to_stick(extent)) -- and the input-padding pass grows the allocation
+# to cover it, so a narrowing slice near the dim end (whose window over-reads the
+# declared size) is padded, not rejected.  Only a *strided* read on the
+# becomes-stick dim still raises (see test_pad_restickify_strided_input_raises).
+OFFSET_STICK_OK = [
+    # Slice the becomes-stick dim (dim0 -> last dim after transpose(0, 1)), whose
+    # declared size 128 is stick-aligned; read window fits, gate skips.
+    (lambda x: x[3:67].transpose(0, 1).clone(), (128, 128)),
+    # Same, with an unaligned extent (63): read window still fits.
+    (lambda x: x[3:66].transpose(0, 1).clone(), (128, 128)),
+    # Stick-aligned slice start on the becomes-stick dim.
+    (lambda x: x[:, :, 64:128, :].transpose(-2, -1).clone(), (2, 2, 128, 128)),
+    # Slice on the becomes-stick dim, aligned (single-stick) extent.
+    (lambda x: x[:, 64:128].transpose(0, 1).clone(), (128, 128)),
+    # Slice on the becomes-stick dim, 1.5-stick extent.
+    (lambda x: x[:, :96].transpose(0, 1).clone(), (128, 128)),
+    # Narrowing slice near the dim end: read window [125, 125+64) over-reads the
+    # 128-row declared size, so the pass grows the allocation to 192 (3 sticks).
+    (lambda x: x[125:128].transpose(0, 1).clone(), (128, 128)),
+    # Wider over-reading slice: extent 70 -> read window [30, 30+128) over-reads
+    # the declared size; the allocation grows to 192.
+    (lambda x: x[30:100].transpose(0, 1).clone(), (128, 128)),
+]
+
+
+@pytest.mark.parametrize(
+    "fn,shape", OFFSET_STICK_OK, ids=lambda p: p if isinstance(p, tuple) else ""
+)
+def test_sliced_transpose_stick_expr_compiles(fn, shape):
+    """A valid sliced transpose compiles correctly regardless of where the slice
+    lands or its extent -- an over-reading narrowing slice on the becomes-stick
+    dim is padded, and only a strided read is rejected (see
+    test_pad_restickify_strided_input_raises)."""
+    x = torch.randn(shape, dtype=torch.float16)
+    result = _compile_and_run(fn, (x,), DEVICE)
+    compare_with_cpu(fn, x, target=result, run_eager=False)
+
+
+# Strict versions of the becomes-stick-dim slices above: a slice that lands on
+# the dim the transpose turns into the stick is the case most likely to misplace
+# a stick lane, and randn + tolerance can mask that.  A distinct-value ramp with
+# torch.equal catches a single displaced lane exactly.
+@pytest.mark.parametrize(
+    "fn,shape", OFFSET_STICK_OK, ids=lambda p: p if isinstance(p, tuple) else ""
+)
+def test_sliced_transpose_stick_expr_strict(fn, shape):
+    x = _arange(*shape)
+    _strict(fn, x)
+
+
+# ------- Restickify padding: large tensors (tolerance oracle) ---------
+#
+# transpose(-2,-1)+clone with an unaligned new stick dim, padded up to a stick
+# boundary.  These tensors are too large for the fp16-exact ramp the strict
+# tests below use (``_arange`` caps at 1024 elements per value band), so they
+# compare ``randn`` data with a tolerance instead.  The exact geometry of every
+# small padded shape is covered strictly below.
+RESTICKIFY_PAD_LARGE_SIZES = [(1025, 1024), (2, 1025, 1024), (2, 2, 1025, 1024)]
+
+
+@pytest.mark.parametrize(
+    "shape", RESTICKIFY_PAD_LARGE_SIZES, ids=lambda p: "x".join(map(str, p))
+)
+def test_pad_large_transpose_clone(shape):
+    x = torch.randn(shape, dtype=torch.float16)
+    _compare(lambda x: x.transpose(-2, -1).clone(), x, check_strides=False)
+
+
+# ------- Restickify input padding fused into a producer ---------
+#
+# When the restickify's input is produced by an internal op, the padding can be
+# folded into that producer instead of inserting a separate copy; a restickify
+# reading a bare graph input has no producer and falls back to the copy.  These
+# tests exercise both outcomes (asserting on the debug log which path fired) and
+# check that the result is correct either way.
+#
+# The tests put BOTH binary operands behind a computation so the transposed side
+# (not a bare graph input) is the one restickified -- a bare graph-input operand
+# would otherwise be the one chosen and hit the fallback.
+
+
+def _run_capturing_padding_log(fn, *args):
+    """Run fn on Spyre, returning (result, fused_fire_count, all_log_records)
+    captured from insert_restickify_padding's debug log."""
+    import logging
+
+    import torch_spyre._inductor.padding as _padding
+
+    records: list[str] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    handler = _Capture()
+    prev_level = _padding.logger.level
+    _padding.logger.addHandler(handler)
+    _padding.logger.setLevel(logging.DEBUG)
+    try:
+        result = _compile_and_run(fn, args, DEVICE)
+    finally:
+        _padding.logger.removeHandler(handler)
+        _padding.logger.setLevel(prev_level)
+
+    # Every padded input logs "padded input"; a graph-input clone additionally
+    # logs "inserted clone". A producer fusion is a padded input with no clone,
+    # so the producer-arm count is padded inputs minus inserted clones.
+    padded = sum("padded input" in m for m in records)
+    cloned = sum("inserted clone" in m for m in records)
+    fused = padded - cloned
+    return result, fused, records
+
+
+RESTICKIFY_FUSE_SIZES = [(67, 67), (2, 67, 67)]
+
+
+@pytest.fixture(params=RESTICKIFY_FUSE_SIZES, ids=lambda p: "x".join(map(str, p)))
+def fuse_tensors(request):
+    shape = request.param
+    x = torch.randn(shape, dtype=torch.float16)
+    y = torch.randn(shape, dtype=torch.float16)
+    return x, y
+
+
+def test_pad_fused_into_producer(fuse_tensors):
+    """(x*2).T + relu(y): the transposed side is an internal single-consumer
+    pointwise producer, so the padding fuses into it (no copy).  Both operands
+    are unaligned, so the same restickify needs both input and output padding."""
+    x, y = fuse_tensors
+
+    def fn(x, y):
+        return (x * 2).transpose(-2, -1) + torch.relu(y)
+
+    result, fused, _ = _run_capturing_padding_log(fn, x, y)
+    assert fused >= 1, "expected producer-fusion to fire, but it did not"
+    compare_with_cpu(fn, x, y, target=result, run_eager=False)
+
+
+def test_pad_fused_into_matmul_producer():
+    """A sliced matmul output (a@b)[:,c:]+z: the producer is a matmul
+    (a reduction), not a pointwise op.  It should still fuse rather than fall
+    back to a copy, and the result must be correct."""
+    a = torch.randn((67, 64), dtype=torch.float16)
+    b = torch.randn((64, 67), dtype=torch.float16)
+    z = torch.randn((67, 64), dtype=torch.float16)
+
+    def fn(a, b, z):
+        return (a @ b)[:, 3:] + z
+
+    result, fused, _ = _run_capturing_padding_log(fn, a, b, z)
+    assert fused >= 1, "matmul (Reduction) producer should fuse, not fall back"
+    compare_with_cpu(fn, a, b, z, target=result, run_eager=False)
+
+
+def test_pad_graph_input_falls_back():
+    """Restickifying a bare graph input has no producer to fuse into, so the
+    padding must fall back to a copy -- and still be correct."""
+    x = torch.randn((67, 67), dtype=torch.float16)
+    y = torch.randn((67, 67), dtype=torch.float16)
+
+    def fn(x, y):
+        return x.transpose(-2, -1) + y
+
+    result, fused, _ = _run_capturing_padding_log(fn, x, y)
+    assert fused == 0, "graph-input restickify should not fuse into a producer"
+    compare_with_cpu(fn, x, y, target=result, run_eager=False)
+
+
+def test_pad_multi_consumer_producer_fuses_with_coreader():
+    """A producer read by a restickify AND a non-restickify co-reader (here
+    p.sum()) still fuses, and the co-reader's result stays correct -- growing
+    the shared producer for the restickify does not disturb the other reader."""
+    x = torch.randn((67, 128), dtype=torch.float16)
+    z = torch.randn((128, 67), dtype=torch.float16)
+
+    def fn(x, z):
+        p = x * 2  # two consumers: the transpose (restickify) and the sum
+        return p.transpose(-2, -1) + z + p.sum()
+
+    result, fused, _ = _run_capturing_padding_log(fn, x, z)
+    assert fused >= 1, "producer with a non-restickify co-reader should still fuse"
+    compare_with_cpu(fn, x, z, target=result, run_eager=False)
+
+
+def _shared_producer_two_restickify_case():
+    """The (inputs, fn) for a producer ``p = x * 2`` whose sole consumers are two
+    transposes taking different new stick dims -- so p fans out to two restickify
+    nodes with different paddings.  Shared by the two tests below, which assert
+    different things about it (fusion + correctness vs the two-node graph shape)."""
+    x = torch.randn((67, 53, 128), dtype=torch.float16)
+    za = torch.randn((128, 53, 67), dtype=torch.float16)
+    zb = torch.randn((67, 128, 53), dtype=torch.float16)
+
+    def fn(x, za, zb):
+        p = x * 2  # sole consumers are the two transposes below (restickifies)
+        return p.transpose(0, 2) + za, p.transpose(1, 2) + zb
+
+    return (x, za, zb), fn
+
+
+def test_pad_shared_all_restickify_consumers_fuse():
+    """A producer read only by restickify ops fuses even with several consumers.
+    Two transposes of the same producer take different new stick dims, so each
+    needs a different padding; both must apply and both results be correct."""
+    (x, za, zb), fn = _shared_producer_two_restickify_case()
+    result, fused, _ = _run_capturing_padding_log(fn, x, za, zb)
+    assert fused >= 1, "all-restickify shared producer should fuse"
+    compare_with_cpu(fn, x, za, zb, target=result, run_eager=False)
+
+
+def _is_restickify_op(op) -> bool:
+    """True when ``op`` is a spyre.restickify ComputedBuffer, detected via its
+    origin FX node's target."""
+    from torch._inductor.ir import ComputedBuffer
+
+    if not isinstance(op, ComputedBuffer):
+        return False
+    origins = op.origins
+    if not origins:
+        return False
+    return next(iter(origins)).target is torch.ops.spyre.restickify.default
+
+
+def _restickify_readers_by_source(fn, *args):
+    """Run fn on Spyre and return {producer_name: [restickify buffer names]},
+    a map of every source buffer to the restickify ops that read it, captured
+    from graph.operations right after insert_restickify splices them in."""
+    import torch_spyre._inductor.passes as _passes
+
+    insert_restickify = _passes.insert_restickify
+    by_source: dict[str, list[str]] = {}
+
+    def capturing_insert_restickify(graph):
+        insert_restickify(graph)
+        for op in graph.operations:
+            if not _is_restickify_op(op):
+                continue
+            for read in op.get_read_writes().reads:
+                name = getattr(read, "name", None)
+                if name is not None:
+                    by_source.setdefault(name, []).append(op.get_name())
+
+    with patch.object(_passes, "insert_restickify", capturing_insert_restickify):
+        _compile_and_run(fn, args, DEVICE)
+    return by_source
+
+
+def test_shared_producer_gets_two_restickify_nodes():
+    """insert_restickify keys its plan by consumer, not by source, so a producer
+    that fans out to two consumers each wanting a different layout gets a
+    *separate* restickify node per consumer -- both reading the one producer.
+    We assert the two-node shape directly rather than via the fusion log."""
+    (x, za, zb), fn = _shared_producer_two_restickify_case()
+    by_source = _restickify_readers_by_source(fn, x, za, zb)
+    shared = [src for src, readers in by_source.items() if len(readers) >= 2]
+    assert shared, (
+        "expected one producer read by >=2 restickify nodes, got "
+        f"{ {s: r for s, r in by_source.items()} }"
+    )
+
+
+# ------- Restickify padding: strict (distinct values + torch.equal) ---------
+#
+# The tolerance-based tests above compare ``randn`` data with atol=rtol=0.1,
+# whose fp16 value collisions in [-3, 3] can MASK an element landing in the
+# wrong stick.  The tests below feed a distinct-per-element ramp (``_arange``)
+# and require exact equality (``_strict``), so a single misplaced element fails.
+# They cover the transpose+clone geometries where a misplaced element is most
+# likely: an unaligned stick split across blocks, multiple leading batch dims,
+# and size-1 dims in or around the stick.
+
+SPLIT_2D = [(65, 4), (67, 4), (128, 67), (130, 33), (67, 128)]
+
+
+@pytest.mark.parametrize("shape", SPLIT_2D, ids=lambda p: f"{p[0]}x{p[1]}")
+def test_strict_2d_transpose_clone(shape):
+    x = _arange(*shape)
+    _strict(lambda x: x.transpose(0, 1).clone(), x)
+
+
+# transpose(-2, -1).clone() with >=2 leading batch dims: every batch plane must
+# survive.  Covers a single stick block (..64..) and multiple blocks (..65..),
+# an unaligned middle (old-stick) dim of size 4, and deeper/larger batch nests.
+SPLIT_ND = [
+    (4, 91, 72),
+    (2, 3, 65, 4),
+    (2, 3, 64, 4),
+    (2, 2, 65, 64),
+    (3, 5, 65, 4),
+    (2, 4, 130, 33),
+    (2, 2, 3, 65, 4),
+    (2, 67, 128),  # single leading batch, unaligned new stick
+    (2, 2, 67, 128),  # two leading batch dims, unaligned new stick
+]
+
+
+@pytest.mark.parametrize("shape", SPLIT_ND, ids=lambda p: "x".join(map(str, p)))
+def test_strict_nd_transpose_clone(shape):
+    x = _arange(*shape)
+    _strict(lambda x: x.transpose(-2, -1).clone(), x)
+
+
+# transpose(1, -1).clone() swaps an inner batch dim with the stick dim, a
+# different demoted-middle geometry than transpose(-2, -1).
+SPLIT_T1_LAST = [(2, 4, 67, 128), (2, 3, 65, 4), (2, 2, 67, 128)]
+
+
+@pytest.mark.parametrize("shape", SPLIT_T1_LAST, ids=lambda p: "x".join(map(str, p)))
+def test_strict_nd_transpose_1_last_clone(shape):
+    x = _arange(*shape)
+    _strict(lambda x: x.transpose(1, -1).clone(), x)
+
+
+# transpose(0, -1).clone() swaps the OUTERMOST dim with the stick dim, with both
+# the source and destination stick dims sub-64 (e.g. 2 and 7) so neither fills a
+# full stick.  Must still place every element exactly.
+SPLIT_T0_LAST = [(7, 67, 2), (7, 65, 2), (5, 3, 2), (7, 67, 63)]
+
+
+@pytest.mark.parametrize("shape", SPLIT_T0_LAST, ids=lambda p: "x".join(map(str, p)))
+def test_strict_transpose_0_last_clone(shape):
+    x = _arange(*shape)
+    _strict(lambda x: x.transpose(0, -1).clone(), x)
+
+
+# ======================================================================
+# Size-1 dims in and around the stick.
+#
+# A size-1 host dim collapses upstream Inductor's within-stick loop symbol, which
+# these transpose+clone/contiguous geometries must handle without dropping or
+# zeroing a plane.  Each family below targets a distinct restickify arm/branch:
+#
+#   family                        arm / branch exercised
+#   ----------------------------  ------------------------------------------
+#   SIZE1_INPUT_STICK             size-1 leaves stick, real enters:
+#     _clone (.exp -> folds to reinterpret_tensor, allclose oracle)
+#     _contiguous_producer        in-place producer grow (_pad_restickify_input)
+#     _clone_graph_input          inserted identity clone we grow
+#   SIZE1_NEW_STICK               size-1 moves INTO stick; pass declines the
+#                                 read, codegen restores the elided OUTPUT stick
+#   SIZE1_MULTI_STICK             size-1 in stick + more size-1 dims (clone arm)
+#   SIZE1_SURVIVING_BATCH         real batch survives outside BOTH sticks; new
+#                                 stick a full 64 (no output-middle pad)
+#   REAL_DIM_INTO_STICK + sweeps  real dim into stick via bare-input clone;
+#                                 full 23-perm sweep across both arms
+#   SIZE1_MULTI_BLOCK             new stick spans >=2 stick blocks
+#   SIZE1_MULTI_BLOCK_MID_DIM     + real dim between old stick and plane
+#                                 (size-1 old stick not farthest from plane)
+# ======================================================================
+
+
+# A size-1 dim IN the input stick: the transpose moves this size-1 dim out of
+# the stick and a real dim in, and every element must come back correctly.
+#
+# The .exp().transpose().clone() chain folds to a reinterpret_tensor, so no
+# restickify is emitted and no padding runs here -- this is the plain
+# size-1-in-stick round-trip.  The producer-grow and graph-input-clone padding
+# paths are exercised by the .contiguous() and graph-input variants below.  The
+# transcendental's last-ULP host/device drift means this asserts allclose rather
+# than exact equality.
+SIZE1_INPUT_STICK = [(7, 65, 1), (5, 3, 1)]
+
+
+@pytest.mark.parametrize(
+    "shape", SIZE1_INPUT_STICK, ids=lambda p: "x".join(map(str, p))
+)
+def test_size1_input_stick_transpose_0_last_clone(shape):
+    def fn(x):
+        return x.exp().transpose(0, -1).clone()
+
+    x = torch.ones(*shape, dtype=torch.float16)
+    spyre = _compile_and_run(fn, (x,), DEVICE)
+    torch.testing.assert_close(spyre.cpu(), fn(x), atol=1e-2, rtol=1e-2)
+
+
+# Same size-1-in-stick shapes, produced buffer, but ending in .contiguous()
+# instead of .clone() -- the one construction that reaches _pad_restickify_input's
+# IN-PLACE PRODUCER GROW: the transpose moves a real dim (7 / 5) into the stick,
+# so its unaligned new-stick dim must be padded to a stick boundary, and inductor
+# keeps the pointwise producer as a real ComputedBuffer we own and grow in place
+# (.clone() would fold to a reinterpret_tensor instead).  Ramp span 511 doubled by
+# x + x stays < 1024 (fp16-exact), so torch.equal catches a mis-placed or
+# uninitialised row precisely.
+@pytest.mark.parametrize(
+    "shape", SIZE1_INPUT_STICK, ids=lambda p: "x".join(map(str, p))
+)
+def test_size1_input_stick_transpose_0_last_contiguous_producer(shape):
+    x = _arange(*shape, span=511)
+    _strict(lambda x: (x + x).transpose(0, -1).contiguous(), x)
+
+
+# Same size-1-in-stick contiguous producer, but the real dim that moves INTO the
+# stick is > 64, so the restored output stick CROSSES a stick boundary (out=67 ->
+# 64 + 3).  This forces the output-buffer grow that covers the full 64-plane
+# sweep; its geometry is asserted device-free by the white-box size-1 tests at the
+# end of this file.  Ramp span 511 doubled by x + x stays < 1024 (fp16-exact), so
+# torch.equal catches a displaced lane.
+SIZE1_INPUT_STICK_CROSSING = [(7, 67, 1), (5, 67, 1), (3, 130, 1)]
+
+
+@pytest.mark.parametrize(
+    "shape", SIZE1_INPUT_STICK_CROSSING, ids=lambda p: "x".join(map(str, p))
+)
+def test_size1_input_stick_crossing_transpose_0_last_contiguous_producer(shape):
+    x = _arange(*shape, span=511)
+    _strict(lambda x: (x + x).transpose(0, -1).contiguous(), x)
+
+
+# A MULTI-STAGE pointwise producer (two or more fused ops) feeding the same
+# transpose + .contiguous() restickify.  A fused chain iterates one order, but the
+# transpose flips it on one interior edge: a buffer written in the original order
+# and read transposed must not come back as a lane permutation (same values, wrong
+# positions).  The single-stage case above cannot exercise this -- it has no
+# interior buffer.  Each direct producer is read in the producer's own order and
+# only the store is permuted, so no interior buffer is dual-ordered.
+#
+# Two axes both matter and are swept independently (a full cross-product would add
+# nothing -- the crossing edge is the same regardless of the combination):
+#   * producer SHAPE, on a fixed linear 2-then-3-stage chain -- covers a size-1
+#     last dim and a non-size-1 last dim (dim 2), proving it is not size-1-specific;
+#   * producer DAG SHAPE, on the fixed [2,3,4] repro -- multi-input, diamond, and
+#     pointwise-stages-on-both-sides-of-the-transpose.
+# Ramp span 255 through the chains stays < 1024 (fp16-exact), so torch.equal pins
+# a displaced lane exactly.
+MULTISTAGE_PRODUCER_CASES = [
+    # (builder, shape, id): linear-chain shape sweep.
+    (
+        lambda x: (x + x).mul(2.0).transpose(0, -1).contiguous(),
+        (2, 3, 4),
+        "2stage_2x3x4",
+    ),
+    (
+        lambda x: (x + x).mul(2.0).transpose(0, -1).contiguous(),
+        (5, 3, 2),
+        "2stage_5x3x2",
+    ),
+    (
+        lambda x: (x + x).mul(2.0).transpose(0, -1).contiguous(),
+        (5, 3, 1),
+        "2stage_5x3x1",
+    ),
+    # A third stage extends the producer chain one more step.
+    (
+        lambda x: (x + x).mul(2.0).add(1.0).transpose(0, -1).contiguous(),
+        (2, 3, 4),
+        "3stage_2x3x4",
+    ),
+    (
+        lambda x: (x + x).mul(2.0).add(1.0).transpose(0, -1).contiguous(),
+        (5, 3, 2),
+        "3stage_5x3x2",
+    ),
+    (
+        lambda x: (x + x).mul(2.0).add(1.0).transpose(0, -1).contiguous(),
+        (5, 3, 1),
+        "3stage_5x3x1",
+    ),
+    # DAG-shape sweep on the [2,3,4] repro.
+    (lambda x: (x + x * 3.0).transpose(0, -1).contiguous(), (2, 3, 4), "multi_input"),
+    (
+        lambda x: ((x + 1.0) * (x + 2.0)).transpose(0, -1).contiguous(),
+        (2, 3, 4),
+        "diamond",
+    ),
+    (
+        lambda x: (x + x).mul(2.0).add(1.0).transpose(0, -1).mul(3.0).contiguous(),
+        (2, 3, 4),
+        "stages_both_sides",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "builder,shape",
+    [(b, s) for b, s, _ in MULTISTAGE_PRODUCER_CASES],
+    ids=[i for _, _, i in MULTISTAGE_PRODUCER_CASES],
+)
+def test_multistage_producer_transpose_contiguous(builder, shape):
+    x = _arange(*shape, span=255)
+    _strict(builder, x)
+
+
+# A size-1 dim moving INTO the stick (the mirror of SIZE1_INPUT_STICK): the
+# transpose destination stick dim has host size 1, so upstream Inductor elides
+# the OUTPUT operand's within-stick loop symbol.  The pass declines the
+# size-1-new-stick read (there is no over-read to cover) and codegen restores the
+# elided OUTPUT stick, so both must come back bit-exact.
+#
+# Each entry is (shape, transpose_dims); .contiguous() (not .clone(), which folds
+# to reinterpret_tensor) keeps a real producer ComputedBuffer and forces the
+# restickify.  Ramp span 511 doubled by x + x stays < 1024 (fp16-exact), so
+# torch.equal catches a mis-placed lane precisely.
+SIZE1_NEW_STICK = [
+    ((1, 1, 5, 67), (1, 3)),  # size-1 dim 1 moves into stick; real 5 survives
+    ((1, 3, 1, 67), (0, 3)),  # size-1 dim 0 moves into stick; real 3 survives
+]
+
+
+@pytest.mark.parametrize(
+    "shape,dims",
+    SIZE1_NEW_STICK,
+    ids=[
+        f"{'x'.join(map(str, s))}_t{'_'.join(map(str, d))}" for s, d in SIZE1_NEW_STICK
+    ],
+)
+def test_size1_new_stick_transpose_contiguous(shape, dims):
+    x = _arange(*shape, span=511)
+    _strict(lambda x: (x + x).transpose(*dims).contiguous(), x)
+
+
+# Same size-1 dim moving INTO the stick, but the restickify input is a bare graph
+# input.  Uses .clone() -- when the elided operand is the OUTPUT, the clone does
+# NOT fold to reinterpret_tensor (the destination stick's size-1 dim keeps a real
+# restickify), so this exercises the elided-output path for a plain input.
+@pytest.mark.parametrize(
+    "shape,dims",
+    SIZE1_NEW_STICK,
+    ids=[
+        f"{'x'.join(map(str, s))}_t{'_'.join(map(str, d))}" for s, d in SIZE1_NEW_STICK
+    ],
+)
+def test_size1_new_stick_transpose_clone_graph_input(shape, dims):
+    x = _arange(*shape, span=511)
+    _strict(lambda x: x.transpose(*dims).clone(), x)
+
+
+# Symmetric mirror of SIZE1_INPUT_STICK_CROSSING, on the elided-OUTPUT side.  A
+# size-1 dim moves INTO the stick (output-elided), and the real dim moving OUT of
+# the stick is > 64, so the INTACT operand -- here the INPUT -- crosses a stick
+# boundary.  _restickify_restore_elided_dim binds the shared symbol to the
+# outermost size-64 gap dim on the intact input just as the mirror does on the
+# intact output, so the input buffer needs the same grow.  _pad_restickify_input
+# supplies it by ensuring the read comes from a buffer we own -- a producer we
+# grow in place, or, for a graph input, a materialised identity clone we grow --
+# via padding._pad_elided_dim, which prepends the size-64 gap dim the restore then
+# reuses.  ``[1,67,7]`` is the mirror of ``[7,67,1]``; ``[1,67,130]`` /
+# ``[1,130,3]`` push the intact-input stick past 64 to force the crossing.  Ramp
+# span 511 doubled by x + x stays < 1024 (fp16-exact), so torch.equal pins a
+# displaced lane precisely.
+SIZE1_NEW_STICK_CROSSING = [
+    ((1, 67, 7), (0, 2)),  # mirror of [7,67,1]
+    ((1, 67, 130), (0, 2)),  # intact input stick 130 -> crosses (64 + 66)
+    ((1, 130, 3), (0, 2)),  # crossing with a real middle dim 130
+]
+
+
+@pytest.mark.parametrize(
+    "shape,dims",
+    SIZE1_NEW_STICK_CROSSING,
+    ids=[
+        f"{'x'.join(map(str, s))}_t{'_'.join(map(str, d))}"
+        for s, d in SIZE1_NEW_STICK_CROSSING
+    ],
+)
+def test_size1_new_stick_crossing_transpose_contiguous_producer(shape, dims):
+    # (x + x) is a real compute op, so its output is a buffer we own: the producer
+    # arm tags it directly.  A bare transpose would instead read the graph input.
+    x = _arange(*shape, span=511)
+    _strict_size1_input_arm(
+        lambda x: (x + x).transpose(*dims).contiguous(), x, "producer"
+    )
+
+
+@pytest.mark.parametrize(
+    "shape,dims",
+    SIZE1_NEW_STICK_CROSSING,
+    ids=[
+        f"{'x'.join(map(str, s))}_t{'_'.join(map(str, d))}"
+        for s, d in SIZE1_NEW_STICK_CROSSING
+    ],
+)
+def test_size1_new_stick_crossing_transpose_clone_graph_input(shape, dims):
+    # A bare transpose of a graph input keeps the input as a direct restickify
+    # read (no compute op interposes a producer buffer), so the clone arm fires:
+    # an identity clone is materialised and tagged for the grow.
+    x = _arange(*shape, span=511)
+    _strict_size1_input_arm(lambda x: x.transpose(*dims).clone(), x, "clone")
+
+
+# Same size-1-in-stick shapes, but the restickify input is a bare graph input
+# (no producer op), exercising the other input path -- an inserted identity
+# clone we grow.  A copy preserves the input bit-for-bit, so this asserts exact
+# equality on the ramp (unlike the allclose above).
+@pytest.mark.parametrize(
+    "shape", SIZE1_INPUT_STICK, ids=lambda p: "x".join(map(str, p))
+)
+def test_size1_input_stick_transpose_0_last_clone_graph_input(shape):
+    x = _arange(*shape)
+    _strict(lambda x: x.transpose(0, -1).clone(), x)
+
+
+# A size-1 dim in the input stick PLUS at least one more size-1 host dim
+# elsewhere, so more than one size-1 dim is present at once.  The transpose must
+# place every real batch plane correctly regardless of where the extra size-1
+# dims sit.  The clone path (x.transpose(*dims).clone()) covers two arrangements:
+#   * the extra size-1 dims are the two UNTOUCHED dims, possibly interleaved with
+#     a real dim between them (the first five entries), and
+#   * an extra size-1 dim sits OUTSIDE both sticks, leading or middle, with one or
+#     two of them (the last five entries).
+# Each entry is (shape, transpose_dims); the transpose swaps the size-1
+# input-stick dim with a real dim.  Distinct-ramp + torch.equal catches a
+# mis-placed plane exactly.
+SIZE1_MULTI_STICK = [
+    # Extra size-1 dims are the untouched dims (or interleaved with a real dim).
+    ((1, 1, 64, 1), (0, -1)),  # three size-1 dims (0, 1, 3)
+    ((1, 1, 67, 1), (0, -1)),  # three size-1 dims, unaligned stick
+    ((1, 5, 67, 1), (0, -1)),  # interleaved: size-1 at 0 and 3, real 5/67 between
+    ((7, 1, 64, 1), (1, 3)),  # interleaved: size-1 at 1 and 3, real 7/64 between
+    ((5, 1, 67, 1), (1, 3)),  # interleaved: size-1 at 1 and 3, real 5/67 between
+    # Extra size-1 dim(s) outside both sticks (leading or middle).
+    ((1, 4, 64, 1), (2, 3)),  # extra size-1 leading (dim0)
+    ((4, 1, 64, 1), (2, 3)),  # extra size-1 in the middle (dim1)
+    ((1, 4, 1, 64, 1), (3, 4)),  # two extra size-1, batch outer
+    ((4, 1, 1, 64, 1), (3, 4)),  # two extra size-1, batch/size-1 interleaved
+    ((1, 1, 4, 64, 1), (3, 4)),  # two extra size-1, batch inner
+]
+
+
+@pytest.mark.parametrize(
+    "shape,dims",
+    SIZE1_MULTI_STICK,
+    ids=[f"{'x'.join(map(str, s))}_t{d}" for s, d in SIZE1_MULTI_STICK],
+)
+def test_size1_multi_input_stick_transpose_clone(shape, dims):
+    x = _arange(*shape)
+    _strict(lambda x: x.transpose(*dims).clone(), x)
+
+
+# A size-1 dim in the input stick where a real batch/leading dim (extent > 1)
+# survives OUTSIDE both the old (size-1) and new sticks -- e.g. (4, 64, 1)
+# transpose(1, 2), whose batch dim 0 stays leading while dims 1 and 2 swap.
+# Every surviving batch plane must come back correct.
+#
+# The new (destination) stick is a full 64 here on purpose: an unaligned
+# destination would additionally need output-middle padding, covered separately
+# above.  Each entry is (shape, transpose_dims).
+SIZE1_SURVIVING_BATCH = [
+    ((4, 64, 1), (1, 2)),  # batch dim 0 = 4 survives; new stick = dim 1
+    ((2, 64, 1), (1, 2)),  # smaller batch
+    ((3, 5, 64, 1), (2, 3)),  # batch 3 + spatial 5 both survive; new stick dim 2
+    ((2, 2, 64, 1), (2, 3)),  # two leading dims survive
+    ((2, 3, 4, 64, 1), (3, 4)),  # deep batch nest
+]
+
+
+@pytest.mark.parametrize(
+    "shape,dims",
+    SIZE1_SURVIVING_BATCH,
+    ids=[f"{'x'.join(map(str, s))}_t{d}" for s, d in SIZE1_SURVIVING_BATCH],
+)
+def test_size1_input_stick_surviving_batch_transpose_clone(shape, dims):
+    x = _arange(*shape)
+    _strict(lambda x: x.transpose(*dims).clone(), x)
+
+
+# A REAL (extent > 1) dim moving into the stick when the restickify input is a
+# bare graph input (no producer op to grow in place).  This is the clone-arm
+# mirror of test_multistage_producer_transpose_contiguous: the pass inserts an
+# identity clone of the input, grows its new-stick dim, and expresses the
+# transpose as a Scatter that reads the clone straight and permutes on the store.
+#
+# Shape [3,2,5,67] has NO size-1 dim, so it covers the real-dim (non-size-1) clone
+# arm.  The size-1 shape [3,1,5,67] is covered exhaustively (every perm) by
+# test_full_perm_sweep_transpose_clone_graph_input below, so it is not repeated
+# here.
+#
+# Must use .permute(...).contiguous(): .clone() on a bare input folds to
+# reinterpret_tensor and never restickifies.  Each perm moves a real dim (size 3
+# or 5) into the stick; the reordered variants ALSO permute the outer real dims,
+# so the store carries a compound transpose.  Ramp span 511 keeps every value
+# < 1024 (fp16-exact), so torch.equal pins a mis-placed lane exactly.
+REAL_DIM_INTO_STICK_PERMS = [
+    (0, 1, 3, 2),  # size-5 dim into stick, outer dims in order
+    (2, 1, 0, 3),  # size-3 dim into an outer slot, outer dims reordered
+    (0, 3, 1, 2),  # size-5 dim into stick, outer real dims reordered (compound)
+    (3, 2, 1, 0),  # full reversal -- size-3 dim into stick, all reordered
+]
+
+
+@pytest.mark.parametrize(
+    "perm", REAL_DIM_INTO_STICK_PERMS, ids=lambda p: "".join(map(str, p))
+)
+def test_real_dim_into_stick_transpose_clone_graph_input(perm):
+    x = _arange(3, 2, 5, 67, span=511)
+    _strict(lambda x: x.permute(*perm).contiguous(), x)
+
+
+# Full sweep of every non-identity permutation of [3,1,5,67] via
+# permute(p).contiguous(), across both restickify input arms.  This generalises
+# test_real_dim_into_stick_transpose_clone_graph_input (which pins a subset of
+# perms for the clone arm) to the whole permutation group and to the producer arm.
+#
+#   clone arm:    x.permute(p).contiguous()            -- restickify reads a bare
+#                 graph input; the pass inserts + grows an identity clone.
+#   producer arm: (x + x * 3.0).permute(p).contiguous() -- a pointwise op
+#                 materialises a ComputedBuffer the pass grows in place.  x * 3.0
+#                 keeps the producer from folding away, so this exercises a path
+#                 the clone arm does not.
+#
+# The producer arm interposes a pointwise op whose transpose-crossing intermediate
+# is staged in LX and work-divided across several cores, so it also exercises the
+# multi-core LX staging path (see #3340).  The two producer sweeps below cover
+# complementary regimes: the padding sweep pins sencores=1 so no work-division
+# occurs (padding restickify in isolation); the aligned sweep runs at the default
+# core count so the transpose reorders work-divided dims.  Every perm on both arms
+# must be bit-exact.
+_SWEEP_SHAPE = (3, 1, 5, 67)
+_ALL_PERMS = [p for p in itertools.permutations(range(4)) if p != (0, 1, 2, 3)]
+
+
+@pytest.mark.parametrize("perm", _ALL_PERMS, ids=lambda p: "".join(map(str, p)))
+def test_full_perm_sweep_transpose_clone_graph_input(perm):
+    # Clone arm copies the input through unchanged, so any band <= 1024 is
+    # fp16-exact; span 511 widens distinct-lane coverage.
+    x = _arange(*_SWEEP_SHAPE, span=511)
+    _strict(lambda x: x.permute(*perm).contiguous(), x)
+
+
+# Producer-arm padding sweep on the UNALIGNED shape [3,1,5,67] (last dim 67 pads to
+# 128 = two sticks, exercising the restickify padding this PR adds).  sencores=1
+# removes work-division, so the LX transpose-crossing defect cannot fire and the
+# result is purely the padding restickify -- which is bit-exact for every perm.
+@config.patch({"sencores": 1})
+@pytest.mark.parametrize("perm", _ALL_PERMS, ids=lambda p: "".join(map(str, p)))
+def test_full_perm_sweep_transpose_contiguous_producer(perm):
+    # t + t * 3.0 == 4 * t, so the input band must satisfy 4 * span <= 1024 to stay
+    # fp16-exact (else CPU-fp16 vs device-DLFloat16 rounding is a false mismatch).
+    x = _arange(*_SWEEP_SHAPE, span=255)
+    _strict(lambda x: (x + x * 3.0).permute(*perm).contiguous(), x)
+
+
+# The producer arm on the aligned shape [3,1,5,64] at the default core count, so
+# every perm that reorders the two real outer dims (3 and 5) drives them into the
+# multi-core work-divided regime -- the transpose-crossing LX staging path (#3340).
+# On the aligned shape (last dim 64 = one stick) there is no padding, so this
+# exercises that path in isolation.  Every perm must be bit-exact.
+_ALIGNED_SWEEP_SHAPE = (3, 1, 5, 64)
+
+
+@pytest.mark.parametrize("perm", _ALL_PERMS, ids=lambda p: "".join(map(str, p)))
+def test_full_perm_sweep_aligned_producer(perm):
+    x = _arange(*_ALIGNED_SWEEP_SHAPE, span=255)
+    _strict(lambda x: (x + x * 3.0).permute(*perm).contiguous(), x)
+
+
+# Producer-arm restickify at the DEFAULT core count on the unaligned shape
+# [5,3,66], so the transpose-crossing intermediate is work-divided across cores
+# (unlike the sencores=1 sweep above).  A two-stage pointwise (x + x*3) feeds a
+# permute+contiguous whose output lands a different host dim within the stick --
+# the "into" restickify.  The staged intermediate is a *transitive* producer of
+# that restickify (it feeds an already-spilled intermediate, which feeds the
+# restickify), and its output must land bit-exact for every "into" perm.  The
+# even stick extent (66) keeps the padded stick clear of the odd-last-dim LX
+# work-division defect, so the "into" perms are correct regardless of residency.
+#
+# perm (1,0,2) swaps only the two non-stick outer dims (dim2=66 stays the stick),
+# so no host dim moves into the stick and no restickify fires: it exercises the
+# same multi-core LX work-division path as the aligned sweep above (#3340), not an
+# "into" case.  Every perm here must be bit-exact.
+_INTO_SWEEP_SHAPE = (5, 3, 66)
+
+
+@pytest.mark.parametrize(
+    "perm",
+    [p for p in itertools.permutations(range(3)) if p != (0, 1, 2)],
+    ids=lambda p: "".join(map(str, p)),
+)
+def test_full_perm_sweep_into_producer_default_cores(perm):
+    # t + t * 3.0 == 4 * t, so span must satisfy 4 * span <= 1024 for fp16 exactness.
+    x = _arange(*_INTO_SWEEP_SHAPE, span=255)
+    _strict(lambda x: (x + x * 3.0).permute(*perm).contiguous(), x)
+
+
+# A size-1 dim in the input stick whose NEW stick dim spans >=2 stick blocks
+# (host size > 64), aligned or unaligned, with and without leading batch dims.
+# Every stick block must land correctly.  Distinct-ramp + torch.equal.
+SIZE1_MULTI_BLOCK = [
+    ((1, 128, 1), (1, 2)),  # 2 aligned blocks, no batch
+    ((1, 192, 1), (1, 2)),  # 3 aligned blocks, no batch
+    ((1, 67, 1), (1, 2)),  # 2 unaligned blocks, no batch
+    ((4, 128, 1), (1, 2)),  # 2 aligned blocks + batch 4
+    ((2, 128, 1), (1, 2)),  # 2 aligned blocks + batch 2
+    ((4, 67, 1), (1, 2)),  # 2 unaligned blocks + batch
+    ((4, 192, 1), (1, 2)),  # 3 blocks + batch
+    ((2, 3, 67, 1), (2, 3)),  # 2 unaligned blocks + leading batch nest
+]
+
+
+@pytest.mark.parametrize(
+    "shape,dims",
+    SIZE1_MULTI_BLOCK,
+    ids=[f"{'x'.join(map(str, s))}_t{d}" for s, d in SIZE1_MULTI_BLOCK],
+)
+def test_size1_multi_block_transpose_clone(shape, dims):
+    x = _arange(*shape)
+    _strict(lambda x: x.transpose(*dims).clone(), x)
+
+
+# A size-1 old stick with a MULTI-BLOCK new stick (host > 64) AND a real
+# (size > 1) dim positioned BETWEEN the old stick and the batch/plane dims, so
+# the collapsed old stick lands at a device dim that is NOT the farthest from the
+# plane.  Every stick block must land correctly regardless of where the size-1
+# old stick sits.  Distinct-ramp + torch.equal catches a misplaced block exactly.
+SIZE1_MULTI_BLOCK_MID_DIM = [
+    ((1, 1, 2, 128, 1), (3, 4)),  # real dim (2) between old stick and plane
+    ((1, 1, 3, 128, 1), (3, 4)),  # size-3 mid dim
+    ((1, 1, 2, 192, 1), (3, 4)),  # 3 blocks
+    ((1, 1, 2, 67, 1), (3, 4)),  # unaligned blocks
+    ((1, 3, 2, 128, 1), (3, 4)),  # plane + mid dim both real
+]
+
+
+@pytest.mark.parametrize(
+    "shape,dims",
+    SIZE1_MULTI_BLOCK_MID_DIM,
+    ids=[f"{'x'.join(map(str, s))}_t{d}" for s, d in SIZE1_MULTI_BLOCK_MID_DIM],
+)
+def test_size1_multi_block_mid_dim_transpose_clone(shape, dims):
+    x = _arange(*shape)
+    _strict(lambda x: x.transpose(*dims).clone(), x)
+
+
+# A restickify input sliced with a contiguous OFFSET on a NON-stick host dim
+# (e.g. x[1:3]), with an unaligned new stick (67) that needs padding.  This is a
+# valid, paddable slice and must compile correctly.  Distinct-ramp + torch.equal
+# catches a misplaced plane exactly.
+OFFSET_NONSTICK_INPUT = [
+    # Graph-input leading-dim offset (rows 1..2 of 4), unaligned new stick (67).
+    (lambda x: x[1:3].transpose(1, 2).clone(), (4, 67, 128)),
+    # Offset on a middle (non-leading, non-stick) dim.
+    (lambda x: x[:, 1:3].transpose(2, 3).clone(), (2, 4, 67, 128)),
+]
+
+
+@pytest.mark.parametrize(
+    "fn,shape",
+    OFFSET_NONSTICK_INPUT,
+    ids=["x".join(map(str, s)) for _, s in OFFSET_NONSTICK_INPUT],
+)
+def test_offset_nonstick_input_transpose_clone(fn, shape):
+    x = _arange(*shape)
+    _strict(fn, x)
+
+
+# A STRIDED (step > 1) read of a restickify input (``x[::2]``) is not paddable:
+# the strided rows are non-adjacent, so a copy would read the wrong data.  With
+# an unaligned new stick (67) that needs padding, this must fail loudly rather
+# than silently miscompile.
+def test_strided_input_transpose_clone_raises():
+    x = _arange(4, 67, 128)
+    with pytest.raises(RuntimeError, match="strided input on host dim"):
+        _compile_and_run(lambda x: x[::2].transpose(1, 2).clone(), (x,), DEVICE)
+
+
+# A BROADCAST read (a dim iterated wider than its size) coexisting with an
+# unaligned new-stick dim that needs padding.  The rope view
+# ``k.view(B, S, H, D)`` on a ``[B, S, H, 2, 1, D/2]`` input folds the size-2 dim
+# into the last dim, so after ``transpose(2, 3)`` that dim is read with a
+# zero-coefficient coord (``floor(v/64)`` / ``Mod(v, 64)``) -- a re-read, not a
+# stride.  Unlike ``x[::2]`` above, this is fine: codegen derives the read's
+# device strides from the device layout, so the broadcast reads correctly while
+# the unaligned new stick (S=67) is padded.  Every element must land exactly.
+def test_broadcast_input_transpose_clone():
+    def fn(k):
+        B, S, H = k.shape[0], k.shape[1], k.shape[2]
+        D = k.shape[-1] * 2
+        return k.view(B, S, H, D).transpose(1, 2).transpose(2, 3).clone()
+
+    x = _arange(1, 67, 1, 2, 1, 64)
+    _strict(fn, x)
+
+
+# Matmul with a SUB-STICK contraction dim (D) reached through a permuted key,
+# k.permute(0,2,3,1), which restickifies k into [B,H,D,Lk] with the sub-stick D
+# demoted to a non-stick device dim.  When D does not fill a whole stick (D=48)
+# the restickify's widened read runs past D's initialized lanes; D must be padded
+# to a stick boundary (and its K-tail zero-filled) so the contraction ignores the
+# pad rows.  Read-side padding grows D's device dim device-size-only, which covers
+# the over-read for every D here (an already-full D=64 is a no-op grow).
+# Small-span ramps keep the fp16 accumulation exact so torch.equal is a true
+# oracle; D spans sub-stick (33, 48), aligned (64), and multi-block (96) sizes.
+SUBSTICK_MATMUL_D = [33, 48, 63, 64, 96]
+
+
+@pytest.mark.parametrize("D", SUBSTICK_MATMUL_D, ids=lambda d: f"D{d}")
+def test_substick_contraction_permuted_key(D):
+    B, H, Lq, Lk = 2, 4, 16, 32
+    q = _arange(B, Lq, H, D, span=3)
+    k = _arange(B, Lk, H, D, span=3)
+
+    def fn(q, k):
+        return torch.matmul(q.permute(0, 2, 1, 3), k.permute(0, 2, 3, 1))
+
+    _strict(fn, q, k)
+
+
 def test_2d_sparse_broadcast_dense_pointwise():
     """a.sum(-1) + b - reduction output broadcast into pointwise with dense b."""
     a = torch.randn((S, S), dtype=torch.float16)
@@ -1123,3 +2151,208 @@ def test_single_arg_size1_after_staggered_ea():
     sf = torch.randn((1, T, 2, 2, half), dtype=torch.float16)
     kc = torch.randn((1, NKV, KVLEN, HD), dtype=torch.float16)
     _compare(fn, x, sf, kc)
+
+
+# --- size-1 old-stick under-allocation regression guard ----------------------
+#
+# This test looks contrived -- most of its body is arena setup, not the op under
+# test.  That setup is the point: it is the recipe that first surfaced the size-1
+# old-stick under-allocation bug, kept here so the bug cannot silently return.  On
+# `(x + x).transpose(0, -1).contiguous()` over the (mb, out, 1) family the output
+# allocation was one plane short and the store overran it.
+#
+# A plain equality check would not catch that -- the extra plane lands on whatever
+# happens to be there, often benign.  The warming ops below make the overrun
+# observable deterministically: they free the region the store would overhang and
+# leave a zeros residue, so an out-of-bounds plane reads 0.0 while the correct
+# output is a nonzero ramp -- a mismatch on every overrun plane.
+
+# Shapes in the (mb, out, 1) size-1 old-stick family, spread across mb and out so
+# they land at differing pool offsets.
+_COVERAGE_GAP_SHAPES = [
+    (7, 67, 1),
+    (7, 66, 1),
+    (7, 65, 1),
+    (7, 63, 1),
+    (5, 67, 1),
+    (9, 67, 1),
+]
+
+
+@pytest.mark.parametrize(
+    "shape", _COVERAGE_GAP_SHAPES, ids=lambda p: "x".join(map(str, p))
+)
+def test_restickify_coverage_gap(shape):
+    # Warm the arena so a short allocation would overrun into a freed, zeroed
+    # region (see the block comment): the large shapes leave the zeros residue,
+    # the small ones position the target's pool over it.
+    for warm_shape in [(2, 1025, 1024), (2, 2, 1025, 1024), (67, 64), (67, 67)]:
+        z = torch.zeros(warm_shape, dtype=torch.float16)
+        _compile_and_run(lambda x: x.transpose(-2, -1).clone(), (z,), DEVICE)
+
+    x = _arange(*shape, span=511)
+    _strict(lambda t: (t + t).transpose(0, -1).contiguous(), x)
+
+
+# --------------------------------------------------------------------------
+# White-box (device-free) geometry of the size-1 stick allocation grow.
+#
+# A restickify whose old stick has host size 1 collapses one operand's
+# within-stick coordinate to a constant, so that operand's STL carries the old
+# stick as a size-1 ``stride_map == -1`` singleton dim, while the restore
+# (_restickify_restore_elided_dim) rebuilds the descriptor to sweep a full
+# 64-plane stick.  The grow is two coupled halves: padding._pad_elided_dim
+# prepends an outermost size-64 ``-1`` gap dim to the (intact) operand's STL so
+# the allocation covers the sweep, and the restore REUSES that dim (binds the
+# shared iteration symbol to it) rather than inserting its own, keeping the
+# descriptor total equal to the grown allocation.  These tests pin each half
+# against the real STL / OpSpec APIs, without a device (the functional
+# lane-displacement checks are the *_stick_crossing_* tests above).
+_SIZE1_COLLAPSED_DEVICE_SIZE = [67, 1, 1, 64]
+_SIZE1_COLLAPSED_STRIDE_MAP = [7, 64, -1, 1]
+_SIZE1_HOST_SIZE = [1, 67, 7]
+_SIZE1_HOST_STRIDE = [469, 7, 1]
+_SIZE1_STICK = 64  # SEN169_FP16 elems_per_stick
+
+
+def test_size1_grow_prepends_size64_gap_dim():
+    from torch_spyre._C import DataFormats, ElementArrangement
+    from torch_spyre._C import SpyreTensorLayout as _CSpyreTensorLayout
+    from torch_spyre._inductor.ir import FixedTiledLayout
+    from torch_spyre._inductor.padding import _pad_elided_dim
+
+    # _C.SpyreTensorLayout takes device_size LITERALLY (unlike torch.spyre's
+    # SpyreTensorLayout, which treats the first arg as a host shape and re-derives
+    # the device layout); we assert on exact device dims here.
+    stl = _CSpyreTensorLayout(
+        list(_SIZE1_COLLAPSED_DEVICE_SIZE),
+        list(_SIZE1_COLLAPSED_STRIDE_MAP),
+        DataFormats.SEN169_FP16,
+        ElementArrangement.STANDARD,
+    )
+    layout = FixedTiledLayout(
+        DEVICE, torch.float16, list(_SIZE1_HOST_SIZE), list(_SIZE1_HOST_STRIDE), stl
+    )
+
+    # _pad_elided_dim reads buf.get_layout() and writes buf.layout; a 2-line stub
+    # is all the ComputedBuffer surface it touches.
+    class _StubBuf:
+        def __init__(self, layout):
+            self.layout = layout
+
+        def get_layout(self):
+            return self.layout
+
+    buf = _StubBuf(layout)
+    _pad_elided_dim(buf)
+
+    dl = buf.layout.device_layout
+    # An outermost size-64 gap dim (stride_map -1) is prepended; the original
+    # device dims follow unchanged.
+    assert list(dl.device_size) == [_SIZE1_STICK, *_SIZE1_COLLAPSED_DEVICE_SIZE]
+    assert list(dl.stride_map) == [-1, *_SIZE1_COLLAPSED_STRIDE_MAP]
+    # Allocation is 128B/stick * prod(device_size[:-1]) (get_device_size_in_bytes
+    # in spyre_tensor_impl.cpp); the prepended dim grows it exactly 64x.
+    alloc_bytes = 128 * math.prod(list(dl.device_size)[:-1])
+    assert alloc_bytes == 64 * 8576 == 548864
+
+
+def _size1_restickify_op_spec():
+    """A restickify op_spec matching [7,67,1] (x+x).transpose(0,-1).contiguous():
+    the INPUT stick is elided (within-stick coord is a constant), the OUTPUT is
+    intact and carries the padding-prepended size-64 gap dim as its outermost dim.
+    """
+    import sympy
+    from torch_spyre._C import DataFormats
+    from torch_spyre._inductor.op_spec import OpSpec, TensorArg
+
+    def tensor_arg(is_input, arg_index, device_size, coords):
+        return TensorArg(
+            is_input=is_input,
+            arg_index=arg_index,
+            device_dtype=DataFormats.SEN169_FP16,
+            device_size=list(device_size),
+            device_coordinates=list(coords),
+            allocation={"hbm": 0x400000000 + arg_index * 0x1000},
+        )
+
+    c = sympy.Symbol("c")
+    # Elided INPUT: within-stick coordinate is a constant (no free symbol); the
+    # old stick shows up as a size-1 dim.
+    in_arg = tensor_arg(
+        is_input=True,
+        arg_index=0,
+        device_size=[67, 1, 1, 64],
+        coords=[c, sympy.Integer(0), sympy.Integer(0), sympy.Integer(0)],
+    )
+    # Intact OUTPUT: the grow prepended an outermost size-64, symbol-less gap dim;
+    # the within-stick coord carries the free symbol.
+    out_arg = tensor_arg(
+        is_input=False,
+        arg_index=1,
+        device_size=[64, 67, 1, 64],
+        coords=[sympy.Integer(0), c, sympy.Integer(0), sympy.Mod(c, 64)],
+    )
+    return OpSpec(
+        op="restickify",
+        is_reduction=False,
+        iteration_space={c: (sympy.Integer(67), 1)},
+        args=[in_arg, out_arg],
+        op_info={},
+    )
+
+
+def test_size1_restore_reuses_prepended_dim():
+    from torch_spyre._inductor.spyre_kernel import _restickify_restore_elided_dim
+
+    op_spec = _size1_restickify_op_spec()
+    out_arg = op_spec.args[1]
+
+    _restickify_restore_elided_dim(op_spec)
+
+    # The outermost size-64 dim is REUSED: the restore binds its shared symbol to
+    # the existing dim rather than inserting a second one, so the intact operand
+    # still has exactly ONE outermost size-64 dim (no 64x double count).
+    assert list(out_arg.device_size) == [64, 67, 1, 64]
+    assert out_arg.device_size.count(64) == 2  # gap dim + within-stick dim
+    # The shared symbol (rs*) now drives that outermost dim ...
+    outer_syms = tuple(out_arg.device_coordinates[0].free_symbols)
+    assert len(outer_syms) == 1
+    shared = outer_syms[0]
+    assert shared.name.startswith("rs")
+    # ... and it iterates with range 1, so it contributes no real stride: the
+    # size-64 device slot is pure back-gap padding, not a 64-plane sweep.
+    assert op_spec.iteration_space[shared] == (_SIZE1_STICK, 1)
+
+
+def test_size1_restore_asserts_when_phantom_absent():
+    from torch_spyre._inductor.spyre_kernel import _restickify_restore_elided_dim
+
+    # If the padding grow did not run, the intact operand has no prepended
+    # size-64 gap dim; the restore must hard-assert rather than silently insert a
+    # second dim (which would double the descriptor total 64x vs the allocation).
+    op_spec = _size1_restickify_op_spec()
+    out_arg = op_spec.args[1]
+    # Drop the prepended gap dim to simulate the un-grown STL.
+    out_arg.device_size = [67, 1, 64]
+    out_arg.device_coordinates = out_arg.device_coordinates[1:]
+
+    with pytest.raises(AssertionError, match="padding-prepended"):
+        _restickify_restore_elided_dim(op_spec)
+
+
+def test_round_up_to_stick_geometry():
+    """round_up_to_stick underlies the input-padding gate's read-window arithmetic
+    (padded_dim_size = slice_offset + round_up_to_stick(extent)).  The gate itself
+    is covered end-to-end by the OFFSET_STICK_OK / *_raises functional tests above;
+    this pins the rounding helper it relies on.
+    """
+    from torch_spyre._inductor.padding import round_up_to_stick
+
+    # No-op on a stick multiple; rounds a partial stick up to the next boundary.
+    assert round_up_to_stick(0, torch.float16) == 0
+    assert round_up_to_stick(64, torch.float16) == 64
+    assert round_up_to_stick(3, torch.float16) == 64
+    assert round_up_to_stick(70, torch.float16) == 128
+    assert round_up_to_stick(128, torch.float16) == 128
+    assert round_up_to_stick(129, torch.float16) == 192

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -1505,6 +1505,20 @@ def _ref_arg(op_spec):
     return op_spec.args[-1]
 
 
+def _round_up_to_stick(
+    sdsc_iteration_space: dict,
+    sym,
+    stick_size: int,
+    caller: str,
+) -> None:
+    """Round ``sdsc_iteration_space[sym]`` up to the next stick boundary."""
+    cur = sdsc_iteration_space[sym]
+    padded = ((cur + stick_size - 1) // stick_size) * stick_size
+    if padded > cur:
+        logger.debug("%s: extending %s %d -> %d", caller, sym, cur, padded)
+        sdsc_iteration_space[sym] = padded
+
+
 def _extend_matmul_k_to_padded(
     op_spec: OpSpec,
     sdsc_iteration_space: dict,
@@ -1566,17 +1580,34 @@ def _extend_matmul_k_to_padded(
     # allocation's K extent, not the slice's logical K, so it can be larger
     # than the matmul's actual K and would over-extend the iteration space.
     stick_size = y_arg.device_dtype.elems_per_stick()
-    k_current = sdsc_iteration_space[k_sym]
-    k_padded = ((k_current + stick_size - 1) // stick_size) * stick_size
+    _round_up_to_stick(
+        sdsc_iteration_space, k_sym, stick_size, "_extend_matmul_k_to_padded"
+    )
 
-    if k_padded > k_current:
-        logger.debug(
-            "_extend_matmul_k_to_padded: extending K %d -> %d (sym=%s)",
-            k_current,
-            k_padded,
-            k_sym,
+
+def _extend_restickify_to_padded(
+    op_spec: OpSpec,
+    sdsc_iteration_space: dict,
+    symbol_mapping: dict,
+) -> None:
+    """Round sdsc_iteration_space[stick_sym] up to a stick boundary for each
+    restickify arg.  Both input (old stick) and output (new stick) may carry
+    the unaligned iter, so we extend per-arg.
+
+    Running before ``_create_sdsc_tensors`` keeps backGap correct: the
+    unaligned-stick arg gets dev_dim_size==it_dim_size on the within-stick
+    axis (no backGap), and the other arg's outer-split strides are computed
+    against the padded extent (no stale-stride mismatch with the later
+    widening done by ``_get_padded_iteration_space``).
+    """
+    for arg in op_spec.args:
+        _, stick_sym = _get_device_dim_order(arg, symbol_mapping)
+        if stick_sym is None or stick_sym not in sdsc_iteration_space:
+            continue
+        stick_size = arg.device_dtype.elems_per_stick()
+        _round_up_to_stick(
+            sdsc_iteration_space, stick_sym, stick_size, "_extend_restickify_to_padded"
         )
-        sdsc_iteration_space[k_sym] = k_padded
 
 
 def _inject_implicit_conv_kernel_dims(
@@ -1659,6 +1690,7 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
     is_matmul = _is_matmul(op_spec.op)
     is_conv2d = _is_conv(op_spec.op)
     is_relayout = is_lx_relayout_identity(op_spec.op, op_spec.args)
+    is_restickify = op_spec.op == RESTICKIFY_OP
     is_pool = _is_pool(op_spec.op)
     is_conv = _is_conv(op_spec.op)
     ndim = len(op_spec.iteration_space)
@@ -1889,6 +1921,8 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
 
     if is_matmul:
         _extend_matmul_k_to_padded(op_spec, sdsc_iteration_space, symbol_mapping)
+    elif is_restickify:
+        _extend_restickify_to_padded(op_spec, sdsc_iteration_space, symbol_mapping)
 
     # For topk: if all output dims are in the input, add a missing dimension.
     injected_dims = {"mb_sym": mb_sym} if mb_sym else {}
@@ -1941,7 +1975,7 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
             [args[0]],
             [args[0].dim_order],
         )
-    elif op_spec.op == RESTICKIFY_OP:
+    elif is_restickify:
         # Pad iteration space using all args so both the old stick (input) and
         # new stick (output) are rounded up to the nearest stick boundary.
         pad_args, pad_sdsc_args, dim_order = (
@@ -1961,7 +1995,7 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
 
     # For restickify, update backGaps based on the padded iteration space,
     # since non-stick dimensions may now have it_dim_size > dev_dim_size.
-    if op_spec.op == RESTICKIFY_OP:
+    if is_restickify:
         for sdsc_arg, op_spec_arg in zip(args, op_spec.args):
             layout = layouts[sdsc_arg.layout]
             stick_dim = layout["stick_dim_order"]

--- a/torch_spyre/_inductor/dedup_constants.py
+++ b/torch_spyre/_inductor/dedup_constants.py
@@ -18,8 +18,8 @@ from torch._inductor.ir import ComputedBuffer, Operation
 from torch._inductor.virtualized import V
 
 from .ir import SpyreConstantFallback
-from .insert_restickify import NameSwapHandler
 from .logging_utils import get_inductor_logger
+from .pass_utils import NameSwapHandler
 from .provenance import merge_provenance
 
 logger = get_inductor_logger("dedup_constants")

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -22,8 +22,7 @@ from .constants import ELIDED_COPY_BACK_ATTR
 from .ir import FixedTiledLayout, SpyreEmptyFallback
 from .optimize_restickify import EdgeCostMap
 from .logging_utils import get_inductor_logger
-from .loop_info import copy_op_metadata
-from .provenance import preserve_provenance
+from .pass_utils import redirect_computed_buffer_reads
 from torch._inductor.graph import GraphLowering
 from torch._inductor.ir import (
     ComputedBuffer,
@@ -37,7 +36,6 @@ from torch._inductor.ir import (
     TensorBox,
 )
 from torch_spyre._C import SpyreTensorLayout
-from torch._inductor.ops_handler import WrapperHandler
 from torch._inductor.virtualized import V
 
 from torch.utils._ordered_set import OrderedSet
@@ -71,24 +69,6 @@ def _record_restickify(
     restickify_plan[op.get_name()].append(
         {"arg_name": dep_name, "target_layout": target_layout}
     )
-
-
-class NameSwapHandler(WrapperHandler):
-    """
-    Wrapper to patch a node's inner_fn to use new buffer names after inserting
-    nodes upstream that change the input buffers.
-
-    This is the canonical example of the correct WrapperHandler wrapping
-    pattern for compiler passes. See CLAUDE.md "Compiler Pass Conventions"
-    and issue #2797.
-    """
-
-    def __init__(self, inner, name_map: dict[str, str]):
-        super().__init__(inner)
-        self._name_map = name_map
-
-    def load(self, name, index):
-        return super().load(self._name_map.get(name, name), index)
 
 
 def _create_restickify_node(
@@ -229,39 +209,13 @@ def insert_restickify_on_node_inputs(
             restick_buff.loop_info = op.loop_info
 
     # Patch inner_fn once with the full name_map covering all restickified args.
-    orig_inner = op.data.inner_fn
-
-    def new_inner_fn(*args, _map=name_map, _orig_inner=orig_inner):
-        with V.set_ops_handler(NameSwapHandler(V.ops, _map)):
-            return _orig_inner(*args)
-
-    object.__setattr__(op.data, "inner_fn", new_inner_fn)
-
-    # Reconstruct ComputedBuffer as a fresh object so the instance-keyed cache
-    # on get_default_sizes_body can be cleanly invalidated below.
-    new_consumer_buffer = ComputedBuffer(
-        name=op.get_name(),
-        layout=op.layout,
-        data=op.data,
-        _split_size=op._split_size,
-        _original_inner_fn=op._original_inner_fn,
-        _original_ranges=op._original_ranges,
-        _original_reduction_ranges=op._original_reduction_ranges,
-    )
-    new_consumer_buffer.operation_name = op.operation_name
-    preserve_provenance(
+    redirect_computed_buffer_reads(
         op,
-        new_consumer_buffer,
+        name_map,
+        operations,
         pass_name="insert_restickify",
         reason="redirect consumer to restickified input",
     )
-    copy_op_metadata(op, new_consumer_buffer)
-    # Replace op in the operations list with the reconstructed buffer.
-    operations[op_index] = new_consumer_buffer
-    V.graph.name_to_buffer[new_consumer_buffer.get_name()] = new_consumer_buffer
-
-    # Invalidate the sizes/body cache so it is recomputed on next access with the patched inner_fn.
-    ComputedBuffer.get_default_sizes_body.clear_cache(new_consumer_buffer)
 
 
 def insert_restickify(graph: GraphLowering) -> None:

--- a/torch_spyre/_inductor/padding.py
+++ b/torch_spyre/_inductor/padding.py
@@ -44,28 +44,35 @@ M=1 (decode phase) correctly.
 """
 
 import torch
+from sympy import Expr
 from torch._inductor.graph import GraphLowering
 from torch._inductor.ir import (
     Buffer,
     ComputedBuffer,
     Operation,
+    Pointwise,
     Reduction,
     TensorBox,
 )
 from torch._inductor.virtualized import V
 
-from .constants import BATCH_MATMUL_OP, BATCH_MATMUL_FP8_OP
+from .constants import BATCH_MATMUL_FP8_OP, BATCH_MATMUL_OP
+from .errors import Unsupported
 from .ir import FixedTiledLayout
 from .logging_utils import get_inductor_logger
 from .pass_utils import (
     concretize_expr,
+    concretize_index,
     find_reduction_var,
-    identify_matmul_inputs,
     host_coordinates,
+    identify_matmul_inputs,
+    is_restickify_coords,
     lower_pad_sequence,
+    redirect_computed_buffer_reads,
     replace_computed_buffer_body,
 )
-from torch_spyre._C import get_elem_in_stick
+from .views import compute_coordinates
+from torch_spyre._C import SpyreTensorLayout, get_elem_in_stick
 
 logger = get_inductor_logger("padding")
 
@@ -74,6 +81,12 @@ def compute_padding(cur_size: int, dtype: torch.dtype) -> int:
     stick_size = get_elem_in_stick(dtype)
     pad = (stick_size - (cur_size % stick_size)) % stick_size
     return pad
+
+
+def round_up_to_stick(cur_size: int, dtype: torch.dtype) -> int:
+    """Round ``cur_size`` up to the next whole stick for ``dtype`` (no-op when
+    already a stick multiple)."""
+    return cur_size + compute_padding(cur_size, dtype)
 
 
 def _patch_env(graph_lowering) -> None:
@@ -86,6 +99,22 @@ def _patch_env(graph_lowering) -> None:
             tb_fx_node = list(tb.data.origins)[0]
             env[tb_fx_node] = tb
     graph_lowering.env.update(env)
+
+
+def _move_ops_before(
+    operations: list[Operation], new_ops: list[Operation], anchor: Operation
+) -> None:
+    """Relocate *new_ops* to sit immediately before *anchor* in *operations*.
+
+    ``run_node`` appends each newly lowered op at the end of ``operations``;
+    this helper moves them to just before the op that consumes them so
+    topological order is preserved.
+    """
+    for o in new_ops:
+        operations.remove(o)
+    idx = operations.index(anchor)
+    for i, o in enumerate(new_ops):
+        operations.insert(idx + i, o)
 
 
 def _find_arg_fx_node(arg_name: str) -> torch.fx.Node:
@@ -293,11 +322,7 @@ def insert_bmm_padding(graph: GraphLowering) -> None:
 
         # --- Relocate new ops before the matmul ---
         # run_node appended them at the end of operations; move before op.
-        for new_op in y_new_ops:
-            operations.remove(new_op)
-        op_idx = operations.index(op)
-        for i, new_op in enumerate(y_new_ops):
-            operations.insert(op_idx + i, new_op)
+        _move_ops_before(operations, y_new_ops, op)
 
         # When coarse-tiling runs pre-stickification, the consuming matmul
         # already carries loop_info.  The padding ops must inherit it so they
@@ -311,3 +336,505 @@ def insert_bmm_padding(graph: GraphLowering) -> None:
         # x is left entirely untouched: the original inner_fn's x loader is
         # preserved as-is.  Only y's loader is replaced with the padded buffer.
         _rebuild_matmul(op, y_padded_buf, operations)
+
+
+# --------------------------------------------------------------------------- #
+# insert_restickify_padding                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def _device_coords(stl: SpyreTensorLayout, dep) -> list[Expr]:
+    """Return device-space coordinate expressions for ``dep`` against ``stl``."""
+    index = concretize_index(dep.index, set(dep.ranges.keys()))
+    return compute_coordinates(stl.device_size, stl.stride_map, dep.ranges, index)
+
+
+def _write_dep(op):
+    """Return op's write dependency on the buffer it produces."""
+    writes = [d for d in op.get_read_writes().writes if hasattr(d, "name")]
+    assert len(writes) == 1, (
+        f"_write_dep: {op.get_name()} has {len(writes)} named writes, want exactly 1"
+    )
+    return writes[0]
+
+
+def _restickify_input(op, graph: GraphLowering):
+    """Return ``(in_dep, in_buf, in_layout)`` for a restickify's single input, or
+    ``(None, None, None)`` if ``op`` cannot be one: it must have exactly one
+    named read whose buffer has a FixedTiledLayout.
+    """
+    # Callers that already know op is a confirmed restickify can assume this
+    # succeeds.
+    reads = [r for r in op.get_read_writes().reads if hasattr(r, "name")]
+    if len(reads) != 1:
+        return None, None, None
+    in_dep = reads[0]
+    in_buf = graph.get_buffer(in_dep.name)
+    if in_buf is None:
+        return None, None, None
+    in_layout = in_buf.get_layout()
+    if not isinstance(in_layout, FixedTiledLayout):
+        return None, None, None
+    return in_dep, in_buf, in_layout
+
+
+def _host_dim_carrying_sym(host_coords: list[Expr], sym) -> int | None:
+    """Return the outermost host dim whose coordinate carries ``sym``, or None."""
+    # A symbol whose range spans more than one tile can appear split across
+    # several coordinates (e.g. v // 64 in one, v % 64 in another); the
+    # outermost (lowest-index) one is the governing dim.
+    for dim, coord in enumerate(host_coords):
+        if sym in coord.free_symbols:
+            return dim
+    return None
+
+
+def _device_dim_carrying_sym(stl: SpyreTensorLayout, write_dep, sym) -> int | None:
+    """Return the outermost non-within-stick ``device_size`` dim whose device
+    coordinate carries ``sym`` (the free symbol of some host dim), or None.
+    """
+    # Two host dims can share a dim size, so only the symbol unambiguously
+    # identifies the dim.  A symbol whose range spans more than one tile can
+    # appear split across several coordinates (e.g. v // 64 in one, v % 64 in
+    # another); the outermost (lowest-index) one is the governing dim.
+    device_coords = _device_coords(stl, write_dep)
+    for dim in range(len(device_coords) - 1):
+        if sym in device_coords[dim].free_symbols:
+            return dim
+    return None
+
+
+def _stick_symbol(stl: SpyreTensorLayout, dep) -> object | None:
+    """Return dep's within-stick device coordinate's free symbol against stl,
+    or None if it has none (e.g. a symbol-free size-1 stick, or a scalar /
+    zero-dim layout with no coords at all).
+    """
+    device_coords = _device_coords(stl, dep)
+    if not device_coords:
+        return None
+    # A coefficient or offset on the coordinate doesn't add free symbols, so
+    # e.g. 2*(Mod(var, 32)) + 1 and Mod(var, 32) both resolve to {var}.
+    syms = device_coords[-1].free_symbols
+    if not syms:
+        return None
+    assert len(syms) == 1, (
+        f"_stick_symbol: within-stick coordinate {device_coords[-1]} carries "
+        f"{len(syms)} free symbols, want exactly 1"
+    )
+    return next(iter(syms))
+
+
+def is_restickify_op(op: Operation, graph: GraphLowering) -> bool:
+    """Return whether ``op`` is a restickify: a single-input pointwise copy
+    between two FixedTiledLayouts that lands a *different* host dim within the
+    stick.
+    """
+    if not isinstance(op, ComputedBuffer):
+        return False
+    out_layout = op.get_layout()
+    if not isinstance(out_layout, FixedTiledLayout):
+        return False
+    if not isinstance(op.data, Pointwise):
+        return False
+
+    in_dep, _in_buf, in_layout = _restickify_input(op, graph)
+    if in_dep is None:
+        return False
+
+    in_coords = _device_coords(in_layout.device_layout, in_dep)
+    out_coords = _device_coords(out_layout.device_layout, _write_dep(op))
+    # A scalar / zero-dim layout has no coordinates, so it can't be a restickify.
+    if not in_coords or not out_coords:
+        return False
+    # is_restickify_coords is the single source of truth for this check, shared
+    # with codegen's store side, so the two can't disagree on which ops restickify.
+    return is_restickify_coords(in_coords, out_coords)
+
+
+def _pad_device_dim(
+    layout: FixedTiledLayout,
+    device_dim: int,
+    new_dim_size,
+) -> FixedTiledLayout:
+    """Pad the device dim ``device_dim`` up to ``new_dim_size``.
+
+    This handles a restickify whose transposed dim survives as a device dim larger
+    than one; when that dim has been elided to size one, use ``_pad_elided_dim``
+    instead.
+
+    The result is a copy of ``layout`` with only that dim's size grown.  The host
+    size is left alone, and since ``stride_map`` stores host strides rather than
+    sizes, it does not need to change either.
+    """
+    stl = layout.device_layout
+    new_device_size = list(stl.device_size)
+    new_device_size[device_dim] = new_dim_size
+    padded_stl = SpyreTensorLayout(
+        new_device_size, list(stl.stride_map), stl.device_dtype, stl.element_arrangement
+    )
+    host_size = [concretize_expr(s) for s in layout.size]
+    host_stride = [concretize_expr(s) for s in layout.stride]
+    return FixedTiledLayout(
+        layout.device, layout.dtype, host_size, host_stride, padded_stl
+    )
+
+
+def _pad_elided_dim(buf: ComputedBuffer) -> None:
+    """Pad ``buf``'s allocation by prepending an outermost size-64 gap dim, for a
+    restickify whose transposed dim was elided to a size-1 device dim.
+
+    The transposed dim is a non-stick dim here -- the new stick on the input side,
+    the old stick on the output side -- that pairs with the stick on the other
+    operand.  When it has host size 1, Inductor elides it, so the STL carries it as
+    a size-1 dim with ``stride_map == -1``, and its allocation holds one plane, but
+    the paired stick needs 64.
+
+    Prepending a size-64 gap dim makes the allocation cover all 64 planes.  This
+    only bumps the dim size; a later pass, ``_restickify_restore_elided_dim``,
+    creates the shared iteration variable that pairs this dim with the stick on the
+    other operand.
+    """
+    layout = buf.get_layout()
+    assert isinstance(layout, FixedTiledLayout)
+    stl = layout.device_layout
+    stick = stl.elems_per_stick()
+    grown_stl = SpyreTensorLayout(
+        [stick, *stl.device_size],
+        [-1, *stl.stride_map],
+        stl.device_dtype,
+        stl.element_arrangement,
+    )
+    host_size = [concretize_expr(s) for s in layout.size]
+    host_stride = [concretize_expr(s) for s in layout.stride]
+    buf.layout = FixedTiledLayout(
+        layout.device, layout.dtype, host_size, host_stride, grown_stl
+    )
+
+
+def _pad_restickify_output(op: Operation, graph: GraphLowering) -> None:
+    """Pad the output dim carrying the input's old stick to a stick boundary, so
+    the second+ stick block and every batch plane land at the correct offset.
+
+    The old stick is a non-stick dim on the output.  Bump its device dim to a stick
+    multiple; only the device layout changes, and ``_create_sdsc_tensors``'s backGap
+    path covers the tail rows, which are never read back.  Does nothing when its
+    device dim is already stick-aligned.
+
+    When the old stick was elided to a size-1 device dim, there is no device dim to
+    bump; delegate to ``_pad_elided_dim`` instead.
+
+    Raises ``Unsupported`` for a sliced output: it writes only part of the
+    old-stick device dim of a base tensor whose layout we do not own, so there is
+    no room to widen the dim (see the TODO below for how it could be supported).
+    """
+    assert isinstance(op, ComputedBuffer)
+    in_dep, _in_buf, in_layout = _restickify_input(op, graph)
+    assert in_dep is not None  # op is a confirmed restickify
+    # The old stick is the INPUT's own stick symbol (None when it collapsed to a
+    # size-1 device dim).
+    old_sym = _stick_symbol(in_layout.device_layout, in_dep)
+    out_layout = op.get_layout()
+    write_dep = _write_dep(op)
+    stl = out_layout.device_layout
+
+    if old_sym is None:
+        _pad_elided_dim(op)
+        logger.debug(
+            "insert_restickify_padding: grew size-1 output %s allocation",
+            op.get_name(),
+        )
+        return
+
+    device_dim = _device_dim_carrying_sym(stl, write_dep, old_sym)
+    assert device_dim is not None
+    unpadded_dim_size = stl.device_size[device_dim]
+
+    # A sliced output writes only part of the old-stick device dim: the rows it
+    # writes are the interior of a base tensor whose layout we do not own, and the
+    # rows around them belong to other slice positions.  We cannot pad such an output
+    # -- growing the dim would overwrite a neighbour's rows.
+    #
+    # TODO: support this by restickifying into a fresh temp buffer sized to a stick
+    # multiple, then cloning that buffer into the slice.
+    host_dim_size = concretize_expr(write_dep.ranges[old_sym])
+    if host_dim_size < unpadded_dim_size:
+        raise Unsupported(
+            f"insert_restickify_padding: sliced output on {op.get_name()} "
+            f"(written size {host_dim_size} < device dim size {unpadded_dim_size}) "
+            f"cannot be padded in place"
+        )
+
+    # Already a stick multiple: stick blocks land aligned, no padding needed.
+    pad = compute_padding(unpadded_dim_size, out_layout.dtype)
+    if pad == 0:
+        return
+
+    padded_dim_size = unpadded_dim_size + pad
+    op.layout = _pad_device_dim(out_layout, device_dim, padded_dim_size)
+
+    logger.debug(
+        "insert_restickify_padding: padded output %s device dim %d %d -> %d",
+        op.get_name(),
+        device_dim,
+        unpadded_dim_size,
+        padded_dim_size,
+    )
+
+
+def _assert_input_paddable(op: ComputedBuffer, in_dep, in_layout) -> None:
+    """Raise ``Unsupported`` for restickify inputs outside what the stick-boundary
+    bump supports, classifying each input dim's read by its coordinate.
+
+    Outside the supported set:
+
+    - **Strided** read of any dim (coord ``k*var``, k not in {0, 1}: step > 1 or
+      reversed), e.g. ``x[::2].transpose(1, 2).clone()``.
+
+    TODO: the strided case is liftable by double-restickifying -- a re-base copy
+    that reads the strided source into a fresh stick-aligned buffer, then
+    restickifies that.  With that in place, these expressions take that path and
+    do not reach this guard.
+    """
+    in_host_coords = host_coordinates(in_layout, in_dep, None)
+    for i, coord in enumerate(in_host_coords):
+        syms = coord.free_symbols
+        if not syms:  # degenerate size-1 host dim, nothing to slice
+            continue
+        assert len(syms) == 1, (
+            f"insert_restickify_padding: host dim {i} of {op.get_name()} "
+            f"(coord {coord}) carries multiple free symbols -- an interleaved "
+            f"index this pass's per-dim strided/sliced classification cannot "
+            f"read; a restickify input must not reach this shape"
+        )
+        sym = next(iter(syms))
+        # Strided (k not in {0, 1}), on any dim: codegen carries only a contiguous
+        # tail.  A broadcast (coeff 0) is read from the device layout, not this
+        # coefficient, so it is not a stride and is left to flow through.
+        if concretize_expr(coord.coeff(sym)) not in (0, 1):
+            raise Unsupported(
+                f"insert_restickify_padding: strided input on host dim "
+                f"{i} of {op.get_name()} (coord {coord}) is not supported"
+            )
+
+
+def lower_identity_clone(
+    arg_fx_node: torch.fx.Node,
+    host_size: list[int],
+    host_stride: list[int],
+    device: torch.device,
+    dtype: torch.dtype,
+    orig_stl: SpyreTensorLayout,
+    insert_before: torch.fx.Node,
+) -> tuple[ComputedBuffer, list[Operation]]:
+    """Lower an identity ``aten.clone`` of ``arg_fx_node`` as a layout-preserving
+    copy: allocated at ``host_size`` / ``host_stride`` (not contiguous) with a
+    ``SpyreTensorLayout`` copied from ``orig_stl``, so it replicates the graph
+    input's layout. The caller then bumps ``device_size`` on the stick dim.
+
+    Returns ``(clone_buf, new_ops)`` -- the single new ComputedBuffer and the
+    (length-1) list of new IR operations.
+    """
+    graph_lowering = V.graph
+    fx_graph = graph_lowering.graph
+
+    ops_before = len(graph_lowering.operations)
+
+    with fx_graph.inserting_before(insert_before):
+        clone_fx = fx_graph.create_node(
+            "call_function", torch.ops.aten.clone.default, args=(arg_fx_node,)
+        )
+        clone_fx.meta["val"] = torch.empty_strided(
+            host_size, host_stride, dtype=dtype, device=device
+        )
+
+    clone_tb = graph_lowering.run_node(clone_fx)
+    graph_lowering.env[clone_fx] = clone_tb
+
+    # aten.clone lowers to an identity Pointwise; force realization so it becomes
+    # a named ComputedBuffer rather than inlining into the consumer.
+    clone_tb.data.realize()
+    new_ops = graph_lowering.operations[ops_before:]
+    assert len(new_ops) == 1 and isinstance(new_ops[0], ComputedBuffer), (
+        f"lower_identity_clone: expected exactly one ComputedBuffer, got "
+        f"{[type(o).__name__ for o in new_ops]}"
+    )
+    clone_buf = new_ops[0]
+
+    host_layout = clone_buf.layout
+    clone_stl = SpyreTensorLayout(
+        list(orig_stl.device_size),
+        list(orig_stl.stride_map),
+        orig_stl.device_dtype,
+        orig_stl.element_arrangement,
+    )
+    # insert_restickify_padding runs after propagate_spyre_tensor_layouts, so
+    # run_node left this op with a FlexibleLayout; assign a FixedTiledLayout
+    # here so the clone carries a real device layout.
+    clone_buf.layout = FixedTiledLayout(
+        host_layout.device,
+        host_layout.dtype,
+        host_layout.size,
+        host_stride,
+        clone_stl,
+    )
+
+    assert clone_buf.origins, "lower_identity_clone: clone buffer has no origins"
+
+    return clone_buf, new_ops
+
+
+def _pad_restickify_input(op: Operation, graph: GraphLowering) -> None:
+    """Pad a restickify input's non-stick dim to cover codegen's stick-boundary
+    read window.
+
+    Decide whether and how to pad first, then apply it.  In general we pad the
+    producer's output buffer in place; a graph input has no producer to pad, so
+    we clone it and pad the clone.  Deciding before cloning keeps the graph
+    unmutated for an input we end up skipping.  The padding differs by whether
+    the new-stick dim collapsed to size 1:
+
+    - **Size-1 new-stick dim:** the input carries the restickify's INTACT operand
+      (``_restickify_restore_elided_dim`` restores the stick on it), so codegen
+      sweeps a full 64-plane stick while the input under-allocates 64x.  Prepend
+      an outermost size-64 gap dim (``_pad_elided_dim``); restore reuses that dim
+      as the restored stick.
+    - **Size>1 new-stick dim:** codegen reads a whole-stick window from the slice
+      base, so the allocation must extend past a narrowing or end-of-dim slice.
+      Bump the device dim carrying the new-stick symbol so the allocation covers
+      that window.
+
+    Does nothing when the read window already fits the allocation, or the input
+    has no device.
+    """
+    assert isinstance(op, ComputedBuffer)
+    in_dep, in_buf, in_layout = _restickify_input(op, graph)
+    assert in_dep is not None  # op is a confirmed restickify
+
+    # --- Gates: decide whether (and how) to pad BEFORE mutating the graph. ---
+    out_stick_sym = _stick_symbol(op.get_layout().device_layout, _write_dep(op))
+    size1 = out_stick_sym is None
+    new_stick_dim = None
+    padded_dim_size = None
+    if not size1:
+        _assert_input_paddable(op, in_dep, in_layout)
+        in_host_coords = host_coordinates(in_layout, in_dep, None)
+        new_stick_dim = _host_dim_carrying_sym(in_host_coords, out_stick_sym)
+        assert new_stick_dim is not None, (
+            f"restickify padding: no input host dim carries new-stick symbol "
+            f"{out_stick_sym} for {op.get_name()} (layout invariant broken)"
+        )
+        dtype = in_layout.dtype
+        coord = in_host_coords[new_stick_dim]
+        syms = coord.free_symbols
+        assert len(syms) == 1
+        sym = next(iter(syms))
+        slice_offset = concretize_expr(coord.as_coeff_Add()[0])
+        slice_size = concretize_expr(in_dep.ranges[sym])
+        device_dim = _device_dim_carrying_sym(in_layout.device_layout, in_dep, sym)
+        assert device_dim is not None
+        dim_size = concretize_expr(in_layout.device_layout.device_size[device_dim])
+        padded_dim_size = slice_offset + round_up_to_stick(slice_size, dtype)
+        if padded_dim_size <= dim_size:
+            return
+
+    # --- Get a buffer we can pad: the producer's output, or a graph-input clone. ---
+    # Run AFTER the gate: cloning mutates the graph (insert + redirect), so
+    # cloning for an input we then skip would strand a redundant clone.
+    if not isinstance(in_buf, ComputedBuffer):
+        # A graph input has no producer output to pad: insert an identity clone
+        # ahead of the restickify, move it into place, redirect the read to it,
+        # then pad the clone.
+        device = in_buf.get_device()
+        if device is None:
+            return
+        clone_buf, new_ops = lower_identity_clone(
+            _find_arg_fx_node(in_dep.name),
+            host_size=[concretize_expr(s) for s in in_layout.size],
+            host_stride=[concretize_expr(s) for s in in_layout.stride],
+            device=device,
+            dtype=in_layout.dtype,
+            orig_stl=in_layout.device_layout,
+            insert_before=next(iter(op.origins)),
+        )
+        _move_ops_before(graph.operations, new_ops, op)
+        redirect_computed_buffer_reads(
+            op,
+            {in_dep.name: clone_buf.get_name()},
+            graph.operations,
+            pass_name="insert_restickify_padding",
+            reason="redirect consumer to padded input",
+        )
+        in_buf = clone_buf
+
+        logger.debug(
+            "insert_restickify_padding: inserted clone %s for input of %s",
+            clone_buf.get_name(),
+            op.get_name(),
+        )
+
+    # --- Pad the input. ---
+    if size1:
+        # Prepend an outermost size-64 gap dim so the elided size-1 dim's
+        # allocation covers the full stick the restickify sweeps.
+        _pad_elided_dim(in_buf)
+    else:
+        assert new_stick_dim is not None  # set in the size>1 gate above
+        assert padded_dim_size is not None  # computed alongside it
+        # Bump device_size on the dim carrying new_stick_dim so the read window
+        # lands inside in_buf's own allocation.
+        layout = in_buf.get_layout()
+        write_dep = _write_dep(in_buf)
+        host_coords = host_coordinates(layout, write_dep, None)
+        syms = host_coords[new_stick_dim].free_symbols
+        assert len(syms) == 1
+        device_dim = _device_dim_carrying_sym(
+            layout.device_layout, write_dep, next(iter(syms))
+        )
+        assert device_dim is not None, (
+            f"restickify padding: {in_buf.get_name()} exposed no paddable device "
+            f"dim for new stick dim {new_stick_dim}"
+        )
+        in_buf.layout = _pad_device_dim(layout, device_dim, padded_dim_size)
+
+    logger.debug(
+        "insert_restickify_padding: padded input %s to device_size %s%s",
+        in_buf.get_name(),
+        in_buf.get_layout().device_layout.device_size,
+        "" if size1 else f" (new stick host dim {new_stick_dim})",
+    )
+
+
+def insert_restickify_padding(graph: GraphLowering) -> None:
+    """Pad a restickify's buffers so both are stick-aligned.
+
+    A restickify re-tiles a tensor so a different host dim lands within the
+    stick.  Codegen widens both its read and its write to stick boundaries, so
+    both buffers need dims that cover the widened access.  The write side and the
+    read side are independent -- either can need padding without the other -- so
+    this pass handles them separately:
+
+    - Write side (``_pad_restickify_output``): keeps the output's old-stick host
+      dim at the correct physical offset.
+    - Read side (``_pad_restickify_input``): keeps the read within the allocation.
+
+    Padding touches only the device layout, never host tensor dim sizes, so later
+    passes that depend on host sizes (e.g. ``propagate_named_dims``) see the
+    tensor unchanged.  Codegen's backGap path covers the resulting host/device
+    gap.
+
+    A size-1 (elided) stick dim needs the same two adjustments, but its size and
+    its coordinate are set by different passes:
+
+    - Size, here: ``_pad_elided_dim`` prepends an outermost size-64 gap dim.
+    - Coordinate, later: ``_restickify_restore_elided_dim`` (spyre_kernel.py)
+      mints a fresh iteration symbol just before ``align_tensors``.  It waits
+      because both operands must share that symbol for align to match them, and
+      align only sees a symbol that already exists when it runs.
+
+    The restore asserts the prepended gap dim is present before binding the
+    symbol, so swapping the pass order fails loudly rather than silently.
+    """
+    for op in list(graph.operations):
+        if is_restickify_op(op, graph):
+            _pad_restickify_output(op, graph)
+            _pad_restickify_input(op, graph)

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -32,6 +32,7 @@ from torch._inductor.ir import (
     Pointwise,
     Reduction,
 )
+from torch._inductor.ops_handler import WrapperHandler
 from torch._inductor.scheduler import SchedulerNode
 from torch._inductor.dependencies import MemoryDep, ReadWrites, StarDep, is_indirect
 from torch._inductor.virtualized import V
@@ -381,6 +382,22 @@ def op_out_coords(op: ComputedBuffer) -> list[sympy.Expr]:
     """Return host coordinates for the output dep of a ComputedBuffer."""
     output_dep = next(iter(op.get_read_writes().writes))
     return host_coordinates(op.get_layout(), output_dep, indirect_sizes_from_op(op))
+
+
+def is_restickify_coords(in_coords: list[Expr], out_coords: list[Expr]) -> bool:
+    """Return whether a single-input pointwise copy is a RESTICKIFY (vs IDENTITY).
+
+    ``in_coords`` / ``out_coords`` are the operands' device-space coordinates.
+    It is a restickify iff a *different* host dim lands within the stick (the
+    within-stick coords carry different free symbols) -- except a broadcast (an
+    all-zero input expanding to non-scalar output), which is an identity fill.
+
+    The authoritative test, shared by the codegen store side and the padding
+    pass matcher (``is_restickify_op``) so the two cannot disagree.
+    """
+    if all(e == 0 for e in in_coords) and not all(e == 0 for e in out_coords):
+        return False  # broadcast: scalar input expanding to non-scalar output
+    return in_coords[-1].free_symbols != out_coords[-1].free_symbols
 
 
 def _scatter_index_buf_names_ordered(op: ComputedBuffer) -> list[str]:
@@ -1346,6 +1363,79 @@ def replace_computed_buffer_body(
 
     op_idx = operations.index(op)
     operations[op_idx] = new_buf
+    return new_buf
+
+
+class NameSwapHandler(WrapperHandler):
+    """Patch an inner_fn's ``load`` calls to read renamed buffers.
+
+    Used after inserting a producer upstream (e.g. a restickify or an identity
+    clone) that supersedes an existing input: the consumer's inner_fn still
+    names the old buffer, so wrap it to remap each ``load(old_name, ...)`` to
+    ``load(new_name, ...)``.
+
+    This is the canonical WrapperHandler wrapping pattern for compiler passes:
+    wrap, never rebuild index expressions from scratch (they go stale — see
+    CLAUDE.md "Compiler Pass Conventions" and issue #2797).
+    """
+
+    def __init__(self, inner, name_map: dict[str, str]):
+        super().__init__(inner)
+        self._name_map = name_map
+
+    def load(self, name, index):
+        return super().load(self._name_map.get(name, name), index)
+
+
+def redirect_computed_buffer_reads(
+    op: ComputedBuffer,
+    name_map: dict[str, str],
+    operations: list[Operation],
+    *,
+    pass_name: str,
+    reason: str | None = None,
+) -> ComputedBuffer:
+    """Redirect ``op``'s reads through ``name_map`` and reconstruct the buffer.
+
+    Wraps ``op.data.inner_fn`` with ``NameSwapHandler`` so every ``load`` of a
+    remapped buffer resolves to its replacement, then reconstructs the frozen
+    ``ComputedBuffer`` so the instance-keyed ``get_default_sizes_body`` cache is
+    cleanly invalidated (the reconstruct is the reason both this helper and
+    ``replace_computed_buffer_body`` rebuild rather than mutate in place).
+
+    Returns the replacement ComputedBuffer.
+    """
+    # Patch inner_fn once with the full name_map covering all remapped args.
+    orig_inner = op.data.inner_fn
+
+    def new_inner_fn(*args, _map=name_map, _orig_inner=orig_inner):
+        with V.set_ops_handler(NameSwapHandler(V.ops, _map)):
+            return _orig_inner(*args)
+
+    object.__setattr__(op.data, "inner_fn", new_inner_fn)
+
+    # Reconstruct ComputedBuffer as a fresh object so the instance-keyed cache
+    # on get_default_sizes_body can be cleanly invalidated below.
+    new_buf = ComputedBuffer(
+        name=op.get_name(),
+        layout=op.layout,
+        data=op.data,
+        _split_size=op._split_size,
+        _original_inner_fn=op._original_inner_fn,
+        _original_ranges=op._original_ranges,
+        _original_reduction_ranges=op._original_reduction_ranges,
+    )
+    new_buf.operation_name = op.operation_name
+    preserve_provenance(op, new_buf, pass_name=pass_name, reason=reason)
+    copy_op_metadata(op, new_buf)
+
+    op_idx = operations.index(op)
+    operations[op_idx] = new_buf
+    V.graph.name_to_buffer[new_buf.get_name()] = new_buf
+
+    # Invalidate the sizes/body cache so it is recomputed on next access with
+    # the patched inner_fn.
+    ComputedBuffer.get_default_sizes_body.clear_cache(new_buf)
     return new_buf
 
 

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -38,7 +38,7 @@ from torch._inductor.scheduler import BaseSchedulerNode
 from .logging_utils import get_inductor_logger
 from .provenance import SpyreGraphTransformObserver, reset_provenance_warnings
 
-from .padding import insert_bmm_padding
+from .padding import insert_bmm_padding, insert_restickify_padding
 from .temp_passes import (
     bmm_unflatten_pass,
     decompose_addmm,
@@ -467,6 +467,7 @@ class CustomPreSchedulingPasses:
             insert_restickify,
             enforce_indirect_access_layout,
             insert_post_mutation_restickify,
+            insert_restickify_padding,
             insert_bmm_padding,
             #
             dedup_and_promote_constants,

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -229,6 +229,23 @@ def _output_stl_from_stick_expr(
     return _make_output_stl(output, output_dep, c_size, c_stride, out_stick_dim, dtype)
 
 
+def _dims_by_alignment(dims, sizes, stick_size: int) -> tuple[list[int], list[int]]:
+    """Split ``dims`` into (aligned, unaligned) by their extent in ``sizes``.
+
+    A caller scans the aligned dims first (no padding needed) and only falls
+    back to the unaligned dims when the aligned group yields nothing; the
+    unaligned dim it then picks is padded up to a stick boundary later by
+    ``insert_restickify_padding`` (See #1756).
+    """
+    aligned, unaligned = [], []
+    for dim in dims:
+        if concretize_expr(sizes[dim]) % stick_size == 0:
+            aligned.append(dim)
+        else:
+            unaligned.append(dim)
+    return aligned, unaligned
+
+
 def _make_output_stl(
     output, output_dep, c_size, c_stride, stick_dim, dtype=None
 ) -> SpyreTensorLayout | None:
@@ -266,19 +283,19 @@ def _candidate_output_stls(
 
     dtype = output.dtype if dtype is None else dtype
     stick_size = get_elem_in_stick(dtype)
-    result = []
-    for alt_stick_dim in range(len(output.size)):
-        if alt_stick_dim == skip_dim:
-            continue
-        if concretize_expr(output.size[alt_stick_dim]) % stick_size != 0:
-            # TODO: Support dimensions with size not divisible by stick_size via padding (See #1756)
-            continue
-        stl = _make_output_stl(
-            output, output_dep, c_size, c_stride, alt_stick_dim, dtype
-        )
-        if stl is not None:
-            result.append(stl)
-    return result
+    # Prefer stick-aligned dims; fall back to unaligned dims (padded later by
+    # insert_restickify_padding) only when no aligned dim yields a candidate.
+    all_dims = [d for d in range(len(output.size)) if d != skip_dim]
+    aligned_dims, unaligned_dims = _dims_by_alignment(all_dims, output.size, stick_size)
+    stls: list[SpyreTensorLayout] = []
+    for dims in (aligned_dims, unaligned_dims):
+        for d in dims:
+            stl = _make_output_stl(output, output_dep, c_size, c_stride, d, dtype)
+            if stl is not None:
+                stls.append(stl)
+        if stls:
+            break
+    return stls
 
 
 def _check_supported_input_sticks(args: list[PropArg], op_label: str) -> None:
@@ -446,36 +463,43 @@ def _single_arg_op_layout(
             if out_stl is not None:
                 return [out_stl]
 
-        # Try alternative layouts when input layout is not supported
+        # Try alternative layouts when input layout is not supported.
+        # Skip the dim already known to produce an unsupported stick.
         in_coords = host_coordinates(in_layout, dep, None)
         out_coords = host_coordinates(output, output_dep, None)
-        stick_dim = matching_dim(in_coords, x_stick_expr)
-        layouts = []
-        for in_dim in range(len(in_layout.size)):
-            if in_dim == stick_dim:
-                continue
-            if concretize_expr(in_layout.size[in_dim]) % stick_size != 0:
-                # TODO: Support dimensions with size not divisible by stick_size via padding (See #1756)
-                continue
-            in_coord = in_coords[in_dim]
-            # Map input dim to output dim. If input dim carries reduction var, it's collapsed
-            if reduction_var is not None and reduction_var in in_coord.free_symbols:
-                out_stick_dim = -1
-            else:
-                out_stick_dim = _pick_stick_dim(in_coord, out_coords)
-                if out_stick_dim < 0:
-                    continue
-            out_stl = _make_output_stl(
-                output,
-                output_dep,
-                c_size,
-                c_stride,
-                out_stick_dim,
-                out_dtype_for_layout,
-            )
-            if out_stl is not None:
-                layouts.append(out_stl)
+        skip_in_dim = matching_dim(in_coords, x_stick_expr)
 
+        # Prefer stick-aligned input dims; fall back to unaligned dims (padded
+        # later by insert_restickify_padding) only when no aligned dim maps to a
+        # supported output stick.
+        all_dims = [d for d in range(len(in_layout.size)) if d != skip_in_dim]
+        aligned_dims, unaligned_dims = _dims_by_alignment(
+            all_dims, in_layout.size, stick_size
+        )
+        layouts: list[SpyreTensorLayout] = []
+        for dims in (aligned_dims, unaligned_dims):
+            for in_dim in dims:
+                in_coord = in_coords[in_dim]
+                # Map input dim to output dim. If input dim carries reduction
+                # var, it's collapsed
+                if reduction_var is not None and reduction_var in in_coord.free_symbols:
+                    out_stick_dim = -1
+                else:
+                    out_stick_dim = _pick_stick_dim(in_coord, out_coords)
+                    if out_stick_dim < 0:
+                        continue
+                out_stl = _make_output_stl(
+                    output,
+                    output_dep,
+                    c_size,
+                    c_stride,
+                    out_stick_dim,
+                    out_dtype_for_layout,
+                )
+                if out_stl is not None:
+                    layouts.append(out_stl)
+            if layouts:
+                break
         return layouts
 
     # Single-arg pointwise
@@ -1164,19 +1188,24 @@ def _multi_arg_pointwise_layouts(
     # input EA and adding STANDARD candidates would corrupt downstream ops.
     # EA omitted from key: the loop below is skipped for staggered ops, so all
     # candidates added (and looked up) here use STANDARD EA — geometry suffices.
+    #
+    # Aligned dims are scanned first; unaligned dims (padded later by
+    # insert_restickify_padding) only when nothing aligned yielded a candidate.
     seen_keys = {(tuple(r.device_size), tuple(r.stride_map)) for r in results}
-    for alt_stick_dim in range(len(output.size)) if not staggered_inputs else []:
-        # TODO: Support dimensions with size not divisible by stick_size via padding (See #1756)
-        if concretize_expr(output.size[alt_stick_dim]) % stick_size != 0:
-            continue
-        pre_len = len(results)
-        _try_stick_dim(alt_stick_dim)
-        if len(results) > pre_len:
-            key = (tuple(results[-1].device_size), tuple(results[-1].stride_map))
-            if key in seen_keys:
-                results.pop()
-            else:
-                seen_keys.add(key)
+    all_dims = range(len(output.size)) if not staggered_inputs else []
+    aligned_dims, unaligned_dims = _dims_by_alignment(all_dims, output.size, stick_size)
+    for dims in (aligned_dims, unaligned_dims):
+        for alt_stick_dim in dims:
+            pre_len = len(results)
+            _try_stick_dim(alt_stick_dim)
+            if len(results) > pre_len:
+                key = (tuple(results[-1].device_size), tuple(results[-1].stride_map))
+                if key in seen_keys:
+                    results.pop()
+                else:
+                    seen_keys.add(key)
+        if results:
+            break
 
     # LX in-place: promote a same-frame input's layout to FIRST so the beam
     # commits it on a cost tie, avoiding a free-but-in-place-defeating permutation

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 import math
 from typing import Any, Callable, Self, Sequence, Tuple, Union
 from abc import ABC
+import itertools
 
 import torch
 import sympy
@@ -57,6 +58,7 @@ from .pass_utils import (
     apply_splits_from_index_coeff,
     iteration_space,
     indirect_access_subs_from_kernel,
+    is_restickify_coords,
 )
 from .views import compute_coordinates, align_tensors, tiling_expr_to_device_expr
 from torch._inductor.dependencies import MemoryDep
@@ -1154,10 +1156,7 @@ class SpyreKernel(Kernel[CSEVariable]):
                 op_indirect_var_names = None
             in_coords = args[-2].device_coordinates
             out_coords = args[-1].device_coordinates
-            if all(e == 0 for e in in_coords) and not all(e == 0 for e in out_coords):
-                # Broadcast: scalar input expanding to non-scalar output.
-                op = IDENTITY_OP
-            elif in_coords[-1].free_symbols != out_coords[-1].free_symbols:
+            if is_restickify_coords(in_coords, out_coords):
                 op = RESTICKIFY_OP
             else:
                 op = IDENTITY_OP
@@ -1587,11 +1586,113 @@ def _remap_work_division(arg: TensorArg, work_division_remap) -> None:
     arg.work_division = TensorWorkDivision(new_splits, new_core_map)
 
 
+def _restickify_restore_elided_dim(op_spec) -> None:
+    """Restore a restickify's elided size-1 dim BEFORE align_tensors (in place).
+
+    A restickify swaps which host dim lands inside the 128-byte stick.  When the
+    dim on EITHER side of the swap has host size 1, upstream Inductor squeezes it
+    away and never emits a loop symbol for it, so exactly one operand's
+    within-stick (last) coordinate collapses to the constant ``0`` -- the
+    "elided" operand (the other, unaffected operand is "intact"). With no
+    iteration symbol the two operands disagree on which dim carries the stick and
+    the backend cannot build a dimension mapping.
+
+    align_tensors matches operands by shared symbol, so we restore the dim here,
+    just before align runs -- creating one fresh symbol ``new_sym`` shared by both
+    operands reduces the size-1 case to the ordinary N>=2 path where both carry a
+    within-stick symbol. Doing it later (e.g. at SDSC time, or in the scheduler's
+    ``mark_run``) is too late to affect the descriptor align has already built.
+    The two operands are rebuilt to share ``new_sym`` (64 = fp16 stick elements):
+
+    - ELIDED operand: its stick is rebuilt as
+      ``[floor(new_sym/64)] + real_dims + [Mod(new_sym, 64)]``.
+    - INTACT operand: ``new_sym`` binds to the outermost size-64 gap dim the
+      padding pass (``_pad_elided_dim``) prepended to cover the 64-plane sweep
+      (see the reuse site below).  ``new_sym`` has iteration RANGE 1, so it only
+      ever takes the value 0: SDSC codegen's back-gap mechanism absorbs the
+      size-64-vs-range-1 gap and it contributes no real stride to either operand.
+    """
+    assert len(op_spec.args) == 2, f"restickify op_spec has {len(op_spec.args)} args"
+    in_arg, out_arg = op_spec.args[0], op_spec.args[1]
+
+    def _stick_sym(arg):
+        syms = tuple(arg.device_coordinates[-1].free_symbols)
+        assert len(syms) <= 1, f"expected 0 or 1 free symbols, got {len(syms)}"
+        return syms[0] if syms else None
+
+    in_sym = _stick_sym(in_arg)
+    out_sym = _stick_sym(out_arg)
+    # Both-intact is the ordinary N>=2 case; nothing to restore.
+    if in_sym is not None and out_sym is not None:
+        return
+    # Both-elided would mean neither operand's within-stick coord carries a
+    # free symbol, contradicting is_restickify_coords's own free-symbol-mismatch test.
+    assert not (in_sym is None and out_sym is None), "both operands elided"
+
+    stick_size = in_arg.device_dtype.elems_per_stick()
+
+    def _restore(new_sym, elided_arg, intact_arg) -> None:
+        # Rebuild the elided stick as [floor(new_sym/64)] + reals + [Mod(new_sym, 64)].
+        elided_coords = list(elided_arg.device_coordinates)
+        elided_size = list(elided_arg.device_size)
+        real_coords, real_sizes = [], []
+        for i in range(len(elided_coords) - 1):  # exclude within-stick
+            if elided_coords[i].free_symbols:
+                real_coords.append(elided_coords[i])
+                real_sizes.append(elided_size[i])
+        new_elided_coords = (
+            [sympy.floor(new_sym / stick_size)]
+            + real_coords
+            + [sympy.Mod(new_sym, stick_size)]
+        )
+        new_elided_size = [1] + real_sizes + [stick_size]
+
+        # Bind new_sym to the size-64 dim _pad_elided_dim prepended, so the
+        # descriptor's total size matches the grown allocation. The grow always
+        # targets the intact operand, so that dim is present here: outermost
+        # size-64 with coordinate 0 (asserted before we overwrite it).
+        intact_coords = list(intact_arg.device_coordinates)
+        intact_size = list(intact_arg.device_size)
+        assert intact_size[0] == stick_size and intact_coords[0] == 0, (
+            f"restickify restore: expected padding-prepended size-{stick_size} "
+            f"gap dim on the intact operand, got size={intact_size[0]} "
+            f"coord={intact_coords[0]}"
+        )
+        intact_coords[0] = new_sym
+
+        # Range 1, not 64: new_sym only ever takes value 0, so it contributes
+        # no real stride and the size-64 device slot is just back-gap padding.
+        op_spec.iteration_space = {new_sym: (stick_size, 1), **op_spec.iteration_space}
+        elided_arg.device_coordinates = new_elided_coords
+        elided_arg.device_size = new_elided_size
+        intact_arg.device_coordinates = intact_coords
+        intact_arg.device_size = intact_size
+
+    # Pick an unused name; new_sym is shared by both operands below so align
+    # matches them as the same iteration var.
+    used = set(op_spec.iteration_space.keys())
+    for idx in itertools.count():
+        new_sym = sympy.Symbol(f"rs{idx}")
+        if new_sym not in used:
+            break
+
+    if in_sym is None:
+        _restore(new_sym, in_arg, out_arg)
+    else:
+        # out_sym is None
+        _restore(new_sym, out_arg, in_arg)
+
+
 def simplify_op_spec(op_spec, indirect_sizes=None, indirect_access_subs=None):
     # Both parameters must be provided together for gather kernels — indirect_sizes
     # decomposes symbols in align_tensors; indirect_access_subs replaces them with IndirectAccess.
-    it_space = op_spec.iteration_space
 
+    if op_spec.op == RESTICKIFY_OP:
+        # Restore a restickify's elided size-1 stick, creating a shared iteration
+        # symbol on both operands, so align_tensors matches them by that symbol.
+        _restickify_restore_elided_dim(op_spec)
+
+    it_space = op_spec.iteration_space
     new_op_space_splits, new_tensors, work_division_remap = align_tensors(
         it_space,
         [

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -3880,8 +3880,7 @@ def _patch_consumers(
     if not consumers or old_name == new_name:
         return
 
-    from ..insert_restickify import NameSwapHandler
-    from ..pass_utils import replace_computed_buffer_body
+    from ..pass_utils import NameSwapHandler, replace_computed_buffer_body
 
     name_map = {old_name: new_name}
     has_retile = (


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

When a restickify (a pointwise transpose+clone, or a restickify the compiler inserts itself) lands a host dim that is not a multiple of the 64-element stick on the *new* stick dimension, codegen currently widens its read and write to whole-stick windows and over-reads / over-writes HBM, miscompiling the layout — e.g. `torch.transpose(x, -2, -1).clone()` on `[2, 2, 65, 64]` (host dim 65 is not stick-aligned) returns wrong results versus CPU.

This PR adds the `insert_restickify_padding` graph pass, which grows the affected device dim to the stick boundary so the restickify's widened window stays inside the allocation.

**Two meanings of &#34;padding&#34;**

&#34;Padding&#34; means two different things with very different costs:

1. Dimension-size bumping — grow a device dim up to a stick boundary (multiple of 64 at fp16). This changes the layout&#39;s shape but writes no data. Almost free: no runtime op, just a slightly larger buffer.

2. Zero-filling — actually write zeros into the padded region. Needed only when a downstream op reads those elements and the values matter (e.g. matmul K-accumulation sums across the padded tail, so it must be zero). This costs a real op at runtime.

**What our PR does**

Our PR is **dimension-size bumping** — no zero-filling. The restickify padded region is never read for its values, so there&#39;s nothing to initialize. (Zero-filling is a separate mechanism, `insert_bmm_padding`, for the matmul case that does read the tail.)

Two consequences of that bump:

- Larger buffer allocation — bumping still reserves the rounded-up span (a space cost, not a runtime op).
- Graph-input copy — if the tensor is a graph input, we can&#39;t re-describe the caller&#39;s buffer in place, so we copy it into a new padded buffer (that copy is a runtime op). For intermediates we produce, we bump the layout directly with no copy.

---

**How the pass works**

`insert_restickify_padding` (in `torch_spyre/_inductor/padding.py`) walks the graph and, for each restickify op (`is_restickify_op`), attempts two independent fixes — either can apply without the other:

- **Write side** (`_pad_restickify_output`): grows the output&#39;s becomes-stick device dim up to the restored stick, so the old-stick host dim lands at the right physical offset.
- **Read side** (`_pad_restickify_input` / `_restickify_input`): grows the becomes-stick (non-stick device) dim to cover the whole-stick read window `[slice_start, slice_start + round_up_to_stick(extent))`, skipping when the declared size already covers it. Unpaddable reads (strided/reversed) raise via `_assert_input_paddable`; graph inputs are cloned first.
- **Size-1 elided dim** (either operand): `_pad_elided_dim` prepends an outermost size-64 gap dim so the allocation covers the 64-plane sweep, and codegen&#39;s `_restickify_restore_elided_dim` (`torch_spyre/_inductor/spyre_kernel.py`) restores the size-1 stick before `align_tensors` so the size-1 case reduces to the ordinary path.

The fixes only bump *device* dim sizes, never host tensor dims, so later passes that key off host sizes (e.g. `propagate_named_dims`) are unaffected; the resulting host/device size gap is what codegen&#39;s backGap path fills in.

> **Note:** an earlier revision of this PR also carried a Scatter rewrite for a fused-kernel transpose miscompile (a `.mul().transpose().contiguous()` whose interior read crossed a fused buffer in a permuted order). That rewrite has been **removed**: on PT 2.13, `loop_ordering_after_fusion` reorders the fused loop nest so the crossing edge no longer lands on an interior read, making the dimension-size bump alone sufficient. The padding pass is the whole of this PR.

**Pass scope and pipeline placement**

The scope is not limited to user-written transpose+clone: it also covers restickify ops that the compiler *itself* inserts (`insert_restickify` / `insert_post_mutation_restickify`) to reconcile a producer&#39;s layout with a consumer&#39;s required stick dim. Those synthesized restickifies can land on an unaligned host dim just as a user transpose can, so the padding pass runs immediately after them:

```text
...
optimize_restickify_locations
finalize_layouts
insert_restickify
enforce_indirect_access_layout
insert_post_mutation_restickify
insert_restickify_padding   ← this PR
insert_bmm_padding
dedup_and_promote_constants
...
```

Running after `insert_restickify` / `insert_post_mutation_restickify` means every restickify op — user-authored or compiler-inserted — is already materialized in the graph and can be padded uniformly. Running before `insert_bmm_padding` and the later work-division / core-division passes means the padded device dims are in place before those passes reason about sizes.

Layout candidate selection now prefers stick-aligned dims but falls back to unaligned dims (`_dims_by_alignment` in `propagate_layouts`) instead of skipping them, so an unaligned dim becomes a paddable candidate rather than raising &#34;no supported output layout found&#34;. A stick mutation that still cannot be relocated (e.g. a 1D buffer) continues to raise.

Shared infrastructure is extracted to `pass_utils`: the `is_restickify_op` predicate (used by both codegen&#39;s `spyre_kernel.store` and this pass), plus `NameSwapHandler` and `redirect_computed_buffer_reads` (reused by several other layout passes).

#### Which issue(s) this PR is related to:

Fixes #1756

Also un-xfails the transpose+clone case from #1859.

#### Special notes for your reviewer:

- Main test coverage is in `tests/inductor/test_restickify.py` (new file: transpose+clone, full permutation sweeps, producer-arm / clone-arm fusion, offset / slice / size-1 functional cases, plus device-free white-box geometry tests and an on-device coverage-gap regression guard), plus edits to `tests/inductor/test_inductor_ops.py` and `tests/inductor/test_inductor_transpose_edge.py`.
- The `test_slice_stick_mutation_no_alt_dim_raises` guard test (in `test_inductor_ops.py`) uses a 1D shape, which has no alternative stick dim to relocate onto and so still raises even with the unaligned-fallback candidate available.

#### Does this PR introduce a user-facing change?

Yes — models that transpose a stick dim against an unaligned non-stick dim (via transpose+clone / restickify) now compile to correct results instead of silently miscompiling.

#### Additional note:
