### PR TITLE
inductor: change default UNROLL_LOOPS from 1 to 0

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -97,7 +97,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
         }
@@ -141,7 +140,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
         }
@@ -203,7 +201,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
         }
@@ -214,7 +211,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
         }
@@ -411,7 +407,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
         }
@@ -494,7 +489,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
         }
@@ -544,7 +538,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
         }
@@ -597,7 +590,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
         }
@@ -650,7 +642,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
         }
@@ -837,7 +828,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
         }
@@ -890,7 +880,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
         }
@@ -1294,7 +1283,6 @@ class TestNamedDimsHint(InductorTestCase):
 
     @config.patch(
         {
-            "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
         }
@@ -1336,7 +1324,6 @@ class TestNamedDimsHint(InductorTestCase):
 
     @config.patch(
         {
-            "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
         }
@@ -1877,7 +1864,7 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
         self.assertIn("sympify('2')", src, "Expected outer loop count 2")
         self.assertIn("sympify('4')", src, "Expected inner loop count 4")
 
-    @config.patch({"lx_planning": False, "unroll_loops": False})
+    @config.patch({"lx_planning": False})
     def test_nested_matmul_copy_after_inner_loop(self):
         """The accum→output copy op appears in generated source for nested K-tiling."""
         from torch_spyre._inductor import spyre_hint
@@ -1917,7 +1904,6 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
         {
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
-            "unroll_loops": False,
         }
     )
     def test_nested_matmul_outer_M_inner_K_accum_in_lx(self):
@@ -1957,43 +1943,35 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
 
 
 # ===========================================================================
-# UNROLL_LOOPS=0 variants
+# UNROLL_LOOPS=1 variants
 #
 # Each class below inherits all test methods from its base.  The class-level
-# @config.patch sets unroll_loops=False for every inherited test.  Tests that
-# are known to give wrong results under the scf.for path already contain
-#   ``if not config.unroll_loops: pytest.xfail(...)``
-# guards, so they are reported as xfail here rather than FAILED.
-#
-# Tests whose method-level @config.patch overrides unroll_loops (e.g.
-# test_hint_unrolled_source_calls_sdsc explicitly sets unroll_loops=True)
-# are unaffected: the method decorator wins over the class decorator and
-# those tests run — and pass — with their own explicit setting.
+# @config.patch sets unroll_loops=True for every inherited test.
 # ===========================================================================
 
 
-@config.patch({"unroll_loops": False})
-class TestCoarseTileSpyreHintsUnroll0(TestCoarseTileSpyreHints):
+@config.patch({"unroll_loops": True})
+class TestCoarseTileSpyreHintsUnroll1(TestCoarseTileSpyreHints):
     pass
 
 
-@config.patch({"unroll_loops": False})
-class TestNamedDimsHintUnroll0(TestNamedDimsHint):
+@config.patch({"unroll_loops": True})
+class TestNamedDimsHintUnroll1(TestNamedDimsHint):
     pass
 
 
-@config.patch({"unroll_loops": False})
-class TestCoarseTileReductionE2EUnroll0(TestCoarseTileReductionE2E):
+@config.patch({"unroll_loops": True})
+class TestCoarseTileReductionE2EUnroll1(TestCoarseTileReductionE2E):
     pass
 
 
-@config.patch({"unroll_loops": False})
-class TestCoarseTileReductionDim0E2EUnroll0(TestCoarseTileReductionDim0E2E):
+@config.patch({"unroll_loops": True})
+class TestCoarseTileReductionDim0E2EUnroll1(TestCoarseTileReductionDim0E2E):
     pass
 
 
-@config.patch({"unroll_loops": False})
-class TestCoarseTileNestedReductionE2EUnroll0(TestCoarseTileNestedReductionE2E):
+@config.patch({"unroll_loops": True})
+class TestCoarseTileNestedReductionE2EUnroll1(TestCoarseTileNestedReductionE2E):
     pass
 
 

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -97,10 +97,10 @@ core_id_k_fast_emission: bool = (
 # into the SDSC JSON and bundle.mlir emits sdsc_execute with no operands.
 bundle_symbolic_args: bool = os.environ.get("BUNDLE_SYMBOLIC_ARGS", "1") == "1"
 
-# When True (default), LoopSpec nodes are fully unrolled into flat OpSpecs
-# before generate_bundle runs.  Set to False to pass LoopSpecs through intact
-# for the scf.for / affine.apply path.
-unroll_loops: bool = os.environ.get("UNROLL_LOOPS", "1") == "1"
+# When True, LoopSpec nodes are fully unrolled into flat OpSpecs before
+# generate_bundle runs.  When False (default), LoopSpecs are passed through
+# intact for the scf.for / affine.apply path.
+unroll_loops: bool = os.environ.get("UNROLL_LOOPS", "0") == "1"
 
 # Layout solver class used by default in scratchpad.allocator.ScratchpadAllocator.
 # Options:


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Changes the default value of `UNROLL_LOOPS` from `1` to `0`, making the
scf.for / affine.apply path the default code generation strategy.

- `torch_spyre/_inductor/config.py`: flip the env-var default from `"1"`
  to `"0"` and update the comment to reflect the new default.
- `tests/inductor/test_coarse_tile_e2e.py`:
  - Remove the now-redundant `"unroll_loops": False` entries from
    method-level `@config.patch` dicts (14 sites).
  - Rename the bottom-of-file mirror classes from `*Unroll0` →
    `*Unroll1` and flip their class-level patches to `unroll_loops=True`,
    so the flat-unroll path continues to be exercised by the test suite.
  - `test_hint_flash_attention` already has an
    `if not config.unroll_loops: pytest.xfail(...)` guard; it now
    xfails by default (nested scf.for loops not yet correct in backend).

`test_coarse_tiling.py` and `test_unroll_loop_specs.py` are unaffected —
they pass `unroll_loops` as an explicit argument to `generate_bundle` and
do not read from config.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
-->

#### Special notes for your reviewer:

Setting `UNROLL_LOOPS=1` restores the old behaviour.  The two tests that
explicitly require the unroll path (`test_hint_unrolled_source_calls_sdsc`
and `test_hint_unrolled_softmax_shaped_execution`) already carry
`@config.patch({"unroll_loops": True, ...})` and are unaffected.

All 81 coarse-tile e2e tests pass (1 expected xfail: `test_hint_flash_attention`).

#### Does this PR introduce a user-facing change?

Yes — `UNROLL_LOOPS` now defaults to `0`. Users who relied on the
flat-unroll path without setting the env var explicitly should set
`UNROLL_LOOPS=1`.

#### Additional note: