### PR TITLE
feat(named-dims): let a graph name its own dims in-graph, no driver calls

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1375,6 +1375,48 @@ class TestNamedDimsHint(InductorTestCase):
         self.assertIn("LoopSpec(", src, "Expected LoopSpec in generated source")
         self.assertIn("sympify('2')", src, "Expected loop count 2")
 
+    @config.patch(
+        {
+            "unroll_loops": False,
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+        }
+    )
+    def test_named_dims_hint_self_contained_no_driver_calls(self):
+        """spyre_hint(named_dims=[...]) alone enables coarse tiling.
+
+        Unlike the tests above, this omits the driver-side declare_tensor_dim /
+        name_tensor_dims calls entirely.  It locks in the in-graph path: the
+        named_dims hint must (1) self-enable propagate_named_dims and (2)
+        self-register the dim sizes, so the tiling hint resolves without any
+        driver bootstrapping.  This is how a decomposition names its own
+        intermediate dims (e.g. the flash SDPA decomposition).
+        """
+        from torch_spyre._inductor import spyre_hint
+
+        M, K = 256, 64
+
+        def fn(x):
+            with spyre_hint(slices={"M": 4}, named_dims=["M", "K"]):
+                bias = torch.full(x.shape, 0.5, dtype=x.dtype, device=x.device)
+            return x + bias
+
+        x = torch.randn(M, K, dtype=torch.float16)
+        x_dev = x.to("spyre")
+        # Deliberately NO _declare_tensor_dim / _name_tensor_dims here.
+
+        cfn = torch.compile(fn)
+        with (
+            mock_patch(_LAUNCH_JOBPLAN),
+            mock_patch(_PREPARE_KERNEL),
+            mock_patch("subprocess.run"),
+        ):
+            _, source_codes = run_and_get_code(cfn, x_dev)
+        self.assertTrue(len(source_codes) > 0)
+        src = source_codes[0]
+        self.assertIn("LoopSpec(", src, "Expected LoopSpec in generated source")
+        self.assertIn("sympify('4')", src, "Expected loop count 4")
+
 
 class TestCoarseTileReductionE2E(InductorTestCase):
     """E2E tests for coarse-tiling a reduction dimension.

--- a/tests/inductor/test_propagate_named_dims.py
+++ b/tests/inductor/test_propagate_named_dims.py
@@ -925,6 +925,49 @@ def test_permute_mul_equal_dims_distinct_names():
     )
 
 
+def test_reshape_split_untracked_dim_tolerated():
+    """Reshape that splits an _untracked_ intermediate dim is tolerated, not raised.
+
+    Mirrors a k/v projection reshaped into heads: an *unannotated* input produces
+    an intermediate whose dims carry only _untracked_ placeholder names (no
+    meaningful name to preserve).  A view then splits that dim into two loop
+    vars, hitting the len(loop_vars) > len(names) branch in
+    compute_input_named_dims.  Because the split name is only _untracked_, the
+    pass assigns fresh untracked names per loop var and keeps going instead of
+    aborting like test_reshape_1d_to_2d_exp (which splits a *real* named dim).
+
+    Contrast with test_reshape_1d_to_2d_exp: that splits the meaningful name "A"
+    and raises "reshape split a named dim"; here nothing meaningful is split, so
+    compilation succeeds and the output dims are all _untracked_.
+
+    x is left unannotated (no tensor_dims entry) so its consuming op is assigned
+    _untracked_ names; y anchors a valid named_dims declaration for the run.
+    """
+    _T, _Hh, _Dd = 8, 4, 64  # HD = 256 splits into H=4, D=64
+    x = torch.randn(_T, _Hh * _Dd, dtype=torch.float16, device=DEVICE) * 0.1
+    y = torch.randn(_T, _Hh, _Dd, dtype=torch.float16, device=DEVICE) * 0.1
+
+    def fn(x, y):
+        # x.exp() forces an intermediate ComputedBuffer with _untracked_ names,
+        # then the view splits its untracked [HD] dim into [H, D].
+        t = x.exp().view(_T, _Hh, _Dd)
+        return t + y
+
+    # The assertion is simply that compilation does not raise: without the
+    # _untracked_ tolerance branch, the split of x.exp()'s untracked dim would
+    # hit "reshape split a named dim" and abort.  We deliberately do not pin the
+    # output op's propagated_dims -- the final op reads annotated y, so its names
+    # come from y, not from the untracked split path under test; asserting them
+    # would test the wrong op.  Reaching this line means the branch tolerated
+    # the split.
+    _run_and_capture(
+        fn,
+        [x, y],
+        named_dims={"T": _T, "H": _Hh, "D": _Dd},
+        tensor_dims={y: ["T", "H", "D"]},
+    )
+
+
 def test_reshape_1d_to_2d_exp():
     """1-D tensor [4096] annotated ['A'] -> reshape(64,64) raises Unsupported.
 

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -417,6 +417,17 @@ def _propagate_named_dims_impl(graph: GraphLowering) -> None:
             if hint:
                 coords = op_out_coords(op)
                 layout_size = op.get_layout().size
+                # zip() below truncates to the shorter of named_dims/layout_size,
+                # so a name-count mismatch would silently drop names (leaving them
+                # unregistered) rather than fail loudly like the input path.  Warn
+                # so a bad in-graph annotation is visible instead of a no-op.
+                if len(named_dims) != len(layout_size):
+                    logger.warning(
+                        f"{op.get_operation_name()}: named_dims hint has "
+                        f"{len(named_dims)} name(s) {named_dims} but output layout "
+                        f"has {len(layout_size)} dim(s) {list(layout_size)}; "
+                        f"extra entries are ignored"
+                    )
                 loop_var_dims: dict[sympy.Symbol, list[str]] = {}
                 for i, (coord, dim_name) in enumerate(zip(coords, named_dims)):
                     # Register the size for every name (including size-1 dims) so
@@ -489,6 +500,11 @@ def _graph_has_named_dims_hint(graph: GraphLowering) -> bool:
     (e.g. the flash SDPA decomposition), without a driver-side name_tensor_dims()
     call.  Such a hint is the only in-graph way to name a matmul output, whose
     loop vars carry no names from inputs.
+
+    This scans graph.operations, which _propagate_named_dims_impl then scans
+    again; the extra pass is a cheap gate on a per-compilation path.  If it ever
+    shows up as a hotspot, fold the check into _propagate_named_dims_impl (run
+    unconditionally, short-circuit inside) so operations is walked once.
     """
     for op in graph.operations:
         if isinstance(op, ComputedBuffer):
@@ -514,6 +530,12 @@ def propagate_named_dims(
     finally:
         _named_tensor_dims.clear()
         _enabled = False
+        # In the normal flow _named_dims is consumed by assign_dim_hints and
+        # cleared by its reset(). But the in-graph path self-registers sizes
+        # here, so if _propagate_named_dims_impl raises, the pipeline aborts
+        # before assign_dim_hints runs and those sizes would leak into the next
+        # compilation. Clear on the way out to keep the reset contract intact.
+        _named_dims.clear()
 
 
 def _assign_dim_hints_impl(operations: list[Operation]) -> None:

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -527,15 +527,19 @@ def propagate_named_dims(
         return
     try:
         _propagate_named_dims_impl(graph)
+    except BaseException:
+        # On the normal path _named_dims MUST survive: assign_dim_hints runs
+        # next and reads it (named_dims_for_sym filters on `name in
+        # _named_dims`), then clears it in its own reset(). Only when
+        # _propagate_named_dims_impl raises does the pipeline abort before
+        # assign_dim_hints runs -- then the sizes self-registered by the
+        # in-graph path (and any driver-declared dims) would leak into the next
+        # compilation, so clear them here on the error path only.
+        _named_dims.clear()
+        raise
     finally:
         _named_tensor_dims.clear()
         _enabled = False
-        # In the normal flow _named_dims is consumed by assign_dim_hints and
-        # cleared by its reset(). But the in-graph path self-registers sizes
-        # here, so if _propagate_named_dims_impl raises, the pipeline aborts
-        # before assign_dim_hints runs and those sizes would leak into the next
-        # compilation. Clear on the way out to keep the reset contract intact.
-        _named_dims.clear()
 
 
 def _assign_dim_hints_impl(operations: list[Operation]) -> None:

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -191,7 +191,20 @@ def compute_input_named_dims(dep: MemoryDep, op=None, ind_sizes=None) -> dict:
                 f"and no indirect index symbol in coord {coord!r} for names {names}"
             )
         elif len(loop_vars) > len(names):
-            # More loop vars than named dims: a single named dim was split by reshape.
+            # More loop vars than named dims: a reshape split this layout dim.
+            if all(n.startswith("_untracked_") for n in names):
+                # The split name is only an _untracked_ placeholder (no
+                # meaningful name to preserve, e.g. a k/v projection output
+                # reshaped into heads).  Assign fresh untracked names per loop
+                # var rather than aborting the whole pass.
+                for loop_var in loop_vars:
+                    size = int(dep.ranges[loop_var])
+                    result.setdefault(loop_var, []).append(
+                        _untracked_name(dep.name, loop_var, size)
+                    )
+                continue
+            # A real (meaningful) name was split — the caller must re-annotate
+            # after the reshape; we cannot guess the split.
             raise Unsupported(
                 f"{dep.name}: layout dim {i} has {len(loop_vars)} loop vars but only "
                 f"{len(names)} name(s) {names} -- reshape split a named dim, "
@@ -403,11 +416,23 @@ def _propagate_named_dims_impl(graph: GraphLowering) -> None:
                     break
             if hint:
                 coords = op_out_coords(op)
-                loop_var_dims = {
-                    sym: [dim_name]
-                    for coord, dim_name in zip(coords, named_dims)
-                    if (sym := _lone_sym(coord)) is not None
-                }
+                layout_size = op.get_layout().size
+                loop_var_dims: dict[sympy.Symbol, list[str]] = {}
+                for i, (coord, dim_name) in enumerate(zip(coords, named_dims)):
+                    # Register the size for every name (including size-1 dims) so
+                    # downstream consumers resolve it: named_dims_for_sym filters
+                    # on `name in _named_dims`, and _consume_names raises KeyError
+                    # for an undeclared name.  setdefault preserves the
+                    # declare-once contract (a driver-side declare_tensor_dim or
+                    # an earlier op naming the same dim wins).
+                    _named_dims.setdefault(dim_name, int(layout_size[i]))
+                    # A size-1 dim yields coord == 0 (sym is None): the name stays
+                    # in named_dims for positional alignment and is declared
+                    # above, but it has no loop var to tile (it is optimized
+                    # away), so it is absent from loop_var_dims.
+                    sym = _lone_sym(coord)
+                    if sym is not None:
+                        loop_var_dims[sym] = [dim_name]
                 op._dim_prop_info = _DimPropInfo(  # type: ignore[attr-defined]
                     named_dims=named_dims,
                     loop_var_dims=loop_var_dims,
@@ -457,12 +482,32 @@ def _propagate_named_dims_impl(graph: GraphLowering) -> None:
             _log_op(op)
 
 
+def _graph_has_named_dims_hint(graph: GraphLowering) -> bool:
+    """True if any op carries a spyre_hint(named_dims=[...]) annotation.
+
+    This lets a decomposition name its own intermediate dims entirely in-graph
+    (e.g. the flash SDPA decomposition), without a driver-side name_tensor_dims()
+    call.  Such a hint is the only in-graph way to name a matmul output, whose
+    loop vars carry no names from inputs.
+    """
+    for op in graph.operations:
+        if isinstance(op, ComputedBuffer):
+            for hint_dict in get_op_hints(op).values():
+                if "named_dims" in hint_dict:
+                    return True
+    return False
+
+
 def propagate_named_dims(
     graph: GraphLowering,
 ) -> None:
     """Propagate named dims from annotated inputs through the op graph."""
     global _enabled
-    if not _enabled:
+    # Run when a driver called name_tensor_dims() (_enabled) OR when the graph
+    # itself carries an in-graph named_dims hint. Do not set _enabled here — the
+    # finally block still resets it, and _graph_has_named_dims_hint re-derives
+    # the in-graph case each run.
+    if not (_enabled or _graph_has_named_dims_hint(graph)):
         return
     try:
         _propagate_named_dims_impl(graph)


### PR DESCRIPTION
## Problem

`propagate_named_dims` only runs when a driver called `name_tensor_dims()` on a graph-**input** tensor (the module-global `_enabled` flag). That makes the existing in-graph `spyre_hint(named_dims=[...])` path unusable on its own: a decomposition cannot name its own **intermediate** dims — e.g. a matmul output, whose loop vars carry no names from inputs — because:

1. the pass no-ops entirely without the driver call, and
2. even when enabled, the in-graph named dims are dropped because their sizes were never registered in `_named_dims` (which `named_dims_for_sym` / `_consume_names` require).

Concretely this means `spyre_hint(tiles=...)` emitted from inside a decomposition (e.g. the flash SDPA decomposition, whose tiling dims like `num_heads` / `max_seqlen_kv` are manufactured *inside* the compiled block and are not dims of any graph input) resolve to `loop_var=None` and are **silently ignored** — no coarse tiling.

Driver-side naming cannot fix this when the whole block is compiled as one unit: the tiling dims aren't input dims, so they must be nameable in-graph.

## Changes (`propagate_named_dims.py`)

- **Self-enable**: run the pass when any op carries a `named_dims` hint, not only when `_enabled` is set (new `_graph_has_named_dims_hint`; `_enabled` is left untouched so the reset contract is unchanged).
- **Self-register sizes**: the in-graph `named_dims` branch now registers each name's size (from the op's output layout) into `_named_dims`, including size-1 dims, so downstream consumers resolve them without a driver-side `declare_tensor_dim`. `setdefault` preserves the declare-once contract.
- **Tolerate reshape-split of placeholder names**: when a reshape splits a dim whose only name is an `_untracked_` placeholder (e.g. a k/v projection reshaped into heads — a path newly reachable once the pass self-enables), assign fresh untracked names per loop var instead of aborting. A real (meaningful) split name still raises.

## Context

This is the enablement half of making flash-attention tiling hints take effect; it is general infrastructure (any decomposition can now name its own dims). The decomposition-side `named_dims` hints and the coarse-tile layout fix are separate changes.

## Test plan

- [x] New self-contained test `test_named_dims_hint_self_contained_no_driver_calls`: `spyre_hint(slices=..., named_dims=...)` with **no** driver `declare_tensor_dim`/`name_tensor_dims` calls; coarse tiling fires purely from the in-graph hint (LoopSpec, count 4).
- [x] `tests/inductor/test_propagate_named_dims.py` — 36 pass
- [x] `tests/inductor/test_coarse_tile_e2e.py::TestNamedDimsHint` — 3 pass (2 existing + new)
- [x] combined suites — 119 pass, 1 xfailed
- [x] pre-commit (ruff, mypy, import-regex) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)