### PR TITLE
Reset hint counter after each run

### DIFF
--- a/torch_spyre/_inductor/__init__.py
+++ b/torch_spyre/_inductor/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from contextlib import contextmanager
 from .constants import DEVICE_NAME
 from .patches import enable_spyre_context
 from . import config
@@ -19,12 +20,13 @@ from . import config
 import threading
 from functools import wraps
 
-from .propagate_hints import spyre_hint, get_op_hints  # noqa: F401
+from .propagate_hints import spyre_hint, get_op_hints, _reset_counter  # noqa: F401
 
 _autoload_lock = threading.Lock()
 
 
 def enable_spyre_compile_fx_wrapper():
+    from torch._dynamo.repro.after_dynamo import WrapBackendDebug
     import torch._inductor.compile_fx as cfx
     import torch.fx as fx
     import torch
@@ -118,6 +120,18 @@ def enable_spyre_compile_fx_wrapper():
                     )
 
             return _orig(gm, example_inputs, *args, **kwargs)
+
+        # Reset the global counter after each
+        # run to prevent recompilation
+        @contextmanager
+        def backend_context():
+            _reset_counter()
+            yield
+
+        def backend_ctx_ctor(self):
+            return backend_context
+
+        setattr(WrapBackendDebug, "backend_ctx_ctor", property(backend_ctx_ctor))
 
         cfx.compile_fx = _wrapper
         cfx._spyre_wrapped = True

--- a/torch_spyre/_inductor/propagate_hints.py
+++ b/torch_spyre/_inductor/propagate_hints.py
@@ -68,7 +68,6 @@ def spyre_hint(**kwargs: Any):
 
 
 def _reset_counter(*args, **kwargs):
-    print("reset counter")
     global _hint_counter
     _hint_counter = 0
 

--- a/torch_spyre/_inductor/propagate_hints.py
+++ b/torch_spyre/_inductor/propagate_hints.py
@@ -56,12 +56,6 @@ class DimHint:
 _HINT_RE = re.compile(r"^_hint_(\d+)$")
 _hint_counter = 0
 
-# Snapshot of FX node `custom` meta taken at CustomPrePasses time, indexed
-# by call_function node position. Used by recover_spyre_hints to restore
-# meta on nodes renamed by AOT re-tracing (e.g. mm -> mm_default), which
-# drops node.meta["custom"].
-_dim_hints: list[tuple[Any, dict[str, Any] | None]] = []
-
 
 def spyre_hint(**kwargs: Any):
     """
@@ -71,6 +65,12 @@ def spyre_hint(**kwargs: Any):
 
     _hint_counter += 1
     return torch.fx.traceback.annotate({f"_hint_{_hint_counter}": kwargs})
+
+
+def _reset_counter(*args, **kwargs):
+    print("reset counter")
+    global _hint_counter
+    _hint_counter = 0
 
 
 def get_op_hints(op: Operation) -> dict[int, dict[str, Any]]:
@@ -105,9 +105,9 @@ def collect_spyre_hints(graph: torch.fx.Graph) -> None:
     *name* is renamed by AOT re-tracing (mm -> mm_default) and so is unstable, but
     the ``target`` OpOverload is preserved and is what we align on.
     """
-    global _dim_hints
+    assert graph.owning_module is not None
 
-    _dim_hints = [
+    graph.owning_module.meta["__spyre_dim_hints"] = [
         (node.target, node.meta.get("custom"))
         for node in graph.nodes
         if node.op == "call_function"
@@ -128,6 +128,7 @@ def recover_spyre_hints(graph: torch.fx.Graph) -> None:
     the same hint. This keeps alignment intact across such insertions, where the
     old count check would bail and silently drop every hint.
     """
+    _dim_hints = graph.owning_module.meta["__spyre_dim_hints"]
     nodes = [n for n in graph.nodes if n.op == "call_function"]
 
     cursor = 0


### PR DESCRIPTION
Addresses https://github.com/torch-spyre/torch-spyre/issues/2989

# Context

The `spyre_hint` context manager stores hints during the model execution using `torch.fx.traceback.annotate()` for later consumption by compilation passes. For each hint it generates a unique ID that is the key of the annotation and these IDs are generated by incrementing a global counter, `torch_spyre._inductor.propagate_hints._hint_counter`. The idea, according to [PR 2226](https://github.com/torch-spyre/torch-spyre/pull/2226), which added them, is that the unique IDs can later be used to unambiguously identify and reconstruct hint scopes. They also have the property of follow the scope and sequence of the python code execution. For example, it is guaranteed that hint 0 was inserted before hint1.

# Problem description

The problem with this design is that it creates a "fake" dependency of the compiled code on the global counter variable. Let's say that 4 hints are inserted in the code. After it executes for the first time the counter is 4. So when the code executes again it is not 0, which is the value that the pytorch Guard is expecting for the first hint. For the second it will be 5 and so one.

As @aishwariyachakraborty commented on the issue, resetting the counter to 0 before each execution makes the problem go away because now the counters are generated in the same order again. If the order changes, it's because the execution has taken a different path and then the recompilation should be invitable.

# Solution constraints

For this solution I tried to work within the following constraints:

1) The solution should not alter the original behavior
2) No additional responsibility should be pushed upon the user. The fix must be applied automatically in the `torch.compile` call and no extra arguments to that call should be required from the user
3) No graph break should be introduced

# Solution description

Basically I added a monkey patch in our initiatilization to add a context manager in `torch._dynamo.repro.after_dynamo.WrapBackendDebug.backend_ctx_ctor`. This context manager resets the counter after each call to the mode. It is a bit ugly, but I couldn't find another extension point that would run at the right moment.

I also tried to partially address @mudhakar's concern in the original PR that the global variables aren't safe against race conditions. So I moved the global `_dim_hints` to `graph.owning_module.meta` so that it would be associated with the current graph instance. I couldn't find a way to move the counter to some local storage during the execution associated to the current compilation run. However, `torch.fx.traceback.annotate()` also uses a global variable `torch.fx.traceback.current_meta` so even without the counter problem, any solution that uses annotate is subject to the same race condition.


# Alternatives

## Assign the IDs during the `collect_spyre_hints` call

Instead of assigning IDs during runtime, the IDs could be assigned later. Inside `spyre_hint` we could create an ID based on the a hash of the hint dict. If the same exact hint was applied again, it would get the same ID, but maybe that's not a problem. Then, later in `collect_spyre_hints` we could convert these IDs to sequential. But the problem is that the topology of the python code would be lost, changing the original behavior. Also, we wouldn't be able to distinguish between identical nested and sequential spyre hint.

## Store the counter in `current_meta`

Unfortunately `current_meta` is not cleared automatically after a run, so it's the exact same problem as before.

## Use custom_ops

Another option would be manage the counter in a custom op that could potentially be removed by optimization passes during compilation But custom ops need an input tensor or a device as arguments because they must know on which device they are operating. Since `spyre_hints()`  doesn't have such an argument, this is not a viable option.

## Add guard filters to remove the guard that is triggered

`torch.compile` accepts a list of guard filters that can be used to remove certain guards.  But we would have to find a way to insert such a filter automatically to avoid changing the user API.  Because of the way the call chain is structured, the `torch.compile` function itself would have to be monkey patched, which would be quite brittle because it would depend on the order of imports in the client code to work.

## Modify the python code in dynamo

This one is purely hypothetical. Since dynamo inspects the python code, it could perhaps be used to modify it slightly to insert the IDs in topological order. I couldn't find any extension points in `torch._dynamo` that would support such a use case.

# Design alternative

The whole problem is caused by the unique hint IDs but currently there are no uses in the code for the IDs, only the hints themselves. If there is no real use case for this, the design could be simplified and the problem be sidestepped entirely.


# Final remarks

If anyone knows a clean, public API supported way to modify the output module of torch.compile to perhaps wrap it in a context manager, or install a hook with `register_module_forward_pre_hook` or perhaps a `TorchDispatchMode` hook the solution could be re-written in a cleaner way.