### PR TITLE
Fix per-tile-fixed affine strides

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -4515,6 +4515,56 @@ class TestAffineStrideMatchesUnrollStride(unittest.TestCase):
             f"for [1024,4096] multi-stick row tiling",
         )
 
+    def test_per_tile_fixed_tensor_has_empty_affine_strides(self):
+        """per_tile_fixed=True tensors must produce empty affine strides (pool scratch
+        at a fixed base address should not be advanced by the tiling loop)."""
+        tiled_sym = self._C_ROW
+        input_tensor = self._make_rc_tensor()
+        pool_tensor = TensorArg(
+            is_input=False,
+            arg_index=-1,
+            device_dtype=_FP16,
+            device_size=list(self._DS_RC),
+            device_coordinates=[
+                self._C_COL // 64,
+                self._C_ROW,
+                sympy.Mod(self._C_COL, 64),
+            ],
+            allocation={"lx": 0},
+            per_tile_fixed=True,
+        )
+        out_tensor = TensorArg(
+            is_input=False,
+            arg_index=1,
+            device_dtype=_FP16,
+            device_size=list(self._DS_RC),
+            device_coordinates=[
+                self._C_COL // 64,
+                self._C_ROW,
+                sympy.Mod(self._C_COL, 64),
+            ],
+            allocation={"hbm": 0x500000000},
+        )
+        iter_range = self._R
+        op_spec = OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space={
+                tiled_sym: (Integer(iter_range), 1),
+                self._C_COL: (Integer(self._C), 1),
+            },
+            args=[input_tensor, pool_tensor, out_tensor],
+            op_info={},
+            tiled_symbols=[[tiled_sym]],
+        )
+        symbols: list[int] = []
+        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
+        # input (idx 0) and output (idx 2) are tiled — must have non-empty strides.
+        self.assertNotEqual(affine_strides[0], [{}])
+        # pool scratch (idx 1) is per_tile_fixed — must produce empty affine strides.
+        self.assertEqual(affine_strides[1], [{}])
+        self.assertNotEqual(affine_strides[2], [{}])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -401,6 +401,7 @@ def generate_sdsc(
     symbol_id_offset: int = 0,
     tiled_symbols=None,
     use_symbols: bool = False,
+    per_tile_fixed_arg_indices: set[int] | None = None,
 ):
     """Generate SDSC JSON for one OpSpec.
 
@@ -430,6 +431,8 @@ def generate_sdsc(
     # tiled_symbols is list[list[Symbol]], outermost-first per nesting level.
     if tiled_symbols is None:
         tiled_symbols = []
+    if per_tile_fixed_arg_indices is None:
+        per_tile_fixed_arg_indices = set()
 
     out_idx = len(sdsc_spec.args) - 1
     core_id_to_wk_slice = {
@@ -529,7 +532,10 @@ def generate_sdsc(
         # the symbols at that level that advance tensor i.  Empty list of dicts
         # (i.e. [{}] * n_levels or []) for non-tiled / lx tensors.
         affine_strides: list[list[dict]] = []
-        for tensor in sdsc_spec.args:
+        for tensor_idx, tensor in enumerate(sdsc_spec.args):
+            if tensor_idx in per_tile_fixed_arg_indices:
+                affine_strides.append([{} for _ in tiled_symbols])
+                continue
             if "lx" in tensor.allocation:
                 affine_strides.append([{} for _ in tiled_symbols])
                 continue

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -907,6 +907,9 @@ def compile_op_spec(
         [symbol_mapping[s] for s in level if s in symbol_mapping]
         for level in reversed(op_spec.tiled_symbols)
     ]
+    per_tile_fixed_arg_indices = {
+        i for i, arg in enumerate(op_spec.args) if arg.per_tile_fixed
+    }
     return generate_sdsc(
         idx,
         sdsc_spec,
@@ -914,4 +917,5 @@ def compile_op_spec(
         symbol_id_offset,
         tiled_symbols=tiled_symbols_per_level,
         use_symbols=use_symbols,
+        per_tile_fixed_arg_indices=per_tile_fixed_arg_indices,
     )


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ x ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

With UNROLL_LOOPS=0, the preserved-loop symbolic-address path incorrectly generated affine advances for per_tile_fixed=True tensors (pool scratch). These tensors hold a fixed base address and must not be advanced by the tiling loop variable.

Fix: pass per_tile_fixed arg indices from compile_op_spec into generate_sdsc and skip affine-stride computation for those indices.


This is a cherry-pick of one of the [fixes](https://github.com/torch-spyre/torch-spyre/pull/3103/changes/a200454e5470a1aa4fb571064e49f775458b5057) from #3103 to enable faster merging of an obviously correct bug fix.


#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
