### PR TITLE
fix(coarse-tile): resolve #3116 stick-dim ambiguity via authoritative identity

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -987,6 +987,35 @@ class TestDivideRanges(unittest.TestCase):
         expected = SpyreTensorLayout([64], [1], torch.float16, [0])
         self.assertEqual(result, expected)
 
+    def test_resize_device_layout_transposed_same_size_dims_ambiguous(self):
+        """Characterization test for issue #3116.
+
+        Flash-attention QK^T output: logical [B, H, Sq, Skv] with Sq == Skv,
+        stored transposed.  The device layout is byte-identical whether Sq or
+        Skv is the stick dim (device_size=[32,512,8,1,64],
+        stride_map=[512,16384,64,-1,1]), so ``_resize_device_layout``'s
+        size-based elimination + contiguous-stride tiebreak cannot tell the two
+        size-512 host dims apart and raises.
+
+        This pins the *current* (pre-refactor) failure.  Phase 2 threads
+        authoritative dim identity (named dims) into ``_resize_device_layout``
+        so the stick host dim is known by label rather than inferred from
+        magnitudes; when that lands, this test is updated to assert the correct
+        reconstruction instead of the raise.
+        """
+        from torch_spyre._C import SpyreTensorLayout
+        from torch_spyre._inductor.coarse_tile import _resize_device_layout
+
+        dev = SpyreTensorLayout([1, 1], torch.float16).device_dtype
+        # Transposed QK^T output: Skv (dim3) is the stick; Sq (dim2) is a
+        # non-stick dim of the same size (512), so they collide by size.
+        stl = SpyreTensorLayout([32, 512, 8, 1, 64], [512, 16384, 64, -1, 1], dev)
+        host_size = [1, 32, 512, 512]
+
+        # Size-based elimination cannot disambiguate the two size-512 dims.
+        with self.assertRaises(RuntimeError):
+            _resize_device_layout(stl, host_size, [1, 32, 256, 512])
+
 
 def _mock_op_out_coords(op):
     """Return pre-built coords stored on op by _make_hinted_op, or empty list."""

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -987,34 +987,40 @@ class TestDivideRanges(unittest.TestCase):
         expected = SpyreTensorLayout([64], [1], torch.float16, [0])
         self.assertEqual(result, expected)
 
-    def test_resize_device_layout_transposed_same_size_dims_ambiguous(self):
-        """Characterization test for issue #3116.
+    def test_resize_device_layout_transposed_same_size_dims(self):
+        """Issue #3116: two host dims of the same size in a transposed layout.
 
         Flash-attention QK^T output: logical [B, H, Sq, Skv] with Sq == Skv,
         stored transposed.  The device layout is byte-identical whether Sq or
         Skv is the stick dim (device_size=[32,512,8,1,64],
-        stride_map=[512,16384,64,-1,1]), so ``_resize_device_layout``'s
-        size-based elimination + contiguous-stride tiebreak cannot tell the two
-        size-512 host dims apart and raises.
+        stride_map=[512,16384,64,-1,1]), so size-based elimination cannot tell
+        the two size-512 host dims apart.
 
-        This pins the *current* (pre-refactor) failure.  Phase 2 threads
-        authoritative dim identity (named dims) into ``_resize_device_layout``
-        so the stick host dim is known by label rather than inferred from
-        magnitudes; when that lands, this test is updated to assert the correct
-        reconstruction instead of the raise.
+        Without identity (``stick_host_dim=None``) this is genuinely ambiguous
+        and must raise.  With the authoritative stick host dim threaded in
+        (named-dim identity), it reconstructs correctly: tiling Sq 512 -> 256
+        shrinks the non-stick Sq device dim and leaves the transposed
+        stride_map / stick untouched.
         """
         from torch_spyre._C import SpyreTensorLayout
         from torch_spyre._inductor.coarse_tile import _resize_device_layout
 
         dev = SpyreTensorLayout([1, 1], torch.float16).device_dtype
-        # Transposed QK^T output: Skv (dim3) is the stick; Sq (dim2) is a
-        # non-stick dim of the same size (512), so they collide by size.
+        # Transposed QK^T output: Skv (host dim 3) is the stick; Sq (host dim 2)
+        # is a non-stick dim of the same size (512), so they collide by size.
         stl = SpyreTensorLayout([32, 512, 8, 1, 64], [512, 16384, 64, -1, 1], dev)
         host_size = [1, 32, 512, 512]
 
-        # Size-based elimination cannot disambiguate the two size-512 dims.
+        # Fallback (no identity): size-based elimination is ambiguous -> raise.
         with self.assertRaises(RuntimeError):
             _resize_device_layout(stl, host_size, [1, 32, 256, 512])
+
+        # With authoritative stick host dim (Skv == host dim 3): unambiguous.
+        result = _resize_device_layout(
+            stl, host_size, [1, 32, 256, 512], stick_host_dim=3
+        )
+        self.assertEqual(list(result.device_size), [32, 256, 8, 1, 64])
+        self.assertEqual(list(result.stride_map), [512, 16384, 64, -1, 1])
 
 
 def _mock_op_out_coords(op):

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -1660,7 +1660,7 @@ def _stamp_group(
     return retiled_infos
 
 
-def _stick_host_dim(op, device_layout) -> int | None:
+def _stick_host_dim(op: ComputedBuffer, device_layout) -> int | None:
     """Authoritative stick host-dim index for ``op``'s output, recovered from
     coordinate identity (issue #3116).
 
@@ -1695,7 +1695,7 @@ def _stick_host_dim(op, device_layout) -> int | None:
         out_dep = next(iter(writes))
         ind_sizes = indirect_sizes_from_op(op)
         dcoords = try_device_coordinates(device_layout, out_dep, ind_sizes)
-        if not dcoords:
+        if not dcoords:  # None (unrepresentable stick) or empty → no identity
             return None
         hcoords = host_coordinates(op.get_layout(), out_dep, ind_sizes)
         return matching_dim(hcoords, dcoords[-1])
@@ -1806,7 +1806,7 @@ def _resize_device_layout(
             stick_host_dim = None
         else:
             expected_tc = -(-int(old_host_size[stick_host_dim]) // eps)  # ceil
-            if expected_tc not in [int(s) for s in orig_ds[:-1]]:
+            if expected_tc not in orig_ds[:-1]:
                 stick_host_dim = None
 
     old_hs = [int(s) for s in FlexibleLayout.contiguous_strides(old_host_size)]

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -1656,7 +1656,12 @@ def _stamp_group(
     return retiled_infos
 
 
-def _resize_device_layout(orig_stl, old_host_size: list[int], new_host_size: list[int]):
+def _resize_device_layout(
+    orig_stl,
+    old_host_size: list[int],
+    new_host_size: list[int],
+    stick_host_dim: int | None = None,
+):
     """Derive a new SpyreTensorLayout for a resized host buffer.
 
     Used in two directions:
@@ -1703,6 +1708,14 @@ def _resize_device_layout(orig_stl, old_host_size: list[int], new_host_size: lis
     that case Passes 3 and 4 are skipped (tile-count and inner-stick entries are
     frozen at their collapsed values).
 
+    ``stick_host_dim`` (optional): the authoritative stick host-dim index,
+    supplied by callers that know it from named-dim identity.  When given, it is
+    used directly as ``p*`` and is excluded from the non-stick candidate pool,
+    which resolves same-size-dim collisions (transposed layouts where two host
+    dims share a size, e.g. flash-attention QK^T with ``Sq == Skv`` — issue
+    #3116) without relying on the ambiguous size-elimination + contiguous-stride
+    tiebreak.  When ``None`` (all current callers), behaviour is unchanged.
+
     Multi-pass algorithm:
 
     * **Pass 1**: match non-inner-stick device dims to host dims by size.
@@ -1748,11 +1761,20 @@ def _resize_device_layout(orig_stl, old_host_size: list[int], new_host_size: lis
         dsz = orig_ds[j]
         if dsz == 1:
             size1_cands = [p for p in range(ndim) if old_host_size[p] == 1]
+            # The authoritative stick host dim is never a non-stick match.
+            if stick_host_dim is not None:
+                size1_cands = [p for p in size1_cands if p != stick_host_dim]
             if len(size1_cands) == 1:
                 matched_host[j] = size1_cands[0]
             # else: sparse placeholder with no host counterpart — skip silently.
         else:
             size_cands = [p for p in range(ndim) if old_host_size[p] == dsz]
+            # When the stick host dim is known (named-dim identity), remove it
+            # from the non-stick candidate pool. This resolves same-size
+            # collisions (e.g. flash-attn QK^T with Sq == Skv, issue #3116)
+            # without falling back to the contiguous-stride tiebreak.
+            if stick_host_dim is not None:
+                size_cands = [p for p in size_cands if p != stick_host_dim]
             if len(size_cands) == 1:
                 # provisional; may be reclassified as tile-count in Pass 1b
                 matched_host[j] = size_cands[0]
@@ -1793,7 +1815,18 @@ def _resize_device_layout(orig_stl, old_host_size: list[int], new_host_size: lis
     matched_p = set(matched_host.values())
     unmatched_all = [p for p in range(ndim) if p not in matched_p]
     pstar: int | None
-    if not unmatched_all:
+    if stick_host_dim is not None:
+        # Authoritative stick host dim from named-dim identity — no inference by
+        # elimination. It must not also have been matched as a non-stick dim.
+        if stick_host_dim not in unmatched_all:
+            raise RuntimeError(
+                f"_resize_device_layout: caller-provided stick_host_dim="
+                f"{stick_host_dim} was matched as a non-stick device dim "
+                f"(matched_host={matched_host}) in {orig_stl!r} "
+                f"(old_host_size={old_host_size}). Inconsistent dim identity."
+            )
+        pstar = stick_host_dim
+    elif not unmatched_all:
         # Reduction output: stick dim eliminated, pstar=None.
         # unmatched_j must be empty — no device dims should be unclaimed.
         if unmatched_j:

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -1795,6 +1795,20 @@ def _resize_device_layout(
     ndev = len(orig_sm)
     ndim = len(old_host_size)
 
+    # Trust a caller-provided stick_host_dim only when it is consistent with the
+    # device tile-count structure: the stick host dim must have a corresponding
+    # tile-count device dim of size ceil(size/eps).  Identity recovery can be
+    # imperfect for permuted layouts (an ambiguous inner-stick coordinate match),
+    # and a wrong label would otherwise *override* correct size-based inference
+    # and break reconstruction.  When it does not validate, drop it and fall back.
+    if stick_host_dim is not None:
+        if not (0 <= stick_host_dim < ndim):
+            stick_host_dim = None
+        else:
+            expected_tc = -(-int(old_host_size[stick_host_dim]) // eps)  # ceil
+            if expected_tc not in [int(s) for s in orig_ds[:-1]]:
+                stick_host_dim = None
+
     old_hs = [int(s) for s in FlexibleLayout.contiguous_strides(old_host_size)]
     new_hs = [int(s) for s in FlexibleLayout.contiguous_strides(new_host_size)]
 

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -927,11 +927,15 @@ def _allocate_full_buffer(
         # scatter copy op computes correct device addresses.
         full_size_ints = [int(s) for s in full_ranges]
         tile_size_ints = [int(s) for s in orig_layout.size]
+        # Authoritative stick host dim from coordinate identity (issue #3116);
+        # None falls back to size-based inference inside _resize_device_layout.
+        stick_hd = _stick_host_dim(tiled_op, orig_layout.device_layout)
         try:
             device_layout = _resize_device_layout(
                 orig_layout.device_layout,
                 tile_size_ints,
                 full_size_ints,
+                stick_host_dim=stick_hd,
             )
         except RuntimeError:
             # Non-standard device layout (e.g. post-restickify HBM strides that
@@ -1656,6 +1660,50 @@ def _stamp_group(
     return retiled_infos
 
 
+def _stick_host_dim(op, device_layout) -> int | None:
+    """Authoritative stick host-dim index for ``op``'s output, recovered from
+    coordinate identity (issue #3116).
+
+    ``SpyreTensorLayout`` discards its ``dim_map`` at construction, so the
+    host<->device dim identity is not carried on the layout object.  We recover
+    only the stick host dim: the device layout's inner-stick coordinate has a
+    single iteration symbol that also drives exactly one host coordinate, so
+    ``matching_dim`` resolves it unambiguously — even when two host dims share a
+    size (transposed flash-attn QK^T with ``Sq == Skv``), which defeats the
+    size-based inference in ``_resize_device_layout``.
+
+    This is the same identity mechanism ``_pick_stick_dim`` uses to choose a
+    stick dim, so it is as reliable as the existing stick logic.  Returns
+    ``None`` when identity cannot be resolved (single-symbol match not unique),
+    so the caller falls back to size-based inference.
+
+    The stick host dim is invariant under coarse tiling (tiling shrinks a range
+    but does not change which axis is the stick), so this may be computed either
+    before or after ``_divide_ranges`` mutates the ranges.
+    """
+    from .pass_utils import (
+        host_coordinates,
+        indirect_sizes_from_op,
+        try_device_coordinates,
+    )
+    from .views import matching_dim
+
+    try:
+        writes = op.get_read_writes().writes
+        if not writes:
+            return None
+        out_dep = next(iter(writes))
+        ind_sizes = indirect_sizes_from_op(op)
+        dcoords = try_device_coordinates(device_layout, out_dep, ind_sizes)
+        if not dcoords:
+            return None
+        hcoords = host_coordinates(op.get_layout(), out_dep, ind_sizes)
+        return matching_dim(hcoords, dcoords[-1])
+    except Exception:
+        # Identity recovery is best-effort; any failure falls back to inference.
+        return None
+
+
 def _resize_device_layout(
     orig_stl,
     old_host_size: list[int],
@@ -2000,8 +2048,12 @@ def _divide_ranges(
     for i in tiled_dims:
         old_host_size[i] = int(new_size[i] * loop_count)
     new_size_ints = [int(s) for s in new_size]
+    # Recover the authoritative stick host dim from coordinate identity so
+    # _resize_device_layout does not have to infer it by size (ambiguous for
+    # transposed same-size dims — issue #3116). Tiling-invariant, so safe here.
+    stick_hd = _stick_host_dim(op, layout.device_layout)
     layout.device_layout = _resize_device_layout(
-        layout.device_layout, old_host_size, new_size_ints
+        layout.device_layout, old_host_size, new_size_ints, stick_host_dim=stick_hd
     )
     return retiled_info
 


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug

#### What this PR does

Fixes the coarse-tiling failure on transposed same-size-dim layouts (flash-attention QKᵀ prefill, `Sq == Skv`), which raised:

```
RuntimeError: cannot uniquely identify the stick host dim by elimination
```

**Root cause (lost-information, not math).** When tiling shrinks a buffer, `_resize_device_layout` must rebuild the device layout, which requires knowing *which host dim is the stick*. That identity exists at layout-construction time (in `dim_map`), but `SpyreTensorLayout` discards `dim_map`, keeping only `device_size` + `stride_map`. So the pass reconstructs identity by **size** (contiguous stride as tiebreak). For a **transposed layout with two equal-size dims**, the device layout is byte-identical whether `Sq` or `Skv` is the stick — size-matching can't tell them apart, so it fails.

**Fix — recover the one lost bit, use it, validate it.**
1. **Recover** the stick host-dim *index* from coordinate identity (`_stick_host_dim`): the device inner-stick coordinate's iteration symbol drives exactly one host coordinate, so `matching_dim` resolves it even for equal-size dims — the same mechanism `_pick_stick_dim` already uses.
2. **Use** it directly as the stick dim and exclude it from the by-size pool → the remaining equal-size dim matches uniquely, ambiguity gone.
3. **Validate** it against the device structure first: the stick dim's required tile-count `ceil(size/eps)` must appear among the device dims; otherwise drop it and fall back to the existing inference.

**Why it's safe.** The new `stick_host_dim` arg defaults to `None`; the change is inert unless it can *correctly* disambiguate — no index recovered → prior behavior; index inconsistent → dropped → prior behavior; index valid → resolves the tie. It can only add a correct answer where inference previously failed. (The validation guard is load-bearing: it caught a mis-recovery on permuted layouts that would otherwise have broken `test_permute_matmul`.)

Supersedes the stride-tiebreak approach of #3116 with a validated identity index.

#### Which issue(s) this PR is related to

Fixes #3116

#### Change surface

2 files, +137/−3 — all in the coarse-tiling path (`coarse_tile.py` + `test_coarse_tiling.py`). `propagate_layouts.py`/`propagate_named_dims.py`/`views.py` untouched; new arg is backward-compatible.

#### Test evidence

Run on a Spyre pod:

| Suite | Result |
|---|---|
| `test_coarse_tiling.py` (incl. flipped #3116 test, both branches) | 209 passed |
| `test_propagate_named_dims.py` | 37 passed |
| **Combined** | **246 passed** |

The flipped `test_resize_device_layout_transposed_same_size_dims` asserts both branches: `stick_host_dim=None` raises; `stick_host_dim=3` reconstructs to `device_size=[32,256,8,1,64]`, `stride_map=[512,16384,64,-1,1]`.

#### Notes

- **E2E:** the ambiguous branch could not be reached by a lightweight compile repro (5 attempts; span-overflow auto-tiling needs a >256 MB/core span). Validated at the unit + two-suite regression bar — matching #3116's own unit-only coverage. A compile-level integration test for `_stick_host_dim` recovery is a tracked follow-up.
- **Follow-ups (not this PR):** `propagate_named_dims.py:176` magnitude-sort → authoritative order; #2561 symbolic offsets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)