### PR TITLE
refactor: move hint-drive WSR passes before stickification

### DIFF
--- a/docs/source/compiler/coarse_tiling_loops.md
+++ b/docs/source/compiler/coarse_tiling_loops.md
@@ -200,6 +200,14 @@ Key points:
   address 0.  Because `y` is produced and fully consumed within the same tile
   iteration and its per-tile size fits in scratchpad, no HBM allocation is
   needed for it at all.
+- This snapshot is taken right after `coarse_tile`, before
+  `insert_tiling_propagation` classifies `buf1` and inserts its copy op (see
+  [Treatment by consumer topology](#treatment-by-consumer-topology) below).
+  `buf1`'s `Pointwise.inner_fn` shown here is what feeds that later
+  classification; the additional `coarse_tile_copy_buf1` op and the
+  `buf1`→pool / copy→HBM buffer split shown in the
+  [Generated OpSpec](#generated-opspec-python-wrapper-source) section below
+  are not yet present at this stage.
 
 ### Generated OpSpec (Python wrapper source)
 
@@ -299,6 +307,41 @@ sdsc_fused_add_mul_0 = async_compile.sdsc('sdsc_fused_add_mul_0',
                                     ],
                                     allocation={'hbm': <base_addr_c>},
                                 ),
+                                TensorArg(              # output z tile (pool: per-tile HBM)
+                                    is_input=False, arg_index=-1,
+                                    device_dtype=DataFormats.SEN169_FP16,
+                                    device_size=[16, 512, 64],
+                                    device_coordinates=[
+                                        sympify('floor(c1/64)'),
+                                        sympify('c0'),
+                                        sympify('Mod(c1, 64)'),
+                                    ],
+                                    allocation={'pool': 0},
+                                ),
+                            ]
+                        ),
+                        OpSpec(
+                            op='identity',                 # coarse_tile_copy_buf1
+                            is_reduction=False,
+                            iteration_space={
+                                sympify('c0'): (sympify('512'), 32),
+                                sympify('c1'): (sympify('1024'), 1),
+                            },
+                            op_info={},
+                            tiled_symbols=[[sympify('c1')], [sympify('c0')]],
+                            symbolic_dim_bounds={},
+                            args=[
+                                TensorArg(              # input: z tile (pool: per-tile HBM)
+                                    is_input=True, arg_index=-1,
+                                    device_dtype=DataFormats.SEN169_FP16,
+                                    device_size=[16, 512, 64],
+                                    device_coordinates=[
+                                        sympify('floor(c1/64)'),
+                                        sympify('c0'),
+                                        sympify('Mod(c1, 64)'),
+                                    ],
+                                    allocation={'pool': 0},
+                                ),
                                 TensorArg(              # output z (HBM, full tensor)
                                     is_input=False, arg_index=3,
                                     device_dtype=DataFormats.SEN169_FP16,
@@ -336,19 +379,35 @@ Key observations:
   fixed across iterations (no `affine.apply` advance).  Because `y` is
   produced and fully consumed within the same tile iteration, no HBM
   allocation is needed.
-- The final output `z` (output of `mul`) has `allocation={'hbm': ...}` and
-  `arg_index=3` — it lives in HBM.  Its `device_size=[64, 1024, 64]` is the
-  **full** tensor shape in Spyre stick layout: `insert_tiling_propagation`
-  applies Case 3 (mutation layout) here because `z` has no inside consumers,
-  so the tiled op writes directly into the full HBM buffer and
-  `per_tile_fixed` is not set.  The per-iteration write offset into the full
-  buffer is computed by `affine.apply` in `bundle.mlir` (see next section).
+- The final output `z` (output of `mul`) has no inside consumers, but
+  `mul`'s own input `y` is itself a loop-internal, tile-sized producer
+  (`buf0`), so `_has_loop_internal_real_input` forces `insert_tiling_propagation`
+  down the **Case 2** (copy-op) path — the row-2 variant that fires with zero
+  inside consumers of `z` — rather than Case 3.  Concretely, `mul` writes its
+  per-tile result into a separate HBM buffer (`allocation={'pool': 0}`) —
+  `pool` is not scratchpad; it is a bulk-allocated HBM region
+  (`memory_planning.py`'s `INTERMEDIATES_SEGMENT`) reserved for tensors used
+  within only a single kernel — and a separate loop-tagged `identity` op (the
+  third `OpSpec` above, generated from `coarse_tile_copy_buf1`) copies each
+  tile from that pool buffer into the correct slice of `z`'s own,
+  separately-allocated full HBM buffer (`allocation={'hbm': ...}`,
+  `arg_index=3`).  `mul`'s own output therefore does *not* have
+  `per_tile_fixed` set; the identity copy is the op whose
+  `MutationLayoutSHOULDREMOVE` targets the full buffer.  The per-iteration
+  copy offset into the full buffer is computed by `affine.apply` in
+  `bundle.mlir` (see next section).
 - HBM inputs `a`, `b`, `c` also have `device_size=[64, 1024, 64]` — the full
   tensor shape `[1024, 4096]` in Spyre stick layout.  Their
   `device_coordinates` use `c0` and `c1` to index the per-iteration tile
-  window into the full tensor.  The LX scratchpad tensor `y` has
-  `device_size=[16, 512, 64]`, the stick-layout shape for `[512, 1024]`
-  fp16: 16 sticks of 64 columns across 512 rows.
+  window into the full tensor.  The LX scratchpad tensor `y` and `mul`'s
+  per-tile `pool`-allocated output both have `device_size=[16, 512, 64]`,
+  the stick-layout shape for `[512, 1024]` fp16: 16 sticks of 64 columns
+  across 512 rows — but they live in different memories.  `y` uses
+  `allocation={'lx': ...}` (Case 1, produced and consumed entirely inside the
+  loop, so it gets a dedicated LX scratchpad slot, no HBM traffic at all);
+  `mul`'s per-tile output uses `allocation={'pool': ...}` (Case 2, an HBM
+  buffer sized for one tile, distinct from `z`'s full-size HBM buffer, that
+  the identity copy reads from once per iteration).
 
 ### Generated `bundle.mlir`
 
@@ -371,14 +430,18 @@ module {
         %sym_2 = arith.constant <base_addr_b> : index
         %sym_3 = arith.constant <base_addr_c> : index
         %sym_4 = arith.constant <base_addr_z> : index
+        %sym_5 = arith.constant <base_addr_pool> : index
         scf.for %i_0 = %c0 to %loop_bound_0 step %c1 {
             scf.for %i_1 = %c0 to %loop_bound_1 step %c1 {
                 %addr_0 = affine.apply #map_0(%i_0, %i_1)[%sym_1]
                 %addr_1 = affine.apply #map_0(%i_0, %i_1)[%sym_2]
                 sdscbundle.sdsc_execute (%addr_0, %addr_1) {sdsc_filename="sdsc_0.json", ...}  // add: a+b→y(lx)
                 %addr_2 = affine.apply #map_0(%i_0, %i_1)[%sym_3]
-                %addr_3 = affine.apply #map_0(%i_0, %i_1)[%sym_4]
-                sdscbundle.sdsc_execute (%addr_2, %addr_3) {sdsc_filename="sdsc_1.json", ...}  // mul: y(lx)*c→z
+                %addr_3 = affine.apply #map_0(%i_0, %i_1)[%sym_5]
+                sdscbundle.sdsc_execute (%addr_2, %addr_3) {sdsc_filename="sdsc_1.json", ...}  // mul: y(lx)*c→z_tile(pool)
+                %addr_4 = affine.apply #map_0(%i_0, %i_1)[%sym_5]
+                %addr_5 = affine.apply #map_0(%i_0, %i_1)[%sym_4]
+                sdscbundle.sdsc_execute (%addr_4, %addr_5) {sdsc_filename="sdsc_2.json", ...}  // identity: z_tile(pool)→z(hbm)
             }
         }
         return
@@ -386,12 +449,21 @@ module {
 }
 ```
 
-Both operations share the same affine map because they operate on tensors of
-the same shape and stride structure.  The scratchpad tensor `y` does not appear
-as a symbol — it has a fixed `lx` address that does not change between
-iterations.  Each inner-loop iteration dispatches `add` then `mul` at tile
-`(i_0, i_1)`, keeping the intermediate result `y` in scratchpad between the
-two dispatches.
+All three dispatches share the same affine map because they operate on
+tensors of the same shape and stride structure.  The LX scratchpad tensor
+`y` does not appear as a symbol — its `per_tile_fixed=True` flag tells the
+unroller its base address is fixed across iterations, so it needs no
+`affine.apply` at all.  `mul`'s `pool` output (`%sym_5`), by contrast, is
+real HBM (`memory_planning.py`'s `INTERMEDIATES_SEGMENT`, not scratchpad)
+and is *not* `per_tile_fixed`, so — like the other HBM operands `a`, `b`,
+`c`, `z` — it does need its own `affine.apply`-computed address each
+iteration, shared between the `mul` dispatch that writes it and the
+`identity` dispatch that reads it back.  Each inner-loop iteration
+dispatches `add`, then `mul`, then the `identity` copy at tile
+`(i_0, i_1)`: `add` keeps `y` in scratchpad for `mul` to consume
+immediately, and `mul` writes its result into that iteration's `pool` slot
+in HBM for the `identity` copy to drain into the correct slice of `z`'s
+full HBM buffer.
 
 ## Layer 1 — Pre-scheduling IR pass
 

--- a/docs/source/compiler/coarse_tiling_loops.md
+++ b/docs/source/compiler/coarse_tiling_loops.md
@@ -607,10 +607,18 @@ wrapped in private helpers tagged with `@_runs(...)` for cache-key purposes:
 ```python
 self.passes = [
     deadcode_elimination,
+    #
+    # Working Set Reduction (hint-driven, pre-stickification)
+    propagate_named_dims,
+    assign_dim_hints,
+    _maybe_coarse_tile_hints,      # reorder_unhinted_interlopers + hints_to_coarse_tile_groups
+                                   # + coarse_tile, on host-side FixedLayout
+    #
     # Tensor Layout (Stickification)
     split_multi_ops,
     propagate_spyre_tensor_layouts,
     validate_ops,
+    resolve_join_clusters,
     optimize_restickify_locations,
     finalize_layouts,
     insert_restickify,
@@ -618,11 +626,10 @@ self.passes = [
     insert_bmm_padding,
     #
     dedup_and_promote_constants,
-    # Working Set Reduction
-    propagate_named_dims,
-    assign_dim_hints,
-    _maybe_coarse_tile,           # reorder_unhinted_interlopers + hints_to_coarse_tile_groups
-                                  # + span_overflow_groups + coarse_tile
+    #
+    # Working Set Reduction (device-layout-aware, post-stickification)
+    _maybe_coarse_tile_span_overflow,  # span_overflow_groups + coarse_tile,
+                                       # needs FixedTiledLayout.device_layout
     # Core Division
     span_reduction,
     _distribute_work,             # calls cost_model_matmul_division + work_distribution
@@ -641,11 +648,34 @@ scope annotations (attached to FX nodes as `meta["custom"]`) to produce
 `op.dim_hints` — a flat list of `DimHint` objects consumed by
 `hints_to_coarse_tile_groups` to form the coarse tiling groups.
 
+**Coarse tiling is split into two slots, not one.** `_maybe_coarse_tile_hints`
+(hint-derived loop groups) runs immediately after dead-code elimination,
+before stickification: it only needs host-side `FixedLayout` (size/stride)
+and loop-variable ranges, and running it here means `_divide_ranges` never
+has to call a cross-phase `_resize_device_layout` correction step —
+stickification computes the correct `SpyreTensorLayout` directly from the
+already-divided ranges. This also removes a cross-phase contract that used
+to exist between `insert_restickify` and hint-copy forwarding
+(issue #3135). `_maybe_coarse_tile_span_overflow` (spans that overflow the
+hardware memory budget, detected independently of hints) stays in the old
+post-stickification slot below, because span arithmetic needs
+`FixedTiledLayout.device_layout` (device size, stride map), which does not
+exist yet pre-stickification.
+
+**`resolve_join_clusters` must run before `optimize_restickify_locations`.**
+Per-op-local, greedy restickify placement cannot jointly optimize sibling
+ops that feed a shared multi-input `AllSameNode` join (e.g. both operands of
+a `torch.maximum`) — placing one sibling's restickify greedily can foreclose
+a jointly-better placement for the other. `resolve_join_clusters` searches
+the joint candidate space for clustered siblings first, so
+`optimize_restickify_locations`'s later per-op placement only has to handle
+what joint resolution didn't already fix.
+
 **Must run after stickify and padding.**  `propagate_spyre_tensor_layouts`,
 `insert_restickify`, and `insert_bmm_padding` establish the final tiled
-memory layout for each tensor.  The tiling pass must see the post-stickify,
-post-padding shapes or it will split on the wrong dimension or produce a
-non-stick-aligned inner size.
+memory layout for each tensor.  The span-overflow half of coarse tiling
+must see the post-stickify, post-padding shapes or it will split on the
+wrong dimension or produce a non-stick-aligned inner size.
 
 **Must run before `work_distribution`.**  `work_distribution` stamps
 `op_it_space_splits` on each `ir.Operation` to assign per-core work
@@ -697,14 +727,45 @@ tile), the loop body reads from full HBM tensors using tile-sized windows
 via `affine.apply` — no conversion, just addressing.  Only producer-side
 crossings need adaptation.
 
-For each tiled `ComputedBuffer`, the pass classifies by consumer topology
-and applies the cheapest treatment that maintains correctness:
+For each tiled `ComputedBuffer`, the pass classifies by consumer *and
+input* topology and applies the cheapest treatment that maintains
+correctness:
 
-| Case | Inside consumers | Outside consumers | Treatment |
-|---|---|---|---|
-| 1 | ✓ | ✗ | Mark `per_tile_fixed` — flag only, no IR change |
-| 2 | ✓ | ✓ | Allocate full HBM buffer; insert a loop-tagged copy op that publishes each tile into the correct slice |
-| 3 | ✗ | ✓ | Rewire the tiled op to write directly into a full HBM buffer via `MutationLayoutSHOULDREMOVE` — a metadata redirect, zero added data movement |
+| Case | Inside consumers | Outside consumers | Loop-internal real input | Treatment |
+|---|---|---|---|---|
+| 1 | ✓ | ✗ | — | Mark `per_tile_fixed` — flag only, no IR change |
+| 2 | ✓ | ✓ | — | Allocate full HBM buffer; insert a loop-tagged copy op that publishes each tile into the correct slice |
+| 2 | ✗ | ✓ | ✓ | Same as above — a loop-internal real *input* forces the copy-op path even with zero inside consumers of this op's own output |
+| 3 | ✗ | ✓ | ✗ | Rewire the tiled op to write directly into a full HBM buffer via `MutationLayoutSHOULDREMOVE` — a metadata redirect, zero added data movement |
+
+The third row is not a corner case worth ignoring: the trigger is
+`_has_loop_internal_real_input(op, ...)` — true when *any* real
+(non-`SpyreConstantFallback`) input of `op` is itself a `ComputedBuffer`
+stamped with `loop_info` in the same outer loop group. Such an input is a
+tile-sized, loop-internal producer with its own tile-sized candidate
+layouts, which can never be made stick-compatible with a full-size
+`MutationLayoutSHOULDREMOVE` target under `AllSameNode`'s
+stick-compatibility rule. Routing through the copy-op path instead keeps
+the tiled op self-consistent — its own layout and its own real inputs stay
+tile-sized — and reuses the copy op's single-real-input path, which fuses
+the tiled op's own upstream computation via `make_loader()`. Without this
+row, Case 3 (rows 3 and 4's condition as originally stated, "no inside
+consumers → mutate directly") is necessary but not sufficient: an op with
+no inside consumers of its own output but a loop-internal input must still
+route through the copy-op path.
+
+This condition (from commit `8ac03da`) is deliberately narrower than an
+earlier version of the same idea, which forced the copy-op path for *any*
+tiled op with more than one real input (`_num_real_inputs(op) > 1`) — that
+rule over-triggered for ops whose several inputs were all external (e.g.
+two graph inputs), producing an unnecessary identity copy. The current rule
+only cares whether an input is loop-internal, not how many inputs there are.
+
+**Note on code-level naming**: `coarse_tile.py`'s own comments and debug
+logging call the copy-op path "Case 1" and the mutation path "Case 2" (a
+two-way split on treatment, ignoring the loop-internal/no-IR-change case
+covered separately above) — do not confuse this with the doc's three/four-row
+numbering above, which classifies by topology rather than by treatment.
 
 **Case 1** is where most of the working-set-reduction win comes from.  An
 intermediate like `y` in the small example flows from one tiled op to
@@ -733,6 +794,24 @@ existing storage in-place.  The full buffer's address is encoded in the
 `TensorArg` via the `tiled_symbols` offset; no copy op is needed.  A
 unified treatment that always inserted a copy would handle all three cases
 correctly but waste a copy op here.
+
+#### Read-side adaptation: full-buffer inputs to a loop-internal op
+
+The write-side perimeter above is not the whole story. `_propagate_tiled_op`
+checks, before any Case classification, whether `op` directly reads a
+full-size `SpyreEmptyFallback` buffer — typically an accumulator that an
+earlier Case-2/mutation rewrite (or a carry rewrite, below) already
+promoted to full size. A loop-internal op cannot read such a buffer
+directly: its own candidate layouts are tile-sized, and a full-size
+`SpyreEmptyFallback` has only one, full-size candidate layout, so the two
+can never be made stick-compatible. `_full_buffer_read_deps` detects this
+and `_insert_read_view_ops` splices in a tile-sized "view" `ComputedBuffer`
+per such read, rewriting `op`'s `inner_fn` (via a `WrapperHandler`
+subclass, per the wrap-never-reconstruct convention) to read the view
+instead of the full buffer. This means the "no conversion, just addressing"
+claim above holds only when the full buffer being read is a genuine graph
+input or other host-side tensor — not when it is itself the product of an
+earlier tile→full promotion inside the same compilation.
 
 #### Reduction tiling: stick and non-stick reduction dims
 
@@ -818,6 +897,97 @@ eliminated" case correctly.
 Nested tiling where outer level(s) tile output dims and the innermost level
 tiles a reduction dim (e.g. outer-B + inner-K for bmm) is fully supported
 and handled by the two-buffer pattern described above.
+
+The device layout for `accum_full`/`accum_tile`'s `MutationLayoutSHOULDREMOVE`
+target is not chosen uniformly: `propagate_spyre_tensor_layouts`
+(`propagate_layouts.py`) dispatches mutation-target layout computation three
+ways depending on what kind of op is writing into it — `BATCH_MATMUL_OP`
+reductions use `_matmul_layouts`, other `Reduction` ops use
+`_single_arg_op_layout`, and plain `Pointwise` ops (including the fill and
+combine ops this section describes) use `_multi_arg_pointwise_layouts`, the
+same `AllSameNode` stick-compatibility path used for ordinary Case 2/3
+routing above. A reduction accumulator write does not fit the broadcast
+relationship `_multi_arg_pointwise_layouts` otherwise assumes, which is why
+the `Reduction`-specific paths exist as separate cases rather than folding
+into the pointwise one.
+
+#### Sequential carry: online-softmax-style recurrences
+
+The fill/combine pattern above is a **monoid combine**: each tile's partial
+result is independent and can be merged into the accumulator in any order.
+Online-softmax-style kernels (flash-attention's running max and
+rescale-accumulate denominator/output) need something structurally
+different — a **true recurrence**, where the value one loop iteration
+writes must be visible, unmodified, as the *next* iteration's input. Re-
+running the traced Python's fill on every tile would silently reset the
+running max/denominator each iteration instead of carrying it forward. This
+fourth regime, "carry ops," is handled by `_seed_buffer_for_carry`,
+`_carry_terminal_op`, and `_propagate_carry_op` — entirely separate from
+the Case 1/2/3 classification and from the reduction accum pattern, even
+though it reuses some of the same buffer shapes.
+
+**Seed buffer.** The recurrence's pre-loop initializer (e.g.
+`M = torch.full((...), -inf)` for a running max) is not a fresh allocation —
+it is reused directly as `accum_full`. Detecting which pre-loop constant
+fill is a carry seed (as opposed to an ordinary hoisted constant) is
+closure-based, not op-local.
+
+**Closure.** `_seed_closure` returns every op in the same outer loop group
+that reads the seed *directly* — e.g. both `max_running = maximum(M,
+block_max)` and `correction = exp(M - max_running)` read `M` directly, so
+both are in `M`'s closure, even though only the first is the actual
+recurrence update. This is deliberately non-transitive: an op that reads a
+closure member but not the seed itself is an ordinary downstream consumer,
+not part of the closure.
+
+**Entry op vs. terminal op.** `_seed_buffer_for_carry` finds the unique
+closure member whose non-seed operands are all external to the closure —
+the entry op, which reads the seed directly (e.g. the multiply in
+`denominator = denominator * correction + tile_sum`). The traced Python's
+actual recurrence value is sometimes one or more ops further downstream:
+`_carry_terminal_op` walks forward from the entry op, through in-group
+Pointwise consumers that are loop-invariant at the same reduction level and
+do not themselves read the seed directly, to find the terminal op (the add,
+in the example above) whose *result* is what must persist as the next
+iteration's carry. Entry and terminal coincide whenever the update is a
+single op reading the seed directly (e.g. the running-max `maximum` itself).
+
+**`accum_tile` and `carry_prev`.** When the group also tiles an outer
+output dim (e.g. H) above the reduction-tiled level, the terminal op's own
+buffer is only tile-sized at that outer level and cannot write into
+`accum_full` (full-size) directly — the same stick-compatibility
+constraint that motivates Case 1/2 for ordinary tiled ops. `accum_tile` is
+a per-outer-tile scratch buffer, `per_tile_fixed=True`, that the entry op
+reads from and the terminal op mutates via `MutationLayoutSHOULDREMOVE`,
+mirroring the reduction pattern's `accum_tile`. It differs in one respect
+that the reduction pattern never needs: other closure members (e.g.
+`correction`) need the carry's value from *before* this iteration's update
+— the same pre-update value the entry op itself reads — but
+`MutationLayoutSHOULDREMOVE` is a plain storage alias with no versioning,
+so a sibling reader positioned after the terminal op in `operations` would
+observe the post-update write instead. `carry_prev` is a distinct
+per-inner-iteration scratch buffer that snapshots `accum_tile` before the
+terminal op's write, and sibling closure members are redirected to read it
+instead of the seed.
+
+**Copy-in/copy-out placement.** Once per outer tile, before the inner loop's
+first iteration, a copy-in op loads `accum_full`'s current outer-tile slice
+into `accum_tile`. Once per outer tile, after the inner loop's *last*
+iteration, a copy-out op writes `accum_tile` back into `accum_full`'s slice
+— reusing `_insert_reduction_copy_op`. The copy-out's insertion point is
+not simply "immediately after the terminal op": it must run after the last
+op in the seed's closure (found via `max(..., key=operations.index)`),
+since sibling closure members like `correction` still need to run inside
+the same inner-loop iteration after the terminal op's write.
+
+**Connection to `resolve_join_clusters`.** A closure with multiple external
+members feeding a shared multi-input `AllSameNode` join (e.g. flash-
+attention's `M = torch.maximum(M, block_max)` join) is exactly the shape
+`resolve_join_clusters` was introduced to optimize jointly — per-op-local
+greedy restickify placement cannot see that two sibling ops' candidate
+layouts should be chosen together. See
+[Groups derivation and placement in `CustomPreSchedulingPasses`](#groups-derivation-and-placement-in-custompreschedulingpasses)
+for where that pass runs relative to coarse tiling.
 
 ## Layer 2 — `CountedLoopSchedulerNode`
 
@@ -907,10 +1077,24 @@ any future fusion path that might otherwise merge across group boundaries.
 
 ### The grouping algorithm
 
-`build_loop_scheduler_nodes` scans the flat node list and groups
-contiguous runs sharing the same outermost `loop_group_id` key:
+`build_loop_scheduler_nodes` first calls `_regroup_by_outer_loop_key`, then
+scans the resulting node list and groups contiguous runs sharing the same
+outermost `loop_group_id` key. The regroup step is necessary because
+Inductor's own `Scheduler.topological_sort_schedule` runs (twice) before
+this pass ever sees the node list, via a plain DFS over
+`unmet_dependencies` — that DFS only guarantees a *valid* topological
+order, not that mutually independent nodes keep their original relative
+order, so it can interleave unrelated nodes into the middle of what
+`coarse_tile.py` built as a single contiguous loop group.
+`_regroup_by_outer_loop_key` merges every node sharing an outermost
+`loop_group_id[0]` key into one virtual unit (dependency set = the union of
+its members' real cross-group dependencies), runs a dependency-respecting
+DFS over `{merged units, ungrouped nodes}`, then expands each unit back
+into its original members in their original relative order — restoring
+contiguity while still producing a valid topological order:
 
 ```
+nodes = _regroup_by_outer_loop_key(nodes)
 result = []
 i = 0
 while i < len(nodes):
@@ -930,11 +1114,16 @@ while i < len(nodes):
 return result
 ```
 
-Key invariant: because the pre-scheduling pass runs in topological order
-and the scheduler's topological sort preserves that order, a loop group's
-`SchedulerNode`s will be contiguous in the post-fusion node list.  If they
-are not contiguous it means a data-flow constraint separates them, which is a
-bug in the tiling pass.  The post-fusion pass asserts contiguity.
+Key invariant: the pre-scheduling pass runs in topological order, but
+Inductor's own topological sort does **not** by itself guarantee that a
+loop group's `SchedulerNode`s stay contiguous — it only guarantees a valid
+order among mutually independent nodes, which can interleave. Contiguity
+is restored by `_regroup_by_outer_loop_key` before grouping runs. If
+`build_loop_scheduler_nodes` still finds a non-contiguous run after that
+call, it means either a bug in `_regroup_by_outer_loop_key` itself, or a
+genuine data-flow constraint that makes the group's own op sequence
+topologically invalid (which would be a tiling-pass bug). The post-fusion
+pass asserts contiguity.
 
 ## Layer 3 — `LoopSpec` and codegen
 
@@ -1233,7 +1422,8 @@ When backend support lands, `unroll_loops` will be flipped to default
 |---|---|
 | `torch_spyre/_inductor/loop_info.py` | Layer 1: `CoarseTileInfo` dataclass; `copy_op_metadata` |
 | `torch_spyre/_inductor/coarse_tile.py` | Layer 1: `reorder_unhinted_interlopers()` reorders interlopers before grouping; `coarse_tile()` stamps `loop_info` and rewrites ranges; `insert_tiling_propagation` handles the data perimeter |
-| `torch_spyre/_inductor/scheduler.py` | Layer 2: `CountedLoopSchedulerNode`, `build_loop_scheduler_nodes`, `_codegen_counted_loop` |
+| `torch_spyre/_inductor/insert_restickify.py` | Commits deferred `_pending_per_tile_fixed` flags in `finalize_layouts`; derives a restickify buffer's own `per_tile_fixed` from the *consuming* op's `loop_info` rather than inheriting the source layout's flag, needed when the restickify buffer takes over an advancing accumulator's role (reduction copy-out, carry-into-accumulator) |
+| `torch_spyre/_inductor/scheduler.py` | Layer 2: `CountedLoopSchedulerNode`, `build_loop_scheduler_nodes`, `_codegen_counted_loop`, `_regroup_by_outer_loop_key` |
 | `torch_spyre/_inductor/op_spec.py` | Layer 3: `LoopSpec` and `OpSpec` dataclasses |
 | `torch_spyre/_inductor/spyre_kernel.py` | Layer 3: serializes `LoopSpec` tree in `codegen_kernel()`; `wrap_op_specs_in_loop()` |
 | `torch_spyre/_inductor/codegen/bundle.py` | Layer 3: emits `scf.for` in `bundle.mlir` for the `unroll_loops=False` path |

--- a/docs/source/compiler/inductor_frontend.md
+++ b/docs/source/compiler/inductor_frontend.md
@@ -60,24 +60,35 @@ Some examples of passes that are appropriate to perform at this level are:
 
 Passes on the LoopLevelIR run late in compilation. `CustomPreSchedulingPasses` dispatches them in a fixed order. Each step takes the `GraphLowering` and mutates `graph.operations` in place. Steps marked "Gated" are skipped when their config flag is off.
 
+Working-set reduction (WSR) runs in two separate slots rather than one: a
+hint-driven half runs immediately after dead-code elimination, before
+stickification, because it only needs host-side `FixedLayout` (size/stride)
+and loop-variable ranges; a span-overflow half stays after stickification
+because it needs `FixedTiledLayout.device_layout` (device size, stride map)
+to reason about physical span. Running the hint-driven half before
+stickification also dissolves a cross-phase contract that used to exist
+between `insert_restickify` and the hint-copy machinery (issue #3135).
+
 | # | Pass | Module | Notes |
 |---|---|---|---|
 | 1 | `deadcode_elimination` | [deadcode_elimination.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/deadcode_elimination.py) | Drops unreachable ops. |
-| 2 | `split_multi_ops` | [split_multi_ops.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/split_multi_ops.py) | Splits multi-op loop bodies (e.g. type conversion + arithmetic) into separate single-op buffers and materializes constant args as `SpyreConstantFallback`. |
-| 3 | `propagate_spyre_tensor_layouts` | [propagate_layouts.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/propagate_layouts.py) | Stamps `FixedTiledLayout` on every `ComputedBuffer`. |
-| 4 | `validate_ops` | [split_multi_ops.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/split_multi_ops.py) | Checks that each op's inputs share the same `ElementArrangement`. Runs after layout propagation, when the `SpyreTensorLayout`s are available. |
-| 5 | `optimize_restickify_locations` | [optimize_restickify.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/optimize_restickify.py) | Moves restickify ops to better placements before the layout is finalized. |
-| 6 | `finalize_layouts` | [insert_restickify.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/insert_restickify.py) | Settles tile-structure decisions before any new restickify is inserted. |
-| 7 | `insert_restickify` | [insert_restickify.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/insert_restickify.py) | Adds explicit re-tile ops where adjacent ops disagree on layout. |
-| 8 | `insert_post_mutation_restickify` | [insert_restickify.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/insert_restickify.py) | Handles restickification for slice-mutation buffers. |
-| 9 | `insert_bmm_padding` | [padding.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/padding.py) | Pads `mm` and `bmm` operands to satisfy hardware alignment. |
-| 10 | `dedup_and_promote_constants` | [dedup_constants.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/dedup_constants.py) | Deduplicates identical constants and promotes shared ones. |
-| 11 | `propagate_named_dims` | [propagate_named_dims.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/propagate_named_dims.py) | Propagates `name_tensor_dims` annotations from inputs through the op graph. |
-| 12 | `assign_dim_hints` | [propagate_named_dims.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/propagate_named_dims.py) | Lowers each `spyre_hint` scope to a per-op `DimHint` list. |
-| 13 | `coarse_tile` | [coarse_tile.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/coarse_tile.py) | Runs only when hint-derived loop groups are present. Wraps each group in nested counted loops. |
-| 14 | `span_reduction` | [work_division.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/work_division.py) | Reduces per-core access spans to fit the hardware memory budget. |
-| 15 | `cost_model_matmul_division` + `work_distribution` | [work_division.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/work_division.py) | The cost-model pass claims a subset of matmuls; `work_distribution` covers the rest. |
-| 16 | `scratchpad_planning` | [scratchpad/](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/scratchpad/) | Gated by `config.lx_planning`. Allocates the LX scratchpad. |
+| 2 | `propagate_named_dims` | [propagate_named_dims.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/propagate_named_dims.py) | Propagates `name_tensor_dims` annotations from inputs through the op graph. Runs pre-stickification — only needs host-side `FixedLayout`. |
+| 3 | `assign_dim_hints` | [propagate_named_dims.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/propagate_named_dims.py) | Lowers each `spyre_hint` scope to a per-op `DimHint` list. |
+| 4 | `_maybe_coarse_tile_hints` | [passes.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/passes.py) | Hint-driven half of coarse tiling: `reorder_unhinted_interlopers` + `hints_to_coarse_tile_groups` + `coarse_tile`. Runs on host-side `FixedLayout` only. |
+| 5 | `split_multi_ops` | [split_multi_ops.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/split_multi_ops.py) | Splits multi-op loop bodies (e.g. type conversion + arithmetic) into separate single-op buffers and materializes constant args as `SpyreConstantFallback`. |
+| 6 | `propagate_spyre_tensor_layouts` | [propagate_layouts.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/propagate_layouts.py) | Stamps `FixedTiledLayout` on every `ComputedBuffer`. |
+| 7 | `validate_ops` | [split_multi_ops.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/split_multi_ops.py) | Checks that each op's inputs share the same `ElementArrangement`. Runs after layout propagation, when the `SpyreTensorLayout`s are available. |
+| 8 | `resolve_join_clusters` | [resolve_join_clusters.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/resolve_join_clusters.py) | Jointly optimizes sibling ops feeding a shared multi-input `AllSameNode` join (e.g. two operands of a `torch.maximum`), before per-op-local restickify placement forecloses better joint choices. See [Coarse-Tiling Loops](coarse_tiling_loops.md). |
+| 9 | `optimize_restickify_locations` | [optimize_restickify.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/optimize_restickify.py) | Moves restickify ops to better placements before the layout is finalized. |
+| 10 | `finalize_layouts` | [insert_restickify.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/insert_restickify.py) | Settles tile-structure decisions before any new restickify is inserted. |
+| 11 | `insert_restickify` | [insert_restickify.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/insert_restickify.py) | Adds explicit re-tile ops where adjacent ops disagree on layout. |
+| 12 | `insert_post_mutation_restickify` | [insert_restickify.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/insert_restickify.py) | Handles restickification for slice-mutation buffers. |
+| 13 | `insert_bmm_padding` | [padding.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/padding.py) | Pads `mm` and `bmm` operands to satisfy hardware alignment. |
+| 14 | `dedup_and_promote_constants` | [dedup_constants.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/dedup_constants.py) | Deduplicates identical constants and promotes shared ones. |
+| 15 | `_maybe_coarse_tile_span_overflow` | [passes.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/passes.py) | Span-overflow half of coarse tiling: `span_overflow_groups` + `coarse_tile`. Runs post-stickification — needs `FixedTiledLayout.device_layout` for physical span arithmetic. |
+| 16 | `span_reduction` | [work_division.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/work_division.py) | Reduces per-core access spans to fit the hardware memory budget. |
+| 17 | `cost_model_matmul_division` + `work_distribution` | [work_division.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/work_division.py) | The cost-model pass claims a subset of matmuls; `work_distribution` covers the rest. |
+| 18 | `scratchpad_planning` | [scratchpad/](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/scratchpad/) | Gated by `config.lx_planning`. Allocates the LX scratchpad. |
 
 Once stickification has run, every `ComputedBuffer` carries a `FixedTiledLayout`, so the later passes can take device layout into account when making decisions.
 

--- a/docs/source/compiler/working_set_reduction.md
+++ b/docs/source/compiler/working_set_reduction.md
@@ -285,11 +285,20 @@ if an input dimension is unnamed, or if a view transformation is
 inconsistent with the user-provided dimension names, a warning is emitted
 and propagation continues with partial or inferred information.
 
-The pass runs in `CustomPreSchedulingPasses`, after tensor layouts have been
-finalized and before work-division and scratchpad planning consume the
-resulting iteration spaces. The slot is rigid: layouts must be settled
-before tiling decisions can refer to them, and work-division must see the
-post-tiling iteration space.
+The pass runs in `CustomPreSchedulingPasses`, split across two slots. A
+hint-driven half (`propagate_named_dims`, `assign_dim_hints`, and the
+hint-derived half of coarse tiling) runs immediately after dead-code
+elimination, **before** stickification — it only needs host-side
+`FixedLayout` (size/stride) and loop-variable ranges, so there is no reason
+to wait for device layouts. A span-overflow half runs later, after
+stickification, because it needs `FixedTiledLayout.device_layout` (device
+size, stride map) to detect and correct spans that overflow the hardware
+memory budget. Both halves still run before work-division and scratchpad
+planning consume the resulting iteration spaces: work-division must see the
+post-tiling iteration space regardless of which half produced it. See
+[`coarse_tiling_loops.md`](coarse_tiling_loops.md#groups-derivation-and-placement-in-custompreschedulingpasses)
+for the full pass ordering and the rationale for the two-slot split
+(issue #3135).
 
 :::{figure} ../_static/images/wsr/pipeline-placement.png
 :alt: Where WSR runs in the Spyre Inductor pipeline
@@ -330,6 +339,17 @@ buffers crossing the loop boundary are classified — are documented in
 [`coarse_tiling_loops.md`](coarse_tiling_loops.md). The design rationale
 for those mechanics is in [RFC 1358: Coarse
 Tiling](https://github.com/torch-spyre/rfcs/blob/main/1358-CoarseTiling/1358-CoarseTiling.md).
+
+A buffer that crosses the loop boundary and is *not* marked
+`per_tile_fixed` (see [`coarse_tiling_loops.md`](coarse_tiling_loops.md))
+advances its base address once per loop iteration, so its HBM pool
+allocation must be sized for every tile it will occupy across the loop's
+run, not just one. `memory_planning.py`'s `_advance_factor` computes this
+as the product of `loop_count` over the levels the buffer is tiled on;
+sizing it for a single tile would let the loop overrun into whatever buffer
+the allocator packed next to it. See
+[`coarse_tiling_loops.md`](coarse_tiling_loops.md) for the `accum_full` /
+`accum_tile` buffers this sizing matters most for.
 
 ## Related documents
 

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -472,6 +472,56 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         )
 
     # ------------------------------------------------------------------
+    # Loop-invariant (broadcast) op gets per_tile_fixed=True
+    # ------------------------------------------------------------------
+
+    @config.patch(
+        {
+            "unroll_loops": True,
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+        }
+    )
+    def test_loop_invariant_op_per_tile_fixed_in_sdsc(self):
+        """A loop-invariant ComputedBuffer inside a coarse-tile group must have
+        per_tile_fixed=True in the generated SDSC source, so the unroller does
+        not advance its address.
+
+        torch.full lowers to a scalar-fill ComputedBuffer with no loop var matching
+        the hinted dim.  Its loop_tiled_dims are all-empty, making it loop-invariant
+        w.r.t. the tiling.  finalize_layouts must stamp per_tile_fixed=True on it.
+        """
+        from torch_spyre._inductor import spyre_hint
+
+        M, K = 256, 64
+        x = torch.randn(M, K, dtype=torch.float16)
+        x_dev = x.to("spyre")
+        _declare_tensor_dim("M", M)
+        _declare_tensor_dim("K", K)
+        _name_tensor_dims(x_dev, ["M", "K"])
+
+        def fn(x):
+            with spyre_hint(num_tiles_per_dim={"M": 4}):
+                # torch.full produces a scalar-fill ComputedBuffer with no M-dim
+                # loop var — its loop_tiled_dims are all empty (loop-invariant).
+                bias = torch.full(x.shape, 0.5, dtype=x.dtype, device=x.device)
+                return x + bias
+
+        cfn = torch.compile(fn)
+        with (
+            mock_patch(_LAUNCH_JOBPLAN),
+            mock_patch(_PREPARE_KERNEL),
+            mock_patch("subprocess.run"),
+        ):
+            _, source_codes = run_and_get_code(cfn, x_dev)
+        src = source_codes[0]
+        self.assertIn(
+            "per_tile_fixed=True",
+            src,
+            "Loop-invariant (scalar-fill) buffer must have per_tile_fixed=True in SDSC",
+        )
+
+    # ------------------------------------------------------------------
     # Hint propagation through mm_to_bmm_pass
     # ------------------------------------------------------------------
 

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -467,7 +467,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "unroll_loops": True,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
         }
@@ -1416,7 +1415,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "unroll_loops": True,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
         }
@@ -2118,7 +2116,6 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
             "Expected tile-sized accum TensorArg with lx allocation for nested M+K tiling",
         )
 
-    @config.patch({"unroll_loops": False})
     def test_nested_matmul_accum_tile_per_tile_fixed_in_sdsc(self):
         """Accumulator tile buffer in nested outer-M + inner-K reduction must have
         per_tile_fixed=True in the generated SDSC source.

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -199,12 +199,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
     # Nested hints: outer K=2, inner M=4 on a single op
     # ------------------------------------------------------------------
 
-    @config.patch(
-        {
-            "lx_planning": True,
-            "allow_all_ops_in_lx_planning": True,
-        }
-    )
     # ------------------------------------------------------------------
     # Scratchpad (LX) allocation for intermediate tiled buffer — hint syntax
     # ------------------------------------------------------------------
@@ -2120,6 +2114,49 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
             "allocation={'lx'",
             src,
             "Expected tile-sized accum TensorArg with lx allocation for nested M+K tiling",
+        )
+
+    @config.patch({"unroll_loops": False})
+    def test_nested_matmul_accum_tile_per_tile_fixed_in_sdsc(self):
+        """Accumulator tile buffer in nested outer-M + inner-K reduction must have
+        per_tile_fixed=True in the generated SDSC source.
+
+        The accum_tile buffer is loop-internal to the inner K-loop, so the unroller
+        must not advance its base address across inner iterations.  This requires
+        _pending_per_tile_fixed to be set by _propagate_tiled_reduction_op (pre-
+        stickify path) and consumed by finalize_layouts.
+        """
+        from torch_spyre._inductor import spyre_hint
+
+        M, K, N = 128, 512, 32
+        a = torch.randn(M, K, dtype=torch.float16) * 0.01
+        b = torch.randn(K, N, dtype=torch.float16) * 0.01
+        a_dev = a.to("spyre")
+        b_dev = b.to("spyre")
+        _declare_tensor_dim("M", M)
+        _declare_tensor_dim("K", K)
+        _declare_tensor_dim("N", N)
+        _name_tensor_dims(a_dev, ["M", "K"])
+        _name_tensor_dims(b_dev, ["K", "N"])
+
+        def fn(a, b):
+            with spyre_hint(num_tiles_per_dim={"M": 2}):
+                with spyre_hint(num_tiles_per_dim={"K": 4}):
+                    return torch.mm(a, b)
+
+        cfn = torch.compile(fn)
+        with (
+            mock_patch(_LAUNCH_JOBPLAN),
+            mock_patch(_PREPARE_KERNEL),
+            mock_patch("subprocess.run"),
+        ):
+            _, source_codes = run_and_get_code(cfn, a_dev, b_dev)
+        self.assertTrue(len(source_codes) > 0)
+        src = source_codes[0]
+        self.assertIn(
+            "per_tile_fixed=True",
+            src,
+            "Nested-reduction accum_tile must have per_tile_fixed=True in SDSC",
         )
 
 

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1414,6 +1414,41 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             fn, a, b, c, run_compile=True, run_eager=False, atol=0.01, rtol=0.01
         )
 
+    # ------------------------------------------------------------------
+    # Tiled pointwise with outside consumer (_allocate_full_buffer)
+    # ------------------------------------------------------------------
+
+    @config.patch(
+        {
+            "unroll_loops": True,
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+        }
+    )
+    def test_hint_tiled_pointwise_outside_consumer_correct(self):
+        """Tiled pointwise op with a consumer outside the loop (tests
+        _allocate_full_buffer pre-stickify: the full buffer must be correctly
+        stickified by layout propagation)."""
+        from torch_spyre._inductor import spyre_hint
+
+        A, B = 128, 64
+        x = torch.randn(A, B, dtype=torch.float16)
+        y = torch.randn(A, B, dtype=torch.float16)
+
+        _declare_tensor_dim("A", A)
+        _declare_tensor_dim("B", B)
+        _name_tensor_dims(x, ["A", "B"])
+        _name_tensor_dims(y, ["A", "B"])
+
+        def fn(x, y):
+            _name_tensor_dims(x, ["A", "B"])
+            _name_tensor_dims(y, ["A", "B"])
+            with spyre_hint(num_tiles_per_dim={"A": 2}):
+                z = x + y  # tiled op
+            return z * 2.0  # outside consumer -- forces _allocate_full_buffer
+
+        compare_with_cpu(fn, x, y, run_compile=True, run_eager=False)
+
 
 class TestNamedDimsHint(InductorTestCase):
     """Tests for propagate_named_dims handling of ops with a named_dims hint.

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -199,10 +199,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
     # Nested hints: outer K=2, inner M=4 on a single op
     # ------------------------------------------------------------------
 
-    # ------------------------------------------------------------------
-    # Scratchpad (LX) allocation for intermediate tiled buffer — hint syntax
-    # ------------------------------------------------------------------
-
     @config.patch(
         {
             "lx_planning": True,

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -701,16 +701,19 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         lk_slices = Lk // block_size  # noqa: F841 — used in commented-out Lk hint
 
         def flash(queries, keys, values):
-            output = torch.zeros_like(queries)
-            M = torch.full(
-                (B, H, Lq),
-                float("-inf"),
-                device=queries.device,
-                dtype=torch.float16,
-            )
-            denominator = torch.zeros(
-                (B, H, Lq), device=queries.device, dtype=torch.float16
-            )
+            with spyre_hint(named_dims=["B", "H", "Lq", "D"]):
+                output = torch.zeros_like(queries)
+            with spyre_hint(named_dims=["B", "H", "Lq"]):
+                M = torch.full(
+                    (B, H, Lq),
+                    float("-inf"),
+                    device=queries.device,
+                    dtype=torch.float16,
+                )
+            with spyre_hint(named_dims=["B", "H", "Lq"]):
+                denominator = torch.zeros(
+                    (B, H, Lq), device=queries.device, dtype=torch.float16
+                )
             with spyre_hint(
                 num_tiles_per_dim={"B": 1}
             ):  # 3 nested scopes exercises multi-hint logic
@@ -949,18 +952,21 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         _name_tensor_dims(values_dev, ["B", "H", "Lk", "D"])
 
         def flash(queries, keys, values):
-            output = torch.zeros_like(queries)
-            M = torch.full(
-                (B, H, Lq),
-                float("-inf"),
-                device=queries.device,
-                dtype=torch.float16,
-            )
-            denominator = torch.zeros(
-                (B, H, Lq),
-                device=queries.device,
-                dtype=torch.float16,
-            )
+            with spyre_hint(named_dims=["B", "H", "Lq", "D"]):
+                output = torch.zeros_like(queries)
+            with spyre_hint(named_dims=["B", "H", "Lq"]):
+                M = torch.full(
+                    (B, H, Lq),
+                    float("-inf"),
+                    device=queries.device,
+                    dtype=torch.float16,
+                )
+            with spyre_hint(named_dims=["B", "H", "Lq"]):
+                denominator = torch.zeros(
+                    (B, H, Lq),
+                    device=queries.device,
+                    dtype=torch.float16,
+                )
             with spyre_hint(num_tiles_per_dim={"B": 1}):
                 with spyre_hint(num_tiles_per_dim={"H": 4}):
                     with spyre_hint(num_tiles_per_dim={"Lk": lk_slices}):

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -60,6 +60,8 @@ from torch._inductor.ops_handler import WrapperHandler
 from torch._inductor.graph import GraphLowering
 from torch._inductor.ir import (
     ComputedBuffer,
+    FixedLayout,
+    FlexibleLayout,
     Layout,
     Loops,
     MutationLayoutSHOULDREMOVE,
@@ -86,7 +88,7 @@ from .span_overflow_hint_analysis import (
     can_conform_pointwise_tile,
     plan_span_overflow_tile,
 )
-from .ir import FixedTiledLayout, _resize_device_layout
+from .ir import FixedTiledLayout, SpyreConstantFallback, _resize_device_layout
 
 logger = get_inductor_logger("coarse_tile")
 hints_logger = get_inductor_logger("assign_dim_hints")
@@ -1037,7 +1039,20 @@ def coarse_tile(
     ] = []
     for group_idx, (group_ops, levels) in enumerate(groups, start=group_idx_offset):
         group_id: tuple[int, ...] = (group_idx,)
+        # Phase 1: create tile-sized fills and insert them before the group.
+        # Returns name_map without patching group ops (patching is deferred to
+        # phase 2 so replace_computed_buffer_body runs after _stamp_group and
+        # therefore copies the already-stamped loop_info onto the new object).
+        name_map = _replace_constant_fill_predecessors(
+            group_ops, levels, operations, group_id
+        )
+        # Rebuild op_to_position after potential insertions from fill replacement.
+        op_to_position = {op.get_operation_name(): i for i, op in enumerate(operations)}
         retiled_infos = _stamp_group(group_ops, group_id, levels, op_to_position)
+        # Phase 2: patch group ops to read tile-sized fills.  Done after
+        # _stamp_group so loop_info is already present on each op when
+        # replace_computed_buffer_body copies metadata to the reconstructed object.
+        _apply_fill_name_swap(group_ops, name_map, operations)
         stamped_group_id = group_id + (0,) * (len(levels) - 1)
         retiled_infos_by_group.append((stamped_group_id, group_ops, retiled_infos))
 
@@ -1322,7 +1337,6 @@ def _allocate_full_buffer(
     FixedTiledLayout post-stickify), splices it into operations at
     insert_at_idx, and returns the new ComputedBuffer.
     """
-    from torch._inductor.ir import FixedLayout  # deferred: avoids circular import
     from .ir import SpyreEmptyFallback  # deferred: avoids circular import
 
     graph_lowering = V.graph
@@ -2011,6 +2025,270 @@ def _patch_graph_outputs(old_name: str, new_buf: ComputedBuffer) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _replace_constant_fill_predecessors(
+    group_ops: list[Operation],
+    levels: list[tuple],
+    operations: list[Operation],
+    group_id: tuple[int, ...],
+) -> dict[str, str]:
+    """Create tile-sized constant-fill buffers for full-size fills feeding the group.
+
+    full.default / zeros_like / zeros ops are often created outside a
+    spyre_hint() scope (so they carry no dim_hints) but feed tiled ops inside
+    the scope.  Rather than absorbing the full-size fill into the tiling loop
+    (which causes DDL slice-size mismatches), we:
+
+      1. Create a new tile-sized SpyreConstantFallback + Pointwise fill op
+         with the same constant value but with the hinted dimension already
+         divided by split_count.
+      2. Insert the new tile-sized fill immediately before the tiling group in
+         operations (outside the loop — no loop_info stamped).
+
+    The tile-sized fill is a loop-invariant constant: its value is identical
+    across all iterations, so creating it once and reading it every iteration
+    is semantically equivalent to slicing a per-iteration fill.  Because it
+    sits outside the loop it is also a candidate for LX scratchpad allocation.
+
+    Returns a name_map {old_fill_name: new_tile_fill_name} for the caller to
+    apply via _apply_fill_name_swap after _stamp_group has run (so that
+    replace_computed_buffer_body preserves the loop_info already stamped on
+    each group op).
+    """
+    from torch._inductor.dependencies import MemoryDep
+
+    # Build a reference dim_hints list from the first op in the group that has them.
+    ref_dim_hints: list[DimHint] = []
+    for op in group_ops:
+        hints = getattr(op, "dim_hints", [])
+        if hints:
+            ref_dim_hints = hints
+            break
+
+    if not ref_dim_hints:
+        return {}
+
+    # Collect the set of buffer names already in the group so we don't confuse
+    # intra-group data-flow edges with inter-group constant-fill edges.
+    group_names: set[str] = {
+        op.get_name() for op in group_ops if isinstance(op, ComputedBuffer)
+    }
+
+    # Find the insert position: just before the first op of the group.
+    first_group_idx = next(
+        (i for i, op in enumerate(operations) if op is group_ops[0]), None
+    )
+    if first_group_idx is None:
+        return {}
+
+    # name_map collects old_fill_name → new_tile_fill_name for the NameSwapHandler.
+    name_map: dict[str, str] = {}
+
+    # Track already-replaced fills so we don't create duplicates when the same
+    # fill feeds multiple ops in the group.
+    replaced: set[str] = set()
+
+    for op in group_ops:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        try:
+            rw = op.get_read_writes()
+        except Exception:
+            continue
+        for dep in rw.reads:
+            if not isinstance(dep, MemoryDep):
+                continue
+            old_name = dep.name
+            if old_name in group_names or old_name in replaced:
+                continue
+            buf = V.graph.get_buffer(old_name)
+            if not isinstance(buf, ComputedBuffer):
+                continue
+            if not _is_constant_fill(buf):
+                continue
+
+            # Read the constant value from the SpyreConstantFallback scalar
+            # that is the fill's only input.
+            fill_rw = buf.get_read_writes()
+            scalar_dep = next(
+                (d for d in fill_rw.reads if isinstance(d, MemoryDep)), None
+            )
+            if scalar_dep is None:
+                continue
+            scalar_buf = V.graph.get_buffer(scalar_dep.name)
+            if not isinstance(scalar_buf, SpyreConstantFallback):
+                continue
+            const_value = scalar_buf.constant_args[0]
+
+            # Compute the tile-sized shape using the consumer op's authoritative
+            # loop_var→ranges_pos mapping.  Size-based matching (_constant_fill_
+            # ranges_pos) is unreliable when two named dims share the same value
+            # (e.g. Lq=256 and Lk=256 in flash attention).  Instead, for each
+            # hint we ask: which output-ranges position of the consumer op does
+            # this hint tile?  If the fill has a dimension at that same position
+            # with the expected size, divide it; otherwise skip (the fill doesn't
+            # have that dimension and should not be divided on it).
+            old_size = [int(r) for r in buf.data.ranges]
+            tile_size = list(old_size)
+            consumer_out = op_out_coords(op)
+            for h in getattr(op, "dim_hints", None) or []:
+                if h.loop_var is None or h.is_reduction or h.split_count <= 1:
+                    continue
+                consumer_pos = _loop_var_to_ranges_pos(consumer_out, h.loop_var)
+                if consumer_pos is None:
+                    continue
+                if consumer_pos >= len(old_size):
+                    continue
+                if old_size[consumer_pos] != int(op.data.ranges[consumer_pos]):
+                    # Fill dim size doesn't match consumer's full range; skip.
+                    continue
+                if tile_size[consumer_pos] % int(h.split_count) != 0:
+                    logger.warning(
+                        "coarse_tile: constant-fill %s dim %d size %d not "
+                        "divisible by split_count %d; skipping replacement",
+                        old_name,
+                        consumer_pos,
+                        tile_size[consumer_pos],
+                        int(h.split_count),
+                    )
+                    tile_size = None  # type: ignore[assignment]
+                    break
+                tile_size[consumer_pos] = tile_size[consumer_pos] // int(h.split_count)
+
+            if tile_size is None:
+                continue
+
+            dtype = buf.get_dtype()
+            device = buf.get_device()
+
+            # Create the tile-sized scalar + fill.
+            new_scalar = SpyreConstantFallback(
+                torch.ops.spyre.constant.default, float(const_value), dtype, device
+            )
+            scalar_stl = SpyreTensorLayout([], dtype)
+            new_scalar.layout = FixedTiledLayout(device, dtype, [], [], scalar_stl)
+            scalar_loader = TensorBox.create(new_scalar).make_loader()
+
+            tile_ranges = [sympy.Integer(s) for s in tile_size]
+            fill_data = Pointwise(
+                device=device,
+                dtype=dtype,
+                inner_fn=lambda index, _loader=scalar_loader: _loader([]),
+                ranges=tile_ranges,
+            )
+            tile_strides = [
+                sympy.Integer(int(s))
+                for s in FlexibleLayout.contiguous_strides(tile_size)
+            ]
+            fill_name = V.graph.qualify_name(f"ct_fill_{old_name}")
+            fill_buf = ComputedBuffer(
+                name=fill_name,
+                layout=FixedLayout(device, dtype, list(tile_ranges), tile_strides),
+                data=fill_data,
+            )
+            fill_buf.origins = buf.origins
+            fill_buf.operation_name = fill_name
+            # Stamp loop_info so the fill is placed inside the loop group by
+            # build_loop_scheduler_nodes, with empty loop_tiled_dims (loop-
+            # invariant: executed once per loop body but no range is divided).
+            # Use the same nested_group_id that _stamp_group assigns to broadcast
+            # ops: group_id + (0,) * (len(levels) - 1).  loop_count length must
+            # equal loop_group_id length (enforced by _loop_count assertion).
+            counts = [count for _, count in levels]
+            nested_group_id = group_id + (0,) * (len(levels) - 1)
+            fill_buf.loop_info = CoarseTileInfo(  # type: ignore[attr-defined]
+                loop_group_id=nested_group_id,
+                loop_count=counts,
+                loop_tiled_dims=[[] for _ in levels],
+                loop_tiled_reduction_dims=[[] for _ in levels],
+            )
+            V.graph.name_to_buffer[fill_name] = fill_buf
+
+            # Splice new_scalar and fill_buf into operations just before the group.
+            # new_scalar was appended to operations by register_operation() inside
+            # SpyreConstantFallback.__init__; move it to the insert position.
+            operations.remove(new_scalar)
+            operations.insert(first_group_idx, new_scalar)
+            first_group_idx += 1
+            operations.insert(first_group_idx, fill_buf)
+            first_group_idx += 1
+
+            name_map[old_name] = fill_name
+            replaced.add(old_name)
+            logger.debug(
+                "coarse_tile: created tile-sized fill %s (shape %s) replacing %s (shape %s)",
+                fill_name,
+                tile_size,
+                old_name,
+                old_size,
+            )
+
+    return name_map
+
+
+def _apply_fill_name_swap(
+    group_ops: list[Operation],
+    name_map: dict[str, str],
+    operations: list[Operation],
+) -> None:
+    """Patch group ops to read tile-sized fills instead of the original full-size ones.
+
+    Must be called AFTER _stamp_group so that replace_computed_buffer_body
+    copies the already-stamped loop_info onto the reconstructed ComputedBuffer.
+    """
+    if not name_map:
+        return
+
+    from torch._inductor.dependencies import MemoryDep
+    from .insert_restickify import NameSwapHandler
+    from .pass_utils import replace_computed_buffer_body
+
+    for op in group_ops:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        reads = set()
+        try:
+            reads = {
+                d.name for d in op.get_read_writes().reads if isinstance(d, MemoryDep)
+            }
+        except Exception:
+            continue
+        if not reads & set(name_map):
+            continue
+
+        orig_inner = op.data.inner_fn
+
+        def new_inner_fn(*args, _map=name_map, _orig=orig_inner):
+            with V.set_ops_handler(NameSwapHandler(V.ops, _map)):
+                return _orig(*args)
+
+        object.__setattr__(op.data, "inner_fn", new_inner_fn)
+        replace_computed_buffer_body(op, op.data, operations)
+
+
+def _is_constant_fill(op: ComputedBuffer) -> bool:
+    """True if op is a Pointwise whose only reads come from SpyreConstantFallback.
+
+    full.default / zeros_like / zeros lower to a SpyreConstantFallback scalar
+    broadcast through a thin Pointwise wrapper.  These ops are position-
+    independent, so shrinking their per-tile range to match the tiled group
+    is semantically equivalent to slicing a full-sized fill.
+    """
+    if not isinstance(op.data, Pointwise):
+        return False
+    try:
+        rw = op.get_read_writes()
+    except Exception:
+        return False
+    from torch._inductor.dependencies import MemoryDep
+
+    reads = [d for d in rw.reads if isinstance(d, MemoryDep)]
+    if not reads:
+        return False
+    return all(
+        isinstance(V.graph.get_buffer(d.name), SpyreConstantFallback) for d in reads
+    )
+
+
 def _stamp_group(
     ops: list[Operation],
     group_id: tuple[int, ...],
@@ -2078,6 +2356,7 @@ def _stamp_group(
         for hint_id, count in levels:
             opos = hint_id_to_ranges_pos.get(hint_id)
             rpos = hint_id_to_reduction_ranges_pos.get(hint_id)
+
             op_tiled_dims.append([opos] if opos is not None else [])
             op_tiled_reduction_dims.append([rpos] if rpos is not None else [])
             # _divide_ranges with tiled_dims=[] is a no-op.
@@ -2225,8 +2504,6 @@ def _divide_ranges(
     _clear_cache(op, _COMPUTED_BUF_FREE_SYMS_KEY)
 
     # Sync layout.size, layout.stride, and layout.device_layout with the new ranges.
-    from torch._inductor.ir import FixedLayout, FlexibleLayout
-
     layout = getattr(op, "layout", None)
     if not (isinstance(layout, FixedLayout) and len(layout.size) == len(ranges)):
         return None

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -1165,17 +1165,16 @@ def _propagate_tiled_op(
     if not outside_consumers and not is_graph_output:
         # Loop-internal: the buffer is a per-tile scratch region reused every
         # iteration.  Mark it so the unroller does not advance its base address.
-        from .ir import FixedTiledLayout
-
         if isinstance(op.layout, FixedTiledLayout):
+            # Post-stickify (span-overflow path): layout is already FixedTiledLayout.
             op.layout.per_tile_fixed = True
         else:
-            # Pre-stickify: layout is FixedLayout.  Defer to finalize_layouts
-            # which sees the committed FixedTiledLayout and can set the flag then.
+            # Pre-stickify (hint path): layout is FixedLayout.  Defer to
+            # finalize_layouts which sees the committed FixedTiledLayout and can
+            # set the flag then.  MutationLayoutSHOULDREMOVE only appears in
+            # the post-stickify span-overflow path and is handled by the branch
+            # above (it would not reach this else).
             op._pending_per_tile_fixed = True  # type: ignore[attr-defined]
-        # Non-FixedTiledLayout buffers (e.g. MutationLayoutSHOULDREMOVE from a
-        # prior pass) are intentionally left unmarked — their addressing is
-        # handled by the layout type itself, not by the unroller.
         return
 
     # Reconstruct the original (pre-division) ranges.
@@ -1324,10 +1323,7 @@ def _allocate_full_buffer(
     insert_at_idx, and returns the new ComputedBuffer.
     """
     from torch._inductor.ir import FixedLayout  # deferred: avoids circular import
-    from .ir import (
-        FixedTiledLayout,
-        SpyreEmptyFallback,
-    )  # deferred: avoids circular import
+    from .ir import SpyreEmptyFallback  # deferred: avoids circular import
 
     graph_lowering = V.graph
     fx_graph = graph_lowering.graph
@@ -1679,10 +1675,15 @@ def _propagate_tiled_reduction_op(
         accum_tile = _allocate_full_buffer(
             op, per_tile_ranges, operations, group_start_idx_after_full
         )
-        from .ir import FixedTiledLayout
-
         if isinstance(accum_tile.layout, FixedTiledLayout):
+            # Post-stickify (span-overflow path): set directly.
             accum_tile.layout.per_tile_fixed = True
+        else:
+            # Pre-stickify (hint path): layout is FixedLayout; defer to
+            # finalize_layouts.  In the span-overflow path this branch is
+            # unreachable because _allocate_full_buffer returns FixedTiledLayout
+            # when the original layout is already FixedTiledLayout.
+            accum_tile._pending_per_tile_fixed = True  # type: ignore[attr-defined]
         fill_target = accum_tile
         combine_target = accum_tile
     else:
@@ -1703,10 +1704,7 @@ def _propagate_tiled_reduction_op(
     # redundant but harmless.
     dtype = op.get_dtype()
     device = op.get_device()
-    from .ir import (
-        FixedTiledLayout,
-        SpyreConstantFallback,
-    )  # deferred: avoids circular import
+    from .ir import SpyreConstantFallback  # deferred: avoids circular import
 
     scalar_op = SpyreConstantFallback(
         torch.ops.spyre.constant.default, float(identity), dtype, device
@@ -2228,8 +2226,6 @@ def _divide_ranges(
 
     # Sync layout.size, layout.stride, and layout.device_layout with the new ranges.
     from torch._inductor.ir import FixedLayout, FlexibleLayout
-
-    from .ir import FixedTiledLayout
 
     layout = getattr(op, "layout", None)
     if not (isinstance(layout, FixedLayout) and len(layout.size) == len(ranges)):

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -58,10 +58,12 @@ import torch
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.ops_handler import WrapperHandler
 from torch._inductor.graph import GraphLowering
+from torch._inductor.utils import sympy_subs
 from torch._inductor.ir import (
     ComputedBuffer,
     FixedLayout,
     FlexibleLayout,
+    IRNode,
     Layout,
     Loops,
     MutationLayoutSHOULDREMOVE,
@@ -1155,6 +1157,20 @@ def _propagate_tiled_op(
 ) -> None:
     """Handle buffer propagation for a single tiled Pointwise or Reduction op."""
     loop_info = getattr(op, "loop_info", None)
+
+    # A tiled op — Pointwise or Reduction, loop-internal or not — may read a
+    # full-size SpyreEmptyFallback buffer directly (e.g. an accumulator
+    # produced by an earlier Case 1/2 rewrite).  That buffer has exactly one
+    # candidate layout, sized to the full buffer, while this op's own
+    # candidates are sized to its tile — the two can never be stick-compatible.
+    # Insert a tile-sized read view for each such input before doing anything
+    # else (mirrors the write-side _insert_copy_op fix, but on the read side).
+    # This must run before the Reduction/has_tiled_reduction branch below,
+    # since _propagate_tiled_reduction_op never touches op's own reads.
+    full_deps = _full_buffer_read_deps(op)
+    if full_deps:
+        op = _insert_read_view_ops(op, full_deps, operations)
+
     if isinstance(op.data, Reduction):
         _validate_reduction_tiling(op)
         has_tiled_reduction = loop_info is not None and any(
@@ -1208,14 +1224,25 @@ def _propagate_tiled_op(
     full_buf = _allocate_full_buffer(op, full_ranges, operations, group_start_idx)
 
     has_inside = _has_inside_consumers(buf_name, loop_group_id, operations)
+    multi_input = _num_real_inputs(op) > 1
 
-    if has_inside:
+    if has_inside or multi_input:
         # Case 1: keep tiled op writing to small buffer; insert copy op.
+        # Multi-input ops must take this path even with no inside consumers:
+        # the tiled op's other real inputs are themselves tile-sized
+        # loop-internal ops whose own stick layout can never be made
+        # compatible with a full-size output under AllSameNode's
+        # stick-compatibility rule. Routing through _insert_copy_op keeps
+        # the tiled op self-consistent (own tile-sized layout, own
+        # tile-sized real inputs) and reuses the copy op's proven
+        # single-real-input path (the copy fuses the tiled op's own
+        # upstream computation via make_loader()).
         _insert_copy_op(op, full_buf, operations)
     else:
-        # Case 2: tiled op has no inside consumers — rewire it to write directly
-        # into the full-size buffer.  Note: MutationLayoutSHOULDREMOVE is
-        # incompatible with lx_planning (scratchpad); do not combine the two.
+        # Case 2: single real input, no inside consumers — rewire it to
+        # write directly into the full-size buffer.  Note:
+        # MutationLayoutSHOULDREMOVE is incompatible with lx_planning
+        # (scratchpad); do not combine the two.
         op.layout = MutationLayoutSHOULDREMOVE(TensorBox(StorageBox(full_buf)))
 
     # Patch outside consumers and graph outputs to read full_buf.
@@ -1228,7 +1255,7 @@ def _propagate_tiled_op(
         "coarse_tile: propagated %s → %s (case %s)",
         buf_name,
         full_name,
-        "1 (copy)" if has_inside else "2 (mutation)",
+        "1 (copy)" if (has_inside or multi_input) else "2 (mutation)",
     )
 
 
@@ -1292,6 +1319,33 @@ def _has_inside_consumers(
         if _reads_buffer(op, buf_name):
             return True
     return False
+
+
+def _num_real_inputs(op: ComputedBuffer) -> int:
+    """Count op's MemoryDep reads that are not SpyreConstantFallback buffers."""
+    reads = [d for d in op.get_read_writes().reads if isinstance(d, MemoryDep)]
+    return sum(
+        1
+        for d in reads
+        if not isinstance(V.graph.get_buffer(d.name), SpyreConstantFallback)
+    )
+
+
+def _full_buffer_read_deps(op: ComputedBuffer) -> list[MemoryDep]:
+    """Return op's MemoryDep reads that target a full-size SpyreEmptyFallback buffer.
+
+    A loop-internal op (own tile-sized layout) that reads one of these
+    directly can never be made stick-compatible with it: the
+    SpyreEmptyFallback target has exactly one candidate layout, sized to the
+    full buffer, while the op's own candidates are sized to its tile.  See
+    _insert_read_view_ops.
+    """
+    from .ir import SpyreEmptyFallback  # deferred: avoids circular import
+
+    reads = [d for d in op.get_read_writes().reads if isinstance(d, MemoryDep)]
+    return [
+        d for d in reads if isinstance(V.graph.get_buffer(d.name), SpyreEmptyFallback)
+    ]
 
 
 def _graph_output_names() -> set[str]:
@@ -1481,6 +1535,127 @@ def _insert_copy_op(
 
     tiled_idx = operations.index(tiled_op)
     operations.insert(tiled_idx + 1, copy_buf)
+
+
+class _NameSwapHandler(WrapperHandler):
+    """Redirect ops.load(name, index) calls for names present in name_map.
+
+    See NameSwapHandler in insert_restickify.py — same pattern (CLAUDE.md
+    "Compiler Pass Conventions": wrap inner_fn via a WrapperHandler, never
+    reconstruct it from index expressions). Duplicated locally rather than
+    imported to avoid a coarse_tile <-> insert_restickify import-order
+    dependency; the two run at different, non-adjacent pipeline stages.
+    """
+
+    def __init__(self, inner, name_map: dict[str, str]):
+        super().__init__(inner)
+        self._name_map = name_map
+
+    def load(self, name, index):
+        return super().load(self._name_map.get(name, name), index)
+
+
+def _insert_read_view_ops(
+    tiled_op: ComputedBuffer,
+    full_deps: list[MemoryDep],
+    operations: list[Operation],
+) -> ComputedBuffer:
+    """Insert, before tiled_op, one tile-sized view op per full-size real input.
+
+    tiled_op is loop-internal (no outside consumers) but reads one or more
+    full-size SpyreEmptyFallback buffers directly. Those buffers get exactly
+    one candidate layout (sized to the full buffer), while tiled_op's own
+    candidates are sized to its tile — the two can never be stick-compatible
+    under AllSameNode.  Mirroring _insert_copy_op's write-side fix: for each
+    such input, insert a small Pointwise "view" op that reads the full
+    buffer's current tile slice (same index expression tiled_op already
+    uses, same loop_info so the per-iteration base address advances
+    identically) and writes it into a fresh tile-sized buffer.  tiled_op's
+    own inner_fn is then patched (WrapperHandler, not reconstructed — see
+    _NameSwapHandler) to read the view instead of the full buffer.
+
+    The view's own ranges/index must match dep (dep.var_names/dep.size), not
+    tiled_op.data.ranges: for a Reduction, the read spans output dims plus
+    the reduction dim, so dep's iteration space has more vars than the op's
+    own output-shaped ranges.  The view's layout reuses full_buf's own
+    per-var strides (extracted from dep.index, which is affine in
+    dep.var_names) rather than fresh contiguous strides, sized down to
+    dep.size — so tiled_op's unmodified read index (dep.index, computed
+    against those same strides) still resolves correctly once _NameSwapHandler
+    retargets the load at the view buffer instead of full_buf.
+
+    Returns the reconstructed ComputedBuffer that replaces tiled_op in
+    operations (see replace_computed_buffer_body below) — callers must
+    rebind their own reference since the original tiled_op object is stale
+    after this call.
+    """
+    name_map: dict[str, str] = {}
+    tiled_idx = operations.index(tiled_op)
+
+    for dep in full_deps:
+        full_buf = V.graph.get_buffer(dep.name)
+
+        tile_ranges = list(dep.size)
+        tile_strides = [dep.index.coeff(v) for v in dep.var_names]
+
+        def _view_inner_fn(idx, _dep=dep, _full_name=full_buf.get_name()):
+            subs = dict(zip(_dep.var_names, idx))
+            flat_index = sympy_subs(_dep.index, subs)
+            return V.ops.load(_full_name, flat_index)
+
+        # Construct under tiled_op's origins so data.origins is non-empty —
+        # _single_arg_op_layout (propagate_layouts.py) unconditionally
+        # dereferences next(iter(data.origins)) for ordinary (non-mutation)
+        # Pointwise ops.  IRNode.origins is populated at construction time
+        # from IRNode._current_origins, so it must be set via this context
+        # manager rather than assigned after the fact (assigning
+        # view_buf.origins below only sets the ComputedBuffer's own origins,
+        # not view_data's).
+        with IRNode.current_origins(tiled_op.origins):
+            view_data = Pointwise(
+                device=tiled_op.get_device(),
+                dtype=full_buf.get_dtype(),
+                inner_fn=_view_inner_fn,
+                ranges=tile_ranges,
+            )
+        view_name = V.graph.qualify_name(
+            f"coarse_tile_read_view_{tiled_op.get_name()}_{dep.name}"
+        )
+        view_layout = FixedLayout(
+            tiled_op.get_device(),
+            full_buf.get_dtype(),
+            tile_ranges,
+            tile_strides,
+        )
+        view_buf = ComputedBuffer(name=view_name, layout=view_layout, data=view_data)
+        view_buf.origins = tiled_op.origins
+        view_buf.operation_name = view_name
+        view_buf.loop_info = tiled_op.loop_info  # type: ignore[attr-defined]
+
+        V.graph.name_to_buffer[view_name] = view_buf
+        operations.insert(tiled_idx, view_buf)
+        tiled_idx += 1
+
+        name_map[dep.name] = view_name
+
+    # Patch tiled_op's inner_fn once with the full name_map (wrap, not
+    # reconstruct — see _NameSwapHandler docstring).  Rebuild via
+    # replace_computed_buffer_body, matching every other inner_fn-rewrite
+    # site in this file (_patch_consumers, _patch_retiled_load_indexes,
+    # _apply_fill_name_swap): a fresh ComputedBuffer has no stale per-object
+    # caches, sidestepping the need to enumerate every cache key by hand.
+    from .pass_utils import replace_computed_buffer_body
+
+    orig_inner = tiled_op.data.inner_fn
+
+    def new_inner_fn(*args, _map=name_map, _orig_inner=orig_inner):
+        with V.set_ops_handler(_NameSwapHandler(V.ops, _map)):
+            return _orig_inner(*args)
+
+    object.__setattr__(tiled_op.data, "inner_fn", new_inner_fn)
+    new_op = replace_computed_buffer_body(tiled_op, tiled_op.data, operations)
+    V.graph.name_to_buffer[new_op.get_name()] = new_op
+    return new_op
 
 
 # ---------------------------------------------------------------------------
@@ -1985,8 +2160,14 @@ def _patch_retiled_load_indexes(
 
     from .pass_utils import replace_computed_buffer_body
 
+    # Only ops that were already in the group when _stamp_group ran can hold a
+    # stale (pre-divide) coefficient for a retiled buffer.  Ops inserted later
+    # by insert_tiling_propagation (e.g. _insert_copy_op's copy_buf) read the
+    # retiled buffer's already-updated layout directly, so rewriting them here
+    # would double-apply the stride correction (see issue found while fixing
+    # test_hint_restickify_stays_in_group).
     retiled_names = set(rewrites_by_name)
-    for op in list(operations):
+    for op in list(group_ops):
         if not _should_patch_retiled_load_indexes(op, group_id, retiled_names):
             continue
 

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -1152,13 +1152,8 @@ def _propagate_tiled_op(
         buf_name, loop_group_id, operations
     )
 
-    # If no dims were tiled (loop_tiled_dims all empty), the op is loop-invariant —
-    # mark per_tile_fixed so the unroller reuses the same address each tile.
+    # If no dims were tiled (loop_tiled_dims all empty), the op is loop-invariant.
     if all(not dims for dims in loop_info.loop_tiled_dims):
-        from .ir import FixedTiledLayout
-
-        if isinstance(op.layout, FixedTiledLayout):
-            op.layout.per_tile_fixed = True
         return
 
     if not outside_consumers and not is_graph_output:

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -1686,9 +1686,11 @@ def _propagate_tiled_reduction_op(
     # Insert fill op immediately after the fill target buffer allocation
     # (outside the loop for flat, inside the outer loop for nested).
     # Use a SpyreConstantFallback scalar as the fill source so that Spyre's
-    # kernel codegen can express this as an IDENTITY_OP broadcast.  We must
-    # assign a FixedTiledLayout manually here because finalize_layouts has
-    # already run when this pass executes.
+    # kernel codegen can express this as an IDENTITY_OP broadcast.  For the
+    # span-overflow path, finalize_layouts has already run so we must assign a
+    # FixedTiledLayout manually here.  For the hint path (pre-stickify),
+    # stickification will overwrite the layout; the manual assignment is
+    # redundant but harmless.
     dtype = op.get_dtype()
     device = op.get_device()
     from .ir import (
@@ -1741,14 +1743,19 @@ def _propagate_tiled_reduction_op(
             op, accum_tile, accum_full, fill_loop_info, operations
         )
 
-    # Mark tiled op's output as per-tile scratch (no address advance).
-    if not isinstance(op.layout, FixedTiledLayout):
-        raise RuntimeError(
-            f"coarse_tile: tiled reduction op {op.get_name()!r} has layout "
-            f"{type(op.layout).__name__}, expected FixedTiledLayout; "
-            "cannot mark per_tile_fixed"
-        )
-    op.layout.per_tile_fixed = True
+    # Mark the tiled reduction op's per-tile scratch as stationary.
+    # Pre-stickify: op.layout is FixedLayout; per_tile_fixed will be set by
+    # finalize_layouts (which inspects CoarseTileInfo) once stickification runs.
+    # Post-stickify (span-overflow path): op.layout is already FixedTiledLayout.
+    if isinstance(op.layout, FixedTiledLayout):
+        op.layout.per_tile_fixed = True
+
+    # Record the accumulation buffer name so finalize_layouts can propagate
+    # the reduction op's post-stickify device layout to accum_full.  Pre-stickify,
+    # accum_full gets a generic STL from propagate_spyre_tensor_layouts; we must
+    # overwrite it with the actual reduction output STL so fill, combine, and copy
+    # all agree on the device coordinate system.
+    op._tiled_reduction_accum_name = accum_full.get_name()  # type: ignore[attr-defined]
 
     # Patch consumers to read accum_full (the fully-assembled output).
     buf_name = op.get_name()

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -336,12 +336,28 @@ def _hint_key(op: Operation) -> frozenset | None:
     return frozenset(h.hint_id for h in hints) if hints else None
 
 
-def _written_names(op: ComputedBuffer) -> set[str]:
+def _is_movable_interloper(op: Operation) -> bool:
+    """True if op is eligible to be relocated by reorder_unhinted_interlopers.
+
+    Either an unhinted ComputedBuffer, or a seed-allocator fallback
+    (SpyreConstantFallback/SpyreEmptyFallback) — a one-time scalar/buffer
+    materialization with no per-iteration significance. A general
+    FallbackKernel is deliberately excluded: it may carry real data-flow
+    side effects (see reorder_unhinted_interlopers's docstring), so it is
+    not safe to relocate on the strength of get_read_names()/
+    get_mutation_names() alone.
+    """
+    from .ir import SpyreEmptyFallback  # deferred: avoids circular import
+
+    return isinstance(op, (ComputedBuffer, SpyreConstantFallback, SpyreEmptyFallback))
+
+
+def _written_names(op: Operation) -> set[str]:
     """Return all buffer names written by op: its output plus any mutation targets."""
     return {op.get_name()} | set(op.get_mutation_names())
 
 
-def _no_dep_conflict(op: ComputedBuffer, others: list[Operation]) -> bool:
+def _no_dep_conflict(op: Operation, others: list[Operation]) -> bool:
     """Return True if moving op past every op in others introduces no data-flow hazard.
 
     A conflict exists if any op in others reads or mutates a buffer written by op,
@@ -375,10 +391,9 @@ def _can_move_before(
 
     Legal iff no data-flow conflict exists between op and ops[start..end-1].
     """
-    # Defensive: _no_dep_conflict requires a ComputedBuffer; the sole caller
-    # (reorder_unhinted_interlopers) already filters for this, but guard here
-    # in case the function is called from a future context.
-    if not isinstance(op, ComputedBuffer):
+    # Defensive: the sole caller (reorder_unhinted_interlopers) already
+    # filters for this, but guard here in case of a future context.
+    if not _is_movable_interloper(op):
         return False
     return _no_dep_conflict(op, ops[start:end])
 
@@ -394,7 +409,7 @@ def _can_move_after(
     Legal iff no data-flow conflict exists between op and ops[start+1..end-1].
     """
     # Defensive: same rationale as _can_move_before.
-    if not isinstance(op, ComputedBuffer):
+    if not _is_movable_interloper(op):
         return False
     return _no_dep_conflict(op, ops[start + 1 : end])
 
@@ -415,8 +430,15 @@ def reorder_unhinted_interlopers(graph: GraphLowering) -> None:
     Inner cursor j: walks forward from i+1 building the run.  For each
     op at ops[j]:
       - Same hint key → absorb into run; j += 1.
-      - Non-ComputedBuffer or differently-hinted → hard stop; break.
-      - Unhinted ComputedBuffer (interloper) → one of three outcomes:
+      - Unhinted ComputedBuffer, or a seed-allocator fallback
+        (SpyreConstantFallback/SpyreEmptyFallback — one-time scalar/buffer
+        materialization with no per-iteration significance, e.g. the
+        torch.zeros(...) that seeds an online-softmax recurrence) →
+        interloper; try to relocate (see below).
+      - Any other non-ComputedBuffer op (e.g. a general FallbackKernel,
+        which may carry real data-flow side effects) or differently-hinted
+        op → hard stop; break.
+      - Interloper → one of three outcomes:
           (a) Move before: insert at run_start, run_start += 1, j stays
               (the rotate shifts subsequent ops left so ops[j] is fresh).
           (b) Move after: pop(j), insert at run_end-1, j stays.
@@ -460,9 +482,10 @@ def reorder_unhinted_interlopers(graph: GraphLowering) -> None:
             if ckey == key:
                 j += 1
                 continue
-            if not isinstance(candidate, ComputedBuffer) or ckey is not None:
+            if not _is_movable_interloper(candidate) or ckey is not None:
                 break
-            # candidate is an unhinted ComputedBuffer interloper.
+            # candidate is an unhinted ComputedBuffer, or a seed-allocator
+            # fallback, interrupting the run.
             # Scan backward for the last same-key op; run_end is one past it.
             # O(n) per interloper → O(n²) overall; acceptable for small graphs.
             run_end = None
@@ -1096,13 +1119,36 @@ def insert_tiling_propagation(
     In both cases the existing tiled_symbols / affine.apply machinery in
     SpyreKernel and bundle.py handles the per-iteration address offset.
     """
+    # A carry dispatch (see _propagate_tiled_op's loop-invariant branch) fully
+    # rewrites its terminal op as a side effect of processing the entry op —
+    # e.g. processing buf13 (entry) also rewires buf17 (terminal) to own
+    # accum_tile's storage and redirects buf17's outside consumers to
+    # accum_full. buf17 is itself a later member of group_ops and would
+    # otherwise be visited again at its own position, re-running Case 1/2
+    # logic on top of the already-correct carry rewrite and clobbering it
+    # (e.g. re-patching outside consumers to a second, wrong full buffer).
+    # Track terminal names claimed by a carry dispatch and skip them here.
+    carry_terminal_names: set[str] = set()
     for group_ops, _ in groups:
-        for op in group_ops:
+        for idx, op in enumerate(group_ops):
             if not isinstance(op, ComputedBuffer):
                 continue
             if not isinstance(op.data, (Pointwise, Reduction)):
                 continue
-            _propagate_tiled_op(op, operations)
+            if op.get_name() in carry_terminal_names:
+                continue
+            _propagate_tiled_op(op, operations, carry_terminal_names)
+            # _propagate_tiled_op (and the Case 1/2/carry rewrites it may
+            # delegate to) can replace op with a new ComputedBuffer object
+            # spliced into `operations` under the same name (see
+            # replace_computed_buffer_body).  group_ops is a separate list
+            # snapshotted before this loop runs, so it must be kept in sync
+            # here — otherwise a later pass reading group_ops (e.g.
+            # _patch_retiled_load_indexes) sees the stale pre-rewrite object
+            # and clobbers the rewrite when it reconstructs from it.
+            current = V.graph.name_to_buffer.get(op.get_name())
+            if current is not None and current is not op:
+                group_ops[idx] = current
 
 
 def _validate_reduction_tiling(op: ComputedBuffer) -> None:
@@ -1154,8 +1200,15 @@ def _validate_reduction_tiling(op: ComputedBuffer) -> None:
 def _propagate_tiled_op(
     op: ComputedBuffer,
     operations: list[Operation],
+    carry_terminal_names: set[str] | None = None,
 ) -> None:
-    """Handle buffer propagation for a single tiled Pointwise or Reduction op."""
+    """Handle buffer propagation for a single tiled Pointwise or Reduction op.
+
+    carry_terminal_names, when provided, is populated with the name of any
+    op's carry terminal_op found during dispatch — see the comment in
+    insert_tiling_propagation's driver loop for why the driver must not
+    re-process an op already claimed this way.
+    """
     loop_info = getattr(op, "loop_info", None)
 
     # A tiled op — Pointwise or Reduction, loop-internal or not — may read a
@@ -1188,6 +1241,50 @@ def _propagate_tiled_op(
     outside_consumers, is_graph_output = _find_outside_consumers(
         buf_name, loop_group_id, operations
     )
+
+    # A Pointwise op that is loop-invariant at the group's reduction-tiled
+    # level(s) may be an online-softmax-style sequential carry (running max,
+    # rescale-accumulate) even though it is genuinely tiled at other, outer,
+    # non-reduction levels (e.g. H) — check that shape first.
+    if _is_loop_invariant_at_reduction_levels_stamped(op, loop_group_id, operations):
+        seed_buf = _seed_buffer_for_carry(op, loop_group_id, operations)
+        if seed_buf is not None:
+            # op reads the seed directly, but the traced Python's actual
+            # recurrence value may be one or more ops further downstream
+            # (e.g. `denominator = denominator * correction +
+            # exp_scores.sum(...)` — op is the multiply, the add is the
+            # real per-iteration carry value). Find that terminal op before
+            # computing outside_consumers/is_graph_output and dispatching:
+            # those must describe the terminal value, not op's own
+            # (possibly partial) one, since the terminal op — not op — is
+            # what accum_tile must hold and what outside readers/graph
+            # outputs actually mean by the recurrence variable.
+            terminal_op = _carry_terminal_op(
+                op, seed_buf.get_name(), loop_group_id, operations
+            )
+            if terminal_op is not None:
+                terminal_name = terminal_op.get_name()
+                terminal_outside_consumers, terminal_is_graph_output = (
+                    _find_outside_consumers(terminal_name, loop_group_id, operations)
+                )
+                _propagate_carry_op(
+                    op,
+                    terminal_op,
+                    seed_buf,
+                    terminal_outside_consumers,
+                    terminal_is_graph_output,
+                    operations,
+                )
+                # terminal_op (e.g. buf17) is fully rewired above as a side
+                # effect of processing op (e.g. buf13/entry_op) — it must not
+                # be independently re-processed when the driver later reaches
+                # its own position in group_ops (see insert_tiling_propagation).
+                if carry_terminal_names is not None:
+                    carry_terminal_names.add(terminal_name)
+                return
+        # Not a carry (e.g. a genuinely shared read-only broadcast input at
+        # the reduction level) — fall through to the loop-invariant/Case 1/2
+        # logic below using the op's actual loop_tiled_dims.
 
     # If no dims were tiled (loop_tiled_dims all empty), the op is loop-invariant.
     if all(not dims for dims in loop_info.loop_tiled_dims):
@@ -1350,6 +1447,644 @@ def _has_loop_internal_real_input(
         if li is not None and li.loop_group_id[0] == outer_key:
             return True
     return False
+
+
+def _op_hint_dim_positions(op: ComputedBuffer, hint_id: int) -> tuple[bool, bool]:
+    """Return (has_output_pos, has_reduction_pos) for op at the given hint_id.
+
+    has_output_pos: op's own output ranges contain a dim driven by this hint.
+    has_reduction_pos: op is a Reduction whose reduction_ranges contain a dim
+    driven by this hint.  Mirrors the lookup _stamp_group performs per op.
+    """
+    dim_hint = next(
+        (h for h in getattr(op, "dim_hints", []) if h.hint_id == hint_id), None
+    )
+    if dim_hint is None or dim_hint.loop_var is None:
+        return False, False
+    if dim_hint.is_reduction:
+        if not isinstance(op.data, Reduction):
+            return False, False
+        pos = _loop_var_to_reduction_ranges_pos(op, dim_hint.loop_var)
+        return False, pos is not None
+    op_out = op_out_coords(op)
+    pos = _loop_var_to_ranges_pos(op_out, dim_hint.loop_var)
+    return pos is not None, False
+
+
+def _group_reduction_tiled_hint_ids(
+    group_ops: list[Operation], levels: list[tuple]
+) -> set[int]:
+    """Return hint_ids among ``levels`` that tile a reduction dim for some
+    Reduction op in group_ops."""
+    reduction_hint_ids: set[int] = set()
+    for hint_id, _count in levels:
+        for op in group_ops:
+            if not isinstance(op, ComputedBuffer) or not isinstance(op.data, Reduction):
+                continue
+            _, has_reduction_pos = _op_hint_dim_positions(op, hint_id)
+            if has_reduction_pos:
+                reduction_hint_ids.add(hint_id)
+                break
+    return reduction_hint_ids
+
+
+def _is_loop_invariant_at_reduction_levels(
+    op: ComputedBuffer, group_ops: list[Operation], levels: list[tuple]
+) -> bool:
+    """True if op is a Pointwise that is loop-invariant at every hint level
+    where the group tiles a Reduction's reduction dim, regardless of whether
+    op is tiled at other (non-reduction) levels.
+
+    This is the carry-candidate shape test: an online-softmax recurrence op
+    (running max, rescale-accumulate) is tiled at outer output-dim levels
+    (e.g. H, a real dim of its own output) exactly like any other op in the
+    group, but is invariant in shape at the inner reduction-tiled level
+    (e.g. Lk) because that dim never appears in its own output — the same
+    surface _stamp_group already computes per op, consulted here from
+    dim_hints directly so this works both before and after _stamp_group has
+    run (needed because _replace_constant_fill_predecessors runs first).
+    """
+    if not isinstance(op.data, Pointwise):
+        return False
+    reduction_hint_ids = _group_reduction_tiled_hint_ids(group_ops, levels)
+    if not reduction_hint_ids:
+        return False
+    for hint_id in reduction_hint_ids:
+        has_output_pos, _ = _op_hint_dim_positions(op, hint_id)
+        if has_output_pos:
+            return False
+    return True
+
+
+def _group_reduction_tiled_levels(
+    loop_group_id: tuple, operations: list[Operation]
+) -> set[int]:
+    """Post-stamp equivalent of _group_reduction_tiled_hint_ids: level indices
+    (positions into loop_tiled_dims/loop_tiled_reduction_dims) where some
+    Reduction op in the same outer loop group has a non-empty
+    loop_tiled_reduction_dims entry.  Used by _propagate_tiled_op, which runs
+    after _stamp_group and only has the flat operations list, not group_ops.
+    """
+    outer_key = loop_group_id[0]
+    levels: set[int] = set()
+    for o in operations:
+        if not isinstance(o, ComputedBuffer) or not isinstance(o.data, Reduction):
+            continue
+        li = getattr(o, "loop_info", None)
+        if li is None or li.loop_group_id[0] != outer_key:
+            continue
+        for i, rdims in enumerate(li.loop_tiled_reduction_dims):
+            if rdims:
+                levels.add(i)
+    return levels
+
+
+def _is_loop_invariant_at_reduction_levels_stamped(
+    op: ComputedBuffer, loop_group_id: tuple, operations: list[Operation]
+) -> bool:
+    """Post-stamp equivalent of _is_loop_invariant_at_reduction_levels, using
+    already-stamped loop_info instead of raw dim_hints."""
+    loop_info = getattr(op, "loop_info", None)
+    if loop_info is None or not isinstance(op.data, Pointwise):
+        return False
+    levels = _group_reduction_tiled_levels(loop_group_id, operations)
+    if not levels:
+        return False
+    return all(not loop_info.loop_tiled_dims[i] for i in levels)
+
+
+def _op_reads(op: ComputedBuffer) -> set[str]:
+    """Return the set of buffer names op reads (via MemoryDep)."""
+    return {d.name for d in op.get_read_writes().reads if isinstance(d, MemoryDep)}
+
+
+def _seed_closure(
+    seed_name: str, loop_group_id: tuple, operations: list[Operation]
+) -> set[str]:
+    """Return the closure of seed_name within its outer loop group.
+
+    The closure is every op in the same outer loop group that reads
+    seed_name *directly* — e.g. both `max_running = maximum(M, block_max)`
+    and `correction = exp(M - max_running)` read `M` directly, so both are
+    in `M`'s closure. This is intentionally NOT transitive: an op that reads
+    a closure member but not the seed itself (e.g.
+    `denominator = denominator * correction + ...`, which reads `correction`
+    but not `M`) is an ordinary downstream consumer, not part of the seed's
+    closure — including it would pull in the whole downstream dependency
+    cone, which is a different (much larger, wrong) set.
+
+    Restricted to ops stamped with loop_info in the same outer group
+    (post-_stamp_group; see _seed_closure_pre_stamp for the pre-stamp
+    equivalent used by _replace_constant_fill_predecessors).
+    """
+    outer_key = loop_group_id[0]
+    closure: set[str] = set()
+    for o in operations:
+        if not isinstance(o, ComputedBuffer):
+            continue
+        li = getattr(o, "loop_info", None)
+        if li is None or li.loop_group_id[0] != outer_key:
+            continue
+        if seed_name in _op_reads(o):
+            closure.add(o.get_name())
+    return closure
+
+
+def _closure_member_has_external_operands_only(
+    op_name: str,
+    seed_name: str,
+    closure: set[str],
+    operations: list[Operation],
+) -> bool:
+    """True if op_name's non-seed read operands are all outside closure.
+
+    This is the carry-producing member test: a true recurrence-update step
+    combines the previous carry value (the seed) with fresh, externally
+    derived per-iteration data. A step that combines the seed with an
+    already-computed sibling closure member is downstream of the actual
+    update, not the update itself (e.g. `correction = exp(M - max_running)`
+    reads `max_running`, a closure member, so it is excluded even though it
+    also reads the seed `M` directly).
+    """
+    op = V.graph.name_to_buffer.get(op_name)
+    if op is None:
+        return False
+    non_seed_reads = _op_reads(op) - {seed_name}
+    return not (non_seed_reads & closure)
+
+
+def _seed_buffer_for_carry(
+    op: ComputedBuffer,
+    loop_group_id: tuple,
+    operations: list[Operation],
+) -> ComputedBuffer | None:
+    """Return the pre-loop seed buffer op carries state through, or None.
+
+    A Pointwise op that is loop-invariant at the group's reduction-tiled
+    level(s) may be the carry-producing step of an online-softmax-style
+    recurrence (running max, rescale-accumulate) rather than an ordinary
+    broadcast/hoisted computation. Detection is closure-based rather than
+    classifying op in isolation, because the seed's closure (the set of ops
+    that read it, directly or transitively, without leaving the loop group)
+    may have more than one member — see _seed_closure — and no single op's
+    own consumer count or escape-the-loop status reliably identifies "the"
+    carry (that correspondence to the traced Python's recurrence-variable
+    rebinding is not recoverable from any one op in isolation):
+
+      1. op must read exactly one pre-loop seed buffer directly (a constant
+         fill — see _is_constant_fill — whose own reads all resolve to a
+         SpyreConstantFallback scalar; torch.full/torch.zeros/
+         torch.zeros_like lower to such a Pointwise wrapper. The seed may
+         or may not have a stamped in-group loop_group_id, depending on
+         whether its Python-source declaration sits inside or outside the
+         tiled scope — that placement does not affect its seed status).
+      2. op must be a member of that seed's closure (trivially true, since
+         op reads the seed directly).
+      3. op must be the *unique* closure member whose non-seed operands are
+         all external to the closure (_closure_member_has_external_operands_only).
+         If zero or more than one closure member satisfies this, return None
+         rather than guessing — this is a known, accepted limitation for
+         closures with more than one externally-fed member (not hit by any
+         current test).
+
+    Caller (_propagate_tiled_op) is responsible for the shape gate
+    (_is_loop_invariant_at_reduction_levels_stamped); this function only
+    checks the seed-buffer data-flow shape.
+    """
+    if not isinstance(op.data, Pointwise):
+        return None
+
+    seed_candidates = []
+    for name in _op_reads(op):
+        buf = V.graph.get_buffer(name)
+        if not isinstance(buf, ComputedBuffer) or not _is_constant_fill(buf):
+            continue
+        # _is_constant_fill already requires every read of buf to come from
+        # a SpyreConstantFallback scalar — an op with real in-group operands
+        # can never satisfy it, so no additional loop_group_id check is
+        # needed to exclude "produced inside the loop" buffers. A seed can
+        # legitimately carry a stamped in-group loop_group_id (e.g. when its
+        # Python-source declaration sits inside the tiled scope).
+        seed_candidates.append(buf)
+
+    if len(seed_candidates) != 1:
+        return None
+    seed_buf = seed_candidates[0]
+    seed_name = seed_buf.get_name()
+
+    closure = _seed_closure(seed_name, loop_group_id, operations)
+    if op.get_name() not in closure:
+        return None
+
+    external_candidates = [
+        name
+        for name in closure
+        if _closure_member_has_external_operands_only(
+            name, seed_name, closure, operations
+        )
+    ]
+    if len(external_candidates) != 1:
+        return None
+
+    return seed_buf if external_candidates[0] == op.get_name() else None
+
+
+def _carry_terminal_op(
+    entry_op: ComputedBuffer,
+    seed_name: str,
+    loop_group_id: tuple,
+    operations: list[Operation],
+) -> ComputedBuffer | None:
+    """Walk forward from entry_op to the op whose value is the new carry.
+
+    entry_op reads the seed directly (e.g. `denominator * correction`), but
+    the traced Python's recurrence value is often one or more ops further
+    downstream — e.g. `denominator = denominator * correction +
+    exp_scores.sum(...)` chains a second op (the add) that combines
+    entry_op's result with a fresh, externally-derived value. That add has
+    no direct read of the seed, so it is not itself in the seed's closure
+    (_seed_closure is deliberately non-transitive — see its docstring) and
+    _seed_buffer_for_carry never considers it as `op`. Its RESULT, not
+    entry_op's, is what must be written into accum_tile and carried to the
+    next outer-tile iteration / copied out at the end.
+
+    The terminal op is found by following chain-link steps forward from
+    entry_op. At each step, in-group consumers of `current` are filtered
+    down to "chain candidates": Pointwise ops, loop-invariant at the
+    reduction level (same shape family as current), that do NOT themselves
+    read seed_name directly. Consumers failing this filter are downstream
+    USES of current's value, not further links in the update chain, and are
+    simply not followed — current may have any number of them without
+    making the search ambiguous. Examples: `correction = exp(M -
+    max_running)` reads M directly, so it is filtered out as a sibling, not
+    a chain link; `scores - max_running.unsqueeze(-2)` is tiled at the
+    reduction level (unlike max_running itself), so it is filtered out by
+    the shape gate. The walk stops (returning `current`) as soon as zero
+    chain candidates remain. Returns entry_op unchanged if entry_op itself
+    has no chain-candidate consumers (M's case: `max_running = maximum(M,
+    block_max)` is itself the terminal value). Returns None if the chain is
+    ambiguous (a step has more than one chain-candidate consumer) rather
+    than guessing.
+    """
+    outer_key = loop_group_id[0]
+    current = entry_op
+    while True:
+        in_group_consumers = [
+            o
+            for o in operations
+            if isinstance(o, ComputedBuffer)
+            and (li := getattr(o, "loop_info", None)) is not None
+            and li.loop_group_id[0] == outer_key
+            and current.get_name() in _op_reads(o)
+        ]
+        # Consumers that read the seed directly (siblings, e.g. `correction
+        # = exp(M - max_running)`) or that aren't loop-invariant at the
+        # reduction level (e.g. `scores - max_running.unsqueeze(-2)`, tiled
+        # over Lk) are downstream USES of current's value, not further links
+        # in the update chain — current may have any number of these; they
+        # don't make the terminal-op search ambiguous and are simply not
+        # followed.
+        chain_candidates = [
+            o
+            for o in in_group_consumers
+            if seed_name not in _op_reads(o)
+            and isinstance(o.data, Pointwise)
+            and _is_loop_invariant_at_reduction_levels_stamped(
+                o, loop_group_id, operations
+            )
+        ]
+        if not chain_candidates:
+            return current
+        if len(chain_candidates) != 1:
+            return None
+        (current,) = chain_candidates
+
+
+def _propagate_carry_op(
+    entry_op: ComputedBuffer,
+    op: ComputedBuffer,
+    seed_buf: ComputedBuffer,
+    outside_consumers: list[ComputedBuffer],
+    is_graph_output: bool,
+    operations: list[Operation],
+) -> None:
+    """Rewire a sequential-carry chain for correct per-tile carry at the
+    reduction-tiled level, keeping seed_buf as the persistent accumulator.
+
+    entry_op is the seed-closure member that reads seed_buf directly
+    (_seed_buffer_for_carry's result); op is the terminal op of the update
+    chain rooted at entry_op (_carry_terminal_op's result) — the op whose
+    RESULT is the traced Python's actual per-iteration recurrence value.
+    These coincide (entry_op is op) whenever the recurrence update is a
+    single op reading the seed directly (e.g. `max_running = maximum(M,
+    block_max)`); they differ when the update chains a second op onto
+    entry_op's result (e.g. `denominator = denominator * correction +
+    exp_scores.sum(...)` — entry_op is the multiply, op is the add).
+
+    seed_buf (accum_full) already holds the correct identity value and full
+    (pre-outer-tiling) shape from the traced Python (e.g. torch.full(-inf)
+    for a running max) — reused directly, no new full-size allocation.  But
+    op's own buffer is tile-sized at any outer output-dim level (e.g. H) that
+    the group also tiles, so op cannot simply write into seed_buf directly
+    (stick-compatibility: seed_buf's candidate layouts are sized to the full
+    tensor, op's are sized to one outer tile — mirrors why Case 1/2 exist for
+    ordinary tiled ops).  Structure, mirroring
+    _propagate_tiled_reduction_op's nested (outer output-dim + inner
+    reduction-dim) branch:
+
+      1. accum_tile: new per-outer-tile scratch buffer, per_tile_fixed=True,
+         shaped like op's own (already outer-tile-sized) output.
+      2. Copy-in op (outer loop_info only): accum_full's current outer-tile
+         slice -> accum_tile, runs once per outer tile before the inner
+         (reduction-tiled) loop's first iteration.
+      3. entry_op is rewired (via NameSwapHandler) to read accum_tile
+         wherever it read seed_buf — entry_op runs before op in the same
+         inner-loop iteration and nothing mutates accum_tile in between, so
+         it correctly observes the previous iteration's carry value with no
+         snapshot needed. op itself is rewired to write into accum_tile via
+         MutationLayoutSHOULDREMOVE, keeping op's own (inner) loop_info —
+         each inner-loop iteration now reads what the previous inner-loop
+         iteration wrote, the actual carry fix. A no-op rewrite (NameSwapHandler
+         with an empty map) when entry_op is op.
+      4. Copy-out op (outer loop_info only, reusing
+         _insert_reduction_copy_op): accum_tile -> accum_full's current
+         outer-tile slice, runs once per outer tile after the inner loop's
+         last iteration.
+      5. Outside consumers / graph outputs (of op, the terminal value)
+         redirected to accum_full.
+    """
+    from .insert_restickify import NameSwapHandler
+    from .pass_utils import replace_computed_buffer_body
+
+    accum_full = seed_buf
+    op_loop_info = op.loop_info
+    outer_loop_info = _compute_fill_loop_info(op)
+
+    if outer_loop_info is None:
+        # Flat (no outer output-dim tiling above the reduction-tiled level):
+        # op's own buffer already spans the full extent, so it can carry
+        # directly in accum_full with no per-tile scratch needed.
+        op.layout = MutationLayoutSHOULDREMOVE(TensorBox(StorageBox(accum_full)))
+    else:
+        per_tile_ranges = list(op.data.ranges)
+        outer_key = op_loop_info.loop_group_id[0]
+        group_start_idx = next(
+            i
+            for i, o in enumerate(operations)
+            if isinstance(o, ComputedBuffer)
+            and getattr(getattr(o, "loop_info", None), "loop_group_id", (None,))[0]
+            == outer_key
+        )
+        # accum_full may itself be an in-group seed (its Python-source
+        # torch.zeros/torch.full sits inside the tiled scope, so the generic
+        # stamping pass tagged it at the inner (reduction-tiled) level, same
+        # as op). Left alone, it would re-run — and re-initialize the
+        # accumulator — on every inner-loop iteration instead of once per
+        # outer tile. Re-stamp it to the outer level, matching copy_in_buf
+        # below, so it runs exactly once per outer tile before the inner
+        # loop starts. A no-op when accum_full is already hoisted
+        # (loop_info=None outside any group).
+        accum_full_was_in_group = getattr(accum_full, "loop_info", None) is not None
+        if accum_full_was_in_group:
+            accum_full.loop_info = outer_loop_info  # type: ignore[attr-defined]
+        # accum_tile's own allocation (a SpyreEmptyFallback ExternKernel) is
+        # never stamped with loop_info, so — unlike copy_in_buf below — it
+        # must sit before the group starts, at group_start_idx, regardless of
+        # where accum_full sits: interposing an untagged allocation inside
+        # the group's contiguous loop_group_id run breaks scheduler
+        # contiguity (build_loop_scheduler_nodes requires every node sharing
+        # an outer loop_group_id key to be adjacent).
+        accum_tile = _allocate_full_buffer(
+            op, per_tile_ranges, operations, group_start_idx
+        )
+        if isinstance(accum_tile.layout, FixedTiledLayout):
+            accum_tile.layout.per_tile_fixed = True
+        else:
+            accum_tile._pending_per_tile_fixed = True  # type: ignore[attr-defined]
+
+        # If accum_full was itself an in-group member (a real ComputedBuffer
+        # sitting inside the (0,0)-tagged run, not a hoisted SpyreConstantFallback
+        # seed), its position in `operations` must move alongside its new
+        # outer loop_info: _build_loop_group (scheduler.py) groups purely by
+        # positional contiguity of loop_group_id at each depth, so an
+        # outer-only ((0,)-shaped) op left in its ORIGINAL position — inside
+        # the (0,0) run — still splits that run in two, even though the
+        # depth-0 prefix matches. It must sit fully before the run starts,
+        # not merely after its old neighbors.
+        if accum_full_was_in_group:
+            # accum_full's own read-dependencies (e.g. the SpyreConstantFallback
+            # its fill loads from) were created at accum_full's ORIGINAL position
+            # in the group, which may be arbitrarily deep — _replace_constant_
+            # fill_predecessors only hoists fills whose closure escapes the
+            # carry (Part C), and denominator's own seed fill is intentionally
+            # left in place since it IS the carry seed. Moving accum_full alone
+            # would leave it reading a dependency that now comes later in
+            # `operations`, violating topological order for downstream passes
+            # (e.g. optimize_restickify's beam search, which assumes
+            # dependencies are registered before their readers). Move any such
+            # dependency to sit immediately before accum_full at its new
+            # position too, preserving their relative order.
+            deps_to_move = [
+                o
+                for o in operations
+                if o.get_name() in _op_reads(accum_full) and o is not accum_full
+            ]
+            for dep in deps_to_move:
+                operations.remove(dep)
+            insert_at = operations.index(accum_tile) + 1
+            for dep in deps_to_move:
+                operations.insert(insert_at, dep)
+                insert_at += 1
+            operations.remove(accum_full)
+            operations.insert(insert_at, accum_full)
+
+        copy_in_data = Pointwise(
+            device=op.get_device(),
+            dtype=op.get_dtype(),
+            inner_fn=accum_full.make_loader(),
+            ranges=per_tile_ranges,
+        )
+        copy_in_name = V.graph.qualify_name(f"coarse_tile_carry_load_{op.get_name()}")
+        copy_in_buf = ComputedBuffer(
+            name=copy_in_name,
+            layout=MutationLayoutSHOULDREMOVE(TensorBox(StorageBox(accum_tile))),
+            data=copy_in_data,
+        )
+        copy_in_buf.origins = op.origins
+        copy_in_buf.operation_name = copy_in_name
+        copy_in_buf.loop_info = outer_loop_info  # type: ignore[attr-defined]
+        V.graph.name_to_buffer[copy_in_name] = copy_in_buf
+
+        # copy_in_buf reads accum_full directly (accum_full.make_loader()), so
+        # propagate_spyre_tensor_layouts (which walks operations in order)
+        # requires accum_full to already have a layout assigned by the time
+        # it's reached — insert right after accum_full's (possibly just
+        # moved) position. Because accum_full now always sits before
+        # group_start_idx (either originally hoisted, or just moved above),
+        # copy_in_buf lands there too — fully before the (0,0) run, so its
+        # shorter ((0,)-shaped) loop_group_id never interposes inside it.
+        accum_full_idx = operations.index(accum_full)
+        operations.insert(accum_full_idx + 1, copy_in_buf)
+
+        seed_name = accum_full.get_name()
+        tile_name = accum_tile.get_name()
+
+        # Other members of the seed's closure (e.g. correction = exp(M -
+        # max_running), which reads M directly alongside op's own result)
+        # need the value of the carry from BEFORE this inner iteration's
+        # update — the same value op itself reads as input. accum_tile has
+        # no snapshot/versioning semantics: MutationLayoutSHOULDREMOVE is a
+        # plain storage alias, and any reader positioned after op in
+        # `operations` would observe op's POST-update write instead (see
+        # scheduler.py's mutation_renames). So capture the pre-update value
+        # into a distinct per-inner-iteration scratch buffer (carry_prev)
+        # BEFORE op is rewired to mutate accum_tile, and redirect those
+        # sibling closure members to read carry_prev instead of the seed.
+        # _seed_closure matches on the outer loop_group_id key only, so it
+        # also catches copy_in_buf itself (loop_info=outer_loop_info, reads
+        # accum_full directly) — copy_in_buf is scaffolding inserted above,
+        # not a Python-source sibling, and it must keep reading the seed
+        # (once per outer tile, before the inner loop's first iteration),
+        # not carry_prev (which is defined inside the inner loop and would
+        # be a forward reference at copy_in_buf's outer-loop position).
+        # Restrict to op's own inner loop_group_id so only true per-inner-
+        # iteration closure members are rewired.
+        sibling_names = {
+            name
+            for name in _seed_closure(seed_name, op_loop_info.loop_group_id, operations)
+            if getattr(V.graph.name_to_buffer[name], "loop_info", None) is not None
+            and V.graph.name_to_buffer[name].loop_info.loop_group_id
+            == op_loop_info.loop_group_id
+        } - {op.get_name(), entry_op.get_name()}
+        if sibling_names:
+            # carry_prev_alloc, like accum_tile, is an untagged SpyreEmptyFallback
+            # allocation — it must sit at group_start_idx (before the whole
+            # outer group), not interposed mid-group, or it breaks the
+            # scheduler's outer loop_group_id contiguity requirement (see the
+            # comment on accum_tile's own allocation above).
+            carry_prev_alloc = _allocate_full_buffer(
+                op, per_tile_ranges, operations, group_start_idx
+            )
+            if isinstance(carry_prev_alloc.layout, FixedTiledLayout):
+                carry_prev_alloc.layout.per_tile_fixed = True
+            else:
+                carry_prev_alloc._pending_per_tile_fixed = True  # type: ignore[attr-defined]
+
+            carry_prev_data = Pointwise(
+                device=op.get_device(),
+                dtype=op.get_dtype(),
+                inner_fn=accum_tile.make_loader(),
+                ranges=per_tile_ranges,
+            )
+            carry_prev_name = V.graph.qualify_name(
+                f"coarse_tile_carry_prev_{op.get_name()}"
+            )
+            carry_prev_copy = ComputedBuffer(
+                name=carry_prev_name,
+                layout=MutationLayoutSHOULDREMOVE(
+                    TensorBox(StorageBox(carry_prev_alloc))
+                ),
+                data=carry_prev_data,
+            )
+            carry_prev_copy.origins = op.origins
+            carry_prev_copy.operation_name = carry_prev_name
+            carry_prev_copy.loop_info = op_loop_info  # type: ignore[attr-defined]
+            V.graph.name_to_buffer[carry_prev_name] = carry_prev_copy
+            operations.insert(operations.index(op), carry_prev_copy)
+
+            prev_name = carry_prev_name
+            for sibling_name in sibling_names:
+                sibling = V.graph.name_to_buffer[sibling_name]
+                orig_sibling_inner = sibling.data.inner_fn
+
+                def new_sibling_inner_fn(
+                    *args, _map={seed_name: prev_name}, _orig=orig_sibling_inner
+                ):
+                    with V.set_ops_handler(NameSwapHandler(V.ops, _map)):
+                        return _orig(*args)
+
+                object.__setattr__(sibling.data, "inner_fn", new_sibling_inner_fn)
+                sibling_loop_info = sibling.loop_info
+                sibling = replace_computed_buffer_body(
+                    sibling, sibling.data, operations
+                )
+                sibling.loop_info = sibling_loop_info  # type: ignore[attr-defined]
+                V.graph.name_to_buffer[sibling.get_name()] = sibling
+
+        # entry_op reads the seed directly — redirect that read to accum_tile
+        # (the read-side fix). entry_op runs before op/terminal in the same
+        # inner-loop iteration and nothing mutates accum_tile in between, so
+        # it correctly observes the previous iteration's carry value. This is
+        # a no-op rewrite (empty _map) when entry_op is op, since seed_name
+        # then equals tile_name's counterpart on the SAME op that also gets
+        # the write-side mutation below.
+        orig_entry_inner = entry_op.data.inner_fn
+
+        def new_entry_inner_fn(
+            *args, _map={seed_name: tile_name}, _orig=orig_entry_inner
+        ):
+            with V.set_ops_handler(NameSwapHandler(V.ops, _map)):
+                return _orig(*args)
+
+        object.__setattr__(entry_op.data, "inner_fn", new_entry_inner_fn)
+        entry_loop_info = entry_op.loop_info
+        entry_op = replace_computed_buffer_body(entry_op, entry_op.data, operations)
+        entry_op.loop_info = entry_loop_info  # type: ignore[attr-defined]
+        V.graph.name_to_buffer[entry_op.get_name()] = entry_op
+
+        # op (the terminal value) owns accum_tile's storage — the write-side
+        # fix. When entry_op is op, this mutates the very buffer whose
+        # inner_fn was just rewired above (the pre-existing single-op
+        # behavior); when entry_op is not op, op does not read the seed
+        # directly at all (e.g. buf17 reads buf13/buf16, neither of which is
+        # the seed), so no inner_fn rewrite is needed here — only the layout
+        # mutation.
+        op.layout = MutationLayoutSHOULDREMOVE(TensorBox(StorageBox(accum_tile)))
+        V.graph.name_to_buffer[op.get_name()] = op
+
+        # The copy-out must run once per outer tile after the inner loop's
+        # LAST iteration — i.e. after every op sharing op's own (full,
+        # inner-tiled) loop_group_id, not just after the seed's closure
+        # (_seed_closure only covers direct readers of the seed, e.g.
+        # {buf10, buf11} for M — it excludes downstream siblings like
+        # exp_scores/denominator/output-accumulate that read op's result
+        # rather than the seed directly, but that still belong to the same
+        # inner loop). The copy-out's own loop_group_id is outer-only
+        # (shorter than op's) — inserting it anywhere before the inner
+        # loop's true last member leaves a same-depth contiguous run split
+        # in two on either side of it (see _build_loop_group in
+        # scheduler.py, which groups by contiguous loop_group_id runs).
+        last_member = max(
+            (
+                o
+                for o in operations
+                if isinstance(o, ComputedBuffer)
+                and getattr(o, "loop_info", None) is not None
+                and o.loop_info.loop_group_id == op_loop_info.loop_group_id
+            ),
+            key=operations.index,
+        )
+        _insert_reduction_copy_op(
+            op,
+            accum_tile,
+            accum_full,
+            outer_loop_info,
+            operations,
+            insert_after=last_member,
+            force_live=not outside_consumers and not is_graph_output,
+        )
+
+    buf_name = op.get_name()
+    seed_name = accum_full.get_name()
+    _patch_consumers(outside_consumers, buf_name, seed_name, operations)
+    if is_graph_output:
+        _patch_graph_outputs(buf_name, accum_full)
+
+    logger.debug(
+        "coarse_tile: propagated carry op %s → seed %s",
+        buf_name,
+        seed_name,
+    )
 
 
 def _full_buffer_read_deps(op: ComputedBuffer) -> list[MemoryDep]:
@@ -1751,12 +2486,32 @@ def _insert_reduction_copy_op(
     accum_full: ComputedBuffer,
     outer_loop_info: "CoarseTileInfo",
     operations: list[Operation],
+    insert_after: ComputedBuffer | None = None,
+    force_live: bool = False,
 ) -> None:
     """Insert a copy op that writes accum_tile → accum_full at the outer loop level.
 
     Reads accum_tile (per_tile_fixed=True, never advances) and writes into
     accum_full via MutationLayoutSHOULDREMOVE.  Carries outer_loop_info so
     the unroller advances accum_full per outer output-dim tile.
+
+    By default inserts immediately after tiled_op (or its combine op, if
+    any) — correct when nothing else in the inner loop group depends on
+    tiled_op.  Pass insert_after to place the copy after a different op
+    instead — needed when tiled_op has sibling closure members later in the
+    same inner loop group (the carry case): the copy must run once per
+    outer tile after the *last* inner-loop iteration, i.e. after every
+    closure member has executed, not immediately after tiled_op itself. See
+    _propagate_carry_op.
+
+    force_live: set for a carry copy-out whose seed has no outside
+    consumers or graph-output status (e.g. online-softmax running state
+    like M, never read after the recurrence's last iteration). Its write
+    is only ever "read" by the NEXT outer-tile iteration's copy-in — a
+    cross-iteration dependency invisible to the single-pass, pre-unroll IR
+    the scheduler's dead_node_elimination walks, so without this the op is
+    (wrongly) seen as dead and removed. Stamps _coarse_tile_force_live,
+    consulted by the has_side_effects patch in patches.py.
     """
     copy_data = Pointwise(
         device=tiled_op.get_device(),
@@ -1773,14 +2528,21 @@ def _insert_reduction_copy_op(
     copy_buf.origins = tiled_op.origins
     copy_buf.operation_name = copy_name
     copy_buf.loop_info = outer_loop_info  # type: ignore[attr-defined]
+    if force_live:
+        copy_buf._coarse_tile_force_live = True  # type: ignore[attr-defined]
     V.graph.name_to_buffer[copy_name] = copy_buf
 
-    combine_name = V.graph.qualify_name(f"coarse_tile_combine_{tiled_op.get_name()}")
-    combine_buf = V.graph.name_to_buffer.get(combine_name)
-    if combine_buf is not None and combine_buf in operations:
-        insert_idx = operations.index(combine_buf) + 1
+    if insert_after is not None:
+        insert_idx = operations.index(insert_after) + 1
     else:
-        insert_idx = operations.index(tiled_op) + 1
+        combine_name = V.graph.qualify_name(
+            f"coarse_tile_combine_{tiled_op.get_name()}"
+        )
+        combine_buf = V.graph.name_to_buffer.get(combine_name)
+        if combine_buf is not None and combine_buf in operations:
+            insert_idx = operations.index(combine_buf) + 1
+        else:
+            insert_idx = operations.index(tiled_op) + 1
     operations.insert(insert_idx, copy_buf)
 
 
@@ -1942,6 +2704,12 @@ def _propagate_tiled_reduction_op(
     if fill_loop_info is not None:
         fill_buf.loop_info = fill_loop_info  # type: ignore[attr-defined]
     # else: no loop_info — fill runs once before all loops (flat reduction case).
+    # fill_buf's write is only ever "read" by the NEXT loop iteration's use of
+    # fill_target as an accumulator seed — a cross-iteration dependency
+    # invisible to the single-pass, pre-unroll IR the scheduler's
+    # dead_node_elimination walks, so without this it is (wrongly) seen as
+    # dead and removed. Mirrors copy_buf's force_live handling above.
+    fill_buf._coarse_tile_force_live = True  # type: ignore[attr-defined]
     V.graph.name_to_buffer[fill_name] = fill_buf
     fill_target_idx = operations.index(fill_target)
     # scalar_op was appended to graph.operations by register_operation(); move it
@@ -2227,6 +2995,22 @@ def _patch_graph_outputs(old_name: str, new_buf: ComputedBuffer) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _seed_closure_pre_stamp(seed_name: str, group_ops: list[Operation]) -> set[str]:
+    """Pre-stamp equivalent of _seed_closure, over a plain group_ops list.
+
+    Not transitive — see _seed_closure's docstring for why. Used by
+    _replace_constant_fill_predecessors, which runs before _stamp_group (so
+    ops in group_ops have no loop_info yet, and the outer-loop-group
+    filtering _seed_closure does via stamped loop_info is unnecessary —
+    group_ops is already scoped to the group).
+    """
+    return {
+        o.get_name()
+        for o in group_ops
+        if isinstance(o, ComputedBuffer) and seed_name in _op_reads(o)
+    }
+
+
 def _replace_constant_fill_predecessors(
     group_ops: list[Operation],
     levels: list[tuple],
@@ -2306,6 +3090,30 @@ def _replace_constant_fill_predecessors(
             if not isinstance(buf, ComputedBuffer):
                 continue
             if not _is_constant_fill(buf):
+                continue
+
+            # A constant fill whose closure (every op in the group that
+            # transitively reads it, directly or through other closure
+            # members) is entirely carry-shaped is not a hoistable broadcast
+            # constant — it is an online-softmax-style recurrence's pre-loop
+            # seed (e.g. `M`, read directly by both
+            # `max_running = maximum(M, block_max)` and
+            # `correction = exp(M - max_running)`), and every op in the
+            # closure must keep reading it directly so _propagate_carry_op
+            # (which runs after _stamp_group) can find it.  Skip the
+            # tile-sized-copy rewrite for this (old_name, op) pair.  Checked
+            # via dim_hints directly (not stamped loop_info, which does not
+            # exist yet at this point in the pass pipeline — this function
+            # runs before _stamp_group).  A closure of size > 1 is not itself
+            # a disqualifying signal (see _seed_buffer_for_carry) — only "is
+            # every closure member carry-shaped" matters here.
+            closure = _seed_closure_pre_stamp(old_name, group_ops)
+            if closure and all(
+                _is_loop_invariant_at_reduction_levels(
+                    V.graph.name_to_buffer[name], group_ops, levels
+                )
+                for name in closure
+            ):
                 continue
 
             # Read the constant value from the SpyreConstantFallback scalar

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -1224,25 +1224,28 @@ def _propagate_tiled_op(
     full_buf = _allocate_full_buffer(op, full_ranges, operations, group_start_idx)
 
     has_inside = _has_inside_consumers(buf_name, loop_group_id, operations)
-    multi_input = _num_real_inputs(op) > 1
+    has_loop_internal_input = _has_loop_internal_real_input(
+        op, loop_group_id, operations
+    )
 
-    if has_inside or multi_input:
+    if has_inside or has_loop_internal_input:
         # Case 1: keep tiled op writing to small buffer; insert copy op.
-        # Multi-input ops must take this path even with no inside consumers:
-        # the tiled op's other real inputs are themselves tile-sized
-        # loop-internal ops whose own stick layout can never be made
-        # compatible with a full-size output under AllSameNode's
-        # stick-compatibility rule. Routing through _insert_copy_op keeps
-        # the tiled op self-consistent (own tile-sized layout, own
+        # Ops with a loop-internal real input must take this path even with
+        # no inside consumers: that input is itself a tile-sized loop-internal
+        # op whose own stick layout can never be made compatible with a
+        # full-size output under AllSameNode's stick-compatibility rule (see
+        # _has_loop_internal_real_input). Routing through _insert_copy_op
+        # keeps the tiled op self-consistent (own tile-sized layout, own
         # tile-sized real inputs) and reuses the copy op's proven
         # single-real-input path (the copy fuses the tiled op's own
         # upstream computation via make_loader()).
         _insert_copy_op(op, full_buf, operations)
     else:
-        # Case 2: single real input, no inside consumers — rewire it to
-        # write directly into the full-size buffer.  Note:
-        # MutationLayoutSHOULDREMOVE is incompatible with lx_planning
-        # (scratchpad); do not combine the two.
+        # Case 2: no inside consumers and every real input is external to the
+        # loop (a graph input or other buffer with its own independent,
+        # unconstrained candidate layouts) — rewire the op to write directly
+        # into the full-size buffer.  Note: MutationLayoutSHOULDREMOVE is
+        # incompatible with lx_planning (scratchpad); do not combine the two.
         op.layout = MutationLayoutSHOULDREMOVE(TensorBox(StorageBox(full_buf)))
 
     # Patch outside consumers and graph outputs to read full_buf.
@@ -1255,7 +1258,7 @@ def _propagate_tiled_op(
         "coarse_tile: propagated %s → %s (case %s)",
         buf_name,
         full_name,
-        "1 (copy)" if (has_inside or multi_input) else "2 (mutation)",
+        "1 (copy)" if (has_inside or has_loop_internal_input) else "2 (mutation)",
     )
 
 
@@ -1321,14 +1324,32 @@ def _has_inside_consumers(
     return False
 
 
-def _num_real_inputs(op: ComputedBuffer) -> int:
-    """Count op's MemoryDep reads that are not SpyreConstantFallback buffers."""
+def _has_loop_internal_real_input(
+    op: ComputedBuffer,
+    loop_group_id: tuple,
+    operations: list[Operation],
+) -> bool:
+    """Return True if any real input of op is itself produced inside the loop.
+
+    A real (non-constant) input that is a ComputedBuffer stamped with
+    loop_info in the same outer loop group is a tile-sized, loop-internal
+    producer with its own tile-sized candidate layouts — those can never be
+    made stick-compatible with a full-size output under AllSameNode's
+    stick-compatibility rule (see Case 1 vs Case 2 above). A real input with
+    no loop_info (a graph input, or any other buffer resolved outside the
+    loop) has its own independent, unconstrained candidate layouts and does
+    not hit this problem, so it does not force Case 1.
+    """
+    outer_key = loop_group_id[0]
     reads = [d for d in op.get_read_writes().reads if isinstance(d, MemoryDep)]
-    return sum(
-        1
-        for d in reads
-        if not isinstance(V.graph.get_buffer(d.name), SpyreConstantFallback)
-    )
+    for dep in reads:
+        buf = V.graph.get_buffer(dep.name)
+        if isinstance(buf, SpyreConstantFallback):
+            continue
+        li = getattr(buf, "loop_info", None)
+        if li is not None and li.loop_group_id[0] == outer_key:
+            return True
+    return False
 
 
 def _full_buffer_read_deps(op: ComputedBuffer) -> list[MemoryDep]:

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -1007,6 +1007,7 @@ def _clear_cache(obj: object, key: str) -> None:
 def coarse_tile(
     graph: GraphLowering,
     groups: list[tuple],
+    group_idx_offset: int = 0,
 ) -> None:
     """Stamp loop_group_id / loop_count on operations and scale their ranges.
 
@@ -1020,6 +1021,11 @@ def coarse_tile(
         Sequence of ``(ops, levels)`` tuples produced by
         ``hints_to_coarse_tile_groups``.  ``levels`` is a list of
         ``(hint_id, count)`` pairs, outermost first.
+    group_idx_offset:
+        Starting index for group IDs assigned to the first group.  Use this
+        when making a second ``coarse_tile`` call on the same graph so that
+        the new group IDs do not collide with IDs already stamped by an
+        earlier call (e.g. hint-driven groups stamped pre-stickification).
     """
     operations = graph.operations
     op_to_position: dict[str, int] = {
@@ -1029,7 +1035,7 @@ def coarse_tile(
     retiled_infos_by_group: list[
         tuple[tuple[int, ...], list[Operation], dict[str, _RetiledBufferInfo]]
     ] = []
-    for group_idx, (group_ops, levels) in enumerate(groups):
+    for group_idx, (group_ops, levels) in enumerate(groups, start=group_idx_offset):
         group_id: tuple[int, ...] = (group_idx,)
         retiled_infos = _stamp_group(group_ops, group_id, levels, op_to_position)
         stamped_group_id = group_id + (0,) * (len(levels) - 1)

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -1163,6 +1163,10 @@ def _propagate_tiled_op(
 
         if isinstance(op.layout, FixedTiledLayout):
             op.layout.per_tile_fixed = True
+        else:
+            # Pre-stickify: layout is FixedLayout.  Defer to finalize_layouts
+            # which sees the committed FixedTiledLayout and can set the flag then.
+            op._pending_per_tile_fixed = True  # type: ignore[attr-defined]
         # Non-FixedTiledLayout buffers (e.g. MutationLayoutSHOULDREMOVE from a
         # prior pass) are intentionally left unmarked — their addressing is
         # handled by the layout type itself, not by the unroller.

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -1309,10 +1309,11 @@ def _allocate_full_buffer(
     """Allocate a full-sized HBM buffer for the tiled op's original shape.
 
     Creates a spyre.empty FX node, lowers it via V.graph.run_node(), assigns
-    a FixedTiledLayout matching tiled_op's layout, splices it into operations
-    at insert_at_idx, and returns the new ComputedBuffer.
+    a layout matching tiled_op's layout type (FixedLayout pre-stickify,
+    FixedTiledLayout post-stickify), splices it into operations at
+    insert_at_idx, and returns the new ComputedBuffer.
     """
-    from .propagate_layouts import generic_layout  # deferred: avoids circular import
+    from torch._inductor.ir import FixedLayout  # deferred: avoids circular import
     from .ir import (
         FixedTiledLayout,
         SpyreEmptyFallback,
@@ -1344,7 +1345,9 @@ def _allocate_full_buffer(
     )
     full_buf.origins = OrderedSet([empty_fx])
 
-    # Assign a FixedTiledLayout with the full size.
+    # Assign a layout for the full-sized buffer.  Pre-stickify we use a plain
+    # FixedLayout (stickification assigns the device layout later); post-stickify
+    # we must build a FixedTiledLayout because stickification has already run.
     orig_layout = tiled_op.layout
     # Recompute strides for the full size (contiguous row-major).
     strides: list[Expr] = []
@@ -1354,11 +1357,10 @@ def _allocate_full_buffer(
         stride = stride * s
 
     if isinstance(orig_layout, FixedTiledLayout):
-        # Derive the full buffer's device layout from the per-tile layout by
-        # scaling device_size entries up to the full host size.  The stick
-        # orientation (dim_order / element_arrangement) is propagated verbatim
-        # from orig_layout — both buffers must agree on physical layout so the
-        # scatter copy op computes correct device addresses.
+        # Post-stickify path (span-overflow groups): stickification has already
+        # run, so we must assign a FixedTiledLayout now.  Derive the full
+        # buffer's device layout by scaling the per-tile device layout up to
+        # the full host size using _resize_device_layout.
         full_size_ints = [int(s) for s in full_ranges]
         tile_size_ints = [int(s) for s in orig_layout.size]
         # Authoritative stick host dim from coordinate identity (issue #3116);
@@ -1391,16 +1393,24 @@ def _allocate_full_buffer(
                 list(range(ndim_full)),
                 orig_layout.device_layout.element_arrangement,
             )
+        layout: FixedTiledLayout | FixedLayout = FixedTiledLayout(
+            device,
+            dtype,
+            list(full_ranges),
+            strides,
+            device_layout,
+        )
     else:
-        device_layout = generic_layout(full_buf)
-
-    layout = FixedTiledLayout(
-        device,
-        dtype,
-        list(full_ranges),
-        strides,
-        device_layout,
-    )
+        # Pre-stickify path (hint-driven groups): stickification has not yet
+        # run, so assign a plain FixedLayout.  Stickification will propagate
+        # SpyreTensorLayout to this buffer via the ExternKernel->generic_layout
+        # path in propagate_spyre_tensor_layouts.
+        layout = FixedLayout(
+            device,
+            dtype,
+            list(full_ranges),
+            strides,
+        )
     full_buf.layout = layout
 
     # Splice into operations at the correct position.

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -2643,6 +2643,14 @@ def _propagate_tiled_reduction_op(
         accum_full = _allocate_full_buffer(
             op, full_output_ranges, operations, group_start_idx
         )
+        # _allocate_full_buffer never stamps loop_info on the buffer it
+        # returns. Without this, memory_planning's _advance_factor sees
+        # loop_info=None and sizes accum_full's pool allocation for a single
+        # outer tile instead of loop_count outer tiles, so the second outer
+        # tile's copy-out (which does carry outer_loop_info, see
+        # _insert_reduction_copy_op) overruns into the next pool buffer.
+        # Mirrors the equivalent stamp in _propagate_carry_op.
+        accum_full.loop_info = fill_loop_info  # type: ignore[attr-defined]
         group_start_idx_after_full = operations.index(accum_full) + 1
         accum_tile = _allocate_full_buffer(
             op, per_tile_ranges, operations, group_start_idx_after_full

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -358,13 +358,17 @@ def finalize_layouts(graph: GraphLowering) -> None:
             if isinstance(mut_target_buf, SpyreEmptyFallback) and committed is not None:
                 accum_layout = mut_target_buf.get_layout()
                 if isinstance(accum_layout, (FixedTiledLayout, FixedLayout)):
-                    mut_target_buf.layout = FixedTiledLayout(
+                    new_layout = FixedTiledLayout(
                         accum_layout.device,
                         accum_layout.dtype,
                         accum_layout.size,
                         accum_layout.stride,
                         committed,
                     )
+                    new_layout.per_tile_fixed = getattr(
+                        accum_layout, "per_tile_fixed", False
+                    )
+                    mut_target_buf.layout = new_layout
             elif isinstance(mut_target_buf, SpyreEmptyFallback) and committed is None:
                 # committed_stl was cleaned up; fall back to the accumulator's layout.
                 accum_layout = mut_target_buf.get_layout()
@@ -374,7 +378,22 @@ def finalize_layouts(graph: GraphLowering) -> None:
             input_buf = graph.get_buffer(edge.dep.name)
             in_layout = input_buf.get_layout()
             if isinstance(in_layout, MutationLayoutSHOULDREMOVE):
-                assert getattr(input_buf, ELIDED_COPY_BACK_ATTR, False), (
+                # Reading real_layout() through a mutation layout is only valid
+                # once the target buffer's own layout is a committed
+                # FixedTiledLayout. Two producers of this shape:
+                #  - the copy-back elision optimization (propagate_layouts.py),
+                #    which stamps ELIDED_COPY_BACK_ATTR on the producer; or
+                #  - a sequential-carry op (_propagate_carry_op) that mutates
+                #    directly into a SpyreEmptyFallback accumulator (accum_tile) —
+                #    a legitimate in-group consumer (e.g. the next recurrence
+                #    step) reads the carry op's own output the same way an
+                #    ordinary producer's output would be read.
+                mutation_target = in_layout.get_buffer()
+                is_elided = getattr(input_buf, ELIDED_COPY_BACK_ATTR, False)
+                is_carry_into_accum = isinstance(
+                    mutation_target, SpyreEmptyFallback
+                ) and isinstance(mutation_target.get_layout(), FixedTiledLayout)
+                assert is_elided or is_carry_into_accum, (
                     f"unexpected mutation layout on {edge.dep.name}"
                 )
                 in_layout = in_layout.real_layout()
@@ -383,6 +402,13 @@ def finalize_layouts(graph: GraphLowering) -> None:
             if restick_stl is None:
                 continue
             restick_target = _fixed_tiled(in_layout, restick_stl)
+            # restick_target's buffer is created fresh by _create_restickify_node
+            # and consumed only by op's own inner_fn (see
+            # insert_restickify_on_node_inputs) — it can never have outside-loop
+            # consumers, so it is always safe to inherit in_layout's per_tile_fixed:
+            # if the source address doesn't advance across iterations, this private
+            # single-consumer copy of it doesn't need to either.
+            restick_target.per_tile_fixed = getattr(in_layout, "per_tile_fixed", False)
             logger.info(
                 f"Injecting restickify on {op.get_name()} input {edge.dep.name}: "
                 f"{list(in_stl.stride_map)} -> {list(target_stl.stride_map)}"

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -328,10 +328,13 @@ def finalize_layouts(graph: GraphLowering) -> None:
             # when the layout is still FixedLayout (pre-stickify).  Transfer that
             # deferred flag now that we have the committed FixedTiledLayout.
             if getattr(op, "_pending_per_tile_fixed", False):
-                if isinstance(op.layout, FixedTiledLayout):
-                    op.layout.per_tile_fixed = True
-                if hasattr(op, "_pending_per_tile_fixed"):
-                    del op._pending_per_tile_fixed  # type: ignore[attr-defined]
+                assert isinstance(op.layout, FixedTiledLayout), (
+                    f"{op.get_name()} has _pending_per_tile_fixed but layout is "
+                    f"{type(op.layout).__name__} — expected FixedTiledLayout "
+                    "after finalize_layouts committed"
+                )
+                op.layout.per_tile_fixed = True
+                del op._pending_per_tile_fixed  # type: ignore[attr-defined]
 
         # For each input edge, schedule a restickify if the input's committed STL
         # is incompatible with what this op requires on that edge.

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -288,6 +288,41 @@ def finalize_layouts(graph: GraphLowering) -> None:
                 )
                 if all_tiled_dims_empty and all_tiled_rdims_empty:
                     op.layout.per_tile_fixed = True
+                # Tiled-reduction scratch: inner level tiles a reduction dim.
+                # The op's output is a per-tile accumulation buffer reused
+                # every inner-loop iteration.
+                elif not all_tiled_rdims_empty:
+                    op.layout.per_tile_fixed = True
+                    # Propagate the reduction op's device layout to accum_full.
+                    # Pre-stickify, _allocate_full_buffer assigned accum_full a
+                    # generic layout; we now overwrite it with the same STL as
+                    # the reduction op (they share the same output shape and
+                    # stick orientation must agree for the combine to work).
+                    accum_name = getattr(op, "_tiled_reduction_accum_name", None)
+                    if accum_name is not None:
+                        accum_buf = graph.get_buffer(accum_name)
+                        accum_layout = accum_buf.layout
+                        if isinstance(accum_layout, FixedTiledLayout):
+                            # finalize_layouts already committed a generic STL
+                            # (from propagate_spyre_tensor_layouts) to accum_full.
+                            # Replace with the reduction op's actual STL so that
+                            # fill, combine, and copy all agree on the device
+                            # coordinate system.  Skip if already has the right
+                            # STL (span-overflow path where _allocate_full_buffer
+                            # already derived it from _resize_device_layout).
+                            if accum_layout.device_layout != op.layout.device_layout:
+                                accum_buf.layout = FixedTiledLayout(
+                                    accum_layout.device,
+                                    accum_layout.dtype,
+                                    accum_layout.size,
+                                    accum_layout.stride,
+                                    op.layout.device_layout,
+                                )
+                        else:
+                            # FixedLayout: wrap with the reduction op's STL.
+                            accum_buf.layout = _fixed_tiled(
+                                accum_layout, op.layout.device_layout
+                            )
 
         # For each input edge, schedule a restickify if the input's committed STL
         # is incompatible with what this op requires on that edge.

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -270,6 +270,24 @@ def finalize_layouts(graph: GraphLowering) -> None:
         if op_layouts and not isinstance(op.layout, MutationLayoutSHOULDREMOVE):
             stl = committed if cost_fn else op_layouts[0]
             op.layout = _fixed_tiled(op.layout, stl)
+            # Mark loop-invariant tiled ops: per_tile_fixed so the unroller
+            # reuses the same base address every tile iteration.  A tiled op is
+            # loop-invariant when its CoarseTileInfo has no tiled dims at any
+            # level (all loop_tiled_dims and loop_tiled_reduction_dims entries
+            # are empty).  The loop-internal and tiled-reduction-scratch cases
+            # are handled later in _propagate_tiled_op /
+            # _propagate_tiled_reduction_op once consumer analysis is available.
+            loop_info = getattr(op, "loop_info", None)
+            if loop_info is not None and isinstance(op.layout, FixedTiledLayout):
+                all_tiled_dims_empty = all(
+                    not dims for dims in loop_info.loop_tiled_dims
+                )
+                all_tiled_rdims_empty = all(
+                    not dims
+                    for dims in getattr(loop_info, "loop_tiled_reduction_dims", [])
+                )
+                if all_tiled_dims_empty and all_tiled_rdims_empty:
+                    op.layout.per_tile_fixed = True
 
         # For each input edge, schedule a restickify if the input's committed STL
         # is incompatible with what this op requires on that edge.

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -21,7 +21,6 @@ from .constants import ELIDED_COPY_BACK_ATTR
 from .ir import FixedTiledLayout
 from .logging_utils import get_inductor_logger
 from .loop_info import copy_op_metadata
-from .pass_utils import copy_fx_custom_meta
 from torch._inductor.graph import GraphLowering
 from torch._inductor.ir import (
     ComputedBuffer,
@@ -125,12 +124,6 @@ def _create_restickify_node(
         restick_fx_node = fx_graph.create_node(
             "call_function", torch.ops.spyre.restickify.default, (fx_arg_node,)
         )
-    # Propagate hint metadata from the consumer op so assign_dim_hints can assign
-    # dim_hints to the restickify buffer after insertion.
-    for consumer_fx_node in op.origins:
-        if "custom" in consumer_fx_node.meta:
-            copy_fx_custom_meta(consumer_fx_node, restick_fx_node)
-            break
     # Lower the FX node; run_node registers the output in graph.buffers and graph.operations.
     restick_tb = graph_lowering.run_node(restick_fx_node)
     restick_buff = restick_tb.data.data  # TensorBox -> StorageBox -> ComputedBuffer

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -18,7 +18,7 @@ from collections import defaultdict
 import torch
 
 from .constants import ELIDED_COPY_BACK_ATTR
-from .ir import FixedTiledLayout
+from .ir import FixedTiledLayout, SpyreEmptyFallback
 from .logging_utils import get_inductor_logger
 from .loop_info import copy_op_metadata
 from torch._inductor.graph import GraphLowering
@@ -340,6 +340,36 @@ def finalize_layouts(graph: GraphLowering) -> None:
         # is incompatible with what this op requires on that edge.
         if not cost_fn:
             continue
+        # Mutation ops targeting a SpyreEmptyFallback: the optimizer commits the
+        # mutation op's output STL via AllSameNode (matching the new-value inputs).
+        # The SpyreEmptyFallback was separately committed by AnyInNode (candidates[0]),
+        # which may differ.  Overwrite the accumulator's FixedTiledLayout to match the
+        # mutation op's committed STL so the backend sees consistent layouts.
+        if isinstance(getattr(op, "layout", None), MutationLayoutSHOULDREMOVE):
+            mut_target = op.layout.target
+            while isinstance(mut_target, ReinterpretView):
+                mut_target = mut_target.data
+            mut_target_name = (
+                mut_target.get_name() if hasattr(mut_target, "get_name") else ""
+            )
+            mut_target_buf = (
+                graph.get_buffer(mut_target_name) if mut_target_name else None
+            )
+            if isinstance(mut_target_buf, SpyreEmptyFallback) and committed is not None:
+                accum_layout = mut_target_buf.get_layout()
+                if isinstance(accum_layout, (FixedTiledLayout, FixedLayout)):
+                    mut_target_buf.layout = FixedTiledLayout(
+                        accum_layout.device,
+                        accum_layout.dtype,
+                        accum_layout.size,
+                        accum_layout.stride,
+                        committed,
+                    )
+            elif isinstance(mut_target_buf, SpyreEmptyFallback) and committed is None:
+                # committed_stl was cleaned up; fall back to the accumulator's layout.
+                accum_layout = mut_target_buf.get_layout()
+                if isinstance(accum_layout, FixedTiledLayout):
+                    committed = accum_layout.device_layout
         for edge, target_stl in cost_fn.required_input_stls(committed):
             input_buf = graph.get_buffer(edge.dep.name)
             in_layout = input_buf.get_layout()

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -167,6 +167,13 @@ def insert_restickify_on_node_inputs(
         operations.insert(op_index, restick_buff)
         op_index += 1  # consumer shifted right by 1
 
+        # When coarse-tiling runs pre-stickification, the consumer op already
+        # carries loop_info (loop_group_id + loop_count).  The restickify node
+        # is inserted inside the same loop group, so it must inherit loop_info
+        # to remain contiguous in build_loop_scheduler_nodes.
+        if hasattr(op, "loop_info"):
+            restick_buff.loop_info = op.loop_info
+
     # Patch inner_fn once with the full name_map covering all restickified args.
     orig_inner = op.data.inner_fn
 
@@ -316,6 +323,15 @@ def finalize_layouts(graph: GraphLowering) -> None:
                             accum_buf.layout = _fixed_tiled(
                                 accum_layout, op.layout.device_layout
                             )
+
+            # Loop-internal buffers: _propagate_tiled_op sets _pending_per_tile_fixed
+            # when the layout is still FixedLayout (pre-stickify).  Transfer that
+            # deferred flag now that we have the committed FixedTiledLayout.
+            if getattr(op, "_pending_per_tile_fixed", False):
+                if isinstance(op.layout, FixedTiledLayout):
+                    op.layout.per_tile_fixed = True
+                if hasattr(op, "_pending_per_tile_fixed"):
+                    del op._pending_per_tile_fixed  # type: ignore[attr-defined]
 
         # For each input edge, schedule a restickify if the input's committed STL
         # is incompatible with what this op requires on that edge.

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -404,11 +404,23 @@ def finalize_layouts(graph: GraphLowering) -> None:
             restick_target = _fixed_tiled(in_layout, restick_stl)
             # restick_target's buffer is created fresh by _create_restickify_node
             # and consumed only by op's own inner_fn (see
-            # insert_restickify_on_node_inputs) — it can never have outside-loop
-            # consumers, so it is always safe to inherit in_layout's per_tile_fixed:
-            # if the source address doesn't advance across iterations, this private
-            # single-consumer copy of it doesn't need to either.
-            restick_target.per_tile_fixed = getattr(in_layout, "per_tile_fixed", False)
+            # insert_restickify_on_node_inputs), which also stamps it with op's
+            # own loop_info.  Its per_tile_fixed must agree with that loop_info
+            # (whether *this* restickify buffer's address advances across op's
+            # loop iterations) rather than blindly inheriting in_layout's flag:
+            # when op is itself an advancing accumulator write (e.g. the
+            # coarse-tiled-reduction copy-out into accum_full), the restickify
+            # buffer takes over accum_full's role and must advance too, even
+            # though its source (accum_tile) is per-tile-fixed scratch.
+            op_loop_info = getattr(op, "loop_info", None)
+            if op_loop_info is not None:
+                restick_target.per_tile_fixed = all(
+                    not dims for dims in op_loop_info.loop_tiled_dims
+                )
+            else:
+                restick_target.per_tile_fixed = getattr(
+                    in_layout, "per_tile_fixed", False
+                )
             logger.info(
                 f"Injecting restickify on {op.get_name()} input {edge.dep.name}: "
                 f"{list(in_stl.stride_map)} -> {list(target_stl.stride_map)}"

--- a/torch_spyre/_inductor/ir.py
+++ b/torch_spyre/_inductor/ir.py
@@ -402,8 +402,9 @@ class SpyreEmptyFallback(ir.ExternKernel):
     SpyrePythonWrapperCodegen.make_buffer_allocation emits
     spyre_empty_with_layout(size, stride, dtype, device_layout) when the layout is
     a FixedTiledLayout; the placeholder FixedLayout set at construction time must be
-    replaced with a FixedTiledLayout before codegen runs (lower_pad_sequence does
-    this immediately after calling run_node).  If the layout is never upgraded the
+    replaced with a FixedTiledLayout before codegen runs.  This upgrade happens via
+    finalize_layouts (post-stickify hint-driven path) or lower_pad_sequence
+    (post-stickify span-overflow path).  If the layout is never upgraded the
     wrapper falls back to the generic CPU allocator, which is incorrect on Spyre.
     codegen() is a no-op because the allocation IS the result — there is no
     separate kernel call.

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -72,6 +72,10 @@ _SPYRE_METADATA_ATTRS = (
     # Deferred per_tile_fixed flag: set by coarse_tile._propagate_tiled_op when
     # the layout is FixedLayout (pre-stickify); consumed by finalize_layouts.
     "_pending_per_tile_fixed",
+    # Links a tiled reduction op to its accumulation buffer; set by
+    # coarse_tile._propagate_tiled_reduction_op, read by finalize_layouts in
+    # insert_restickify.py to overwrite accum_full's generic layout.
+    "_tiled_reduction_accum_name",
 )
 
 

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -69,6 +69,9 @@ _SPYRE_METADATA_ATTRS = (
     "_restickify_plan",
     "_input_layout_overrides",
     "_emit_set_layout",
+    # Deferred per_tile_fixed flag: set by coarse_tile._propagate_tiled_op when
+    # the layout is FixedLayout (pre-stickify); consumed by finalize_layouts.
+    "_pending_per_tile_fixed",
 )
 
 

--- a/torch_spyre/_inductor/memory_planning.py
+++ b/torch_spyre/_inductor/memory_planning.py
@@ -186,13 +186,16 @@ def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
     }
 
     # SpyreEmptyFallback nodes allocate a buffer but emit no dep-tracked write
-    # so they never appear in `written` via the dep walk above.  Collect them here explicitly
+    # so they never appear in `written` via the dep walk above.  Collect them here
+    # explicitly, using the underlying buffer's name (node.node.get_name()) rather
+    # than the scheduler node's own operation name (node.get_name()) — for an
+    # ExternKernelSchedulerNode these differ (e.g. "op30" vs "buf27").
     written |= {
-        node.get_name()
+        node.node.get_name()
         for node in flat_nodes
         if isinstance(node, ExternKernelSchedulerNode)
         and isinstance(node.node, SpyreEmptyFallback)
-        and node.get_name() not in graph_outputs
+        and node.node.get_name() not in graph_outputs
     }
 
     read = {
@@ -279,6 +282,19 @@ def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
             layout.allocation["pool"] = offset
         else:
             layout.allocation["pool"] = INTERMEDIATES_SEGMENT + offset
+
+        if isinstance(buf, SpyreEmptyFallback):
+            # SpyreEmptyFallback.should_allocate() returns False once pool-
+            # allocated, so the wrapper never emits an AllocateLine for it.
+            # Base Inductor's free machinery (Scheduler.free_buffers ->
+            # codegen_free -> can_reuse) does not consult should_allocate();
+            # it frees any buffer whose last use has passed regardless of
+            # whether it was ever allocated. Without this, the generated
+            # wrapper emits `del buf27` with no prior `buf27 = ...`, raising
+            # UnboundLocalError. free_buffers() itself subtracts
+            # V.graph.removed_buffers before iterating, so adding the name
+            # here keeps it out of codegen entirely.
+            V.graph.removed_buffers.add(name)
 
         pending_frees.append((end, offset, size))
 

--- a/torch_spyre/_inductor/memory_planning.py
+++ b/torch_spyre/_inductor/memory_planning.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from sympy import Symbol
+from sympy import Symbol, Integer
 from torch._inductor.scheduler import (
     BaseSchedulerNode,
     ExternKernelSchedulerNode,
@@ -94,6 +94,37 @@ def _align_up(n: int, alignment: int) -> int:
     return ((n + alignment - 1) // alignment) * alignment
 
 
+def _advance_factor(buf, layout) -> int:
+    """Return how many tiles an advancing coarse-tiled buffer occupies.
+
+    A buffer's `device_size` reflects a single tile after coarse-tiling divides
+    the iteration ranges.  If the buffer is `per_tile_fixed=False`, the unroller
+    advances its base address once per loop iteration, so it actually occupies
+    `loop_count` tiles along each dimension it is tiled on — not one.  Sizing it
+    for a single tile lets the loop overrun into the next pooled buffer.
+
+    The factor is the product of `loop_count[level]` over exactly the levels
+    where this buffer carries a tiled dimension (`loop_tiled_dims[level]`
+    non-empty).  It is 1 for:
+      * `per_tile_fixed=True` buffers (base never advances — pinned scratch),
+      * buffers with no tiled dimension at any level (loop-invariant), and
+      * buffers with no coarse-tile `loop_info`.
+    Keying off the loop metadata rather than the `device_size` shape is
+    deliberate: the tiled dimension does not occupy a fixed device index
+    (e.g. it can be device dim 0 or dim 3), so a shape-based guess is wrong.
+    """
+    if getattr(layout, "per_tile_fixed", False):
+        return 1
+    loop_info = getattr(buf, "loop_info", None)
+    if loop_info is None:
+        return 1
+    factor = 1
+    for count, dims in zip(loop_info.loop_count, loop_info.loop_tiled_dims):
+        if dims and isinstance(count, (int, Integer)):
+            factor *= int(count)
+    return factor
+
+
 def _compute_size_bytes(name: str) -> int:
     """Return the stick-aligned device size in bytes for buffer `name`."""
     buf = V.graph.get_buffer(name)
@@ -103,7 +134,8 @@ def _compute_size_bytes(name: str) -> int:
     )
     dev_layout = layout.device_layout
     num_sticks = math.prod(dev_layout.device_size[:-1])
-    size_bytes = num_sticks * _STICK_BYTES
+    factor = _advance_factor(buf, layout)
+    size_bytes = num_sticks * _STICK_BYTES * factor
     return _align_up(size_bytes, _STICK_BYTES)
 
 

--- a/torch_spyre/_inductor/padding.py
+++ b/torch_spyre/_inductor/padding.py
@@ -293,6 +293,14 @@ def insert_bmm_padding(graph: GraphLowering) -> None:
         for i, new_op in enumerate(y_new_ops):
             operations.insert(op_idx + i, new_op)
 
+        # When coarse-tiling runs pre-stickification, the consuming matmul
+        # already carries loop_info.  The padding ops must inherit it so they
+        # remain contiguous in the loop group for build_loop_scheduler_nodes.
+        if hasattr(op, "loop_info"):
+            for new_op in y_new_ops:
+                if isinstance(new_op, ComputedBuffer):
+                    new_op.loop_info = op.loop_info  # type: ignore[attr-defined]
+
         # --- Rebuild matmul inner_fn to load y from the padded buffer ---
         # x is left entirely untouched: the original inner_fn's x loader is
         # preserved as-is.  Only y's loader is replaced with the padded buffer.

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -44,7 +44,7 @@ from .codegen.superdsc import (
     _should_use_k_fast_mapping,
 )
 from .constants import BATCH_MATMUL_OP, ELIDED_COPY_BACK_ATTR
-from .ir import FixedTiledLayout, SpyreConstantFallback
+from .ir import FixedTiledLayout, SpyreConstantFallback, SpyreEmptyFallback
 from .logging_utils import get_inductor_logger
 from .loop_info import copy_op_metadata
 from .views import compute_coordinates, matching_dim
@@ -62,7 +62,22 @@ class SchedNodeArg(NamedTuple):
 def _fixed_read_layout(buf) -> "FixedTiledLayout":
     layout = buf.get_layout()
     if isinstance(layout, MutationLayoutSHOULDREMOVE):
-        if not getattr(buf, ELIDED_COPY_BACK_ATTR, False):
+        # Reading real_layout() through a mutation layout is only valid once
+        # the target buffer's own layout is a committed FixedTiledLayout. Two
+        # producers of this shape:
+        #  - the copy-back elision optimization (propagate_layouts.py), which
+        #    stamps ELIDED_COPY_BACK_ATTR on the producer; or
+        #  - a sequential-carry op (_propagate_carry_op) that mutates directly
+        #    into a SpyreEmptyFallback accumulator (accum_tile) — a legitimate
+        #    in-group consumer (e.g. the next recurrence step) reads the carry
+        #    op's own output the same way an ordinary producer's output would
+        #    be read.
+        mutation_target = layout.get_buffer()
+        is_elided = getattr(buf, ELIDED_COPY_BACK_ATTR, False)
+        is_carry_into_accum = isinstance(
+            mutation_target, SpyreEmptyFallback
+        ) and isinstance(mutation_target.get_layout(), FixedTiledLayout)
+        if not (is_elided or is_carry_into_accum):
             raise RuntimeError(f"unexpected mutation layout on read buffer {buf}")
         layout = layout.real_layout()
     if not isinstance(layout, FixedTiledLayout):

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -329,12 +329,17 @@ def _maybe_coarse_tile_span_overflow(graph: GraphLowering) -> None:
     groups = span_overflow_groups(graph)
     if not groups:
         return
-    # span_overflow_groups assigns synthetic hint IDs starting from
-    # _SPAN_OVERFLOW_HINT_ID, so they never collide with hint-driven
-    # group IDs already stamped by _maybe_coarse_tile_hints.
+    # Compute offset to avoid loop_group_id collision with any hint-driven
+    # groups already stamped by _maybe_coarse_tile_hints.
+    used_ids = [
+        op.loop_info.loop_group_id[0]
+        for op in graph.operations
+        if hasattr(op, "loop_info") and op.loop_info is not None
+    ]
+    group_idx_offset = max(used_ids, default=-1) + 1
     op_order = {id(op): idx for idx, op in enumerate(graph.operations)}
     groups.sort(key=lambda group: op_order.get(id(group[0][0]), len(op_order)))
-    coarse_tile(graph, groups=groups)
+    coarse_tile(graph, groups=groups, group_idx_offset=group_idx_offset)
 
 
 @_runs(cost_model_matmul_division, work_distribution)

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -60,6 +60,7 @@ from .propagate_layouts import (
     propagate_spyre_tensor_layouts,
 )
 from .optimize_restickify import optimize_restickify_locations
+from .resolve_join_clusters import resolve_join_clusters
 from .insert_restickify import (
     finalize_layouts,
     insert_post_mutation_restickify,
@@ -395,6 +396,7 @@ class CustomPreSchedulingPasses:
             split_multi_ops,
             propagate_spyre_tensor_layouts,
             validate_ops,
+            resolve_join_clusters,
             optimize_restickify_locations,
             finalize_layouts,
             insert_restickify,

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -310,6 +310,52 @@ def _maybe_coarse_tile(graph: GraphLowering) -> None:
         coarse_tile(graph, groups=groups)
 
 
+@_runs(
+    reorder_unhinted_interlopers,
+    hints_to_coarse_tile_groups,
+    coarse_tile,
+)
+def _maybe_coarse_tile_hints(graph: GraphLowering) -> None:
+    """Hint-driven coarse tiling only.  Runs PRE-stickification.
+
+    span_overflow_groups is intentionally absent: it requires FixedTiledLayout
+    (device_layout) and must run post-stickification.
+    """
+    if config.ignore_wsr_hints:
+        return
+    reorder_unhinted_interlopers(graph)
+    groups = hints_to_coarse_tile_groups(graph)
+    if not groups:
+        return
+    op_order = {id(op): idx for idx, op in enumerate(graph.operations)}
+    groups.sort(key=lambda group: op_order.get(id(group[0][0]), len(op_order)))
+    coarse_tile(graph, groups=groups)
+
+
+@_runs(
+    span_overflow_groups,
+    coarse_tile,
+)
+def _maybe_coarse_tile_span_overflow(graph: GraphLowering) -> None:
+    """Span-overflow coarse tiling only.  Runs POST-stickification.
+
+    Requires FixedTiledLayout (device_layout) on all ops.
+    hint-driven groups (hints_to_coarse_tile_groups) are intentionally
+    absent: they have already run pre-stickification.
+    """
+    if config.ignore_span_overflow_hints:
+        return
+    groups = span_overflow_groups(graph)
+    if not groups:
+        return
+    # span_overflow_groups assigns synthetic hint IDs starting from
+    # _SPAN_OVERFLOW_HINT_ID, so they never collide with hint-driven
+    # group IDs already stamped by _maybe_coarse_tile_hints.
+    op_order = {id(op): idx for idx, op in enumerate(graph.operations)}
+    groups.sort(key=lambda group: op_order.get(id(group[0][0]), len(op_order)))
+    coarse_tile(graph, groups=groups)
+
+
 @_runs(cost_model_matmul_division, work_distribution)
 def _distribute_work(graph: GraphLowering) -> None:
     # cost_model_matmul_division claims a subset of ops; work_distribution skips

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -331,6 +331,7 @@ def _maybe_coarse_tile_span_overflow(graph: GraphLowering) -> None:
         return
     # Compute offset to avoid loop_group_id collision with any hint-driven
     # groups already stamped by _maybe_coarse_tile_hints.
+    # E.g. if hints used groups 0 and 1, span-overflow groups start at 2.
     used_ids = [
         op.loop_info.loop_group_id[0]
         for op in graph.operations

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -294,25 +294,6 @@ def _runs(*passes: Callable) -> Callable[[Callable], Callable]:
 @_runs(
     reorder_unhinted_interlopers,
     hints_to_coarse_tile_groups,
-    span_overflow_groups,
-    coarse_tile,
-)
-def _maybe_coarse_tile(graph: GraphLowering) -> None:
-    groups = []
-    if not config.ignore_wsr_hints:
-        reorder_unhinted_interlopers(graph)
-        groups += hints_to_coarse_tile_groups(graph)
-    if not config.ignore_span_overflow_hints:
-        groups += span_overflow_groups(graph)
-    if groups:
-        op_order = {id(op): idx for idx, op in enumerate(graph.operations)}
-        groups.sort(key=lambda group: op_order.get(id(group[0][0]), len(op_order)))
-        coarse_tile(graph, groups=groups)
-
-
-@_runs(
-    reorder_unhinted_interlopers,
-    hints_to_coarse_tile_groups,
     coarse_tile,
 )
 def _maybe_coarse_tile_hints(graph: GraphLowering) -> None:
@@ -393,6 +374,17 @@ class CustomPreSchedulingPasses:
         self.passes = [
             deadcode_elimination,
             #
+            # Working Set Reduction (hint-driven, pre-stickification)
+            # These passes only need host-side FixedLayout (size/stride) and
+            # loop variable ranges.  Running before stickification means
+            # _divide_ranges does not call _resize_device_layout: stickification
+            # computes the correct SpyreTensorLayout from the already-divided
+            # ranges.  This also dissolves the insert_restickify→hint cross-phase
+            # contract (issue #3135).
+            propagate_named_dims,
+            assign_dim_hints,
+            _maybe_coarse_tile_hints,
+            #
             # Tensor Layout (Stickification)
             split_multi_ops,
             propagate_spyre_tensor_layouts,
@@ -405,10 +397,10 @@ class CustomPreSchedulingPasses:
             #
             dedup_and_promote_constants,
             #
-            # Working Set Reduction
-            propagate_named_dims,
-            assign_dim_hints,
-            _maybe_coarse_tile,
+            # Working Set Reduction (device-layout-aware, post-stickification)
+            # These passes require FixedTiledLayout.device_layout (device_size,
+            # stride_map, elems_per_stick) for physical span arithmetic.
+            _maybe_coarse_tile_span_overflow,
             #
             # Core Division
             span_reduction,

--- a/torch_spyre/_inductor/patches.py
+++ b/torch_spyre/_inductor/patches.py
@@ -16,6 +16,7 @@ from contextlib import contextmanager
 
 import torch
 from torch._inductor.graph import GraphLowering
+from torch._inductor.scheduler import SchedulerNode
 from torch._inductor.utils import InputType
 from torch._inductor.virtualized import V
 from typing import Callable, Optional
@@ -121,6 +122,26 @@ def enable_spyre_context(
         old_update_scheduler(self)
 
     GraphLowering._update_scheduler = _spyre_update_scheduler  # type: ignore[method-assign]
+
+    # coarse_tile.py's sequential-carry mechanism (_propagate_carry_op) inserts
+    # a copy-out op that mutates a pre-loop seed buffer (accum_full) so its
+    # updated value is visible to the NEXT outer-tile iteration's copy-in.
+    # That cross-iteration read has no representation in the single-pass,
+    # pre-unroll IR the scheduler's own dead_node_elimination walks, so a
+    # carry copy-out with no other downstream reader looks dead and is
+    # removed — even though it is required for correctness. Mark such ops
+    # with _coarse_tile_force_live (see _insert_reduction_copy_op) and force
+    # SchedulerNode.has_side_effects() to report True for them, mirroring how
+    # upstream itself protects effectful FallbackKernels from the same DCE
+    # pass (torch/_inductor/lowering.py, effectful op handling).
+    old_scheduler_node_has_side_effects = SchedulerNode.has_side_effects
+
+    def _spyre_scheduler_node_has_side_effects(self: SchedulerNode) -> bool:
+        if getattr(self.node, "_coarse_tile_force_live", False):
+            return True
+        return old_scheduler_node_has_side_effects(self)
+
+    SchedulerNode.has_side_effects = _spyre_scheduler_node_has_side_effects  # type: ignore[method-assign]
 
     with (
         spyre_data_types(),

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -1369,11 +1369,42 @@ def propagate_spyre_tensor_layouts(
                     )
                     if not isinstance(target_buf, SpyreEmptyFallback):
                         continue
-                    # SpyreEmptyFallback accumulator has no device layout yet
-                    # (it is assigned during stickification).  Skip the
-                    # restickify optimizer for this op — the accumulator's STL
-                    # is determined by propagate_spyre_tensor_layouts on the
-                    # post-stickify path.
+                    # SpyreEmptyFallback accumulator has no device layout yet.
+                    # Treat the mutation op like a normal pointwise op: run
+                    # _multi_arg_pointwise_layouts with the "new value" inputs
+                    # (excluding the running accumulator read-back).  This
+                    # enforces the same input-compatibility and slice constraints
+                    # as a regular add, so the backend DDL slice check passes.
+                    rw = op.get_read_writes()
+                    output_dep = next(iter(rw.writes))
+                    all_args = _get_prop_args(rw.reads)
+                    # Exclude the running accumulator itself (dep.name == target_name)
+                    # from the layout constraint: it IS the output, not a new input.
+                    new_value_args = [a for a in all_args if a.dep.name != target_name]
+                    if not new_value_args:
+                        # No real inputs — fall back to unconstrained candidates.
+                        candidates = _all_constant_layouts(target_buf)
+                        target_buf.layouts = candidates
+                        op.layouts = candidates
+                        op.restick_cost_fn = AllSameNode.from_args(
+                            all_args, candidates, output_dep, op
+                        )
+                    else:
+                        accum_layout = target_buf.get_layout()
+                        candidates = _multi_arg_pointwise_layouts(
+                            op, accum_layout, output_dep, new_value_args
+                        )
+                        # op.restick_cost_fn was set by _multi_arg_pointwise_layouts
+                        # using only new_value_args.  The accumulator read-back
+                        # (target_name) is also a real input to this add and its
+                        # stick must match the output.  Rebuild the cost function
+                        # with all_args so the beam search enforces that constraint
+                        # and doesn't commit the accumulator to a mismatched layout.
+                        op.restick_cost_fn = AllSameNode.from_args(
+                            all_args, candidates, output_dep, op
+                        )
+                        target_buf.layouts = candidates
+                        op.layouts = candidates
                     continue
                 rw = op.get_read_writes()
                 output_dep = next(iter(rw.writes))

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -28,6 +28,7 @@ from torch._inductor.ir import (
     ExternKernel,
     FallbackKernel,
     FixedLayout,
+    FlexibleLayout,
     InputBuffer,
     MutationLayoutSHOULDREMOVE,
     MultiOutput,
@@ -716,7 +717,33 @@ def _matmul_layouts(
     # Concretize for C++ SpyreTensorLayout constructor.
     c_size = [concretize_expr(s) for s in output.size]
     c_stride = [concretize_expr(s) for s in output.stride]
-    out_stl = SpyreTensorLayout(c_size, c_stride, output.dtype, out_dim_order)
+
+    # For loop-internal bmm ops (_pending_per_tile_fixed=True), the host layout
+    # has been divided to per-tile size by _divide_ranges.  The C++ constructor
+    # produces stride_map[j]=64 for the tile-count device dim because it only
+    # sees the per-tile host size (e.g. 2) and cannot infer that this dim is a
+    # coarse-tile loop dim (not a real host dim).
+    #
+    # Fix: reconstruct the full-size host layout, compute its STL, then shrink
+    # back to the per-tile STL via _resize_device_layout.  This gives the
+    # correct stride_map (e.g. -1 for the tile-count device dim) that matches
+    # what post-stickify coarse tiling would produce on the main branch.
+    loop_info = getattr(op, "loop_info", None)
+    if getattr(op, "_pending_per_tile_fixed", False) and loop_info is not None:
+        from .coarse_tile import _resize_device_layout
+
+        full_c_size = list(c_size)
+        for level_dims, count in zip(loop_info.loop_tiled_dims, loop_info.loop_count):
+            for d in level_dims:
+                full_c_size[d] = c_size[d] * int(count)
+        full_c_stride = [int(s) for s in FlexibleLayout.contiguous_strides(full_c_size)]
+        full_stl = SpyreTensorLayout(
+            full_c_size, full_c_stride, output.dtype, out_dim_order
+        )
+        out_stl = _resize_device_layout(full_stl, full_c_size, c_size)
+    else:
+        out_stl = SpyreTensorLayout(c_size, c_stride, output.dtype, out_dim_order)
+
     op.restick_cost_fn = FixedInOutNode.from_args(
         [x, y], out_stl, [x_req_stl, y_req_stl], op
     )
@@ -1353,8 +1380,25 @@ def propagate_spyre_tensor_layouts(
                 while isinstance(target, ReinterpretView):
                     target = target.data
                 target_name = target.get_name() if hasattr(target, "get_name") else ""
+                # Look up the actual buffer node (unwraps TensorBox/StorageBox
+                # wrappers that coarse_tile.py places around SpyreEmptyFallback).
+                target_buf = V.graph.get_buffer(target_name) if target_name else None
                 target_stl = _target_device_layout(target, target_name)
                 if target_stl is None:
+                    logger.debug(
+                        "MutationLayoutSHOULDREMOVE target_stl=None: "
+                        "op=%s target_name=%r buf_type=%s",
+                        op.get_operation_name(),
+                        target_name,
+                        type(target_buf).__name__,
+                    )
+                    if not isinstance(target_buf, SpyreEmptyFallback):
+                        continue
+                    # SpyreEmptyFallback accumulator has no device layout yet
+                    # (it is assigned during stickification).  Skip the
+                    # restickify optimizer for this op — the accumulator's STL
+                    # is determined by propagate_spyre_tensor_layouts on the
+                    # post-stickify path.
                     continue
                 rw = op.get_read_writes()
                 output_dep = next(iter(rw.writes))
@@ -1363,8 +1407,12 @@ def propagate_spyre_tensor_layouts(
                 # Find an alternative layout if the write has an unsupported stick
                 # expression (e.g. offset like v+32). Force the optimizer to use
                 # this layout for the mutation target.
+                # Note: SpyreEmptyFallback targets are not graph inputs so skip
+                # the alt-layout path (which only applies to graph inputs).
                 target_layout = target.get_layout()
-                if isinstance(target_layout, FixedLayout):
+                if isinstance(target_layout, FixedLayout) and not isinstance(
+                    target_buf, SpyreEmptyFallback
+                ):
                     alt_stl = _find_alt_target_stl(
                         target_layout, target_stl, output_dep
                     )

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -1389,6 +1389,32 @@ def propagate_spyre_tensor_layouts(
                         op.restick_cost_fn = AllSameNode.from_args(
                             all_args, candidates, output_dep, op
                         )
+                    elif (
+                        isinstance(op.data, Reduction)
+                        and op.data.reduction_type == BATCH_MATMUL_OP
+                    ):
+                        # Tiled matmul/bmm accumulator: op computes a per-tile
+                        # partial matmul and writes it into a slice of the
+                        # full-size accumulator. x and y are the two genuine
+                        # matmul operands (never the accumulator read-back —
+                        # mirrors the non-accumulator BATCH_MATMUL_OP dispatch
+                        # in compute_layouts, whose args also never include the
+                        # reduction's own output buffer). _matmul_layouts
+                        # derives a single out_stl deterministically from
+                        # accum_layout and installs its own FixedInOutNode, so
+                        # the accumulator is automatically pinned to that same
+                        # out_stl -- no separate AllSameNode join is needed.
+                        assert len(new_value_args) == 2, (
+                            "BATCH_MATMUL_OP accumulator op should have exactly "
+                            f"two non-accumulator inputs, got {len(new_value_args)} "
+                            f"for {op.get_name()}"
+                        )
+                        accum_layout = target_buf.get_layout()
+                        candidates = _matmul_layouts(
+                            op, accum_layout, output_dep, new_value_args
+                        )
+                        target_buf.layouts = candidates
+                        op.layouts = candidates
                     elif isinstance(op.data, Reduction):
                         # Tiled-reduction accumulator: op computes a per-tile
                         # partial reduction and writes it into a slice of the

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -60,7 +60,7 @@ from .constants import (
     STAGGERED_EAS,
     TOPK_OPS,
 )
-from .ir import FixedTiledLayout, SpyreConstantFallback
+from .ir import FixedTiledLayout, SpyreConstantFallback, SpyreEmptyFallback
 from .pass_utils import (
     compute_restickify_target_layout,
     concretize_expr,
@@ -1429,6 +1429,13 @@ def propagate_spyre_tensor_layouts(
             op.layouts = [generic_layout(op)]
             op.restick_cost_fn = AnyInNode.from_args()
         elif isinstance(op, SpyreConstantFallback):
+            op.layouts = [generic_layout(op)]
+            op.restick_cost_fn = AnyInNode.from_args()
+        elif isinstance(op, SpyreEmptyFallback):
+            # Full-buffer placeholder allocated by _allocate_full_buffer when
+            # hint-driven coarse tiling runs pre-stickify.  Treat it like a
+            # constant: assign a single generic STL so downstream ops can read
+            # its layout through _get_prop_args without raising.
             op.layouts = [generic_layout(op)]
             op.restick_cost_fn = AnyInNode.from_args()
         elif isinstance(op, DeviceCopy):

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -1389,6 +1389,49 @@ def propagate_spyre_tensor_layouts(
                         op.restick_cost_fn = AllSameNode.from_args(
                             all_args, candidates, output_dep, op
                         )
+                    elif isinstance(op.data, Reduction):
+                        # Tiled-reduction accumulator: op computes a per-tile
+                        # partial reduction and writes it into a slice of the
+                        # full-size accumulator. The "new value" input is the
+                        # reduction's own un-reduced, higher-rank input, so
+                        # this must go through the same per-arg reduction
+                        # layout logic compute_layouts uses for ordinary
+                        # reductions (_single_arg_op_layout), not the
+                        # broadcast-oriented pointwise join path.
+                        assert len(new_value_args) == 1, (
+                            "Reduction op should have exactly one non-accumulator "
+                            f"input, got {len(new_value_args)} for {op.get_name()}"
+                        )
+                        accum_layout = target_buf.get_layout()
+                        in_arg = new_value_args[0]
+                        candidates = []
+                        for stl in in_arg.layouts:
+                            candidates.extend(
+                                _single_arg_op_layout(
+                                    op,
+                                    accum_layout,
+                                    output_dep,
+                                    in_arg.dep,
+                                    in_arg.layout,
+                                    stl,
+                                )
+                            )
+                        if not candidates:
+                            raise Unsupported(
+                                f"{op.get_name()}: no supported output layout "
+                                f"found for any of {len(in_arg.layouts)} "
+                                f"candidate input layouts; accum size="
+                                f"{accum_layout.size}"
+                            )
+                        # The accumulator read-back (target_name) is also a
+                        # real input to this op and its stick must match the
+                        # output, so build the cost function from all_args
+                        # (not just in_arg) — mirrors the pointwise branch.
+                        op.restick_cost_fn = AllSameNode.from_args(
+                            all_args, candidates, output_dep, op
+                        )
+                        target_buf.layouts = candidates
+                        op.layouts = candidates
                     else:
                         accum_layout = target_buf.get_layout()
                         candidates = _multi_arg_pointwise_layouts(

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -28,7 +28,6 @@ from torch._inductor.ir import (
     ExternKernel,
     FallbackKernel,
     FixedLayout,
-    FlexibleLayout,
     InputBuffer,
     MutationLayoutSHOULDREMOVE,
     MultiOutput,
@@ -718,31 +717,7 @@ def _matmul_layouts(
     c_size = [concretize_expr(s) for s in output.size]
     c_stride = [concretize_expr(s) for s in output.stride]
 
-    # For loop-internal bmm ops (_pending_per_tile_fixed=True), the host layout
-    # has been divided to per-tile size by _divide_ranges.  The C++ constructor
-    # produces stride_map[j]=64 for the tile-count device dim because it only
-    # sees the per-tile host size (e.g. 2) and cannot infer that this dim is a
-    # coarse-tile loop dim (not a real host dim).
-    #
-    # Fix: reconstruct the full-size host layout, compute its STL, then shrink
-    # back to the per-tile STL via _resize_device_layout.  This gives the
-    # correct stride_map (e.g. -1 for the tile-count device dim) that matches
-    # what post-stickify coarse tiling would produce on the main branch.
-    loop_info = getattr(op, "loop_info", None)
-    if getattr(op, "_pending_per_tile_fixed", False) and loop_info is not None:
-        from .coarse_tile import _resize_device_layout
-
-        full_c_size = list(c_size)
-        for level_dims, count in zip(loop_info.loop_tiled_dims, loop_info.loop_count):
-            for d in level_dims:
-                full_c_size[d] = c_size[d] * int(count)
-        full_c_stride = [int(s) for s in FlexibleLayout.contiguous_strides(full_c_size)]
-        full_stl = SpyreTensorLayout(
-            full_c_size, full_c_stride, output.dtype, out_dim_order
-        )
-        out_stl = _resize_device_layout(full_stl, full_c_size, c_size)
-    else:
-        out_stl = SpyreTensorLayout(c_size, c_stride, output.dtype, out_dim_order)
+    out_stl = SpyreTensorLayout(c_size, c_stride, output.dtype, out_dim_order)
 
     op.restick_cost_fn = FixedInOutNode.from_args(
         [x, y], out_stl, [x_req_stl, y_req_stl], op

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -829,8 +829,7 @@ def _multi_arg_pointwise_layouts(
         for arg in args
         for stl in arg.layouts
         if arg.dep.name not in ind_names
-        and (coords := try_device_coordinates(stl, arg.dep, ind_sizes))
-        is not None
+        and (coords := try_device_coordinates(stl, arg.dep, ind_sizes)) is not None
     }
 
     # If the indexing and device element size are identical
@@ -871,9 +870,7 @@ def _multi_arg_pointwise_layouts(
             # whole compile should abort -- so use try_device_coordinates and
             # treat None like a non-offset-free stick.
             coord = try_device_coordinates(in_stl, arg.dep, ind_sizes)
-            if coord is None or not is_stick_expr_offset_free(
-                coord[-1], stick_size
-            ):
+            if coord is None or not is_stick_expr_offset_free(coord[-1], stick_size):
                 return False
         return True
 
@@ -899,28 +896,12 @@ def _multi_arg_pointwise_layouts(
     elif not stick_exprs:
         _try_stick_dim(-1)
     else:
-        # A stick_expr of 0 (no free symbols) comes from a broadcast operand
-        # whose device stick maps to a size-1 host axis — it has no real dim
-        # to preserve. matching_dim (via _pick_stick_dim) already returns -1
-        # for such exprs, but that -1 is also the deliberate sentinel used by
-        # the `not stick_exprs` branch above to request a genuine sparse-stick
-        # layout (dim_order's trailing -1 protocol, see spyre_tensor_impl.cpp
-        # get_generic_stick_layout). Passing the broadcast operand's trivial 0
-        # through to _try_stick_dim would conflate the two, producing a bogus
-        # sparse-stick candidate for what is really a dense op. Drop
-        # zero-free-symbol exprs here so only genuine candidate stick dims
-        # reach _try_stick_dim.
         offset_free_stick_exprs = {
-            e
-            for e in stick_exprs
-            if e.free_symbols and is_stick_expr_offset_free(e, stick_size)
+            e for e in stick_exprs if is_stick_expr_offset_free(e, stick_size)
         }
-        if not offset_free_stick_exprs:
-            _try_stick_dim(-1)
-        else:
-            # Sort stick exprs for determinism
-            for stick_expr in sorted(offset_free_stick_exprs, key=iter_var_id):
-                _try_stick_dim(_pick_stick_dim(stick_expr, out_coords))
+        # Sort stick exprs for determinism
+        for stick_expr in sorted(offset_free_stick_exprs, key=iter_var_id):
+            _try_stick_dim(_pick_stick_dim(stick_expr, out_coords))
 
     # Always scan all dims so that dims absent from any input stick expression
     # (e.g. the outer broadcast dim) are also offered as candidates. Deduplicate
@@ -1010,9 +991,7 @@ def _multi_arg_pointwise_layouts(
     # committed. Reduction-accumulate combines are same-shape (no broadcast
     # operand) and keep their legitimately-bloated accumulator candidate.
     if any(list(arg.layout.size) != list(output.size) for arg in args):
-        host_elems = (
-            math.prod([int(s) for s in output.size]) if output.size else 1
-        )
+        host_elems = math.prod([int(s) for s in output.size]) if output.size else 1
         dense = [
             r
             for r in results

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -997,6 +997,30 @@ def _multi_arg_pointwise_layouts(
             f"with size={output.size} and coordinates={out_coords}"
         )
 
+    # A multi-arg pointwise op with a broadcast operand (an input whose host
+    # shape differs from the output, e.g. `output / denominator.unsqueeze(-1)`)
+    # can spawn a degenerate sparse/bloated output candidate whose device
+    # footprint exceeds the host element count (from the sparse-stick sentinel
+    # path). When the op reads a coarse-tile full accumulator whose own layout
+    # is that same degenerate shape, the beam commits the bloated candidate;
+    # the operands then restickify into a dimension-collapsed layout and the
+    # cross-tile read is misaligned (silent wrong result -- flash-attention's
+    # out-of-tiling-scope `output / denominator` divide). If an exact-footprint
+    # (dense) candidate exists, drop the bloated ones so the dense layout is
+    # committed. Reduction-accumulate combines are same-shape (no broadcast
+    # operand) and keep their legitimately-bloated accumulator candidate.
+    if any(list(arg.layout.size) != list(output.size) for arg in args):
+        host_elems = (
+            math.prod([int(s) for s in output.size]) if output.size else 1
+        )
+        dense = [
+            r
+            for r in results
+            if math.prod([d for d in r.device_size if d > 0]) == host_elems
+        ]
+        if dense and len(dense) < len(results):
+            results = dense
+
     if len(results) > 1:
         logger.info(
             f"Multi-arg pointwise ({op.get_name()}): producing {len(results)} candidate output layouts."

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -817,11 +817,20 @@ def _multi_arg_pointwise_layouts(
         output_ea = ElementArrangement.STANDARD
 
     ind_names, _, ind_sizes = indirect_info_from_op(op)
+    # arg.layouts is a set of *candidate* layouts; some candidates can map
+    # the device stick to a strided/unrepresentable host access (e.g. 2*d0
+    # from a coarse-tile fill buffer whose other candidates are fine). This
+    # is an enumeration of candidates, not a committed layout, so skip the
+    # unrepresentable ones via try_device_coordinates instead of letting
+    # device_coordinates abort the whole compile. The committed-layout
+    # selection below already filters on is_stick_expr_offset_free.
     stick_exprs = {
-        device_coordinates(stl, arg.dep, ind_sizes)[-1]
+        coords[-1]
         for arg in args
         for stl in arg.layouts
         if arg.dep.name not in ind_names
+        and (coords := try_device_coordinates(stl, arg.dep, ind_sizes))
+        is not None
     }
 
     # If the indexing and device element size are identical
@@ -857,8 +866,14 @@ def _multi_arg_pointwise_layouts(
             in_stl = SpyreTensorLayout(
                 c_in_size, c_in_stride, output.dtype, projected_dim_order, output_ea
             )
-            coord = device_coordinates(in_stl, arg.dep, ind_sizes)
-            if not is_stick_expr_offset_free(coord[-1], stick_size):
+            # Enumerating candidate dim_orders: an unrepresentable stick
+            # (e.g. 2*d0) means this candidate is unsupported, not that the
+            # whole compile should abort -- so use try_device_coordinates and
+            # treat None like a non-offset-free stick.
+            coord = try_device_coordinates(in_stl, arg.dep, ind_sizes)
+            if coord is None or not is_stick_expr_offset_free(
+                coord[-1], stick_size
+            ):
                 return False
         return True
 

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -884,12 +884,28 @@ def _multi_arg_pointwise_layouts(
     elif not stick_exprs:
         _try_stick_dim(-1)
     else:
+        # A stick_expr of 0 (no free symbols) comes from a broadcast operand
+        # whose device stick maps to a size-1 host axis — it has no real dim
+        # to preserve. matching_dim (via _pick_stick_dim) already returns -1
+        # for such exprs, but that -1 is also the deliberate sentinel used by
+        # the `not stick_exprs` branch above to request a genuine sparse-stick
+        # layout (dim_order's trailing -1 protocol, see spyre_tensor_impl.cpp
+        # get_generic_stick_layout). Passing the broadcast operand's trivial 0
+        # through to _try_stick_dim would conflate the two, producing a bogus
+        # sparse-stick candidate for what is really a dense op. Drop
+        # zero-free-symbol exprs here so only genuine candidate stick dims
+        # reach _try_stick_dim.
         offset_free_stick_exprs = {
-            e for e in stick_exprs if is_stick_expr_offset_free(e, stick_size)
+            e
+            for e in stick_exprs
+            if e.free_symbols and is_stick_expr_offset_free(e, stick_size)
         }
-        # Sort stick exprs for determinism
-        for stick_expr in sorted(offset_free_stick_exprs, key=iter_var_id):
-            _try_stick_dim(_pick_stick_dim(stick_expr, out_coords))
+        if not offset_free_stick_exprs:
+            _try_stick_dim(-1)
+        else:
+            # Sort stick exprs for determinism
+            for stick_expr in sorted(offset_free_stick_exprs, key=iter_var_id):
+                _try_stick_dim(_pick_stick_dim(stick_expr, out_coords))
 
     # Always scan all dims so that dims absent from any input stick expression
     # (e.g. the outer broadcast dim) are also offered as candidates. Deduplicate

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -273,6 +273,7 @@ def _set_no_named_dims(op):
 def _compute_named_dims(op, inputs):
     loop_var_dims = get_input_named_dims(inputs, op)
     output_dep = next(iter(op.get_read_writes().writes))
+
     for sym in output_dep.ranges:
         if sym not in loop_var_dims:
             size = int(output_dep.ranges[sym])
@@ -282,8 +283,22 @@ def _compute_named_dims(op, inputs):
     named_dims = []
     for coord in out_coords:
         sym = _lone_sym(coord)
-        if sym is not None:
-            named_dims.extend(loop_var_dims.get(sym, []))
+        if sym is None:
+            continue
+        names = loop_var_dims.get(sym, [])
+        # Skip size-1 loop vars that carry only untracked placeholder names.
+        # These arise when B=1: i0 (range 1) is absent from every input's
+        # loop_var_dims (compute_input_named_dims skips size-1 layout dims),
+        # so the fallback above assigns _untracked_1. Including it in
+        # named_dims would prepend an extra entry that confuses _consume_names
+        # in downstream ops (it would consume "B" into the wrong pair).
+        # Omitting it keeps named_dims aligned with the non-unit layout dims,
+        # matching the contract of compute_input_named_dims (size-1 → skip).
+        if int(output_dep.ranges.get(sym, 0)) == 1 and all(
+            n.startswith("_untracked_") for n in names
+        ):
+            continue
+        named_dims.extend(names)
     reduction_named_dims = None
     if isinstance(op.data, Reduction):
         reduction_sym = find_reduction_var(inputs[0], output_dep)

--- a/torch_spyre/_inductor/resolve_join_clusters.py
+++ b/torch_spyre/_inductor/resolve_join_clusters.py
@@ -1,0 +1,320 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Join-aware pre-pass for AllSameNode layout candidates.
+
+greedy_local_min_cost/beam_global_min_cost each commit an op's output layout
+using only that op's own local input costs. Two independent sibling ops that
+both feed a shared multi-input AllSameNode join (e.g. torch.maximum(M,
+block_max)) can each commit to a candidate that is individually cheapest for
+themselves but not mutually stick-compatible with each other at the join --
+and no per-op-local cost function can see far enough ahead to avoid this.
+
+This module runs as a pre-pass, before optimize_restickify_locations, and
+resolves such conflicts by jointly searching each cluster of siblings/joins
+for the assignment that minimizes total cost, then narrowing the affected
+buffers' own candidate lists so the later optimizer converges on that
+assignment. See docs in the coarse_tile / restickify design notes for the
+buf20/buf21/buf22 flash-attention case this was built to fix.
+"""
+
+import itertools
+import math
+from collections import defaultdict
+
+from torch._inductor.dependencies import MemoryDep
+from torch._inductor.graph import GraphLowering
+from torch._inductor.virtualized import V
+
+from .logging_utils import get_inductor_logger
+from .optimize_restickify import AllSameNode
+
+logger = get_inductor_logger("resolve_join_clusters")
+
+INF = math.inf
+
+# Skip clusters whose Cartesian product of candidate assignments exceeds this
+# bound. optimize_restickify_locations still runs afterward and raises its
+# usual, detailed _no_feasible_layout_error if the cluster turns out to be
+# genuinely infeasible, so skipping is no worse than doing nothing here.
+_MAX_COMBINATIONS = 4096
+
+
+def _stl_key(stl):
+    return (tuple(stl.device_size), tuple(stl.stride_map))
+
+
+def _find_join_ops(operations: list) -> list:
+    """Return every op whose restick_cost_fn is a multi-input AllSameNode."""
+    joins = []
+    for op in operations:
+        cost_fn = getattr(op, "restick_cost_fn", None)
+        if isinstance(cost_fn, AllSameNode) and len(cost_fn.edge_costs) > 1:
+            joins.append(op)
+    return joins
+
+
+def _sibling_names(op) -> list[str]:
+    return [
+        dep.name for dep in op.get_read_writes().reads if isinstance(dep, MemoryDep)
+    ]
+
+
+def _build_clusters(join_ops: list) -> list[list]:
+    """Union-find over join ops that share at least one input buffer.
+
+    Two join ops belong in the same cluster if they share a sibling input --
+    this keeps a buffer that feeds two different joins (e.g. a loop-carried
+    value read by both the running-max update and a later correction term)
+    in one cluster, so all of its constraints are considered together.
+    """
+    parent: dict[int, int] = {id(op): id(op) for op in join_ops}
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a, b):
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    buf_to_join: dict[str, int] = {}
+    for op in join_ops:
+        for name in _sibling_names(op):
+            if name in buf_to_join:
+                union(id(op), buf_to_join[name])
+            else:
+                buf_to_join[name] = id(op)
+
+    groups: dict[int, list] = defaultdict(list)
+    for op in join_ops:
+        groups[find(id(op))].append(op)
+    return list(groups.values())
+
+
+def _consumer_counts(operations: list) -> dict[str, int]:
+    """Return {buf_name: number of ops that read it} over the whole graph.
+
+    A buffer with more than one consumer can't have its candidate list
+    truncated for just one consumer's benefit, so _walk_chain uses this to
+    stop before it would affect an unrelated second reader.
+    """
+    counts: dict[str, int] = defaultdict(int)
+    for op in operations:
+        for dep in op.get_read_writes().reads:
+            if isinstance(dep, MemoryDep):
+                counts[dep.name] += 1
+    return counts
+
+
+def _walk_chain(buf, consumer_counts: dict[str, int]) -> list:
+    """Walk upstream from `buf` through single-input AllSameNode links.
+
+    Continues while the current buffer's restick_cost_fn is a single-edge
+    AllSameNode (one real input) and that input has at most one consumer
+    (safe to retarget without affecting a different reader). Returns
+    [root, ..., buf] -- root is the furthest-upstream buffer reached.
+    """
+    chain = [buf]
+    current = buf
+    while True:
+        cost_fn = getattr(current, "restick_cost_fn", None)
+        if not isinstance(cost_fn, AllSameNode) or len(cost_fn.edge_costs) != 1:
+            break
+        reads = [
+            dep for dep in current.get_read_writes().reads if isinstance(dep, MemoryDep)
+        ]
+        if len(reads) != 1:
+            break
+        in_name = reads[0].name
+        if consumer_counts.get(in_name, 0) > 1:
+            break
+        in_buf = V.graph.get_buffer(in_name)
+        if not hasattr(in_buf, "layouts"):
+            break
+        chain.append(in_buf)
+        current = in_buf
+    chain.reverse()
+    return chain
+
+
+def _derive_chain_value(chain: list, root_stl) -> tuple:
+    """Propagate a root candidate down a single-input AllSameNode chain.
+
+    Returns (final_stl, total_cost), or (None, INF) if the root candidate is
+    incompatible with the root's own upstream inputs, or some later link has
+    no compatible candidate for the value produced by the previous link.
+    """
+    root_cost = _own_upstream_cost(chain[0], root_stl)
+    if root_cost == INF:
+        return None, INF
+    stl, cost = root_stl, root_cost
+    for buf in chain[1:]:
+        cost_fn = buf.restick_cost_fn
+        ec = cost_fn.edge_costs[0]
+        best_c, best_cost = None, INF
+        for candidate in buf.layouts:
+            c = ec.cost(stl, candidate)
+            if c < best_cost:
+                best_cost, best_c = c, candidate
+        if best_c is None or best_cost == INF:
+            return None, INF
+        stl, cost = best_c, cost + best_cost
+    return stl, cost
+
+
+def _flexible_siblings(
+    cluster: list, consumer_counts: dict[str, int]
+) -> dict[str, list]:
+    """Return {buf_name: chain} for every distinct input buffer in the
+    cluster whose upstream chain root has more than one candidate layout.
+
+    Each chain is [root, ..., direct_sibling] as returned by _walk_chain --
+    a chain of length 1 means the sibling itself is the root.
+    """
+    siblings: dict[str, list] = {}
+    for op in cluster:
+        for name in _sibling_names(op):
+            if name in siblings:
+                continue
+            buf = V.graph.get_buffer(name)
+            if not hasattr(buf, "layouts"):
+                continue
+            chain = _walk_chain(buf, consumer_counts)
+            if len(chain[0].layouts) > 1:
+                siblings[name] = chain
+    return siblings
+
+
+def _own_upstream_cost(buf, candidate) -> float:
+    """Cost of `buf` committing to `candidate`, against its own upstream
+    inputs (0.0 for buffers with no restick_cost_fn, e.g. graph inputs)."""
+    cost_fn = getattr(buf, "restick_cost_fn", None)
+    if cost_fn is None:
+        return 0.0
+    in_layouts = []
+    for dep in buf.get_read_writes().reads:
+        if isinstance(dep, MemoryDep):
+            in_buf = V.graph.get_buffer(dep.name)
+            in_layouts.append(
+                getattr(in_buf, "committed_stl", None) or in_buf.layouts[0]
+            )
+    return cost_fn.cost(in_layouts, candidate)
+
+
+def _join_best_cost(join_op, assignment: dict) -> float:
+    """Best achievable cost for `join_op`, given a candidate assignment for
+    its sibling inputs, minimized over the join's own output candidates."""
+    sibling_names = _sibling_names(join_op)
+    in_layouts = []
+    for name in sibling_names:
+        if name in assignment:
+            in_layouts.append(assignment[name])
+        else:
+            buf = V.graph.get_buffer(name)
+            in_layouts.append(getattr(buf, "committed_stl", None) or buf.layouts[0])
+    cost_fn = join_op.restick_cost_fn
+    best = INF
+    for candidate in join_op.layouts:
+        best = min(best, cost_fn.cost(in_layouts, candidate))
+    return best
+
+
+def _resolve_cluster(cluster: list, consumer_counts: dict[str, int]) -> None:
+    siblings = _flexible_siblings(cluster, consumer_counts)
+    if not siblings:
+        return
+
+    names = list(siblings.keys())
+    chains = [siblings[name] for name in names]
+    root_candidate_lists = [chain[0].layouts for chain in chains]
+    n_combinations = math.prod(len(c) for c in root_candidate_lists)
+    if n_combinations > _MAX_COMBINATIONS:
+        logger.info(
+            "resolve_join_clusters: skipping cluster with %d combinations "
+            "(> %d cap): %s",
+            n_combinations,
+            _MAX_COMBINATIONS,
+            [op.get_name() for op in cluster],
+        )
+        return
+
+    best_cost = INF
+    best_assignment = None  # name -> (sibling_stl, chain_cost, root_stl)
+    for combo in itertools.product(*root_candidate_lists):
+        assignment = {}
+        total = 0.0
+        feasible = True
+        for name, chain, root_stl in zip(names, chains, combo):
+            sibling_stl, chain_cost = _derive_chain_value(chain, root_stl)
+            if sibling_stl is None:
+                feasible = False
+                break
+            assignment[name] = (sibling_stl, chain_cost, root_stl)
+            total += chain_cost
+        if not feasible:
+            continue
+        join_layouts = {name: stl for name, (stl, _, _) in assignment.items()}
+        for join_op in cluster:
+            total += _join_best_cost(join_op, join_layouts)
+        if total < best_cost:
+            best_cost = total
+            best_assignment = assignment
+
+    if best_assignment is None or best_cost == INF:
+        # No jointly feasible assignment found -- leave candidates untouched
+        # so optimize_restickify_locations's own diagnostic fires normally.
+        return
+
+    for name, (sibling_stl, _, root_stl) in best_assignment.items():
+        chain = siblings[name]
+        root = chain[0]
+        own_best_root = min(root.layouts, key=lambda c: _own_upstream_cost(root, c))
+        if _stl_key(own_best_root) == _stl_key(root_stl):
+            continue  # chain's own optimum already matches the joint winner
+
+        stl = root_stl
+        root.layouts[:] = [stl]
+        for buf in chain[1:]:
+            cost_fn = buf.restick_cost_fn
+            ec = cost_fn.edge_costs[0]
+            best_c, best_c_cost = None, INF
+            for candidate in buf.layouts:
+                c = ec.cost(stl, candidate)
+                if c < best_c_cost:
+                    best_c_cost, best_c = c, candidate
+            buf.layouts[:] = [best_c]
+            stl = best_c
+        logger.debug(
+            "resolve_join_clusters: pinned chain %s to joint-optimal candidate "
+            "device_size=%s (own-optimal candidate was not jointly feasible)",
+            [buf.get_name() for buf in chain],
+            list(sibling_stl.device_size),
+        )
+
+
+def resolve_join_clusters(graph: GraphLowering) -> None:
+    """Pin sibling candidates that feed a shared multi-input join to the
+    combination with globally-minimal cost, when that differs from each
+    sibling's own independently-cheapest choice."""
+    join_ops = _find_join_ops(graph.operations)
+    if not join_ops:
+        return
+    consumer_counts = _consumer_counts(graph.operations)
+    for cluster in _build_clusters(join_ops):
+        _resolve_cluster(cluster, consumer_counts)

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -123,6 +123,96 @@ def _loop_count(node: BaseSchedulerNode, depth: int) -> sympy.Expr:
     raise AssertionError(f"Node {node.get_name()} has no loop_count for depth {depth}")
 
 
+def _regroup_by_outer_loop_key(
+    nodes: list[BaseSchedulerNode],
+) -> list[BaseSchedulerNode]:
+    """Reorder ``nodes`` so every outermost loop_group_id run is contiguous.
+
+    Inductor's own ``Scheduler.topological_sort_schedule`` runs (twice) before
+    this pass ever sees the node list, via a plain DFS over
+    ``unmet_dependencies``.  That DFS only guarantees a *valid* topological
+    order — it does not preserve the original relative order of mutually
+    independent nodes, so it can interleave unrelated nodes into the middle
+    of what coarse_tile.py built as a single contiguous loop group.
+
+    A naive "stable sort by first occurrence of the group key" is unsound: it
+    can hoist a later group member forward past an interleaved node it
+    genuinely depends on, producing an invalid order. Instead, merge every
+    node sharing an outermost loop_group_id[0] key into one virtual unit for
+    ordering purposes — its dependency set is the union of its members' real
+    unmet_dependencies on buffers produced outside the group — and run a
+    dependency-respecting DFS (mirroring topological_sort_schedule's own
+    shape) over {merged units, ungrouped nodes}. Each unit then expands back
+    into its original members in their original relative order, which is
+    always safe because that intra-group order is coarse_tile's deliberate
+    op sequence, not something this pass reorders.
+
+    The result is a valid topological order (edges are the real edges of the
+    original graph) in which every outermost loop group is contiguous by
+    construction.
+    """
+    name_to_node: dict[str, BaseSchedulerNode] = {}
+    for node in nodes:
+        for name in node.get_buffer_names():
+            name_to_node[name] = node
+
+    outer_key_to_unit: dict[object, list[BaseSchedulerNode]] = {}
+    units: list[Union[BaseSchedulerNode, list[BaseSchedulerNode]]] = []
+    unit_of_node: dict[int, Union[BaseSchedulerNode, list[BaseSchedulerNode]]] = {}
+
+    for node in nodes:
+        gid = _loop_group_id(node)
+        outer_key = gid[0] if gid is not None else None
+        if outer_key is None:
+            units.append(node)
+            unit_of_node[id(node)] = node
+            continue
+        unit = outer_key_to_unit.get(outer_key)
+        if unit is None:
+            unit = []
+            outer_key_to_unit[outer_key] = unit
+            units.append(unit)
+        unit.append(node)
+        unit_of_node[id(node)] = unit
+
+    def unit_key(unit) -> int:
+        return id(unit) if isinstance(unit, list) else id(unit)
+
+    unit_deps: dict[int, OrderedSet] = {}
+    unit_members: dict[int, list[BaseSchedulerNode]] = {}
+    for unit in units:
+        members = unit if isinstance(unit, list) else [unit]
+        member_ids = {id(m) for m in members}
+        deps: OrderedSet = OrderedSet()
+        for member in members:
+            for dep in member.unmet_dependencies:
+                producer = name_to_node.get(dep.name)
+                if producer is None or id(producer) in member_ids:
+                    continue
+                deps.add(unit_key(unit_of_node[id(producer)]))
+        unit_deps[unit_key(unit)] = deps
+        unit_members[unit_key(unit)] = members
+
+    seen: set = set()
+    ordered_units: list = []
+
+    def visit(key: int) -> None:
+        if key in seen:
+            return
+        seen.add(key)
+        for dep_key in unit_deps[key]:
+            visit(dep_key)
+        ordered_units.append(key)
+
+    for unit in units:
+        visit(unit_key(unit))
+
+    result: list[BaseSchedulerNode] = []
+    for key in ordered_units:
+        result.extend(unit_members[key])
+    return result
+
+
 def _build_loop_group(
     nodes: list[BaseSchedulerNode], depth: int
 ) -> list[BaseSchedulerNode]:
@@ -130,6 +220,10 @@ def _build_loop_group(
 
     depth is the nesting level being processed (0 = outermost).  Each node's
     loop_group_id is a tuple; we group on element [depth].
+
+    Callers are expected to have already made outermost (depth 0) runs
+    contiguous via ``_regroup_by_outer_loop_key`` — this function itself only
+    scans linearly and does not tolerate gaps.
     """
     result: list[BaseSchedulerNode] = []
     i = 0
@@ -182,9 +276,11 @@ def build_loop_scheduler_nodes(
 
     loop_group_id is a tuple of ints encoding the nesting path, e.g.
     (0,) for an outermost group, (0, 1) for a nested group inside group 0.
-    Nodes sharing the same outermost key must be contiguous; a gap indicates
-    a data-flow dependency crossing the group boundary, which is a bug in
-    the tiling pass.
+    Nodes sharing the same outermost key are made contiguous by
+    ``_regroup_by_outer_loop_key`` before grouping, since Inductor's own
+    ``Scheduler.topological_sort_schedule`` (a DFS that runs twice before
+    this pass ever sees the node list) does not preserve the tiling pass's
+    intended contiguous ordering for mutually independent nodes.
 
     Running before Inductor's fusion pass ensures CountedLoopSchedulerNodes are
     visible to SuperDSCScheduling.can_fuse_vertical/horizontal (which return False),
@@ -192,9 +288,12 @@ def build_loop_scheduler_nodes(
     aware of CountedLoopSchedulerNodes: they are accumulated alongside plain
     SchedulerNodes and may share a bundle with adjacent ops.
     """
+    nodes = _regroup_by_outer_loop_key(nodes)
     result = _build_loop_group(nodes, depth=0)
 
-    # Verify contiguity: no loop_group_id should appear in two separate runs.
+    # _regroup_by_outer_loop_key guarantees outermost runs are contiguous by
+    # construction; this is a defensive check, not the primary correctness
+    # mechanism.  A failure here would indicate a bug in that construction.
     seen: dict[tuple, str] = {}
     for node in result:
         if isinstance(node, CountedLoopSchedulerNode):
@@ -204,8 +303,9 @@ def build_loop_scheduler_nodes(
                 name = node.get_name()
                 if key in seen and seen[key] != name:
                     raise RuntimeError(
-                        f"Loop group {key} is not contiguous in the scheduler node list. "
-                        "This indicates a data-flow dependency crossing a loop group boundary."
+                        f"Loop group {key} is not contiguous in the scheduler node list "
+                        "after _regroup_by_outer_loop_key. This indicates a bug in that "
+                        "regrouping, not a data-flow issue in the tiling pass."
                     )
                 seen[key] = name
 

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -75,6 +75,7 @@ from torch_spyre._inductor.scratchpad.utils import (
     GraphView,
     get_op_pointwise_inputs,
     _would_produce_lx_back_gap,
+    _is_tiled_advancing,
 )
 from torch_spyre._inductor.scratchpad.graph_editor import GraphEditor
 
@@ -218,6 +219,15 @@ class ScratchpadAllocator:
             for op in graph.operations
             if op.name not in drop_list and buffer_not_read_in_full(graph, op.name)
         )
+
+        # filter out advancing (tiled, non-per_tile_fixed) buffers: LX
+        # addresses cannot be expressed as affine.apply symbols today (see
+        # compute_ops.py's is_tiled_lx check), so such a buffer must stay in
+        # HBM, where its per-iteration address advance is fully supported.
+        for op in graph.operations:
+            if op.name not in drop_list and _is_tiled_advancing(op):
+                drop_list.add(op.name)
+                self.reject_reasons[op.name] = "tiled (advancing), not per_tile_fixed"
 
         if not clone_at_graph_boundaries():
             # Without clone support, graph outputs cannot be LX-pinned: the caller

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -28,6 +28,7 @@ from torch._inductor.ops_handler import WrapperHandler
 import sympy
 
 from torch_spyre._inductor import config
+from torch_spyre._inductor.ir import FixedTiledLayout
 from torch_spyre._inductor.pass_utils import (
     _per_core_view_on_buf,
     concretize_expr,
@@ -210,6 +211,28 @@ def buffer_not_read_in_full(graph: GraphLowering | GraphView, buf_name: str) -> 
             except (TypeError, ValueError, AttributeError):
                 return True
     return False
+
+
+def _is_tiled_advancing(op: Operation) -> bool:
+    """True if ``op``'s output advances its address across a coarse-tile loop.
+
+    LX addresses are never registered as ``affine.apply`` symbols in the SDSC
+    JSON (see ``compute_ops.py``'s ``is_tiled_lx`` check), so a buffer that
+    advances per loop iteration (tiled, and not ``per_tile_fixed``) has no way
+    to express its address change if pinned to LX. This mirrors that check,
+    but at IR time via ``loop_info`` instead of the later per-tensor strides
+    representation, letting the allocator exclude such buffers from LX
+    candidacy up front instead of crashing at codegen time.
+    """
+    layout = getattr(op, "layout", None)
+    if not isinstance(layout, FixedTiledLayout) or layout.per_tile_fixed:
+        return False
+    loop_info = getattr(op, "loop_info", None)
+    if loop_info is None:
+        return False
+    return any(dims for dims in loop_info.loop_tiled_dims) or any(
+        dims for dims in getattr(loop_info, "loop_tiled_reduction_dims", [])
+    )
 
 
 def _writes_at_constant_offset(op: Operation) -> bool:

--- a/torch_spyre/_inductor/split_multi_ops.py
+++ b/torch_spyre/_inductor/split_multi_ops.py
@@ -17,7 +17,12 @@ import dataclasses
 import sympy
 import torch
 import torch.fx as fx
-from torch._inductor.ir import ComputedBuffer, FixedLayout, Pointwise
+from torch._inductor.ir import (
+    ComputedBuffer,
+    FixedLayout,
+    MutationLayoutSHOULDREMOVE,
+    Pointwise,
+)
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.graph import GraphLowering
 from torch._inductor.ops_handler import WrapperHandler
@@ -724,7 +729,7 @@ def split_multi_ops(graph: GraphLowering):
         if not (
             isinstance(op, ComputedBuffer)
             and isinstance(op.data, Pointwise)
-            and isinstance(op.layout, FixedLayout)
+            and isinstance(op.layout, (FixedLayout, MutationLayoutSHOULDREMOVE))
         ):
             continue
 
@@ -737,7 +742,13 @@ def split_multi_ops(graph: GraphLowering):
         if len(compute_ops) <= 1:
             continue
 
-        layout = op.layout
+        # Use real_layout() for MutationLayoutSHOULDREMOVE so _make_intermediate_bufs
+        # gets a valid device and dtype from the underlying FixedLayout.
+        layout = (
+            op.layout.real_layout()
+            if isinstance(op.layout, MutationLayoutSHOULDREMOVE)
+            else op.layout
+        )
         dtype_map = _propagate_dtypes(trace, layout.dtype)
         bufname_map = _init_vid_to_bufname(trace)
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Moves `propagate_named_dims`, `assign_dim_hints`, and the hint-driven half of
`_maybe_coarse_tile` to run **before** the stickification passes in
`CustomPreSchedulingPasses`. The span-overflow path and
`_maybe_chunk_large_tensors` stay post-stickify (they require
`FixedTiledLayout.device_layout`).

**Motivation**

Three interconnected problems with the previous ordering:

1. **Cross-phase hint contract (issue #3135):** `insert_restickify` had to call
   `copy_fx_custom_meta` to forward `_hint_N` metadata onto newly-inserted
   restickify nodes so that `propagate_named_dims`/`assign_dim_hints` — running
   later — could see hints on them. This was an invisible semantic contract that
   required restickify to understand hint semantics.

2. **`_resize_device_layout` complexity:** When coarse tiling ran post-stickify,
   `_divide_ranges` had to call a 200-line four-pass heuristic to
   reverse-engineer the updated `SpyreTensorLayout` after shrinking a buffer's
   iteration ranges. This was fragile and the primary source of failures in
   multi-level nested tiling scenarios.

3. **Nested tiling regressions:** The device-layout recomputation caused wrong
   results in `outer_M + inner_K` and `outer_Batch + inner_K` tiling
   combinations (seen on the flash-debug branch).

**Approach**

- Split `_maybe_coarse_tile` into `_maybe_coarse_tile_hints` (pre-stickify) and
  `_maybe_coarse_tile_span_overflow` (post-stickify)
- Move `propagate_named_dims`, `assign_dim_hints`, `_maybe_coarse_tile_hints`
  before the stickification block; stickification now runs after ranges are
  already divided and assigns the correct `SpyreTensorLayout` from scratch
- Remove `copy_fx_custom_meta` from `insert_restickify` — the cross-phase
  contract no longer exists
- Move loop-invariant `per_tile_fixed` assignment to `finalize_layouts`; add
  `_pending_per_tile_fixed` deferred flag for loop-internal buffers
- Fix `_allocate_full_buffer` to produce plain `FixedLayout` pre-stickify
- Relax `FixedTiledLayout` guard in `_propagate_tiled_reduction_op`
- Copy `loop_info` onto inserted restickify nodes for contiguity check
- Add `group_idx_offset` to `coarse_tile()` to prevent `loop_group_id`
  collision between the two separate calls

**Results**

- All 5 nested matmul/bmm tests pass (`TestCoarseTileNestedReductionE2E`) —
  previously failing on the flash-debug branch
- 326 tests pass, 1 xfailed
- `_resize_device_layout` is no longer called from the hint-driven path; it
  remains only for the post-stickify span-overflow path

#### Which issue(s) this PR is related to:

Fixes #3135

#### Special notes for your reviewer:

One pre-existing test failure remains: `test_hint_flash_attention`. This test
also fails on `main` before this branch (with a `DtException` from the hardware
backend). On this branch it fails with a slice-size mismatch in DDL codegen.
The failure mode changed but the test was not passing before this PR.

`_resize_device_layout` is retained in `coarse_tile.py` for the post-stickify
span-overflow path. Its scope is now documented in its docstring.

#### Does this PR introduce a user-facing change?

No change to the user-facing `spyre_hint` API or model compilation interface.
Compilation of models that use `spyre_hint` for coarse tiling will produce
identical output (and now produce correct output for nested outer+inner tiling
combinations that were previously broken).

#### Additional note:

The new pass ordering is documented in the `CustomPreSchedulingPasses.__init__`
comments in `passes.py`.