### PR TITLE
fix(views): materialize unbind slice views so on-device reads are correct

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_misc_shape_b_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_misc_shape_b_config.yaml
@@ -29,16 +29,9 @@ test_suite_config:
             - LxPlanning.*::test_flatten_4d_full_lx_planning_(pointwise|reduction)
             - LxPlanning.*::test_flatten_4d_large_full_lx_planning_(pointwise|reduction)
             - LxPlanning.*::test_flatten_4d_trailing_lx_planning_(pointwise|reduction)
-            - LxPlanning.*::test_unbind_1d_dim0_lx_planning_(pointwise|reduction)
-            - LxPlanning.*::test_unbind_2d_dim0_lx_planning_(pointwise|reduction)
-            - LxPlanning.*::test_unbind_2d_dim1_lx_planning_(pointwise|reduction)
-            - LxPlanning.*::test_unbind_2d_dimneg1_lx_planning_(pointwise|reduction)
-            - LxPlanning.*::test_unbind_3d_dim0_lx_planning_(pointwise|reduction)
-            - LxPlanning.*::test_unbind_3d_dim1_lx_planning_(pointwise|reduction)
-            - LxPlanning.*::test_unbind_3d_dim2_lx_planning_(pointwise|reduction)
-            - LxPlanning.*::test_unbind_3d_dimneg1_lx_planning_(pointwise|reduction)
-            - LxPlanning.*::test_unbind_4d_dim0_lx_planning_(pointwise|reduction)
-            - LxPlanning.*::test_unbind_4d_dim3_lx_planning_(pointwise|reduction)
+            # unbind_* LX cases now pass via the unbind slice-view CPU-roundtrip
+            # reroute (this PR); promoted to the test_unbind.* mandatory_success
+            # block below.
             - LxPlanning.*::test_flatten_3d_leading_lx_planning_reduction
             - LxPlanning.*::test_flatten_4d_leading_lx_planning_reduction
             - LxPlanning.*::test_round_trip_to_dtype_add_float16_to_float32_4x8x128_lx_planning_reduction

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -528,6 +528,27 @@ def _(
     return input.new_empty(shape)
 
 
+@torch.library.custom_op("spyre::unbind_via_cpu", mutates_args=(), device_types="spyre")
+def spyre_unbind_via_cpu(input: torch.Tensor, dim: int) -> list[torch.Tensor]:
+    """Unbind materialized on CPU: returns a list of compact (contiguous) slices.
+
+    ``aten.unbind`` returns strided slice views that share the parent storage; an
+    on-device read of such a slice mis-addresses (an unsupported stick expression,
+    or -- on some dims -- an incompatible host_size/dim_order). Materializing each
+    slice into its own compact buffer (CPU round-trip, then ``.contiguous()``)
+    lets consumers read normal buffers. Mirrors ``spyre.reshape_via_cpu`` but
+    returns a list, one tensor per slice.
+    """
+    warn_fallback("torch.ops.spyre.unbind_via_cpu")
+    cpu = input.to("cpu")
+    return [s.contiguous().to(input.device) for s in cpu.unbind(dim)]
+
+
+@spyre_unbind_via_cpu.register_fake
+def _(input: torch.Tensor, dim: int) -> list[torch.Tensor]:
+    return [s.contiguous() for s in input.unbind(dim)]
+
+
 @torch.library.custom_op("spyre::min_dim_int64_fallback", mutates_args=())
 def min_dim_int64_fallback(
     input: torch.Tensor, dim: int, keepdim: bool = False

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -42,6 +42,7 @@ from .temp_passes import (
     bmm_unflatten_pass,
     mark_direct_unit_bmm_pass,
     mm_to_bmm_pass,
+    reroute_unbind,
 )
 from .coarse_tile import (
     hints_to_coarse_tile_groups,
@@ -212,6 +213,9 @@ class CustomPostPasses(_SpyreGraphPassPipeline):
                 mm_to_bmm_pass.apply,
                 mark_direct_unit_bmm_pass,
                 bmm_unflatten_pass.apply,
+                # Materialize aten.unbind's strided slice views (they mis-address
+                # when read on-device) through the CPU round-trip fallback.
+                reroute_unbind,
             ]
         )
 

--- a/torch_spyre/_inductor/temp_passes.py
+++ b/torch_spyre/_inductor/temp_passes.py
@@ -14,6 +14,8 @@
 
 # This file contains inductor passes that are only needed as temp fixes
 
+import warnings
+
 import torch
 from torch._inductor.pattern_matcher import (
     Arg,
@@ -25,6 +27,7 @@ from torch._inductor.pattern_matcher import (
 from .logging_utils import get_inductor_logger
 from .constants import SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY
 from .pass_utils import copy_fx_custom_meta
+from ..ops.fallbacks import FallbackWarning
 
 aten = torch.ops.aten
 
@@ -363,3 +366,42 @@ def _unflatten_bmm_batch_dims(
                 and not expand_node.users
             ):
                 graph.erase_node(expand_node)
+
+
+def reroute_unbind(graph: torch.fx.Graph) -> None:
+    """Route ``aten.unbind`` through a CPU round-trip fallback.
+
+    ``aten.unbind`` returns strided slice views (one per index along ``dim``,
+    surfacing as ``getitem`` nodes) that share the parent storage. An on-device
+    read of such a slice mis-addresses -- an unsupported stick expression, or an
+    incompatible host_size/dim_order on some dims. Rewrite the unbind to
+    ``spyre.unbind_via_cpu`` (returns a list of compact slices) so the downstream
+    ``getitem`` consumers read normal buffers. Correctness fallback with a
+    device<->host copy cost; each rewrite emits a ``FallbackWarning``. Mirrors the
+    ``spyre.reshape_via_cpu`` materialize fallback.
+    """
+    for node in list(graph.nodes):
+        if node.op != "call_function" or node.target != aten.unbind.int:
+            continue
+        # Only rewrite an unbind that is actually used (its slices surface as
+        # getitem nodes feeding on-device ops); an unused unbind is dropped by
+        # DCE anyway.
+        if not any(user.op != "output" for user in node.users):
+            continue
+        inp = node.args[0]
+        dim = int(node.args[1]) if len(node.args) > 1 else 0
+        with graph.inserting_after(node):
+            new_node = graph.call_function(
+                torch.ops.spyre.unbind_via_cpu.default, (inp, dim)
+            )
+        new_node.meta.update(node.meta)
+        copy_fx_custom_meta(node, new_node)
+        node.replace_all_uses_with(new_node)
+        graph.erase_node(node)
+        warnings.warn(
+            f"unbind (dim={dim}) routed through a CPU round-trip "
+            "(spyre.unbind_via_cpu): correctness fallback with a device<->host "
+            "copy cost",
+            category=FallbackWarning,
+        )
+    graph.lint()

--- a/torch_spyre/csrc/spyre_views.cpp
+++ b/torch_spyre/csrc/spyre_views.cpp
@@ -240,6 +240,27 @@ at::Tensor spyre_unfold(const at::Tensor& self, int64_t dimension, int64_t size,
   return result;
 }
 
+std::vector<at::Tensor> spyre_unbind(const at::Tensor& self, int64_t dim) {
+  // aten.unbind returns strided slice views (one per index along dim) that
+  // share the parent storage and mis-address when read on-device. Materialize
+  // each slice into a compact buffer instead of returning aliasing views (CPU
+  // round-trip). Correctness fallback with a device<->host copy cost; gives up
+  // unbind view aliasing. The compiled path has the equivalent reroute_unbind
+  // pass; mirrors the spyre.reshape_via_cpu materialize fallback.
+  TORCH_WARN_ONCE(
+      "Spyre: unbind (dim ", dim,
+      ") materialized via a CPU round-trip; correctness fallback with a "
+      "device<->host copy cost. Gives up unbind view aliasing: unbind's slices "
+      "are strided views of the parent storage that mis-address when read "
+      "on-device.");
+  dim = c10::maybe_wrap_dim(dim, self.dim());
+  std::vector<at::Tensor> out;
+  for (const auto& slice : self.cpu().unbind(dim)) {
+    out.push_back(slice.contiguous().to(self.device()));
+  }
+  return out;
+}
+
 TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
   m.impl("view", TORCH_FN(spyre_view));
   m.impl("_unsafe_view", TORCH_FN(spyre__unsafe_view));
@@ -247,6 +268,7 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
   m.impl("alias", TORCH_FN(spyre_alias));
   m.impl("as_strided", TORCH_FN(spyre_as_strided));
   m.impl("unfold", TORCH_FN(spyre_unfold));
+  m.impl("unbind.int", TORCH_FN(spyre_unbind));
 }
 
 }  // namespace spyre


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the contributing guidelines (https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Materializes aten.unbind's slice views so downstream on-device reads are correct.

aten.unbind returns strided slice views (one per index along dim, surfacing as getitem nodes) that share the parent storage. When an on-device kernel reads such a slice it mis-addresses, either an unsupported multi-variable stick expression (some dims) or an Incompatible host_size and dim_order error (others). Materializing each slice into its own compact buffer resolves both.

The fix covers both execution paths, mirroring the existing spyre.reshape_via_cpu fallback:
- Compiled: a reroute_unbind post-grad FX pass rewrites aten.unbind.int -> a new spyre::unbind_via_cpu op (CPU round-trip returning a list of compact slices).
- Eager: spyre_unbind returns materialized (contiguous) slices instead of aliasing views.

#### Which issue(s) this PR is related to:

No dedicated issue — this is the unbind analog of the view-materialization work tracked for unfold in #2346. It clears the unbind cases in the LX-planning op suite.

#### Special notes for your reviewer:

- main already carries the spyre::reshape_via_cpu op; this adds the parallel unbind_via_cpu op, the reroute pass, and the eager guard.
- The predicate is intentionally broad (materialize any used aten.unbind); over-materialization only adds a copy, never affects correctness.

#### Does this PR introduce a user-facing change?

Eager torch.unbind on the spyre device now returns materialized (non-aliasing) slices rather than views — in-place writes through an unbind slice will no longer propagate to the parent. (The aliasing-write path is a separate concern; unbind's views were not correctly readable on-device anyway.)

#### Additional note:

Validation (greedy LX-planning, main base):
- Unbind op subset: 30/30 pass (all LX unbind cases + base test_unbind), both compiled and eager paths.