### PR TITLE
fix: for PR https://github.com/torch-spyre/torch-spyre/pull/2913

### DIFF
--- a/torch_spyre/_C.pyi
+++ b/torch_spyre/_C.pyi
@@ -21,6 +21,7 @@ __all__: list[str] = [
     "as_strided_with_layout",
     "empty_with_layout",
     "copy_tensor",
+    "fill_tensor",
     "encode_constant",
     "free_runtime",
     "get_device_dtype",
@@ -287,6 +288,16 @@ def copy_tensor(
 
     Args:
         self or dst: one of that must be on spyre device
+    """
+    ...
+
+def fill_tensor(self: torch.Tensor, value: float) -> torch.Tensor:
+    """
+    Fill a spyre tensor with a scalar value using device-side FillDMA.
+
+    Args:
+        self: the spyre tensor to fill (in-place)
+        value: the fill value (converted to the tensor's dtype pattern)
     """
     ...
 

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -339,6 +339,11 @@ PYBIND11_MODULE(_C, m) {
         "Copy tensor between host and device using DMA", py::arg("self"),
         py::arg("dst"), py::arg("non_blocking") = false);
 
+  // Device-side fill using FillDMA (no host buffer or H2D copy)
+  m.def("fill_tensor", &spyre::spyre_fill_tensor,
+        "Fill a spyre tensor with a scalar value using device-side FillDMA",
+        py::arg("self"), py::arg("value"));
+
   // Stream management functions
   m.def("get_stream_from_pool", &spyre::getStreamFromPool, py::arg("device"),
         py::arg("priority") = 0,

--- a/torch_spyre/csrc/module.h
+++ b/torch_spyre/csrc/module.h
@@ -52,6 +52,7 @@ class GlobalRuntime {
 };
 bool get_downcast_warn_enabled();
 bool is_supported_dtype(c10::ScalarType dtype);
+DataFormats get_device_dtype(c10::ScalarType torch_dtype);
 
 int device_count();
 void startRuntime();

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -769,6 +769,28 @@ const at::Tensor& spyre_resize_(
   return self;
 }
 
+at::Tensor spyre_fill_tensor(const at::Tensor& self, double value) {
+  TORCH_CHECK(self.is_privateuseone(), "spyre_fill_tensor: tensor must be on spyre device");
+  TORCH_CHECK(self.numel() > 0, "spyre_fill_tensor: cannot fill empty tensor");
+
+  // Get the device allocation (CompositeAddress) from the spyre tensor
+  auto* spyre_impl = static_cast<SpyreTensorImpl*>(self.unsafeGetTensorImpl());
+  auto& storage = spyre_impl->storage();
+  auto* ctx = static_cast<SharedOwnerCtx*>(storage.data_ptr().get_context());
+
+  // Map torch dtype to DataFormats for the fill pattern conversion
+  DataFormats dtype = get_device_dtype(self.scalar_type());
+
+  // Construct FillParams and launch via SpyreStream
+  flex::FillParams params(&ctx->composite_addr, ctx->composite_addr.total_size(),
+                          flex::RuntimeOperationFill::valueToFillPattern(value, dtype),
+                          /*use_dmai=*/true);
+  SpyreStream stream;
+  stream.launchFill(&params);
+
+  return self;
+}
+
 TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
   m.impl("empty.memory_format", TORCH_FN(spyre_empty));
   m.impl("empty_strided", TORCH_FN(spyre_empty_strided));

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -770,7 +770,8 @@ const at::Tensor& spyre_resize_(
 }
 
 at::Tensor spyre_fill_tensor(const at::Tensor& self, double value) {
-  TORCH_CHECK(self.is_privateuseone(), "spyre_fill_tensor: tensor must be on spyre device");
+  TORCH_CHECK(self.is_privateuseone(),
+              "spyre_fill_tensor: tensor must be on spyre device");
   TORCH_CHECK(self.numel() > 0, "spyre_fill_tensor: cannot fill empty tensor");
 
   // Get the device allocation (CompositeAddress) from the spyre tensor
@@ -782,9 +783,10 @@ at::Tensor spyre_fill_tensor(const at::Tensor& self, double value) {
   DataFormats dtype = get_device_dtype(self.scalar_type());
 
   // Construct FillParams and launch via SpyreStream
-  flex::FillParams params(&ctx->composite_addr, ctx->composite_addr.total_size(),
-                          flex::RuntimeOperationFill::valueToFillPattern(value, dtype),
-                          /*use_dmai=*/true);
+  flex::FillParams params(
+      &ctx->composite_addr, ctx->composite_addr.total_size(),
+      flex::RuntimeOperationFill::valueToFillPattern(value, dtype),
+      /*use_dmai=*/true);
   SpyreStream stream;
   stream.launchFill(&params);
 

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -779,16 +779,17 @@ at::Tensor spyre_fill_tensor(const at::Tensor& self, double value) {
   auto& storage = spyre_impl->storage();
   auto* ctx = static_cast<SharedOwnerCtx*>(storage.data_ptr().get_context());
 
-  // Map torch dtype to DataFormats for the fill pattern conversion
+  // Map torch dtype to DataFormats; fillAsync converts the value to the correct
+  // 32-bit hardware pattern internally.
   DataFormats dtype = get_device_dtype(self.scalar_type());
 
-  // Construct FillParams and launch via SpyreStream
-  flex::FillParams params(
-      &ctx->composite_addr, ctx->composite_addr.total_size(),
-      flex::RuntimeOperationFill::valueToFillPattern(value, dtype),
-      /*use_dmai=*/true);
+  // Launch the device-side fill via SpyreStream. We use the typed fillAsync
+  // overload rather than building a FillParams ourselves: it does the
+  // value→pattern conversion internally, avoiding a dependency on
+  // flex::RuntimeOperationFill::valueToFillPattern (which is not exported from
+  // libflex).
   SpyreStream stream;
-  stream.launchFill(&params);
+  stream.fillAsync(&ctx->composite_addr, value, dtype, /*use_dmai=*/true);
 
   return self;
 }

--- a/torch_spyre/csrc/spyre_mem.h
+++ b/torch_spyre/csrc/spyre_mem.h
@@ -32,6 +32,19 @@ at::Tensor spyre_empty_strided(c10::IntArrayRef size, c10::IntArrayRef stride,
 at::Tensor spyre_copy_from(const at::Tensor& self, const at::Tensor& dst,
                            bool non_blocking);
 
+/**
+ * Fill a spyre tensor with a scalar value using device-side FillDMA.
+ *
+ * Uses flex::RuntimeStream::fillAsync() to perform the fill entirely
+ * on-device without allocating a host buffer or performing an H2D DMA.
+ *
+ * @param self The spyre tensor to fill (in-place)
+ * @param value The fill value as a double (converted to the correct hardware
+ *              pattern based on the tensor's dtype)
+ * @return The filled tensor (same as self)
+ */
+at::Tensor spyre_fill_tensor(const at::Tensor& self, double value);
+
 class SpyreTensorLayout;
 at::Tensor spyre_empty_with_layout(c10::IntArrayRef size,
                                    c10::IntArrayRef stride,

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -226,6 +226,10 @@ void SpyreStream::launchHostCallback(flex::HostCallbackParams* params) const {
   resolveRuntimeHandle()->launchOperationHostCallback(params);
 }
 
+void SpyreStream::launchFill(flex::FillParams* params) const {
+  resolveRuntimeHandle()->launchOperationFill(params);
+}
+
 void SpyreStream::launch(const JobPlan& plan,
                          const std::vector<at::Tensor>& args) const {
   // Validate all tensors are on Spyre device

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -226,8 +226,9 @@ void SpyreStream::launchHostCallback(flex::HostCallbackParams* params) const {
   resolveRuntimeHandle()->launchOperationHostCallback(params);
 }
 
-void SpyreStream::launchFill(flex::FillParams* params) const {
-  resolveRuntimeHandle()->launchOperationFill(params);
+void SpyreStream::fillAsync(const flex::CompositeAddress* dst, double value,
+                            DataFormats dtype, bool use_dmai) const {
+  resolveRuntimeHandle()->fillAsync(dst, value, dtype, use_dmai);
 }
 
 void SpyreStream::launch(const JobPlan& plan,

--- a/torch_spyre/csrc/spyre_stream.h
+++ b/torch_spyre/csrc/spyre_stream.h
@@ -59,6 +59,7 @@ class SpyreStream {
   void launchD2H(flex::DmaParams* params) const;
   void launchCompute(flex::ComputeParams* params) const;
   void launchHostCallback(flex::HostCallbackParams* params) const;
+  void launchFill(flex::FillParams* params) const;
 
   // Conversions
   c10::Stream unwrap() const;

--- a/torch_spyre/csrc/spyre_stream.h
+++ b/torch_spyre/csrc/spyre_stream.h
@@ -59,7 +59,11 @@ class SpyreStream {
   void launchD2H(flex::DmaParams* params) const;
   void launchCompute(flex::ComputeParams* params) const;
   void launchHostCallback(flex::HostCallbackParams* params) const;
-  void launchFill(flex::FillParams* params) const;
+
+  // Device-side memory fill. Converts `value` to the correct 32-bit hardware
+  // pattern for `dtype` internally (no host buffer or H2D copy).
+  void fillAsync(const flex::CompositeAddress* dst, double value,
+                 DataFormats dtype, bool use_dmai = true) const;
 
   // Conversions
   c10::Stream unwrap() const;

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -129,8 +129,7 @@ register_torch_compile_kernel(
 def spyre__fill_scalar(
     self: torch.Tensor, other: int | float | bool | complex
 ) -> torch.Tensor:
-    tmp = torch.ones(self.size(), dtype=self.dtype) * other
-    self.copy_(tmp)
+    torch_spyre._C.fill_tensor(self, float(other))
     return self
 
 
@@ -149,12 +148,8 @@ def spyre__normal_(self, mean=0.0, std=1.0, *, generator=None):
 
 @torch.library.register_kernel("aten::zero_", ["spyre"])  # type:ignore
 def spyre__zero_(self: torch.Tensor) -> torch.Tensor:
-    """Zero out the tensor in-place."""
-    # Create zeros on CPU
-    tmp = torch.zeros(self.size(), dtype=self.dtype, device="cpu")
-    # Copy to device
-    self.copy_(tmp)
-    # TODO: Can we zero out tensors in-place without copy
+    """Zero out the tensor in-place using device-side FillDMA."""
+    torch_spyre._C.fill_tensor(self, 0.0)
     return self
 
 

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -133,6 +133,39 @@ def spyre__fill_scalar(
     return self
 
 
+@torch.library.register_kernel("aten::full", ["spyre"])  # type:ignore
+def spyre_full(
+    size: list | tuple,
+    fill_value: int | float | bool | complex,
+    *,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
+) -> torch.Tensor:
+    assert layout in (torch.strided, None), f"doesn't support layout={layout}"
+    assert not pin_memory, f"doesn't support pin_memory={pin_memory}"
+    t = torch.empty(size, dtype=dtype, device=device)
+    torch_spyre._C.fill_tensor(t, float(fill_value))
+    return t
+
+
+@torch.library.register_kernel("aten::ones", ["spyre"])  # type:ignore
+def spyre_ones(
+    size: list | tuple,
+    *,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
+) -> torch.Tensor:
+    assert layout in (torch.strided, None), f"doesn't support layout={layout}"
+    assert not pin_memory, f"doesn't support pin_memory={pin_memory}"
+    t = torch.empty(size, dtype=dtype, device=device)
+    torch_spyre._C.fill_tensor(t, 1.0)
+    return t
+
+
 @torch.library.register_kernel("aten::normal_", ["spyre"])  # type:ignore
 def spyre__normal_(self, mean=0.0, std=1.0, *, generator=None):
     # "normal_" generates a random tensor, thus copying

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -129,6 +129,8 @@ register_torch_compile_kernel(
 def spyre__fill_scalar(
     self: torch.Tensor, other: int | float | bool | complex
 ) -> torch.Tensor:
+    if isinstance(other, complex):
+        raise TypeError("spyre fill_ does not support complex fill values")
     torch_spyre._C.fill_tensor(self, float(other))
     return self
 
@@ -145,6 +147,8 @@ def spyre_full(
 ) -> torch.Tensor:
     assert layout in (torch.strided, None), f"doesn't support layout={layout}"
     assert not pin_memory, f"doesn't support pin_memory={pin_memory}"
+    if isinstance(fill_value, complex):
+        raise TypeError("spyre full does not support complex fill values")
     t = torch.empty(size, dtype=dtype, device=device)
     torch_spyre._C.fill_tensor(t, float(fill_value))
     return t


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

fix: for PR https://github.com/torch-spyre/torch-spyre/pull/2913

#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/pull/2913

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

  ## Root cause & fix: `undefined symbol` at backend autoload

  ### Symptom

  Every test failed at collection with:

  ```
  ImportError while loading conftest '.../pytorch/test/conftest.py'
    ...
    from torch.testing._internal.common_utils import parse_cmd_line_args
    torch/__init__.py: _import_device_backends()
  RuntimeError: Failed to load the backend extension: torch_spyre.
    You can disable extension auto-loading with TORCH_DEVICE_BACKEND_AUTOLOAD=0.
  ```

  Because every test file imports `torch`, and importing `torch` auto-loads the `torch_spyre` backend, a failure to load `torch_spyre._C` breaks **the entire suite** at collection time — not just the fill tests.

  ### Root cause

  The generic `RuntimeError: Failed to load the backend extension` wraps a lower-level exception that the CI test driver doesn't surface. Reproduced on a pod with the same Flex build as CI (`ibm-flex-2.0.0-0.main.1+380.05bd9fa`), the real error
  is:

  ```
  ImportError: torch_spyre/_C.so: undefined symbol:
    _ZN4flex20RuntimeOperationFill18valueToFillPatternEd11DataFormats
  ```

  Demangled: `flex::RuntimeOperationFill::valueToFillPattern(double, DataFormats)`.

  `spyre_fill_tensor()` called this helper to compute the 32-bit fill pattern:

  ```cpp
  flex::FillParams params(
      &ctx->composite_addr, ctx->composite_addr.total_size(),
      flex::RuntimeOperationFill::valueToFillPattern(value, dtype),  // <-- unresolved at load time
      /*use_dmai=*/true);
  stream.launchFill(&params);
  ```

  The symbol **is declared** in the installed Flex header (`runtime_operation.hpp:496`), so `_C.so` compiles and links cleanly (shared-library symbols are resolved lazily at `dlopen`, not at link time). But in the installed `libflex.so` it is a
  **local, non-exported symbol**:

  ```
  $ nm -DC /opt/ibm/spyre/runtime/lib/libflex.so | grep -iE 'valueToFillPattern|launchOperationFill|fillAsync'
  000000000026e630 t flex::RuntimeOperationFill::valueToFillPattern(double, DataFormats)   # lowercase t = local/hidden — NOT exported
  0000000000222440 T flex::RuntimeStream::launchOperationFill(flex::FillParams*)           # T = exported
  000000000021fb00 T flex::RuntimeStream::fillAsync(const CompositeAddress*, double, DataFormats, bool)  # T = exported
  000000000021fb30 T flex::RuntimeStream::fillAsync(const CompositeAddress*, uint32_t, bool)             # T = exported
  ```

  Flex is built with hidden default visibility. `struct FLEX_EXPORT FillParams`, `launchOperationFill`, and both `fillAsync` overloads carry the `FLEX_EXPORT` visibility attribute, but the `static valueToFillPattern` method declaration does not
  — so it never entered the dynamic symbol table. `_C.so` therefore has one unresolvable dependency, and `dlopen` fails the moment PyTorch autoloads the backend.

  This is the "depends on a PR in Flex" note in the PR description: that Flex change landed **partially** in the CI image — the fill entry points shipped, but the `valueToFillPattern` helper is not exported.

  (The `FillParams` constructor is defined inline in the header, so it produces no symbol dependency; `valueToFillPattern` was the only breakage.)

  ### Fix

  Route the fill through the **exported** typed overload `flex::RuntimeStream::fillAsync(const CompositeAddress*, double, DataFormats, bool)`, which performs the value→pattern conversion internally. This removes torch-spyre's dependency on the
  unexported `valueToFillPattern` (and on building a `FillParams` at all), and matches the behavior already described in `spyre_mem.h`'s docstring ("Uses `flex::RuntimeStream::fillAsync()`").

  `spyre_mem.cpp` — `spyre_fill_tensor()`:

  ```cpp
  DataFormats dtype = get_device_dtype(self.scalar_type());
  SpyreStream stream;
  stream.fillAsync(&ctx->composite_addr, value, dtype, /*use_dmai=*/true);
  ```

  `spyre_stream.{h,cpp}` — replaced `launchFill(FillParams*)` with a thin `fillAsync` wrapper:

  ```cpp
  void SpyreStream::fillAsync(const flex::CompositeAddress* dst, double value,
                              DataFormats dtype, bool use_dmai) const {
    resolveRuntimeHandle()->fillAsync(dst, value, dtype, use_dmai);
  }
  ```

  Files changed:

  ```
   torch_spyre/csrc/spyre_mem.cpp    | 15 ++++++++-------
   torch_spyre/csrc/spyre_stream.cpp |  5 +++--
   torch_spyre/csrc/spyre_stream.h   |  6 +++++-
  ```

  ### Verification

  On a pod with the same Flex build as CI, after rebuilding `_C.so`:

  - **No unresolved fill symbols** — the only remaining fill dependency is `fillAsync`, which is exported (`T`):
    ```
    $ nm -DC torch_spyre/_C.so | grep ' U .*fill'
      U flex::RuntimeStream::fillAsync(const flex::CompositeAddress*, double, DataFormats, bool)
    ```
  - **Backend imports** — `import torch` succeeds; `torch.spyre.is_available()` → `True`.
  - **Correct results** for `torch.full`, `torch.ones`, `torch.zeros`, `fill_`, `zero_`, incl. `int32` dtype (value→pattern conversion happens correctly inside Flex).
  - `pytest tests/test_spyre.py -k "fill or zero or ones or full"` → **3 passed**.

  ### Follow-up (not required by this PR)

  The missing `FLEX_EXPORT` on `flex::RuntimeOperationFill::valueToFillPattern` is a latent Flex bug — any future caller of that helper will hit the same wall. Worth filing against Flex so the method is exported. This PR no longer depends on it.

  If you'd rather have it as a file in the repo (e.g. to attach or link), I can write it to a .md — just say where.