### PR TITLE
feat(explorer): link knowledge-graph nodes to source and add interactivity

### DIFF
--- a/docs/source/_ext/extract_graph.py
+++ b/docs/source/_ext/extract_graph.py
@@ -879,6 +879,11 @@ def build_graph(torch_spyre_root):
         "metadata": {
             "source_commit": _get_git_sha(repo_root),
             "torch_spyre_root": str(root.relative_to(repo_root)),
+            # Canonical repo used to build "view source" links in the explorer.
+            # The JS pins links to source_commit when available and falls back
+            # to the default branch otherwise.
+            "repo_url": "https://github.com/torch-spyre/torch-spyre",
+            "default_branch": "main",
         },
         "nodes": list(seen.values()),
         "edges": valid_edges,

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -101,3 +101,45 @@ code.literal {
     border-color: #3498db;
     box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.15);
 }
+
+/* View control buttons (fit / focus / png / reset) */
+.kg-ctrl-btn {
+    padding: 5px 12px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #fff;
+    color: #444;
+    font-size: 0.85em;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.kg-ctrl-btn:hover {
+    background: #f0f4f8;
+    border-color: #3498db;
+    color: #2c3e50;
+}
+
+.kg-ctrl-btn.active {
+    background: #3498db;
+    border-color: #3498db;
+    color: #fff;
+    font-weight: 600;
+}
+
+/* "View source" link in the info panel */
+.kg-source-link {
+    display: inline-block;
+    margin-top: 2px;
+    text-decoration: none;
+    color: #2c3e50;
+}
+
+.kg-source-link:hover {
+    text-decoration: underline;
+}
+
+/* Neighbor links stay quiet until hovered */
+.kg-neighbor:hover {
+    background: #fffbe6;
+}

--- a/docs/source/_static/js/knowledge_graph.js
+++ b/docs/source/_static/js/knowledge_graph.js
@@ -136,8 +136,30 @@
   // -------------------------------------------------------------------------
 
   var graphData = null;
+  var graphMeta = {};
   var activeCy = null;
   var activeView = null;
+  var focusMode = false;
+
+  // -------------------------------------------------------------------------
+  // Build a "view source" URL back to the code that defines a node.
+  //
+  // Node source_file paths are repo-relative (e.g.
+  // "torch_spyre/_inductor/lowering.py"). We pin to the exact commit the
+  // graph was extracted from so a link never rots against a moved line;
+  // if the commit is unknown (graph built outside a git checkout), fall
+  // back to the default branch.
+  // -------------------------------------------------------------------------
+
+  function buildSourceUrl(sourceFile, line) {
+    if (!sourceFile) return null;
+    var repo = graphMeta.repo_url || "https://github.com/torch-spyre/torch-spyre";
+    var commit = graphMeta.source_commit;
+    var ref = commit && commit !== "unknown" ? commit : graphMeta.default_branch || "main";
+    var url = repo + "/blob/" + ref + "/" + sourceFile;
+    if (line) url += "#L" + line;
+    return url;
+  }
 
   // -------------------------------------------------------------------------
   // Cytoscape style shared across views
@@ -318,6 +340,11 @@
     if (activeView === viewKey && activeCy) return;
     activeView = viewKey;
 
+    // A new view has no selection; drop any lingering focus state.
+    focusMode = false;
+    var focusBtn = document.getElementById("kg-focus");
+    if (focusBtn) focusBtn.classList.remove("active");
+
     var view = VIEWS[viewKey];
     var filtered = filterForView(viewKey);
 
@@ -375,19 +402,22 @@
 
     activeCy.layout(layoutOpts).run();
 
-    // Click handler
+    // Single click: select the node (highlight + info panel).
     activeCy.on("tap", "node", function (evt) {
-      activeCy.elements().removeClass("selected-node neighbor");
-      var node = evt.target;
-      node.addClass("selected-node");
-      node.neighborhood("node").addClass("neighbor");
-      showNodeInfo(node.data());
+      selectNode(evt.target.id());
     });
 
+    // Double click: jump straight to the defining source on GitHub.
+    activeCy.on("dbltap", "node", function (evt) {
+      var d = evt.target.data();
+      var url = buildSourceUrl(d.source_file, d.line);
+      if (url) window.open(url, "_blank", "noopener");
+    });
+
+    // Background click: clear selection, focus, and the deep link.
     activeCy.on("tap", function (evt) {
       if (evt.target === activeCy) {
-        activeCy.elements().removeClass("selected-node neighbor");
-        clearInfo();
+        clearSelection();
       }
     });
 
@@ -413,11 +443,22 @@
     // Clear search
     var search = document.getElementById("kg-search");
     if (search) search.value = "";
+
+    // Reflect the active view in the URL (node cleared on view switch).
+    updateHash(null);
   }
 
   // -------------------------------------------------------------------------
   // UI: info panel
   // -------------------------------------------------------------------------
+
+  function escapeHtml(s) {
+    return String(s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
 
   function showNodeInfo(data) {
     var info = document.getElementById("kg-info");
@@ -427,28 +468,47 @@
       "background:" +
       meta.color +
       ';border-radius:2px;vertical-align:middle;margin-right:6px;"></span>';
-    html += "<strong>" + data.label + "</strong>";
-    html += " <em>(" + meta.label + ")</em>";
+    html += "<strong>" + escapeHtml(data.label) + "</strong>";
+    html += " <em>(" + escapeHtml(meta.label) + ")</em>";
+
+    // Source location: a clickable link straight to the defining code.
     if (data.source_file) {
-      html += "<br>File: <code>" + data.source_file + "</code>";
-      if (data.line) {
-        html += " line " + data.line;
+      var url = buildSourceUrl(data.source_file, data.line);
+      var locText = escapeHtml(data.source_file);
+      if (data.line) locText += ":" + data.line;
+      if (url) {
+        html +=
+          '<br><a class="kg-source-link" href="' +
+          escapeHtml(url) +
+          '" target="_blank" rel="noopener noreferrer" ' +
+          'title="Open this definition on GitHub">' +
+          "&#128196; <code>" +
+          locText +
+          "</code> &#8599;</a>";
+      } else {
+        html += "<br>File: <code>" + locText + "</code>";
       }
+    } else {
+      html +=
+        '<br><span style="color:#999;">No single source location ' +
+        "(this node is referenced from several places).</span>";
     }
-    var neighbors = activeCy
-      .getElementById(data.id)
-      .neighborhood("node");
+
+    var neighbors = activeCy.getElementById(data.id).neighborhood("node");
     if (neighbors.length > 0) {
       html += "<br><strong>Connected to:</strong> ";
       var items = neighbors
         .map(function (n) {
           var nm = TYPE_META[n.data("type")] || { color: "#bdc3c7" };
           return (
-            '<span style="border-bottom:2px solid ' +
+            '<a href="#" class="kg-neighbor" data-node-id="' +
+            escapeHtml(n.id()) +
+            '" style="border-bottom:2px solid ' +
             nm.color +
-            '">' +
-            n.data("label") +
-            "</span>"
+            ';text-decoration:none;color:inherit;" ' +
+            'title="Focus this node">' +
+            escapeHtml(n.data("label")) +
+            "</a>"
           );
         })
         .slice(0, 15);
@@ -462,7 +522,149 @@
 
   function clearInfo() {
     document.getElementById("kg-info").innerHTML =
-      "<em>Click a node to see its source location and connections.</em>";
+      "<em>Click a node to see its source location and connections. " +
+      "Double-click a node to jump straight to its code.</em>";
+  }
+
+  // Select a node by id: highlight it and its neighbors, center the
+  // viewport on it, and refresh the info panel. Shared by tap handlers,
+  // the "Connected to" neighbor links, and deep-link restoration.
+  function selectNode(nodeId, opts) {
+    if (!activeCy) return;
+    var node = activeCy.getElementById(nodeId);
+    if (!node || node.empty()) return;
+    activeCy.elements().removeClass("selected-node neighbor");
+    node.addClass("selected-node");
+    node.neighborhood("node").addClass("neighbor");
+    if (focusMode) applyFocus(node);
+    if (!opts || opts.center !== false) {
+      activeCy.animate({ center: { eles: node }, duration: 250 });
+    }
+    showNodeInfo(node.data());
+    updateHash(nodeId);
+  }
+
+  // -------------------------------------------------------------------------
+  // Focus mode, selection, and deep-linking
+  // -------------------------------------------------------------------------
+
+  // Fade everything except a node and its immediate neighborhood, so a
+  // dense view collapses to just the relationships around one concept.
+  function applyFocus(node) {
+    activeCy.elements().addClass("faded");
+    node.closedNeighborhood().removeClass("faded");
+  }
+
+  function clearFocus() {
+    if (activeCy) activeCy.elements().removeClass("faded");
+  }
+
+  function toggleFocus() {
+    focusMode = !focusMode;
+    var btn = document.getElementById("kg-focus");
+    if (btn) btn.classList.toggle("active", focusMode);
+    var selected = activeCy ? activeCy.$(".selected-node") : null;
+    if (focusMode && selected && selected.length) {
+      applyFocus(selected);
+    } else {
+      clearFocus();
+    }
+  }
+
+  function clearSelection() {
+    if (activeCy) activeCy.elements().removeClass("selected-node neighbor");
+    clearFocus();
+    clearInfo();
+    updateHash(null);
+  }
+
+  // Reflect the current view (and optionally a selected node) in the URL
+  // hash so a specific node can be linked and shared, e.g. the page can be
+  // opened at "#ops/op::mm" to land directly on that op.
+  function updateHash(nodeId) {
+    if (!activeView) return;
+    var hash = "#" + activeView;
+    if (nodeId) hash += "/" + encodeURIComponent(nodeId);
+    if (typeof history !== "undefined" && history.replaceState) {
+      history.replaceState(null, "", hash);
+    } else {
+      location.hash = hash;
+    }
+  }
+
+  function parseHash() {
+    var h = (location.hash || "").replace(/^#/, "");
+    if (!h) return null;
+    var slash = h.indexOf("/");
+    if (slash === -1) return { view: h, nodeId: null };
+    return {
+      view: h.slice(0, slash),
+      nodeId: decodeURIComponent(h.slice(slash + 1)),
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // UI: view controls (fit / focus / reset / export)
+  // -------------------------------------------------------------------------
+
+  function setupControls() {
+    var fit = document.getElementById("kg-fit");
+    if (fit) {
+      fit.addEventListener("click", function () {
+        if (activeCy) activeCy.animate({ fit: { padding: 30 }, duration: 250 });
+      });
+    }
+
+    var focus = document.getElementById("kg-focus");
+    if (focus) focus.addEventListener("click", toggleFocus);
+
+    var reset = document.getElementById("kg-reset");
+    if (reset) {
+      reset.addEventListener("click", function () {
+        focusMode = false;
+        var fb = document.getElementById("kg-focus");
+        if (fb) fb.classList.remove("active");
+        var search = document.getElementById("kg-search");
+        if (search) search.value = "";
+        if (activeCy) {
+          activeCy.elements().removeClass("highlighted faded");
+          clearSelection();
+          activeCy.animate({ fit: { padding: 30 }, duration: 250 });
+        }
+      });
+    }
+
+    var png = document.getElementById("kg-png");
+    if (png) {
+      png.addEventListener("click", function () {
+        if (!activeCy) return;
+        var uri = activeCy.png({ full: true, scale: 2, bg: "#ffffff" });
+        var a = document.createElement("a");
+        a.href = uri;
+        a.download = "torch-spyre-" + (activeView || "graph") + ".png";
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+      });
+    }
+
+    // Escape clears the current selection.
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape") clearSelection();
+    });
+
+    // Delegate clicks on the "Connected to" neighbor links so navigating
+    // between related nodes stays inside the graph.
+    var info = document.getElementById("kg-info");
+    if (info) {
+      info.addEventListener("click", function (e) {
+        var link = e.target.closest ? e.target.closest(".kg-neighbor") : null;
+        if (link && link.dataset && link.dataset.nodeId) {
+          e.preventDefault();
+          selectNode(link.dataset.nodeId);
+        }
+      });
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -542,15 +744,30 @@
 
   function init(data) {
     graphData = data;
+    graphMeta = data.metadata || {};
     buildTabs();
     setupSearch();
+    setupControls();
 
-    // Activate first tab
+    // Restore the view (and node) from the URL hash if present, so shared
+    // deep links like "#architecture/class::SpyreScheduler" land correctly.
+    var parsed = parseHash();
+    var initialView = parsed && VIEWS[parsed.view] ? parsed.view : "ops";
+
     var tabBar = document.getElementById("kg-tabs");
-    if (tabBar && tabBar.firstChild) {
-      tabBar.firstChild.classList.add("active");
+    if (tabBar) {
+      tabBar.querySelectorAll(".kg-tab").forEach(function (b) {
+        b.classList.toggle("active", b.dataset.view === initialView);
+      });
     }
-    renderView("ops");
+    renderView(initialView);
+
+    if (parsed && parsed.nodeId) {
+      // Defer until the layout has placed nodes for the freshly rendered view.
+      setTimeout(function () {
+        selectNode(parsed.nodeId);
+      }, 0);
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/docs/source/explorer/index.md
+++ b/docs/source/explorer/index.md
@@ -7,13 +7,19 @@ without noise from unrelated subsystems.
 ```{raw} html
 <div id="kg-tabs"></div>
 <p id="kg-view-desc" style="margin: 0.4em 0 0.8em; font-size: 0.9em; color: #555;"></p>
-<div style="display: flex; align-items: center; gap: 1em; margin-bottom: 0.5em;">
+<div style="display: flex; align-items: center; gap: 1em; margin-bottom: 0.5em; flex-wrap: wrap;">
   <input id="kg-search" type="text" placeholder="Search nodes..." style="padding: 5px 10px; border: 1px solid #ccc; border-radius: 4px; width: 220px; font-size: 0.9em;">
+  <div id="kg-controls" style="display: flex; gap: 0.4em;">
+    <button id="kg-fit" class="kg-ctrl-btn" type="button" title="Fit the graph to the viewport">Fit</button>
+    <button id="kg-focus" class="kg-ctrl-btn" type="button" title="Dim everything except the selected node and its neighbors">Focus</button>
+    <button id="kg-png" class="kg-ctrl-btn" type="button" title="Download the current view as a PNG">PNG</button>
+    <button id="kg-reset" class="kg-ctrl-btn" type="button" title="Clear selection, search, and focus">Reset</button>
+  </div>
   <div id="kg-legend" style="display: flex; flex-wrap: wrap; gap: 0.8em; font-size: 0.8em;"></div>
 </div>
 <div id="cy"></div>
 <div id="kg-info">
-  <em>Click a node to see its source location and connections.</em>
+  <em>Click a node to see its source location and connections. Double-click a node to jump straight to its code.</em>
 </div>
 <p id="kg-stats" style="font-size: 0.8em; color: #888; margin-top: 0.5em;"></p>
 <script src="https://cdn.jsdelivr.net/npm/cytoscape@3.30.4/dist/cytoscape.min.js" integrity="sha384-H3uzGzTfGHUAumB8+s4GEdfFwzAceN9wCCndN8AXubWKFIPuBSWKKtWDx7RhSf/z" crossorigin="anonymous"></script>
@@ -40,9 +46,26 @@ them, showing which runtime knobs control which subsystems.
 
 - Switch views with the tab bar.
 - Pan by dragging the background; zoom with the scroll wheel.
-- Click a node to highlight its connections and see its source file,
-  line number, and neighbors.
+- **Click a node** to highlight its connections and see its source
+  file, line number, and neighbors in the panel below.
+- **Follow the source link** — the file:line shown in the panel is a
+  clickable link straight to the defining code on GitHub, pinned to the
+  commit the graph was built from.
+- **Double-click a node** to jump directly to that code in a new tab.
+- **Click a neighbor name** in the "Connected to" list to hop to that
+  node without leaving the graph.
+- **Focus** dims everything except the selected node and its immediate
+  neighbors, so a dense view collapses to one concept and its edges.
+- **Fit** re-frames the graph; **PNG** downloads the current view;
+  **Reset** clears selection, search, and focus. Press **Esc** to clear
+  the current selection.
 - Type in the search box to filter nodes by name.
+- **Deep links:** selecting a node updates the page URL (for example
+  `…/explorer/index.html#ops/op::mm`). Copy that URL to link a
+  teammate straight to a specific node and view.
+
+For a deeper walkthrough of *why* this is useful and how each persona
+gets value from it, see {doc}`using_the_explorer`.
 
 ## How the graph is built
 

--- a/docs/source/explorer/using_the_explorer.md
+++ b/docs/source/explorer/using_the_explorer.md
@@ -1,0 +1,148 @@
+# Why the Knowledge Graph Explorer Is Useful
+
+The {doc}`index` is a live map of the Torch-Spyre codebase. It is
+regenerated from the source tree on every documentation build, so it
+never drifts from the code the way a hand-drawn diagram would. Every
+node knows the file and line it came from, and the panel below the
+graph links straight there.
+
+This page explains what you can actually *do* with it — first for
+people running models on Spyre, then for people building the backend.
+
+## The problem it solves
+
+Torch-Spyre spans a few hundred Python modules plus a C++ runtime, and
+the interesting facts are relationships: *this* PyTorch op is handled by
+*that* lowering, which lives in *this* pass group, which reads *that*
+environment variable. Those relationships are spread across decorators,
+class definitions, and import statements. Reading them one file at a
+time is slow, and any diagram that tries to summarize them goes stale
+the moment someone lands a PR.
+
+The explorer takes the opposite approach. Instead of describing the
+structure in prose, it extracts it directly from the code with Python's
+`ast` module at build time. What you see is what the code says right
+now — down to the commit the docs were built from.
+
+## For users
+
+If you run models on Spyre through `torch.compile`, the two views that
+pay off fastest are **Operations** and **Configuration**.
+
+### "Is this op supported, and how?"
+
+Open the **Operations** view and search for the op — say `mm` or
+`softmax`. The color of the node and its outgoing edge tell you the
+path the backend takes:
+
+- **Decomposition** — the op is rewritten into smaller ops before it
+  ever reaches the hardware.
+- **Lowering** — the op maps to a Spyre kernel during compilation.
+- **Custom op** — a hand-written Spyre operator backs it.
+- **CPU fallback** (dashed red edge) — the op runs on the host, not on
+  the accelerator. Fallbacks are where graph breaks and slowdowns come
+  from, so this is the view to check when a model is slower than you
+  expect.
+- **Eager kernel** — the op has a direct implementation that also works
+  outside `torch.compile`.
+
+If an op isn't in the graph at all, the backend has no registration for
+it yet. That is a concrete answer you can act on, and a good thing to
+mention when you file an issue.
+
+### "Which knob controls this behavior?"
+
+The **Configuration** view shows every environment variable the code
+reads (`SENCORES`, `LX_PLANNING`, `TORCH_SPYRE_DEBUG`, and the rest)
+and the module that reads each one. When you want to change runtime or
+compilation behavior, this tells you the exact variable and — via the
+source link — the code that consumes it, so you can see what values it
+accepts and what the default is.
+
+### Reporting something upstream
+
+Because selecting a node writes a shareable link into the URL, you can
+paste "the `embedding` op falls back to CPU — see
+`…/explorer/index.html#ops/op::embedding`" into an issue and the
+maintainer lands on exactly the node you mean.
+
+## For developers
+
+If you contribute to Torch-Spyre, the explorer is most useful as an
+*orientation and impact-analysis* tool.
+
+### Getting oriented in an unfamiliar area
+
+The **Architecture** view is a module dependency and class-inheritance
+map of the whole `torch_spyre` package. When you are dropped into a
+subsystem you have never touched, start here: find the class you were
+told about, turn on **Focus** to hide everything else, and read just
+its base classes and the modules that import it. That is usually enough
+to know where to put a breakpoint.
+
+### Jumping to the code
+
+Every node that has a single definition site is a link. Click it and
+read the panel for the file and line; **double-click** to open that
+definition on GitHub in a new tab. The link is pinned to the commit the
+graph was built from, so it points at the code as it actually was, not
+at a line number that has since moved.
+
+### Impact analysis before a change
+
+Two relationships are worth tracing before you refactor:
+
+- **`imports` edges** (Architecture view) — who depends on the module
+  you are about to change. Focus the module node and the inbound edges
+  are your blast radius.
+- **`inherits_from` edges** — subclasses that a base-class change would
+  ripple into.
+
+It will not replace running the tests, but it tells you where to look.
+
+### Learning the op registration patterns
+
+When you add an operation, the **Operations** view is a catalog of
+prior art. Filter to the op family you are implementing and click
+through to the decomposition, lowering, or custom-op definitions that
+already exist. Pair this with the {doc}`../compiler/adding_operations`
+guide: the guide explains the three patterns, and the graph shows you
+every op that currently uses each one, with a link to its code.
+
+### Seeing the compiler pipeline
+
+The **Compiler Passes** view lays out each `Custom*Passes` group and
+the pass functions it runs, top to bottom in pipeline order. It is the
+fastest way to answer "where in the pipeline does this transformation
+happen, and what runs before it?" before you add or reorder a pass.
+
+## How it stays honest
+
+A few properties are worth trusting the explorer for — and a few limits
+worth knowing.
+
+- **Regenerated every build.** A Sphinx extension runs
+  `docs/source/_ext/extract_graph.py` at build time and writes a fresh
+  `graph.json`. There is no committed snapshot to fall out of date.
+- **Purely syntactic.** Extraction parses the source with `ast` and
+  imports nothing, so it works without Spyre hardware or the C++
+  extensions, and it cannot be thrown off by import-time side effects.
+- **Commit-pinned links.** Source links use the commit the graph was
+  built from, falling back to the default branch only when the build
+  runs outside a git checkout.
+
+What it does **not** show: it captures registrations, class hierarchies,
+imports, dataclass fields, and env-var reads — the structural surface.
+It does not trace runtime call graphs or data flow, and it only parses
+the file list wired into `build_graph()`. If a new registration pattern
+or source file appears and the graph misses it, that is a signal the
+extractor needs updating; the {doc}`../contributing/index` notes and
+the `check-docs` maintenance checklist cover how.
+
+## See also
+
+- {doc}`index` — the explorer itself, with the navigation reference.
+- {doc}`../compiler/adding_operations` — the op registration patterns
+  the Operations view catalogs.
+- {doc}`../compiler/architecture` — the compilation pipeline the
+  Compiler Passes view lays out.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,6 +47,7 @@ It enables standard PyTorch models to run on the Spyre device with full
    :maxdepth: 2
 
    explorer/index
+   explorer/using_the_explorer
 
 Indices and tables
 ------------------


### PR DESCRIPTION
## Summary

The Knowledge Graph Explorer already extracted each node's `source_file` and `line`, but only showed them as plain text. This PR turns that provenance into **navigation** and adds the interactions that make a dense graph actually usable — the headline being **every node now links back to the code that defines it**.

## Code linking

- `extract_graph.py` records `repo_url` and `default_branch` in the graph metadata, so links resolve with no extra Sphinx config.
- The info panel renders the source location as a clickable link to the definition on GitHub, **pinned to the commit the graph was built from** (falls back to the default branch when built outside a git checkout, e.g. some CI).
- **Double-click** a node to open its definition directly in a new tab.

## Interactivity

- **Connected-node navigation** — the "Connected to" neighbor names are now links that select that node, so you can traverse relationships without leaving the graph.
- **Focus mode** — dims everything except the selected node and its immediate neighbors, collapsing a dense view to one concept and its edges.
- **Fit / PNG / Reset** controls, plus **Esc** to clear the selection.
- **Deep links** — selecting a node writes a shareable hash into the URL (e.g. `#ops/op::mm`); the page restores that view and node on load, so you can link a teammate straight to a node.

## Docs

- `explorer/index.md` documents the new controls and interactions.
- **New page** `explorer/using_the_explorer.md` explains the value for both personas — users (is my op supported and how? which env var controls X?) and developers (orientation in an unfamiliar subsystem, jump-to-code, import/inheritance impact analysis, op-registration patterns, the pass pipeline) — wired into the Explorer toctree.

## Verification

- `ruff check` + `ruff format --check` clean on `extract_graph.py`.
- Full `sphinx` build clean — new page renders, `graph.json` regenerates with the repo URL + commit.
- `node --check` passes on `knowledge_graph.js`.
- `graph.json` remains gitignored (generated at build time).
