### PR TITLE
feat(explorer): link graph nodes to their source, add navigation

### DIFF
--- a/docs/source/_ext/extract_graph.py
+++ b/docs/source/_ext/extract_graph.py
@@ -879,6 +879,11 @@ def build_graph(torch_spyre_root):
         "metadata": {
             "source_commit": _get_git_sha(repo_root),
             "torch_spyre_root": str(root.relative_to(repo_root)),
+            # Canonical repo used to build "view source" links in the explorer.
+            # The JS pins links to source_commit when available and falls back
+            # to the default branch otherwise.
+            "repo_url": "https://github.com/torch-spyre/torch-spyre",
+            "default_branch": "main",
         },
         "nodes": list(seen.values()),
         "edges": valid_edges,

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -101,3 +101,45 @@ code.literal {
     border-color: #3498db;
     box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.15);
 }
+
+/* View control buttons (fit / focus / png / reset) */
+.kg-ctrl-btn {
+    padding: 5px 12px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #fff;
+    color: #444;
+    font-size: 0.85em;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.kg-ctrl-btn:hover {
+    background: #f0f4f8;
+    border-color: #3498db;
+    color: #2c3e50;
+}
+
+.kg-ctrl-btn.active {
+    background: #3498db;
+    border-color: #3498db;
+    color: #fff;
+    font-weight: 600;
+}
+
+/* "View source" link in the info panel */
+.kg-source-link {
+    display: inline-block;
+    margin-top: 2px;
+    text-decoration: none;
+    color: #2c3e50;
+}
+
+.kg-source-link:hover {
+    text-decoration: underline;
+}
+
+/* Neighbor links stay quiet until hovered */
+.kg-neighbor:hover {
+    background: #fffbe6;
+}

--- a/docs/source/_static/js/knowledge_graph.js
+++ b/docs/source/_static/js/knowledge_graph.js
@@ -136,8 +136,30 @@
   // -------------------------------------------------------------------------
 
   var graphData = null;
+  var graphMeta = {};
   var activeCy = null;
   var activeView = null;
+  var focusMode = false;
+
+  // -------------------------------------------------------------------------
+  // Build a "view source" URL back to the code that defines a node.
+  //
+  // Node source_file paths are repo-relative (e.g.
+  // "torch_spyre/_inductor/lowering.py"). We pin to the exact commit the
+  // graph was extracted from so a link never rots against a moved line;
+  // if the commit is unknown (graph built outside a git checkout), fall
+  // back to the default branch.
+  // -------------------------------------------------------------------------
+
+  function buildSourceUrl(sourceFile, line) {
+    if (!sourceFile) return null;
+    var repo = graphMeta.repo_url || "https://github.com/torch-spyre/torch-spyre";
+    var commit = graphMeta.source_commit;
+    var ref = commit && commit !== "unknown" ? commit : graphMeta.default_branch || "main";
+    var url = repo + "/blob/" + ref + "/" + sourceFile;
+    if (line) url += "#L" + line;
+    return url;
+  }
 
   // -------------------------------------------------------------------------
   // Cytoscape style shared across views
@@ -318,6 +340,11 @@
     if (activeView === viewKey && activeCy) return;
     activeView = viewKey;
 
+    // A new view has no selection; drop any lingering focus state.
+    focusMode = false;
+    var focusBtn = document.getElementById("kg-focus");
+    if (focusBtn) focusBtn.classList.remove("active");
+
     var view = VIEWS[viewKey];
     var filtered = filterForView(viewKey);
 
@@ -375,19 +402,22 @@
 
     activeCy.layout(layoutOpts).run();
 
-    // Click handler
+    // Single click: select the node (highlight + info panel).
     activeCy.on("tap", "node", function (evt) {
-      activeCy.elements().removeClass("selected-node neighbor");
-      var node = evt.target;
-      node.addClass("selected-node");
-      node.neighborhood("node").addClass("neighbor");
-      showNodeInfo(node.data());
+      selectNode(evt.target.id());
     });
 
+    // Double click: jump straight to the defining source on GitHub.
+    activeCy.on("dbltap", "node", function (evt) {
+      var d = evt.target.data();
+      var url = buildSourceUrl(d.source_file, d.line);
+      if (url) window.open(url, "_blank", "noopener");
+    });
+
+    // Background click: clear selection, focus, and the deep link.
     activeCy.on("tap", function (evt) {
       if (evt.target === activeCy) {
-        activeCy.elements().removeClass("selected-node neighbor");
-        clearInfo();
+        clearSelection();
       }
     });
 
@@ -413,11 +443,22 @@
     // Clear search
     var search = document.getElementById("kg-search");
     if (search) search.value = "";
+
+    // Reflect the active view in the URL (node cleared on view switch).
+    updateHash(null);
   }
 
   // -------------------------------------------------------------------------
   // UI: info panel
   // -------------------------------------------------------------------------
+
+  function escapeHtml(s) {
+    return String(s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
 
   function showNodeInfo(data) {
     var info = document.getElementById("kg-info");
@@ -427,28 +468,47 @@
       "background:" +
       meta.color +
       ';border-radius:2px;vertical-align:middle;margin-right:6px;"></span>';
-    html += "<strong>" + data.label + "</strong>";
-    html += " <em>(" + meta.label + ")</em>";
+    html += "<strong>" + escapeHtml(data.label) + "</strong>";
+    html += " <em>(" + escapeHtml(meta.label) + ")</em>";
+
+    // Source location: a clickable link straight to the defining code.
     if (data.source_file) {
-      html += "<br>File: <code>" + data.source_file + "</code>";
-      if (data.line) {
-        html += " line " + data.line;
+      var url = buildSourceUrl(data.source_file, data.line);
+      var locText = escapeHtml(data.source_file);
+      if (data.line) locText += ":" + data.line;
+      if (url) {
+        html +=
+          '<br><a class="kg-source-link" href="' +
+          escapeHtml(url) +
+          '" target="_blank" rel="noopener noreferrer" ' +
+          'title="Open this definition on GitHub">' +
+          "&#128196; <code>" +
+          locText +
+          "</code> &#8599;</a>";
+      } else {
+        html += "<br>File: <code>" + locText + "</code>";
       }
+    } else {
+      html +=
+        '<br><span style="color:#999;">No single source location ' +
+        "(this node is referenced from several places).</span>";
     }
-    var neighbors = activeCy
-      .getElementById(data.id)
-      .neighborhood("node");
+
+    var neighbors = activeCy.getElementById(data.id).neighborhood("node");
     if (neighbors.length > 0) {
       html += "<br><strong>Connected to:</strong> ";
       var items = neighbors
         .map(function (n) {
           var nm = TYPE_META[n.data("type")] || { color: "#bdc3c7" };
           return (
-            '<span style="border-bottom:2px solid ' +
+            '<a href="#" class="kg-neighbor" data-node-id="' +
+            escapeHtml(n.id()) +
+            '" style="border-bottom:2px solid ' +
             nm.color +
-            '">' +
-            n.data("label") +
-            "</span>"
+            ';text-decoration:none;color:inherit;" ' +
+            'title="Focus this node">' +
+            escapeHtml(n.data("label")) +
+            "</a>"
           );
         })
         .slice(0, 15);
@@ -462,7 +522,149 @@
 
   function clearInfo() {
     document.getElementById("kg-info").innerHTML =
-      "<em>Click a node to see its source location and connections.</em>";
+      "<em>Click a node to see its source location and connections. " +
+      "Double-click a node to jump straight to its code.</em>";
+  }
+
+  // Select a node by id: highlight it and its neighbors, center the
+  // viewport on it, and refresh the info panel. Shared by tap handlers,
+  // the "Connected to" neighbor links, and deep-link restoration.
+  function selectNode(nodeId, opts) {
+    if (!activeCy) return;
+    var node = activeCy.getElementById(nodeId);
+    if (!node || node.empty()) return;
+    activeCy.elements().removeClass("selected-node neighbor");
+    node.addClass("selected-node");
+    node.neighborhood("node").addClass("neighbor");
+    if (focusMode) applyFocus(node);
+    if (!opts || opts.center !== false) {
+      activeCy.animate({ center: { eles: node }, duration: 250 });
+    }
+    showNodeInfo(node.data());
+    updateHash(nodeId);
+  }
+
+  // -------------------------------------------------------------------------
+  // Focus mode, selection, and deep-linking
+  // -------------------------------------------------------------------------
+
+  // Fade everything except a node and its immediate neighborhood, so a
+  // dense view collapses to just the relationships around one concept.
+  function applyFocus(node) {
+    activeCy.elements().addClass("faded");
+    node.closedNeighborhood().removeClass("faded");
+  }
+
+  function clearFocus() {
+    if (activeCy) activeCy.elements().removeClass("faded");
+  }
+
+  function toggleFocus() {
+    focusMode = !focusMode;
+    var btn = document.getElementById("kg-focus");
+    if (btn) btn.classList.toggle("active", focusMode);
+    var selected = activeCy ? activeCy.$(".selected-node") : null;
+    if (focusMode && selected && selected.length) {
+      applyFocus(selected);
+    } else {
+      clearFocus();
+    }
+  }
+
+  function clearSelection() {
+    if (activeCy) activeCy.elements().removeClass("selected-node neighbor");
+    clearFocus();
+    clearInfo();
+    updateHash(null);
+  }
+
+  // Reflect the current view (and optionally a selected node) in the URL
+  // hash so a specific node can be linked and shared, e.g. the page can be
+  // opened at "#ops/op::mm" to land directly on that op.
+  function updateHash(nodeId) {
+    if (!activeView) return;
+    var hash = "#" + activeView;
+    if (nodeId) hash += "/" + encodeURIComponent(nodeId);
+    if (typeof history !== "undefined" && history.replaceState) {
+      history.replaceState(null, "", hash);
+    } else {
+      location.hash = hash;
+    }
+  }
+
+  function parseHash() {
+    var h = (location.hash || "").replace(/^#/, "");
+    if (!h) return null;
+    var slash = h.indexOf("/");
+    if (slash === -1) return { view: h, nodeId: null };
+    return {
+      view: h.slice(0, slash),
+      nodeId: decodeURIComponent(h.slice(slash + 1)),
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // UI: view controls (fit / focus / reset / export)
+  // -------------------------------------------------------------------------
+
+  function setupControls() {
+    var fit = document.getElementById("kg-fit");
+    if (fit) {
+      fit.addEventListener("click", function () {
+        if (activeCy) activeCy.animate({ fit: { padding: 30 }, duration: 250 });
+      });
+    }
+
+    var focus = document.getElementById("kg-focus");
+    if (focus) focus.addEventListener("click", toggleFocus);
+
+    var reset = document.getElementById("kg-reset");
+    if (reset) {
+      reset.addEventListener("click", function () {
+        focusMode = false;
+        var fb = document.getElementById("kg-focus");
+        if (fb) fb.classList.remove("active");
+        var search = document.getElementById("kg-search");
+        if (search) search.value = "";
+        if (activeCy) {
+          activeCy.elements().removeClass("highlighted faded");
+          clearSelection();
+          activeCy.animate({ fit: { padding: 30 }, duration: 250 });
+        }
+      });
+    }
+
+    var png = document.getElementById("kg-png");
+    if (png) {
+      png.addEventListener("click", function () {
+        if (!activeCy) return;
+        var uri = activeCy.png({ full: true, scale: 2, bg: "#ffffff" });
+        var a = document.createElement("a");
+        a.href = uri;
+        a.download = "torch-spyre-" + (activeView || "graph") + ".png";
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+      });
+    }
+
+    // Escape clears the current selection.
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape") clearSelection();
+    });
+
+    // Delegate clicks on the "Connected to" neighbor links so navigating
+    // between related nodes stays inside the graph.
+    var info = document.getElementById("kg-info");
+    if (info) {
+      info.addEventListener("click", function (e) {
+        var link = e.target.closest ? e.target.closest(".kg-neighbor") : null;
+        if (link && link.dataset && link.dataset.nodeId) {
+          e.preventDefault();
+          selectNode(link.dataset.nodeId);
+        }
+      });
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -542,15 +744,30 @@
 
   function init(data) {
     graphData = data;
+    graphMeta = data.metadata || {};
     buildTabs();
     setupSearch();
+    setupControls();
 
-    // Activate first tab
+    // Restore the view (and node) from the URL hash if present, so shared
+    // deep links like "#architecture/class::SpyreScheduler" land correctly.
+    var parsed = parseHash();
+    var initialView = parsed && VIEWS[parsed.view] ? parsed.view : "ops";
+
     var tabBar = document.getElementById("kg-tabs");
-    if (tabBar && tabBar.firstChild) {
-      tabBar.firstChild.classList.add("active");
+    if (tabBar) {
+      tabBar.querySelectorAll(".kg-tab").forEach(function (b) {
+        b.classList.toggle("active", b.dataset.view === initialView);
+      });
     }
-    renderView("ops");
+    renderView(initialView);
+
+    if (parsed && parsed.nodeId) {
+      // Defer until the layout has placed nodes for the freshly rendered view.
+      setTimeout(function () {
+        selectNode(parsed.nodeId);
+      }, 0);
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/docs/source/explorer/index.md
+++ b/docs/source/explorer/index.md
@@ -7,13 +7,19 @@ without noise from unrelated subsystems.
 ```{raw} html
 <div id="kg-tabs"></div>
 <p id="kg-view-desc" style="margin: 0.4em 0 0.8em; font-size: 0.9em; color: #555;"></p>
-<div style="display: flex; align-items: center; gap: 1em; margin-bottom: 0.5em;">
+<div style="display: flex; align-items: center; gap: 1em; margin-bottom: 0.5em; flex-wrap: wrap;">
   <input id="kg-search" type="text" placeholder="Search nodes..." style="padding: 5px 10px; border: 1px solid #ccc; border-radius: 4px; width: 220px; font-size: 0.9em;">
+  <div id="kg-controls" style="display: flex; gap: 0.4em;">
+    <button id="kg-fit" class="kg-ctrl-btn" type="button" title="Fit the graph to the viewport">Fit</button>
+    <button id="kg-focus" class="kg-ctrl-btn" type="button" title="Dim everything except the selected node and its neighbors">Focus</button>
+    <button id="kg-png" class="kg-ctrl-btn" type="button" title="Download the current view as a PNG">PNG</button>
+    <button id="kg-reset" class="kg-ctrl-btn" type="button" title="Clear selection, search, and focus">Reset</button>
+  </div>
   <div id="kg-legend" style="display: flex; flex-wrap: wrap; gap: 0.8em; font-size: 0.8em;"></div>
 </div>
 <div id="cy"></div>
 <div id="kg-info">
-  <em>Click a node to see its source location and connections.</em>
+  <em>Click a node to see its source location and connections. Double-click a node to jump straight to its code.</em>
 </div>
 <p id="kg-stats" style="font-size: 0.8em; color: #888; margin-top: 0.5em;"></p>
 <script src="https://cdn.jsdelivr.net/npm/cytoscape@3.30.4/dist/cytoscape.min.js" integrity="sha384-H3uzGzTfGHUAumB8+s4GEdfFwzAceN9wCCndN8AXubWKFIPuBSWKKtWDx7RhSf/z" crossorigin="anonymous"></script>
@@ -40,9 +46,26 @@ them, showing which runtime knobs control which subsystems.
 
 - Switch views with the tab bar.
 - Pan by dragging the background; zoom with the scroll wheel.
-- Click a node to highlight its connections and see its source file,
-  line number, and neighbors.
+- **Click a node** to highlight its connections and see its source
+  file, line number, and neighbors in the panel below.
+- **Follow the source link** — the file:line shown in the panel is a
+  clickable link straight to the defining code on GitHub, pinned to the
+  commit the graph was built from.
+- **Double-click a node** to jump directly to that code in a new tab.
+- **Click a neighbor name** in the "Connected to" list to hop to that
+  node without leaving the graph.
+- **Focus** dims everything except the selected node and its immediate
+  neighbors, so a dense view collapses to one concept and its edges.
+- **Fit** re-frames the graph; **PNG** downloads the current view;
+  **Reset** clears selection, search, and focus. Press **Esc** to clear
+  the current selection.
 - Type in the search box to filter nodes by name.
+- **Deep links:** selecting a node updates the page URL (for example
+  `…/explorer/index.html#ops/op::mm`). Copy that URL to link a
+  teammate straight to a specific node and view.
+
+For a deeper walkthrough of *why* this is useful and how each persona
+gets value from it, see {doc}`using_the_explorer`.
 
 ## How the graph is built
 

--- a/docs/source/explorer/using_the_explorer.md
+++ b/docs/source/explorer/using_the_explorer.md
@@ -1,0 +1,138 @@
+# Using the knowledge graph explorer
+
+The {doc}`index` is a generated view of the Torch-Spyre codebase. Sphinx
+rebuilds it from the source tree on every documentation build, so it
+matches the code at the commit it was built from. Every node records the
+file and line it came from, and the panel below the graph links to that
+location.
+
+This page describes what you can do with it. The first half is for people
+running models on Spyre. The second is for people working on the backend.
+
+## What it is for
+
+Torch-Spyre is a few hundred Python modules plus a C++ runtime. Most of
+the useful facts are relationships: a PyTorch op is handled by a lowering,
+that lowering is part of a pass group, and the pass group reads an
+environment variable. These relationships are spread across decorators,
+class definitions, and import statements, so reading them one file at a
+time is slow. A diagram maintained by hand goes out of date as soon as
+someone merges a PR.
+
+The explorer avoids that. It reads the structure directly from the code
+with Python's `ast` module at build time, so the graph shows the current
+code rather than a description of it.
+
+## For users
+
+If you run models through `torch.compile`, the two most useful views are
+Operations and Configuration.
+
+### Checking whether an op is supported
+
+Open the Operations view and search for the op, for example `mm` or
+`softmax`. The node color and its outgoing edge show how the backend
+handles it:
+
+- Decomposition: the op is rewritten into smaller ops before it runs on
+  the hardware.
+- Lowering: the op maps to a Spyre kernel during compilation.
+- Custom op: a hand-written Spyre operator implements it.
+- CPU fallback (dashed red edge): the op runs on the host instead of the
+  accelerator. Fallbacks cause graph breaks and slowdowns, so check this
+  view when a model is slower than you expect.
+- Eager kernel: the op has a direct implementation that also works outside
+  `torch.compile`.
+
+If an op is not in the graph, the backend has no registration for it. That
+is a concrete answer, and a useful detail to include when you file an
+issue.
+
+### Finding the variable that controls a behavior
+
+The Configuration view shows every environment variable the code reads
+(`SENCORES`, `LX_PLANNING`, `TORCH_SPYRE_DEBUG`, and the rest) and the
+module that reads it. To change runtime or compilation behavior, use this
+view to find the variable, then follow the source link to the code that
+reads it, where you can see the accepted values and the default.
+
+### Sharing a node in a bug report
+
+Selecting a node writes a link into the page URL. You can paste that link,
+for example `.../explorer/index.html#ops/op::embedding`, into an issue,
+and it opens on that node and view.
+
+## For developers
+
+For contributors, the explorer helps with two things: learning an
+unfamiliar area, and checking what a change affects.
+
+### Exploring an unfamiliar subsystem
+
+The Architecture view shows module dependencies and class inheritance for
+the `torch_spyre` package. When you start working in a subsystem you have
+not seen before, find the class you were pointed to, turn on Focus to hide
+everything else, and read its base classes and the modules that import it.
+That is usually enough to decide where to set a breakpoint.
+
+### Opening the source
+
+Every node with a single definition site is a link. Click it to see the
+file and line in the panel, or double-click to open that definition on
+GitHub in a new tab. The link uses the commit the graph was built from, so
+the line number stays correct even after the code moves.
+
+### Checking what a change affects
+
+Two relationships are worth tracing before you refactor:
+
+- `imports` edges (Architecture view) show which modules depend on the one
+  you are changing. Focus the module node to see the inbound edges.
+- `inherits_from` edges show the subclasses a base-class change affects.
+
+This does not replace running the tests, but it shows you where to look.
+
+### Learning the op registration patterns
+
+When you add an operation, the Operations view shows the ops already
+implemented with each pattern. Filter to the op family you are working on
+and open the existing decomposition, lowering, or custom-op definitions.
+Use this with the {doc}`../compiler/adding_operations` guide: the guide
+explains the three patterns, and the graph shows every op that uses each
+one, with a link to its code.
+
+### Viewing the compiler pipeline
+
+The Compiler Passes view shows each `Custom*Passes` group and the pass
+functions it runs, in pipeline order from top to bottom. Use it to see
+where a transformation happens and what runs before it, before you add or
+reorder a pass.
+
+## Accuracy and limits
+
+Three properties are worth relying on:
+
+- The graph is rebuilt on every documentation build. A Sphinx extension
+  runs `docs/source/_ext/extract_graph.py` and writes a fresh
+  `graph.json`, so there is no stored copy that can go out of date.
+- Extraction is syntactic. It parses the source with `ast` and imports
+  nothing, so it runs without Spyre hardware or the C++ extensions and is
+  not affected by import-time side effects.
+- Source links are commit-pinned. They use the commit the graph was built
+  from, and use the default branch only when the build runs outside a git
+  checkout.
+
+The graph covers registrations, class hierarchies, imports, dataclass
+fields, and environment-variable reads. It does not trace runtime call
+graphs or data flow, and it only parses the files listed in
+`build_graph()`. If a new registration pattern or source file is not
+showing up, the extractor needs updating. The {doc}`../contributing/index`
+notes and the `check-docs` checklist explain how.
+
+## See also
+
+- {doc}`index`: the explorer, with the navigation reference.
+- {doc}`../compiler/adding_operations`: the op registration patterns the
+  Operations view lists.
+- {doc}`../compiler/architecture`: the compilation pipeline the Compiler
+  Passes view shows.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,6 +47,7 @@ It enables standard PyTorch models to run on the Spyre device with full
    :maxdepth: 2
 
    explorer/index
+   explorer/using_the_explorer
 
 Indices and tables
 ------------------


### PR DESCRIPTION
## What it does

Graph nodes already knew their source file and line but only showed them as text. Now that's navigable.

- Each node links to its definition on GitHub, pinned to the build commit (uses the default branch when there's no git checkout).
- Double-click a node to open its source.
- "Connected to" neighbor names are links that jump to that node.
- Focus dims everything except the selected node and its neighbors.
- Fit, PNG export, Reset, and Esc to clear.
- Selecting a node writes a deep link to the URL (e.g. `#ops/op::mm`), restored on load.

Supporting changes: the extractor writes `repo_url` and `default_branch` into the graph metadata so links need no extra config; `explorer/index.md` documents the controls; new `explorer/using_the_explorer.md` covers when it helps users vs contributors.

## Checks

ruff, full sphinx build (graph.json regenerates), `node --check`. graph.json stays gitignored.
