### PR TITLE
fix(conv2d): CPU fallback for geometries with unrepresentable stick expressions

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_scalar_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_scalar_config.yaml
@@ -18,11 +18,14 @@ test_suite_config:
         # xfail: an unexpected pass (XPASS) does not fail CI. Entries failing
         # in both wraps collapse to (pointwise|reduction).
         - names:
-            - LxPlanning.*::test_conv2d_1x3x32_ksize3_no_pad_lx_planning_(pointwise|reduction)
-            - LxPlanning.*::test_conv2d_1x64_ksize3_depthwise_lx_planning_(pointwise|reduction)
-            - LxPlanning.*::test_conv2d_2x32_ksize1_stride2_lx_planning_(pointwise|reduction)
-            - LxPlanning.*::test_conv2d_2x3x32_ksize1_lx_planning_(pointwise|reduction)
-            - LxPlanning.*::test_conv2d_mistral_model_lx_planning_(pointwise|reduction)
+            # conv2d now compiles for all geometries via the CPU-fallback
+            # decomposition (#3053); the previously-xfailed conv2d cases now
+            # pass and are enforced by the mandatory_success entry below. Only
+            # the mistral_model reduction still fails -- on a separate
+            # large-tensor torch.sum(dim=0) bug (reproduces with no conv
+            # involved; the conv output itself is correct and the pointwise
+            # wrap passes).
+            - LxPlanning.*::test_conv2d_mistral_model_lx_planning_reduction
           mode: xfail
         - names:
             - LxPlanning.*::test_(all_dim|any_dim|count_nonzero|cummax|cummin|cumprod|logcumsumexp|max_default|median|mode_|nanmean|nanmedian|nanquantile|nansum|quantile|std_|topk|conv2d|var_).*_lx_planning_(pointwise|reduction)

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -528,6 +528,59 @@ def _(
     return input.new_empty(shape)
 
 
+@torch.library.custom_op("spyre::conv2d_via_cpu", mutates_args=(), device_types="spyre")
+def spyre_conv2d_via_cpu(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    stride: list[int],
+    padding: list[int],
+    dilation: list[int],
+    groups: int,
+) -> torch.Tensor:
+    """conv2d executed on CPU, for geometries whose on-device unfold+matmul
+    decomposition produces a compound stick expression the backend cannot
+    represent (see #3053 -- any stride>1 or non-same-padding geometry). Moves
+    inputs to CPU, runs the op, and copies the result back. Mirrors
+    ``spyre.reshape_via_cpu`` / ``spyre.unfold_via_cpu``. CPU ``conv2d`` never
+    re-enters the Spyre decomposition (it dispatches on the CPU device).
+    """
+    warn_fallback("torch.ops.spyre.conv2d_via_cpu")
+    device = input.device
+    bias_cpu = bias.to("cpu") if bias is not None else None
+    result_cpu = torch.conv2d(
+        input.to("cpu"),
+        weight.to("cpu"),
+        bias_cpu,
+        stride,
+        padding,
+        dilation,
+        groups,
+    )
+    return result_cpu.to(device)
+
+
+@spyre_conv2d_via_cpu.register_fake
+def _(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    stride: list[int],
+    padding: list[int],
+    dilation: list[int],
+    groups: int,
+) -> torch.Tensor:
+    # Compute the output shape directly (do NOT call conv2d here -- that would
+    # re-enter the Spyre convolution decomposition and recurse).
+    n = input.shape[0]
+    c_out = weight.shape[0]
+    k_h, k_w = weight.shape[2], weight.shape[3]
+    h_in, w_in = input.shape[2], input.shape[3]
+    h_out = (h_in + 2 * padding[0] - dilation[0] * (k_h - 1) - 1) // stride[0] + 1
+    w_out = (w_in + 2 * padding[1] - dilation[1] * (k_w - 1) - 1) // stride[1] + 1
+    return input.new_empty((n, c_out, h_out, w_out))
+
+
 @torch.library.custom_op("spyre::min_dim_int64_fallback", mutates_args=())
 def min_dim_int64_fallback(
     input: torch.Tensor, dim: int, keepdim: bool = False

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -15,6 +15,7 @@
 from contextlib import contextmanager
 
 import math
+import warnings
 from typing import Optional, Union, Sequence, Callable, TypeVar
 from typing_extensions import ParamSpec
 import torch
@@ -23,6 +24,7 @@ import torch._decomp as decomp
 
 from .constants import DEVICE_NAME, FP8_E4M3_MAX
 from .errors import Unsupported
+from torch_spyre.ops.fallbacks import FallbackWarning
 from . import customops  # noqa: F401
 from . import spyre_hint
 from torch_spyre._C import DataFormats, get_device_dtype
@@ -859,6 +861,36 @@ def conv2d_via_bmm_decomp(
     if C_in != groups * C_in_per_group:
         raise Unsupported(
             f"conv2d_via_bmm: expect C_in == groups * C_in_per_group, got C_in: {C_in}, groups: {groups} C_in_per_group: {C_in_per_group}"
+        )
+
+    # Only the stride-1, full-same-padding geometry lowers to a stick expression
+    # the backend can represent. Any other geometry (stride > 1, or non-same
+    # padding) makes the unfold+matmul access produce a compound stick expression
+    # (e.g. d2 + 8*Mod(3*d1, 8)) that propagate_spyre_tensor_layouts rejects
+    # (#3053). Route those through a CPU round-trip fallback -- correct, and cheap
+    # for the main affected case (vision patch embeds are a negligible fraction of
+    # tower FLOPs). The stride-1/same-padding path stays on the native bmm decomp.
+    same_pad_h = dil_h * (K_h - 1) // 2
+    same_pad_w = dil_w * (K_w - 1) // 2
+    native_ok = (
+        groups == 1
+        and stride_h == 1
+        and stride_w == 1
+        and pad_h == same_pad_h
+        and pad_w == same_pad_w
+        and K_h > 1
+        and K_w > 1
+    )
+    if not native_ok:
+        warnings.warn(
+            f"conv2d geometry (stride={list(stride)}, padding={list(padding)}, "
+            f"dilation={list(dilation)}) routed through a CPU round-trip "
+            "(spyre.conv2d_via_cpu): correctness fallback with a device<->host "
+            "copy cost; on-device support tracked by #3053",
+            category=FallbackWarning,
+        )
+        return torch.ops.spyre.conv2d_via_cpu(
+            input, weight, bias, stride, padding, dilation, groups
         )
 
     H_out = (H_in + 2 * pad_h - dil_h * (K_h - 1) - 1) // stride_h + 1


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

conv2d is lowered by conv2d_via_bmm_decomp (unfold + matmul). For any geometry other than groups=1, stride=1, full same-padding, kernel>1, the unfold+matmul access produces a compound stick expression like d2 + 8*Mod(3*d1, 8) that propagate_spyre_tensor_layouts cannot represent, so the compile aborts (#3053), blocking on-device vision patch embeds (Granite-Vision, Pixtral, Mistral-Small).

Add a spyre::conv2d_via_cpu op (mirrors spyre.reshape_via_cpu) and gate the decomposition: geometries outside the supported set route through the CPU round-trip; the native bmm path is preserved for groups=1 / stride=1 / same-padding / kernel>1 (PR #2317's working case). The decomposition runs at trace time and also registers the eager kernel, so both compiled and eager paths are covered. Correctness fallback with a device<->host copy cost; conv patch embeds are a negligible fraction of tower FLOPs.

Clears all conv2d stick-expression failures in the LX-planning op suite (17/18 conv cases pass). The remaining conv2d_mistral_model reduction failure is an orthogonal torch.sum(dim=0) bug on large tensors (reproduces with no conv involved), not this change.

#### Which issue(s) this PR is related to:

Fixes #3053

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
