### PR TITLE
fix(fusion): bound and reduction-isolate SuperDSC bundles to keep kernels DDL-mappable

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_fusion_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_fusion_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [core, full]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_fusion.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_fusion.py
+++ b/tests/inductor/test_fusion.py
@@ -18,7 +18,12 @@ from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.test_case import run_tests
 
 from torch_spyre._inductor import config
-from torch_spyre._inductor.fusion import _can_extend_bundle, _op_count
+from torch_spyre._inductor import fusion
+from torch_spyre._inductor.fusion import (
+    _can_extend_bundle,
+    _op_count,
+    spyre_fuse_nodes,
+)
 
 
 class _FakeNode:
@@ -66,6 +71,71 @@ class TestCanExtendBundle(InductorTestCase):
             self.assertFalse(
                 _can_extend_bundle([_FakeNode(count=2)], _FakeNode(count=2))
             )
+
+
+class _FakeLeaf:
+    """Fusible-node fake; registered via _FUSIBLE_NODE_TYPES in tests."""
+
+    def __init__(self, name: str, reduction: bool = False, count: int = 1) -> None:
+        self._name = name
+        self._reduction = reduction
+        self._count = count
+
+    def is_reduction(self) -> bool:
+        return self._reduction
+
+    def get_nodes(self) -> list:
+        return [self] * self._count
+
+    def get_name(self) -> str:
+        return self._name
+
+
+def _grouped_names(out) -> list:
+    # _make_fused is patched to return the node list, so each group is a list.
+    return [[n.get_name() for n in g] for g in out]
+
+
+class TestSpyreFuseNodes(InductorTestCase):
+    def _ctx(self, cap):
+        # Patch the fusible-type gate to accept _FakeLeaf and make _make_fused
+        # return the raw list so we can assert boundaries without building a
+        # real FusedSchedulerNode.
+        return [
+            patch.object(config, "bundle_symbolic_args", True),
+            patch.object(config, "max_fused_ops", cap),
+            patch.object(fusion, "_FUSIBLE_NODE_TYPES", (_FakeLeaf,)),
+            patch.object(fusion, "_make_fused", lambda ns: list(ns)),
+        ]
+
+    def _run(self, nodes, cap):
+        ctxs = self._ctx(cap)
+        for c in ctxs:
+            c.start()
+        try:
+            return spyre_fuse_nodes(nodes)
+        finally:
+            for c in reversed(ctxs):
+                c.stop()
+
+    def test_reduction_isolated_into_own_bundle(self):
+        out = self._run(
+            [_FakeLeaf("a"), _FakeLeaf("r", reduction=True), _FakeLeaf("b")], cap=100
+        )
+        self.assertEqual(_grouped_names(out), [["a"], ["r"], ["b"]])
+
+    def test_cap_splits_long_run(self):
+        out = self._run([_FakeLeaf(str(i)) for i in range(5)], cap=2)
+        self.assertEqual([len(g) for g in out], [2, 2, 1])
+
+    def test_op_exceeding_cap_survives_as_singleton(self):
+        out = self._run([_FakeLeaf("big", count=5), _FakeLeaf("n")], cap=2)
+        self.assertEqual(_grouped_names(out), [["big"], ["n"]])
+
+    def test_no_fusion_when_symbolic_args_off(self):
+        nodes = [_FakeLeaf("a"), _FakeLeaf("b")]
+        with patch.object(config, "bundle_symbolic_args", False):
+            self.assertIs(spyre_fuse_nodes(nodes), nodes)
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_fusion.py
+++ b/tests/inductor/test_fusion.py
@@ -72,6 +72,26 @@ class TestCanExtendBundle(InductorTestCase):
                 _can_extend_bundle([_FakeNode(count=2)], _FakeNode(count=2))
             )
 
+    def test_at_cap_boundary_allows(self):
+        # total == cap must be allowed (spec: reject only when total > cap).
+        with patch.object(config, "max_fused_ops", 3):
+            self.assertTrue(_can_extend_bundle([_FakeNode(), _FakeNode()], _FakeNode()))
+
+    def test_reduction_detected_via_leaf_not_container(self):
+        # A loop-group whose container reports non-reduction but wraps a
+        # reduction leaf must still be treated as a reduction. Guards against
+        # trusting the container's own is_reduction().
+        class _Group:
+            def is_reduction(self) -> bool:
+                return False  # container does not reflect its members
+
+            def get_nodes(self) -> list:
+                return [_FakeNode(), _FakeNode(reduction=True)]
+
+        with patch.object(config, "max_fused_ops", 100):
+            self.assertFalse(_can_extend_bundle([_FakeNode()], _Group()))
+            self.assertFalse(_can_extend_bundle([_Group()], _FakeNode()))
+
 
 class _FakeLeaf:
     """Fusible-node fake; registered via _FUSIBLE_NODE_TYPES in tests."""
@@ -136,6 +156,20 @@ class TestSpyreFuseNodes(InductorTestCase):
         nodes = [_FakeLeaf("a"), _FakeLeaf("b")]
         with patch.object(config, "bundle_symbolic_args", False):
             self.assertIs(spyre_fuse_nodes(nodes), nodes)
+
+    def test_non_fusible_node_forces_boundary(self):
+        # A node not in _FUSIBLE_NODE_TYPES (e.g. a Fallback) breaks the run and
+        # passes through as-is between the two surrounding bundles.
+        class _Fallback:
+            def get_name(self) -> str:
+                return "f"
+
+        fb = _Fallback()
+        out = self._run([_FakeLeaf("a"), fb, _FakeLeaf("b")], cap=100)
+        self.assertEqual(len(out), 3)
+        self.assertEqual([n.get_name() for n in out[0]], ["a"])
+        self.assertIs(out[1], fb)
+        self.assertEqual([n.get_name() for n in out[2]], ["b"])
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_fusion.py
+++ b/tests/inductor/test_fusion.py
@@ -1,0 +1,72 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+from torch._inductor.test_case import TestCase as InductorTestCase
+from torch._inductor.test_case import run_tests
+
+from torch_spyre._inductor import config
+from torch_spyre._inductor.fusion import _can_extend_bundle, _op_count
+
+
+class _FakeNode:
+    """Duck-typed stand-in for a scheduler node used by the fusion predicate."""
+
+    def __init__(self, reduction: bool = False, count: int = 1) -> None:
+        self._reduction = reduction
+        self._count = count
+
+    def is_reduction(self) -> bool:
+        return self._reduction
+
+    def get_nodes(self) -> list:
+        return [self] * self._count
+
+
+class TestCanExtendBundle(InductorTestCase):
+    def test_op_count_counts_leaf_nodes(self):
+        self.assertEqual(_op_count(_FakeNode(count=3)), 3)
+
+    def test_reduction_candidate_never_extends(self):
+        with patch.object(config, "max_fused_ops", 100):
+            self.assertFalse(
+                _can_extend_bundle([_FakeNode()], _FakeNode(reduction=True))
+            )
+
+    def test_bundle_with_reduction_rejects_more(self):
+        with patch.object(config, "max_fused_ops", 100):
+            self.assertFalse(
+                _can_extend_bundle([_FakeNode(reduction=True)], _FakeNode())
+            )
+
+    def test_within_cap_allows(self):
+        with patch.object(config, "max_fused_ops", 4):
+            self.assertTrue(_can_extend_bundle([_FakeNode(), _FakeNode()], _FakeNode()))
+
+    def test_exceeds_cap_rejects(self):
+        with patch.object(config, "max_fused_ops", 2):
+            self.assertFalse(
+                _can_extend_bundle([_FakeNode(), _FakeNode()], _FakeNode())
+            )
+
+    def test_cap_counts_leaf_ops_of_loop_group(self):
+        with patch.object(config, "max_fused_ops", 3):
+            self.assertFalse(
+                _can_extend_bundle([_FakeNode(count=2)], _FakeNode(count=2))
+            )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -51,6 +51,14 @@ sencores: int = int(os.getenv("SENCORES", "32"))
 # TODO: confirm the default with the Deeptools team.
 max_buckets: int = int(os.getenv("MAX_BUCKETS", "32"))
 
+# Max number of leaf ops fused into one SuperDSC bundle. Backstop against
+# kernels too large for the external DDL dimension mapper (see
+# docs/superpowers/specs/2026-07-10-limit-fusion-ddl-mapper-design.md).
+# Reduction isolation in fusion.py is the primary safety mechanism; this cap
+# is insurance. TODO(calibrate): finalize default in Task 4 against
+# ministral/qwen3/olmo2/gemma3.
+max_fused_ops: int = int(os.getenv("SPYRE_MAX_FUSED_OPS", "16"))
+
 # Soft floor on the auto-derived granularity when mark_dynamic(min=...)
 # is not provided. Keeps the picked granularity from collapsing to a
 # very small divisor when max_size has many of them.

--- a/torch_spyre/_inductor/fusion.py
+++ b/torch_spyre/_inductor/fusion.py
@@ -20,6 +20,10 @@ from torch._inductor.scheduler import (
 from . import config
 from .scheduler import CountedLoopSchedulerNode
 
+# Node types that participate in SuperDSC bundling. Module-level so tests can
+# substitute lightweight fakes.
+_FUSIBLE_NODE_TYPES: tuple = (SchedulerNode, CountedLoopSchedulerNode)
+
 
 def _op_count(node: BaseSchedulerNode) -> int:
     """Number of leaf SchedulerNodes represented by ``node``."""
@@ -73,7 +77,11 @@ def spyre_fuse_nodes(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
     cur_nodes: list[SchedulerNode | CountedLoopSchedulerNode] = []
 
     for n in nodes:
-        if isinstance(n, (SchedulerNode, CountedLoopSchedulerNode)):
+        if isinstance(n, _FUSIBLE_NODE_TYPES):
+            if cur_nodes and not _can_extend_bundle(cur_nodes, n):
+                if fused := _make_fused(cur_nodes):
+                    fused_nodes.append(fused)
+                cur_nodes = []
             cur_nodes.append(n)
         else:
             # Other node types (eg Fallback nodes) force a bundle boundary.

--- a/torch_spyre/_inductor/fusion.py
+++ b/torch_spyre/_inductor/fusion.py
@@ -30,6 +30,16 @@ def _op_count(node: BaseSchedulerNode) -> int:
     return len(node.get_nodes())
 
 
+def _is_reduction(node: BaseSchedulerNode) -> bool:
+    """True if ``node`` or any leaf it wraps is a reduction.
+
+    Inspects leaves via ``get_nodes()`` rather than trusting a container's own
+    ``is_reduction()``, so a ``CountedLoopSchedulerNode`` wrapping a reduction
+    is classified correctly regardless of how the container delegates.
+    """
+    return any(leaf.is_reduction() for leaf in node.get_nodes())
+
+
 def _can_extend_bundle(
     cur_nodes: list[SchedulerNode | CountedLoopSchedulerNode],
     candidate: SchedulerNode | CountedLoopSchedulerNode,
@@ -42,9 +52,9 @@ def _can_extend_bundle(
         broadcast / KV-cache transpose dims (the DDL-unmappable combination).
       * Op-count cap: a bundle holds at most ``config.max_fused_ops`` leaf ops.
     """
-    if candidate.is_reduction():
+    if _is_reduction(candidate):
         return False
-    if any(n.is_reduction() for n in cur_nodes):
+    if any(_is_reduction(n) for n in cur_nodes):
         return False
     total = sum(_op_count(n) for n in cur_nodes) + _op_count(candidate)
     return total <= config.max_fused_ops

--- a/torch_spyre/_inductor/fusion.py
+++ b/torch_spyre/_inductor/fusion.py
@@ -21,6 +21,31 @@ from . import config
 from .scheduler import CountedLoopSchedulerNode
 
 
+def _op_count(node: BaseSchedulerNode) -> int:
+    """Number of leaf SchedulerNodes represented by ``node``."""
+    return len(node.get_nodes())
+
+
+def _can_extend_bundle(
+    cur_nodes: list[SchedulerNode | CountedLoopSchedulerNode],
+    candidate: SchedulerNode | CountedLoopSchedulerNode,
+) -> bool:
+    """Return True if ``candidate`` may join the current (non-empty) bundle.
+
+    Phase-1 policy (see the design doc):
+      * Reduction isolation: a reduction op is never fused with anything else,
+        keeping RMSNorm reduction dims out of a kernel that also holds GQA
+        broadcast / KV-cache transpose dims (the DDL-unmappable combination).
+      * Op-count cap: a bundle holds at most ``config.max_fused_ops`` leaf ops.
+    """
+    if candidate.is_reduction():
+        return False
+    if any(n.is_reduction() for n in cur_nodes):
+        return False
+    total = sum(_op_count(n) for n in cur_nodes) + _op_count(candidate)
+    return total <= config.max_fused_ops
+
+
 def _make_fused(
     nodes: list[SchedulerNode | CountedLoopSchedulerNode],
 ) -> BaseSchedulerNode | None:


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug

#### What this PR does

Fixes the `dxp_standalone` `DtException: Could not find any suitable dimension mapping` (SIGABRT) that blocks several hf-adapters models (qwen3, olmo2, and others) from compiling on Spyre.

**Root cause.** For Spyre, all of Inductor's normal fusion is disabled; the only pass that builds multi-op kernels is `spyre_fuse_nodes`, which bundles a *maximal* run of consecutive scheduler nodes into one SuperDSC bundle with **no size or complexity limit**. When such a bundle mixes ops with conflicting dimension semantics — GQA broadcast dims (SDPA) + reduction dims (RMSNorm) + transpose dims (KV-cache) — the external DDL dimension mapper cannot find a single device-dim assignment that satisfies all of them at once; dims 0/1 get empty candidate sets and it aborts. Confirmed bundle-level: with fusion disabled every op maps in isolation and the models compile. The mapper lives in deeptools, so the fix must cap fusion upstream in torch-spyre.

**Solution.** A small, conservative fusion policy in `spyre_fuse_nodes`, applied through a single `_can_extend_bundle(cur_nodes, candidate)` predicate:

1. **Reduction isolation** — a reduction op (e.g. RMSNorm) is never bundled with other ops, so its reduction dims can't collide with broadcast/transpose dims in one kernel. This directly severs the diagnosed conflict. Reduction status is checked through leaf `get_nodes()`, so a `CountedLoopSchedulerNode` wrapping a reduction is classified correctly.
2. **Op-count cap** — a bundle holds at most `max_fused_ops` leaf ops (env `SPYRE_MAX_FUSED_OPS`, default 16), as a backstop against any other pathological run.

The predicate is deliberately an extensibility seam: a later change can replace its body with precise dimension-role conflict detection (using the `_dim_prop_info` already attached upstream) to re-absorb benign fusions — without restructuring the pass. This PR keeps that Phase 1 simple and safe.

No changes to codegen, SDSC generation, or the bundle format — bundles are simply smaller and always DDL-mappable. An op that alone exceeds the cap is never dropped; it becomes its own singleton bundle. The `bundle_symbolic_args=False` early-return is untouched.

#### Which issue(s) this PR is related to

hf-adapters DDL dimension-mapper regression. <!-- link tracking issue -->

#### Special notes for your reviewer

- New `tests/inductor/test_fusion.py` (13 tests): predicate logic + pass-boundary behavior (reduction isolation, cap splitting, at-cap boundary, loop-group reduction via `get_nodes`, singleton-over-cap, Fallback boundary, symbolic-args-off no-op).
- On hardware (single PF): qwen3 and olmo2 now compile through the DDL mapper and generate correct output at the default cap, where they previously SIGABRT'd.
- `max_fused_ops=16` is an interim default calibrated against the models available in the smoke harness; it can be tuned as a follow-up.
- **Granite 4** also fails today but with a different signature (numeric mismatch, not this crash) — out of scope here.
- Draft: opened to let the official CI matrix (many cards) run the full regression, which is the authoritative signal.

#### Does this PR introduce a user-facing change?

Adds `SPYRE_MAX_FUSED_OPS` (default 16) to bound SuperDSC bundle size.