### PR TITLE
ci(integration): test the pre-baked torch-spyre-dev image (no on-runner checkout/build)

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -62,6 +62,11 @@ on:
         required: false
         type: string
         default: ''
+      rpm_location:
+        description: Artifactory location for RPM download
+        required: false
+        type: string
+        default: ''
       rpm_names:
         description: Space-separated list of RPM names to download and install
         required: false
@@ -140,16 +145,18 @@ jobs:
         id: filter
         run: |
           # Prebaked: read the configs baked in the dev image; else the checkout cwd.
+          # cd into the source root so every path below stays repo-relative and
+          # byte-identical to the normal path (the CI-coverage scanner greps
+          # `--config-dir tests/configs/torch_spyre_tests` literally).
           if [ "${{ inputs.prebaked_image }}" = "true" ]; then
-            SRC="${PREBAKED_TORCH_SPYRE_DIR}"
+            cd "${PREBAKED_TORCH_SPYRE_DIR}"
           else
-            SRC="${GITHUB_WORKSPACE}"
             pip install pyyaml --quiet
           fi
-          matrix=$(python3 "${SRC}/tests/oot_framework/utils/filter_configs.py" \
-            --config-dir "${SRC}/tests/configs/torch_spyre_tests" \
+          matrix=$(python3 tests/oot_framework/utils/filter_configs.py \
+            --config-dir tests/configs/torch_spyre_tests \
             --test-type "${{ inputs.test_type || 'full' }}" \
-            --runner-map "${SRC}/.github/runner_overrides.yaml" \
+            --runner-map .github/runner_overrides.yaml \
             --format matrix-json)
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -125,7 +125,8 @@ jobs:
     # Prebaked path: run ON the runner image so the matrix is computed from the
     # SAME PR-pinned configs baked into the dev image (not a re-fetch of main),
     # keeping content-addressed consistency.
-    runs-on: ${{ inputs.prebaked_image && fromJSON(format('["x86_64","spyre_pf_x0","{0}","{1}"]', inputs.runner_label, inputs.image_label)) || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.prebaked_image && fromJSON(format('["x86_64","spyre_pf_x0","{0}","{1}"]', inputs.runner_label, inputs.image_label)) || 'ubuntu-latest'
+      }}
     outputs:
       matrix: ${{ steps.filter.outputs.matrix }}
     steps:

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -62,11 +62,6 @@ on:
         required: false
         type: string
         default: ''
-      rpm_location:
-        description: Artifactory location for RPM download
-        required: false
-        type: string
-        default: ''
       rpm_names:
         description: Space-separated list of RPM names to download and install
         required: false
@@ -87,9 +82,28 @@ on:
         type: string
         default: full
 
+      # Spyre-Next integration path: test the PRE-BAKED dev image directly instead
+      # of checking out + rebuilding torch-spyre on the runner. The ephemeral ARC
+      # runner is FROM torch-spyre-dev, which already has the editable-installed
+      # torch_spyre + the full source tree (incl tests/, tests/configs/) + the
+      # shared venv at $PREBAKED_TORCH_SPYRE_DIR. When true: skip the product
+      # checkout, the build_torch_spyre wheel job, and install-prebuilt-torch-spyre;
+      # run the suite against the baked dir. DEFAULT false → the normal PR/nightly
+      # callers (tests.yml / tests-nightly.yml) are byte-for-byte unchanged.
+      prebaked_image:
+        description: Test the pre-baked torch-spyre-dev image (no checkout/build). Integration path only.
+        required: false
+        type: boolean
+        default: false
+
 defaults:
   run:
     shell: bash
+
+env:
+  # The baked torch-spyre source+venv dir in the dev image (runner is FROM
+  # torch-spyre-dev). Used by the prebaked_image path in place of a checkout.
+  PREBAKED_TORCH_SPYRE_DIR: /home/senuser/torch-spyre
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -102,11 +116,17 @@ jobs:
   # ---------------------------------------------------------------------------
   generate_matrix:
     name: Generate test matrix (${{ inputs.test_type || 'full' }})
-    runs-on: ubuntu-latest
+    # Normal path: ubuntu-latest with a fresh sparse checkout of the configs.
+    # Prebaked path: run ON the runner image so the matrix is computed from the
+    # SAME PR-pinned configs baked into the dev image (not a re-fetch of main),
+    # keeping content-addressed consistency.
+    runs-on: ${{ inputs.prebaked_image && fromJSON(format('["x86_64","spyre_pf_x0","{0}","{1}"]', inputs.runner_label, inputs.image_label)) || 'ubuntu-latest' }}
     outputs:
       matrix: ${{ steps.filter.outputs.matrix }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # NORMAL: sparse-checkout the configs from github.com at the requested ref.
+      - if: ${{ !inputs.prebaked_image }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
           repository: ${{ inputs.repository || github.event.pull_request.head.repo.full_name || github.repository }}
@@ -119,11 +139,17 @@ jobs:
       - name: Filter configs by TEST_TYPE
         id: filter
         run: |
-          pip install pyyaml --quiet
-          matrix=$(python3 tests/oot_framework/utils/filter_configs.py \
-            --config-dir tests/configs/torch_spyre_tests \
+          # Prebaked: read the configs baked in the dev image; else the checkout cwd.
+          if [ "${{ inputs.prebaked_image }}" = "true" ]; then
+            SRC="${PREBAKED_TORCH_SPYRE_DIR}"
+          else
+            SRC="${GITHUB_WORKSPACE}"
+            pip install pyyaml --quiet
+          fi
+          matrix=$(python3 "${SRC}/tests/oot_framework/utils/filter_configs.py" \
+            --config-dir "${SRC}/tests/configs/torch_spyre_tests" \
             --test-type "${{ inputs.test_type || 'full' }}" \
-            --runner-map .github/runner_overrides.yaml \
+            --runner-map "${SRC}/.github/runner_overrides.yaml" \
             --format matrix-json)
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
@@ -138,7 +164,10 @@ jobs:
   # ---------------------------------------------------------------------------
   build_torch_spyre:
     name: Build torch-spyre wheel (once)
-    if: ${{ inputs.rpm_names == '' || inputs.build_torch_spyre }}
+    # Prebaked path skips the build entirely — torch_spyre is already editable-
+    # installed in the baked dev image. (Guarded first so the normal condition is
+    # only evaluated off the prebaked path.)
+    if: ${{ !inputs.prebaked_image && (inputs.rpm_names == '' || inputs.build_torch_spyre) }}
     # Compile-only: needs the backend image + SDK toolchain but NO physical Spyre
     # card, so it targets the cardless spyre_pf_x0 pool. This leaves the scarce
     # card runners (spyre_pf_x1/x2) for the test jobs below.
@@ -221,13 +250,21 @@ jobs:
       matrix: ${{ fromJSON(needs.generate_matrix.outputs.matrix) }}
 
     steps:
+      # Composite actions: on the prebaked path the baked dir already has
+      # .github/actions (full source is baked), so this checkout is only needed
+      # on the normal path.
       - name: Checkout composite actions
+        if: ${{ !inputs.prebaked_image }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # Product source: NORMAL path checks out the PR ref. PREBAKED path uses the
+      # baked /home/senuser/torch-spyre (source + editable venv already in image)
+      # → no checkout, no runtime mkdir under $HOME (this was the collision).
+      - if: ${{ !inputs.prebaked_image }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: torch-spyre
           ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
@@ -240,12 +277,13 @@ jobs:
       - uses: ./.github/actions/gather-runner-info
         with:
           verbose: 'true'
+          torch_spyre_dir: ${{ inputs.prebaked_image && env.PREBAKED_TORCH_SPYRE_DIR || 'torch-spyre' }}
 
       # Install the wheel built once by build_torch_spyre — no recompile.
-      # Skipped on the RPM path (build_torch_spyre skipped), where the RPM
-      # provides torch-spyre exactly as before.
+      # Skipped on the RPM path (build_torch_spyre skipped) AND on the prebaked
+      # path (torch_spyre already editable-installed in the baked image).
       - name: Install prebuilt torch-spyre
-        if: ${{ needs.build_torch_spyre.result == 'success' }}
+        if: ${{ !inputs.prebaked_image && needs.build_torch_spyre.result == 'success' }}
         uses: ./.github/actions/install-prebuilt-torch-spyre
 
       - name: Derive report paths
@@ -261,6 +299,9 @@ jobs:
         with:
           suite_name: ${{ matrix.suite.name }}
           config: tests/configs/torch_spyre_tests/${{ matrix.suite.config }}
+          # Prebaked: run FROM the baked dir (its .venv + editable torch_spyre);
+          # normal: from the checkout (default 'torch-spyre').
+          torch_spyre_dir: ${{ inputs.prebaked_image && env.PREBAKED_TORCH_SPYRE_DIR || 'torch-spyre' }}
           extra_test_flags: ${{ inputs.extra_test_flags }}
           junit_xml_path: ${{ env.REPORT_PATH }}
           report_name: ${{ env.REPORT_NAME }}
@@ -331,12 +372,14 @@ jobs:
 
     steps:
       - name: Checkout composite actions
+        if: ${{ !inputs.prebaked_image }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - if: ${{ !inputs.prebaked_image }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: torch-spyre
           ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
@@ -349,12 +392,12 @@ jobs:
       - uses: ./.github/actions/gather-runner-info
         with:
           verbose: 'true'
+          torch_spyre_dir: ${{ inputs.prebaked_image && env.PREBAKED_TORCH_SPYRE_DIR || 'torch-spyre' }}
 
       # Install the wheel built once by build_torch_spyre — no recompile.
-      # Skipped on the RPM path (build_torch_spyre skipped), where the RPM
-      # provides torch-spyre exactly as before.
+      # Skipped on the RPM path (build skipped) AND on the prebaked path.
       - name: Install prebuilt torch-spyre
-        if: ${{ needs.build_torch_spyre.result == 'success' }}
+        if: ${{ !inputs.prebaked_image && needs.build_torch_spyre.result == 'success' }}
         uses: ./.github/actions/install-prebuilt-torch-spyre
 
       - name: Derive report paths
@@ -369,6 +412,7 @@ jobs:
         with:
           suite_name: ${{ matrix.suite.name }}
           config: tests/configs/${{ matrix.suite.config }}
+          torch_spyre_dir: ${{ inputs.prebaked_image && env.PREBAKED_TORCH_SPYRE_DIR || 'torch-spyre' }}
           extra_test_flags: ${{ inputs.extra_test_flags_multi_spyre }}
           parallel: 'false'
           junit_xml_path: ${{ env.REPORT_PATH }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -11,9 +11,10 @@ name: integration-tests
 #     --repo <org>/torch-spyre \
 #     -f triggering_repo=<repo link to deeptools/flex> \
 #     -f triggering_sha=${{ github.sha }} \
-#     -f pr_url_hash=$(echo -n "${{ github.event.pull_request.html_url }}" | sha256sum | cut -c1-16) \
-#     -f rpm_location=... \
-#     -f rpm_names=...
+#     -f pr_url_hash=$(echo -n "${{ github.event.pull_request.html_url }}" | sha256sum | cut -c1-16)
+#
+# Tests the PRE-BAKED torch-spyre-dev image (prebaked_image=true, default): no
+# checkout/build/RPM-install on the runner.
 # ---------------------------------------------------------------------------
 on:
   workflow_dispatch:
@@ -50,22 +51,15 @@ on:
         type: string
         default: ''
 
-      # ---- RPM / image overrides ------------------
-      rpm_location:
-        description: Artifactory location for RPM download
-        required: false
-        type: string
-        default: ''
-      rpm_names:
-        description: Space-separated list of RPM names to download and install
-        required: false
-        type: string
-        default: ''
-      build_torch_spyre:
-        description: Whether to re-build torch-spyre after installing the RPM
-        required: false
-        type: boolean
-        default: true
+      # ---- image override ------------------
+      # NOTE: rpm_location / rpm_names / build_torch_spyre are intentionally NOT
+      # exposed here. This entrypoint tests the PRE-BAKED torch-spyre-dev image
+      # (prebaked_image, default true) — nothing is built or RPM-installed on the
+      # runner, so those knobs are meaningless. _test_matrix.yaml still declares
+      # them (workflow_call, no input cap) for its legacy callers; on the
+      # prebaked_image=false fallback it uses their defaults (build_torch_spyre
+      # true, rpm_names ''). Dropping them also keeps this workflow_dispatch under
+      # the hard 10-input cap.
       runner_label:
         description: |
           Per-PR ephemeral runner-set IMAGE label
@@ -81,6 +75,15 @@ on:
         required: false
         type: string
         default: full
+      prebaked_image:
+        description: >-
+          Test the pre-baked torch-spyre-dev image directly (no checkout/build) —
+          the Spyre-Next default for this entrypoint. The ephemeral runner is FROM
+          torch-spyre-dev, which already has the editable torch_spyre + full source
+          + venv. Set false to fall back to the legacy checkout+build path.
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.pull_request.html_url) || (github.event_name == 'workflow_dispatch'
@@ -110,7 +113,7 @@ jobs:
             echo "| Upstream commit | ${{ inputs.triggering_sha || '(not specified)' }} |"
             echo "| PR URL hash     | ${{ inputs.pr_url_hash || '(not specified)' }} |"
             echo "| torch-spyre ref | ${{ inputs.ref || github.sha }} |"
-            echo "| RPM names       | ${{ inputs.rpm_names || '(none)' }} |"
+            echo "| prebaked image  | ${{ inputs.prebaked_image }} |"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
@@ -127,10 +130,8 @@ jobs:
       checkout_pytorch: false
       ref: ${{ inputs.ref || '' }}
       repository: ${{ inputs.repository || '' }}
-      rpm_location: ${{ inputs.rpm_location || '' }}
-      rpm_names: ${{ inputs.rpm_names || '' }}
-      build_torch_spyre: ${{ inputs.build_torch_spyre == true }}
       test_type: ${{ inputs.test_type || 'full' }}
+      prebaked_image: ${{ inputs.prebaked_image }}
 
   # ----------------------------------------------------------------------------------
   # Fan-in gate job which is similar to run-spyre-unit-tests in torch_spyre_tests.yaml


### PR DESCRIPTION
## What
Adds a **`prebaked_image`** path to the integration-tests entrypoint (`integration-tests.yaml`) + the reusable `_test_matrix.yaml`. When the Spyre-Next integration pipeline dispatches with `prebaked_image=true` (the entrypoint's default), the run does **NOT** check out + rebuild torch-spyre on the ephemeral runner — it tests the **torch-spyre-dev image the runner is FROM**, which already has `torch_spyre` editable-installed + the full source (`tests/`, `tests/configs/`) + the shared venv at `/home/senuser/torch-spyre`.

## Why
- Removes the redundant per-run `torch_spyre._C` rebuild from the integration path (the dev image already built it from the PR's pinned source — content-addressed).
- Eliminates the ephemeral-runner workspace `mkdir` collision under `/home/senuser` (no checkout → no runtime mkdir).

## Safety / scope
- `prebaked_image` **defaults `false`** in `_test_matrix.yaml` → the normal PR/nightly callers (`tests.yml` / `tests-nightly.yml`) are **byte-for-byte unchanged**. Only `integration-tests.yaml` (the Spyre-Next dispatch entrypoint) defaults it true. Every prebaked branch is gated `if: inputs.prebaked_image`.
- When true: skip product `actions/checkout` (all jobs), skip `build_torch_spyre`, skip `install-prebuilt-torch-spyre`; point `run-test-suite`/`gather-runner-info` at `torch_spyre_dir=/home/senuser/torch-spyre` (both already accept an absolute dir). Existing `!cancelled() && (success || skipped)` guard already runs tests when the build is skipped (same as the RPM path). `generate_matrix`, when prebaked, runs on the runner image + reads the baked (PR-pinned) configs.

## Validation
Being validated end-to-end via the Spyre-Next integration flow on this branch before merge (dispatch runs THIS branch's modified workflow). Legacy checkout+build path is fully intact (`prebaked_image=false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)