### PR TITLE
feat(cicd): cap `MAX_JOBS` to the runner's cgroup CPU quota instead of the host in build-torch-spyre-wheel

### DIFF
--- a/.github/actions/build-torch-spyre-wheel/action.yml
+++ b/.github/actions/build-torch-spyre-wheel/action.yml
@@ -78,6 +78,25 @@ runs:
         uv sync --verbose --frozen --all-extras --no-install-project
 
         ccache --zero-stats || true
+
+        # torch's cpp_extension (ninja backend) sizes its parallelism off
+        # os.cpu_count(), which reports the NODE's total cores, not this pod's
+        # actual CPU quota. On a CPU-limited runner that oversubscribes ninja
+        # jobs, starving each other for the same slice of CPU and inflating
+        # individual compile times. Detect the real quota from cgroup v2
+        # (cpu.max = "<quota> <period>", or "max" for unlimited) and cap
+        # MAX_JOBS to it; cpp_extension reads MAX_JOBS directly.
+        MAX_JOBS="$(nproc)"
+        if [[ -f /sys/fs/cgroup/cpu.max ]]; then
+          read -r cpu_quota cpu_period < /sys/fs/cgroup/cpu.max
+          if [[ "$cpu_quota" != "max" ]]; then
+            MAX_JOBS=$(( cpu_quota / cpu_period ))
+            [[ "$MAX_JOBS" -lt 1 ]] && MAX_JOBS=1
+          fi
+        fi
+        export MAX_JOBS
+        echo "MAX_JOBS $MAX_JOBS"
+
         # Non-isolated wheel build reuses the just-synced .venv, guaranteeing the
         # _C.so links against the same torch the test jobs install.
         uv build --wheel --no-build-isolation --out-dir dist


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### Decrease build wheel time from 11 mins to 6 mins, 8 mins

<img width="1752" height="266" alt="image" src="https://github.com/user-attachments/assets/d5347479-3968-49b3-93b5-bab28dd9ab56" />

#### What this PR does:

Caps `MAX_JOBS` to the runner's actual cgroup CPU quota in `build-torch-spyre-wheel`, instead of letting ninja size parallelism off the host's (i.e. node's) total core count. On CPU-limited pods this was oversubscribing compile jobs and inflating individual C++ file compile times (observed ~100-150s per changed file instead of ~20-40s) in merge-queue builds.
