### PR TITLE
2666 Propagate RuntimeStream errors through SpyreStream into pytest

### DIFF
--- a/tests/configs/torch_spyre_tests/test_device_error_skip_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_device_error_skip_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [smoke, core, full]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/test_device_error_skip.py
+      unlisted_test_mode: mandatory_success

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -508,25 +508,19 @@ def _is_spyre_hardware_available() -> bool:
 
 def pytest_runtest_setup(item: pytest.Item) -> None:
     """
-    Automatically skip tests marked with @pytest.mark.requires_spyre_profiler
-    when the Spyre profiler is not available.
+    Skip tests marked with @pytest.mark.requires_spyre_profiler when the
+    Spyre profiler is not available.
 
-    Also skips any test when the device has entered an unrecoverable error
-    state from a previous test.  The flex stream shutdown latch is permanent —
-    there is no recovery path within a process — so all subsequent tests on
-    that device would produce meaningless results.
+    Also skips any test when the device has entered an error state from a
+    previous test. This check runs before every test so that a single
+    hardware fault does not cascade into a wall of misleading FAILED results.
     """
-    # Skip all remaining tests if the device is in an unrecoverable error state.
-    # This check runs before every test so that a single hardware fault does not
-    # cascade into a wall of misleading FAILED results.
+    # Skip if the device is in an error state from a prior test failure.
     try:
         from torch_spyre import _C  # noqa: PLC0415
 
         if _C.has_stream_error():
-            pytest.skip(
-                "Device is in an unrecoverable error state from a previous test "
-                "failure — no further tests can run on this device"
-            )
+            pytest.skip("Device is in error state")
     except (ImportError, RuntimeError):
         # Runtime not yet initialized or not available — nothing to check.
         pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ import os
 from pathlib import Path
 import yaml
 import pytest
-import re
+import regex as re
 
 import shared_config
 from oot_framework.oot_test_utilities import _RUNTIME_TAGS, _RUNTIME_SHAPES
@@ -510,7 +510,27 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
     """
     Automatically skip tests marked with @pytest.mark.requires_spyre_profiler
     when the Spyre profiler is not available.
+
+    Also skips any test when the device has entered an unrecoverable error
+    state from a previous test.  The flex stream shutdown latch is permanent —
+    there is no recovery path within a process — so all subsequent tests on
+    that device would produce meaningless results.
     """
+    # Skip all remaining tests if the device is in an unrecoverable error state.
+    # This check runs before every test so that a single hardware fault does not
+    # cascade into a wall of misleading FAILED results.
+    try:
+        from torch_spyre import _C  # noqa: PLC0415
+
+        if _C.has_stream_error():
+            pytest.skip(
+                "Device is in an unrecoverable error state from a previous test "
+                "failure — no further tests can run on this device"
+            )
+    except (ImportError, RuntimeError):
+        # Runtime not yet initialized or not available — nothing to check.
+        pass
+
     if "requires_spyre_profiler" in item.keywords:
         use_profiler = os.environ.get("USE_SPYRE_PROFILER") == "1"
         hardware_available = _is_spyre_hardware_available()

--- a/tests/test_device_error_skip.py
+++ b/tests/test_device_error_skip.py
@@ -66,21 +66,24 @@ def _run_pytest_subprocess(
     subprocess, returning the CompletedProcess so callers can inspect stdout
     and returncode.
     """
-    import tempfile
     import os
+    import tempfile
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        conftest_path = os.path.join(tmpdir, "conftest.py")
-        test_path = os.path.join(tmpdir, "test_tmp.py")
-        with open(conftest_path, "w") as f:
-            f.write(textwrap.dedent(conftest_src))
-        with open(test_path, "w") as f:
-            f.write(textwrap.dedent(test_src))
-        return subprocess.run(
-            [sys.executable, "-m", "pytest", "-v", "-rs", tmpdir],
-            capture_output=True,
-            text=True,
-        )
+    tmpdir = tempfile.mkdtemp()
+    conftest_path = os.path.join(tmpdir, "conftest.py")
+    test_path = os.path.join(tmpdir, "test_tmp.py")
+    with open(conftest_path, "w") as f:
+        f.write(textwrap.dedent(conftest_src))
+    with open(test_path, "w") as f:
+        f.write(textwrap.dedent(test_src))
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(sys.path)
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", "-v", "-rs", "-p", "no:cacheprovider", tmpdir],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
 
 
 class TestDeviceErrorSkipIntegration(TestCase):

--- a/tests/test_device_error_skip.py
+++ b/tests/test_device_error_skip.py
@@ -17,19 +17,14 @@
 """
 Tests for the device-error-state skip mechanism.
 
-1. TestHasStreamErrorBinding
-   Tests the _C.has_stream_error() pybind11 binding in isolation using
-   unittest.mock so no hardware fault needs to be induced.
-
-2. TestDeviceErrorSkipIntegration
-   Uses pytest's pytester plugin to spin up a throwaway sub-process pytest
-   session and assert on skip outcomes without touching the host device.
-
-Running
--------
-    pytest tests/test_device_error_skip.py -p pytester
+- TestHasStreamErrorBinding: unit-tests _C.has_stream_error() via unittest.mock.
+- TestDeviceErrorSkipIntegration: runs hermetic subprocess pytest sessions to
+  verify the conftest skip hook end-to-end.
 """
 
+import subprocess
+import sys
+import textwrap
 from unittest.mock import patch
 
 from torch.testing._internal.common_utils import TestCase, run_tests
@@ -63,118 +58,134 @@ class TestHasStreamErrorBinding(TestCase):
             self.assertFalse(_C.has_stream_error())
 
 
-class TestDeviceErrorSkipIntegration:
+def _run_pytest_subprocess(
+    conftest_src: str, test_src: str
+) -> subprocess.CompletedProcess:
+    """
+    Write conftest.py and test_tmp.py into a temp dir and run pytest in a
+    subprocess, returning the CompletedProcess so callers can inspect stdout
+    and returncode.
+    """
+    import tempfile
+    import os
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        conftest_path = os.path.join(tmpdir, "conftest.py")
+        test_path = os.path.join(tmpdir, "test_tmp.py")
+        with open(conftest_path, "w") as f:
+            f.write(textwrap.dedent(conftest_src))
+        with open(test_path, "w") as f:
+            f.write(textwrap.dedent(test_src))
+        return subprocess.run(
+            [sys.executable, "-m", "pytest", "-v", "-rs", tmpdir],
+            capture_output=True,
+            text=True,
+        )
+
+
+class TestDeviceErrorSkipIntegration(TestCase):
     """
     Verifies the conftest pytest_runtest_setup hook behaviour end-to-end.
 
-    Uses pytest's pytester plugin to run a hermetic sub-session so the host
-    device state is never mutated and outcomes are inspectable as plain data.
+    Runs a hermetic subprocess pytest session so the host device state is
+    never mutated and outcomes are inspectable as plain text.
     """
 
-    def test_healthy_device_does_not_skip(self, pytester):
+    def test_healthy_device_does_not_skip(self):
         """When has_stream_error() is False the test must run normally."""
-        pytester.makepyfile(
-            conftest="""
-            from unittest.mock import patch
-            import pytest
-            from torch_spyre import _C
+        result = _run_pytest_subprocess(
+            conftest_src="""
+                from unittest.mock import patch
+                import pytest
+                from torch_spyre import _C
 
-            def pytest_runtest_setup(item):
-                with patch.object(_C, "has_stream_error", return_value=False):
-                    try:
-                        if _C.has_stream_error():
-                            pytest.skip("Device is in error state")
-                    except (ImportError, RuntimeError):
-                        pass
-            """
+                def pytest_runtest_setup(item):
+                    with patch.object(_C, "has_stream_error", return_value=False):
+                        try:
+                            if _C.has_stream_error():
+                                pytest.skip("Device is in error state")
+                        except (ImportError, RuntimeError):
+                            pass
+            """,
+            test_src="""
+                def test_should_run():
+                    assert True
+            """,
         )
-        pytester.makepyfile(
-            """
-            def test_should_run():
-                assert True
-            """
-        )
-        result = pytester.runpytest()
-        result.assert_outcomes(passed=1, skipped=0)
+        self.assertIn("1 passed", result.stdout)
+        self.assertNotIn("skipped", result.stdout)
 
-    def test_faulted_device_skips_all_tests(self, pytester):
+    def test_faulted_device_skips_all_tests(self):
         """
         When has_stream_error() is True every test in the session must be
         skipped. Two tests are declared to confirm all are affected, not
         just the first.
         """
-        pytester.makepyfile(
-            conftest="""
-            from unittest.mock import patch
-            import pytest
-            from torch_spyre import _C
+        result = _run_pytest_subprocess(
+            conftest_src="""
+                from unittest.mock import patch
+                import pytest
+                from torch_spyre import _C
 
-            def pytest_runtest_setup(item):
-                with patch.object(_C, "has_stream_error", return_value=True):
-                    try:
+                def pytest_runtest_setup(item):
+                    with patch.object(_C, "has_stream_error", return_value=True):
+                        try:
+                            if _C.has_stream_error():
+                                pytest.skip("Device is in error state")
+                        except (ImportError, RuntimeError):
+                            pass
+            """,
+            test_src="""
+                def test_first():
+                    assert True
+
+                def test_second():
+                    assert True
+            """,
+        )
+        self.assertIn("2 skipped", result.stdout)
+        self.assertNotIn("passed", result.stdout)
+
+    def test_skip_message_content(self):
+        """The skip reason reported by pytest must contain 'Device is in error state'."""
+        result = _run_pytest_subprocess(
+            conftest_src="""
+                from unittest.mock import patch
+                import pytest
+                from torch_spyre import _C
+
+                def pytest_runtest_setup(item):
+                    with patch.object(_C, "has_stream_error", return_value=True):
                         if _C.has_stream_error():
                             pytest.skip("Device is in error state")
+            """,
+            test_src="""
+                def test_something():
+                    pass
+            """,
+        )
+        self.assertIn("1 skipped", result.stdout)
+        self.assertIn("Device is in error state", result.stdout)
+
+    def test_import_error_does_not_block_test(self):
+        """If _C is unavailable the hook must silently pass and not skip."""
+        result = _run_pytest_subprocess(
+            conftest_src="""
+                import pytest
+
+                def pytest_runtest_setup(item):
+                    try:
+                        raise ImportError("_C not available")
                     except (ImportError, RuntimeError):
                         pass
-            """
+            """,
+            test_src="""
+                def test_still_runs():
+                    assert True
+            """,
         )
-        pytester.makepyfile(
-            """
-            def test_first():
-                assert True
-
-            def test_second():
-                assert True
-            """
-        )
-        result = pytester.runpytest()
-        result.assert_outcomes(passed=0, skipped=2)
-
-    def test_skip_message_content(self, pytester):
-        """The skip message must contain 'Device is in error state'."""
-        pytester.makepyfile(
-            conftest="""
-            from unittest.mock import patch
-            import pytest
-            from torch_spyre import _C
-
-            def pytest_runtest_setup(item):
-                with patch.object(_C, "has_stream_error", return_value=True):
-                    if _C.has_stream_error():
-                        pytest.skip("Device is in error state")
-            """
-        )
-        pytester.makepyfile(
-            """
-            def test_something():
-                pass
-            """
-        )
-        result = pytester.runpytest("-v")
-        result.assert_outcomes(skipped=1)
-        result.stdout.fnmatch_lines(["*Device is in error state*"])
-
-    def test_import_error_does_not_block_test(self, pytester):
-        """If _C is unavailable the hook must silently pass and not skip."""
-        pytester.makepyfile(
-            conftest="""
-            import pytest
-
-            def pytest_runtest_setup(item):
-                try:
-                    raise ImportError("_C not available")
-                except (ImportError, RuntimeError):
-                    pass
-            """
-        )
-        pytester.makepyfile(
-            """
-            def test_still_runs():
-                assert True
-            """
-        )
-        result = pytester.runpytest()
-        result.assert_outcomes(passed=1, skipped=0)
+        self.assertIn("1 passed", result.stdout)
+        self.assertNotIn("skipped", result.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_device_error_skip.py
+++ b/tests/test_device_error_skip.py
@@ -18,17 +18,18 @@
 Tests for the device-error-state skip mechanism.
 
 - TestHasStreamErrorBinding: unit-tests _C.has_stream_error() via unittest.mock.
-- TestDeviceErrorSkipIntegration: runs hermetic subprocess pytest sessions to
-  verify the conftest skip hook end-to-end.
+- TestDeviceErrorSkipIntegration: calls the conftest hook directly to verify
+  skip behaviour without spawning subprocesses.
+
+Usage: ``python test_device_error_skip.py`` or ``pytest test_device_error_skip.py``
 """
 
-import subprocess
-import sys
-import textwrap
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from torch.testing._internal.common_utils import TestCase
+import pytest
+from torch.testing._internal.common_utils import TestCase, run_tests
 
+from conftest import pytest_runtest_setup
 from torch_spyre import _C
 
 
@@ -58,144 +59,44 @@ class TestHasStreamErrorBinding(TestCase):
             self.assertFalse(_C.has_stream_error())
 
 
-def _run_pytest_subprocess(
-    conftest_src: str, test_src: str
-) -> subprocess.CompletedProcess:
-    """
-    Write conftest.py and test_tmp.py into a temp dir and run pytest in a
-    subprocess, returning the CompletedProcess so callers can inspect stdout
-    and returncode.
-    """
-    import os
-    import tempfile
-
-    tmpdir = tempfile.mkdtemp()
-    conftest_path = os.path.join(tmpdir, "conftest.py")
-    test_path = os.path.join(tmpdir, "test_tmp.py")
-    with open(conftest_path, "w") as f:
-        f.write(textwrap.dedent(conftest_src))
-    with open(test_path, "w") as f:
-        f.write(textwrap.dedent(test_src))
-    env = os.environ.copy()
-    env["PYTHONPATH"] = os.pathsep.join(p for p in sys.path if p)
-    return subprocess.run(
-        [sys.executable, "-m", "pytest", "-v", "-rs", "-p", "no:cacheprovider", tmpdir],
-        capture_output=True,
-        text=True,
-        env=env,
-    )
-
-
 class TestDeviceErrorSkipIntegration(TestCase):
     """
-    Verifies the conftest pytest_runtest_setup hook behaviour end-to-end.
-
-    Runs a hermetic subprocess pytest session so the host device state is
-    never mutated and outcomes are inspectable as plain text.
+    Calls pytest_runtest_setup() directly with a mock item to verify the
+    skip hook without subprocesses or pytester.
     """
 
+    def _make_item(self, keywords=()):
+        """Return a minimal mock pytest.Item with the given keyword names."""
+        item = MagicMock(spec=pytest.Item)
+        item.keywords = set(keywords)
+        return item
+
     def test_healthy_device_does_not_skip(self):
-        """When has_stream_error() is False the test must run normally."""
-        result = _run_pytest_subprocess(
-            conftest_src="""
-                from unittest.mock import patch
-                import pytest
-                from torch_spyre import _C
+        """When has_stream_error() is False the hook must not skip."""
+        with patch.object(_C, "has_stream_error", return_value=False):
+            # Should complete without raising pytest.skip.Exception
+            pytest_runtest_setup(self._make_item())
 
-                def pytest_runtest_setup(item):
-                    with patch.object(_C, "has_stream_error", return_value=False):
-                        try:
-                            if _C.has_stream_error():
-                                pytest.skip("Device is in error state")
-                        except (ImportError, RuntimeError):
-                            pass
-            """,
-            test_src="""
-                def test_should_run():
-                    assert True
-            """,
-        )
-        self.assertIn("1 passed", result.stdout, msg=result.stdout)
-        self.assertNotIn("skipped", result.stdout)
-
-    def test_faulted_device_skips_all_tests(self):
-        """
-        When has_stream_error() is True every test in the session must be
-        skipped. Two tests are declared to confirm all are affected, not
-        just the first.
-        """
-        result = _run_pytest_subprocess(
-            conftest_src="""
-                from unittest.mock import patch
-                import pytest
-                from torch_spyre import _C
-
-                def pytest_runtest_setup(item):
-                    with patch.object(_C, "has_stream_error", return_value=True):
-                        try:
-                            if _C.has_stream_error():
-                                pytest.skip("Device is in error state")
-                        except (ImportError, RuntimeError):
-                            pass
-            """,
-            test_src="""
-                def test_first():
-                    assert True
-
-                def test_second():
-                    assert True
-            """,
-        )
-        self.assertIn("2 skipped", result.stdout)
-        self.assertNotIn("passed", result.stdout)
+    def test_faulted_device_skips(self):
+        """When has_stream_error() is True every hook call must skip — not just the first."""
+        with patch.object(_C, "has_stream_error", return_value=True):
+            for _ in range(3):
+                with self.assertRaises(pytest.skip.Exception):
+                    pytest_runtest_setup(self._make_item())
 
     def test_skip_message_content(self):
-        """The skip reason reported by pytest must contain 'Device is in error state'."""
-        result = _run_pytest_subprocess(
-            conftest_src="""
-                from unittest.mock import patch
-                import pytest
-                from torch_spyre import _C
-
-                def pytest_runtest_setup(item):
-                    with patch.object(_C, "has_stream_error", return_value=True):
-                        if _C.has_stream_error():
-                            pytest.skip("Device is in error state")
-            """,
-            test_src="""
-                def test_something():
-                    pass
-            """,
-        )
-        self.assertIn("1 skipped", result.stdout)
-        self.assertIn("Device is in error state", result.stdout)
+        """The skip reason must contain 'Device is in error state'."""
+        with patch.object(_C, "has_stream_error", return_value=True):
+            with self.assertRaises(pytest.skip.Exception) as ctx:
+                pytest_runtest_setup(self._make_item())
+        self.assertIn("Device is in error state", str(ctx.exception))
 
     def test_import_error_does_not_block_test(self):
-        """If _C is unavailable the hook must silently pass and not skip."""
-        result = _run_pytest_subprocess(
-            conftest_src="""
-                import pytest
-
-                def pytest_runtest_setup(item):
-                    try:
-                        raise ImportError("_C not available")
-                    except (ImportError, RuntimeError):
-                        pass
-            """,
-            test_src="""
-                def test_still_runs():
-                    assert True
-            """,
-        )
-        self.assertIn("1 passed", result.stdout)
-        self.assertNotIn("skipped", result.stdout)
+        """If _C raises ImportError the hook must silently pass."""
+        with patch.object(_C, "has_stream_error", side_effect=ImportError):
+            # Should complete without raising anything
+            pytest_runtest_setup(self._make_item())
 
 
 if __name__ == "__main__":
-    import unittest
-
-    # TestHasStreamErrorBinding uses PyTorch's run_tests(); the integration
-    # class uses plain unittest since run_tests() hijacks stdout/stderr which
-    # breaks capture_output=True in the subprocess helper.
-    suite = unittest.TestLoader().loadTestsFromTestCase(TestHasStreamErrorBinding)
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    run_tests()

--- a/tests/test_device_error_skip.py
+++ b/tests/test_device_error_skip.py
@@ -62,7 +62,7 @@ class TestHasStreamErrorBinding(TestCase):
 class TestDeviceErrorSkipIntegration(TestCase):
     """
     Calls pytest_runtest_setup() directly with a mock item to verify the
-    skip hook without subprocesses or pytester.
+    skip hook
     """
 
     def _make_item(self, keywords=()):

--- a/tests/test_device_error_skip.py
+++ b/tests/test_device_error_skip.py
@@ -1,0 +1,181 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Owner(s): ["module: stream"]
+
+"""
+Tests for the device-error-state skip mechanism.
+
+1. TestHasStreamErrorBinding
+   Tests the _C.has_stream_error() pybind11 binding in isolation using
+   unittest.mock so no hardware fault needs to be induced.
+
+2. TestDeviceErrorSkipIntegration
+   Uses pytest's pytester plugin to spin up a throwaway sub-process pytest
+   session and assert on skip outcomes without touching the host device.
+
+Running
+-------
+    pytest tests/test_device_error_skip.py -p pytester
+"""
+
+from unittest.mock import patch
+
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+from torch_spyre import _C
+
+
+class TestHasStreamErrorBinding(TestCase):
+    """Unit tests for the _C.has_stream_error() pybind11 binding."""
+
+    def test_binding_exists_and_returns_bool(self):
+        """has_stream_error() must be importable and return a bool."""
+        result = _C.has_stream_error()
+        self.assertIsInstance(result, bool)
+
+    def test_returns_false_when_mocked_healthy(self):
+        """Returns False when the runtime reports no error."""
+        with patch.object(_C, "has_stream_error", return_value=False):
+            self.assertFalse(_C.has_stream_error())
+
+    def test_returns_true_when_mocked_faulted(self):
+        """Returns True when the runtime reports a stream error."""
+        with patch.object(_C, "has_stream_error", return_value=True):
+            self.assertTrue(_C.has_stream_error())
+
+    def test_return_value_is_not_cached(self):
+        """Consecutive calls reflect the live state, not a cached value."""
+        with patch.object(_C, "has_stream_error", side_effect=[False, True, False]):
+            self.assertFalse(_C.has_stream_error())
+            self.assertTrue(_C.has_stream_error())
+            self.assertFalse(_C.has_stream_error())
+
+
+class TestDeviceErrorSkipIntegration:
+    """
+    Verifies the conftest pytest_runtest_setup hook behaviour end-to-end.
+
+    Uses pytest's pytester plugin to run a hermetic sub-session so the host
+    device state is never mutated and outcomes are inspectable as plain data.
+    """
+
+    def test_healthy_device_does_not_skip(self, pytester):
+        """When has_stream_error() is False the test must run normally."""
+        pytester.makepyfile(
+            conftest="""
+            from unittest.mock import patch
+            import pytest
+            from torch_spyre import _C
+
+            def pytest_runtest_setup(item):
+                with patch.object(_C, "has_stream_error", return_value=False):
+                    try:
+                        if _C.has_stream_error():
+                            pytest.skip("Device is in error state")
+                    except (ImportError, RuntimeError):
+                        pass
+            """
+        )
+        pytester.makepyfile(
+            """
+            def test_should_run():
+                assert True
+            """
+        )
+        result = pytester.runpytest()
+        result.assert_outcomes(passed=1, skipped=0)
+
+    def test_faulted_device_skips_all_tests(self, pytester):
+        """
+        When has_stream_error() is True every test in the session must be
+        skipped. Two tests are declared to confirm all are affected, not
+        just the first.
+        """
+        pytester.makepyfile(
+            conftest="""
+            from unittest.mock import patch
+            import pytest
+            from torch_spyre import _C
+
+            def pytest_runtest_setup(item):
+                with patch.object(_C, "has_stream_error", return_value=True):
+                    try:
+                        if _C.has_stream_error():
+                            pytest.skip("Device is in error state")
+                    except (ImportError, RuntimeError):
+                        pass
+            """
+        )
+        pytester.makepyfile(
+            """
+            def test_first():
+                assert True
+
+            def test_second():
+                assert True
+            """
+        )
+        result = pytester.runpytest()
+        result.assert_outcomes(passed=0, skipped=2)
+
+    def test_skip_message_content(self, pytester):
+        """The skip message must contain 'Device is in error state'."""
+        pytester.makepyfile(
+            conftest="""
+            from unittest.mock import patch
+            import pytest
+            from torch_spyre import _C
+
+            def pytest_runtest_setup(item):
+                with patch.object(_C, "has_stream_error", return_value=True):
+                    if _C.has_stream_error():
+                        pytest.skip("Device is in error state")
+            """
+        )
+        pytester.makepyfile(
+            """
+            def test_something():
+                pass
+            """
+        )
+        result = pytester.runpytest("-v")
+        result.assert_outcomes(skipped=1)
+        result.stdout.fnmatch_lines(["*Device is in error state*"])
+
+    def test_import_error_does_not_block_test(self, pytester):
+        """If _C is unavailable the hook must silently pass and not skip."""
+        pytester.makepyfile(
+            conftest="""
+            import pytest
+
+            def pytest_runtest_setup(item):
+                try:
+                    raise ImportError("_C not available")
+                except (ImportError, RuntimeError):
+                    pass
+            """
+        )
+        pytester.makepyfile(
+            """
+            def test_still_runs():
+                assert True
+            """
+        )
+        result = pytester.runpytest()
+        result.assert_outcomes(passed=1, skipped=0)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/test_device_error_skip.py
+++ b/tests/test_device_error_skip.py
@@ -27,7 +27,7 @@ import sys
 import textwrap
 from unittest.mock import patch
 
-from torch.testing._internal.common_utils import TestCase, run_tests
+from torch.testing._internal.common_utils import TestCase
 
 from torch_spyre import _C
 
@@ -77,7 +77,7 @@ def _run_pytest_subprocess(
     with open(test_path, "w") as f:
         f.write(textwrap.dedent(test_src))
     env = os.environ.copy()
-    env["PYTHONPATH"] = os.pathsep.join(sys.path)
+    env["PYTHONPATH"] = os.pathsep.join(p for p in sys.path if p)
     return subprocess.run(
         [sys.executable, "-m", "pytest", "-v", "-rs", "-p", "no:cacheprovider", tmpdir],
         capture_output=True,
@@ -115,7 +115,7 @@ class TestDeviceErrorSkipIntegration(TestCase):
                     assert True
             """,
         )
-        self.assertIn("1 passed", result.stdout)
+        self.assertIn("1 passed", result.stdout, msg=result.stdout)
         self.assertNotIn("skipped", result.stdout)
 
     def test_faulted_device_skips_all_tests(self):
@@ -192,4 +192,10 @@ class TestDeviceErrorSkipIntegration(TestCase):
 
 
 if __name__ == "__main__":
-    run_tests()
+    import unittest
+
+    # TestHasStreamErrorBinding uses PyTorch's run_tests(); the integration
+    # class uses plain unittest since run_tests() hijacks stdout/stderr which
+    # breaks capture_output=True in the subprocess helper.
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestHasStreamErrorBinding)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/torch_spyre/_C.pyi
+++ b/torch_spyre/_C.pyi
@@ -380,13 +380,7 @@ def spyre_empty_with_layout(
     arg3: SpyreTensorLayout,
 ) -> torch.Tensor: ...
 def has_stream_error() -> bool:
-    """
-    Return true if any stream on the current device is in an unrecoverable
-    error state.
-
-    Once true, the device must be considered dead for the lifetime of this
-    process — there is no recovery path.
-    """
+    """Returns true if any stream on the current device is in an error state."""
     ...
 
 def start_runtime() -> None: ...

--- a/torch_spyre/_C.pyi
+++ b/torch_spyre/_C.pyi
@@ -16,6 +16,7 @@ __all__: list[str] = [
     "current_stream",
     "default_stream",
     "get_stream_from_pool",
+    "has_stream_error",
     "set_current_stream",
     "synchronize",
     "as_strided_with_layout",
@@ -378,5 +379,15 @@ def spyre_empty_with_layout(
     arg2: torch.dtype,
     arg3: SpyreTensorLayout,
 ) -> torch.Tensor: ...
+def has_stream_error() -> bool:
+    """
+    Return true if any stream on the current device is in an unrecoverable
+    error state.
+
+    Once true, the device must be considered dead for the lifetime of this
+    process — there is no recovery path.
+    """
+    ...
+
 def start_runtime() -> None: ...
 def to_with_layout(arg0: torch.Tensor, arg1: SpyreTensorLayout) -> torch.Tensor: ...

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -494,4 +494,15 @@ PYBIND11_MODULE(_C, m) {
         allocator.resetPeakStats(device);
       },
       py::arg("device"), "Reset peak allocator statistics");
+
+  m.def(
+      "has_stream_error",
+      []() -> bool {
+        auto runtime = spyre::GlobalRuntime::get();
+        if (!runtime) return false;
+        return runtime->hasStreamError();
+      },
+      "Return true if any stream on the current device is in an unrecoverable "
+      "error state. Once true, the device must be considered dead for the "
+      "lifetime of this process — there is no recovery path.");
 }

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -495,14 +495,11 @@ PYBIND11_MODULE(_C, m) {
       },
       py::arg("device"), "Reset peak allocator statistics");
 
-  m.def(
-      "has_stream_error",
-      []() -> bool {
-        auto runtime = spyre::GlobalRuntime::get();
-        if (!runtime) return false;
-        return runtime->hasStreamError();
-      },
-      "Return true if any stream on the current device is in an unrecoverable "
-      "error state. Once true, the device must be considered dead for the "
-      "lifetime of this process — there is no recovery path.");
+  // Returns true if any stream on the current device is in an error state.
+  // When true, no further work can be submitted on the affected streams.
+  m.def("has_stream_error", []() -> bool {
+    auto runtime = spyre::GlobalRuntime::get();
+    if (!runtime) return false;
+    return runtime->hasStreamError();
+  });
 }


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [X] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

When a flex RuntimeStream faults, its shutdown latch is set permanently with no recovery path. Previously this caused all subsequent tests to cascade into misleading FAILED results from StreamInErrorState exceptions.

This PR adds a _C.has_stream_error() pybind11 binding over RuntimeContext::hasStreamError() and wires it into pytest_runtest_setup — turning those failures into clearly-marked SKIPPED results when the device is in an unrecoverable error state.

So the flow for a faulted session should look like this:

test_A runs         → passes, hasStreamError() = False
test_B runs         → causes a hardware fault mid-test, hasStreamError() = True
test_C setup        → hook calls hasStreamError() → True → pytest.skip() ← skipped
test_D setup        → hook calls hasStreamError() → True → pytest.skip() ← skipped
test_E setup        → hook calls hasStreamError() → True → pytest.skip() ← skipped

#### Which issue(s) this PR is related to:

Fixes #2666 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
