### PR TITLE
fix(span-overflow): tile large matmuls by joining the weight-producer group (#3217)

### DIFF
--- a/docs/source/compiler/span_overflow_hint_analysis.md
+++ b/docs/source/compiler/span_overflow_hint_analysis.md
@@ -194,10 +194,14 @@ C[b, m, n] = reduce_k A[b, m, k] * B[b, k, n]
 ```
 
 Spans controlled by `b`, `m`, or `n` are output-range tileable.  Spans
-controlled by `k` are not.  In the LM-head lowering, the restickify producer can
-be auto-tiled independently.  The BMM consumer is not automatically fused with
-that producer yet, so current codegen coverage checks for a restickify
-`LoopSpec` plus a plain BMM consumer:
+controlled by `k` are not.  In the LM-head lowering, the restickify producer is
+auto-tiled on its vocab output dim, and the BMM consumer **joins that
+producer's group** (see [Adapter and Coarse
+Tiling](#adapter-and-coarse-tiling) below) when it tiles the
+corresponding output `n` dim at the same split count — one synchronized loop
+nest, the producer's per-tile weight slice feeding the consumer's per-tile
+matmul.  Codegen therefore sees a restickify `LoopSpec` and a BMM sharing that
+loop:
 
 ```text
 LoopSpec(
@@ -205,8 +209,22 @@ count=sympify('4')
 op='ReStickifyOpHBM'
 tiled_symbols=[[sympify('c0')]]
 
-op='batchmatmul'
+op='batchmatmul'   # same loop, tiled on the corresponding output n dim
 ```
+
+The join is gated: split counts must match *and* the consumer's tiled loop
+variable must actually index the producer's tiled dim through the read
+(`_reduction_shares_group_tiled_dim`), so unrelated dims that merely share a
+split count are not fused.  A matmul can only join on an **output**-range
+tile, never the reduction (`k`) range, and each auto-tiled producer feeds at
+most one matmul consumer.
+
+The join is currently restricted to batch-matmul reductions, because that is
+the only path validated end-to-end on hardware (the #1918 LM-head case). The
+grouping mechanism is reduction-type-agnostic, so extending it to other
+reductions (`sum`/`mean`/`max` tiled on a shared output dim) is future work
+that needs on-device numeric validation; until then a non-matmul reduction
+reading an auto-tiled producer falls back to the fail-safe `Unsupported` path.
 
 Code flow:
 
@@ -717,18 +735,31 @@ synthetic `DimHint` per level.  `coarse_tile` then stamps a multi-level
    (b) an op's own plan disagrees but the op directly reads a buffer written
    by the open run and the run's split is *also* legal and sufficient for
    that op on its own (`can_conform_pointwise_tile`) — the op then adopts the
-   run's split instead of its own. Reduction/BMM ops are never grouped or
-   used as a conform target in this pass and always get an independent
-   singleton group;
+   run's split instead of its own. A Reduction/BMM op does not start or extend
+   a run and is never a conform target, but a **batch-matmul** reduction may
+   **join** an open run's group when it reads a producer in that run and tiles
+   the same shared output dim at the same split count(s) — verified by
+   `_reduction_shares_group_tiled_dim`, which confirms the consumer's tiled
+   loop variable actually indexes the producer's tiled dim through the read
+   (matching split counts alone do not qualify). Only output-range tiles may
+   join (never a reduction range). The join is gated to matmul because that is
+   the only hardware-validated path; the mechanism is reduction-type-agnostic
+   and extending it to other reductions is future work. On joining, the group
+   is flushed immediately, so a matmul is always the last member of its group
+   and each auto-tiled producer feeds at most one matmul consumer. A Reduction
+   that cannot join (including any non-matmul reduction) gets an independent
+   singleton group, or raises `Unsupported` if it reads an auto-tiled producer;
 6. rejects any op that reads a buffer from an already-closed auto-tiled
    group, from a producer already tiled by a user `spyre_hint` (checked via
    the same `dim_hints` attribute `assign_dim_hints` leaves behind, since
    this pass never clears it), or from the open run without being fusable
-   into it (mismatched signature and conform fails, or the reading op is a
-   Reduction/BMM), since two independent loop nests over the same
+   into it (mismatched signature and conform fails, or a Reduction/BMM that
+   cannot join per step 5), since two independent loop nests over the same
    span-overflow-sized data can desynchronize, and materializing a tiled
    Pointwise producer's full buffer for such an "outside consumer" can
-   reintroduce the exact span violation tiling was meant to prevent;
+   reintroduce the exact span violation tiling was meant to prevent. A second
+   consumer of a producer already joined by a matmul is rejected with a
+   distinct "multi-consumer not yet supported" message;
 7. creates synthetic `DimHint`s with ids starting at
    `_SPAN_OVERFLOW_HINT_ID = 10000`, shared across every op in a fused group;
 8. returns coarse-tile groups in the same format as user hints.
@@ -789,7 +820,13 @@ automatic output-range tile plan.  Common reasons:
 - `_resize_device_layout` cannot reconstruct the post-tile layout;
 - every tried combination still leaves output/input spans above the limit;
 - an automatically tiled op reads a producer that was already automatically
-  tiled, which would require producer-consumer loop fusion to be correct.
+  tiled and cannot be fused into that producer's loop (a Pointwise op whose
+  split does not conform, a non-matmul reduction — which is not yet eligible
+  to join — or a matmul that does not share the producer's tiled output dim),
+  since independent loop nests would require producer-consumer loop fusion to
+  stay synchronized;
+- a second consumer reads a producer that a matmul has already joined
+  (one auto-tiled producer currently feeds at most one matmul consumer).
 
 These failures are deliberate.  They avoid silently emitting a plan that still
 violates the hardware span limit or silently creates unsynchronized tile loops.

--- a/tests/inductor/test_span_overflow_hint_analysis.py
+++ b/tests/inductor/test_span_overflow_hint_analysis.py
@@ -400,6 +400,340 @@ class TestSpanOverflowGroups(InductorTestCase):
         self.assertEqual(op0.dim_hints[0].split_count, 5)
         self.assertEqual(op1.dim_hints[0].split_count, 5)
 
+    def test_matmul_joins_tiled_weight_producer_group(self):
+        """A Reduction (matmul) that reads its auto-tiled producer joins the
+        producer's group on the shared split rather than raising Unsupported
+        (#3217).  The shared dim sits at a different output-range position in
+        the matmul (host_dim=2) than in the producer (host_dim=1), so the join
+        is matched on split_count, and both hints keep their own loop_var."""
+        producer = _pointwise_op(_E2E_SHAPE, name="buf0")
+        matmul = _reduction_op(_E2E_SHAPE, name="buf1", reduction_type="batchmatmul")
+        matmul.get_read_writes = MagicMock(
+            return_value=SimpleNamespace(
+                reads={
+                    MemoryDep(
+                        "buf0",
+                        sympy.Symbol("h"),
+                        (sympy.Symbol("h"),),
+                        (8195,),
+                    )
+                },
+                writes=_default_read_writes_for_output(
+                    "buf1", _E2E_SHAPE, matmul.layout
+                ).writes,
+            )
+        )
+
+        def fake_plan(op, _max_cores):
+            # Producer tiles host_dim=1 (h); matmul tiles host_dim=2 (l); same split.
+            return self._fake_plan(1 if op.get_name() == "buf0" else 2, 5)
+
+        with (
+            patch(
+                "torch_spyre._inductor.coarse_tile.plan_span_overflow_tile", fake_plan
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile.op_out_coords", _out_coords_for_bhld
+            ),
+            # Through the read, the matmul's tiled symbol (l) indexes the
+            # producer's tiled dim (host_dim=1) -> same logical dim -> join.
+            patch(
+                "torch_spyre._inductor.coarse_tile.host_coordinates",
+                lambda layout, dep, indirect: [
+                    sympy.Symbol("b"),
+                    sympy.Symbol("l"),
+                    sympy.Symbol("x"),
+                    sympy.Symbol("y"),
+                ],
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile.indirect_sizes_from_op",
+                lambda op: {},
+            ),
+            config.patch({"sencores": 8, "ignore_span_overflow_hints": False}),
+        ):
+            groups = span_overflow_groups(_graph([producer, matmul]))
+
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0][0], [producer, matmul])
+        # Synchronized: shared hint_id and split, each on its own loop_var.
+        self.assertEqual(producer.dim_hints[0].hint_id, matmul.dim_hints[0].hint_id)
+        self.assertEqual(producer.dim_hints[0].split_count, 5)
+        self.assertEqual(matmul.dim_hints[0].split_count, 5)
+        self.assertEqual(producer.dim_hints[0].loop_var, sympy.Symbol("h"))
+        self.assertEqual(matmul.dim_hints[0].loop_var, sympy.Symbol("l"))
+
+    def test_matmul_join_rejected_when_tiled_dim_not_shared(self):
+        """Matching split counts are not enough: if the matmul's tiled loop var
+        does not index the producer's tiled dim through the read (i.e. they tile
+        unrelated dims that merely share a split count), the join is refused and
+        the normal fail-safe Unsupported path is taken (#3217)."""
+        producer = _pointwise_op(_E2E_SHAPE, name="buf0")
+        matmul = _reduction_op(_E2E_SHAPE, name="buf1", reduction_type="batchmatmul")
+        matmul.get_read_writes = MagicMock(
+            return_value=SimpleNamespace(
+                reads={
+                    MemoryDep(
+                        "buf0",
+                        sympy.Symbol("h"),
+                        (sympy.Symbol("h"),),
+                        (8195,),
+                    )
+                },
+                writes=_default_read_writes_for_output(
+                    "buf1", _E2E_SHAPE, matmul.layout
+                ).writes,
+            )
+        )
+
+        def fake_plan(op, _max_cores):
+            return self._fake_plan(1 if op.get_name() == "buf0" else 2, 5)
+
+        with (
+            patch(
+                "torch_spyre._inductor.coarse_tile.plan_span_overflow_tile", fake_plan
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile.op_out_coords", _out_coords_for_bhld
+            ),
+            # Producer's tiled dim (host_dim=1) is indexed by 'z', NOT the
+            # matmul's tiled symbol 'l' -> unrelated dims -> must not join.
+            patch(
+                "torch_spyre._inductor.coarse_tile.host_coordinates",
+                lambda layout, dep, indirect: [
+                    sympy.Symbol("b"),
+                    sympy.Symbol("z"),
+                    sympy.Symbol("x"),
+                    sympy.Symbol("y"),
+                ],
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile.indirect_sizes_from_op",
+                lambda op: {},
+            ),
+            config.patch({"sencores": 8, "ignore_span_overflow_hints": False}),
+        ):
+            with self.assertRaisesRegex(
+                Unsupported,
+                "already auto-tiled producer.*grouping currently only synchronizes "
+                "compatible contiguous pointwise ops",
+            ):
+                span_overflow_groups(_graph([producer, matmul]))
+
+    def test_non_matmul_reduction_does_not_join_gated_to_matmul(self):
+        """The join is gated to batch-matmul reductions: only that path is
+        hardware-validated (#3217).  A non-matmul reduction (here a ``sum``)
+        that would otherwise satisfy every join condition -- reads the producer,
+        matching split count, and a read correspondence that *would* pass
+        ``_reduction_shares_group_tiled_dim`` -- is still refused and falls
+        through to the fail-safe Unsupported path, because the join branch is
+        gated on ``_is_batch_matmul_reduction``.  Extending the join to other
+        reductions is future work and needs on-device numeric validation;
+        this test pins the current matmul-only scope.  Compare with
+        ``test_matmul_joins_tiled_weight_producer_group``: the *only* difference
+        is ``reduction_type`` ('sum' vs 'batchmatmul')."""
+        producer = _pointwise_op(_E2E_SHAPE, name="buf0")
+        reduction = _reduction_op(_E2E_SHAPE, name="buf1", reduction_type="sum")
+        reduction.get_read_writes = MagicMock(
+            return_value=SimpleNamespace(
+                reads={
+                    MemoryDep(
+                        "buf0",
+                        sympy.Symbol("h"),
+                        (sympy.Symbol("h"),),
+                        (8195,),
+                    )
+                },
+                writes=_default_read_writes_for_output(
+                    "buf1", _E2E_SHAPE, reduction.layout
+                ).writes,
+            )
+        )
+
+        def fake_plan(op, _max_cores):
+            # Producer tiles host_dim=1 (h); reduction tiles host_dim=2 (l).
+            return self._fake_plan(1 if op.get_name() == "buf0" else 2, 5)
+
+        with (
+            patch(
+                "torch_spyre._inductor.coarse_tile.plan_span_overflow_tile", fake_plan
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile.op_out_coords", _out_coords_for_bhld
+            ),
+            # Correspondence that WOULD pass the loop-var check -- so the only
+            # reason this is refused is the matmul gate, not the shared-dim check.
+            patch(
+                "torch_spyre._inductor.coarse_tile.host_coordinates",
+                lambda layout, dep, indirect: [
+                    sympy.Symbol("b"),
+                    sympy.Symbol("l"),
+                    sympy.Symbol("x"),
+                    sympy.Symbol("y"),
+                ],
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile.indirect_sizes_from_op",
+                lambda op: {},
+            ),
+            config.patch({"sencores": 8, "ignore_span_overflow_hints": False}),
+        ):
+            with self.assertRaisesRegex(
+                Unsupported,
+                "already auto-tiled producer.*grouping currently only synchronizes "
+                "compatible contiguous pointwise ops",
+            ):
+                span_overflow_groups(_graph([producer, reduction]))
+
+    def test_reduction_range_tile_never_joins(self):
+        """A reduction that tiles its *reduction* range (``is_reduction=True``)
+        must never join, even if split counts match and the read correspondence
+        would otherwise hold: tile ``t`` of a reduction range is not
+        self-contained (it needs partial-result accumulation across tiles), so
+        sharing a per-tile loop nest would be wrong.  This is a batch-matmul
+        (so it passes the matmul gate) identical to the passing matmul-join
+        case except its plan is flagged ``is_reduction=True`` -- the
+        ``is_reduction`` guard in ``_reduction_shares_group_tiled_dim`` alone
+        must flip join -> reject (#3217).  The auto planner never emits such a
+        plan today (``SpanOverflowTileLevel.is_reduction`` is always False), so
+        this guard is belt-and-suspenders against a future planner change."""
+        producer = _pointwise_op(_E2E_SHAPE, name="buf0")
+        reduction = _reduction_op(_E2E_SHAPE, name="buf1", reduction_type="batchmatmul")
+        reduction.get_read_writes = MagicMock(
+            return_value=SimpleNamespace(
+                reads={
+                    MemoryDep(
+                        "buf0",
+                        sympy.Symbol("h"),
+                        (sympy.Symbol("h"),),
+                        (8195,),
+                    )
+                },
+                writes=_default_read_writes_for_output(
+                    "buf1", _E2E_SHAPE, reduction.layout
+                ).writes,
+            )
+        )
+
+        def reduction_range_plan(host_dim, split_count):
+            return SpanOverflowTilePlan(
+                levels=(
+                    SpanOverflowTileLevel(
+                        selected_host_dim=host_dim,
+                        split_count=split_count,
+                        is_reduction=True,
+                    ),
+                ),
+                chunking_infos=(
+                    ChunkingInfo(
+                        total_bytes=1,
+                        per_core_span=1,
+                        core_split_estimate=1,
+                        selected_device_dim_size=split_count,
+                        selected_device_span_stride_elems=1,
+                        selected_host_dim=host_dim,
+                        stick_elems=64,
+                        reason="reduction span overflow",
+                    ),
+                ),
+                reason="reduction span overflow",
+            )
+
+        def fake_plan(op, _max_cores):
+            if op.get_name() == "buf0":
+                return self._fake_plan(1, 5)
+            # Same split (5) and a correspondence that WOULD pass the loop-var
+            # check -- only the is_reduction flag differs from the passing case.
+            return reduction_range_plan(2, 5)
+
+        with (
+            patch(
+                "torch_spyre._inductor.coarse_tile.plan_span_overflow_tile", fake_plan
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile.op_out_coords", _out_coords_for_bhld
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile.host_coordinates",
+                lambda layout, dep, indirect: [
+                    sympy.Symbol("b"),
+                    sympy.Symbol("l"),
+                    sympy.Symbol("x"),
+                    sympy.Symbol("y"),
+                ],
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile.indirect_sizes_from_op",
+                lambda op: {},
+            ),
+            config.patch({"sencores": 8, "ignore_span_overflow_hints": False}),
+        ):
+            with self.assertRaisesRegex(
+                Unsupported,
+                "already auto-tiled producer.*grouping currently only synchronizes "
+                "compatible contiguous pointwise ops",
+            ):
+                span_overflow_groups(_graph([producer, reduction]))
+
+    def test_second_reduction_consumer_of_joined_producer_rejected(self):
+        """One auto-tiled producer feeds at most one reduction consumer: the
+        group is flushed as soon as the first matmul joins, so a *second* matmul
+        reading the same weight is rejected -- with a distinct 'multi-consumer
+        not yet supported' message rather than the generic pointwise-only one
+        (#3217)."""
+        producer = _pointwise_op(_E2E_SHAPE, name="buf0")
+        matmul1 = _reduction_op(_E2E_SHAPE, name="buf1", reduction_type="batchmatmul")
+        matmul2 = _reduction_op(_E2E_SHAPE, name="buf2", reduction_type="batchmatmul")
+        for mm in (matmul1, matmul2):
+            mm.get_read_writes = MagicMock(
+                return_value=SimpleNamespace(
+                    reads={
+                        MemoryDep(
+                            "buf0",
+                            sympy.Symbol("h"),
+                            (sympy.Symbol("h"),),
+                            (8195,),
+                        )
+                    },
+                    writes=_default_read_writes_for_output(
+                        mm.get_name(), _E2E_SHAPE, mm.layout
+                    ).writes,
+                )
+            )
+
+        def fake_plan(op, _max_cores):
+            return self._fake_plan(1 if op.get_name() == "buf0" else 2, 5)
+
+        with (
+            patch(
+                "torch_spyre._inductor.coarse_tile.plan_span_overflow_tile", fake_plan
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile.op_out_coords", _out_coords_for_bhld
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile.host_coordinates",
+                lambda layout, dep, indirect: [
+                    sympy.Symbol("b"),
+                    sympy.Symbol("l"),
+                    sympy.Symbol("x"),
+                    sympy.Symbol("y"),
+                ],
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile.indirect_sizes_from_op",
+                lambda op: {},
+            ),
+            config.patch({"sencores": 8, "ignore_span_overflow_hints": False}),
+        ):
+            with self.assertRaisesRegex(
+                Unsupported,
+                "already auto-tiled and joined by another reduction consumer.*"
+                "multiple consumers sharing one auto-tiled producer is not yet "
+                "supported",
+            ):
+                span_overflow_groups(_graph([producer, matmul1, matmul2]))
+
     def test_chained_pointwise_ops_conform_failure_still_raises(self):
         """op1's own search disagrees with op0's, and op0's split (5) does not
         evenly divide op1's H dim (8194) -- conform must fail and the
@@ -427,14 +761,15 @@ class TestSpanOverflowGroups(InductorTestCase):
             ):
                 span_overflow_groups(_graph([op0, op1]))
 
-    def test_lm_head_auto_tiled_restickify_consumer_fails_safe(self):
-        """LM-head restickify and BMM cannot be auto-tiled independently.
+    def test_lm_head_matmul_joins_tiled_restickify_producer(self):
+        """LM-head restickify and BMM are tiled into one synchronized group (#3217).
 
         This models F.linear(x[1,4096], weight[49216,4096]): lowering first
-        creates a restickified weight buffer ``buf1`` and then a BMM reduction
-        ``buf0`` that reads ``buf1``.  If both receive independent automatic
-        span-overflow groups, their 769 vocab tiles are not one shared loop nest,
-        so the adapter must fail loudly until producer-consumer fusion exists.
+        creates a restickified weight buffer ``buf1`` (tiled on its vocab dim
+        host_dim=0) and then a BMM reduction ``buf0`` that reads ``buf1`` (tiled
+        on the corresponding output vocab dim host_dim=1).  Because both tile the
+        shared vocab dim at the same split, the matmul joins the producer's group
+        rather than raising -- one shared loop nest, each op on its own loop_var.
         """
         restickify_weight = _pointwise_op((49216, 4096), name="buf1")
         lm_head_bmm = _reduction_op(
@@ -482,26 +817,42 @@ class TestSpanOverflowGroups(InductorTestCase):
                 reason="output span overflow",
             )
 
+        # Through the read, the matmul's tiled output dim (d1) indexes the
+        # weight producer's tiled dim0 -- the same logical vocab dim.
         with (
             patch(
                 "torch_spyre._inductor.coarse_tile.plan_span_overflow_tile", fake_plan
             ),
             patch(
                 "torch_spyre._inductor.coarse_tile.op_out_coords",
-                lambda op: (
-                    [sympy.Symbol("d0"), sympy.Symbol("d1")]
-                    if op.get_name() == "buf0"
-                    else [sympy.Symbol("d0"), sympy.Symbol("d1")]
-                ),
+                lambda op: [sympy.Symbol("d0"), sympy.Symbol("d1")],
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile.host_coordinates",
+                lambda layout, dep, indirect: [
+                    sympy.Symbol("d1"),
+                    sympy.Symbol("d0"),
+                ],
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile.indirect_sizes_from_op",
+                lambda op: {},
             ),
             config.patch({"sencores": 4, "ignore_span_overflow_hints": False}),
         ):
-            with self.assertRaisesRegex(
-                Unsupported,
-                "already auto-tiled producer.*grouping currently only synchronizes "
-                "compatible contiguous pointwise ops",
-            ):
-                span_overflow_groups(_graph([restickify_weight, lm_head_bmm]))
+            groups = span_overflow_groups(_graph([restickify_weight, lm_head_bmm]))
+
+        # One synchronized group containing the weight producer and the matmul.
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0][0], [restickify_weight, lm_head_bmm])
+        self.assertEqual(
+            restickify_weight.dim_hints[0].hint_id, lm_head_bmm.dim_hints[0].hint_id
+        )
+        self.assertEqual(restickify_weight.dim_hints[0].split_count, 769)
+        self.assertEqual(lm_head_bmm.dim_hints[0].split_count, 769)
+        # Each op tiles the shared vocab dim on its own loop_var (dim0 vs dim1).
+        self.assertEqual(restickify_weight.dim_hints[0].loop_var, sympy.Symbol("d0"))
+        self.assertEqual(lm_head_bmm.dim_hints[0].loop_var, sympy.Symbol("d1"))
 
     def test_manually_hinted_producer_blocks_auto_tiled_consumer(self):
         """A user spyre_hint on a producer must also guard its auto-tiled consumer.
@@ -1881,9 +2232,9 @@ class TestSpanOverflowPointwiseCodegen(InductorTestCase):
     # own candidate search reads buf1's full, undivided output size -- it has
     # no way to know buf1 will later be sliced. Confirmed empirically across
     # several (x, weight) shapes: buf1 always gets a plan, and whenever buf0's
-    # own search completes, it does too, hitting the same producer-consumer
-    # guard test_lm_head_auto_tiled_restickify_consumer_fails_safe already
-    # covers -- so this test always asserted the same outcome as that one.
+    # own search completes, it does too, and the two are now tiled into one
+    # synchronized group by test_lm_head_matmul_joins_tiled_restickify_producer
+    # -- so this test always asserted the same outcome as that one.
 
     @patch("torch_spyre._inductor.span_overflow_hint_analysis.MAX_SPAN_BYTES", 8192)
     @config.patch(

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -79,9 +79,10 @@ from .errors import Unsupported
 from .logging_utils import get_inductor_logger
 from .loop_info import CoarseTileInfo
 from .propagate_hints import DimHint
-from .pass_utils import op_out_coords
+from .pass_utils import op_out_coords, host_coordinates, indirect_sizes_from_op
 from .span_overflow_hint_analysis import (
     SpanOverflowTilePlan,
+    _is_batch_matmul_reduction,
     can_conform_pointwise_tile,
     plan_span_overflow_tile,
 )
@@ -119,6 +120,91 @@ def _auto_span_read_deps(op: ComputedBuffer) -> set[str]:
         }
     except (AttributeError, TypeError):
         return set()
+
+
+def _reduction_shares_group_tiled_dim(
+    op: ComputedBuffer,
+    signature: tuple[tuple[int, int, bool], ...],
+    current_group: list,
+) -> bool:
+    """True if a reduction's tiled output dim(s) are the *same logical dim(s)*
+    as the tiled dim(s) of the producer(s) it reads in the open group.
+
+    Joining ops into one group means they share a single loop nest: iteration
+    ``t`` computes tile ``t`` of every member.  For that to be correct, the
+    consumer's tiled dimension must be the dimension that — through its read of
+    the producer — indexes the producer's tiled dimension.  Matching split
+    counts is necessary but not sufficient (two unrelated dims could split into
+    the same count), so verify the loop-variable correspondence explicitly: the
+    symbol tiling the consumer's output dim must appear in the producer's tiled
+    coordinate as seen through the read.
+
+    Conservative: any failure to establish the correspondence returns False, so
+    an unverifiable pair is left to the normal (Unsupported) conflict path
+    rather than fused into a possibly-desynchronized loop.
+
+    This check itself is reduction-type-agnostic — what makes the join safe is
+    that the tiled dim is an **output range**, not the reduction range: tile
+    ``t`` of an output dim is self-contained (it reads only tile ``t`` of the
+    producer).  The caller currently gates the join to batch-matmul reductions
+    (only that path is hardware-validated; see the reduction-join branch in
+    ``span_overflow_groups``), so in practice ``op`` is always a matmul here,
+    but nothing in this function relies on that.
+
+    The automatic span-overflow planner only ever tiles output ranges (see
+    ``SpanOverflowTileLevel``: ``is_reduction`` is always False on the auto
+    path, because reduction-range tiling would require partial-result
+    accumulation), so every signature reaching here should already be
+    output-only.  We assert that invariant explicitly below and fail closed if
+    a future planner change ever emits a reduction-range tile — such a tile
+    would break the loop-carried accumulation this join assumes away.
+    """
+    # Guard: only output-range tiles may join.  A reduction (K) range tile
+    # would need cross-tile accumulation and cannot share a per-tile loop nest.
+    if any(is_reduction for _host_dim, _split, is_reduction in signature):
+        return False
+    try:
+        consumer_coords = op_out_coords(op)
+        reads = {
+            dep.name: dep
+            for dep in op.get_read_writes().reads
+            if isinstance(dep, MemoryDep)
+        }
+        indirect = indirect_sizes_from_op(op)
+    except (AttributeError, TypeError, ValueError, RuntimeError, KeyError, IndexError):
+        # op_out_coords internally calls host_coordinates, which can raise the
+        # same ValueError/RuntimeError/IndexError as the direct call below, so
+        # this list must cover that set too (plus AttributeError for the
+        # get_read_writes()/indirect_sizes_from_op attribute access).
+        return False
+
+    consumer_tiled_syms: set = set()
+    for host_dim, _split, _is_reduction in signature:
+        if host_dim >= len(consumer_coords):
+            return False
+        consumer_tiled_syms |= consumer_coords[host_dim].free_symbols
+    if not consumer_tiled_syms:
+        return False
+
+    group_by_name = {gop.get_name(): (gop, dims) for gop, dims in current_group}
+    verified_any = False
+    for name, dep in reads.items():
+        if name not in group_by_name:
+            continue
+        producer, producer_dims = group_by_name[name]
+        try:
+            producer_coords = host_coordinates(producer.get_layout(), dep, indirect)
+        except (TypeError, ValueError, RuntimeError, KeyError, IndexError):
+            return False
+        for host_dim_p, _split, _is_reduction in producer_dims:
+            if host_dim_p >= len(producer_coords):
+                return False
+            if not (producer_coords[host_dim_p].free_symbols & consumer_tiled_syms):
+                # Consumer's tiled loop var does not index this producer's tiled
+                # dim -> not the same logical dim -> unsafe to share a loop.
+                return False
+            verified_any = True
+    return verified_any
 
 
 def _dims_to_hints(
@@ -537,15 +623,26 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
         (``can_conform_pointwise_tile``) — the op then adopts the run's split
         instead of its own.
 
-    Reduction/BMM ops are never grouped (this pass is Pointwise-only for now)
-    and always get an independent singleton group. An op that reads a buffer
-    from an already-closed group, or from the open run without being
-    fusable into it, still raises ``Unsupported``: two independent loop nests
-    over the same span-overflow-sized data can desynchronize, and for ops
-    tiled specifically because their *full* buffer violates the hardware
-    span limit, falling back to materializing that full buffer for an
-    "outside consumer" would silently reintroduce the exact span violation
-    tiling was meant to prevent.
+    A Reduction/BMM op does not *start* or extend a Pointwise run.  A
+    **batch-matmul** reduction may **join** an open run's group when it reads a
+    producer in that run and tiles the same shared logical (output) dim at the
+    same split count — e.g. an F.linear matmul reading its auto-tiled
+    restickified weight (see the reduction-join branch below and
+    ``_reduction_shares_group_tiled_dim``).  The join is gated to matmul
+    because only that path is hardware-validated; the mechanism is otherwise
+    reduction-type-agnostic and extending it to other reductions is future work
+    (see the branch comment).  On joining, the group is flushed immediately, so
+    a matmul is always the last member of its group and each auto-tiled
+    producer feeds at most one matmul consumer.  A Reduction that cannot join
+    (including any non-matmul reduction) gets an independent singleton group or,
+    if it reads an auto-tiled producer, raises ``Unsupported``.  An op that
+    reads a buffer from an already-closed group, or from the open run without
+    being fusable into it, still raises ``Unsupported``: two independent loop
+    nests over the same span-overflow-sized data can desynchronize, and for ops
+    tiled specifically because their *full* buffer violates the hardware span
+    limit, falling back to materializing that full buffer for an "outside
+    consumer" would silently reintroduce the exact span violation tiling was
+    meant to prevent.
     """
     from . import config
 
@@ -565,6 +662,12 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
     groups: list[tuple] = []
     next_hint_id = _SPAN_OVERFLOW_HINT_ID
     auto_tiled_producers: set[str] = set()
+    # Producers whose group was closed by a Reduction consumer joining it (see
+    # the reduction-join branch below).  These are a subset of
+    # ``auto_tiled_producers``; tracked separately only so a *second* consumer
+    # reading such a producer gets a precise "multi-consumer not yet supported"
+    # error rather than the generic pointwise-only conflict message.
+    reduction_joined_producers: set[str] = set()
     # Producers already tiled by a user spyre_hint (assign_dim_hints runs
     # before this pass and leaves dim_hints set; hints_to_coarse_tile_groups
     # only reads it, it never clears it). An op reading one of these has the
@@ -576,15 +679,15 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
         if isinstance(op, ComputedBuffer) and getattr(op, "dim_hints", [])
     }
     _PwDims = tuple[tuple[int, int, bool], ...]
-    current_pw_group: list[tuple[ComputedBuffer, _PwDims]] = []
-    current_pw_signature: _PwDims | None = None
+    current_group: list[tuple[ComputedBuffer, _PwDims]] = []
+    current_signature: _PwDims | None = None
 
-    def flush_current_pw_group() -> None:
-        nonlocal next_hint_id, current_pw_group, current_pw_signature
-        if not current_pw_group:
+    def flush_current_group() -> None:
+        nonlocal next_hint_id, current_group, current_signature
+        if not current_group:
             return
 
-        signature = current_pw_signature
+        signature = current_signature
         assert signature is not None
         hint_ids = list(range(next_hint_id, next_hint_id + len(signature)))
         next_hint_id += len(signature)
@@ -596,7 +699,7 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
         ]
 
         group_ops: list[Operation] = []
-        for grouped_op, dims in current_pw_group:
+        for grouped_op, dims in current_group:
             grouped_op.dim_hints = _dims_to_hints(  # type: ignore[attr-defined]
                 grouped_op, dims, hint_ids
             )
@@ -610,30 +713,28 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
             [op.get_name() for op in group_ops],
             levels,
         )
-        current_pw_group = []
-        current_pw_signature = None
+        current_group = []
+        current_signature = None
 
     for op in graph.operations:
         if not isinstance(op, ComputedBuffer):
-            flush_current_pw_group()
+            flush_current_group()
             continue
         if not isinstance(op.data, (Pointwise, Reduction)):
-            flush_current_pw_group()
+            flush_current_group()
             continue
         if isinstance(op.data, Reduction) and not list(op.data.ranges):
-            flush_current_pw_group()
+            flush_current_group()
             continue
         if not isinstance(op.layout, FixedTiledLayout):
-            flush_current_pw_group()
+            flush_current_group()
             continue
         if getattr(op, "dim_hints", []):
-            flush_current_pw_group()
+            flush_current_group()
             continue
 
         read_deps = _auto_span_read_deps(op)
-        current_group_names = {
-            grouped_op.get_name() for grouped_op, _ in current_pw_group
-        }
+        current_group_names = {grouped_op.get_name() for grouped_op, _ in current_group}
 
         plan = plan_span_overflow_tile(op, config.sencores)
         if plan is None:
@@ -644,7 +745,7 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
             # plan_span_overflow_tile returning None here means that op's own
             # full-size reads/writes are already known not to overflow.
             logger.debug("[span-overflow groups] op=%s no auto plan", op.get_name())
-            flush_current_pw_group()
+            flush_current_group()
             continue
 
         signature = _auto_span_plan_signature(plan)
@@ -656,7 +757,7 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
         )
         logger.debug(
             "[span-overflow groups] op=%s read_deps=%s auto_tiled_producers=%s "
-            "current_pw_group=%s",
+            "current_group=%s",
             op.get_name(),
             sorted(read_deps),
             sorted(auto_tiled_producers),
@@ -672,6 +773,23 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
                 op.get_name(),
                 completed_conflicts,
             )
+            joined_conflicts = sorted(
+                set(completed_conflicts) & reduction_joined_producers
+            )
+            if joined_conflicts:
+                # The producer was already auto-tiled *and* joined into a
+                # synchronized loop by an earlier reduction consumer.  A single
+                # auto-tiled producer can currently feed only one reduction
+                # consumer; a second consumer would need its own tile loop over
+                # the same producer, which is not yet supported.
+                raise Unsupported(
+                    f"Cannot auto-tile {op.get_name()}: it reads producer(s) "
+                    f"{joined_conflicts} that were already auto-tiled and joined "
+                    "by another reduction consumer. A single auto-tiled producer "
+                    "can currently feed only one reduction consumer in one "
+                    "synchronized group; multiple consumers sharing one "
+                    "auto-tiled producer is not yet supported (#3217)."
+                )
             raise Unsupported(
                 f"Cannot auto-tile {op.get_name()}: it reads already auto-tiled "
                 f"producer(s) {completed_conflicts}. Automatic span-overflow "
@@ -681,14 +799,15 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
             )
 
         is_reduction_op = isinstance(op.data, Reduction)
+        is_matmul_reduction = _is_batch_matmul_reduction(op)
 
         can_join_pw_group = (
             not is_reduction_op
-            and current_pw_signature is not None
-            and signature == current_pw_signature
+            and current_signature is not None
+            and signature == current_signature
         )
         if can_join_pw_group:
-            current_pw_group.append((op, signature))
+            current_group.append((op, signature))
             logger.info(
                 "[span-overflow groups] op=%s joined_matching_signature=%s",
                 op.get_name(),
@@ -704,18 +823,17 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
         conform_dims: tuple[tuple[int, int, bool], ...] | None = None
         if (
             not is_reduction_op
-            and current_pw_signature is not None
+            and current_signature is not None
             and (read_deps & current_group_names)
         ):
             split_by_host_dim = {
-                host_dim: split_count
-                for host_dim, split_count, _ in current_pw_signature
+                host_dim: split_count for host_dim, split_count, _ in current_signature
             }
             if can_conform_pointwise_tile(op, split_by_host_dim, config.sencores):
-                conform_dims = current_pw_signature
+                conform_dims = current_signature
 
         if conform_dims is not None:
-            current_pw_group.append((op, conform_dims))
+            current_group.append((op, conform_dims))
             logger.info(
                 "[span-overflow groups] op=%s conformed_to_group_split=%s "
                 "(own_independent_plan_was=%s)",
@@ -725,8 +843,63 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
             )
             continue
 
+        # A batch-matmul consumer (e.g. an F.linear matmul reading its
+        # restickified weight) can join its tiled producer's open group when it
+        # tiles the same shared logical dimension at the same split count(s).
+        # The shared dim sits at a different position in the matmul's output
+        # ranges (the producer tiles its V output dim; the matmul tiles the
+        # corresponding output N dim), so signatures match on split_count, not
+        # host_dim.  Both are output-dim tiles, so they share one synchronized
+        # loop nest and the producer's per-tile slice feeds the consumer's
+        # per-tile compute — no unsynchronized second loop, no full-buffer
+        # materialization.
+        #
+        # Scope: the join is gated to batch-matmul reductions only. The join is
+        # correct-by-construction for *any* reduction tiled on a shared output
+        # range (tile t is self-contained, so sum/mean/max would pair
+        # slice-for-slice too), and the grouping logic here does not depend on
+        # the reduction type — but only the matmul path (the #1918 LM-head case)
+        # has been validated end-to-end on hardware. Extending to other
+        # reductions is future work: drop the _is_batch_matmul_reduction gate
+        # and validate a non-matmul reduction (e.g. a sum reading a
+        # span-overflowing pointwise producer) numerically on device. Until
+        # then, non-matmul reductions fall through to the fail-safe Unsupported
+        # path below rather than silently taking an unvalidated route.
+        #
+        # Split-count equality alone is insufficient: two unrelated dims could
+        # split into the same count.  _reduction_shares_group_tiled_dim verifies
+        # the consumer's tiled loop var actually indexes the producer's tiled dim
+        # through the read, so the shared loop pairs matching slices.  It also
+        # fails closed if the matmul tiles its reduction (K) range rather than an
+        # output range (see its docstring) — only output-range tiles may join.
+        #
+        # The group is flushed immediately after the matmul joins: a reduction
+        # terminates the extendable run (its output shape/tiling differs from
+        # the producers'), so nothing further can be folded into this loop nest.
+        # A consequence is one-consumer-per-group — a *second* op reading the
+        # same producer is rejected below.  Supporting several sibling matmuls
+        # sharing one auto-tiled producer is a deliberate non-goal here (matches
+        # the validated single-matmul LM-head case); see #3217.
+        if (
+            is_matmul_reduction
+            and current_signature is not None
+            and (read_deps & current_group_names)
+            and [s for _, s, _ in signature] == [s for _, s, _ in current_signature]
+            and _reduction_shares_group_tiled_dim(op, signature, current_group)
+        ):
+            current_group.append((op, signature))
+            reduction_joined_producers |= read_deps & current_group_names
+            logger.info(
+                "[span-overflow groups] op=%s joined_producer_group_as_reduction "
+                "split=%s",
+                op.get_name(),
+                list(signature),
+            )
+            flush_current_group()
+            continue
+
         pending_conflicts = sorted(read_deps & current_group_names)
-        flush_current_pw_group()
+        flush_current_group()
         if pending_conflicts:
             logger.warning(
                 "[span-overflow groups] op=%s rejected_conflicting_auto_producers=%s",
@@ -742,8 +915,8 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
             )
 
         if not is_reduction_op:
-            current_pw_group.append((op, signature))
-            current_pw_signature = signature
+            current_group.append((op, signature))
+            current_signature = signature
             logger.info(
                 "[span-overflow groups] op=%s started_new_pw_group split=%s",
                 op.get_name(),
@@ -751,8 +924,8 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
             )
             continue
 
-        # Reduction/BMM ops are never grouped in this pass: always an
-        # independent singleton group.
+        # A Reduction/BMM op that did not join an open producer group (above)
+        # gets an independent singleton group.
         hint_ids = list(range(next_hint_id, next_hint_id + len(signature)))
         next_hint_id += len(signature)
         op.dim_hints = _dims_to_hints(  # type: ignore[attr-defined]
@@ -786,7 +959,7 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
             max_span / (1024**2),
         )
 
-    flush_current_pw_group()
+    flush_current_group()
     return groups
 
 


### PR DESCRIPTION
## Summary

Enables the automatic span-overflow coarse-tiler to tile large `F.linear`-shaped matmuls (the mechanism intended to fix #1918), by letting a matmul **join its tiled weight-producer's group** instead of bailing with `Unsupported`.

Fixes gap (a) from #3217. The span-overflow tiler already had matmul/BMM support (`plan_span_overflow_tile` handles `Reduction`), but when a matmul read its auto-tiled restickified weight, `span_overflow_groups` raised:

> `Cannot auto-tile buf0: it reads already auto-tiled producer(s) [...]. Automatic span-overflow grouping currently only synchronizes compatible contiguous pointwise ops.`

## What changed

- **`span_overflow_groups`:** a `Reduction`/BMM consumer that reads its producer's open group now **joins** that group when it tiles the same shared logical dimension at the same split count(s). The shared dim sits at a different position in the matmul's output ranges (producer tiles its vocab output dim; the matmul tiles the corresponding output-N dim), so both are output-dim tiles sharing one synchronized loop nest — the producer's per-tile slice feeds the consumer's per-tile compute.
- **`_reduction_shares_group_tiled_dim`:** split-count equality is necessary but not sufficient (two unrelated dims could split into the same count). This helper verifies the consumer's tiled loop variable actually indexes the producer's tiled dim *through the read* (via `host_coordinates`). If the correspondence can't be established, the join is refused and the fail-safe `Unsupported` path is taken.

## Scope / non-goals

- **Feature remains disabled by default** (`ignore_span_overflow_hints`). This makes the tiler *work* for matmuls when opted in (`SPYRE_INDUCTOR_IGNORE_SPAN_OVERFLOW_HINTS=0`); it does not enable it.
- **Does not address gap (b)** — a prime stick-count (e.g. `49216` → 769) still has no stick-aligned split ≤ `_MAX_AUTO_TILE_SPLIT_COUNT`; that needs uneven tiling or a cap change and is out of scope here.

## Validation (pod, feature enabled)

`F.linear(x[1,4096], W[V,4096])`:

| V | sticks | before | after |
|---|---|---|---|
| 49152 | 768 | FAIL (producer/consumer bail) | **PASS** |
| 87616 | 1369 = 37² (work-div can't split, coarse-tile can) | FAIL | **PASS** — matmul tiled by 37 |
| 49216 | 769 (prime) | FAIL | FAIL (gap b, unchanged) |

- **Numerics** (`87616`): 0.5% rel error vs fp32 ref, top-5 exact. N-tiling is exact by construction (splits independent output columns, never the K reduction).
- **Regressions:** `test_coarse_tile_e2e` 83 passed/1 xfailed · `test_coarse_tiling` 209 passed · `test_span_overflow_hint_analysis` 71 passed (incl. converted lm_head join test + a new negative test for the shared-dim guard).

Refs #1918, #3217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
