### PR TITLE
Additional layouts allowed for pointwise redux

### DIFF
--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -894,7 +894,7 @@ def test_sparse_broadcast_dense_pointwise():
     """
     a = torch.randn((S, S), dtype=torch.float16)
     b = torch.randn((S, S), dtype=torch.float16)
-    _compare(lambda a, b: a.sum(1) + b, a, b, optimal_cost=0)
+    _compare(lambda a, b: a.sum(1) + b, a, b, optimal_cost=16384)
 
 
 def test_sparse_broadcast_dense_pointwise_d0_stick():

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -29,6 +29,7 @@ from unittest.mock import patch
 
 import torch
 from torch._inductor.virtualized import V
+from torch.spyre import SpyreTensorLayout
 
 import torch_spyre._inductor.optimize_restickify as _optimize_restickify
 from torch._inductor.exc import InductorError
@@ -847,9 +848,20 @@ def test_amax_full_and_amax_live_maximum():
 
 # ------- Unsupported stick configurations ---------
 
+def test_sparse_dense_pointwise():
+    """a.sum(2) + b - reduction followed by pointwise without broadcasting."""
+    a = torch.randn((S, S, S), dtype=torch.float16).to(DEVICE)
+    b = torch.randn((S, S), dtype=torch.float16).to(DEVICE)
 
-def test_sparse_dense_pointwise_unsupported():
-    """a.sum(1) + b - pointwise of sparse and dense tensors not yet supported.
+    with pytest.raises(
+        InductorError, match="No mechanism to gather elements from multiple sticks"
+    ):
+        _compare(lambda a, b: a.sum(2) + b, a, b)
+
+
+@pytest.mark.skip
+def test_sparse_broadcast_dense_pointwise():
+    """a.sum(1) + b - reduction followed by broadcast and pointwise
 
     There is no restickify resolution for this configuration so we must catch this and report error
     """
@@ -859,3 +871,86 @@ def test_sparse_dense_pointwise_unsupported():
         InductorError, match="No mechanism to gather elements from multiple sticks"
     ):
         _compare(lambda a, b: a.sum(1) + b, a, b)
+
+
+def test_sparse_dense_pointwise_d0_stick():
+    """a.sum(1) + b where b has a d0 stick — verifies sparse detection with alt-dim candidate.
+    """
+
+    a = torch.randn((S, S, S), dtype=torch.float16).to(DEVICE)
+    b_layout = SpyreTensorLayout([S, S], [S, 1], torch.float16, [1, 0])
+    b = torch.randn((S, S), dtype=torch.float16).to(device_layout=b_layout)
+    with pytest.raises(
+        InductorError, match="No mechanism to gather elements from multiple sticks"
+    ):
+        _compare(lambda a, b: a.sum(2) + b, a, b)
+
+@pytest.mark.skip
+def test_sparse_broadcast_dense_pointwise_d0_stick():
+    """a.sum(1) + b where b has a d0 stick — verifies sparse detection with alt-dim candidate.
+    """
+
+    a = torch.randn((S, S), dtype=torch.float16).to(DEVICE)
+    b_layout = SpyreTensorLayout([S, S], [S, 1], torch.float16, [1, 0])
+    b = torch.randn((S, S), dtype=torch.float16).to(device_layout=b_layout)
+    with pytest.raises(
+        InductorError, match="No mechanism to gather elements from multiple sticks"
+    ):
+        _compare(lambda a, b: a.sum(1) + b, a, b)
+
+# ------- Broadcast outer-product tests ---------
+
+
+def test_broadcast_outer_diff():
+    """acs.unsqueeze(-1) - acs.unsqueeze(-2): outer-product subtraction over [BH, C].
+
+    Both reads of acs conflict (stick on d1 vs d2); the optimizer picks stick on
+    dim 0 (BH) at cost 2 * acs.numel() — two restickifies of the 2D input.
+    """
+    BH, C = 64, 64
+    acs = torch.randn((BH, C), dtype=torch.float16)
+    _compare(
+        lambda acs: torch.exp(acs.unsqueeze(-1) - acs.unsqueeze(-2)),
+        acs,
+        optimal_cost=2 * acs.numel(),
+        check_strides=False,
+    )
+
+
+def test_broadcast_expand_first():
+    """expand on unsqueeze(-1) only — one input expanded, one bare unsqueeze."""
+    BH, C = 64, 64
+    acs = torch.randn((BH, C), dtype=torch.float16)
+    _compare(
+        lambda acs: torch.exp(acs.unsqueeze(-1).expand(-1, -1, C) - acs.unsqueeze(-2)),
+        acs,
+        optimal_cost=2 * acs.numel(),
+        check_strides=False,
+    )
+
+
+def test_broadcast_expand_second():
+    """expand on unsqueeze(-2) only — one input expanded, one bare unsqueeze."""
+    BH, C = 64, 64
+    acs = torch.randn((BH, C), dtype=torch.float16)
+    _compare(
+        lambda acs: torch.exp(acs.unsqueeze(-1) - acs.unsqueeze(-2).expand(-1, C, -1)),
+        acs,
+        optimal_cost=2 * acs.numel(),
+        check_strides=False,
+    )
+
+def test_broadcast_expand_both():
+    """expand on both unsqueezes — both inputs fully expanded to [BH, C, C]."""
+    BH, C = 64, 64
+    acs = torch.randn((BH, C), dtype=torch.float16)
+    _compare(
+        lambda acs: torch.exp(
+            acs.unsqueeze(-1).expand(-1, -1, C) - acs.unsqueeze(-2).expand(-1, C, -1)
+        ),
+        acs,
+        optimal_cost=2 * acs.numel(),
+        check_strides=False,
+    )
+
+

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -863,6 +863,7 @@ def test_amax_full_and_amax_live_maximum():
 
 # ------- Unsupported stick configurations ---------
 
+
 def test_sparse_dense_pointwise():
     """a.sum(2) + b - reduction followed by pointwise without broadcasting."""
     a = torch.randn((S, S, S), dtype=torch.float16).to(DEVICE)
@@ -875,8 +876,7 @@ def test_sparse_dense_pointwise():
 
 
 def test_sparse_dense_pointwise_d0_stick():
-    """a.sum(1) + b where b has a d0 stick — verifies sparse detection with alt-dim candidate.
-    """
+    """a.sum(1) + b where b has a d0 stick — verifies sparse detection with alt-dim candidate."""
 
     a = torch.randn((S, S, S), dtype=torch.float16).to(DEVICE)
     b_layout = SpyreTensorLayout([S, S], [S, 1], torch.float16, [1, 0])
@@ -885,6 +885,7 @@ def test_sparse_dense_pointwise_d0_stick():
         InductorError, match="No mechanism to gather elements from multiple sticks"
     ):
         _compare(lambda a, b: a.sum(2) + b, a, b)
+
 
 def test_sparse_broadcast_dense_pointwise():
     """a.sum(1) + b - reduction followed by broadcast and pointwise
@@ -895,15 +896,18 @@ def test_sparse_broadcast_dense_pointwise():
     b = torch.randn((S, S), dtype=torch.float16)
     _compare(lambda a, b: a.sum(1) + b, a, b, optimal_cost=0)
 
+
 def test_sparse_broadcast_dense_pointwise_d0_stick():
-    """a.sum(1) + b where b has a d0 stick — verifies sparse detection with alt-dim candidate.
-    """
+    """a.sum(1) + b where b has a d0 stick — verifies sparse detection with alt-dim candidate."""
 
     a = torch.randn((S, S), dtype=torch.float16)
     b = torch.randn((S, S), dtype=torch.float16)
     b_layout = SpyreTensorLayout([S, S], [S, 1], torch.float16, [1, 0])
     b_dev = b.to(device_layout=b_layout)
-    _compare_with_device_args(lambda a, b: a.sum(1) + b, [a, b], [a.to(DEVICE), b_dev], optimal_cost=0)
+    _compare_with_device_args(
+        lambda a, b: a.sum(1) + b, [a, b], [a.to(DEVICE), b_dev], optimal_cost=0
+    )
+
 
 def test_unsqueeze_broadcast_dense_pointwise():
     """a.unsqueeze(-1) + b - unsqueeze broadcast followed by pointwise
@@ -922,7 +926,9 @@ def test_unsqueeze_broadcast_dense_pointwise_d0_stick():
     b = torch.randn((S, S), dtype=torch.float16)
     b_layout = SpyreTensorLayout([S, S], [S, 1], torch.float16, [1, 0])
     b_dev = b.to(device_layout=b_layout)
-    _compare_with_device_args(lambda a, b: a.unsqueeze(-1) + b, [a, b], [a.to(DEVICE), b_dev], optimal_cost=0)
+    _compare_with_device_args(
+        lambda a, b: a.unsqueeze(-1) + b, [a, b], [a.to(DEVICE), b_dev], optimal_cost=0
+    )
 
 
 def test_unsqueeze_expand_broadcast_dense_pointwise():
@@ -942,7 +948,12 @@ def test_unsqueeze_expand_broadcast_dense_pointwise_d0_stick():
     b = torch.randn((S, S), dtype=torch.float16)
     b_layout = SpyreTensorLayout([S, S], [S, 1], torch.float16, [1, 0])
     b_dev = b.to(device_layout=b_layout)
-    _compare_with_device_args(lambda a, b: a.unsqueeze(-1).expand(S, S) + b, [a, b], [a.to(DEVICE), b_dev], optimal_cost=0)
+    _compare_with_device_args(
+        lambda a, b: a.unsqueeze(-1).expand(S, S) + b,
+        [a, b],
+        [a.to(DEVICE), b_dev],
+        optimal_cost=0,
+    )
 
 
 # ------- Broadcast outer-product tests ---------
@@ -987,6 +998,7 @@ def test_broadcast_expand_second():
         check_strides=False,
     )
 
+
 def test_broadcast_expand_both():
     """expand on both unsqueezes — both inputs fully expanded to [BH, C, C]."""
     BH, C = 64, 64
@@ -999,5 +1011,3 @@ def test_broadcast_expand_both():
         optimal_cost=2 * acs.numel(),
         check_strides=False,
     )
-
-

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -87,6 +87,21 @@ def _compare(fn, *args, check_strides=True, optimal_cost=None, skip_correctness=
         )
 
 
+def _compare_with_device_args(fn, cpu_args, device_args, optimal_cost=None):
+    """Like _compare, but allows pre-placed device tensors (e.g. custom layouts).
+
+    cpu_args: plain CPU tensors used for the reference result.
+    device_args: tensors already on DEVICE (possibly with custom layouts) used for the compiled run.
+    """
+    spyre_result, plan = _compile_and_run_plan_capture(fn, *device_args)
+    if optimal_cost is not None:
+        actual_cost = _compute_cost(plan)
+        assert actual_cost == optimal_cost, (
+            f"restickify cost: expected {optimal_cost}, got {actual_cost}"
+        )
+    compare_with_cpu(fn, *cpu_args, target=spyre_result, run_eager=False)
+
+
 def _make_tensors(n, *shape):
     """Make n scaled fp16 tensors of the given shape. Scale keeps values small enough for chained matmuls."""
     return [torch.randn(*shape, dtype=torch.float16) * 0.1 for _ in range(n)]
@@ -859,20 +874,6 @@ def test_sparse_dense_pointwise():
         _compare(lambda a, b: a.sum(2) + b, a, b)
 
 
-@pytest.mark.skip
-def test_sparse_broadcast_dense_pointwise():
-    """a.sum(1) + b - reduction followed by broadcast and pointwise
-
-    There is no restickify resolution for this configuration so we must catch this and report error
-    """
-    a = torch.randn((S, S), dtype=torch.float16).to(DEVICE)
-    b = torch.randn((S, S), dtype=torch.float16).to(DEVICE)
-    with pytest.raises(
-        InductorError, match="No mechanism to gather elements from multiple sticks"
-    ):
-        _compare(lambda a, b: a.sum(1) + b, a, b)
-
-
 def test_sparse_dense_pointwise_d0_stick():
     """a.sum(1) + b where b has a d0 stick — verifies sparse detection with alt-dim candidate.
     """
@@ -885,18 +886,64 @@ def test_sparse_dense_pointwise_d0_stick():
     ):
         _compare(lambda a, b: a.sum(2) + b, a, b)
 
-@pytest.mark.skip
+def test_sparse_broadcast_dense_pointwise():
+    """a.sum(1) + b - reduction followed by broadcast and pointwise
+
+    There is no restickify resolution for this configuration so we must catch this and report error
+    """
+    a = torch.randn((S, S), dtype=torch.float16)
+    b = torch.randn((S, S), dtype=torch.float16)
+    _compare(lambda a, b: a.sum(1) + b, a, b, optimal_cost=0)
+
 def test_sparse_broadcast_dense_pointwise_d0_stick():
     """a.sum(1) + b where b has a d0 stick — verifies sparse detection with alt-dim candidate.
     """
 
-    a = torch.randn((S, S), dtype=torch.float16).to(DEVICE)
+    a = torch.randn((S, S), dtype=torch.float16)
+    b = torch.randn((S, S), dtype=torch.float16)
     b_layout = SpyreTensorLayout([S, S], [S, 1], torch.float16, [1, 0])
-    b = torch.randn((S, S), dtype=torch.float16).to(device_layout=b_layout)
-    with pytest.raises(
-        InductorError, match="No mechanism to gather elements from multiple sticks"
-    ):
-        _compare(lambda a, b: a.sum(1) + b, a, b)
+    b_dev = b.to(device_layout=b_layout)
+    _compare_with_device_args(lambda a, b: a.sum(1) + b, [a, b], [a.to(DEVICE), b_dev], optimal_cost=0)
+
+def test_unsqueeze_broadcast_dense_pointwise():
+    """a.unsqueeze(-1) + b - unsqueeze broadcast followed by pointwise
+
+    There is no restickify resolution for this configuration so we must catch this and report error
+    """
+    a = torch.randn((S,), dtype=torch.float16)
+    b = torch.randn((S, S), dtype=torch.float16)
+    _compare(lambda a, b: a.unsqueeze(-1) + b, a, b, optimal_cost=S * S)
+
+
+def test_unsqueeze_broadcast_dense_pointwise_d0_stick():
+    """a.unsqueeze(-1) + b where b has a d0 stick — verifies sparse detection with alt-dim candidate."""
+
+    a = torch.randn((S,), dtype=torch.float16)
+    b = torch.randn((S, S), dtype=torch.float16)
+    b_layout = SpyreTensorLayout([S, S], [S, 1], torch.float16, [1, 0])
+    b_dev = b.to(device_layout=b_layout)
+    _compare_with_device_args(lambda a, b: a.unsqueeze(-1) + b, [a, b], [a.to(DEVICE), b_dev], optimal_cost=0)
+
+
+def test_unsqueeze_expand_broadcast_dense_pointwise():
+    """a.unsqueeze(-1).expand(S, S) + b - unsqueeze+expand broadcast followed by pointwise
+
+    There is no restickify resolution for this configuration so we must catch this and report error
+    """
+    a = torch.randn((S,), dtype=torch.float16)
+    b = torch.randn((S, S), dtype=torch.float16)
+    _compare(lambda a, b: a.unsqueeze(-1).expand(S, S) + b, a, b, optimal_cost=S * S)
+
+
+def test_unsqueeze_expand_broadcast_dense_pointwise_d0_stick():
+    """a.unsqueeze(-1).expand(S, S) + b where b has a d0 stick — verifies sparse detection with alt-dim candidate."""
+
+    a = torch.randn((S,), dtype=torch.float16)
+    b = torch.randn((S, S), dtype=torch.float16)
+    b_layout = SpyreTensorLayout([S, S], [S, 1], torch.float16, [1, 0])
+    b_dev = b.to(device_layout=b_layout)
+    _compare_with_device_args(lambda a, b: a.unsqueeze(-1).expand(S, S) + b, [a, b], [a.to(DEVICE), b_dev], optimal_cost=0)
+
 
 # ------- Broadcast outer-product tests ---------
 

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -66,40 +66,36 @@ def _compile_and_run_plan_capture(fn, *args):
     return spyre_result, captured.get("plan", {})
 
 
-def _compare(fn, *args, check_strides=True, optimal_cost=None, skip_correctness=False):
+def _compare(
+    fn,
+    *args,
+    device_args=None,
+    check_strides=True,
+    optimal_cost=None,
+    skip_correctness=False,
+):
     """Run fn on Spyre, assert correctness against CPU, and optionally assert the restickify
     plan has cost == optimal_cost.
+
+    device_args: if provided, used for the Spyre run instead of args (allows pre-placed
+    tensors with custom layouts). args are still used for the CPU reference.
     """
+    run_args = device_args if device_args is not None else args
     if optimal_cost is None:
-        spyre_result = _compile_and_run(fn, args, DEVICE)
+        spyre_result = _compile_and_run(fn, run_args, DEVICE)
     else:
-        spyre_result, plan = _compile_and_run_plan_capture(fn, *args)
+        spyre_result, plan = _compile_and_run_plan_capture(fn, *run_args)
         actual_cost = _compute_cost(plan)
         assert actual_cost == optimal_cost, (
             f"restickify cost: expected {optimal_cost}, got {actual_cost}"
         )
     if not skip_correctness:
         compare_with_cpu(fn, *args, target=spyre_result, run_eager=False)
-    if check_strides:
+    if check_strides and device_args is None:
         cpu_result = fn(*args)
         assert cpu_result.stride() == spyre_result.stride(), (
             f"Stride mismatch: CPU {cpu_result.stride()} vs Spyre {spyre_result.stride()}"
         )
-
-
-def _compare_with_device_args(fn, cpu_args, device_args, optimal_cost=None):
-    """Like _compare, but allows pre-placed device tensors (e.g. custom layouts).
-
-    cpu_args: plain CPU tensors used for the reference result.
-    device_args: tensors already on DEVICE (possibly with custom layouts) used for the compiled run.
-    """
-    spyre_result, plan = _compile_and_run_plan_capture(fn, *device_args)
-    if optimal_cost is not None:
-        actual_cost = _compute_cost(plan)
-        assert actual_cost == optimal_cost, (
-            f"restickify cost: expected {optimal_cost}, got {actual_cost}"
-        )
-    compare_with_cpu(fn, *cpu_args, target=spyre_result, run_eager=False)
 
 
 def _make_tensors(n, *shape):
@@ -888,13 +884,10 @@ def test_sparse_dense_pointwise_d0_stick():
 
 
 def test_sparse_broadcast_dense_pointwise():
-    """a.sum(1) + b - reduction followed by broadcast and pointwise
-
-    There is no restickify resolution for this configuration so we must catch this and report error
-    """
+    """a.sum(1) + b - reduction output broadcast into pointwise with dense b."""
     a = torch.randn((S, S), dtype=torch.float16)
     b = torch.randn((S, S), dtype=torch.float16)
-    _compare(lambda a, b: a.sum(1) + b, a, b, optimal_cost=16384)
+    _compare(lambda a, b: a.sum(1) + b, a, b, optimal_cost=S * S)
 
 
 def test_sparse_broadcast_dense_pointwise_d0_stick():
@@ -904,16 +897,11 @@ def test_sparse_broadcast_dense_pointwise_d0_stick():
     b = torch.randn((S, S), dtype=torch.float16)
     b_layout = SpyreTensorLayout([S, S], [S, 1], torch.float16, [1, 0])
     b_dev = b.to(device_layout=b_layout)
-    _compare_with_device_args(
-        lambda a, b: a.sum(1) + b, [a, b], [a.to(DEVICE), b_dev], optimal_cost=0
-    )
+    _compare(lambda a, b: a.sum(1) + b, a, b, device_args=[a.to(DEVICE), b_dev], optimal_cost=0)
 
 
 def test_unsqueeze_broadcast_dense_pointwise():
-    """a.unsqueeze(-1) + b - unsqueeze broadcast followed by pointwise
-
-    There is no restickify resolution for this configuration so we must catch this and report error
-    """
+    """a.unsqueeze(-1) + b - unsqueeze broadcast followed by pointwise."""
     a = torch.randn((S,), dtype=torch.float16)
     b = torch.randn((S, S), dtype=torch.float16)
     _compare(lambda a, b: a.unsqueeze(-1) + b, a, b, optimal_cost=S * S)
@@ -926,16 +914,11 @@ def test_unsqueeze_broadcast_dense_pointwise_d0_stick():
     b = torch.randn((S, S), dtype=torch.float16)
     b_layout = SpyreTensorLayout([S, S], [S, 1], torch.float16, [1, 0])
     b_dev = b.to(device_layout=b_layout)
-    _compare_with_device_args(
-        lambda a, b: a.unsqueeze(-1) + b, [a, b], [a.to(DEVICE), b_dev], optimal_cost=0
-    )
+    _compare(lambda a, b: a.unsqueeze(-1) + b, a, b, device_args=[a.to(DEVICE), b_dev], optimal_cost=0)
 
 
 def test_unsqueeze_expand_broadcast_dense_pointwise():
-    """a.unsqueeze(-1).expand(S, S) + b - unsqueeze+expand broadcast followed by pointwise
-
-    There is no restickify resolution for this configuration so we must catch this and report error
-    """
+    """a.unsqueeze(-1).expand(S, S) + b - unsqueeze+expand broadcast followed by pointwise."""
     a = torch.randn((S,), dtype=torch.float16)
     b = torch.randn((S, S), dtype=torch.float16)
     _compare(lambda a, b: a.unsqueeze(-1).expand(S, S) + b, a, b, optimal_cost=S * S)
@@ -948,12 +931,7 @@ def test_unsqueeze_expand_broadcast_dense_pointwise_d0_stick():
     b = torch.randn((S, S), dtype=torch.float16)
     b_layout = SpyreTensorLayout([S, S], [S, 1], torch.float16, [1, 0])
     b_dev = b.to(device_layout=b_layout)
-    _compare_with_device_args(
-        lambda a, b: a.unsqueeze(-1).expand(S, S) + b,
-        [a, b],
-        [a.to(DEVICE), b_dev],
-        optimal_cost=0,
-    )
+    _compare(lambda a, b: a.unsqueeze(-1).expand(S, S) + b, a, b, device_args=[a.to(DEVICE), b_dev], optimal_cost=0)
 
 
 # ------- Broadcast outer-product tests ---------

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -863,18 +863,32 @@ def test_amax_full_and_amax_live_maximum():
 
 
 def test_sparse_dense_pointwise():
-    """a.sum(2) + b - reduction followed by pointwise without broadcasting."""
+    """a.sum(-1) + b - reduction followed by pointwise without broadcasting."""
     a = torch.randn((S, S, S), dtype=torch.float16).to(DEVICE)
     b = torch.randn((S, S), dtype=torch.float16).to(DEVICE)
 
     with pytest.raises(
         InductorError, match="No mechanism to gather elements from multiple sticks"
     ):
-        _compare(lambda a, b: a.sum(2) + b, a, b)
+        _compare(lambda a, b: a.amin(-1) + b, a, b)
+
+
+def test_2d_sparse_broadcast_dense_pointwise():
+    """a.sum(-1) + b - reduction output broadcast into pointwise with dense b."""
+    a = torch.randn((S, S), dtype=torch.float16)
+    b = torch.randn((S, S), dtype=torch.float16)
+    _compare(lambda a, b: a.amin(-1) + b, a, b, optimal_cost=S * S)
+
+
+def test_3d_sparse_broadcast_dense_pointwise():
+    """a.sum(-1) + b - reduction output broadcast into pointwise with dense b."""
+    a = torch.randn((S, S, S), dtype=torch.float16)
+    b = torch.randn((S, S, S), dtype=torch.float16)
+    _compare(lambda a, b: a.amin(-1) + b, a, b, optimal_cost=S * S * S)
 
 
 def test_sparse_dense_pointwise_d0_stick():
-    """a.sum(2) + b where b has a d0 stick — verifies sparse detection with alt-dim candidate."""
+    """a.sum(-1) + b where b has a d0 stick — verifies sparse detection with alt-dim candidate."""
 
     a = torch.randn((S, S, S), dtype=torch.float16).to(DEVICE)
     b_layout = SpyreTensorLayout([S, S], [S, 1], torch.float16, [1, 0])
@@ -882,30 +896,35 @@ def test_sparse_dense_pointwise_d0_stick():
     with pytest.raises(
         InductorError, match="No mechanism to gather elements from multiple sticks"
     ):
-        _compare(lambda a, b: a.sum(2) + b, a, b)
-
-
-def test_sparse_broadcast_dense_pointwise():
-    """a.sum(1) + b - reduction output broadcast into pointwise with dense b."""
-    a = torch.randn((S, S), dtype=torch.float16)
-    b = torch.randn((S, S), dtype=torch.float16)
-    _compare(lambda a, b: a.sum(1) + b, a, b, optimal_cost=S * S)
+        _compare(lambda a, b: a.amin(-1) + b, a, b)
 
 
 def test_sparse_broadcast_dense_pointwise_d0_stick():
-    """a.sum(1) + b where b has a d0 stick — verifies sparse detection with alt-dim candidate."""
+    """a.sum(-1) + b where b has a d0 stick — verifies sparse detection with alt-dim candidate."""
 
     a = torch.randn((S, S), dtype=torch.float16)
     b = torch.randn((S, S), dtype=torch.float16)
     b_layout = SpyreTensorLayout([S, S], [S, 1], torch.float16, [1, 0])
     b_dev = b.to(device_layout=b_layout)
     _compare(
-        lambda a, b: a.sum(1) + b,
+        lambda a, b: a.amin(-1) + b,
         a,
         b,
         device_args=[a.to(DEVICE), b_dev],
         optimal_cost=0,
     )
+
+
+def test_broadcast_dense_pointwise():
+    a = torch.randn((S), dtype=torch.float16)
+    b = torch.randn((S, S), dtype=torch.float16)
+    _compare(lambda a, b: a + b, a, b, optimal_cost=0)
+
+
+def test_broadcast_3d_dense_pointwise():
+    a = torch.randn((S, S), dtype=torch.float16)
+    b = torch.randn((S, S, S), dtype=torch.float16)
+    _compare(lambda a, b: a + b, a, b, optimal_cost=0)
 
 
 def test_unsqueeze_broadcast_dense_pointwise():

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -897,7 +897,13 @@ def test_sparse_broadcast_dense_pointwise_d0_stick():
     b = torch.randn((S, S), dtype=torch.float16)
     b_layout = SpyreTensorLayout([S, S], [S, 1], torch.float16, [1, 0])
     b_dev = b.to(device_layout=b_layout)
-    _compare(lambda a, b: a.sum(1) + b, a, b, device_args=[a.to(DEVICE), b_dev], optimal_cost=0)
+    _compare(
+        lambda a, b: a.sum(1) + b,
+        a,
+        b,
+        device_args=[a.to(DEVICE), b_dev],
+        optimal_cost=0,
+    )
 
 
 def test_unsqueeze_broadcast_dense_pointwise():
@@ -914,7 +920,13 @@ def test_unsqueeze_broadcast_dense_pointwise_d0_stick():
     b = torch.randn((S, S), dtype=torch.float16)
     b_layout = SpyreTensorLayout([S, S], [S, 1], torch.float16, [1, 0])
     b_dev = b.to(device_layout=b_layout)
-    _compare(lambda a, b: a.unsqueeze(-1) + b, a, b, device_args=[a.to(DEVICE), b_dev], optimal_cost=0)
+    _compare(
+        lambda a, b: a.unsqueeze(-1) + b,
+        a,
+        b,
+        device_args=[a.to(DEVICE), b_dev],
+        optimal_cost=0,
+    )
 
 
 def test_unsqueeze_expand_broadcast_dense_pointwise():
@@ -931,7 +943,13 @@ def test_unsqueeze_expand_broadcast_dense_pointwise_d0_stick():
     b = torch.randn((S, S), dtype=torch.float16)
     b_layout = SpyreTensorLayout([S, S], [S, 1], torch.float16, [1, 0])
     b_dev = b.to(device_layout=b_layout)
-    _compare(lambda a, b: a.unsqueeze(-1).expand(S, S) + b, a, b, device_args=[a.to(DEVICE), b_dev], optimal_cost=0)
+    _compare(
+        lambda a, b: a.unsqueeze(-1).expand(S, S) + b,
+        a,
+        b,
+        device_args=[a.to(DEVICE), b_dev],
+        optimal_cost=0,
+    )
 
 
 # ------- Broadcast outer-product tests ---------

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -91,7 +91,9 @@ def _compare(
         )
     if not skip_correctness:
         compare_with_cpu(fn, *args, target=spyre_result, run_eager=False)
-    if check_strides and device_args is None:
+    if (
+        check_strides and device_args is None
+    ):  # skip when device_args differ from CPU args: strides intentionally won't match
         cpu_result = fn(*args)
         assert cpu_result.stride() == spyre_result.stride(), (
             f"Stride mismatch: CPU {cpu_result.stride()} vs Spyre {spyre_result.stride()}"
@@ -872,7 +874,7 @@ def test_sparse_dense_pointwise():
 
 
 def test_sparse_dense_pointwise_d0_stick():
-    """a.sum(1) + b where b has a d0 stick — verifies sparse detection with alt-dim candidate."""
+    """a.sum(2) + b where b has a d0 stick — verifies sparse detection with alt-dim candidate."""
 
     a = torch.randn((S, S, S), dtype=torch.float16).to(DEVICE)
     b_layout = SpyreTensorLayout([S, S], [S, 1], torch.float16, [1, 0])

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -892,6 +892,8 @@ def _multi_arg_pointwise_layouts(
     # against layouts already produced by the input-stick loop above.
     # Skip for staggered-EA ops: their output layout is dictated by the staggered
     # input EA and adding STANDARD candidates would corrupt downstream ops.
+    # EA omitted from key: the loop below is skipped for staggered ops, so all
+    # candidates added (and looked up) here use STANDARD EA — geometry suffices.
     seen_keys = {(tuple(r.device_size), tuple(r.stride_map)) for r in results}
     for alt_stick_dim in range(len(output.size)) if not staggered_inputs else []:
         # TODO: Support dimensions with size not divisible by stick_size via padding (See #1756)

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -365,7 +365,12 @@ def _single_arg_op_layout(
             # alignment. For example, 4x16 FP16 has 48 elements of padding (64 total),
             # which becomes 64 FP32 elements when converted. We need to reflect this
             # in the output host size so the constructor creates the correct device layout.
-            in_stick_expr = device_coordinates(stl, dep, None)[-1]
+            try:
+                in_stick_expr = device_coordinates(stl, dep, None)[-1]
+            except Unsupported:
+                # Staggered-EA candidate whose physical stick depth differs from
+                # elems_per_stick — not a valid input for this conversion path.
+                return []
             if not is_stick_expr_offset_free(in_stick_expr, stl.elems_per_stick()):
                 return []
 
@@ -882,13 +887,24 @@ def _multi_arg_pointwise_layouts(
         for stick_expr in sorted(offset_free_stick_exprs, key=iter_var_id):
             _try_stick_dim(_pick_stick_dim(stick_expr, out_coords))
 
-    # Try alternative layouts if no valid layouts found
-    if not results:
-        for alt_stick_dim in range(len(output.size) - 1):
-            # TODO: Support dimensions with size not divisible by stick_size via padding (See #1756)
-            if concretize_expr(output.size[alt_stick_dim]) % stick_size != 0:
-                continue
-            _try_stick_dim(alt_stick_dim)
+    # Always scan all dims so that dims absent from any input stick expression
+    # (e.g. the outer broadcast dim) are also offered as candidates. Deduplicate
+    # against layouts already produced by the input-stick loop above.
+    # Skip for staggered-EA ops: their output layout is dictated by the staggered
+    # input EA and adding STANDARD candidates would corrupt downstream ops.
+    seen_keys = {(tuple(r.device_size), tuple(r.stride_map)) for r in results}
+    for alt_stick_dim in range(len(output.size)) if not staggered_inputs else []:
+        # TODO: Support dimensions with size not divisible by stick_size via padding (See #1756)
+        if concretize_expr(output.size[alt_stick_dim]) % stick_size != 0:
+            continue
+        pre_len = len(results)
+        _try_stick_dim(alt_stick_dim)
+        if len(results) > pre_len:
+            key = (tuple(results[-1].device_size), tuple(results[-1].stride_map))
+            if key in seen_keys:
+                results.pop()
+            else:
+                seen_keys.add(key)
 
     # LX in-place: promote a same-frame input's layout to FIRST so the beam
     # commits it on a cost tie, avoiding a free-but-in-place-defeating permutation
@@ -1258,6 +1274,11 @@ def _resolve_copy_back_candidates(operations: list[Operation]) -> None:
             continue
         producer_layouts = getattr(producer, "layouts", None)
         if not producer_layouts or target_stl not in producer_layouts:
+            continue
+        # Only elide when the producer has a single unambiguous layout. With
+        # multiple candidates the optimizer may not commit to target_stl, so
+        # eliding the copy would be incorrect.
+        if len(producer_layouts) != 1:
             continue
 
         producer.layout = copy_op.layout


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
propagate_layouts.py is currently somewhat conservative with the set of candidate layouts it chooses for various operations.    One example is that for pointwise ops, the set of possible stick_exprs is limited to the stick_exprs of the inputs.  This logic assumes that some stick expression from an input will always be a valid output.

But this PR includes some tests where this assumption is not true, so these tests fail on `main` raising the exception that there are no viable stick layouts
- test_broadcast_outer_diff
- test_broadcast_expand_first
- test_broadcast_expand_second
- test_broadcast_expand_both

These tests do unsqueeze + broadcast to create the scenario where neither of the input sticks (dims 1 & 2) can be restickified to the other.  But if **both** inputs are restickifed to put the stick on dim 0,  the operation completes successfully.   

While it may seem odd or inefficient to restickify _two_ inputs, when the pointwise operation does unsqueeze/expand/broadcast  it creates an output that is N^2 in size.  Restickifying both inputs before this blowup can indeed be more efficient in some cases, and the global optimizer handles this seamlessly.  It should never happen unless it is actually optimal.

Several other tests were added to stress test concerns over broadcast vs sparse tensor stick compatibility.  All pass




#### Which issue(s) this PR is related to:


#### Special notes for your reviewer:

FYI @AdnanHoque 
The len(producer_layouts) == 1 guard in _resolve_copy_back_candidates is intentionally conservative. Adding more output layout candidates (the core change here) broke copy-back elision for unrelated ops — the real safety condition is that the optimizer commits the producer to target_stl, which isn't known until after optimize_restickify_locations runs. The guard also reduces elision opportunities: any producer with multiple candidates won't be elided even when it would be safe. The proper fix is either to to move the resolver to run post-optimizer and check producer.committed_stl == target_stl directly, or update the logic to be correct in the presence of multiple output STL candidates. Left as a follow-up.

#### Does this PR introduce a user-facing change?

#### Additional note:

Granite passes:

```
### Instruction:
Provide a list of instructions for preparing chicken soup.

### Response:

1. Gather ingredients: 1<|end_of_text|>
```