### PR TITLE
fix(inductor): honor per_tile_fixed in symbolic affine-stride path

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -30,7 +30,6 @@ import sys
 import os
 import regex as re
 
-import pytest
 import torch
 import unittest
 from unittest.mock import patch as mock_patch
@@ -770,10 +769,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         # is numerically wrong (~90% element mismatch).  Investigate and fix
         # before re-adding spyre_hint(num_tiles_per_dim={"Lk": lk_slices}).
         """
-        if not config.unroll_loops:
-            pytest.xfail(
-                "UNROLL_LOOPS=0: nested scf.for loops not yet correct in backend"
-            )
         import math
         from torch_spyre._inductor import spyre_hint
 

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -527,10 +527,30 @@ def generate_sdsc(
         # affine_strides[i] is a list of dicts, one per loop-nesting level
         # (outermost first), where each dict maps tiled_sym -> stride_bytes for
         # the symbols at that level that advance tensor i.  Empty list of dicts
-        # (i.e. [{}] * n_levels or []) for non-tiled / lx tensors.
+        # (i.e. [{}] * n_levels or []) for non-tiled tensors.
         affine_strides: list[list[dict]] = []
         for tensor in sdsc_spec.args:
             if "lx" in tensor.allocation:
+                # LX addresses are never registered as symbols in the SDSC JSON
+                # (isStartAddrSymbolic_ is always unset for lx, and bundle.py's
+                # _get_tensor_core_sym_id returns None for non-hbm components), so
+                # affine.apply can never target an LX address today. A tiled
+                # (advancing) lx tensor therefore has no way to express its
+                # per-iteration address change in this preserved-loop path.
+                # per_tile_fixed lx tensors are fine: they don't advance, same as
+                # non-tiled tensors, so [{}] * n_levels is correct either way.
+                is_tiled_lx = tensor.per_tile_fixed is False and any(
+                    s in tensor.strides and tensor.scales.get(s, 1) > 0
+                    for level_syms in tiled_symbols
+                    for s in level_syms
+                )
+                if is_tiled_lx:
+                    raise NotImplementedError(
+                        "Tiled (advancing) lx-allocated tensors are not supported "
+                        "in the symbolic preserved-loop path: LX addresses cannot "
+                        "be expressed as affine.apply symbols. Mark this tensor "
+                        "per_tile_fixed or set UNROLL_LOOPS=1."
+                    )
                 affine_strides.append([{} for _ in tiled_symbols])
                 continue
             nb = num_bytes(tensor.data_format)
@@ -595,19 +615,24 @@ def generate_sdsc(
             # whose stride describes element layout within one tile, not the advance
             # between tiles.  Tiling by a reduction-dim symbol would incorrectly
             # advance the base address of a pool output past its single allocated slot.
+            # per_tile_fixed tensors (tile-local scratch reused every iteration, see
+            # unroll.py) never advance either, regardless of allocation type.
             per_level_strides: list[dict] = []
             any_tiled = False
-            for level_syms in tiled_symbols:
-                tensor_tiled_at_level = [
-                    s
-                    for s in level_syms
-                    if s in tensor.strides and tensor.scales.get(s, 1) > 0
-                ]
-                strides_for_level: dict = {}
-                for s in tensor_tiled_at_level:
-                    strides_for_level[s] = _tiled_byte_stride(tensor, s)
-                    any_tiled = True
-                per_level_strides.append(strides_for_level)
+            if not tensor.per_tile_fixed:
+                for level_syms in tiled_symbols:
+                    tensor_tiled_at_level = [
+                        s
+                        for s in level_syms
+                        if s in tensor.strides and tensor.scales.get(s, 1) > 0
+                    ]
+                    strides_for_level: dict = {}
+                    for s in tensor_tiled_at_level:
+                        strides_for_level[s] = _tiled_byte_stride(tensor, s)
+                        any_tiled = True
+                    per_level_strides.append(strides_for_level)
+            else:
+                per_level_strides = [{} for _ in tiled_symbols]
             if not any_tiled:
                 # Non-tiled HBM: register per-core addresses.
                 for c in range(sdsc_spec.num_cores):

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -69,6 +69,7 @@ class SDSCArgs:
     arg_index: int = -1
     is_index_tensor: bool = False
     related_value_tensor_idx: int = -1
+    per_tile_fixed: bool = False
 
     def __str__(self) -> str:
         scales = ", ".join(f"{k}={v}" for k, v in self.scales.items())
@@ -564,6 +565,7 @@ def _create_sdsc_tensors(
                 arg_index=arg.arg_index,
                 is_index_tensor=is_idx_tensor,
                 related_value_tensor_idx=related_val_idx,
+                per_tile_fixed=arg.per_tile_fixed,
             )
         )
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ x ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

The preserved-loop path (UNROLL_LOOPS=0) computed per-tensor affine strides in generate_sdsc() purely from device geometry, with no way to know a tensor was per_tile_fixed. As a result, per_tile_fixed pool tensors got a nonzero affine.apply stride and incorrectly advanced their address on every loop iteration, unlike the unroll path (unroll.py) which correctly treats per_tile_fixed as fixed regardless of allocation type.

Propagate TensorArg.per_tile_fixed into SDSCArgs and skip stride computation for per_tile_fixed tensors so they fall through to the non-tiled/fixed-address path, matching UNROLL_LOOPS=1 semantics.

Also close the same allocation-based blind spot for lx tensors: lx addresses can never be expressed as affine.apply symbols in the current SDSC JSON schema (isStartAddrSymbolic_ is always unset for lx, and bundle.py's _get_tensor_core_sym_id returns None for non-hbm components). A tiled, non-per_tile_fixed lx tensor has no way to express its per-iteration advance today, so raise NotImplementedError for that case instead of silently treating it as fixed.
#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

These commits were cherry-picked from #3114 to enable us to merge it separately.

#### Does this PR introduce a user-facing change?

#### Additional note:
