### PR TITLE
BEAM_WIDTH=200 and log elapsed time of each pass

### DIFF
--- a/torch_spyre/_inductor/optimize_restickify.py
+++ b/torch_spyre/_inductor/optimize_restickify.py
@@ -388,7 +388,8 @@ class BeamState:
     cost: float
 
 
-BEAM_WIDTH = 64
+BEAM_WIDTH = 10000
+MAX_BEAM_STATES_LOGGED = 10
 
 
 class Frontier:
@@ -486,10 +487,13 @@ def beam_global_min_cost(operations: list) -> None:
         max_states = max(max_states, len(frontier.states))
         if logger.isEnabledFor(logging.DEBUG):
             lines = [f"beam after {op.get_name()} [{len(frontier.states)} states]:"]
-            for i, s in enumerate(frontier.states):
+            for i, s in enumerate(frontier.states[:MAX_BEAM_STATES_LOGGED]):
                 lines.append(f"  state {i} (cost={s.cost}):")
                 for name, stl in zip(frontier.buf_names, s.assignments):
                     lines.append(f"    {name}: stride_map={list(stl.stride_map)}")
+            extra = len(frontier.states) - MAX_BEAM_STATES_LOGGED
+            if extra > 0:
+                lines.append(f"    ... {extra} additional states not logged")
             logger.debug("\n".join(lines))
 
     logger.info(

--- a/torch_spyre/_inductor/optimize_restickify.py
+++ b/torch_spyre/_inductor/optimize_restickify.py
@@ -388,7 +388,7 @@ class BeamState:
     cost: float
 
 
-BEAM_WIDTH = 10000
+BEAM_WIDTH = 200
 MAX_BEAM_STATES_LOGGED = 10
 
 

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -16,6 +16,7 @@
 import inspect
 import io
 import logging
+import time
 from typing import Optional, Any, Callable
 
 import torch
@@ -381,7 +382,13 @@ class CustomPreSchedulingPasses:
             )
 
         for pass_fn in self.passes:
+            t0 = time.perf_counter()
             pass_fn(graph)
+            logger.info(
+                "elapsed %5dms  %s",
+                (time.perf_counter() - t0) * 1000,
+                _get_pass_name(pass_fn),
+            )
 
             pass_name = _get_pass_name(pass_fn)
             if logger.isEnabledFor(logging.DEBUG) and _should_log_pass(pass_name):

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -384,11 +384,12 @@ class CustomPreSchedulingPasses:
         for pass_fn in self.passes:
             t0 = time.perf_counter()
             pass_fn(graph)
-            logger.info(
-                "elapsed %5dms  %s",
-                (time.perf_counter() - t0) * 1000,
-                _get_pass_name(pass_fn),
-            )
+            if logger.isEnabledFor(logging.INFO):
+                logger.info(
+                    "elapsed %5dms  %s",
+                    (time.perf_counter() - t0) * 1000,
+                    _get_pass_name(pass_fn),
+                )
 
             pass_name = _get_pass_name(pass_fn)
             if logger.isEnabledFor(logging.DEBUG) and _should_log_pass(pass_name):


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR does 2 things:
1. **optimize_restickify.py**:  Increases the max beam width in the global restickify optimizer from 64 to 200.  The debug logging of the beam states in the optimizer is capped with `MAX_BEAM_STATES_LOGGED = 10` to not create exponential blowup
2. **passes.py**:  Log with `INFO` the elapsed time of each pass so we can monitor that runtime has not grown out of control

**Why increase max beam size**
A sub-optimal restickify plan is achieved for `test_flash.py` (2 restickifies instead of 1) when  `reorder_for_locality=False` is changed in patches.py because the optimal solution is pruned with BEAM_WIDTH=64.  It still produces a valid restickify solution but it is (a) is sub optimal performance and (b) the extra restickify is trigging other bugs downstream while system stability is evolving.   `reorder_for_locality=False` is not the default but it is useful for debugging and shows that the beam width is close to maxed out in general for flash.    

**Why pick 200?**

On main, 200 is a modest max runtime increase for the `optimize_restickify_locations` pass (196ms --> 237ms).

However the not-yet-merged #3220 increases the number of candidate layouts which impacts runtime as well (Runtime is `num_nodes * num_candidates * beam_width`

So I suggest we increase gradually to not let compile time jump to rapidly.

<img width="60%" alt="image" src="https://github.com/user-attachments/assets/d4f789bc-cf65-4525-86b3-5bb579c51edf" />

------
**Sample pass elapsed time logging**
```
[INFO] [spyre.inductor.passes] elapsed     2ms  deadcode_elimination
[INFO] [spyre.inductor.passes] elapsed     1ms  split_multi_ops
[INFO] [spyre.inductor.passes] elapsed   100ms  propagate_spyre_tensor_layouts
[INFO] [spyre.inductor.passes] elapsed     2ms  validate_ops
[INFO] [spyre.inductor.passes] elapsed   287ms  optimize_restickify_locations
[INFO] [spyre.inductor.passes] elapsed     0ms  finalize_layouts
[INFO] [spyre.inductor.passes] elapsed     0ms  insert_restickify
[INFO] [spyre.inductor.passes] elapsed     0ms  insert_post_mutation_restickify
[INFO] [spyre.inductor.passes] elapsed     0ms  insert_bmm_padding
[INFO] [spyre.inductor.passes] elapsed     8ms  dedup_and_promote_constants
[INFO] [spyre.inductor.passes] elapsed    61ms  propagate_named_dims
[INFO] [spyre.inductor.passes] elapsed    16ms  assign_dim_hints
[INFO] [spyre.inductor.passes] elapsed   161ms  _maybe_coarse_tile
[INFO] [spyre.inductor.passes] elapsed   221ms  span_reduction
[INFO] [spyre.inductor.passes] elapsed    23ms  _distribute_work
[INFO] [spyre.inductor.passes] elapsed    46ms  _maybe_scratchpad_planning
```

#### Which issue(s) this PR is related to:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

Note: there are many opportunities for improving the time it takes to run optimized_restickify_layouts but they are not being prioritized given this phase will likely be combined with other optimizations in the mid-term.

These two features can be spit into separate PRs if preferred