### PR TITLE
fix(inductor): make sure d2d copy of a sliced input work properly

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_copy_from_d2d_offsets.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_copy_from_d2d_offsets.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [core, full]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_copy_from_d2d_offsets.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_copy_from_d2d_offsets.py
+++ b/tests/inductor/test_copy_from_d2d_offsets.py
@@ -1,0 +1,169 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for device-to-device copies of offset / strided views.
+
+Guards against the silent-wrong-data bug where copying different slices of a
+Spyre tensor D2D more than once returned the *first* call's data. The slice
+position lives only in the tensor's storage_offset, and a graph input's
+storage_offset is dropped by the Inductor backend (its FixedLayout.offset is
+0 and SpyreTensorLayout has no offset field), so the compiled kernel bound the
+storage base pointer and read from element 0.
+
+The fix re-introduces the offset in-graph in lower_spyre_from_d2d
+(torch_spyre/_inductor/lowering.py) via a ReinterpretView, so the offset lands
+in the coordinate that superdsc bakes into the SDSC binary.
+
+The transpose / permute / strided cases below deliberately exercise
+NON-contiguous views. They probe whether re-injecting only the scalar
+storage_offset onto the input's own (size, stride) layout is sufficient
+("Option 2"), or whether the full view (size + stride + offset) must be
+reconstructed from the base tensor ("Option 1"). If any strided case fails on
+hardware while the contiguous cases pass, Option 2 is insufficient.
+"""
+
+import unittest
+
+import torch
+
+import torch_spyre  # noqa: F401
+
+
+DEVICE = "spyre"
+DTYPE = torch.float16
+
+
+class TestCopyFromD2DContiguousOffsets(unittest.TestCase):
+    """Contiguous slices at varying offsets — the core reproducer."""
+
+    def test_multi_offset_clone(self):
+        x = torch.arange(4 * 64, dtype=DTYPE, device=DEVICE).reshape(4, 64)
+        a = x.narrow(0, 0, 1).clone()
+        b = x.narrow(0, 2, 1).clone()
+        torch.testing.assert_close(a.cpu(), x.cpu()[0:1])
+        torch.testing.assert_close(b.cpu(), x.cpu()[2:3])
+
+    def test_loop_varying_offsets(self):
+        x = torch.arange(8 * 64, dtype=DTYPE, device=DEVICE).reshape(8, 64)
+        for r in [0, 2, 4, 6, 7]:
+            out = x.narrow(0, r, 1).clone()
+            torch.testing.assert_close(
+                out.cpu(),
+                x.cpu()[r : r + 1],
+                msg=f"row {r}: got {out.cpu()[0, 0].item()}",
+            )
+
+    def test_revisit_offset(self):
+        x = torch.arange(6 * 64, dtype=DTYPE, device=DEVICE).reshape(6, 64)
+        for r in [1, 3, 1, 5, 3]:
+            out = x.narrow(0, r, 1).clone()
+            torch.testing.assert_close(out.cpu(), x.cpu()[r : r + 1])
+
+    def test_copy_into_sliced_dst(self):
+        """dst is itself a narrow (nonzero dst storage_offset)."""
+        x = torch.arange(4 * 64, dtype=DTYPE, device=DEVICE).reshape(4, 64)
+        dst = torch.full((4, 64), -1.0, dtype=DTYPE, device=DEVICE)
+        dst.narrow(0, 0, 1).copy_(x.narrow(0, 0, 1))
+        dst.narrow(0, 2, 1).copy_(x.narrow(0, 3, 1))
+        out = dst.cpu()
+        torch.testing.assert_close(out[0:1], x.cpu()[0:1])
+        torch.testing.assert_close(out[2:3], x.cpu()[3:4])
+        torch.testing.assert_close(out[1:2], torch.full((1, 64), -1.0, dtype=DTYPE))
+        torch.testing.assert_close(out[3:4], torch.full((1, 64), -1.0, dtype=DTYPE))
+
+    @unittest.expectedFailure
+    def test_column_slice_inner_offset(self):
+        """Offset along the last (stick) dim: narrow columns at an offset.
+
+        KNOWN LIMITATION (silent wrong data). A storage_offset that falls in
+        the innermost / stick dimension is not correctly baked: the fix
+        re-introduces the flat offset onto the layout, but superdsc decomposes
+        per-dim offsets against device_size and does not split a stick-dim
+        offset correctly, so the read is off by the stick-dim component.
+        Tracked for the follow-up PR (stick-dim offset handling), distinct from
+        the row-offset bug fixed here."""
+        x = torch.arange(2 * 128, dtype=DTYPE, device=DEVICE).reshape(2, 128)
+        # columns [64:128) -> nonzero offset within a row
+        out = x.narrow(1, 64, 64).clone()
+        torch.testing.assert_close(out.cpu(), x.cpu()[:, 64:128])
+
+
+class TestCopyFromD2DStridedViews(unittest.TestCase):
+    """Non-contiguous views: transpose / permute / step slices / select.
+
+    permute and select work (the offset fix carries them). transpose and
+    stepped-slice cases are marked expectedFailure: they fail in the Spyre
+    restickify layout pass ("no mechanism to resolve stick incompatibility" /
+    "scatter elements from one stick to multiple sticks"), NOT in offset
+    handling. Verified to fail identically on the pre-fix baseline (offset==0
+    transpose reduces lower_spyre_from_d2d to the original mutate_to), so these
+    are pre-existing backend limitations, not regressions from this fix, and
+    reconstructing size+stride explicitly (Option 1) would not resolve them.
+    Tracked for the follow-up PR.
+    """
+
+    @unittest.expectedFailure
+    def test_transpose_clone(self):
+        x = torch.arange(4 * 64, dtype=DTYPE, device=DEVICE).reshape(4, 64)
+        out = x.t().clone()  # (64, 4), non-contiguous
+        torch.testing.assert_close(out.cpu(), x.cpu().t())
+
+    @unittest.expectedFailure
+    def test_transpose_then_offset_clone(self):
+        """Transpose AND a nonzero offset along the transposed dim."""
+        x = torch.arange(4 * 64, dtype=DTYPE, device=DEVICE).reshape(4, 64)
+        xt = x.t()  # (64, 4)
+        out = xt.narrow(1, 2, 2).clone()  # rows of original [2:4], transposed
+        torch.testing.assert_close(out.cpu(), x.cpu().t()[:, 2:4])
+
+    def test_permute_clone(self):
+        x = torch.arange(2 * 3 * 64, dtype=DTYPE, device=DEVICE).reshape(2, 3, 64)
+        out = x.permute(1, 0, 2).clone()  # (3, 2, 64)
+        torch.testing.assert_close(out.cpu(), x.cpu().permute(1, 0, 2))
+
+    def test_permute_with_offset_clone(self):
+        x = torch.arange(4 * 3 * 64, dtype=DTYPE, device=DEVICE).reshape(4, 3, 64)
+        v = x.permute(1, 0, 2).narrow(1, 1, 2)  # offset along a permuted dim
+        out = v.clone()
+        torch.testing.assert_close(out.cpu(), x.cpu().permute(1, 0, 2)[:, 1:3])
+
+    def test_select_clone(self):
+        """select drops a dim and introduces an offset."""
+        x = torch.arange(4 * 64, dtype=DTYPE, device=DEVICE).reshape(4, 64)
+        out = x.select(0, 2).clone()  # row 2 as 1-D (64,), storage_offset=128
+        torch.testing.assert_close(out.cpu(), x.cpu()[2])
+
+    @unittest.expectedFailure
+    def test_stepped_slice_clone(self):
+        """Strided (step>1) slice — non-unit stride plus offset."""
+        x = torch.arange(8 * 64, dtype=DTYPE, device=DEVICE).reshape(8, 64)
+        out = x[1::2].clone()  # rows 1,3,5,7 ; offset=64, stride[0]=128
+        torch.testing.assert_close(out.cpu(), x.cpu()[1::2])
+
+    @unittest.expectedFailure
+    def test_transpose_varying_offsets_loop(self):
+        """Multiple distinct offsets on a transposed view in one process."""
+        x = torch.arange(8 * 64, dtype=DTYPE, device=DEVICE).reshape(8, 64)
+        xt = x.t()  # (64, 8)
+        for c in [0, 2, 5, 7]:
+            out = xt.narrow(1, c, 1).clone()
+            torch.testing.assert_close(
+                out.cpu(),
+                x.cpu().t()[:, c : c + 1],
+                msg=f"transpose col {c}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/inductor/test_copy_from_d2d_offsets.py
+++ b/tests/inductor/test_copy_from_d2d_offsets.py
@@ -25,12 +25,29 @@ The fix re-introduces the offset in-graph in lower_spyre_from_d2d
 (torch_spyre/_inductor/lowering.py) via a ReinterpretView, so the offset lands
 in the coordinate that superdsc bakes into the SDSC binary.
 
+REQUIREMENT (not a missing feature): the re-injected offset must step by whole
+sticks. The innermost device dim holds elems_per_stick elements (64 at fp16) and
+the backend cannot bake an offset landing inside a stick. Measured on hardware
+(sweep_d2d_offsets.py): across contiguous narrow AND select views of every inner
+size, a copy is correct iff offset % elems_per_stick == 0, and every unaligned
+offset instead raises "no mechanism to resolve stick incompatibility" in the
+restickify pass — there is NO silent-wrong-data path for contiguous views. Note
+the rule keys on the OFFSET, not the inner-dim size: an inner dim of 96 (not a
+stick multiple) still copies correctly at offset 192 (3 sticks) but errors at
+offset 96 (1.5 sticks). _validate_reoffset_supported in lower_spyre_from_d2d
+surfaces this rejection early with an actionable message; see
+test_unaligned_offset_raises{,_select} and
+test_stick_multiple_offset_unaligned_inner_dim_ok.
+
+The one remaining silent-wrong-data case is an offset that falls INSIDE the
+stick dim (a column narrow) — see test_column_slice_inner_offset, a documented
+known limitation tracked for the follow-up PR.
+
 The transpose / permute / strided cases below deliberately exercise
-NON-contiguous views. They probe whether re-injecting only the scalar
-storage_offset onto the input's own (size, stride) layout is sufficient
-("Option 2"), or whether the full view (size + stride + offset) must be
-reconstructed from the base tensor ("Option 1"). If any strided case fails on
-hardware while the contiguous cases pass, Option 2 is insufficient.
+NON-contiguous views (see TestCopyFromD2DStridedViews). permute / select at
+stick-aligned offsets are carried by the offset fix; transpose / stepped-slice
+fail in the restickify layout pass (a pre-existing backend limitation, not a
+regression from this fix).
 """
 
 import unittest
@@ -86,17 +103,73 @@ class TestCopyFromD2DContiguousOffsets(unittest.TestCase):
     def test_column_slice_inner_offset(self):
         """Offset along the last (stick) dim: narrow columns at an offset.
 
-        KNOWN LIMITATION (silent wrong data). A storage_offset that falls in
-        the innermost / stick dimension is not correctly baked: the fix
-        re-introduces the flat offset onto the layout, but superdsc decomposes
-        per-dim offsets against device_size and does not split a stick-dim
-        offset correctly, so the read is off by the stick-dim component.
-        Tracked for the follow-up PR (stick-dim offset handling), distinct from
-        the row-offset bug fixed here."""
+        KNOWN LIMITATION — the SOLE remaining silent-wrong-data case. Here the
+        offset (64) IS a stick multiple, so _validate_reoffset_supported accepts
+        it, but it falls inside the stick DIMENSION: superdsc decomposes per-dim
+        offsets against device_size and does not split a stick-dim offset
+        correctly, so the read is off by the stick-dim component (measured WRONG
+        in sweep_d2d_offsets.py: got 0.0, expected 64.0). The offset%eps guard
+        cannot catch this (the offset is aligned); detecting it needs the
+        base-storage layout, which is unavailable at lowering. Tracked for the
+        follow-up PR (stick-dim offset handling), distinct from the row-offset
+        bug fixed here."""
         x = torch.arange(2 * 128, dtype=DTYPE, device=DEVICE).reshape(2, 128)
         # columns [64:128) -> nonzero offset within a row
         out = x.narrow(1, 64, 64).clone()
         torch.testing.assert_close(out.cpu(), x.cpu()[:, 64:128])
+
+    def test_unaligned_offset_raises(self):
+        """A storage_offset that is not a whole number of sticks is rejected.
+
+        REQUIREMENT (not a missing feature). The re-injected offset must step by
+        complete sticks: the innermost device dim holds elems_per_stick elements
+        (64 at fp16) and the backend cannot bake an offset landing inside a
+        stick. Measured on hardware (sweep_d2d_offsets.py): across contiguous
+        narrow / select views of every inner size, a copy is correct iff
+        offset % elems_per_stick == 0 and otherwise the restickify pass raises
+        "no mechanism to resolve stick incompatibility".
+
+        The rule keys on the OFFSET, not the inner-dim size. reshape(4, 100)
+        row 2 has offset 200 (200 % 64 != 0), so _validate_reoffset_supported in
+        lower_spyre_from_d2d raises Unsupported at lowering time — surfacing the
+        rejection early with an actionable message instead of the cryptic
+        downstream restickify error. Row 0 (offset 0) is always fine."""
+        x = torch.arange(4 * 100, dtype=DTYPE, device=DEVICE).reshape(4, 100)
+        # offset 0 -> guard no-op, must succeed and be correct
+        a = x.narrow(0, 0, 1).clone()
+        torch.testing.assert_close(a.cpu(), x.cpu()[0:1])
+        # offset 200 is not a stick multiple -> clean compile-time error
+        with self.assertRaises(Exception) as cm:
+            x.narrow(0, 2, 1).clone()
+        self.assertIn("stick", str(cm.exception).lower())
+
+    def test_unaligned_offset_raises_select(self):
+        """select (rank-reducing) with an unaligned offset is rejected too.
+
+        select(0, r) drops the outer dim, so the view handed to the op is 1-D
+        with the outer-dim offset baked into its storage_offset. The rule keys
+        on the offset alone, so rank reduction is irrelevant: reshape(4, 100)
+        select(0, 2) has offset 200 (not a stick multiple) and must raise, while
+        select(0, 0) (offset 0) succeeds. Guards against the earlier concern
+        that the select path could silently misread (it cannot: it either copies
+        correctly or errors)."""
+        x = torch.arange(4 * 100, dtype=DTYPE, device=DEVICE).reshape(4, 100)
+        torch.testing.assert_close(x.select(0, 0).clone().cpu(), x.cpu()[0])
+        with self.assertRaises(Exception) as cm:
+            x.select(0, 2).clone()
+        self.assertIn("stick", str(cm.exception).lower())
+
+    def test_stick_multiple_offset_unaligned_inner_dim_ok(self):
+        """A stick-multiple offset is accepted even if the inner dim is not.
+
+        Proves the rule is about the OFFSET, not the inner-dim size. reshape(
+        4, 96): 96 is not a stick multiple, but row 2 sits at offset 192 == 3
+        sticks, so the copy is representable and correct. (Row 1 at offset 96 ==
+        1.5 sticks would instead error — see test_unaligned_offset_raises.)
+        Verified on hardware in sweep_d2d_offsets.py."""
+        x = torch.arange(4 * 96, dtype=DTYPE, device=DEVICE).reshape(4, 96)
+        out = x.narrow(0, 2, 1).clone()  # offset 192 == 3 * 64
+        torch.testing.assert_close(out.cpu(), x.cpu()[2:3])
 
 
 class TestCopyFromD2DStridedViews(unittest.TestCase):

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -244,15 +244,39 @@ def _(input: torch.Tensor):
 def copy_from_d2d(
     src: torch.Tensor,
     dst: torch.Tensor,
+    src_off: int,
+    dst_off: int,
     compiled,
 ) -> None:
-    return compiled(src, dst)
+    # src_off/dst_off are the src/dst storage_offsets, passed as explicit ints
+    # because a sliced tensor's offset is invisible to the compiled kernel
+    # otherwise: a graph input's storage_offset is dropped by Inductor (its
+    # FixedLayout.offset is 0 and SpyreTensorLayout has no offset field), so the
+    # kernel binds the storage BASE pointer and reads from element 0. The
+    # lowering (lower_spyre_from_d2d) consumes these ints to re-introduce the
+    # offsets in-graph via a ReinterpretView, putting them into the coordinate
+    # that superdsc bakes into the SDSC binary.
+    #
+    # specialize_int=True is required on top of that: dynamo's TENSOR_MATCH
+    # guard keys on dtype/device/size/stride but NOT storage_offset, and its
+    # default auto-dynamic promotes the offset int to a symbol after the second
+    # distinct value — a symbolic offset cannot be baked as a constant into the
+    # coordinate. specialize_int installs int-equality guards so each distinct
+    # offset triggers a fresh trace and a fresh SDSC binary with the offset
+    # baked as a constant. This mirrors the spyre.overwrite fix above (PR
+    # #2084). Patch is call-scoped to leave process-wide dynamo behavior alone.
+    # Note: one compiled binary per unique (input shape, offsets) tuple;
+    # dynamo's cache_size_limit is bumped to 1024 in torch_spyre/__init__.py.
+    with torch._dynamo.config.patch(specialize_int=True):
+        return compiled(src, dst, src_off, dst_off)
 
 
 @copy_from_d2d.register_fake
 def _(
     src: torch.Tensor,
     dst: torch.Tensor,
+    src_off: int,
+    dst_off: int,
 ) -> None:
     pass
 

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -16,6 +16,7 @@
 from contextlib import contextmanager
 from warnings import warn
 
+import sympy
 import torch
 
 from torch._inductor.ir import Reduction, Pointwise, StorageBox
@@ -815,8 +816,50 @@ def clone(x, *, memory_format=None):
     return result
 
 
+def _reoffset(node, offset):
+    """Re-introduce a storage_offset onto a graph-input node in-graph.
+
+    A tensor that was sliced OUTSIDE the compiled region (e.g. a
+    ``x.narrow(0, 2, 1)`` handed to a standalone-compiled op) reaches the
+    lowering as a placeholder whose FixedLayout carries the right size and
+    stride but ``offset == 0`` — upstream Inductor's placeholder path reads
+    ``static_sizes_strides`` only and drops ``storage_offset`` (see
+    torch/_inductor/graph.py). The Spyre SpyreTensorLayout likewise has no
+    offset field, so the compiled kernel binds the storage BASE pointer
+    (job_plan.cpp / spyre_stream.cpp use ``storage().data_ptr()``) and reads
+    from element 0 regardless of the view's true offset.
+
+    To make the offset survive into the SDSC binary it must live in the
+    in-graph coordinate: superdsc.py bakes a per-dim byte offset from the
+    coordinate's constant term (``as_coeff_Add()[0]``). We therefore rebuild
+    the node as a ReinterpretView over the same storage with the offset
+    installed on the layout — the same mechanism aten.slice / SliceView use.
+    Size and stride are preserved from the input's own layout, so this is
+    correct for arbitrary (including transposed / permuted) views as long as
+    the device layout preserved the stride.
+    """
+    if offset == 0:
+        return node
+    storage, old_layout = ir.as_storage_and_layout(node)
+    new_layout = ir.FixedLayout(
+        old_layout.device,
+        old_layout.dtype,
+        list(old_layout.size),
+        list(old_layout.stride),
+        sympy.expand(offset),
+    )
+    return ir.TensorBox(ir.ReinterpretView(data=storage, layout=new_layout))
+
+
 @register_spyre_lowering(torch.ops.spyre.copy_from_d2d)
-def lower_spyre_from_d2d(src, dst):
+def lower_spyre_from_d2d(src, dst, src_off, dst_off):
+    # A sliced src/dst reaches us as a graph input whose storage_offset was
+    # dropped (offset==0 on its layout). Re-introduce the offsets in-graph so
+    # they land in the coordinate that superdsc bakes into the kernel; without
+    # this the kernel reads/writes from the storage base and every offset
+    # silently returns the first call's data. See _reoffset above.
+    src = _reoffset(src, src_off)
+    dst = _reoffset(dst, dst_off)
     lowering.mutate_to(dst, src)
 
 

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -834,13 +834,35 @@ def _reoffset(node, offset):
     coordinate's constant term (``as_coeff_Add()[0]``). We therefore rebuild
     the node as a ReinterpretView over the same storage with the offset
     installed on the layout — the same mechanism aten.slice / SliceView use.
-    Size and stride are preserved from the input's own layout, so this is
-    correct for arbitrary (including transposed / permuted) views as long as
-    the device layout preserved the stride.
+    Size and stride are preserved from the input's own layout.
+
+    REQUIREMENT — the offset is a single *host-space* flat scalar (in host
+    elements). ``compute_coordinates`` (views.py) distributes it across dims
+    against the *device* ``stride_map``; the innermost (stick) dim holds
+    ``elems_per_stick`` elements (64 at fp16, 128 at fp8), and the backend has
+    no mechanism to bake an offset that lands *inside* a stick. So a re-injected
+    offset is only representable when it is a whole multiple of
+    ``elems_per_stick`` — i.e. it steps by complete sticks. This was measured
+    directly (see ``sweep_d2d_offsets.py`` / ``tests/inductor/
+    test_copy_from_d2d_offsets.py``): across contiguous ``narrow`` and
+    ``select`` views of every inner size, the copy is correct iff
+    ``offset % elems_per_stick == 0`` and otherwise the restickify pass raises
+    "no mechanism to resolve stick incompatibility". Notably this depends on the
+    OFFSET, not the inner-dim size: e.g. an inner dim of 96 (not a stick
+    multiple) still copies correctly at offset 192 (== 3 sticks) but errors at
+    offset 96 (== 1.5 sticks).
+
+    ``_validate_reoffset_supported`` converts the unaligned case into a clean,
+    actionable ``Unsupported`` at lowering time instead of the cryptic
+    restickify error deeper in the pipeline. It does NOT guard the separate
+    offset-*within*-the-stick-dim case (a column narrow, e.g.
+    ``x.narrow(1, 64, 64)``), which the backend still miscompiles silently — see
+    ``test_column_slice_inner_offset`` (tracked for the follow-up PR).
     """
     if offset == 0:
         return node
     storage, old_layout = ir.as_storage_and_layout(node)
+    _validate_reoffset_supported(old_layout, offset)
     new_layout = ir.FixedLayout(
         old_layout.device,
         old_layout.dtype,
@@ -849,6 +871,48 @@ def _reoffset(node, offset):
         sympy.expand(offset),
     )
     return ir.TensorBox(ir.ReinterpretView(data=storage, layout=new_layout))
+
+
+def _validate_reoffset_supported(layout, offset) -> None:
+    """Fail fast when a D2D-copy offset is not a whole number of sticks.
+
+    A re-injected storage_offset must step by complete sticks: the innermost
+    device dim holds ``elems_per_stick`` elements and the backend cannot bake an
+    offset that lands inside a stick. Measured behavior (``sweep_d2d_offsets.py``)
+    is unambiguous — across contiguous ``narrow`` / ``select`` views of every
+    inner size, the copy is correct iff ``offset % elems_per_stick == 0``; every
+    unaligned offset instead raises deep in the restickify pass ("no mechanism
+    to resolve stick incompatibility"). This check surfaces the same rejection
+    earlier with an actionable message rather than silently miscompiling or
+    emitting a cryptic downstream error.
+
+    Scope — this rule is keyed on the OFFSET alone, so it holds regardless of
+    rank reduction (``select`` drops the outer dim but the flat offset is
+    unchanged) and does not need the device layout, which is not attached to the
+    placeholder yet. It deliberately does NOT cover an offset that falls *inside*
+    the stick dimension itself (a column narrow): that case is
+    ``offset % elems_per_stick == 0`` yet still miscompiles, and detecting it
+    would require the base-storage layout that is unavailable here. It stays a
+    documented known limitation (``test_column_slice_inner_offset``).
+    """
+    try:
+        off = int(offset)
+    except (TypeError, ValueError):
+        # Symbolic offset: cannot check statically, let it through
+        # (specialize_int bakes concrete offsets, so this is the rare path).
+        return
+    if off == 0:
+        return
+    eps = get_elem_in_stick(layout.dtype)
+    if off % eps != 0:
+        raise Unsupported(
+            "spyre::copy_from_d2d of a sliced view requires a stick-aligned "
+            f"storage_offset: {off} is not a multiple of elems_per_stick={eps} "
+            f"(dtype {layout.dtype}). The offset must step by whole sticks; an "
+            "offset landing inside a stick cannot be baked into the kernel "
+            "coordinate. Re-slice on a stick-aligned boundary (a multiple of "
+            f"{eps} elements), or copy the full (unsliced) tensor."
+        )
 
 
 @register_spyre_lowering(torch.ops.spyre.copy_from_d2d)

--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -152,7 +152,13 @@ def _patch_tensor_for_spyre():
                 ):
                     return self
                 else:
-                    return torch.ops.spyre.copy_from_d2d(self, dst)
+                    # Pass storage_offsets explicitly: a graph input's
+                    # storage_offset is dropped by Inductor, so the lowering
+                    # must re-introduce it in-graph (see copy_from_d2d in
+                    # customops.py and lower_spyre_from_d2d).
+                    return torch.ops.spyre.copy_from_d2d(
+                        self, dst, self.storage_offset(), dst.storage_offset()
+                    )
 
     def spyre_empty(
         *args,

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -244,7 +244,12 @@ def spyre__copy_from(self, dst, non_blocking=False):
         torch_spyre._C.copy_tensor(self, dst, non_blocking)
         return dst
     elif self.device.type == "spyre" and self.device == dst.device:
-        torch.ops.spyre.copy_from_d2d(self, dst)
+        # Pass storage_offsets explicitly: a graph input's storage_offset is
+        # dropped by Inductor, so the lowering must re-introduce it in-graph
+        # (see copy_from_d2d in customops.py and lower_spyre_from_d2d).
+        torch.ops.spyre.copy_from_d2d(
+            self, dst, self.storage_offset(), dst.storage_offset()
+        )
         return dst
     else:
         if non_blocking:


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes a silent-wrong-data bug in device-to-device copies of a **sliced tensor**.
Copying different offset slices of a Spyre tensor D2D more than once in the same
process returned the **first** slice's data for every later call — no error, no
warning:

```python
x = torch.arange(4 * 64, dtype=torch.float16, device="spyre:0").reshape(4, 64)
a = x.narrow(0, 0, 1).clone()   # rows [0] — correct
b = x.narrow(0, 2, 1).clone()   # rows [2] — WRONG: silently returned row 0
```

Root cause: a graph input's storage_offset is dropped by Inductor. When a sliced view (e.g. x.narrow(0, 2, 1)) is passed to the standalone-compiled spyre::copy_from_d2d op, the narrow happened outside the traced region, so the input reaches the lowering as a placeholder whose FixedLayout.offset is 0 (static_sizes_strides reads size/stride only). SpyreTensorLayout has no offset field, and the compiled kernel binds the storage BASE pointer, so superdsc bakes a zero byte-offset and the kernel always reads from element 0. narrow(0, 0, 1) looked correct only because row 0 is at offset 0.

**FIX**:
1. Pass the src/dst `storage_offset`s to `copy_from_d2d` as explicit ints and
   re-introduce them in-graph in `lower_spyre_from_d2d` via a `ReinterpretView`
   (`_reoffset`), so the offset lands in the coordinate that `superdsc` bakes
   into the SDSC binary. This mirrors how `spyre::overwrite/cat/pad` inject
   offsets via `SliceView`. `specialize_int=True` is kept so each distinct
   offset is baked as a constant rather than promoted to a symbol by dynamo's
   auto-dynamic.

2. Add `_validate_reoffset_supported`: raise `Unsupported` at lowering time when
   `offset % elems_per_stick != 0`, with an actionable message, instead of the
   cryptic downstream restickify error. A re-injected offset can only be baked
   into the kernel coordinate when it steps by whole sticks (the innermost
   device dim holds `elems_per_stick` elements — 64 at fp16 — and the backend
   cannot represent an offset landing inside a stick).

#### Which issue(s) this PR is related to:

Issue #3236 


#### Special notes for your reviewer:

**The offset-alignment rule was established by direct hardware measurement**
(`sweep_d2d_offsets.py`), not by static analysis. Across contiguous `narrow`
**and** `select` views of every inner size, a copy is correct iff
`offset % elems_per_stick == 0`; every unaligned offset otherwise errors in the
restickify pass. Key findings:

- **No silent-wrong-data path exists for contiguous views** (including `select`,
  which reduces rank). Unaligned offsets *error*; they do not misread. The guard
  simply surfaces that rejection earlier with a clearer message.
- **The rule keys on the offset, not the inner-dim size.** An inner dim of 96
  (not a stick multiple) still copies correctly at offset 192 (3 sticks) but
  errors at offset 96 (1.5 sticks). Because it needs only the flat offset, it
  holds regardless of rank reduction and needs no device layout.

**Test results:** `pytest tests/inductor/test_copy_from_d2d_offsets.py` →
**10 passed, 5 xfailed**. Passing cases include the exact reproducer, contiguous
row-offset loops/revisits, stick-aligned `permute`/`select`, the new
`_validate_reoffset_supported` rejection tests (`narrow` and `select` at an
unaligned offset), and the offset-not-size case (`(4, 96)` at offset 192).

**The 5 xfails are pre-existing backend limitations, not regressions**, tracked
for the follow-up PR:

1. **Restickify stick-incompatibility** (transpose / stepped-slice) — hard
   compile errors in `optimize_restickify.py`, unrelated to offset handling.
   Verified to fail identically on the pre-fix baseline (an `offset==0`
   transpose reduces the lowering to the original `mutate_to`), and rebuilding
   size+stride would not resolve a stick-layout rejection.
2. **Stick-dim offset** (`test_column_slice_inner_offset`) — the sole remaining
   silent-wrong-data case: an offset that falls *inside* the innermost/stick dim
   (a column narrow) is `offset % elems_per_stick == 0` yet still miscompiles,
   because `superdsc` does not split a stick-dim offset. The `offset % eps` guard
   cannot catch this (the offset is aligned); detecting it needs the base-storage
   layout, which is unavailable at lowering.

#### Does this PR introduce a user-facing change?

N/A

