### PR TITLE
fix(scratchpad): exclude tiled/advancing buffers from LX eligibility

### DIFF
--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -75,6 +75,7 @@ from torch_spyre._inductor.scratchpad.utils import (
     GraphView,
     get_op_pointwise_inputs,
     _would_produce_lx_back_gap,
+    _is_tiled_advancing,
 )
 from torch_spyre._inductor.scratchpad.graph_editor import GraphEditor
 
@@ -218,6 +219,15 @@ class ScratchpadAllocator:
             for op in graph.operations
             if op.name not in drop_list and buffer_not_read_in_full(graph, op.name)
         )
+
+        # filter out advancing (tiled, non-per_tile_fixed) buffers: LX
+        # addresses cannot be expressed as affine.apply symbols today (see
+        # compute_ops.py's is_tiled_lx check), so such a buffer must stay in
+        # HBM, where its per-iteration address advance is fully supported.
+        for op in graph.operations:
+            if op.name not in drop_list and _is_tiled_advancing(op):
+                drop_list.add(op.name)
+                self.reject_reasons[op.name] = "tiled (advancing), not per_tile_fixed"
 
         if not clone_at_graph_boundaries():
             # Without clone support, graph outputs cannot be LX-pinned: the caller

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -28,6 +28,7 @@ from torch._inductor.ops_handler import WrapperHandler
 import sympy
 
 from torch_spyre._inductor import config
+from torch_spyre._inductor.ir import FixedTiledLayout
 from torch_spyre._inductor.pass_utils import (
     _per_core_view_on_buf,
     concretize_expr,
@@ -210,6 +211,28 @@ def buffer_not_read_in_full(graph: GraphLowering | GraphView, buf_name: str) -> 
             except (TypeError, ValueError, AttributeError):
                 return True
     return False
+
+
+def _is_tiled_advancing(op: Operation) -> bool:
+    """True if ``op``'s output advances its address across a coarse-tile loop.
+
+    LX addresses are never registered as ``affine.apply`` symbols in the SDSC
+    JSON (see ``compute_ops.py``'s ``is_tiled_lx`` check), so a buffer that
+    advances per loop iteration (tiled, and not ``per_tile_fixed``) has no way
+    to express its address change if pinned to LX. This mirrors that check,
+    but at IR time via ``loop_info`` instead of the later per-tensor strides
+    representation, letting the allocator exclude such buffers from LX
+    candidacy up front instead of crashing at codegen time.
+    """
+    layout = getattr(op, "layout", None)
+    if not isinstance(layout, FixedTiledLayout) or layout.per_tile_fixed:
+        return False
+    loop_info = getattr(op, "loop_info", None)
+    if loop_info is None:
+        return False
+    return any(dims for dims in loop_info.loop_tiled_dims) or any(
+        dims for dims in getattr(loop_info, "loop_tiled_reduction_dims", [])
+    )
 
 
 def _writes_at_constant_offset(op: Operation) -> bool:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ x ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

LX addresses can never be registered as affine.apply symbols in the SDSC JSON, so a buffer that advances its address across coarse-tile loop iterations (tiled, and not per_tile_fixed) has no way to express that change if pinned to LX. Previously this was only caught late, at SDSC codegen time, as a NotImplementedError crash in compute_ops.py -- by then the scratchpad allocator had already committed the buffer to LX.

Teach ScratchpadAllocator._filter_ops to exclude such buffers from LX candidacy up front, using op.loop_info (already resolved by this point in the pass pipeline) to detect tiled, non-per_tile_fixed buffers -- the same fact compute_ops.py's is_tiled_lx check reconstructs much later from per-tensor strides. Buffers caught by this guard now stay in HBM, where advancing addresses via affine.apply are fully supported.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
