### PR TITLE
chore(Makefile): remove egg-info directories on make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,4 +88,6 @@ clean: ## Remove auto-generated OOT wrappers, conftest files, merged configs, an
 	@find tests/ -name '_spyre_merged_config_*.yaml' -delete
 	@find tests/ -name '*.markers.json' -delete
 	@find tests/ -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true
+	@rm -rf torch_spyre.egg-info
+	@rm -rf tests/oot_framework/oot_framework.egg-info
 	@echo "Cleaned auto-generated files under tests/"


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds cleanup of `torch_spyre.egg-info` and `tests/oot_framework/oot_framework.egg-info` to themake clean target.
