### PR TITLE
fix(test framework): fix invalid privateuse1 device strings on multi-device hosts in  `OOTTestBase.get_all_devices()`

### DIFF
--- a/tests/oot_framework/oot_test_base_common.py
+++ b/tests/oot_framework/oot_test_base_common.py
@@ -160,6 +160,29 @@ class OOTTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa: F
         # calls generate the correct class name.
         OOTTestBase.device_type = "privateuse1"
 
+    @classmethod
+    def get_all_devices(cls):
+        # PrivateUse1TestBase.get_all_devices() builds non-primary device
+        # strings from cls.device_type, which setUpClass() above resets to
+        # "privateuse1" (for class-naming purposes) right after super()
+        # computes it as the real backend name (e.g. "spyre"). On a
+        # single-device host the resulting non-primary list is always empty
+        # so this never surfaces, but on a multi-device host (e.g. s390x with
+        # several Spyre devices) it produces invalid device strings like
+        # "privateuse1:1" that torch.device() rejects, since only the
+        # (correctly-cached) primary_device escapes the reset. Use the real
+        # registered backend name here instead of cls.device_type.
+        primary_device_idx = int(cls.get_primary_device().split(":")[1])
+        num_devices = cls.device_mod.device_count()
+        prim_device = cls.get_primary_device()
+        device_str = f"{_OOT_DEVICE_TYPE}:{{0}}"
+        non_primary_devices = [
+            device_str.format(idx)
+            for idx in range(num_devices)
+            if idx != primary_device_idx
+        ]
+        return [prim_device] + non_primary_devices
+
     # ------------------------------------------------------------------
     # Config loading  (called once per test run via instantiate_test)
     # ------------------------------------------------------------------


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup


### Summary
- `OOTTestBase.setUpClass()` resets `device_type` back to `"privateuse1"` after `super().setUpClass()` sets it to the real backend name (`"spyre"`), so that dynamically-generated test class names stay `...PRIVATEUSE1` for `PYTORCH_TESTING_DEVICE_ONLY_FOR` filtering.
- `PrivateUse1TestBase.get_all_devices()` (inherited, unoverridden) builds non-primary device strings from `cls.device_type`, so it picks up the reset `"privateuse1"` instead of `"spyre"`, producing invalid strings like `privateuse1:1`.
- This is silent on single-device hosts (x86) since the non-primary device list is empty, but breaks on multi-device hosts (s390x, 4 Spyre devices) with `RuntimeError: Invalid device string: 'privateuse1:1'` in `test_advancedindex_mixed_devices_error_spyre`.
- Fixes #3229.

### Fix
Override `get_all_devices()` in `OOTTestBase` to build device strings from `_OOT_DEVICE_TYPE` (the real registered backend name, resolved once at import) instead of `cls.device_type`.

<img width="2140" height="492" alt="image" src="https://github.com/user-attachments/assets/892d1816-9dd4-45a7-828b-5d3c817b21a5" />


#### Which issue(s) this PR is related to:

Fixes https://github.com/torch-spyre/torch-spyre/issues/3229

#### Repro fix: 
```bash
bash tests/run_test.sh tests/configs/upstream_tests_beta/test_torch.yaml -v -k test_advancedindex_mixed_devices_error
```

#### Special notes for your reviewer:

- Reproduced the failure locally by simulating a 4-device backend and confirming `get_all_devices()` returned `['spyre:0', 'privateuse1:1', 'privateuse1:2', 'privateuse1:3']` before the fix.
- Verified the fix returns `['spyre:0', 'spyre:1', 'spyre:2', 'spyre:3']` and `.to()` no longer raises.
- `bash tests/run_test.sh tests/configs/upstream_tests_beta/test_torch.yaml -v -k test_advancedindex_mixed_devices_error` passes on x86 (no regression).