### PR TITLE
feat(cicd): avoid tests execution on merge queue for docs changes

### DIFF
--- a/.github/actions/detect-doc-only-change/action.yml
+++ b/.github/actions/detect-doc-only-change/action.yml
@@ -1,0 +1,57 @@
+name: Detect doc-only change
+description: |
+  Determines whether the triggering pull_request or merge_group event only
+  touched doc paths (tests/docs/, docs/, README.md, CODEOWNERS). push and
+  workflow_dispatch events have nothing to diff against, so they always
+  report a code change.
+
+outputs:
+  code_changed:
+    description: >-
+      'true' if any file outside the doc paths changed (or there is nothing
+      to diff, e.g. push/workflow_dispatch); 'false' if only doc/CODEOWNERS
+      files changed.
+    value: ${{ steps.filter.outputs.code_changed }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check which paths changed
+      id: filter
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        # On pull_request events, fetch the full list of changed files via
+        # the GitHub API. On merge_group events (merge queue), there is no
+        # PR to query, so diff the queue's base against the temporary merge
+        # commit instead -- this yields the same file list a pull_request
+        # event would see. On push to main/tag or workflow_dispatch, assume
+        # tests should always run since we don't have anything to diff.
+        if [[ -n "${{ github.event.pull_request.number }}" ]]; then
+          FILES=$(gh pr view ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --json files --jq '.files[].path')
+        elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+          FILES=$(gh api "repos/${{ github.repository }}/compare/${{ github.event.merge_group.base_sha }}...${{ github.event.merge_group.head_sha }}" \
+            --jq '.files[].filename')
+        else
+          # push to main, tag, or manual dispatch -- always run tests
+          FILES="non-doc-change"
+        fi
+
+        echo "Changed files:"
+        echo "$FILES"
+
+        # Check if any changed file is outside the doc directories.
+        # tests/docs/, docs/, README.md, and CODEOWNERS are the only paths
+        # that should skip tests.
+        NON_DOC=$(echo "$FILES" | grep -v '^tests/docs/' | grep -v '^docs/' | grep -v '^README\.md$' | grep -v '^CODEOWNERS$' || true)
+
+        if [[ -z "$NON_DOC" ]]; then
+          echo "Only doc files changed — skipping tests."
+          echo "code_changed=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "Non-doc files changed — running tests."
+          echo "code_changed=true" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -72,9 +72,9 @@ jobs:
   # ---------------------------------------------------------------------------
   # Job 1: changes
   #
-  # Runs on every PR and merge-queue check. Uses gh CLI to fetch the full
-  # list of changed files and checks if any file outside tests/docs/, docs/,
-  # README.md, or CODEOWNERS was modified.
+  # Runs on every PR and merge-queue check. Delegates to the shared
+  # detect-doc-only-change composite action, which checks if any file outside
+  # tests/docs/, docs/, README.md, or CODEOWNERS was modified.
   #
   # code_changed=true  --> non-doc files changed  --> run tests
   # code_changed=false --> only doc/CODEOWNERS files changed --> skip tests
@@ -85,44 +85,15 @@ jobs:
     outputs:
       code_changed: ${{ steps.filter.outputs.code_changed }}
     steps:
+      - name: Checkout composite actions
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+
       - name: Check which paths changed
         id: filter
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # On pull_request events, fetch the full list of changed files via
-          # the GitHub API. On merge_group events (merge queue), there is no
-          # PR to query, so diff the queue's base against the temporary merge
-          # commit instead -- this yields the same file list a pull_request
-          # event would see. On push to main/tag or workflow_dispatch, assume
-          # tests should always run since we don't have anything to diff.
-          if [[ -n "${{ github.event.pull_request.number }}" ]]; then
-            FILES=$(gh pr view ${{ github.event.pull_request.number }} \
-              --repo ${{ github.repository }} \
-              --json files --jq '.files[].path')
-          elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
-            FILES=$(gh api "repos/${{ github.repository }}/compare/${{ github.event.merge_group.base_sha }}...${{ github.event.merge_group.head_sha }}" \
-              --jq '.files[].filename')
-          else
-            # push to main, tag, or manual dispatch -- always run tests
-            FILES="non-doc-change"
-          fi
-
-          echo "Changed files:"
-          echo "$FILES"
-
-          # Check if any changed file is outside the doc directories.
-          # tests/docs/, docs/, README.md, and CODEOWNERS are the only paths
-          # that should skip tests.
-          NON_DOC=$(echo "$FILES" | grep -v '^tests/docs/' | grep -v '^docs/' | grep -v '^README\.md$' | grep -v '^CODEOWNERS$' || true)
-
-          if [[ -z "$NON_DOC" ]]; then
-            echo "Only doc files changed — skipping tests."
-            echo "code_changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Non-doc files changed — running tests."
-            echo "code_changed=true" >> "$GITHUB_OUTPUT"
-          fi
+        uses: ./.github/actions/detect-doc-only-change
 
   # ---------------------------------------------------------------------------
   # Job 2: delegate to the shared test matrix

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -72,9 +72,9 @@ jobs:
   # ---------------------------------------------------------------------------
   # Job 1: changes
   #
-  # Runs on every PR. Uses gh CLI to fetch the full list of changed files
-  # and checks if any file outside tests/docs/, docs/, README.md, or
-  # CODEOWNERS was modified.
+  # Runs on every PR and merge-queue check. Uses gh CLI to fetch the full
+  # list of changed files and checks if any file outside tests/docs/, docs/,
+  # README.md, or CODEOWNERS was modified.
   #
   # code_changed=true  --> non-doc files changed  --> run tests
   # code_changed=false --> only doc/CODEOWNERS files changed --> skip tests
@@ -91,12 +91,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # On pull_request events, fetch the full list of changed files via
-          # the GitHub API. On push to main/tag or workflow_dispatch, assume
-          # tests should always run since we don't have a PR to query.
+          # the GitHub API. On merge_group events (merge queue), there is no
+          # PR to query, so diff the queue's base against the temporary merge
+          # commit instead -- this yields the same file list a pull_request
+          # event would see. On push to main/tag or workflow_dispatch, assume
+          # tests should always run since we don't have anything to diff.
           if [[ -n "${{ github.event.pull_request.number }}" ]]; then
             FILES=$(gh pr view ${{ github.event.pull_request.number }} \
               --repo ${{ github.repository }} \
               --json files --jq '.files[].path')
+          elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            FILES=$(gh api "repos/${{ github.repository }}/compare/${{ github.event.merge_group.base_sha }}...${{ github.event.merge_group.head_sha }}" \
+              --jq '.files[].filename')
           else
             # push to main, tag, or manual dispatch -- always run tests
             FILES="non-doc-change"

--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -32,12 +32,64 @@ defaults:
 permissions:
   contents: read
   checks: write
+  pull-requests: read # so that gh pr view can fetch the file list
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Job: changes
+  #
+  # push and pull_request already skip doc-only changes via the workflow-level
+  # paths-ignore filter above. merge_group events, however, do not support
+  # paths-ignore, so without this job every merge-queue run would execute the
+  # full suite regardless of what changed. This job fetches the changed-file
+  # list (via the PR API for pull_request, or a base/head compare for
+  # merge_group) and downstream jobs are gated on the result.
+  #
+  # code_changed=true  --> non-doc files changed  --> run tests
+  # code_changed=false --> only doc/CODEOWNERS files changed --> skip tests
+  # ---------------------------------------------------------------------------
+  changes:
+    name: Detect changed files
+    runs-on: ubuntu-latest
+    outputs:
+      code_changed: ${{ steps.filter.outputs.code_changed }}
+    steps:
+      - name: Check which paths changed
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ -n "${{ github.event.pull_request.number }}" ]]; then
+            FILES=$(gh pr view ${{ github.event.pull_request.number }} \
+              --repo ${{ github.repository }} \
+              --json files --jq '.files[].path')
+          elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            FILES=$(gh api "repos/${{ github.repository }}/compare/${{ github.event.merge_group.base_sha }}...${{ github.event.merge_group.head_sha }}" \
+              --jq '.files[].filename')
+          else
+            # push to main -- always run tests
+            FILES="non-doc-change"
+          fi
+
+          echo "Changed files:"
+          echo "$FILES"
+
+          NON_DOC=$(echo "$FILES" | grep -v '^tests/docs/' | grep -v '^docs/' | grep -v '^README\.md$' | grep -v '^CODEOWNERS$' || true)
+
+          if [[ -z "$NON_DOC" ]]; then
+            echo "Only doc files changed — skipping tests."
+            echo "code_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Non-doc files changed — running tests."
+            echo "code_changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
   # Build the torch_spyre._C extension ONCE and publish it as a wheel; the
   # matrix job below installs that single wheel instead of recompiling per entry.
   build:
     name: Build torch-spyre wheel (once)
+    needs: changes
+    if: needs.changes.outputs.code_changed == 'true'
     # Compile-only: needs the backend image + SDK toolchain but NO physical Spyre
     # card, so it targets the cardless spyre_pf_x0 pool and leaves card runners
     # for the test jobs.

--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -41,9 +41,9 @@ jobs:
   # push and pull_request already skip doc-only changes via the workflow-level
   # paths-ignore filter above. merge_group events, however, do not support
   # paths-ignore, so without this job every merge-queue run would execute the
-  # full suite regardless of what changed. This job fetches the changed-file
-  # list (via the PR API for pull_request, or a base/head compare for
-  # merge_group) and downstream jobs are gated on the result.
+  # full suite regardless of what changed. Delegates to the shared
+  # detect-doc-only-change composite action, and downstream jobs are gated on
+  # the result.
   #
   # code_changed=true  --> non-doc files changed  --> run tests
   # code_changed=false --> only doc/CODEOWNERS files changed --> skip tests
@@ -54,35 +54,15 @@ jobs:
     outputs:
       code_changed: ${{ steps.filter.outputs.code_changed }}
     steps:
+      - name: Checkout composite actions
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+
       - name: Check which paths changed
         id: filter
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if [[ -n "${{ github.event.pull_request.number }}" ]]; then
-            FILES=$(gh pr view ${{ github.event.pull_request.number }} \
-              --repo ${{ github.repository }} \
-              --json files --jq '.files[].path')
-          elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
-            FILES=$(gh api "repos/${{ github.repository }}/compare/${{ github.event.merge_group.base_sha }}...${{ github.event.merge_group.head_sha }}" \
-              --jq '.files[].filename')
-          else
-            # push to main -- always run tests
-            FILES="non-doc-change"
-          fi
-
-          echo "Changed files:"
-          echo "$FILES"
-
-          NON_DOC=$(echo "$FILES" | grep -v '^tests/docs/' | grep -v '^docs/' | grep -v '^README\.md$' | grep -v '^CODEOWNERS$' || true)
-
-          if [[ -z "$NON_DOC" ]]; then
-            echo "Only doc files changed — skipping tests."
-            echo "code_changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Non-doc files changed — running tests."
-            echo "code_changed=true" >> "$GITHUB_OUTPUT"
-          fi
+        uses: ./.github/actions/detect-doc-only-change
 
   # Build the torch_spyre._C extension ONCE and publish it as a wheel; the
   # matrix job below installs that single wheel instead of recompiling per entry.


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

####  Summary
- Doc-only PRs already skipped `torch_spyre_tests` and `upstream_tests` on the per-PR commit, but not when the PR entered the merge queue ------ `merge_group` events are NOT covered by `paths-ignore`, and `torch_spyre_tests`'s changed-files job had no `merge_group` branch, so it fell through to "always run".

#### Fix
- `torch_spyre_tests.yaml`: `changes` job now detects `merge_group` events and diffs `merge_group.base_sha...merge_group.head_sha` via `gh api compare` to get the changed-file list (refers to the existing `gh pr view` path used for `pull_request`).
- `upstream_tests.yaml`: added the same `changes` job (this workflow had no doc-skip gate at all for `merge_group`); `build` is now gated on `code_changed == 'true'`, and `upstream-tests` skips transitively when `build` is skipped.