### PR TITLE
Fix model name corruption: preserve dots in job log filenames

### DIFF
--- a/.github/workflows/push-model-ops-logs-to-clickhouse.yaml
+++ b/.github/workflows/push-model-ops-logs-to-clickhouse.yaml
@@ -104,7 +104,7 @@ jobs:
           jobs = [json.loads(l) for l in open("/tmp/jobs.jsonl") if l.strip()]
 
           for idx, j in enumerate(jobs):
-              safe   = re.sub(r"[^\w\s\-]", "", j["name"]).strip()
+              safe   = re.sub(r"[^\w\s\-\.]", "", j["name"]).strip()
               out    = f"raw_logs/{idx}_{safe}.txt"
               result = subprocess.run(
                   ["gh", "api", f"/repos/{repo}/actions/jobs/{j['id']}/logs"],


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fix model name corruption: preserve dots in job log filenames

The filename sanitisation regex on line 107 strips any character that isn't a word char, whitespace, or hyphen. A dot (.) matches none of those, so version strings like 3.3 are silently collapsed to 33 before the file is written to disk.

