### PR TITLE
fix: : force sync in launch_jobplan test to surface async RuntimeError

### DIFF
--- a/tests/test_launch_jobplan.py
+++ b/tests/test_launch_jobplan.py
@@ -142,6 +142,8 @@ class TestLaunchJobPlan(TestCase):
             with stream:
                 with pytest.raises(RuntimeError, match="Expect one DCI"):
                     torch_spyre._C.launch_jobplan(job_plan, [])
+                    # launch_jobplan only enqueues; sync to surface the error.
+                    torch_spyre._C.synchronize()
 
 
 if __name__ == "__main__":

--- a/tests/test_launch_jobplan.py
+++ b/tests/test_launch_jobplan.py
@@ -140,9 +140,9 @@ class TestLaunchJobPlan(TestCase):
             stream = torch.Stream("spyre")
 
             with stream:
+                # launch_jobplan only enqueues; assert on synchronize() alone.
+                torch_spyre._C.launch_jobplan(job_plan, [])
                 with pytest.raises(RuntimeError, match="Expect one DCI"):
-                    torch_spyre._C.launch_jobplan(job_plan, [])
-                    # launch_jobplan only enqueues; sync to surface the error.
                     torch_spyre._C.synchronize()
 
 


### PR DESCRIPTION


Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->
This test adds an explicit torch_spyre._C.synchronize() inside the pytest.raises block to force a wait for completion, so the expected RuntimeError actually surfaces and is asserted, rather than being deferred (and silently suppressed) at stream teardown, when we run into async runtime model

#### Which issue(s) this PR is related to:
flex PR 1306
<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
