### PR TITLE
fix(inductor): match DXP usable LX reservation

### DIFF
--- a/tests/inductor/test_scratchpad_patterns.py
+++ b/tests/inductor/test_scratchpad_patterns.py
@@ -25,6 +25,7 @@ import torch
 
 from torch_spyre._inductor.scratchpad.allocator import (
     LifetimeBoundBuffer,
+    _lx_planning_size,
 )
 from torch_spyre._inductor.scratchpad.firstfit_bestfit_solver import (
     BestFitLayoutSolver,
@@ -38,10 +39,8 @@ from torch_spyre._inductor.scratchpad.plan_solver import (
     GreedyLayoutSolver,
     LifetimeBoundBuffer as Buffer,
 )
-from torch_spyre._inductor import config
 
-# From scratchpad.py
-AVAILABLE_LX_SIZE = int((2 << 20) * (1.0 - config.dxp_lx_frac_avail))
+AVAILABLE_LX_SIZE = _lx_planning_size()
 
 BYPASS_XFAIL = os.environ.get("SCRATCHPAD_PATTERN_BYPASS_XFAIL", "0") == "1"
 

--- a/tests/inductor/test_scratchpad_solver.py
+++ b/tests/inductor/test_scratchpad_solver.py
@@ -21,6 +21,8 @@ import sys
 import unittest
 from unittest import TestCase
 
+from torch_spyre._inductor import config
+from torch_spyre._inductor.scratchpad.allocator import _lx_planning_size
 from torch_spyre._inductor.scratchpad.plan_solver import (
     MemoryPlanSolver,
     CoreDivision,
@@ -53,6 +55,27 @@ from torch_spyre._inductor.scratchpad.simulated_annealing import (
 LARGE_SIZE = 512
 SMALL_SIZE = 10
 ALIGNMENT = 128
+
+
+class TestLxPlanningContract(TestCase):
+    def test_matches_deeptools_frontend_reservation(self):
+        # Deeptools removes 64 KiB for program/debug data before applying the
+        # frontend/backend partition, then rounds the frontend reservation up to
+        # its 128-byte allocation granularity.
+        cases = ((0.0, 2_031_616), (0.2, 1_625_344), (1.0, 0))
+        for fraction, expected in cases:
+            with self.subTest(fraction=fraction):
+                with config.patch({"dxp_lx_frac_avail": fraction}):
+                    self.assertEqual(_lx_planning_size(), expected)
+
+    def test_rejects_invalid_backend_fraction(self):
+        for fraction in (-0.01, 1.01, float("nan")):
+            with self.subTest(fraction=fraction):
+                with config.patch({"dxp_lx_frac_avail": fraction}):
+                    with self.assertRaisesRegex(
+                        ValueError, "DXP_LX_FRAC_AVAIL must be >=0 and <=1"
+                    ):
+                        _lx_planning_size()
 
 
 def _two_gap_buffers():

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -65,6 +65,7 @@ from torch_spyre._inductor.scratchpad.passes import (
 )
 from torch_spyre._inductor.scratchpad.utils import (
     OP_OUTPUT_GOOD_FOR_LX_REUSE,
+    round_up_to_alignment,
     clone_at_graph_boundaries,
     mem_usage_by_buf,
     calculate_liveness,
@@ -84,6 +85,22 @@ from torch_spyre._inductor.logging_utils import get_inductor_logger
 from torch_spyre._inductor.pass_utils import _is_matmul_op
 
 logger = get_inductor_logger("scratchpad.allocator")
+
+# Keep these values synchronized with Deeptools' LX memory tracker:
+#
+# * ``SenSystemDef`` removes 64 KiB of the physical 2 MiB LX for program and
+#   debug data (``dsc/sysdef.cpp``).
+# * ``MemTrackBundle::initializeMemoryTrackers`` uses one 128-byte stick as the
+#   LX allocation granularity (``sharedtools/mem_track_bundle.cpp``).
+#
+# Torch and DXP independently consume ``DXP_LX_FRAC_AVAIL``.  These constants
+# define the fixed part of that cross-compiler ownership contract.
+_LX_PHYSICAL_CAPACITY_BYTES = 2 << 20
+_LX_PROGRAM_DEBUG_RESERVATION_BYTES = 64 << 10
+_LX_TRACKER_CAPACITY_BYTES = (
+    _LX_PHYSICAL_CAPACITY_BYTES - _LX_PROGRAM_DEBUG_RESERVATION_BYTES
+)
+_LX_ALLOCATION_GRANULARITY_BYTES = 128
 
 
 class ScratchpadAllocator:
@@ -507,19 +524,23 @@ def _op_short_name(op: Any) -> str:
 
 
 def _lx_planning_size() -> int:
-    """LX scratchpad bytes available to the layout solver.
+    """Return the frontend LX reservation, matching Deeptools exactly.
 
-    TEMPORARY GUARD: subtracts a 100KB safety margin from the frontend's
-    declared share. The backend compiler has been observed placing its own
-    internal LX allocations at a fixed address (~1587KB) inside the
-    frontend's nominal `dxp_lx_frac_avail` partition, silently corrupting
-    frontend data resident there once per-core usage gets close enough to
-    the partition boundary (see Issue 3222). This
-    margin keeps frontend buffers clear of that address until the backend
-    allocator itself is fixed to stay within its own reserved share.
+    The shared Torch/DXP contract partitions Deeptools' allocatable LX capacity,
+    not the physical 2 MiB.  The frontend reserves
+    ``1 - DXP_LX_FRAC_AVAIL`` from address zero, truncates the fractional byte
+    count to an integer, and rounds that reservation up to the memory tracker's
+    128-byte allocation granularity.  DXP marks that interval unavailable and
+    allocates at or above the returned exclusive upper bound.  This is the
+    ownership boundary whose mismatch was reported in torch-spyre issue #3222,
+    not a safety margin.
     """
-    lx_backend_spill_margin = 100 << 10
-    return int((2 << 20) * (1.0 - config.dxp_lx_frac_avail)) - lx_backend_spill_margin
+    backend_fraction = config.dxp_lx_frac_avail
+    if not 0.0 <= backend_fraction <= 1.0:
+        raise ValueError("DXP_LX_FRAC_AVAIL must be >=0 and <=1")
+
+    frontend_reservation = int(_LX_TRACKER_CAPACITY_BYTES * (1.0 - backend_fraction))
+    return round_up_to_alignment(frontend_reservation, _LX_ALLOCATION_GRANULARITY_BYTES)
 
 
 def _fixed_core_division(op: Operation) -> CoreDivision:

--- a/torch_spyre/_inductor/scratchpad/firstfit_bestfit_solver.py
+++ b/torch_spyre/_inductor/scratchpad/firstfit_bestfit_solver.py
@@ -22,16 +22,13 @@ from torch_spyre._inductor.scratchpad.plan_solver import (
     MemoryPlanSolver,
     _assert_in_place_relationships,
 )
+from torch_spyre._inductor.scratchpad.utils import round_up_to_alignment
 
 __all__ = [
     "FirstFitLayoutSolver",
     "BestFitLayoutSolver",
     "_assert_in_place_relationships",
 ]
-
-
-def round_up_to_alignment(arg: int, alignment: int) -> int:
-    return ((arg + alignment - 1) // alignment) * alignment
 
 
 @dataclass(frozen=True)

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -65,6 +65,10 @@ OP_OUTPUT_GOOD_FOR_LX_REUSE = frozenset(
 )
 
 
+def round_up_to_alignment(arg: int, alignment: int) -> int:
+    return ((arg + alignment - 1) // alignment) * alignment
+
+
 def clone_at_graph_boundaries() -> bool:
     """True when clone ops are eligible for LX, enabling clone insertion at graph
     input/output boundaries so those buffers can also be LX-pinned.


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Torch and DXP must agree on the exact LX ownership boundary. Torch currently estimates its available capacity using a hard-coded guard and may plan with a different fraction than the one passed to DXP. This can waste usable LX or cause the two allocators to disagree.
This PR calculates Torch’s budget from DXP’s actual usable LX capacity, applies the shared alignment rules, validates the configured fraction, and forwards that same value to DXP.

Fixes #3222

#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/issues/2787
https://github.com/torch-spyre/torch-spyre/issues/3049 
https://github.com/torch-spyre/torch-spyre/issues/3222
#3216 
#### Special notes for your reviewer:

This is part of a broader effort to size https://github.com/torch-spyre/torch-spyre/pull/2939 into several smaller PRs. 

#### Does this PR introduce a user-facing change?

#### Additional note:
