### PR TITLE
feat: consolidate physical core mapping policy

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_core_mapping_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_core_mapping_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [core, full]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_core_mapping.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -1,0 +1,169 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+import pytest
+import sympy
+
+import torch_spyre._inductor.codegen.superdsc as superdsc_module
+import torch_spyre._inductor.pass_utils as pass_utils_module
+from torch_spyre._C import DataFormats
+from torch_spyre._inductor.codegen.superdsc import parse_op_spec
+from torch_spyre._inductor.constants import (
+    BATCH_MATMUL_FP8_OP,
+    BATCH_MATMUL_OP,
+)
+from torch_spyre._inductor.core_mapping import core_to_slice_mapping
+from torch_spyre._inductor.op_spec import OpSpec, TensorArg
+
+
+def _coordinates(splits, num_cores, **kwargs):
+    dims = sympy.symbols(f"dim_0:{len(splits)}")
+    mapping = core_to_slice_mapping(dims, splits, num_cores, **kwargs)
+    core_id = sympy.Symbol("core_id")
+    return [
+        tuple(int(mapping[str(dim)].subs(core_id, core)) for dim in dims)
+        for core in range(num_cores)
+    ]
+
+
+def test_default_mapping_preserves_existing_core_order():
+    one_grid = [(0, 0), (1, 0), (0, 1), (1, 1), (0, 2), (1, 2)]
+    assert _coordinates((2, 3), 12) == one_grid * 2
+
+
+@pytest.mark.parametrize("contiguous_dim", [0, 1, 2])
+def test_selected_dim_varies_first(contiguous_dim):
+    splits = (2, 3, 4)
+    coordinates = _coordinates(
+        splits,
+        math.prod(splits),
+        contiguous_dim=contiguous_dim,
+    )
+    assert [
+        coordinate[contiguous_dim]
+        for coordinate in coordinates[: splits[contiguous_dim]]
+    ] == list(range(splits[contiguous_dim]))
+    assert all(
+        coordinate[dim] == 0
+        for coordinate in coordinates[: splits[contiguous_dim]]
+        for dim in range(len(splits))
+        if dim != contiguous_dim
+    )
+
+
+def _bmm_op_spec(op: str) -> OpSpec:
+    mb, out, reduction = sympy.symbols("mb out reduction")
+    args = [
+        TensorArg(
+            True,
+            0,
+            DataFormats.SEN169_FP16,
+            [512, 64, 1, 64],
+            [
+                mb,
+                sympy.floor(reduction / 64),
+                sympy.Integer(0),
+                sympy.Mod(reduction, 64),
+            ],
+            {"hbm": 0},
+        ),
+        TensorArg(
+            True,
+            1,
+            DataFormats.SEN169_FP16,
+            [200, 4096, 64],
+            [sympy.floor(out / 64), reduction, sympy.Mod(out, 64)],
+            {"hbm": 0x400000000},
+        ),
+        TensorArg(
+            False,
+            2,
+            DataFormats.SEN169_FP16,
+            [512, 200, 1, 64],
+            [
+                mb,
+                sympy.floor(out / 64),
+                sympy.Integer(0),
+                sympy.Mod(out, 64),
+            ],
+            {"hbm": 0x800000000},
+        ),
+    ]
+    return OpSpec(
+        op,
+        True,
+        {mb: (512, 2), out: (12800, 4), reduction: (4096, 4)},
+        args,
+        {},
+    )
+
+
+@pytest.mark.parametrize("op", [BATCH_MATMUL_OP, BATCH_MATMUL_FP8_OP])
+@pytest.mark.parametrize("reduction_contiguous", [False, True])
+def test_planner_and_sdsc_use_the_same_mapping(monkeypatch, op, reduction_contiguous):
+    class FakeReduction:
+        def __init__(self, reduction_type):
+            self.reduction_type = reduction_type
+
+    class FakeComputedBuffer:
+        def __init__(self, reduction_type):
+            self.data = FakeReduction(reduction_type)
+
+    monkeypatch.setattr(pass_utils_module, "Reduction", FakeReduction)
+    monkeypatch.setattr(pass_utils_module, "ComputedBuffer", FakeComputedBuffer)
+    monkeypatch.setattr(
+        pass_utils_module.config,
+        "core_id_k_fast_emission",
+        reduction_contiguous,
+    )
+    monkeypatch.setattr(
+        superdsc_module._spyre_config,
+        "core_id_k_fast_emission",
+        reduction_contiguous,
+    )
+
+    op_spec = _bmm_op_spec(op)
+    dims = tuple(op_spec.iteration_space)
+    splits = dict(zip(dims, (2, 4, 4)))
+    monkeypatch.setattr(
+        pass_utils_module, "apply_splits_from_index_coeff", lambda *_: splits
+    )
+    prep = pass_utils_module._ViewPrep(
+        iter_space=op_spec.iteration_space,
+        write_index=dims[0],
+        read_index=dims[-1],
+        dep_coeff={dims[0]: 1, dims[1]: 2, dims[2]: 0},
+        device_size=[2, 4],
+        stride_map=[1, 2],
+        elems_per_stick=64,
+        device_stride_to_dim={1: 0, 2: 1},
+        stick_host_stride=None,
+        num_stick_dim=None,
+        num_stick=0,
+        num_stick_stride=0,
+        is_matmul=pass_utils_module._is_matmul_op(FakeComputedBuffer(op)),
+    )
+    planner_view, _, representable = pass_utils_module._per_core_view_from_prep(
+        prep, ({1: 2, 2: 4}, {3: 4})
+    )
+
+    sdsc_spec, renamed = parse_op_spec(op_spec)
+    sdsc_output_mapping = {
+        device_dim: sdsc_spec.core_id_to_work_slice[str(renamed[dim])]
+        for device_dim, dim in enumerate(dims[:2])
+    }
+    assert representable
+    assert dict(planner_view.core_to_slot) == sdsc_output_mapping

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -16,7 +16,7 @@ import dataclasses
 import math
 from typing import Any
 from collections import Counter
-from sympy import Integer, Symbol, Expr, Mod, floor
+from sympy import Integer, Symbol, Expr
 
 from torch._inductor.virtualized import V
 from torch_spyre._C import DataFormats
@@ -27,10 +27,12 @@ from torch_spyre._inductor.constants import (
     LAYOUT_LABELS,
     MATMUL_DIM_LABELS,
     MATMUL_LAYOUT_LABELS,
+    MATMUL_REDUCTION_OPS,
     RESTICKIFY_OP,
     TOPK_OPS,
 )
 from torch_spyre._inductor import config as _spyre_config
+from torch_spyre._inductor.core_mapping import core_to_slice_mapping
 from torch_spyre._inductor.indirect_access import (
     compute_indirect_max_dim_sizes,
     get_index_tensor_for_value,
@@ -156,69 +158,6 @@ class SDSCSpec:
                 f"  constants=[{', '.join(f'{k}={v}' for k, v in self.constants.items())}]"
             )
         return "SDSCSpec(\n" + "\n".join(parts) + "\n)"
-
-
-def _get_core_to_slice_mapping(
-    iteration_space, dim_splits: dict[Symbol, int], num_cores: int
-) -> dict[Symbol, Expr]:
-    core_id_sym = Symbol("core_id")
-
-    dim_to_expr: dict[str, object] = {}
-    inner_product = Integer(1)
-
-    for dim in iteration_space:
-        if dim_splits[dim] == 1:
-            expr = Integer(0)
-        elif inner_product == Integer(1):
-            expr = Mod(core_id_sym, Integer(dim_splits[dim]))
-        else:
-            expr = Mod(floor(core_id_sym / inner_product), Integer(dim_splits[dim]))
-        dim_to_expr[str(dim)] = expr
-        inner_product = inner_product * Integer(dim_splits[dim])
-
-    return dim_to_expr
-
-
-def _k_fast_core_to_slice_mapping(
-    iteration_space, dim_splits: dict[Symbol, int], num_cores: int
-) -> dict[Symbol, Expr]:
-    """K-cohort-adjacent core-to-slice mapping for matmul.
-
-    Computed directly from the same `(iteration_space, dim_splits, num_cores)`
-    inputs as `_get_core_to_slice_mapping`, by treating the K (reduction) dim
-    as the innermost/fastest-varying axis along `core_id`. K-cohort members
-    (varying `i_k`, fixed `i_m, i_n`) then sit at adjacent physical core IDs,
-    so the PSUM ring reduction traverses 1 hop per output tile instead of
-    `m * n`.
-
-    Caller is responsible for the gating decision (matmul + k_fast flag + k>1).
-    """
-    dim_list = list(iteration_space.keys())
-    k_dim = dim_list[-1]
-    reordered = {k_dim: iteration_space[k_dim]}
-    for d in dim_list[:-1]:
-        reordered[d] = iteration_space[d]
-    return _get_core_to_slice_mapping(reordered, dim_splits, num_cores)
-
-
-def _should_use_k_fast_mapping(
-    is_matmul: bool, iteration_space, dim_splits: dict[Symbol, int]
-) -> bool:
-    """Decide whether the k_fast mapping should be used for this op.
-
-    Fires only when all three hold: this op is a matmul, the feature flag is
-    on, and the planner has chosen a K-split (k > 1). When k == 1 the k_fast
-    mapping is identical to the default, so we just use the default to keep
-    the code path explicit.
-    """
-    if not is_matmul:
-        return False
-    if not _spyre_config.core_id_k_fast_emission:
-        return False
-    dim_list = list(iteration_space.keys())
-    if len(dim_list) < 3:
-        return False
-    return dim_splits[dim_list[-1]] > 1
 
 
 # Pointwise ops whose *output* padding lanes are seeded to a deterministic value
@@ -382,7 +321,7 @@ def _get_padded_iteration_space(
 
 
 def _is_matmul(op: str) -> bool:
-    return op in ("matmul", "batchmatmul", "batchmatmulfp8")
+    return op in MATMUL_REDUCTION_OPS
 
 
 def _is_topk(op: str) -> bool:
@@ -922,14 +861,24 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
     if _is_topk(op_spec.op):
         num_inputs = 1  # topk has exactly 1 input tensor and 1 output tensor
 
-    if _should_use_k_fast_mapping(is_matmul, sdsc_iteration_space, dim_splits):
-        core_id_to_work_slice = _k_fast_core_to_slice_mapping(
-            sdsc_iteration_space, dim_splits, num_cores
-        )
-    else:
-        core_id_to_work_slice = _get_core_to_slice_mapping(
-            sdsc_iteration_space, dim_splits, num_cores
-        )
+    # Project dim_splits into final SDSC iteration-space order; normalization
+    # can add unit axes to either mapping independently.
+    mapping_dims = tuple(sdsc_iteration_space)
+    mapping_splits = tuple(int(dim_splits[dim]) for dim in mapping_dims)
+    # Generic reductions do not yet define the same physical cohort contract as
+    # matmul partial sums.
+    contiguous_dim = (
+        len(mapping_splits) - 1
+        if is_matmul and _spyre_config.core_id_k_fast_emission
+        else None
+    )
+    # TODO: Choose the mapping before LX planning and pass it through to codegen.
+    core_id_to_work_slice = core_to_slice_mapping(
+        mapping_dims,
+        mapping_splits,
+        num_cores,
+        contiguous_dim=contiguous_dim,
+    )
 
     # Collect index tensor indices for indirect access
     indirect_access_indices = [

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -18,6 +18,7 @@ BATCH_MATMUL_OP = "batchmatmul"
 IDENTITY_OP = "identity"
 RESTICKIFY_OP = "ReStickifyOpHBM"
 BATCH_MATMUL_FP8_OP = "batchmatmulfp8"
+MATMUL_REDUCTION_OPS = frozenset({BATCH_MATMUL_OP, BATCH_MATMUL_FP8_OP})
 
 # Reduction ops that cannot reduce along the stick dimension.
 # Native prod reduction is not currently available in the backend.

--- a/torch_spyre/_inductor/core_mapping.py
+++ b/torch_spyre/_inductor/core_mapping.py
@@ -1,0 +1,68 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Map a logical work division onto physical cores."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+from sympy import Expr, Integer, Mod, Symbol, floor
+
+
+def core_to_slice_mapping(
+    dims: Sequence[Symbol],
+    dim_splits: Sequence[int],
+    num_cores: int,
+    *,
+    contiguous_dim: int | None = None,
+) -> dict[str, Expr]:
+    """Return the logical work slice assigned to each physical core.
+
+    By default dimensions vary in iteration-space order. ``contiguous_dim``
+    moves one caller-selected dimension first so its participants are adjacent.
+    """
+
+    dims = tuple(dims)
+    splits = tuple(dim_splits)
+    if len(dims) != len(splits):
+        raise ValueError(f"dimension/split count differs: {len(dims)} != {len(splits)}")
+
+    logical_cores = math.prod(splits)
+    if num_cores < logical_cores or num_cores % logical_cores != 0:
+        raise ValueError(
+            "num_cores must be a multiple of the logical work split "
+            f"({logical_cores}), got {num_cores}"
+        )
+
+    dim_order = list(range(len(dims)))
+    if contiguous_dim is not None and splits[contiguous_dim] > 1:
+        dim_order.remove(contiguous_dim)
+        dim_order.insert(0, contiguous_dim)
+
+    core_id: Expr = Symbol("core_id")
+    stride = Integer(1)
+    result: dict[str, Expr] = {}
+    for dim in dim_order:
+        split = Integer(splits[dim])
+        if split == 1:
+            coordinate = Integer(0)
+        elif stride == 1:
+            coordinate = Mod(core_id, split)
+        else:
+            coordinate = Mod(floor(core_id / stride), split)
+        result[str(dims[dim])] = coordinate
+        stride *= split
+    return result

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -38,12 +38,8 @@ from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.op_spec import IndirectAccess
 
 from . import config
-from .codegen.superdsc import (
-    _get_core_to_slice_mapping,
-    _k_fast_core_to_slice_mapping,
-    _should_use_k_fast_mapping,
-)
-from .constants import BATCH_MATMUL_OP, ELIDED_COPY_BACK_ATTR
+from .core_mapping import core_to_slice_mapping
+from .constants import ELIDED_COPY_BACK_ATTR, MATMUL_REDUCTION_OPS
 from .ir import FixedTiledLayout, SpyreConstantFallback
 from .logging_utils import get_inductor_logger
 from .loop_info import copy_op_metadata
@@ -1362,12 +1358,12 @@ def _is_matmul_op(op: Operation) -> bool:
     return (
         isinstance(op, ComputedBuffer)
         and isinstance(op.data, Reduction)
-        and op.data.reduction_type == BATCH_MATMUL_OP
+        and op.data.reduction_type in MATMUL_REDUCTION_OPS
     )
 
 
-# TODO: refactor core assignment so the LX planner consumes determined
-# assignments instead of re-deriving them here.
+# TODO: Select and store the core mapping before LX planning, then pass the
+# winning mapping to codegen.
 class _ViewPrep(NamedTuple):
     """Candidate-invariant precompute shared across every core-division
     candidate of one ``(op, dep, buf_name)``.
@@ -1578,16 +1574,23 @@ def _per_core_view_from_prep(
         work_slice_dims[dev_dim] = split
         sym_to_device_dim[sym] = dev_dim
 
-    # Step 3: build the core→slot mapping using the same gate codegen uses
-    # (_should_use_k_fast_mapping), so K-fast matmul ops compare under the
-    # K-cohort-adjacent ordering they will actually emit.
+    # Step 4: model the same physical ownership SDSC will emit. LX compatibility
+    # requires producer and consumer to assign each slice to the same physical
+    # core; matching split factors alone is insufficient.
     num_cores = int(math.prod(per_sym.values()))
-    is_matmul = prep.is_matmul
-    if _should_use_k_fast_mapping(is_matmul, iter_space, per_sym):
-        _mapping_func = _k_fast_core_to_slice_mapping
-    else:
-        _mapping_func = _get_core_to_slice_mapping
-    core_to_slot_by_name = _mapping_func(iter_space, per_sym, num_cores)
+    iter_symbols = tuple(iter_space)
+    dim_splits = tuple(int(per_sym[sym]) for sym in iter_symbols)
+    contiguous_dim = (
+        len(dim_splits) - 1
+        if prep.is_matmul and config.core_id_k_fast_emission
+        else None
+    )
+    core_to_slot_by_name = core_to_slice_mapping(
+        iter_symbols,
+        dim_splits,
+        num_cores,
+        contiguous_dim=contiguous_dim,
+    )
     # Re-key by the buffer's device-dim index (canonical) instead of the op's
     # iter symbol name. Two ops with the same per-core slicing on this buffer
     # compare equal even if they name their iter axes differently.


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Centralizes physical core mapping so scratchpad planning and SDSC codegen use the same implementation. It preserves the existing default mapping, adds FP8 matmul coverage, and lets a caller select the exact logical dimension whose participants should occupy adjacent cores.

The mapping helper moves only that caller-selected dimension; it does not infer a group dimension by reversing the iteration space.

#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/issues/2787
https://github.com/torch-spyre/torch-spyre/issues/3049

#### Special notes for your reviewer:

This is part of splitting https://github.com/torch-spyre/torch-spyre/pull/2939 into smaller PRs. PR #2939 supplies its all-gather dimension explicitly on top of this generic mapping API.

#### Does this PR introduce a user-facing change?

No.

#### Additional note:
