### PR TITLE
fix(test framework): Fix OOT classifier to gate CPU-only parametrize-only test classes via TorchTestBase, resolving mkldnn pattern matcher s390x failures

### DIFF
--- a/tests/configs/upstream_tests_beta/inductor-test_mkldnn_pattern_matcher.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_mkldnn_pattern_matcher.yaml
@@ -4,12 +4,6 @@ test_suite_config:
     - path: ${TORCH_ROOT}/test/inductor/test_mkldnn_pattern_matcher.py
       unlisted_test_mode: skip
       tests:
-        # These tests exercise the `conv2d` and `add` operations, focusing on tensor manipulations and scalar additions.
-        # They are classified as `mandatory_success` due to the critical nature of these operations in neural network computations.
-        # The relevance is high as these operations are fully supported by Spyre's capabilities, ensuring accurate and efficient tensor processing.
-        - names:
-            - TestPatternMatcher::test_conv2d_add_scalar
-          mode: mandatory_success
         # These tests exercise various convolution and transpose operations with dynamic shapes and broadcasting.
         # They are classified as xfail due to unsupported stick expressions and coordinate normalization errors.
         # The relevant Spyre limitations include unsupported stick expressions and complex coordinate normalization.
@@ -36,6 +30,7 @@ test_suite_config:
             - TestDynamicPatternMatcher::test_linear_unary
             - TestDynamicPatternMatcher::test_linear_unary_dynamic_shapes
             - TestDynamicPatternMatcherGeneric::test_multi_linear_share_same_input_dynamic
+            - TestPatternMatcher::test_conv2d_add_scalar
             - TestPatternMatcher::test_conv2d_binary
             - TestPatternMatcher::test_conv2d_binary_fusion_failed
             - TestPatternMatcher::test_conv2d_binary_inplace_fusion_failed_cpu

--- a/tests/oot_framework/run_test.sh
+++ b/tests/oot_framework/run_test.sh
@@ -705,6 +705,20 @@ def analyze(path):
     # can gate them via the YAML config, AND need cleanup so the raw star-imported
     # instance is not collected by pytest as a plain TestCase.
     class_level_parametrized_mixed = set()
+    # is_upstream/is_oot for THIS file, computed once up front (reused below).
+    import os as _os
+    _torch_root = _os.environ.get("TORCH_ROOT", "")
+    _torch_device_root = _os.environ.get("TORCH_DEVICE_ROOT", "")
+    _is_upstream_file = bool(
+        _torch_root
+        and _os.path.abspath(path).startswith(_os.path.abspath(_torch_root))
+    )
+    _is_oot_file = bool(
+        _torch_device_root
+        and _os.path.abspath(path).startswith(_os.path.abspath(_torch_device_root))
+    )
+    _apply_transitive_closure = _is_upstream_file and not _is_oot_file
+
     # Transitive closure: a class counts as a TestCase subclass if any of its
     # bases (directly or transitively, through locally-defined intermediate
     # classes) is TestCase-like. This catches chains like
@@ -713,18 +727,33 @@ def analyze(path):
     # test_mkldnn_pattern_matcher.py, whose base name does not literally end
     # in "TestBase" and was previously invisible to this scan entirely
     # (see issue #3188).
+    #
+    # Scoped to upstream-only files: OOT-native files under TORCH_DEVICE_ROOT
+    # commonly use non-"TestCase"/"TestBase"-named helper base classes on
+    # purpose for classes that already hand-roll direct Spyre-device testing
+    # without any instantiate_device_type_tests() dispatch (e.g.
+    # BaseTestScratchpadUsage in test_scratchpad_use.py). Making those newly
+    # "visible" here sweeps them into needs_injection/uncontrolled below, and
+    # instantiate_device_type_tests() rebuilding them via multiple inheritance
+    # silently changes their setUp()/MRO — verified this regressed
+    # test_scratchpad_use.py from 109 passed (main) to 39 failed when the
+    # transitive check was applied unconditionally. So for non-upstream files
+    # we keep the original direct-only check.
     _local_bases = {}
-    for _n in ast.iter_child_nodes(tree):
-        if isinstance(_n, ast.ClassDef):
-            _names = []
-            for _b in _n.bases:
-                if isinstance(_b, ast.Name):        _names.append(_b.id)
-                elif isinstance(_b, ast.Attribute): _names.append(_b.attr)
-            _local_bases[_n.name] = _names
+    if _apply_transitive_closure:
+        for _n in ast.iter_child_nodes(tree):
+            if isinstance(_n, ast.ClassDef):
+                _names = []
+                for _b in _n.bases:
+                    if isinstance(_b, ast.Name):        _names.append(_b.id)
+                    elif isinstance(_b, ast.Attribute): _names.append(_b.attr)
+                _local_bases[_n.name] = _names
 
     def _is_testcase_like(name, _seen=None):
         if "TestCase" in name or name.endswith("TestBase"):
             return True
+        if not _apply_transitive_closure:
+            return False
         _seen = _seen or set()
         if name in _seen:
             return False
@@ -839,33 +868,19 @@ def analyze(path):
                     #
                     # Scope this correction to transitive_only_classes: classes
                     # that are only newly visible to this analyzer via the
-                    # transitive-closure TestCase check above. Long-established
-                    # directly-visible classes using this same standalone-call
-                    # pattern (e.g. TestConvolutionNN in test_convolution.py,
-                    # TestLRScheduler in test_lrscheduler.py) keep their prior
-                    # "fully handled" classification unchanged, since other YAML
-                    # suites already depend on that behavior and default to
-                    # unlisted_test_mode: skip — reclassifying them here would
-                    # silently drop coverage for tests not explicitly listed in
-                    # those unrelated configs.
+                    # transitive-closure TestCase check above (itself already
+                    # scoped to upstream-only files via _apply_transitive_closure).
+                    # Long-established directly-visible classes using this same
+                    # standalone-call pattern (e.g. TestConvolutionNN in
+                    # test_convolution.py, TestLRScheduler in
+                    # test_lrscheduler.py) keep their prior "fully handled"
+                    # classification unchanged, since other YAML suites already
+                    # depend on that behavior and default to unlisted_test_mode:
+                    # skip — reclassifying them here would silently drop
+                    # coverage for tests not explicitly listed in those
+                    # unrelated configs.
                     if cls_name in transitive_only_classes:
-                        import os as _os
-                        torch_root = _os.environ.get("TORCH_ROOT", "")
-                        torch_device_root = _os.environ.get("TORCH_DEVICE_ROOT", "")
-                        is_upstream = (
-                            torch_root
-                            and _os.path.abspath(path).startswith(
-                                _os.path.abspath(torch_root)
-                            )
-                        )
-                        is_oot = (
-                            torch_device_root
-                            and _os.path.abspath(path).startswith(
-                                _os.path.abspath(torch_device_root)
-                            )
-                        )
-                        if is_upstream and not is_oot:
-                            continue  # leave out of parametrized_instantiated -> uncontrolled
+                        continue  # leave out of parametrized_instantiated -> uncontrolled
                     parametrized_instantiated.add(cls_name)
     # A class that appears in BOTH open and restricted sets (e.g. the file
     # calls instantiate_device_type_tests twice for the same class, once with

--- a/tests/oot_framework/run_test.sh
+++ b/tests/oot_framework/run_test.sh
@@ -705,13 +705,52 @@ def analyze(path):
     # can gate them via the YAML config, AND need cleanup so the raw star-imported
     # instance is not collected by pytest as a plain TestCase.
     class_level_parametrized_mixed = set()
+    # Transitive closure: a class counts as a TestCase subclass if any of its
+    # bases (directly or transitively, through locally-defined intermediate
+    # classes) is TestCase-like. This catches chains like
+    # `class FooBase(TestCase)` -> `class Foo(FooBase)` regardless of naming,
+    # e.g. TestPatternMatcher(TestPatternMatcherBase) in
+    # test_mkldnn_pattern_matcher.py, whose base name does not literally end
+    # in "TestBase" and was previously invisible to this scan entirely
+    # (see issue #3188).
+    _local_bases = {}
+    for _n in ast.iter_child_nodes(tree):
+        if isinstance(_n, ast.ClassDef):
+            _names = []
+            for _b in _n.bases:
+                if isinstance(_b, ast.Name):        _names.append(_b.id)
+                elif isinstance(_b, ast.Attribute): _names.append(_b.attr)
+            _local_bases[_n.name] = _names
+
+    def _is_testcase_like(name, _seen=None):
+        if "TestCase" in name or name.endswith("TestBase"):
+            return True
+        _seen = _seen or set()
+        if name in _seen:
+            return False
+        _seen.add(name)
+        return any(_is_testcase_like(_b, _seen) for _b in _local_bases.get(name, []))
+
+    # Classes whose TestCase-ness is established ONLY via the transitive
+    # closure above (their immediate base name does not itself contain
+    # "TestCase" / end in "TestBase") — e.g. TestPatternMatcher, whose direct
+    # base "TestPatternMatcherBase" does not match the direct check. These are
+    # newly-visible classes (see issue #3188) and are treated more carefully
+    # below when classifying standalone instantiate_parametrized_tests() calls,
+    # since long-established directly-visible classes (e.g. TestConvolutionNN
+    # in test_convolution.py, based directly on NNTestCase) must keep their
+    # existing classification to avoid changing behavior for unrelated suites.
+    transitive_only_classes = set()
+
     for node in ast.iter_child_nodes(tree):
         if isinstance(node, ast.ClassDef):
             for base in node.bases:
                 base_name = ""
                 if isinstance(base, ast.Name):        base_name = base.id
                 elif isinstance(base, ast.Attribute): base_name = base.attr
-                if "TestCase" in base_name or base_name.endswith("TestBase"):
+                if _is_testcase_like(base_name):
+                    if not ("TestCase" in base_name or base_name.endswith("TestBase")):
+                        transitive_only_classes.add(node.name)
                     has_device, all_parametrized, _ = class_methods_info(node, parametrize_names)
                     all_classes[node.name] = has_device
                     # Check for @instantiate_parametrized_tests as a class decorator.
@@ -787,7 +826,47 @@ def analyze(path):
             elif fname == "instantiate_parametrized_tests" and node.args:
                 arg = node.args[0]
                 if isinstance(arg, ast.Name):
-                    parametrized_instantiated.add(arg.id)
+                    cls_name = arg.id
+                    # Standalone-call form only expands @parametrize methods; it
+                    # says nothing about per-device dispatch. Treating it alone as
+                    # "fully handled" leaves upstream classes that are NEVER also
+                    # passed to instantiate_device_type_tests() completely
+                    # unwrapped, so TorchTestBase never sees them and YAML
+                    # mode:skip/xfail entries are silently ignored (see issue
+                    # #3188: TestPatternMatcher in test_mkldnn_pattern_matcher.py
+                    # hardcodes device="cpu" and is only ever passed to
+                    # instantiate_parametrized_tests()).
+                    #
+                    # Scope this correction to transitive_only_classes: classes
+                    # that are only newly visible to this analyzer via the
+                    # transitive-closure TestCase check above. Long-established
+                    # directly-visible classes using this same standalone-call
+                    # pattern (e.g. TestConvolutionNN in test_convolution.py,
+                    # TestLRScheduler in test_lrscheduler.py) keep their prior
+                    # "fully handled" classification unchanged, since other YAML
+                    # suites already depend on that behavior and default to
+                    # unlisted_test_mode: skip — reclassifying them here would
+                    # silently drop coverage for tests not explicitly listed in
+                    # those unrelated configs.
+                    if cls_name in transitive_only_classes:
+                        import os as _os
+                        torch_root = _os.environ.get("TORCH_ROOT", "")
+                        torch_device_root = _os.environ.get("TORCH_DEVICE_ROOT", "")
+                        is_upstream = (
+                            torch_root
+                            and _os.path.abspath(path).startswith(
+                                _os.path.abspath(torch_root)
+                            )
+                        )
+                        is_oot = (
+                            torch_device_root
+                            and _os.path.abspath(path).startswith(
+                                _os.path.abspath(torch_device_root)
+                            )
+                        )
+                        if is_upstream and not is_oot:
+                            continue  # leave out of parametrized_instantiated -> uncontrolled
+                    parametrized_instantiated.add(cls_name)
     # A class that appears in BOTH open and restricted sets (e.g. the file
     # calls instantiate_device_type_tests twice for the same class, once with
     # only_for and once without) is treated as open: the open call already


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup



####  Summary

Fixes #3188 — `inductor-test_mkldnn_pattern_matcher.yaml` failed on s390x but passed on x86.

### Root cause

`TestPatternMatcher` / `TestDynamicPatternMatcher` in upstream's `test_mkldnn_pattern_matcher.py` are plain CPU-only classes (hardcoded `device="cpu"`, some methods take no `device` param at all). They are never passed to `instantiate_device_type_tests()` — only to the standalone `instantiate_parametrized_tests(TestPatternMatcher)` call.

The OOT classifier in `run_test.sh` treated any class reached via `instantiate_parametrized_tests()` as "fully handled," so these classes were never injected into `TorchTestBase`. That means our YAML `mode:` entries for them were silently ignored, and the raw upstream test bodies always ran directly, unconditionally, against the host CPU.

Those bodies assert on x86-specific oneDNN/MKLDNN fusion output (e.g. `mkldnn._convolution_pointwise` appearing in generated C++, or `torch.ops.mkldnn._is_mkldnn_bf16_supported()`), which has nothing to do with Spyre — Spyre uses its own LX/stick-based codegen, not CPU oneDNN fusion.

- **On x86**, the host CPU's real oneDNN supports these fusions, so the ungated test bodies happened to pass — a false positive, since none of it exercised the Spyre backend.
- **On s390x**, oneDNN doesn't register the same x86-specific fused ops, so the identical ungated bodies genuinely failed (`AttributeError: ..._is_mkldnn_bf16_supported`, fusion counts of 0, etc.) — also unrelated to Spyre correctness, just a difference in host CPU capability.

Net effect: the suite was silently testing host-CPU oneDNN behavior instead of the Spyre `privateuse1` device, and the two host architectures disagreed because their CPUs differ, not because of anything torch-spyre does.

###  Fix

`run_test.sh`'s AST classifier now properly routes these classes through `instantiate_device_type_tests()` so `TorchTestBase` — and therefore our YAML `mode:` config — actually governs them, the same as every other test class in the suite. The fix is scoped to classes only newly discovered via the transitive base-class check (e.g. `TestPatternMatcher(TestPatternMatcherBase)`), so it does not change behavior for other upstream suites that rely on the prior classification (verified via A/B run of `optim-test_lrscheduler.yaml`: 190 passed, unchanged).

## Why `mode: skip`, not `mandatory_success`

Once properly gated, these tests would run against `device="privateuse1"` instead of `"cpu"`. But their assertions are inherently CPU/oneDNN-specific — they check for MKLDNN fusion ops or oneDNN capability flags that only exist in the CPU Inductor backend and have no Spyre equivalent. There's no meaningful "pass" condition for them on Spyre: they don't exercise any Spyre-specific code path, so keeping them as `mandatory_success` (or even `xfail`) would just track an assertion that will never be true, for the wrong reason. `mode: skip` correctly reflects "not applicable to this device," which is the accurate status regardless of host architecture — the same result on x86 and s390x.

(Note: this framework deletes `mode: skip` test methods from the generated class entirely rather than reporting them as `SKIPPED`, to avoid skip-spam in CI reports — so these 18 tests no longer appear in results at all, by existing design, not as a side effect of this fix.)

## Verification

```bash
cd tests/configs/upstream_tests_beta
../../run_test.sh inductor-test_mkldnn_pattern_matcher.yaml
```

Before: `13 failed, 3 passed, 13 skipped, 1 xfailed` (mixed failures)
After: `10 xfailed` (exit code 0) — the pre-existing, correctly-gated `TestPatternMatcherGeneric` / `TestDynamicPatternMatcherGeneric` xfail entries, unchanged.



#### Which issue(s) this PR is related to:

Fixes https://github.com/torch-spyre/torch-spyre/issues/3188
