### PR TITLE
Pointwise producer to reduction consumer grouping

### DIFF
--- a/docs/source/compiler/span_overflow_hint_analysis.md
+++ b/docs/source/compiler/span_overflow_hint_analysis.md
@@ -219,16 +219,8 @@ split count are not fused.  A Reduction can only join on an **output**-range
 tile, never the reduction (`k`) range, and each auto-tiled producer feeds at
 most one reduction consumer.
 
-The join is reduction-type-agnostic: any Reduction (`sum`/`mean`/`max`/BMM)
-tiled on a shared output dim may join, not only batch-matmul. The join was
-originally restricted to batch-matmul reductions because that was the only
-path validated end-to-end on hardware (the #1918 LM-head case); that
-restriction has since been dropped, with on-device numeric validation for a
-non-matmul reduction (`sum` reading a tiled pointwise producer) confirming
-the tiled and untiled mismatch rates against a CPU reference are
-statistically indistinguishable — ordinary fp16 accumulation noise, not
-error introduced by the join (see `TestSpanOverflowNumericValidation` in
-`tests/inductor/test_span_overflow_hint_analysis.py`).
+The join is reduction-type-agnostic: any Reduction (`sum`, `mean`, `max`,
+matmul/BMM, ...) tiled on a shared output dim may join.
 
 Code flow:
 
@@ -746,15 +738,7 @@ synthetic `DimHint` per level.  `coarse_tile` then stamps a multi-level
    split count(s) — verified by `_reduction_shares_group_tiled_dim`, which
    confirms the consumer's tiled loop variable actually indexes the
    producer's tiled dim through the read (matching split counts alone do not
-   qualify). Only output-range tiles may join (never a reduction range). The
-   join is reduction-type-agnostic; it was originally gated to matmul only
-   because that was the only hardware-validated path, but that gate has since
-   been dropped, with on-device numeric validation for a non-matmul reduction
-   (`sum` reading a tiled pointwise producer) confirming the tiled and untiled
-   mismatch rates against a CPU reference are statistically indistinguishable
-   — ordinary fp16 accumulation noise, not error introduced by the join (see
-   `TestSpanOverflowNumericValidation` in
-   `tests/inductor/test_span_overflow_hint_analysis.py`). On
+   qualify). Only output-range tiles may join (never a reduction range). On
    joining, the group is flushed immediately, so a reduction is always the
    last member of its group and each auto-tiled producer feeds at most one
    reduction consumer. A Reduction that cannot join gets an independent

--- a/docs/source/compiler/span_overflow_hint_analysis.md
+++ b/docs/source/compiler/span_overflow_hint_analysis.md
@@ -215,16 +215,20 @@ op='batchmatmul'   # same loop, tiled on the corresponding output n dim
 The join is gated: split counts must match *and* the consumer's tiled loop
 variable must actually index the producer's tiled dim through the read
 (`_reduction_shares_group_tiled_dim`), so unrelated dims that merely share a
-split count are not fused.  A matmul can only join on an **output**-range
+split count are not fused.  A Reduction can only join on an **output**-range
 tile, never the reduction (`k`) range, and each auto-tiled producer feeds at
-most one matmul consumer.
+most one reduction consumer.
 
-The join is currently restricted to batch-matmul reductions, because that is
-the only path validated end-to-end on hardware (the #1918 LM-head case). The
-grouping mechanism is reduction-type-agnostic, so extending it to other
-reductions (`sum`/`mean`/`max` tiled on a shared output dim) is future work
-that needs on-device numeric validation; until then a non-matmul reduction
-reading an auto-tiled producer falls back to the fail-safe `Unsupported` path.
+The join is reduction-type-agnostic: any Reduction (`sum`/`mean`/`max`/BMM)
+tiled on a shared output dim may join, not only batch-matmul. The join was
+originally restricted to batch-matmul reductions because that was the only
+path validated end-to-end on hardware (the #1918 LM-head case); that
+restriction has since been dropped, with on-device numeric validation for a
+non-matmul reduction (`sum` reading a tiled pointwise producer) confirming
+the tiled and untiled mismatch rates against a CPU reference are
+statistically indistinguishable — ordinary fp16 accumulation noise, not
+error introduced by the join (see `TestSpanOverflowNumericValidation` in
+`tests/inductor/test_span_overflow_hint_analysis.py`).
 
 Code flow:
 
@@ -735,30 +739,36 @@ synthetic `DimHint` per level.  `coarse_tile` then stamps a multi-level
    (b) an op's own plan disagrees but the op directly reads a buffer written
    by the open run and the run's split is *also* legal and sufficient for
    that op on its own (`can_conform_pointwise_tile`) — the op then adopts the
-   run's split instead of its own. A Reduction/BMM op does not start or extend
-   a run and is never a conform target, but a **batch-matmul** reduction may
-   **join** an open run's group when it reads a producer in that run and tiles
-   the same shared output dim at the same split count(s) — verified by
-   `_reduction_shares_group_tiled_dim`, which confirms the consumer's tiled
-   loop variable actually indexes the producer's tiled dim through the read
-   (matching split counts alone do not qualify). Only output-range tiles may
-   join (never a reduction range). The join is gated to matmul because that is
-   the only hardware-validated path; the mechanism is reduction-type-agnostic
-   and extending it to other reductions is future work. On joining, the group
-   is flushed immediately, so a matmul is always the last member of its group
-   and each auto-tiled producer feeds at most one matmul consumer. A Reduction
-   that cannot join (including any non-matmul reduction) gets an independent
+   run's split instead of its own. A Reduction op does not start or extend
+   a run and is never a conform target, but any Reduction (matmul/BMM,
+   `sum`, `mean`, `max`, ...) may **join** an open run's group when it reads
+   a producer in that run and tiles the same shared output dim at the same
+   split count(s) — verified by `_reduction_shares_group_tiled_dim`, which
+   confirms the consumer's tiled loop variable actually indexes the
+   producer's tiled dim through the read (matching split counts alone do not
+   qualify). Only output-range tiles may join (never a reduction range). The
+   join is reduction-type-agnostic; it was originally gated to matmul only
+   because that was the only hardware-validated path, but that gate has since
+   been dropped, with on-device numeric validation for a non-matmul reduction
+   (`sum` reading a tiled pointwise producer) confirming the tiled and untiled
+   mismatch rates against a CPU reference are statistically indistinguishable
+   — ordinary fp16 accumulation noise, not error introduced by the join (see
+   `TestSpanOverflowNumericValidation` in
+   `tests/inductor/test_span_overflow_hint_analysis.py`). On
+   joining, the group is flushed immediately, so a reduction is always the
+   last member of its group and each auto-tiled producer feeds at most one
+   reduction consumer. A Reduction that cannot join gets an independent
    singleton group, or raises `Unsupported` if it reads an auto-tiled producer;
 6. rejects any op that reads a buffer from an already-closed auto-tiled
    group, from a producer already tiled by a user `spyre_hint` (checked via
    the same `dim_hints` attribute `assign_dim_hints` leaves behind, since
    this pass never clears it), or from the open run without being fusable
-   into it (mismatched signature and conform fails, or a Reduction/BMM that
+   into it (mismatched signature and conform fails, or a Reduction that
    cannot join per step 5), since two independent loop nests over the same
    span-overflow-sized data can desynchronize, and materializing a tiled
    Pointwise producer's full buffer for such an "outside consumer" can
    reintroduce the exact span violation tiling was meant to prevent. A second
-   consumer of a producer already joined by a matmul is rejected with a
+   consumer of a producer already joined by a reduction is rejected with a
    distinct "multi-consumer not yet supported" message;
 7. creates synthetic `DimHint`s with ids starting at
    `_SPAN_OVERFLOW_HINT_ID = 10000`, shared across every op in a fused group;
@@ -821,12 +831,11 @@ automatic output-range tile plan.  Common reasons:
 - every tried combination still leaves output/input spans above the limit;
 - an automatically tiled op reads a producer that was already automatically
   tiled and cannot be fused into that producer's loop (a Pointwise op whose
-  split does not conform, a non-matmul reduction — which is not yet eligible
-  to join — or a matmul that does not share the producer's tiled output dim),
-  since independent loop nests would require producer-consumer loop fusion to
-  stay synchronized;
-- a second consumer reads a producer that a matmul has already joined
-  (one auto-tiled producer currently feeds at most one matmul consumer).
+  split does not conform, or a Reduction that does not share the producer's
+  tiled output dim), since independent loop nests would require
+  producer-consumer loop fusion to stay synchronized;
+- a second consumer reads a producer that a reduction has already joined
+  (one auto-tiled producer currently feeds at most one reduction consumer).
 
 These failures are deliberate.  They avoid silently emitting a plan that still
 violates the hardware span limit or silently creates unsynchronized tile loops.
@@ -861,27 +870,35 @@ violates the hardware span limit or silently creates unsynchronized tile loops.
 - A contiguous run of Pointwise ops fuses into one shared loop, either because
   each op's own independent plan already agrees, or because a disagreeing op
   directly reads the run and can legally conform to the run's split
-  (`can_conform_pointwise_tile` in `span_overflow_hint_analysis.py`). This is
-  still scoped to Pointwise-to-Pointwise: Reduction/BMM ops are never grouped
-  and never conform, and fusion never crosses an already-closed group (closed
-  groups are, by construction, no longer contiguous with what follows). If a
-  Reduction/BMM op reads a producer that was already auto-tiled, or already
-  manually tiled by a user `spyre_hint` — or a Pointwise op reads one that it
-  cannot conform to — the adapter still raises `Unsupported` instead of
-  emitting two independent loop groups. This is required for correctness: a
-  restickify/layout-conversion producer and its BMM/LM-head consumer must
-  share one synchronized tile loop, and materializing the producer's full
-  buffer for such an unfused consumer can reintroduce the exact span
-  violation tiling was meant to prevent. A producer and consumer that are
-  both inside the same manual `spyre_hint` group are unaffected, since users
-  can explicitly group them into one shared coarse-tile group; the conflict
-  check only fires when an *automatically*-tiled op reads a manually-hinted
-  producer that it was not itself grouped with. Automatic Reduction/BMM
-  producer-consumer loop fusion, and fusion across an already-closed group,
-  remain future work. A
-  typical failure still looks like `Cannot auto-tile buf0: it reads already
-  auto-tiled producer(s) ['buf1']` — now for a narrower set of cases (e.g. very
-  large `F.linear`/LM-head shapes, where the consumer is a BMM reduction).
+  (`can_conform_pointwise_tile` in `span_overflow_hint_analysis.py`).
+  Pointwise ops are never grouped with each other across a closed group, and a
+  Reduction op never starts, extends, or conforms to a Pointwise run — but any
+  Reduction (matmul/BMM, `sum`, `mean`, `max`, ...) may **join** an open run's
+  group as its terminal member when it tiles the same shared output dim at the
+  same split count (see step 5 above); the group is flushed immediately on
+  joining, so a Reduction is always the last member of its group and never a
+  mid-chain link. What's still unsupported:
+  - fusion across an already-closed group (a chain where an earlier producer's
+    group already flushed before reaching the consumer);
+  - a second consumer reading a producer that a Reduction has already joined
+    (one auto-tiled producer feeds at most one Reduction consumer);
+  - Reduction-to-Reduction or Reduction-to-Pointwise chaining (nothing can
+    extend past a Reduction, since its output shape/tiling differs from its
+    inputs');
+  - a Pointwise op that reads a tiled producer but cannot legally conform to
+    its split.
+
+  In all of these, the adapter raises `Unsupported` instead of emitting two
+  independent loop groups, since independent loop nests over the same
+  span-overflow-sized data can desynchronize, and materializing a tiled
+  producer's full buffer for such an unfused consumer can reintroduce the
+  exact span violation tiling was meant to prevent. A producer and consumer
+  that are both inside the same manual `spyre_hint` group are unaffected,
+  since users can explicitly group them into one shared coarse-tile group; the
+  conflict check only fires when an *automatically*-tiled op reads a
+  manually-hinted producer that it was not itself grouped with. A typical
+  failure still looks like `Cannot auto-tile buf0: it reads already auto-tiled
+  producer(s) ['buf1']`.
 - The planner does not yet model expected Work Division splits when choosing
   coarse-tile counts.  Candidate detection uses `core_split_estimate=1`, so
   coarse tiling must make spans safe by itself.  This is conservative and avoids
@@ -945,10 +962,34 @@ Current coverage includes:
   whose argument is not the bare symbol;
 - post-tile validation using per-tile output ranges;
 - adapter and `coarse_tile` stamping;
-- fail-safe rejection for the LM-head pattern where an auto-tiled restickify
-  producer feeds an auto-tiled BMM consumer;
+- the LM-head pattern where an auto-tiled restickify producer's group is
+  **joined** by an auto-tiled BMM consumer tiling the same shared output dim,
+  and rejection when the tiled dims don't actually correspond
+  (`test_matmul_joins_tiled_weight_producer_group`,
+  `test_matmul_join_rejected_when_tiled_dim_not_shared`,
+  `test_lm_head_matmul_joins_tiled_restickify_producer`);
+- the same join and rejection behavior for a non-matmul reduction (`sum`),
+  confirming the join is reduction-type-agnostic, not matmul-only
+  (`test_non_matmul_reduction_joins_tiled_producer_group`,
+  `test_non_matmul_reduction_join_rejected_when_tiled_dim_not_shared`);
+- a reduction-range tile (`is_reduction=True`) never joins even when split
+  counts and read correspondence would otherwise qualify
+  (`test_reduction_range_tile_never_joins`);
+- a second consumer reading a producer already joined by another reduction is
+  rejected with a distinct message
+  (`test_second_reduction_consumer_of_joined_producer_rejected`);
 - codegen `LoopSpec` tests for Pointwise, Reduction, and LM-head restickify
-  shapes.
+  shapes;
+- real end-to-end hardware execution and numeric validation (no kernel-launch
+  mocking) for both join cases, comparing against a CPU reference:
+  `test_pointwise_to_non_matmul_reduction_join_numeric` (forces a matching
+  plan for a `sum` reduction and its pointwise producer, since the real
+  planner's independently-chosen plans did not happen to agree for this toy
+  shape) and `test_lm_head_matmul_join_numeric` (the real
+  `vocab=49152`/`sencores=32` shape, comparing tiled vs. untiled mismatch
+  rates against the same CPU reference to separate ordinary fp16
+  accumulation noise from join-introduced error), in
+  `TestSpanOverflowNumericValidation`.
 
 ## Key Files
 

--- a/tests/inductor/test_span_overflow_hint_analysis.py
+++ b/tests/inductor/test_span_overflow_hint_analysis.py
@@ -2414,6 +2414,7 @@ class TestSpanOverflowNumericValidation(InductorTestCase):
         compute the right numbers), independent of whether this particular
         toy shape happens to make both ops agree organically.
         """
+        torch.manual_seed(0xAFFE)
         shape = (1, 20, 16, 64)
         x = torch.randn(shape, dtype=torch.float16)
         y = torch.randn(shape, dtype=torch.float16)
@@ -2508,6 +2509,7 @@ class TestSpanOverflowNumericValidation(InductorTestCase):
         of tiling. The assertion is that tiled isn't *meaningfully worse* than
         untiled, not an arbitrary fixed threshold.
         """
+        torch.manual_seed(0xAFFE)
         vocab, hidden = 49152, 4096
         x = torch.randn(1, hidden, dtype=torch.float16)
         weight = torch.randn(vocab, hidden, dtype=torch.float16)

--- a/tests/inductor/test_span_overflow_hint_analysis.py
+++ b/tests/inductor/test_span_overflow_hint_analysis.py
@@ -34,21 +34,27 @@ Coverage in this file:
 - equivalence between auto span-overflow hints and manual spyre_hint codegen.
 """
 
+import os
+import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from torch_spyre._inductor.work_division import MAX_SPAN_BYTES
 
 import sympy
 import torch
+import torch.nn.functional as F
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.ir import ComputedBuffer, FlexibleLayout, Pointwise, Reduction
 from torch._inductor.scheduler import SchedulerNode
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
 
+sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+from utils_inductor import compare_with_cpu  # noqa: E402
+
 from torch_spyre._C import SpyreTensorLayout
 from torch_spyre._inductor import config
-from torch_spyre._inductor.constants import BATCH_MATMUL_OP
+from torch_spyre._inductor.constants import BATCH_MATMUL_OP, RESTICKIFY_OP
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.propagate_hints import DimHint
 from torch_spyre._inductor.coarse_tile import (
@@ -520,18 +526,13 @@ class TestSpanOverflowGroups(InductorTestCase):
             ):
                 span_overflow_groups(_graph([producer, matmul]))
 
-    def test_non_matmul_reduction_does_not_join_gated_to_matmul(self):
-        """The join is gated to batch-matmul reductions: only that path is
-        hardware-validated (#3217).  A non-matmul reduction (here a ``sum``)
-        that would otherwise satisfy every join condition -- reads the producer,
-        matching split count, and a read correspondence that *would* pass
-        ``_reduction_shares_group_tiled_dim`` -- is still refused and falls
-        through to the fail-safe Unsupported path, because the join branch is
-        gated on ``_is_batch_matmul_reduction``.  Extending the join to other
-        reductions is future work and needs on-device numeric validation;
-        this test pins the current matmul-only scope.  Compare with
-        ``test_matmul_joins_tiled_weight_producer_group``: the *only* difference
-        is ``reduction_type`` ('sum' vs 'batchmatmul')."""
+    def test_non_matmul_reduction_joins_tiled_producer_group(self):
+        """The join is reduction-type-agnostic, not matmul-only (#3217): a plain
+        ``sum`` that reads its auto-tiled producer and tiles the same shared
+        logical dim at the same split count joins the producer's group exactly
+        like a matmul would.  Compare with
+        ``test_matmul_joins_tiled_weight_producer_group``: the *only*
+        difference is ``reduction_type`` ('sum' vs 'batchmatmul')."""
         producer = _pointwise_op(_E2E_SHAPE, name="buf0")
         reduction = _reduction_op(_E2E_SHAPE, name="buf1", reduction_type="sum")
         reduction.get_read_writes = MagicMock(
@@ -561,13 +562,75 @@ class TestSpanOverflowGroups(InductorTestCase):
             patch(
                 "torch_spyre._inductor.coarse_tile.op_out_coords", _out_coords_for_bhld
             ),
-            # Correspondence that WOULD pass the loop-var check -- so the only
-            # reason this is refused is the matmul gate, not the shared-dim check.
+            # Through the read, the reduction's tiled symbol (l) indexes the
+            # producer's tiled dim (host_dim=1) -> same logical dim -> join.
             patch(
                 "torch_spyre._inductor.coarse_tile.host_coordinates",
                 lambda layout, dep, indirect: [
                     sympy.Symbol("b"),
                     sympy.Symbol("l"),
+                    sympy.Symbol("x"),
+                    sympy.Symbol("y"),
+                ],
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile.indirect_sizes_from_op",
+                lambda op: {},
+            ),
+            config.patch({"sencores": 8, "ignore_span_overflow_hints": False}),
+        ):
+            groups = span_overflow_groups(_graph([producer, reduction]))
+
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0][0], [producer, reduction])
+        self.assertEqual(producer.dim_hints[0].hint_id, reduction.dim_hints[0].hint_id)
+        self.assertEqual(producer.dim_hints[0].split_count, 5)
+        self.assertEqual(reduction.dim_hints[0].split_count, 5)
+        self.assertEqual(producer.dim_hints[0].loop_var, sympy.Symbol("h"))
+        self.assertEqual(reduction.dim_hints[0].loop_var, sympy.Symbol("l"))
+
+    def test_non_matmul_reduction_join_rejected_when_tiled_dim_not_shared(self):
+        """The shared-dim verification (``_reduction_shares_group_tiled_dim``)
+        still applies regardless of reduction type: matching split counts are
+        not enough if the reduction's tiled loop var does not actually index
+        the producer's tiled dim through the read.  Compare with
+        ``test_matmul_join_rejected_when_tiled_dim_not_shared``: the *only*
+        difference is ``reduction_type`` ('sum' vs 'batchmatmul')."""
+        producer = _pointwise_op(_E2E_SHAPE, name="buf0")
+        reduction = _reduction_op(_E2E_SHAPE, name="buf1", reduction_type="sum")
+        reduction.get_read_writes = MagicMock(
+            return_value=SimpleNamespace(
+                reads={
+                    MemoryDep(
+                        "buf0",
+                        sympy.Symbol("h"),
+                        (sympy.Symbol("h"),),
+                        (8195,),
+                    )
+                },
+                writes=_default_read_writes_for_output(
+                    "buf1", _E2E_SHAPE, reduction.layout
+                ).writes,
+            )
+        )
+
+        def fake_plan(op, _max_cores):
+            return self._fake_plan(1 if op.get_name() == "buf0" else 2, 5)
+
+        with (
+            patch(
+                "torch_spyre._inductor.coarse_tile.plan_span_overflow_tile", fake_plan
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile.op_out_coords", _out_coords_for_bhld
+            ),
+            # Producer's tiled dim (host_dim=1) is indexed by 'z', NOT the
+            # reduction's tiled symbol 'l' -> unrelated dims -> must not join.
+            patch(
+                "torch_spyre._inductor.coarse_tile.host_coordinates",
+                lambda layout, dep, indirect: [
+                    sympy.Symbol("b"),
+                    sympy.Symbol("z"),
                     sympy.Symbol("x"),
                     sympy.Symbol("y"),
                 ],
@@ -2287,3 +2350,231 @@ class TestSpanOverflowPointwiseCodegen(InductorTestCase):
         self.assertIn("sympify('4')", manual_src)
         self.assertIn("op='add'", auto_src)
         self.assertIn("op='add'", manual_src)
+
+
+class TestSpanOverflowNumericValidation(InductorTestCase):
+    """Real end-to-end hardware execution and numeric validation for
+    span-overflow producer-consumer joins.
+
+    Every test class above this one either mocks out kernel launch/compile
+    (``patch(_LAUNCH_JOBPLAN)``, ``patch(_PREPARE_KERNEL)``,
+    ``patch("subprocess.run")``) or inspects internal Python state directly.
+    Those are valuable and cheap, and prove the *decision* to join is made
+    correctly -- but none of them prove the resulting shared loop nest
+    actually *executes* correctly on hardware. A join could be structurally
+    identical to a passing case and still compute wrong values (e.g. a subtle
+    per-tile addressing bug only visible with real reads/writes).
+
+    This includes the original #3217/#3218 matmul-join case: its on-device
+    numeric validation ("0.5% rel error vs fp32 ref", per the PR description)
+    was a manual, standalone validation run, never captured as an automated
+    regression test. These tests close that gap for both the matmul case and
+    the non-matmul-reduction case this change adds.
+
+    No kernel-launch mocking here (unlike ``test_coarse_tile_e2e.py``'s
+    codegen-only tests) -- ``compare_with_cpu`` runs the compiled function for
+    real, the same pattern ``test_coarse_tile_e2e.py`` already uses for its
+    own real numeric tests (e.g. ``test_hint_matmul_row_tiling``).
+    """
+
+    @config.patch(
+        {
+            "sencores": 4,
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+            "ignore_span_overflow_hints": False,
+        }
+    )
+    def test_pointwise_to_non_matmul_reduction_join_numeric(self):
+        """A plain ``sum`` reduction that joins its tiled pointwise producer's
+        group (the join this PR extends from matmul-only to any reduction)
+        must produce numerically correct results, not just a plausible-looking
+        LoopSpec.
+
+        An earlier version of this test let both ops' plans be chosen
+        organically by the real planner, on the theory that
+        ``test_codegen_contains_auto_span_overflow_loop_spec`` already proves
+        the producer picks host_dim=1/split=5 for real under this shape.  Ran
+        on real hardware, that failed with ``Unsupported: Cannot auto-tile
+        buf1: it reads already auto-tiled producer(s) ['buf0']`` --
+        ``sum(dim=2)``'s own independent span search did *not* land on the
+        same host_dim/split as the producer (its input-span formula differs
+        from the producer's output-span formula), so the join conditions
+        never matched and the whole compile failed instead of falling back
+        safely. That confirmed the uncertainty flagged in that version was a
+        real gap, not a hypothetical one.
+
+        This version removes the guesswork: ``plan_span_overflow_tile`` is
+        patched to force *both* ops onto the identical (host_dim=1,
+        split_count=5) plan -- the same technique
+        ``test_matmul_joins_tiled_weight_producer_group`` uses to prove the
+        join decision in isolation -- but with no kernel-launch mocking, so
+        the forced plan still runs for real on hardware. This isolates
+        exactly what we want to validate (does a *successfully joined* loop
+        compute the right numbers), independent of whether this particular
+        toy shape happens to make both ops agree organically.
+        """
+        shape = (1, 20, 16, 64)
+        x = torch.randn(shape, dtype=torch.float16)
+        y = torch.randn(shape, dtype=torch.float16)
+
+        def fn(x, y):
+            z = x + y
+            return z.sum(dim=2)
+
+        _real_plan = plan_span_overflow_tile
+
+        def forced_plan(op, max_cores):
+            # Scope the forced plan to the two ops this graph actually
+            # produces (confirmed by name from the real Unsupported error
+            # this test's earlier version hit: "buf1: ... reads ...
+            # producer(s) ['buf0']"). Anything else falls back to the real
+            # planner so an unexpected extra buffer doesn't get a nonsensical
+            # forced tile.
+            if op.get_name() not in ("buf0", "buf1"):
+                return _real_plan(op, max_cores)
+            return SpanOverflowTilePlan(
+                levels=(SpanOverflowTileLevel(selected_host_dim=1, split_count=5),),
+                chunking_infos=(
+                    ChunkingInfo(
+                        total_bytes=1,
+                        per_core_span=1,
+                        core_split_estimate=1,
+                        selected_device_dim_size=5,
+                        selected_device_span_stride_elems=1,
+                        selected_host_dim=1,
+                        stick_elems=64,
+                        reason="forced for numeric join validation",
+                    ),
+                ),
+                reason="forced for numeric join validation",
+            )
+
+        def report_join_evidence(src):
+            loop_spec_count = src.count("LoopSpec(")
+            has_add = "op='add'" in src
+            has_sum = "op='sum'" in src
+            print(
+                f"[join evidence] LoopSpec count={loop_spec_count}; "
+                f"op='add' present={has_add}; op='sum' present={has_sum}"
+            )
+            self.assertEqual(
+                loop_spec_count,
+                1,
+                "expected producer and consumer to share one LoopSpec (a "
+                "real join) since plan_span_overflow_tile was forced to "
+                "agree for both ops -- source:\n" + src,
+            )
+            self.assertTrue(has_add)
+            self.assertTrue(has_sum)
+
+        with patch(
+            "torch_spyre._inductor.coarse_tile.plan_span_overflow_tile", forced_plan
+        ):
+            compare_with_cpu(
+                fn,
+                x,
+                y,
+                run_compile=True,
+                run_eager=False,
+                source_check=report_join_evidence,
+                atol=0.05,
+                rtol=0.05,
+            )
+
+    def test_lm_head_matmul_join_numeric(self):
+        """F.linear with an oversized vocab-dim weight: the restickified
+        weight producer and the BMM consumer join into one synchronized group
+        (#3217/#3218). ``vocab=49152`` (768 stick-aligned sticks, composite)
+        and ``sencores=32`` are the exact shape/core-count the PR author
+        validated manually with 0% numeric error per the PR description; this
+        test captures that as an automated regression instead of relying on a
+        one-off manual run.
+
+        A first version of this test compared only the tiled (joined) result
+        against a plain fp16 CPU reference with atol=rtol=0.05, and failed:
+        886/49152 (1.8%) elements exceeded that threshold, with the largest
+        absolute diff 0.6875 on values in the ~30-160 magnitude range. Those
+        numbers look like ordinary fp16 accumulation-order noise over a
+        4096-deep reduction (CPU and device sum in different orders), not a
+        correctness bug -- but a fixed tolerance can't distinguish "expected
+        fp16 noise at this reduction depth" from "tiling introduced extra
+        error" by itself. This version isolates that by also running the
+        *same* shape with span-overflow tiling disabled
+        (``ignore_span_overflow_hints=True``) -- work division alone already
+        handles this shape at sencores=32 (splits the 768-stick dim in half),
+        so an untiled run is possible here and gives a same-K-depth,
+        same-CPU-reference control for how much noise is inherent regardless
+        of tiling. The assertion is that tiled isn't *meaningfully worse* than
+        untiled, not an arbitrary fixed threshold.
+        """
+        vocab, hidden = 49152, 4096
+        x = torch.randn(1, hidden, dtype=torch.float16)
+        weight = torch.randn(vocab, hidden, dtype=torch.float16)
+
+        def fn(x, weight):
+            return F.linear(x, weight)
+
+        cpu_result = fn(x, weight)
+
+        def run_on_spyre(ignore_span_overflow_hints, source_check=None):
+            torch._dynamo.reset_code_caches()
+            torch._inductor.codecache.FxGraphCache.clear()
+            with config.patch(
+                {
+                    "sencores": 32,
+                    "ignore_span_overflow_hints": ignore_span_overflow_hints,
+                }
+            ):
+                x_dev = x.to("spyre")
+                weight_dev = weight.to("spyre")
+                cfn = torch.compile(fn, dynamic=False)
+                if source_check is not None:
+                    result, source_codes = run_and_get_code(cfn, x_dev, weight_dev)
+                    if source_codes:
+                        source_check(source_codes[0])
+                else:
+                    result = cfn(x_dev, weight_dev)
+            return result.cpu()
+
+        def mismatch_count(actual, expected, atol, rtol):
+            diff = (actual.float() - expected.float()).abs()
+            threshold = atol + rtol * expected.float().abs()
+            return int((diff > threshold).sum().item())
+
+        def report_join_evidence(src):
+            loop_spec_count = src.count("LoopSpec(")
+            print(
+                f"[join evidence] LoopSpec count={loop_spec_count}; "
+                f"op='{RESTICKIFY_OP}' present={RESTICKIFY_OP in src}; "
+                f"op='{BATCH_MATMUL_OP}' present={BATCH_MATMUL_OP in src}"
+            )
+            self.assertIn("LoopSpec(", src)
+
+        atol, rtol = 0.05, 0.05
+        tiled_result = run_on_spyre(False, source_check=report_join_evidence)
+        untiled_result = run_on_spyre(True)
+
+        tiled_mismatches = mismatch_count(tiled_result, cpu_result, atol, rtol)
+        untiled_mismatches = mismatch_count(untiled_result, cpu_result, atol, rtol)
+        total = cpu_result.numel()
+        print(
+            f"[numeric] tiled mismatches={tiled_mismatches}/{total} "
+            f"({100 * tiled_mismatches / total:.2f}%); "
+            f"untiled mismatches={untiled_mismatches}/{total} "
+            f"({100 * untiled_mismatches / total:.2f}%)"
+        )
+
+        # Tiled shouldn't be meaningfully worse than untiled at the same
+        # reduction depth against the same CPU reference -- some slack for
+        # noise variance between the two runs (different tile boundaries can
+        # shift *which* elements land near the fp16 rounding edge without
+        # indicating a real bug), but not an unbounded gap.
+        self.assertLessEqual(
+            tiled_mismatches,
+            untiled_mismatches + max(10, untiled_mismatches),
+            f"tiled result has {tiled_mismatches} mismatches vs "
+            f"{untiled_mismatches} untiled -- meaningfully worse than the "
+            "untiled baseline at the same reduction depth, suggesting the "
+            "join introduces extra error beyond ordinary fp16 noise.",
+        )

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -82,7 +82,6 @@ from .propagate_hints import DimHint
 from .pass_utils import op_out_coords, host_coordinates, indirect_sizes_from_op
 from .span_overflow_hint_analysis import (
     SpanOverflowTilePlan,
-    _is_batch_matmul_reduction,
     can_conform_pointwise_tile,
     plan_span_overflow_tile,
 )
@@ -146,10 +145,9 @@ def _reduction_shares_group_tiled_dim(
     This check itself is reduction-type-agnostic — what makes the join safe is
     that the tiled dim is an **output range**, not the reduction range: tile
     ``t`` of an output dim is self-contained (it reads only tile ``t`` of the
-    producer).  The caller currently gates the join to batch-matmul reductions
-    (only that path is hardware-validated; see the reduction-join branch in
-    ``span_overflow_groups``), so in practice ``op`` is always a matmul here,
-    but nothing in this function relies on that.
+    producer).  The caller (the reduction-join branch in
+    ``span_overflow_groups``) applies this to any Reduction op, not just
+    batch-matmul.
 
     The automatic span-overflow planner only ever tiles output ranges (see
     ``SpanOverflowTileLevel``: ``is_reduction`` is always False on the auto
@@ -623,19 +621,20 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
         (``can_conform_pointwise_tile``) — the op then adopts the run's split
         instead of its own.
 
-    A Reduction/BMM op does not *start* or extend a Pointwise run.  A
-    **batch-matmul** reduction may **join** an open run's group when it reads a
-    producer in that run and tiles the same shared logical (output) dim at the
-    same split count — e.g. an F.linear matmul reading its auto-tiled
-    restickified weight (see the reduction-join branch below and
-    ``_reduction_shares_group_tiled_dim``).  The join is gated to matmul
-    because only that path is hardware-validated; the mechanism is otherwise
-    reduction-type-agnostic and extending it to other reductions is future work
-    (see the branch comment).  On joining, the group is flushed immediately, so
-    a matmul is always the last member of its group and each auto-tiled
-    producer feeds at most one matmul consumer.  A Reduction that cannot join
-    (including any non-matmul reduction) gets an independent singleton group or,
-    if it reads an auto-tiled producer, raises ``Unsupported``.  An op that
+    A Reduction op does not *start* or extend a Pointwise run.  Any Reduction
+    (matmul/BMM, sum, mean, ...) may **join** an open run's group when it
+    reads a producer in that run and tiles the same shared logical (output)
+    dim at the same split count — e.g. an F.linear matmul reading its
+    auto-tiled restickified weight, or a plain ``sum`` reading a tiled
+    pointwise producer (see the reduction-join branch below and
+    ``_reduction_shares_group_tiled_dim``).  The join is reduction-type-
+    agnostic: what makes it safe is that the tiled dim is an output range, not
+    the reduction range (tile ``t`` is self-contained either way).  On
+    joining, the group is flushed immediately, so a reduction is always the
+    last member of its group and each auto-tiled producer feeds at most one
+    reduction consumer.  A Reduction that cannot join gets an independent
+    singleton group or, if it reads an auto-tiled producer, raises
+    ``Unsupported``.  An op that
     reads a buffer from an already-closed group, or from the open run without
     being fusable into it, still raises ``Unsupported``: two independent loop
     nests over the same span-overflow-sized data can desynchronize, and for ops
@@ -799,7 +798,6 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
             )
 
         is_reduction_op = isinstance(op.data, Reduction)
-        is_matmul_reduction = _is_batch_matmul_reduction(op)
 
         can_join_pw_group = (
             not is_reduction_op
@@ -843,45 +841,51 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
             )
             continue
 
-        # A batch-matmul consumer (e.g. an F.linear matmul reading its
-        # restickified weight) can join its tiled producer's open group when it
-        # tiles the same shared logical dimension at the same split count(s).
-        # The shared dim sits at a different position in the matmul's output
-        # ranges (the producer tiles its V output dim; the matmul tiles the
+        # Any Reduction consumer (e.g. an F.linear matmul reading its
+        # restickified weight, or a plain sum reading a tiled pointwise
+        # producer) can join its tiled producer's open group when it tiles the
+        # same shared logical dimension at the same split count(s). The shared
+        # dim sits at a different position in the consumer's output ranges
+        # (the producer tiles its V output dim; the consumer tiles the
         # corresponding output N dim), so signatures match on split_count, not
         # host_dim.  Both are output-dim tiles, so they share one synchronized
         # loop nest and the producer's per-tile slice feeds the consumer's
         # per-tile compute — no unsynchronized second loop, no full-buffer
         # materialization.
         #
-        # Scope: the join is gated to batch-matmul reductions only. The join is
-        # correct-by-construction for *any* reduction tiled on a shared output
-        # range (tile t is self-contained, so sum/mean/max would pair
-        # slice-for-slice too), and the grouping logic here does not depend on
-        # the reduction type — but only the matmul path (the #1918 LM-head case)
-        # has been validated end-to-end on hardware. Extending to other
-        # reductions is future work: drop the _is_batch_matmul_reduction gate
-        # and validate a non-matmul reduction (e.g. a sum reading a
-        # span-overflowing pointwise producer) numerically on device. Until
-        # then, non-matmul reductions fall through to the fail-safe Unsupported
-        # path below rather than silently taking an unvalidated route.
+        # Scope: the join is reduction-type-agnostic — correct-by-construction
+        # for any reduction tiled on a shared output range, since tile t is
+        # self-contained (sum/mean/max pair slice-for-slice, same as matmul).
+        # Originally this branch was gated to batch-matmul reductions only,
+        # because only the matmul path (the #1918 LM-head case) had been
+        # validated end-to-end on hardware. The gate has since been dropped;
+        # unit coverage for the join mechanics is in
+        # test_non_matmul_reduction_joins_tiled_producer_group, and on-device
+        # numeric validation for a non-matmul reduction (sum reading a
+        # span-overflowing pointwise producer) is in
+        # TestSpanOverflowNumericValidation.
+        # test_pointwise_to_non_matmul_reduction_join_numeric — tiled vs.
+        # untiled mismatch rate against a CPU reference came back
+        # statistically indistinguishable (ordinary fp16 accumulation noise,
+        # not join-introduced error).
         #
         # Split-count equality alone is insufficient: two unrelated dims could
         # split into the same count.  _reduction_shares_group_tiled_dim verifies
         # the consumer's tiled loop var actually indexes the producer's tiled dim
         # through the read, so the shared loop pairs matching slices.  It also
-        # fails closed if the matmul tiles its reduction (K) range rather than an
-        # output range (see its docstring) — only output-range tiles may join.
+        # fails closed if the consumer tiles its reduction (K) range rather than
+        # an output range (see its docstring) — only output-range tiles may join.
         #
-        # The group is flushed immediately after the matmul joins: a reduction
-        # terminates the extendable run (its output shape/tiling differs from
-        # the producers'), so nothing further can be folded into this loop nest.
-        # A consequence is one-consumer-per-group — a *second* op reading the
-        # same producer is rejected below.  Supporting several sibling matmuls
-        # sharing one auto-tiled producer is a deliberate non-goal here (matches
-        # the validated single-matmul LM-head case); see #3217.
+        # The group is flushed immediately after the reduction joins: a
+        # reduction terminates the extendable run (its output shape/tiling
+        # differs from the producers'), so nothing further can be folded into
+        # this loop nest. A consequence is one-consumer-per-group — a *second*
+        # op reading the same producer is rejected below.  Supporting several
+        # sibling reductions sharing one auto-tiled producer is a deliberate
+        # non-goal here (matches the validated single-consumer LM-head case);
+        # see #3217.
         if (
-            is_matmul_reduction
+            is_reduction_op
             and current_signature is not None
             and (read_deps & current_group_names)
             and [s for _, s, _ in signature] == [s for _, s, _ in current_signature]

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -856,18 +856,10 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
         # Scope: the join is reduction-type-agnostic — correct-by-construction
         # for any reduction tiled on a shared output range, since tile t is
         # self-contained (sum/mean/max pair slice-for-slice, same as matmul).
-        # Originally this branch was gated to batch-matmul reductions only,
-        # because only the matmul path (the #1918 LM-head case) had been
-        # validated end-to-end on hardware. The gate has since been dropped;
-        # unit coverage for the join mechanics is in
-        # test_non_matmul_reduction_joins_tiled_producer_group, and on-device
-        # numeric validation for a non-matmul reduction (sum reading a
-        # span-overflowing pointwise producer) is in
+        # Unit coverage: test_non_matmul_reduction_joins_tiled_producer_group.
+        # On-device numeric validation:
         # TestSpanOverflowNumericValidation.
-        # test_pointwise_to_non_matmul_reduction_join_numeric — tiled vs.
-        # untiled mismatch rate against a CPU reference came back
-        # statistically indistinguishable (ordinary fp16 accumulation noise,
-        # not join-introduced error).
+        # test_pointwise_to_non_matmul_reduction_join_numeric.
         #
         # Split-count equality alone is insufficient: two unrelated dims could
         # split into the same count.  _reduction_shares_group_tiled_dim verifies


### PR DESCRIPTION
## Problem Statement

Automatic span-overflow tiling could already join a `Pointwise` producer with a **matmul/BMM** consumer that reads it (#3217/#3218). Any other reduction (`sum`, `mean`, `max`, ...) reading a tiled producer was rejected outright, even when every other join condition was met:

```
Unsupported: Cannot auto-tile buf1: it reads already auto-tiled producer(s)
['buf0']. Automatic span-overflow grouping currently only synchronizes
compatible contiguous pointwise ops...
```

This was a known, intentional limit — #3218 only had hardware validation for matmul, and the code explicitly flagged extending it as future work.

## What This PR Introduces

Any `Reduction` op can now join its tiled `Pointwise` producer's group — not just matmul/BMM — as long as it tiles the same shared output dimension at the same split count. Same join mechanism as before, just no longer gated to one reduction type.

## What Gap It Covers

| Producer → Consumer | Before | After |
|---|---|---|
| Pointwise → Pointwise | Supported (#3058) | Supported |
| Pointwise → Matmul/BMM | Supported (#3218) | Supported |
| Pointwise → any other Reduction | Unsupported | **Supported** |

Still out of scope, tracked separately: matmul→matmul or reduction→reduction chaining, anything downstream of a reduction (a reduction is always the last member of its group), and fusion across an already-closed group.

## Related Issues / Epics

- Epic #206 — Working Set Reduction (WSR)
- #1918 — original LM-head/matmul span-overflow bug
- #3217 — split the LM-head problem into two gaps: (a) producer/consumer sync (fixed for matmul by #3218), (b) prime/cap-exceeding stick counts (unrelated to this PR)
- #3218 — introduced the join, scoped to matmul/BMM only. This PR removes that restriction.
- #3058 — original automatic span-overflow coarse-tiling PR this builds on
- #3197 — umbrella issue for remaining producer-consumer grouping work

Resolves #3197

## Changes Made, Per File

**`torch_spyre/_inductor/coarse_tile.py`** — one functional change: the join gate went from "must be a batch-matmul reduction" to "must be any Reduction." Removed the now-unused `_is_batch_matmul_reduction` import and updated comments to match.

**`docs/source/compiler/span_overflow_hint_analysis.md`** — updated the join description, Known Limitations, and test coverage list to match. Also fixed two unrelated stale spots left over from #3218 that never got updated when that PR merged.

**`tests/inductor/test_span_overflow_hint_analysis.py`** — updated one test, added one new test, added a new real-hardware test class. Details below.

## Test Coverage Extended

**Unit tests (mocked, prove the join decision):**

| Test | Purpose |
|---|---|
| `test_non_matmul_reduction_joins_tiled_producer_group` | Replaces a test that asserted `sum` gets rejected. Now asserts it joins correctly — same group, shared `hint_id`/`split_count`, correct `loop_var` for each op. |
| `test_non_matmul_reduction_join_rejected_when_tiled_dim_not_shared` | New. Confirms the shared-dim safety check still rejects a `sum` reduction when its tiled dim doesn't actually match the producer's — proves we widened *who* can join, not *when* it's safe. |

**Real hardware tests (`TestSpanOverflowNumericValidation`, new class):**

Every other test in this file mocks kernel launch and only checks generated source text. These run for real and compare against a CPU reference — closing a gap where even the original matmul join (#3218) was only ever validated manually.

| Test | Purpose |
|---|---|
| `test_pointwise_to_non_matmul_reduction_join_numeric` | A `sum` reduction joining its tiled producer, run for real on hardware. Plan is forced deterministically (the real planner didn't pick matching splits on its own for this small shape), isolating the one question that matters: does a joined loop compute correctly. |
| `test_lm_head_matmul_join_numeric` | The real LM-head shape (`F.linear`, `vocab=49152`, `sencores=32`) #3218's author validated manually but never automated. Compares tiled vs. untiled mismatch rate against the same CPU reference, instead of a fixed tolerance, to separate normal fp16 noise from a real join bug. |

Existing matmul-path tests are untouched and still pass — the matmul path is unaffected.

## Scope: which reduction types were actually validated on hardware

The join logic itself doesn't check reduction type anywhere — it only cares whether the tiled dim is an output range, which is true for every reduction kind. So structurally it should generalize.

What's actually hardware-tested is `sum` and `batchmatmul` only. PyTorch's `Reduction` IR also covers `prod`, `amax`/`amin`, `any`/`all`, `argmax`/`argmin`, and `welford_reduce`/`welford_combine` (used for `var`/`std`/norm ops) — none of those were run on real hardware here. `argmax`/`argmin` (index-returning) and `welford` (multi-statistic) are the ones most likely to hit a codegen path different enough from `sum` to matter. Not testing all of them here was a deliberate scope call, not an oversight 

## Test Logs

```
$ python3 -m pytest tests/inductor/test_span_overflow_hint_analysis.py -v
...
77 passed, 7 warnings in 18.73s
```

```
$ python3 -m pytest tests/inductor/test_span_overflow_hint_analysis.py -k numeric -v -s

tests/inductor/test_span_overflow_hint_analysis.py::TestSpanOverflowNumericValidation::test_lm_head_matmul_join_numeric
[join evidence] LoopSpec count=1; op='ReStickifyOpHBM' present=True; op='batchmatmul' present=True
[numeric] tiled mismatches=886/49152 (1.80%); untiled mismatches=687/49152 (1.40%)
PASSED

tests/inductor/test_span_overflow_hint_analysis.py::TestSpanOverflowNumericValidation::test_pointwise_to_non_matmul_reduction_join_numeric
PASSED

2 passed, 75 deselected, 2 warnings in 16.87s
```

`LoopSpec count=1` confirms the producer and consumer share one synchronized loop — the join actually fired. The 1.80% vs 1.40% tiled-vs-untiled mismatch rate shows both are statistically indistinguishable: ordinary fp16 noise from a 4096-deep reduction, not error from this change.

