### PR TITLE
fix(cicd): drop mkldnn pattern matcher suite from upstream tests (all-xfail,zero collected under not xfail)

### DIFF
--- a/.github/workflows/upstream_tests_beta.yaml
+++ b/.github/workflows/upstream_tests_beta.yaml
@@ -140,8 +140,6 @@ jobs:
             config: inductor-test_exc_lowering_stack_trace.yaml
           - name: Inductor fuzzer
             config: inductor-test_fuzzer.yaml
-          - name: Inductor mkldnn pattern matcher
-            config: inductor-test_mkldnn_pattern_matcher.yaml
           - name: Inductor move constructor to gpu
             config: inductor-test_move_constructors_to_gpu.yaml
           - name: Inductor pattern matcher
@@ -167,6 +165,11 @@ jobs:
           #   config: inductor-test_op_dtype_prop.yaml
           # - name: NeuralNet convolution
           #   config: nn-test_convolution.yaml
+          # All xfail/skip tests (no mandatory_success entries). Will result in
+          # zero tests collected in "not xfail" mode.
+          # Retaining the yaml for future use as new spyre capabilities are added.
+          # - name: Inductor mkldnn pattern matcher
+          #   config: inductor-test_mkldnn_pattern_matcher.yaml
 
     steps:
       # Sparse checkout into the GHA workspace so the local composite


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

After the fix PR https://github.com/torch-spyre/torch-spyre/pull/3269 which removed false positives CPU only tests from mklddnn pattern matcher, now all the tests are xfail as expected.

So this PR moves it to the list of xfail tests commented out along with existing commented out tests otherwise throws an exit code 5 with `no tests collected`

This is required because CI uses `not xfail` flag with pytest, as a result tests with all xfailed tests will throw exit code 5.