### PR TITLE
Fix/memory planning advance factor

### DIFF
--- a/torch_spyre/_inductor/memory_planning.py
+++ b/torch_spyre/_inductor/memory_planning.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from sympy import Symbol
+from sympy import Symbol, Integer
 from torch._inductor.scheduler import (
     BaseSchedulerNode,
     ExternKernelSchedulerNode,
@@ -94,6 +94,39 @@ def _align_up(n: int, alignment: int) -> int:
     return ((n + alignment - 1) // alignment) * alignment
 
 
+def _advance_factor(buf, layout) -> int:
+    """Return how many tiles an advancing coarse-tiled buffer occupies.
+
+    A buffer's `device_size` reflects a single tile after coarse-tiling divides
+    the iteration ranges.  If the buffer is `per_tile_fixed=False`, the unroller
+    advances its base address once per loop iteration, so it actually occupies
+    `loop_count` tiles along each dimension it is tiled on — not one.  Sizing it
+    for a single tile lets the loop overrun into the next pooled buffer (the
+    last-iteration corruption seen in coarse-tiled flash attention: the
+    advancing softmax outputs clobber the `-inf` M fill that sits after them).
+
+    The factor is the product of `loop_count[level]` over exactly the levels
+    where this buffer carries a tiled dimension (`loop_tiled_dims[level]`
+    non-empty).  It is 1 for:
+      * `per_tile_fixed=True` buffers (base never advances — pinned scratch),
+      * buffers with no tiled dimension at any level (loop-invariant), and
+      * buffers with no coarse-tile `loop_info`.
+    Keying off the loop metadata rather than the `device_size` shape is
+    deliberate: the tiled dimension does not occupy a fixed device index
+    (e.g. it can be device dim 0 or dim 3), so a shape-based guess is wrong.
+    """
+    if getattr(layout, "per_tile_fixed", False):
+        return 1
+    loop_info = getattr(buf, "loop_info", None)
+    if loop_info is None:
+        return 1
+    factor = 1
+    for count, dims in zip(loop_info.loop_count, loop_info.loop_tiled_dims):
+        if dims and isinstance(count, (int, Integer)):
+            factor *= int(count)
+    return factor
+
+
 def _compute_size_bytes(name: str) -> int:
     """Return the stick-aligned device size in bytes for buffer `name`."""
     buf = V.graph.get_buffer(name)
@@ -103,7 +136,7 @@ def _compute_size_bytes(name: str) -> int:
     )
     dev_layout = layout.device_layout
     num_sticks = math.prod(dev_layout.device_size[:-1])
-    size_bytes = num_sticks * _STICK_BYTES
+    size_bytes = num_sticks * _STICK_BYTES * _advance_factor(buf, layout)
     return _align_up(size_bytes, _STICK_BYTES)
 
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes an under-allocation in `memory_planning` that lets a coarse-tiled buffer
overrun into its neighbor in the HBM intermediates pool.

`_compute_size_bytes` sizes each pooled buffer from `device_layout.device_size`,
which after coarse-tiling reflects a **single tile**. A buffer marked
`per_tile_fixed=False` has its base address advanced once per loop iteration by
the unroller, so at runtime it occupies **`loop_count` tiles** along each tiled
dimension — not one. The allocator hands it a one-tile block, the loop writes
`loop_count×` that size, and the tail iterations write out of bounds, clobbering
whatever buffer was packed next in the segment. (Static pool offsets don't
overlap; the dynamic per-iteration advance does.)

The fix adds `_advance_factor(buf, layout)` and multiplies the stick-aligned
size by it — `prod(loop_count[level])` over exactly the levels where the buffer
carries a tiled dimension. It is `1` for `per_tile_fixed=True` (pinned scratch),
loop-invariant buffers, and buffers with no coarse-tile `loop_info`, so
already-correctly-sized buffers are never over-allocated. The factor is keyed
off the loop metadata rather than the `device_size` shape on purpose: the tiled
dimension is not at a fixed device index (it can be the outermost or a middle
dim), so a shape-based guess is wrong.

#### Which issue(s) this PR is related to:

Partial fix for #3145 — **does not close it.** `test_hint_flash_attention`
fails from two independent bugs; this PR fixes one of them (the pool overrun
that clobbers the rank-3 `-inf` running-max buffer). The test remains red due to
a second, unrelated defect in the Case-1 scatter/materialization of the rank-4
output accumulator, tracked separately. Please do not auto-close #3145 on merge.

#### Special notes for your reviewer:

- **A/B evidence (H-tiled flash attention, toggling only this change):** the
  softmax `correction = exp(M - max_running)` output goes from 37.5% → 0% wrong,
  and end-to-end `max_abs_err` drops from ~7752 / `inf` → ~1.4 (the overrun
  garbage is eliminated). The final-output mismatch stays ~90% because the
  separate bug above dominates — this fix is necessary but not sufficient for
  #3145, and is not orthogonal to it.
- **No regressions:** `tests/inductor/test_coarse_tile_e2e.py` → 44 passed,
  1 failed (only `test_hint_flash_attention`, blocked by the second bug).
- `memory_planning.py` is byte-identical between `main` and the #3145 branch, so
  this is a pre-existing latent sizing bug and the change applies to `main`
  verbatim.
- **Follow-up requested:** a targeted regression test exercising an advancing
  (`per_tile_fixed=False`) coarse-tiled buffer should accompany this change — the
  overrun is currently only exercised by the still-failing flash test, so no
  green test yet guards the fix. Happy to add one if preferred before merge.

#### Does this PR introduce a user-facing change?

Fixes a latent correctness bug: coarse-tiled compiled models with advancing
(`per_tile_fixed=False`) pooled buffers could silently produce wrong numerics
(and out-of-bounds writes) due to buffer under-allocation. No API change.

#### Additional note:

Scope is intentionally limited to the allocation-sizing fix in
`memory_planning._compute_size_bytes`; the coarse_tile scatter bug behind the
remaining #3145 failure is out of scope here.
