### PR TITLE
fix(inductor): harden copy_from_d2d offset guard (symbolic + stick-dim)

### DIFF
--- a/tests/inductor/test_copy_from_d2d_offsets.py
+++ b/tests/inductor/test_copy_from_d2d_offsets.py
@@ -56,6 +56,7 @@ regression from this fix).
 import unittest
 
 import torch
+from torch._inductor.exc import InductorError
 
 import torch_spyre  # noqa: F401
 
@@ -118,7 +119,7 @@ class TestCopyFromD2DContiguousOffsets(unittest.TestCase):
         PR); this test asserts the failure is clean, not silent."""
         x = torch.arange(2 * 128, dtype=DTYPE, device=DEVICE).reshape(2, 128)
         # columns [64:128) -> offset 64 lands inside the row (stride 128)
-        with self.assertRaises(Exception) as cm:
+        with self.assertRaises(InductorError) as cm:
             x.narrow(1, 64, 64).clone()
         self.assertIn("stick", str(cm.exception).lower())
 
@@ -143,7 +144,7 @@ class TestCopyFromD2DContiguousOffsets(unittest.TestCase):
         a = x.narrow(0, 0, 1).clone()
         torch.testing.assert_close(a.cpu(), x.cpu()[0:1])
         # offset 200 is not a stick multiple -> clean compile-time error
-        with self.assertRaises(Exception) as cm:
+        with self.assertRaises(InductorError) as cm:
             x.narrow(0, 2, 1).clone()
         self.assertIn("stick", str(cm.exception).lower())
 
@@ -159,7 +160,7 @@ class TestCopyFromD2DContiguousOffsets(unittest.TestCase):
         correctly or errors)."""
         x = torch.arange(4 * 100, dtype=DTYPE, device=DEVICE).reshape(4, 100)
         torch.testing.assert_close(x.select(0, 0).clone().cpu(), x.cpu()[0])
-        with self.assertRaises(Exception) as cm:
+        with self.assertRaises(InductorError) as cm:
             x.select(0, 2).clone()
         self.assertIn("stick", str(cm.exception).lower())
 
@@ -263,11 +264,32 @@ class TestValidateReoffsetUnit(unittest.TestCase):
         """A symbolic (non-int) offset must raise, not silently bake 0."""
         import sympy
 
+        from torch_spyre._inductor.errors import Unsupported
         from torch_spyre._inductor.lowering import _validate_reoffset_supported
 
-        with self.assertRaises(Exception) as cm:
+        with self.assertRaises(Unsupported) as cm:
             _validate_reoffset_supported(
                 self._FakeLayout(DTYPE, [64, 1]), sympy.Symbol("s0")
+            )
+        self.assertIn("symbolic", str(cm.exception).lower())
+
+    def test_symbolic_stride_raises(self):
+        """A symbolic stride[-2] must raise, not bypass the boundary check.
+
+        A concrete, stick-aligned offset still cannot be proven to land outside
+        the stick dim when stride[-2] is symbolic, so bypassing the check could
+        re-enable the silent column-offset miscompile. The guard fails loudly
+        instead, like the symbolic-offset branch."""
+        import sympy
+
+        from torch_spyre._inductor.errors import Unsupported
+        from torch_spyre._inductor.lowering import _validate_reoffset_supported
+
+        # offset 128 is stick-aligned (128 % 64 == 0) so it clears branch (1);
+        # the symbolic stride[-2] then cannot prove the boundary condition.
+        with self.assertRaises(Unsupported) as cm:
+            _validate_reoffset_supported(
+                self._FakeLayout(DTYPE, [sympy.Symbol("s0"), 1]), 128
             )
         self.assertIn("symbolic", str(cm.exception).lower())
 

--- a/tests/inductor/test_copy_from_d2d_offsets.py
+++ b/tests/inductor/test_copy_from_d2d_offsets.py
@@ -248,12 +248,15 @@ class TestValidateReoffsetUnit(unittest.TestCase):
 
     The stick-alignment, stick-dim, accept, and zero-offset branches are all
     covered end-to-end (test_unaligned_offset_raises,
-    test_column_slice_inner_offset_raises, the passing contiguous tests). The
-    symbolic-offset branch is NOT: specialize_int bakes every offset as a
-    concrete int, so a symbolic offset never reaches the guard through the
-    normal path — it is a fail-loud guard against silently reintroducing the
-    #3236 read-from-base bug if that invariant ever breaks. We exercise it
-    directly with a minimal stand-in layout."""
+    test_column_slice_inner_offset_raises, the passing contiguous tests). Two
+    branches have no e2e equivalent and are exercised here with a minimal stand-
+    in layout: (a) the symbolic-offset branch — specialize_int bakes every offset
+    as a concrete int, so a symbolic offset never reaches the guard through the
+    normal path; it is a fail-loud guard against silently reintroducing the #3236
+    read-from-base bug if that invariant ever breaks. (b) the symbolic-stride
+    fallback — under automatic-dynamic shapes stride[-2] is a symbol, so the
+    column-narrow boundary check is undecidable and we fall back to the stick-
+    alignment check only."""
 
     class _FakeLayout:
         def __init__(self, dtype, stride):
@@ -273,25 +276,45 @@ class TestValidateReoffsetUnit(unittest.TestCase):
             )
         self.assertIn("symbolic", str(cm.exception).lower())
 
-    def test_symbolic_stride_raises(self):
-        """A symbolic stride[-2] must raise, not bypass the boundary check.
+    def test_symbolic_stride_falls_back_to_stick_check(self):
+        """A symbolic stride[-2] skips the boundary check (check 2), not raise.
 
-        A concrete, stick-aligned offset still cannot be proven to land outside
-        the stick dim when stride[-2] is symbolic, so bypassing the check could
-        re-enable the silent column-offset miscompile. The guard fails loudly
-        instead, like the symbolic-offset branch."""
+        Under automatic-dynamic shapes the inner-dim size becomes symbolic, so
+        stride[-2] is a symbol and `offset % stride[-2]` is undecidable at
+        lowering time. The column-narrow boundary check therefore applies only to
+        concrete strides; when the stride is symbolic we fall back to the stick-
+        alignment check (1) only, matching upstream (which documents the column-
+        narrow-inside-the-stick-dim case as a known limitation). A stick-aligned
+        offset is accepted; only an unaligned offset (caught by check 1 above,
+        which is stride-independent) still raises. Rejecting on a symbolic stride
+        would regress legitimate dynamic-shape row and permute copies whose
+        offset does land on a boundary (measured correct on hardware:
+        test_stick_multiple_offset_unaligned_inner_dim_ok,
+        test_permute_with_offset_clone)."""
+        import sympy
+
+        from torch_spyre._inductor.lowering import _validate_reoffset_supported
+
+        # stick-aligned offset + symbolic stride -> accepted (no raise).
+        _validate_reoffset_supported(
+            self._FakeLayout(DTYPE, [sympy.Symbol("s0"), 1]), 192
+        )
+
+    def test_symbolic_stride_unaligned_offset_still_raises(self):
+        """Check 1 is stride-independent: an unaligned offset raises even when
+        stride[-2] is symbolic."""
         import sympy
 
         from torch_spyre._inductor.errors import Unsupported
         from torch_spyre._inductor.lowering import _validate_reoffset_supported
 
-        # offset 128 is stick-aligned (128 % 64 == 0) so it clears branch (1);
-        # the symbolic stride[-2] then cannot prove the boundary condition.
+        # offset 100 is not a stick multiple (100 % 64 != 0) -> check 1 raises
+        # before the stride is ever consulted.
         with self.assertRaises(Unsupported) as cm:
             _validate_reoffset_supported(
-                self._FakeLayout(DTYPE, [sympy.Symbol("s0"), 1]), 128
+                self._FakeLayout(DTYPE, [sympy.Symbol("s0"), 1]), 100
             )
-        self.assertIn("symbolic", str(cm.exception).lower())
+        self.assertIn("stick", str(cm.exception).lower())
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_copy_from_d2d_offsets.py
+++ b/tests/inductor/test_copy_from_d2d_offsets.py
@@ -39,9 +39,12 @@ surfaces this rejection early with an actionable message; see
 test_unaligned_offset_raises{,_select} and
 test_stick_multiple_offset_unaligned_inner_dim_ok.
 
-The one remaining silent-wrong-data case is an offset that falls INSIDE the
-stick dim (a column narrow) — see test_column_slice_inner_offset, a documented
-known limitation tracked for the follow-up PR.
+An offset that falls INSIDE the stick dim (a column narrow) is also rejected:
+it is stick-aligned by (1) but offset % stride[-2] != 0, detectable from the
+view's own stride — see test_column_slice_inner_offset_raises. The underlying
+stick-dim copy is still unsupported (tracked for the follow-up PR); the guard
+just makes the failure clean rather than silent. With both checks there is no
+remaining silent-wrong-data path for these views.
 
 The transpose / permute / strided cases below deliberately exercise
 NON-contiguous views (see TestCopyFromD2DStridedViews). permute / select at
@@ -99,24 +102,25 @@ class TestCopyFromD2DContiguousOffsets(unittest.TestCase):
         torch.testing.assert_close(out[1:2], torch.full((1, 64), -1.0, dtype=DTYPE))
         torch.testing.assert_close(out[3:4], torch.full((1, 64), -1.0, dtype=DTYPE))
 
-    @unittest.expectedFailure
-    def test_column_slice_inner_offset(self):
-        """Offset along the last (stick) dim: narrow columns at an offset.
+    def test_column_slice_inner_offset_raises(self):
+        """Offset inside the stick dim (column narrow) is rejected, not silent.
 
-        KNOWN LIMITATION — the SOLE remaining silent-wrong-data case. Here the
-        offset (64) IS a stick multiple, so _validate_reoffset_supported accepts
-        it, but it falls inside the stick DIMENSION: superdsc decomposes per-dim
-        offsets against device_size and does not split a stick-dim offset
-        correctly, so the read is off by the stick-dim component (measured WRONG
-        in sweep_d2d_offsets.py: got 0.0, expected 64.0). The offset%eps guard
-        cannot catch this (the offset is aligned); detecting it needs the
-        base-storage layout, which is unavailable at lowering. Tracked for the
-        follow-up PR (stick-dim offset handling), distinct from the row-offset
-        bug fixed here."""
+        Here the offset (64) IS a stick multiple, so the offset % eps check
+        passes, but it falls inside the stick DIMENSION: it starts partway into
+        a row (size=(2, 64), stride=(128, 1), offset=64), which superdsc bakes
+        incorrectly — measured WRONG in sweep_d2d_offsets.py (got 0.0, expected
+        64.0). This was previously the sole remaining silent-wrong-data case.
+
+        _validate_reoffset_supported now detects it from the view's OWN stride:
+        offset % stride[-2] == 64 % 128 != 0 means the offset is not on an outer-
+        dimension boundary, so it raises Unsupported instead of miscompiling. The
+        underlying stick-dim copy is still unsupported (tracked for the follow-up
+        PR); this test asserts the failure is clean, not silent."""
         x = torch.arange(2 * 128, dtype=DTYPE, device=DEVICE).reshape(2, 128)
-        # columns [64:128) -> nonzero offset within a row
-        out = x.narrow(1, 64, 64).clone()
-        torch.testing.assert_close(out.cpu(), x.cpu()[:, 64:128])
+        # columns [64:128) -> offset 64 lands inside the row (stride 128)
+        with self.assertRaises(Exception) as cm:
+            x.narrow(1, 64, 64).clone()
+        self.assertIn("stick", str(cm.exception).lower())
 
     def test_unaligned_offset_raises(self):
         """A storage_offset that is not a whole number of sticks is rejected.
@@ -236,6 +240,36 @@ class TestCopyFromD2DStridedViews(unittest.TestCase):
                 x.cpu().t()[:, c : c + 1],
                 msg=f"transpose col {c}",
             )
+
+
+class TestValidateReoffsetUnit(unittest.TestCase):
+    """Direct unit test for the one guard branch with no e2e equivalent.
+
+    The stick-alignment, stick-dim, accept, and zero-offset branches are all
+    covered end-to-end (test_unaligned_offset_raises,
+    test_column_slice_inner_offset_raises, the passing contiguous tests). The
+    symbolic-offset branch is NOT: specialize_int bakes every offset as a
+    concrete int, so a symbolic offset never reaches the guard through the
+    normal path — it is a fail-loud guard against silently reintroducing the
+    #3236 read-from-base bug if that invariant ever breaks. We exercise it
+    directly with a minimal stand-in layout."""
+
+    class _FakeLayout:
+        def __init__(self, dtype, stride):
+            self.dtype = dtype
+            self.stride = stride
+
+    def test_symbolic_offset_raises(self):
+        """A symbolic (non-int) offset must raise, not silently bake 0."""
+        import sympy
+
+        from torch_spyre._inductor.lowering import _validate_reoffset_supported
+
+        with self.assertRaises(Exception) as cm:
+            _validate_reoffset_supported(
+                self._FakeLayout(DTYPE, [64, 1]), sympy.Symbol("s0")
+            )
+        self.assertIn("symbolic", str(cm.exception).lower())
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -944,7 +944,17 @@ def _validate_reoffset_supported(layout, offset) -> None:
     try:
         stride = [int(s) for s in layout.stride]
     except (TypeError, ValueError):
-        return  # symbolic strides: the stick-aligned check above still applied
+        # A symbolic stride[-2] cannot prove off % stride[-2] == 0, so a concrete
+        # stick-aligned offset could still fall inside the stick dim and silently
+        # miscompile (the column-offset case). Fail loudly rather than bypass the
+        # boundary check, mirroring the symbolic-offset branch above.
+        raise Unsupported(
+            "spyre::copy_from_d2d of a sliced view received a symbolic stride "
+            f"({list(layout.stride)!r}); a concrete stride is required to prove "
+            f"the storage_offset {off} lands on an outer-dimension boundary and "
+            "not inside the stick dimension. A symbolic stride cannot rule out "
+            "the silent column-offset miscompile, so it is rejected."
+        )
     if len(stride) >= 2 and stride[-2] and off % stride[-2] != 0:
         raise Unsupported(
             "spyre::copy_from_d2d of a sliced view requires an offset on an "

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -908,6 +908,13 @@ def _validate_reoffset_supported(layout, offset) -> None:
        last silent-wrong-data path; the view's own stride reveals it, so we
        reject it here rather than miscompile.
 
+       This check applies only when ``stride[-2]`` is concrete. Under automatic-
+       dynamic shapes it may be symbolic, so the modulo is undecidable at
+       lowering time; we then fall back to check (1) only, matching upstream,
+       which already documents the column-narrow case as a known limitation.
+       Rejecting on a symbolic stride would regress legitimate dynamic-shape row
+       and permute copies whose offset does land on a boundary.
+
     The checks hold regardless of rank reduction (``select`` drops the outer dim
     but the flat offset is unchanged) and are the safe failure direction: a
     mis-tuned check false-rejects a working copy, never silently corrupts.
@@ -944,17 +951,14 @@ def _validate_reoffset_supported(layout, offset) -> None:
     try:
         stride = [int(s) for s in layout.stride]
     except (TypeError, ValueError):
-        # A symbolic stride[-2] cannot prove off % stride[-2] == 0, so a concrete
-        # stick-aligned offset could still fall inside the stick dim and silently
-        # miscompile (the column-offset case). Fail loudly rather than bypass the
-        # boundary check, mirroring the symbolic-offset branch above.
-        raise Unsupported(
-            "spyre::copy_from_d2d of a sliced view received a symbolic stride "
-            f"({list(layout.stride)!r}); a concrete stride is required to prove "
-            f"the storage_offset {off} lands on an outer-dimension boundary and "
-            "not inside the stick dimension. A symbolic stride cannot rule out "
-            "the silent column-offset miscompile, so it is rejected."
-        )
+        # Symbolic stride[-2] (automatic-dynamic shapes): off % stride[-2] cannot
+        # be evaluated, so the column-narrow check below is undecidable here. Fall
+        # back to check (1) only, matching upstream, which already documents the
+        # column-narrow-inside-the-stick-dim case as a known limitation. Rejecting
+        # on a symbolic stride would instead regress legitimate dynamic-shape row
+        # and permute copies the backend compiles correctly (their offset lands on
+        # a boundary; only the stride symbol, not the offset, is dynamic).
+        return
     if len(stride) >= 2 and stride[-2] and off % stride[-2] != 0:
         raise Unsupported(
             "spyre::copy_from_d2d of a sliced view requires an offset on an "

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -852,12 +852,16 @@ def _reoffset(node, offset):
     multiple) still copies correctly at offset 192 (== 3 sticks) but errors at
     offset 96 (== 1.5 sticks).
 
-    ``_validate_reoffset_supported`` converts the unaligned case into a clean,
-    actionable ``Unsupported`` at lowering time instead of the cryptic
-    restickify error deeper in the pipeline. It does NOT guard the separate
+    ``_validate_reoffset_supported`` converts every unsupported offset into a
+    clean, actionable ``Unsupported`` at lowering time instead of the cryptic
+    restickify error deeper in the pipeline or (worse) a silent miscompile. It
+    covers both the unaligned case above and the separate
     offset-*within*-the-stick-dim case (a column narrow, e.g.
-    ``x.narrow(1, 64, 64)``), which the backend still miscompiles silently — see
-    ``test_column_slice_inner_offset`` (tracked for the follow-up PR).
+    ``x.narrow(1, 64, 64)``): the latter is stick-aligned yet
+    ``offset % stride[-2] != 0``, detectable from the view's own stride. The
+    underlying stick-dim copy is still unsupported (tracked for the follow-up
+    PR); the guard only ensures the failure is loud, not silent. See
+    ``test_column_slice_inner_offset_raises``.
     """
     if offset == 0:
         return node
@@ -886,21 +890,42 @@ def _validate_reoffset_supported(layout, offset) -> None:
     earlier with an actionable message rather than silently miscompiling or
     emitting a cryptic downstream error.
 
-    Scope — this rule is keyed on the OFFSET alone, so it holds regardless of
-    rank reduction (``select`` drops the outer dim but the flat offset is
-    unchanged) and does not need the device layout, which is not attached to the
-    placeholder yet. It deliberately does NOT cover an offset that falls *inside*
-    the stick dimension itself (a column narrow): that case is
-    ``offset % elems_per_stick == 0`` yet still miscompiles, and detecting it
-    would require the base-storage layout that is unavailable here. It stays a
-    documented known limitation (``test_column_slice_inner_offset``).
+    Two conditions are checked, both derived from the view's own layout (no
+    device layout is needed — it is not attached to the placeholder yet):
+
+    1. ``offset % elems_per_stick == 0`` — the offset steps by whole sticks.
+       Measured behavior (``sweep_d2d_offsets.py``) is unambiguous: across
+       contiguous ``narrow`` / ``select`` views of every inner size, the copy is
+       correct iff this holds; every unaligned offset otherwise raises deep in
+       the restickify pass ("no mechanism to resolve stick incompatibility").
+
+    2. ``offset % stride[-2] == 0`` (rank >= 2) — the offset lands on an
+       outer-dimension boundary, i.e. does NOT fall *inside* the innermost
+       (stick) dimension. A column narrow (e.g. ``x.narrow(1, 64, 64)`` →
+       ``size=(2, 64), stride=(128, 1), offset=64``) is stick-aligned by (1) yet
+       ``64 % 128 != 0``: the offset starts partway into a row, which superdsc
+       bakes incorrectly (it does not split a stick-dim offset). This was the
+       last silent-wrong-data path; the view's own stride reveals it, so we
+       reject it here rather than miscompile.
+
+    The checks hold regardless of rank reduction (``select`` drops the outer dim
+    but the flat offset is unchanged) and are the safe failure direction: a
+    mis-tuned check false-rejects a working copy, never silently corrupts.
     """
     try:
         off = int(offset)
     except (TypeError, ValueError):
-        # Symbolic offset: cannot check statically, let it through
-        # (specialize_int bakes concrete offsets, so this is the rare path).
-        return
+        # A symbolic offset cannot be baked into the kernel coordinate: superdsc
+        # reads only the constant term (as_coeff_Add()[0]), which is 0 for a bare
+        # symbol, silently reintroducing the #3236 read-from-base bug.
+        # specialize_int is meant to bake every offset as a concrete int, so this
+        # branch should be unreachable — fail loudly rather than risk corruption.
+        raise Unsupported(
+            "spyre::copy_from_d2d received a symbolic storage_offset "
+            f"({offset!r}); a concrete int is required (specialize_int should "
+            "bake it). A symbolic offset cannot be baked into the kernel "
+            "coordinate and would silently read from the storage base."
+        )
     if off == 0:
         return
     eps = get_elem_in_stick(layout.dtype)
@@ -912,6 +937,23 @@ def _validate_reoffset_supported(layout, offset) -> None:
             "offset landing inside a stick cannot be baked into the kernel "
             "coordinate. Re-slice on a stick-aligned boundary (a multiple of "
             f"{eps} elements), or copy the full (unsliced) tensor."
+        )
+    # Offset must land on an outer-dimension boundary; a remainder smaller than
+    # the innermost dim's stride means it falls inside the stick dim (a column
+    # narrow), which superdsc bakes incorrectly. Detectable from the view stride.
+    try:
+        stride = [int(s) for s in layout.stride]
+    except (TypeError, ValueError):
+        return  # symbolic strides: the stick-aligned check above still applied
+    if len(stride) >= 2 and stride[-2] and off % stride[-2] != 0:
+        raise Unsupported(
+            "spyre::copy_from_d2d of a sliced view requires an offset on an "
+            f"outer-dimension boundary: storage_offset {off} leaves a remainder "
+            f"of {off % stride[-2]} within the innermost dimension "
+            f"(stride {stride[-2]}), i.e. it falls inside the stick dimension "
+            "and cannot be baked into the kernel coordinate. This happens for a "
+            "column slice (narrow on the last dim); copy the full rows instead, "
+            "or make the sliced region contiguous first."
         )
 
 


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Follow-up to #3237. That PR added _validate_reoffset_supported to reject a d2d-copy storage_offset that is not a whole number of sticks. Two gaps in that guard could still lead to silent wrong data; close both, keeping the same lowering-time fail-fast behavior.

1. Symbolic offset. A non-int (symbolic) offset was let through with a bare `return`. It would then reach superdsc, whose as_coeff_Add()[0] constant term is 0 for a bare symbol, baking a zero byte-offset and silently reading from the storage base — the exact #3236 bug. specialize_int is meant to bake every offset as a concrete int, so this branch should be unreachable; make it raise Unsupported loudly rather than risk corruption if that invariant breaks.

2. Offset inside the stick dimension. offset % elems_per_stick == 0 accepts a column narrow (e.g. x.narrow(1, 64, 64) -> stride (128, 1), offset 64) whose offset starts partway into a row; superdsc does not split a stick-dim offset, so the copy silently reads wrong data (measured: got 0.0, expected 64.0). This is detectable from the view's OWN stride: offset % stride[-2] != 0 means the offset is not on an outer-dimension boundary. Reject it here instead of miscompiling. (The earlier docstring's claim that detecting this needs the base-storage layout was wrong — the view stride reveals it.)

The underlying stick-dim copy is still unsupported (fails cleanly), tracked for the follow-up work.

Tests: flip test_column_slice_inner_offset to _raises (was expectedFailure / silent wrong, now a clean raise), and add TestValidateReoffsetUnit for the symbolic branch (the one guard path with no e2e equivalent).

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).


#### Which issue(s) this PR is related to:

Issue #3236 
