### PR TITLE
fix(scratchpad): keep restickify-read buffers out of LX on the greedy…

### DIFF
--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -287,6 +287,15 @@ class ScratchpadAllocator:
             if _would_produce_lx_back_gap(graph, output_name, uses):
                 self.reject_reasons[output_name] = "lx back gap"
                 continue
+            # A buffer read by a restickifying consumer (spyre.restickify, or a
+            # transpose+contiguous that lowers to RESTICKIFY_OP) must stay in HBM:
+            # ReStickifyOpHBM addresses its input as HBM, so an LX-resident input
+            # is mis-read (silently wrong past the LX-representable region). The
+            # greedy path never applied this guard (only the CP-SAT residency path
+            # did, and it missed the clone case) -- see #3145 flash attention.
+            if _read_by_restickifying_consumer(graph, output_name, uses):
+                self.reject_reasons[output_name] = "read by restickify (cross-frame barrier)"
+                continue
 
             uses = lifetimes[output_name]
             parents = in_place.get(output_name, [])
@@ -504,6 +513,41 @@ def _op_short_name(op: Any) -> str:
         if name is not None:
             break
     return name if name is not None else "None"
+
+
+# Consumer op short-names that lower to a stick-dimension-moving read
+# (``RESTICKIFY_OP`` in codegen). A ``.contiguous()`` after a transpose lowers to
+# a ``clone`` whose store becomes ``RESTICKIFY_OP`` when it moves the stick dim
+# (see ``SpyreKernel.store``: ``op == RESTICKIFY_OP`` iff the input and output
+# innermost/stick device coordinates differ). A same-stick clone lowers to
+# ``IDENTITY_OP`` instead, but Inductor elides no-op clones, so treating any
+# surviving ``clone``/``restickify`` reader as a restickify hazard is correct and
+# not over-broad in practice.
+_RESTICKIFYING_READER_NAMES = ("restickify", "clone")
+
+
+def _read_by_restickifying_consumer(
+    graph: GraphLowering, buf_name: str, uses: Sequence[int]
+) -> bool:
+    """True if a *consumer* reads ``buf_name`` via an op that lowers to
+    ``RESTICKIFY_OP``.
+
+    Such a buffer must stay in HBM: ``ReStickifyOpHBM`` addresses its input as an
+    HBM (global) tensor, so an LX-resident input is mis-addressed and the read is
+    silently wrong past the LX-representable region. The producing op is skipped
+    -- a restickify's *output* is a normal core-local LX write and is not barred
+    (see ``ScratchpadAllocator._residency_reason``). We also confirm the op
+    actually reads ``buf_name`` (``uses`` is a liveness interval, not a read set).
+    """
+    for u in uses:
+        op = graph.operations[u]
+        if op.get_name() == buf_name:  # the producer (writes buf_name); skip it
+            continue
+        if _op_short_name(op) not in _RESTICKIFYING_READER_NAMES:
+            continue
+        if any(r.name == buf_name for r in op_read_writes(op).reads):
+            return True
+    return False
 
 
 def _lx_planning_size() -> int:


### PR DESCRIPTION
What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

What this PR does:

Keeps a buffer that is read by a restickifying op out of LX scratchpad on the default (greedy) allocator path.

ReStickifyOpHBM addresses its input as a global HBM tensor. When LX planning placed such an input in LX scratchpad, the restickify read it with HBM stick addressing and returned silently-wrong data past the LX-representable region.

The allocator already encodes the invariant "a buffer a restickify reads must stay in HBM" (ScratchpadAllocator._residency_reason), but it had two gaps:

1. Only the CP-SAT / co-optimizing path consulted it. The default greedy path (config.layout_solver == "greedy") builds its LX candidates in _build_bound_buffers, which had no restickify-read exclusion, and GreedyLayoutSolver._try_allocate ignores resid
2. A clone that restickifies was missed. The guard matched _op_short_name(op) == "restickify", but a .contiguous() after a transpose(-1, -2) lowers to a clone op whose store becomes RESTICKIFY_OP at codegen (SpyreKernel.store: op == RESTICKIFY_OP iff the input and output innermost/stick device coordinates differ). Such a clone is a restickify read "restickify".

Fix: add _read_by_restickifying_consumer(graph, buf_name, uses) — a reader consumer whose short name is restickify or clone and that actually reads buf_name; the producing op is skipped so a restickify's output stays LX-eligible — and apply it as a new reject reason in _build_bound_buffers.                                                       
if _read_by_restickifying_consumer(graph, output_name, uses):                                                                                                               self.reject_reasons[output_name] = "read by restickify (cross-frame barri
    continue                                                                                                                                                            
Which issue(s) this PR is related to:                                                                                                                                   
Pre-existing base correctness bug, reproducible on main with LX planning at its default (LX_PLANNING=1) and no hint / named-dim / coarse-tiling machinery. It is one of the three independent defects behind the failing test_hint_flash_attention (the target of #3145, which Fixes #3135); this PR removes the LX-planning one. It stands on its own andon #3145. The other two are separate changes (a memory_planning advance-factorse_tile Case-1 producer/consumer layout mismatch); all three are requiredtogether for that test to pass.

Special notes for your reviewer:
                                                                                                                                                                        - Minimal reproducer (no flash, no tiling, no hints), LX planning on:
torch.amax(torch.matmul(a, b).transpose(-1, -2).contiguous(), dim=-2)                                                                                                   # a=[1,8,256,64] b=[1,8,64,256]  ->  24.5% wrong, rows >=~106 garbage, max_ab
- With this fix: 0.0% (fp16 noise floor). Confirmed equivalent to LX_PLANNING=0.
- Root-caused via the SDSC bundle dxp_standalone compiles. The broken case (matmul output in LX) and its native-input twin (clean, in HBM) produce byte-identical ReSticmaxnonstick sub-ops; the only difference is the restickify input tensor's comm" (clean). dxp_standalone --dump-bundle-module shows dxp lowers the bundlefaithfully, so the defect is frontend LX placement, not the backend.
- Effect / no regressions (LX on): test_coarse_tile_e2e 44 → 45 passed (the flash test passes when combined with the two sibling fixes); test_lx_inplace_layout passes; test_scratchpad_use and the matmul slice of test_inductor_ops_lx_planning areor baseline (identical pass/fail counts — those failures are pre-existing inthis environment, not caused by this change). The fix only ever removes a restickify-read buffer from LX; HBM reads are always correct, so it cannot regress numerics.
- Scope: this fixes the default greedy path. The CP-SAT _residency_reason sti(gap 2); extending it to the clone case there is a natural follow-up but isnot exercised by the default LAYOUT_SOLVER=greedy and was not validated here.
- The clone set member is conservative: a same-stick clone lowers to IDENTITY_OP (LX-safe), but Inductor elides no-op clones, so a surviving clone reader is a genuine restickify in
practice. A reviewer may prefer a precise stick-dim comparison instead of the

Does this PR introduce a user-facing change?

Fixes a latent correctness bug: a model that feeds a matmul output through a transpose(...).contiguous() into a reduction (e.g. attention-score normalization) could get silently-wrong numerics when LX planning placed the matmul output in scratchpad. No API change.

Additional note:                                                                                                                                                                        
Touches only torch_spyre/_inductor/scratchpad/allocator.py (+44 lines: one module-level helper plus one reject-reason check in _build_bound_buffers). Independent of #3145 — the patched region is byte-identical between main and the #3145 branch, and on main the gllocator(GreedyLayoutSolver(...)).plan_allocation → _build_bound_buffers, sothe guard is active.