### PR TITLE
Validate spyre hint groups.

### DIFF
--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -600,6 +600,34 @@ def hints_to_coarse_tile_groups(graph: GraphLowering) -> list[tuple]:
     return groups
 
 
+def validate_coarse_tile_groups(groups: list[tuple]) -> None:
+    """Raise RuntimeError if any hint_id appears in more than one group.
+
+    Each spyre_hint scope has a unique hint_id.  All ops sharing a hint scope
+    must be contiguous in the operation list and therefore land in a single group.
+    A hint_id appearing in two groups means ops from the same hint scope were
+    split — e.g. because an unrelated op migrated into the middle of the run —
+    producing two separate loop nests over the same hint scope that would iterate
+    different tiles in an unsynchronized fashion.
+    """
+    hint_id_to_group: dict[int, int] = {}
+    for group_idx, (group_ops, _levels) in enumerate(groups):
+        group_hint_ids: set[int] = set()
+        for op in group_ops:
+            for h in getattr(op, "dim_hints", []):
+                group_hint_ids.add(h.hint_id)
+        for hint_id in group_hint_ids:
+            prior = hint_id_to_group.get(hint_id)
+            if prior is not None:
+                raise RuntimeError(
+                    f"coarse_tile: hint_id={hint_id} appears in both group {prior} "
+                    f"and group {group_idx}. Ops from the same hint scope were split "
+                    "across two separate loop nests, which would produce unsynchronized "
+                    "tiling."
+                )
+            hint_id_to_group[hint_id] = group_idx
+
+
 def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
     """Build coarse_tile() groups from automatic span-overflow plans.
 

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -48,6 +48,7 @@ from .coarse_tile import (
     hints_to_coarse_tile_groups,
     reorder_unhinted_interlopers,
     span_overflow_groups,
+    validate_coarse_tile_groups,
 )
 from . import config
 from .propagate_hints import (
@@ -295,6 +296,7 @@ def _runs(*passes: Callable) -> Callable[[Callable], Callable]:
     reorder_unhinted_interlopers,
     hints_to_coarse_tile_groups,
     span_overflow_groups,
+    validate_coarse_tile_groups,
     coarse_tile,
 )
 def _maybe_coarse_tile(graph: GraphLowering) -> None:
@@ -307,6 +309,7 @@ def _maybe_coarse_tile(graph: GraphLowering) -> None:
     if groups:
         op_order = {id(op): idx for idx, op in enumerate(graph.operations)}
         groups.sort(key=lambda group: op_order.get(id(group[0][0]), len(op_order)))
+        validate_coarse_tile_groups(groups)
         coarse_tile(graph, groups=groups)
 
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

spyre tiling hints (eg `with spyre_hint(tiles={"B": B // b_block_size}):`) are intended to create consecutive groups of operations that become loop nests.  However the hints do not create a movement barrier, thus it is possible that inductor moves unhinted operations into the middle of the group, which causes the group being broken up.  The pass `reorder_unhinted_interlopers` is intended to identify and remedy this problem.

This PR introduces a sanity check to ensure that groups have not been broken up (a failure mode that has occurred in the past).  It takes advantage of the fact that each hint group has a unique id, so simply checks that a single hint IDs should not occur in multiple groups.


#### Which issue(s) this PR is related to:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
