### PR TITLE
fix(inductor): REFIX skip size-1 stick candidates in _single_arg_op_layout 

### DIFF
--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -1044,3 +1044,41 @@ def test_single_arg_size1_interior_dim():
     """
     x = torch.randn((1, 2, T, 128), dtype=torch.float16)
     _compare(lambda x: x[:, :, 1:2, :].contiguous(), x)
+
+
+def test_single_arg_size1_after_staggered_ea():
+    """RoPE output written into a KV cache at a single token position.
+
+    A RoPE-style mul+sum produces a staggered 7-dim device layout for k of
+    shape [1, NKV, T, HD]. The single-position KV write slices k to
+    [1, NKV, 1, HD] and scatters it into the cache via copy_. The mutation op
+    is a single-arg op whose output is [1, NKV, 1, HD]; when propagate_layouts
+    evaluates the staggered input STL against this op's dep, the stick
+    expression concretizes to the literal 1 (the size-1 seq dim). That
+    candidate must be skipped via try_device_coordinates, not abort the compile.
+
+    test_single_arg_size1_interior_dim does not cover this because its input
+    STL is plain row-major; here the input STL is a committed staggered-EA
+    layout from the RoPE op.
+    """
+    NKV, HD = 2, 128
+    half = HD // 2
+    KVLEN = 3 * T  # cache longer than one block
+
+    def fn(x, sf, kc):
+        # RoPE: [1, NKV, T, HD] -> staggered-EA output
+        B, H, L, D = x.shape
+        h = D // 2
+        x_ = x.transpose(1, 2).reshape(B, L, H, 2, h)
+        sf6 = sf[:, :, None, :, :, :]
+        k = sf6.mul(x_.unsqueeze(-3)).sum(4, keepdim=True).flatten(3)
+        k = k.transpose(1, 2)
+        # Single-position KV write: slice [1, NKV, 1, HD] into cache
+        kw = k[:, :, 1:2, :]
+        kc[:, :, T : T + 1, :] = kw
+        return kc
+
+    x = torch.randn((1, NKV, T, HD), dtype=torch.float16)
+    sf = torch.randn((1, T, 2, 2, half), dtype=torch.float16)
+    kc = torch.randn((1, NKV, KVLEN, HD), dtype=torch.float16)
+    _compare(fn, x, sf, kc)

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -743,11 +743,10 @@ def try_device_coordinates(
     """Like ``device_coordinates`` but returns ``None`` instead of raising when
     the layout's stick expression is one the backend cannot represent.
 
-    Intended for callers that *enumerate* candidate layouts (e.g. matmul input
-    layout selection) and want to skip an unrepresentable candidate rather than
-    abort the whole compile. Callers that have already committed to a single
-    layout should keep using ``device_coordinates`` so an unrepresentable stick
-    remains a hard error.
+    Use this to probe whether a layout is representable under a given dep —
+    for example, when iterating candidate input STLs and wanting to skip any
+    whose stick concretizes to an unsupported expression (e.g. the literal 1
+    when the stick dimension is size-1 in the current op's loop ranges).
     """
     try:
         return device_coordinates(stl, dep, indirect_sizes)

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -469,7 +469,9 @@ def _single_arg_op_layout(
         )
         return [stl]
 
-    in_device_coords = device_coordinates(stl, dep, None)
+    in_device_coords = try_device_coordinates(stl, dep, None)
+    if in_device_coords is None:
+        return []
     stick_expr = in_device_coords[-1]
 
     # Try to preserve input layout, fall back to scanning all output dims


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
**Context:**
PR #3243 offered a bug fix for when `_single_arg_op_layout` derives a candidate output layout from the input stick expression via the raising device_coordinates(stl, dep, None), but it was insufficient for the hf adapters models.  This PR moves back to a variant of the original fix proposed by @arielge in commit https://github.com/torch-spyre/torch-spyre/pull/3243/changes/0639eb89b93969934a97f323bfea45e883ebbe42

**Problem and fix:**
_single_arg_op_layout iterates over candidate input STLs and tries to derive a valid output layout from each. When a candidate is geometrically incompatible with the current op's dep — as happens here when a staggered RoPE layout is evaluated against a dep with a size-1 range — device_coordinates concretizes the stick to the literal 1, which is unsupported. The right response is to skip that candidate, not abort. try_device_coordinates is the established probe for exactly this: "can this STL be represented under this dep?" Returning [] hands control back to the caller loop, which moves on to the next candidate. The compile only fails if all candidates are exhausted.

A test case `test_single_arg_size1_after_staggered_ea` is added that fails without the fix in this PR to ensure this does not regress.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
