### PR TITLE
feat(cicd): integration tests to use label `device_critical` in CI (subset) instead of full suite per PR

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -79,10 +79,16 @@ on:
         default: true
       test_type:
         description: >-
-          Suite subset to run: smoke | core | full | suite_<group> | <label>.
-          Selects configs whose test_suite_config.labels array contains this
-          value, or (for suite_<group>) whose path sits under that directory.
-          Default: full (every config).
+          Suite subset to run: smoke | core | full | device_critical |
+          suite_<group> | <label>. Selects configs whose
+          test_suite_config.labels array contains this value, or (for
+          suite_<group>) whose path sits under that directory.
+          device_critical covers the device-layer surfaces flex and
+          deeptools/dxp_standalone exercise most (streams, job launch
+          plans, codegen, LX/scratchpad planning, tensor layout,
+          allocator/GC, D2D copies). Default: full (every config) -- callers
+          that want the narrower CI default (e.g. tests.yml) pass
+          test_type explicitly.
         required: false
         type: string
         default: full
@@ -355,6 +361,10 @@ jobs:
   #
   # Only runs for test_type values that include the distributed suite:
   #   full              — includes everything
+  #   device_critical    — the reduced CI default; distributed comms
+  #                        (streams/barrier/broadcast/gather/allgather) are
+  #                        exactly the device-layer surface this label exists
+  #                        to protect, so it always runs alongside it
   #   suite_distributed — targets the distributed_tests/ directory directly
   #   (empty)           — same as full
   # For smoke / core / suite_<other> the distributed job is skipped entirely
@@ -372,6 +382,7 @@ jobs:
       !cancelled() &&
       (inputs.test_type == '' ||
        inputs.test_type == 'full' ||
+       inputs.test_type == 'device_critical' ||
        inputs.test_type == 'suite_distributed') &&
       (needs.build_torch_spyre.result == 'success' ||
        needs.build_torch_spyre.result == 'skipped')

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -87,8 +87,8 @@ on:
           deeptools/dxp_standalone exercise most (streams, job launch
           plans, codegen, LX/scratchpad planning, tensor layout,
           allocator/GC, D2D copies). Default: full (every config) -- callers
-          that want the narrower CI default (e.g. tests.yml) pass
-          test_type explicitly.
+          that want the narrower CI default (e.g. integration-tests.yaml)
+          pass test_type explicitly.
         required: false
         type: string
         default: full
@@ -361,10 +361,10 @@ jobs:
   #
   # Only runs for test_type values that include the distributed suite:
   #   full              — includes everything
-  #   device_critical    — the reduced CI default; distributed comms
-  #                        (streams/barrier/broadcast/gather/allgather) are
-  #                        exactly the device-layer surface this label exists
-  #                        to protect, so it always runs alongside it
+  #   device_critical    — used as the reduced default by integration-tests.yaml;
+  #                        distributed comms (streams/barrier/broadcast/gather/
+  #                        allgather) are exactly the device-layer surface this
+  #                        label exists to protect, so it always runs alongside it
   #   suite_distributed — targets the distributed_tests/ directory directly
   #   (empty)           — same as full
   # For smoke / core / suite_<other> the distributed job is skipped entirely

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -2,8 +2,11 @@ name: integration-tests
 
 # ---------------------------------------------------------------------------
 # Triggered by commits in upstream dependant repos (deeptools, flex, etc.) via
-# workflow_dispatch.  Runs the full test matrix against a specified
-# torch-spyre ref so regressions from upstream changes are caught early.
+# workflow_dispatch.  Runs the device_critical test subset (streams, job
+# launch plans, codegen, LX/scratchpad planning, tensor layout, allocator/GC,
+# D2D copies -- the device-layer surfaces these upstream tools exercise
+# most) against a specified torch-spyre ref so regressions from upstream
+# changes are caught early. Pass test_type=full for full coverage.
 #
 # Example caller pattern from an upstream repo's workflow:
 #
@@ -70,11 +73,15 @@ on:
         default: ''
       test_type:
         description: >-
-          Suite subset to run: smoke | core | full | suite_<group> | <label>.
-          Default: full (every config).
+          Suite subset to run: smoke | core | full | device_critical |
+          suite_<group> | <label>. Default: device_critical (configs whose
+          test_suite_config.labels cover the device-layer surfaces flex and
+          deeptools/dxp_standalone exercise most -- streams, job launch
+          plans, codegen, LX/scratchpad planning, tensor layout,
+          allocator/GC, D2D copies). Pass "full" to run every config.
         required: false
         type: string
-        default: full
+        default: device_critical
       prebaked_image:
         description: >-
           Test the pre-baked torch-spyre-dev image directly (no checkout/build) —
@@ -117,8 +124,9 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
-  # Run the full test matrix currently same as "run-tests" job in
-  # torch_spyre_tests.yaml
+  # Run the test matrix, defaulting to the device_critical subset -- same
+  # default as the "run-tests" job in torch_spyre_tests.yaml. Callers can
+  # still request test_type=full for complete coverage.
   # ---------------------------------------------------------------------------
   run-tests:
     needs: provenance
@@ -130,7 +138,7 @@ jobs:
       checkout_pytorch: false
       ref: ${{ inputs.ref || '' }}
       repository: ${{ inputs.repository || '' }}
-      test_type: ${{ inputs.test_type || 'full' }}
+      test_type: ${{ inputs.test_type || 'device_critical' }}
       prebaked_image: ${{ inputs.prebaked_image }}
 
   # ----------------------------------------------------------------------------------

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -52,11 +52,15 @@ on:
         default: ''
       test_type:
         description: >-
-          Suite subset to run: smoke | core | full | suite_<group> | <label>.
-          Default: full (every config).
+          Suite subset to run: smoke | core | full | device_critical |
+          suite_<group> | <label>. Default: device_critical (configs whose
+          test_suite_config.labels cover the device-layer surfaces flex and
+          deeptools/dxp_standalone exercise most -- streams, job launch
+          plans, codegen, LX/scratchpad planning, tensor layout,
+          allocator/GC, D2D copies). Pass "full" to run every config.
         required: false
         type: string
-        default: full
+        default: device_critical
 
 concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.pull_request.html_url) || (github.event_name == 'workflow_dispatch'
@@ -117,7 +121,7 @@ jobs:
       rpm_location: ${{ inputs.rpm_location || '' }}
       rpm_names: ${{ inputs.rpm_names || '' }}
       build_torch_spyre: ${{ inputs.build_torch_spyre == true }}
-      test_type: ${{ inputs.test_type || 'full' }}
+      test_type: ${{ inputs.test_type || 'device_critical' }}
 
   # ---------------------------------------------------------------------------
   # Job 3: run-spyre-unit-tests (required check gate)

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -52,15 +52,11 @@ on:
         default: ''
       test_type:
         description: >-
-          Suite subset to run: smoke | core | full | device_critical |
-          suite_<group> | <label>. Default: device_critical (configs whose
-          test_suite_config.labels cover the device-layer surfaces flex and
-          deeptools/dxp_standalone exercise most -- streams, job launch
-          plans, codegen, LX/scratchpad planning, tensor layout,
-          allocator/GC, D2D copies). Pass "full" to run every config.
+          Suite subset to run: smoke | core | full | suite_<group> | <label>.
+          Default: full (every config).
         required: false
         type: string
-        default: device_critical
+        default: full
 
 concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.pull_request.html_url) || (github.event_name == 'workflow_dispatch'
@@ -121,7 +117,7 @@ jobs:
       rpm_location: ${{ inputs.rpm_location || '' }}
       rpm_names: ${{ inputs.rpm_names || '' }}
       build_torch_spyre: ${{ inputs.build_torch_spyre == true }}
-      test_type: ${{ inputs.test_type || 'device_critical' }}
+      test_type: ${{ inputs.test_type || 'full' }}
 
   # ---------------------------------------------------------------------------
   # Job 3: run-spyre-unit-tests (required check gate)

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,16 @@ PYTEST_ARGS ?= -v
 TEST_CONFIGS ?= tests/configs/torch_spyre_tests
 
 # TEST_TYPE selects which suite subset to run:
-#   smoke          — fast sanity checks (~4 suites)
-#   core           — all functional tests, excludes special-purpose hardware
-#   full           — everything (core + LX-planning); default
-#   suite_<group>  — all configs inside the <group>/ sub-directory
-#                    (e.g. suite_inductor, suite_tensors)
-#   <label>        — any arbitrary label defined in test_suite_config.labels
+#   smoke            — fast sanity checks (~4 suites)
+#   core             — all functional tests, excludes special-purpose hardware
+#   device_critical  — device-layer surfaces flex and deeptools/dxp_standalone
+#                       exercise most: streams, job launch plans, codegen,
+#                       LX/scratchpad planning, tensor layout, allocator/GC,
+#                       D2D copies (used as the default in tests.yml CI)
+#   full             — everything (core + LX-planning); default for `make tests`
+#   suite_<group>    — all configs inside the <group>/ sub-directory
+#                      (e.g. suite_inductor, suite_tensors)
+#   <label>          — any arbitrary label defined in test_suite_config.labels
 # Empty / unset defaults to "full" (all configs under TEST_CONFIGS).
 TEST_TYPE ?= full
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ TEST_CONFIGS ?= tests/configs/torch_spyre_tests
 #   device_critical  — device-layer surfaces flex and deeptools/dxp_standalone
 #                       exercise most: streams, job launch plans, codegen,
 #                       LX/scratchpad planning, tensor layout, allocator/GC,
-#                       D2D copies (used as the default in tests.yml CI)
+#                       D2D copies (used as the default in integration-tests.yaml,
+#                       triggered by those upstream repos)
 #   full             — everything (core + LX-planning); default for `make tests`
 #   suite_<group>    — all configs inside the <group>/ sub-directory
 #                      (e.g. suite_inductor, suite_tensors)

--- a/tests/configs/torch_spyre_tests/inductor/test_cache_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_cache_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_cache.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_coarse_tile_e2e_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_coarse_tile_e2e_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_coarse_tile_e2e.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_coarse_tiling_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_coarse_tiling_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_coarse_tiling.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_codegen_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_codegen_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_codegen.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_copy_back_elision_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_copy_back_elision_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_copy_back_elision.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_copy_from_d2d_offsets.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_copy_from_d2d_offsets.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_copy_from_d2d_offsets.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_dedup_constants_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_dedup_constants_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_dedup_constants.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_ea_bidirectional_conversion_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_ea_bidirectional_conversion_config.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_ea_bidirectional_conversion.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_fallback_kernel_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_fallback_kernel_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_fallback_kernel.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_indirect_access_gather_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_indirect_access_gather_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_indirect_access_gather.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_indirect_access_internals_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_indirect_access_internals_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_indirect_access_internals.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_indirect_access_scatter_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_indirect_access_scatter_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_indirect_access_scatter.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_log_passes_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_log_passes_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_log_passes.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_lx_inplace_layout_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_lx_inplace_layout_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_lx_inplace_layout.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_matmul_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_matmul_config.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [core, full]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_matmul.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_perm_layout_solver_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_perm_layout_solver_config.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_perm_layout_solver.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_provenance_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_provenance_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_provenance.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_restickify_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_restickify_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_restickify.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_scratchpad_patterns_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_scratchpad_patterns_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_scratchpad_patterns.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_scratchpad_solver_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_scratchpad_solver_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_scratchpad_solver.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_scratchpad_use_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_scratchpad_use_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_scratchpad_use.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_simulated_annealing_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_simulated_annealing_config.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_simulated_annealing.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_span_overflow_hint_analysis_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_span_overflow_hint_analysis_config.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_span_overflow_hint_analysis.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_work_division_hint_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_work_division_hint_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_work_division_hint.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/tensors/test_coordinates_config.yaml
+++ b/tests/configs/torch_spyre_tests/tensors/test_coordinates_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/tensor/test_coordinates.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/tensors/test_it_space_splits_config.yaml
+++ b/tests/configs/torch_spyre_tests/tensors/test_it_space_splits_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/tensor/test_it_space_splits.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/tensors/test_memory_format_config.yaml
+++ b/tests/configs/torch_spyre_tests/tensors/test_memory_format_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/tensor/test_memory_format.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/tensors/test_model_utils_config.yaml
+++ b/tests/configs/torch_spyre_tests/tensors/test_model_utils_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/tensor/test_model_utils.py
       # Uses @instantiate_parametrized_tests — pytest collects the test

--- a/tests/configs/torch_spyre_tests/tensors/test_resize_config.yaml
+++ b/tests/configs/torch_spyre_tests/tensors/test_resize_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/tensor/test_resize.py
       # Uses ParameterizedTestMeta — pytest collects the test class

--- a/tests/configs/torch_spyre_tests/tensors/test_tensor_layout_config.yaml
+++ b/tests/configs/torch_spyre_tests/tensors/test_tensor_layout_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/tensor/test_tensor_layout.py
       # This file uses @instantiate_parametrized_tests which is a pure parametrize

--- a/tests/configs/torch_spyre_tests/test_allocator_e2e_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_allocator_e2e_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_allocator_e2e.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_device_enum_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_device_enum_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [smoke, core, full]
+  labels: [smoke, core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_device_enum.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_execution_trace_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_execution_trace_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/profiler/test_execution_trace.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_ffdc_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_ffdc_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/profiler/test_ffdc.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_launch_jobplan_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_launch_jobplan_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_launch_jobplan.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_memory_pressure_gc_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_memory_pressure_gc_config.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_memory_pressure_gc.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_prepare_kernel_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_prepare_kernel_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_prepare_kernel.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_spyre_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_spyre_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [smoke, core, full]
+  labels: [smoke, core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_spyre.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_spyre_generator_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_spyre_generator_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_spyre_generator.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_spyre_lazy_init_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_spyre_lazy_init_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_spyre_lazy_init.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_spyre_lazy_silent_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_spyre_lazy_silent_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_spyre_lazy_silent.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_spyre_profiler_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_spyre_profiler_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/profiler/test_spyre_profiler.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_stream_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_stream_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [smoke, core, full]
+  labels: [smoke, core, full, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_stream.py
       unlisted_test_mode: mandatory_success

--- a/tests/oot_framework/utils/filter_configs.py
+++ b/tests/oot_framework/utils/filter_configs.py
@@ -20,6 +20,12 @@ Selection rules
   (empty) / "full"   All configs (backward compatible by default).
   "smoke"            Configs whose test_suite_config.labels contains "smoke".
   "core"             Configs whose test_suite_config.labels contains "core".
+  "device_critical"  Configs whose test_suite_config.labels contains
+                     "device_critical" -- the device-layer surfaces flex and
+                     deeptools/dxp_standalone exercise most (streams, job
+                     launch plans, codegen, LX/scratchpad planning, tensor
+                     layout, allocator/GC, D2D copies). Used as the default
+                     test_type for the tests.yml CI workflow.
   "suite_<group>"    Configs residing inside a directory named "<group>", or
                      whose filename starts with "<group>_".  This lets the
                      existing <group>/<name>_config.yaml layout act as a
@@ -27,7 +33,11 @@ Selection rules
   <other>            Treated as an arbitrary label name; matches configs
                      whose labels array contains the value.
 
-Configs with no labels field default to ["full"] (backward compatible).
+Configs with no labels field default to ["full"] (backward compatible) --
+they run under "full" but are excluded from every narrower test_type
+(smoke, core, device_critical, suite_<group>, custom labels). Every config
+should carry an explicit labels list; an unlabeled config is a gap to close
+by adding one, not a signal to widen matching.
 
 Output formats
 --------------


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

### Summary

Adds a new `device_critical` label to 42 `torch_spyre_tests` configs and uses it as the default `test_type` for `integration-tests.yaml` --- the workflow triggered directly by **flex** and **deeptools/dxp_standalone** on their own upstream commits  instead of `full`. That cuts the default integration-check run from 90 → 42 configs (~50%) while keeping every device-layer surface those upstream tools actually exercise.

`torch_spyre_tests.yaml` (the standard per-PR CI gate) is **unchanged** and continues to default to `full`, per reviewer feedback --- this PR only narrows the upstream-triggered integration check, not the merge-blocking per-PR suite. `full` remains fully selectable everywhere (`test_type: full`), and nightly CI (`runtests_nightly.yaml`) never passes `test_type` and continues to run `full` unconditionally, so complete coverage still runs daily regardless.


#### Why these configs - reasons listed below (we can extend this anytime and is backward compatible)

**Runtime / device**
- `test_stream_config.yaml` — streams are the async execution primitive flex schedules work through
- `test_launch_jobplan_config.yaml` — job launch plan is the exact hand-off surface deeptools/dxp_standalone drives
- `test_device_enum_config.yaml` — device enumeration underpins how flex/deeptools discover and address cards
- `test_allocator_e2e_config.yaml` — end-to-end allocator path that FlexAllocator sits on top of
- `test_memory_pressure_gc_config.yaml` — directly exercises FlexAllocator's GC callback under OOM pressure
- `test_prepare_kernel_config.yaml` — kernel-prep step immediately preceding every device launch
- `test_execution_trace_config.yaml` — execution trace is what deeptools consumes for diagnostics
- `test_ffdc_config.yaml` — FFDC auto-capture hooks around compile/runtime/unimplemented failures
- `test_spyre_profiler_config.yaml` — profiler hooks wrap every device execution flex/deeptools instrument
- `test_spyre_lazy_init_config.yaml` — lazy device init ordering that all downstream launches depend on
- `test_spyre_lazy_silent_config.yaml` — silent-init variant of the same lazy bring-up path
- `test_spyre_generator_config.yaml` — device RNG/generator state, stateful across launches
- `test_spyre_config.yaml` — core device smoke path everything else builds on

**Codegen / compiler**
- `inductor/test_codegen_config.yaml` — the codegen pass itself
- `inductor/test_work_division_hint_config.yaml` — multi-core work-division planning (how a job splits across cores)
- `inductor/test_scratchpad_solver_config.yaml` — LX scratchpad memory planning solver
- `inductor/test_scratchpad_use_config.yaml` — scratchpad allocation usage patterns
- `inductor/test_scratchpad_patterns_config.yaml` — scratchpad access pattern coverage
- `inductor/test_perm_layout_solver_config.yaml` — capacity-bounded layout/allocation planner
- `inductor/test_simulated_annealing_config.yaml` — the simulated-annealing layout solver end-to-end
- `inductor/test_span_overflow_hint_analysis_config.yaml` — coarse-tiling hints feeding the scheduler/codegen
- `inductor/test_coarse_tiling_config.yaml` — coarse-tile IR itself
- `inductor/test_coarse_tile_e2e_config.yaml` — coarse-tile pipeline end-to-end
- `inductor/test_restickify_config.yaml` — restickify pass, a canonical compiler-pass pattern for this repo
- `inductor/test_copy_from_d2d_offsets.yaml` — device-to-device copy correctness
- `inductor/test_copy_back_elision_config.yaml` — copy-back elision optimization around device buffers
- `inductor/test_indirect_access_gather_config.yaml` — indirect device memory access (gather)
- `inductor/test_indirect_access_scatter_config.yaml` — indirect device memory access (scatter)
- `inductor/test_indirect_access_internals_config.yaml` — internals backing both indirect-access paths
- `inductor/test_dedup_constants_config.yaml` — constant staging/dedup onto device memory
- `inductor/test_lx_inplace_layout_config.yaml` — LX in-place layout handling
- `inductor/test_ea_bidirectional_conversion_config.yaml` — FP16/FP32 element-arrangement conversion, a device dtype/layout path
- `inductor/test_fallback_kernel_config.yaml` — fallback-kernel launch path onto the device
- `inductor/test_cache_config.yaml` — compile-cache reuse of device-compiled artifacts across runs
- `inductor/test_provenance_config.yaml` — pass provenance tracking, used to localize codegen regressions
- `inductor/test_log_passes_config.yaml` — per-pass logging used to diagnose codegen ordering regressions

**Tensor layout**
- `tensors/test_tensor_layout_config.yaml` — the tiled tensor layout spec itself, central to the Spyre memory model
- `tensors/test_coordinates_config.yaml` — coordinate mapping underlying that layout
- `tensors/test_memory_format_config.yaml` — memory-format conversions across device layouts
- `tensors/test_it_space_splits_config.yaml` — iteration-space splitting used by work division
- `tensors/test_resize_config.yaml` — resize behavior under the tiled layout
- `tensors/test_model_utils_config.yaml` — layout utility helpers shared across model code

**Distributed** (`distributed_tests/*`, 5 configs) — kept unconditional regardless of `test_type`: streams/barrier/broadcast/gather/allgather are exactly the multi-device surface this label protects, and the job is cheap enough to always run.

#### Excluded (stay at `core`/`full` only)

Pure op-correctness suites (matmul, pointwise, reduction, fp8, dtype/normalization scalars, FX passes) and generic infra (`test_modules`, `test_regex`, `test_fallbacks`) -- these validate numerical correctness rather than device-layer/job-scheduling behavior, so they are lower priority for a fast default gate.

`device_critical` is strict opt-in --- only configs explicitly carrying the label are selected; unlabeled configs keep the original behavior of defaulting to `["full"]` internally, so they run under `full` but are excluded from every narrower `test_type`.

#### Where it applies now:

| Workflow | Default `test_type` | Change |
|---|---|---|
| `torch_spyre_tests.yaml` (per-PR CI) | `full` | **unchanged**, per reviewer feedback |
| `integration-tests.yaml` (flex/deeptools-triggered) | `device_critical` | **new default**, `full` still available via input |
| `runtests_nightly.yaml` | `full` | unchanged (never passes `test_type`) |

Verified: `device_critical` → 42 configs, `core` → 73, `smoke` → 4, `full` → 90, no config in the tree missing a `labels` field.
