### PR TITLE
Alignment of scratchpad allocators to all use declarative exclusion

### DIFF
--- a/.github/actions/build-torch-spyre-wheel/action.yml
+++ b/.github/actions/build-torch-spyre-wheel/action.yml
@@ -35,15 +35,31 @@ runs:
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
     - name: Restore ccache
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      id: ccache_restore
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ github.workspace }}/.ccache
         # Keyed on the C++ sources + build config. image_label discriminates the
         # ABI/toolchain (it also fixes the Python version — each image ships one
         # interpreter). An exact key => full hit; the prefix restore-key warm-
         # starts a partial rebuild when only a few .cpp/.h files changed.
+        #
+        # The run_id suffix makes the key unique, so it never exact-matches and
+        # the save step below always gets the chance to publish a refreshed
+        # entry. That matters because the ccache also depends on inputs this key
+        # does NOT cover — above all the Spyre SDK headers (<flex/...>,
+        # <util/sendefs.h>) that come from the runner image, which 12 of the 19
+        # TUs include. When one of those drifts the objects go stale while the
+        # key stays identical, and since actions/cache never overwrites an entry
+        # whose primary key hit, the stale entry used to be served forever (one
+        # sat unrefreshed from 2026-07-20, costing ~8 min of recompiles on every
+        # run for days). Entries keep the default retention and are reaped by
+        # the 7-day-unused rule / 10 GB LRU.
         key: ts-ccache-${{ inputs.image_label }}-${{ hashFiles(format('{0}/torch_spyre/csrc/**', inputs.torch_spyre_dir), format('{0}/setup.py', inputs.torch_spyre_dir),
-          format('{0}/pyproject.toml', inputs.torch_spyre_dir), format('{0}/uv.lock', inputs.torch_spyre_dir)) }}
+          format('{0}/pyproject.toml', inputs.torch_spyre_dir), format('{0}/uv.lock', inputs.torch_spyre_dir)) }}-${{ github.run_id }}
+        # The prefix does the real warm start: it restores the most recent entry
+        # for this label, which the save step then republishes with whatever was
+        # missing folded in.  
         restore-keys: |
           ts-ccache-${{ inputs.image_label }}-
 
@@ -102,6 +118,21 @@ runs:
         uv build --wheel --no-build-isolation --out-dir dist
         ccache --show-stats || true
 
+        # Publish a refreshed cache only when this build actually compiled
+        # something. A clean 19/19 hit has nothing new to add, and re-uploading
+        # ~130 MB per run would churn the repo's shared 10 GB cache quota.
+        # Anything unparseable (older ccache without --print-stats) counts as
+        # dirty: a needless save costs bandwidth, a skipped one costs every
+        # later build.
+        misses="$({ ccache --print-stats 2>/dev/null || true; } \
+                  | awk '$1 == "cache_miss" { print $2; exit }')"
+        echo "ccache misses this build: ${misses:-unknown}"
+        if [[ "$misses" == "0" ]]; then
+          echo "ccache_dirty=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "ccache_dirty=true" >> "$GITHUB_OUTPUT"
+        fi
+
         WHEEL="$(ls -1 dist/*.whl | head -1)"
         if [[ -z "$WHEEL" ]]; then
           echo "::error::No wheel produced under ${TORCH_SPYRE_DIR}/dist" >&2
@@ -109,3 +140,16 @@ runs:
         fi
         echo "Built wheel: $WHEEL"
         echo "wheel_name=$(basename "$WHEEL")" >> "$GITHUB_OUTPUT"
+
+    # Restore/save are split because the all-in-one cache action saves only as a
+    # post-step and only when the primary key MISSED — the exact behaviour that
+    # kept a stale entry alive. Cache entries are immutable, so this publishes a
+    # new entry rather than overwriting anything. Skipped on build failure by
+    # the usual step semantics: a half-populated cache from a build that died
+    # partway is not worth publishing.
+    - name: Save ccache
+      if: steps.build.outputs.ccache_dirty == 'true'
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ${{ github.workspace }}/.ccache
+        key: ${{ steps.ccache_restore.outputs.cache-primary-key }}

--- a/docs/source/compiler/scratchpad_planning.md
+++ b/docs/source/compiler/scratchpad_planning.md
@@ -255,10 +255,11 @@ The relevant code lives under `torch_spyre/_inductor/scratchpad/`:
 | File | Responsibility |
 |---|---|
 | `passes.py` | `ScratchpadOptimizationPass` ABC, `CloneInputNodesPass` |
-| `plan_solver.py` | `MemoryPlanSolver` ABC, `LifetimeBoundBuffer`, `GreedyLayoutSolver` |
+| `plan_solver.py` | `MemoryPlanSolver` ABC (declarative exclusion via `partition`/`excluded`), `LifetimeBoundBuffer` |
+| `greedy_solver.py` | `GreedyLayoutSolver` |
 | `firstfit_bestfit_solver.py` | `FirstFitLayoutSolver`, `BestFitLayoutSolver` |
-| `allocator.py` | `ScratchpadAllocator`, `StrategyBCoOptimizingAllocator` |
-| `utils.py` | liveness, in-place candidates, op eligibility lists |
+| `allocator.py` | `ScratchpadAllocator`, `StrategyBCoOptimizingAllocator`, and the single LX-eligibility predicate (`_residency_reasons`, one reason per buffer) |
+| `utils.py` | liveness, mem usage, op-name/eligibility helpers |
 
 ### Entry point
 
@@ -271,16 +272,61 @@ scratchpad_planning(graph, allocator=ScratchpadAllocator())
 1. **Pre-passes.** `CloneInputNodesPass` walks graph inputs and inserts a
    `clone` for any HBM input that is read more than once *and* fits on
    LX. The clone output becomes a fresh LX-eligible buffer.
-2. **Buffer analysis.** `_generate_buffers` produces a list of
-   `LifetimeBoundBuffer(name, size, start_time, end_time, in_place_parents)`
-   for every op that survives the eligibility filter (graph i/o is
-   excluded; so are buffers whose users have incompatible core splits).
-3. **Layout planning.** The solver assigns an `address` to each buffer
-   it can fit; the rest get `address=None` and stay on HBM.
+2. **Buffer analysis.** `_generate_buffers` produces one
+   `LifetimeBoundBuffer` per buffer — *including* the ones that may not
+   reside. Nothing is filtered out; `ScratchpadAllocator._residency_reasons`
+   (in `allocator.py`) decides eligibility and the verdict rides along as
+   `residency_reason` (see
+   [Declarative exclusion](#declarative-exclusion) below).
+3. **Layout planning.** The solver partitions off every barred buffer
+   (`MemoryPlanSolver.partition`), then assigns an `address` to each of the
+   rest it can fit; whatever is left gets `address=None` and stays on HBM.
 4. **Push allocation.** Successful placements are written to
    `layout.allocation["lx"] = addr` on each buffer's `FixedTiledLayout`.
 5. **Post-passes.** Currently empty. Reserved for solver-driven graph
    mutations (output cloning, op re-ordering).
+
+### Declarative exclusion
+
+Eligibility is decided in exactly one place — `ScratchpadAllocator._residency_reasons`
+in `allocator.py` — and carried
+to the solver as a single field, `LifetimeBoundBuffer.residency_reason`:
+`None` means the buffer may be pinned, any string is the reason it may not.
+
+**No buffer is ever dropped.** A barred buffer is still handed to the
+solver so it keeps participating in slicing matching and in-place chains: a
+forced-out consumer keeps its producers' residency viable instead of
+orphaning them, and an in-place parent reference always resolves. Honouring
+the verdict is therefore each solver's responsibility, via
+`MemoryPlanSolver.excluded`, and every solver (greedy, first-fit, best-fit,
+simulated annealing, CP-SAT) routes its exclusions through it.
+
+**Where a check belongs.** Precomputable from the graph ⇒ it lives in
+`_residency_reasons` as a reason string. Depends on the solver's free variables ⇒
+it stays a constraint in the solver — today that is only CP-SAT's per-edge
+slicing match over the division variables and its in-place merge gate.
+Capacity is the exception that belongs to neither allocator: it is solver
+state, so it lives on `MemoryPlanSolver.excluded` alongside the tag.
+
+The checks, in evaluation order (the first failure is the reason reported):
+
+| Reason | Why |
+|---|---|
+| `op not allowed` | not a `ComputedBuffer`, a mutation layout, or an op name outside `OP_OUTPUT_GOOD_FOR_LX_REUSE` |
+| `unsized (no device layout)` | no computable footprint (e.g. a `MultiOutputLayout` tuple op) |
+| `mutation target` | filled by offset writes, so one LX base mis-addresses it |
+| `tiled (advancing), not per_tile_fixed` | LX addresses cannot be `affine.apply` symbols |
+| `read by restickify (cross-frame barrier)` | the read and write frames are transposes, so a per-core LX slice is not self-sufficient (the buffer a restickify reads; its own output is safe and is not barred) |
+| `extern kernel user` | extern ops read from HBM |
+| `graph output (no clone)` / `graph input (no clone)` | without boundary cloning there is nothing to redirect |
+| `graph output is a ReinterpretView` | output cloning cannot rewrap the view |
+| `partial/offset read` | a sliced or multi-offset read mis-addresses a single LX base |
+| `core div mismatch: …` | the buffer's users disagree on core slicing (**placement path only** — the joint solver *chooses* the division, so its slicing gate decides instead) |
+| `no consumer reads it from LX` | residency would save nothing |
+| `lx back gap` | `backGap` is supported for HBM but not LX |
+
+That last distinction is the only difference between the two allocators,
+and it is a parameter (`division_is_fixed`) rather than a second predicate.
 
 ### Per-core size and core-division mismatch
 

--- a/tests/inductor/test_scratchpad_patterns.py
+++ b/tests/inductor/test_scratchpad_patterns.py
@@ -36,9 +36,9 @@ from torch_spyre._inductor.scratchpad.simulated_annealing import (
 )
 from torch_spyre._inductor.scratchpad.plan_solver import (
     MemoryPlanSolver,
-    GreedyLayoutSolver,
     LifetimeBoundBuffer as Buffer,
 )
+from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
 
 AVAILABLE_LX_SIZE = _lx_planning_size()
 

--- a/tests/inductor/test_scratchpad_solver.py
+++ b/tests/inductor/test_scratchpad_solver.py
@@ -28,9 +28,9 @@ from torch_spyre._inductor.scratchpad.plan_solver import (
     MemoryPlanSolver,
     CoreDivision,
     CoreDivisionBuffer,
-    GreedyLayoutSolver,
     LifetimeBoundBuffer,
 )
+from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
 
 try:
     from ortools.sat.python import cp_model  # noqa: F401
@@ -142,7 +142,8 @@ class BaseLayoutSolverTests:
         return LifetimeBoundBuffer(name, size, uses, **kwargs)
 
     def solve(self, buffers, size=LARGE_SIZE, alignment=1):
-        return self.solver_class(size, alignment).plan_layout(buffers)
+        self.last_solver = self.solver_class(size, alignment)
+        return self.last_solver.plan_layout(buffers)
 
     def check_result(self, result, expected_addresses, size, alignment):
         """Assert the solved layout matches the heuristic-solver expectation.
@@ -170,6 +171,42 @@ class BaseLayoutSolverTests:
     ):
         result = self.solve(buffers, size, alignment)
         self.check_result(result, expected_addresses, size, alignment)
+
+    # -- the declarative-exclusion contract, run against every solver --------
+    #
+    # The allocator hands over *every* buffer, barred ones included, so that
+    # in-place parents always resolve and the joint solver can still match
+    # slicing across a barred buffer. Honouring the verdict is therefore each
+    # solver's responsibility, not the allocator's, and placing a barred buffer
+    # is a correctness bug rather than a heuristic choice.
+
+    def test_barred_buffer_is_never_placed(self):
+        # The allocator's declared verdict (here the restickify cross-frame
+        # barrier) keeps the buffer out of LX, and the solver reports it back
+        # verbatim so the allocator can explain the spill. An unbarred buffer of
+        # the same shape still resides, proving the bar did the work.
+        reason = "read by restickify (cross-frame barrier)"
+        barred = self.make_buffer("barred", 40, [0, 1], residency_reason=reason)
+        free = self.make_buffer("free", 40, [0, 1])
+        result = {b.name: b for b in self.solve([barred, free])}
+
+        self.assertIsNone(result["barred"].address)
+        self.assertIsNotNone(result["free"].address)
+        self.assertEqual(self.last_solver.spill_reasons["barred"], reason)
+        self.assertNotIn("free", self.last_solver.spill_reasons)
+
+    def test_barred_in_place_parent_does_not_orphan_its_child(self):
+        # A barred parent leaves a dangling in_place_parents name once it is
+        # partitioned out. The child must still be placed (on its own slot,
+        # since there is none to inherit) rather than crashing the solver.
+        parent = self.make_buffer(
+            "parent", 40, [0, 1], residency_reason="mutation target"
+        )
+        child = self.make_buffer("child", 40, [1, 2], in_place_parents=["parent"])
+        result = {b.name: b for b in self.solve([parent, child])}
+
+        self.assertIsNone(result["parent"].address)
+        self.assertIsNotNone(result["child"].address)
 
     def test_simple_layout(self):
         # Three non-overlapping buffers fill memory sequentially.
@@ -623,9 +660,8 @@ class JointDivisionSolverTests(BaseLayoutSolverTests):
             parents=names,
             cd_parent_matches={n: [(0, 0)] for n in names},
         )
-        result = self.solver_class(size, alignment).plan_layout_and_core_divisions(
-            buffers + [sink]
-        )
+        self.last_solver = self.solver_class(size, alignment)
+        result = self.last_solver.plan_layout_and_core_divisions(buffers + [sink])
         return [b for b in result if b.name != "__sink__"]
 
     def check_result(self, result, expected_addresses, size, alignment):
@@ -665,7 +701,16 @@ class JointDivisionSolverTests(BaseLayoutSolverTests):
                 core_divisions=_whole(),
             ),
             CoreDivisionBuffer("Q", 75, [16, 17], core_divisions=_whole()),
-            CoreDivisionBuffer("TERMINAL", 75, [17, 18], core_divisions=_whole()),
+            # Consumer-less tail: the allocator declares its non-residency
+            # ("no consumer reads it from LX") up front, exactly as it would for
+            # any buffer nothing reads from LX, and the solver honours it.
+            CoreDivisionBuffer(
+                "TERMINAL",
+                75,
+                [17, 18],
+                core_divisions=_whole(),
+                residency_reason="no consumer reads it from LX",
+            ),
         ]
         for i in range(1, len(buffers)):
             buffers[i].cd_parent_matches = {buffers[i - 1].name: [(0, 0)]}
@@ -739,13 +784,21 @@ class JointDivisionSolverTests(BaseLayoutSolverTests):
         self.assertEqual(p_cd.output_partition, 4)
 
     def test_no_consumer_division_buffer_is_spilled(self):
-        # A buffer that carries divisions but has no local consumer edge can
-        # never match anything, so it is force-spilled even when it would fit.
-        leaf = CoreDivisionBuffer("leaf", 40, [0, 1], core_divisions=_divs())
-        result = self.solver_class(
-            size=256, alignment=1
-        ).plan_layout_and_core_divisions([leaf])
+        # "Nothing reads this from LX" is a graph fact, so the allocator decides
+        # it (read_count == 0 -> residency_reason) rather than the solver
+        # re-deriving it from the absence of consumer edges. The solver's job is
+        # to honour that verdict and report it back.
+        leaf = CoreDivisionBuffer(
+            "leaf",
+            40,
+            [0, 1],
+            core_divisions=_divs(),
+            residency_reason="no consumer reads it from LX",
+        )
+        solver = self.solver_class(size=256, alignment=1)
+        result = solver.plan_layout_and_core_divisions([leaf])
         self.assertIsNone(result[0].address)
+        self.assertEqual(solver.spill_reasons["leaf"], "no consumer reads it from LX")
 
     def test_oversized_min_footprint_is_spilled(self):
         # Even the smallest candidate footprint (total/4 = 250) exceeds the
@@ -849,10 +902,18 @@ class TestCpSatJointDivision(JointDivisionSolverTests, TestCase):
 
     def test_spill_reasons_recorded(self):
         # The solver records a per-buffer drop cause for every spilled buffer so
-        # the allocator can report why each landed in HBM. `leaf` has divisions
-        # but no consumer edge (forced out by the residency gate); `big`'s
-        # smallest footprint exceeds capacity (forced out up front).
-        leaf = CoreDivisionBuffer("leaf", 40, [0, 1], core_divisions=_whole())
+        # the allocator can report why each landed in HBM. The two sources are
+        # covered: `leaf` and `C` carry the allocator's declared verdict (nothing
+        # reads them from LX), while `big` is spilled by the solver's own
+        # capacity check -- its smallest per-core footprint (1000/4) exceeds the
+        # 200 B limit.
+        leaf = CoreDivisionBuffer(
+            "leaf",
+            40,
+            [0, 1],
+            core_divisions=_whole(),
+            residency_reason="no consumer reads it from LX",
+        )
         big = CoreDivisionBuffer(
             "big", 1000, [0, 1], core_divisions=[CoreDivision(output_splits={256: 4})]
         )
@@ -862,6 +923,7 @@ class TestCpSatJointDivision(JointDivisionSolverTests, TestCase):
             [1, 2],
             core_divisions=[CoreDivision(output_splits={256: 4})],
             parents=["big"],
+            residency_reason="no consumer reads it from LX",
         )
         solver = self.solver_class(size=200, alignment=1)
         result = {
@@ -903,7 +965,8 @@ class TestCpSatPlacementOnly(BaseLayoutSolverTests, TestCase):
             # Below one alignment unit the unit-scaled capacity rounds to zero
             # and the solver cannot represent any placement.
             return buffers
-        return self.solver_class(size, alignment).plan_layout(buffers)
+        self.last_solver = self.solver_class(size, alignment)
+        return self.last_solver.plan_layout(buffers)
 
     def check_result(self, result, expected_addresses, size, alignment):
         _assert_legal_packing(self, result, expected_addresses, size, alignment)
@@ -986,7 +1049,7 @@ class TestCpSatUnallocatedReads(TestCase):
     *not* pin the producer. All without a Spyre device.
     """
 
-    def _mk(self, name, uses, parents=(), unallocated_reads=0, matches=None):
+    def _mk(self, name, uses, parents=(), matches=None, barred=False):
         """A single-fixed-division ``CoreDivisionBuffer``. ``matches`` overrides
         the per-parent match pairs; by default every parent edge is compatible
         (``[(0, 0)]``), matching a producer/consumer whose fixed divisions slice
@@ -1002,22 +1065,23 @@ class TestCpSatUnallocatedReads(TestCase):
             core_divisions=[CoreDivision()],
             parents=list(parents),
             cd_parent_matches=matches,
-            unallocated_reads=unallocated_reads,
+            residency_reason="no consumer reads it from LX" if barred else None,
         )
 
     def _pinned(self, bufs):
         out = CpSatLayoutSolver(1 << 20).plan_layout_and_core_divisions(bufs)
         return {b.name for b in out if b.address is not None}
 
-    def test_only_unallocated_reads_is_pinned(self):
+    def test_only_non_candidate_reads_is_pinned(self):
         """A buffer read solely by a non-candidate consumer (no children) is
-        pinned on the strength of its unallocated read."""
-        self.assertIn("b0", self._pinned([self._mk("b0", [0, 1], unallocated_reads=1)]))
+        pinned on the strength of that read: the allocator counted it in
+        ``read_count`` and so did not bar the buffer."""
+        self.assertIn("b0", self._pinned([self._mk("b0", [0, 1])]))
 
     def test_no_reads_is_not_pinned(self):
-        """A buffer with no children and no unallocated reads is forced to HBM
-        (nothing reads it from LX)."""
-        self.assertNotIn("b0", self._pinned([self._mk("b0", [0, 1])]))
+        """A buffer nothing reads from LX is barred by the allocator and the
+        solver honours that, leaving it in HBM."""
+        self.assertNotIn("b0", self._pinned([self._mk("b0", [0, 1], barred=True)]))
 
     def test_candidate_parent_edge_still_pins(self):
         """The ordinary producer->consumer edge still pins the producer."""
@@ -1080,9 +1144,9 @@ class TestTopologicalSort(TestCase):
         # A 3-level in-place chain gp -> p -> c. Each level has exactly one
         # ready node at a time, so topology alone fixes the order regardless of
         # the tie-break key or input order.
-        gp = LifetimeBoundBuffer("gp", 100, 0, 2)
-        p = LifetimeBoundBuffer("p", 100, 2, 4, in_place_parents=["gp"])
-        c = LifetimeBoundBuffer("c", 100, 4, 6, in_place_parents=["p"])
+        gp = LifetimeBoundBuffer("gp", 100, [0, 1])
+        p = LifetimeBoundBuffer("p", 100, [2, 3], in_place_parents=["gp"])
+        c = LifetimeBoundBuffer("c", 100, [4, 5], in_place_parents=["p"])
         # Pass the inputs out of order to prove the result is driven by the
         # in-place edges, not the input order.
         self.assertEqual(self._names([c, p, gp], lambda b: 0), ["gp", "p", "c"])
@@ -1099,13 +1163,13 @@ class TestTopologicalSort(TestCase):
         # f sorts ascending by size, so the smaller buffer `a` must come first.
         # `a` deliberately has the LONGER lifetime, so the old lifetime-keyed
         # tie-break would (incorrectly) emit `b` before `a`.
-        root = LifetimeBoundBuffer("root", 100, 0, 1)
-        mid = LifetimeBoundBuffer("mid", 100, 1, 2, in_place_parents=["root"])
+        root = LifetimeBoundBuffer("root", 100, [0])
+        mid = LifetimeBoundBuffer("mid", 100, [1], in_place_parents=["root"])
         a = LifetimeBoundBuffer(
-            "a", 1, 2, 102, in_place_parents=["mid"]
+            "a", 1, [2, 101], in_place_parents=["mid"]
         )  # size 1, lifetime 100
         b = LifetimeBoundBuffer(
-            "b", 100, 2, 3, in_place_parents=["mid"]
+            "b", 100, [2], in_place_parents=["mid"]
         )  # size 100, lifetime 1
 
         self.assertEqual(

--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -1049,8 +1049,8 @@ class TestIntermediatePartialReadNotPinned(BaseTestScratchpadUsage):
     """An *intermediate* buffer read partially (sliced) must not be LX-pinned.
 
     Companion to ``TestCloneAtGraphBoundaries``, which guards graph
-    input/output clones. ``_filter_ops`` applies the same
-    ``buffer_not_read_in_full`` guard to intermediate buffers: a buffer that is
+    input/output clones. ``ScratchpadAllocator._residency_reasons`` applies the
+    same ``buffer_not_read_in_full`` guard to intermediate buffers: a buffer that is
     produced in full and then read over a sub-extent (an inner-dim slice that
     feeds a chained op) would be LX-pinned and mis-addressed by the single-base
     LX path. Without the intermediate guard this regresses to a large
@@ -1089,7 +1089,7 @@ class TestIntermediatePartialReadNotPinned(BaseTestScratchpadUsage):
             cpu_result,
             atol=0.1,
             rtol=0.1,
-            msg="sliced intermediate miscompiled — is the _filter_ops guard present?",
+            msg="sliced intermediate miscompiled — is the partial-read guard present?",
         )
 
 
@@ -1210,7 +1210,7 @@ class TestCpSatTimeoutFallback(BaseTestScratchpadUsage):
         """Count ``GreedyLayoutSolver.plan_layout`` invocations while still running
         the real method.
         """
-        from torch_spyre._inductor.scratchpad.plan_solver import GreedyLayoutSolver
+        from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
 
         original_plan_layout = GreedyLayoutSolver.plan_layout
         calls = {"count": 0}
@@ -1288,7 +1288,7 @@ class TestSelectAllocator(unittest.TestCase):
             StrategyBCoOptimizingAllocator,
             select_allocator,
         )
-        from torch_spyre._inductor.scratchpad.plan_solver import GreedyLayoutSolver
+        from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
         from torch_spyre._inductor.scratchpad.firstfit_bestfit_solver import (
             BestFitLayoutSolver,
         )
@@ -1312,11 +1312,18 @@ class TestSelectAllocator(unittest.TestCase):
         ):
             self.assertIsInstance(select_allocator(), StrategyBCoOptimizingAllocator)
 
-        # cpsat + co-optimization routes to the joint allocator.
+        # cpsat + co-optimization routes to the joint allocator when ortools is
+        # present, else degrades to greedy placement (the fallback now lives in
+        # select_allocator, not inside CoOptimizingAllocator).
         with ts_inductor_config.patch(
             layout_solver="cpsat", co_optimizing_lx_planning=True
         ):
-            self.assertIsInstance(select_allocator(), CoOptimizingAllocator)
+            a = select_allocator()
+            if _HAS_ORTOOLS:
+                self.assertIsInstance(a, CoOptimizingAllocator)
+            else:
+                self.assertIs(type(a), ScratchpadAllocator)
+                self.assertIsInstance(a.layout_planning, GreedyLayoutSolver)
 
         # cpsat without co-optimization is placement-only: a ScratchpadAllocator
         # driven by the CP-SAT solver on the pre-determined core divisions.

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -23,12 +23,12 @@ import torch
 from torch._inductor.ir import (
     TensorBox,
     ComputedBuffer,
-    Operation,
+    ExternKernel,
     MutationLayoutSHOULDREMOVE,
-    ReinterpretView,
+    Operation,
     Pointwise,
     Reduction,
-    ExternKernel,
+    ReinterpretView,
 )
 from torch._inductor.graph import GraphLowering
 
@@ -47,12 +47,12 @@ from torch_spyre._inductor.scratchpad.plan_solver import (
     CoreDivision,
     CoreDivisionBuffer,
     CoreDivisionLayoutSolver,
-    GreedyLayoutSolver,
     LifetimeBoundBuffer,
     MemoryPlanSolver,
     SolveError,
     BufferType,
 )
+from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
 from torch_spyre._inductor.scratchpad.firstfit_bestfit_solver import (
     BestFitLayoutSolver,
     FirstFitLayoutSolver,
@@ -64,19 +64,18 @@ from torch_spyre._inductor.scratchpad.passes import (
     ScratchpadOptimizationPass,
 )
 from torch_spyre._inductor.scratchpad.utils import (
-    OP_OUTPUT_GOOD_FOR_LX_REUSE,
     round_up_to_alignment,
     clone_at_graph_boundaries,
     mem_usage_by_buf,
     calculate_liveness,
-    get_ncores_for_buffers,
     get_buffer_users,
-    buffer_not_read_in_full,
     ops_in_offset_mutation_component,
-    GraphView,
     get_op_pointwise_inputs,
-    _would_produce_lx_back_gap,
+    buffer_not_read_in_full,
+    get_ncores_for_buffers,
     _is_tiled_advancing,
+    _would_produce_lx_back_gap,
+    OP_OUTPUT_GOOD_FOR_LX_REUSE,
 )
 from torch_spyre._inductor.scratchpad.graph_editor import GraphEditor
 
@@ -131,7 +130,8 @@ class ScratchpadAllocator:
             post_optimization_passes = []
 
         # Populated during plan_allocation: maps buffer/op name → reason string.
-        # Stamped by _filter_ops, _build_bound_buffers, and plan_allocation
+        # Stamped by _record_spill_reasons from the solver's own spill_reasons
+        # (the declared residency verdict, or its capacity check)
         # (for the solver decision). Reset at the start of each plan_allocation.
         self.reject_reasons: dict[str, str] = {}
         self.pre_optimization_passes = pre_optimization_passes
@@ -141,26 +141,68 @@ class ScratchpadAllocator:
     def plan_allocation(self, graph: GraphLowering):
         """Run pre-passes, assign LX addresses to eligible buffers, then run post-passes.
 
+        This is a template method: the skeleton (reset reasons -> pre-passes ->
+        generate buffers -> solve -> commit -> record reasons -> push -> log ->
+        post-passes) is fixed, while subclasses override the ``_prepare_buffers``
+        / ``_solve`` / ``_post_solve`` / ``_record_reject_reasons`` hooks to swap
+        in their buffer type, solver call, and post-solve commit. The base hooks
+        implement the fixed-division, placement-only flow.
+
         Args:
             graph: Lowered graph whose buffers will be assigned LX scratchpad
                 addresses where viable.
         """
         self.reject_reasons = {}
-        for p in self.pre_optimization_passes:
-            p.apply_pass(graph)
-        buffers = self._generate_buffers(graph)
-        assert self.layout_planning is not None
-        allocation = self.layout_planning.plan_layout(buffers, log_lx_usage=True)
-        for b in allocation:
-            if b.address is None:
-                self.reject_reasons[b.name] = (
-                    f"no room on scratchpad (t={b.start_time}-{b.end_time},"
-                    f" size={b.size // 1024} KB)"
-                )
+        self._run_passes(self.pre_optimization_passes, graph)
+        buffers = self._prepare_buffers(graph)
+        allocation = self._solve(buffers)
+        self._post_solve(graph, allocation)
+        self._record_reject_reasons(allocation)
         self._push_allocation(graph, allocation)
         self._log_lx_pinning(graph)
-        for p in self.post_optimization_passes:
+        self._run_passes(self.post_optimization_passes, graph)
+
+    @staticmethod
+    def _run_passes(
+        passes: Sequence[ScratchpadOptimizationPass], graph: GraphLowering
+    ) -> None:
+        for p in passes:
             p.apply_pass(graph)
+
+    def _prepare_buffers(self, graph: GraphLowering) -> Sequence[Any]:
+        """Buffers to hand the solver. Base: fixed-division LifetimeBoundBuffers."""
+        return self._generate_buffers(graph)
+
+    def _solve(self, buffers: Sequence[Any]) -> Sequence[Any]:
+        """Assign LX addresses. Base: placement-only ``plan_layout``."""
+        assert self.layout_planning is not None
+        return self.layout_planning.plan_layout(buffers, log_lx_usage=True)
+
+    def _post_solve(self, graph: GraphLowering, allocation: Sequence[Any]) -> None:
+        """Hook run after the solve, before reasons/push. Base: nothing to commit."""
+
+    def _record_reject_reasons(self, allocation: Sequence[Any]) -> None:
+        """Stamp ``reject_reasons`` for spilled buffers. Base: from the solver's
+        per-buffer :meth:`_record_spill_reasons`."""
+        self._record_spill_reasons(allocation)
+
+    def _record_spill_reasons(self, allocation: Sequence[LifetimeBoundBuffer]) -> None:
+        """Stamp ``reject_reasons`` for every buffer that did not land in LX.
+
+        The solver's own :attr:`spill_reasons` is authoritative -- it carries the
+        declared verdict (``residency_reason``) or its capacity check. Anything
+        spilled without a reason there simply did not fit once the higher-value
+        buffers were placed.
+        """
+        assert self.layout_planning is not None
+        solver_reasons = self.layout_planning.spill_reasons
+        for b in allocation:
+            if b.address is None:
+                self.reject_reasons[b.name] = solver_reasons.get(
+                    b.name,
+                    f"no room on scratchpad (t={b.start_time}-{b.end_time},"
+                    f" size={b.size // 1024} KB)",
+                )
 
     def _get_op_name(self, op: Any) -> str:
         return _op_short_name(op)
@@ -174,6 +216,188 @@ class ScratchpadAllocator:
             self._get_op_name(op) in OP_OUTPUT_GOOD_FOR_LX_REUSE
         )
 
+    @staticmethod
+    def _read_count(uses: list[int]) -> int:
+        """Reads residency would serve from LX. The first use is never one of
+        them: it is either the producer's write (an intermediate) or the clone-in
+        read a graph input cannot avoid. Mirrors
+        ``LifetimeBoundBuffer.read_count``."""
+        return max(0, len(uses) - 1)
+
+    def _buffer_residency_reason(
+        self,
+        graph: GraphLowering,
+        name: str,
+        uses: list[int],
+        op: Optional[Operation],
+        *,
+        mutated_buffers: set[str],
+        graph_output_names: set[str],
+        reinterpret_output_names: set[str],
+        ncores: dict[str, int],
+        ncores_reasons: dict[str, str],
+        division_is_fixed: bool,
+    ) -> Optional[str]:
+        """The first check ``name`` fails, or ``None`` if it clears them all.
+
+        Order matters. The unsized and op-kind guards come first because
+        everything below assumes a placeable ``ComputedBuffer``; the back-gap
+        probe comes last because it touches ``device_layout`` and is the most
+        expensive. The graph-wide facts (``mutated_buffers``,
+        ``graph_output_names``, ``ncores`` ...) are computed once per solve by
+        :meth:`_residency_reasons` and passed in, so this stays O(1) in the graph.
+
+        Args:
+            graph: The lowered graph.
+            name: Buffer name (an op name -- graph inputs go through
+                :meth:`_input_residency_reason`).
+            uses: ``name``'s liveness (the op indices where it is accessed).
+            op: ``name``'s producing op, or ``None`` if it has none.
+            division_is_fixed: True on the placement path, where each op's core
+                division was committed upstream and a mismatch between a buffer's
+                users is fatal. False on the joint path, where the solver chooses
+                the division and its slicing gate decides instead.
+        """
+        if op is None or not self._op_output_good_for_lx_reuse(op):
+            return "op not allowed"
+        if not hasattr(getattr(op, "layout", None), "device_layout"):
+            # No device layout => no computable footprint (e.g. a
+            # MultiOutputLayout tuple op). There is nothing to place, and the
+            # checks below would raise.
+            return "unsized (no device layout)"
+        if name in mutated_buffers:
+            return "mutation target"
+        if _is_tiled_advancing(op):
+            # LX addresses cannot be expressed as affine.apply symbols today (see
+            # compute_ops.py's is_tiled_lx check), so a buffer whose address
+            # advances per coarse-tile iteration must stay in HBM, where that is
+            # supported.
+            return "tiled (advancing), not per_tile_fixed"
+        restickify = self._restickify_barrier(graph, name, uses)
+        if restickify is not None:
+            return restickify
+        if any(isinstance(graph.operations[u], ExternKernel) for u in uses):
+            return "extern kernel user"
+        if name in graph_output_names:
+            # A graph output normally can't reside (the value must land back in
+            # HBM), but with boundary cloning on it is pinned via an output clone
+            # that still writes HBM once; that unavoidable write cancels from the
+            # CP-SAT differential spill cost, so allow residency then.
+            if not clone_at_graph_boundaries():
+                return "graph output (no clone)"
+            if name in reinterpret_output_names:
+                return "graph output is a ReinterpretView"
+        if buffer_not_read_in_full(graph, name):
+            return "partial/offset read"
+        if division_is_fixed and ncores.get(name, -1) < 0:
+            reason = ncores_reasons.get(name, "core div mismatch")
+            return f"core div mismatch: {reason}"
+        if self._read_count(uses) == 0:
+            # Only the producer's write touches it, so residency saves nothing.
+            return "no consumer reads it from LX"
+        if _would_produce_lx_back_gap(graph, name, uses):
+            # backGap fires when device_size[d] > it_dim_size; the backend
+            # supports it for HBM but not for LX.
+            return "lx back gap"
+        return None
+
+    def _input_residency_reason(
+        self,
+        graph: GraphLowering,
+        name: str,
+        uses: list[int],
+        *,
+        ncores: Optional[dict[str, int]] = None,
+        ncores_reasons: Optional[dict[str, str]] = None,
+        division_is_fixed: bool,
+    ) -> Optional[str]:
+        """The residency verdict for a *graph input*, which is pinned by cloning
+        it into LX rather than by placing it directly.
+
+        An input has no producing op, so the op-kind checks do not apply; what
+        does apply is that the clone must be substitutable at every use, and that
+        residency has to beat the clone-in transfer it costs. An input read only
+        once is already in HBM and would need one transfer to clone, so pinning
+        it saves nothing -- which ``_read_count`` (first use excluded) states
+        directly.
+
+        ``ncores``/``ncores_reasons`` are consulted only on the placement path
+        (``division_is_fixed``); the joint path defers the core division to the
+        solver and passes neither.
+        """
+        if not clone_at_graph_boundaries():
+            return "graph input (no clone)"
+        if self._read_count(uses) == 0:
+            return "no consumer reads it from LX"
+        if not GraphEditor.all_uses_are_rewritable(graph, uses):
+            return "use is not rewritable to the clone"
+        if buffer_not_read_in_full(graph, name):
+            return "partial/offset read"
+        restickify = self._restickify_barrier(graph, name, uses)
+        if restickify is not None:
+            return restickify
+        if division_is_fixed and (ncores or {}).get(name, -1) < 0:
+            reason = (ncores_reasons or {}).get(name, "core div mismatch")
+            return f"core div mismatch: {reason}"
+        if _would_produce_lx_back_gap(graph, name, uses):
+            return "lx back gap"
+        return None
+
+    def _residency_reasons(
+        self,
+        graph: GraphLowering,
+        names: "list[str] | set[str]",
+        *,
+        division_is_fixed: bool,
+        lifetimes: Optional[dict[str, list[int]]] = None,
+        ncores: Optional[dict[str, int]] = None,
+        ncores_reasons: Optional[dict[str, str]] = None,
+    ) -> dict[str, Optional[str]]:
+        """:meth:`_buffer_residency_reason` over ``names``, as ``name -> reason``.
+
+        Computes the graph-wide facts the per-buffer check needs once, here, and
+        passes them down -- there is no shared context object. ``lifetimes`` and
+        ``ncores`` are accepted so a caller that already has them (the placement
+        path, the co-opt search) skips recomputing; ``ncores`` is built only on
+        the placement path, since the joint path's slicing gate decides core
+        division and ``_buffer_residency_reason`` skips that check when
+        ``division_is_fixed`` is False.
+        """
+        if lifetimes is None:
+            lifetimes = calculate_liveness(graph)
+        op_by_name = {op.name: op for op in graph.operations}
+        mutated_buffers = {
+            op.layout.target.get_name()
+            for op in graph.operations
+            if isinstance(op.layout, MutationLayoutSHOULDREMOVE)
+        }
+        graph_output_names = set(graph.get_output_names())
+        reinterpret_output_names = {
+            go.get_name()
+            for go in graph.graph_outputs
+            if isinstance(go, ReinterpretView)
+            or isinstance(getattr(go, "data", None), ReinterpretView)
+        }
+        if division_is_fixed and ncores is None:
+            ncores, ncores_reasons = get_ncores_for_buffers(graph)
+        ncores = ncores or {}
+        ncores_reasons = ncores_reasons or {}
+        return {
+            name: self._buffer_residency_reason(
+                graph,
+                name,
+                lifetimes.get(name, []),
+                op_by_name.get(name),
+                mutated_buffers=mutated_buffers,
+                graph_output_names=graph_output_names,
+                reinterpret_output_names=reinterpret_output_names,
+                ncores=ncores,
+                ncores_reasons=ncores_reasons,
+                division_is_fixed=division_is_fixed,
+            )
+            for name in names
+        }
+
     def _op_inputs_good_for_lx_inplace(self, op: Any) -> list[str]:
         target = getattr(getattr(op, "origin_node", None), "target", None)
         if target is None:
@@ -182,7 +406,7 @@ class ScratchpadAllocator:
         # ``tags`` is an OpOverload attribute; some origin targets (e.g. builtin
         # functions behind int64 fallbacks) don't have it. Treat a tag-less
         # target as not-pointwise rather than crashing. The joint-division path
-        # reaches this for ops the greedy path's _filter_ops drops first.
+        # reaches this for ops the residency checks bar on the greedy path.
         if torch.Tag.pointwise in getattr(target, "tags", ()):
             # If the op is tagged as pointwise by pytorch upstream
             # allow all inputs. Does not work for all ops
@@ -190,65 +414,6 @@ class ScratchpadAllocator:
         if hasattr(op, "data"):
             return get_op_pointwise_inputs(op.data)
         return []
-
-    def _filter_ops(
-        self,
-        graph: GraphLowering,
-        cache: Optional[dict] = None,
-    ) -> list[Operation]:
-        core_div_reasons: dict[str, str] = {}
-        core_div_mismatch = get_ncores_for_buffers(
-            graph, cache, reject_reasons_out=core_div_reasons
-        )
-        drop_list = set()
-
-        # filter out by permitted operations
-        for op in graph.operations:
-            if not self._op_output_good_for_lx_reuse(op):
-                drop_list.add(op.name)
-                self.reject_reasons[op.name] = "op not allowed"
-
-        # filter out core division mismatches
-        for key, mismatch in core_div_mismatch.items():
-            if mismatch == -1:
-                drop_list.add(key)
-                reason = core_div_reasons.get(key, "core div mismatch")
-                self.reject_reasons[key] = f"core div mismatch: {reason}"
-
-        # filter out intermediates read partially (sliced / multi-offset): the
-        # single-base LX path mis-addresses such reads (see
-        # buffer_not_read_in_full / compute_ops._start_addr_data), e.g. an
-        # inner-dim slice x[:, :, 32:96] feeding a chained op. _build_bound_buffers
-        # applies the same guard to graph input/output clones; this covers the
-        # intermediate buffers. Overrides allow_all_ops_in_lx_planning by design.
-        # Only check ops still eligible above: ops already dropped include
-        # non-ComputedBuffer outputs (e.g. multi-output) whose layouts have no
-        # size for buffer_not_read_in_full to inspect.
-        drop_list.update(
-            op.name
-            for op in graph.operations
-            if op.name not in drop_list and buffer_not_read_in_full(graph, op.name)
-        )
-
-        # filter out advancing (tiled, non-per_tile_fixed) buffers: LX
-        # addresses cannot be expressed as affine.apply symbols today (see
-        # compute_ops.py's is_tiled_lx check), so such a buffer must stay in
-        # HBM, where its per-iteration address advance is fully supported.
-        for op in graph.operations:
-            if op.name not in drop_list and _is_tiled_advancing(op):
-                drop_list.add(op.name)
-                self.reject_reasons[op.name] = "tiled (advancing), not per_tile_fixed"
-
-        if not clone_at_graph_boundaries():
-            # Without clone support, graph outputs cannot be LX-pinned: the caller
-            # holds an HBM reference and there is no clone to redirect it to.
-            # graph_input_names is a no-op here (inputs are not in graph.operations),
-            # but kept for symmetry with _build_bound_buffers, which handles inputs
-            # separately when clone is available.
-            drop_list.update(graph.get_output_names())
-            drop_list.update(graph.graph_input_names)
-
-        return [op for op in graph.operations if op.name not in drop_list]
 
     def _restickify_barrier(
         self, graph: GraphLowering, name: str, uses: Sequence[int]
@@ -277,135 +442,116 @@ class ScratchpadAllocator:
     def _build_bound_buffers(
         self,
         graph: GraphLowering,
-        in_place: Optional[dict[str, list[str]]],
+        in_place: dict[str, list[str]],
         mem_usage: dict,
+        reasons: dict[str, Optional[str]],
+        *,
         lifetimes: dict[str, list[int]],
-        cache: Optional[dict] = None,
+        ncores: dict[str, int],
+        ncores_reasons: dict[str, str],
     ) -> list[LifetimeBoundBuffer]:
-        in_place = {} if in_place is None else in_place
+        """Build one :class:`LifetimeBoundBuffer` per buffer, barred or not.
+
+        Nothing is dropped for eligibility: an ineligible buffer is handed over
+        carrying its ``residency_reason`` and the solver declines to place it
+        (see :meth:`MemoryPlanSolver.excluded`). Only buffers with no lifetime at
+        all are skipped -- an unused graph input has no ``uses[0]``, so there is
+        no interval to reason about.
+
+        Graph inputs are pinned by cloning them into LX rather than placed
+        directly, so their verdict comes from
+        :meth:`_input_residency_reason` and their footprint is computed
+        here rather than read off ``mem_usage`` (which covers ops only).
+        """
         buffers: list[LifetimeBoundBuffer] = []
-        graph_output_names = set(graph.get_output_names())
-        # Graph outputs wrapped in a ReinterpretView (e.g. a transpose applied on
-        # top of an op's raw output, as SDPA does): output cloning
-        # (GraphEditor.change_graph_output / _replace_matching_buffer) does not
-        # currently know how to rewrap a ReinterpretView around the clone, so
-        # these must not be promoted as output-clone candidates below.
-        reinterp_buf_names = {
-            go.get_name()
-            for go in graph.graph_outputs
-            if isinstance(go, ReinterpretView)
-            or isinstance(getattr(go, "data", None), ReinterpretView)
-        }
-        cloning_allowed = clone_at_graph_boundaries()
         for output_name, info in mem_usage.items():
-            uses = lifetimes[output_name]
-            if len(uses) <= 1:
-                self.reject_reasons[output_name] = "single use"
-                continue  # output is not read (only the write, or never touched)
-            if any(isinstance(graph.operations[u], ExternKernel) for u in uses):
-                self.reject_reasons[output_name] = "extern kernel user"
+            uses = lifetimes.get(output_name, [])
+            if not uses:
                 continue
-            if output_name in graph_output_names and not cloning_allowed:
-                self.reject_reasons[output_name] = "graph output (no clone)"
-                continue  # we can only allocate graph outputs if we're allowed to clone
-            if output_name in graph_output_names and buffer_not_read_in_full(
-                graph, output_name
-            ):
-                # A pinned graph output is cloned for the HBM return; if a
-                # consumer reads it partially (sliced / multi-offset), SDSC
-                # mis-addresses the single-base LX buffer. Don't pin it.
-                continue
-            if output_name in reinterp_buf_names:
-                self.reject_reasons[output_name] = "graph output is a ReinterpretView"
-                continue
-            if _would_produce_lx_back_gap(graph, output_name, uses):
-                self.reject_reasons[output_name] = "lx back gap"
-                continue
-
-            uses = lifetimes[output_name]
-            parents = in_place.get(output_name, [])
-            size = info["size_per_core"]
-
             buffers.append(
                 LifetimeBoundBuffer(
                     output_name,
-                    size,
+                    # An unsized (-1) or core-div-mismatched (negative) entry is
+                    # always barred, so its footprint is never used; clamp it so
+                    # a nonsense size can never look placeable.
+                    max(0, info["size_per_core"]),
                     uses,
                     first_use_is_read=False,
-                    in_place_parents=parents,
-                    residency_reason=self._restickify_barrier(graph, output_name, uses),
+                    in_place_parents=in_place.get(output_name, []),
+                    residency_reason=reasons.get(output_name),
                 )
             )
 
-        if cloning_allowed:
-            core_div_reasons: dict[str, str] = {}
-            ncores = get_ncores_for_buffers(
-                graph, cache, reject_reasons_out=core_div_reasons
+        for input_name in graph.graph_input_names:
+            uses = lifetimes.get(input_name, [])
+            if not uses:
+                continue
+            reason = self._input_residency_reason(
+                graph,
+                input_name,
+                uses,
+                ncores=ncores,
+                ncores_reasons=ncores_reasons,
+                division_is_fixed=True,
             )
-            for input_name in graph.graph_input_names:
-                uses = lifetimes[input_name]
-                if len(uses) <= 1:
-                    # Input read only once, or not at all. A non-input that's read only once still
-                    # saves a roundtrip to HBM if it is allocated in LX, but the input is already
-                    # present in HBM and would need to be cloned to LX explicitly, which costs one
-                    # transfer anyway.
-                    continue
-                if not GraphEditor.all_uses_are_rewritable(graph, uses):
-                    continue
-                if buffer_not_read_in_full(graph, input_name):
-                    # A consumer reads this input partially -- a sliced/
-                    # multi-offset read (e.g. x[:, 0:512] + x[:, 512:1024], or
-                    # x[:, :, 0:64]). The clone would be pinned to LX, which
-                    # SDSC addresses by a single base, so partial reads
-                    # mis-address and produce wrong results.
-                    continue
-                num_cores = ncores.get(input_name, -1)
-                if num_cores < 0:
-                    reason = core_div_reasons.get(input_name, "core div mismatch")
-                    self.reject_reasons[input_name] = f"core div mismatch: {reason}"
-                    continue  # core division mismatch across consumers
-                if _would_produce_lx_back_gap(graph, input_name, uses):
-                    self.reject_reasons[input_name] = "lx back gap"
-                    continue
-                buf = graph.get_buffer(input_name)
-                dev_layout = buf.layout.device_layout
-                dev_size = math.prod(dev_layout.device_size[:-1]) * 128
-                buffers.append(
-                    LifetimeBoundBuffer(
-                        input_name,
-                        dev_size // num_cores,
-                        uses,
-                        first_use_is_read=True,
-                        in_place_parents=[],
-                        residency_reason=self._restickify_barrier(
-                            graph, input_name, uses
-                        ),
-                    )
+            buffers.append(
+                LifetimeBoundBuffer(
+                    input_name,
+                    self._input_footprint(graph, input_name, ncores),
+                    uses,
+                    first_use_is_read=True,
+                    in_place_parents=[],
+                    residency_reason=reason,
                 )
+            )
 
         return buffers
+
+    @staticmethod
+    def _input_footprint(
+        graph: GraphLowering, name: str, ncores: dict[str, int]
+    ) -> int:
+        """Per-core LX footprint of a cloned graph input, or 0 when it has no
+        computable one (in which case ``input_residency_reason`` has already
+        barred it, so the value is never used)."""
+        layout = getattr(graph.get_buffer(name), "layout", None)
+        dev_layout = getattr(layout, "device_layout", None)
+        num_cores = ncores.get(name, -1)
+        if dev_layout is None or num_cores < 1:
+            return 0
+        return math.prod(dev_layout.device_size[:-1]) * 128 // num_cores
 
     def _determine_in_place(
         self,
         graph: GraphLowering,
-        graph_view: "GraphView",
         mem_usage: dict,
         lifetimes: dict[str, list[int]],
+        reasons: dict[str, Optional[str]],
     ) -> dict[str, list[str]]:
+        """In-place reuse candidates: ``buf -> [inputs whose slot it may take]``.
+
+        Only buffers that may actually reside are considered on either side of
+        the pair. A barred buffer has no LX slot to hand over or inherit, so
+        pairing with one is meaningless -- and it would let two unsized (-1)
+        sentinels match each other on size.
+        """
         allow_inplace: dict[str, list[str]] = {}
         in_place_allowed = {
-            op.name: self._op_inputs_good_for_lx_inplace(op)
-            for op in graph_view.operations
+            op.name: self._op_inputs_good_for_lx_inplace(op) for op in graph.operations
         }
         for buf_name, info in mem_usage.items():
             allow_inplace[buf_name] = []
-            if not in_place_allowed[buf_name]:
+            if not in_place_allowed.get(buf_name):
+                continue
+            if reasons.get(buf_name) is not None or not lifetimes.get(buf_name):
                 continue
             out_start = lifetimes[buf_name][0]
             out_ten_layout = graph.get_buffer(buf_name).get_layout().device_layout
             out_size = info["size_per_core"]
             for input_buf in info["op_inputs"]:
                 if input_buf not in mem_usage or not lifetimes[input_buf]:
+                    continue
+                if reasons.get(input_buf) is not None:
                     continue
                 in_end = lifetimes[input_buf][-1]  # inclusive last use
                 in_ten_layout = graph.get_buffer(input_buf).get_layout().device_layout
@@ -430,33 +576,44 @@ class ScratchpadAllocator:
         cache: Optional[dict] = None,
         timings: Optional[dict[str, float]] = None,
         lifetimes: Optional[dict[str, list[int]]] = None,
-    ) -> list[Operation]:
-        # Build graph_view + mem_usage once and share; both helpers below treat
-        # them read-only. `lifetimes` is split-invariant, so the co-opt search
-        # passes it in (computed here only for the single-shot path).
-        # get_read_writes() is memoized per op by `op_read_writes`, so the
-        # per-leaf core-div check doesn't re-trace it across leaves.
-        #
-        # TODO: graph_view + mem_usage still rebuilt per leaf; only their
-        #   split-dependent part is the (cached) core-div check, so the rest
-        #   could be hoisted out of the per-leaf path too.
+    ) -> list[LifetimeBoundBuffer]:
+        # Compute the graph-wide residency facts + mem_usage once and share; the
+        # helpers below treat them read-only. `lifetimes` is split-invariant, so
+        # the co-opt search passes it in (computed here only for the single-shot
+        # path). `ncores` is the placement path's split-dependent core-div check;
+        # get_read_writes() is memoized per op by `op_read_writes`, so it doesn't
+        # re-trace across leaves.
         t0 = time.perf_counter()
-        graph_view = GraphView(graph, lambda g: self._filter_ops(g, cache))
-        t1 = time.perf_counter()
-        mem_usage = mem_usage_by_buf(graph_view, cache)
-        t2 = time.perf_counter()
-        if timings is not None:
-            timings["graph_view"] += t1 - t0
-            timings["mem_usage"] += t2 - t1
-
         if lifetimes is None:
             lifetimes = calculate_liveness(graph)
+        ncores, ncores_reasons = get_ncores_for_buffers(graph)
+        t1 = time.perf_counter()
+        mem_usage = mem_usage_by_buf(graph, cache)
+        t2 = time.perf_counter()
+        if timings is not None:
+            timings["residency"] += t1 - t0
+            timings["mem_usage"] += t2 - t1
 
-        in_place = self._determine_in_place(graph, graph_view, mem_usage, lifetimes)
-        buffers = self._build_bound_buffers(
-            graph, in_place, mem_usage, lifetimes, cache
+        # Divisions are already committed on this path, so a core-division
+        # mismatch between a buffer's users is fatal and is checked here.
+        reasons = self._residency_reasons(
+            graph,
+            list(mem_usage),
+            division_is_fixed=True,
+            lifetimes=lifetimes,
+            ncores=ncores,
+            ncores_reasons=ncores_reasons,
         )
-        return buffers
+        in_place = self._determine_in_place(graph, mem_usage, lifetimes, reasons)
+        return self._build_bound_buffers(
+            graph,
+            in_place,
+            mem_usage,
+            reasons,
+            lifetimes=lifetimes,
+            ncores=ncores,
+            ncores_reasons=ncores_reasons,
+        )
 
     def _log_lx_pinning(self, graph: GraphLowering) -> None:
         """Log the final LX pinning decision for every op in the graph."""
@@ -520,30 +677,6 @@ class ScratchpadAllocator:
         layout.allocation["lx"] = address
 
 
-def _op_short_name(op: Any) -> str:
-    """Resolve an op's short name from its ``origin_node`` target, falling back
-    to each fused fx node in ``op.origins``; ``"None"`` when unresolvable.
-
-    ``origin_node`` is tried first (independent of ``origins``, which may be
-    empty), so a plain op still resolves; the ``origins`` fallback recovers a
-    fused op like bmm+permute, whose ``origin_node`` target has no resolvable
-    name and would otherwise resolve to ``"None"`` and be wrongly rejected as
-    "op not allowed". Module-level so ``ScratchpadAllocator._get_op_name`` and the
-    module-level buffer conversion share one implementation.
-    """
-    name = None
-    for fx_node in (getattr(op, "origin_node", None), *getattr(op, "origins", ())):
-        target = getattr(fx_node, "target", None)
-        name = (
-            getattr(target, "_opname", None)
-            or getattr(target, "__name__", None)
-            or getattr(target, "name", None)
-        )
-        if name is not None:
-            break
-    return name if name is not None else "None"
-
-
 def _lx_planning_size() -> int:
     """Return the frontend LX reservation, matching Deeptools exactly.
 
@@ -570,6 +703,30 @@ def _fixed_core_division(op: Operation) -> CoreDivision:
     """
     seed: tuple[dict, dict] = getattr(op, "op_it_space_splits", None) or ({}, {})
     return CoreDivision(output_splits=dict(seed[0]), reduction_splits=dict(seed[1]))
+
+
+def _op_short_name(op: Any) -> str:
+    """Resolve an op's short name from its ``origin_node`` target, falling back
+    to each fused fx node in ``op.origins``; ``"None"`` when unresolvable.
+
+    ``origin_node`` is tried first (independent of ``origins``, which may be
+    empty), so a plain op still resolves; the ``origins`` fallback recovers a
+    fused op like bmm+permute, whose ``origin_node`` target has no resolvable
+    name and would otherwise resolve to ``"None"`` and be wrongly rejected as
+    "op not allowed". Module-level so ``ScratchpadAllocator._get_op_name``
+    delegates to one implementation.
+    """
+    name = None
+    for fx_node in (getattr(op, "origin_node", None), *getattr(op, "origins", ())):
+        target = getattr(fx_node, "target", None)
+        name = (
+            getattr(target, "_opname", None)
+            or getattr(target, "__name__", None)
+            or getattr(target, "name", None)
+        )
+        if name is not None:
+            break
+    return name if name is not None else "None"
 
 
 DEFAULT_VARIANT_CAP = 6
@@ -1000,11 +1157,11 @@ class StrategyBCoOptimizingAllocator(ScratchpadAllocator):
         }
         logger.info(
             "co-opt search: %d paths in %.1fms (key components in "
-            "_generate_buffers(): graph_view %.1fms + mem_usage %.1fms); "
+            "_generate_buffers(): residency %.1fms + mem_usage %.1fms); "
             "winner=%s",
             n_paths,
             t_search * 1e3,
-            timings["graph_view"] * 1e3,
+            timings["residency"] * 1e3,
             timings["mem_usage"] * 1e3,
             winner,
         )
@@ -1031,12 +1188,7 @@ class StrategyBCoOptimizingAllocator(ScratchpadAllocator):
         )
         assert self.layout_planning is not None
         allocation = self.layout_planning.plan_layout(buffers, log_lx_usage=True)
-        for b in allocation:
-            if b.address is None:
-                self.reject_reasons[b.name] = (
-                    f"no room on scratchpad (t={b.start_time}-{b.end_time},"
-                    f" size={b.size // 1024} KB)"
-                )
+        self._record_spill_reasons(allocation)
         self._push_allocation(graph, allocation)
         self._log_lx_pinning(graph)
         for p in self.post_optimization_passes:
@@ -1055,7 +1207,7 @@ class StrategyBCoOptimizingAllocator(ScratchpadAllocator):
         """DFS over the option cross-product, scoring each leaf via
         _score_layout. Returns (best option index per op, timing breakdown in
         seconds, _per_core_view_on_buf cache, liveness). The timing dict has
-        keys `graph_view` and `mem_usage` — the two split-dependent
+        keys `residency` and `mem_usage` — the two split-dependent
         shared-object builds inside _generate_buffers, which dominate per-leaf
         cost. Liveness is split-invariant and computed once here, not per leaf.
         No early-stop pruning — bounded by ≤ K^N leaves where N counts ops with
@@ -1070,7 +1222,7 @@ class StrategyBCoOptimizingAllocator(ScratchpadAllocator):
         best_total: float = math.inf
         best_chosen: list[int] = list(chosen)
         timings: dict[str, float] = {
-            "graph_view": 0.0,
+            "residency": 0.0,
             "mem_usage": 0.0,
         }
 
@@ -1082,7 +1234,7 @@ class StrategyBCoOptimizingAllocator(ScratchpadAllocator):
         # get_read_writes() re-traces the store function over the iteration space
         # on every call and is NOT memoized upstream, yet its result is
         # split-invariant (the symbolic deps don't depend on op_it_space_splits).
-        # The per-leaf _filter_ops/get_ncores path calls it for every op, so across
+        # The per-leaf residency/get_ncores path calls it for every op, so across
         # ~K^N leaves it would dominate — but `op_read_writes` memoizes it per op
         # instance (split-invariant), so the first leaf warms the cache for all.
 
@@ -1142,7 +1294,7 @@ class StrategyBCoOptimizingAllocator(ScratchpadAllocator):
         (addresses land on throwaway buffers) and solver-agnostic.
 
         If `timings` is provided, _generate_buffers accumulates its
-        `graph_view` / `mem_usage` sub-step seconds into it. `lifetimes`
+        `residency` / `mem_usage` sub-step seconds into it. `lifetimes`
         (split-invariant) is forwarded to avoid recomputing it per leaf.
         """
         buffers = self._generate_buffers(graph, cache, timings, lifetimes)
@@ -1158,83 +1310,53 @@ class StrategyBCoOptimizingAllocator(ScratchpadAllocator):
 class CoOptimizingAllocator(ScratchpadAllocator):
     def __init__(
         self,
+        layout_planning: CoreDivisionLayoutSolver,
         pre_optimization_passes: list[ScratchpadOptimizationPass] | None = None,
         post_optimization_passes: list[ScratchpadOptimizationPass] | None = None,
     ):
-        """Joint core-division + LX-placement allocator. The solver is the
-        OR-Tools ``CpSatLayoutSolver`` (``config.layout_solver == "cpsat"``)
-        sized to available LX memory; ``pre_optimization_passes`` /
-        ``post_optimization_passes`` (default none) run before / after layout
-        planning.
+        """Joint core-division + LX-placement allocator.
 
-        When the CP-SAT solver is unavailable (``ortools`` not installed),
-        planning falls back to the placement-only :class:`ScratchpadAllocator`
-        (greedy) so a ``layout_solver="cpsat"`` request degrades to a correct
-        plan instead of aborting the compile. The greedy path does not
-        co-optimize core division, but every op keeps its upstream-chosen
-        division, so the result is correct -- just less optimal.
+        Args:
+            layout_planning: A core-division-aware solver (the OR-Tools
+                ``CpSatLayoutSolver``). This allocator drives the *joint* entry
+                point, so it needs the ``CoreDivisionLayoutSolver`` interface
+                rather than a plain ``MemoryPlanSolver``. The ortools-missing
+                fallback to greedy placement lives in :func:`select_allocator`,
+                which never constructs this allocator without a valid solver.
+            pre_optimization_passes: Graph passes applied before layout planning.
+            post_optimization_passes: Graph passes applied after layout planning.
         """
-        size = _lx_planning_size()
-        if pre_optimization_passes is None:
-            pre_optimization_passes = []
-        if post_optimization_passes is None:
-            post_optimization_passes = []
+        super().__init__(
+            layout_planning=layout_planning,
+            pre_optimization_passes=pre_optimization_passes,
+            post_optimization_passes=post_optimization_passes,
+        )
+        # Narrow the base's ``MemoryPlanSolver`` annotation: the joint entry
+        # point requires the core-division interface.
+        self.layout_planning: Optional[CoreDivisionLayoutSolver] = layout_planning
 
-        self.pre_optimization_passes = pre_optimization_passes
-        self.post_optimization_passes = post_optimization_passes
+    def _prepare_buffers(self, graph: GraphLowering) -> Sequence[Any]:
+        in_place = self._determine_in_place_division_invariant(graph)
+        buffers = self._build_cd_bound_buffers(
+            graph, in_place, self._division_map(graph)
+        )
+        return buffers
 
-        # Greedy fallback for when CP-SAT is unavailable (ortools not installed).
-        self._fallback = ScratchpadAllocator(layout_planning=GreedyLayoutSolver(size))
+    def _solve(self, buffers: Sequence[Any]) -> Sequence[Any]:
+        assert self.layout_planning is not None
+        return self.layout_planning.plan_layout_and_core_divisions(buffers)
 
-        # This allocator drives the *joint* entry point, so it needs the
-        # core-division interface rather than plain ``MemoryPlanSolver``.
-        self.layout_planning: Optional[CoreDivisionLayoutSolver]
-        try:
-            # Imported lazily so this module (and the greedy path) load even when
-            # ortools is absent: CpSatLayoutSolver.__init__ raises ImportError
-            # when ortools is missing, which we catch to fall back.
-            from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
-                CpSatLayoutSolver,
-            )
-
-            self.layout_planning = CpSatLayoutSolver(size)
-        except ImportError as exc:
-            logger.warning(
-                "cpsat layout solver unavailable (%s); falling back to the "
-                "default greedy allocator.",
-                exc,
-            )
-            self.layout_planning = None
-
-    def plan_allocation(self, graph: GraphLowering):
-        """Run pre-passes, jointly solve core-division + LX placement, commit the
-        chosen divisions, then run post-passes.
-
-        Falls back to the greedy :class:`ScratchpadAllocator` when the CP-SAT solver
-        is unavailable.
-        """
-        self.reject_reasons = {}
-        if self.layout_planning is None:
-            self._fallback.plan_allocation(graph)
-            return
-
-        for p in self.pre_optimization_passes:
-            p.apply_pass(graph)
-        buffers = self._generate_cd_buffers(graph, self._division_map(graph))
-        allocation = self.layout_planning.plan_layout_and_core_divisions(buffers)
-        # the divisions must be committed such that any buffer clones can correctly
-        # pull the selected core division from the dependent buffers when
-        # the graph is updated with clones in ``_push_allocation``
+    def _post_solve(self, graph: GraphLowering, allocation: Sequence[Any]) -> None:
+        # The divisions must be committed such that any buffer clones can correctly
+        # pull the selected core division from the dependent buffers when the graph
+        # is updated with clones in ``_push_allocation``.
         self._commit_divisions(graph, allocation)
-        self._push_allocation(graph, allocation)
-        for p in self.post_optimization_passes:
-            p.apply_pass(graph)
 
+    def _record_reject_reasons(self, allocation: Sequence[Any]) -> None:
         # Surface the solver's per-buffer spill causes so the LX-pinning debug
         # log reports why each buffer landed in HBM, on par with the other
         # allocators. ``getattr`` because only ``CpSatLayoutSolver`` exposes it.
         self.reject_reasons = dict(getattr(self.layout_planning, "spill_reasons", {}))
-        self._log_lx_pinning(graph)
 
     def _division_map(self, graph: GraphLowering) -> dict[str, list[CoreDivision]]:
         """Per-op core-division candidates for the joint-division solve.
@@ -1243,7 +1365,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
         constrain it. Pointwise / Reduction ops get the enumerated candidates;
         every other op falls back to a single fixed division read off its
         committed ``op_it_space_splits``. No op-kind pre-filter -- residency is
-        gated per buffer (``residency_allowed``) and by the solver, so ineligible
+        gated per buffer (``_residency_by_buf``) and by the solver, so ineligible
         ops still participate as producers/consumers in the match.
 
         Exception: ops data-connected to a sliced in-place mutation (a constant-
@@ -1260,19 +1382,12 @@ class CoOptimizingAllocator(ScratchpadAllocator):
         fixed_division_ops = ops_in_offset_mutation_component(graph)
         return {
             op.name: (
-                [self._fixed_division(op)]
+                [_fixed_core_division(op)]
                 if op.name in fixed_division_ops
                 else self._enumerate_core_divisions(op, max_cores)
             )
             for op in graph.operations
         }
-
-    def _fixed_division(self, op: Operation) -> CoreDivision:
-        """The op's upstream-committed division as a single pinned CoreDivision;
-        used as the fallback for ops with no enumerable candidates, so every
-        buffer carries at least one division. See :func:`_fixed_core_division`.
-        """
-        return _fixed_core_division(op)
 
     def _enumerate_core_divisions(
         self, op: Operation, max_cores: int
@@ -1284,7 +1399,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
         slicing signature. Ops without a divisible iteration space, or whose
         space can't be enumerated, fall back to a single fixed division.
         """
-        fixed = [self._fixed_division(op)]
+        fixed = [_fixed_core_division(op)]
         if not isinstance(op, ComputedBuffer) or not isinstance(
             op.data, (Pointwise, Reduction)
         ):
@@ -1350,15 +1465,6 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                 dict(cd.reduction_splits),
             )
 
-    def _generate_cd_buffers(
-        self,
-        graph: GraphLowering,
-        divisions: dict[str, list[CoreDivision]],
-    ) -> list[CoreDivisionBuffer]:
-        in_place = self._determine_in_place_division_invariant(graph)
-        buffers = self._build_cd_bound_buffers(graph, in_place, divisions)
-        return buffers
-
     def _determine_in_place_division_invariant(
         self, graph: GraphLowering
     ) -> dict[str, list[str]]:
@@ -1413,99 +1519,23 @@ class CoOptimizingAllocator(ScratchpadAllocator):
         self,
         graph: GraphLowering,
         mem_usage: dict,
-        op_by_name: dict[str, Operation],
         lifetimes: dict[str, list[int]],
     ) -> dict[str, Optional[str]]:
-        """Per-buffer residency verdict: ``None`` if the buffer may be pinned
-        (resident) in LX, else the reason it may not.
+        """Per-buffer residency verdict: ``None`` if the buffer may be pinned in
+        LX, else the reason it may not.
 
         Every buffer is handed to the solver so it participates in the slicing
-        match, but participation is not residency. A buffer may be *pinned* only
-        if its producing op clears ``_op_output_good_for_lx_reuse``, has no
-        ExternKernel consumer (extern ops read from HBM), is not the target of an
-        in-place mutation, is off a graph boundary, is read in full (offset reads
-        mis-address a single LX base), would not produce a backGapCore_ (the
-        backend supports backGap for HBM but not LX), and is actually read.
-        Otherwise it stays non-resident (carrying the reason) so it doesn't
-        orphan its neighbours. The reason strings mirror the ``ScratchpadAllocator``
-        ``reject_reasons`` vocabulary where the checks overlap.
-
-        Note: core-division consistency is *not* pre-filtered here (unlike the
-        gap allocators' "core div mismatch" drop); the joint solver enforces it
-        via the ``cd_parent_matches`` slicing gate instead.
+        match, but participation is not residency. The predicate is the shared
+        one in :meth:`_buffer_residency_reason` -- the same list the placement
+        path uses -- with ``division_is_fixed=False``: this allocator *chooses*
+        each op's core division, so pre-rejecting a buffer whose users disagree
+        under the upstream-committed division would be premature. The solver's
+        ``cd_parent_matches`` slicing gate decides that instead. ``ncores`` is
+        therefore not needed here.
         """
-        # Targets of a ``MutationLayoutSHOULDREMOVE`` op (e.g. a ``cat`` dest
-        # filled by per-input ``copy_`` slices): the producing op reads nothing
-        # -- its data arrives via offset writes -- so pinning it to one LX base
-        # mis-addresses. The mutating ops are rejected by
-        # ``_op_output_good_for_lx_reuse``, but their target is a normal layout
-        # that would otherwise pass, so exclude it explicitly. Computed once so
-        # the predicate stays linear in the graph.
-        mutated_buffers = {
-            op.layout.target.get_name()
-            for op in graph.operations
-            if isinstance(op.layout, MutationLayoutSHOULDREMOVE)
-        }
-        graph_output_names = set(graph.get_output_names())
-        return {
-            name: self._residency_reason(
-                graph,
-                op_by_name.get(name),
-                name,
-                lifetimes[name],
-                mutated_buffers,
-                graph_output_names,
-            )
-            for name in mem_usage
-        }
-
-    def _residency_reason(
-        self,
-        graph: GraphLowering,
-        op: Optional[Operation],
-        name: str,
-        uses: list[int],
-        mutated_buffers: set[str],
-        graph_output_names: set[str],
-    ) -> Optional[str]:
-        """The first check ``name`` fails (the reason it may not reside), or
-        ``None`` if it clears them all. Order matters: the back-gap probe (last)
-        touches ``device_layout``, so the earlier guards ensure it only runs on a
-        non-mutation ``ComputedBuffer`` that is read in full."""
-        if op is None or not self._op_output_good_for_lx_reuse(op):
-            return "op not allowed"
-        # Restickify moves the stick dimension: its per-core read frame and write
-        # frame are transposes, so a per-core (LX) slice of the OUTPUT can need
-        # bytes from another core's slice of the INPUT. That hazard is one-sided
-        # -- it only bites when the input is core-sliced in LX. So the barrier is
-        # asymmetric: a buffer a restickify *reads* must stay in HBM (global HBM
-        # reads let each core gather its whole output slice), while the
-        # restickify's *output* is fine in LX given that -- a normal core-local
-        # write, read back in its single new-STL frame -- so it is not barred here
-        # (it takes the normal residency + slicing-match path). TODO(follow-up): a
-        # precise cross-STL gate (split axis non-stick in both the pre- and
-        # post-restickify layouts) would relax even the read side for the
-        # core-local cases.
-        if any(self._get_op_name(graph.operations[u]) == "restickify" for u in uses):
-            return "read by restickify (cross-frame barrier)"
-        if any(isinstance(graph.operations[u], ExternKernel) for u in uses):
-            return "extern kernel user"
-        if name in mutated_buffers:
-            return "mutation target"
-        # A graph output normally can't reside (the value must land back in HBM),
-        # but with boundary cloning on it is pinned via an output clone that still
-        # writes HBM once; that unavoidable write cancels from the CP-SAT
-        # differential spill cost (``Boundary.Output`` in ``spill_cost``), so allow
-        # residency then.
-        if name in graph_output_names and not clone_at_graph_boundaries():
-            return "graph output"
-        if buffer_not_read_in_full(graph, name):
-            return "partial/offset read"
-        if len(uses) <= 1:
-            return "single use"
-        if _would_produce_lx_back_gap(graph, name, uses):
-            return "lx back gap"
-        return None
+        return self._residency_reasons(
+            graph, list(mem_usage), division_is_fixed=False, lifetimes=lifetimes
+        )
 
     def _build_cd_bound_buffers(
         self,
@@ -1528,9 +1558,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
 
         prep_cache: dict = {}
         buffers: list[CoreDivisionBuffer] = []
-        residency_by_buf = self._residency_by_buf(
-            graph, mem_usage, op_by_name, lifetimes
-        )
+        residency_by_buf = self._residency_by_buf(graph, mem_usage, lifetimes)
 
         input_clone_matches: dict[str, dict[str, list[tuple[int, int]]]] = {}
         if clone_at_graph_boundaries():
@@ -1634,27 +1662,22 @@ class CoOptimizingAllocator(ScratchpadAllocator):
     def _eligible_clone_inputs(
         self, graph: GraphLowering, lifetimes: dict[str, list[int]]
     ) -> list[str]:
-        """Graph inputs eligible to be cloned into LX, applying the same
-        correctness guards as the placement path's input loop.
+        """Graph inputs eligible to be cloned into LX.
 
-        The core division is deferred to the solver as clones can be assigned any core
-        division provided a valid core division satisfies all children. This
-        constraint is enforced by ensuring that each child matches that of
-        the parent.
+        The same shared predicate the placement path's input loop uses, with
+        ``division_is_fixed=False``: the core division is deferred to the solver,
+        since a clone can take any division for which some valid choice
+        satisfies all its children. That constraint is enforced by requiring
+        each child to match the parent, not by pre-rejecting here.
         """
-        eligible: list[str] = []
-        for input_name in graph.graph_input_names:
-            uses = lifetimes[input_name]
-            if len(uses) <= 1:
-                continue
-            if not GraphEditor.all_uses_are_rewritable(graph, uses):
-                continue
-            if buffer_not_read_in_full(graph, input_name):
-                continue
-            if _would_produce_lx_back_gap(graph, input_name, uses):
-                continue
-            eligible.append(input_name)
-        return eligible
+        return [
+            name
+            for name in graph.graph_input_names
+            if self._input_residency_reason(
+                graph, name, lifetimes.get(name, []), division_is_fixed=False
+            )
+            is None
+        ]
 
     def _clone_divisions_and_matches(
         self,
@@ -1900,8 +1923,8 @@ def select_allocator() -> ScratchpadAllocator:
     the allocators themselves take an explicit solver and never inspect config:
 
     * ``layout_solver == "cpsat"`` with ``co_optimizing_lx_planning`` -> joint
-      core-division + LX placement via :class:`CoOptimizingAllocator` (with a
-      built-in greedy fallback).
+      core-division + LX placement via :class:`CoOptimizingAllocator`. Falls back
+      to placement-only greedy :class:`ScratchpadAllocator` when ortools is absent.
     * ``layout_solver == "cpsat"`` without co-optimization -> placement-only
       :class:`ScratchpadAllocator` driven by the CP-SAT solver, placing buffers on
       each op's pre-determined core division (the buffers are converted to
@@ -1914,16 +1937,24 @@ def select_allocator() -> ScratchpadAllocator:
     """
     size = _lx_planning_size()
     if config.layout_solver == "cpsat":
-        if config.co_optimizing_lx_planning:
-            return CoOptimizingAllocator()
-        # Placement-only CP-SAT on the pre-determined core divisions. When
-        # ortools is missing, degrade to greedy placement (still correct).
+        # Both cpsat paths share the same ortools-missing degradation: build the
+        # CP-SAT solver here and fall back to greedy placement (still correct)
+        # when it is unavailable, so the allocators never see a ``None`` solver.
         solver = _make_cpsat_solver(size)
+        if config.co_optimizing_lx_planning:
+            if solver is None:
+                return ScratchpadAllocator(layout_planning=GreedyLayoutSolver(size))
+            # CpSatLayoutSolver implements the core-division interface the joint
+            # allocator drives; the narrowing is safe since this is the only
+            # solver _make_cpsat_solver ever returns.
+            assert isinstance(solver, CoreDivisionLayoutSolver)
+            return CoOptimizingAllocator(layout_planning=solver)
+        # Placement-only CP-SAT on the pre-determined core divisions.
         if solver is None:
             logger.debug(
                 "falling back to greedy solver. Make sure Or-Tools is available"
             )
-            solver = GreedyLayoutSolver(size)
+            return ScratchpadAllocator(layout_planning=GreedyLayoutSolver(size))
         return ScratchpadAllocator(layout_planning=solver)
 
     try:

--- a/torch_spyre/_inductor/scratchpad/firstfit_bestfit_solver.py
+++ b/torch_spyre/_inductor/scratchpad/firstfit_bestfit_solver.py
@@ -49,7 +49,12 @@ def _topological_sort(
 
     for i, child in enumerate(buffers):
         for parent_name in child.in_place_parents:
-            p = name_to_idx[parent_name]
+            # A parent barred from LX (or otherwise absent from the candidate
+            # set) imposes no ordering: there is no slot for the child to
+            # inherit, so it is placed on its own like any other buffer.
+            p = name_to_idx.get(parent_name)
+            if p is None:
+                continue
             children[p].append(i)
             in_degree[i] += 1
 
@@ -185,8 +190,11 @@ class FirstFitLayoutSolver(MemoryPlanSolver):
         )
         _assert_in_place_relationships(buffers)
 
+        # Barred buffers keep address=None and are never candidates for a gap,
+        # nor obstacles in one (they occupy no LX).
+        placeable, _ = self.partition(buffers)
         buffers_filtered = [
-            buffer for buffer in buffers if buffer.end_time >= buffer.start_time + 1
+            buffer for buffer in placeable if buffer.end_time >= buffer.start_time + 1
         ]
         parent_names = {p for b in buffers_filtered for p in b.in_place_parents}
 

--- a/torch_spyre/_inductor/scratchpad/greedy_solver.py
+++ b/torch_spyre/_inductor/scratchpad/greedy_solver.py
@@ -1,0 +1,190 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+from collections.abc import Sequence
+from typing import Optional
+
+from torch_spyre._inductor.scratchpad.plan_solver import (
+    LifetimeBoundBuffer,
+    MemoryPlanSolver,
+    _assert_in_place_relationships,
+)
+from torch_spyre._inductor.logging_utils import get_inductor_logger
+
+__all__ = ["GreedyLayoutSolver"]
+
+logger = get_inductor_logger("scratchpad.greedy_solver")
+
+
+class GreedyLayoutSolver(MemoryPlanSolver):
+    def __init__(self, size: int, alignment: int = 128):
+        super().__init__(size, alignment)
+        # `usage` tracks live placements during planning. It is specific to the
+        # greedy time-stepping algorithm; the gap-based solvers don't use it.
+        self.usage: list[LifetimeBoundBuffer] = []
+
+    def _get_lowest_addr_in_use(self):
+        return min(
+            (rec.address for rec in self.usage if rec.address is not None),
+            default=0,
+        )
+
+    def _get_highest_addr_in_use(self):
+        return max(
+            (rec.address + rec.size for rec in self.usage if rec.address is not None),
+            default=0,
+        )
+
+    def _find_free_block(self, size_needed: int) -> Optional[int]:
+        assert all(x.address is not None for x in self.usage)
+        curr_lo = self._get_lowest_addr_in_use()
+        curr_hi = self._get_highest_addr_in_use()
+        if self.limit < size_needed:
+            return None
+
+        if not self.usage or curr_lo >= size_needed:
+            return 0
+
+        address = math.ceil(curr_hi / self.alignment) * self.alignment
+        if address + size_needed <= self.limit:
+            return address
+
+        # Search for a gap between existing allocations
+        self.usage.sort(key=lambda x: (x.address is None, x.address))
+        for i in range(len(self.usage) - 1):
+            assert (current_address := self.usage[i].address) is not None
+            assert (next_address := self.usage[i + 1].address) is not None
+            frag_st = (
+                math.ceil((current_address + self.usage[i].size) / self.alignment)
+                * self.alignment
+            )
+            if next_address - frag_st >= size_needed:
+                return frag_st
+
+        return None
+
+    def _try_allocate(self, buffer: LifetimeBoundBuffer):
+        # Check if the current buffer can be in-placed
+        for in_place_opt in buffer.in_place_parents:
+            matched_obj = next((u for u in self.usage if u.name == in_place_opt), None)
+            if matched_obj is not None and buffer.size <= matched_obj.size:
+                buffer.address = matched_obj.address
+                self.usage.append(buffer)
+                self.usage.remove(matched_obj)
+                return None
+
+        # Decide where to allocate the block from
+        addr = self._find_free_block(buffer.size)
+
+        # Push the allocation result to the buffer and the usage table
+        if addr is not None:
+            buffer.address = addr
+            self.usage.append(buffer)
+        else:
+            buffer.address = None
+
+    def _try_deallocate(self, bufs: list[LifetimeBoundBuffer] | LifetimeBoundBuffer):
+        if isinstance(bufs, LifetimeBoundBuffer):
+            bufs = [bufs]
+
+        for buf in bufs:
+            if buf in self.usage:
+                self.usage.remove(buf)
+
+    def plan_layout(
+        self, buffers: Sequence[LifetimeBoundBuffer], log_lx_usage: bool = False
+    ) -> list[LifetimeBoundBuffer]:
+        """Allocates addresses to the provided buffer list
+
+        Accepts a set of buffers with pre-defined sizes and lifetimes. These buffers are
+        allocated addresses with 0 -> `limit` where the maximum starting address of
+        buffers are at most `self.limit` - `LifetimeBoundBuffer.size` - 1. The algorithm
+        increments through logical time where time increments 1 unit for each
+        step in a computation graph. At each step the lifetimes of all buffers are
+        evaluated for allocation and deallocation based on its lifetime relative
+        to the time being evaluated. As an optimization, times where no buffers
+        enter or exit scope are not evaluated.
+
+        When a buffer enters scope, the current usage is evaluated in the following
+        manner:
+            1. Check if there is a permissible in-place buffer already allocated
+            2. Is there enough space from address 0 -> first usage.
+            3. Is there enough space for the current buffer from the max address
+                to the maximum memory address. Allocate as current_max + 1 + alignment.
+            4. Is there space between allocations. Check for gaps between current
+                allocations and find where gaps exceed current size. Allocate if
+                current gap is larger than current size + alignment.
+
+        Args:
+            buffers (list[LifetimeBoundBuffer]): The set of buffers to be planned.
+
+        Returns:
+            list[LifetimeBoundBuffer]: The supplied buffers with addresses assigned.
+        """
+        if not buffers:
+            return []
+        assert all(buf.address is None for buf in buffers), (
+            "Buffers cannot be previously or partially planned"
+        )
+        _assert_in_place_relationships(buffers)
+
+        # Barred buffers keep address=None and never enter the time-stepping
+        # loop, so they can neither be placed nor occupy space others need.
+        placeable, _ = self.partition(buffers)
+        if not placeable:
+            return list(buffers)
+
+        self.usage = []
+
+        # Walk through all transition points in chronological order.
+        # Include end_time + 1 so deallocation fires even when no other
+        # buffer starts or ends at that tick.
+        times = set()
+        for b in placeable:
+            times.add(b.start_time)
+            times.add(b.end_time)
+        sorted_times = sorted(times)
+
+        for idx in sorted_times:
+            # Deallocate all expired buffers before allocating new ones so that
+            # freed slots are immediately available at the same time step.
+            for buffer in placeable:
+                if idx == buffer.end_time:
+                    self._try_deallocate(buffer)
+
+            for buffer in placeable:
+                if idx == buffer.start_time:
+                    self._try_allocate(buffer)
+
+        if log_lx_usage and logger.isEnabledFor(10):  # logging.DEBUG
+            logger.debug("scratchpad limit: %d KB", self.limit // 1024)
+            for idx in range(sorted_times[0], sorted_times[-1]):
+                live = []
+                # Sum by distinct address: an in-place reuse places two buffers
+                # (a dying parent and its just-born child) at the same address
+                # for one overlapping tick, and the child's region is contained
+                # in the parent's. Counting both would double-count the shared
+                # slot, so track the max size per address and sum those.
+                size_by_addr: dict[int, int] = {}
+                for b in buffers:
+                    if b.address is not None and b.start_time <= idx < b.end_time:
+                        live.append(f"{b.name}_{b.size // 1024}KB@{hex(b.address)}")
+                        size_by_addr[b.address] = max(
+                            size_by_addr.get(b.address, 0), b.size
+                        )
+                used = sum(size_by_addr.values())
+                logger.debug("t=%d: %d KB  [%s]", idx, used // 1024, ", ".join(live))
+
+        return list(buffers)

--- a/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
+++ b/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
@@ -76,7 +76,6 @@ from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Generic, TypeVar, cast
 import torch
-import numpy as np
 
 
 if TYPE_CHECKING:
@@ -90,6 +89,7 @@ else:
 
 from torch_spyre._inductor.scratchpad.plan_solver import (
     CoreDivisionBuffer,
+    ceil_div,
     CoreDivisionLayoutSolver,
     LifetimeBoundBuffer,
     SolveError,
@@ -200,31 +200,26 @@ class _LifetimeBufferWithCpVars(Generic[_BufT]):
         return []
 
     # ------------------------------ residency ------------------------------
-    @property
-    def min_footprint(self) -> int:
-        """Smallest footprint the buffer can take, for the capacity trim."""
-        return self.buffer.size
-
-    @property
-    def residency_reason(self) -> "str | None":
-        """Allocator-supplied reason the buffer may not reside, if any. Carried
-        on the buffer itself, so both entry points honour the allocator's
-        hard bars (e.g. the restickify cross-frame barrier) identically."""
-        return self.buffer.residency_reason
-
-    def spill_cost(self, num_children: int) -> int:
-        """Differential HBM traffic a spill adds over residency. Without the
-        producer/consumer edges of the joint model, the accesses are read
-        straight off ``uses``: the producer's write (absent for a graph input,
-        whose first use is a read) plus one re-read per later use."""
+    def spill_cost(self) -> int:
+        """Differential HBM traffic a spill adds over residency: the reads
+        residency would have served from LX (``read_count``, computed by the
+        allocator) plus the producer's write, which residency turns into a free
+        LX write. A graph input has no producer write to save; a graph output's
+        write-out is unavoidable either way, so it too cancels. Both cases are
+        exactly ``boundary != Intermediate`` -- for a plain
+        :class:`LifetimeBoundBuffer`, whose boundary is not tracked,
+        ``first_use_is_read`` marks the same distinction for inputs."""
         b = self.buffer
-        writes = 0 if b.first_use_is_read else 1
-        reads = len(b.uses) - writes
-        return (reads + writes) * b.size
+        boundary = getattr(b, "boundary", None)
+        is_intermediate = (
+            boundary == BufferType.Intermediate
+            if boundary is not None
+            else not b.first_use_is_read
+        )
+        return (b.read_count + (1 if is_intermediate else 0)) * b.size
 
-    def constrain_residency(self, model, kids, bufs) -> "str | None":
+    def constrain_residency(self, model, kids, bufs) -> None:
         """Placement-only: any buffer may reside, so there is no slicing gate."""
-        return None
 
     def constrain_merge(self, model, parent: "_LifetimeBufferWithCpVars", edge) -> None:
         """Extra conditions on an active in-place merge. None when the division
@@ -257,9 +252,7 @@ class _CoreDivisionBufferWithCpVars(_LifetimeBufferWithCpVars[CoreDivisionBuffer
         b = self.buffer
         m = self.model
 
-        per_core = [
-            int(np.ceil(b.size / cd.output_partition)) for cd in b.core_divisions
-        ]
+        per_core = [ceil_div(b.size, cd.output_partition) for cd in b.core_divisions]
         # Total cores the op runs on under each division -- includes any
         # reduction-axis split, so a reduction-parallel division counts its full
         # parallelism (``output_partition`` alone would score it as 1 core).
@@ -281,48 +274,21 @@ class _CoreDivisionBufferWithCpVars(_LifetimeBufferWithCpVars[CoreDivisionBuffer
     def match_pairs(self, parent: str) -> list[tuple[int, int]]:
         return self.buffer.cd_parent_matches.get(parent, [])
 
-    @property
-    def min_footprint(self) -> int:
-        t = self.buffer
-        return min(
-            int(np.ceil(t.size / cd.output_partition)) for cd in t.core_divisions
-        )
-
-    def spill_cost(self, num_children: int) -> int:
-        b = self.buffer
-        reads = num_children + b.unallocated_reads
-        if b.boundary == BufferType.Input and reads > 0:
-            reads -= 1
-        writes = 1 if b.boundary == BufferType.Intermediate else 0
-        return (reads + writes) * b.size
-
-    def constrain_residency(self, model, kids, bufs) -> "str | None":
+    def constrain_residency(self, model, kids, bufs) -> None:
         """Slicing-consistency gate: a resident buffer's division must match
-        *every* consumer's division under the ``cd_parent_matches`` pairs. A
-        buffer with no consumer edge, or with a consumer that has no compatible
-        pair, can never reside; the reason returned here is surfaced to the
-        allocator as the buffer's drop cause."""
-        t = self.buffer
-        if not kids:
-            if t.unallocated_reads:
-                # Read only by consumers the solver never sees (filtered-out
-                # ops / graph outputs). They still read it from LX when it
-                # resides, so residency is worthwhile; there is no resident
-                # consumer to constrain the division against, so no gate.
-                # TODO: Remove this when the other solvers are brought to parity
-                return None
-            # Nothing consumes this buffer from LX -> it can never reside.
-            model.add(self.in_buffer == 0)
-            return "no consumer reads it from LX"
+        *every* consumer's division under the ``cd_parent_matches`` pairs.
+
+        This is the part of residency that genuinely depends on the solver's
+        free variables, so it stays here as a constraint. The precomputable
+        parts -- having no LX reader at all, or a consumer with no compatible
+        pair -- are decided by the allocator and arrive as ``read_count`` /
+        ``residency_reason``. A consumer with no compatible pair still lands
+        correctly if it slips through: ``_gate_divisions`` forces ``in_buffer``
+        false when the pair list is empty."""
         for child, compatible in kids:
-            if not compatible:
-                # This child can never match -> the buffer cannot reside.
-                model.add(self.in_buffer == 0)
-                return f"consumer {child} has no slicing-compatible core division"
             _gate_divisions(
                 model, compatible, self.division, bufs[child].division, self.in_buffer
             )
-        return None
 
     def constrain_merge(self, model, parent, edge) -> None:
         """An active merge means the child reuses the parent's exact per-core
@@ -341,7 +307,7 @@ class _CoreDivisionBufferWithCpVars(_LifetimeBufferWithCpVars[CoreDivisionBuffer
     def footprint(self, solver: "cp_model.CpSolver") -> int:
         t = self.buffer
         cd = t.core_divisions[solver.Value(self.division)]
-        return int(np.ceil(t.size / cd.output_partition))
+        return ceil_div(t.size, cd.output_partition)
 
     def record_division(self, solver: "cp_model.CpSolver") -> None:
         self.buffer.chosen_division = solver.Value(self.division)
@@ -373,10 +339,6 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
         self._capacity_units = self.limit // self.alignment
         self._time_limit_seconds = time_limit_seconds
         self._bottom_justify = bottom_justify
-        # Per-buffer drop cause for the most recent solve ({buffer name: reason},
-        # spilled buffers only). The allocator reads this to populate its own
-        # ``reject_reasons`` so cpsat spills show up in the LX-pinning debug log.
-        self.spill_reasons: dict[str, str] = {}
 
     def plan_layout(
         self, buffers: Sequence[LifetimeBoundBuffer], log_lx_usage: bool = False
@@ -420,7 +382,7 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
         division); anything else -- a plain :class:`LifetimeBoundBuffer`, or a
         :class:`CoreDivisionBuffer` with nothing to choose from -- gets the
         placement-only wrapper, whose footprint is ``size`` as given."""
-        units = int(np.ceil(buffer.size / self.alignment))
+        units = ceil_div(buffer.size, self.alignment)
         if isinstance(buffer, CoreDivisionBuffer) and buffer.core_divisions:
             return _CoreDivisionBufferWithCpVars(
                 replace(buffer, size=units), model, self._capacity_units
@@ -434,7 +396,6 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
         buffers: Sequence[LifetimeBoundBuffer | CoreDivisionBuffer],
         log_lx_usage: bool = False,
     ) -> list[LifetimeBoundBuffer | CoreDivisionBuffer]:
-        self.spill_reasons = {}
         if not buffers:
             return []
         assert all(b.address is None for b in buffers), (
@@ -443,16 +404,25 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
 
         _assert_in_place_relationships(buffers)
 
+        # Declarative exclusion, shared with every other solver: whatever the
+        # allocator barred (each buffer's ``residency_reason``), plus the
+        # no-LX-reader and capacity checks. Unlike the gap solvers -- which
+        # ``partition`` these out -- we still hand the barred buffers to the
+        # model (they must stay available for slicing matching and in-place
+        # chains) but pin them non-resident below, so we only need the reasons.
+        forced_reasons = dict(self.record_exclusions(buffers))
+
         model = cp_model.CpModel()
         # Solve on copies so we never mutate the caller's buffers.
         working = {b.name: self._wrap(model, b) for b in buffers}
 
-        solved, forced_reasons = self._run(model, working)
-        spilled = {name for name, sb in solved.items() if sb.address is None}
+        solved = self._run(model, working, forced_reasons)
         # Surface a drop cause for every spilled buffer: the pre-solve forced
         # reason when we have one, otherwise the solver chose to spill it.
         self.spill_reasons = {
-            name: forced_reasons.get(name, _SOLVER_CHOSE_SPILL) for name in spilled
+            name: forced_reasons.get(name, _SOLVER_CHOSE_SPILL)
+            for name, sb in solved.items()
+            if sb.address is None
         }
 
         # Copy the solved results back onto the caller's buffers. Offsets come
@@ -472,10 +442,11 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
         self,
         model: "cp_model.CpModel",
         tensors: dict[str, _LifetimeBufferWithCpVars],
-    ) -> tuple[dict[str, LifetimeBoundBuffer], dict[str, str]]:
+        forced_reasons: dict[str, str],
+    ) -> dict[str, LifetimeBoundBuffer]:
         children_of = self._get_children(tensors)
         self._add_inplace_relaxation(model, tensors)
-        forced_reasons = self._add_core_division(model, tensors, children_of)
+        self._add_core_division(model, tensors, children_of, forced_reasons)
 
         solver = cp_model.CpSolver()
         if self._time_limit_seconds:
@@ -488,10 +459,7 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
 
         # TODO: Update objective to a maxmin optimization to optimize overall
         # throughput.
-        hbm_terms = [
-            sb.spill_cost(len(children_of.get(sb.name, []))) * (1 - sb.in_buffer)
-            for sb in tensors.values()
-        ]
+        hbm_terms = [sb.spill_cost() * (1 - sb.in_buffer) for sb in tensors.values()]
         status = cp_model.INFEASIBLE
         if hbm_terms:
             model.minimize(sum(hbm_terms))
@@ -542,7 +510,7 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
                     forced_reasons.get(name, _SOLVER_CHOSE_SPILL),
                 )
 
-        return final_tensors, forced_reasons
+        return final_tensors
 
     def _add_inplace_relaxation(
         self,
@@ -670,47 +638,22 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
                 )
         return children_of
 
-    def _trim_oversized_tensors(
-        self,
-        model: "cp_model.CpModel",
-        bufs: dict[str, _LifetimeBufferWithCpVars],
-    ) -> dict[str, str]:
-        """Pin out of LX the buffers whose non-residency is fixed up front: those
-        whose *smallest* candidate footprint still exceeds capacity, and those
-        the allocator marked non-resident (``residency_reason`` set). Returns
-        ``name -> reason`` for the buffers it forces out (drop-cause debug
-        logging), using the allocator's specific reason when it has one."""
-        forced: dict[str, str] = {}
-        for sb in bufs.values():
-            min_size = sb.min_footprint
-            if min_size > self._capacity_units:
-                forced[sb.name] = (
-                    f"min per-core footprint {min_size} > LX capacity "
-                    f"{self._capacity_units} (alignment units)"
-                )
-                model.add(sb.in_buffer == 0)
-            elif sb.residency_reason is not None:
-                forced[sb.name] = sb.residency_reason
-                model.add(sb.in_buffer == 0)
-        return forced
-
     def _add_core_division(
         self,
         model: "cp_model.CpModel",
         bufs: dict[str, _LifetimeBufferWithCpVars],
         children_of: dict[str, list[tuple[str, list[tuple[int, int]]]]],
-    ) -> dict[str, str]:
-        """Wire up forced spills and the per-buffer residency gate. Returns
-        ``name -> reason`` for every buffer pinned non-resident up front, so the
-        solve can log why each buffer was dropped to HBM. In the joint model the
-        gate is the slicing match, driven entirely by the precomputed
-        ``cd_parent_matches`` pairs; placement-only buffers have no gate."""
-        forced = self._trim_oversized_tensors(model, bufs)
+        forced: dict[str, str],
+    ) -> None:
+        """Pin out every buffer ``forced`` non-resident (decided declaratively by
+        :meth:`MemoryPlanSolver.partition`) and install the per-buffer residency
+        gate. In the joint model that gate is the slicing match, driven entirely
+        by the precomputed ``cd_parent_matches`` pairs; placement-only buffers
+        have no gate."""
+        for name in forced:
+            model.add(bufs[name].in_buffer == 0)
         for sb in bufs.values():
-            why = sb.constrain_residency(model, children_of.get(sb.name, []), bufs)
-            if why is not None:
-                forced.setdefault(sb.name, why)
-        return forced
+            sb.constrain_residency(model, children_of.get(sb.name, []), bufs)
 
     # ------------------------------------------------------------------
     # Extract

--- a/torch_spyre/_inductor/scratchpad/plan_solver.py
+++ b/torch_spyre/_inductor/scratchpad/plan_solver.py
@@ -34,6 +34,12 @@ class BufferType(Enum):
     Output = 2
 
 
+def ceil_div(a: int, b: int) -> int:
+    """Integer ceiling division. Used wherever a footprint is divided down by a
+    core count, so every such site rounds identically (no float intermediate)."""
+    return -(-a // b)
+
+
 @dataclass
 class LifetimeBoundBuffer:
     """
@@ -57,14 +63,14 @@ class LifetimeBoundBuffer:
     first_use_is_read: bool = False
     address: Optional[int] = None
     in_place_parents: list[str] = field(default_factory=list)
-    # Why the buffer may not be made resident, or ``None`` if it may. A non-None
-    # reason (e.g. "lx back gap", "single use") pins it out of LX up front and is
-    # surfaced as its spill cause; ``None`` means residency is allowed. The buffer
-    # is handed to the solver either way so it still participates in matching and
-    # in-place chains -- a forced-out consumer keeps its producers' residency
-    # viable instead of orphaning them. Only :class:`CpSatLayoutSolver` honours
-    # this; the gap heuristics ignore it, as they always have.
+    # define the reason for excluding the buffer based on allocator
+    # or solver logic paths.
     residency_reason: Optional[str] = None
+
+    @property
+    def read_count(self) -> int:
+        """Reports the number of reads base on the number of uses."""
+        return max(0, len(self.uses) - 1)
 
     @property
     def start_time(self) -> int:
@@ -73,6 +79,11 @@ class LifetimeBoundBuffer:
     @property
     def end_time(self) -> int:
         return self.uses[-1] + 1
+
+    @property
+    def min_footprint(self) -> int:
+        """Smallest LX footprint the buffer can take, for the capacity check"""
+        return self.size
 
     def overlaps_in_time(self, other: "LifetimeBoundBuffer") -> bool:
         """Returns true iff self and other overlap in time."""
@@ -141,17 +152,18 @@ class CoreDivisionBuffer(LifetimeBoundBuffer):
     # the merge/residency across that edge.
     cd_parent_matches: dict[str, list[tuple[int, int]]] = field(default_factory=dict)
     chosen_division: Optional[int] = None
-    # Count of reads of this buffer by consumers the solver never sees as
-    # candidates -- ops filtered out of the candidate set or graph outputs.
-    # Such a consumer still reads this buffer *from LX* when it resides,
-    # so the read counts toward the buffer's spill cost even though no ``parents``
-    # edge represents it, and it lets the buffer reside despite having no resident
-    # (candidate) consumer to match a division against. Zero for the joint
-    # allocator, where every consumer is a candidate, so the objective and
-    # residency gate are unchanged there.
-    # TODO: Drop this and make other solvers use the placement = False flag
-    unallocated_reads: int = 0
     boundary: BufferType = BufferType.Intermediate
+
+    @property
+    def min_footprint(self) -> int:
+        """Smallest per-core footprint any candidate division allows. With no
+        candidates there is nothing to divide by, so it falls back to ``size``
+        (the placement-only case ``_wrap`` also dispatches on)."""
+        if not self.core_divisions:
+            return self.size
+        return min(
+            ceil_div(self.size, cd.output_partition) for cd in self.core_divisions
+        )
 
 
 def _assert_in_place_relationships(
@@ -161,24 +173,25 @@ def _assert_in_place_relationships(
     buf_by_name = {b.name: b for b in buffers}
     for child in buffers:
         for parent_name in child.in_place_parents:
-            parent = buf_by_name[parent_name]
-            assert parent.end_time == child.start_time + 1, (
-                f"In-place parent {parent_name}.end_time={parent.end_time} must equal "
-                f"child {child.name}.start_time+1={child.start_time + 1}"
-            )
-            # With core_divisions ``size`` is the *total* footprint, so a static
-            # size check doesn't apply; the per-core match is enforced against the
-            # chosen division in ``CpSatLayoutSolver._add_inplace_relaxation``. Only
-            # the division-fixed case (plain ``LifetimeBoundBuffer``, no
-            # ``core_divisions``) keeps the static check.
-            if not (
-                getattr(parent, "core_divisions", None)
-                or getattr(child, "core_divisions", None)
-            ):
-                assert child.size <= parent.size, (
-                    f"In-place child {child.name}.size={child.size} "
-                    f"must be <= parent {parent_name}.size={parent.size}"
+            parent = buf_by_name.get(parent_name)
+            if parent:
+                assert parent.end_time == child.start_time + 1, (
+                    f"In-place parent {parent_name}.end_time={parent.end_time} must equal "
+                    f"child {child.name}.start_time+1={child.start_time + 1}"
                 )
+                # With core_divisions ``size`` is the *total* footprint, so a static
+                # size check doesn't apply; the per-core match is enforced against the
+                # chosen division in ``CpSatLayoutSolver._add_inplace_relaxation``. Only
+                # the division-fixed case (plain ``LifetimeBoundBuffer``, no
+                # ``core_divisions``) keeps the static check.
+                if not (
+                    getattr(parent, "core_divisions", None)
+                    or getattr(child, "core_divisions", None)
+                ):
+                    assert child.size <= parent.size, (
+                        f"In-place child {child.name}.size={child.size} "
+                        f"must be <= parent {parent_name}.size={parent.size}"
+                    )
 
 
 class MemoryPlanSolver(ABC):
@@ -203,6 +216,46 @@ class MemoryPlanSolver(ABC):
         """
         self.limit = size
         self.alignment = alignment
+        self.spill_reasons: dict[str, str] = {}
+
+    def excluded(self, buffer: "LifetimeBoundBuffer") -> Optional[str]:
+        """Why ``buffer`` may not reside in LX, or ``None`` if it may."""
+        if buffer.residency_reason is not None:
+            return buffer.residency_reason
+        if buffer.min_footprint > self.limit:
+            return (
+                f"min footprint {buffer.min_footprint} B > LX capacity {self.limit} B"
+            )
+        return None
+
+    def record_exclusions(
+        self, buffers: Sequence["LifetimeBoundBuffer"]
+    ) -> dict[str, str]:
+        """Compute, store, and return the ``name -> reason`` map of every buffer
+        barred from LX residency.
+
+        This is the piece a solver that keeps barred buffers in its model (e.g.
+        CP-SAT, which pins them non-resident rather than dropping them) needs on
+        its own; :meth:`partition` layers the placeable/excluded split on top.
+        The returned map is also stored in :attr:`spill_reasons`.
+        """
+        self.spill_reasons = {
+            buffer.name: reason
+            for buffer in buffers
+            if (reason := self.excluded(buffer)) is not None
+        }
+        return self.spill_reasons
+
+    def partition(
+        self, buffers: Sequence["LifetimeBoundBuffer"]
+    ) -> tuple[list["LifetimeBoundBuffer"], list["LifetimeBoundBuffer"]]:
+        """Split ``buffers`` into ``(placeable, excluded)``, recording every
+        exclusion in :attr:`spill_reasons` via :meth:`record_exclusions`.
+        """
+        excluded_reasons = self.record_exclusions(buffers)
+        placeable = [b for b in buffers if b.name not in excluded_reasons]
+        excluded = [b for b in buffers if b.name in excluded_reasons]
+        return placeable, excluded
 
     @abstractmethod
     def plan_layout(
@@ -258,159 +311,3 @@ class CoreDivisionLayoutSolver(MemoryPlanSolver):
         Returns:
             The same buffers, with placements and chosen divisions defined.
         """
-
-
-class GreedyLayoutSolver(MemoryPlanSolver):
-    def __init__(self, size: int, alignment: int = 128):
-        super().__init__(size, alignment)
-        # `usage` tracks live placements during planning. It is specific to the
-        # greedy time-stepping algorithm; the gap-based solvers don't use it.
-        self.usage: list[LifetimeBoundBuffer] = []
-
-    def _get_lowest_addr_in_use(self):
-        return min(
-            (rec.address for rec in self.usage if rec.address is not None),
-            default=0,
-        )
-
-    def _get_highest_addr_in_use(self):
-        return max(
-            (rec.address + rec.size for rec in self.usage if rec.address is not None),
-            default=0,
-        )
-
-    def _find_free_block(self, size_needed: int) -> Optional[int]:
-        assert all(x.address is not None for x in self.usage)
-        curr_lo = self._get_lowest_addr_in_use()
-        curr_hi = self._get_highest_addr_in_use()
-        if self.limit < size_needed:
-            return None
-
-        if not self.usage or curr_lo >= size_needed:
-            return 0
-
-        address = math.ceil(curr_hi / self.alignment) * self.alignment
-        if address + size_needed <= self.limit:
-            return address
-
-        # Search for a gap between existing allocations
-        self.usage.sort(key=lambda x: (x.address is None, x.address))
-        for i in range(len(self.usage) - 1):
-            assert (current_address := self.usage[i].address) is not None
-            assert (next_address := self.usage[i + 1].address) is not None
-            frag_st = (
-                math.ceil((current_address + self.usage[i].size) / self.alignment)
-                * self.alignment
-            )
-            if next_address - frag_st >= size_needed:
-                return frag_st
-
-        return None
-
-    def _try_allocate(self, buffer: LifetimeBoundBuffer):
-        # Check if the current buffer can be in-placed
-        for in_place_opt in buffer.in_place_parents:
-            matched_obj = next((u for u in self.usage if u.name == in_place_opt), None)
-            if matched_obj is not None and buffer.size <= matched_obj.size:
-                buffer.address = matched_obj.address
-                self.usage.append(buffer)
-                self.usage.remove(matched_obj)
-                return None
-
-        # Decide where to allocate the block from
-        addr = self._find_free_block(buffer.size)
-
-        # Push the allocation result to the buffer and the usage table
-        if addr is not None:
-            buffer.address = addr
-            self.usage.append(buffer)
-        else:
-            buffer.address = None
-
-    def _try_deallocate(self, bufs: list[LifetimeBoundBuffer] | LifetimeBoundBuffer):
-        if isinstance(bufs, LifetimeBoundBuffer):
-            bufs = [bufs]
-
-        for buf in bufs:
-            if buf in self.usage:
-                self.usage.remove(buf)
-
-    def plan_layout(
-        self, buffers: Sequence[LifetimeBoundBuffer], log_lx_usage: bool = False
-    ) -> list[LifetimeBoundBuffer]:
-        """Allocates addresses to the provided buffer list
-
-        Accepts a set of buffers with pre-defined sizes and lifetimes. These buffers are
-        allocated addresses with 0 -> `limit` where the maximum starting address of
-        buffers are at most `self.limit` - `LifetimeBoundBuffer.size` - 1. The algorithm
-        increments through logical time where time increments 1 unit for each
-        step in a computation graph. At each step the lifetimes of all buffers are
-        evaluated for allocation and deallocation based on its lifetime relative
-        to the time being evaluated. As an optimization, times where no buffers
-        enter or exit scope are not evaluated.
-
-        When a buffer enters scope, the current usage is evaluated in the following
-        manner:
-            1. Check if there is a permissible in-place buffer already allocated
-            2. Is there enough space from address 0 -> first usage.
-            3. Is there enough space for the current buffer from the max address
-                to the maximum memory address. Allocate as current_max + 1 + alignment.
-            4. Is there space between allocations. Check for gaps between current
-                allocations and find where gaps exceed current size. Allocate if
-                current gap is larger than current size + alignment.
-
-        Args:
-            buffers (list[LifetimeBoundBuffer]): The set of buffers to be planned.
-
-        Returns:
-            list[LifetimeBoundBuffer]: The supplied buffers with addresses assigned.
-        """
-        if not buffers:
-            return []
-        assert all(buf.address is None for buf in buffers), (
-            "Buffers cannot be previously or partially planned"
-        )
-        _assert_in_place_relationships(buffers)
-
-        self.usage = []
-
-        # Walk through all transition points in chronological order.
-        # Include end_time + 1 so deallocation fires even when no other
-        # buffer starts or ends at that tick.
-        times = set()
-        for b in buffers:
-            times.add(b.start_time)
-            times.add(b.end_time)
-        sorted_times = sorted(times)
-
-        for idx in sorted_times:
-            # Deallocate all expired buffers before allocating new ones so that
-            # freed slots are immediately available at the same time step.
-            for buffer in buffers:
-                if idx == buffer.end_time:
-                    self._try_deallocate(buffer)
-
-            for buffer in buffers:
-                if idx == buffer.start_time:
-                    self._try_allocate(buffer)
-
-        if log_lx_usage and logger.isEnabledFor(10):  # logging.DEBUG
-            logger.debug("scratchpad limit: %d KB", self.limit // 1024)
-            for idx in range(sorted_times[0], sorted_times[-1]):
-                live = []
-                # Sum by distinct address: an in-place reuse places two buffers
-                # (a dying parent and its just-born child) at the same address
-                # for one overlapping tick, and the child's region is contained
-                # in the parent's. Counting both would double-count the shared
-                # slot, so track the max size per address and sum those.
-                size_by_addr: dict[int, int] = {}
-                for b in buffers:
-                    if b.address is not None and b.start_time <= idx < b.end_time:
-                        live.append(f"{b.name}_{b.size // 1024}KB@{hex(b.address)}")
-                        size_by_addr[b.address] = max(
-                            size_by_addr.get(b.address, 0), b.size
-                        )
-                used = sum(size_by_addr.values())
-                logger.debug("t=%d: %d KB  [%s]", idx, used // 1024, ", ".join(live))
-
-        return list(buffers)

--- a/torch_spyre/_inductor/scratchpad/simulated_annealing.py
+++ b/torch_spyre/_inductor/scratchpad/simulated_annealing.py
@@ -59,10 +59,10 @@ from torch_spyre._inductor.scratchpad.firstfit_bestfit_solver import (
     FirstFitLayoutSolver,
 )
 from torch_spyre._inductor.scratchpad.plan_solver import (
-    GreedyLayoutSolver,
     LifetimeBoundBuffer,
     MemoryPlanSolver,
 )
+from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
 from torch_spyre._inductor.scratchpad.permutation_layout import (
     PermutationBasedLayoutSolver,
 )
@@ -122,7 +122,12 @@ class SimulatedAnnealingLayoutSolver(MemoryPlanSolver):
     def plan_layout(
         self, buffers: Sequence[LifetimeBoundBuffer], log_lx_usage: bool = False
     ) -> list[LifetimeBoundBuffer]:
-        _buffers = list(buffers)
+        # Barred buffers keep address=None and stay out of the permutation
+        # entirely, so no annealing move can ever place one.
+        placeable, _ = self.partition(buffers)
+        if not placeable:
+            return list(buffers)
+        _buffers = list(placeable)
         solver = SimulatedAnnealingSolverWithBuffers(
             _buffers,
             self.limit,
@@ -133,7 +138,9 @@ class SimulatedAnnealingLayoutSolver(MemoryPlanSolver):
         )
         solver.solve()
         solver.finalize()
-        return _buffers
+        # The annealer mutates the buffer objects in place, so the caller's full
+        # list (barred buffers included, still at address=None) is the result.
+        return list(buffers)
 
 
 class SimulatedAnnealingSolverWithBuffers:

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -81,20 +81,6 @@ def clone_at_graph_boundaries() -> bool:
     return "clone" in OP_OUTPUT_GOOD_FOR_LX_REUSE
 
 
-class GraphView:
-    """
-    Simple wrapper which allows filtering of returned operations
-    without mutating the underlying graph.
-    """
-
-    def __init__(self, graph, predicate):
-        self.graph = graph
-        self.operations = predicate(graph)
-
-    def __getattr__(self, name):
-        return getattr(self.graph, name)
-
-
 def calculate_liveness(graph: GraphLowering) -> dict[str, list[int]]:
     """Return a dict mapping each buffer name to the sorted list of operation indices
     at which that buffer is accessed (read or written).  Graph inputs are seeded with
@@ -118,7 +104,7 @@ def calculate_liveness(graph: GraphLowering) -> dict[str, list[int]]:
 
 
 def mem_usage_by_buf(
-    graph: GraphLowering | GraphView,
+    graph: GraphLowering,
     cache: Optional[dict] = None,
 ) -> dict:
     """
@@ -128,7 +114,9 @@ def mem_usage_by_buf(
     NOTE:
     if a buf is not in core_div_mismatch => it has no users => graph output
     """
-    num_cores_per_op = get_ncores_for_buffers(graph, cache)
+    # The mismatch reasons are surfaced by the residency path; here only the
+    # per-buffer core count (with -1 marking a mismatch) drives mem_usage.
+    num_cores_per_op, _ = get_ncores_for_buffers(graph, cache)
     mem_usage: dict = {}
 
     for op in graph.operations:
@@ -137,8 +125,18 @@ def mem_usage_by_buf(
         num_cores = num_cores_per_op.get(buf_name, -1)
         rw = op_read_writes(op)
         layout = buf.layout
-        if isinstance(layout, MutationLayoutSHOULDREMOVE) or not isinstance(
-            op, ComputedBuffer
+        # Only ComputedBuffers backed by a real Spyre device layout
+        # (FixedTiledLayout, which carries ``device_layout``) can be sized for
+        # scratchpad/LX residency. Mutation aliases and plain host FixedLayout
+        # buffers (e.g. fallback / CPU-roundtrip outputs) have no device_layout,
+        # so they get the unsized sentinel below. Testing for FixedTiledLayout
+        # here — rather than the broader ``isinstance(layout, FixedLayout)`` —
+        # avoids excluding genuine device buffers, which subclass FixedLayout
+        # and must be sized (see the ``layout.device_layout`` access below).
+        if (
+            isinstance(layout, MutationLayoutSHOULDREMOVE)
+            or not isinstance(layout, FixedTiledLayout)
+            or not isinstance(op, ComputedBuffer)
         ):
             mem_usage[buf_name] = {
                 "size": -1,
@@ -163,7 +161,7 @@ def mem_usage_by_buf(
     return mem_usage
 
 
-def buffer_not_read_in_full(graph: GraphLowering | GraphView, buf_name: str) -> bool:
+def buffer_not_read_in_full(graph: GraphLowering, buf_name: str) -> bool:
     """True if any consumer reads less than the whole ``buf_name`` (a sliced,
     partial, or multi-offset read), or if the footprint can't be proven to
     cover the full buffer.
@@ -261,7 +259,7 @@ def _writes_at_constant_offset(op: Operation) -> bool:
 
 
 def ops_in_offset_mutation_component(
-    graph: GraphLowering | GraphView,
+    graph: GraphLowering,
 ) -> set[str]:
     """Names of ops data-connected to a sliced in-place mutation that writes at
     a constant non-zero offset (e.g. ``x[:, 32:96] = ...``).
@@ -325,7 +323,7 @@ def ops_in_offset_mutation_component(
     return component & op_names
 
 
-def get_buffer_users(graph: GraphLowering | GraphView) -> dict[str, list[Operation]]:
+def get_buffer_users(graph: GraphLowering) -> dict[str, list[Operation]]:
     buf_users_read_and_write: dict[str, list[Operation]] = {}
     for op in graph.operations:
         rw = op_read_writes(op)
@@ -336,7 +334,7 @@ def get_buffer_users(graph: GraphLowering | GraphView) -> dict[str, list[Operati
 
 
 def _get_buffer_user_deps(
-    graph: GraphLowering | GraphView,
+    graph: GraphLowering,
 ) -> dict[str, list[tuple[Operation, MemoryDep]]]:
     """Like get_buffer_users but pairs each op with the specific dep it uses.
 
@@ -367,25 +365,21 @@ def _op_num_cores(op: Operation) -> int:
 
 
 def get_ncores_for_buffers(
-    graph: GraphLowering | GraphView,
-    cache: Optional[dict] = None,
-    reject_reasons_out: Optional[dict[str, str]] = None,
-) -> dict[str, int]:
+    graph: GraphLowering, cache: Optional[dict] = None
+) -> tuple[dict[str, int], dict[str, str]]:
     """
-    Return a dictionary mapping buffer names to the number of cores
-    used by all the operations that uses the buffer.
-    If there is a core division mismatch return -1 instead of the
-    number of cores.
+    Return ``(num_cores, mismatch_reasons)``, where ``num_cores`` maps each
+    buffer name to the number of cores used by all the operations that use the
+    buffer (``-1`` on a core-division mismatch) and ``mismatch_reasons`` maps
+    each mismatched buffer name to a human-readable reason for the ``-1``.
 
     Pass an optional `cache` dict to memoize `_per_core_view_on_buf`
     results across calls (e.g. across co-opt search leaves). Safe to
     share only within a single graph, since the cache key includes the
     op name and `dep` (which carries the buffer name).
-
-    Pass an optional `reject_reasons_out` dict to receive detailed
-    reasons for core division mismatches (keyed by buffer name).
     """
     result: dict[str, int] = {}
+    mismatch_reasons_cache: dict[str, str] = {}
     using_multicore = config.sencores > 1
     buf_user_deps = _get_buffer_user_deps(graph)
     for buf_name, users in buf_user_deps.items():
@@ -448,8 +442,7 @@ def get_ncores_for_buffers(
                     break
             if mismatch_reason is not None:
                 num_cores = -1
-                if reject_reasons_out is not None:
-                    reject_reasons_out[buf_name] = mismatch_reason
+                mismatch_reasons_cache[buf_name] = mismatch_reason
             elif writer_cores is not None:
                 num_cores = writer_cores
             else:
@@ -461,7 +454,7 @@ def get_ncores_for_buffers(
         else:
             num_cores = 1
         result[buf_name] = num_cores
-    return result
+    return result, mismatch_reasons_cache
 
 
 class _GetLoadStoreIndices(WrapperHandler):


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [X] cleanup

#### What this PR does:

Placements into scratchpad are dependent on optimizations within solvers but other buffer attributes unrelated to the solver can also remove them from scratchpad contention. Examples of fixed attributes which force buffers to HBM are mutation layout targets, buffers which are reductions on padded stick axes and buffers not read in-full for example. These attributes are common to placement and CoOptimizing allocators and are not dependent on the outcome of solvers. Thus, this PR moves the exclusion criteria into `ScratchpadAllocator._input_residency_reason` for input buffer pinning and `ScratchpadAllocator._buffer_residency_reason` for general placement. This allows shared inclusion logic entirely across allocators with reduced complexity in solvers.

Alignment between allocators is accomplished by adopting a declarative method for filtering out buffers. This allows solvers to see all buffers in a graph even if some buffers are ineligible for scratchpad. Specifically, the status of `LifetimeBoundBuffer.residency_reason` is the eligibility flag. If  `LifetimeBoundBuffer.residency_reason` is `None` the solver will attempt to place it otherwise it contains a descriptive `str` declaring what filtering stage rejected the buffer. 

#### Which issue(s) this PR is related to:
None.

#### Special notes for your reviewer:
Please merge https://github.com/torch-spyre/torch-spyre/pull/3325 first as the change in `actions.yml` is an unrelated change that enables fast CI feedback. 

#### Does this PR introduce a user-facing change?
No.

#### Additional note:
None.