### PR TITLE
docs: fix supported_operations drift

### DIFF
--- a/docs/source/user_guide/supported_operations.md
+++ b/docs/source/user_guide/supported_operations.md
@@ -67,14 +67,11 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.mean` | Y | Y | Spyre | |
 | `torch.amax` | Y | Y | Spyre | |
 | `torch.amin` | | Y | Spyre | Custom decomposition |
-| `torch.aminmax` | | Y | Spyre | Decomposes to `amax` + `amin` |
 | `torch.prod` | | Y | Spyre | Requires `dim` argument; custom decomposition + lowering |
 | `torch.max` | Y | Y | Spyre | `max.dim` via custom decomposition |
 | `torch.min` | Y | Y | Spyre | `min.dim` via custom decomposition (fp16) |
 | `torch.topk` | | Y | Spyre | Custom decomposition + custom ops (`spyre::topkvalue`, `spyre::topkindex`) |
-| `torch.linalg.vector_norm` | | Y | Spyre | Compiled only (eager misroutes `ord`) |
-| `torch.linalg.norm` | | Y | Spyre | Compiled only |
-| `torch.linalg.matrix_norm` | | Y | Spyre | Compiled only |
+| `torch.linalg.vector_norm` | Y | | Spyre | Eager only |
 | **View Ops** [^views] | | | | |
 | `torch.reshape` / `torch.view` | | Y | Spyre | Includes `_reshape_alias` (a C++ device view, not an Inductor lowering) |
 | `torch.transpose` | Y | Y | Spyre | |


### PR DESCRIPTION
## Summary

- Remove `torch.aminmax` from supported operations table (not independently supported).
- Remove `torch.linalg.norm` and `torch.linalg.matrix_norm` (not currently compiled).
- Correct `torch.linalg.vector_norm` to eager-only (compiled path not active).

## Test plan

- [ ] `pre-commit run --all-files` passes (pymarkdown, yamlfmt)
- [ ] Visual check that the table renders correctly in Sphinx