### PR TITLE
Fix/device size tiling

### DIFF
--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -1366,11 +1366,17 @@ def _allocate_full_buffer(
         # None falls back to size-based inference inside _resize_device_layout.
         stick_hd = _stick_host_dim(tiled_op, orig_layout.device_layout)
         try:
+            tiled_host_dims = {
+                d
+                for dims in tiled_op.loop_info.loop_tiled_dims
+                for d in dims
+            }
             device_layout = _resize_device_layout(
                 orig_layout.device_layout,
                 tile_size_ints,
                 full_size_ints,
                 stick_host_dim=stick_hd,
+                preserve_unit_host_dims=tiled_host_dims,
             )
         except RuntimeError:
             # Non-standard device layout (e.g. post-restickify HBM strides that
@@ -2244,8 +2250,16 @@ def _divide_ranges(
     # _resize_device_layout does not have to infer it by size (ambiguous for
     # transposed same-size dims — issue #3116). Tiling-invariant, so safe here.
     stick_hd = _stick_host_dim(op, layout.device_layout)
+    unit_dims = {i for i, s in enumerate(new_size_ints) if s == 1}
+    preserve_unit_host_dims = {
+        i for i in tiled_dims if i in unit_dims and len(unit_dims) > 1
+    }
     layout.device_layout = _resize_device_layout(
-        layout.device_layout, old_host_size, new_size_ints, stick_host_dim=stick_hd
+        layout.device_layout,
+        old_host_size,
+        new_size_ints,
+        stick_host_dim=stick_hd,
+        preserve_unit_host_dims=preserve_unit_host_dims,
     )
     return retiled_info
 

--- a/torch_spyre/_inductor/ir.py
+++ b/torch_spyre/_inductor/ir.py
@@ -112,6 +112,7 @@ def _resize_device_layout(
     old_host_size: list[int],
     new_host_size: list[int],
     stick_host_dim: int | None = None,
+    preserve_unit_host_dims: set[int] | None = None,
 ):
     """Derive a new SpyreTensorLayout for a resized host buffer.
 
@@ -197,6 +198,7 @@ def _resize_device_layout(
     eps = orig_stl.elems_per_stick()
     ndev = len(orig_sm)
     ndim = len(old_host_size)
+    preserve_unit_host_dims = preserve_unit_host_dims or set()
 
     # Trust a caller-provided stick_host_dim only when it is consistent with the
     # device tile-count structure: the stick host dim must have a corresponding
@@ -229,7 +231,17 @@ def _resize_device_layout(
             # The authoritative stick host dim is never a non-stick match.
             if stick_host_dim is not None:
                 size1_cands = [p for p in size1_cands if p != stick_host_dim]
-            if len(size1_cands) == 1:
+            preserved_cands = [
+                p
+                for p in size1_cands
+                if p in preserve_unit_host_dims
+                and new_host_size[p] != old_host_size[p]
+                and orig_sm[j] != -1
+                and (orig_sm[j] == old_hs[p] or orig_sm[j] == new_hs[p])
+            ]
+            if len(preserved_cands) == 1:
+                matched_host[j] = preserved_cands[0]
+            elif len(size1_cands) == 1:
                 matched_host[j] = size1_cands[0]
             # else: sparse placeholder with no host counterpart — skip silently.
         else:
@@ -321,7 +333,13 @@ def _resize_device_layout(
     for j, p in matched_host.items():
         new_ds[j] = new_host_size[p]
         if new_host_size[p] == 1:
-            new_sm[j] = -1
+            if p in preserve_unit_host_dims:
+                if orig_sm[j] == old_hs[p] or orig_sm[j] == -1:
+                    new_sm[j] = new_hs[p]
+                else:
+                    new_sm[j] = orig_sm[j]
+            else:
+                new_sm[j] = -1
         elif orig_sm[j] == old_hs[p] or orig_sm[j] == -1:
             new_sm[j] = new_hs[p]
         # else: non-contiguous stride; physical layout is invariant — leave unchanged.


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes coarse-tiled output layout reconstruction when a tiled dimension becomes size 1.
For cases like:
```
shape = (1,20,16,64)
tile dim = 1
tiles = 20
```
the tile body shrinks to:
`(1,1,16,64)`
Previously, layout resize lost the identity of the tiled dim once it became singleton. As a result, the full-buffer/copy path could not reliably grow the correct dim back to the full output size, and the generated output layout could remain tile-sized or store into the wrong slice.
This PR passes coarse-tiled host-dim identity into _resize_device_layout() so singleton dims created by tiling are handled correctly.
Before, the final output layout could stay effectively tile-sized:
`device_size=[1,1,16,64]`
After, the full output layout is reconstructed correctly:
`device_size=[1,20,16,64]`
The stride for the tiled singleton dim is also preserved during tile-body resize so the outer tile loop can advance stores correctly.

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
