### PR TITLE
FIX:  _all_constant_layouts: exclude layouts that would create non-full stick

### DIFF
--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -1117,6 +1117,7 @@ def _all_constant_layouts(op: Operation) -> list[SpyreTensorLayout]:
     output: FixedLayout = op.get_layout()
     c_size = [concretize_expr(s) for s in output.size]
     c_stride = [concretize_expr(s) for s in output.stride]
+    stick_size = get_elem_in_stick(output.dtype)
     layouts = [
         SpyreTensorLayout(
             c_size,
@@ -1125,7 +1126,7 @@ def _all_constant_layouts(op: Operation) -> list[SpyreTensorLayout]:
             [d for d in range(len(c_size)) if d != stick_dim] + [stick_dim],
         )
         for stick_dim in range(len(c_size))
-        if c_size[stick_dim] > 1  # no sticks of size 1
+        if c_size[stick_dim] % stick_size == 0 and c_size[stick_dim] >= stick_size
     ]
     if not layouts:
         layouts = [generic_layout(op)]


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

`_all_constant_layouts` assigns all layouts to constant tensors, to prevent them from being restickified. They are already compatible if you start with the right layout, so there is on reason to pick the wrong one and trigger a restickify.

The current code on main allows putting the stick on dimension that  is not a multiple of the stick size.  This works (in theory) because the downstream code does padding of partial sticks.  However it is creating numerical instability for flash, so we are disabling this feature for now until it is stable.

This PR changes the code so `_all_constant_layouts` selects **_only_** layouts where the stick is a multiple of the stick size.

This can be relaxed again once partial stick handling is more stable and can be validated to not break flash

#### Which issue(s) this PR is related to:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
