### PR TITLE
[Bug] Fixing issues with CPU-resident tensors in a graph

### DIFF
--- a/tests/inductor/test_fallback_kernel.py
+++ b/tests/inductor/test_fallback_kernel.py
@@ -35,6 +35,13 @@ mixes Spyre and CPU-C++ kernels (TestReinterpretTensorCpuBuffer).
 Plus a traced spyre -> cpu -> spyre round-trip via plain `.to()`
 (TestTracedDeviceCopy).
 
+Plus a CPU tensor lifted as a graph input (TestLiftedCpuGraphInput) and CPU
+pointwise ComputedBuffers inside the graph (TestInGraphCpuComputedBuffers) --
+two ways a non-Spyre buffer enters a mixed CPU/Spyre graph. The lifted input
+tripped propagate_layouts' graph-input loop ("missing device_tensor_layout on
+graph input"); the CPU ComputedBuffers tripped the scratchpad planner
+("'FixedLayout' object has no attribute 'device_layout'").
+
 All tests run end-to-end through `torch.compile(..., backend="inductor")` on
 the Spyre device to guard against regressions.
 """
@@ -43,6 +50,8 @@ import unittest
 
 import torch
 import torch.nn.functional as F
+
+from torch_spyre._inductor import config
 
 
 DEVICE = "spyre"
@@ -281,6 +290,107 @@ class TestFallbackKernelPoolResidentArg(unittest.TestCase):
         out = compiled(x.clone().to(DEVICE))
         self.assertEqual(out.dtype, DTYPE)
         torch.testing.assert_close(out.cpu(), fn(x.clone()), atol=0.01, rtol=0.01)
+
+
+class TestLiftedCpuGraphInput(unittest.TestCase):
+    """A CPU tensor lifted as a graph input must not crash layout propagation.
+
+    When a compiled fn closes over (or Dynamo/AOTAutograd constant-folds) a CPU
+    tensor that has no data-dependency on any declared input, it is lifted as an
+    extra graph-input placeholder. That input is CPU-resident, so
+    `device_tensor_layout()` returns None. propagate_layouts' graph-input loop
+    used to treat that as fatal and raised
+    `missing device_tensor_layout on graph input <name>`; it now skips the input
+    (leaving its FixedLayout intact), mirroring the non-Spyre ComputedBuffer skip
+    further down the same pass. The lifted CPU input's only consumer here is the
+    convert fallback that moves it onto Spyre.
+
+    """
+
+    def test_lifted_cpu_constant_matmul_compiles(self):
+        spyre = torch.device(DEVICE)
+        inner, padded, num_tokens = 32, 64, 16
+
+        # Built outside the compiled region -> closed over -> lifted as a CPU
+        # graph input. A {0,1} expand matrix, like RoPE's _get_expand_matrix.
+        e_cpu = torch.zeros(2 * inner, 2 * padded, dtype=DTYPE)
+        idx = torch.arange(inner)
+        e_cpu[idx, idx] = 1
+        e_cpu[inner + idx, padded + idx] = 1
+
+        def fn(x):
+            e = torch.ops.test_fk_conv.convert(e_cpu, spyre)
+            return x @ e
+
+        x = torch.randn(num_tokens, 2 * inner, dtype=DTYPE)
+        compiled = torch.compile(fn, fullgraph=True, dynamic=False, backend="inductor")
+        out = compiled(x.to(spyre))
+        self.assertEqual(out.device.type, DEVICE)
+        self.assertEqual(tuple(out.shape), (num_tokens, 2 * padded))
+        torch.testing.assert_close(out.cpu(), x @ e_cpu, atol=0.01, rtol=0.01)
+
+
+class TestInGraphCpuComputedBuffers(unittest.TestCase):
+    """CPU pointwise ComputedBuffers in a mixed graph must not crash scratchpad planning.
+
+    A convert fallback returns a CPU tensor; a chain of pointwise ops
+    (add/sub/mul -- all in OP_OUTPUT_GOOD_FOR_LX_REUSE) then runs on it inside
+    the same graph, before converting back to Spyre. propagate_layouts SKIPS
+    those CPU ComputedBuffers (device != spyre), leaving them a plain
+    `FixedLayout` with no `device_layout`. The scratchpad planner's op gate
+    (`_op_output_good_for_lx_reuse`) whitelisted by op NAME only, so a CPU
+    add/sub/mul passed the gate, entered graph_view, and reached
+    `mem_usage_by_buf`, which read `layout.device_layout` and raised
+    `'FixedLayout' object has no attribute 'device_layout'`. The gate now also
+    requires a Spyre `FixedTiledLayout`, so CPU buffers stay out of the planner.
+
+    Same class of bug as spyre-inference's RoPE `_get_expand_matrix` (a CPU
+    constant built in-graph) and the TP>1 vocab-shard mask. Uses tensor-bound
+    ops (no dtype change / no scalar-int constants) so the ONLY thing under test
+    is "CPU pointwise ComputedBuffer in a Spyre graph".
+
+    Both scratchpad allocators are covered: the default greedy allocator (which
+    filters ops through `_op_output_good_for_lx_reuse` -> the gate fix) and the
+    co-optimizing allocator (`co_optimizing_lx_planning`), whose `_search`
+    footprint accounting reads `.device_layout` over every buffer -> the
+    `buf_total_bytes` guard.
+    """
+
+    @staticmethod
+    def _run_and_check(test: "unittest.TestCase") -> None:
+        cpu = torch.device("cpu")
+        spyre = torch.device(DEVICE)
+        num_tokens, hidden = 16, 256
+
+        def fn(x):
+            # Opaque spyre -> cpu: CPU FallbackKernel output.
+            x_cpu = torch.ops.test_fk_conv.convert(x, cpu)
+            # CPU pointwise chain -> CPU ComputedBuffers (add/sub/mul).
+            y = (x_cpu + 1.0) * (x_cpu - 1.0)
+            # Opaque cpu -> spyre and an on-device consumer.
+            y_s = torch.ops.test_fk_conv.convert(y, spyre)
+            return y_s * 2.0
+
+        x = torch.randn(num_tokens, hidden, dtype=DTYPE)
+        compiled = torch.compile(fn, fullgraph=True, dynamic=False, backend="inductor")
+        out = compiled(x.to(spyre))
+        test.assertEqual(out.device.type, DEVICE)
+        # ((x + 1)(x - 1)) * 2 = (x^2 - 1) * 2
+        torch.testing.assert_close(
+            out.cpu(), ((x + 1.0) * (x - 1.0)) * 2.0, atol=0.05, rtol=0.05
+        )
+
+    def test_cpu_pointwise_chain_compiles_greedy(self):
+        """Default greedy allocator: exercises the `_op_output_good_for_lx_reuse`
+        gate (mem_usage_by_buf over the filtered graph_view)."""
+        self._run_and_check(self)
+
+    @config.patch({"co_optimizing_lx_planning": True})
+    def test_cpu_pointwise_chain_compiles_co_optimizing(self):
+        """Co-optimizing allocator: `mem_usage_by_buf` runs on the RAW graph in
+        `_build_cd_bound_buffers` / `_determine_in_place_division_invariant`,
+        bypassing the gate -> exercises the defensive sentinel."""
+        self._run_and_check(self)
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -1314,11 +1314,11 @@ def propagate_spyre_tensor_layouts(
             if isinstance(real_input, torch.Tensor):
                 stl = real_input.device_tensor_layout()
                 if stl is None:
-                    # All spyre tensors are created with device layouts.
-                    # Therefore we expect all graph inputs to have them.
-                    raise Unsupported(
-                        f"missing device_tensor_layout on graph input {name}"
-                    )
+                    # A CPU tensor lifted as a graph input, or a host tensor
+                    # feeding a FallbackKernel has no Spyre layout;
+                    # leave its FixedLayout and .layouts untouched,
+                    # mirroring the non-Spyre ComputedBuffer skip below.
+                    continue
                 tb = graph.graph_inputs[name]
                 if (
                     not isinstance(tb, TensorBox)

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -78,6 +78,7 @@ from torch_spyre._inductor.scratchpad.utils import (
     _is_tiled_advancing,
 )
 from torch_spyre._inductor.scratchpad.graph_editor import GraphEditor
+from torch_spyre._inductor.ir import FixedTiledLayout
 
 from torch_spyre._inductor import config
 from torch_spyre._inductor.logging_utils import get_inductor_logger
@@ -159,6 +160,10 @@ class ScratchpadAllocator:
         if not isinstance(op, ComputedBuffer):
             return False
         if isinstance(op.layout, MutationLayoutSHOULDREMOVE):
+            return False
+        # A CPU-resident ComputedBuffer has a plain FixedLayout
+        # with no device_layout and can never be LX-pinned.
+        if not isinstance(op.layout, FixedTiledLayout):
             return False
         return config.allow_all_ops_in_lx_planning or (
             self._get_op_name(op) in OP_OUTPUT_GOOD_FOR_LX_REUSE
@@ -1197,8 +1202,14 @@ class StrategyBCoOptimizingAllocator(ScratchpadAllocator):
             "mem_usage": 0.0,
         }
 
+        # HBM footprint per buffer. A buffer with no Spyre device_layout
+        # occupies no on-device HBM, so it contributes 0.
         buf_total_bytes: dict[str, int] = {
-            name: math.prod(buf.layout.device_layout.device_size[:-1]) * 128
+            name: (
+                math.prod(buf.layout.device_layout.device_size[:-1]) * 128
+                if isinstance(buf.layout, FixedTiledLayout)
+                else 0
+            )
             for name, buf in graph.name_to_buffer.items()
         }
 

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -1307,7 +1307,7 @@ class StrategyBCoOptimizingAllocator(ScratchpadAllocator):
         If `timings` is provided, _generate_buffers accumulates its
         `residency` / `mem_usage` sub-step seconds into it. `lifetimes`
         (split-invariant) is forwarded to avoid recomputing it per leaf.
-        
+
         Note: 0-byte entries are guaranteed never to appear in pinned_names.
         """
         buffers = self._generate_buffers(graph, cache, timings, lifetimes)

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -1307,6 +1307,8 @@ class StrategyBCoOptimizingAllocator(ScratchpadAllocator):
         If `timings` is provided, _generate_buffers accumulates its
         `residency` / `mem_usage` sub-step seconds into it. `lifetimes`
         (split-invariant) is forwarded to avoid recomputing it per leaf.
+        
+        Note: 0-byte entries are guaranteed never to appear in pinned_names.
         """
         buffers = self._generate_buffers(graph, cache, timings, lifetimes)
         assert self.layout_planning is not None


### PR DESCRIPTION
#### What type of PR is this?

- [X] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

When a torch.compile graph mixes Spyre and CPU tensors — e.g. a small constant is folded/lifted onto the host, or a CPU tensor feeds an opaque device-transfer FallbackKernel — two Spyre Inductor passes assumed every buffer they touched was Spyre-resident (i.e. carried a FixedTiledLayout with a device_layout). A CPU buffer keeps a plain FixedLayout, so those passes raised instead of tolerating it.

Two distinct crashes, both surfaced while enabling fullgraph compile for the vLLM Spyre backend (RoPE was recently moved on-device, which introduced a lifted CPU constant):

1. Layout propagation — the graph-input loop in propagate_spyre_tensor_layouts raised Unsupported: missing device_tensor_layout on graph input <name> on any CPU input.
2. Scratchpad planning — a CPU ComputedBuffer (from CPU pointwise ops between device transfers) passed the LX op-name whitelist and reached mem_usage_by_buf, which read layout.device_layout → AttributeError: 'FixedLayout' object has no attribute 'device_layout'.

The fix is to make both passes device-aware, skipping/zeroing non-Spyre buffers

#### Which issue(s) this PR is related to:

This issues surfaced during enabling fullgraph compile in spyre-inference, see https://github.com/torch-spyre/spyre-inference/issues/243

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
