### PR TITLE
Support Calling Torch Empty with Size Kwarg

### DIFF
--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -15,20 +15,20 @@
 # Owner(s): ["module: cpp"]
 
 import os
-import regex as re
-import psutil
 import warnings
 from contextlib import contextmanager
-import pytest
 
+import psutil
+import pytest
+import regex as re
 import torch
 from torch.testing._internal.common_utils import (
+    TestCase,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
     set_warn_always_context,
     subtest,
-    TestCase,
 )
 
 # 0-dim scalar roundtrip: shared dtype × factory lambdas (used by parametrized fill test).
@@ -110,6 +110,22 @@ class TestSpyre(TestCase):
         with torch.device("spyre"):
             a = torch.empty(50, dtype=torch.float16)
         self.assertEqual(a.device.type, "spyre")
+
+    def test_empty_size_arguments(self):
+        # Positional size argument
+        a = torch.empty((2, 3), device="spyre", dtype=torch.float16)
+        self.assertEqual(tuple(a.shape), (2, 3))
+
+        # Keyword size argument
+        a = torch.empty(size=(2, 3), device="spyre", dtype=torch.float16)
+        self.assertEqual(tuple(a.shape), (2, 3))
+
+        # Both positonal and keyword size arguments
+        with pytest.raises(
+            TypeError,
+            match="received an invalid combination of arguments",
+        ):
+            torch.empty((2, 3), size=(2, 3), device="spyre", dtype=torch.float16)
 
     def test_ones_factory(self):
         a = torch.ones(50, device="spyre", dtype=torch.float16)

--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -162,6 +162,7 @@ def _patch_tensor_for_spyre():
 
     def spyre_empty(
         *args,
+        size=None,
         device_layout=None,
         out=None,
         dtype=None,
@@ -171,6 +172,10 @@ def _patch_tensor_for_spyre():
         pin_memory=False,
         memory_format=torch.contiguous_format,
     ):
+        # torch.empty supports size as either a positional arg or keyword arg.
+        # Normalise so downstream always receives it as positional.
+        if size is not None and not args:
+            args = (size,)
         if (
             device_layout is None
         ):  # use original implementation if no layout is provided

--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 
-from torch_spyre.constants import DEVICE_NAME
-
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from torch._dynamo.guards import GuardBuilder
+
+from torch_spyre.constants import DEVICE_NAME
 
 if TYPE_CHECKING:
     from torch_spyre._C import SpyreTensorLayout
@@ -174,8 +174,13 @@ def _patch_tensor_for_spyre():
     ):
         # torch.empty supports size as either a positional arg or keyword arg.
         # Normalise so downstream always receives it as positional.
-        if size is not None and not args:
+        if size is not None:
+            if args:
+                raise TypeError(
+                    "empty() received an invalid combination of arguments - got (tuple, size=tuple)"
+                )
             args = (size,)
+
         if (
             device_layout is None
         ):  # use original implementation if no layout is provided


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR adds support for calling `torch.empty(size=0)` instead of mandating that size be a positional argument `torch.empty(0)`.

#### Which issue(s) this PR is related to:

#1729

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No

#### Additional note:
