### PR TITLE
Dist: Add asyncOp support and allreduce/reduce unit tests

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -429,6 +429,10 @@ jobs:
             config: distributed_tests/test_gather.yaml
           - name: Test Multi-Spyre Allgather
             config: distributed_tests/test_allgather.yaml
+          - name: Test Multi-Spyre Allreduce
+            config: distributed_tests/test_allreduce.yaml
+          - name: Test Multi-Spyre Reduce
+            config: distributed_tests/test_reduce.yaml
           - name: Test Multi-Spyre Broadcast Compiled
             config: distributed_tests/test_broadcast_compiled.yaml
 

--- a/docs/source/user_guide/examples/distributed/allgather.py
+++ b/docs/source/user_guide/examples/distributed/allgather.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import argparse
 import torch
 import torch.distributed as dist
 import os
@@ -19,8 +20,15 @@ DEVICE = torch.device(f"spyre:{os.getenv('RANK', '0')}")
 C10D_BACKEND = "spyreccl"
 
 
-def run_test(comm_rank, comm_size):
-    """Run an allgather test where each rank contributes and receives from all."""
+def run_test(comm_rank, comm_size, async_op=False):
+    """Run an allgather test where each rank contributes and receives from all.
+
+    Args:
+        comm_rank: Rank of the current process
+        comm_size: Total number of processes
+        async_op: If True, launch the collective asynchronously and overlap CPU
+                  work with the hardware operation before calling work.wait().
+    """
     global DEVICE
 
     num_elements = 128
@@ -41,23 +49,39 @@ def run_test(comm_rank, comm_size):
     # Prepare output tensors - all ranks need this for allgather
     output_list = [torch.zeros_like(input_device) for _ in range(comm_size)]
 
-    # Allgather with the collective library
-    print(f"[{comm_rank} of {comm_size}] Allgather Tensor: Spyre")
-    dist.all_gather(output_list, input_device)
+    if async_op:
+        # Launch allgather asynchronously — returns a Work handle immediately
+        print(f"[{comm_rank} of {comm_size}] Allgather Tensor (async): Spyre")
+        work = dist.all_gather(output_list, input_device, async_op=True)
+
+        # Overlap: build expected values on CPU while the collective runs on hardware
+        expected = []
+        for rank_idx in range(comm_size):
+            rank_start = rank_idx * num_elements
+            rank_end = rank_start + num_elements
+            expected.append(torch.arange(rank_start, rank_end, dtype=torch.float16))
+
+        # Block until the async collective has completed
+        work.wait()
+    else:
+        # Allgather with the collective library
+        print(f"[{comm_rank} of {comm_size}] Allgather Tensor: Spyre")
+        dist.all_gather(output_list, input_device)
+
+        expected = []
+        for rank_idx in range(comm_size):
+            rank_start = rank_idx * num_elements
+            rank_end = rank_start + num_elements
+            expected.append(torch.arange(rank_start, rank_end, dtype=torch.float16))
 
     # Check the result at all ranks
     print(f"[{comm_rank} of {comm_size}] Gathered tensors from all ranks:")
     all_correct = True
     for rank_idx in range(comm_size):
         result = output_list[rank_idx].to("cpu")
-        # Expected values for each rank: contiguous range starting at rank_idx * num_elements
-        rank_start = rank_idx * num_elements
-        rank_end = rank_start + num_elements
-        expected_tensor = torch.arange(rank_start, rank_end, dtype=torch.float16)
-
         print(f"  From rank {rank_idx}: {result[:10]} .. {result[-10:]}")
 
-        if torch.allclose(result, expected_tensor):
+        if torch.allclose(result, expected[rank_idx]):
             print(f"  Rank {rank_idx} tensor is correct")
         else:
             print(f"  Rank {rank_idx} tensor is incorrect!")
@@ -72,6 +96,16 @@ def run_test(comm_rank, comm_size):
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Distributed allgather example")
+    parser.add_argument(
+        "--async",
+        dest="async_op",
+        action="store_true",
+        default=False,
+        help="Launch allgather asynchronously (async_op=True)",
+    )
+    args = parser.parse_args()
+
     # Check that the c10d backend was loaded properly
     if dist.distributed_c10d.is_backend_available(C10D_BACKEND) is False:
         raise RuntimeError(f"Error: Missing the C10 Backend {C10D_BACKEND}")
@@ -88,8 +122,6 @@ if __name__ == "__main__":
     comm_size = dist.get_world_size()
     comm_rank = dist.get_rank()
 
-    run_test(comm_rank, comm_size)
+    run_test(comm_rank, comm_size, async_op=args.async_op)
 
     dist.destroy_process_group()
-
-# Made with Bob

--- a/docs/source/user_guide/examples/distributed/allgather.py
+++ b/docs/source/user_guide/examples/distributed/allgather.py
@@ -49,17 +49,19 @@ def run_test(comm_rank, comm_size, async_op=False):
     # Prepare output tensors - all ranks need this for allgather
     output_list = [torch.zeros_like(input_device) for _ in range(comm_size)]
 
+    # Build expected values on CPU while the collective runs on hardware
+    expected = []
+    for rank_idx in range(comm_size):
+        rank_start = rank_idx * num_elements
+        rank_end = rank_start + num_elements
+        expected.append(torch.arange(rank_start, rank_end, dtype=torch.float16))
+
     if async_op:
         # Launch allgather asynchronously — returns a Work handle immediately
         print(f"[{comm_rank} of {comm_size}] Allgather Tensor (async): Spyre")
         work = dist.all_gather(output_list, input_device, async_op=True)
 
-        # Overlap: build expected values on CPU while the collective runs on hardware
-        expected = []
-        for rank_idx in range(comm_size):
-            rank_start = rank_idx * num_elements
-            rank_end = rank_start + num_elements
-            expected.append(torch.arange(rank_start, rank_end, dtype=torch.float16))
+        # Note: Opportunity for overlapping of host activities with asynchronous communication.
 
         # Block until the async collective has completed
         work.wait()
@@ -67,12 +69,6 @@ def run_test(comm_rank, comm_size, async_op=False):
         # Allgather with the collective library
         print(f"[{comm_rank} of {comm_size}] Allgather Tensor: Spyre")
         dist.all_gather(output_list, input_device)
-
-        expected = []
-        for rank_idx in range(comm_size):
-            rank_start = rank_idx * num_elements
-            rank_end = rank_start + num_elements
-            expected.append(torch.arange(rank_start, rank_end, dtype=torch.float16))
 
     # Check the result at all ranks
     print(f"[{comm_rank} of {comm_size}] Gathered tensors from all ranks:")

--- a/docs/source/user_guide/examples/distributed/allreduce.py
+++ b/docs/source/user_guide/examples/distributed/allreduce.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import argparse
 import torch
 import torch.distributed as dist
 import os
@@ -19,8 +20,15 @@ DEVICE = torch.device(f"spyre:{os.getenv('RANK', '0')}")
 C10D_BACKEND = "spyreccl"
 
 
-def run_test(comm_rank, comm_size):
-    """Run an allreduce test where all ranks contribute and all receive the sum."""
+def run_test(comm_rank, comm_size, async_op=False):
+    """Run an allreduce test where all ranks contribute and all receive the sum.
+
+    Args:
+        comm_rank: Rank of the current process
+        comm_size: Total number of processes
+        async_op: If True, launch the collective asynchronously and overlap CPU
+                  work with the hardware operation before calling work.wait().
+    """
     global DEVICE
 
     num_elements = 128
@@ -40,15 +48,6 @@ def run_test(comm_rank, comm_size):
     # Send input tensor to Spyre device
     input_device = input_tensor.to(DEVICE)
 
-    # Allreduce with the collective library (SUM operation)
-    print(f"[{comm_rank} of {comm_size}] Allreduce Tensor (SUM): Spyre")
-    dist.all_reduce(input_device, op=dist.ReduceOp.SUM)
-
-    # Check the result at all ranks
-    result = input_device.to("cpu")
-    print(f"[{comm_rank} of {comm_size}] Reduced Tensor (SUM of all ranks):")
-    print(f"[{comm_rank} of {comm_size}] {result[:10]} .. {result[-10:]}")
-
     # Expected result: sum of all ranks' contributions at each position
     # Position i gets: (0*num_elements + i) + (1*num_elements + i) + ... + ((comm_size-1)*num_elements + i)
     # = i*comm_size + num_elements*(0 + 1 + ... + (comm_size-1))
@@ -59,6 +58,25 @@ def run_test(comm_rank, comm_size):
             i * comm_size + num_elements * comm_size * (comm_size - 1) / 2
         )
 
+    if async_op:
+        # Launch allreduce asynchronously — returns a Work handle immediately
+        print(f"[{comm_rank} of {comm_size}] Allreduce Tensor (SUM, async): Spyre")
+        work = dist.all_reduce(input_device, op=dist.ReduceOp.SUM, async_op=True)
+
+        # Overlap: expected_tensor was already computed above on CPU while the
+        # collective runs on hardware
+
+        # Block until the async collective has completed
+        work.wait()
+    else:
+        # Allreduce with the collective library (SUM operation)
+        print(f"[{comm_rank} of {comm_size}] Allreduce Tensor (SUM): Spyre")
+        dist.all_reduce(input_device, op=dist.ReduceOp.SUM)
+
+    # Check the result at all ranks
+    result = input_device.to("cpu")
+    print(f"[{comm_rank} of {comm_size}] Reduced Tensor (SUM of all ranks):")
+    print(f"[{comm_rank} of {comm_size}] {result[:10]} .. {result[-10:]}")
     print(f"  Expected values: {expected_tensor[:10]} .. {expected_tensor[-10:]}")
 
     if torch.allclose(result, expected_tensor):
@@ -71,6 +89,16 @@ def run_test(comm_rank, comm_size):
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Distributed allreduce example")
+    parser.add_argument(
+        "--async",
+        dest="async_op",
+        action="store_true",
+        default=False,
+        help="Launch allreduce asynchronously (async_op=True)",
+    )
+    args = parser.parse_args()
+
     # Check that the c10d backend was loaded properly
     if dist.distributed_c10d.is_backend_available(C10D_BACKEND) is False:
         raise RuntimeError(f"Error: Missing the C10 Backend {C10D_BACKEND}")
@@ -87,8 +115,6 @@ if __name__ == "__main__":
     comm_size = dist.get_world_size()
     comm_rank = dist.get_rank()
 
-    run_test(comm_rank, comm_size)
+    run_test(comm_rank, comm_size, async_op=args.async_op)
 
     dist.destroy_process_group()
-
-# Made with Bob

--- a/docs/source/user_guide/examples/distributed/allreduce.py
+++ b/docs/source/user_guide/examples/distributed/allreduce.py
@@ -63,8 +63,7 @@ def run_test(comm_rank, comm_size, async_op=False):
         print(f"[{comm_rank} of {comm_size}] Allreduce Tensor (SUM, async): Spyre")
         work = dist.all_reduce(input_device, op=dist.ReduceOp.SUM, async_op=True)
 
-        # Overlap: expected_tensor was already computed above on CPU while the
-        # collective runs on hardware
+        # Note: Opportunity for overlapping of host activities with asynchronous communication.
 
         # Block until the async collective has completed
         work.wait()

--- a/docs/source/user_guide/examples/distributed/barrier.py
+++ b/docs/source/user_guide/examples/distributed/barrier.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import argparse
 import torch
 import torch.distributed as dist
 import time
@@ -28,6 +29,16 @@ if C10D_BACKEND != dist.get_default_backend_for_device("spyre"):
         f"Error: Missing a C10 Backend for {'spyre'}! Expected {C10D_BACKEND}"
     )
 
+parser = argparse.ArgumentParser(description="Distributed barrier example")
+parser.add_argument(
+    "--async",
+    dest="async_op",
+    action="store_true",
+    default=False,
+    help="Launch barrier asynchronously (async_op=True)",
+)
+args = parser.parse_args()
+
 # Initialize the distributed environment
 print("# Initialize Distributed Group ")
 dist.init_process_group(device_id=DEVICE)
@@ -39,11 +50,27 @@ print(
     f"[{comm_rank} of {comm_size}] Before the barrier: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
 )
 
-# Add a delay to slow down the barrier. Different at different ranks.
+# Add a delay to slow down some ranks so the async overlap is visible
 time.sleep(comm_rank % 3)
 
-# Execute the barrier
-dist.barrier()
+if args.async_op:
+    # Launch barrier asynchronously — returns a Work handle immediately
+    work = dist.barrier(async_op=True)
+    print(
+        f"[{comm_rank} of {comm_size}] Issued the barrier: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+    )
+
+    # Overlap: do local CPU work while the barrier runs on hardware
+    cpu_result = sum(range(comm_rank + 1))  # trivial local computation
+    print(
+        f"[{comm_rank} of {comm_size}] Local CPU work completed (sum 0..{comm_rank} = {cpu_result})"
+    )
+
+    # Block until all ranks have reached the barrier
+    work.wait()
+else:
+    # Execute the barrier
+    dist.barrier()
 
 print(
     f"[{comm_rank} of {comm_size}] After the barrier : {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"

--- a/docs/source/user_guide/examples/distributed/broadcast.py
+++ b/docs/source/user_guide/examples/distributed/broadcast.py
@@ -68,8 +68,7 @@ def run_test(shape, comm_rank, comm_size, async_op=False):
         print(f"[{comm_rank} of {comm_size}] Broadcast Tensor (async): Spyre")
         work = dist.broadcast(x_device, src=0, async_op=True)
 
-        # Overlap: expected_tensor was already computed above on CPU while the
-        # collective runs on hardware
+        # Note: Opportunity for overlapping of host activities with asynchronous communication.
 
         # Block until the async collective has completed
         work.wait()

--- a/docs/source/user_guide/examples/distributed/broadcast.py
+++ b/docs/source/user_guide/examples/distributed/broadcast.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import argparse
 import torch
 import torch.distributed as dist
 import os
@@ -19,13 +20,15 @@ DEVICE = torch.device(f"spyre:{os.getenv('RANK', '0')}")
 C10D_BACKEND = "spyreccl"
 
 
-def run_test(shape, comm_rank, comm_size):
+def run_test(shape, comm_rank, comm_size, async_op=False):
     """Run a broadcast test with the given tensor shape.
 
     Args:
         shape: Either an integer (for 1D tensor) or tuple (for multi-dimensional tensor)
         comm_rank: Rank of the current process
         comm_size: Total number of processes
+        async_op: If True, launch the collective asynchronously and overlap CPU
+                  work with the hardware operation before calling work.wait().
     """
     global DEVICE
 
@@ -55,9 +58,25 @@ def run_test(shape, comm_rank, comm_size):
         print(f"[{comm_rank} of {comm_size}] {x.flatten()[:10]}")
     x_device = x.to(DEVICE)
 
-    # Broadcast with the collective library
-    print(f"[{comm_rank} of {comm_size}] Broadcast Tensor: Spyre")
-    dist.broadcast(x_device, 0)
+    # Expected result: root's original tensor
+    expected_tensor = torch.arange(0, num_elements, dtype=torch.float16).reshape(
+        tensor_shape
+    )
+
+    if async_op:
+        # Launch broadcast asynchronously — returns a Work handle immediately
+        print(f"[{comm_rank} of {comm_size}] Broadcast Tensor (async): Spyre")
+        work = dist.broadcast(x_device, src=0, async_op=True)
+
+        # Overlap: expected_tensor was already computed above on CPU while the
+        # collective runs on hardware
+
+        # Block until the async collective has completed
+        work.wait()
+    else:
+        # Broadcast with the collective library
+        print(f"[{comm_rank} of {comm_size}] Broadcast Tensor: Spyre")
+        dist.broadcast(x_device, 0)
 
     result = x_device.to("cpu")
     print(f"[{comm_rank} of {comm_size}] Tensor after collective")
@@ -69,9 +88,6 @@ def run_test(shape, comm_rank, comm_size):
         )
 
     # Check the result - should match root's original tensor
-    expected_tensor = torch.arange(0, num_elements, dtype=torch.float16).reshape(
-        tensor_shape
-    )
     if torch.allclose(result, expected_tensor):
         print(f"[{comm_rank} of {comm_size}] Tensor is correct")
     else:
@@ -82,6 +98,16 @@ def run_test(shape, comm_rank, comm_size):
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Distributed broadcast example")
+    parser.add_argument(
+        "--async",
+        dest="async_op",
+        action="store_true",
+        default=False,
+        help="Launch broadcast asynchronously (async_op=True)",
+    )
+    args = parser.parse_args()
+
     # Check that the c10d backend was loaded properly
     if dist.distributed_c10d.is_backend_available(C10D_BACKEND) is False:
         raise RuntimeError(f"Error: Missing the C10 Backend {C10D_BACKEND}")
@@ -98,8 +124,6 @@ if __name__ == "__main__":
     comm_size = dist.get_world_size()
     comm_rank = dist.get_rank()
 
-    run_test(128, comm_rank, comm_size)
+    run_test(128, comm_rank, comm_size, async_op=args.async_op)
 
     dist.destroy_process_group()
-
-# Made with Bob

--- a/docs/source/user_guide/examples/distributed/gather.py
+++ b/docs/source/user_guide/examples/distributed/gather.py
@@ -49,9 +49,15 @@ def run_test(comm_rank, comm_size, async_op=False):
 
     # Prepare output tensors (only needed at root, but we prepare for all for simplicity)
     output_list = None
+    expected = []
     if comm_rank == dst_rank:
         # Root rank prepares a list to receive tensors from all ranks
         output_list = [torch.zeros_like(input_device) for _ in range(comm_size)]
+        # build expected tensors on CPU while the collective runs on hardware
+        for rank_idx in range(comm_size):
+            rank_start = rank_idx * num_elements
+            rank_end = rank_start + num_elements
+            expected.append(torch.arange(rank_start, rank_end, dtype=torch.float16))
 
     if async_op:
         # Launch gather asynchronously — returns a Work handle immediately
@@ -60,12 +66,7 @@ def run_test(comm_rank, comm_size, async_op=False):
             input_device, gather_list=output_list, dst=dst_rank, async_op=True
         )
 
-        # Overlap: build expected tensors on CPU while the collective runs on hardware
-        expected = []
-        for rank_idx in range(comm_size):
-            rank_start = rank_idx * num_elements
-            rank_end = rank_start + num_elements
-            expected.append(torch.arange(rank_start, rank_end, dtype=torch.float16))
+        # Note: Opportunity for overlapping of host activities with asynchronous communication.
 
         # Block until the async collective has completed
         work.wait()
@@ -73,12 +74,6 @@ def run_test(comm_rank, comm_size, async_op=False):
         # Gather with the collective library
         print(f"[{comm_rank} of {comm_size}] Gather Tensor: Spyre")
         dist.gather(input_device, gather_list=output_list, dst=dst_rank)
-
-        expected = []
-        for rank_idx in range(comm_size):
-            rank_start = rank_idx * num_elements
-            rank_end = rank_start + num_elements
-            expected.append(torch.arange(rank_start, rank_end, dtype=torch.float16))
 
     # Check the result at root
     if comm_rank == dst_rank:

--- a/docs/source/user_guide/examples/distributed/gather.py
+++ b/docs/source/user_guide/examples/distributed/gather.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import argparse
 import torch
 import torch.distributed as dist
 import os
@@ -19,8 +20,15 @@ DEVICE = torch.device(f"spyre:{os.getenv('RANK', '0')}")
 C10D_BACKEND = "spyreccl"
 
 
-def run_test(comm_rank, comm_size):
-    """Run a gather test where each rank contributes a unique tensor."""
+def run_test(comm_rank, comm_size, async_op=False):
+    """Run a gather test where each rank contributes a unique tensor.
+
+    Args:
+        comm_rank: Rank of the current process
+        comm_size: Total number of processes
+        async_op: If True, launch the collective asynchronously and overlap CPU
+                  work with the hardware operation before calling work.wait().
+    """
     global DEVICE
 
     dst_rank = 0
@@ -45,9 +53,32 @@ def run_test(comm_rank, comm_size):
         # Root rank prepares a list to receive tensors from all ranks
         output_list = [torch.zeros_like(input_device) for _ in range(comm_size)]
 
-    # Gather with the collective library
-    print(f"[{comm_rank} of {comm_size}] Gather Tensor: Spyre")
-    dist.gather(input_device, gather_list=output_list, dst=dst_rank)
+    if async_op:
+        # Launch gather asynchronously — returns a Work handle immediately
+        print(f"[{comm_rank} of {comm_size}] Gather Tensor (async): Spyre")
+        work = dist.gather(
+            input_device, gather_list=output_list, dst=dst_rank, async_op=True
+        )
+
+        # Overlap: build expected tensors on CPU while the collective runs on hardware
+        expected = []
+        for rank_idx in range(comm_size):
+            rank_start = rank_idx * num_elements
+            rank_end = rank_start + num_elements
+            expected.append(torch.arange(rank_start, rank_end, dtype=torch.float16))
+
+        # Block until the async collective has completed
+        work.wait()
+    else:
+        # Gather with the collective library
+        print(f"[{comm_rank} of {comm_size}] Gather Tensor: Spyre")
+        dist.gather(input_device, gather_list=output_list, dst=dst_rank)
+
+        expected = []
+        for rank_idx in range(comm_size):
+            rank_start = rank_idx * num_elements
+            rank_end = rank_start + num_elements
+            expected.append(torch.arange(rank_start, rank_end, dtype=torch.float16))
 
     # Check the result at root
     if comm_rank == dst_rank:
@@ -55,14 +86,9 @@ def run_test(comm_rank, comm_size):
         all_correct = True
         for rank_idx in range(comm_size):
             result = output_list[rank_idx].to("cpu")
-            # Expected values for each rank: contiguous range starting at rank_idx * num_elements
-            rank_start = rank_idx * num_elements
-            rank_end = rank_start + num_elements
-            expected_tensor = torch.arange(rank_start, rank_end, dtype=torch.float16)
-
             print(f"  From rank {rank_idx}: {result[:10]} .. {result[-10:]}")
 
-            if torch.allclose(result, expected_tensor):
+            if torch.allclose(result, expected[rank_idx]):
                 print(f"  Rank {rank_idx} tensor is correct")
             else:
                 print(f"  Rank {rank_idx} tensor is incorrect!")
@@ -75,10 +101,21 @@ def run_test(comm_rank, comm_size):
                 f"[{comm_rank} of {comm_size}] Some gathered tensors are incorrect"
             )
     else:
-        print(f"[{comm_rank} of {comm_size}] Non-root rank completed gather")
+        mode = " (async)" if async_op else ""
+        print(f"[{comm_rank} of {comm_size}] Non-root rank completed gather{mode}")
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Distributed gather example")
+    parser.add_argument(
+        "--async",
+        dest="async_op",
+        action="store_true",
+        default=False,
+        help="Launch gather asynchronously (async_op=True)",
+    )
+    args = parser.parse_args()
+
     # Check that the c10d backend was loaded properly
     if dist.distributed_c10d.is_backend_available(C10D_BACKEND) is False:
         raise RuntimeError(f"Error: Missing the C10 Backend {C10D_BACKEND}")
@@ -95,8 +132,6 @@ if __name__ == "__main__":
     comm_size = dist.get_world_size()
     comm_rank = dist.get_rank()
 
-    run_test(comm_rank, comm_size)
+    run_test(comm_rank, comm_size, async_op=args.async_op)
 
     dist.destroy_process_group()
-
-# Made with Bob

--- a/docs/source/user_guide/examples/distributed/reduce.py
+++ b/docs/source/user_guide/examples/distributed/reduce.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import argparse
 import torch
 import torch.distributed as dist
 import os
@@ -19,8 +20,15 @@ DEVICE = torch.device(f"spyre:{os.getenv('RANK', '0')}")
 C10D_BACKEND = "spyreccl"
 
 
-def run_test(comm_rank, comm_size):
-    """Run a reduce test where all ranks contribute and root receives the sum."""
+def run_test(comm_rank, comm_size, async_op=False):
+    """Run a reduce test where all ranks contribute and root receives the sum.
+
+    Args:
+        comm_rank: Rank of the current process
+        comm_size: Total number of processes
+        async_op: If True, launch the collective asynchronously and overlap CPU
+                  work with the hardware operation before calling work.wait().
+    """
     global DEVICE
 
     num_elements = 128
@@ -40,9 +48,30 @@ def run_test(comm_rank, comm_size):
     # Send input tensor to Spyre device
     input_device = input_tensor.to(DEVICE)
 
-    # Reduce with the collective library (SUM operation to root rank 0)
-    print(f"[{comm_rank} of {comm_size}] Reduce Tensor (SUM): Spyre")
-    dist.reduce(input_device, dst=0, op=dist.ReduceOp.SUM)
+    # Expected result: sum of all ranks' contributions at each position
+    # Position i gets: (0*num_elements + i) + (1*num_elements + i) + ... + ((comm_size-1)*num_elements + i)
+    # = i*comm_size + num_elements*(0 + 1 + ... + (comm_size-1))
+    # = i*comm_size + num_elements*comm_size*(comm_size-1)/2
+    expected_tensor = torch.zeros(num_elements, dtype=torch.float16)
+    for i in range(num_elements):
+        expected_tensor[i] = (
+            i * comm_size + num_elements * comm_size * (comm_size - 1) / 2
+        )
+
+    if async_op:
+        # Launch reduce asynchronously — returns a Work handle immediately
+        print(f"[{comm_rank} of {comm_size}] Reduce Tensor (SUM, async): Spyre")
+        work = dist.reduce(input_device, dst=0, op=dist.ReduceOp.SUM, async_op=True)
+
+        # Overlap: expected_tensor was already computed above on CPU while the
+        # collective runs on hardware
+
+        # Block until the async collective has completed
+        work.wait()
+    else:
+        # Reduce with the collective library (SUM operation to root rank 0)
+        print(f"[{comm_rank} of {comm_size}] Reduce Tensor (SUM): Spyre")
+        dist.reduce(input_device, dst=0, op=dist.ReduceOp.SUM)
 
     # Check the result at root
     if comm_rank == 0:
@@ -51,17 +80,6 @@ def run_test(comm_rank, comm_size):
             f"[{comm_rank} of {comm_size}] Reduced Tensor at root (SUM of all ranks):"
         )
         print(f"[{comm_rank} of {comm_size}] {result[:10]} .. {result[-10:]}")
-
-        # Expected result: sum of all ranks' contributions at each position
-        # Position i gets: (0*num_elements + i) + (1*num_elements + i) + ... + ((comm_size-1)*num_elements + i)
-        # = i*comm_size + num_elements*(0 + 1 + ... + (comm_size-1))
-        # = i*comm_size + num_elements*comm_size*(comm_size-1)/2
-        expected_tensor = torch.zeros(num_elements, dtype=torch.float16)
-        for i in range(num_elements):
-            expected_tensor[i] = (
-                i * comm_size + num_elements * comm_size * (comm_size - 1) / 2
-            )
-
         print(f"  Expected values: {expected_tensor[:10]} .. {expected_tensor[-10:]}")
 
         if torch.allclose(result, expected_tensor):
@@ -72,12 +90,21 @@ def run_test(comm_rank, comm_size):
                 f"expected {expected_tensor[:10]} but got {result[:10]}"
             )
     else:
-        print(
-            f"[{comm_rank} of {comm_size}] Non-root rank completed reduce (input consumed)"
-        )
+        mode = " (async, input consumed)" if async_op else " (input consumed)"
+        print(f"[{comm_rank} of {comm_size}] Non-root rank completed reduce{mode}")
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Distributed reduce example")
+    parser.add_argument(
+        "--async",
+        dest="async_op",
+        action="store_true",
+        default=False,
+        help="Launch reduce asynchronously (async_op=True)",
+    )
+    args = parser.parse_args()
+
     # Check that the c10d backend was loaded properly
     if dist.distributed_c10d.is_backend_available(C10D_BACKEND) is False:
         raise RuntimeError(f"Error: Missing the C10 Backend {C10D_BACKEND}")
@@ -94,8 +121,6 @@ if __name__ == "__main__":
     comm_size = dist.get_world_size()
     comm_rank = dist.get_rank()
 
-    run_test(comm_rank, comm_size)
+    run_test(comm_rank, comm_size, async_op=args.async_op)
 
     dist.destroy_process_group()
-
-# Made with Bob

--- a/docs/source/user_guide/examples/distributed/reduce.py
+++ b/docs/source/user_guide/examples/distributed/reduce.py
@@ -48,23 +48,24 @@ def run_test(comm_rank, comm_size, async_op=False):
     # Send input tensor to Spyre device
     input_device = input_tensor.to(DEVICE)
 
-    # Expected result: sum of all ranks' contributions at each position
-    # Position i gets: (0*num_elements + i) + (1*num_elements + i) + ... + ((comm_size-1)*num_elements + i)
-    # = i*comm_size + num_elements*(0 + 1 + ... + (comm_size-1))
-    # = i*comm_size + num_elements*comm_size*(comm_size-1)/2
-    expected_tensor = torch.zeros(num_elements, dtype=torch.float16)
-    for i in range(num_elements):
-        expected_tensor[i] = (
-            i * comm_size + num_elements * comm_size * (comm_size - 1) / 2
-        )
+    expected_tensor = None
+    if comm_rank == 0:
+        # Expected result: sum of all ranks' contributions at each position
+        # Position i gets: (0*num_elements + i) + (1*num_elements + i) + ... + ((comm_size-1)*num_elements + i)
+        # = i*comm_size + num_elements*(0 + 1 + ... + (comm_size-1))
+        # = i*comm_size + num_elements*comm_size*(comm_size-1)/2
+        expected_tensor = torch.zeros(num_elements, dtype=torch.float16)
+        for i in range(num_elements):
+            expected_tensor[i] = (
+                i * comm_size + num_elements * comm_size * (comm_size - 1) / 2
+            )
 
     if async_op:
         # Launch reduce asynchronously — returns a Work handle immediately
         print(f"[{comm_rank} of {comm_size}] Reduce Tensor (SUM, async): Spyre")
         work = dist.reduce(input_device, dst=0, op=dist.ReduceOp.SUM, async_op=True)
 
-        # Overlap: expected_tensor was already computed above on CPU while the
-        # collective runs on hardware
+        # Note: Opportunity for overlapping of host activities with asynchronous communication.
 
         # Block until the async collective has completed
         work.wait()

--- a/tests/configs/distributed_tests/test_allreduce.yaml
+++ b/tests/configs/distributed_tests/test_allreduce.yaml
@@ -1,0 +1,21 @@
+# Configuration file for torch-spyre distributed tests
+# These tests require multi-process execution via torchrun
+#
+# Usage:
+#   cd torch-spyre/tests
+#   ./run_test.sh configs/distributed_tests/test_allreduce.yaml
+#
+# The run_test.sh script automatically detects tests in the distributed/
+# directory and launches them with: torchrun --nproc-per-node $AIU_WORLD_SIZE
+
+test_suite_config:
+  files:
+    # AllReduce Tests
+    - path: ${TORCH_DEVICE_ROOT}/tests/distributed/test_allreduce.py
+      unlisted_test_mode: mandatory_success
+
+  global:
+    # Global configuration for distributed tests
+    # These tests use the spyreccl backend for distributed operations
+    supported_dtypes:
+      - name: float16

--- a/tests/configs/distributed_tests/test_reduce.yaml
+++ b/tests/configs/distributed_tests/test_reduce.yaml
@@ -1,0 +1,21 @@
+# Configuration file for torch-spyre distributed tests
+# These tests require multi-process execution via torchrun
+#
+# Usage:
+#   cd torch-spyre/tests
+#   ./run_test.sh configs/distributed_tests/test_reduce.yaml
+#
+# The run_test.sh script automatically detects tests in the distributed/
+# directory and launches them with: torchrun --nproc-per-node $AIU_WORLD_SIZE
+
+test_suite_config:
+  files:
+    # Reduce Tests
+    - path: ${TORCH_DEVICE_ROOT}/tests/distributed/test_reduce.py
+      unlisted_test_mode: mandatory_success
+
+  global:
+    # Global configuration for distributed tests
+    # These tests use the spyreccl backend for distributed operations
+    supported_dtypes:
+      - name: float16

--- a/tests/distributed/test_allgather.py
+++ b/tests/distributed/test_allgather.py
@@ -108,6 +108,7 @@ class TestAllGather(TestCase):
         if async_op:
             self.assertIsNotNone(work, "async_op=True must return a Work handle")
             work.wait()
+            self.assertTrue(work.is_completed())
         else:
             self.assertIsNone(work, "async_op=False must return None")
 

--- a/tests/distributed/test_allgather.py
+++ b/tests/distributed/test_allgather.py
@@ -74,13 +74,15 @@ class TestAllGather(TestCase):
         if dist.is_initialized():
             dist.destroy_process_group()
 
-    def _test_allgather_helper(self, shape, dtype):
+    def _test_allgather_helper(self, shape, dtype, async_op=False):
         """
         Helper method to test allgather with specific parameters.
 
         Args:
             shape: Tensor shape
             dtype: Tensor data type
+            async_op: If True, launch the collective asynchronously and call
+                      work.wait() before inspecting the result
         """
         # Calculate total number of elements in the tensor
         num_elements = torch.tensor(shape).prod().item()
@@ -101,7 +103,13 @@ class TestAllGather(TestCase):
 
         output_list = [torch.zeros_like(input_device) for _ in range(self.comm_size)]
 
-        dist.all_gather(output_list, input_device)
+        work = dist.all_gather(output_list, input_device, async_op=async_op)
+
+        if async_op:
+            self.assertIsNotNone(work, "async_op=True must return a Work handle")
+            work.wait()
+        else:
+            self.assertIsNone(work, "async_op=False must return None")
 
         # Build all expected slices at once and compare in bulk.
         # All ranks contribute contiguous blocks: rank r owns [r*N .. (r+1)*N - 1],
@@ -142,6 +150,22 @@ class TestAllGather(TestCase):
     def test_allgather_2d_tensor_int32(self):
         """Test allgather with 2D tensor shapes using int32."""
         self._test_allgather_helper(shape=(4, 64), dtype=torch.int32)
+
+    def test_allgather_float16_async(self):
+        """Test allgather with float16 tensors using async_op=True."""
+        self._test_allgather_helper(shape=(128,), dtype=torch.float16, async_op=True)
+
+    def test_allgather_float32_async(self):
+        """Test allgather with float32 tensors using async_op=True."""
+        self._test_allgather_helper(shape=(256,), dtype=torch.float32, async_op=True)
+
+    def test_allgather_int32_async(self):
+        """Test allgather with int32 tensors using async_op=True."""
+        self._test_allgather_helper(shape=(192,), dtype=torch.int32, async_op=True)
+
+    def test_allgather_2d_tensor_float16_async(self):
+        """Test allgather with 2D float16 tensors using async_op=True."""
+        self._test_allgather_helper(shape=(4, 64), dtype=torch.float16, async_op=True)
 
 
 if __name__ == "__main__":

--- a/tests/distributed/test_allreduce.py
+++ b/tests/distributed/test_allreduce.py
@@ -74,13 +74,15 @@ class TestAllReduce(TestCase):
         if dist.is_initialized():
             dist.destroy_process_group()
 
-    def _test_allreduce_helper(self, shape, dtype):
+    def _test_allreduce_helper(self, shape, dtype, async_op=False):
         """
         Helper method to test allreduce with specific parameters.
 
         Args:
             shape: Tensor shape
             dtype: Tensor data type
+            async_op: If True, launch the collective asynchronously and call
+                      work.wait() before inspecting the result
         """
         # Calculate total number of elements in the tensor
         num_elements = torch.tensor(shape).prod().item()
@@ -100,7 +102,13 @@ class TestAllReduce(TestCase):
         input_device = input_tensor.to(DEVICE)
 
         # Allreduce with SUM operation — all ranks receive the result
-        dist.all_reduce(input_device, op=dist.ReduceOp.SUM)
+        work = dist.all_reduce(input_device, op=dist.ReduceOp.SUM, async_op=async_op)
+
+        if async_op:
+            self.assertIsNotNone(work, "async_op=True must return a Work handle")
+            work.wait()
+        else:
+            self.assertIsNone(work, "async_op=False must return None")
 
         result = input_device.to("cpu")
 
@@ -132,6 +140,14 @@ class TestAllReduce(TestCase):
     def test_allreduce_2d_tensor_float16(self):
         """Test allreduce with 2D tensor shapes using float16."""
         self._test_allreduce_helper(shape=(4, 64), dtype=torch.float16)
+
+    def test_allreduce_float16_async(self):
+        """Test allreduce with float16 tensors using async_op=True."""
+        self._test_allreduce_helper(shape=(128,), dtype=torch.float16, async_op=True)
+
+    def test_allreduce_2d_tensor_float16_async(self):
+        """Test allreduce with 2D tensor shapes using float16 and async_op=True."""
+        self._test_allreduce_helper(shape=(4, 64), dtype=torch.float16, async_op=True)
 
 
 if __name__ == "__main__":

--- a/tests/distributed/test_allreduce.py
+++ b/tests/distributed/test_allreduce.py
@@ -1,0 +1,138 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+from utils import _assert_tensor_equal
+
+# Skip all tests if RANK is not defined, or WORLD_SIZE is not set or less than 2
+if "RANK" not in os.environ:
+    pytest.skip(
+        "RANK environment variable not defined, skipping distributed tests",
+        allow_module_level=True,
+    )
+
+if "WORLD_SIZE" not in os.environ:
+    pytest.skip(
+        "WORLD_SIZE environment variable not defined, skipping distributed tests",
+        allow_module_level=True,
+    )
+
+try:
+    world_size = int(os.environ.get("WORLD_SIZE", "0"))
+    if world_size < 2:
+        pytest.skip(
+            f"WORLD_SIZE is {world_size}, need at least 2 for distributed tests",
+            allow_module_level=True,
+        )
+except ValueError:
+    pytest.skip(
+        "WORLD_SIZE environment variable is not a valid integer, skipping distributed tests",
+        allow_module_level=True,
+    )
+
+DEVICE = torch.device(f"spyre:{os.getenv('RANK', '0')}")
+C10D_BACKEND = "spyreccl"
+
+
+class TestAllReduce(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Set up the distributed environment once for all tests."""
+        if not dist.distributed_c10d.is_backend_available(C10D_BACKEND):
+            raise RuntimeError(f"Error: Missing the C10 Backend {C10D_BACKEND}")
+        if C10D_BACKEND != dist.get_default_backend_for_device("spyre"):
+            raise RuntimeError(
+                f"Error: Missing a C10 Backend for 'spyre'! Expected {C10D_BACKEND}"
+            )
+
+        if not dist.is_initialized():
+            dist.init_process_group(f"cpu:gloo,spyre:{C10D_BACKEND}")
+
+        cls.comm_size = dist.get_world_size()
+        cls.comm_rank = dist.get_rank()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up the distributed environment after all tests."""
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def _test_allreduce_helper(self, shape, dtype):
+        """
+        Helper method to test allreduce with specific parameters.
+
+        Args:
+            shape: Tensor shape
+            dtype: Tensor data type
+        """
+        # Calculate total number of elements in the tensor
+        num_elements = torch.tensor(shape).prod().item()
+
+        if num_elements > 256:
+            self.skipTest(
+                f"AllReduce test case is not designed for more than 256 elements, got {num_elements}"
+            )
+
+        # Create bounded float16 values for this rank to avoid overflow during SUM.
+        start_value = self.comm_rank + 1
+        input_tensor = (
+            (torch.arange(num_elements, dtype=torch.float32).div(10.0).add(start_value))
+            .to(dtype)
+            .reshape(shape)
+        )
+        input_device = input_tensor.to(DEVICE)
+
+        # Allreduce with SUM operation — all ranks receive the result
+        dist.all_reduce(input_device, op=dist.ReduceOp.SUM)
+
+        result = input_device.to("cpu")
+
+        # Expected result: comm_size * (i / 10.0) + sum_{r=1..comm_size}(r)
+        offset = self.comm_size * (self.comm_size + 1) / 2
+        expected = (
+            (
+                torch.arange(num_elements, dtype=torch.float32)
+                .div(10.0)
+                .mul(self.comm_size)
+                .add(offset)
+            )
+            .to(dtype)
+            .reshape(shape)
+        )
+
+        _assert_tensor_equal(
+            result,
+            expected,
+            dtype,
+            f"Rank {self.comm_rank}: allreduce result incorrect",
+            atol=0.2,
+        )
+
+    def test_allreduce_float16(self):
+        """Test allreduce with float16 tensors."""
+        self._test_allreduce_helper(shape=(128,), dtype=torch.float16)
+
+    def test_allreduce_2d_tensor_float16(self):
+        """Test allreduce with 2D tensor shapes using float16."""
+        self._test_allreduce_helper(shape=(4, 64), dtype=torch.float16)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/distributed/test_allreduce.py
+++ b/tests/distributed/test_allreduce.py
@@ -107,6 +107,7 @@ class TestAllReduce(TestCase):
         if async_op:
             self.assertIsNotNone(work, "async_op=True must return a Work handle")
             work.wait()
+            self.assertTrue(work.is_completed())
         else:
             self.assertIsNone(work, "async_op=False must return None")
 

--- a/tests/distributed/test_barrier.py
+++ b/tests/distributed/test_barrier.py
@@ -77,8 +77,8 @@ class TestBarrier(TestCase):
     def test_barrier_basic(self):
         """Test basic barrier functionality - all ranks should proceed together."""
         # Simple barrier test - just verify it doesn't hang or crash
-        dist.barrier()
-        # If we reach here, barrier worked
+        work = dist.barrier()
+        self.assertIsNone(work, "async_op=False must return None")
         self.assertTrue(True, "Barrier completed successfully")
 
     def test_barrier_synchronization_timing(self):
@@ -130,6 +130,40 @@ class TestBarrier(TestCase):
 
         # If we reach here, all barriers completed successfully
         self.assertTrue(True, "Multiple barriers completed successfully")
+
+    def test_barrier_basic_async(self):
+        """Test barrier with async_op=True returns a Work handle and completes."""
+        work = dist.barrier(async_op=True)
+        self.assertIsNotNone(work, "async_op=True must return a Work handle")
+        work.wait()
+        self.assertTrue(True, "Async barrier completed successfully")
+
+    def test_barrier_synchronization_timing_async(self):
+        """
+        Test that async barrier synchronizes all ranks correctly.
+        Work handle is obtained immediately; work.wait() does the blocking.
+        """
+        sleep_duration = self.comm_rank * 0.5
+        max_sleep = (self.comm_size - 1) * 0.5
+
+        time.sleep(sleep_duration)
+
+        start_time = time.time()
+        work = dist.barrier(async_op=True)
+        self.assertIsNotNone(work, "async_op=True must return a Work handle")
+
+        # Block until all ranks have reached the barrier
+        work.wait()
+
+        elapsed_time = time.time() - start_time
+
+        tolerance = 0.2
+        self.assertGreaterEqual(
+            elapsed_time,
+            max_sleep - sleep_duration - tolerance,
+            f"Rank {self.comm_rank}: Async barrier did not wait long enough. "
+            f"Got {elapsed_time:.3f}s",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/distributed/test_barrier.py
+++ b/tests/distributed/test_barrier.py
@@ -136,6 +136,7 @@ class TestBarrier(TestCase):
         work = dist.barrier(async_op=True)
         self.assertIsNotNone(work, "async_op=True must return a Work handle")
         work.wait()
+        self.assertTrue(work.is_completed())
         self.assertTrue(True, "Async barrier completed successfully")
 
     def test_barrier_synchronization_timing_async(self):
@@ -154,6 +155,7 @@ class TestBarrier(TestCase):
 
         # Block until all ranks have reached the barrier
         work.wait()
+        self.assertTrue(work.is_completed())
 
         elapsed_time = time.time() - start_time
 

--- a/tests/distributed/test_broadcast.py
+++ b/tests/distributed/test_broadcast.py
@@ -74,7 +74,7 @@ class TestBroadcast(TestCase):
         if dist.is_initialized():
             dist.destroy_process_group()
 
-    def _test_broadcast_helper(self, shape, dtype, root, fill_value):
+    def _test_broadcast_helper(self, shape, dtype, root, fill_value, async_op=False):
         """
         Helper method to test broadcast with specific parameters.
 
@@ -83,6 +83,8 @@ class TestBroadcast(TestCase):
             dtype: Tensor data type
             root: Root rank for broadcast
             fill_value: Value to fill the tensor at root rank
+            async_op: If True, launch the collective asynchronously and call
+                      work.wait() before inspecting the result
         """
         # Create expected tensor (what all ranks should have after broadcast)
         expected_tensor = torch.zeros(shape, dtype=dtype)
@@ -99,15 +101,18 @@ class TestBroadcast(TestCase):
         x_device = x.to(DEVICE)
 
         # Broadcast from root rank
-        dist.broadcast(x_device, root)
+        work = dist.broadcast(x_device, root, async_op=async_op)
+
+        if async_op:
+            self.assertIsNotNone(work, "async_op=True must return a Work handle")
+            work.wait()
+        else:
+            self.assertIsNone(work, "async_op=False must return None")
 
         # Get result back to CPU for verification
         result = x_device.to("cpu")
 
         # Verify result matches expected tensor at ALL ranks (including root)
-        # print(f"Shape: {shape}")
-        # print(f"Expected {expected_tensor}")
-        # print(f"Got {result}")
         self.assertTrue(
             torch.allclose(result, expected_tensor, rtol=1e-5, atol=1e-5),
             f"Rank {self.comm_rank}: Broadcast result incorrect. "
@@ -195,6 +200,29 @@ class TestBroadcast(TestCase):
             self._test_broadcast_helper(
                 shape=(10,), dtype=torch.float32, root=invalid_root, fill_value=1.0
             )
+
+    def test_broadcast_from_rank_zero_float16_async(self):
+        """Test broadcast from rank 0 with float16 and async_op=True."""
+        self._test_broadcast_helper(
+            shape=(128,), dtype=torch.float16, root=0, fill_value=2.0, async_op=True
+        )
+
+    def test_broadcast_from_rank_zero_float32_async(self):
+        """Test broadcast from rank 0 with float32 and async_op=True."""
+        self._test_broadcast_helper(
+            shape=(256,), dtype=torch.float32, root=0, fill_value=3.5, async_op=True
+        )
+
+    def test_broadcast_from_non_zero_root_async(self):
+        """Test broadcast from a non-zero root rank with async_op=True."""
+        root_rank = 1 if self.comm_size > 1 else 0
+        self._test_broadcast_helper(
+            shape=(256,),
+            dtype=torch.float32,
+            root=root_rank,
+            fill_value=7.5,
+            async_op=True,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/distributed/test_broadcast.py
+++ b/tests/distributed/test_broadcast.py
@@ -106,6 +106,7 @@ class TestBroadcast(TestCase):
         if async_op:
             self.assertIsNotNone(work, "async_op=True must return a Work handle")
             work.wait()
+            self.assertTrue(work.is_completed())
         else:
             self.assertIsNone(work, "async_op=False must return None")
 

--- a/tests/distributed/test_gather.py
+++ b/tests/distributed/test_gather.py
@@ -117,6 +117,7 @@ class TestGather(TestCase):
         if async_op:
             self.assertIsNotNone(work, "async_op=True must return a Work handle")
             work.wait()
+            self.assertTrue(work.is_completed())
         else:
             self.assertIsNone(work, "async_op=False must return None")
 

--- a/tests/distributed/test_gather.py
+++ b/tests/distributed/test_gather.py
@@ -74,7 +74,7 @@ class TestGather(TestCase):
         if dist.is_initialized():
             dist.destroy_process_group()
 
-    def _test_gather_helper(self, shape, dtype, dst):
+    def _test_gather_helper(self, shape, dtype, dst, async_op=False):
         """
         Helper method to test gather with specific parameters.
 
@@ -82,6 +82,8 @@ class TestGather(TestCase):
             shape: Tensor shape
             dtype: Tensor data type
             dst: Destination rank for gather
+            async_op: If True, launch the collective asynchronously and call
+                      work.wait() before inspecting the result
         """
         # Calculate total number of elements in the tensor
         num_elements = torch.tensor(shape).prod().item()
@@ -104,8 +106,21 @@ class TestGather(TestCase):
             gather_list = [
                 torch.zeros_like(input_device) for _ in range(self.comm_size)
             ]
-            dist.gather(input_device, gather_list=gather_list, dst=dst)
+            work = dist.gather(
+                input_device, gather_list=gather_list, dst=dst, async_op=async_op
+            )
+        else:
+            work = dist.gather(
+                input_device, gather_list=None, dst=dst, async_op=async_op
+            )
 
+        if async_op:
+            self.assertIsNotNone(work, "async_op=True must return a Work handle")
+            work.wait()
+        else:
+            self.assertIsNone(work, "async_op=False must return None")
+
+        if self.comm_rank == dst:
             # Build all expected slices at once and compare in bulk.
             # All ranks contribute contiguous blocks: rank r owns [r*N .. (r+1)*N - 1],
             # so the full expected output is simply arange(comm_size * N) reshaped.
@@ -122,7 +137,6 @@ class TestGather(TestCase):
                 f"Rank {self.comm_rank}: gather result incorrect at destination rank {dst}",
             )
         else:
-            dist.gather(input_device, gather_list=None, dst=dst)
             self.assertTrue(True, "Non-destination rank completed gather successfully")
 
     def test_gather_float16(self):
@@ -178,6 +192,35 @@ class TestGather(TestCase):
         """Test gather to non-zero destination rank with 2D tensor shapes using int32."""
         dst_rank = min(1, self.comm_size - 1)
         self._test_gather_helper(shape=(4, 64), dtype=torch.int32, dst=dst_rank)
+
+    def test_gather_float16_async(self):
+        """Test gather to rank 0 with float16 tensors using async_op=True."""
+        self._test_gather_helper(
+            shape=(128,), dtype=torch.float16, dst=0, async_op=True
+        )
+
+    def test_gather_float32_async(self):
+        """Test gather to rank 0 with float32 tensors using async_op=True."""
+        self._test_gather_helper(
+            shape=(256,), dtype=torch.float32, dst=0, async_op=True
+        )
+
+    def test_gather_int32_async(self):
+        """Test gather to rank 0 with int32 tensors using async_op=True."""
+        self._test_gather_helper(shape=(192,), dtype=torch.int32, dst=0, async_op=True)
+
+    def test_gather_2d_tensor_float16_async(self):
+        """Test gather with 2D float16 tensors using async_op=True."""
+        self._test_gather_helper(
+            shape=(4, 64), dtype=torch.float16, dst=0, async_op=True
+        )
+
+    def test_gather_rank_non_zero_float16_async(self):
+        """Test gather to non-zero destination rank with float16 tensors using async_op=True."""
+        dst_rank = min(1, self.comm_size - 1)
+        self._test_gather_helper(
+            shape=(128,), dtype=torch.float16, dst=dst_rank, async_op=True
+        )
 
 
 if __name__ == "__main__":

--- a/tests/distributed/test_reduce.py
+++ b/tests/distributed/test_reduce.py
@@ -1,0 +1,152 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+from utils import _assert_tensor_equal
+
+# Skip all tests if RANK is not defined, or WORLD_SIZE is not set or less than 2
+if "RANK" not in os.environ:
+    pytest.skip(
+        "RANK environment variable not defined, skipping distributed tests",
+        allow_module_level=True,
+    )
+
+if "WORLD_SIZE" not in os.environ:
+    pytest.skip(
+        "WORLD_SIZE environment variable not defined, skipping distributed tests",
+        allow_module_level=True,
+    )
+
+try:
+    world_size = int(os.environ.get("WORLD_SIZE", "0"))
+    if world_size < 2:
+        pytest.skip(
+            f"WORLD_SIZE is {world_size}, need at least 2 for distributed tests",
+            allow_module_level=True,
+        )
+except ValueError:
+    pytest.skip(
+        "WORLD_SIZE environment variable is not a valid integer, skipping distributed tests",
+        allow_module_level=True,
+    )
+
+DEVICE = torch.device(f"spyre:{os.getenv('RANK', '0')}")
+C10D_BACKEND = "spyreccl"
+
+
+class TestReduce(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Set up the distributed environment once for all tests."""
+        if not dist.distributed_c10d.is_backend_available(C10D_BACKEND):
+            raise RuntimeError(f"Error: Missing the C10 Backend {C10D_BACKEND}")
+        if C10D_BACKEND != dist.get_default_backend_for_device("spyre"):
+            raise RuntimeError(
+                f"Error: Missing a C10 Backend for 'spyre'! Expected {C10D_BACKEND}"
+            )
+
+        if not dist.is_initialized():
+            dist.init_process_group(f"cpu:gloo,spyre:{C10D_BACKEND}")
+
+        cls.comm_size = dist.get_world_size()
+        cls.comm_rank = dist.get_rank()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up the distributed environment after all tests."""
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def _test_reduce_helper(self, shape, dtype, dst):
+        """
+        Helper method to test reduce with specific parameters.
+
+        Args:
+            shape: Tensor shape
+            dtype: Tensor data type
+            dst: Destination rank for reduce
+        """
+        # Calculate total number of elements in the tensor
+        num_elements = torch.tensor(shape).prod().item()
+
+        if num_elements > 256:
+            self.skipTest(
+                f"Reduce test case is not designed for more than 256 elements, got {num_elements}"
+            )
+
+        # Create bounded float16 values for this rank to avoid overflow during SUM.
+        start_value = self.comm_rank + 1
+        input_tensor = (
+            (torch.arange(num_elements, dtype=torch.float32).div(10.0).add(start_value))
+            .to(dtype)
+            .reshape(shape)
+        )
+        input_device = input_tensor.to(DEVICE)
+
+        # Reduce with SUM operation to destination rank
+        dist.reduce(input_device, dst=dst, op=dist.ReduceOp.SUM)
+
+        if self.comm_rank == dst:
+            result = input_device.to("cpu")
+
+            # Expected result: comm_size * (i / 10.0) + sum_{r=1..comm_size}(r)
+            offset = self.comm_size * (self.comm_size + 1) / 2
+            expected = (
+                (
+                    torch.arange(num_elements, dtype=torch.float32)
+                    .div(10.0)
+                    .mul(self.comm_size)
+                    .add(offset)
+                )
+                .to(dtype)
+                .reshape(shape)
+            )
+
+            _assert_tensor_equal(
+                result,
+                expected,
+                dtype,
+                f"Rank {self.comm_rank}: reduce result incorrect at destination rank {dst}",
+                atol=0.2,
+            )
+        else:
+            self.assertTrue(True, "Non-destination rank completed reduce successfully")
+
+    def test_reduce_float16(self):
+        """Test reduce to rank 0 with float16 tensors."""
+        self._test_reduce_helper(shape=(128,), dtype=torch.float16, dst=0)
+
+    def test_reduce_2d_tensor_float16(self):
+        """Test reduce with 2D tensor shapes using float16."""
+        self._test_reduce_helper(shape=(4, 64), dtype=torch.float16, dst=0)
+
+    def test_reduce_rank_non_zero_float16(self):
+        """Test reduce to non-zero destination rank with float16 tensors."""
+        dst_rank = min(1, self.comm_size - 1)
+        self._test_reduce_helper(shape=(128,), dtype=torch.float16, dst=dst_rank)
+
+    def test_reduce_2d_tensor_rank_non_zero_float16(self):
+        """Test reduce to non-zero destination rank with 2D tensor shapes using float16."""
+        dst_rank = min(1, self.comm_size - 1)
+        self._test_reduce_helper(shape=(4, 64), dtype=torch.float16, dst=dst_rank)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/distributed/test_reduce.py
+++ b/tests/distributed/test_reduce.py
@@ -74,7 +74,7 @@ class TestReduce(TestCase):
         if dist.is_initialized():
             dist.destroy_process_group()
 
-    def _test_reduce_helper(self, shape, dtype, dst):
+    def _test_reduce_helper(self, shape, dtype, dst, async_op=False):
         """
         Helper method to test reduce with specific parameters.
 
@@ -82,6 +82,8 @@ class TestReduce(TestCase):
             shape: Tensor shape
             dtype: Tensor data type
             dst: Destination rank for reduce
+            async_op: If True, launch the collective asynchronously and call
+                      work.wait() before inspecting the result
         """
         # Calculate total number of elements in the tensor
         num_elements = torch.tensor(shape).prod().item()
@@ -101,7 +103,15 @@ class TestReduce(TestCase):
         input_device = input_tensor.to(DEVICE)
 
         # Reduce with SUM operation to destination rank
-        dist.reduce(input_device, dst=dst, op=dist.ReduceOp.SUM)
+        work = dist.reduce(
+            input_device, dst=dst, op=dist.ReduceOp.SUM, async_op=async_op
+        )
+
+        if async_op:
+            self.assertIsNotNone(work, "async_op=True must return a Work handle")
+            work.wait()
+        else:
+            self.assertIsNone(work, "async_op=False must return None")
 
         if self.comm_rank == dst:
             result = input_device.to("cpu")
@@ -146,6 +156,25 @@ class TestReduce(TestCase):
         """Test reduce to non-zero destination rank with 2D tensor shapes using float16."""
         dst_rank = min(1, self.comm_size - 1)
         self._test_reduce_helper(shape=(4, 64), dtype=torch.float16, dst=dst_rank)
+
+    def test_reduce_float16_async(self):
+        """Test reduce to rank 0 with float16 tensors using async_op=True."""
+        self._test_reduce_helper(
+            shape=(128,), dtype=torch.float16, dst=0, async_op=True
+        )
+
+    def test_reduce_2d_tensor_float16_async(self):
+        """Test reduce with 2D float16 tensors using async_op=True."""
+        self._test_reduce_helper(
+            shape=(4, 64), dtype=torch.float16, dst=0, async_op=True
+        )
+
+    def test_reduce_rank_non_zero_float16_async(self):
+        """Test reduce to non-zero destination rank with float16 tensors using async_op=True."""
+        dst_rank = min(1, self.comm_size - 1)
+        self._test_reduce_helper(
+            shape=(128,), dtype=torch.float16, dst=dst_rank, async_op=True
+        )
 
 
 if __name__ == "__main__":

--- a/tests/distributed/test_reduce.py
+++ b/tests/distributed/test_reduce.py
@@ -176,6 +176,13 @@ class TestReduce(TestCase):
             shape=(128,), dtype=torch.float16, dst=dst_rank, async_op=True
         )
 
+    def test_reduce_2d_tensor_rank_non_zero_float16_async(self):
+        """Test reduce with 2D float16 tensors to a non-zero destination rank using async_op=True."""
+        dst_rank = min(1, self.comm_size - 1)
+        self._test_reduce_helper(
+            shape=(4, 64), dtype=torch.float16, dst=dst_rank, async_op=True
+        )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/tests/distributed/test_reduce.py
+++ b/tests/distributed/test_reduce.py
@@ -110,6 +110,7 @@ class TestReduce(TestCase):
         if async_op:
             self.assertIsNotNone(work, "async_op=True must return a Work handle")
             work.wait()
+            self.assertTrue(work.is_completed())
         else:
             self.assertIsNone(work, "async_op=False must return None")
 

--- a/tests/distributed/utils.py
+++ b/tests/distributed/utils.py
@@ -16,13 +16,15 @@ import pytest
 import torch
 
 
-def _assert_tensor_equal(result, expected, dtype, message_prefix):
+def _assert_tensor_equal(
+    result, expected, dtype, message_prefix, *, rtol=1e-5, atol=1e-5
+):
     if dtype.is_floating_point:
-        matches = torch.allclose(result, expected, rtol=1e-5, atol=1e-5)
+        matches = torch.allclose(result, expected, rtol=rtol, atol=atol)
         if not matches:
             # Find first mismatch for detailed error reporting
             diff = torch.abs(result - expected)
-            mismatch_mask = diff > (1e-5 + 1e-5 * torch.abs(expected))
+            mismatch_mask = diff > (atol + rtol * torch.abs(expected))
             if mismatch_mask.any():
                 mismatch_indices = torch.nonzero(mismatch_mask, as_tuple=False)
                 first_mismatch = mismatch_indices[0].tolist()

--- a/torch_spyre/csrc/distributed/spyre_ccl.cpp
+++ b/torch_spyre/csrc/distributed/spyre_ccl.cpp
@@ -635,6 +635,10 @@ c10::intrusive_ptr<Work> SpyreCCLBackend::scatter(
 
 c10::intrusive_ptr<Work> SpyreCCLBackend::send(std::vector<at::Tensor>& tensors,
                                                int dstRank, int tag) {
+  // NOTE: The c10d::Backend::send() signature carries no opts struct and
+  // therefore exposes no asyncOp flag.  We follow the same non-blocking
+  // submission pattern used by all collectives and leave completion control
+  // to the caller via Work::wait().
   check_vector_tensor(tensors, 1, 1);
 
   spyre_comms::Tensor tensor;
@@ -644,12 +648,15 @@ c10::intrusive_ptr<Work> SpyreCCLBackend::send(std::vector<at::Tensor>& tensors,
       c10::make_intrusive<SpyreCCLWork>(OpType::SEND);
   work->work_schedule_ = group_context_->send(tensor, dstRank, tag);
   work->work_schedule_->start();
-  work->work_schedule_->wait();
   return work;
 }
 
 c10::intrusive_ptr<Work> SpyreCCLBackend::recv(std::vector<at::Tensor>& tensors,
                                                int srcRank, int tag) {
+  // NOTE: The c10d::Backend::recv() signature carries no opts struct and
+  // therefore exposes no asyncOp flag.  We follow the same non-blocking
+  // submission pattern used by all collectives and leave completion control
+  // to the caller via Work::wait().
   check_vector_tensor(tensors, 1, 1);
 
   spyre_comms::Tensor tensor;
@@ -659,7 +666,6 @@ c10::intrusive_ptr<Work> SpyreCCLBackend::recv(std::vector<at::Tensor>& tensors,
       c10::make_intrusive<SpyreCCLWork>(OpType::RECV);
   work->work_schedule_ = group_context_->recv(tensor, srcRank, tag);
   work->work_schedule_->start();
-  work->work_schedule_->wait();
   return work;
 }
 

--- a/torch_spyre/csrc/distributed/spyre_ccl.cpp
+++ b/torch_spyre/csrc/distributed/spyre_ccl.cpp
@@ -482,6 +482,12 @@ c10::intrusive_ptr<Work> SpyreCCLBackend::allreduce(
                            " Actual: " + std::to_string(opts.reduceOp);
     TORCH_CHECK(false, _err_msg);
   }
+  if (spyre::torchScalarToString[tensors[0].scalar_type()] != "float16") {
+    std::string _err_msg =
+        "[" + getBackendName() + "]: Allreduce only supports float16 tensors." +
+        " Actual: " + spyre::torchScalarToString[tensors[0].scalar_type()];
+    TORCH_CHECK(false, _err_msg);
+  }
 
   spyre_comms::Tensor tensor;
   prepare_tensor(tensors[0], &tensor);
@@ -615,6 +621,12 @@ c10::intrusive_ptr<Work> SpyreCCLBackend::reduce(
     std::string _err_msg = "[" + getBackendName() +
                            "]: Reduce only supports SUM operation." +
                            " Actual: " + std::to_string(opts.reduceOp);
+    TORCH_CHECK(false, _err_msg);
+  }
+  if (spyre::torchScalarToString[tensors[0].scalar_type()] != "float16") {
+    std::string _err_msg =
+        "[" + getBackendName() + "]: Reduce only supports float16 tensors." +
+        " Actual: " + spyre::torchScalarToString[tensors[0].scalar_type()];
     TORCH_CHECK(false, _err_msg);
   }
 

--- a/torch_spyre/csrc/distributed/spyre_ccl.cpp
+++ b/torch_spyre/csrc/distributed/spyre_ccl.cpp
@@ -15,8 +15,10 @@
  */
 #include "spyre_ccl.hpp"
 
+#include <chrono>
 #include <iostream>
 #include <string>
+#include <thread>
 #include <torch/csrc/distributed/c10d/Types.hpp>
 #include <unordered_map>
 #include <utility>
@@ -684,19 +686,51 @@ SpyreCCLWork::SpyreCCLWork(OpType opType)
 bool SpyreCCLWork::isCompleted() {
   if (work_schedule_ && !completed_) {
     completed_ = work_schedule_->query();
+    // Resolve the future as soon as completion is first detected so that
+    // callers who poll isCompleted() rather than calling wait() still see
+    // a resolved future — matching the c10d::Work contract.
+    if (completed_ && !future_->completed()) {
+      future_->markCompleted(c10::IValue(std::vector<at::Tensor>{}));
+    }
   }
   return completed_;
 }
 
 bool SpyreCCLWork::isSuccess() const {
-  return true;
+  return exception_ == nullptr;
 }
 
 bool SpyreCCLWork::wait(std::chrono::milliseconds timeout) {
-  if (work_schedule_ && !completed_) {
-    work_schedule_->wait();
-    completed_ = true;
+  if (!work_schedule_ || completed_) {
+    // Already done; resolve the future if it hasn't been yet.
+    if (!future_->completed()) {
+      future_->markCompleted(c10::IValue(std::vector<at::Tensor>{}));
+    }
+    return true;
   }
+
+  if (timeout == kUnsetTimeout || timeout == kNoTimeout) {
+    // No deadline: block until the device signals completion.
+    work_schedule_->wait();
+  } else {
+    // Timed wait: poll query() until completion or deadline, then throw on
+    // timeout to match the c10d::Work base-class contract.
+    auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (!work_schedule_->query()) {
+      if (std::chrono::steady_clock::now() >= deadline) {
+        TORCH_CHECK(false, "[SpyreCCL]: Operation timed out!");
+      }
+      std::this_thread::sleep_for(std::chrono::microseconds(100));
+    }
+  }
+
+  completed_ = true;
+
+  // Resolve the future so any getFuture() chain-continuations are unblocked.
+  if (!future_->completed()) {
+    future_->markCompleted(c10::IValue(std::vector<at::Tensor>{}));
+  }
+
   return true;
 }
 

--- a/torch_spyre/csrc/distributed/spyre_ccl.cpp
+++ b/torch_spyre/csrc/distributed/spyre_ccl.cpp
@@ -691,7 +691,14 @@ SpyreCCLWork::SpyreCCLWork(OpType opType)
 
 bool SpyreCCLWork::isCompleted() {
   if (work_schedule_ && !completed_) {
-    completed_ = work_schedule_->query();
+    try {
+      completed_ = work_schedule_->query();
+    }
+    catch (...) {
+      exception_ = std::current_exception();
+      completed_ = true;
+      std::rethrow_exception(exception_);
+    }
     // Resolve the future as soon as completion is first detected so that
     // callers who poll isCompleted() rather than calling wait() still see
     // a resolved future — matching the c10d::Work contract.
@@ -717,16 +724,28 @@ bool SpyreCCLWork::wait(std::chrono::milliseconds timeout) {
 
   if (timeout == kUnsetTimeout || timeout == kNoTimeout) {
     // No deadline: block until the device signals completion.
-    work_schedule_->wait();
+    try {
+      work_schedule_->wait();
+    }
+    catch (...) {
+      exception_ = std::current_exception();
+      std::rethrow_exception(exception_);
+    }
   } else {
     // Timed wait: poll query() until completion or deadline, then throw on
     // timeout to match the c10d::Work base-class contract.
     auto deadline = std::chrono::steady_clock::now() + timeout;
-    while (!work_schedule_->query()) {
-      if (std::chrono::steady_clock::now() >= deadline) {
-        TORCH_CHECK(false, "[SpyreCCL]: Operation timed out!");
+    try {
+      while (!work_schedule_->query()) {
+        if (std::chrono::steady_clock::now() >= deadline) {
+          TORCH_CHECK(false, "[SpyreCCL]: Operation timed out!");
+        }
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
       }
-      std::this_thread::sleep_for(std::chrono::microseconds(100));
+    }
+    catch (...) {
+      exception_ = std::current_exception();
+      std::rethrow_exception(exception_);
     }
   }
 

--- a/torch_spyre/csrc/distributed/spyre_ccl.cpp
+++ b/torch_spyre/csrc/distributed/spyre_ccl.cpp
@@ -416,10 +416,6 @@ void SpyreCCLBackend::check_vector_tensor(
 c10::intrusive_ptr<Work> SpyreCCLBackend::allgather(
     std::vector<std::vector<at::Tensor>>& outputTensors,
     std::vector<at::Tensor>& inputTensors, const AllgatherOptions& opts) {
-  if (opts.asyncOp) {
-    throw SpyreCCLNotSupportedException(getBackendName(),
-                                        "asyncOp in allgather");
-  }
   if (static_cast<int>(outputTensors.size()) != 1) {
     std::string _err_msg =
         "[" + getBackendName() +
@@ -453,17 +449,15 @@ c10::intrusive_ptr<Work> SpyreCCLBackend::allgather(
   work->work_schedule_ =
       group_context_->allgather(output_tensors, input_tensor);
   work->work_schedule_->start();
-  work->work_schedule_->wait();
+  if (!opts.asyncOp) {
+    work->wait();
+  }
   return work;
 }
 
 c10::intrusive_ptr<Work> SpyreCCLBackend::_allgather_base(
     at::Tensor& outputBuffer, at::Tensor& inputBuffer,
     const AllgatherOptions& opts) {
-  if (opts.asyncOp) {
-    throw SpyreCCLNotSupportedException(getBackendName(),
-                                        "asyncOp in _allgather_base");
-  }
   // Do not intend to support: It is deprecated
   // https://github.com/pytorch/pytorch/blob/62226611ded023ff1119b103ed3f540f75e38e9d/torch/csrc/distributed/c10d/Backend.hpp#L197-L209
   throw SpyreCCLNotSupportedException(getBackendName(), __func__);
@@ -471,10 +465,6 @@ c10::intrusive_ptr<Work> SpyreCCLBackend::_allgather_base(
 
 c10::intrusive_ptr<Work> SpyreCCLBackend::allreduce(
     std::vector<at::Tensor>& tensors, const AllreduceOptions& opts) {
-  if (opts.asyncOp) {
-    throw SpyreCCLNotSupportedException(getBackendName(),
-                                        "asyncOp in allreduce");
-  }
   check_vector_tensor(tensors, 1, 1);
   if (opts.reduceOp != ReduceOp::SUM) {
     std::string _err_msg = "[" + getBackendName() +
@@ -497,16 +487,14 @@ c10::intrusive_ptr<Work> SpyreCCLBackend::allreduce(
   work->work_schedule_ =
       group_context_->allreduce(tensor, convert_reduce_op_type(opts.reduceOp));
   work->work_schedule_->start();
-  work->work_schedule_->wait();
+  if (!opts.asyncOp) {
+    work->wait();
+  }
   return work;
 }
 
 c10::intrusive_ptr<Work> SpyreCCLBackend::allreduce_coalesced(
     std::vector<at::Tensor>& tensors, const AllreduceCoalescedOptions& opts) {
-  if (opts.asyncOp) {
-    throw SpyreCCLNotSupportedException(getBackendName(),
-                                        "asyncOp in allreduce_coalesced");
-  }
   // Do not intend to support: No public interface
   throw SpyreCCLNotSupportedException(getBackendName(), __func__);
 }
@@ -514,10 +502,6 @@ c10::intrusive_ptr<Work> SpyreCCLBackend::allreduce_coalesced(
 c10::intrusive_ptr<Work> SpyreCCLBackend::alltoall(
     std::vector<at::Tensor>& outputTensors,
     std::vector<at::Tensor>& inputTensors, const AllToAllOptions& opts) {
-  if (opts.asyncOp) {
-    throw SpyreCCLNotSupportedException(getBackendName(),
-                                        "asyncOp in alltoall");
-  }
   throw SpyreCCLNotSupportedException(getBackendName(), __func__);
 }
 
@@ -525,31 +509,22 @@ c10::intrusive_ptr<Work> SpyreCCLBackend::alltoall_base(
     at::Tensor& outputTensor, at::Tensor& inputTensor,
     std::vector<int64_t>& outputSplitSizes,
     std::vector<int64_t>& inputSplitSizes, const AllToAllOptions& opts) {
-  if (opts.asyncOp) {
-    throw SpyreCCLNotSupportedException(getBackendName(),
-                                        "asyncOp in alltoall_base");
-  }
   throw SpyreCCLNotSupportedException(getBackendName(), __func__);
 }
 
 c10::intrusive_ptr<Work> SpyreCCLBackend::barrier(const BarrierOptions& opts) {
-  if (opts.asyncOp) {
-    throw SpyreCCLNotSupportedException(getBackendName(), "asyncOp in barrier");
-  }
   c10::intrusive_ptr<SpyreCCLWork> work =
       c10::make_intrusive<SpyreCCLWork>(OpType::BARRIER);
   work->work_schedule_ = group_context_->barrier();
   work->work_schedule_->start();
-  work->work_schedule_->wait();
+  if (!opts.asyncOp) {
+    work->wait();
+  }
   return work;
 }
 
 c10::intrusive_ptr<Work> SpyreCCLBackend::broadcast(
     std::vector<at::Tensor>& tensors, const BroadcastOptions& opts) {
-  if (opts.asyncOp) {
-    throw SpyreCCLNotSupportedException(getBackendName(),
-                                        "asyncOp in broadcast");
-  }
   check_vector_tensor(tensors, 1, 1);
   c10::intrusive_ptr<SpyreCCLWork> work =
       c10::make_intrusive<SpyreCCLWork>(OpType::BROADCAST);
@@ -559,7 +534,9 @@ c10::intrusive_ptr<Work> SpyreCCLBackend::broadcast(
 
   work->work_schedule_ = group_context_->broadcast(tensor, opts.rootRank);
   work->work_schedule_->start();
-  work->work_schedule_->wait();
+  if (!opts.asyncOp) {
+    work->wait();
+  }
 
   return work;
 }
@@ -567,9 +544,6 @@ c10::intrusive_ptr<Work> SpyreCCLBackend::broadcast(
 c10::intrusive_ptr<Work> SpyreCCLBackend::gather(
     std::vector<std::vector<at::Tensor>>& outputTensors,
     std::vector<at::Tensor>& inputTensors, const GatherOptions& opts) {
-  if (opts.asyncOp) {
-    throw SpyreCCLNotSupportedException(getBackendName(), "asyncOp in gather");
-  }
   if (opts.rootRank == group_context_->getRank()) {
     if (static_cast<int>(outputTensors.size()) != 1) {
       std::string _err_msg =
@@ -607,15 +581,14 @@ c10::intrusive_ptr<Work> SpyreCCLBackend::gather(
   work->work_schedule_ =
       group_context_->gather(output_tensors, input_tensor, opts.rootRank);
   work->work_schedule_->start();
-  work->work_schedule_->wait();
+  if (!opts.asyncOp) {
+    work->wait();
+  }
   return work;
 }
 
 c10::intrusive_ptr<Work> SpyreCCLBackend::reduce(
     std::vector<at::Tensor>& tensors, const ReduceOptions& opts) {
-  if (opts.asyncOp) {
-    throw SpyreCCLNotSupportedException(getBackendName(), "asyncOp in reduce");
-  }
   check_vector_tensor(tensors, 1, 1);
   if (opts.reduceOp != ReduceOp::SUM) {
     std::string _err_msg = "[" + getBackendName() +
@@ -638,7 +611,9 @@ c10::intrusive_ptr<Work> SpyreCCLBackend::reduce(
   work->work_schedule_ = group_context_->reduce(
       tensor, convert_reduce_op_type(opts.reduceOp), opts.rootRank);
   work->work_schedule_->start();
-  work->work_schedule_->wait();
+  if (!opts.asyncOp) {
+    work->wait();
+  }
   return work;
 }
 
@@ -646,10 +621,6 @@ c10::intrusive_ptr<Work> SpyreCCLBackend::reduce_scatter(
     std::vector<at::Tensor>& outputTensors,
     std::vector<std::vector<at::Tensor>>& inputTensors,
     const ReduceScatterOptions& opts) {
-  if (opts.asyncOp) {
-    throw SpyreCCLNotSupportedException(getBackendName(),
-                                        "asyncOp in reduce_scatter");
-  }
   throw SpyreCCLNotSupportedException(getBackendName(), __func__);
 }
 
@@ -657,9 +628,6 @@ c10::intrusive_ptr<Work> SpyreCCLBackend::scatter(
     std::vector<at::Tensor>& outputTensors,
     std::vector<std::vector<at::Tensor>>& inputTensors,
     const ScatterOptions& opts) {
-  if (opts.asyncOp) {
-    throw SpyreCCLNotSupportedException(getBackendName(), "asyncOp in scatter");
-  }
   throw SpyreCCLNotSupportedException(getBackendName(), __func__);
 }
 
@@ -714,7 +682,10 @@ SpyreCCLWork::SpyreCCLWork(OpType opType)
           c10::ListType::create(c10::TensorType::get()))) {}
 
 bool SpyreCCLWork::isCompleted() {
-  return true;
+  if (work_schedule_ && !completed_) {
+    completed_ = work_schedule_->query();
+  }
+  return completed_;
 }
 
 bool SpyreCCLWork::isSuccess() const {
@@ -722,6 +693,10 @@ bool SpyreCCLWork::isSuccess() const {
 }
 
 bool SpyreCCLWork::wait(std::chrono::milliseconds timeout) {
+  if (work_schedule_ && !completed_) {
+    work_schedule_->wait();
+    completed_ = true;
+  }
   return true;
 }
 

--- a/torch_spyre/csrc/distributed/spyre_ccl.cpp
+++ b/torch_spyre/csrc/distributed/spyre_ccl.cpp
@@ -474,6 +474,8 @@ c10::intrusive_ptr<Work> SpyreCCLBackend::allreduce(
                            " Actual: " + std::to_string(opts.reduceOp);
     TORCH_CHECK(false, _err_msg);
   }
+  // Spyre Comms only supports float16 tensors because of the 'op' path
+  // through the compiler. The data transfers do not have this restriction.
   if (spyre::torchScalarToString[tensors[0].scalar_type()] != "float16") {
     std::string _err_msg =
         "[" + getBackendName() + "]: Allreduce only supports float16 tensors." +
@@ -598,6 +600,8 @@ c10::intrusive_ptr<Work> SpyreCCLBackend::reduce(
                            " Actual: " + std::to_string(opts.reduceOp);
     TORCH_CHECK(false, _err_msg);
   }
+  // Spyre Comms only supports float16 tensors because of the 'op' path
+  // through the compiler. The data transfers do not have this restriction.
   if (spyre::torchScalarToString[tensors[0].scalar_type()] != "float16") {
     std::string _err_msg =
         "[" + getBackendName() + "]: Reduce only supports float16 tensors." +

--- a/torch_spyre/csrc/distributed/spyre_ccl.hpp
+++ b/torch_spyre/csrc/distributed/spyre_ccl.hpp
@@ -18,6 +18,8 @@
 #include <pybind11/chrono.h>
 #include <torch/python.h>
 
+#include <chrono>
+#include <exception>
 #include <spyre_comms.hpp>
 #include <torch/csrc/distributed/c10d/Backend.hpp>
 #include <torch/csrc/distributed/c10d/Store.hpp>
@@ -168,9 +170,18 @@ class SpyreCCLBackend : public c10d::Backend {
 
   /*
    * Shutdown
+   *
+   * shutdown() is a silent no-op: spyre_comms has no graceful-shutdown API,
+   * and the silent no-op matches the behaviour of the Gloo, MPI, and UCC
+   * backends. Finalization is handled by the SpyreCCLBackend destructor.
+   *
+   * abort() is not supported by the underlying spyre_comms library and will
+   * throw SpyreCCLNotSupportedException.
    */
-  void abort() {};
-  void shutdown() {};
+  void abort() override {
+    throw SpyreCCLNotSupportedException(getBackendName(), __func__);
+  }
+  void shutdown() override {}
 
   /*
    * Backend registration
@@ -209,6 +220,7 @@ class SpyreCCLWork : public Work {
   c10::intrusive_ptr<c10::ivalue::Future> future_;
   std::shared_ptr<spyre_comms::WorkSchedule> work_schedule_;
   bool completed_ = false;
+  std::exception_ptr exception_ = nullptr;
 };
 
 }  // namespace c10d

--- a/torch_spyre/csrc/distributed/spyre_ccl.hpp
+++ b/torch_spyre/csrc/distributed/spyre_ccl.hpp
@@ -208,6 +208,7 @@ class SpyreCCLWork : public Work {
  private:
   c10::intrusive_ptr<c10::ivalue::Future> future_;
   std::shared_ptr<spyre_comms::WorkSchedule> work_schedule_;
+  bool completed_ = false;
 };
 
 }  // namespace c10d


### PR DESCRIPTION

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

* Adds `asyncOp` support to torch.distributed collectives.
  * This is needed for HF Adapters support until functional collectives are available.
* Adds allreduce/reduce unit tests

#### Which issue(s) this PR is related to:

* Fixes https://github.com/torch-spyre/torch-spyre/issues/2080
* Supports work on https://github.com/torch-spyre/hf-adapters/issues/158

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

Yes. When calling a collective, they can now pass the optional `async_op` argument, and it will work correctly. Prior to this PR, it would throw an unsupported exception.

```python
    # Start the collective asynchronously
    work = dist.all_reduce(input_device, op=dist.ReduceOp.SUM, async_op=True)
    # Block until the async collective has completed
    work.wait()
```

#### Additional note:

None