### PR TITLE
pointwise try_device_coordinates to avoid hard failure on problematic sticks

### DIFF
--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -818,10 +818,12 @@ def _multi_arg_pointwise_layouts(
 
     ind_names, _, ind_sizes = indirect_info_from_op(op)
     stick_exprs = {
-        device_coordinates(stl, arg.dep, ind_sizes)[-1]
+        dc[-1]
         for arg in args
         for stl in arg.layouts
         if arg.dep.name not in ind_names
+        for dc in [try_device_coordinates(stl, arg.dep, ind_sizes)]
+        if dc is not None
     }
 
     # If the indexing and device element size are identical
@@ -857,8 +859,8 @@ def _multi_arg_pointwise_layouts(
             in_stl = SpyreTensorLayout(
                 c_in_size, c_in_stride, output.dtype, projected_dim_order, output_ea
             )
-            coord = device_coordinates(in_stl, arg.dep, ind_sizes)
-            if not is_stick_expr_offset_free(coord[-1], stick_size):
+            coord = try_device_coordinates(in_stl, arg.dep, ind_sizes)
+            if coord is None or not is_stick_expr_offset_free(coord[-1], stick_size):
                 return False
         return True
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

**Summary**: 
This PR uses `try_coordinates` in additional places in propagate_layouts to avoid a hard failure that is unnecessary

**Context**: 
device_coordinates(..) contains error checking to raise `UnsupportedException` for certain coordinates that we know the system does not yet support.  This check is helpful as it prevents errors from occurring far downstream where the root cause is lost and they become orders of magnitude more difficult to debug.

The problem is that there are now places in the code, particularly `propagate_layouts.py` where device_coordinates are constructed speculatively, and filtered if they are invalid or unsupported.  In these cases, `device_coordinates` will raise a terminating exception if not caught.

**Current Solution**:
There is already a pattern in the code for this scenario, which is to call `pass_utils.py::try_device_coordinates(..)` which catches the exception and returns None for unsupported coordinates.  This PR extends this pattern to two cases in `multi_arg_pointwise_layouts`, which on branch `passes-reorder-clean` are unnecessarily aborting when considering coordinates.

This pattern will receive a larger cleanup in the future as we probably don't want to use exceptions for control flow, but the pattern already exists in the code, so we are continuing to use it for now until the cleanup.  Using `try_device_coordinates` keeps the pattern consistent and encapsulated for future swap of the implementation, or identification of callers that need to be revisited.


#### Which issue(s) this PR is related to:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
