### PR TITLE
fix(cicd): reject bare-colon false match from PCIDEVICE_IBM_COM_AIU_PF script-preview self-reference

### DIFF
--- a/.github/scripts/parse_hw_failures.py
+++ b/.github/scripts/parse_hw_failures.py
@@ -143,11 +143,19 @@ RE_NODE_NAME = re.compile(
 RE_POD_NAME = re.compile(
     r"GHA_RUNNER_POD_NAME(?!\w)[ \t]*(?:->|=)?[ \t]*(?P<v>[\w.*-]+)"
 )
+# gather-runner-info's own script preview -- `echo "PCIDEVICE_IBM_COM_AIU_PF
+# ${PCIDEVICE_IBM_COM_AIU_PF:-}"` -- references the var name TWICE on one
+# line. The first occurrence is followed by `$` (rejected, not in the value
+# class), but the SECOND occurrence, inside `${...:-}`, is followed by `:`,
+# which the old `[0-9a-fA-F:.,]+` class allowed -- capturing a bare ':' as
+# the "value" before ever reaching the real output line. Real PCI addresses
+# always start with a hex digit (e.g. "0000:..."), so requiring the first
+# captured character to be one rejects that bare-colon false match.
 RE_PCI_DEVICE = re.compile(
-    r"PCIDEVICE_IBM_COM_AIU_PF(?!\w)[ \t]*(?:->|=)?[ \t]*(?P<v>[0-9a-fA-F:.,]+)"
+    r"PCIDEVICE_IBM_COM_AIU_PF(?!\w)[ \t]*(?:->|=)?[ \t]*(?P<v>[0-9a-fA-F][0-9a-fA-F:.,]*)"
 )
 RE_AIU_RANK0 = re.compile(
-    r"AIU_WORLD_RANK_0(?!\w)[ \t]*(?:->|=)?[ \t]*(?P<v>[0-9a-fA-F:.,]+)"
+    r"AIU_WORLD_RANK_0(?!\w)[ \t]*(?:->|=)?[ \t]*(?P<v>[0-9a-fA-F][0-9a-fA-F:.,]*)"
 )
 RE_PCI_DEV_ID = re.compile(
     r"pcidevid\.cpp.*?Device id \(for card idx \d+\):\s*(?P<v>[0-9a-f:.]+)"


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes `pci_device` capturing a bare `:` instead of the real PCI address, caused by the `gather-runner-info` script-preview line's self-referencing `${PCIDEVICE_IBM_COM_AIU_PF:-}` matching before the real output line.