### PR TITLE
fix(inductor): use stick-count basis in align_tensors work-division gcd

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_pointwise_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_pointwise_config.yaml
@@ -32,6 +32,7 @@ test_suite_config:
           mode: xfail
         - names:
             - LxPlanning.*::test_(pointwise|sqrt|rsqrt|log_|alias_operands|cmp|logical_not|bool|eq_scalar|scalar_(comparison|multidim|vs_tensor)_base|scalar_comparison_simple1|eq_scalar_constant_int).*_lx_planning_(pointwise|reduction)
+            - LxPlanning.*::test_binary_op_stick_crossing_last_dim_lx_planning_(pointwise|reduction)
           mode: mandatory_success
           tags:
             - ops__inductor-pointwise

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_pointwise_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_pointwise_config.yaml
@@ -8,6 +8,7 @@ test_suite_config:
             # Covers pointwise ops plus PR 2180 eq-scalar tests, including
             # parameterized variants, shared base helpers, and standalone cases.
             - TestOps::test_(pointwise|sqrt|rsqrt|log_|alias_operands|cmp|logical_not|bool|eq_scalar|scalar_(comparison|multidim|vs_tensor)_base|scalar_comparison_simple1|eq_scalar_constant_int).*
+            - TestOps::test_binary_op_stick_crossing_last_dim
           mode: mandatory_success
           tags:
             - ops__inductor-pointwise

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import math
 import pytest
 import unittest
 import torch
@@ -4732,6 +4732,56 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             b[tiny_value_mask] = FP16_EPS
 
         self.compare_with_cpu(op, a, b)
+
+    def test_binary_op_stick_crossing_last_dim(self):
+        """A pointwise binary op whose stick (last) dim spans multiple sticks
+        with an extent coprime with the committed core split must stay
+        bit-exact.
+
+        When the stick dim occupies S>1 sticks and the outer dims are too small
+        to absorb the core split, work division splits the stick dim across S
+        cores. If the element count N is coprime with S (e.g. N=67 over S=2
+        sticks, or N=130 over S=3), the iteration-space realignment used to
+        re-intersect that split against N instead of S and collapse it to a
+        single core -- the layout the backend then miscompiled, corrupting
+        every element past the first stick.
+        """
+
+        # neg keeps both add operands LX-resident: the collapsed single-core
+        # layout only misaddresses the second stick when its operands come from
+        # LX (single per-core base). Feeding the add plain graph inputs would
+        # keep them in HBM, whose per-core addressing masks the bug even when
+        # the split still collapses.
+        def fn(x, y):
+            return torch.neg(x) + torch.neg(y)
+
+        # Last dim > 64 and coprime with the core split; outer dims kept small
+        # so work division divides the stick dim, not the outer.
+        shapes = [
+            (67,),  # 1D, 2 sticks, odd -> gcd(2,67)=1
+            (127,),  # 1D, 2 sticks, odd
+            (130,),  # 1D, 3 sticks, gcd(3,130)=1
+            (193,),  # 1D, 4 sticks, gcd(4,193)=1
+            (3, 67),  # 2D, stick dim split across cores
+            (4, 193),  # 2D, 4-stick coprime last dim
+            (2, 3, 67),  # 3D
+            (3, 5, 127),  # 3D
+            (2, 3, 2, 127),  # 4D
+        ]
+
+        for shape in shapes:
+            with self.subTest(shape=shape):
+                n = math.prod(shape)
+                # Distinct exact-fp16 integer patterns so a per-element
+                # permutation or a dropped trailing stick shows up as a value
+                # mismatch rather than washing out.
+                x = (torch.arange(n) % 251).to(torch.float16).reshape(shape)
+                y = ((torch.arange(n) + 100) % 251).to(torch.float16).reshape(shape)
+
+                result = torch.compile(fn, dynamic=False)(
+                    x.to("spyre"), y.to("spyre")
+                ).cpu()
+                torch.testing.assert_close(result, fn(x, y))
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_fallback_binary_op_cpu(self, op, x, y):

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -631,7 +631,18 @@ def align_tensors(
 
             # distribute work division for old var to new vars
             for v in reversed(remap[var]):
-                new_op_it_space_splits[v] = math.gcd(div, new_var_ranges[v])
+                # Re-intersect the committed split against the basis work
+                # division used for this var.
+                if v == var and v in stick_dim:
+                    # Stick var: stick count. The element range would drop a
+                    # legal split when the size is not a multiple of it
+                    # (e.g. gcd(2, 67) == 1).
+                    eps = int(stick_size[stick_dim.index(v)])
+                    basis = (int(new_var_ranges[v]) + eps - 1) // eps  # stick count
+                else:
+                    # Non-stick var (or synthetic sub-dim): element range.
+                    basis = new_var_ranges[v]
+                new_op_it_space_splits[v] = math.gcd(div, basis)
                 div //= new_op_it_space_splits[v]
         else:
             # no splits keep existing var, range, and work division

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -55,6 +55,7 @@ from .pass_utils import (
     op_read_writes,
 )
 from .propagate_hints import get_op_hints
+from collections.abc import Iterable
 from typing import Callable
 
 from .logging_utils import get_inductor_logger
@@ -189,6 +190,35 @@ def _most_splittable_dim(
         if s > best_split:
             best_dim, best_split = d, s
     return (best_dim, best_split) if best_split > 1 else None
+
+
+def coordinate_mask_blocked_vars(
+    reduction_vars: Iterable[Symbol],
+    stick_vars: dict[Symbol, int],
+    it_space: dict[Symbol, Expr],
+) -> set[Symbol]:
+    """Return reduction stick vars that cannot be split across cores.
+
+    The backend compiler cannot apply coordinate masking to a dimension spread
+    over cores, and masking is applied to a dim that is padded, reduced, and the
+    stick dim (mirrors ``_get_coordinate_mask`` in codegen/superdsc.py). A stick
+    var is guaranteed non-symbolic, so its element count concretizes; it is
+    padded iff not stick-aligned.
+
+    ``it_space`` must be the element-valued iteration space (not the
+    stick-adjusted copy), since padding is defined on element counts.
+    ``stick_vars`` maps each stick var to its elems_per_stick (as returned by
+    ``adjust_it_space_for_sticks``).
+
+    Both work-division paths consult this: the greedy path drops these from its
+    reduction candidates, and ``enumerate_work_division_candidates`` rejects any
+    split that divides one of them.
+    """
+    return {
+        v
+        for v in reduction_vars
+        if v in stick_vars and concretize_expr(it_space[v]) % stick_vars[v] != 0
+    }
 
 
 def multi_dim_iteration_space_split(
@@ -692,6 +722,7 @@ def enumerate_work_division_candidates(
     # device coordinates (mirrors prioritize_dimensions / splits_by_index_coeff).
     coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
     reduction_vars = [v for v in it_space_adjusted if v not in coord_vars]
+    mask_blocked = coordinate_mask_blocked_vars(reduction_vars, stick_vars, it_space)
 
     # Per-dim candidate factors, mirroring must_split_vars.valid_splits but with
     # no ``>= current_min`` floor (we want the full set, including 1).
@@ -717,15 +748,8 @@ def enumerate_work_division_candidates(
             for td in all_tds
         ):
             return False
-        if any(  # a coordinate-masked dim cannot be split across cores: the
-            # backend can't apply coordinate masking to a dimension spread over
-            # cores (ddc ddcv1.cpp:3433). Masking is applied to a dim that is
-            # padded, reduced, and the stick dim -- mirrors _get_coordinate_mask
-            # in codegen/superdsc.py. A stick var is guaranteed non-symbolic, so
-            # its element count concretizes; padded iff not stick-aligned.
-            splits[v] > 1
-            for v in reduction_vars
-            if v in stick_vars and concretize_expr(it_space[v]) % stick_vars[v] != 0
+        if any(  # a coordinate-masked dim cannot be split across cores
+            splits[v] > 1 for v in mask_blocked
         ):
             return False
         return True
@@ -915,6 +939,7 @@ def _default_split(
     committed_splits: dict[Symbol, int],
     max_cores: int,
     symbol_meta: SymbolMeta,
+    blocked: set[Symbol],
 ) -> tuple[dict[Symbol, int], list[Symbol], list[Symbol]]:
     """Distribute max_cores by priority on top of span_reduction's commits.
 
@@ -939,6 +964,10 @@ def _default_split(
     coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
     if any(v not in coord_vars for v in committed_splits):
         reduction_dims = []
+
+    # Drop reduction dims the backend compiler can't split across cores before
+    # the greedy distributor commits them.
+    reduction_dims = [v for v in reduction_dims if v not in blocked]
 
     # Pass max_cores, not remaining_cores: multi_dim_iteration_space_split
     # accounts for committed_splits in its first pass, consuming those cores
@@ -970,7 +999,9 @@ def work_distribution_pass(
 
     symbol_meta = _collect_symbol_metadata(it_space)
 
-    it_space_adjusted, _ = adjust_it_space_for_sticks(it_space, all_tds, symbol_meta)
+    it_space_adjusted, stick_vars = adjust_it_space_for_sticks(
+        it_space, all_tds, symbol_meta
+    )
 
     # Recover splits committed by span_reduction_pass using the same
     # coeff-keyed encoding that codegen uses — stable across passes.
@@ -1022,8 +1053,11 @@ def work_distribution_pass(
             )
             return
 
+    coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
+    reduction_vars = [v for v in it_space_adjusted if v not in coord_vars]
+    blocked = coordinate_mask_blocked_vars(reduction_vars, stick_vars, it_space)
     splits, output_dims, reduction_dims = _default_split(
-        it_space_adjusted, output_td, committed_splits, max_cores, symbol_meta
+        it_space_adjusted, output_td, committed_splits, max_cores, symbol_meta, blocked
     )
 
     apply_splits(op, splits, output_td)
@@ -1543,8 +1577,11 @@ def _cost_model_divide_op(op: ComputedBuffer, max_cores: int) -> bool:
     else:
         committed_splits = {}
 
+    coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
+    reduction_vars = [v for v in it_space_adjusted if v not in coord_vars]
+    blocked = coordinate_mask_blocked_vars(reduction_vars, stick_vars, it_space)
     default_splits, _, _ = _default_split(
-        it_space_adjusted, output_td, committed_splits, max_cores, symbol_meta
+        it_space_adjusted, output_td, committed_splits, max_cores, symbol_meta, blocked
     )
     splits = _cost_model_matmul_planner(
         op,


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
A pointwise op whose stick (last) dimension spans multiple sticks silently miscompiles when work division divides that stick dimension across multiple cores — every element past the first stick is corrupted.

`align_tensors` (`torch_spyre/_inductor/views.py`) re-intersects work division's committed per-dimension core split against a variable's range via `gcd`. For a stick dimension, work division commits its core count against the **stick count** (`adjust_it_space_for_sticks`), but `align_tensors` used the **element count** as the `gcd` basis. When the element count is coprime with the committed split — e.g. 67 elements over a 2-stick / 2-core split, `gcd(2, 67) == 1` — the split collapses to a single core, so one core now owns a fold spanning both sticks.

The fix feeds the stick-count basis (`ceil(elems / elems_per_stick)`) into the `gcd` for the stick var's reused first segment; synthetic sub-segments and all non-stick vars keep the element basis, so genuine multi-segment non-stick splits are unchanged.

Fixing that `gcd` collapse exposed a second latent defect. The DXP backend compiler cannot apply coordinate masking to a dimension split across cores; such masking is applied to a dim that is padded, reduced, and the stick dim. `enumerate_work_division_candidates` already rejected splits dividing such a dim, but the greedy default path (`_default_split` → `multi_dim_iteration_space_split`) did not — it could commit a split entirely on a padded reduction stick dim, aborting the backend compile. Previously the element-basis `gcd` accidentally collapsed that split to one core (e.g. `gcd(8, 511) == 1`), masking the gap; once the stick-count fix keeps the split alive, the abort surfaces. This PR extracts the shared predicate `coordinate_mask_blocked_vars()` and has both paths consult it, so the greedy path drops such dims from its reduction candidates. This fixes the backend `SIGABRT` on `test_t_2d_127x131_lx_planning_reduction` and `test_copy_roundtrip_1d_padded_lx_planning_reduction`.

Adds a regression test (`test_binary_op_stick_crossing_last_dim`) exercising a pointwise binary op whose stick dim spans multiple sticks with a coprime extent, across 1D–4D shapes and 2/3/4-stick spans. Registered in both the base (`test_inductor_ops_pointwise_config.yaml`) and LX-planning (`test_inductor_ops_lx_pointwise_config.yaml`) CI configs.

#### Which issue(s) this PR is related to:

Fixes #3339

#### Special notes for your reviewer:

The collapsed layout only produces wrong output when both operands are **LX-resident** (`LX_PLANNING` on, the default). With `LX_PLANNING=0` the operands live in HBM and the same collapsed split compiles correctly — so LX planning is a *necessary condition* for the miscompile, not the cause. The repro uses `torch.neg` on both operands so their results are LX-resident; a plain `x + y` of two graph inputs keeps them in HBM and does not fire. `SENCORES=1` also masks it (no split to collapse).

**Why LX is affected and HBM is not.** The difference is entirely in how `_start_addr_data` (`torch_spyre/_inductor/codegen/compute_ops.py`) computes each core's start address. For an HBM tensor it adds a per-core work-slice offset, so every core reads from the region it actually owns:

```python
# HBM branch: per-core base = start_address + this core's work-slice offset
return {
    f"[{c}, 0, 0]": str(
        tensor.start_address
        + core_idx_to_slice_offset(
            tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
        )
        * num_bytes(tensor.data_format)
    )
    for c in range(sdsc_spec.num_cores)
}
```

For an LX tensor the `core_idx_to_slice_offset` term is dropped entirely — every core is handed the *same* base address:

```python
# LX branch: every core gets the identical base, no per-core slice offset
if "lx" in tensor.allocation:
    return {
        f"[{c}, 0, 0]": str(tensor.start_address)
        for c in range(sdsc_spec.num_cores)
    }
```

Normally that is fine, because work division puts each stick on its own core and each core's kernel only touches its own stick relative to that shared base. But once the split collapses to a single core, that one core's fold spans *both* sticks off the single LX base `{0, 128}` — and the second stick's loads land in the wrong region. The HBM path is immune to the same collapse because its per-core offset is recomputed per read edge; even a single-core fold resolves the second stick against a base that already folds in the work-slice offset.

This PR targets the collapse rather than the LX addressing: keeping the split at two cores lands each stick on its own core, so the single-core cross-stick fold never forms and the LX single-base addressing is never exercised. The underlying LX limitation (one per-core base address, no per-access offset) is a separate backend-side capability gap.

#### Does this PR introduce a user-facing change?

Fixes a silent miscompile for pointwise ops whose stick (last) dimension has an extent coprime with the multi-core work-division split.

#### Additional note:

The parameterized binary-op shapes never covered this case: they carry a stick-aligned last dim and place odd counts on outer dims, so a coprime extent never landed on the stick dim.
