### PR TITLE
feat(scratchpad): reuse input boundary clones in place (#3212)

### DIFF
--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -1646,18 +1646,16 @@ class TestBoundaryCloneInPlace(BaseTestScratchpadUsage):
         merged = False
         for bufs in captured:
             for b in bufs:
-                if not b.in_place_parents:
-                    continue
-                # output feeder as in-place child, or as in-place parent of another.
-                if b.name in output_feeders or (
-                    set(b.in_place_parents) & output_feeders
-                ):
+                # An output-feeding buffer is used as an in-place *parent*: some
+                # consumer names it in its in_place_parents (matches the docstring;
+                # the sibling aliasing test uses the same tighter check).
+                if set(b.in_place_parents) & output_feeders:
                     merged = True
                     break
         self.assertTrue(
             merged,
-            "expected a graph-output-feeding buffer to participate in an in-place "
-            "merge (output-clone in-place should work via the normal path)",
+            "expected a graph-output-feeding buffer to be reused in place as a "
+            "parent (output-clone in-place should work via the normal path)",
         )
         ref_y, ref_q = fn(x.to("cpu"))
         self.assertTrue(
@@ -1733,6 +1731,71 @@ class TestBoundaryCloneInPlace(BaseTestScratchpadUsage):
         self.assertTrue(
             torch.allclose(ref_y, ry, atol=1e-2, rtol=1e-3),
             "returned buffer y was corrupted by in-place reuse of its slot",
+        )
+        self.assertTrue(
+            torch.allclose(ref_u, ru, atol=1e-2, rtol=1e-3), "output u changed"
+        )
+
+    @unittest.skipUnless(_HAS_ORTOOLS, "co-optimizing path needs ortools")
+    def test_returned_buffer_reused_in_place_correct_in_cooptimizing_path(self):
+        """Same aliasing hazard as the sibling test, exercised on the co-optimizing
+        (joint CP-SAT) path: a returned buffer whose LX slot is reused in place must
+        still be handed back to the caller intact (#3212)."""
+        from torch_spyre._inductor.scratchpad.allocator import (
+            CoOptimizingAllocator,
+            _op_short_name,
+        )
+
+        x = self.rand_device((64, 1024))
+
+        def fn(x):
+            y = x * 2.0  # returned AND read by z, w, v -> pinned + cloned to HBM
+            z = y * 3.0
+            w = y + z
+            v = y + w  # y's last internal read; v is realized (read by u)
+            u = v + 1.0
+            return y, u
+
+        output_feeders: set[str] = set()
+        captured: list[list] = []
+        orig = CoOptimizingAllocator._build_cd_bound_buffers
+
+        def spy(self, *a, **k):
+            bufs = orig(self, *a, **k)
+            captured.append(list(bufs))
+            return bufs
+
+        def collect_feeders(graph: GraphLowering) -> None:
+            by_name = {op.name: op for op in graph.operations}
+            for name in graph.get_output_names():
+                output_feeders.add(name)
+                op = by_name.get(name)
+                if op is not None and _op_short_name(op) == "clone":
+                    output_feeders.update(d.name for d in op.get_read_writes().reads)
+
+        with self.pre_scheduling_iterating_pass(collect_feeders):
+            with patch.object(CoOptimizingAllocator, "_build_cd_bound_buffers", spy):
+                with ts_inductor_config.patch(
+                    lx_planning=True,
+                    layout_solver="cpsat",
+                    co_optimizing_lx_planning=True,
+                ):
+                    compiled = torch.compile(fn, fullgraph=True)
+                    ry, ru = compiled(x)
+                    ry, ru = ry.to("cpu"), ru.to("cpu")
+
+        reused = any(
+            set(b.in_place_parents) & output_feeders for bufs in captured for b in bufs
+        )
+        self.assertTrue(
+            reused,
+            "expected the returned buffer's slot to be reused in place on the "
+            "co-optimizing path (hazard not exercised)",
+        )
+        ref_y, ref_u = fn(x.to("cpu"))
+        self.assertTrue(
+            torch.allclose(ref_y, ry, atol=1e-2, rtol=1e-3),
+            "returned buffer y was corrupted by in-place reuse (co-opt path)",
         )
         self.assertTrue(
             torch.allclose(ref_u, ru, atol=1e-2, rtol=1e-3), "output u changed"

--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -1425,6 +1425,70 @@ class TestBoundaryCloneInPlace(BaseTestScratchpadUsage):
     and the final LX addresses), so they live in a plain non-parameterized class
     rather than the model-sweep ``TestCloneAtGraphBoundaries``."""
 
+    @unittest.skipUnless(_HAS_ORTOOLS, "co-optimizing path needs ortools")
+    def test_division_invariant_edges_respect_per_input_pointwise(self):
+        """``_determine_in_place_division_invariant`` routes through
+        ``_inplace_edge_ok(division_invariant=True)``, so every in-place parent it
+        returns is a pointwise-eligible read of the child's op -- the per-input
+        check the loop previously omitted (#3212 follow-up).
+
+        Invariant guard: an input read at a different index than the output write
+        must never be offered as an in-place parent pre-solver. For pointwise-tagged
+        ops every read is eligible (so this holds trivially), but the assertion locks
+        the property in against a future regression that drops the per-input check."""
+        from torch_spyre._inductor.scratchpad.allocator import CoOptimizingAllocator
+
+        x = self.rand_device((64, 1024))
+
+        def fn(x):
+            a = x + 1.0
+            b = a * 2.0
+            return b + 3.0
+
+        # The check must run inside the spy: _op_inputs_good_for_lx_inplace needs
+        # the virtualized (V) compile context, which is torn down once the
+        # torch.compile block exits.
+        violations: list[str] = []
+        edge_count = [0]
+        called = [False]
+        orig = CoOptimizingAllocator._determine_in_place_division_invariant
+
+        def spy(self, graph):
+            result = orig(self, graph)
+            called[0] = True
+            op_by_name = {op.name: op for op in graph.operations}
+            for buf_name, parents in result.items():
+                op = op_by_name.get(buf_name)
+                if op is None:
+                    continue
+                eligible = self._op_inputs_good_for_lx_inplace(op)
+                for parent in parents:
+                    edge_count[0] += 1
+                    if parent not in eligible:
+                        violations.append(f"{buf_name} -> {parent}")
+            return result
+
+        with patch.object(
+            CoOptimizingAllocator,
+            "_determine_in_place_division_invariant",
+            spy,
+        ):
+            with ts_inductor_config.patch(
+                lx_planning=True,
+                layout_solver="cpsat",
+                co_optimizing_lx_planning=True,
+            ):
+                torch.compile(fn, fullgraph=True)(x)
+
+        self.assertTrue(
+            called[0], "_determine_in_place_division_invariant was not called"
+        )
+        self.assertFalse(
+            violations,
+            f"in-place parents that are not pointwise-eligible reads: {violations}",
+        )
+        self.assertTrue(edge_count[0] > 0, "no in-place edges were produced to verify")
+
     def test_input_clone_reused_in_place_by_last_consumer(self):
         """The input clone's last consumer names the clone as an in-place parent
         (issue #3212), so the two may share an LX slot.

--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -1342,5 +1342,397 @@ class TestSelectAllocator(unittest.TestCase):
                 select_allocator()
 
 
+class TestInplaceEdgeGate(unittest.TestCase):
+    """Unit tests for ``ScratchpadAllocator._inplace_edge_ok``, the sole predicate
+    defining a legal in-place edge (shared by the normal producer path and the
+    graph-input clone reverse-parent path, issue #3212)."""
+
+    def _base_kwargs(self) -> dict:
+        layout = ("device-layout-sentinel",)
+        return dict(
+            child_pointwise_inputs=["p"],
+            parent_name="p",
+            child_size_per_core=128,
+            parent_size_per_core=128,
+            child_device_layout=layout,
+            parent_device_layout=layout,
+            child_start=5,
+            parent_end=5,
+            child_core_div_mismatch=False,
+        )
+
+    def test_all_conditions_met(self):
+        from torch_spyre._inductor.scratchpad.allocator import ScratchpadAllocator
+
+        self.assertTrue(ScratchpadAllocator._inplace_edge_ok(**self._base_kwargs()))
+
+    def test_each_condition_blocks_edge(self):
+        from torch_spyre._inductor.scratchpad.allocator import ScratchpadAllocator
+
+        # Each entry flips exactly one of the five conditions to failing.
+        for label, overrides in {
+            "parent not a pointwise input": {"child_pointwise_inputs": []},
+            "per-core size mismatch": {"parent_size_per_core": 127},
+            "device-layout mismatch": {"parent_device_layout": ("other",)},
+            "not single handoff tick": {"parent_end": 4},
+            "child core-division mismatch": {"child_core_div_mismatch": True},
+        }.items():
+            with self.subTest(label):
+                kwargs = self._base_kwargs()
+                kwargs.update(overrides)
+                self.assertFalse(
+                    ScratchpadAllocator._inplace_edge_ok(**kwargs),
+                    f"edge should be forbidden when: {label}",
+                )
+
+    def test_division_invariant_defers_size_and_core_div(self):
+        from torch_spyre._inductor.scratchpad.allocator import ScratchpadAllocator
+
+        # Under division_invariant (the co-optimizing path), the per-core size match
+        # and core-division check are deferred to the solver, so a mismatch there is
+        # ignored -- but the division-invariant preconditions still gate.
+        self.assertTrue(
+            ScratchpadAllocator._inplace_edge_ok(
+                **{
+                    **self._base_kwargs(),
+                    "parent_size_per_core": 999,
+                    "child_core_div_mismatch": True,
+                    "division_invariant": True,
+                }
+            )
+        )
+        for overrides in (
+            {"child_pointwise_inputs": []},
+            {"parent_device_layout": ("other",)},
+            {"parent_end": 4},
+        ):
+            with self.subTest(str(overrides)):
+                self.assertFalse(
+                    ScratchpadAllocator._inplace_edge_ok(
+                        **{
+                            **self._base_kwargs(),
+                            **overrides,
+                            "division_invariant": True,
+                        }
+                    )
+                )
+
+
+class TestBoundaryCloneInPlace(BaseTestScratchpadUsage):
+    """In-place reuse of boundary-clone buffers in the greedy build path (#3212).
+
+    These are assertion-style tests (they inspect the buffers the allocator builds
+    and the final LX addresses), so they live in a plain non-parameterized class
+    rather than the model-sweep ``TestCloneAtGraphBoundaries``."""
+
+    def test_input_clone_reused_in_place_by_last_consumer(self):
+        """The input clone's last consumer names the clone as an in-place parent
+        (issue #3212), so the two may share an LX slot.
+
+        The clone (buffer named after the graph input) is pinned to LX and dies at
+        its last read; when that last reader is pointwise and writes a same-shape
+        buffer that is itself read again (a realized candidate),
+        ``_build_bound_buffers`` marks the clone as that consumer's in-place parent.
+        We capture the buffers the allocator builds and assert the reverse-parent
+        edge is present. Values must be unchanged.
+
+        ``x * 2 + x * 3`` gives x two direct pointwise readers; the second (``x*3``)
+        is x's last read and its output feeds the final add, so that output is a
+        candidate that names the input clone as parent. (A shape like
+        ``torch.abs(x) + x`` would instead have x's last reader be the graph output
+        itself -- single-use, never a candidate -- so no edge, correctly.)"""
+        from torch_spyre._inductor.scratchpad.allocator import ScratchpadAllocator
+
+        x = self.rand_device((64, 1024))
+
+        def fn(x):
+            return x * 2.0 + x * 3.0
+
+        captured: list[list] = []
+        orig = ScratchpadAllocator._build_bound_buffers
+
+        def spy(self, *a, **k):
+            bufs = orig(self, *a, **k)
+            captured.append(list(bufs))
+            return bufs
+
+        with patch.object(ScratchpadAllocator, "_build_bound_buffers", spy):
+            with ts_inductor_config.patch(lx_planning=True):
+                compiled = torch.compile(fn, fullgraph=True)
+                result = compiled(x).to("cpu")
+
+        self.assertTrue(captured, "allocator._build_bound_buffers was not called")
+        edge_found = False
+        for bufs in captured:
+            # Input clones are exactly the buffers whose first access is a read.
+            input_clone_names = {b.name for b in bufs if b.first_use_is_read}
+            if any(set(b.in_place_parents) & input_clone_names for b in bufs):
+                edge_found = True
+                break
+        self.assertTrue(
+            edge_found,
+            "expected the input clone to be named as an in-place parent by its "
+            "last consumer",
+        )
+        self.assertTrue(
+            torch.allclose(fn(x.to("cpu")), result, atol=1e-2, rtol=1e-3),
+            "input clone in-place reuse changed the numerical result",
+        )
+
+    @unittest.skipUnless(_HAS_ORTOOLS, "co-optimizing path needs ortools")
+    def test_input_clone_reverse_parent_in_cooptimizing_path(self):
+        """The co-optimizing (joint CP-SAT) path also lets an input clone's last
+        consumer name it as an in-place parent, with the merge gate populated
+        (issue #3212). Mirrors the placement-path test above on the joint builder."""
+        from torch_spyre._inductor.scratchpad.allocator import CoOptimizingAllocator
+        from torch_spyre._inductor.scratchpad.plan_solver import BufferType
+
+        x = self.rand_device((64, 1024))
+
+        def fn(x):
+            return x * 2.0 + x * 3.0
+
+        captured: list[list] = []
+        orig = CoOptimizingAllocator._build_cd_bound_buffers
+
+        def spy(self, *a, **k):
+            bufs = orig(self, *a, **k)
+            captured.append(list(bufs))
+            return bufs
+
+        with patch.object(CoOptimizingAllocator, "_build_cd_bound_buffers", spy):
+            with ts_inductor_config.patch(
+                lx_planning=True,
+                layout_solver="cpsat",
+                co_optimizing_lx_planning=True,
+            ):
+                result = torch.compile(fn, fullgraph=True)(x).to("cpu")
+
+        self.assertTrue(captured, "_build_cd_bound_buffers was not called")
+        edge_found = False
+        for bufs in captured:
+            input_clones = {b.name for b in bufs if b.boundary == BufferType.Input}
+            for b in bufs:
+                merged = set(b.in_place_parents) & input_clones
+                # The CP-SAT merge also needs the division-match gate populated.
+                if merged and any(p in b.cd_parent_matches for p in merged):
+                    edge_found = True
+                    break
+        self.assertTrue(
+            edge_found,
+            "expected an input clone to be an in-place parent (with a "
+            "cd_parent_matches gate) in the co-optimizing path",
+        )
+        self.assertTrue(
+            torch.allclose(fn(x.to("cpu")), result, atol=1e-2, rtol=1e-3),
+            "co-opt input clone in-place reuse changed the numerical result",
+        )
+
+    def test_output_feeding_buffer_reused_in_place(self):
+        """A buffer feeding a graph output participates in in-place merge via the
+        normal computed-buffer path -- issue #3212's output side needs no dedicated
+        metadata (unlike the input side).
+
+        An LX-pinned buffer that is (or is cloned into) a graph output is a normal
+        op-backed ComputedBuffer, so ``_determine_in_place`` already gives it in-place
+        parents (as a child of its producer's input) and lets consumers name it as a
+        parent. Here ``y`` is a graph output also read internally; its pointwise
+        consumer ``p`` (whose result is itself read, so it is a realized candidate)
+        reuses ``y``'s slot -- i.e. the output-feeding buffer is an in-place parent.
+        This is a regression guard: if output in-place ever breaks, it fails here."""
+        from torch_spyre._inductor.scratchpad.allocator import (
+            ScratchpadAllocator,
+            _op_short_name,
+        )
+
+        x = self.rand_device((64, 1024))
+
+        def fn(x):
+            y = x * 2.0  # graph output, also read internally -> pinned + cloned
+            p = y + 1.0  # p reads y (pointwise) at y's last use
+            q = p * 3.0  # p read by q -> p is a realized candidate
+            return y, q
+
+        output_feeders: set[str] = set()
+        captured: list[list] = []
+        orig = ScratchpadAllocator._build_bound_buffers
+
+        def spy(self, *a, **k):
+            bufs = orig(self, *a, **k)
+            captured.append(list(bufs))
+            return bufs
+
+        def collect_feeders(graph: GraphLowering) -> None:
+            by_name = {op.name: op for op in graph.operations}
+            for name in graph.get_output_names():
+                output_feeders.add(name)
+                op = by_name.get(name)
+                # A graph output that is a clone pins the buffer it copies.
+                if op is not None and _op_short_name(op) == "clone":
+                    output_feeders.update(d.name for d in op.get_read_writes().reads)
+
+        with self.pre_scheduling_iterating_pass(collect_feeders):
+            with patch.object(ScratchpadAllocator, "_build_bound_buffers", spy):
+                with ts_inductor_config.patch(lx_planning=True):
+                    compiled = torch.compile(fn, fullgraph=True)
+                    ry, rq = compiled(x)
+                    ry, rq = ry.to("cpu"), rq.to("cpu")
+
+        self.assertTrue(captured, "allocator._build_bound_buffers was not called")
+        merged = False
+        for bufs in captured:
+            for b in bufs:
+                if not b.in_place_parents:
+                    continue
+                # output feeder as in-place child, or as in-place parent of another.
+                if b.name in output_feeders or (
+                    set(b.in_place_parents) & output_feeders
+                ):
+                    merged = True
+                    break
+        self.assertTrue(
+            merged,
+            "expected a graph-output-feeding buffer to participate in an in-place "
+            "merge (output-clone in-place should work via the normal path)",
+        )
+        ref_y, ref_q = fn(x.to("cpu"))
+        self.assertTrue(
+            torch.allclose(ref_y, ry, atol=1e-2, rtol=1e-3), "output y changed"
+        )
+        self.assertTrue(
+            torch.allclose(ref_q, rq, atol=1e-2, rtol=1e-3), "output q changed"
+        )
+
+    def test_returned_buffer_reused_in_place_is_still_returned_correctly(self):
+        """Aliasing guard: a returned buffer read multiple times internally may have
+        its LX slot reused in-place by its last consumer, yet the value handed to the
+        caller must be intact (issue #3212 aliasing risk).
+
+        ``y`` is returned *and* read three times inside the graph, so it is pinned to
+        LX and copied to HBM for the return. Its last reader ``v`` is pointwise and
+        its result is read again (``u``), so ``v`` is a realized candidate that the
+        allocator may let reuse ``y``'s slot in place. That reuse happens at ``y``'s
+        *last* tick, while the HBM copy of ``y`` is taken at its *first* -- so the
+        returned ``y`` is captured before its slot is overwritten. We assert the
+        reuse edge is actually offered (the hazard is exercised, not vacuous) and
+        that both returned values are correct."""
+        from torch_spyre._inductor.scratchpad.allocator import (
+            ScratchpadAllocator,
+            _op_short_name,
+        )
+
+        x = self.rand_device((64, 1024))
+
+        def fn(x):
+            y = x * 2.0  # returned AND read by z, w, v -> pinned + cloned to HBM
+            z = y * 3.0
+            w = y + z
+            v = y + w  # y's last internal read; v is realized (read by u)
+            u = v + 1.0
+            return y, u
+
+        output_feeders: set[str] = set()
+        captured: list[list] = []
+        orig = ScratchpadAllocator._build_bound_buffers
+
+        def spy(self, *a, **k):
+            bufs = orig(self, *a, **k)
+            captured.append(list(bufs))
+            return bufs
+
+        def collect_feeders(graph: GraphLowering) -> None:
+            by_name = {op.name: op for op in graph.operations}
+            for name in graph.get_output_names():
+                output_feeders.add(name)
+                op = by_name.get(name)
+                if op is not None and _op_short_name(op) == "clone":
+                    output_feeders.update(d.name for d in op.get_read_writes().reads)
+
+        with self.pre_scheduling_iterating_pass(collect_feeders):
+            with patch.object(ScratchpadAllocator, "_build_bound_buffers", spy):
+                with ts_inductor_config.patch(lx_planning=True):
+                    compiled = torch.compile(fn, fullgraph=True)
+                    ry, ru = compiled(x)
+                    ry, ru = ry.to("cpu"), ru.to("cpu")
+
+        # The hazard is real only if a returned (output-feeding) buffer is actually
+        # named as an in-place parent by some consumer.
+        reused = any(
+            set(b.in_place_parents) & output_feeders for bufs in captured for b in bufs
+        )
+        self.assertTrue(
+            reused,
+            "expected the returned buffer's slot to be reused in place (hazard not "
+            "exercised); adjust the graph so the aliasing case is actually tested",
+        )
+        ref_y, ref_u = fn(x.to("cpu"))
+        self.assertTrue(
+            torch.allclose(ref_y, ry, atol=1e-2, rtol=1e-3),
+            "returned buffer y was corrupted by in-place reuse of its slot",
+        )
+        self.assertTrue(
+            torch.allclose(ref_u, ru, atol=1e-2, rtol=1e-3), "output u changed"
+        )
+
+    def test_input_clone_inplace_shares_lx_slot(self):
+        """Peak-LX: the input clone reuses a slot rather than adding one (#3212).
+
+        End-to-end confirmation that the reverse-parent edge actually lowers peak LX:
+        the physical input clone shares its LX address with the consumer that reuses
+        it in place, so it does not occupy a dedicated slot. We read the final LX
+        allocations after the allocator runs and assert the input clone's address is
+        shared by another LX buffer (and values are correct)."""
+        from torch_spyre._inductor.scratchpad.allocator import _op_short_name
+
+        x = self.rand_device((64, 1024))
+
+        def fn(x):
+            return x * 2.0 + x * 3.0
+
+        input_names: set[str] = set()
+        per_op: dict[str, dict] = {}
+
+        def visit(graph: GraphLowering) -> None:
+            input_names.update(graph.graph_input_names)
+            for op in graph.operations:
+                alloc = getattr(
+                    graph.get_buffer(op.name).get_layout(), "allocation", {}
+                )
+                per_op[op.name] = {
+                    "short": _op_short_name(op),
+                    "lx": alloc.get("lx"),
+                    "reads": [d.name for d in op.get_read_writes().reads],
+                }
+
+        with self.pre_scheduling_iterating_pass(visit):
+            with ts_inductor_config.patch(lx_planning=True):
+                result = torch.compile(fn, fullgraph=True)(x).to("cpu")
+
+        # Group LX-resident buffers by address; a shared address == in-place reuse.
+        addr_to_buffers: dict[int, list[str]] = {}
+        for name, info in per_op.items():
+            if info["lx"] is not None:
+                addr_to_buffers.setdefault(info["lx"], []).append(name)
+
+        # The physical input clone: a clone op reading a graph input, LX-resident.
+        input_clones = [
+            name
+            for name, info in per_op.items()
+            if info["short"] == "clone"
+            and info["lx"] is not None
+            and any(r in input_names for r in info["reads"])
+        ]
+        self.assertTrue(input_clones, "expected an LX-resident clone of a graph input")
+        self.assertTrue(
+            any(len(addr_to_buffers[per_op[c]["lx"]]) > 1 for c in input_clones),
+            "input clone occupies a dedicated LX slot -- expected it to share a slot "
+            "with the consumer that reuses it in place (no peak-LX reduction)",
+        )
+        self.assertTrue(
+            torch.allclose(fn(x.to("cpu")), result, atol=1e-2, rtol=1e-3),
+            "input clone slot sharing changed the numerical result",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -1500,23 +1500,23 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                 in_layout = graph.get_buffer(input_buf).layout
                 if not hasattr(in_layout, "device_layout"):
                     continue
-                in_end = lifetimes[input_buf][-1]  # inclusive last use
                 in_ten_layout = in_layout.device_layout
-                # This duplicates the division-invariant subset of
-                # ``_inplace_edge_ok`` (layout match + single handoff tick; per-core
-                # size and core-division deferred to the solver). The helper now
-                # expresses exactly this via ``division_invariant=True`` and is used
-                # for the boundary-clone reverse-parent edges in
-                # ``_build_cd_bound_buffers`` -- but this producer->output loop still
-                # inlines the check and omits the helper's per-input
-                # pointwise-eligibility test (``input_buf in in_place_allowed``),
-                # a likely-unintended divergence that is benign today because
-                # pointwise-tagged ops expose all reads.
-                # TODO(follow-up): route this loop through ``_inplace_edge_ok`` too,
-                # resolving the per-input divergence with test coverage.
-                inp_i_lay_match = out_ten_layout == in_ten_layout
-                inp_i_eol = in_end == out_start  # same op reads input, writes output
-                if inp_i_lay_match and inp_i_eol:
+                # The division-invariant edge gate (layout match + single handoff
+                # tick; per-core size and core-division deferred to the solver). The
+                # ``division_invariant`` mode also applies the per-input
+                # pointwise-eligibility test (``input_buf in in_place_allowed``): for
+                # pointwise-tagged ops that is every read (a no-op), but for a
+                # non-tagged Pointwise op it drops an input read at a different index
+                # than the output write -- which must not be aliased over the output.
+                if self._inplace_edge_ok(
+                    child_pointwise_inputs=in_place_allowed[buf_name],
+                    parent_name=input_buf,
+                    child_device_layout=out_ten_layout,
+                    parent_device_layout=in_ten_layout,
+                    child_start=out_start,
+                    parent_end=lifetimes[input_buf][-1],  # inclusive last use
+                    division_invariant=True,
+                ):
                     allow_inplace[buf_name].append(input_buf)
         return allow_inplace
 

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -342,6 +342,13 @@ class ScratchpadAllocator:
             ncores = get_ncores_for_buffers(
                 graph, cache, reject_reasons_out=core_div_reasons
             )
+            # Consumer buffers already built above (intermediates + graph outputs),
+            # indexed for the reverse-parent edge below. A graph-input clone can
+            # only ever be an in-place *parent* -- it is pinned to LX and dies at
+            # its last read, and its source stays in HBM (not an LX candidate), so
+            # it has no parent of its own. The value is letting the consumer that
+            # performs that last read reuse the clone's slot for its own output.
+            built_by_name = {b.name: b for b in buffers}
             for input_name in graph.graph_input_names:
                 uses = lifetimes[input_name]
                 if len(uses) <= 1:
@@ -370,10 +377,11 @@ class ScratchpadAllocator:
                 buf = graph.get_buffer(input_name)
                 dev_layout = buf.layout.device_layout
                 dev_size = math.prod(dev_layout.device_size[:-1]) * 128
+                clone_size = dev_size // num_cores
                 buffers.append(
                     LifetimeBoundBuffer(
                         input_name,
-                        dev_size // num_cores,
+                        clone_size,
                         uses,
                         first_use_is_read=True,
                         in_place_parents=[],
@@ -383,7 +391,100 @@ class ScratchpadAllocator:
                     )
                 )
 
+                # Reverse-parent edge (issue #3212): let the input clone's last
+                # consumer reuse the clone's LX slot in place. The op at the
+                # clone's last-use tick both reads the clone and writes its own
+                # output, so the single-handoff-tick invariant holds for that
+                # consumer alone -- enforced by ``_inplace_edge_ok``'s
+                # ``parent_end == child_start`` check. Only emit the edge when the
+                # consumer is itself an LX candidate (built above) with matching
+                # per-core size, device layout, a pointwise producer, and no
+                # core-division mismatch; otherwise there is nothing safe to merge.
+                last_use = uses[-1]
+                consumer_op = graph.operations[last_use]
+                consumer = built_by_name.get(consumer_op.name)
+                if consumer is None:
+                    continue
+                if input_name in consumer.in_place_parents:
+                    continue
+                # A multi-output op (e.g. max/aminmax, which returns values *and*
+                # indices) carries a MultiOutputLayout with no single
+                # ``device_layout``, so it cannot alias one input clone in place.
+                # Candidates in ``built_by_name`` always have a device_layout (they
+                # cleared the back-gap probe above), so this is defensive -- but it
+                # keeps the safety local rather than relying on that invariant, and
+                # matches the guard in ``_determine_in_place_division_invariant``.
+                consumer_layout = graph.get_buffer(consumer_op.name).get_layout()
+                if not hasattr(consumer_layout, "device_layout"):
+                    continue
+                if self._inplace_edge_ok(
+                    child_pointwise_inputs=self._op_inputs_good_for_lx_inplace(
+                        consumer_op
+                    ),
+                    parent_name=input_name,
+                    child_size_per_core=consumer.size,
+                    parent_size_per_core=clone_size,
+                    child_device_layout=consumer_layout.device_layout,
+                    parent_device_layout=dev_layout,
+                    child_start=lifetimes[consumer_op.name][0],
+                    parent_end=last_use,
+                    child_core_div_mismatch=mem_usage[consumer_op.name][
+                        "core_div_mismatch"
+                    ],
+                ):
+                    consumer.in_place_parents.append(input_name)
+
         return buffers
+
+    @staticmethod
+    def _inplace_edge_ok(
+        *,
+        child_pointwise_inputs: list[str],
+        parent_name: str,
+        child_device_layout: Any,
+        parent_device_layout: Any,
+        child_start: int,
+        parent_end: int,
+        child_size_per_core: Optional[int] = None,
+        parent_size_per_core: Optional[int] = None,
+        child_core_div_mismatch: bool = False,
+        division_invariant: bool = False,
+    ) -> bool:
+        """Whether ``parent_name`` may be reused in place by the child buffer.
+
+        The child (which writes at ``child_start``) reuses the parent's storage,
+        so the parent must die exactly as the child is born. The conditions:
+
+        - the parent is a pointwise-eligible read input of the child;
+        - matching device layout (so the storage can alias);
+        - single handoff tick (``parent_end == child_start``: the same op that reads
+          the parent as its last use writes the child), the invariant the solvers'
+          in-place relaxation relies on (see ``_assert_in_place_relationships``);
+        - matching per-core footprint and no core-division mismatch on the child.
+
+        With ``division_invariant`` the last condition (per-core size + core-div) is
+        skipped: those depend on a core division the joint solver has not chosen
+        yet, so it enforces them itself (``eff_size`` equality + the
+        ``cd_parent_matches`` gate). Only the division-invariant preconditions are
+        checked -- mirroring ``_determine_in_place_division_invariant``, but keeping
+        the per-input pointwise-eligibility check the latter omits.
+
+        This is the sole definition of a legal in-place edge, shared by
+        ``_determine_in_place`` / ``_build_bound_buffers`` (placement path) and
+        ``_build_cd_bound_buffers`` (co-optimizing path), so they cannot drift.
+        """
+        base_ok = (
+            parent_name in child_pointwise_inputs
+            and child_device_layout == parent_device_layout
+            and parent_end == child_start
+        )
+        if division_invariant:
+            return base_ok
+        return (
+            base_ok
+            and child_size_per_core == parent_size_per_core
+            and not child_core_div_mismatch
+        )
 
     def _determine_in_place(
         self,
@@ -407,19 +508,17 @@ class ScratchpadAllocator:
             for input_buf in info["op_inputs"]:
                 if input_buf not in mem_usage or not lifetimes[input_buf]:
                     continue
-                in_end = lifetimes[input_buf][-1]  # inclusive last use
                 in_ten_layout = graph.get_buffer(input_buf).get_layout().device_layout
-                in_size = mem_usage[input_buf]["size_per_core"]
-                inp_i_size_match = out_size == in_size
-                inp_i_lay_match = out_ten_layout == in_ten_layout
-                inp_i_eol = in_end == out_start  # same op reads input and writes output
-                no_core_div_mismatch = not info["core_div_mismatch"]
-                if (
-                    input_buf in in_place_allowed[buf_name]
-                    and inp_i_size_match
-                    and inp_i_lay_match
-                    and inp_i_eol
-                    and no_core_div_mismatch
+                if self._inplace_edge_ok(
+                    child_pointwise_inputs=in_place_allowed[buf_name],
+                    parent_name=input_buf,
+                    child_size_per_core=out_size,
+                    parent_size_per_core=mem_usage[input_buf]["size_per_core"],
+                    child_device_layout=out_ten_layout,
+                    parent_device_layout=in_ten_layout,
+                    child_start=out_start,
+                    parent_end=lifetimes[input_buf][-1],  # inclusive last use
+                    child_core_div_mismatch=info["core_div_mismatch"],
                 ):
                     allow_inplace[buf_name].append(input_buf)
         return allow_inplace
@@ -1403,6 +1502,18 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                     continue
                 in_end = lifetimes[input_buf][-1]  # inclusive last use
                 in_ten_layout = in_layout.device_layout
+                # This duplicates the division-invariant subset of
+                # ``_inplace_edge_ok`` (layout match + single handoff tick; per-core
+                # size and core-division deferred to the solver). The helper now
+                # expresses exactly this via ``division_invariant=True`` and is used
+                # for the boundary-clone reverse-parent edges in
+                # ``_build_cd_bound_buffers`` -- but this producer->output loop still
+                # inlines the check and omits the helper's per-input
+                # pointwise-eligibility test (``input_buf in in_place_allowed``),
+                # a likely-unintended divergence that is benign today because
+                # pointwise-tagged ops expose all reads.
+                # TODO(follow-up): route this loop through ``_inplace_edge_ok`` too,
+                # resolving the per-input divergence with test coverage.
                 inp_i_lay_match = out_ten_layout == in_ten_layout
                 inp_i_eol = in_end == out_start  # same op reads input, writes output
                 if inp_i_lay_match and inp_i_eol:
@@ -1533,6 +1644,11 @@ class CoOptimizingAllocator(ScratchpadAllocator):
         )
 
         input_clone_matches: dict[str, dict[str, list[tuple[int, int]]]] = {}
+        # Consumer op name -> input clones for which it is the last reader, and so
+        # may reuse the clone's LX slot in place (reverse-parent, #3212). Stays
+        # empty unless cloning is on, making the reverse-parent block in the output
+        # loop a no-op otherwise.
+        last_consumer_clones: dict[str, list[str]] = {}
         if clone_at_graph_boundaries():
             buffer_users = get_buffer_users(graph)
             for input_name in self._eligible_clone_inputs(graph, lifetimes):
@@ -1548,6 +1664,13 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                     continue
                 input_clone_matches[input_name] = matches
                 residency_by_buf[input_name] = None
+                # Only the op at the clone's last-use tick both reads the clone and
+                # writes its own output, so only it satisfies the single handoff
+                # tick for reusing the clone's slot in place.
+                last_use = lifetimes[input_name][-1]
+                last_consumer_clones.setdefault(
+                    graph.operations[last_use].name, []
+                ).append(input_name)
                 dev_layout = graph.get_buffer(input_name).layout.device_layout
                 size = math.prod(dev_layout.device_size[:-1]) * 128
                 buffers.append(
@@ -1572,7 +1695,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             residency_reason = residency_by_buf[output_name]
 
             buf_divisions = divisions[output_name]
-            parents = in_place.get(output_name, [])
+            parents = list(in_place.get(output_name, []))
             size = info["size"]  # total footprint; solver divides per chosen cd
             parent_proj = info["op_inputs"].copy()
             cd_parent_matches = self._cd_parent_matches(
@@ -1590,6 +1713,36 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                     cd_parent_matches[input_name] = input_clone_matches[input_name][
                         output_name
                     ]
+
+            # Reverse-parent edge (#3212): when this op is an input clone's last
+            # reader, let it reuse the clone's LX slot in place. Division-invariant
+            # gate (pointwise child reading the clone + matching device layout;
+            # single tick guaranteed by "last reader"); per-core size and core
+            # division are deferred to the solver, which also gates the merge on the
+            # cd_parent_matches entry set just above. Multi-output ops carry a
+            # MultiOutputLayout with no single device_layout and cannot alias one
+            # clone, so they are skipped.
+            out_layout = graph.get_buffer(output_name).get_layout()
+            for clone_name in last_consumer_clones.get(output_name, []):
+                if clone_name in parents:
+                    continue
+                clone_layout = graph.get_buffer(clone_name).get_layout()
+                if (
+                    op is None
+                    or not hasattr(out_layout, "device_layout")
+                    or not hasattr(clone_layout, "device_layout")
+                ):
+                    continue
+                if self._inplace_edge_ok(
+                    child_pointwise_inputs=self._op_inputs_good_for_lx_inplace(op),
+                    parent_name=clone_name,
+                    child_device_layout=out_layout.device_layout,
+                    parent_device_layout=clone_layout.device_layout,
+                    child_start=uses[0],
+                    parent_end=lifetimes[clone_name][-1],
+                    division_invariant=True,
+                ):
+                    parents.append(clone_name)
 
             buffers.append(
                 CoreDivisionBuffer(

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -323,7 +323,10 @@ class ScratchpadAllocator:
                 continue
 
             uses = lifetimes[output_name]
-            parents = in_place.get(output_name, [])
+            # Copy: the reverse-parent block below appends to a consumer's
+            # in_place_parents, which would otherwise mutate this list in the shared
+            # ``in_place`` dict (matches the copy in ``_build_cd_bound_buffers``).
+            parents = list(in_place.get(output_name, []))
             size = info["size_per_core"]
 
             buffers.append(
@@ -465,13 +468,13 @@ class ScratchpadAllocator:
         With ``division_invariant`` the last condition (per-core size + core-div) is
         skipped: those depend on a core division the joint solver has not chosen
         yet, so it enforces them itself (``eff_size`` equality + the
-        ``cd_parent_matches`` gate). Only the division-invariant preconditions are
-        checked -- mirroring ``_determine_in_place_division_invariant``, but keeping
-        the per-input pointwise-eligibility check the latter omits.
+        ``cd_parent_matches`` gate). Only the first three (division-invariant)
+        preconditions are checked.
 
         This is the sole definition of a legal in-place edge, shared by
         ``_determine_in_place`` / ``_build_bound_buffers`` (placement path) and
-        ``_build_cd_bound_buffers`` (co-optimizing path), so they cannot drift.
+        ``_determine_in_place_division_invariant`` / ``_build_cd_bound_buffers``
+        (co-optimizing path), so they cannot drift.
         """
         base_ok = (
             parent_name in child_pointwise_inputs


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Enables **in-place reuse of input boundary-clone buffers** in LX scratchpad planning.

When boundary cloning pins a graph input into LX, the clone buffer was built with empty in-place metadata in **both** allocators (`_build_bound_buffers` and `_build_cd_bound_buffers`), so it always occupied its own dedicated LX slot and could never share storage — working against the point of cloning (fit more data into LX).

An input clone is produced when the clone runs and dies at its last read, and its source stays in HBM (not an LX candidate), so it can only ever be an in-place **parent**. This PR lets the clone's **last reader** reuse its slot: that reader is the only consumer satisfying the single-handoff-tick invariant (its op both reads the clone as the clone's final use and writes its own output), and if it passes the in-place compatibility gate, it names the clone in its `in_place_parents`.

- **Placement allocator** (`_build_bound_buffers`): full gate — pointwise producer, matching per-core size and device layout, single tick, no core-division mismatch.
- **Co-optimizing allocator** (`_build_cd_bound_buffers`): division-invariant subset of the gate; per-core size and core division are deferred to the CP-SAT solver (`eff_size` equality + the `cd_parent_matches` gate already wired for the clone's residency edge).

The gate is factored into one predicate, `_inplace_edge_ok` (with a `division_invariant` flag selecting the subset), shared across paths so they can't drift. A follow-up commit routes `_determine_in_place_division_invariant`'s producer→output edges through the same predicate, closing a per-input pointwise-eligibility divergence.

**This PR is input-only by design.** The issue reads as though both input and output boundary clones carried empty in-place metadata, but that was only true for inputs. An output clone is the graph-output buffer itself — a normal op-backed `ComputedBuffer`, pinned to LX and copied to HBM by the clone — so it already receives in-place parents from the normal producer path (`_determine_in_place` / `_determine_in_place_division_invariant`) and is already named as a parent by downstream consumers, in both allocators and both directions. That behaviour predates this PR (the co-optimizing side coming from #3154); it is verified end-to-end here rather than adding redundant output-side metadata.

#### Which issue(s) this PR is related to:

Fixes #3212

#### Special notes for your reviewer:

- **Three commits:** (1) `feat` — the input reverse-parent edge in both allocators + the shared `_inplace_edge_ok` gate; (2) `refactor` — route the co-opt division-invariant gate through that predicate; (3) `test` — polish from a pre-submission review (see the PR comment).
- **All solvers honour it:** greedy/firstfit/bestfit/simulated_annealing read `in_place_parents` directly; CP-SAT (placement-only and co-optimizing) via the merge relaxation + `cd_parent_matches`. The `BufferType.Input/Output/Intermediate` field only affects spill cost, not merge eligibility.
- **Output-clone verification:** confirmed both directions (output as in-place child of its producer's input, and as in-place parent of a downstream consumer) on real graphs, in the greedy and co-optimizing paths.
- **Multi-output consumers** (a `MultiOutputLayout` with no single `device_layout`, e.g. `max`-with-indices) can't alias one clone and are skipped in both paths.
- **Aliasing safety:** the source input stays untouched in HBM; the clone is dead after its last read (the reuse tick). For a returned buffer whose slot is reused in place, the HBM copy is taken at the buffer's *first* use while reuse happens only at its *last*, so the caller's value is captured before the slot is overwritten (dedicated regression tests on both paths).
- **Tests:** reverse-parent edge on both paths, output-feeding in-place, returned-buffer aliasing safety (both paths), peak-LX slot sharing, the `_inplace_edge_ok` gate (incl. `division_invariant` mode), and the division-invariant per-input invariant. Full scratchpad suite green (316 passed / 11 xfailed); pre-commit clean.

#### Does this PR introduce a user-facing change?

No. Boundary cloning is already enabled by default (`clone_at_graph_boundaries()`); this only changes LX-planning metadata when a clone is pinned. No new config or API.

#### Additional note:

Rebased on current `main` (includes the recent CP-SAT input/output cloning work, #2907/#3154, and the simulated-annealing solver, #2660). No outstanding follow-ups: the second commit completed the one previously-flagged TODO — routing `_determine_in_place_division_invariant` through `_inplace_edge_ok` — and I'm not aware of remaining boundary-clone in-place gaps.
