### PR TITLE
Implement tiling_expr_to_device_expr

### DIFF
--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -27,7 +27,7 @@ from torch_spyre._inductor.propagate_layouts import (
     PropArg,
     _check_supported_input_sticks,
 )
-from torch_spyre._inductor.views import compute_coordinates
+from torch_spyre._inductor.views import compute_coordinates, tiling_expr_to_device_expr
 from torch.utils._sympy.functions import ModularIndexing
 
 p0, p1, p2, p3, p4, p5 = sympy.symbols("p0 p1 p2 p3 p4 p5", integer=True)
@@ -269,6 +269,20 @@ class TestUnrepresentableStickCandidates(TestCase):
         dep, bad, _ = self._traced_scenario()
         arg = PropArg(dep, None, [bad])
         _check_supported_input_sticks([arg], "batchmatmul")  # must not raise
+
+
+class TestTilingExprToDeviceExpr(TestCase):
+    def test_tiling_expr_row_major(self):
+        # [1024, 4096] tensor tiled 2x4 times (generic stick format)
+        index = 4096 * 512 * p0 + 1024 * p1
+        result = tiling_expr_to_device_expr([64, 1024, 64], [64, 4096, 1], index)
+        self.assertEqual(result, 32768 * p0 + 1048576 * p1)
+
+    def test_tiling_expr_column_major(self):
+        # [4096, 1024] tensor tiled 4x2 times (generic stick format) transposed before use
+        index = 512 * p0 + 1024 * 1024 * p1
+        result = tiling_expr_to_device_expr([16, 4096, 64], [64, 1024, 1], index)
+        self.assertEqual(result, 2097152 * p0 + 65536 * p1)
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -775,3 +775,37 @@ def align_tensors(
     }
 
     return new_iteration_space, new_tensors
+
+
+def tiling_expr_to_device_expr(
+    device_size: Sequence[sympy.Expr],
+    stride_map: Sequence[sympy.Expr],
+    index: sympy.Expr,
+) -> sympy.Expr:
+    """
+    Convert a tile offset expression (index) to a device layout (device_size and
+    stride_map)
+    """
+
+    assert all(isinstance(s, (int, sympy.Integer)) for s in device_size), (
+        f"tiling_expr_to_device_expr requires a concrete device_size, got {device_size}"
+    )
+    assert all(isinstance(s, (int, sympy.Integer)) for s in stride_map), (
+        f"tiling_expr_to_device_expr requires a concrete stride_map, got {stride_map}"
+    )
+
+    out = sympy.S.Zero
+    n = len(stride_map)
+    vars = index.free_symbols
+    for var in vars:
+        step = index.xreplace({var: 1}).xreplace({v: 0 for v in vars})
+        j = n - 1  # device dimension for var
+        for i in range(n - 1):
+            if (
+                device_size[i] > 1
+                and stride_map[i] > stride_map[j]
+                and stride_map[i] <= step
+            ):
+                j = i
+        out += var * math.prod(device_size[j + 1 : n]) * step // stride_map[j]
+    return out


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [X] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR implements a function to convert an index expression expressing a PyTorch offset to an expression producing the equivalent offset for a given device layout.

This function is intended to be used for index expressions that point to the offset of the first element of a tile in a tensor.

Logically, the function is equivalent to converting an index expression into device coordinates and then converting the device coordinates into an index by computing the sum of the products of device coordinates and device strides. The direct implementation ensures the resulting index is expressed as a linear combination of variables without repetitions or integer division and modulo operations.


#### Which issue(s) this PR is related to:

This is required to implement coarse tiling (#206).

#### Does this PR introduce a user-facing change?

No