### PR TITLE
Fix incorrect assumption in tiling_expr_to_device_expr

### DIFF
--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -284,6 +284,13 @@ class TestTilingExprToDeviceExpr(TestCase):
         result = tiling_expr_to_device_expr([16, 4096, 64], [64, 1024, 1], index)
         self.assertEqual(result, 2097152 * p0 + 65536 * p1)
 
+    def test_tiling_expr_row_major_transposed_restickified(self):
+        # [1024, 4096] tensor tiled 2x4 times (generic stick format) transposed
+        # and restickified before use
+        index = 512 * p0 + 1024 * 1024 * p1
+        result = tiling_expr_to_device_expr([64, 1024, 64], [65536, 1, 1024], index)
+        self.assertEqual(result, 32768 * p0 + 1048576 * p1)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -799,11 +799,11 @@ def tiling_expr_to_device_expr(
     vars = index.free_symbols
     for var in vars:
         step = index.xreplace({var: 1}).xreplace({v: 0 for v in vars})
-        j = n - 1  # device dimension for var
-        for i in range(n - 1):
+        j = -1  # device dimension for var
+        for i in range(n):
             if (
                 device_size[i] > 1
-                and stride_map[i] > stride_map[j]
+                and stride_map[i] > (stride_map[j] if j != -1 else 0)
                 and stride_map[i] <= step
             ):
                 j = i


### PR DESCRIPTION
#### What type of PR is this?

- [X] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fix a confusion between `stride_map` and device stride in `tiling_expr_to_device_expr`.

#### Does this PR introduce a user-facing change?

No
