### PR TITLE
feat(scratchpad): native C++ packer for the SA layout solver (+ resize/set_eligible)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,8 @@ Test sub-suites:
 | `SENCORES` | Number of Spyre cores (1–32, default 32) |
 | `LX_PLANNING=1` | Enable LX scratchpad memory planning |
 | `HBM_POOL_PLANNING=1` | Enable HBM-pool planning for intermediates not in LX |
-| `LAYOUT_SOLVER` | LX layout solver: `greedy` (default), `firstfit`, `bestfit`, `cpsat` |
+| `LAYOUT_SOLVER` | LX layout solver: `greedy` (default), `firstfit`, `bestfit`, `cpsat`, `simulated_annealing` |
+| `TORCH_SPYRE_NATIVE_PACKER` | Use the C++ layout packer in the `simulated_annealing` solver (default `1`; `0` = pure Python) |
 | `TORCH_LOGS="+inductor"` | Verbose Inductor logging |
 | `TORCH_COMPILE_DEBUG=1` | Dump Inductor debug artifacts |
 | `TORCH_SPYRE_DOWNCAST_WARN=0` | Suppress int64→int32 downcast warnings |

--- a/docs/source/api/torch_spyre.rst
+++ b/docs/source/api/torch_spyre.rst
@@ -635,6 +635,12 @@ Environment Variables
    * - ``SPYRE_LOG_PASSES``
      - Comma-separated list of pass names after which to log the
        op-spec IR at pipeline stage boundaries (default empty)
+   * - ``TORCH_SPYRE_NATIVE_PACKER``
+     - Use the C++ permutation-layout packer accelerator in the
+       simulated-annealing layout solver (default ``1``; set ``0`` to force
+       the pure-Python packer). No effect unless
+       ``LAYOUT_SOLVER=simulated_annealing``.
+       See :doc:`/compiler/simulated_annealing_layout`
    * - ``MAX_BUCKETS``
      - Maximum number of work division buckets (default ``32``)
    * - ``MIN_DEFAULT_GRANULARITY``

--- a/docs/source/compiler/index.rst
+++ b/docs/source/compiler/index.rst
@@ -61,4 +61,5 @@ test coverage, bug classification), see :doc:`/contributing/op_enablement`.
    work_division_planning
    scratchpad_planning
    simulated_annealing_layout
+   native_packer_performance
    hbm_pool_planning

--- a/docs/source/compiler/native_packer_performance.md
+++ b/docs/source/compiler/native_packer_performance.md
@@ -1,0 +1,160 @@
+# Native packer performance
+
+**Measured 2026-08-12.** These numbers describe the C++
+`NativePermutationLayoutSolver` as it stood when it became the default packer for
+the simulated-annealing layout solver. They are a snapshot, not a contract: re-run
+the harness rather than trusting them after the packer, the annealing driver, or
+the cost model changes.
+
+Harness:
+[`docs/source/user_guide/examples/scratchpad/profile_native_packer.py`](../user_guide/examples/index.md).
+Every invocation below prints the tables it produced and can emit the raw
+per-instance timings with `--json`.
+
+## What is being compared
+
+The permutation packer that the annealing search drives has two interchangeable
+implementations — the canonical Python `PermutationBasedLayoutSolver` and the C++
+accelerator — selected by `config.native_layout_packer` /
+`TORCH_SPYRE_NATIVE_PACKER`. They are behaviourally identical, asserted
+bit-for-bit by the differential and SA-equivalence suites. See
+[Simulated annealing layout planner](simulated_annealing_layout.md).
+
+That identity is what makes the comparison clean: layout quality is not a random
+variable across the two arms, so **time is the only thing under test**.
+
+## Method
+
+- Both arms solve **the same instance**, and the ratio is formed per instance.
+  Dividing summed per-size totals — the obvious shortcut — makes dispersion
+  unrecoverable.
+- Timed region is solver construction plus `plan_layout()` (solve and finalize).
+  `deepcopy` of the buffer list is deliberately outside it: at ~0.6–1% of a native
+  solve it is small, but it is an additive constant present in both arms, so
+  including it biases every ratio toward 1.
+- Arm order alternates per repeat, so CPU frequency or thermal drift cannot
+  systematically favour whichever arm runs first.
+- Repeats are reduced by **min** — timing noise is one-sided, so the minimum is
+  the better estimate of true cost. The median-of-repeats is computed too and
+  agrees.
+- Wall (`perf_counter`) and CPU (`process_time`) time are both recorded. In the
+  runs below they agree to three decimal places, which is the evidence that
+  nothing else on the machine perturbed them.
+- An `isinstance` check runs per solve, so a mis-selected packer cannot silently
+  turn this into a native-versus-native measurement.
+- Instances whose annealing search takes fewer than `--min-steps` steps are
+  reported separately. If the initial layout is already optimal, `solve()` returns
+  immediately and the timing reflects construction, not the packer.
+- Per size the harness reports median paired ratio, IQR, percentile bootstrap 95%
+  confidence interval (20k resamples), win count, and a one-sided sign test.
+
+Instances come from the `_random_buffers` generator in
+`tests/inductor/test_perm_layout_solver.py` — the same one the differential and
+SA-equivalence suites drive, so the benchmark and correctness workloads share a
+distribution. `horizon=12` (heavy lifetime overlap), `max_size=200`, 25% in-place
+child probability, default reheating schedule.
+
+The step budget is a deterministic function of size: 500 steps for n≤16, 960 at
+n=32, 1920 at n=64, 3840 at n=128, and 5000 (capped) at n=256.
+
+Environment for the numbers below: single x86_64 dev box (128 cores), Python
+3.12.13, `_C` built `-O3 -DNDEBUG`, BLAS/OMP threads pinned to 1,
+`TORCH_DEVICE_BACKEND_AUTOLOAD=0`. No accelerator is involved — layout planning is
+single-threaded CPU work.
+
+## Capacity pressure is the dominant variable
+
+Scratchpad capacity matters more than problem size, so quote the rule with any
+number. `--cap-rule` selects it:
+
+| rule | capacity | character |
+|---|---|---|
+| `3xmax` | 3 × largest buffer | does not scale with footprint: pressure climbs with n, and at n=128 only ~25 of 128 buffers place at all |
+| `foot4` | footprint // 4 | tight, but pressure holds constant as n grows |
+| `foot2` | footprint // 2 | representative; most buffers place |
+
+## Results
+
+Median paired speedup (Python ÷ native) with bootstrap 95% CI, 15 seeds per cell.
+`placed` is how many buffers were allocated; the rest are evicted.
+
+| n | `3xmax` | placed | `foot4` | placed | `foot2` | placed |
+|--:|--:|--:|--:|--:|--:|--:|
+| 8 | 10.56× [3.97, 11.92] | 6/8 | 7.39× [6.00, 8.06] | 2/8 | 9.19× [8.14, 10.39] | 4/8 |
+| 16 | 11.08× [10.23, 11.86] | 10/16 | 9.86× [9.57, 10.10] | 6/16 | 12.04× [11.50, 13.39] | 11/16 |
+| 32 | 10.70× [9.81, 11.35] | 15/32 | 11.14× [10.52, 11.98] | 14/32 | 14.60× [13.69, 15.31] | 25/32 |
+| 64 | 10.68× [10.27, 11.16] | 21/64 | 14.41× [12.83, 14.54] | 40/64 | 16.32× [15.76, 17.48] | 58/64 |
+| 128 | 10.52× [10.35, 11.63] | 25/128 | 13.94× [13.09, 14.19] | 74/128 | 14.31× [13.61, 15.02] | 108/128 |
+| 256 | 7.59× [6.05, 10.71]¹ | 34/256 | — | — | 5.79× [4.83, 7.15]¹ | 214/256 |
+
+¹ 5 and 3 seeds respectively, one repeat — indicative only.
+
+Pooled over n=8–128:
+
+| rule | median | 95% CI | paired wins | sign test |
+|---|--:|--:|--:|--:|
+| `3xmax` | **10.62×** | [10.49, 11.08] | 75/75 | p = 3.1e-5 |
+| `foot4` | **11.34×** | [10.52, 12.44] | 75/75 | p = 3.1e-5 |
+| `foot2` | **13.93×** | [13.50, 14.50] | 74/75 | p = 6.1e-5 |
+
+Absolute scale, `foot2`: at n=128 a solve takes 1.64 s native against 23.0 s
+Python; at n=32, 49 ms against 713 ms.
+
+Across all 233 instances and 1066 timed solves, finalized addresses and
+`quality()` were identical between the two arms — zero mismatches.
+
+## Reading the numbers
+
+**The win is a large constant factor, and it erodes as n grows.** It is not an
+asymptotic improvement. Per-step cost under `foot2`:
+
+| n | native µs/step | Python µs/step | ratio | growth vs previous n |
+|--:|--:|--:|--:|---|
+| 8 | 15.9 | 146.5 | 9.19× | — |
+| 16 | 27.0 | 334.7 | 12.04× | native ×1.70, Python ×2.28 |
+| 32 | 51.1 | 742.7 | 14.60× | native ×1.89, Python ×2.22 |
+| 64 | 113.7 | 1902.7 | 16.32× | native ×2.23, Python ×2.56 |
+| 128 | 428.0 | 6001.6 | 14.31× | native ×3.76, Python ×3.15 |
+| 256 | 2950.6 | 17083.0 | 5.79× | native ×6.89, Python ×2.85 |
+
+Past n≈128 the native per-step cost grows faster than the Python one, which
+follows from the design. The native packer recomputes placement from scratch in
+permutation order after every operation; the Python packer is genuinely
+incremental, splicing contact profiles. The port buys a very large constant factor
+by deleting per-operation interpreter and pybind overhead, at the cost of the
+incremental algorithm, so its advantage narrows as the recompute grows. Earlier
+profiling put the crossover with a truly incremental C++ packer near n≈640.
+
+Two things bound how much that matters. Captured real graphs run n≈5–80, which is
+the 12–16× region under representative capacity. And the large-n cells are a
+stress probe rather than a prediction: `horizon` stays at 12 as n grows, so at
+n=256 nearly every buffer overlaps nearly every other, far denser than a real
+schedule.
+
+**Small sizes have degenerate cells.** Under `3xmax`, five of fifteen n=8
+instances have an already-optimal initial layout, run 0–20 annealing steps, and
+therefore time construction rather than the packer. They are the source of the
+1.30–5.63× tail. `--min-steps` excludes them; the tables above use it.
+
+**Where the remaining time goes.** Sampling profiles taken while developing the
+`max_top_at_` fast path put `RecomputeAll` at roughly 40% of solve self-time, with
+about a 60/40 C++/Python split overall, and the candidate gather at about
+two-thirds of `RecomputeAll`. The residual Python share is the annealing driver's
+own move logic plus per-call round trips (`is_fully_allocated`, `quality`,
+`overlaps`), each a separate pybind crossing — a plausible second-order target,
+well behind the recompute.
+
+## Not covered
+
+- **Captured graphs.** All instances are synthetic; the capture loader and its
+  data are not available here. Real graphs have sparser in-place reuse and
+  lifetimes spread over a longer schedule, both of which should favour the native
+  packer more than these instances do.
+- **Iso-time quality.** At equal step count the two arms produce identical
+  layouts, so "more steps in the same wall clock yields better layouts" needs a
+  separate matched-budget run.
+- **The packer in isolation.** These figures are end-to-end through the annealing
+  solver, which is what a compile experiences. A microbenchmark of the packer
+  alone, driven by a synthetic operation mix, gives substantially higher ratios
+  and is not directly comparable.
+- **One machine.** No cross-machine or cross-toolchain variance.

--- a/docs/source/compiler/simulated_annealing_layout.md
+++ b/docs/source/compiler/simulated_annealing_layout.md
@@ -37,7 +37,11 @@ interchangeable implementations: the canonical Python
 (`csrc/perm_layout_native.cpp`) that is the default. They are behaviourally
 identical — the differential and SA-equivalence tests assert bit-for-bit
 agreement on addresses, quality, allocation count, and per-operation deltas —
-and the C++ one is substantially faster. Select the Python packer explicitly with
+and the C++ one is substantially faster: measured at roughly 14× end-to-end on
+mid-sized problems at representative capacity, though the margin depends on
+capacity pressure and narrows as the problem grows. See
+[Native packer performance](native_packer_performance.md) for the measurements
+and the harness that produced them. Select the Python packer explicitly with
 `config.native_layout_packer = False` or `TORCH_SPYRE_NATIVE_PACKER=0`. Because
 the `_C` extension is required for torch-spyre to function at all, a missing
 native packer means a stale or incomplete build and raises rather than silently

--- a/docs/source/compiler/simulated_annealing_layout.md
+++ b/docs/source/compiler/simulated_annealing_layout.md
@@ -25,8 +25,11 @@ which contains the following files.
   orders (following a paper by Imanishi & Xu) that drives the permutation solver by composition. It
   is wired in as the opt-in `layout_solver = "simulated_annealing"` config option; the default stays
   `greedy`.
-- **`benchmarks/`** and **`examples/scratchpad/`** — profiling scripts, result docs, and runnable
-  examples.
+
+Runnable examples that drive the solver in isolation — a fixed-ordering layout plot,
+a first-fit vs simulated-annealing quality comparison, and an in-place convergence
+study — live in
+[`docs/source/user_guide/examples/scratchpad/`](../user_guide/examples/index.md).
 
 **Native packer.** The permutation packer the search drives has two
 interchangeable implementations: the canonical Python

--- a/docs/source/compiler/simulated_annealing_layout.md
+++ b/docs/source/compiler/simulated_annealing_layout.md
@@ -28,6 +28,18 @@ which contains the following files.
 - **`benchmarks/`** and **`examples/scratchpad/`** — profiling scripts, result docs, and runnable
   examples.
 
+**Native packer.** The permutation packer the search drives has two
+interchangeable implementations: the canonical Python
+`PermutationBasedLayoutSolver` and a C++ accelerator
+(`csrc/perm_layout_native.cpp`) that is the default. They are behaviourally
+identical — the differential and SA-equivalence tests assert bit-for-bit
+agreement on addresses, quality, allocation count, and per-operation deltas —
+and the C++ one is substantially faster. Select the Python packer explicitly with
+`config.native_layout_packer = False` or `TORCH_SPYRE_NATIVE_PACKER=0`. Because
+the `_C` extension is required for torch-spyre to function at all, a missing
+native packer means a stale or incomplete build and raises rather than silently
+falling back to Python.
+
 **Validation philosophy:** every incremental operation is checked against the
 from-scratch reference oracle — randomized *differential* tests, a gated *stress* suite
 (`TORCH_SPYRE_STRESS_SCRATCHPAD=1`, tens of thousands of seeds), and in places *exhaustive*

--- a/docs/source/user_guide/examples/index.md
+++ b/docs/source/user_guide/examples/index.md
@@ -41,6 +41,7 @@ resulting buffer layouts. They require `matplotlib` and `numpy`.
 | `scratchpad/toy_layout.py` | Plot the layout for a fixed ordering of four buffers, with no annealing |
 | `scratchpad/random_buffers.py` | Compare first-fit against simulated-annealing quality on a set of random buffers |
 | `scratchpad/inplace_annealing.py` | Convergence study on an 18-buffer workload with in-place reuse |
+| `scratchpad/profile_native_packer.py` | Paired A/B benchmark of the C++ packer against the Python one, with dispersion statistics (needs neither `matplotlib` nor `numpy`; see [results](../../compiler/native_packer_performance.md)) |
 
 ## Provenance Audit
 

--- a/docs/source/user_guide/examples/scratchpad/profile_native_packer.py
+++ b/docs/source/user_guide/examples/scratchpad/profile_native_packer.py
@@ -1,0 +1,454 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Paired A/B of the native C++ packer vs the Python packer, with dispersion.
+
+Successor to ``benchmarks/profile_native_packer.py`` on the
+``packer-native-benchmarks`` branch, which reported a ratio of *summed* per-size
+totals over 4 seeds x 1 repeat -- no per-instance pairing and no interval. This
+version keeps the same workload generator (so the numbers stay comparable) and
+changes only the measurement:
+
+* every (size, seed) instance is solved by BOTH packers, so ratios are paired;
+* arm order alternates per repeat, so frequency/thermal drift cannot favour
+  whichever arm runs first;
+* both wall-clock (``perf_counter``) and CPU time (``process_time``) recorded;
+* ``deepcopy`` of the buffer list is hoisted OUT of the timed region (the old
+  script timed it, an additive constant on both arms that biases the ratio
+  toward 1);
+* the finalized addresses and quality are compared across arms per instance --
+  the packers are bit-identical, so this doubles as a correctness check and
+  establishes that only time is under test;
+* per size: median paired ratio, IQR, bootstrap 95% CI, win count, sign test.
+
+No Spyre hardware is touched: layout planning is single-threaded CPU work, and
+the backend is kept unloaded via ``TORCH_DEVICE_BACKEND_AUTOLOAD=0``.
+
+Measured results, and the methodology in prose, are in
+``docs/source/compiler/native_packer_performance.md``.
+
+Reproducing the reported figures
+--------------------------------
+Build the ``_C`` extension WITHOUT ``TORCH_SPYRE_DEBUG`` (a ``-O0`` build inflates
+every ratio), then, from anywhere::
+
+    P=docs/source/user_guide/examples/scratchpad/profile_native_packer.py
+
+    # representative capacity -- the headline number
+    python $P --sizes 8 16 32 64 128 --seeds 15 --repeats 2 \\
+        --cap-rule foot2 --min-steps 100 --json foot2.json
+
+    # tighter capacity, for the pressure axis
+    python $P ... --cap-rule foot4 ...
+
+    # the rule the original measurement used, for comparability
+    python $P ... --cap-rule 3xmax --repeats 3 ...
+
+Ratios depend strongly on ``--cap-rule``: capacity pressure, not problem size, is
+the dominant variable (see ``_capacity``). Quote the rule alongside any number.
+The speedup is a large constant factor that erodes as ``n`` grows past ~128,
+because the native packer recomputes placement from scratch per operation while
+the Python one is incremental -- so ``--sizes`` matters too. Real captured graphs
+run n~5-80.
+"""
+
+import os
+
+# Pin BLAS/OMP threads *before* importing torch.
+for _v in (
+    "OPENBLAS_NUM_THREADS",
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+):
+    os.environ.setdefault(_v, "1")
+# Keep the backend (and the accelerator) out of this entirely.
+os.environ.setdefault("TORCH_DEVICE_BACKEND_AUTOLOAD", "0")
+
+import argparse  # noqa: E402
+import copy  # noqa: E402
+import json  # noqa: E402
+import platform  # noqa: E402
+import random as rnd  # noqa: E402
+import statistics  # noqa: E402
+import sys  # noqa: E402
+import time  # noqa: E402
+
+
+def _repo_root():
+    """Walk up from this file to the checkout root.
+
+    The instance generator is imported from ``tests/`` (see below), so the repo
+    root has to be importable no matter where this script is invoked from or
+    where in the tree it ends up living.
+    """
+    d = os.path.dirname(os.path.abspath(__file__))
+    while d != os.path.dirname(d):
+        if os.path.isdir(os.path.join(d, "torch_spyre")) and os.path.isdir(
+            os.path.join(d, "tests")
+        ):
+            return d
+        d = os.path.dirname(d)
+    raise RuntimeError("cannot locate the torch-spyre checkout root from __file__")
+
+
+sys.path.insert(0, _repo_root())
+
+from torch_spyre._inductor import config  # noqa: E402
+from torch_spyre._inductor.scratchpad.permutation_layout import (  # noqa: E402
+    NativePermutationLayoutSolver,
+    PermutationBasedLayoutSolver,
+)
+from torch_spyre._inductor.scratchpad.simulated_annealing import (  # noqa: E402
+    SimulatedAnnealingLayoutSolver,
+)
+
+# The canonical instance generator: the very one the native-vs-Python
+# differential suite and the SA equivalence test drive. The old benchmark
+# inlined its own copy, which can wire a *write-only* in-place parent -- a
+# relationship current validation rejects outright (assert_in_place_parent_is_read),
+# so that copy no longer runs on this tree at all past n~8. Importing the test's
+# version fixes that and makes the workload provenance exact.
+from tests.inductor.test_perm_layout_solver import _random_buffers  # noqa: E402
+
+
+def _capacity(buffers, rule):
+    """Scratchpad capacity for one instance under the chosen rule.
+
+    ``3xmax`` is what the archived benchmark used. It forces the SA search to
+    iterate, but scales badly: capacity tracks the *largest buffer* while the
+    footprint grows with ``n``, so cap/footprint falls from ~0.8 at n=8 to ~0.03
+    at n=256 and all but ~13% of buffers end up evicted -- an over-subscribed
+    regime unlike real LX planning. ``foot<K>`` sets capacity to
+    ``footprint // K``, the convention the sibling co-optimizer benchmarks use,
+    which holds the pressure constant as ``n`` grows.
+    """
+    if rule == "3xmax":
+        return max(b.size for b in buffers) * 3
+    return max(1, sum(b.size for b in buffers) // int(rule[4:]))
+
+
+def _make_instances(sizes, seeds, rule):
+    """Deterministic (n, seed, capacity, buffers) instances across sizes x seeds."""
+    instances = []
+    for n in sizes:
+        for seed in seeds:
+            rng = rnd.Random(seed * 1000 + n)
+            buffers = _random_buffers(rng, n)
+            instances.append((n, seed, _capacity(buffers, rule), buffers))
+    return instances
+
+
+# --- one timed solve -------------------------------------------------------- #
+def _timed_solve(buffers, capacity, seed, native):
+    """Solve one pre-copied instance under one packer.
+
+    Returns (wall_seconds, cpu_seconds, addresses, quality). The buffer copy is
+    the caller's job: only solver construction + solve + finalize are timed.
+    """
+    with config.patch(native_layout_packer=native):
+        w0, c0 = time.perf_counter(), time.process_time()
+        solver = SimulatedAnnealingLayoutSolver(
+            buffers, capacity, 128, random=rnd.Random(seed)
+        )
+        # Guard against the knob silently selecting the wrong packer, which would
+        # quietly turn this into a native-vs-native measurement.
+        expect = (
+            NativePermutationLayoutSolver if native else PermutationBasedLayoutSolver
+        )
+        if not isinstance(solver.plan, expect):
+            raise RuntimeError(
+                f"native={native} selected {type(solver.plan).__name__}, "
+                f"expected {expect.__name__}"
+            )
+        out = solver.plan_layout()
+        wall = time.perf_counter() - w0
+        cpu = time.process_time() - c0
+    quality = solver.plan.quality()
+    # Annealing steps actually taken. An instance whose initial layout is already
+    # optimal exits solve() immediately (steps == 0) and its timing reflects
+    # construction overhead, not the packer -- reported separately below.
+    steps = sum(len(q) for q in solver.quality_logs)
+    allocated = solver.plan.count_allocated()
+    return wall, cpu, tuple(b.address for b in out), quality, steps, allocated
+
+
+def _copy_cost(buffers, reps=5):
+    """Wall-clock of one deepcopy, to quantify the old script's additive bias."""
+    best = float("inf")
+    for _ in range(reps):
+        t0 = time.perf_counter()
+        copy.deepcopy(buffers)
+        best = min(best, time.perf_counter() - t0)
+    return best
+
+
+# --- statistics ------------------------------------------------------------- #
+def _bootstrap_ci(xs, rng, iters=20000, alpha=0.05):
+    """Percentile bootstrap CI for the median of ``xs``."""
+    if len(xs) < 2:
+        return (float("nan"), float("nan"))
+    meds = []
+    k = len(xs)
+    for _ in range(iters):
+        meds.append(statistics.median(rng.choices(xs, k=k)))
+    meds.sort()
+    lo = meds[int(alpha / 2 * iters)]
+    hi = meds[min(iters - 1, int((1 - alpha / 2) * iters))]
+    return (lo, hi)
+
+
+def _iqr(xs):
+    if len(xs) < 4:
+        return (min(xs), max(xs))
+    q = statistics.quantiles(xs, n=4, method="inclusive")
+    return (q[0], q[2])
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--sizes",
+        type=int,
+        nargs="+",
+        default=[8, 16, 32, 64, 128],
+        help="Buffer counts to sweep. Captured real graphs run n~5-80.",
+    )
+    ap.add_argument("--seeds", type=int, default=15, help="Instances per size.")
+    ap.add_argument(
+        "--repeats", type=int, default=3, help="Timed repeats of each (arm, instance)."
+    )
+    ap.add_argument(
+        "--reduce",
+        choices=("min", "median"),
+        default="min",
+        help="How to reduce repeats to one time per (arm, instance). Timing "
+        "noise is one-sided, so min is the better estimate of true cost; "
+        "median is reported alongside for comparison.",
+    )
+    ap.add_argument(
+        "--cap-rule",
+        default="3xmax",
+        help="Capacity rule: '3xmax' (archived benchmark) or 'footK' "
+        "(footprint // K, e.g. foot2), which holds pressure constant in n.",
+    )
+    ap.add_argument(
+        "--min-steps",
+        type=int,
+        default=1,
+        help="Instances whose SA search took fewer steps than this are reported "
+        "separately: their timing measures construction, not the search.",
+    )
+    ap.add_argument("--json", default=None, help="Write raw + summary JSON here.")
+    args = ap.parse_args()
+
+    seeds = list(range(args.seeds))
+    instances = _make_instances(args.sizes, seeds, args.cap_rule)
+    print(
+        f"instances: {len(instances)} ({len(args.sizes)} sizes x {args.seeds} seeds), "
+        f"repeats={args.repeats}, sizes={args.sizes}",
+        flush=True,
+    )
+    print(
+        f"host: {platform.node()} {platform.machine()} "
+        f"cpus={os.cpu_count()} python={sys.version.split()[0]}",
+        flush=True,
+    )
+
+    # raw[(n, seed)][arm] = {"wall": [...], "cpu": [...]}
+    raw: dict = {}
+    mismatches = []
+    for n, seed, capacity, buffers in instances:
+        key = (n, seed)
+        footprint = sum(b.size for b in buffers)
+        raw[key] = {
+            "python": {"wall": [], "cpu": []},
+            "native": {"wall": [], "cpu": []},
+            "copy": _copy_cost(buffers),
+            "capacity": capacity,
+            "footprint": footprint,
+            "cap_over_footprint": capacity / footprint,
+            "steps": None,
+            "allocated": None,
+            "n_buffers": n,
+        }
+        results = {}
+        for rep in range(args.repeats):
+            # Alternate which arm goes first, so drift within a pair cannot
+            # systematically favour one packer.
+            arms = [("native", True), ("python", False)]
+            if rep % 2:
+                arms.reverse()
+            for label, native in arms:
+                work = copy.deepcopy(buffers)
+                wall, cpu, addrs, quality, steps, alloc = _timed_solve(
+                    work, capacity, seed, native
+                )
+                raw[key][label]["wall"].append(wall)
+                raw[key][label]["cpu"].append(cpu)
+                raw[key]["steps"] = steps
+                raw[key]["allocated"] = alloc
+                results.setdefault(label, (addrs, quality))
+                if results[label] != (addrs, quality):
+                    mismatches.append((n, seed, label, "nondeterministic"))
+        if results["native"] != results["python"]:
+            mismatches.append((n, seed, "cross-arm", "addresses/quality differ"))
+        print(
+            f"  n={n:4d} seed={seed:2d}  "
+            f"native={min(raw[key]['native']['wall']) * 1e3:8.2f} ms  "
+            f"python={min(raw[key]['python']['wall']) * 1e3:8.2f} ms  "
+            f"ratio={min(raw[key]['python']['wall']) / min(raw[key]['native']['wall']):5.2f}x"
+            f"  steps={raw[key]['steps']:5d} alloc={alloc:4d}/{n}"
+            f" cap/foot={capacity / footprint:.3f}",
+            flush=True,
+        )
+
+    reduce_fn = min if args.reduce == "min" else statistics.median
+    rng = rnd.Random(12345)
+    summary = {}
+
+    trivial = [k for k, v in raw.items() if v["steps"] < args.min_steps]
+    if trivial:
+        print(
+            f"\nexcluded {len(trivial)}/{len(raw)} instances with < {args.min_steps} "
+            f"annealing steps (initial layout already optimal -> solve() returns "
+            f"immediately, so the timing measures construction, not the packer):"
+        )
+        for n, seed in sorted(trivial):
+            r = raw[(n, seed)]
+            print(
+                f"    n={n:4d} seed={seed:2d} steps={r['steps']:5d} "
+                f"ratio={reduce_fn(r['python']['wall']) / reduce_fn(r['native']['wall']):5.2f}x "
+                f"native={reduce_fn(r['native']['wall']) * 1e3:7.3f} ms"
+            )
+
+    print("\n=== paired per-instance ratios (python / native), search-exercising ===")
+    hdr = (
+        f"{'n':>5} {'inst':>5} {'steps':>6} {'c/f':>5} {'alloc':>6} "
+        f"{'native ms':>10} {'python ms':>10} "
+        f"{'median':>7} {'IQR':>15} {'95% CI':>15} {'wins':>7} {'sign p':>9}"
+    )
+    print(hdr)
+    print("-" * len(hdr))
+    for axis in ("wall", "cpu"):
+        if axis == "cpu":
+            print(f"\n--- CPU time ({axis}) ---")
+            print(hdr)
+            print("-" * len(hdr))
+        for n in args.sizes:
+            ratios, nat, pyt = [], [], []
+            for seed in seeds:
+                r = raw[(n, seed)]
+                if r["steps"] < args.min_steps:
+                    continue
+                a = reduce_fn(r["native"][axis])
+                b = reduce_fn(r["python"][axis])
+                nat.append(a)
+                pyt.append(b)
+                ratios.append(b / a)
+            if not ratios:
+                continue
+            ref = next(
+                raw[(n, s)] for s in seeds if raw[(n, s)]["steps"] >= args.min_steps
+            )
+            med = statistics.median(ratios)
+            lo, hi = _bootstrap_ci(ratios, rng)
+            q1, q3 = _iqr(ratios)
+            wins = sum(1 for r in ratios if r > 1.0)
+            # One-sided sign test against "the packers are equally fast".
+            p = 0.5 ** len(ratios) if wins == len(ratios) else float("nan")
+            summary[f"{axis}/n={n}"] = {
+                "instances": len(ratios),
+                "steps": ref["steps"],
+                "cap_over_footprint": ref["cap_over_footprint"],
+                "allocated": ref["allocated"],
+                "native_ms_median": statistics.median(nat) * 1e3,
+                "python_ms_median": statistics.median(pyt) * 1e3,
+                "ratio_median": med,
+                "ratio_iqr": [q1, q3],
+                "ratio_ci95": [lo, hi],
+                "wins": wins,
+                "sign_p": p,
+                "ratios": ratios,
+            }
+            print(
+                f"{n:>5} {len(ratios):>5} {ref['steps']:>6} "
+                f"{ref['cap_over_footprint']:>5.2f} {ref['allocated']:>3}/{n:<3} "
+                f"{statistics.median(nat) * 1e3:>10.2f} "
+                f"{statistics.median(pyt) * 1e3:>10.2f} "
+                f"{med:>6.2f}x [{q1:>5.2f}, {q3:>5.2f}] "
+                f"[{lo:>5.2f}, {hi:>5.2f}] {wins:>3}/{len(ratios):<3} "
+                f"{p:>9.2e}"
+            )
+
+    # Pooled across all sizes, wall-clock, search-exercising instances only.
+    pooled = [
+        reduce_fn(raw[(n, s)]["python"]["wall"])
+        / reduce_fn(raw[(n, s)]["native"]["wall"])
+        for n in args.sizes
+        for s in seeds
+        if raw[(n, s)]["steps"] >= args.min_steps
+    ]
+    lo, hi = _bootstrap_ci(pooled, rng)
+    print(
+        f"\npooled (all sizes, wall, {args.reduce}-of-{args.repeats}): "
+        f"median {statistics.median(pooled):.2f}x, "
+        f"95% CI [{lo:.2f}, {hi:.2f}], range [{min(pooled):.2f}, {max(pooled):.2f}], "
+        f"n={len(pooled)} instances"
+    )
+
+    copy_frac = statistics.median(
+        [
+            raw[(n, s)]["copy"] / reduce_fn(raw[(n, s)]["native"]["wall"])
+            for n in args.sizes
+            for s in seeds
+        ]
+    )
+    print(
+        f"deepcopy cost (excluded here, included by the old script): "
+        f"median {copy_frac * 100:.1f}% of a native solve"
+    )
+
+    if mismatches:
+        print(f"\n!! {len(mismatches)} MISMATCHES: {mismatches[:5]}")
+    else:
+        print(
+            f"\ncross-arm check: addresses + quality identical on all "
+            f"{len(instances)} instances (bit-exact, as the differential suite asserts)"
+        )
+
+    if args.json:
+        with open(args.json, "w") as f:
+            json.dump(
+                {
+                    "config": vars(args),
+                    "host": {
+                        "node": platform.node(),
+                        "machine": platform.machine(),
+                        "cpus": os.cpu_count(),
+                        "python": sys.version.split()[0],
+                    },
+                    "summary": summary,
+                    "raw": {f"{n}/{s}": raw[(n, s)] for n in args.sizes for s in seeds},
+                    "mismatches": mismatches,
+                },
+                f,
+                indent=1,
+            )
+        print(f"wrote {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/inductor/test_perm_layout_solver.py
+++ b/tests/inductor/test_perm_layout_solver.py
@@ -1295,6 +1295,12 @@ class ResizeEligibilityDifferentialTests(TestCase):
         # in-place reuse (both size/eligibility dependent) must match exactly.
         rebuilt = _rebuilt_with_state(fast, cap, align)
         self.assertEqual(fast.addresses, rebuilt.addresses, tag)
+        # Quality against the *rebuild*, not just ``ref``: ``_sync_reference``
+        # copies ``_qualities`` into ``ref``, so ``ref.quality()`` only re-sums
+        # whatever ``fast`` already computed and cannot catch a wrong size ->
+        # quality formula in ``resize``. The rebuild derives it independently by
+        # feeding the current ``_sizes`` through a fresh constructor.
+        self.assertEqual(fast.quality(), rebuilt.quality(), tag)
         self.assertEqual(fast.below_profile, rebuilt.below_profile, tag)
         self.assertEqual(fast.above_profile, rebuilt.above_profile, tag)
         self.assertEqual(fast.inplace_reuse, rebuilt.inplace_reuse, tag)
@@ -1390,6 +1396,39 @@ class NativeSolverDifferentialTests(TestCase):
         self.assertEqual(list(cpp_plan.addresses), list(py_plan.addresses), tag)
         self.assertEqual(cpp_plan.quality(), py_plan.quality(), tag)
         self.assertEqual(cpp_plan.count_allocated(), py_plan.count_allocated(), tag)
+
+    def test_fast_path_reads_pokethrough_top_not_dead_parent(self):
+        """The aggregate fast path's boundary case, pinned deterministically.
+
+        ``RecomputeAll`` takes the interval-aggregate fast path for a buffer with
+        no in-place partner and the gather + ``PlaceDecision`` path for one with,
+        so the discriminating state is a partner-free buffer resting on a
+        *poke-through*: ``c`` co-locates into ``p``'s slot, so its top (64) sits
+        below ``p``'s (128), and ``h`` starts at 5 -- after ``p`` dies -- so its
+        only candidate is ``c``. Its floor must therefore be 64, not 128.
+
+        ``h`` overlapping ``p`` as well (as in the contact-profile poke-through
+        test) makes both answers 128, which is why that case cannot distinguish a
+        correct aggregate from one that folds in a dead-but-taller buffer. The
+        alignment must stay 1: at 128-byte alignment ``align_up(64) ==
+        align_up(128)`` and the discrimination vanishes.
+        """
+        p = _buf("p", 128, 0, 5)
+        c = _buf("c", 64, 4, 10, in_place_parents=["p"])
+        h = _buf("h", 32, 5, 10)
+        buffers = [p, c, h]
+        perm = [0, 1, 2]
+
+        cpp_plan = NativePermutationLayoutSolver(buffers, perm, 10_000, 1)
+        self.assertEqual(list(cpp_plan.addresses), [0, 0, 64])
+
+        # Both Python packers agree, so the expectation is the specification's,
+        # not just this implementation's. The from-scratch reference is the
+        # independent oracle the randomized native tests never consult.
+        py_plan = PermutationBasedLayoutSolver(buffers, perm, 10_000, 1)
+        ref_plan = ReferencePermutationBasedLayoutSolver(buffers, perm, 10_000, 1)
+        self._assert_equal(py_plan, cpp_plan, "pokethrough fast path")
+        self._assert_equal(ref_plan, cpp_plan, "pokethrough fast path vs reference")
 
     def test_random_mixed_sequences_match_python(self):
         seeds = 4000 if _STRESS else 800

--- a/tests/inductor/test_perm_layout_solver.py
+++ b/tests/inductor/test_perm_layout_solver.py
@@ -29,6 +29,7 @@ from torch_spyre._inductor.scratchpad.permutation_layout import (
     PermutationBasedLayoutSolver,
     ReferencePermutationBasedLayoutSolver,
 )
+from torch_spyre._C import NativePermutationLayoutSolver
 
 ALIGNMENT = 128
 
@@ -1348,6 +1349,108 @@ class ResizeEligibilityDifferentialTests(TestCase):
                 self._sync_reference(ref, fast)
                 tag = f"seed={seed} step={step} op={op} elig={fast._eligible}"
                 self._assert_matches(fast, ref, cap, align, d_fast, before, tag)
+
+
+class NativeSolverDifferentialTests(TestCase):
+    """Differential coverage for the C++ ``NativePermutationLayoutSolver``
+    accelerator against the canonical Python ``PermutationBasedLayoutSolver``.
+
+    The C++ class is an opt-in accelerator; the Python packer stays canonical
+    and is the correctness oracle. This drives the SAME random interleaved
+    swap / rotate / resize / set_eligible sequences (the ``_apply`` mix from
+    :class:`ResizeEligibilityDifferentialTests`) through both and asserts
+    observable equality -- bit-for-bit identical ``addresses`` (None ==
+    evicted / HBM), ``quality()`` and ``count_allocated()`` -- after every op,
+    plus that the per-op quality delta each returns agrees.
+    """
+
+    def _apply_both(self, op, py_plan, cpp_plan, rng, n):
+        """Apply one random instance of ``op`` identically to both plans.
+
+        Returns ``(delta_py, delta_cpp)``. Every random parameter is drawn once
+        and reused, so the two plans receive byte-identical operations.
+        """
+        if op == "swap":
+            i = rng.randrange(n - 1)
+            return py_plan.swap(i), cpp_plan.swap(i)
+        if op == "rotate":
+            i, j = rng.randrange(n), rng.randrange(n)
+            return py_plan.rotate(i, j), cpp_plan.rotate(i, j)
+        if op == "resize":
+            idx = rng.randrange(n)
+            new = rng.choice([1, rng.randint(1, 300), rng.randint(300, 1200)])
+            return py_plan.resize(idx, new), cpp_plan.resize(idx, new)
+        # toggle-eligibility: the Python plan is the source of truth for the
+        # current flag; flip the same (idx, flag) on both.
+        idx = rng.randrange(n)
+        flag = not py_plan._eligible[idx]
+        return py_plan.set_eligible(idx, flag), cpp_plan.set_eligible(idx, flag)
+
+    def _assert_equal(self, py_plan, cpp_plan, tag):
+        self.assertEqual(list(cpp_plan.addresses), list(py_plan.addresses), tag)
+        self.assertEqual(cpp_plan.quality(), py_plan.quality(), tag)
+        self.assertEqual(cpp_plan.count_allocated(), py_plan.count_allocated(), tag)
+
+    def test_random_mixed_sequences_match_python(self):
+        seeds = 4000 if _STRESS else 800
+        for seed in range(seeds):
+            rng = random.Random(seed)
+            n = rng.randint(1, 9)
+            buffers = _random_buffers(rng, n)
+            perm = list(range(n))
+            rng.shuffle(perm)
+            cap = rng.choice([150, 400, 10_000])
+            align = rng.choice([1, 64, 128])
+            py_plan = PermutationBasedLayoutSolver(buffers, perm, cap, align)
+            py_plan._rotate_remove_insert_threshold = 1  # exercise the fast path
+            cpp_plan = NativePermutationLayoutSolver(buffers, perm, cap, align)
+
+            self._assert_equal(py_plan, cpp_plan, f"seed={seed} init")
+
+            ops = ["swap", "rotate", "resize", "toggle"]
+            for step in range(rng.randint(1, 3 * n + 3)):
+                op = rng.choice(ops)
+                if op == "swap" and n < 2:
+                    op = "resize"  # no adjacent pair to swap
+                d_py, d_cpp = self._apply_both(op, py_plan, cpp_plan, rng, n)
+                tag = f"seed={seed} step={step} op={op}"
+                self.assertEqual(d_cpp, d_py, tag)
+                self._assert_equal(py_plan, cpp_plan, tag)
+
+    def test_copy_is_independent_and_matches_python(self):
+        # copy() yields an independent snapshot: mutating the clone leaves the
+        # source observably unchanged, and the mutated clone still matches a
+        # Python plan driven through the same swaps.
+        for seed in range(400):
+            rng = random.Random(seed)
+            n = rng.randint(2, 9)
+            buffers = _random_buffers(rng, n)
+            perm = list(range(n))
+            rng.shuffle(perm)
+            cap = rng.choice([150, 400, 10_000])
+            align = rng.choice([1, 64, 128])
+            cpp_plan = NativePermutationLayoutSolver(buffers, perm, cap, align)
+            src_addr = list(cpp_plan.addresses)
+            src_q = cpp_plan.quality()
+
+            clone = cpp_plan.copy()
+            py_plan = PermutationBasedLayoutSolver(buffers, perm, cap, align)
+            swaps = [rng.randrange(n - 1) for _ in range(rng.randint(1, 2 * n))]
+            for i in swaps:
+                clone.swap(i)
+                py_plan.swap(i)
+
+            # Source untouched by clone mutations.
+            self.assertEqual(list(cpp_plan.addresses), src_addr, f"seed={seed}")
+            self.assertEqual(cpp_plan.quality(), src_q, f"seed={seed}")
+            # Mutated clone matches the Python plan run through the same swaps.
+            self.assertEqual(
+                list(clone.addresses), list(py_plan.addresses), f"seed={seed}"
+            )
+            self.assertEqual(clone.quality(), py_plan.quality(), f"seed={seed}")
+            self.assertEqual(
+                clone.count_allocated(), py_plan.count_allocated(), f"seed={seed}"
+            )
 
 
 class CopyTests(TestCase):

--- a/tests/inductor/test_perm_layout_solver.py
+++ b/tests/inductor/test_perm_layout_solver.py
@@ -14,6 +14,8 @@
 
 """Tests for the capacity-bounded allocation plans."""
 
+import copy
+import gc
 import itertools
 import os
 import random
@@ -1796,3 +1798,127 @@ class NativeGuardTests(TestCase):
     def test_zero_alignment_raises(self):
         with self.assertRaises(ValueError):
             NativePermutationLayoutSolver([_buf("a", 64, 0, 3)], [0], 10_000, 0)
+
+
+class NativePermutationViewTests(TestCase):
+    """Lifetime and reference semantics of the native ``permutation`` view.
+
+    ``plan.permutation`` returns a ``PermutationView`` that *borrows* its solver
+    and reads straight through to the solver's ``std::vector``. Two opposite
+    things must hold, and the rest of the suite establishes neither:
+
+    - It must stay **valid**. Nothing else in these tests lets a view outlive its
+      solver, so a view left reading freed memory would go unnoticed -- and did:
+      the ``py::keep_alive`` securing this was initially attached to the property
+      rather than to the getter, where it silently does nothing, and the whole
+      suite passed regardless.
+    - It must stay **live**. ``annealing_step_swap`` captures the view once and
+      re-reads it after each ``swap``, so a snapshot would make the search read
+      pre-swap values. That degrades rather than breaks: the search would simply
+      explore a different trajectory and still return a feasible layout, so only
+      the cross-packer equivalence test could notice, and only because it demands
+      bit-identical trajectories.
+
+    These are failures where the program keeps running and produces plausible
+    output, which is why they are asserted against the mechanism directly.
+    """
+
+    def _bufs(self):
+        return [_buf("a", 64, 0, 4), _buf("c", 96, 0, 4), _buf("d", 32, 0, 4)]
+
+    def _plan(self, perm=(0, 1, 2), capacity=200, alignment=1):
+        return NativePermutationLayoutSolver(
+            self._bufs(), list(perm), capacity, alignment
+        )
+
+    def test_view_outlives_its_solver(self):
+        """keep_alive must make the view retain the solver it borrows."""
+        plan = self._plan()
+        view = plan.permutation
+        del plan
+        for _ in range(3):
+            gc.collect()
+        self.assertEqual(list(view), [0, 1, 2])
+
+    def test_view_survives_reuse_of_the_solver_s_memory(self):
+        """Stronger than the above: reading freed memory often *appears* to work
+        because the block has not been handed out again. Force it to be reused."""
+        plan = self._plan(perm=(2, 1, 0))
+        view = plan.permutation
+        del plan
+        gc.collect()
+        churn = [self._plan(perm=(1, 0, 2)) for _ in range(200)]
+        self.assertEqual(list(view), [2, 1, 0])
+        self.assertEqual(len(churn), 200)  # keep the churn alive to this point
+
+    def test_captured_view_observes_later_mutation(self):
+        """The liveness half: ``annealing_step_swap`` depends on this exactly."""
+        plan = self._plan()
+        view = plan.permutation  # captured ONCE, before the mutation
+        plan.swap(0)
+        self.assertEqual(list(view), [1, 0, 2])
+        plan.rotate(0, 2)
+        self.assertEqual(list(view), [0, 2, 1])
+
+    def test_copy_detaches_from_the_live_order(self):
+        """The mirror image of liveness. The search stores its best-so-far
+        permutation with a copy and later compares the live order against it; were
+        the copy to track the original, that test would be vacuously equal and
+        "commit the best permutation seen" would quietly stop working."""
+        plan = self._plan()
+        view = plan.permutation
+        snapshot = copy.copy(view)
+        deep = copy.deepcopy(view)
+        plan.swap(0)
+        self.assertIsInstance(snapshot, list)
+        self.assertIsInstance(deep, list)
+        self.assertEqual(snapshot, [0, 1, 2])
+        self.assertEqual(deep, [0, 1, 2])
+        self.assertEqual(list(view), [1, 0, 2])
+        self.assertNotEqual(snapshot, list(view))
+
+    def test_clone_view_tracks_the_clone_not_the_original(self):
+        """``copy()`` deep-copies the order, and the search clones plans."""
+        original = self._plan()
+        clone = original.copy()
+        clone.swap(0)
+        self.assertEqual(list(original.permutation), [0, 1, 2])
+        self.assertEqual(list(clone.permutation), [1, 0, 2])
+
+    def test_view_is_read_only(self):
+        """Read-only by construction, so Python cannot reorder the permutation
+        behind the solver's back (which would desync it from the addresses)."""
+        view = self._plan().permutation
+        with self.assertRaises(TypeError):
+            view[0] = 5
+        with self.assertRaises(TypeError):
+            del view[0]
+
+    def test_view_sequence_protocol(self):
+        """len / indexing / negative offsets / equality against a plain list, and
+        IndexError past the end so ``list(view)`` and iteration terminate."""
+        plan = self._plan(perm=(2, 0, 1))
+        view = plan.permutation
+        self.assertEqual(len(view), 3)
+        self.assertEqual(view[0], 2)
+        self.assertEqual(view[-1], 1)
+        self.assertEqual(list(view), [2, 0, 1])
+        self.assertEqual([x for x in view], [2, 0, 1])
+        self.assertEqual(view, [2, 0, 1])
+        self.assertNotEqual(view, [0, 1, 2])
+        self.assertEqual(view, plan.permutation)
+        for bad in (3, 99, -4):
+            with self.assertRaises(IndexError):
+                view[bad]
+
+    def test_finalize_writes_addresses_back_including_none(self):
+        """``finalize`` writes to EVERY buffer, so an evicted one is cleared to
+        ``None`` rather than left holding a stale address."""
+        buffers = [_buf("x", 150, 0, 3), _buf("y", 150, 0, 3)]
+        plan = NativePermutationLayoutSolver(buffers, [0, 1], 200, 1)
+        plan.finalize()
+        self.assertEqual(
+            [(b.name, b.address) for b in buffers], [("x", 0), ("y", None)]
+        )
+        # The retained list is the caller's, not a copy.
+        self.assertEqual([b.name for b in plan.buffers], ["x", "y"])

--- a/tests/inductor/test_perm_layout_solver.py
+++ b/tests/inductor/test_perm_layout_solver.py
@@ -1718,3 +1718,42 @@ class ProfileTests(TestCase):
         p.splice(3, 7, [3, 7], [2])
         self.assertEqual(p, Profile([0, 3, 7, 10], [None, 2, None]))
         p.validate()
+
+
+class NativeGuardTests(TestCase):
+    """The C++ accelerator validates out-of-range / degenerate arguments and
+    raises (like ``swap()`` already did, and like the Python packer's fail-fast
+    asserts) instead of corrupting the heap or crashing. Regression coverage for
+    the memory-safety review's ASan-confirmed findings (bad ``idx``/``i``/``j``
+    into resize/rotate/set_eligible, empty ``uses``, zero alignment)."""
+
+    def _plan(self, n=3):
+        bufs = [_buf(f"b{i}", 64, 0, 3) for i in range(n)]
+        return NativePermutationLayoutSolver(bufs, list(range(n)), 10_000, 128)
+
+    def test_resize_index_out_of_range_raises(self):
+        p = self._plan()
+        for bad in (-1, 3, 999):
+            with self.assertRaises(ValueError):
+                p.resize(bad, 100)
+
+    def test_rotate_index_out_of_range_raises(self):
+        p = self._plan()
+        for i, j in ((5, 0), (0, 5), (-1, 0), (0, -1)):
+            with self.assertRaises(ValueError):
+                p.rotate(i, j)
+
+    def test_set_eligible_index_out_of_range_raises(self):
+        p = self._plan()
+        for bad in (-1, 3, 999):
+            with self.assertRaises(ValueError):
+                p.set_eligible(bad, False)
+
+    def test_empty_uses_raises(self):
+        bad = LifetimeBoundBuffer(name="x", size=64, uses=[], in_place_parents=[])
+        with self.assertRaises(ValueError):
+            NativePermutationLayoutSolver([bad], [0], 10_000, 128)
+
+    def test_zero_alignment_raises(self):
+        with self.assertRaises(ValueError):
+            NativePermutationLayoutSolver([_buf("a", 64, 0, 3)], [0], 10_000, 0)

--- a/tests/inductor/test_perm_layout_solver.py
+++ b/tests/inductor/test_perm_layout_solver.py
@@ -116,10 +116,11 @@ def _check_contact_faithful(test, plan, tag=""):
     pos = plan.position
 
     def top(w):
-        # Exclusive top of a placed buffer; +inf for an evicted (None) one.
+        # Exclusive top of a placed buffer; +inf for an evicted (None) one. Uses
+        # the plan-local size so a resize is reflected.
         if plan.addresses[w] is None:
             return float("inf")
-        return plan.addresses[w] + plan.buffers[w].size
+        return plan.addresses[w] + plan._sizes[w]
 
     def alive(w):
         return plan.buffers[w].start_time <= t < plan.buffers[w].end_time
@@ -127,13 +128,19 @@ def _check_contact_faithful(test, plan, tag=""):
     for c in range(n):
         bc = plan.buffers[c]
         if plan.addresses[c] is None:
-            # c is evicted: it has no concrete geometry to validate. (Its
-            # order-based contact relation is still checked via _check_consistency
-            # and the placed buffers below.)
+            # c is evicted (or ineligible / in HBM): no concrete geometry to
+            # validate. (Its order-based contact relation is still checked via
+            # _check_consistency and the placed buffers below.)
             continue
         for t in range(bc.start_time, bc.end_time):
             contact = plan.contact_at(c, t)
-            cand = [w for w in plan.overlap_dict[c] if pos[w] < pos[c] and alive(w)]
+            # Only eligible earlier buffers are in the stack (an ineligible one is
+            # transparent), matching the candidate set placement actually uses.
+            cand = [
+                w
+                for w in plan.overlap_dict[c]
+                if pos[w] < pos[c] and alive(w) and plan._eligible[w]
+            ]
             if not cand:
                 test.assertIsNone(contact, f"{tag} c={c} t={t}")
                 continue
@@ -198,6 +205,36 @@ def _buf(name, size, start, end, in_place_parents=None):
         size=size,
         uses=uses,
         in_place_parents=in_place_parents or [],
+    )
+
+
+def _rebuilt_with_state(plan, capacity, alignment):
+    """A fresh ``PermutationBasedLayoutSolver`` reproducing ``plan``'s current
+    permutation, *sizes*, and *eligibility* -- the from-scratch oracle for the
+    resize / set_eligible differential checks.
+
+    ``resize`` mutates the plan-local ``_sizes`` (never the shared buffer
+    objects), so the rebuild is fed fresh buffers carrying those sizes; the live
+    eligibility is passed through the constructor. This is the analogue of the
+    ``rebuilt = PermutationBasedLayoutSolver(buffers, fast.permutation, ...)``
+    oracle the swap/rotate tests use, extended to the co-opt state.
+    """
+    fresh = [
+        LifetimeBoundBuffer(
+            name=b.name,
+            size=plan._sizes[i],
+            uses=list(b.uses),
+            first_use_is_read=b.first_use_is_read,
+            in_place_parents=list(b.in_place_parents),
+        )
+        for i, b in enumerate(plan.buffers)
+    ]
+    return PermutationBasedLayoutSolver(
+        fresh,
+        list(plan.permutation),
+        capacity,
+        alignment,
+        eligible=list(plan._eligible),
     )
 
 
@@ -1095,6 +1132,222 @@ class FastRotateTests(TestCase):
             self.assertEqual(fast.below_profile, chain.below_profile, tag)
             self.assertEqual(fast.above_profile, chain.above_profile, tag)
             self.assertEqual(fast.inplace_reuse, chain.inplace_reuse, tag)
+
+
+class EligibilityConstructionTests(TestCase):
+    """Constructing a plan with some buffers ineligible up front."""
+
+    def plan(self, buffers, permutation, eligible, capacity=10_000, alignment=1):
+        return PermutationBasedLayoutSolver(
+            buffers, permutation, capacity, alignment, eligible=eligible
+        )
+
+    def test_default_all_eligible(self):
+        buffers = [_buf("a", 64, 0, 2), _buf("b", 50, 0, 2)]
+        plan = PermutationBasedLayoutSolver(buffers, [0, 1], 10_000, 1)
+        self.assertEqual(plan._eligible, [True, True])
+
+    def test_bad_eligible_length_rejected(self):
+        buffers = [_buf("a", 64, 0, 2)]
+        with self.assertRaises(AssertionError):
+            self.plan(buffers, [0], eligible=[True, False])
+
+    def test_ineligible_buffer_is_transparent(self):
+        # b ineligible: routed to HBM (no address, no quality), and c stacks
+        # directly on a as if b were absent -- not on b.
+        buffers = [_buf("a", 64, 0, 3), _buf("b", 50, 0, 3), _buf("c", 40, 0, 3)]
+        plan = self.plan(buffers, [0, 1, 2], eligible=[True, False, True])
+        self.assertEqual(_addr(plan, "a"), 0)
+        self.assertIsNone(_addr(plan, "b"))
+        self.assertEqual(_addr(plan, "c"), 64)  # rests on a, not on b
+        self.assertEqual(plan.quality(), 2.5 * (64 + 40))
+        self.assertEqual(plan.count_allocated(), 2)
+        self.assertEqual(_below_named(plan, "c"), [(0, 3, "a")])
+        # b's own profile is a trivial "nothing here" step function.
+        self.assertEqual(_below_named(plan, "b"), [(0, 3, None)])
+        self.assertEqual(_above_named(plan, "b"), [(0, 3, None)])
+        _check_consistency(self, plan)
+        _check_contact_faithful(self, plan)
+
+    def test_matches_reference_with_initial_eligibility(self):
+        buffers = [_buf("a", 64, 0, 3), _buf("b", 50, 0, 3), _buf("c", 40, 0, 3)]
+        elig = [True, False, True]
+        fast = self.plan(buffers, [0, 1, 2], eligible=elig)
+        ref = ReferencePermutationBasedLayoutSolver(
+            buffers, [0, 1, 2], 10_000, 1, eligible=list(elig)
+        )
+        self.assertEqual(fast.addresses, ref.addresses)
+        self.assertEqual(fast.quality(), ref.quality())
+
+
+class ResizeTests(TestCase):
+    """resize(idx, new_size): change a footprint in place and re-place."""
+
+    def plan(self, buffers, permutation, capacity=10_000, alignment=1):
+        return PermutationBasedLayoutSolver(buffers, permutation, capacity, alignment)
+
+    def test_resize_shifts_stacked_neighbour(self):
+        buffers = [_buf("a", 64, 0, 3), _buf("b", 50, 0, 3)]
+        plan = self.plan(buffers, [0, 1])
+        self.assertEqual([_addr(plan, "a"), _addr(plan, "b")], [0, 64])
+        delta = plan.resize(0, 100)  # a grows -> b moves up
+        self.assertEqual([_addr(plan, "a"), _addr(plan, "b")], [0, 100])
+        # a's quality rises (2.5 * (100 - 64)); b's is unchanged.
+        self.assertEqual(delta, 2.5 * (100 - 64))
+        self.assertEqual(plan.quality(), 2.5 * (100 + 50))
+        # The shared buffer object is NOT mutated.
+        self.assertEqual(buffers[0].size, 64)
+
+    def test_resize_over_capacity_evicts_and_uneviction(self):
+        buffers = [_buf("a", 40, 0, 2), _buf("b", 40, 0, 2)]
+        plan = self.plan(buffers, [0, 1], capacity=100)
+        self.assertEqual([_addr(plan, "a"), _addr(plan, "b")], [0, 40])
+        plan.resize(0, 80)  # a@0..80, b@80..120 > 100 -> b evicted
+        self.assertEqual(_addr(plan, "a"), 0)
+        self.assertIsNone(_addr(plan, "b"))
+        self.assertEqual(plan.count_allocated(), 1)
+        plan.resize(0, 40)  # shrink back -> b re-fits
+        self.assertEqual([_addr(plan, "a"), _addr(plan, "b")], [0, 40])
+        self.assertEqual(plan.count_allocated(), 2)
+
+    def test_resize_ineligible_is_bookkeeping_only(self):
+        buffers = [_buf("a", 64, 0, 3), _buf("b", 50, 0, 3)]
+        plan = PermutationBasedLayoutSolver(
+            buffers, [0, 1], 10_000, 1, eligible=[True, False]
+        )
+        before = list(plan.addresses)
+        delta = plan.resize(1, 5000)  # b is in HBM: nothing observable changes
+        self.assertEqual(delta, 0.0)
+        self.assertEqual(plan.addresses, before)
+        self.assertEqual(plan._sizes[1], 5000)  # but the size is recorded
+
+    def test_resize_crosses_inplace_fit_boundary(self):
+        # child reuses parent while it fits; growing it past the parent forces a
+        # stack, and shrinking it back restores the reuse.
+        parent = _buf("p", 128, 0, 5)
+        child = _buf("c", 64, 4, 10, in_place_parents=["p"])
+        plan = self.plan([parent, child], [0, 1])
+        self.assertEqual(_addr(plan, "c"), 0)  # reuses p
+        plan.resize(1, 200)  # c no longer fits in p
+        self.assertEqual(_addr(plan, "c"), 128)  # stacks on p
+        plan.resize(1, 64)
+        self.assertEqual(_addr(plan, "c"), 0)  # reuse restored
+
+
+class SetEligibleTests(TestCase):
+    """set_eligible(idx, flag): toggle a buffer in/out of LX."""
+
+    def plan(self, buffers, permutation, capacity=10_000, alignment=1):
+        return PermutationBasedLayoutSolver(buffers, permutation, capacity, alignment)
+
+    def test_toggle_out_then_in_restores(self):
+        buffers = [_buf("a", 64, 0, 3), _buf("b", 50, 0, 3), _buf("c", 40, 0, 3)]
+        plan = self.plan(buffers, [0, 1, 2])
+        self.assertEqual([_addr(plan, n) for n in "abc"], [0, 64, 114])
+        d_out = plan.set_eligible(1, False)  # b -> HBM
+        self.assertEqual(_addr(plan, "a"), 0)
+        self.assertIsNone(_addr(plan, "b"))
+        self.assertEqual(_addr(plan, "c"), 64)  # c drops onto a
+        self.assertEqual(d_out, -2.5 * 50)
+        d_in = plan.set_eligible(1, True)  # b -> LX at its slot
+        self.assertEqual([_addr(plan, n) for n in "abc"], [0, 64, 114])
+        self.assertEqual(d_in, 2.5 * 50)
+        # Profiles match a fresh build after the round trip.
+        rebuilt = _rebuilt_with_state(plan, 10_000, 1)
+        self.assertEqual(plan.below_profile, rebuilt.below_profile)
+        self.assertEqual(plan.above_profile, rebuilt.above_profile)
+        _check_consistency(self, plan)
+        _check_contact_faithful(self, plan)
+
+    def test_toggle_unchanged_flag_is_noop(self):
+        buffers = [_buf("a", 64, 0, 2)]
+        plan = self.plan(buffers, [0])
+        before = list(plan.addresses)
+        self.assertEqual(plan.set_eligible(0, True), 0.0)  # already eligible
+        self.assertEqual(plan.addresses, before)
+
+    def test_toggle_out_uneviction(self):
+        # a@0(60); b rests on a -> 120 > 100 evicted. Making a ineligible frees
+        # the floor so b re-fits at 0.
+        buffers = [_buf("a", 60, 0, 3), _buf("b", 60, 0, 3)]
+        plan = self.plan(buffers, [0, 1], capacity=100)
+        self.assertEqual(_addr(plan, "a"), 0)
+        self.assertIsNone(_addr(plan, "b"))
+        plan.set_eligible(0, False)
+        self.assertIsNone(_addr(plan, "a"))
+        self.assertEqual(_addr(plan, "b"), 0)  # un-evicted
+        self.assertEqual(plan.count_allocated(), 1)
+
+
+class ResizeEligibilityDifferentialTests(TestCase):
+    """Randomized differential coverage for resize + set_eligible interleaved
+    with swap / rotate, against both the from-scratch reference (O(n^2) scan) and
+    a fresh rebuild carrying the same size/eligibility state."""
+
+    def _assert_matches(self, fast, ref, cap, align, delta, before, tag):
+        # Live reference (independent O(n^2) scan of the current state).
+        self.assertEqual(fast.addresses, ref.addresses, tag)
+        self.assertEqual(fast.quality(), ref.quality(), tag)
+        self.assertEqual(fast.count_allocated(), ref.count_allocated(), tag)
+        self.assertEqual(delta, fast.quality() - before, tag)
+        # Fresh rebuild reproducing the current sizes + eligibility: profiles and
+        # in-place reuse (both size/eligibility dependent) must match exactly.
+        rebuilt = _rebuilt_with_state(fast, cap, align)
+        self.assertEqual(fast.addresses, rebuilt.addresses, tag)
+        self.assertEqual(fast.below_profile, rebuilt.below_profile, tag)
+        self.assertEqual(fast.above_profile, rebuilt.above_profile, tag)
+        self.assertEqual(fast.inplace_reuse, rebuilt.inplace_reuse, tag)
+        _check_consistency(self, fast, tag)
+        _check_contact_faithful(self, fast, tag)
+
+    def _apply(self, op, plan, rng, n):
+        """Apply a random instance of ``op`` to ``plan``; return its delta."""
+        if op == "swap":
+            return plan.swap(rng.randrange(n - 1))
+        if op == "rotate":
+            return plan.rotate(rng.randrange(n), rng.randrange(n))
+        if op == "resize":
+            idx = rng.randrange(n)
+            # A mix of shrink, grow-in-bounds, and grow-past-capacity (evicts).
+            new = rng.choice([1, rng.randint(1, 300), rng.randint(300, 1200)])
+            return plan.resize(idx, new)
+        # toggle-eligibility
+        idx = rng.randrange(n)
+        return plan.set_eligible(idx, not plan._eligible[idx])
+
+    def _sync_reference(self, ref, fast):
+        """Rebuild ``ref`` to reproduce ``fast``'s post-move state, giving an
+        independent O(n^2) oracle regardless of how the move was chosen."""
+        ref.permutation = list(fast.permutation)
+        ref._sizes = list(fast._sizes)
+        ref._qualities = list(fast._qualities)
+        ref._eligible = list(fast._eligible)
+        ref._build()
+
+    def test_random_mixed_sequences_match_oracles(self):
+        seeds = 4000 if _STRESS else 800
+        for seed in range(seeds):
+            rng = random.Random(seed)
+            n = rng.randint(1, 9)
+            buffers = _random_buffers(rng, n)
+            perm = list(range(n))
+            rng.shuffle(perm)
+            cap = rng.choice([150, 400, 10_000])
+            align = rng.choice([1, 64, 128])
+            fast = PermutationBasedLayoutSolver(buffers, perm, cap, align)
+            fast._rotate_remove_insert_threshold = 1  # exercise the fast path
+            ref = ReferencePermutationBasedLayoutSolver(buffers, perm, cap, align)
+
+            ops = ["swap", "rotate", "resize", "toggle"]
+            for step in range(rng.randint(1, 3 * n + 3)):
+                op = rng.choice(ops)
+                if op == "swap" and n < 2:
+                    op = "resize"  # no adjacent pair to swap
+                before = fast.quality()
+                d_fast = self._apply(op, fast, rng, n)
+                self._sync_reference(ref, fast)
+                tag = f"seed={seed} step={step} op={op} elig={fast._eligible}"
+                self._assert_matches(fast, ref, cap, align, d_fast, before, tag)
 
 
 class CopyTests(TestCase):

--- a/tests/inductor/test_simulated_annealing.py
+++ b/tests/inductor/test_simulated_annealing.py
@@ -25,8 +25,8 @@ from torch_spyre._inductor.scratchpad.plan_solver import (
     LifetimeBoundBuffer,
 )
 from torch_spyre._inductor.scratchpad.permutation_layout import (
+    NativePermutationLayoutSolver,
     PermutationBasedLayoutSolver,
-    _NativePackerAdapter,
     buffer_quality,
 )
 from torch_spyre._inductor.scratchpad.cooling_schedules import (
@@ -456,10 +456,11 @@ class NativePackerEquivalenceTests(TestCase):
                 schedule=_short_schedule(),
                 random=rnd.Random(seed),
             )
-            # Guard against a silent fallback masking a real divergence: with the
-            # flag set we must actually be exercising the native adapter.
+            # Guard against the knob silently selecting the wrong packer and
+            # masking a real divergence: with the flag set we must actually be
+            # running on the C++ solver.
             if native:
-                self.assertIsInstance(solver.plan, _NativePackerAdapter)
+                self.assertIsInstance(solver.plan, NativePermutationLayoutSolver)
             else:
                 self.assertIsInstance(solver.plan, PermutationBasedLayoutSolver)
             solver.solve()

--- a/tests/inductor/test_simulated_annealing.py
+++ b/tests/inductor/test_simulated_annealing.py
@@ -19,7 +19,7 @@ import math
 import os
 import random as rnd
 import unittest
-from unittest import TestCase, mock
+from unittest import TestCase
 
 from torch_spyre._inductor.scratchpad.plan_solver import (
     LifetimeBoundBuffer,
@@ -39,6 +39,7 @@ from torch_spyre._inductor.scratchpad.cooling_schedules import (
 from torch_spyre._inductor.scratchpad.simulated_annealing import (
     SimulatedAnnealingLayoutSolver,
 )
+from torch_spyre._inductor import config
 
 # Heavy randomized anneals over many seeds, larger problems and longer
 # schedules. Skipped by default (slow); opt in with the env var.
@@ -448,12 +449,10 @@ class NativePackerEquivalenceTests(TestCase):
     Any divergence here is a wiring/parity bug, not a tolerance to loosen."""
 
     def _run(self, buffers, capacity, initial, seed, *, native):
-        # The factory reads TORCH_SPYRE_NATIVE_PACKER at construction time, so the
-        # flag must be set across the whole solver lifetime (construct + solve +
-        # the reconstruction in solve() + finalize).
-        with mock.patch.dict(
-            os.environ, {"TORCH_SPYRE_NATIVE_PACKER": "1" if native else "0"}
-        ):
+        # The factory reads config.native_layout_packer at construction time, so
+        # the knob must be patched across the whole solver lifetime (construct +
+        # solve + the reconstruction in solve() + finalize).
+        with config.patch(native_layout_packer=native):
             solver = SimulatedAnnealingLayoutSolver(
                 buffers,
                 capacity,

--- a/tests/inductor/test_simulated_annealing.py
+++ b/tests/inductor/test_simulated_annealing.py
@@ -27,7 +27,6 @@ from torch_spyre._inductor.scratchpad.plan_solver import (
 from torch_spyre._inductor.scratchpad.permutation_layout import (
     PermutationBasedLayoutSolver,
     _NativePackerAdapter,
-    _native_solver_class,
     buffer_quality,
 )
 from torch_spyre._inductor.scratchpad.cooling_schedules import (
@@ -436,12 +435,8 @@ class SimulatedAnnealingTests(TestCase):
             self.assertGreaterEqual(_committed_total(buffers), initial_quality, seed)
 
 
-@unittest.skipUnless(
-    _native_solver_class() is not None,
-    "the C++ NativePermutationLayoutSolver is not available in this build",
-)
 class NativePackerEquivalenceTests(TestCase):
-    """The C++ packer is an opt-in accelerator that must reproduce the canonical
+    """The C++ packer is the default accelerator and must reproduce the canonical
     Python packer exactly. Native quality is bit-exact against Python and the RNG
     is seeded, so the entire annealing trajectory -- and hence the finalized
     buffer addresses, the plan quality, and the committed permutation -- must be

--- a/tests/inductor/test_simulated_annealing.py
+++ b/tests/inductor/test_simulated_annealing.py
@@ -19,13 +19,15 @@ import math
 import os
 import random as rnd
 import unittest
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from torch_spyre._inductor.scratchpad.plan_solver import (
     LifetimeBoundBuffer,
 )
 from torch_spyre._inductor.scratchpad.permutation_layout import (
     PermutationBasedLayoutSolver,
+    _NativePackerAdapter,
+    _native_solver_class,
     buffer_quality,
 )
 from torch_spyre._inductor.scratchpad.cooling_schedules import (
@@ -431,6 +433,65 @@ class SimulatedAnnealingTests(TestCase):
 
             _assert_feasible(buffers, cap)
             self.assertGreaterEqual(_committed_total(buffers), initial_quality, seed)
+
+
+@unittest.skipUnless(
+    _native_solver_class() is not None,
+    "the C++ NativePermutationLayoutSolver is not available in this build",
+)
+class NativePackerEquivalenceTests(TestCase):
+    """The C++ packer is an opt-in accelerator that must reproduce the canonical
+    Python packer exactly. Native quality is bit-exact against Python and the RNG
+    is seeded, so the entire annealing trajectory -- and hence the finalized
+    buffer addresses, the plan quality, and the committed permutation -- must be
+    IDENTICAL whether the search runs on the Python packer or the native one.
+    Any divergence here is a wiring/parity bug, not a tolerance to loosen."""
+
+    def _run(self, buffers, capacity, initial, seed, *, native):
+        # The factory reads TORCH_SPYRE_NATIVE_PACKER at construction time, so the
+        # flag must be set across the whole solver lifetime (construct + solve +
+        # the reconstruction in solve() + finalize).
+        with mock.patch.dict(
+            os.environ, {"TORCH_SPYRE_NATIVE_PACKER": "1" if native else "0"}
+        ):
+            solver = SimulatedAnnealingLayoutSolver(
+                buffers,
+                capacity,
+                128,
+                initial=initial,
+                schedule=_short_schedule(),
+                random=rnd.Random(seed),
+            )
+            # Guard against a silent fallback masking a real divergence: with the
+            # flag set we must actually be exercising the native adapter.
+            if native:
+                self.assertIsInstance(solver.plan, _NativePackerAdapter)
+            else:
+                self.assertIsInstance(solver.plan, PermutationBasedLayoutSolver)
+            solver.solve()
+            solver.finalize()
+            return (
+                [b.address for b in buffers],
+                solver.plan.quality(),
+                list(solver.plan.permutation),
+            )
+
+    def test_python_and_native_produce_identical_plans(self):
+        for seed in range(40):
+            rng = rnd.Random(seed)
+            n = rng.randint(2, 8)
+            buffers = _random_buffers(rng, n)
+            cap = max(b.size for b in buffers) * rng.randint(2, 4)
+            initial = list(range(n))
+            rng.shuffle(initial)
+
+            py = self._run(
+                copy.deepcopy(buffers), cap, list(initial), seed, native=False
+            )
+            nat = self._run(
+                copy.deepcopy(buffers), cap, list(initial), seed, native=True
+            )
+            self.assertEqual(py, nat, f"seed={seed}")
 
 
 @unittest.skipUnless(

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -166,4 +166,11 @@ layout_solver: Literal[
     "greedy", "bestfit", "firstfit", "cpsat", "simulated_annealing"
 ] = os.environ.get("LAYOUT_SOLVER", "greedy")  # type: ignore[assignment]
 
+# Use the C++ (native) permutation-layout packer accelerator when it is built
+# into the ``_C`` extension. The native and Python packers are behaviourally
+# identical (verified bit-for-bit); the native one is faster. Set False (or
+# ``TORCH_SPYRE_NATIVE_PACKER=0``, which backs this default) to force the
+# pure-Python packer; it is also used automatically if the extension lacks it.
+native_layout_packer: bool = os.environ.get("TORCH_SPYRE_NATIVE_PACKER", "1") != "0"
+
 install_config_module(sys.modules[__name__])

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -166,11 +166,12 @@ layout_solver: Literal[
     "greedy", "bestfit", "firstfit", "cpsat", "simulated_annealing"
 ] = os.environ.get("LAYOUT_SOLVER", "greedy")  # type: ignore[assignment]
 
-# Use the C++ (native) permutation-layout packer accelerator when it is built
-# into the ``_C`` extension. The native and Python packers are behaviourally
-# identical (verified bit-for-bit); the native one is faster. Set False (or
-# ``TORCH_SPYRE_NATIVE_PACKER=0``, which backs this default) to force the
-# pure-Python packer; it is also used automatically if the extension lacks it.
-native_layout_packer: bool = os.environ.get("TORCH_SPYRE_NATIVE_PACKER", "1") != "0"
+# Use the C++ (native) permutation-layout packer accelerator, which the
+# simulated-annealing layout solver drives. The native and Python packers are
+# behaviourally identical (verified bit-for-bit); the native one is faster. Set
+# False (or ``TORCH_SPYRE_NATIVE_PACKER=0``/``false``, which backs this default)
+# to force the pure-Python packer. A missing native class is a stale or
+# incomplete build, not a supported mode, and raises rather than falling back.
+native_layout_packer: bool = _get_env_bool("TORCH_SPYRE_NATIVE_PACKER", True)
 
 install_config_module(sys.modules[__name__])

--- a/torch_spyre/_inductor/scratchpad/permutation_layout.py
+++ b/torch_spyre/_inductor/scratchpad/permutation_layout.py
@@ -38,6 +38,16 @@ from torch_spyre._inductor.scratchpad.plan_solver import (
 )
 
 
+def _quality_for(buf: LifetimeBoundBuffer, size: int) -> float:
+    """The :func:`buffer_quality` value ``buf`` would have at footprint ``size``.
+
+    Factored out so a plan can re-score a buffer after :meth:`resize` without
+    mutating the shared buffer object: the use-weight is a function of ``buf``'s
+    access pattern only, so only the size varies.
+    """
+    return (len(buf.uses) + (0.0 if buf.first_use_is_read else 0.5)) * size
+
+
 def buffer_quality(buf: LifetimeBoundBuffer) -> float:
     """The contribution buffer ``buf`` makes to a plan's :meth:`quality` when it
     is fully allocated below capacity.
@@ -48,7 +58,7 @@ def buffer_quality(buf: LifetimeBoundBuffer) -> float:
     touches the slot. Formally
     ``(len(buf.uses) + (0 if buf.first_use_is_read else 0.5)) * buf.size``.
     """
-    return (len(buf.uses) + (0.0 if buf.first_use_is_read else 0.5)) * buf.size
+    return _quality_for(buf, buf.size)
 
 
 # ===========================================================================
@@ -91,6 +101,12 @@ class PermutationBasedLayoutSolverBase(ABC):
         capacity: Scratchpad capacity in bytes.
         alignment: Byte alignment boundary for placed addresses. Defaults to 128
             (one Spyre stick).
+        eligible: Optional per-buffer LX-eligibility flags (indexed like
+            ``buffers``). ``None`` means every buffer is eligible -- the layout-
+            only default, byte-for-byte identical to the pre-eligibility solver.
+            An ineligible buffer keeps its permutation slot but is routed to HBM:
+            it is transparent to the stack (contributes no address, no quality,
+            and nothing rests on it). Toggle it live with :meth:`set_eligible`.
     """
 
     def __init__(
@@ -99,6 +115,7 @@ class PermutationBasedLayoutSolverBase(ABC):
         permutation: list[int],
         capacity: int,
         alignment: int = 128,
+        eligible: Optional[list[bool]] = None,
     ):
         n = len(buffers)
         assert sorted(permutation) == list(range(n)), (
@@ -111,12 +128,22 @@ class PermutationBasedLayoutSolverBase(ABC):
         self._name_to_idx = {buf.name: i for i, buf in enumerate(buffers)}
 
         # Per-buffer size as a flat list, for fast access in the placement hot
-        # loop (avoids a dataclass attribute lookup per candidate). Immutable.
+        # loop (avoids a dataclass attribute lookup per candidate). Mutable via
+        # :meth:`resize` (which never touches the shared buffer objects), so
+        # :meth:`copy` deep-copies it.
         self._sizes = [buf.size for buf in buffers]
 
         # Per-buffer quality contribution (use-weighted size) as a flat list,
-        # summed into total_quality for every fully-allocated buffer. Immutable.
+        # summed into total_quality for every fully-allocated buffer. Mutable via
+        # :meth:`resize` (tracks ``_sizes``); deep-copied by :meth:`copy`.
         self._qualities = [buffer_quality(buf) for buf in buffers]
+
+        # Per-buffer LX-eligibility. An ineligible buffer holds its slot but is
+        # skipped by the placer and excluded from the contact order (routed to
+        # HBM). Mutable via :meth:`set_eligible`; deep-copied by :meth:`copy`.
+        # Defaults to all-True, which reproduces the layout-only solver exactly.
+        self._eligible = [True] * n if eligible is None else list(eligible)
+        assert len(self._eligible) == n, "eligible must have one flag per buffer"
 
         # Per-buffer set of possible in-place partners (its declared parents and
         # the children that declare it). Static -- a function of names and
@@ -162,17 +189,78 @@ class PermutationBasedLayoutSolverBase(ABC):
             The change in :meth:`quality` caused by the swap (new minus old).
         """
 
+    @abstractmethod
+    def _reflow_resized(self, idx: int) -> None:
+        """Re-establish a valid layout after ``self._sizes[idx]`` /
+        ``self._qualities[idx]`` changed (the permutation is unchanged).
+
+        Called by :meth:`resize` once the size/quality arrays are updated; must
+        rebuild ``addresses`` / ``total_quality`` / ``total_allocated_count`` (and
+        any subclass structures) to match a from-scratch placement at the new
+        size.
+        """
+
+    @abstractmethod
+    def _reflow_eligibility(self, idx: int, flag: bool) -> None:
+        """Set ``self._eligible[idx] = flag`` and re-establish a valid layout.
+
+        Called by :meth:`set_eligible` only when the flag actually changes; must
+        leave ``addresses`` / ``total_quality`` / ``total_allocated_count`` (and
+        any subclass structures, e.g. contact profiles) matching a from-scratch
+        placement under the new eligibility.
+        """
+
     # --- shared helpers -----------------------------------------------------
 
+    def resize(self, idx: int, new_size: int) -> float:
+        """Change buffer ``idx``'s footprint to ``new_size`` in place and
+        re-place. Returns the change in :meth:`quality` (new minus old).
+
+        The buffer's lifetime and permutation slot are unchanged, so only its
+        size-derived footprint and quality move; the shared buffer object is
+        **not** mutated (the plan tracks size in ``_sizes``). One of the two
+        co-optimization packer extensions (Plan §4.2 / §7.3).
+        """
+        old_total = self.total_quality
+        old_q = self._qualities[idx]
+        self._sizes[idx] = new_size
+        self._qualities[idx] = _quality_for(self.buffers[idx], new_size)
+        # Reconcile the running total to the new quality *before* reflow. An
+        # incremental ``_reflow_resized`` re-scores ``idx`` via a remove/re-add of
+        # ``_qualities[idx]`` (see :meth:`PermutationBasedLayoutSolver._propagate_addresses`),
+        # which assumes the value it removes is the one currently baked into the
+        # total; since we just overwrote it, ``idx`` (if allocated) still
+        # contributes its *old* quality here, so swap in the delta now. Harmless to
+        # the from-scratch reference (its ``_build`` resets the total anyway).
+        if self.is_fully_allocated(idx):
+            self.total_quality += self._qualities[idx] - old_q
+        self._reflow_resized(idx)
+        return self.total_quality - old_total
+
+    def set_eligible(self, idx: int, flag: bool) -> float:
+        """Toggle buffer ``idx``'s LX-eligibility and re-place. Returns the
+        change in :meth:`quality` (new minus old); a no-op (returns ``0.0``) when
+        the flag is unchanged.
+
+        An ineligible buffer keeps its permutation slot but is routed to HBM
+        (transparent to the stack). The other co-optimization packer extension
+        (Plan §2.2 / §7.3): the SA engine flips this as a division change makes a
+        buffer's tiling edge (in)compatible.
+        """
+        if self._eligible[idx] == flag:
+            return 0.0
+        old_total = self.total_quality
+        self._reflow_eligibility(idx, flag)
+        return self.total_quality - old_total
+
     def rotate(self, i: int, j: int) -> float:
-        """Modify the permutation by taking ``self.permutation[i]`` out of the
-        permutation and reinserting it at position ``j``. Returns the change in
-        :meth:`quality` caused by the rotation (new minus old)."""
-        # A product of swaps, even over the full distance, beats a permutation-edit +
-        # _build(): most of the swaps are O(1) no-ops, so the chain is far cheaper
-        # than an O(n^2) rebuild in the realistic (sparse-overlap) regime. (A rebuild
-        # only wins for dense overlap, where it is a symptom of swap propagation
-        # degenerating -- a thing to fix, not to route around. See
+        """Modify the permutation by taking ``self.permutation[i]`` out of the permutation and
+        reinserting it at position ``j``. Returns the change in :meth:`quality` caused by the
+        rotation (new minus old)."""
+        # A product of swaps, even over the full distance, beats a permutation-edit + _build():
+        # most of the swaps are O(1) no-ops, so the chain is far cheaper than an O(n^2) rebuild in
+        # the realistic (sparse-overlap) regime. (A rebuild only wins for dense overlap, where it
+        # is a symptom of swap propagation degenerating -- a thing to fix, not to route around. See
         # benchmarks/copy_vs_swap_results.md.)
         delta = 0.0
         if i < j:
@@ -261,8 +349,11 @@ class PermutationBasedLayoutSolverBase(ABC):
         A child may only reuse a parent's storage if it fits within it; a
         larger child would still need the parent's inputs while writing past
         the parent's footprint.
+
+        Reads the plan-local ``_sizes`` (not ``buffers[...].size``) so a
+        :meth:`resize` that crosses the fit boundary flips in-place legality.
         """
-        return self.buffers[child].size <= self.buffers[parent].size
+        return self._sizes[child] <= self._sizes[parent]
 
     def _placement_decision(
         self, idx: int, candidates: list[int]
@@ -326,11 +417,7 @@ class PermutationBasedLayoutSolverBase(ABC):
                 partner_addr = addr[partner]
                 assert partner_addr is not None  # the partner is allocated
                 others_top = max(
-                    (
-                        addr[q] + sizes[q]  # type: ignore
-                        for q in candidates
-                        if q != partner
-                    ),
+                    (addr[q] + sizes[q] for q in candidates if q != partner),  # type: ignore
                     default=0,
                 )
                 if others_top <= partner_addr:
@@ -425,12 +512,30 @@ class PermutationBasedLayoutSolverBase(ABC):
         done_at = [total_at[t] == 0 for t in range(k)]
         not_done = k - sum(done_at)
 
+        eligible = self._eligible
         stop = n  # permutation position at which the early-stop fired (n => none)
         for pos in range(n):
             if not_done == 0:
                 stop = pos
                 break
             idx = perm[pos]
+            if not eligible[idx]:
+                # Ineligible: routed to HBM, transparent to the stack. It gets no
+                # address and no quality, and -- crucially -- does NOT mark its
+                # intervals ``has_none`` (nothing rests on it, so it evicts
+                # nothing). It is still *processed* (counted into ``placed_at``),
+                # so an interval whose remaining occupants are all ineligible can
+                # still saturate and let the early-stop fire. Candidate lists
+                # already exclude it (the get_candidates closures filter on
+                # eligibility), so no placed buffer ever names it.
+                self.addresses[idx] = None
+                lo, hi = buf_intervals[idx]
+                for t in range(lo, hi):
+                    placed_at[t] += 1
+                    if not done_at[t] and placed_at[t] == total_at[t]:
+                        done_at[t] = True
+                        not_done -= 1
+                continue
             addr, partner = self._placement_decision(idx, get_candidates(pos, idx))
             self.addresses[idx] = addr
             if partner is not None:
@@ -487,8 +592,16 @@ class ReferencePermutationBasedLayoutSolver(PermutationBasedLayoutSolverBase):
         self.total_allocated_count = 0
         for pos in range(n):
             idx = self.permutation[pos]
+            # An ineligible buffer is routed to HBM: no address, no quality, and
+            # excluded from every later buffer's candidate set (so it is
+            # transparent to the stack, not an evicting support).
+            if not self._eligible[idx]:
+                self.addresses[idx] = None
+                continue
             prior = self.permutation[:pos]
-            candidates = [p for p in prior if self.overlaps(idx, p)]
+            candidates = [
+                p for p in prior if self.overlaps(idx, p) and self._eligible[p]
+            ]
             self.addresses[idx] = self._address_from_candidates(idx, candidates)
             if self.is_fully_allocated(idx):
                 self.total_quality += self._qualities[idx]
@@ -501,6 +614,15 @@ class ReferencePermutationBasedLayoutSolver(PermutationBasedLayoutSolverBase):
         perm[i], perm[i + 1] = perm[i + 1], perm[i]
         self._build()
         return self.total_quality - old_total
+
+    def _reflow_resized(self, idx: int) -> None:
+        """Rebuild from scratch at the new size (the oracle path)."""
+        self._build()
+
+    def _reflow_eligibility(self, idx: int, flag: bool) -> None:
+        """Flip the flag and rebuild from scratch (the oracle path)."""
+        self._eligible[idx] = flag
+        self._build()
 
 
 class PermutationBasedLayoutSolver(PermutationBasedLayoutSolverBase):
@@ -539,7 +661,9 @@ class PermutationBasedLayoutSolver(PermutationBasedLayoutSolverBase):
         # addresses, inplace_reuse and the running totals.
         self._sequential_place(
             lambda pos, idx: [
-                p for p in self.permutation[:pos] if self.overlaps(idx, p)
+                p
+                for p in self.permutation[:pos]
+                if self.overlaps(idx, p) and self._eligible[p]
             ]
         )
         # Persistent position index, maintained in O(1) by swap().
@@ -596,8 +720,15 @@ class PermutationBasedLayoutSolver(PermutationBasedLayoutSolverBase):
         }
         breakpoints = sorted({b.start_time for b in bufs} | {b.end_time for b in bufs})
         for t0 in breakpoints[:-1]:
+            # Only *eligible* buffers participate in the stacking order; an
+            # ineligible one is in HBM and transparent, so it never appears as a
+            # neighbour. (All-eligible -> identical to the pre-eligibility order.)
             alive = sorted(
-                (i for i in range(n) if bufs[i].start_time <= t0 < bufs[i].end_time),
+                (
+                    i
+                    for i in range(n)
+                    if self._eligible[i] and bufs[i].start_time <= t0 < bufs[i].end_time
+                ),
                 key=lambda i: self.position[i],
             )
             for idx, c in enumerate(alive):
@@ -608,6 +739,17 @@ class PermutationBasedLayoutSolver(PermutationBasedLayoutSolverBase):
                 above_segs[c][0].append(t0)
                 above_segs[c][1].append(above)
         for i in range(n):
+            if not self._eligible[i]:
+                # Out of the stack: a trivial "nothing below/above me" profile
+                # over its lifetime, so it stays a well-formed step function that
+                # names no neighbour (and no neighbour names it).
+                self.below_profile[i] = Profile.uniform(
+                    bufs[i].start_time, bufs[i].end_time, None
+                )
+                self.above_profile[i] = Profile.uniform(
+                    bufs[i].start_time, bufs[i].end_time, None
+                )
+                continue
             bs, bl = below_segs[i]
             bs.append(bufs[i].end_time)
             self.below_profile[i] = Profile.from_segments(bs, bl)
@@ -658,6 +800,11 @@ class PermutationBasedLayoutSolver(PermutationBasedLayoutSolverBase):
         x, y = perm[i], perm[i + 1]
         perm[i], perm[i + 1] = y, x
         self.position[x], self.position[y] = i + 1, i
+        if not (self._eligible[x] and self._eligible[y]):
+            # At least one is transparent (in HBM), so it is not part of the
+            # eligible stacking order: reordering across it leaves every eligible
+            # buffer's contacts and address untouched. Only the positions moved.
+            return 0
         if not self.overlaps(x, y):
             # Independent buffers: their order does not affect any address.
             return 0
@@ -668,8 +815,8 @@ class PermutationBasedLayoutSolver(PermutationBasedLayoutSolverBase):
         self._update_profiles_for_swap(x, y, a, b)
 
         # 2. Re-place affected addresses, propagating along order-above edges and
-        # in-place transitions (see the method docstring). Seed with the swapped
-        # pair and whatever rested on them before the swap.
+        # in-place transitions. Seed with the swapped pair and whatever rested on
+        # them before the swap.
         old_total = self.total_quality
         seed: set[int] = {x, y}
         for lbl in (
@@ -677,6 +824,36 @@ class PermutationBasedLayoutSolver(PermutationBasedLayoutSolverBase):
         ):
             if lbl is not None:
                 seed.add(lbl)
+        self._propagate_addresses(seed)
+        return self.total_quality - old_total
+
+    def _propagate_addresses(self, seed: set[int]) -> None:
+        """Re-place the buffers in ``seed`` and everything that transitively rests
+        on them, maintaining ``addresses`` / ``inplace_reuse`` / ``total_quality`` /
+        ``total_allocated_count``.
+
+        The frontier is processed in a min-heap by permutation position: a
+        dependency always points to an earlier position, so a buffer is settled
+        before anything resting on it (``position`` is maintained in O(1)). Two
+        kinds of edge feed the dirty set:
+
+        - *Order-above.* When ``z``'s address changes, the buffers directly above
+          it (``above_profile[z]``) are dirtied -- the cheap contact-profile
+          frontier, exactly right whenever the buffer a dependent rests on is also
+          its order-below neighbour.
+        - *In-place transition.* When ``z``'s in-place status flips, a
+          poke-through appears or vanishes, so the buffer resting on the pair must
+          be revisited even though nothing it can see changed value; dirty the
+          order-above neighbour of *both* members at their shared (overlap) tick.
+
+        Shared by every incremental re-placement -- :meth:`swap` (seed = the
+        swapped pair plus their order-above neighbours), :meth:`_reflow_resized`
+        (seed = the resized buffer plus what rests on it), and
+        :meth:`_reflow_eligibility` (seed = what rests / used to rest on the
+        toggled buffer). ``seed`` must already reflect any profile edits the caller
+        made; the caller captures the pre-change ``total_quality`` and computes its
+        own delta.
+        """
         heap = [(self.position[idx], idx) for idx in seed]
         heapq.heapify(heap)
         queued = set(seed)
@@ -732,7 +909,6 @@ class PermutationBasedLayoutSolver(PermutationBasedLayoutSolverBase):
                     t = self.buffers[child].start_time
                     _dirty(self.above_profile[child].label_at(t), pos_z)
                     _dirty(self.above_profile[parent].label_at(t), pos_z)
-        return self.total_quality - old_total
 
     def _flip_evicted_closure(self, z: int, flipped: set[int]) -> None:
         """Evict every buffer resting (transitively) on the just-evicted ``z``.
@@ -878,6 +1054,13 @@ class PermutationBasedLayoutSolver(PermutationBasedLayoutSolverBase):
         """
         if i == j:
             return 0
+        if not self._eligible[self.permutation[i]]:
+            # Moving a transparent (HBM) buffer changes no eligible buffer's
+            # relative order, so no address or profile moves; just relocate its
+            # slot. (Both rotate paths below would otherwise mishandle a buffer
+            # that is not in the contact order.)
+            self._move_in_permutation(i, j)
+            return 0.0
         if abs(i - j) < self._rotate_remove_insert_threshold:
             return super().rotate(i, j)
         return self._fast_rotate(i, j)
@@ -935,7 +1118,9 @@ class PermutationBasedLayoutSolver(PermutationBasedLayoutSolverBase):
         """
         pos = self.position
         self._sequential_place(
-            lambda p, idx: [w for w in self.overlap_dict[idx] if pos[w] < p]
+            lambda p, idx: [
+                w for w in self.overlap_dict[idx] if pos[w] < p and self._eligible[w]
+            ]
         )
 
     @staticmethod
@@ -960,34 +1145,59 @@ class PermutationBasedLayoutSolver(PermutationBasedLayoutSolverBase):
 
         Two stages, both order-based (in-place placement is irrelevant here):
 
-        1. **Remove x.** Over each column x used to occupy, its old below
-           neighbour ``a`` and above neighbour ``b`` become adjacent: splice
-           ``above_profile[a] := b`` and ``below_profile[b] := a`` (handling the
-           ``None`` ends, where the survivor becomes bottom/top).
-        2. **Reinsert x.** x's contact neighbours can only be members of
-           ``overlaps[x]``; sweep the breakpoints those members induce across
-           x's lifetime. On each sub-interval the alive subset is constant, so
-           x's new below neighbour is the alive member with the greatest
-           ``position < position[x]`` and its above neighbour the one with the
-           least greater position (``None`` if none). Rebuild x's own profiles
-           and splice x into each neighbour's profile.
-        """
-        bufs = self.buffers
-        s_x, e_x = bufs[x].start_time, bufs[x].end_time
+        1. **Remove x** (:meth:`_stitch_around_removed`). Over each column x used
+           to occupy, its old below neighbour ``a`` and above neighbour ``b``
+           become adjacent.
+        2. **Reinsert x** (:meth:`_insert_into_profiles`). Sweep the breakpoints
+           x's overlap-members induce and splice x back in at its new position.
 
-        # --- 1. Remove x: stitch its former below/above neighbours together. --
+        The two stages are the exact halves :meth:`_reflow_eligibility` reuses to
+        drop a buffer out of / back into the stack (toggle-eligibility).
+        """
+        self._stitch_around_removed(x, old_below, old_above)
+        self._insert_into_profiles(x)
+
+    def _stitch_around_removed(
+        self, x: int, old_below: Profile, old_above: Profile
+    ) -> None:
+        """Splice ``x`` out of the contact profiles: over each column ``x``
+        occupied, its old below neighbour ``a`` and above neighbour ``b`` become
+        directly adjacent (``above_profile[a] := b`` and ``below_profile[b] :=
+        a``; a ``None`` end just makes the survivor the new bottom/top).
+
+        ``old_below`` / ``old_above`` are ``x``'s profiles *before* removal (the
+        caller captures them, since this overwrites neighbours' views of ``x``).
+        Every named neighbour is eligible -- an ineligible buffer never appears in
+        ``x``'s profile -- so no eligibility test is needed here.
+        """
         for lo, hi, a, b in self._iter_common(old_below, old_above):
             if a is not None:
                 self.above_profile[a].splice(lo, hi, [lo, hi], [b])
             if b is not None:
                 self.below_profile[b].splice(lo, hi, [lo, hi], [a])
 
-        # --- 2. Reinsert x at its new position. ------------------------------
+    def _insert_into_profiles(self, x: int) -> None:
+        """Build ``x``'s own contact profiles at its current position and splice
+        ``x`` into each new neighbour's profile.
+
+        ``x``'s contact neighbours can only be *eligible* members of
+        ``overlaps[x]``; sweep the breakpoints those members induce across ``x``'s
+        lifetime. On each sub-interval the alive-eligible subset is constant, so
+        ``x``'s below neighbour is the eligible member with the greatest
+        ``position < position[x]`` and its above neighbour the one with the least
+        greater position (``None`` if none). Ineligible members are skipped -- they
+        are transparent to the stack -- so with everything eligible this is
+        identical to the pre-eligibility reinsert.
+        """
+        bufs = self.buffers
+        s_x, e_x = bufs[x].start_time, bufs[x].end_time
         pos = self.position
         pos_x = pos[x]
         members = self.overlap_dict[x]
         cuts = {s_x, e_x}
         for w in members:
+            if not self._eligible[w]:
+                continue
             if bufs[w].start_time > s_x:
                 cuts.add(bufs[w].start_time)
             if bufs[w].end_time < e_x:
@@ -1004,6 +1214,8 @@ class PermutationBasedLayoutSolver(PermutationBasedLayoutSolverBase):
             above = None  # least position above pos_x among alive members
             above_pos = len(self.permutation)
             for w in members:
+                if not self._eligible[w]:
+                    continue
                 if bufs[w].start_time <= lo < bufs[w].end_time:
                     pw = pos[w]
                     if pw < pos_x:
@@ -1024,6 +1236,107 @@ class PermutationBasedLayoutSolver(PermutationBasedLayoutSolverBase):
         above_starts.append(e_x)
         self.below_profile[x] = Profile.from_segments(below_starts, below_labels)
         self.above_profile[x] = Profile.from_segments(above_starts, above_labels)
+
+    # --- resize / toggle-eligibility reflow (co-optimization extensions) ----
+
+    def _above_seed(self, idx: int) -> set[int]:
+        """The buffers directly resting on ``idx`` -- its order-above neighbours,
+        the frontier :meth:`_propagate_addresses` starts from when ``idx``'s
+        footprint or presence changes."""
+        return {lbl for lbl in self.above_profile[idx].label_set() if lbl is not None}
+
+    def _inplace_pokethrough_seed(self, idx: int) -> set[int]:
+        """Buffers resting on ``idx`` through an in-place poke-through.
+
+        When ``idx`` is co-located with an in-place partner, the buffer above the
+        *shorter* member rests on the *taller* member's top -- so its order-below
+        neighbour is the partner, not ``idx``, and the plain order-above frontier
+        (:meth:`_above_seed`) misses it. This mirrors the in-place dirtying inside
+        :meth:`_propagate_addresses`, but seeded up front: a :meth:`resize` moves
+        ``idx``'s top while its address and its in-place pairing can both stay put,
+        firing none of the loop's normal dirty triggers (address move / partner
+        flip). Over-seeding is harmless -- an unaffected buffer re-places to the
+        same address.
+        """
+        extra: set[int] = set()
+        for partner in self._inplace_partners[idx]:
+            if (
+                self.inplace_reuse.get(idx) == partner
+                or self.inplace_reuse.get(partner) == idx
+            ):
+                parent, child = self._in_place_pair(idx, partner)  # type: ignore
+                t = self.buffers[child].start_time
+                for w in (
+                    self.above_profile[child].label_at(t),
+                    self.above_profile[parent].label_at(t),
+                ):
+                    if w is not None:
+                        extra.add(w)
+        return extra
+
+    def _reflow_resized(self, idx: int) -> None:
+        """Re-place after ``idx``'s footprint changed.
+
+        The contact profiles are a function of the permutation order and
+        lifetimes only, so a size change leaves them untouched -- only addresses
+        (and the quality totals they drive) move. An ineligible buffer is not in
+        the stack, so nothing depends on its size and there is nothing to redo.
+        Otherwise only ``idx`` (its top moved, and an in-place fit may have
+        flipped), the buffers resting on it, and any in-place poke-through
+        dependents can change, so propagate from that frontier rather than
+        re-placing the whole graph. (``resize`` has already reconciled the running
+        total to ``idx``'s new quality, so the propagation's remove/re-add of it
+        nets correctly.)
+        """
+        if not self._eligible[idx]:
+            return
+        seed = {idx} | self._above_seed(idx) | self._inplace_pokethrough_seed(idx)
+        self._propagate_addresses(seed)
+
+    def _reflow_eligibility(self, idx: int, flag: bool) -> None:
+        """Toggle ``idx`` in/out of the contact order and re-place.
+
+        Reuses the two halves of the single-move profile patch: dropping to HBM
+        is the *remove* half (:meth:`_stitch_around_removed`), returning to LX is
+        the *reinsert* half (:meth:`_insert_into_profiles`) at ``idx``'s retained
+        slot. Only the buffers resting on ``idx`` can move, so addresses propagate
+        from that frontier: the buffers that *now* rest on ``idx`` (plus ``idx``
+        itself) when it re-enters, or the ones that *used* to rest on it when it
+        leaves.
+        """
+        bufs = self.buffers
+        if flag:
+            # HBM -> LX: reinsert idx into the order at its slot. Buffers that now
+            # rest on idx move up (or evict); idx itself gets an address. Seed
+            # after the profile edit so above_profile[idx] names the new frontier.
+            self._eligible[idx] = True
+            self._insert_into_profiles(idx)
+            seed = {idx} | self._above_seed(idx)
+        else:
+            # LX -> HBM: capture idx's adjacency (the seed is what *used* to rest
+            # on it), stitch its former neighbours together, drop idx's own quality
+            # and address, and give it a transparent (all-None) profile. Buffers
+            # that rested on idx drop onto its old support (or may un-evict).
+            old_below = Profile(
+                list(self.below_profile[idx].starts),
+                list(self.below_profile[idx].labels),
+            )
+            old_above = Profile(
+                list(self.above_profile[idx].starts),
+                list(self.above_profile[idx].labels),
+            )
+            seed = {lbl for lbl in old_above.label_set() if lbl is not None}
+            if self.is_fully_allocated(idx):
+                self.total_quality -= self._qualities[idx]
+                self.total_allocated_count -= 1
+            self.addresses[idx] = None
+            self.inplace_reuse.pop(idx, None)
+            self._eligible[idx] = False
+            self._stitch_around_removed(idx, old_below, old_above)
+            s, e = bufs[idx].start_time, bufs[idx].end_time
+            self.below_profile[idx] = Profile.uniform(s, e, None)
+            self.above_profile[idx] = Profile.uniform(s, e, None)
+        self._propagate_addresses(seed)
 
     def contact_at(self, c: int, t: int) -> Optional[int] | tuple[int, int]:
         """What occupies the address slot directly below ``c`` at column ``t``,
@@ -1084,18 +1397,21 @@ class PermutationBasedLayoutSolver(PermutationBasedLayoutSolverBase):
         clone.capacity = self.capacity
         clone.alignment = self.alignment
         clone.overlap_dict = self.overlap_dict
-        clone._sizes = self._sizes
-        clone._qualities = self._qualities
         clone._inplace_partners = self._inplace_partners
         # Lifetime-interval data for the saturation early-stop (static).
         clone._interval_starts = self._interval_starts
         clone._num_intervals = self._num_intervals
         clone._total_at = self._total_at
         clone._buf_intervals = self._buf_intervals
-        # Rotate-policy knob (a cheap scalar; carried so a clone rotates the
-        # same way as its source and tests can flip it on a clone).
+        # Rotate-policy knob (a cheap scalar; carried so a clone rotates the same
+        # way as its source and tests can flip it on a clone).
         clone._rotate_remove_insert_threshold = self._rotate_remove_insert_threshold
-        # Deep-copied dynamic state.
+        # Deep-copied dynamic state. ``_sizes`` / ``_qualities`` / ``_eligible``
+        # are per-plan mutable now (resize / set_eligible), so a clone must own
+        # its own copies rather than aliasing the source's.
+        clone._sizes = list(self._sizes)
+        clone._qualities = list(self._qualities)
+        clone._eligible = list(self._eligible)
         clone.permutation = list(self.permutation)
         clone.addresses = list(self.addresses)
         clone.position = list(self.position)

--- a/torch_spyre/_inductor/scratchpad/permutation_layout.py
+++ b/torch_spyre/_inductor/scratchpad/permutation_layout.py
@@ -30,6 +30,8 @@ from abc import ABC, abstractmethod
 import bisect
 import heapq
 import math
+import os
+import warnings
 
 from torch_spyre._inductor.scratchpad.contact_profile import Profile
 from torch_spyre._inductor.scratchpad.plan_solver import (
@@ -1427,3 +1429,188 @@ class PermutationBasedLayoutSolver(PermutationBasedLayoutSolverBase):
             for k, p in self.above_profile.items()
         }
         return clone
+
+
+# ===========================================================================
+# Native (C++) packer accelerator: opt-in drop-in for the Python packer
+# ===========================================================================
+#
+# The Python :class:`PermutationBasedLayoutSolver` above stays canonical. The
+# C++ ``torch_spyre._C.NativePermutationLayoutSolver`` reproduces its *observable*
+# behaviour bit-for-bit (differentially proven in test_perm_layout_solver.py) but
+# never touches a Python object per op. This adapter wraps the native solver so it
+# is a drop-in for the exact surface the simulated-annealing search drives.
+
+# One-time warning latch: emit the "requested but unavailable" fallback warning at
+# most once per process, so a native-less build does not spam every layout plan.
+_native_packer_warned = False
+
+
+def _native_solver_class():
+    """The C++ ``NativePermutationLayoutSolver`` class, or ``None`` if the ``_C``
+    extension is not importable / does not expose it (e.g. a pure-Python build)."""
+    try:
+        from torch_spyre._C import NativePermutationLayoutSolver
+
+        return NativePermutationLayoutSolver
+    except (ImportError, AttributeError):
+        return None
+
+
+class _NativePackerAdapter:
+    """Drop-in for :class:`PermutationBasedLayoutSolver` backed by the C++
+    ``NativePermutationLayoutSolver``.
+
+    Delegates every mutating / query op to the native solver and exposes the
+    two list-valued attributes (``permutation``, ``addresses``) the search reads
+    inside its hot loops. The native properties rebuild a fresh Python list per
+    access, so naive delegation would be O(n) per read (O(n^2) per step); this
+    adapter avoids that two ways:
+
+    - ``permutation`` is a *persistent* Python list, mutated in place to mirror
+      each ``swap`` / ``rotate`` (exactly as the Python packer mutates its own
+      ``permutation`` list). Access is O(1) and -- crucially -- a caller that
+      captures ``perm = plan.permutation`` and then calls ``plan.swap(i)`` sees
+      the swap through ``perm``, matching the Python packer's live-list semantics
+      (``annealing_step_swap`` relies on this).
+    - ``addresses`` is cached and invalidated on any mutating op, rebuilt at most
+      once per read burst. Nothing in the search holds an ``addresses`` list
+      across a mutation, so the cache is always fresh when read.
+
+    All other observable state (quality, count, per-op deltas, eviction ==
+    ``None`` address) comes straight from the native solver, which is bit-exact
+    against the Python packer.
+    """
+
+    def __init__(
+        self,
+        native_cls,
+        buffers: list[LifetimeBoundBuffer],
+        permutation: list[int],
+        capacity: int,
+        alignment: int = 128,
+        eligible: Optional[list[bool]] = None,
+    ):
+        self.buffers = buffers
+        self._native = native_cls(
+            buffers, list(permutation), capacity, alignment, eligible
+        )
+        # Persistent, in-place-mutated mirror of the native permutation (see the
+        # class docstring). Seed from the native solver so it reflects any
+        # normalization the constructor did.
+        self._perm: list[int] = list(self._native.permutation)
+        self._addr_cache: Optional[list[Optional[int]]] = None
+
+    # --- list-valued attributes (hot-loop reads) ----------------------------
+
+    @property
+    def permutation(self) -> list[int]:
+        return self._perm
+
+    @property
+    def addresses(self) -> list[Optional[int]]:
+        if self._addr_cache is None:
+            self._addr_cache = list(self._native.addresses)
+        return self._addr_cache
+
+    # --- mutating ops (delegate, then keep the mirror / cache consistent) ----
+
+    def swap(self, i: int) -> float:
+        # Delegate first: the native solver validates ``i`` and raises on a bad
+        # index, so the mirror is only mutated once the op is known valid.
+        delta = self._native.swap(i)
+        self._perm[i], self._perm[i + 1] = self._perm[i + 1], self._perm[i]
+        self._addr_cache = None
+        return delta
+
+    def rotate(self, i: int, j: int) -> float:
+        delta = self._native.rotate(i, j)
+        if i != j:
+            # Native rotate == remove ``permutation[i]`` and reinsert it at ``j``
+            # (a no-op when i == j, which it returns early); mirror that pop/insert.
+            x = self._perm.pop(i)
+            self._perm.insert(j, x)
+        self._addr_cache = None
+        return delta
+
+    def resize(self, idx: int, new_size: int) -> float:
+        delta = self._native.resize(idx, new_size)
+        self._addr_cache = None
+        return delta
+
+    def set_eligible(self, idx: int, flag: bool) -> float:
+        delta = self._native.set_eligible(idx, flag)
+        self._addr_cache = None
+        return delta
+
+    # --- pure queries (straight delegation) ---------------------------------
+
+    def quality(self) -> float:
+        return self._native.quality()
+
+    def count_allocated(self) -> int:
+        return self._native.count_allocated()
+
+    def overlaps(self, i: int, j: int) -> bool:
+        return self._native.overlaps(i, j)
+
+    def is_fully_allocated(self, idx: int) -> bool:
+        return self._native.is_fully_allocated(idx)
+
+    # --- copy / finalize -----------------------------------------------------
+
+    def copy(self) -> "_NativePackerAdapter":
+        """An independent snapshot sharing the (immutable) ``buffers`` list, over
+        an independent native ``copy()``. Mirrors the Python packer's ``copy``."""
+        clone = _NativePackerAdapter.__new__(_NativePackerAdapter)
+        clone.buffers = self.buffers
+        clone._native = self._native.copy()
+        clone._perm = list(self._perm)
+        clone._addr_cache = None
+        return clone
+
+    def finalize(self) -> None:
+        """Write each buffer's address back to the buffer object -- for EVERY
+        index, exactly like :meth:`PermutationBasedLayoutSolverBase.finalize`
+        (an evicted buffer gets ``None``)."""
+        addresses = self.addresses
+        for idx, buf in enumerate(self.buffers):
+            buf.address = addresses[idx]
+
+
+def make_permutation_packer(
+    buffers: list[LifetimeBoundBuffer],
+    permutation: list[int],
+    capacity: int,
+    alignment: int = 128,
+    eligible: Optional[list[bool]] = None,
+):
+    """Construct a permutation packer, choosing the C++ accelerator when opted in.
+
+    Returns a :class:`_NativePackerAdapter` (over the C++
+    ``NativePermutationLayoutSolver``) iff the environment variable
+    ``TORCH_SPYRE_NATIVE_PACKER == "1"`` *and* the native class is importable;
+    otherwise the canonical Python :class:`PermutationBasedLayoutSolver`. If the
+    flag is set but the native class is unavailable, a one-time warning is emitted
+    and the Python packer is used. With the flag unset (the default) the Python
+    packer is always returned, so existing behaviour is byte-for-byte unchanged.
+    """
+    if os.environ.get("TORCH_SPYRE_NATIVE_PACKER") == "1":
+        native_cls = _native_solver_class()
+        if native_cls is not None:
+            return _NativePackerAdapter(
+                native_cls, buffers, permutation, capacity, alignment, eligible
+            )
+        global _native_packer_warned
+        if not _native_packer_warned:
+            _native_packer_warned = True
+            warnings.warn(
+                "TORCH_SPYRE_NATIVE_PACKER=1 was set but "
+                "torch_spyre._C.NativePermutationLayoutSolver is unavailable; "
+                "falling back to the Python permutation packer.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+    return PermutationBasedLayoutSolver(
+        buffers, permutation, capacity, alignment, eligible
+    )

--- a/torch_spyre/_inductor/scratchpad/permutation_layout.py
+++ b/torch_spyre/_inductor/scratchpad/permutation_layout.py
@@ -29,7 +29,9 @@ from typing import Optional
 from abc import ABC, abstractmethod
 import bisect
 import heapq
+import math
 
+from torch_spyre._C import NativePermutationLayoutSolver
 from torch_spyre._inductor.scratchpad.contact_profile import Profile
 from torch_spyre._inductor.scratchpad.plan_solver import (
     LifetimeBoundBuffer,
@@ -299,6 +301,18 @@ class PermutationBasedLayoutSolverBase(ABC):
         if self.addresses[idx] is None:
             return None
         return self.addresses[idx] + self._sizes[idx]  # type: ignore
+
+    def top_or_inf(self, idx: int) -> float:
+        """:meth:`_top` as a float, with ``inf`` for an evicted buffer.
+
+        The public form the annealing search sorts on: an evicted buffer sorts as
+        if it sat arbitrarily high, so it is treated as above any placed buffer
+        and never reordered below one. Lives on the packer (rather than in the
+        search, where it used to read ``buffers[idx].size``) so that it reads the
+        plan-local ``_sizes``, which :meth:`resize` mutates.
+        """
+        top = self._top(idx)
+        return math.inf if top is None else float(top)
 
     def is_fully_allocated(self, idx: int) -> bool:
         """True if buffer ``idx`` has an address (and so fits below ``capacity``).
@@ -1471,146 +1485,20 @@ class PermutationBasedLayoutSolver(PermutationBasedLayoutSolverBase):
 
 
 # ===========================================================================
-# Native (C++) packer accelerator: opt-in drop-in for the Python packer
+# Native (C++) packer accelerator: the default packer
 # ===========================================================================
 #
-# The Python :class:`PermutationBasedLayoutSolver` above stays canonical. The
-# C++ ``torch_spyre._C.NativePermutationLayoutSolver`` reproduces its *observable*
-# behaviour bit-for-bit (differentially proven in test_perm_layout_solver.py) but
-# never touches a Python object per op. This adapter wraps the native solver so it
-# is a drop-in for the exact surface the simulated-annealing search drives.
-
-
-def _native_solver_class():
-    """The C++ ``NativePermutationLayoutSolver`` class, or ``None`` if the ``_C``
-    extension is not importable / does not expose it (e.g. a pure-Python build)."""
-    try:
-        from torch_spyre._C import NativePermutationLayoutSolver
-
-        return NativePermutationLayoutSolver
-    except (ImportError, AttributeError):
-        return None
-
-
-class _NativePackerAdapter:
-    """Drop-in for :class:`PermutationBasedLayoutSolver` backed by the C++
-    ``NativePermutationLayoutSolver``.
-
-    Delegates every mutating / query op to the native solver and exposes the
-    two list-valued attributes (``permutation``, ``addresses``) the search reads
-    inside its hot loops. The native properties rebuild a fresh Python list per
-    access, so naive delegation would be O(n) per read (O(n^2) per step); this
-    adapter avoids that two ways:
-
-    - ``permutation`` is a *persistent* Python list, mutated in place to mirror
-      each ``swap`` / ``rotate`` (exactly as the Python packer mutates its own
-      ``permutation`` list). Access is O(1) and -- crucially -- a caller that
-      captures ``perm = plan.permutation`` and then calls ``plan.swap(i)`` sees
-      the swap through ``perm``, matching the Python packer's live-list semantics
-      (``annealing_step_swap`` relies on this).
-    - ``addresses`` is cached and invalidated on any mutating op, rebuilt at most
-      once per read burst. Nothing in the search holds an ``addresses`` list
-      across a mutation, so the cache is always fresh when read.
-
-    All other observable state (quality, count, per-op deltas, eviction ==
-    ``None`` address) comes straight from the native solver, which is bit-exact
-    against the Python packer.
-    """
-
-    def __init__(
-        self,
-        native_cls,
-        buffers: list[LifetimeBoundBuffer],
-        permutation: list[int],
-        capacity: int,
-        alignment: int = 128,
-        eligible: Optional[list[bool]] = None,
-    ):
-        self.buffers = buffers
-        self._native = native_cls(
-            buffers, list(permutation), capacity, alignment, eligible
-        )
-        # Persistent, in-place-mutated mirror of the native permutation (see the
-        # class docstring). Seed from the native solver so it reflects any
-        # normalization the constructor did.
-        self._perm: list[int] = list(self._native.permutation)
-        self._addr_cache: Optional[list[Optional[int]]] = None
-
-    # --- list-valued attributes (hot-loop reads) ----------------------------
-
-    @property
-    def permutation(self) -> list[int]:
-        return self._perm
-
-    @property
-    def addresses(self) -> list[Optional[int]]:
-        if self._addr_cache is None:
-            self._addr_cache = list(self._native.addresses)
-        return self._addr_cache
-
-    # --- mutating ops (delegate, then keep the mirror / cache consistent) ----
-
-    def swap(self, i: int) -> float:
-        # Delegate first: the native solver validates ``i`` and raises on a bad
-        # index, so the mirror is only mutated once the op is known valid.
-        delta = self._native.swap(i)
-        self._perm[i], self._perm[i + 1] = self._perm[i + 1], self._perm[i]
-        self._addr_cache = None
-        return delta
-
-    def rotate(self, i: int, j: int) -> float:
-        delta = self._native.rotate(i, j)
-        if i != j:
-            # Native rotate == remove ``permutation[i]`` and reinsert it at ``j``
-            # (a no-op when i == j, which it returns early); mirror that pop/insert.
-            x = self._perm.pop(i)
-            self._perm.insert(j, x)
-        self._addr_cache = None
-        return delta
-
-    def resize(self, idx: int, new_size: int) -> float:
-        delta = self._native.resize(idx, new_size)
-        self._addr_cache = None
-        return delta
-
-    def set_eligible(self, idx: int, flag: bool) -> float:
-        delta = self._native.set_eligible(idx, flag)
-        self._addr_cache = None
-        return delta
-
-    # --- pure queries (straight delegation) ---------------------------------
-
-    def quality(self) -> float:
-        return self._native.quality()
-
-    def count_allocated(self) -> int:
-        return self._native.count_allocated()
-
-    def overlaps(self, i: int, j: int) -> bool:
-        return self._native.overlaps(i, j)
-
-    def is_fully_allocated(self, idx: int) -> bool:
-        return self._native.is_fully_allocated(idx)
-
-    # --- copy / finalize -----------------------------------------------------
-
-    def copy(self) -> "_NativePackerAdapter":
-        """An independent snapshot sharing the (immutable) ``buffers`` list, over
-        an independent native ``copy()``. Mirrors the Python packer's ``copy``."""
-        clone = _NativePackerAdapter.__new__(_NativePackerAdapter)
-        clone.buffers = self.buffers
-        clone._native = self._native.copy()
-        clone._perm = list(self._perm)
-        clone._addr_cache = None
-        return clone
-
-    def finalize(self) -> None:
-        """Write each buffer's address back to the buffer object -- for EVERY
-        index, exactly like :meth:`PermutationBasedLayoutSolverBase.finalize`
-        (an evicted buffer gets ``None``)."""
-        addresses = self.addresses
-        for idx, buf in enumerate(self.buffers):
-            buf.address = addresses[idx]
+# The Python :class:`PermutationBasedLayoutSolver` above stays canonical, and
+# ``torch_spyre._C.NativePermutationLayoutSolver`` reproduces its *observable*
+# behaviour bit-for-bit (differentially proven in test_perm_layout_solver.py)
+# without touching a Python object per operation. The native class implements the
+# full surface the annealing search drives -- including ``finalize()``,
+# ``top_or_inf()`` and a live read-only ``permutation`` view -- so it is used
+# directly, with no Python adapter in the hot path.
+#
+# The import is unconditional, like every other ``torch_spyre._C`` import in the
+# tree: ``_C`` is required for torch-spyre to function at all, so a missing symbol
+# means a stale or incomplete build rather than a supported pure-Python mode.
 
 
 def make_permutation_packer(
@@ -1622,33 +1510,18 @@ def make_permutation_packer(
 ):
     """Construct a permutation packer, using the C++ accelerator by default.
 
-    Returns a :class:`_NativePackerAdapter` (over the C++
-    ``NativePermutationLayoutSolver``) when ``config.native_layout_packer`` is
-    true (the default -- back it off with that config knob, or its
-    ``TORCH_SPYRE_NATIVE_PACKER=0`` env default), and the canonical Python
-    :class:`PermutationBasedLayoutSolver` when it is false. The two packers are
-    behaviourally identical (verified bit-for-bit by the differential and the
-    SA-equivalence tests); the C++ one is the faster default.
-
-    A missing native class is *not* a supported mode: ``_C`` is required for the
-    package to work at all, so its absence means an incomplete or stale build
-    rather than a pure-Python installation. Raise instead of silently falling
-    back, which would otherwise trade a build error for a quiet 2-25x slowdown.
+    Returns the C++ :class:`NativePermutationLayoutSolver` when
+    ``config.native_layout_packer`` is true (the default -- back it off with that
+    config knob, or its ``TORCH_SPYRE_NATIVE_PACKER=0`` env default), and the
+    canonical Python :class:`PermutationBasedLayoutSolver` when it is false. The
+    two are behaviourally identical (verified bit-for-bit by the differential and
+    the SA-equivalence tests); the C++ one is the faster default.
     """
     from torch_spyre._inductor import config
 
     if config.native_layout_packer:
-        native_cls = _native_solver_class()
-        if native_cls is None:
-            raise RuntimeError(
-                "torch_spyre._C.NativePermutationLayoutSolver is unavailable, "
-                "which means the _C extension is missing or stale -- rebuild it. "
-                "To use the pure-Python packer deliberately, set "
-                "config.native_layout_packer = False (or "
-                "TORCH_SPYRE_NATIVE_PACKER=0)."
-            )
-        return _NativePackerAdapter(
-            native_cls, buffers, permutation, capacity, alignment, eligible
+        return NativePermutationLayoutSolver(
+            buffers, permutation, capacity, alignment, eligible
         )
     return PermutationBasedLayoutSolver(
         buffers, permutation, capacity, alignment, eligible

--- a/torch_spyre/_inductor/scratchpad/permutation_layout.py
+++ b/torch_spyre/_inductor/scratchpad/permutation_layout.py
@@ -30,7 +30,6 @@ from abc import ABC, abstractmethod
 import bisect
 import heapq
 import math
-import os
 import warnings
 
 from torch_spyre._inductor.scratchpad.contact_profile import Profile
@@ -1585,17 +1584,22 @@ def make_permutation_packer(
     alignment: int = 128,
     eligible: Optional[list[bool]] = None,
 ):
-    """Construct a permutation packer, choosing the C++ accelerator when opted in.
+    """Construct a permutation packer, using the C++ accelerator by default.
 
     Returns a :class:`_NativePackerAdapter` (over the C++
-    ``NativePermutationLayoutSolver``) iff the environment variable
-    ``TORCH_SPYRE_NATIVE_PACKER == "1"`` *and* the native class is importable;
-    otherwise the canonical Python :class:`PermutationBasedLayoutSolver`. If the
-    flag is set but the native class is unavailable, a one-time warning is emitted
-    and the Python packer is used. With the flag unset (the default) the Python
-    packer is always returned, so existing behaviour is byte-for-byte unchanged.
+    ``NativePermutationLayoutSolver``) when ``config.native_layout_packer`` is
+    true (the default -- back it off with that config knob, or its
+    ``TORCH_SPYRE_NATIVE_PACKER=0`` env default) and the native class is
+    importable. When the knob is false, or the native class is unavailable, the
+    canonical Python :class:`PermutationBasedLayoutSolver` is used instead. The
+    two packers are behaviourally identical (verified bit-for-bit by the
+    differential and the SA-equivalence tests); the C++ one is the faster default.
+    If the native class is unavailable a one-time warning is emitted before
+    falling back to Python.
     """
-    if os.environ.get("TORCH_SPYRE_NATIVE_PACKER") == "1":
+    from torch_spyre._inductor import config
+
+    if config.native_layout_packer:
         native_cls = _native_solver_class()
         if native_cls is not None:
             return _NativePackerAdapter(
@@ -1605,9 +1609,10 @@ def make_permutation_packer(
         if not _native_packer_warned:
             _native_packer_warned = True
             warnings.warn(
-                "TORCH_SPYRE_NATIVE_PACKER=1 was set but "
                 "torch_spyre._C.NativePermutationLayoutSolver is unavailable; "
-                "falling back to the Python permutation packer.",
+                "using the Python permutation packer. Set "
+                "config.native_layout_packer = False to select the Python packer "
+                "explicitly and silence this warning.",
                 RuntimeWarning,
                 stacklevel=2,
             )

--- a/torch_spyre/_inductor/scratchpad/permutation_layout.py
+++ b/torch_spyre/_inductor/scratchpad/permutation_layout.py
@@ -29,8 +29,6 @@ from typing import Optional
 from abc import ABC, abstractmethod
 import bisect
 import heapq
-import math
-import warnings
 
 from torch_spyre._inductor.scratchpad.contact_profile import Profile
 from torch_spyre._inductor.scratchpad.plan_solver import (
@@ -127,6 +125,11 @@ class PermutationBasedLayoutSolverBase(ABC):
         self.capacity = capacity
         self.alignment = alignment
         self._name_to_idx = {buf.name: i for i, buf in enumerate(buffers)}
+        # Names are the identity in-place parents are resolved by, so a
+        # duplicate makes ``in_place_parents=["a"]`` ambiguous -- the dict
+        # comprehension above silently keeps the last such buffer. Reject
+        # instead of resolving to an arbitrary one.
+        assert len(self._name_to_idx) == n, "buffer names must be unique"
 
         # Per-buffer size as a flat list, for fast access in the placement hot
         # loop (avoids a dataclass attribute lookup per candidate). Mutable via
@@ -221,7 +224,14 @@ class PermutationBasedLayoutSolverBase(ABC):
         size-derived footprint and quality move; the shared buffer object is
         **not** mutated (the plan tracks size in ``_sizes``). One of the two
         co-optimization packer extensions (Plan §4.2 / §7.3).
+
+        ``new_size`` must be non-negative. A negative footprint puts a buffer's
+        top below its own address, which breaks the "rest on the max top"
+        invariant the narrow candidate set in :meth:`_recompute_address` relies
+        on -- the incremental result then diverges from a from-scratch place.
+        Zero is allowed: the allocator clamps unsized entries to 0.
         """
+        assert new_size >= 0, "resize size must be non-negative"
         old_total = self.total_quality
         old_q = self._qualities[idx]
         self._sizes[idx] = new_size
@@ -273,8 +283,15 @@ class PermutationBasedLayoutSolverBase(ABC):
         return delta
 
     def _align_up(self, addr: int) -> int:
-        """Round ``addr`` up to the next multiple of ``self.alignment``."""
-        return math.ceil(addr / self.alignment) * self.alignment
+        """Round ``addr`` up to the next multiple of ``self.alignment``.
+
+        Integer ceiling division, not ``math.ceil(addr / alignment)``: the float
+        form loses precision above ``2**53`` and there *under*-aligns, handing
+        back an address below ``addr`` (and so two live buffers the same slot).
+        The C++ packer computes this exactly, so the float form was also the one
+        place the two could disagree on in-range input.
+        """
+        return -(-addr // self.alignment) * self.alignment
 
     def _top(self, idx: int) -> Optional[int]:
         """Return ``address + size`` for a placed buffer (its exclusive top), or
@@ -340,6 +357,29 @@ class PermutationBasedLayoutSolverBase(ABC):
                     # is simply not placed in-place, see ``_can_inplace`` -- so
                     # asserting them would reject plans this solver handles.
                     assert_in_place_parent_is_read(self.buffers[parent], buf.name)
+                    # Single-tick handoff: a valid in-place pair overlaps at
+                    # exactly one tick, the child's first. Both in-place
+                    # candidate generators upstream enforce it
+                    # (``allocator._determine_in_place`` and
+                    # ``_determine_in_place_division_invariant``), and
+                    # ``_assert_in_place_relationships`` re-checks it. The
+                    # incremental machinery *relies* on it and cannot re-derive
+                    # it: ``_placement_decision`` co-locates any overlapping
+                    # partner that fits, while the in-place dirtying in
+                    # :meth:`_propagate_addresses` and the seed in
+                    # :meth:`_inplace_pokethrough_seed` both sample the contact
+                    # profiles at that single tick. On a multi-tick overlap they
+                    # under-seed (stale addresses); when the child starts first
+                    # they index outside the parent's span. Fail here instead.
+                    assert (
+                        self.buffers[parent].end_time
+                        == self.buffers[child].start_time + 1
+                    ), (
+                        f"in-place pair ({self.buffers[parent].name}, "
+                        f"{buf.name}) must hand off at a single tick: parent "
+                        f"end_time {self.buffers[parent].end_time} != child "
+                        f"start_time {self.buffers[child].start_time} + 1"
+                    )
                     partners[child].add(parent)
                     partners[parent].add(child)
         return partners
@@ -1440,10 +1480,6 @@ class PermutationBasedLayoutSolver(PermutationBasedLayoutSolverBase):
 # never touches a Python object per op. This adapter wraps the native solver so it
 # is a drop-in for the exact surface the simulated-annealing search drives.
 
-# One-time warning latch: emit the "requested but unavailable" fallback warning at
-# most once per process, so a native-less build does not spam every layout plan.
-_native_packer_warned = False
-
 
 def _native_solver_class():
     """The C++ ``NativePermutationLayoutSolver`` class, or ``None`` if the ``_C``
@@ -1589,33 +1625,31 @@ def make_permutation_packer(
     Returns a :class:`_NativePackerAdapter` (over the C++
     ``NativePermutationLayoutSolver``) when ``config.native_layout_packer`` is
     true (the default -- back it off with that config knob, or its
-    ``TORCH_SPYRE_NATIVE_PACKER=0`` env default) and the native class is
-    importable. When the knob is false, or the native class is unavailable, the
-    canonical Python :class:`PermutationBasedLayoutSolver` is used instead. The
-    two packers are behaviourally identical (verified bit-for-bit by the
-    differential and the SA-equivalence tests); the C++ one is the faster default.
-    If the native class is unavailable a one-time warning is emitted before
-    falling back to Python.
+    ``TORCH_SPYRE_NATIVE_PACKER=0`` env default), and the canonical Python
+    :class:`PermutationBasedLayoutSolver` when it is false. The two packers are
+    behaviourally identical (verified bit-for-bit by the differential and the
+    SA-equivalence tests); the C++ one is the faster default.
+
+    A missing native class is *not* a supported mode: ``_C`` is required for the
+    package to work at all, so its absence means an incomplete or stale build
+    rather than a pure-Python installation. Raise instead of silently falling
+    back, which would otherwise trade a build error for a quiet 2-25x slowdown.
     """
     from torch_spyre._inductor import config
 
     if config.native_layout_packer:
         native_cls = _native_solver_class()
-        if native_cls is not None:
-            return _NativePackerAdapter(
-                native_cls, buffers, permutation, capacity, alignment, eligible
+        if native_cls is None:
+            raise RuntimeError(
+                "torch_spyre._C.NativePermutationLayoutSolver is unavailable, "
+                "which means the _C extension is missing or stale -- rebuild it. "
+                "To use the pure-Python packer deliberately, set "
+                "config.native_layout_packer = False (or "
+                "TORCH_SPYRE_NATIVE_PACKER=0)."
             )
-        global _native_packer_warned
-        if not _native_packer_warned:
-            _native_packer_warned = True
-            warnings.warn(
-                "torch_spyre._C.NativePermutationLayoutSolver is unavailable; "
-                "using the Python permutation packer. Set "
-                "config.native_layout_packer = False to select the Python packer "
-                "explicitly and silence this warning.",
-                RuntimeWarning,
-                stacklevel=2,
-            )
+        return _NativePackerAdapter(
+            native_cls, buffers, permutation, capacity, alignment, eligible
+        )
     return PermutationBasedLayoutSolver(
         buffers, permutation, capacity, alignment, eligible
     )

--- a/torch_spyre/_inductor/scratchpad/permutation_layout.py
+++ b/torch_spyre/_inductor/scratchpad/permutation_layout.py
@@ -233,7 +233,8 @@ class PermutationBasedLayoutSolverBase(ABC):
         on -- the incremental result then diverges from a from-scratch place.
         Zero is allowed: the allocator clamps unsized entries to 0.
         """
-        assert new_size >= 0, "resize size must be non-negative"
+        if new_size < 0:
+            raise ValueError("resize size must be non-negative")
         old_total = self.total_quality
         old_q = self._qualities[idx]
         self._sizes[idx] = new_size
@@ -1507,7 +1508,7 @@ def make_permutation_packer(
     capacity: int,
     alignment: int = 128,
     eligible: Optional[list[bool]] = None,
-):
+) -> PermutationBasedLayoutSolver | NativePermutationLayoutSolver:
     """Construct a permutation packer, using the C++ accelerator by default.
 
     Returns the C++ :class:`NativePermutationLayoutSolver` when

--- a/torch_spyre/_inductor/scratchpad/simulated_annealing.py
+++ b/torch_spyre/_inductor/scratchpad/simulated_annealing.py
@@ -240,7 +240,11 @@ class SimulatedAnnealingLayoutSolver(MemoryPlanSolver):
             temperature_log.append(temperature)
             if quality > self.best_quality:
                 self.best_quality = quality
-                self.best_permutation = copy.copy(self.plan.permutation)
+                # ``list(...)``, not ``copy.copy(...)``: ``plan.permutation`` is a
+                # live view of the packer's order, so the best-so-far snapshot has
+                # to be detached or the comparison in :meth:`solve` that decides
+                # whether to rebuild would be vacuously equal.
+                self.best_permutation = list(self.plan.permutation)
 
             if self._is_optimal():
                 # All buffers fit: quality is maximal, so stop cooling early --
@@ -278,22 +282,19 @@ class SimulatedAnnealingLayoutSolver(MemoryPlanSolver):
         if j == len(perm) - 1:
             j = len(perm) - 2
 
-        def _top_or_inf(p: int) -> float:
-            # Exclusive top (address + size) of buffer ``p``, or +inf when ``p``
-            # is evicted (address is None). An evicted buffer sorts as if it sits
-            # arbitrarily high, so it is treated as "above" any placed buffer and
-            # is never reordered below one; two placed buffers compare by their
-            # real tops, unchanged from before eviction used None.
-            addr = plan.addresses[p]
-            if addr is None:
-                return math.inf
-            return addr + self.buffers[p].size
+        # ``plan.top_or_inf`` is the packer's own accessor: the exclusive top
+        # (address + size) of a buffer, or +inf when it is evicted. An evicted
+        # buffer sorts as if it sits arbitrarily high, so it is treated as "above"
+        # any placed buffer and never reordered below one. It reads the plan-local
+        # size rather than ``self.buffers[p].size``, so it stays correct once a
+        # co-optimizer drives ``resize``.
+        top_or_inf = plan.top_or_inf
 
         while i <= j:
             pi = perm[i]
             pi1 = perm[i + 1]
 
-            if (not plan.overlaps(pi, pi1)) and _top_or_inf(pi) > _top_or_inf(pi1):
+            if (not plan.overlaps(pi, pi1)) and top_or_inf(pi) > top_or_inf(pi1):
                 # Swap buffers pi and pi1. This makes no difference for the quality
                 # of the result *now*, but it makes it easier to rotate to an
                 # improved state.

--- a/torch_spyre/_inductor/scratchpad/simulated_annealing.py
+++ b/torch_spyre/_inductor/scratchpad/simulated_annealing.py
@@ -64,7 +64,7 @@ from torch_spyre._inductor.scratchpad.plan_solver import (
 )
 from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
 from torch_spyre._inductor.scratchpad.permutation_layout import (
-    PermutationBasedLayoutSolver,
+    make_permutation_packer,
 )
 
 
@@ -162,9 +162,7 @@ class SimulatedAnnealingLayoutSolver(MemoryPlanSolver):
             convertor = SolverToPermutation(initial)
             self.initial = convertor.permutation(self.buffers)
 
-        self.plan = PermutationBasedLayoutSolver(
-            self.buffers, self.initial, size, alignment
-        )
+        self.plan = make_permutation_packer(self.buffers, self.initial, size, alignment)
         self.quality_logs: list[list[float]] = []
         self.temperature_logs: list[list[float]] = []
         self.best_quality = self.plan.quality()
@@ -223,7 +221,7 @@ class SimulatedAnnealingLayoutSolver(MemoryPlanSolver):
         # Commit the best permutation seen, so finalize() writes it rather than
         # whatever state annealing happened to end in.
         if self.plan.permutation != self.best_permutation:
-            self.plan = PermutationBasedLayoutSolver(
+            self.plan = make_permutation_packer(
                 self.buffers, list(self.best_permutation), self.size, self.alignment
             )
 

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -46,6 +46,7 @@
 #include "logging.h"
 #include "logging_bindings.h"
 #include "logging_config.h"
+#include "perm_layout_native.h"
 #include "prepare_kernel.h"
 #include "spyre_allocator.h"
 #include "spyre_device_enum.h"
@@ -236,6 +237,9 @@ PYBIND11_MODULE(_C, m) {
 
   // Initialize logging bindings
   torch_spyre::logging::init_logging_bindings(m);
+
+  // Register the native scratchpad layout packer accelerator.
+  torch_spyre::scratchpad::register_perm_layout_native(m);
 
   py::enum_<spyre::ElementArrangement>(m, "ElementArrangement")
       .value("STANDARD", spyre::ElementArrangement::STANDARD)

--- a/torch_spyre/csrc/perm_layout_native.cpp
+++ b/torch_spyre/csrc/perm_layout_native.cpp
@@ -279,6 +279,33 @@ class NativePermutationLayoutSolver {
     return out;
   }
 
+  // Current allocation order as a Python list (mirrors the Python packer's
+  // ``permutation`` list attribute).
+  py::list permutation() const {
+    py::list out;
+    for (int idx : permutation_) out.append(py::cast(idx));
+    return out;
+  }
+
+  // True if buffers ``i`` and ``j`` are alive at a common tick. Buffer-index
+  // args, bounds-checked; mirrors the Python base ``overlaps(i, j)``.
+  bool overlaps(int i, int j) const {
+    const int n = st_->n;
+    if (i < 0 || i >= n || j < 0 || j >= n) {
+      throw std::invalid_argument("overlaps index out of range");
+    }
+    return Overlaps(i, j);
+  }
+
+  // True if buffer ``idx`` has an address (fits below capacity).
+  // Bounds-checked; mirrors the Python base ``is_fully_allocated(idx)``.
+  bool is_fully_allocated(int idx) const {
+    if (idx < 0 || idx >= st_->n) {
+      throw std::invalid_argument("is_fully_allocated index out of range");
+    }
+    return allocated_[idx] != 0;
+  }
+
  private:
   // Mirrors PermutationBasedLayoutSolverBase._build_interval_data. Takes a
   // reference (not a pointer): the StaticData is a required, non-null argument.
@@ -511,6 +538,12 @@ void register_perm_layout_native(py::module_& m) {
       .def("copy", &NativePermutationLayoutSolver::copy)
       .def("quality", &NativePermutationLayoutSolver::quality)
       .def("count_allocated", &NativePermutationLayoutSolver::count_allocated)
+      .def("overlaps", &NativePermutationLayoutSolver::overlaps, py::arg("i"),
+           py::arg("j"))
+      .def("is_fully_allocated",
+           &NativePermutationLayoutSolver::is_fully_allocated, py::arg("idx"))
+      .def_property_readonly("permutation",
+                             &NativePermutationLayoutSolver::permutation)
       .def_property_readonly("addresses",
                              &NativePermutationLayoutSolver::addresses);
 }

--- a/torch_spyre/csrc/perm_layout_native.cpp
+++ b/torch_spyre/csrc/perm_layout_native.cpp
@@ -1,0 +1,490 @@
+/*
+ * Copyright 2026 The Torch-Spyre Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Native (C++) accelerator for the permutation-based scratchpad layout packer.
+//
+// This mirrors the *observable* behaviour of the canonical Python
+// ``PermutationBasedLayoutSolver``
+// (``torch_spyre/_inductor/scratchpad/permutation_layout.py``): given a
+// permutation (allocation order), per-buffer sizes and LX-eligibility, it
+// places every buffer on top of the earlier-placed, time-overlapping buffers
+// (with in-place reuse and a capacity/eviction gate) and exposes the resulting
+// ``addresses`` (None == evicted / HBM), ``quality()`` and
+// ``count_allocated()``.
+//
+// Placement is a pure function of (permutation, sizes, eligibility, lifetimes),
+// so after every mutating op the layout is recomputed from scratch in
+// permutation order using precomputed time-overlap sets plus the saturation
+// early-stop -- i.e. the same decision the Python reference/from-scratch placer
+// makes, which the incremental Python packer is differentially proven equal to.
+// The internal representation is therefore deliberately simpler than Python's
+// below/above contact profiles (the task allows any internal representation
+// that reproduces the observable state); the speedup comes from staying in C++
+// and never touching a Python object per operation. Buffer fields are read
+// exactly once, in the constructor.
+
+#include "perm_layout_native.h"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace py = pybind11;
+
+namespace torch_spyre {
+namespace scratchpad {
+
+namespace {
+
+// Immutable-during-planning data derived from the buffers, the capacity and the
+// alignment. Shared by reference between a solver and its ``copy()`` clones.
+struct StaticData {
+  int n = 0;
+  int64_t capacity = 0;
+  int64_t alignment = 128;
+  std::vector<int64_t> start;  // start_time == uses.front()
+  std::vector<int64_t> end;    // end_time == uses.back() + 1
+  std::vector<double> weight;  // len(uses) + (first_use_is_read ? 0.0 : 0.5)
+  // Time-overlap members of each buffer (order-independent, lifetimes only).
+  std::vector<std::vector<int>> overlap;
+  // Possible in-place partners: declared parents + children that declare it.
+  std::vector<std::vector<int>> inplace_partners;
+  // Parent indices this buffer names in ``in_place_parents`` (for direction).
+  std::vector<std::unordered_set<int>> declared_parents;
+  // Saturation early-stop interval data (lifetimes only).
+  int num_intervals = 0;
+  std::vector<int> total_at;                       // alive count per interval
+  std::vector<std::pair<int, int>> buf_intervals;  // [lo, hi) interval range
+};
+
+}  // namespace
+
+class NativePermutationLayoutSolver {
+ public:
+  NativePermutationLayoutSolver(const py::list& buffers,
+                                std::vector<int> permutation, int64_t capacity,
+                                int64_t alignment, const py::object& eligible) {
+    auto st = std::make_shared<StaticData>();
+    const int n = static_cast<int>(buffers.size());
+    st->n = n;
+    st->capacity = capacity;
+    st->alignment = alignment;
+
+    // Validate the permutation is a permutation of range(n).
+    {
+      std::vector<int> sorted_perm = permutation;
+      std::sort(sorted_perm.begin(), sorted_perm.end());
+      bool ok = static_cast<int>(sorted_perm.size()) == n;
+      for (int i = 0; ok && i < n; ++i) ok = sorted_perm[i] == i;
+      if (!ok) {
+        throw std::invalid_argument(
+            "permutation must be a permutation of range(len(buffers))");
+      }
+    }
+
+    // Read every buffer field exactly once.
+    st->start.resize(n);
+    st->end.resize(n);
+    st->weight.resize(n);
+    sizes_.resize(n);
+    std::vector<std::string> names(n);
+    std::vector<std::vector<std::string>> parent_names(n);
+    for (int i = 0; i < n; ++i) {
+      py::handle b = buffers[i];
+      names[i] = b.attr("name").cast<std::string>();
+      sizes_[i] = b.attr("size").cast<int64_t>();
+      std::vector<int64_t> uses = b.attr("uses").cast<std::vector<int64_t>>();
+      bool first_read = b.attr("first_use_is_read").cast<bool>();
+      parent_names[i] =
+          b.attr("in_place_parents").cast<std::vector<std::string>>();
+      st->start[i] = uses.front();
+      st->end[i] = uses.back() + 1;
+      st->weight[i] =
+          static_cast<double>(uses.size()) + (first_read ? 0.0 : 0.5);
+    }
+
+    std::unordered_map<std::string, int> name_to_idx;
+    name_to_idx.reserve(n * 2);
+    for (int i = 0; i < n; ++i) name_to_idx.emplace(names[i], i);
+
+    // Time-overlap sets (half-open [start, end) intervals).
+    st->overlap.assign(n, {});
+    for (int a = 0; a < n; ++a) {
+      for (int c = a + 1; c < n; ++c) {
+        if (st->start[a] < st->end[c] && st->start[c] < st->end[a]) {
+          st->overlap[a].push_back(c);
+          st->overlap[c].push_back(a);
+        }
+      }
+    }
+
+    // In-place partners and declared-parent direction.
+    st->declared_parents.assign(n, {});
+    std::vector<std::unordered_set<int>> partner_sets(n);
+    for (int child = 0; child < n; ++child) {
+      for (const std::string& pname : parent_names[child]) {
+        auto it = name_to_idx.find(pname);
+        if (it == name_to_idx.end()) continue;
+        int parent = it->second;
+        st->declared_parents[child].insert(parent);
+        partner_sets[child].insert(parent);
+        partner_sets[parent].insert(child);
+      }
+    }
+    st->inplace_partners.assign(n, {});
+    for (int i = 0; i < n; ++i) {
+      st->inplace_partners[i].assign(partner_sets[i].begin(),
+                                     partner_sets[i].end());
+    }
+
+    BuildIntervalData(st.get());
+
+    st_ = std::move(st);
+
+    // Dynamic state.
+    permutation_ = std::move(permutation);
+    position_.assign(n, 0);
+    for (int pos = 0; pos < n; ++pos) position_[permutation_[pos]] = pos;
+    if (eligible.is_none()) {
+      eligible_.assign(n, 1);
+    } else {
+      std::vector<bool> flags = eligible.cast<std::vector<bool>>();
+      if (static_cast<int>(flags.size()) != n) {
+        throw std::invalid_argument("eligible must have one flag per buffer");
+      }
+      eligible_.resize(n);
+      for (int i = 0; i < n; ++i) eligible_[i] = flags[i] ? 1 : 0;
+    }
+    addr_.assign(n, 0);
+    allocated_.assign(n, 0);
+    cand_mark_.assign(n, 0);
+    RecomputeAll();
+  }
+
+  double swap(int i) {
+    const int n = st_->n;
+    if (i < 0 || i >= n - 1) {
+      throw std::invalid_argument("swap index out of range");
+    }
+    const int x = permutation_[i];
+    const int y = permutation_[i + 1];
+    permutation_[i] = y;
+    permutation_[i + 1] = x;
+    position_[x] = i + 1;
+    position_[y] = i;
+    // No-op cases (identical to the Python packer): a transparent (HBM) member
+    // is outside the eligible stacking order, and independent buffers do not
+    // affect any address -- only the positions moved.
+    if (!(eligible_[x] && eligible_[y])) return 0.0;
+    if (!Overlaps(x, y)) return 0.0;
+    const double old_total = total_quality_;
+    RecomputeAll();
+    return total_quality_ - old_total;
+  }
+
+  double rotate(int i, int j) {
+    if (i == j) return 0.0;
+    if (!eligible_[permutation_[i]]) {
+      // Moving a transparent (HBM) buffer changes no eligible buffer's relative
+      // order, so no address moves; just relocate its slot.
+      MoveInPermutation(i, j);
+      return 0.0;
+    }
+    const double old_total = total_quality_;
+    MoveInPermutation(i, j);
+    RecomputeAll();
+    return total_quality_ - old_total;
+  }
+
+  double resize(int idx, int64_t new_size) {
+    const double old_total = total_quality_;
+    sizes_[idx] = new_size;
+    // An ineligible buffer is in HBM: its size affects nothing observable, but
+    // the new size is recorded so a later set_eligible(True) uses it.
+    if (!eligible_[idx]) return 0.0;
+    RecomputeAll();
+    return total_quality_ - old_total;
+  }
+
+  double set_eligible(int idx, bool flag) {
+    if (static_cast<bool>(eligible_[idx]) == flag) return 0.0;
+    const double old_total = total_quality_;
+    eligible_[idx] = flag ? 1 : 0;
+    RecomputeAll();
+    return total_quality_ - old_total;
+  }
+
+  NativePermutationLayoutSolver copy() const {
+    return *this;
+  }
+
+  double quality() const {
+    return total_quality_;
+  }
+  int count_allocated() const {
+    return total_allocated_count_;
+  }
+
+  py::list addresses() const {
+    py::list out;
+    for (int i = 0; i < st_->n; ++i) {
+      if (allocated_[i]) {
+        out.append(py::cast(addr_[i]));
+      } else {
+        out.append(py::none());
+      }
+    }
+    return out;
+  }
+
+ private:
+  static void BuildIntervalData(StaticData* st) {
+    const int n = st->n;
+    std::vector<int64_t> pts;
+    pts.reserve(2 * n);
+    for (int i = 0; i < n; ++i) {
+      pts.push_back(st->start[i]);
+      pts.push_back(st->end[i]);
+    }
+    std::sort(pts.begin(), pts.end());
+    pts.erase(std::unique(pts.begin(), pts.end()), pts.end());
+    const int k = std::max(0, static_cast<int>(pts.size()) - 1);
+    st->num_intervals = k;
+    st->total_at.assign(k, 0);
+    st->buf_intervals.assign(n, {0, 0});
+    if (k == 0) return;
+    // Delta sweep: +1 at each start interval, -1 at each end interval.
+    std::vector<int> deltas(k + 1, 0);
+    auto bisect_left = [&pts](int64_t v) {
+      return static_cast<int>(std::lower_bound(pts.begin(), pts.end(), v) -
+                              pts.begin());
+    };
+    for (int i = 0; i < n; ++i) {
+      int lo = bisect_left(st->start[i]);
+      int hi = bisect_left(st->end[i]);
+      deltas[lo] += 1;
+      deltas[hi] -= 1;
+      st->buf_intervals[i] = {lo, hi};
+    }
+    int running = 0;
+    for (int i = 0; i < k; ++i) {
+      running += deltas[i];
+      st->total_at[i] = running;
+    }
+  }
+
+  bool Overlaps(int x, int y) const {
+    return st_->start[x] < st_->end[y] && st_->start[y] < st_->end[x];
+  }
+
+  int64_t AlignUp(int64_t addr) const {
+    const int64_t a = st_->alignment;
+    return ((addr + a - 1) / a) * a;
+  }
+
+  // Returns (parent, child) for an in-place pair. One of the two members must
+  // declare the other as an in-place parent.
+  std::pair<int, int> InPlacePair(int i, int j) const {
+    if (st_->declared_parents[i].count(j)) return {j, i};  // j parents i
+    return {i, j};                                         // i parents j
+  }
+
+  // Mirrors PermutationBasedLayoutSolverBase._placement_decision. ``cand`` are
+  // the already-placed, time-overlapping, eligible candidates for ``idx``.
+  // Returns true (with ``*out_addr`` set) if placed, false if evicted (None).
+  bool PlaceDecision(int idx, const std::vector<int>& cand, int64_t* out_addr) {
+    const int64_t cap = st_->capacity;
+    if (cand.empty()) {
+      // Lone buffer sits on the floor unless it alone exceeds capacity.
+      if (sizes_[idx] > cap) return false;
+      *out_addr = 0;
+      return true;
+    }
+    // A None (evicted) candidate dominates: idx would rest on it.
+    for (int p : cand) {
+      if (!allocated_[p]) return false;
+    }
+    int64_t max_top = std::numeric_limits<int64_t>::min();
+    for (int p : cand) {
+      const int64_t top = addr_[p] + sizes_[p];
+      if (top > max_top) max_top = top;
+    }
+    // Try to drop into an in-place partner's slot.
+    const std::vector<int>& partners = st_->inplace_partners[idx];
+    if (!partners.empty()) {
+      ++cand_gen_;
+      for (int p : cand) cand_mark_[p] = cand_gen_;
+      for (int partner : partners) {
+        if (cand_mark_[partner] != cand_gen_) continue;
+        std::pair<int, int> pr = InPlacePair(idx, partner);
+        const int parent = pr.first;
+        const int child = pr.second;
+        if (sizes_[child] > sizes_[parent]) continue;  // _can_inplace
+        const int64_t partner_addr = addr_[partner];
+        int64_t others_top = 0;
+        for (int q : cand) {
+          if (q == partner) continue;
+          const int64_t top = addr_[q] + sizes_[q];
+          if (top > others_top) others_top = top;
+        }
+        if (others_top <= partner_addr) {
+          if (partner_addr + sizes_[idx] > cap) return false;
+          *out_addr = partner_addr;
+          return true;
+        }
+      }
+    }
+    const int64_t aligned = AlignUp(max_top);
+    if (aligned + sizes_[idx] > cap) return false;
+    *out_addr = aligned;
+    return true;
+  }
+
+  // Places every buffer in permutation order with the saturation early-stop,
+  // rebuilding addresses, quality and the allocated count from scratch.
+  void RecomputeAll() {
+    const int n = st_->n;
+    for (int pos = 0; pos < n; ++pos) position_[permutation_[pos]] = pos;
+    total_quality_ = 0.0;
+    total_allocated_count_ = 0;
+
+    const int k = st_->num_intervals;
+    placed_at_.assign(k, 0);
+    has_none_at_.assign(k, 0);
+    done_at_.assign(k, 0);
+    int not_done = 0;
+    for (int t = 0; t < k; ++t) {
+      if (st_->total_at[t] == 0) {
+        done_at_[t] = 1;
+      } else {
+        ++not_done;
+      }
+    }
+
+    int stop = n;
+    for (int pos = 0; pos < n; ++pos) {
+      if (not_done == 0) {
+        stop = pos;
+        break;
+      }
+      const int idx = permutation_[pos];
+      if (!eligible_[idx]) {
+        // Ineligible: routed to HBM, transparent to the stack. No address / no
+        // quality, and it does not mark its intervals has_none (nothing rests
+        // on it), but it is still counted into placed_at so an interval whose
+        // remaining occupants are all ineligible can still saturate.
+        allocated_[idx] = 0;
+        const int lo = st_->buf_intervals[idx].first;
+        const int hi = st_->buf_intervals[idx].second;
+        for (int t = lo; t < hi; ++t) {
+          ++placed_at_[t];
+          if (!done_at_[t] && placed_at_[t] == st_->total_at[t]) {
+            done_at_[t] = 1;
+            --not_done;
+          }
+        }
+        continue;
+      }
+      cand_.clear();
+      for (int w : st_->overlap[idx]) {
+        if (position_[w] < pos && eligible_[w]) cand_.push_back(w);
+      }
+      int64_t a = 0;
+      const bool placed = PlaceDecision(idx, cand_, &a);
+      allocated_[idx] = placed ? 1 : 0;
+      addr_[idx] = a;
+      const bool evicted = !placed;
+      if (!evicted) {
+        total_quality_ += st_->weight[idx] * static_cast<double>(sizes_[idx]);
+        ++total_allocated_count_;
+      }
+      const int lo = st_->buf_intervals[idx].first;
+      const int hi = st_->buf_intervals[idx].second;
+      for (int t = lo; t < hi; ++t) {
+        ++placed_at_[t];
+        if (evicted) has_none_at_[t] = 1;
+        if (!done_at_[t] &&
+            (has_none_at_[t] || placed_at_[t] == st_->total_at[t])) {
+          done_at_[t] = 1;
+          --not_done;
+        }
+      }
+    }
+    for (int pos = stop; pos < n; ++pos) allocated_[permutation_[pos]] = 0;
+  }
+
+  void MoveInPermutation(int i, int j) {
+    const int x = permutation_[i];
+    permutation_.erase(permutation_.begin() + i);
+    permutation_.insert(permutation_.begin() + j, x);
+    const int lo = std::min(i, j);
+    const int hi = std::max(i, j);
+    for (int p = lo; p <= hi; ++p) position_[permutation_[p]] = p;
+  }
+
+  std::shared_ptr<const StaticData> st_;
+
+  // Dynamic per-plan state (deep-copied by copy()).
+  std::vector<int> permutation_;
+  std::vector<int> position_;   // inverse of permutation_
+  std::vector<int64_t> sizes_;  // mutable footprint (resize)
+  std::vector<char> eligible_;  // LX-eligibility (set_eligible)
+  std::vector<int64_t> addr_;   // address; valid iff allocated_[i]
+  std::vector<char> allocated_;
+  double total_quality_ = 0.0;
+  int total_allocated_count_ = 0;
+
+  // Scratch reused across RecomputeAll / PlaceDecision calls.
+  std::vector<int> cand_;
+  std::vector<int> cand_mark_;
+  int cand_gen_ = 0;
+  std::vector<int> placed_at_;
+  std::vector<char> has_none_at_;
+  std::vector<char> done_at_;
+};
+
+void register_perm_layout_native(py::module_& m) {
+  py::class_<NativePermutationLayoutSolver>(m, "NativePermutationLayoutSolver")
+      .def(py::init<const py::list&, std::vector<int>, int64_t, int64_t,
+                    const py::object&>(),
+           py::arg("buffers"), py::arg("permutation"), py::arg("size"),
+           py::arg("alignment") = 128, py::arg("eligible") = py::none())
+      .def("swap", &NativePermutationLayoutSolver::swap, py::arg("i"))
+      .def("rotate", &NativePermutationLayoutSolver::rotate, py::arg("i"),
+           py::arg("j"))
+      .def("resize", &NativePermutationLayoutSolver::resize, py::arg("idx"),
+           py::arg("new_size"))
+      .def("set_eligible", &NativePermutationLayoutSolver::set_eligible,
+           py::arg("idx"), py::arg("flag"))
+      .def("copy", &NativePermutationLayoutSolver::copy)
+      .def("quality", &NativePermutationLayoutSolver::quality)
+      .def("count_allocated", &NativePermutationLayoutSolver::count_allocated)
+      .def_property_readonly("addresses",
+                             &NativePermutationLayoutSolver::addresses);
+}
+
+}  // namespace scratchpad
+}  // namespace torch_spyre

--- a/torch_spyre/csrc/perm_layout_native.cpp
+++ b/torch_spyre/csrc/perm_layout_native.cpp
@@ -59,12 +59,15 @@ namespace scratchpad {
 
 namespace {
 
+// Default placement alignment: one Spyre stick (128 bytes).
+constexpr int64_t kDefaultAlignment = 128;
+
 // Immutable-during-planning data derived from the buffers, the capacity and the
 // alignment. Shared by reference between a solver and its ``copy()`` clones.
 struct StaticData {
   int n = 0;
   int64_t capacity = 0;
-  int64_t alignment = 128;
+  int64_t alignment = kDefaultAlignment;
   std::vector<int64_t> start;  // start_time == uses.front()
   std::vector<int64_t> end;    // end_time == uses.back() + 1
   std::vector<double> weight;  // len(uses) + (first_use_is_read ? 0.0 : 0.5)
@@ -166,7 +169,7 @@ class NativePermutationLayoutSolver {
                                      partner_sets[i].end());
     }
 
-    BuildIntervalData(st.get());
+    BuildIntervalData(*st);
 
     st_ = std::move(st);
 
@@ -277,20 +280,22 @@ class NativePermutationLayoutSolver {
   }
 
  private:
-  static void BuildIntervalData(StaticData* st) {
-    const int n = st->n;
+  // Mirrors PermutationBasedLayoutSolverBase._build_interval_data. Takes a
+  // reference (not a pointer): the StaticData is a required, non-null argument.
+  static void BuildIntervalData(StaticData& st) {
+    const int n = st.n;
     std::vector<int64_t> pts;
     pts.reserve(2 * n);
     for (int i = 0; i < n; ++i) {
-      pts.push_back(st->start[i]);
-      pts.push_back(st->end[i]);
+      pts.push_back(st.start[i]);
+      pts.push_back(st.end[i]);
     }
     std::sort(pts.begin(), pts.end());
     pts.erase(std::unique(pts.begin(), pts.end()), pts.end());
     const int k = std::max(0, static_cast<int>(pts.size()) - 1);
-    st->num_intervals = k;
-    st->total_at.assign(k, 0);
-    st->buf_intervals.assign(n, {0, 0});
+    st.num_intervals = k;
+    st.total_at.assign(k, 0);
+    st.buf_intervals.assign(n, {0, 0});
     if (k == 0) return;
     // Delta sweep: +1 at each start interval, -1 at each end interval.
     std::vector<int> deltas(k + 1, 0);
@@ -299,16 +304,16 @@ class NativePermutationLayoutSolver {
                               pts.begin());
     };
     for (int i = 0; i < n; ++i) {
-      int lo = bisect_left(st->start[i]);
-      int hi = bisect_left(st->end[i]);
+      int lo = bisect_left(st.start[i]);
+      int hi = bisect_left(st.end[i]);
       deltas[lo] += 1;
       deltas[hi] -= 1;
-      st->buf_intervals[i] = {lo, hi};
+      st.buf_intervals[i] = {lo, hi};
     }
     int running = 0;
     for (int i = 0; i < k; ++i) {
       running += deltas[i];
-      st->total_at[i] = running;
+      st.total_at[i] = running;
     }
   }
 
@@ -322,7 +327,8 @@ class NativePermutationLayoutSolver {
   }
 
   // Returns (parent, child) for an in-place pair. One of the two members must
-  // declare the other as an in-place parent.
+  // declare the other as an in-place parent. Mirrors
+  // PermutationBasedLayoutSolverBase._in_place_pair.
   std::pair<int, int> InPlacePair(int i, int j) const {
     if (st_->declared_parents[i].count(j)) return {j, i};  // j parents i
     return {i, j};                                         // i parents j
@@ -380,7 +386,8 @@ class NativePermutationLayoutSolver {
   }
 
   // Places every buffer in permutation order with the saturation early-stop,
-  // rebuilding addresses, quality and the allocated count from scratch.
+  // rebuilding addresses, quality and the allocated count from scratch. Mirrors
+  // PermutationBasedLayoutSolverBase._sequential_place.
   void RecomputeAll() {
     const int n = st_->n;
     for (int pos = 0; pos < n; ++pos) position_[permutation_[pos]] = pos;
@@ -473,7 +480,12 @@ class NativePermutationLayoutSolver {
   double total_quality_ = 0.0;
   int total_allocated_count_ = 0;
 
-  // Scratch reused across RecomputeAll / PlaceDecision calls.
+  // Scratch reused across RecomputeAll / PlaceDecision calls. cand_mark_ is a
+  // generation-stamped membership set (replacing Python's
+  // partners.intersection(candidates)): PlaceDecision bumps cand_gen_ and
+  // stamps every candidate, so cand_mark_[p] == cand_gen_ tests "p is a
+  // candidate" without clearing the array each call. uint64_t so the counter
+  // never wraps.
   std::vector<int> cand_;
   std::vector<uint64_t> cand_mark_;
   uint64_t cand_gen_ = 0;
@@ -486,8 +498,9 @@ void register_perm_layout_native(py::module_& m) {
   py::class_<NativePermutationLayoutSolver>(m, "NativePermutationLayoutSolver")
       .def(py::init<const py::list&, std::vector<int>, int64_t, int64_t,
                     const py::object&>(),
-           py::arg("buffers"), py::arg("permutation"), py::arg("size"),
-           py::arg("alignment") = 128, py::arg("eligible") = py::none())
+           py::arg("buffers"), py::arg("permutation"), py::arg("capacity"),
+           py::arg("alignment") = kDefaultAlignment,
+           py::arg("eligible") = py::none())
       .def("swap", &NativePermutationLayoutSolver::swap, py::arg("i"))
       .def("rotate", &NativePermutationLayoutSolver::rotate, py::arg("i"),
            py::arg("j"))

--- a/torch_spyre/csrc/perm_layout_native.cpp
+++ b/torch_spyre/csrc/perm_layout_native.cpp
@@ -85,7 +85,44 @@ struct StaticData {
   std::vector<std::pair<int, int>> buf_intervals;  // [lo, hi) interval range
 };
 
-}  // namespace
+// Both classes below stay in this file's anonymous namespace. They are handed
+// to pybind11 by ``register_perm_layout_native`` and are never named from
+// another translation unit, and internal linkage matches the hidden visibility
+// of their pybind11 members (external linkage draws -Wattributes for
+// ``buffers_``).
+class NativePermutationLayoutSolver;
+
+// Read-only, always-live view of a solver's current allocation order.
+//
+// The search captures ``perm = plan.permutation`` once and then mutates the
+// plan through it -- ``annealing_step_swap`` re-reads ``perm[i]`` and ``perm[i
+// + 1]`` after every ``plan.swap(i)`` -- so the object it holds must reflect
+// later mutations. Reading straight through to the owner's ``std::vector``
+// makes that true by construction: there is no mirrored Python list for a
+// future mutator to forget to update. Read-only, so Python cannot corrupt the
+// order behind the solver's back either. ``py::keep_alive`` on the property
+// keeps the owner alive for as long as any view of it.
+class PermutationView {
+ public:
+  explicit PermutationView(const NativePermutationLayoutSolver& owner)
+      : owner_(owner) {}
+
+  int64_t len() const;
+  // Python list indexing, negative offsets included.
+  int getitem(int64_t i) const;
+  bool eq(const py::object& other) const;
+  // A *detached* snapshot. ``copy.copy(view)`` must not alias the live order:
+  // the search stores the best-so-far permutation that way and later compares
+  // the live one against it, a test that would be vacuously equal if the copy
+  // tracked the original.
+  py::list to_list() const;
+  std::string repr() const;
+
+ private:
+  const std::vector<int>& vec() const;
+
+  const NativePermutationLayoutSolver& owner_;
+};
 
 class NativePermutationLayoutSolver {
  public:
@@ -93,6 +130,10 @@ class NativePermutationLayoutSolver {
                                 std::vector<int> permutation, int64_t capacity,
                                 int64_t alignment, const py::object& eligible) {
     auto st = std::make_shared<StaticData>();
+    // Retained (not just read once): ``finalize`` writes each address back onto
+    // the Python buffer objects. Shared, never deep-copied by ``copy()`` --
+    // the same contract as the Python packer's ``self.buffers = buffers``.
+    buffers_ = buffers;
     const int n = static_cast<int>(buffers.size());
     st->n = n;
     st->capacity = capacity;
@@ -319,12 +360,44 @@ class NativePermutationLayoutSolver {
     return out;
   }
 
-  // Current allocation order as a Python list (mirrors the Python packer's
-  // ``permutation`` list attribute).
-  py::list permutation() const {
-    py::list out;
-    for (int idx : permutation_) out.append(py::cast(idx));
-    return out;
+  // Current allocation order, as a live read-only view (see PermutationView).
+  PermutationView permutation() const {
+    return PermutationView(*this);
+  }
+
+  const std::vector<int>& permutation_vec() const {
+    return permutation_;
+  }
+
+  py::list buffers() const {
+    return buffers_;
+  }
+
+  // Exclusive top (``address + size``) of buffer ``idx``, or +inf when it is
+  // evicted. Lives on the packer rather than in the search so it reads the
+  // plan-local ``sizes_`` -- which ``resize`` mutates -- instead of the shared
+  // buffer object's ``size``, which goes stale the moment a co-optimizer starts
+  // driving resizes. An evicted buffer sorting as arbitrarily high is what
+  // keeps it from being reordered below a placed one.
+  double top_or_inf(int idx) const {
+    if (idx < 0 || idx >= st_->n) {
+      throw std::invalid_argument("top_or_inf index out of range");
+    }
+    if (!allocated_[idx]) {
+      return std::numeric_limits<double>::infinity();
+    }
+    return static_cast<double>(addr_[idx] + sizes_[idx]);
+  }
+
+  // Write each buffer's address back onto the Python buffer object, for EVERY
+  // index -- an evicted buffer gets ``None`` -- exactly like
+  // ``PermutationBasedLayoutSolverBase.finalize``.
+  void finalize() const {
+    for (int i = 0; i < st_->n; ++i) {
+      py::object value =
+          allocated_[i] ? py::cast(addr_[i]) : py::object(py::none());
+      buffers_[i].attr("address") = value;
+    }
   }
 
   // True if buffers ``i`` and ``j`` are alive at a common tick. Buffer-index
@@ -610,6 +683,12 @@ class NativePermutationLayoutSolver {
 
   std::shared_ptr<const StaticData> st_;
 
+  // The Python buffer objects, retained for finalize(). Shared with clones (the
+  // copy ctor copies the handle, not the list). Deliberately NOT in StaticData:
+  // that struct is held by const shared_ptr and is Python-free, so it can be
+  // destroyed without the GIL -- and finalize() writes through this handle.
+  py::list buffers_;
+
   // Dynamic per-plan state (deep-copied by copy()).
   std::vector<int> permutation_;
   std::vector<int> position_;   // inverse of permutation_
@@ -635,7 +714,71 @@ class NativePermutationLayoutSolver {
   std::vector<int64_t> max_top_at_;  // running max exclusive-top per interval
 };
 
+const std::vector<int>& PermutationView::vec() const {
+  return owner_.permutation_vec();
+}
+
+int64_t PermutationView::len() const {
+  return static_cast<int64_t>(vec().size());
+}
+
+int PermutationView::getitem(int64_t i) const {
+  const int64_t n = len();
+  if (i < 0) i += n;  // list semantics
+  if (i < 0 || i >= n) {
+    // py::index_error, not invalid_argument: ``list(view)`` and ``for x in
+    // view`` walk the sequence protocol until IndexError stops them.
+    throw py::index_error("permutation index out of range");
+  }
+  return vec()[static_cast<size_t>(i)];
+}
+
+bool PermutationView::eq(const py::object& other) const {
+  if (py::isinstance<PermutationView>(other)) {
+    return vec() == other.cast<const PermutationView&>().vec();
+  }
+  // Elementwise against a plain list -- how the search compares the live order
+  // with its stored best-so-far snapshot.
+  try {
+    return vec() == other.cast<std::vector<int>>();
+  }
+  catch (const py::cast_error&) {
+    return false;
+  }
+}
+
+py::list PermutationView::to_list() const {
+  py::list out;
+  for (int idx : vec()) out.append(py::cast(idx));
+  return out;
+}
+
+std::string PermutationView::repr() const {
+  std::string s = "PermutationView([";
+  const std::vector<int>& v = vec();
+  for (size_t i = 0; i < v.size(); ++i) {
+    if (i != 0) s += ", ";
+    s += std::to_string(v[i]);
+  }
+  return s + "])";
+}
+
+}  // namespace
+
 void register_perm_layout_native(py::module_& m) {
+  py::class_<PermutationView>(m, "PermutationView")
+      .def("__len__", &PermutationView::len)
+      .def("__getitem__", &PermutationView::getitem, py::arg("i"))
+      .def("__eq__", &PermutationView::eq, py::arg("other"))
+      .def("__copy__", &PermutationView::to_list)
+      .def(
+          "__deepcopy__",
+          [](const PermutationView& v, const py::object&) {
+            return v.to_list();
+          },
+          py::arg("memo"))
+      .def("__repr__", &PermutationView::repr);
+
   py::class_<NativePermutationLayoutSolver>(m, "NativePermutationLayoutSolver")
       .def(py::init<const py::list&, std::vector<int>, int64_t, int64_t,
                     const py::object&>(),
@@ -656,8 +799,19 @@ void register_perm_layout_native(py::module_& m) {
            py::arg("j"))
       .def("is_fully_allocated",
            &NativePermutationLayoutSolver::is_fully_allocated, py::arg("idx"))
-      .def_property_readonly("permutation",
-                             &NativePermutationLayoutSolver::permutation)
+      .def("top_or_inf", &NativePermutationLayoutSolver::top_or_inf,
+           py::arg("idx"))
+      .def("finalize", &NativePermutationLayoutSolver::finalize)
+      .def_property_readonly("buffers", &NativePermutationLayoutSolver::buffers)
+      // The view borrows the solver, so the solver must outlive it. The
+      // keep_alive has to be attached to an explicit cpp_function: passed as a
+      // trailing extra to def_property_readonly it is applied to the property
+      // rather than to the getter, silently does nothing, and the view is left
+      // reading freed memory once the last reference to the solver goes away.
+      .def_property_readonly(
+          "permutation",
+          py::cpp_function(&NativePermutationLayoutSolver::permutation,
+                           py::keep_alive<0, 1>()))
       .def_property_readonly("addresses",
                              &NativePermutationLayoutSolver::addresses);
 }

--- a/torch_spyre/csrc/perm_layout_native.cpp
+++ b/torch_spyre/csrc/perm_layout_native.cpp
@@ -76,7 +76,9 @@ struct StaticData {
   // Possible in-place partners: declared parents + children that declare it.
   std::vector<std::vector<int>> inplace_partners;
   // Parent indices this buffer names in ``in_place_parents`` (for direction).
-  std::vector<std::unordered_set<int>> declared_parents;
+  // A vector (not a set): a typical buffer declares 0-1 parents, and the sole
+  // read is a boolean membership test, so a linear scan beats a hash lookup.
+  std::vector<std::vector<int>> declared_parents;
   // Saturation early-stop interval data (lifetimes only).
   int num_intervals = 0;
   std::vector<int> total_at;                       // alive count per interval
@@ -158,7 +160,7 @@ class NativePermutationLayoutSolver {
         auto it = name_to_idx.find(pname);
         if (it == name_to_idx.end()) continue;
         int parent = it->second;
-        st->declared_parents[child].insert(parent);
+        st->declared_parents[child].push_back(parent);
         partner_sets[child].insert(parent);
         partner_sets[parent].insert(child);
       }
@@ -236,6 +238,7 @@ class NativePermutationLayoutSolver {
     if (idx < 0 || idx >= st_->n) {
       throw std::invalid_argument("resize index out of range");
     }
+    if (sizes_[idx] == new_size) return 0.0;  // no-op: footprint unchanged
     const double old_total = total_quality_;
     sizes_[idx] = new_size;
     // An ineligible buffer is in HBM: its size affects nothing observable, but
@@ -313,10 +316,9 @@ class NativePermutationLayoutSolver {
     const int n = st.n;
     std::vector<int64_t> pts;
     pts.reserve(2 * n);
-    for (int i = 0; i < n; ++i) {
-      pts.push_back(st.start[i]);
-      pts.push_back(st.end[i]);
-    }
+    // Order does not matter -- pts is sorted below -- so bulk-copy both arrays.
+    pts.insert(pts.end(), st.start.begin(), st.start.end());
+    pts.insert(pts.end(), st.end.begin(), st.end.end());
     std::sort(pts.begin(), pts.end());
     pts.erase(std::unique(pts.begin(), pts.end()), pts.end());
     const int k = std::max(0, static_cast<int>(pts.size()) - 1);
@@ -357,24 +359,33 @@ class NativePermutationLayoutSolver {
   // declare the other as an in-place parent. Mirrors
   // PermutationBasedLayoutSolverBase._in_place_pair.
   std::pair<int, int> InPlacePair(int i, int j) const {
-    if (st_->declared_parents[i].count(j)) return {j, i};  // j parents i
-    return {i, j};                                         // i parents j
+    const std::vector<int>& dp = st_->declared_parents[i];
+    if (std::find(dp.begin(), dp.end(), j) != dp.end()) {
+      return {j, i};  // j parents i
+    }
+    return {i, j};  // i parents j
   }
 
   // Mirrors PermutationBasedLayoutSolverBase._placement_decision. ``cand`` are
   // the already-placed, time-overlapping, eligible candidates for ``idx``.
-  // Returns true (with ``*out_addr`` set) if placed, false if evicted (None).
-  bool PlaceDecision(int idx, const std::vector<int>& cand, int64_t* out_addr) {
+  // Returns {placed, addr}: {true, addr} if placed, {false, 0} if evicted
+  // (None).
+  //
+  // ``noinline`` here and on the RecomputeAll phase helpers below is purely for
+  // profiling: it keeps each phase a distinct frame so a sampling profiler
+  // (py-spy --native) can attribute wall-clock self-time per phase. The bodies
+  // are large enough that the lost inlining is not measurable (A/B confirmed).
+  [[gnu::noinline]] std::pair<bool, int64_t> PlaceDecision(
+      int idx, const std::vector<int>& cand) {
     const int64_t cap = st_->capacity;
     if (cand.empty()) {
       // Lone buffer sits on the floor unless it alone exceeds capacity.
-      if (sizes_[idx] > cap) return false;
-      *out_addr = 0;
-      return true;
+      if (sizes_[idx] > cap) return {false, 0};
+      return {true, 0};
     }
     // A None (evicted) candidate dominates: idx would rest on it.
     for (int p : cand) {
-      if (!allocated_[p]) return false;
+      if (!allocated_[p]) return {false, 0};
     }
     int64_t max_top = std::numeric_limits<int64_t>::min();
     for (int p : cand) {
@@ -400,31 +411,29 @@ class NativePermutationLayoutSolver {
           if (top > others_top) others_top = top;
         }
         if (others_top <= partner_addr) {
-          if (partner_addr + sizes_[idx] > cap) return false;
-          *out_addr = partner_addr;
-          return true;
+          if (partner_addr + sizes_[idx] > cap) return {false, 0};
+          return {true, partner_addr};
         }
       }
     }
     const int64_t aligned = AlignUp(max_top);
-    if (aligned + sizes_[idx] > cap) return false;
-    *out_addr = aligned;
-    return true;
+    if (aligned + sizes_[idx] > cap) return {false, 0};
+    return {true, aligned};
   }
 
   // Places every buffer in permutation order with the saturation early-stop,
   // rebuilding addresses, quality and the allocated count from scratch. Mirrors
   // PermutationBasedLayoutSolverBase._sequential_place.
-  void RecomputeAll() {
-    const int n = st_->n;
-    for (int pos = 0; pos < n; ++pos) position_[permutation_[pos]] = pos;
-    total_quality_ = 0.0;
-    total_allocated_count_ = 0;
+  // --- RecomputeAll phases (see the noinline note on PlaceDecision) ---
 
+  // Reset the saturation early-stop state and return the count of not-yet-
+  // saturated intervals (those with at least one live buffer).
+  [[gnu::noinline]] int InitIntervals() {
     const int k = st_->num_intervals;
     placed_at_.assign(k, 0);
     has_none_at_.assign(k, 0);
     done_at_.assign(k, 0);
+    max_top_at_.assign(k, 0);
     int not_done = 0;
     for (int t = 0; t < k; ++t) {
       if (st_->total_at[t] == 0) {
@@ -433,6 +442,59 @@ class NativePermutationLayoutSolver {
         ++not_done;
       }
     }
+    return not_done;
+  }
+
+  // Gather idx's already-placed, time-overlapping, eligible candidates into
+  // cand_ (the buffers idx would stack on top of).
+  [[gnu::noinline]] void GatherCandidates(int idx, int pos) {
+    cand_.clear();
+    for (int w : st_->overlap[idx]) {
+      if (position_[w] < pos && eligible_[w]) cand_.push_back(w);
+    }
+  }
+
+  // Advance the per-interval aggregates over idx's live intervals and update
+  // not_done. ``set_none`` marks the interval as holding an evicted (None)
+  // buffer (only ever set on the eligible-and-evicted path). ``top`` is a
+  // placed buffer's exclusive top (addr + size), folded into the running
+  // per-interval max; pass a negative value for buffers that do not stack
+  // (evicted, or ineligible/HBM) so it never updates the max (max_top_at_ is
+  // always >= 0). These aggregates let the common no-in-place-partner placement
+  // read its floor and eviction straight off its intervals -- see RecomputeAll.
+  //
+  // (The former ineligible branch tested placed_at_ == total_at without the
+  // has_none_at_ term; the unified test here is equivalent because has_none_at_
+  // can only be true once done_at_ is already set, so it never fires alone.)
+  [[gnu::noinline]] void CommitIntervals(int idx, bool set_none, int64_t top,
+                                         int& not_done) {
+    const int lo = st_->buf_intervals[idx].first;
+    const int hi = st_->buf_intervals[idx].second;
+    for (int t = lo; t < hi; ++t) {
+      ++placed_at_[t];
+      if (set_none) {
+        has_none_at_[t] = 1;
+      } else if (top > max_top_at_[t]) {
+        max_top_at_[t] = top;
+      }
+      if (!done_at_[t] &&
+          (has_none_at_[t] || placed_at_[t] == st_->total_at[t])) {
+        done_at_[t] = 1;
+        --not_done;
+      }
+    }
+  }
+
+  void RecomputeAll() {
+    const int n = st_->n;
+    const int64_t cap = st_->capacity;
+    // position_ is the inverse of permutation_ and is maintained incrementally
+    // by every mutator (constructor, swap, rotate/MoveInPermutation) -- resize
+    // and set_eligible leave the permutation untouched -- so it is always in
+    // sync here and needs no rebuild.
+    total_quality_ = 0.0;
+    total_allocated_count_ = 0;
+    int not_done = InitIntervals();
 
     int stop = n;
     for (int pos = 0; pos < n; ++pos) {
@@ -447,49 +509,69 @@ class NativePermutationLayoutSolver {
         // on it), but it is still counted into placed_at so an interval whose
         // remaining occupants are all ineligible can still saturate.
         allocated_[idx] = 0;
-        const int lo = st_->buf_intervals[idx].first;
-        const int hi = st_->buf_intervals[idx].second;
-        for (int t = lo; t < hi; ++t) {
-          ++placed_at_[t];
-          if (!done_at_[t] && placed_at_[t] == st_->total_at[t]) {
-            done_at_[t] = 1;
-            --not_done;
-          }
-        }
+        CommitIntervals(idx, /*set_none=*/false, /*top=*/-1, not_done);
         continue;
-      }
-      cand_.clear();
-      for (int w : st_->overlap[idx]) {
-        if (position_[w] < pos && eligible_[w]) cand_.push_back(w);
-      }
-      int64_t a = 0;
-      const bool placed = PlaceDecision(idx, cand_, &a);
-      allocated_[idx] = placed ? 1 : 0;
-      addr_[idx] = a;
-      const bool evicted = !placed;
-      if (!evicted) {
-        total_quality_ += st_->weight[idx] * static_cast<double>(sizes_[idx]);
-        ++total_allocated_count_;
       }
       const int lo = st_->buf_intervals[idx].first;
       const int hi = st_->buf_intervals[idx].second;
-      for (int t = lo; t < hi; ++t) {
-        ++placed_at_[t];
-        if (evicted) has_none_at_[t] = 1;
-        if (!done_at_[t] &&
-            (has_none_at_[t] || placed_at_[t] == st_->total_at[t])) {
-          done_at_[t] = 1;
-          --not_done;
+      bool evicted;
+      int64_t a;
+      if (st_->inplace_partners[idx].empty()) {
+        // Fast path (no in-place partner): PlaceDecision needs only whether an
+        // overlapping earlier buffer was evicted (a None dominates) and the max
+        // top to stack on -- both are per-interval aggregates, so we skip
+        // gathering the candidate list. Bit-exact with the scan: idx's
+        // intervals are exactly the times it overlaps an earlier buffer, so the
+        // max over them of max_top_at_ equals the candidate max-top, and
+        // has_none_at_ on any of them means a None candidate exists.
+        bool none = false;
+        int64_t max_top = 0;
+        for (int t = lo; t < hi; ++t) {
+          if (has_none_at_[t]) {
+            none = true;
+            break;
+          }
+          if (max_top_at_[t] > max_top) max_top = max_top_at_[t];
         }
+        if (none) {
+          evicted = true;
+          a = 0;
+        } else {
+          const int64_t aligned = AlignUp(max_top);
+          evicted = aligned + sizes_[idx] > cap;
+          a = evicted ? 0 : aligned;
+        }
+      } else {
+        // In-place partner present: needs the real candidate list for the
+        // partner-slot logic.
+        GatherCandidates(idx, pos);
+        const auto [placed, addr] = PlaceDecision(idx, cand_);
+        evicted = !placed;
+        a = addr;
+      }
+      allocated_[idx] = evicted ? 0 : 1;
+      addr_[idx] = a;
+      if (!evicted) {
+        total_quality_ += st_->weight[idx] * static_cast<double>(sizes_[idx]);
+        ++total_allocated_count_;
+        CommitIntervals(idx, /*set_none=*/false, /*top=*/a + sizes_[idx],
+                        not_done);
+      } else {
+        CommitIntervals(idx, /*set_none=*/true, /*top=*/-1, not_done);
       }
     }
     for (int pos = stop; pos < n; ++pos) allocated_[permutation_[pos]] = 0;
   }
 
   void MoveInPermutation(int i, int j) {
-    const int x = permutation_[i];
-    permutation_.erase(permutation_.begin() + i);
-    permutation_.insert(permutation_.begin() + j, x);
+    const auto begin = permutation_.begin();
+    // Move the element at i to j by rotating the [lo, hi] subrange by one: a
+    // left rotate when moving forward (i < j), a right rotate when moving back.
+    if (i < j) {
+      std::rotate(begin + i, begin + i + 1, begin + j + 1);
+    } else {
+      std::rotate(begin + j, begin + i, begin + i + 1);
+    }
     const int lo = std::min(i, j);
     const int hi = std::max(i, j);
     for (int p = lo; p <= hi; ++p) position_[permutation_[p]] = p;
@@ -519,6 +601,7 @@ class NativePermutationLayoutSolver {
   std::vector<int> placed_at_;
   std::vector<char> has_none_at_;
   std::vector<char> done_at_;
+  std::vector<int64_t> max_top_at_;  // running max exclusive-top per interval
 };
 
 void register_perm_layout_native(py::module_& m) {

--- a/torch_spyre/csrc/perm_layout_native.cpp
+++ b/torch_spyre/csrc/perm_layout_native.cpp
@@ -92,6 +92,9 @@ class NativePermutationLayoutSolver {
     st->n = n;
     st->capacity = capacity;
     st->alignment = alignment;
+    if (alignment <= 0) {
+      throw std::invalid_argument("alignment must be positive");
+    }
 
     // Validate the permutation is a permutation of range(n).
     {
@@ -117,6 +120,9 @@ class NativePermutationLayoutSolver {
       names[i] = b.attr("name").cast<std::string>();
       sizes_[i] = b.attr("size").cast<int64_t>();
       std::vector<int64_t> uses = b.attr("uses").cast<std::vector<int64_t>>();
+      if (uses.empty()) {
+        throw std::invalid_argument("buffer uses must be non-empty");
+      }
       bool first_read = b.attr("first_use_is_read").cast<bool>();
       parent_names[i] =
           b.attr("in_place_parents").cast<std::vector<std::string>>();
@@ -207,6 +213,10 @@ class NativePermutationLayoutSolver {
 
   double rotate(int i, int j) {
     if (i == j) return 0.0;
+    const int n = st_->n;
+    if (i < 0 || i >= n || j < 0 || j >= n) {
+      throw std::invalid_argument("rotate index out of range");
+    }
     if (!eligible_[permutation_[i]]) {
       // Moving a transparent (HBM) buffer changes no eligible buffer's relative
       // order, so no address moves; just relocate its slot.
@@ -220,6 +230,9 @@ class NativePermutationLayoutSolver {
   }
 
   double resize(int idx, int64_t new_size) {
+    if (idx < 0 || idx >= st_->n) {
+      throw std::invalid_argument("resize index out of range");
+    }
     const double old_total = total_quality_;
     sizes_[idx] = new_size;
     // An ineligible buffer is in HBM: its size affects nothing observable, but
@@ -230,6 +243,9 @@ class NativePermutationLayoutSolver {
   }
 
   double set_eligible(int idx, bool flag) {
+    if (idx < 0 || idx >= st_->n) {
+      throw std::invalid_argument("set_eligible index out of range");
+    }
     if (static_cast<bool>(eligible_[idx]) == flag) return 0.0;
     const double old_total = total_quality_;
     eligible_[idx] = flag ? 1 : 0;
@@ -459,8 +475,8 @@ class NativePermutationLayoutSolver {
 
   // Scratch reused across RecomputeAll / PlaceDecision calls.
   std::vector<int> cand_;
-  std::vector<int> cand_mark_;
-  int cand_gen_ = 0;
+  std::vector<uint64_t> cand_mark_;
+  uint64_t cand_gen_ = 0;
   std::vector<int> placed_at_;
   std::vector<char> has_none_at_;
   std::vector<char> done_at_;

--- a/torch_spyre/csrc/perm_layout_native.cpp
+++ b/torch_spyre/csrc/perm_layout_native.cpp
@@ -121,25 +121,53 @@ class NativePermutationLayoutSolver {
     std::vector<std::string> names(n);
     std::vector<std::vector<std::string>> parent_names(n);
     for (int i = 0; i < n; ++i) {
-      py::handle b = buffers[i];
-      names[i] = b.attr("name").cast<std::string>();
-      sizes_[i] = b.attr("size").cast<int64_t>();
-      std::vector<int64_t> uses = b.attr("uses").cast<std::vector<int64_t>>();
-      if (uses.empty()) {
-        throw std::invalid_argument("buffer uses must be non-empty");
+      // ``py::object``, not ``py::handle``: a handle is a *borrowed* reference
+      // owned only by ``buffers``, so Python code running during the field
+      // reads below (a property, ``__getattr__``) could drop the element from
+      // the list and free the object out from under us.
+      py::object b = buffers[i];
+      try {
+        names[i] = b.attr("name").cast<std::string>();
+        sizes_[i] = b.attr("size").cast<int64_t>();
+        if (sizes_[i] < 0) {
+          throw std::invalid_argument("buffer " + std::to_string(i) +
+                                      ": size must be non-negative");
+        }
+        std::vector<int64_t> uses = b.attr("uses").cast<std::vector<int64_t>>();
+        if (uses.empty()) {
+          throw std::invalid_argument("buffer uses must be non-empty");
+        }
+        bool first_read = b.attr("first_use_is_read").cast<bool>();
+        parent_names[i] =
+            b.attr("in_place_parents").cast<std::vector<std::string>>();
+        st->start[i] = uses.front();
+        st->end[i] = uses.back() + 1;
+        st->weight[i] =
+            static_cast<double>(uses.size()) + (first_read ? 0.0 : 0.5);
       }
-      bool first_read = b.attr("first_use_is_read").cast<bool>();
-      parent_names[i] =
-          b.attr("in_place_parents").cast<std::vector<std::string>>();
-      st->start[i] = uses.front();
-      st->end[i] = uses.back() + 1;
-      st->weight[i] =
-          static_cast<double>(uses.size()) + (first_read ? 0.0 : 0.5);
+      catch (const py::cast_error&) {
+        // pybind11 turns a failed cast into a RuntimeError whose message names
+        // neither the field nor the buffer (and, in a release build, not even
+        // the target type). Every other rejection in this class is a
+        // ValueError, so restate it as one and name the offending buffer.
+        throw std::invalid_argument(
+            "buffer " + std::to_string(i) +
+            ": could not read fields (name, size, uses, first_use_is_read, "
+            "in_place_parents)");
+      }
     }
 
     std::unordered_map<std::string, int> name_to_idx;
     name_to_idx.reserve(n * 2);
     for (int i = 0; i < n; ++i) name_to_idx.emplace(names[i], i);
+    // Names are the identity in-place parents are resolved by, so a duplicate
+    // makes ``in_place_parents=["a"]`` ambiguous: first-wins (``emplace``) and
+    // last-wins (Python's dict comprehension) are both arbitrary. Reject
+    // instead of silently picking one. Mirrors the assert in
+    // ``PermutationBasedLayoutSolverBase.__init__``.
+    if (static_cast<int>(name_to_idx.size()) != n) {
+      throw std::invalid_argument("buffer names must be unique");
+    }
 
     // Time-overlap sets (half-open [start, end) intervals).
     st->overlap.assign(n, {});
@@ -217,11 +245,13 @@ class NativePermutationLayoutSolver {
   }
 
   double rotate(int i, int j) {
-    if (i == j) return 0.0;
+    // Bounds first, then the i == j no-op: the other way round, an out-of-range
+    // ``rotate(999, 999)`` would return 0.0 instead of raising.
     const int n = st_->n;
     if (i < 0 || i >= n || j < 0 || j >= n) {
       throw std::invalid_argument("rotate index out of range");
     }
+    if (i == j) return 0.0;
     if (!eligible_[permutation_[i]]) {
       // Moving a transparent (HBM) buffer changes no eligible buffer's relative
       // order, so no address moves; just relocate its slot.
@@ -237,6 +267,13 @@ class NativePermutationLayoutSolver {
   double resize(int idx, int64_t new_size) {
     if (idx < 0 || idx >= st_->n) {
       throw std::invalid_argument("resize index out of range");
+    }
+    // A negative footprint puts a buffer's top below its own address, breaking
+    // the "stack on the max top" invariant the placer rests on -- and it is the
+    // one input that made AlignUp overflow and the fast path disagree with the
+    // candidate scan.
+    if (new_size < 0) {
+      throw std::invalid_argument("resize size must be non-negative");
     }
     if (sizes_[idx] == new_size) return 0.0;  // no-op: footprint unchanged
     const double old_total = total_quality_;

--- a/torch_spyre/csrc/perm_layout_native.cpp
+++ b/torch_spyre/csrc/perm_layout_native.cpp
@@ -370,13 +370,8 @@ class NativePermutationLayoutSolver {
   // the already-placed, time-overlapping, eligible candidates for ``idx``.
   // Returns {placed, addr}: {true, addr} if placed, {false, 0} if evicted
   // (None).
-  //
-  // ``noinline`` here and on the RecomputeAll phase helpers below is purely for
-  // profiling: it keeps each phase a distinct frame so a sampling profiler
-  // (py-spy --native) can attribute wall-clock self-time per phase. The bodies
-  // are large enough that the lost inlining is not measurable (A/B confirmed).
-  [[gnu::noinline]] std::pair<bool, int64_t> PlaceDecision(
-      int idx, const std::vector<int>& cand) {
+  std::pair<bool, int64_t> PlaceDecision(int idx,
+                                         const std::vector<int>& cand) {
     const int64_t cap = st_->capacity;
     if (cand.empty()) {
       // Lone buffer sits on the floor unless it alone exceeds capacity.
@@ -424,11 +419,11 @@ class NativePermutationLayoutSolver {
   // Places every buffer in permutation order with the saturation early-stop,
   // rebuilding addresses, quality and the allocated count from scratch. Mirrors
   // PermutationBasedLayoutSolverBase._sequential_place.
-  // --- RecomputeAll phases (see the noinline note on PlaceDecision) ---
+  // --- RecomputeAll phases ---
 
   // Reset the saturation early-stop state and return the count of not-yet-
   // saturated intervals (those with at least one live buffer).
-  [[gnu::noinline]] int InitIntervals() {
+  int InitIntervals() {
     const int k = st_->num_intervals;
     placed_at_.assign(k, 0);
     has_none_at_.assign(k, 0);
@@ -447,7 +442,7 @@ class NativePermutationLayoutSolver {
 
   // Gather idx's already-placed, time-overlapping, eligible candidates into
   // cand_ (the buffers idx would stack on top of).
-  [[gnu::noinline]] void GatherCandidates(int idx, int pos) {
+  void GatherCandidates(int idx, int pos) {
     cand_.clear();
     for (int w : st_->overlap[idx]) {
       if (position_[w] < pos && eligible_[w]) cand_.push_back(w);
@@ -466,8 +461,7 @@ class NativePermutationLayoutSolver {
   // (The former ineligible branch tested placed_at_ == total_at without the
   // has_none_at_ term; the unified test here is equivalent because has_none_at_
   // can only be true once done_at_ is already set, so it never fires alone.)
-  [[gnu::noinline]] void CommitIntervals(int idx, bool set_none, int64_t top,
-                                         int& not_done) {
+  void CommitIntervals(int idx, bool set_none, int64_t top, int& not_done) {
     const int lo = st_->buf_intervals[idx].first;
     const int hi = st_->buf_intervals[idx].second;
     for (int t = lo; t < hi; ++t) {

--- a/torch_spyre/csrc/perm_layout_native.h
+++ b/torch_spyre/csrc/perm_layout_native.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 The Torch-Spyre Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace torch_spyre {
+namespace scratchpad {
+
+// Registers the NativePermutationLayoutSolver py::class_ on module ``m``.
+// Called from the _C PYBIND11_MODULE block in module.cpp.
+void register_perm_layout_native(pybind11::module_& m);
+
+}  // namespace scratchpad
+}  // namespace torch_spyre


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds a C++ (pybind11) reimplementation of the permutation-based LX scratchpad
layout packer and makes it the default backend for the simulated-annealing
layout solver (#2660), plus two small additions to the packer API.

- **Native packer.** `NativePermutationLayoutSolver` in `_C` mirrors the
  *observable* behaviour of the Python `PermutationBasedLayoutSolver`
  bit-for-bit (addresses, `quality()`, `count_allocated()`), computed from
  scratch per op in permutation order with the saturation early-stop. It never
  touches a Python object per operation — that's where the speedup comes from.
- **Wired in + default.** The SA layout solver now builds its packer via
  `make_permutation_packer(...)`, which returns the native packer ~~by default and
  falls back to the pure-Python one automatically if `_C` was built without it~~.
  Opt out with `TORCH_SPYRE_NATIVE_PACKER=0` or
  `config.native_layout_packer=False`.
- **API additions.** `resize(idx, new_size)` and `set_eligible(idx, flag)` on
  the permutation packer (Python and native), with tests. **These are not used
  anywhere on `main` yet** — they are Phase-1 prep for the SA co-optimization
  engine (#3182), which flips eligibility and resizes buffers as core-division
  moves change per-core buffer footprints.
- **Performance.** The native packer is ~~9-11~~ ~10.6–13.9× faster than the Python packer on
  the SA layout workload. A follow-up `RecomputeAll` optimization (a per-interval
  max-top aggregate that lets partner-free buffers skip the candidate scan, plus
  dropping a redundant inverse-permutation rebuild) adds ~2× on the recompute
  loop / ~19% on a full SA solve.

#### Which issue(s) this PR is related to:

- Prep for #2753 (make the SA layout solver support work division + LX planning)
  — the `resize` / `set_eligible` API exists to serve that integration.
- Consumer of the new API: #3182 (SA co-optimization engine), landing shortly.
- Accelerates #2660 (simulated annealing layout solver).

#### Special notes for your reviewer:

- **The two API additions are intentionally dead code on `main` today.** They're
  split out ahead of #3182 so that PR can stay focused on the engine.
- **Why this matters now vs. later.** As-is this is a straight, meaningful speed
  boost for the SA *layout* solver. It becomes *substantially* more impactful for
  the SA *co-optimization* solver (#3182, expected ready in ~a week): that engine
  runs an inner layout loop that drives the packer far harder, so the per-op cost
  we removed compounds.
- **Correctness is validated as bit-exact against the Python oracle.** A
  differential suite checks the native packer against `PermutationBasedLayoutSolver`
  over thousands of random seeds (dense in-place wiring, `resize`, and
  `set_eligible` toggles included), and the SA solver produces identical layouts
  (addresses / quality / permutation) under both packers. Run the exhaustive
  version with `TORCH_SPYRE_STRESS_SCRATCHPAD=1`.
- A multi-agent memory-safety review (with an ASan build/run) informed the
  argument-validation/bounds hardening commit.

#### Does this PR introduce a user-facing change?

The SA layout solver now uses the native C++ packer by default — layouts are
identical to before (bit-exact), just computed faster. Opt out with
`TORCH_SPYRE_NATIVE_PACKER=0`. Adds (currently unused) `resize` /
`set_eligible` operations to the permutation packer API.

#### Additional note:

Based on current `upstream/main`; no dependencies. ~~The profiling/benchmark
harness used to derive these numbers is~~ More profiling/benchmark scripts
informing this PR exist; they are kept out of this PR (on a personal
branch), not in the official tree.
