### PR TITLE
Prioritize Preferred matmul Layout

### DIFF
--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -376,10 +376,51 @@ class TestMatmulPreferredLayout(TestCase):
             )
         )
 
+    def test_preferred_order_allows_folded_lhs_stick_outer_dim(self):
+        b, m, k = sympy.symbols("b m k", integer=True, nonnegative=True)
+        dep = MemoryDep("x", 512 * b + 64 * m + k, (b, m, k), (2, 8, 64))
+        stl = SpyreTensorLayout([2, 8, 64], [512, 64, 1], torch.float16, [1, 0, 2])
+
+        self.assertEqual(device_coordinates(stl, dep, None), [b, 0, m, k])
+        self.assertTrue(
+            _matches_preferred_matmul_device_order(
+                stl, dep, MatmulPreferredOrder(frozenset({b}), k, m)
+            )
+        )
+
+    def test_preferred_order_allows_folded_rhs_stick_outer_dim(self):
+        b, k, n = sympy.symbols("b k n", integer=True, nonnegative=True)
+        dep = MemoryDep("y", 8192 * b + 64 * k + n, (b, k, n), (2, 128, 64))
+        stl = SpyreTensorLayout([2, 128, 64], [8192, 64, 1], torch.float16, [1, 0, 2])
+
+        self.assertEqual(device_coordinates(stl, dep, None), [b, 0, k, n])
+        self.assertTrue(
+            _matches_preferred_matmul_device_order(
+                stl, dep, MatmulPreferredOrder(frozenset({b}), n, k)
+            )
+        )
+
     def test_preferred_matmul_output_dim_order(self):
         self.assertEqual(_preferred_matmul_output_dim_order(3, 2), [1, 0, 2])
         self.assertEqual(_preferred_matmul_output_dim_order(4, 3), [2, 0, 1, 3])
         self.assertEqual(_preferred_matmul_output_dim_order(4, 2), [3, 0, 1, 2])
+
+    def test_preferred_output_dim_order_produces_batch_stick_row_device_order(self):
+        b, m, n = sympy.symbols("b m n", integer=True, nonnegative=True)
+        dep = MemoryDep("out", 512 * b + 64 * m + n, (b, m, n), (2, 8, 64))
+        stl = SpyreTensorLayout(
+            [2, 8, 64],
+            [512, 64, 1],
+            torch.float16,
+            _preferred_matmul_output_dim_order(3, 2),
+        )
+
+        self.assertEqual(device_coordinates(stl, dep, None), [b, 0, m, n])
+        self.assertTrue(
+            _matches_preferred_matmul_device_order(
+                stl, dep, MatmulPreferredOrder(frozenset({b}), n, m)
+            )
+        )
 
     def test_preferred_matmul_output_layout_with_size_one_dims(self):
         b, m, n = sympy.symbols("b m n", integer=True, nonnegative=True)

--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -677,7 +677,7 @@ class TestMatmulPreferredLayout(TestCase):
         self.assertEqual(_preferred_matmul_output_dim_order(2, 1), [0, 1])
         self.assertEqual(_preferred_matmul_output_dim_order(3, 2), [1, 0, 2])
         self.assertEqual(
-            _preferred_matmul_output_dim_order(3, 2, [1, 8, 128]), [0, 1, 2]
+            _preferred_matmul_output_dim_order(3, 2, [1, 8, 128]), [1, 0, 2]
         )
         self.assertEqual(
             _preferred_matmul_output_dim_order(3, 2, [2, 1, 128]), [0, 1, 2]
@@ -687,6 +687,10 @@ class TestMatmulPreferredLayout(TestCase):
         )
         self.assertEqual(_preferred_matmul_output_dim_order(4, 3), [2, 0, 1, 3])
         self.assertEqual(_preferred_matmul_output_dim_order(4, 2), [3, 0, 1, 2])
+        self.assertEqual(
+            _preferred_matmul_output_dim_order(4, 3, [1, 4, 8, 128]),
+            [2, 0, 1, 3],
+        )
 
     def test_preferred_output_dim_order_produces_2d_stick_row_device_order(self):
         m, n = sympy.symbols("m n", integer=True, nonnegative=True)
@@ -726,8 +730,8 @@ class TestMatmulPreferredLayout(TestCase):
         b, m, n = sympy.symbols("b m n", integer=True, nonnegative=True)
         cases = [
             ((2, 1, 128), 128 * b + n, [0, n // 64, b, n % 64]),
-            ((1, 8, 64), 64 * m + n, [m, 0, 0, n]),
-            ((1, 8, 128), 128 * m + n, [m, n // 64, 0, n % 64]),
+            ((1, 8, 64), 64 * m + n, [0, 0, m, n]),
+            ((1, 8, 128), 128 * m + n, [0, n // 64, m, n % 64]),
             ((2, 8, 64), 512 * b + 64 * m + n, [b, 0, m, n]),
             ((2, 8, 128), 1024 * b + 128 * m + n, [b, n // 64, m, n % 64]),
             ((2, 8, 1), 8 * b + m, [b, 0, m, 0]),

--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -318,6 +318,30 @@ class TestMatmulPreferredLayout(TestCase):
 
         self.assertEqual(result, preferred)
 
+    def test_matches_preferred_order_for_2d_lhs(self):
+        m, k = sympy.symbols("m k", integer=True, nonnegative=True)
+        dep = MemoryDep("x", 128 * m + k, (m, k), (8, 128))
+        stl = SpyreTensorLayout([8, 128], [128, 1], torch.float16, [0, 1])
+
+        self.assertEqual(device_coordinates(stl, dep, None), [k // 64, m, k % 64])
+        self.assertTrue(
+            _matches_preferred_matmul_device_order(
+                stl, dep, MatmulPreferredOrder(frozenset(), k, m)
+            )
+        )
+
+    def test_matches_preferred_order_for_2d_rhs(self):
+        k, n = sympy.symbols("k n", integer=True, nonnegative=True)
+        dep = MemoryDep("y", 128 * k + n, (k, n), (8, 128))
+        stl = SpyreTensorLayout([8, 128], [128, 1], torch.float16, [0, 1])
+
+        self.assertEqual(device_coordinates(stl, dep, None), [n // 64, k, n % 64])
+        self.assertTrue(
+            _matches_preferred_matmul_device_order(
+                stl, dep, MatmulPreferredOrder(frozenset(), n, k)
+            )
+        )
+
     def test_preferred_input_orders_with_y_broadcast_batch(self):
         b, m, k, n = sympy.symbols("b m k n", integer=True, nonnegative=True)
         x_dep = MemoryDep("x", 1024 * b + 128 * m + k, (b, m, k), (2, 8, 128))
@@ -359,6 +383,7 @@ class TestMatmulPreferredLayout(TestCase):
         dep = MemoryDep("x", 128 * m + k, (b, m, k), (1, 8, 128))
         stl = SpyreTensorLayout([1, 8, 128], [1024, 128, 1], torch.float16, [1, 0, 2])
 
+        self.assertEqual(device_coordinates(stl, dep, None), [0, k // 64, m, k % 64])
         self.assertTrue(
             _matches_preferred_matmul_device_order(
                 stl, dep, MatmulPreferredOrder(frozenset(), k, m)
@@ -388,17 +413,29 @@ class TestMatmulPreferredLayout(TestCase):
             )
         )
 
-    def test_preferred_order_rejects_lhs_row_before_folded_stick_outer(self):
+    def test_preferred_order_rejects_lhs_row_before_outer_stick(self):
         b, m, k = sympy.symbols("b m k", integer=True, nonnegative=True)
         cases = [
-            ((1, 8, 128), 128 * m + k, [m, k // 64, 0, k % 64], frozenset()),
-            ((2, 8, 64), 512 * b + 64 * m + k, [m, 0, b, k], frozenset({b})),
+            (
+                (1, 8, 128),
+                128 * m + k,
+                [m, k // 64, 0, k % 64],
+                frozenset(),
+                [0, 1, 2],
+            ),
+            (
+                (2, 8, 64),
+                512 * b + 64 * m + k,
+                [m, 0, b, k],
+                frozenset({b}),
+                [0, 1, 2],
+            ),
         ]
 
-        for size, index, expected_coords, batch_vars in cases:
+        for size, index, expected_coords, batch_vars, dim_order in cases:
             stride = [size[1] * size[2], size[2], 1]
             dep = MemoryDep("x", index, (b, m, k), size)
-            stl = SpyreTensorLayout(list(size), stride, torch.float16, [0, 1, 2])
+            stl = SpyreTensorLayout(list(size), stride, torch.float16, dim_order)
 
             self.assertEqual(device_coordinates(stl, dep, None), expected_coords)
             self.assertFalse(
@@ -484,10 +521,40 @@ class TestMatmulPreferredLayout(TestCase):
             )
         )
 
+    def test_preferred_order_allows_folded_rhs_stick_outer_before_reduction(self):
+        b, k, n = sympy.symbols("b k n", integer=True, nonnegative=True)
+        dep = MemoryDep("y", 64 * k + n, (b, k, n), (1, 128, 64))
+        stl = SpyreTensorLayout([1, 128, 64], [8192, 64, 1], torch.float16, [1, 0, 2])
+
+        self.assertEqual(device_coordinates(stl, dep, None), [0, 0, k, n])
+        self.assertTrue(
+            _matches_preferred_matmul_device_order(
+                stl, dep, MatmulPreferredOrder(frozenset(), n, k)
+            )
+        )
+
     def test_preferred_matmul_output_dim_order(self):
+        self.assertEqual(_preferred_matmul_output_dim_order(2, 1), [0, 1])
         self.assertEqual(_preferred_matmul_output_dim_order(3, 2), [1, 0, 2])
         self.assertEqual(_preferred_matmul_output_dim_order(4, 3), [2, 0, 1, 3])
         self.assertEqual(_preferred_matmul_output_dim_order(4, 2), [3, 0, 1, 2])
+
+    def test_preferred_output_dim_order_produces_2d_stick_row_device_order(self):
+        m, n = sympy.symbols("m n", integer=True, nonnegative=True)
+        dep = MemoryDep("out", 128 * m + n, (m, n), (8, 128))
+        stl = SpyreTensorLayout(
+            [8, 128],
+            [128, 1],
+            torch.float16,
+            _preferred_matmul_output_dim_order(2, 1),
+        )
+
+        self.assertEqual(device_coordinates(stl, dep, None), [n // 64, m, n % 64])
+        self.assertTrue(
+            _matches_preferred_matmul_device_order(
+                stl, dep, MatmulPreferredOrder(frozenset(), n, m)
+            )
+        )
 
     def test_preferred_output_dim_order_produces_batch_stick_row_device_order(self):
         b, m, n = sympy.symbols("b m n", integer=True, nonnegative=True)

--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -430,7 +430,18 @@ class TestMatmulPreferredLayout(TestCase):
         stl = _default_matmul_input_layout(arg, k)
 
         self.assertIsNotNone(stl)
-        self.assertEqual(device_coordinates(stl, dep, None), [0, k // 64, b, k % 64])
+        device_coords = device_coordinates(stl, dep, None)
+        sdsc_arg = TensorArg(
+            True,
+            0,
+            DataFormats.SEN169_FP16,
+            list(stl.device_size),
+            device_coords,
+            {"hbm": 0},
+        )
+
+        self.assertEqual(device_coords, [0, k // 64, b, k % 64])
+        self.assertEqual(_get_device_dim_order(sdsc_arg, {})[0], [b, k])
 
     def test_preserve_shared_weight_unit_bmm_keeps_outer_stick_before_row(self):
         m, k, n = sympy.symbols("m k n", integer=True, nonnegative=True)

--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -388,6 +388,78 @@ class TestMatmulPreferredLayout(TestCase):
             )
         )
 
+    def test_preferred_order_rejects_lhs_row_before_folded_stick_outer(self):
+        b, m, k = sympy.symbols("b m k", integer=True, nonnegative=True)
+        cases = [
+            ((1, 8, 128), 128 * m + k, [m, k // 64, 0, k % 64], frozenset()),
+            ((2, 8, 64), 512 * b + 64 * m + k, [m, 0, b, k], frozenset({b})),
+        ]
+
+        for size, index, expected_coords, batch_vars in cases:
+            stride = [size[1] * size[2], size[2], 1]
+            dep = MemoryDep("x", index, (b, m, k), size)
+            stl = SpyreTensorLayout(list(size), stride, torch.float16, [0, 1, 2])
+
+            self.assertEqual(device_coordinates(stl, dep, None), expected_coords)
+            self.assertFalse(
+                _matches_preferred_matmul_device_order(
+                    stl, dep, MatmulPreferredOrder(batch_vars, k, m)
+                )
+            )
+
+    def test_preferred_order_allows_lhs_with_single_folded_dim(self):
+        b, m, k = sympy.symbols("b m k", integer=True, nonnegative=True)
+        cases = [
+            ((1, 8, 128), 128 * m + k, [0, k // 64, m, k % 64], frozenset()),
+            ((2, 8, 64), 512 * b + 64 * m + k, [b, 0, m, k], frozenset({b})),
+        ]
+
+        for size, index, expected_coords, batch_vars in cases:
+            stride = [size[1] * size[2], size[2], 1]
+            dep = MemoryDep("x", index, (b, m, k), size)
+            stl = SpyreTensorLayout(list(size), stride, torch.float16, [1, 0, 2])
+
+            self.assertEqual(device_coordinates(stl, dep, None), expected_coords)
+            self.assertTrue(
+                _matches_preferred_matmul_device_order(
+                    stl, dep, MatmulPreferredOrder(batch_vars, k, m)
+                )
+            )
+
+    def test_preferred_order_rejects_folded_lhs_stick_outer_after_row(self):
+        b, m, k = sympy.symbols("b m k", integer=True, nonnegative=True)
+        dep = MemoryDep("x", 64 * m + k, (b, m, k), (1, 8, 64))
+        stl = SpyreTensorLayout([1, 8, 64], [512, 64, 1], torch.float16, [0, 1, 2])
+
+        self.assertEqual(device_coordinates(stl, dep, None), [m, 0, 0, k])
+        self.assertFalse(
+            _matches_preferred_matmul_device_order(
+                stl, dep, MatmulPreferredOrder(frozenset(), k, m)
+            )
+        )
+
+    def test_find_stick_compatible_input_layout_prefers_folded_lhs_with_batch_one(self):
+        b, m, k = sympy.symbols("b m k", integer=True, nonnegative=True)
+        dep = MemoryDep("x", 64 * m + k, (b, m, k), (1, 8, 64))
+        first_valid = SpyreTensorLayout(
+            [1, 8, 64], [512, 64, 1], torch.float16, [0, 1, 2]
+        )
+        preferred = SpyreTensorLayout(
+            [1, 8, 64], [512, 64, 1], torch.float16, [1, 0, 2]
+        )
+        arg = PropArg(dep, None, [first_valid, preferred])
+
+        result = find_stick_compatible_input_layout(
+            arg,
+            k,
+            "batchmatmul",
+            "x",
+            MatmulPreferredOrder(frozenset(), k, m),
+        )
+
+        self.assertEqual(device_coordinates(preferred, dep, None), [0, 0, m, k])
+        self.assertEqual(result, preferred)
+
     def test_preferred_order_allows_folded_rhs_stick_outer_dim(self):
         b, k, n = sympy.symbols("b k n", integer=True, nonnegative=True)
         dep = MemoryDep("y", 8192 * b + 64 * k + n, (b, k, n), (2, 128, 64))
@@ -397,6 +469,18 @@ class TestMatmulPreferredLayout(TestCase):
         self.assertTrue(
             _matches_preferred_matmul_device_order(
                 stl, dep, MatmulPreferredOrder(frozenset({b}), n, k)
+            )
+        )
+
+    def test_preferred_order_rejects_folded_rhs_stick_outer_after_reduction(self):
+        b, k, n = sympy.symbols("b k n", integer=True, nonnegative=True)
+        dep = MemoryDep("y", 64 * k + n, (b, k, n), (1, 128, 64))
+        stl = SpyreTensorLayout([1, 128, 64], [8192, 64, 1], torch.float16, [0, 1, 2])
+
+        self.assertEqual(device_coordinates(stl, dep, None), [k, 0, 0, n])
+        self.assertFalse(
+            _matches_preferred_matmul_device_order(
+                stl, dep, MatmulPreferredOrder(frozenset(), n, k)
             )
         )
 
@@ -426,7 +510,10 @@ class TestMatmulPreferredLayout(TestCase):
         b, m, n = sympy.symbols("b m n", integer=True, nonnegative=True)
         cases = [
             ((2, 1, 128), 128 * b + n, [b, n // 64, 0, n % 64]),
+            ((1, 8, 64), 64 * m + n, [0, 0, m, n]),
             ((1, 8, 128), 128 * m + n, [0, n // 64, m, n % 64]),
+            ((2, 8, 64), 512 * b + 64 * m + n, [b, 0, m, n]),
+            ((2, 8, 128), 1024 * b + 128 * m + n, [b, n // 64, m, n % 64]),
             ((2, 8, 1), 8 * b + m, [b, 0, m, 0]),
             ((1, 1, 128), n, [0, n // 64, 0, n % 64]),
             ((2, 1, 1), b, [b, 0, 0, 0]),

--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -28,6 +28,7 @@ from torch_spyre._inductor.propagate_layouts import (
     PropArg,
     _check_supported_input_sticks,
     _matches_preferred_matmul_device_order,
+    _matmul_preferred_input_orders,
     _preferred_matmul_output_dim_order,
     find_stick_compatible_input_layout,
 )
@@ -316,6 +317,42 @@ class TestMatmulPreferredLayout(TestCase):
         )
 
         self.assertEqual(result, preferred)
+
+    def test_preferred_input_orders_with_y_broadcast_batch(self):
+        b, m, k, n = sympy.symbols("b m k n", integer=True, nonnegative=True)
+        x_dep = MemoryDep("x", 1024 * b + 128 * m + k, (b, m, k), (2, 8, 128))
+        y_dep = MemoryDep("y", 64 * k + n, (k, n), (128, 64))
+
+        x_order, y_order = _matmul_preferred_input_orders(
+            x_dep, y_dep, [b, m, n], 2, k, n
+        )
+
+        self.assertEqual(x_order, MatmulPreferredOrder(frozenset({b}), k, m))
+        self.assertEqual(y_order, MatmulPreferredOrder(frozenset(), n, k))
+
+    def test_preferred_input_orders_with_x_broadcast_batch(self):
+        b, m, k, n = sympy.symbols("b m k n", integer=True, nonnegative=True)
+        x_dep = MemoryDep("x", 128 * m + k, (m, k), (8, 128))
+        y_dep = MemoryDep("y", 8192 * b + 64 * k + n, (b, k, n), (2, 128, 64))
+
+        x_order, y_order = _matmul_preferred_input_orders(
+            x_dep, y_dep, [b, m, n], 2, k, n
+        )
+
+        self.assertEqual(x_order, MatmulPreferredOrder(frozenset(), k, m))
+        self.assertEqual(y_order, MatmulPreferredOrder(frozenset({b}), n, k))
+
+    def test_preferred_input_orders_keep_y_when_row_dim_is_folded(self):
+        b, m, k, n = sympy.symbols("b m k n", integer=True, nonnegative=True)
+        x_dep = MemoryDep("x", 128 * b + k, (b, m, k), (2, 1, 128))
+        y_dep = MemoryDep("y", 64 * k + n, (k, n), (128, 64))
+
+        x_order, y_order = _matmul_preferred_input_orders(
+            x_dep, y_dep, [b, 0, n], 2, k, n
+        )
+
+        self.assertIsNone(x_order)
+        self.assertEqual(y_order, MatmulPreferredOrder(frozenset(), n, k))
 
     def test_preferred_order_allows_folded_batch_dim(self):
         b, m, k = sympy.symbols("b m k", integer=True, nonnegative=True)

--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -17,8 +17,11 @@ import sympy
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch._inductor.dependencies import MemoryDep
-from torch_spyre._C import SpyreTensorLayout
+from torch._inductor.ir import FixedLayout
+from torch_spyre._C import DataFormats, SpyreTensorLayout
+from torch_spyre._inductor.codegen.superdsc import _get_device_dim_order
 from torch_spyre._inductor.errors import Unsupported
+from torch_spyre._inductor.op_spec import TensorArg
 from torch_spyre._inductor.pass_utils import (
     device_coordinates,
     try_device_coordinates,
@@ -27,11 +30,13 @@ from torch_spyre._inductor.propagate_layouts import (
     MatmulPreferredOrder,
     PropArg,
     _check_supported_input_sticks,
+    _default_matmul_input_layout,
     _matches_preferred_matmul_device_order,
     _matmul_preferred_input_orders,
     _preferred_matmul_output_dim_order,
     find_stick_compatible_input_layout,
 )
+from torch_spyre._inductor.spyre_kernel import _preserve_shared_weight_unit_bmm_dim
 from torch_spyre._inductor.views import compute_coordinates, tiling_expr_to_device_expr
 from torch.utils._sympy.functions import ModularIndexing
 
@@ -378,6 +383,63 @@ class TestMatmulPreferredLayout(TestCase):
         self.assertIsNone(x_order)
         self.assertEqual(y_order, MatmulPreferredOrder(frozenset(), n, k))
 
+    def test_default_matmul_input_layout_keeps_batch_before_stick_for_folded_row(self):
+        b, m, k = sympy.symbols("b m k", integer=True, nonnegative=True)
+        layout = FixedLayout(
+            torch.device("spyre"),
+            torch.float16,
+            [4, 1, 128],
+            [128, 128, 1],
+        )
+        dep = MemoryDep("x", 128 * b + k, (b, m, k), (4, 1, 128))
+        arg = PropArg(dep, layout, [])
+
+        stl = _default_matmul_input_layout(arg, k)
+
+        self.assertIsNotNone(stl)
+        self.assertEqual(device_coordinates(stl, dep, None), [0, k // 64, b, k % 64])
+
+    def test_preserve_shared_weight_unit_bmm_keeps_outer_stick_before_row(self):
+        m, k, n = sympy.symbols("m k n", integer=True, nonnegative=True)
+        x_arg = TensorArg(
+            True,
+            0,
+            DataFormats.SEN169_FP16,
+            [1, 64, 512, 64],
+            [sympy.S.Zero, k // 64, m, k % 64],
+            {"hbm": 0},
+        )
+        y_arg = TensorArg(
+            True,
+            1,
+            DataFormats.SEN169_FP16,
+            [64, 4096, 64],
+            [n // 64, k, n % 64],
+            {"hbm": 1},
+        )
+        out_arg = TensorArg(
+            False,
+            2,
+            DataFormats.SEN169_FP16,
+            [1, 64, 512, 64],
+            [sympy.S.Zero, n // 64, m, n % 64],
+            {"hbm": 2},
+        )
+
+        _preserve_shared_weight_unit_bmm_dim(
+            "batchmatmul",
+            {m: (512, 1), n: (4096, 1), k: (4096, 1)},
+            [x_arg, y_arg, out_arg],
+            {"shared_weight_unit_bmm": {"batch_dim": 0}},
+        )
+
+        unit = x_arg.device_coordinates[0]
+        self.assertEqual(str(unit), "_spyre_bmm_unit")
+        self.assertEqual(x_arg.device_coordinates, [unit, k // 64, m, k % 64])
+        self.assertEqual(out_arg.device_coordinates, [unit, n // 64, m, n % 64])
+        self.assertEqual(_get_device_dim_order(x_arg, {})[0], [m, k, unit])
+        self.assertEqual(_get_device_dim_order(out_arg, {})[0], [m, n, unit])
+
     def test_preferred_order_allows_folded_batch_dim(self):
         b, m, k = sympy.symbols("b m k", integer=True, nonnegative=True)
         dep = MemoryDep("x", 128 * m + k, (b, m, k), (1, 8, 128))
@@ -536,6 +598,15 @@ class TestMatmulPreferredLayout(TestCase):
     def test_preferred_matmul_output_dim_order(self):
         self.assertEqual(_preferred_matmul_output_dim_order(2, 1), [0, 1])
         self.assertEqual(_preferred_matmul_output_dim_order(3, 2), [1, 0, 2])
+        self.assertEqual(
+            _preferred_matmul_output_dim_order(3, 2, [1, 8, 128]), [0, 1, 2]
+        )
+        self.assertEqual(
+            _preferred_matmul_output_dim_order(3, 2, [2, 1, 128]), [0, 1, 2]
+        )
+        self.assertEqual(
+            _preferred_matmul_output_dim_order(3, 2, [2, 8, 128]), [1, 0, 2]
+        )
         self.assertEqual(_preferred_matmul_output_dim_order(4, 3), [2, 0, 1, 3])
         self.assertEqual(_preferred_matmul_output_dim_order(4, 2), [3, 0, 1, 2])
 
@@ -563,7 +634,7 @@ class TestMatmulPreferredLayout(TestCase):
             [2, 8, 64],
             [512, 64, 1],
             torch.float16,
-            _preferred_matmul_output_dim_order(3, 2),
+            _preferred_matmul_output_dim_order(3, 2, [2, 8, 64]),
         )
 
         self.assertEqual(device_coordinates(stl, dep, None), [b, 0, m, n])
@@ -576,14 +647,14 @@ class TestMatmulPreferredLayout(TestCase):
     def test_preferred_matmul_output_layout_with_size_one_dims(self):
         b, m, n = sympy.symbols("b m n", integer=True, nonnegative=True)
         cases = [
-            ((2, 1, 128), 128 * b + n, [b, n // 64, 0, n % 64]),
-            ((1, 8, 64), 64 * m + n, [0, 0, m, n]),
-            ((1, 8, 128), 128 * m + n, [0, n // 64, m, n % 64]),
+            ((2, 1, 128), 128 * b + n, [0, n // 64, b, n % 64]),
+            ((1, 8, 64), 64 * m + n, [m, 0, 0, n]),
+            ((1, 8, 128), 128 * m + n, [m, n // 64, 0, n % 64]),
             ((2, 8, 64), 512 * b + 64 * m + n, [b, 0, m, n]),
             ((2, 8, 128), 1024 * b + 128 * m + n, [b, n // 64, m, n % 64]),
             ((2, 8, 1), 8 * b + m, [b, 0, m, 0]),
             ((1, 1, 128), n, [0, n // 64, 0, n % 64]),
-            ((2, 1, 1), b, [b, 0, 0, 0]),
+            ((2, 1, 1), b, [0, 0, b, 0]),
         ]
 
         for size, index, expected_coords in cases:
@@ -592,7 +663,7 @@ class TestMatmulPreferredLayout(TestCase):
                 list(size),
                 stride,
                 torch.float16,
-                _preferred_matmul_output_dim_order(3, 2),
+                _preferred_matmul_output_dim_order(3, 2, list(size)),
             )
             dep = MemoryDep("out", index, (b, m, n), size)
 

--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -24,8 +24,12 @@ from torch_spyre._inductor.pass_utils import (
     try_device_coordinates,
 )
 from torch_spyre._inductor.propagate_layouts import (
+    MatmulPreferredOrder,
     PropArg,
     _check_supported_input_sticks,
+    _matches_preferred_matmul_device_order,
+    _preferred_matmul_output_dim_order,
+    find_stick_compatible_input_layout,
 )
 from torch_spyre._inductor.views import compute_coordinates, tiling_expr_to_device_expr
 from torch.utils._sympy.functions import ModularIndexing
@@ -269,6 +273,110 @@ class TestUnrepresentableStickCandidates(TestCase):
         dep, bad, _ = self._traced_scenario()
         arg = PropArg(dep, None, [bad])
         _check_supported_input_sticks([arg], "batchmatmul")  # must not raise
+
+
+class TestMatmulPreferredLayout(TestCase):
+    def test_matches_preferred_order_with_permuted_batch_dims(self):
+        b0, b1, m, k = sympy.symbols("b0 b1 m k", integer=True, nonnegative=True)
+        dep = MemoryDep(
+            "x",
+            4096 * b0 + 1024 * b1 + 128 * m + k,
+            (b0, b1, m, k),
+            (2, 4, 8, 128),
+        )
+        size = [2, 4, 8, 128]
+        stride = [4096, 1024, 128, 1]
+
+        preferred_a = SpyreTensorLayout(size, stride, torch.float16, [2, 0, 1, 3])
+        preferred_b = SpyreTensorLayout(size, stride, torch.float16, [2, 1, 0, 3])
+        not_preferred = SpyreTensorLayout(size, stride, torch.float16, [0, 1, 2, 3])
+        order = MatmulPreferredOrder(frozenset({b0, b1}), k, m)
+
+        self.assertTrue(_matches_preferred_matmul_device_order(preferred_a, dep, order))
+        self.assertTrue(_matches_preferred_matmul_device_order(preferred_b, dep, order))
+        self.assertFalse(
+            _matches_preferred_matmul_device_order(not_preferred, dep, order)
+        )
+
+    def test_find_stick_compatible_input_layout_prefers_matmul_order(self):
+        b, m, k = sympy.symbols("b m k", integer=True, nonnegative=True)
+        dep = MemoryDep("x", 1024 * b + 128 * m + k, (b, m, k), (2, 8, 128))
+        size = [2, 8, 128]
+        stride = [1024, 128, 1]
+        first_valid = SpyreTensorLayout(size, stride, torch.float16, [0, 1, 2])
+        preferred = SpyreTensorLayout(size, stride, torch.float16, [1, 0, 2])
+        arg = PropArg(dep, None, [first_valid, preferred])
+
+        result = find_stick_compatible_input_layout(
+            arg,
+            k,
+            "batchmatmul",
+            "x",
+            MatmulPreferredOrder(frozenset({b}), k, m),
+        )
+
+        self.assertEqual(result, preferred)
+
+    def test_preferred_order_allows_folded_batch_dim(self):
+        b, m, k = sympy.symbols("b m k", integer=True, nonnegative=True)
+        dep = MemoryDep("x", 128 * m + k, (b, m, k), (1, 8, 128))
+        stl = SpyreTensorLayout([1, 8, 128], [1024, 128, 1], torch.float16, [1, 0, 2])
+
+        self.assertTrue(
+            _matches_preferred_matmul_device_order(
+                stl, dep, MatmulPreferredOrder(frozenset(), k, m)
+            )
+        )
+
+    def test_preferred_order_rejects_folded_row_dim(self):
+        b, m, k = sympy.symbols("b m k", integer=True, nonnegative=True)
+        dep = MemoryDep("x", 128 * b + k, (b, m, k), (2, 1, 128))
+        stl = SpyreTensorLayout([2, 1, 128], [128, 128, 1], torch.float16, [1, 0, 2])
+
+        self.assertFalse(
+            _matches_preferred_matmul_device_order(
+                stl, dep, MatmulPreferredOrder(frozenset({b}), k, m)
+            )
+        )
+
+    def test_preferred_matmul_output_dim_order(self):
+        self.assertEqual(_preferred_matmul_output_dim_order(3, 2), [1, 0, 2])
+        self.assertEqual(_preferred_matmul_output_dim_order(4, 3), [2, 0, 1, 3])
+        self.assertEqual(_preferred_matmul_output_dim_order(4, 2), [3, 0, 1, 2])
+
+    def test_preferred_matmul_output_layout_with_size_one_dims(self):
+        b, m, n = sympy.symbols("b m n", integer=True, nonnegative=True)
+        cases = [
+            ((2, 1, 128), 128 * b + n, [b, n // 64, 0, n % 64]),
+            ((1, 8, 128), 128 * m + n, [0, n // 64, m, n % 64]),
+            ((2, 8, 1), 8 * b + m, [b, 0, m, 0]),
+            ((1, 1, 128), n, [0, n // 64, 0, n % 64]),
+            ((2, 1, 1), b, [b, 0, 0, 0]),
+        ]
+
+        for size, index, expected_coords in cases:
+            stride = [size[1] * size[2], size[2], 1]
+            stl = SpyreTensorLayout(
+                list(size),
+                stride,
+                torch.float16,
+                _preferred_matmul_output_dim_order(3, 2),
+            )
+            dep = MemoryDep("out", index, (b, m, n), size)
+
+            self.assertEqual(device_coordinates(stl, dep, None), expected_coords)
+
+    def test_preferred_x_layout_with_k_size_one_has_no_symbolic_stick(self):
+        b, m, k = sympy.symbols("b m k", integer=True, nonnegative=True)
+        dep = MemoryDep("x", 8 * b + m, (b, m, k), (2, 8, 1))
+        stl = SpyreTensorLayout([2, 8, 1], [8, 1, 1], torch.float16, [1, 0, 2])
+
+        self.assertEqual(device_coordinates(stl, dep, None), [b, 0, m, 0])
+        self.assertFalse(
+            _matches_preferred_matmul_device_order(
+                stl, dep, MatmulPreferredOrder(frozenset({b}), k, m)
+            )
+        )
 
 
 class TestTilingExprToDeviceExpr(TestCase):

--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -383,15 +383,48 @@ class TestMatmulPreferredLayout(TestCase):
         self.assertIsNone(x_order)
         self.assertEqual(y_order, MatmulPreferredOrder(frozenset(), n, k))
 
+    def test_preferred_input_orders_project_folded_host_axes(self):
+        b, m, k, n = sympy.symbols("b m k n", integer=True, nonnegative=True)
+        y_dep = MemoryDep("y", 128 * k + n, (k, n), (128, 128))
+        cases = [
+            (
+                MemoryDep("x", 128 * b + k, (b, m, k), (4, 1, 128)),
+                [b, 0, k],
+                [b, n],
+                None,
+            ),
+            (
+                MemoryDep("x", 128 * m + k, (b, m, k), (1, 8, 128)),
+                [0, m, k],
+                [m, n],
+                MatmulPreferredOrder(frozenset(), k, m),
+            ),
+        ]
+
+        for x_dep, x_host_coords, out_coords, expected_x_order in cases:
+            x_order, y_order = _matmul_preferred_input_orders(
+                x_dep,
+                y_dep,
+                out_coords,
+                1,
+                k,
+                n,
+                x_host_coords,
+                [k, n],
+            )
+
+            self.assertEqual(x_order, expected_x_order)
+            self.assertEqual(y_order, MatmulPreferredOrder(frozenset(), n, k))
+
     def test_default_matmul_input_layout_keeps_batch_before_stick_for_folded_row(self):
         b, m, k = sympy.symbols("b m k", integer=True, nonnegative=True)
         layout = FixedLayout(
             torch.device("spyre"),
             torch.float16,
-            [4, 1, 128],
-            [128, 128, 1],
+            [4, 1, 4096],
+            [4096, 4096, 1],
         )
-        dep = MemoryDep("x", 128 * b + k, (b, m, k), (4, 1, 128))
+        dep = MemoryDep("x", 4096 * b + k, (b, m, k), (4, 1, 4096))
         arg = PropArg(dep, layout, [])
 
         stl = _default_matmul_input_layout(arg, k)
@@ -594,6 +627,40 @@ class TestMatmulPreferredLayout(TestCase):
                 stl, dep, MatmulPreferredOrder(frozenset(), n, k)
             )
         )
+
+    def test_preferred_order_selects_rhs_with_batch_one_and_outer_stick_gt_one(self):
+        b, k, n = sympy.symbols("b k n", integer=True, nonnegative=True)
+        order = MatmulPreferredOrder(frozenset(), n, k)
+        dep = MemoryDep("y", 128 * k + n, (b, k, n), (1, 128, 128))
+        first_valid = SpyreTensorLayout(
+            [1, 128, 128], [16384, 128, 1], torch.float16, [0, 1, 2]
+        )
+        preferred = SpyreTensorLayout(
+            [1, 128, 128], [16384, 128, 1], torch.float16, [1, 0, 2]
+        )
+        preferred_coords = device_coordinates(preferred, dep, None)
+        arg = PropArg(dep, None, [first_valid, preferred])
+
+        result = find_stick_compatible_input_layout(
+            arg,
+            n,
+            "batchmatmul",
+            "y",
+            order,
+        )
+        sdsc_arg = TensorArg(
+            True,
+            1,
+            DataFormats.SEN169_FP16,
+            list(preferred.device_size),
+            preferred_coords,
+            {"hbm": 1},
+        )
+
+        self.assertEqual(preferred_coords, [0, n // 64, k, n % 64])
+        self.assertTrue(_matches_preferred_matmul_device_order(preferred, dep, order))
+        self.assertEqual(_get_device_dim_order(sdsc_arg, {})[0], [k, n])
+        self.assertEqual(result, preferred)
 
     def test_preferred_matmul_output_dim_order(self):
         self.assertEqual(_preferred_matmul_output_dim_order(2, 1), [0, 1])

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -27,6 +27,15 @@ hbm_pool_planning: bool = _get_env_bool("HBM_POOL_PLANNING", True)
 
 global_stick_optimizer: bool = os.environ.get("GLOBAL_STICK_OPTIMIZER", "1") == "1"
 
+# Prefer matmul layouts whose device order is [batch..., stick_outer, row].
+# Options:
+#   "":       disabled
+#   "on":     prefer this layout for matmul inputs and output
+#   "output": prefer this layout for matmul output only
+matmul_preferred_layout: Literal["", "on", "output"] = os.environ.get(
+    "SPYRE_MATMUL_PREFERRED_LAYOUT", ""
+)  # type: ignore[assignment]
+
 allow_all_ops_in_lx_planning: bool = False
 
 dxp_lx_frac_avail: float = float(os.environ.get("DXP_LX_FRAC_AVAIL", "0.2"))

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -681,6 +681,42 @@ def _preferred_matmul_output_dim_order(out_dims: int, out_stick_dim: int) -> lis
     return [out_row_dim] + out_batch_dims + [out_stick_dim]
 
 
+def _matmul_preferred_input_orders(
+    x_dep: MemoryDep,
+    y_dep: MemoryDep,
+    out_coords: list[sympy.Expr],
+    out_stick_dim: int,
+    reduction_var: sympy.Symbol,
+    generated_var: sympy.Symbol,
+) -> tuple[MatmulPreferredOrder | None, MatmulPreferredOrder]:
+    x_syms = x_dep.index.free_symbols
+    y_syms = y_dep.index.free_symbols
+    out_row_dim = (
+        len(out_coords) - 2
+        if out_stick_dim == len(out_coords) - 1
+        else len(out_coords) - 1
+    )
+    out_batch_vars = frozenset(
+        sym
+        for dim, coord in enumerate(out_coords)
+        if dim not in (out_row_dim, out_stick_dim)
+        for sym in sympy.sympify(coord).free_symbols
+    )
+
+    row_vars = sympy.sympify(out_coords[out_row_dim]).free_symbols & x_syms
+    x_preferred_order = None
+    if len(row_vars) == 1:
+        row_var = next(iter(row_vars))
+        x_preferred_order = MatmulPreferredOrder(
+            out_batch_vars & x_syms, reduction_var, row_var
+        )
+
+    y_preferred_order = MatmulPreferredOrder(
+        out_batch_vars & y_syms, generated_var, reduction_var
+    )
+    return x_preferred_order, y_preferred_order
+
+
 def find_stick_compatible_input_layout(
     arg: PropArg,
     reduction_var: sympy.Symbol,
@@ -781,16 +817,18 @@ def _matmul_layouts(
     x_preferred_order = None
     y_preferred_order = None
     if preferred_mode == "on":
-        x_syms = x.dep.index.free_symbols
-        y_syms = y.dep.index.free_symbols
-        out_syms = output_dep.index.free_symbols
-        row_vars = (x_syms & out_syms) - y_syms
-        if len(row_vars) == 1:
-            row_var = next(iter(row_vars))
-            batch_vars = frozenset(x_syms & y_syms & out_syms)
-            x_preferred_order = MatmulPreferredOrder(batch_vars, reduction_var, row_var)
-            y_preferred_order = MatmulPreferredOrder(
-                batch_vars, generated_var, reduction_var
+        out_stick_dim = next(
+            (i for i, c in enumerate(out_coords) if generated_var in c.free_symbols),
+            None,
+        )
+        if out_stick_dim is not None:
+            x_preferred_order, y_preferred_order = _matmul_preferred_input_orders(
+                x.dep,
+                y.dep,
+                out_coords,
+                out_stick_dim,
+                reduction_var,
+                generated_var,
             )
 
     x_req_stl = find_stick_compatible_input_layout(

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -718,18 +718,17 @@ def _preferred_matmul_output_dim_order(
     For non-degenerate Nd outputs the desired SDSC order is
     [row, outer-stick, batch...]. SDSC reports order from least significant to
     most significant after size-one dimensions have folded to constant-zero
-    coordinates. Once a row or batch dimension folds away, its relative position
-    is not a meaningful preference signal; in those cases the preferred host
+    coordinates. Once the row dimension folds away, its relative position is
+    not a meaningful preference signal; in that case the preferred host
     dim_order can make SDSC report outer-stick before the surviving row/batch
-    coordinate, so keep the default dim_order instead.
+    coordinate, so keep the default dim_order instead. Folded batch dimensions
+    do not affect the preference among the remaining active batch dimensions.
     """
     out_row_dim = out_dims - 2 if out_stick_dim == out_dims - 1 else out_dims - 1
     out_batch_dims = [
         dim for dim in range(out_dims) if dim not in (out_row_dim, out_stick_dim)
     ]
-    if out_size is not None and any(
-        concretize_expr(out_size[dim]) == 1 for dim in [out_row_dim] + out_batch_dims
-    ):
+    if out_size is not None and concretize_expr(out_size[out_row_dim]) == 1:
         return _default_matmul_output_dim_order(out_dims, out_stick_dim)
     return [out_row_dim] + out_batch_dims + [out_stick_dim]
 

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -622,14 +622,7 @@ def _dev_coord_for_var(dev_coords, arg_host_coords, var):
     return None
 
 
-def _device_order_vars(
-    stl: SpyreTensorLayout,
-    dep: MemoryDep,
-) -> list[sympy.Symbol] | None:
-    coords = try_device_coordinates(stl, dep, None)
-    if coords is None:
-        return None
-
+def _nonstick_device_order_vars(coords: list[sympy.Expr]) -> list[sympy.Symbol] | None:
     result = []
     for coord in coords[:-1]:
         free_symbols = coord.free_symbols
@@ -641,6 +634,24 @@ def _device_order_vars(
     return result
 
 
+def _matches_with_folded_stick_var(
+    coords: list[sympy.Expr],
+    nonstick_vars: list[sympy.Symbol],
+    preferred_order: MatmulPreferredOrder,
+) -> bool:
+    first = preferred_order.first_matmul_var
+    second = preferred_order.second_matmul_var
+    if first in nonstick_vars or first not in coords[-1].free_symbols:
+        return False
+    if second not in nonstick_vars:
+        return False
+
+    second_pos = nonstick_vars.index(second)
+    return set(nonstick_vars[:second_pos]) == set(
+        preferred_order.batch_vars
+    ) and nonstick_vars[second_pos:] == [second]
+
+
 def _matches_preferred_matmul_device_order(
     stl: SpyreTensorLayout,
     dep: MemoryDep,
@@ -649,8 +660,18 @@ def _matches_preferred_matmul_device_order(
     if preferred_order is None:
         return False
 
-    actual_vars = _device_order_vars(stl, dep)
-    if actual_vars is None or len(actual_vars) < 2:
+    coords = try_device_coordinates(stl, dep, None)
+    if coords is None:
+        return False
+
+    actual_vars = _nonstick_device_order_vars(coords)
+    if actual_vars is None:
+        return False
+
+    if _matches_with_folded_stick_var(coords, actual_vars, preferred_order):
+        return True
+
+    if len(actual_vars) < 2:
         return False
 
     actual_batch_vars = actual_vars[:-2]
@@ -674,6 +695,7 @@ def _matmul_preferred_layout_mode() -> str:
 
 
 def _preferred_matmul_output_dim_order(out_dims: int, out_stick_dim: int) -> list[int]:
+    """Return host dim_order that produces device order [batch..., stick, row]."""
     out_row_dim = out_dims - 2 if out_stick_dim == out_dims - 1 else out_dims - 1
     out_batch_dims = [
         dim for dim in range(out_dims) if dim not in (out_row_dim, out_stick_dim)

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -713,7 +713,16 @@ def _default_matmul_output_dim_order(out_dims: int, out_stick_dim: int) -> list[
 def _preferred_matmul_output_dim_order(
     out_dims: int, out_stick_dim: int, out_size: list | None = None
 ) -> list[int]:
-    """Return host dim_order for preferred matmul output device order."""
+    """Return host dim_order for the preferred matmul output layout.
+
+    For non-degenerate Nd outputs the desired SDSC order is
+    [row, outer-stick, batch...]. SDSC reports order from least significant to
+    most significant after size-one dimensions have folded to constant-zero
+    coordinates. Once a row or batch dimension folds away, its relative position
+    is not a meaningful preference signal; in those cases the preferred host
+    dim_order can make SDSC report outer-stick before the surviving row/batch
+    coordinate, so keep the default dim_order instead.
+    """
     out_row_dim = out_dims - 2 if out_stick_dim == out_dims - 1 else out_dims - 1
     out_batch_dims = [
         dim for dim in range(out_dims) if dim not in (out_row_dim, out_stick_dim)
@@ -729,6 +738,14 @@ def _default_matmul_input_layout(
     arg: PropArg,
     stick_var: sympy.Symbol,
 ) -> SpyreTensorLayout | None:
+    """Build the default input layout while preserving the required stick var.
+
+    This is used when preferred input ordering cannot be derived because the
+    logical row dimension folded to a constant. Choosing the first compatible
+    explicit layout can leave SDSC reporting [outer-stick, batch] for inputs;
+    rebuilding from the host layout keeps the default batch/row placement while
+    still requiring the matmul stick dimension.
+    """
     if arg.layout is None:
         return None
 
@@ -761,9 +778,30 @@ def _matmul_preferred_input_orders(
     out_stick_dim: int,
     reduction_var: sympy.Symbol,
     generated_var: sympy.Symbol,
+    x_host_coords: list[sympy.Expr] | None = None,
+    y_host_coords: list[sympy.Expr] | None = None,
 ) -> tuple[MatmulPreferredOrder | None, MatmulPreferredOrder]:
+    """Derive preferred device orders for the two matmul inputs.
+
+    x is [batch..., row, reduction] and must stick on reduction_var, while y is
+    [batch..., reduction, generated] and must stick on generated_var. The
+    preferred order object stores the expected non-stick device order as
+    [batch..., outer-stick, row-like-var], where the row-like var is row for x
+    and reduction for y. Folded batch dimensions, such as B=1, are ignored by
+    this match: their SDSC position is a don't-care because they no longer carry
+    a symbolic coordinate. If x's row folded to a constant, return None so the
+    caller can use the default input layout fallback.
+    """
     x_syms = x_dep.index.free_symbols
     y_syms = y_dep.index.free_symbols
+
+    def active_dependency_vars(
+        coords: list[sympy.Expr], syms: set[sympy.Symbol]
+    ) -> frozenset[sympy.Symbol]:
+        return frozenset(
+            sym for coord in coords for sym in sympy.sympify(coord).free_symbols & syms
+        )
+
     out_row_dim = (
         len(out_coords) - 2
         if out_stick_dim == len(out_coords) - 1
@@ -776,17 +814,23 @@ def _matmul_preferred_input_orders(
         for sym in sympy.sympify(coord).free_symbols
     )
 
-    row_vars = sympy.sympify(out_coords[out_row_dim]).free_symbols & x_syms
+    if x_host_coords is not None and len(x_host_coords) >= 2:
+        x_batch_vars = active_dependency_vars(x_host_coords[:-2], x_syms)
+        row_vars = active_dependency_vars([x_host_coords[-2]], x_syms)
+    else:
+        x_batch_vars = out_batch_vars & x_syms
+        row_vars = sympy.sympify(out_coords[out_row_dim]).free_symbols & x_syms
+
     x_preferred_order = None
     if len(row_vars) == 1:
         row_var = next(iter(row_vars))
-        x_preferred_order = MatmulPreferredOrder(
-            out_batch_vars & x_syms, reduction_var, row_var
-        )
+        x_preferred_order = MatmulPreferredOrder(x_batch_vars, reduction_var, row_var)
 
-    y_preferred_order = MatmulPreferredOrder(
-        out_batch_vars & y_syms, generated_var, reduction_var
-    )
+    if y_host_coords is not None and len(y_host_coords) >= 2:
+        y_batch_vars = active_dependency_vars(y_host_coords[:-2], y_syms)
+    else:
+        y_batch_vars = out_batch_vars & y_syms
+    y_preferred_order = MatmulPreferredOrder(y_batch_vars, generated_var, reduction_var)
     return x_preferred_order, y_preferred_order
 
 
@@ -895,6 +939,8 @@ def _matmul_layouts(
             None,
         )
         if out_stick_dim is not None:
+            x_host_coords = host_coordinates(x.layout, x.dep, None)
+            y_host_coords = host_coordinates(y.layout, y.dep, None)
             x_preferred_order, y_preferred_order = _matmul_preferred_input_orders(
                 x.dep,
                 y.dep,
@@ -902,6 +948,8 @@ def _matmul_layouts(
                 out_stick_dim,
                 reduction_var,
                 generated_var,
+                x_host_coords,
+                y_host_coords,
             )
 
     x_req_stl = None

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -107,6 +107,12 @@ class PropArg(NamedTuple):
     layouts: list[SpyreTensorLayout]
 
 
+class MatmulPreferredOrder(NamedTuple):
+    batch_vars: frozenset[sympy.Symbol]
+    first_matmul_var: sympy.Symbol
+    second_matmul_var: sympy.Symbol
+
+
 def _get_prop_args(reads) -> list[PropArg]:
     # Local to this pass — the FixedLayout/FixedTiledLayout ambiguity only exists
     # during propagation and should not infect downstream passes.
@@ -616,11 +622,71 @@ def _dev_coord_for_var(dev_coords, arg_host_coords, var):
     return None
 
 
+def _device_order_vars(
+    stl: SpyreTensorLayout,
+    dep: MemoryDep,
+) -> list[sympy.Symbol] | None:
+    coords = try_device_coordinates(stl, dep, None)
+    if coords is None:
+        return None
+
+    result = []
+    for coord in coords[:-1]:
+        free_symbols = coord.free_symbols
+        if not free_symbols:
+            continue
+        if len(free_symbols) != 1:
+            return None
+        result.append(next(iter(free_symbols)))
+    return result
+
+
+def _matches_preferred_matmul_device_order(
+    stl: SpyreTensorLayout,
+    dep: MemoryDep,
+    preferred_order: MatmulPreferredOrder | None,
+) -> bool:
+    if preferred_order is None:
+        return False
+
+    actual_vars = _device_order_vars(stl, dep)
+    if actual_vars is None or len(actual_vars) < 2:
+        return False
+
+    actual_batch_vars = actual_vars[:-2]
+    actual_matmul_vars = actual_vars[-2:]
+    return set(actual_batch_vars) == set(
+        preferred_order.batch_vars
+    ) and actual_matmul_vars == [
+        preferred_order.first_matmul_var,
+        preferred_order.second_matmul_var,
+    ]
+
+
+def _matmul_preferred_layout_mode() -> str:
+    mode = config.matmul_preferred_layout
+    if mode not in ("", "on", "output"):
+        raise Unsupported(
+            "SPYRE_MATMUL_PREFERRED_LAYOUT must be one of '', 'on', or 'output'; "
+            f"got {mode!r}"
+        )
+    return mode
+
+
+def _preferred_matmul_output_dim_order(out_dims: int, out_stick_dim: int) -> list[int]:
+    out_row_dim = out_dims - 2 if out_stick_dim == out_dims - 1 else out_dims - 1
+    out_batch_dims = [
+        dim for dim in range(out_dims) if dim not in (out_row_dim, out_stick_dim)
+    ]
+    return [out_row_dim] + out_batch_dims + [out_stick_dim]
+
+
 def find_stick_compatible_input_layout(
     arg: PropArg,
     reduction_var: sympy.Symbol,
     reduction_type: str,
     label: str,
+    preferred_order: MatmulPreferredOrder | None = None,
 ) -> SpyreTensorLayout:
     """Find the required STL for a matmul input by iterating all candidate layouts.
 
@@ -640,12 +706,19 @@ def find_stick_compatible_input_layout(
     # Pass 1: already stick-compatible.
     # stick_compatible() checks cross-tensor compatibility; here we only need
     # to know if this input's stick coord already carries the target loop variable.
+    first_compatible = None
     for stl, dev_coords in candidates:
         if reduction_var in dev_coords[-1].free_symbols:
-            return stl
+            if first_compatible is None:
+                first_compatible = stl
+            if _matches_preferred_matmul_device_order(stl, arg.dep, preferred_order):
+                return stl
+    if first_compatible is not None:
+        return first_compatible
 
     # Pass 2: can be restickified — find the resolvable device coord for reduction_var
     # and use it as target_stick_expr for compute_restickify_target_layout.
+    first_restickified = None
     arg_host_coords = host_coordinates(arg.layout, arg.dep, None)
     for stl, dev_coords in candidates:
         target_stick_expr = _dev_coord_for_var(
@@ -657,7 +730,13 @@ def find_stick_compatible_input_layout(
             stl, arg.layout, target_stick_expr, arg_host_coords, dev_coords
         )
         if result is not None:
-            return result
+            if first_restickified is None:
+                first_restickified = result
+            if _matches_preferred_matmul_device_order(result, arg.dep, preferred_order):
+                return result
+
+    if first_restickified is not None:
+        return first_restickified
 
     raise Unsupported(
         f"{reduction_type}: cannot restickify any input layout of {label} to carry {label}_var={reduction_var}"
@@ -697,12 +776,28 @@ def _matmul_layouts(
     #   Output:     stick on generated_var
     reduction_var = find_reduction_var(x.dep, output_dep)
     generated_var = find_matmul_generated_var(y.dep, x.dep, output_dep)
+    preferred_mode = _matmul_preferred_layout_mode()
+
+    x_preferred_order = None
+    y_preferred_order = None
+    if preferred_mode == "on":
+        x_syms = x.dep.index.free_symbols
+        y_syms = y.dep.index.free_symbols
+        out_syms = output_dep.index.free_symbols
+        row_vars = (x_syms & out_syms) - y_syms
+        if len(row_vars) == 1:
+            row_var = next(iter(row_vars))
+            batch_vars = frozenset(x_syms & y_syms & out_syms)
+            x_preferred_order = MatmulPreferredOrder(batch_vars, reduction_var, row_var)
+            y_preferred_order = MatmulPreferredOrder(
+                batch_vars, generated_var, reduction_var
+            )
 
     x_req_stl = find_stick_compatible_input_layout(
-        x, reduction_var, data.reduction_type, "x"
+        x, reduction_var, data.reduction_type, "x", x_preferred_order
     )
     y_req_stl = find_stick_compatible_input_layout(
-        y, generated_var, data.reduction_type, "y"
+        y, generated_var, data.reduction_type, "y", y_preferred_order
     )
 
     out_stick_dim = next(
@@ -715,11 +810,14 @@ def _matmul_layouts(
         )
 
     out_dims = len(output.size)
-    out_dim_order = list(range(out_dims - 2))
-    if out_stick_dim == out_dims - 1:
-        out_dim_order = out_dim_order + [out_dims - 2, out_dims - 1]
+    if preferred_mode in ("on", "output"):
+        out_dim_order = _preferred_matmul_output_dim_order(out_dims, out_stick_dim)
     else:
-        out_dim_order = out_dim_order + [out_dims - 1, out_dims - 2]
+        out_dim_order = list(range(out_dims - 2))
+        if out_stick_dim == out_dims - 1:
+            out_dim_order = out_dim_order + [out_dims - 2, out_dims - 1]
+        else:
+            out_dim_order = out_dim_order + [out_dims - 1, out_dims - 2]
     # Concretize for C++ SpyreTensorLayout constructor.
     c_size = [concretize_expr(s) for s in output.size]
     c_stride = [concretize_expr(s) for s in output.stride]

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -703,13 +703,55 @@ def _matmul_preferred_layout_mode() -> str:
     return mode
 
 
-def _preferred_matmul_output_dim_order(out_dims: int, out_stick_dim: int) -> list[int]:
+def _default_matmul_output_dim_order(out_dims: int, out_stick_dim: int) -> list[int]:
+    dim_order = list(range(out_dims - 2))
+    if out_stick_dim == out_dims - 1:
+        return dim_order + [out_dims - 2, out_dims - 1]
+    return dim_order + [out_dims - 1, out_dims - 2]
+
+
+def _preferred_matmul_output_dim_order(
+    out_dims: int, out_stick_dim: int, out_size: list | None = None
+) -> list[int]:
     """Return host dim_order for preferred matmul output device order."""
     out_row_dim = out_dims - 2 if out_stick_dim == out_dims - 1 else out_dims - 1
     out_batch_dims = [
         dim for dim in range(out_dims) if dim not in (out_row_dim, out_stick_dim)
     ]
+    if out_size is not None and any(
+        concretize_expr(out_size[dim]) == 1 for dim in [out_row_dim] + out_batch_dims
+    ):
+        return _default_matmul_output_dim_order(out_dims, out_stick_dim)
     return [out_row_dim] + out_batch_dims + [out_stick_dim]
+
+
+def _default_matmul_input_layout(
+    arg: PropArg,
+    stick_var: sympy.Symbol,
+) -> SpyreTensorLayout | None:
+    if arg.layout is None:
+        return None
+
+    arg_host_coords = host_coordinates(arg.layout, arg.dep, None)
+    stick_dim = None
+    for coord in arg_host_coords:
+        if stick_var not in coord.free_symbols:
+            continue
+        stick_dim = matching_dim(arg_host_coords, coord)
+        if stick_dim is not None:
+            break
+    if stick_dim is None:
+        return None
+
+    dim_order = [dim for dim in range(len(arg.layout.size)) if dim != stick_dim]
+    dim_order.append(stick_dim)
+    c_size = [concretize_expr(s) for s in arg.layout.size]
+    c_stride = [concretize_expr(s) for s in arg.layout.stride]
+    stl = SpyreTensorLayout(c_size, c_stride, arg.layout.dtype, dim_order)
+    coords = try_device_coordinates(stl, arg.dep, None)
+    if coords is not None and stick_var in coords[-1].free_symbols:
+        return stl
+    return None
 
 
 def _matmul_preferred_input_orders(
@@ -862,9 +904,13 @@ def _matmul_layouts(
                 generated_var,
             )
 
-    x_req_stl = find_stick_compatible_input_layout(
-        x, reduction_var, data.reduction_type, "x", x_preferred_order
-    )
+    x_req_stl = None
+    if preferred_mode == "on" and x_preferred_order is None:
+        x_req_stl = _default_matmul_input_layout(x, reduction_var)
+    if x_req_stl is None:
+        x_req_stl = find_stick_compatible_input_layout(
+            x, reduction_var, data.reduction_type, "x", x_preferred_order
+        )
     y_req_stl = find_stick_compatible_input_layout(
         y, generated_var, data.reduction_type, "y", y_preferred_order
     )
@@ -880,13 +926,11 @@ def _matmul_layouts(
 
     out_dims = len(output.size)
     if preferred_mode in ("on", "output"):
-        out_dim_order = _preferred_matmul_output_dim_order(out_dims, out_stick_dim)
+        out_dim_order = _preferred_matmul_output_dim_order(
+            out_dims, out_stick_dim, output.size
+        )
     else:
-        out_dim_order = list(range(out_dims - 2))
-        if out_stick_dim == out_dims - 1:
-            out_dim_order = out_dim_order + [out_dims - 2, out_dims - 1]
-        else:
-            out_dim_order = out_dim_order + [out_dims - 1, out_dims - 2]
+        out_dim_order = _default_matmul_output_dim_order(out_dims, out_stick_dim)
     # Concretize for C++ SpyreTensorLayout constructor.
     c_size = [concretize_expr(s) for s in output.size]
     c_stride = [concretize_expr(s) for s in output.stride]

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -646,10 +646,19 @@ def _matches_with_folded_stick_var(
     if second not in nonstick_vars:
         return False
 
-    second_pos = nonstick_vars.index(second)
-    return set(nonstick_vars[:second_pos]) == set(
-        preferred_order.batch_vars
-    ) and nonstick_vars[second_pos:] == [second]
+    second_coord_pos = next(
+        i for i, coord in enumerate(coords[:-1]) if coord.free_symbols == {second}
+    )
+    if second_coord_pos == 0 or coords[second_coord_pos - 1] != sympy.S.Zero:
+        return False
+
+    before_second = _nonstick_device_order_vars(coords[:second_coord_pos])
+    after_second = _nonstick_device_order_vars(coords[second_coord_pos + 1 : -1])
+    return (
+        before_second is not None
+        and set(before_second) == set(preferred_order.batch_vars)
+        and after_second == []
+    )
 
 
 def _matches_preferred_matmul_device_order(

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -704,7 +704,7 @@ def _matmul_preferred_layout_mode() -> str:
 
 
 def _preferred_matmul_output_dim_order(out_dims: int, out_stick_dim: int) -> list[int]:
-    """Return host dim_order that produces device order [batch..., stick, row]."""
+    """Return host dim_order for preferred matmul output device order."""
     out_row_dim = out_dims - 2 if out_stick_dim == out_dims - 1 else out_dims - 1
     out_batch_dims = [
         dim for dim in range(out_dims) if dim not in (out_row_dim, out_stick_dim)

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -87,6 +87,14 @@ def _preserve_shared_weight_unit_bmm_dim(
     args: Sequence[TensorArg],
     op_info: dict[str, Any],
 ) -> dict[sympy.Symbol, tuple[sympy.Expr, int]]:
+    """Keep a size-one shared-weight BMM batch dim visible to SDSC.
+
+    Plain BMMs with B=1 can lose their batch axis because unit dimensions fold
+    to constant-zero device coordinates. Replacing that axis with a synthetic
+    loop symbol preserves the logical rank. When reordering the physical axes,
+    keep the outer-stick axis before the row axis so SDSC's reverse walk reports
+    [row, outer-stick, batch] for preferred explicit layouts.
+    """
     # TensorArg layout is normalized in-place below to match the surrounding
     # OpSpec construction helpers.
     if SHARED_WEIGHT_UNIT_BMM_INFO_KEY not in op_info:

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -142,7 +142,23 @@ def _preserve_shared_weight_unit_bmm_dim(
     for arg, unit_idx in rewrite_targets:
         arg.device_coordinates[unit_idx] = unit_sym
         nonstick = list(range(len(arg.device_size) - 1))
-        order = [unit_idx] + [i for i in reversed(nonstick) if i != unit_idx]
+        stick_symbols = arg.device_coordinates[-1].free_symbols
+        outer_stick_idx = next(
+            (
+                i
+                for i in nonstick
+                if i != unit_idx
+                and bool(arg.device_coordinates[i].free_symbols & stick_symbols)
+            ),
+            None,
+        )
+        if outer_stick_idx is None:
+            order = [unit_idx] + [i for i in reversed(nonstick) if i != unit_idx]
+        else:
+            order = [unit_idx, outer_stick_idx]
+            order += [
+                i for i in reversed(nonstick) if i not in (unit_idx, outer_stick_idx)
+            ]
         order.append(len(arg.device_size) - 1)
         arg.device_size[:] = [arg.device_size[i] for i in order]
         arg.device_coordinates[:] = [arg.device_coordinates[i] for i in order]


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Matmul layout of input and output tensors can have a significant impact on performance of memory bound problem sizes. This PR changes the default behavior:

- choose preferred layout for inputs if they are in the candidate set
- choose preferred layout for output if matmul is functional (i.e. output not preallocated)

#### Which issue(s) this PR is related to:

Experimental for #3311 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
