### PR TITLE
Add early DCI conversion support check in generate_dci

### DIFF
--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -384,6 +384,12 @@ auto generate_dci(const at::Tensor* cpu_tensor, const at::Tensor* dev_tensor,
   dci.isHostToSen_ = host2device;
   dci.dataformat_src_ = host2device ? cpu_format_host : dev_format_dev;
   dci.dataformat_dst_ = host2device ? dev_format_dev : cpu_format_host;
+  TORCH_CHECK(
+      isDCIConversionSupported(dci.dataformat_src_, dci.dataformat_dst_),
+      "Unsupported DCI data format conversion: src=",
+      static_cast<int>(dci.dataformat_src_),
+      " dst=", static_cast<int>(dci.dataformat_dst_),
+      " (cpu_type=", cpu_str_type, ", dev_type=", dev_str_type, ")");
 
   std::vector<int64_t> cpu_shape;
   std::vector<int64_t> dev_shape = stl.device_size;

--- a/torch_spyre/csrc/types_mapping.h
+++ b/torch_spyre/csrc/types_mapping.h
@@ -352,6 +352,61 @@ stringToSenDatatypePair(const std::string& type_name) {
   return {sendnn::sen_datatype_enum::dt_undef,
           sendnn::sen_datatype_enum::dt_undef};
 }
+// Returns true if deeptools ConvertData_general_shuffle supports the given
+// (src, dst) DataFormats pair.  The set of supported pairs is derived from
+// the exhaustive if/else-if chain in
+// deeptools/util/sen_data_convert.cpp :: ConvertData_general_shuffle.
+inline bool isDCIConversionSupported(DataFormats src, DataFormats dst) {
+  // clang-format off
+  using DF = DataFormats;
+  // Pairs listed as (src, dst) matching the order in
+  // ConvertData_general_shuffle.
+  static const std::pair<DataFormats, DataFormats> kSupported[] = {
+      {DF::IEEE_FP32,   DF::IEEE_FP32},
+      {DF::SEN169_FP16, DF::IEEE_FP32},
+      {DF::IEEE_FP16,   DF::IEEE_FP32},
+      {DF::IEEE_FP32,   DF::SEN169_FP16},
+      {DF::SEN169_FP16, DF::SEN169_FP16},
+      {DF::SEN169_FP16, DF::SENINT16},
+      {DF::SENINT16,    DF::SEN169_FP16},
+      {DF::IEEE_FP32,   DF::BFLOAT16},
+      {DF::IEEE_FP16,   DF::BFLOAT16},
+      {DF::BFLOAT16,    DF::IEEE_FP32},
+      {DF::SEN143_FP8,  DF::IEEE_FP32},
+      {DF::IEEE_FP32,   DF::SEN143_FP8},
+      {DF::SEN143_FP8,  DF::SEN143_FP8},
+      {DF::SENINT4,     DF::IEEE_FP32},
+      {DF::IEEE_FP32,   DF::SENINT4},
+      {DF::SENINT8,     DF::IEEE_FP32},
+      {DF::IEEE_FP32,   DF::SENINT8},
+      {DF::SENUINT2,    DF::IEEE_FP32},
+      {DF::IEEE_FP32,   DF::SENUINT2},
+      {DF::BOOL,        DF::SEN169_FP16},
+      {DF::SEN169_FP16, DF::BOOL},
+      {DF::IEEE_INT64,  DF::SEN169_FP16},
+      {DF::IEEE_FP16,   DF::SEN169_FP16},
+      {DF::SEN169_FP16, DF::IEEE_FP16},
+      {DF::SENINT4,     DF::SENINT4},
+      {DF::SENINT8,     DF::SENINT8},
+      {DF::IEEE_INT64,  DF::IEEE_INT32},
+      {DF::IEEE_INT32,  DF::IEEE_INT64},
+      {DF::IEEE_INT32,  DF::IEEE_INT32},
+      {DF::SENUINT32,   DF::IEEE_INT64},
+      {DF::IEEE_INT64,  DF::SENUINT32},
+      {DF::SENUINT32,   DF::SENUINT32},
+      {DF::SEN169_FP16, DF::IEEE_INT64},
+      {DF::BFLOAT16,    DF::SEN169_FP16},
+      {DF::SEN169_FP16, DF::BFLOAT16},
+  };
+  // clang-format on
+  for (const auto& p : kSupported) {
+    if (p.first == src && p.second == dst) {
+      return true;
+    }
+  }
+  return false;
+}
+
 inline std::pair<size_t, size_t> elementSize(const c10::ScalarType& dtype) {
   /* return size (bytes) on CPU and on Spyre*/
   static const std::unordered_map<c10::ScalarType, std::pair<size_t, size_t>>


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

<!--
Please describe your changes
-->
Add early DCI conversion support check in `generate_dci` to throw dci error before reaching stream. 
This is a **temporary** solution. Will be removed once we add check in flex.

#### Which issue(s) this PR is related to:
add dci check to prevent flex 1283 poisoning stream in `torch-spyre` unit test

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->
fixed #3370 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
