### PR TITLE
Update model_ops nightly YAML to include Qwen model details in dashboard

### DIFF
--- a/.github/workflows/model_ops_tests_nightly.yaml
+++ b/.github/workflows/model_ops_tests_nightly.yaml
@@ -118,6 +118,10 @@ jobs:
             config: Mistral-Small-3.2-24B-Instruct-2506.yaml
           - name: Mistral Small 3.2 24B Instruct 2506 Spyre
             config: Mistral-Small-3.2-24B-Instruct-2506_spyre.yaml
+          - name: Qwen 2.5
+            config: Qwen2.5-7B-Instruct.yaml
+          - name: Qwen 2.5 7B Spyre
+            config: Qwen2.5-7B-Instruct_spyre.yaml
 
     steps:
       # Sparse checkout into the GHA workspace so the local composite


### PR DESCRIPTION
Update model_ops nightly YAML to include Qwen model details in dashboard

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

It include the Qwen model data into the github workflow run and get the logs to push the data to the click house 

