### PR TITLE
fix(coarse_tile): advance the copy op's full-buffer write by a whole tile

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -642,7 +642,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             "allow_all_ops_in_lx_planning": True,
         }
     )
-    @unittest.expectedFailure
     def test_hint_softmax_row_tiling(self):
         """spyre_hint(num_tiles_per_dim={"NROW": 4}) tiles softmax over the row dimension.
 
@@ -651,12 +650,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         shrinks the row-stride dimension corrupts all stick groups after the
         first in each non-first tile.  atol=0.02 is tight enough to catch
         values from the wrong row (fp16 errors from random inputs exceed 0.5).
-
-        Decision xfail: failing in CI (Actions run 30385154736, job
-        90362755639) on PR #3293. We've decided to xfail the coarse tiling
-        tests to allow us to merge to main -- deliberate decision to unblock
-        the merge, not a claim about a specific bisected root cause. Un-xfail
-        once the underlying regression is investigated and fixed.
         """
         from torch_spyre._inductor import spyre_hint
 
@@ -677,16 +670,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
     # Matmul with row-tiling: tile the M dimension of x @ y
     # ------------------------------------------------------------------
 
-    @unittest.expectedFailure
     def test_hint_matmul_row_tiling(self):
-        """spyre_hint(num_tiles_per_dim={"M": 4}) tiles matmul over the row (M) dimension.
-
-        Decision xfail: failing in CI (Actions run 30385154736, job
-        90362755639) on PR #3293. We've decided to xfail the coarse tiling
-        tests to allow us to merge to main -- deliberate decision to unblock
-        the merge, not a claim about a specific bisected root cause. Un-xfail
-        once the underlying regression is investigated and fixed.
-        """
+        """spyre_hint(num_tiles_per_dim={"M": 4}) tiles matmul over the row (M) dimension."""
         from torch_spyre._inductor import spyre_hint
 
         M, K, N = 256, 128, 64
@@ -1710,29 +1695,12 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             " divide Lq ranges on each op using that op's own dim role",
         )
 
-    @unittest.expectedFailure
     def test_hint_h_tiling_elementwise(self):
         """spyre_hint(num_tiles_per_dim={"H": 2}) tiles elementwise multiply over the H dimension.
 
         Regression test for a bug in per-tile byte-stride computation where
         per-tile HBM base addresses advanced by the wrong amount when the tiled
         dimension was not the outermost host dimension (e.g. H in BHLD).
-
-        Accepted, tracked regression, newly exposed (not caused) by the
-        unconditional-copy change: confirmed via direct A/B (passes at the
-        commit immediately before the unconditional-copy change lands,
-        fails starting exactly at that landing commit, continuing to fail
-        at HEAD). Distinct from the 5 `superdsc.py` backGap-class xfails
-        elsewhere in this file/test_building_blocks.py: this test's sibling
-        (`test_hint_h_tiling_elementwise_loopspec`) shows a
-        host-range-index -> iteration-space-key mapping defect on the
-        newly-inserted copy op itself (the advance expression references
-        the copy op's own minted symbol/coefficient instead of the real
-        op's), not a device_size-mismatch backGap misfire -- do not
-        conflate the two mechanisms. Deferred per user decision
-        (2026-07-28): fold into follow-up investigation rather than
-        blocking branch completion. Un-xfail once the host-range ->
-        iteration-space mapping is fixed for the inserted copy-op case.
         """
         from torch_spyre._inductor import spyre_hint
 
@@ -1863,7 +1831,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                 f"NOT a multiple of Lq's stride (64) -- got: {advance_expr}",
             )
 
-    @unittest.expectedFailure
     def test_hint_row_tiling_multi_stick_pointwise_correct(self):
         """Row-tiling a multi-stick pointwise chain produces correct output.
 
@@ -1875,12 +1842,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         atol=0.01: fp16 (a+b)*c on inputs in [0,1) accumulates ~0.002 rounding
         error; atol=0.01 clears that comfortably while remaining well below the
         ~0.1 average error produced by a wrong-address read.
-
-        Decision xfail: failing in CI (Actions run 30385154736, job
-        90362755639) on PR #3293. We've decided to xfail the coarse tiling
-        tests to allow us to merge to main -- deliberate decision to unblock
-        the merge, not a claim about a specific bisected root cause. Un-xfail
-        once the underlying regression is investigated and fixed.
         """
         from torch_spyre._inductor import spyre_hint
 
@@ -1915,24 +1876,10 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             "allow_all_ops_in_lx_planning": True,
         }
     )
-    @unittest.expectedFailure
     def test_hint_tiled_pointwise_outside_consumer_correct(self):
         """Tiled pointwise op with a consumer outside the loop (tests
         _allocate_full_buffer pre-stickify: the full buffer must be correctly
         stickified by layout propagation).
-
-        Accepted, tracked regression (not a defect in the change that
-        exposed it): this op used to take the direct-mutation Case 2/"Case
-        3" branch of `_propagate_tiled_op`, which coarse_tile.py's
-        unconditional-copy change deletes, routing every cross-loop-group
-        write through `_insert_copy_op` instead. That path has its own
-        pre-existing, general addressing bug in `superdsc.py`'s
-        `_get_device_dim_order`/backGap logic (misfires when a copy op's
-        destination `device_size` differs from its source at a slot for a
-        dim that isn't actually the tiled dim). Confirmed pre-existing on
-        unmodified baseline via a standalone repro script (handed off
-        separately; ~87% mismatch with zero divergent input layouts
-        needed). Un-xfail once `superdsc.py`'s addressing is fixed.
         """
         from torch_spyre._inductor import spyre_hint
 
@@ -1954,31 +1901,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
         compare_with_cpu(fn, x, y, run_compile=True, run_eager=False)
 
-    @unittest.expectedFailure
     def test_hint_nested_tiling_copy_mutation_correct(self):
-        """Nested Lq/D tiling into a direct copy_() mutation (Case 3 rewire).
-
-        Accepted, tracked regression, newly exposed (not caused) by the
-        unconditional-copy change: before that change, `c.copy_(a + b)`
-        routed `add` into the direct-mutation Case 2/"Case 3" branch of
-        `_propagate_tiled_op` (`add`'s own layout became
-        `MutationLayoutSHOULDREMOVE(c)`, no separate copy op). The
-        unconditional-copy change deletes that branch, so this now takes
-        the `_insert_copy_op` path unconditionally instead -- which has its
-        own pre-existing, general addressing bug in `superdsc.py`'s
-        `_get_device_dim_order`/backGap logic (same class as the two
-        already-tracked regressions in
-        `test_hint_tiled_pointwise_outside_consumer_correct`/
-        `test_mixed_plain_and_loop_bundle_codegen` above/nearby). Confirmed
-        via 4-way bisection that this test passes through the commit
-        immediately before the unconditional-copy change lands and fails
-        starting exactly at that landing commit, continuing to fail at
-        HEAD -- a real, reproducible, on-device regression, not a
-        pre-existing failure merely inherited. Deferred per user decision:
-        fold into the existing `superdsc.py` backGap investigation already
-        underway rather than opening separate work now. Un-xfail once
-        `superdsc.py`'s addressing is fixed.
-        """
+        """Nested Lq/D tiling into a direct copy_() mutation (Case 3 rewire)."""
         from torch_spyre._inductor import spyre_hint
 
         Lq, D = 256, 128
@@ -1999,28 +1923,11 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
         compare_with_cpu(fn, a, b, run_compile=True, run_eager=False)
 
-    @unittest.expectedFailure
     def test_hint_nested_tiling_copy_mutation_divergent_input_layout(self):
         """Case 3 nested coarse-tiling where `a`'s device layout genuinely
         diverges from `b`'s -- exercises per-arg tile_advance_expr (each arg
         must compute its own device-byte-stride/device_coordinates, not
         share the output's).
-
-        Accepted, tracked regression, newly exposed (not caused) by the
-        unconditional-copy change: this test now takes the unconditional
-        `_insert_copy_op` path instead of the deleted direct-mutation
-        Case 2/"Case 3" branch, which has its own pre-existing, general
-        addressing bug in `superdsc.py`'s `_get_device_dim_order`/backGap
-        logic (same class as
-        `test_hint_tiled_pointwise_outside_consumer_correct`/
-        `test_mixed_plain_and_loop_bundle_codegen` above). Confirmed via
-        4-way bisection that this test passes through the commit
-        immediately before the unconditional-copy change lands and fails
-        starting exactly at that landing commit, continuing to fail at
-        HEAD. Deferred per user decision: fold into the existing
-        `superdsc.py` backGap investigation already underway rather than
-        opening separate work now. Un-xfail once `superdsc.py`'s
-        addressing is fixed.
 
         Uses a 3-D [B, Lq, D] shape (unlike
         test_hint_nested_tiling_copy_mutation_correct's 2-D [Lq, D]) so the
@@ -2070,7 +1977,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         spyre_result = torch.compile(fn)(a_dev, b_dev).cpu()
         compare_with_cpu(fn, a, b, target=spyre_result, run_eager=False)
 
-    @unittest.expectedFailure
     def test_hint_nested_tiling_copy_mutation_flat(self):
         """Same Case 3 rewire as test_hint_nested_tiling_copy_mutation_correct,
         but on a flattened [Lq * D] 1-D tensor rather than [Lq, D] 2-D.
@@ -2081,19 +1987,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         (tile_size, supertile_count) fact per nesting level rather than one
         per host dim, so this no longer collapses the two levels' facts into
         one.
-
-        Accepted, tracked regression, newly exposed (not caused) by the
-        unconditional-copy change: same `superdsc.py`
-        `_get_device_dim_order`/backGap addressing bug class as this
-        test's siblings above/nearby, now hit via the unconditional
-        `_insert_copy_op` path rather than the deleted direct-mutation
-        branch. Confirmed via 4-way bisection that this test passes
-        through the commit immediately before the unconditional-copy
-        change lands and fails starting exactly at that landing commit,
-        continuing to fail at HEAD. Deferred per user decision: fold into
-        the existing `superdsc.py` backGap investigation already underway
-        rather than opening separate work now. Un-xfail once
-        `superdsc.py`'s addressing is fixed.
         """
         from torch_spyre._inductor import spyre_hint
 
@@ -2719,11 +2612,11 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
     def test_nested_bmm_outer_Batch_inner_K_correct(self):
         """bmm [B,M,K]@[B,K,N] outer B (output) + inner K (reduction) — correct.
 
-        Decision xfail: failing in CI (Actions run 30385154736, job
-        90362755639) on PR #3293. We've decided to xfail the coarse tiling
-        tests to allow us to merge to main -- deliberate decision to unblock
-        the merge, not a claim about a specific bisected root cause. Un-xfail
-        once the underlying regression is investigated and fixed.
+        Stays xfailed: this reproduces on the CI runners but NOT on every local
+        stack, so a passing local run is not evidence it is fixed. Observed
+        10.2% element mismatch (833/8192) on CI, repeatable across all retry
+        attempts, while the same commit passes on a dev pod. Un-xfail only on
+        the strength of a green CI run.
         """
         from torch_spyre._inductor import spyre_hint
 

--- a/tests/inductor/test_span_overflow_hint_analysis.py
+++ b/tests/inductor/test_span_overflow_hint_analysis.py
@@ -2450,18 +2450,11 @@ class TestSpanOverflowNumericValidation(InductorTestCase):
             "ignore_span_overflow_hints": False,
         }
     )
-    @unittest.expectedFailure
     def test_pointwise_to_non_matmul_reduction_join_numeric(self):
         """A plain ``sum`` reduction that joins its tiled pointwise producer's
         group (the join this PR extends from matmul-only to any reduction)
         must produce numerically correct results, not just a plausible-looking
         LoopSpec.
-
-        Decision xfail: failing in CI (Actions run 30385154736, job
-        90362759197) on PR #3293. We've decided to xfail the coarse tiling
-        tests to allow us to merge to main -- deliberate decision to unblock
-        the merge, not a claim about a specific bisected root cause. Un-xfail
-        once the underlying regression is investigated and fixed.
 
         An earlier version of this test let both ops' plans be chosen
         organically by the real planner, on the theory that

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -1972,15 +1972,47 @@ def _insert_copy_op(
     copy_buf.operation_name = copy_name
 
     # Fresh per-level tiled-dim decisions from copy_buf's own reads/write
-    # (positionally different from tiled_op's). copy_buf's ranges are
-    # identical to tiled_op's post-division ranges, so each tiled dim's
-    # level-0..N extent is simply 1 -- the copy op is not itself re-divided,
-    # it just re-reads tiled_op's already-divided buffer once per tile.
+    # (positionally different from tiled_op's).  The read and write sides need
+    # DIFFERENT extents, because they address differently sized buffers:
+    #
+    # READS re-read tiled_op's already-divided per-tile buffer, which is
+    # per_tile_fixed scratch reused in place every iteration -- it does not
+    # move, so each tiled dim's level-0..N extent is simply 1 (the copy op is
+    # not itself re-divided).
     tiled_op_info = tiled_op.loop_info  # type: ignore[attr-defined]
-    per_level_extents = [
+    read_level_extents = [
         {d: sympy.Integer(1) for d in level_dims}
         for level_dims in tiled_op_info.loop_tiled_dims
     ]
+    # The WRITE targets full_buf, which is NOT divided, so its store base must
+    # advance a whole tile per iteration -- the same real per-level extents
+    # plan_coarse_tile_groups derives for an op's own reads/write via
+    # _planned_tile_extents_per_level, and what the deleted direct-mutation
+    # branch used to get for free from the tiled op's own output_tiled_dims.
+    # Reusing the extent-1 read decision here instead emitted an advance of a
+    # single row rather than a full tile (e.g. 64 elements instead of 32768 for
+    # a [1024, 4096] fp16 buffer tiled 2-ways), so every tile after the first
+    # landed almost on top of tile 0 -- the multi-stick row-tiling and
+    # softmax-row-tiling wrong-address failures.  Now that every
+    # cross-loop-group write routes through this function unconditionally, this
+    # is the only place that decision gets made.
+    #
+    # copy_buf.data.ranges are already divided, so a dim's innermost-level
+    # extent is the range itself; each step outward multiplies by the
+    # next-inner level's trip count (same per-level formula as
+    # _planned_tile_extents_per_level's _per_level_extent_for).
+    copy_ranges = list(copy_data.ranges)
+    write_level_extents: list[dict[int, Expr]] = [
+        {} for _ in tiled_op_info.loop_tiled_dims
+    ]
+    for d in {d for level in tiled_op_info.loop_tiled_dims for d in level}:
+        levels_tiling_d = [
+            i for i, dims in enumerate(tiled_op_info.loop_tiled_dims) if d in dims
+        ]
+        running = sympy.sympify(copy_ranges[d])
+        for level_idx in reversed(levels_tiling_d):
+            write_level_extents[level_idx][d] = running
+            running = running * tiled_op_info.loop_count[level_idx]
     copy_reads = [
         dep for dep in copy_buf.get_read_writes().reads if isinstance(dep, MemoryDep)
     ]
@@ -1988,10 +2020,10 @@ def _insert_copy_op(
         dep for dep in copy_buf.get_read_writes().writes if isinstance(dep, MemoryDep)
     ]
     tiled_dims_per_read = [
-        _tiled_dims_for_dep(dep, per_level_extents) for dep in copy_reads
+        _tiled_dims_for_dep(dep, read_level_extents) for dep in copy_reads
     ]
     output_tiled_dims = (
-        _tiled_dims_for_dep(copy_writes[0], per_level_extents) if copy_writes else []
+        _tiled_dims_for_dep(copy_writes[0], write_level_extents) if copy_writes else []
     )
     copy_buf.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
         tiled_op_info,


### PR DESCRIPTION
## What

`coarse_tile._insert_copy_op` built **one** set of per-level tiled-dim extents, **all `1`**, and used it for both `tiled_dims_per_read` and `output_tiled_dims`.

Extent 1 is correct only for the **reads** — the copy re-reads the tiled op's already-divided per-tile buffer, which is `per_tile_fixed` scratch reused in place and never moves between iterations.

The **write** is different. It targets `full_buf`, which is *not* divided, so its store base must step a whole tile per iteration — what the (now-deleted) direct-mutation branch got for free from the tiled op's own `output_tiled_dims`. With extent 1 the emitted advance was **a single row instead of a full tile**: 64 elements instead of 32768 for a `[1024, 4096]` fp16 buffer tiled 2-ways. Every tile after the first landed almost on top of tile 0.

This splits the two apart and derives the write extents from the copy's own (already-divided) ranges: a dim's innermost-level extent is the range itself, and each step outward multiplies by the next-inner level's trip count — the same per-level formula `_planned_tile_extents_per_level._per_level_extent_for` already uses.

## Evidence

Per-arg dump of the SDSC advance for `add` → `mul` → `identity` (the copy-out) on `[1024, 4096]` fp16, tile = 2:

```
add      arg0/1 (full inputs)  adv=floor(32768*_tile_adv_op0_lvl0)  (65536 B, 2)  <- correct
add      arg2   (per-tile out) adv=None  dev_size=[64,512,64]                     <- correct BY DESIGN
identity arg1   (full DEST)    adv=floor(   64*_tile_adv_..._lvl0)  (  128 B, 2)  <- the bug
```

After the fix the destination advance is `floor(32768*sym)` / 65536 B — **byte-identical to the inputs' advance in the same op**. That equality is the invariant to check.

Note the per-tile output's `dev_size=[64,512,64]` and its halved stick-group stride are *intentional*: `_divide_ranges` deliberately shrinks the tiled op's own layout to the tile, and that buffer is `per_tile_fixed` scratch drained by the copy each iteration. It is not the defect.

## Why this now affects 9 tests

`#3293`'s "always insert copy op for cross-loop-group writes" deletes the direct-mutation Case 2/"Case 3" branch, routing **every** cross-loop-group write through `_insert_copy_op`. Ops that previously took the direct-mutation path got correct extents from their own `output_tiled_dims` and never touched this bug; now nothing does. `_insert_copy_op` is the sole place the write-advance decision is made.

## Testing

Verified on Spyre hardware at `0658128` (torch 2.12.1+cpu), `tests/inductor/test_coarse_tile_e2e.py`:

| | before | after |
|---|---|---|
| passed | 36 | **44** |
| xfailed | 23 | 15 |
| failed | 0 | 0 |

No regressions: `passed` rises by exactly the un-xfailed tests, nothing else moves.

The 9 tests the second commit un-xfails — **8** in `test_coarse_tile_e2e.py`:

- `test_hint_matmul_row_tiling`
- `test_hint_row_tiling_multi_stick_pointwise_correct`
- `test_hint_softmax_row_tiling`
- `test_hint_h_tiling_elementwise`
- `test_hint_nested_tiling_copy_mutation_correct`
- `test_hint_nested_tiling_copy_mutation_divergent_input_layout`
- `test_hint_nested_tiling_copy_mutation_flat`
- `test_hint_tiled_pointwise_outside_consumer_correct`

and **1** in `test_span_overflow_hint_analysis.py`, xfailed by the same change and repaired by the same fix:

- `test_pointwise_to_non_matmul_reduction_join_numeric` (that file: 74 passed / 3 xfailed)

Scope notes, so the un-xfail list is unambiguous:

- `test_hint_h_tiling_elementwise_loopspec`, `test_building_blocks.py::test_mixed_plain_and_loop_bundle_codegen`, and the remaining three span-overflow xfails still fail and are **left xfailed** — not addressed here.
- `test_nested_bmm_outer_Batch_inner_K_correct` **stays xfailed.** An earlier revision of this PR un-xfailed it on the strength of a passing dev-pod run; CI then failed it at 10.2% (833/8192), repeatably across retries. It reproduces on the CI runners but not on every local stack, so its docstring now says to un-xfail it only on a green CI run.

See the commit messages for the per-test detail.

## Size

2 commits, 3 files. The fix is **39+/7−** in one function, of which 24 lines are comments — 15 lines of actual code. The test commit is **7+/128−** across two test files (decorator + rationale-paragraph removal; three docstrings collapse to one-liners).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
