### PR TITLE
fix(tests): bind CpSatLayoutSolver on the ortools-missing path

### DIFF
--- a/tests/inductor/test_scratchpad_solver.py
+++ b/tests/inductor/test_scratchpad_solver.py
@@ -41,6 +41,9 @@ try:
 
     _HAS_ORTOOLS = True
 except ImportError:
+    # Bound so class bodies below can reference it; Python evaluates a class body
+    # before skipUnless can suppress the class.
+    CpSatLayoutSolver = None  # type: ignore[assignment,misc]
     _HAS_ORTOOLS = False
 
 from torch_spyre._inductor.scratchpad.firstfit_bestfit_solver import (


### PR DESCRIPTION
## Problem

`tests/inductor/test_scratchpad_solver.py` fails at **collection** time with
`NameError: name 'CpSatLayoutSolver' is not defined` when `ortools` is not installed.

Two classes reference the name in their **class body**:

- L834 `TestCpSatJointDivision` — `solver_class = CpSatLayoutSolver`
- L959 `TestCpSatPlacementOnly` — `solver_class = CpSatLayoutSolver`

Both carry `@unittest.skipUnless(_HAS_ORTOOLS, ...)`, but that decorator cannot help here:
Python evaluates a class body *while constructing the class*, which happens before the
decorator is applied. So the guard never gets a chance to suppress the class, and the
`NameError` escapes as a collection error rather than a skip.

## Fix

Bind `CpSatLayoutSolver = None` on the `except ImportError` path. The class bodies then
evaluate cleanly, and `skipUnless` skips both classes as originally intended.

The change is entirely inside the `except ImportError` branch, so it is a no-op whenever
ortools is present.

The third reference (L1072) is inside a method body, already correctly guarded by the
`skipUnless` at L1035 — no change needed there.

## Verification

Simulated an `ortools`-less import and confirmed:

- the guard block sets `_HAS_ORTOOLS = False` and binds `CpSatLayoutSolver = None`
- a `@skipUnless(_HAS_ORTOOLS)` class whose body assigns `solver_class = CpSatLayoutSolver`
  now constructs without raising

## Context

Surfaced on **ppc64le**, where `ortools` has no wheel available and the `cpsat` extra is
omitted from the image. On that platform these tests should skip; instead they aborted
collection of the whole module.