### PR TITLE
fix(lx): align an LX buffer's producer loop order to its consumers'

### DIFF
--- a/.claude/skills/project-overview/SKILL.md
+++ b/.claude/skills/project-overview/SKILL.md
@@ -81,7 +81,7 @@ torch-spyre/
 │
 ├── examples/                    # Usage examples (softmax, gelu, mul, etc.)
 ├── setup.py                     # Build: C++ extension compilation
-├── pyproject.toml               # PEP 517/518 metadata, deps (torch~=2.12.0)
+├── pyproject.toml               # PEP 517/518 metadata, deps (torch~=2.13.0)
 └── tools/                       # Developer tooling (lint, format, mypy)
 ```
 
@@ -194,7 +194,7 @@ Two separate pybind11 modules:
    against `sendnn`, `flex`
 2. **Entry point**: `torch.backends` → `torch_spyre = torch_spyre:_autoload`
 
-Key external deps: `torch~=2.12.0`, `sendnn`, `flex`, `dxp_standalone`
+Key external deps: `torch~=2.13.0`, `sendnn`, `flex`, `dxp_standalone`
 
 ---
 

--- a/docs/source/getting_started/installation.md
+++ b/docs/source/getting_started/installation.md
@@ -14,7 +14,7 @@ in early access.
 | Component | Version |
 |---|---|
 | Python | ≥ 3.11 |
-| PyTorch | ~= 2.12.0 |
+| PyTorch | ~= 2.13.0 |
 
 The exact pins live in [`pyproject.toml`](https://github.com/torch-spyre/torch-spyre/blob/main/pyproject.toml) and are resolved through [`requirements/run.txt`](https://github.com/torch-spyre/torch-spyre/blob/main/requirements/run.txt).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ requires = [
     "numpy",
     "pyyaml", # needed for codegen
     "regex",
-    "setuptools>=70.1.0,<82",
-    "torch~=2.12.0",
-#    "torch>=2.12.0",
+    "setuptools>=77.0.3",  # match upstream torch dependency range
+    "torch~=2.13.0",
+#    "torch>=2.13.0",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
@@ -25,8 +25,8 @@ description = "Torch-Spyre out of tree registration"
 dependencies = [
     "numpy",
     "regex",
-    "torch~=2.12.0",
-#    "torch>=2.12.0",
+    "torch~=2.13.0",
+#    "torch>=2.13.0",
     "psutil"
 ]
 requires-python = ">=3.11"
@@ -46,9 +46,9 @@ build = [ # no-isolation build
     "numpy",
     "pyyaml", # needed for codegen
     "regex",
-    "setuptools>=70.1.0,<82",
-    "torch~=2.12.0",
-#    "torch>=2.12.0",
+    "setuptools>=77.0.3",  # match upstream torch dependency range
+    "torch~=2.13.0",
+#    "torch>=2.13.0",
     "wheel"
 ]
 test = [

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -70,9 +70,9 @@ setuptools==79.0.1
     #   torch-spyre
 sympy==1.14.0
     # via torch
-torch==2.12.1 ; sys_platform == 'darwin'
+torch==2.13.0 ; python_full_version < '3.15' and sys_platform == 'darwin'
     # via torch-spyre
-torch==2.12.1+cpu ; sys_platform != 'darwin'
+torch==2.13.0+cpu ; python_full_version >= '3.15' or sys_platform != 'darwin'
     # via torch-spyre
 types-pyyaml==6.0.12.20260518
     # via torch-spyre

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -110,9 +110,9 @@ six==1.17.0
     # via python-dateutil
 sympy==1.14.0
     # via torch
-torch==2.12.1 ; sys_platform == 'darwin'
+torch==2.13.0 ; python_full_version < '3.15' and sys_platform == 'darwin'
     # via torch-spyre
-torch==2.12.1+cpu ; sys_platform != 'darwin'
+torch==2.13.0+cpu ; python_full_version >= '3.15' or sys_platform != 'darwin'
     # via torch-spyre
 types-pyyaml==6.0.12.20260518
     # via torch-spyre

--- a/requirements/run.txt
+++ b/requirements/run.txt
@@ -22,9 +22,9 @@ setuptools==79.0.1
     # via torch
 sympy==1.14.0
     # via torch
-torch==2.12.1 ; sys_platform == 'darwin'
+torch==2.13.0 ; python_full_version < '3.15' and sys_platform == 'darwin'
     # via torch-spyre
-torch==2.12.1+cpu ; sys_platform != 'darwin'
+torch==2.13.0+cpu ; python_full_version >= '3.15' or sys_platform != 'darwin'
     # via torch-spyre
 typing-extensions==4.15.0
     # via torch

--- a/tests/configs/upstream_tests/test_profiler_config.yaml
+++ b/tests/configs/upstream_tests/test_profiler_config.yaml
@@ -1,40 +1,49 @@
 test_suite_config:
   files:
-    # Classes: TestProfiler, TestExperimentalUtils, TestProfilerEventsParity None of these use instantiate_device_type_tests(). 
+    # Classes exercised here:
+    #   TestProfiler, TestExperimentalUtils, TestProfilerEventsParity
+    #     - do NOT use instantiate_device_type_tests(); run once on CPU.
+    #   TestProfilerDevice (NEW in PyTorch 2.13)
+    #     - DOES use instantiate_device_type_tests(), so it generates a
+    #       PrivateUse1/_spyre variant per method. In 2.12 these methods
+    #       lived in the CPU-only TestProfiler class; 2.13 moved them into
+    #       TestProfilerDevice and their payload() now runs on the device
+    #       (torch.mm on fp32) -- which Spyre does not support. The whole
+    #       class is skipped for Spyre below (see the TestProfilerDevice
+    #       entry); only genuine profiler infrastructure would need to be
+    #       enabled, and that requires an fp16/PrivateUse1-aware payload
+    #       upstream.
     - path: ${TORCH_ROOT}/test/profiler/test_profiler.py
       unlisted_test_mode: skip
       tests:
         - names:
-            - TestProfiler::test_kineto
+            # Still CPU-only in TestProfiler on 2.13 (no device param).
             - TestProfiler::test_module_hierarchy
             - TestProfiler::test_profiler_correlation_id
-            - TestProfiler::test_memory_profiler
-            - TestProfiler::test_flops
-            - TestProfiler::test_kineto_profiler_api
-            - TestProfiler::test_tensorboard_trace_handler
             - TestProfiler::test_profiler_tracing
-            - TestProfiler::test_basic_chrome_trace
-            - TestProfiler::test_cpu_annotation_overlap
-            - TestProfiler::test_user_annotation
             - TestExperimentalUtils::test_utils_compute_idle_time
           mode: mandatory_success
 
         - names:
+            # Their shared payload() runs `torch.mm(x, y)` on fp32
+            # tensors moved to the device
+            - TestProfilerDevice::test_kineto
+            - TestProfilerDevice::test_memory_profiler
+            - TestProfilerDevice::test_flops
+            - TestProfilerDevice::test_kineto_profiler_api
+            - TestProfilerDevice::test_tensorboard_trace_handler
+            - TestProfilerDevice::test_basic_chrome_trace
+            - TestProfilerDevice::test_cpu_annotation_overlap
+            - TestProfilerDevice::test_user_annotation
             # RuntimeError: VFIO DeviceOpenFail during profiler teardown ->
-            # subprocess exit 255 -> AssertionError: Kineto is not working
-            # properly with the Dynolog environment variable (segfault in
-            # ProfilerStateBase destructor). Needs PrivateUse1 activity
-            # check and device-init guard in subprocess snippet.
-            - TestProfiler::test_kineto_profiler_with_environment_variable
-            # SKIPPED: @unittest.skipUnless(TEST_CUDA or TEST_XPU, "requires gpu")
-            # Needs TEST_SPYRE added to upstream skip decorator.
-            - TestProfiler::test_basic_profile
-            # SKIPPED: @unittest.skipIf(not torch.cuda.is_available()) —
-            # needs Spyre guard; forward portion only (has backward).
-            - TestProfiler::test_event_list
-            # SKIPPED: @unittest.skipIf(not torch.cuda.is_available()) —
-            # needs Spyre guard + ProfilerActivity swap.
-            - TestProfiler::test_dynamic_toggle
+            # subprocess exit 255 (segfault in ProfilerStateBase dtor).
+            - TestProfilerDevice::test_kineto_profiler_with_environment_variable
+            # @onlyAccelerator forward payload -> fp32 device compute.
+            - TestProfilerDevice::test_basic_profile
+            # Device-parametrized; forward payload runs on device.
+            - TestProfilerDevice::test_event_list
+            # Device-parametrized; needs ProfilerActivity swap for Spyre.
+            - TestProfilerDevice::test_dynamic_toggle
             # Class-level @skipIf(not torch.cuda.is_available()) blocks
             # all 4 tests silently. Needs: class gate +
             # ProfilerActivity.CUDA -> PrivateUse1, device="cuda" -> "spyre".

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -5659,7 +5659,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         def fn(dst, src):
             dst = dst.clone()
             result = op(dst, src)
-            assert id(result) == id(dst)
+            assert result.data_ptr() == dst.data_ptr()
             return result
 
         # Eager mode hangs/crashes when executing inplace operations on Spyre tensors

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -77,7 +77,7 @@ from .scratchpad.allocator import (
     scratchpad_planning,
 )
 from .fusion import spyre_fuse_nodes
-from .scheduler import build_loop_scheduler_nodes
+from .scheduler import align_lx_producer_loop_order, build_loop_scheduler_nodes
 from .constants import DEVICE_NAME
 from .deadcode_elimination import deadcode_elimination
 from .dedup_constants import dedup_and_promote_constants
@@ -238,7 +238,16 @@ class CustomPreFusionPasses(_SpyreNodePassPipeline):
     # are visible to SuperDSCScheduling.can_fuse_vertical/horizontal (which return
     # False), so loop groups survive Inductor fusion intact.
     def __init__(self):
-        super().__init__([propagate_mutation_layouts, build_loop_scheduler_nodes])
+        # align_lx_producer_loop_order runs before build_loop_scheduler_nodes so
+        # it still sees plain SchedulerNodes (the only kind that can reorder
+        # their loops) rather than CountedLoopSchedulerNode wrappers.
+        super().__init__(
+            [
+                propagate_mutation_layouts,
+                align_lx_producer_loop_order,
+                build_loop_scheduler_nodes,
+            ]
+        )
 
 
 class CustomPostFusionPasses(_SpyreNodePassPipeline):

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -22,6 +22,7 @@ from torch._inductor.utils import (
     get_fused_kernel_name,
     sympy_product,
 )
+from torch._inductor.dependencies import MemoryDep
 from torch._inductor.scheduler import (
     BaseScheduling,
     BaseSchedulerNode,
@@ -210,6 +211,91 @@ def build_loop_scheduler_nodes(
                 seen[key] = name
 
     return result
+
+
+def _lx_resident(node: SchedulerNode) -> bool:
+    """True if ``node``'s output buffer was pinned into LX by scratchpad planning."""
+    allocation = getattr(getattr(node.node, "layout", None), "allocation", None)
+    return allocation is not None and "lx" in allocation
+
+
+def align_lx_producer_loop_order(
+    nodes: list[BaseSchedulerNode],
+) -> list[BaseSchedulerNode]:
+    """Pre-fusion pass: match an LX buffer's producer loop order to its consumers'.
+
+    LX is per-core scratchpad, so every op touching an LX-resident buffer must
+    agree on which core owns which slice.  That mapping is *positional*:
+    ``core_to_slice_mapping`` hands out ``core_id`` strides in iteration-space
+    order, so a producer that walks the buffer in a different dim order than its
+    consumers read it gets a transposed core->slice assignment.  The split
+    factors still multiply to the same core count, so nothing downstream
+    complains -- each core simply reads the slice a different core wrote, and the
+    kernel silently returns another core's data.
+
+    Scratchpad planning creates the clone that pins a graph input into LX, and it
+    builds that clone in the buffer's natural dim order, which need not match how
+    the consumers read it.  Through PyTorch 2.12 Inductor's
+    ``loop_ordering_after_fusion`` happened to rewrite the clone into the
+    consumers' order, so the assignments lined up by accident.  As of 2.13 the
+    reorder is computed and then discarded (see
+    ``Scheduler._try_reorder_loops_for_candidates``), which exposed the
+    incoherence as wrong results for any two reductions sharing one LX-pinned
+    input.  Align the orders here so correctness does not rest on an Inductor
+    scoring heuristic.
+
+    Consumers of an LX buffer are already known to agree with each other -- a
+    disagreement is a core-division mismatch that keeps the buffer in HBM (see
+    ``get_ncores_for_buffers``) -- so matching the first consumer matches all.
+    """
+    producers: dict[str, SchedulerNode] = {}
+    for node in nodes:
+        if isinstance(node, SchedulerNode) and _lx_resident(node):
+            for dep in node.read_writes.writes:
+                if isinstance(dep, MemoryDep):
+                    producers[dep.name] = node
+
+    if not producers:
+        return nodes
+
+    # Keyed by producer, not by buffer: reordering a producer twice would leave
+    # it matching only whichever consumer came last.  A ComputedBuffer has a
+    # single output (multi-output ops carry no device_layout and never reach LX),
+    # so one alignment per producer covers every LX buffer it writes.
+    aligned: OrderedSet[str] = OrderedSet()
+    for node in nodes:
+        if not isinstance(node, SchedulerNode):
+            continue
+        for read in node.read_writes.reads:
+            if not isinstance(read, MemoryDep):
+                continue
+            producer = producers.get(read.name)
+            if producer is None or producer is node:
+                continue
+            if producer.get_name() in aligned:
+                continue
+            write = next(
+                (
+                    dep
+                    for dep in producer.read_writes.writes
+                    if isinstance(dep, MemoryDep) and dep.name == read.name
+                ),
+                None,
+            )
+            if write is None:
+                continue
+            # Reorders `producer`'s loops so its write dep matches `read`.
+            if producer.reorder_loops_by_dep_pair(write, read):
+                aligned.add(producer.get_name())
+                logger.debug(
+                    "align_lx_producer_loop_order: %s reordered to match %s's "
+                    "read of LX buffer %s",
+                    producer.get_name(),
+                    node.get_name(),
+                    read.name,
+                )
+
+    return nodes
 
 
 class SuperDSCScheduling(BaseScheduling):

--- a/torch_spyre/csrc/spyre_tensor_impl.cpp
+++ b/torch_spyre/csrc/spyre_tensor_impl.cpp
@@ -250,7 +250,7 @@ SpyreTensorImpl::shallow_copy_and_detach_core(
     bool allow_tensor_metadata_change) const {
   if (key_set_.has(c10::DispatchKey::Python) &&
       !c10::impl::tls_is_dispatch_key_excluded(c10::DispatchKey::Python)) {
-    auto r = pyobj_slot_.load_pyobj_interpreter()->detach(this);
+    auto r = (*c10::impl::getGlobalPyInterpreter())->detach(this);
     if (r) {
       r->set_version_counter(version_counter);
       r->set_allow_tensor_metadata_change(allow_tensor_metadata_change);

--- a/uv.lock
+++ b/uv.lock
@@ -1117,33 +1117,32 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version < '3.14' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "sys_platform == 'darwin'" },
-    { name = "networkx", marker = "sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "sys_platform == 'darwin'" },
-    { name = "sympy", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:ef81f503912effea2ce3d9b12a2e3a6ed488943e91271c90c7a829f60baf6aa2", upload-time = "2026-06-17T15:43:57Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:d2dd0f2c5f7ccbddaf34cade0deaf476808368f902b9cdb7f36a2ab42301bc0e", upload-time = "2026-06-17T15:44:03Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:c75e93173c700bccd6bfcc4a9d19ce242ab6dacd1f1781483027a16239b9e650", upload-time = "2026-06-17T15:44:09Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e9b6f7d2dd66ea87a3ae620069d31335d594c06effb1a383bdd21cfe61e44ece", upload-time = "2026-06-17T15:44:16Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:2afbb2bdaa8a95040e733f05492ddf133c3967c9b7ce0abd218d704b6cab437d", upload-time = "2026-06-17T15:44:24Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:e76f9bcecc52b8ff711239a2f7547d5353df95878ab232f0773c1d95928b92f8", upload-time = "2026-07-08T12:26:13Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", upload-time = "2026-07-08T12:26:18Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:33449899ce5496c1b84b4853179d94fd102028ae1407314d9fb956bb79e70d09", upload-time = "2026-07-08T12:26:23Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d849b390e07d8d333ce8ecaf91b273c656c598379a19c9acf1318a883f6b391c", upload-time = "2026-07-08T12:26:28Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:c28def70706c2f9ecc752574766e8ae4da9b810ab6676b611166761a78a9f1e1", upload-time = "2026-07-08T12:26:33Z" },
 ]
 
 [[package]]
 name = "torch"
-version = "2.12.1+cpu"
+version = "2.13.0+cpu"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -1155,38 +1154,45 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform == 'win32'",
     "python_full_version < '3.14' and sys_platform == 'emscripten'",
     "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "sys_platform != 'darwin'" },
-    { name = "networkx", marker = "sys_platform != 'darwin'" },
-    { name = "setuptools", marker = "sys_platform != 'darwin'" },
-    { name = "sympy", marker = "sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:c6cf299bad55b045abdc0969f298385845c25bc8ace587215e5538d6a73e7712", upload-time = "2026-06-18T01:56:56Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:6d1b61e53a2c000e1e5cc49fc88aebc665bdf02c63910c243116d395d7cbc164", upload-time = "2026-06-18T01:57:02Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:04cd8b002c03dd6a246fbb4ae5abf1edd42adf0a9929ad82162c973e5737b5ac", upload-time = "2026-06-18T01:57:09Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:cf9ef28ef8d1a7d56aba206780cbb09e8a643a942f26a2374ab21b9a02b9d9fd", upload-time = "2026-06-18T01:57:15Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp311-cp311-win_arm64.whl", hash = "sha256:9b4f554e5e461545b1b42551e27f97b4fbc58e05f2bad0603120aa929d4562e1", upload-time = "2026-06-18T01:57:19Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:900b253fc8c739bebffb63d7f75abff4cd53d79947265a00c16cb53b68ecdb91", upload-time = "2026-06-18T01:57:23Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d1620bc7bcf8087f3e48821b5db994a03e32ddb083d58c000b8e032f8a6e2d15", upload-time = "2026-06-18T01:57:29Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ae4bb28409f5370852bd71af221066236c38d647f780d9b0a7240c330a9c12df", upload-time = "2026-06-18T01:57:35Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:51c6c6e26eaa0d64ed439ebdc9ce3b8cc2d5cfcc7cdd4e72f17831d80886b7f4", upload-time = "2026-06-18T01:57:42Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:4ca206a35f2aeba7da944a69ef857103358e8d4bc6b06b49b9e554dcfa57777d", upload-time = "2026-06-18T01:57:47Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:8d47e0cfc59679d4e367646c3df4cf433c7d1595b31307e0e7b2391c58ca2160", upload-time = "2026-06-18T01:57:52Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:77d049968c7817456dbdebf0aadcac0813e302218b0e857a8723463331339d55", upload-time = "2026-06-18T01:57:59Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:06d13c354df07953ae0d150da22a071496cbbedd22d1b644961813c0f0fc3b23", upload-time = "2026-06-18T01:58:05Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314-linux_s390x.whl", hash = "sha256:ef228ec70f5e73762c213f145c0fdb672e5770a6de760801c58b933b0d5b6957", upload-time = "2026-06-18T01:58:09Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:1b9ad70d0a300d6bd883fffc153a6c0f9bc64bf4190519aeeed0373807bffbcc", upload-time = "2026-06-18T01:58:15Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:618120d79360688595e61162147d37e1d69fc3f2e13d60584a1eb6a74c74735a", upload-time = "2026-06-18T01:58:22Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:6354069774ce2d9c26d6d8612fc252586428467b7e4ced7c8bbbfb961fafb783", upload-time = "2026-06-18T01:58:29Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314t-linux_s390x.whl", hash = "sha256:0706eb7b53c4b1381b2acc418f6d89d6ed18a308677125ced7ca30519c57dc42", upload-time = "2026-06-18T01:58:33Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:21ed774c10a0fd24ab2cfaabfa98a9260fc28d518946c98c0151b6e447730250", upload-time = "2026-06-18T01:58:39Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:e3c3b5c275dd57cff1aa34a0ab8f84beab8976c63c8dc1d84f29430eac0590ea", upload-time = "2026-06-18T01:58:46Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:03094411b20e85a221125a332211d59c099dc556afb1423e04193fcf1b4c1cbd", upload-time = "2026-06-18T01:58:52Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:6e9817dbdf5ea76789babd46e457eac5bf14ff566cf85f8addbfdff2d56601ce", upload-time = "2026-07-08T19:27:52Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:84453b69508ec79902f899c5ed9495acb9e2bbe9fda5f1d5d6f19e3c3842e1a7", upload-time = "2026-07-08T19:28:03Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:6746dbcbeb526eb61330b76b41ff1b4eb848951103a892eeb080dfa2b264667b", upload-time = "2026-07-08T19:28:16Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:10717d8b3b67c45a4788bf7ffc0bab1ea1e5ebbedd24466be6100102d141fac1", upload-time = "2026-07-08T19:28:27Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-win_arm64.whl", hash = "sha256:2b3d093abd919ad934c43d47e73ba63ceba7cbd7269fc2e9c1e4fc29e8fe45fa", upload-time = "2026-07-08T19:28:33Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:ffadde149901c8afa138daa38d898264003cfcf1a3336ca5cd964b5af227d867", upload-time = "2026-07-08T19:28:41Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f307c2c32d764ffc6ff6893b801fad6d4752f3e67966cb8abf1843427c02604", upload-time = "2026-07-08T19:28:51Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4ca4a9394b0c771238a4f73590fdbbc4debad85ed0fa63d026ae1b085da7d6e2", upload-time = "2026-07-08T19:29:03Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:a8b450c1e58e5800e5b4691dac412f8d2d65a1dc3298166f91596603a3531e6f", upload-time = "2026-07-08T19:29:15Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-win_arm64.whl", hash = "sha256:fa0762705b933624d59f6823db9ce7ec2e35b3e1e9c319c9db51fbeecfc3e319", upload-time = "2026-07-08T19:29:21Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:966d020354f465672dc7dd10d3a5c6cd17d7eb48620aa1d265b48a1f78f06898", upload-time = "2026-07-08T19:29:30Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:0b8f7d0423027ae8b90c7977c627f3379f325363a08224dffad9b4b2d684a83d", upload-time = "2026-07-08T19:29:40Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3fbf9c9d1f3c10c2d59d04aca426dee9ccc6ceb32d255c61e93acc3b4f75fae6", upload-time = "2026-07-08T19:29:54Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:a17ff48608634db245e17e8bb00a9558554a49aeb1e4f5fe6cd039af2a10515b", upload-time = "2026-07-08T19:30:05Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:ac7aaf322be4777765a53bed7264a214dd81b3a1d276b93150515a3c5f75e4b0", upload-time = "2026-07-08T19:30:12Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314-linux_s390x.whl", hash = "sha256:dec241fef3984c0d1edadd1f58708e218d4eae881ceef7bc10cf9964d41b68b9", upload-time = "2026-07-08T19:30:20Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:ca021f9eb2f8345c83fa03e3a04587308afb8df71bd472670b3ece00df58621c", upload-time = "2026-07-08T19:30:32Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d20fa53ee744502fa4c69818a720b05ca0d37abd055d4f6e66cae155114bc691", upload-time = "2026-07-08T19:30:45Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:e2e5134decf00e218da62318f3dc5df156231d367871918e91eba95ab0ad43ab", upload-time = "2026-07-08T19:30:58Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314t-linux_s390x.whl", hash = "sha256:991cc14b39e751122c01f017be6448533989868731cb5eecd1006893d26787c2", upload-time = "2026-07-08T19:31:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:7b8d26e29bceafbdaa8d63bfe7612f23875b5af2cc07e13f809c3ed890bbe1d8", upload-time = "2026-07-08T19:31:21Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b222c15a0fc2ce207d1c1a59700b46c8fa6748df1f447ad11e5c870dde0933d9", upload-time = "2026-07-08T19:31:35Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:a43376bd094124ef626bfdd3d4c2c62eacb0b5ddc99776f4a32d4fd16f1f3420", upload-time = "2026-07-08T19:31:48Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp315-cp315-manylinux_2_28_aarch64.whl", hash = "sha256:8eb5002ca81af00ae69b57540f615b58b8ae922b6d4848176b366a52bd2196e6", upload-time = "2026-07-08T19:32:00Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp315-cp315-manylinux_2_28_x86_64.whl", hash = "sha256:1a3a35229fdc13446b4eab50e7fcf9399ff941e89a3b761497786297a5d8dde5", upload-time = "2026-07-08T19:32:16Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp315-cp315t-manylinux_2_28_aarch64.whl", hash = "sha256:8e109528e6bab044815daebaf71770fbaace3a66ef1c816cb55c875350f78a60", upload-time = "2026-07-08T19:32:30Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp315-cp315t-manylinux_2_28_x86_64.whl", hash = "sha256:222a6681467cc7f6f05cd3068dfbc603def3a1e46d1d4620c1c8cdf6178bd563", upload-time = "2026-07-08T19:32:44Z" },
 ]
 
 [[package]]
@@ -1196,8 +1202,8 @@ dependencies = [
     { name = "numpy" },
     { name = "psutil" },
     { name = "regex" },
-    { name = "torch", version = "2.12.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
 ]
 
 [package.optional-dependencies]
@@ -1211,8 +1217,8 @@ build = [
     { name = "pyyaml" },
     { name = "regex" },
     { name = "setuptools" },
-    { name = "torch", version = "2.12.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
     { name = "wheel" },
 ]
 cpsat = [
@@ -1249,9 +1255,9 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'build'" },
     { name = "regex" },
     { name = "regex", marker = "extra == 'build'" },
-    { name = "setuptools", marker = "extra == 'build'", specifier = ">=70.1.0,<82" },
-    { name = "torch", specifier = "~=2.12.0", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "torch", marker = "extra == 'build'", specifier = "~=2.12.0", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "setuptools", marker = "extra == 'build'", specifier = ">=77.0.3" },
+    { name = "torch", specifier = "~=2.13.0", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torch", marker = "extra == 'build'", specifier = "~=2.13.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "types-pyyaml", marker = "extra == 'lint'", specifier = "~=6.0.12.20260518" },
     { name = "uv", marker = "extra == 'lint'", specifier = "~=0.11.15" },
     { name = "wheel", marker = "extra == 'build'" },


### PR DESCRIPTION
> **Draft — opened to get a full CI run. Cherry-pick the last commit; the first two are @ani300's from #3374.** It sits on top of `2.13-upgrade` because the fix only matters on 2.13.

#### What type of PR is this?

- [x] bug

#### What this PR does:

Fixes the 6 `test_aminmax_keepdim{0,1}_aminmax_pad_{2,3,4}d_dim_0` failures on #3374, and the same 6 in the LX-planning job.

Not an `aminmax` bug: any two device reductions over one LX-pinned input reducing a non-trailing dim are wrong. LX is per-core scratchpad and the core-to-slice mapping is positional, so the clone that pins a graph input into LX ends up transposed relative to its consumers. Inductor used to reorder that clone to match, but 2.13 computes the permutation and discards it, so torch-spyre had been relying on an Inductor heuristic for correctness. The fix aligns the orders explicitly in a pre-fusion pass.

Locally on 2.13: `aminmax` 44 passed, LX-planning `aminmax` 88 passed, `keepdim or index_copy or norm` 751 passed / 12 xfailed, codegen byte-identical to 2.12 so no perf change.
