### PR TITLE
Replace has_stream_error() with typed SpyreStreamError/SpyreDeviceState API

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -527,11 +527,8 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
 
         state = _C.get_device_state()
         if state == _C.SpyreDeviceState.StreamError:
-            # Include the error class name in the skip reason so it appears in
-            # the pytest output and can be matched by tests.
-            error_name = _C.SpyreStreamError.StreamError.name
             pytest.skip(
-                f"Device is in error state ({error_name})"
+                f"Device is in error state ({state.name})"
                 " — a process restart is required"
             )
         # SpyreDeviceState.NotInitialized → proceed (runtime not started yet)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -525,8 +525,17 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
     try:
         from torch_spyre import _C  # noqa: PLC0415
 
-        if _C.has_stream_error():
-            pytest.skip("Device is in error state — a process restart is required")
+        state = _C.get_device_state()
+        if state == _C.SpyreDeviceState.StreamError:
+            # Include the error class name in the skip reason so it appears in
+            # the pytest output and can be matched by tests.
+            error_name = _C.SpyreStreamError.StreamError.name
+            pytest.skip(
+                f"Device is in error state ({error_name})"
+                " — a process restart is required"
+            )
+        # SpyreDeviceState.NotInitialized → proceed (runtime not started yet)
+        # SpyreDeviceState.Ok             → proceed
     except ImportError:
         # torch_spyre._C not built or not installed — nothing to check.
         pass

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -3452,7 +3452,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             "disabled (see FIXME on kv_block_size in this file), unrelated to "
             "carry propagation. Confirmed (4/4 local full-suite runs) to leave "
             "the device in an error state that cascades skips to every later "
-            "test in the same process (see conftest.py's has_stream_error() "
+            "test in the same process (see conftest.py's get_device_state() "
             "check) when run as xfail -- skipped outright instead. Revisit "
             "once the Lk coarse-tiling limitation above is fixed; a real fix "
             "there should make this test pass rather than merely change its "

--- a/tests/test_device_error_skip.py
+++ b/tests/test_device_error_skip.py
@@ -17,7 +17,10 @@
 """
 Tests for the device-error-state skip mechanism.
 
-- TestHasStreamErrorBinding: unit-tests _C.has_stream_error() via unittest.mock.
+- TestStreamErrorBindings: unit-tests the typed _C.SpyreStreamError /
+  _C.SpyreDeviceState enums and the associated query functions.
+- TestHasStreamErrorBackCompat: verifies that the deprecated
+  _C.has_stream_error() wrapper still works correctly.
 - TestDeviceErrorSkipIntegration: calls the conftest hook directly to verify
   skip behaviour without spawning subprocesses.
 
@@ -46,36 +49,128 @@ _spec.loader.exec_module(_tests_conftest)  # type: ignore[union-attr]
 pytest_runtest_setup = _tests_conftest.pytest_runtest_setup
 
 
-class TestHasStreamErrorBinding(TestCase):
-    """Unit tests for the _C.has_stream_error() pybind11 binding."""
+class TestStreamErrorBindings(TestCase):
+    """Unit tests for the typed SpyreStreamError / SpyreDeviceState bindings."""
 
-    def test_binding_exists_and_returns_bool(self):
-        """has_stream_error() must be importable and return a bool."""
-        result = _C.has_stream_error()
-        self.assertIsInstance(result, bool)
+    # ── SpyreStreamError ──────────────────────────────────────────────────────
 
-    def test_returns_false_when_mocked_healthy(self):
-        """Returns False when the runtime reports no error."""
+    def test_stream_error_enum_members_exist(self):
+        """SpyreStreamError must expose Success and StreamError members."""
+        self.assertIsInstance(_C.SpyreStreamError.Success, _C.SpyreStreamError)
+        self.assertIsInstance(_C.SpyreStreamError.StreamError, _C.SpyreStreamError)
+
+    def test_stream_error_integer_values(self):
+        """SpyreStreamError values must match the documented ABI (Success=0, StreamError=1)."""
+        self.assertEqual(int(_C.SpyreStreamError.Success), 0)
+        self.assertEqual(int(_C.SpyreStreamError.StreamError), 1)
+
+    def test_stream_error_names(self):
+        """SpyreStreamError .name must return the enum member's string name."""
+        self.assertEqual(_C.SpyreStreamError.Success.name, "Success")
+        self.assertEqual(_C.SpyreStreamError.StreamError.name, "StreamError")
+
+    # ── SpyreDeviceState ─────────────────────────────────────────────────────
+
+    def test_device_state_enum_members_exist(self):
+        """SpyreDeviceState must expose Ok, NotInitialized, and StreamError."""
+        self.assertIsInstance(_C.SpyreDeviceState.Ok, _C.SpyreDeviceState)
+        self.assertIsInstance(_C.SpyreDeviceState.NotInitialized, _C.SpyreDeviceState)
+        self.assertIsInstance(_C.SpyreDeviceState.StreamError, _C.SpyreDeviceState)
+
+    def test_device_state_integer_values(self):
+        """SpyreDeviceState values must match the ABI (Ok=0, NotInitialized=1, StreamError=2)."""
+        self.assertEqual(int(_C.SpyreDeviceState.Ok), 0)
+        self.assertEqual(int(_C.SpyreDeviceState.NotInitialized), 1)
+        self.assertEqual(int(_C.SpyreDeviceState.StreamError), 2)
+
+    def test_device_state_names(self):
+        """SpyreDeviceState .name must return the enum member's string name."""
+        self.assertEqual(_C.SpyreDeviceState.Ok.name, "Ok")
+        self.assertEqual(_C.SpyreDeviceState.NotInitialized.name, "NotInitialized")
+        self.assertEqual(_C.SpyreDeviceState.StreamError.name, "StreamError")
+
+    # ── get_device_state() ───────────────────────────────────────────────────
+
+    def test_get_device_state_returns_device_state(self):
+        """get_device_state() must be importable and return a SpyreDeviceState."""
+        result = _C.get_device_state()
+        self.assertIsInstance(result, _C.SpyreDeviceState)
+
+    def test_get_device_state_healthy(self):
+        """get_device_state() returns Ok when mocked healthy."""
+        with patch.object(_C, "get_device_state", return_value=_C.SpyreDeviceState.Ok):
+            self.assertEqual(_C.get_device_state(), _C.SpyreDeviceState.Ok)
+
+    def test_get_device_state_faulted(self):
+        """get_device_state() returns StreamError when mocked faulted."""
+        with patch.object(
+            _C, "get_device_state", return_value=_C.SpyreDeviceState.StreamError
+        ):
+            self.assertEqual(_C.get_device_state(), _C.SpyreDeviceState.StreamError)
+
+    def test_get_device_state_not_initialized(self):
+        """get_device_state() returns NotInitialized when mocked pre-init."""
+        with patch.object(
+            _C,
+            "get_device_state",
+            return_value=_C.SpyreDeviceState.NotInitialized,
+        ):
+            self.assertEqual(_C.get_device_state(), _C.SpyreDeviceState.NotInitialized)
+
+    def test_get_device_state_not_cached(self):
+        """Consecutive calls reflect live state, not a cached value."""
+        states = [
+            _C.SpyreDeviceState.Ok,
+            _C.SpyreDeviceState.StreamError,
+            _C.SpyreDeviceState.Ok,
+        ]
+        with patch.object(_C, "get_device_state", side_effect=states):
+            self.assertEqual(_C.get_device_state(), _C.SpyreDeviceState.Ok)
+            self.assertEqual(_C.get_device_state(), _C.SpyreDeviceState.StreamError)
+            self.assertEqual(_C.get_device_state(), _C.SpyreDeviceState.Ok)
+
+    # ── stream_get_error_string() ─────────────────────────────────────────────
+
+    def test_error_string_success(self):
+        """stream_get_error_string(Success) == 'Success'."""
+        self.assertEqual(
+            _C.stream_get_error_string(_C.SpyreStreamError.Success), "Success"
+        )
+
+    def test_error_string_stream_error(self):
+        """stream_get_error_string(StreamError) == 'StreamError'."""
+        self.assertEqual(
+            _C.stream_get_error_string(_C.SpyreStreamError.StreamError), "StreamError"
+        )
+
+
+class TestHasStreamErrorBackCompat(TestCase):
+    """
+    Verifies that the deprecated has_stream_error() wrapper is present and
+    returns a bool. The C++ implementation delegates to SpyreGetDeviceState()
+    internally; here we mock the Python-visible symbol directly.
+    """
+
+    def test_back_compat_false_when_healthy(self):
+        """has_stream_error() returns False when mocked healthy."""
         with patch.object(_C, "has_stream_error", return_value=False):
             self.assertFalse(_C.has_stream_error())
 
-    def test_returns_true_when_mocked_faulted(self):
-        """Returns True when the runtime reports a stream error."""
+    def test_back_compat_true_when_faulted(self):
+        """has_stream_error() returns True when mocked faulted."""
         with patch.object(_C, "has_stream_error", return_value=True):
             self.assertTrue(_C.has_stream_error())
 
-    def test_return_value_is_not_cached(self):
-        """Consecutive calls reflect the live state, not a cached value."""
-        with patch.object(_C, "has_stream_error", side_effect=[False, True, False]):
-            self.assertFalse(_C.has_stream_error())
-            self.assertTrue(_C.has_stream_error())
-            self.assertFalse(_C.has_stream_error())
+    def test_back_compat_returns_bool(self):
+        """has_stream_error() must return a plain bool."""
+        result = _C.has_stream_error()
+        self.assertIsInstance(result, bool)
 
 
 class TestDeviceErrorSkipIntegration(TestCase):
     """
     Calls pytest_runtest_setup() directly with a mock item to verify the
-    skip hook
+    skip hook.
     """
 
     def _make_item(self, keywords=()):
@@ -85,31 +180,50 @@ class TestDeviceErrorSkipIntegration(TestCase):
         return item
 
     def test_healthy_device_does_not_skip(self):
-        """When has_stream_error() is False the hook must not skip."""
-        with patch.object(_C, "has_stream_error", return_value=False):
+        """When device state is Ok the hook must not skip."""
+        with patch.object(_C, "get_device_state", return_value=_C.SpyreDeviceState.Ok):
             # Should complete without raising pytest.skip.Exception
             pytest_runtest_setup(self._make_item())
 
+    def test_not_initialized_does_not_skip(self):
+        """When device state is NotInitialized the hook must not skip (proceed)."""
+        with patch.object(
+            _C,
+            "get_device_state",
+            return_value=_C.SpyreDeviceState.NotInitialized,
+        ):
+            pytest_runtest_setup(self._make_item())
+
     def test_faulted_device_skips(self):
-        """When has_stream_error() is True every hook call must skip — not just the first."""
-        with patch.object(_C, "has_stream_error", return_value=True):
+        """When device state is StreamError every hook call must skip."""
+        with patch.object(
+            _C, "get_device_state", return_value=_C.SpyreDeviceState.StreamError
+        ):
             for _ in range(3):
                 with self.assertRaises(pytest.skip.Exception):
                     pytest_runtest_setup(self._make_item())
 
-    def test_skip_message_content(self):
+    def test_skip_message_contains_device_is_in_error_state(self):
         """The skip reason must contain 'Device is in error state'."""
-        with patch.object(_C, "has_stream_error", return_value=True):
+        with patch.object(
+            _C, "get_device_state", return_value=_C.SpyreDeviceState.StreamError
+        ):
             with self.assertRaises(pytest.skip.Exception) as ctx:
                 pytest_runtest_setup(self._make_item())
         self.assertIn("Device is in error state", str(ctx.exception))
 
+    def test_skip_message_contains_error_class_name(self):
+        """The skip reason must name the error class (e.g. 'StreamError')."""
+        with patch.object(
+            _C, "get_device_state", return_value=_C.SpyreDeviceState.StreamError
+        ):
+            with self.assertRaises(pytest.skip.Exception) as ctx:
+                pytest_runtest_setup(self._make_item())
+        self.assertIn("StreamError", str(ctx.exception))
+
     def test_import_error_does_not_block_test(self):
         """If torch_spyre._C is not importable the hook must silently pass."""
-        # Simulate the module being absent so `from torch_spyre import _C`
-        # inside pytest_runtest_setup raises ImportError.
         with patch.dict(sys.modules, {"torch_spyre._C": None}):
-            # Should complete without raising anything
             pytest_runtest_setup(self._make_item())
 
 

--- a/tests/test_device_error_skip.py
+++ b/tests/test_device_error_skip.py
@@ -52,24 +52,24 @@ pytest_runtest_setup = _tests_conftest.pytest_runtest_setup
 class TestStreamErrorBindings(TestCase):
     """Unit tests for the typed SpyreStreamError / SpyreDeviceState bindings."""
 
-    # ── SpyreStreamError ──────────────────────────────────────────────────────
+    # Testing SpyreStreamError
 
     def test_stream_error_enum_members_exist(self):
-        """SpyreStreamError must expose Success and StreamError members."""
+        """SpyreStreamError must expose Success and Shutdown members."""
         self.assertIsInstance(_C.SpyreStreamError.Success, _C.SpyreStreamError)
-        self.assertIsInstance(_C.SpyreStreamError.StreamError, _C.SpyreStreamError)
+        self.assertIsInstance(_C.SpyreStreamError.Shutdown, _C.SpyreStreamError)
 
     def test_stream_error_integer_values(self):
-        """SpyreStreamError values must match the documented ABI (Success=0, StreamError=1)."""
+        """SpyreStreamError values must match the documented ABI (Success=0, Shutdown=1)."""
         self.assertEqual(int(_C.SpyreStreamError.Success), 0)
-        self.assertEqual(int(_C.SpyreStreamError.StreamError), 1)
+        self.assertEqual(int(_C.SpyreStreamError.Shutdown), 1)
 
     def test_stream_error_names(self):
         """SpyreStreamError .name must return the enum member's string name."""
         self.assertEqual(_C.SpyreStreamError.Success.name, "Success")
-        self.assertEqual(_C.SpyreStreamError.StreamError.name, "StreamError")
+        self.assertEqual(_C.SpyreStreamError.Shutdown.name, "Shutdown")
 
-    # ── SpyreDeviceState ─────────────────────────────────────────────────────
+    # Testing SpyreDeviceState
 
     def test_device_state_enum_members_exist(self):
         """SpyreDeviceState must expose Ok, NotInitialized, and StreamError."""
@@ -89,7 +89,7 @@ class TestStreamErrorBindings(TestCase):
         self.assertEqual(_C.SpyreDeviceState.NotInitialized.name, "NotInitialized")
         self.assertEqual(_C.SpyreDeviceState.StreamError.name, "StreamError")
 
-    # ── get_device_state() ───────────────────────────────────────────────────
+    # Testing get_device_state()
 
     def test_get_device_state_returns_device_state(self):
         """get_device_state() must be importable and return a SpyreDeviceState."""
@@ -129,7 +129,16 @@ class TestStreamErrorBindings(TestCase):
             self.assertEqual(_C.get_device_state(), _C.SpyreDeviceState.StreamError)
             self.assertEqual(_C.get_device_state(), _C.SpyreDeviceState.Ok)
 
-    # ── stream_get_error_string() ─────────────────────────────────────────────
+    # Testing stream_get_error() / stream_get_error_string()
+
+    def test_stream_get_error_returns_stream_error(self):
+        """stream_get_error() must return a SpyreStreamError."""
+        mock_stream = MagicMock()
+        with patch.object(
+            _C, "stream_get_error", return_value=_C.SpyreStreamError.Success
+        ):
+            result = _C.stream_get_error(mock_stream)
+        self.assertIsInstance(result, _C.SpyreStreamError)
 
     def test_error_string_success(self):
         """stream_get_error_string(Success) == 'Success'."""
@@ -137,10 +146,10 @@ class TestStreamErrorBindings(TestCase):
             _C.stream_get_error_string(_C.SpyreStreamError.Success), "Success"
         )
 
-    def test_error_string_stream_error(self):
-        """stream_get_error_string(StreamError) == 'StreamError'."""
+    def test_error_string_shutdown(self):
+        """stream_get_error_string(Shutdown) == 'Shutdown'."""
         self.assertEqual(
-            _C.stream_get_error_string(_C.SpyreStreamError.StreamError), "StreamError"
+            _C.stream_get_error_string(_C.SpyreStreamError.Shutdown), "Shutdown"
         )
 
 

--- a/tests/test_device_error_skip.py
+++ b/tests/test_device_error_skip.py
@@ -19,8 +19,6 @@ Tests for the device-error-state skip mechanism.
 
 - TestStreamErrorBindings: unit-tests the typed _C.SpyreStreamError /
   _C.SpyreDeviceState enums and the associated query functions.
-- TestHasStreamErrorBackCompat: verifies that the deprecated
-  _C.has_stream_error() wrapper still works correctly.
 - TestDeviceErrorSkipIntegration: calls the conftest hook directly to verify
   skip behaviour without spawning subprocesses.
 
@@ -151,29 +149,6 @@ class TestStreamErrorBindings(TestCase):
         self.assertEqual(
             _C.stream_get_error_string(_C.SpyreStreamError.Shutdown), "Shutdown"
         )
-
-
-class TestHasStreamErrorBackCompat(TestCase):
-    """
-    Verifies that the deprecated has_stream_error() wrapper is present and
-    returns a bool. The C++ implementation delegates to SpyreGetDeviceState()
-    internally; here we mock the Python-visible symbol directly.
-    """
-
-    def test_back_compat_false_when_healthy(self):
-        """has_stream_error() returns False when mocked healthy."""
-        with patch.object(_C, "has_stream_error", return_value=False):
-            self.assertFalse(_C.has_stream_error())
-
-    def test_back_compat_true_when_faulted(self):
-        """has_stream_error() returns True when mocked faulted."""
-        with patch.object(_C, "has_stream_error", return_value=True):
-            self.assertTrue(_C.has_stream_error())
-
-    def test_back_compat_returns_bool(self):
-        """has_stream_error() must return a plain bool."""
-        result = _C.has_stream_error()
-        self.assertIsInstance(result, bool)
 
 
 class TestDeviceErrorSkipIntegration(TestCase):

--- a/torch_spyre/_C.pyi
+++ b/torch_spyre/_C.pyi
@@ -19,7 +19,6 @@ __all__: list[str] = [
     "default_stream",
     "get_device_state",
     "get_stream_from_pool",
-    "has_stream_error",
     "set_current_stream",
     "stream_get_error",
     "stream_get_error_string",
@@ -384,9 +383,6 @@ def spyre_empty_with_layout(
     arg2: torch.dtype,
     arg3: SpyreTensorLayout,
 ) -> torch.Tensor: ...
-def has_stream_error() -> bool:
-    """Deprecated. Use get_device_state() instead."""
-    ...
 
 class SpyreStreamError:
     Success: typing.ClassVar[SpyreStreamError]  # value = <SpyreStreamError.Success: 0>

--- a/torch_spyre/_C.pyi
+++ b/torch_spyre/_C.pyi
@@ -11,13 +11,18 @@ __all__: list[str] = [
     "DataFormats",
     "JobPlan",
     "ElementArrangement",
+    "SpyreStreamError",
+    "SpyreDeviceState",
     "SpyreTensorLayout",
     "_SpyreStreamBase",
     "current_stream",
     "default_stream",
+    "get_device_state",
     "get_stream_from_pool",
     "has_stream_error",
     "set_current_stream",
+    "stream_get_error",
+    "stream_get_error_string",
     "synchronize",
     "as_strided_with_layout",
     "empty_with_layout",
@@ -380,8 +385,44 @@ def spyre_empty_with_layout(
     arg3: SpyreTensorLayout,
 ) -> torch.Tensor: ...
 def has_stream_error() -> bool:
-    """Returns true if any stream in the runtime has been shut down (unrecoverable)."""
+    """Deprecated. Use get_device_state() instead."""
     ...
 
+class SpyreStreamError:
+    Success: typing.ClassVar[SpyreStreamError]  # value = <SpyreStreamError.Success: 0>
+    StreamError: typing.ClassVar[
+        SpyreStreamError
+    ]  # value = <SpyreStreamError.StreamError: 1>
+    __members__: typing.ClassVar[dict[str, SpyreStreamError]]
+    def __eq__(self, other: typing.Any) -> bool: ...
+    def __hash__(self) -> int: ...
+    def __int__(self) -> int: ...
+    def __repr__(self) -> str: ...
+    @property
+    def name(self) -> str: ...
+    @property
+    def value(self) -> int: ...
+
+class SpyreDeviceState:
+    Ok: typing.ClassVar[SpyreDeviceState]  # value = <SpyreDeviceState.Ok: 0>
+    NotInitialized: typing.ClassVar[
+        SpyreDeviceState
+    ]  # value = <SpyreDeviceState.NotInitialized: 1>
+    StreamError: typing.ClassVar[
+        SpyreDeviceState
+    ]  # value = <SpyreDeviceState.StreamError: 2>
+    __members__: typing.ClassVar[dict[str, SpyreDeviceState]]
+    def __eq__(self, other: typing.Any) -> bool: ...
+    def __hash__(self) -> int: ...
+    def __int__(self) -> int: ...
+    def __repr__(self) -> str: ...
+    @property
+    def name(self) -> str: ...
+    @property
+    def value(self) -> int: ...
+
+def stream_get_error(stream: _SpyreStreamBase) -> SpyreStreamError: ...
+def stream_get_error_string(error: SpyreStreamError) -> str: ...
+def get_device_state() -> SpyreDeviceState: ...
 def start_runtime() -> None: ...
 def to_with_layout(arg0: torch.Tensor, arg1: SpyreTensorLayout) -> torch.Tensor: ...

--- a/torch_spyre/_C.pyi
+++ b/torch_spyre/_C.pyi
@@ -390,9 +390,9 @@ def has_stream_error() -> bool:
 
 class SpyreStreamError:
     Success: typing.ClassVar[SpyreStreamError]  # value = <SpyreStreamError.Success: 0>
-    StreamError: typing.ClassVar[
+    Shutdown: typing.ClassVar[
         SpyreStreamError
-    ]  # value = <SpyreStreamError.StreamError: 1>
+    ]  # value = <SpyreStreamError.Shutdown: 1>
     __members__: typing.ClassVar[dict[str, SpyreStreamError]]
     def __eq__(self, other: typing.Any) -> bool: ...
     def __hash__(self) -> int: ...

--- a/torch_spyre/csrc/job_plan.cpp
+++ b/torch_spyre/csrc/job_plan.cpp
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <memory>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "spyre_allocator.h"
@@ -40,24 +41,67 @@ void JobPlanStepH2D::construct(LaunchContext&,
 void JobPlanStepH2D::write(std::ostream& os) const {
   os << "  H2D (Host-to-Device)\n";
   os << "    Host address: " << host_address_ << "\n";
-  os << "    Device address: " << device_address_ << "\n";
+  os << "    Device CompositeAddress: " << device_address_ << "\n";
   os << "    Pipeline barrier: " << (pipeline_barrier_ ? "enabled" : "disabled")
      << "\n";
 }
 
-void JobPlanStepD2H::construct(LaunchContext&,
+void JobPlanStepD2H::construct(LaunchContext& ctx,
                                const SpyreStream& stream) const {
-  auto* params =
-      flex::createDmaParams(host_address_, device_address_.total_size(),
-                            /*to_device=*/false, &device_address_);
-  params->pipeline_barrier = pipeline_barrier_;
-  stream.launchD2H(params);
-  flex::destroyDmaParams(params);
+  if (std::holds_alternative<flex::CompositeAddress>(device_address_)) {
+    const auto& device_address =
+        std::get<flex::CompositeAddress>(device_address_);
+    auto* params =
+        flex::createDmaParams(host_address_, device_address.total_size(),
+                              /*to_device=*/false, &device_address);
+    params->pipeline_barrier = pipeline_barrier_;
+    stream.launchD2H(params);
+    flex::destroyDmaParams(params);
+  } else {
+    const uint64_t dmva = std::get<Dmva>(device_address_).value;
+    auto segment_id = flex::dmvaToSegmentId(dmva);
+    TORCH_CHECK(segment_id < ctx.inputs_outputs.size(),
+                "D2H tensor-segment lookup out of range: segment ", segment_id,
+                " but only ", ctx.inputs_outputs.size(),
+                " launch args were provided");
+    const auto& tensor = ctx.inputs_outputs.at(segment_id);
+    const auto& tensor_address =
+        static_cast<SharedOwnerCtx*>(tensor.storage().data_ptr().get_context())
+            ->composite_addr;
+    TORCH_CHECK(tensor_address.chunks().size() == 1,
+                "Tensor address must have 1 chunk");
+    const auto& base_chunk = tensor_address.chunks()[0];
+    uint64_t segment_offset = dmva - (segment_id << flex::SEGMENT_SIZE_BITS);
+    TORCH_CHECK(segment_offset + size_ <= tensor_address.total_size(),
+                "D2H transfer out of bounds: offset ", segment_offset,
+                " + size ", size_, " exceeds tensor allocation size ",
+                tensor_address.total_size());
+    flex::LogicalAddress offset_addr(base_chunk.addr.region_id,
+                                     base_chunk.addr.offset + segment_offset);
+    flex::Chunk offset_chunk(offset_addr, size_, base_chunk.domain_id);
+
+    // Create shared_ptr to manage lifetime - will be kept alive by callback
+    auto device_address =
+        std::make_shared<flex::CompositeAddress>(offset_chunk);
+
+    auto* params =
+        flex::createDmaParams(host_address_, device_address->total_size(),
+                              /*to_device=*/false, device_address.get());
+    params->pipeline_barrier = pipeline_barrier_;
+    params->callback = [device_address](void*) {};
+    stream.launchD2H(params);
+    flex::destroyDmaParams(params);
+  }
 }
 
 void JobPlanStepD2H::write(std::ostream& os) const {
   os << "  D2H (Device-to-Host)\n";
-  os << "    Device address: " << device_address_ << "\n";
+  if (std::holds_alternative<flex::CompositeAddress>(device_address_)) {
+    os << "    Device CompositeAddress: "
+       << std::get<flex::CompositeAddress>(device_address_) << "\n";
+  } else {
+    os << "    Device dmva: " << std::get<Dmva>(device_address_).value << "\n";
+  }
   os << "    Host address: " << host_address_ << "\n";
   os << "    Pipeline barrier: " << (pipeline_barrier_ ? "enabled" : "disabled")
      << "\n";
@@ -85,7 +129,7 @@ void JobPlanStepCompute::construct(LaunchContext& ctx,
 void JobPlanStepCompute::write(std::ostream& os) const {
   os << "  Device Compute\n";
   os << "    Name: " << (name_.empty() ? "(unnamed)" : name_) << "\n";
-  os << "    Program address: " << program_address_ << "\n";
+  os << "    Program CompositeAddress: " << program_address_ << "\n";
   os << "    Bind I/O addresses: " << (bind_io_addresses_ ? "yes" : "no")
      << "\n";
   os << "    Pipeline barrier: " << (pipeline_barrier_ ? "enabled" : "disabled")

--- a/torch_spyre/csrc/job_plan.cpp
+++ b/torch_spyre/csrc/job_plan.cpp
@@ -19,7 +19,6 @@
 #include <iostream>
 #include <memory>
 #include <utility>
-#include <variant>
 #include <vector>
 
 #include "spyre_allocator.h"
@@ -41,67 +40,24 @@ void JobPlanStepH2D::construct(LaunchContext&,
 void JobPlanStepH2D::write(std::ostream& os) const {
   os << "  H2D (Host-to-Device)\n";
   os << "    Host address: " << host_address_ << "\n";
-  os << "    Device CompositeAddress: " << device_address_ << "\n";
+  os << "    Device address: " << device_address_ << "\n";
   os << "    Pipeline barrier: " << (pipeline_barrier_ ? "enabled" : "disabled")
      << "\n";
 }
 
-void JobPlanStepD2H::construct(LaunchContext& ctx,
+void JobPlanStepD2H::construct(LaunchContext&,
                                const SpyreStream& stream) const {
-  if (std::holds_alternative<flex::CompositeAddress>(device_address_)) {
-    const auto& device_address =
-        std::get<flex::CompositeAddress>(device_address_);
-    auto* params =
-        flex::createDmaParams(host_address_, device_address.total_size(),
-                              /*to_device=*/false, &device_address);
-    params->pipeline_barrier = pipeline_barrier_;
-    stream.launchD2H(params);
-    flex::destroyDmaParams(params);
-  } else {
-    const uint64_t dmva = std::get<Dmva>(device_address_).value;
-    auto segment_id = flex::dmvaToSegmentId(dmva);
-    TORCH_CHECK(segment_id < ctx.inputs_outputs.size(),
-                "D2H tensor-segment lookup out of range: segment ", segment_id,
-                " but only ", ctx.inputs_outputs.size(),
-                " launch args were provided");
-    const auto& tensor = ctx.inputs_outputs.at(segment_id);
-    const auto& tensor_address =
-        static_cast<SharedOwnerCtx*>(tensor.storage().data_ptr().get_context())
-            ->composite_addr;
-    TORCH_CHECK(tensor_address.chunks().size() == 1,
-                "Tensor address must have 1 chunk");
-    const auto& base_chunk = tensor_address.chunks()[0];
-    uint64_t segment_offset = dmva - (segment_id << flex::SEGMENT_SIZE_BITS);
-    TORCH_CHECK(segment_offset + size_ <= tensor_address.total_size(),
-                "D2H transfer out of bounds: offset ", segment_offset,
-                " + size ", size_, " exceeds tensor allocation size ",
-                tensor_address.total_size());
-    flex::LogicalAddress offset_addr(base_chunk.addr.region_id,
-                                     base_chunk.addr.offset + segment_offset);
-    flex::Chunk offset_chunk(offset_addr, size_, base_chunk.domain_id);
-
-    // Create shared_ptr to manage lifetime - will be kept alive by callback
-    auto device_address =
-        std::make_shared<flex::CompositeAddress>(offset_chunk);
-
-    auto* params =
-        flex::createDmaParams(host_address_, device_address->total_size(),
-                              /*to_device=*/false, device_address.get());
-    params->pipeline_barrier = pipeline_barrier_;
-    params->callback = [device_address](void*) {};
-    stream.launchD2H(params);
-    flex::destroyDmaParams(params);
-  }
+  auto* params =
+      flex::createDmaParams(host_address_, device_address_.total_size(),
+                            /*to_device=*/false, &device_address_);
+  params->pipeline_barrier = pipeline_barrier_;
+  stream.launchD2H(params);
+  flex::destroyDmaParams(params);
 }
 
 void JobPlanStepD2H::write(std::ostream& os) const {
   os << "  D2H (Device-to-Host)\n";
-  if (std::holds_alternative<flex::CompositeAddress>(device_address_)) {
-    os << "    Device CompositeAddress: "
-       << std::get<flex::CompositeAddress>(device_address_) << "\n";
-  } else {
-    os << "    Device dmva: " << std::get<Dmva>(device_address_).value << "\n";
-  }
+  os << "    Device address: " << device_address_ << "\n";
   os << "    Host address: " << host_address_ << "\n";
   os << "    Pipeline barrier: " << (pipeline_barrier_ ? "enabled" : "disabled")
      << "\n";
@@ -129,7 +85,7 @@ void JobPlanStepCompute::construct(LaunchContext& ctx,
 void JobPlanStepCompute::write(std::ostream& os) const {
   os << "  Device Compute\n";
   os << "    Name: " << (name_.empty() ? "(unnamed)" : name_) << "\n";
-  os << "    Program CompositeAddress: " << program_address_ << "\n";
+  os << "    Program address: " << program_address_ << "\n";
   os << "    Bind I/O addresses: " << (bind_io_addresses_ ? "yes" : "no")
      << "\n";
   os << "    Pipeline barrier: " << (pipeline_barrier_ ? "enabled" : "disabled")

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -46,6 +46,7 @@
 #include "prepare_kernel.h"
 #include "spyre_allocator.h"
 #include "spyre_device_enum.h"
+#include "spyre_error.h"
 #include "spyre_generator_impl.h"
 #include "spyre_guard.h"
 #include "spyre_kernel.h"
@@ -518,12 +519,42 @@ PYBIND11_MODULE(_C, m) {
       },
       py::arg("device"), "Reset peak allocator statistics");
 
-  // Returns true if any stream in the runtime has been shut down
-  // (unrecoverable). When true, no further work can be submitted on the
-  // affected streams.
+  // ── Typed stream error API ───────────────────────────────────────────────
+
+  py::enum_<spyre::SpyreStreamError>(m, "SpyreStreamError")
+      .value("Success", spyre::SpyreStreamError::Success)
+      .value("StreamError", spyre::SpyreStreamError::StreamError)
+      .export_values();
+
+  py::enum_<spyre::SpyreDeviceState>(m, "SpyreDeviceState")
+      .value("Ok", spyre::SpyreDeviceState::Ok)
+      .value("NotInitialized", spyre::SpyreDeviceState::NotInitialized)
+      .value("StreamError", spyre::SpyreDeviceState::StreamError)
+      .export_values();
+
+  m.def(
+      "stream_get_error",
+      [](const spyre::SpyreStream& stream) {
+        return spyre::SpyreStreamGetError(stream);
+      },
+      py::arg("stream"),
+      "Return the SpyreStreamError state of a single stream.");
+
+  m.def(
+      "stream_get_error_string",
+      [](spyre::SpyreStreamError err) -> std::string {
+        return spyre::SpyreStreamGetErrorString(err);
+      },
+      py::arg("error"),
+      "Return a human-readable string for a SpyreStreamError value.");
+
+  m.def(
+      "get_device_state", []() { return spyre::SpyreGetDeviceState(); },
+      "Return the SpyreDeviceState aggregate for the process. "
+      "Returns NotInitialized when the runtime has not been created yet; "
+      "callers should treat this as 'proceed / no error'.");
+
   m.def("has_stream_error", []() -> bool {
-    auto runtime = spyre::GlobalRuntime::get();
-    if (!runtime) return false;
-    return runtime->hasStreamError();
+    return spyre::SpyreGetDeviceState() == spyre::SpyreDeviceState::StreamError;
   });
 }

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -523,14 +523,12 @@ PYBIND11_MODULE(_C, m) {
 
   py::enum_<spyre::SpyreStreamError>(m, "SpyreStreamError")
       .value("Success", spyre::SpyreStreamError::Success)
-      .value("StreamError", spyre::SpyreStreamError::StreamError)
-      .export_values();
+      .value("Shutdown", spyre::SpyreStreamError::Shutdown);
 
   py::enum_<spyre::SpyreDeviceState>(m, "SpyreDeviceState")
       .value("Ok", spyre::SpyreDeviceState::Ok)
       .value("NotInitialized", spyre::SpyreDeviceState::NotInitialized)
-      .value("StreamError", spyre::SpyreDeviceState::StreamError)
-      .export_values();
+      .value("StreamError", spyre::SpyreDeviceState::StreamError);
 
   m.def(
       "stream_get_error",

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -551,8 +551,4 @@ PYBIND11_MODULE(_C, m) {
       "Return the SpyreDeviceState aggregate for the process. "
       "Returns NotInitialized when the runtime has not been created yet; "
       "callers should treat this as 'proceed / no error'.");
-
-  m.def("has_stream_error", []() -> bool {
-    return spyre::SpyreGetDeviceState() == spyre::SpyreDeviceState::StreamError;
-  });
 }

--- a/torch_spyre/csrc/spyre_error.h
+++ b/torch_spyre/csrc/spyre_error.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 The Torch-Spyre Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace spyre {
+
+// Forward declaration — defined in spyre_stream.h
+class SpyreStream;
+
+// Per-stream error state. Values 2-5 (HardwareFault, Timeout, MemoryFault,
+// CoreUnavailable) are reserved pending flex::RuntimeStream typed error codes.
+enum class SpyreStreamError : int {
+  Success = 0,      ///< Stream is healthy; no shutdown, no deferred error
+  StreamError = 1,  ///< Stream has been shut down (unrecoverable)
+};
+
+// Device-level aggregate over all streams in the global runtime.
+enum class SpyreDeviceState : int {
+  Ok = 0,              ///< All streams healthy; device is usable
+  NotInitialized = 1,  ///< Runtime not yet created — treat as Ok, proceed
+  StreamError = 2,     ///< One or more streams are in an unrecoverable state
+};
+
+/**
+ * @brief Return a string literal for a SpyreStreamError value.
+ * @returns A non-null string such as "Success" or "StreamError". Never throws.
+ */
+const char* SpyreStreamGetErrorString(SpyreStreamError error) noexcept;
+
+/**
+ * @brief Query the error state of a single stream.
+ * @returns SpyreStreamError::StreamError if the stream has been shut down,
+ *          SpyreStreamError::Success otherwise.
+ */
+SpyreStreamError SpyreStreamGetError(const SpyreStream& stream);
+
+/**
+ * @brief Return the device-level aggregate state.
+ * @returns SpyreDeviceState::NotInitialized if the runtime has not been
+ *          created yet (callers should treat this as proceed / no error),
+ *          SpyreDeviceState::StreamError if any stream is unrecoverable,
+ *          SpyreDeviceState::Ok otherwise.
+ */
+SpyreDeviceState SpyreGetDeviceState();
+
+}  // namespace spyre

--- a/torch_spyre/csrc/spyre_error.h
+++ b/torch_spyre/csrc/spyre_error.h
@@ -18,26 +18,25 @@
 
 namespace spyre {
 
-// Forward declaration — defined in spyre_stream.h
 class SpyreStream;
 
 // Per-stream error state. Values 2-5 (HardwareFault, Timeout, MemoryFault,
 // CoreUnavailable) are reserved pending flex::RuntimeStream typed error codes.
 enum class SpyreStreamError : int {
-  Success = 0,   ///< Stream is healthy (not shut down; deferred errors surface
-                 ///< only on synchronize())
-  Shutdown = 1,  ///< Stream has been shut down (unrecoverable)
+  Success = 0,   // Stream is healthy (not shut down; deferred errors surface
+                 // only on synchronize())
+  Shutdown = 1,  // Stream has been shut down (unrecoverable)
 };
 
 // Device-level aggregate over all streams in the global runtime.
 enum class SpyreDeviceState : int {
-  Ok = 0,              ///< All streams healthy; device is usable
-  NotInitialized = 1,  ///< Runtime not yet created — treat as Ok, proceed
-  StreamError = 2,     ///< One or more streams are in an unrecoverable state
+  Ok = 0,              // All streams healthy; device is usable
+  NotInitialized = 1,  // Runtime not yet created — treat as Ok, proceed
+  StreamError = 2,     // One or more streams are in an unrecoverable state
 };
 
 /**
- * @brief Return a string literal for a SpyreStreamError value.
+ * @brief Returns a string literal for a SpyreStreamError value.
  * @returns A non-null string such as "Success" or "Shutdown". Never throws.
  */
 const char* SpyreStreamGetErrorString(SpyreStreamError error) noexcept;

--- a/torch_spyre/csrc/spyre_error.h
+++ b/torch_spyre/csrc/spyre_error.h
@@ -24,8 +24,9 @@ class SpyreStream;
 // Per-stream error state. Values 2-5 (HardwareFault, Timeout, MemoryFault,
 // CoreUnavailable) are reserved pending flex::RuntimeStream typed error codes.
 enum class SpyreStreamError : int {
-  Success = 0,      ///< Stream is healthy; no shutdown, no deferred error
-  StreamError = 1,  ///< Stream has been shut down (unrecoverable)
+  Success = 0,   ///< Stream is healthy (not shut down; deferred errors surface
+                 ///< only on synchronize())
+  Shutdown = 1,  ///< Stream has been shut down (unrecoverable)
 };
 
 // Device-level aggregate over all streams in the global runtime.
@@ -37,14 +38,16 @@ enum class SpyreDeviceState : int {
 
 /**
  * @brief Return a string literal for a SpyreStreamError value.
- * @returns A non-null string such as "Success" or "StreamError". Never throws.
+ * @returns A non-null string such as "Success" or "Shutdown". Never throws.
  */
 const char* SpyreStreamGetErrorString(SpyreStreamError error) noexcept;
 
 /**
  * @brief Query the error state of a single stream.
- * @returns SpyreStreamError::StreamError if the stream has been shut down,
+ * @returns SpyreStreamError::Shutdown if the stream has been shut down,
  *          SpyreStreamError::Success otherwise.
+ * @throws if the runtime has not been started or the stream pool is not
+ *         initialized for this stream's device.
  */
 SpyreStreamError SpyreStreamGetError(const SpyreStream& stream);
 

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -32,6 +32,7 @@
 #include "logging.h"
 #include "module.h"
 #include "spyre_allocator.h"
+#include "spyre_error.h"
 #include "spyre_guard.h"
 #include "spyre_mem.h"
 #include "spyre_tensor_impl.h"
@@ -209,6 +210,10 @@ flex::RuntimeStream* SpyreStream::resolveRuntimeHandle() const {
               "SpyreStream: no flex handle for stream id ", id(),
               " — was the stream pool initialized for this device?");
   return it->second;
+}
+
+flex::RuntimeStream* SpyreStream::getRuntimeHandle() const {
+  return resolveRuntimeHandle();
 }
 
 void SpyreStream::copyAsyncImpl(void* cpu_ptr,
@@ -503,6 +508,42 @@ void synchronizeDevice(c10::optional<c10::Device> device) {
     sync_one_device(
         c10::Device(c10::DeviceType::PrivateUse1, SpyreGuardImpl::tls_idx));
   }
+}
+
+// ============================================================================
+// Error query functions (declared in spyre_error.h)
+// ============================================================================
+
+const char* SpyreStreamGetErrorString(SpyreStreamError error) noexcept {
+  switch (error) {
+    case SpyreStreamError::Success:
+      return "Success";
+    case SpyreStreamError::StreamError:
+      return "StreamError";
+    default:
+      return "Unknown";
+  }
+}
+
+SpyreStreamError SpyreStreamGetError(const SpyreStream& stream) {
+  flex::RuntimeStream* handle = stream.getRuntimeHandle();
+  if (handle->needsShutdown()) {
+    return SpyreStreamError::StreamError;
+  }
+  return SpyreStreamError::Success;
+}
+
+SpyreDeviceState SpyreGetDeviceState() {
+  auto runtime = GlobalRuntime::get();
+  if (!runtime) {
+    return SpyreDeviceState::NotInitialized;
+  }
+  // Use RuntimeContext::hasStreamError() which already iterates all streams
+  // under its own internal lock — consistent with the existing roll-up.
+  if (runtime->hasStreamError()) {
+    return SpyreDeviceState::StreamError;
+  }
+  return SpyreDeviceState::Ok;
 }
 
 }  // namespace spyre

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -212,10 +212,6 @@ flex::RuntimeStream* SpyreStream::resolveRuntimeHandle() const {
   return it->second;
 }
 
-flex::RuntimeStream* SpyreStream::getRuntimeHandle() const {
-  return resolveRuntimeHandle();
-}
-
 void SpyreStream::copyAsyncImpl(void* cpu_ptr,
                                 const flex::CompositeAddress* device_address,
                                 const DataConversionInfo* dci,
@@ -522,7 +518,7 @@ const char* SpyreStreamGetErrorString(SpyreStreamError error) noexcept {
 }
 
 SpyreStreamError SpyreStreamGetError(const SpyreStream& stream) {
-  flex::RuntimeStream* handle = stream.getRuntimeHandle();
+  flex::RuntimeStream* handle = stream.resolveRuntimeHandle();
   return handle->needsShutdown() ? SpyreStreamError::Shutdown
                                  : SpyreStreamError::Success;
 }

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -212,6 +212,11 @@ flex::RuntimeStream* SpyreStream::resolveRuntimeHandle() const {
   return it->second;
 }
 
+SpyreStreamError SpyreStream::getError() const {
+  return resolveRuntimeHandle()->needsShutdown() ? SpyreStreamError::Shutdown
+                                                 : SpyreStreamError::Success;
+}
+
 void SpyreStream::copyAsyncImpl(void* cpu_ptr,
                                 const flex::CompositeAddress* device_address,
                                 const DataConversionInfo* dci,
@@ -518,9 +523,7 @@ const char* SpyreStreamGetErrorString(SpyreStreamError error) noexcept {
 }
 
 SpyreStreamError SpyreStreamGetError(const SpyreStream& stream) {
-  flex::RuntimeStream* handle = stream.resolveRuntimeHandle();
-  return handle->needsShutdown() ? SpyreStreamError::Shutdown
-                                 : SpyreStreamError::Success;
+  return stream.getError();
 }
 
 SpyreDeviceState SpyreGetDeviceState() {

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -510,16 +510,12 @@ void synchronizeDevice(c10::optional<c10::Device> device) {
   }
 }
 
-// ============================================================================
-// Error query functions (declared in spyre_error.h)
-// ============================================================================
-
 const char* SpyreStreamGetErrorString(SpyreStreamError error) noexcept {
   switch (error) {
     case SpyreStreamError::Success:
       return "Success";
-    case SpyreStreamError::StreamError:
-      return "StreamError";
+    case SpyreStreamError::Shutdown:
+      return "Shutdown";
     default:
       return "Unknown";
   }
@@ -527,10 +523,8 @@ const char* SpyreStreamGetErrorString(SpyreStreamError error) noexcept {
 
 SpyreStreamError SpyreStreamGetError(const SpyreStream& stream) {
   flex::RuntimeStream* handle = stream.getRuntimeHandle();
-  if (handle->needsShutdown()) {
-    return SpyreStreamError::StreamError;
-  }
-  return SpyreStreamError::Success;
+  return handle->needsShutdown() ? SpyreStreamError::Shutdown
+                                 : SpyreStreamError::Success;
 }
 
 SpyreDeviceState SpyreGetDeviceState() {
@@ -538,8 +532,12 @@ SpyreDeviceState SpyreGetDeviceState() {
   if (!runtime) {
     return SpyreDeviceState::NotInitialized;
   }
-  // Use RuntimeContext::hasStreamError() which already iterates all streams
-  // under its own internal lock — consistent with the existing roll-up.
+  // NOTE: intentionally uses RuntimeContext::hasStreamError() (one locked
+  // iteration) instead of rolling up SpyreStreamGetError per stream. These
+  // agree only while both reduce to needsShutdown().
+  // TODO(#3365): once flex exposes typed per-stream codes, roll up via
+  // SpyreStreamGetError so the aggregate (and the pytest skip reason) can
+  // surface the actual fault class.
   if (runtime->hasStreamError()) {
     return SpyreDeviceState::StreamError;
   }

--- a/torch_spyre/csrc/spyre_stream.h
+++ b/torch_spyre/csrc/spyre_stream.h
@@ -68,6 +68,14 @@ class SpyreStream {
   // Conversions
   c10::Stream unwrap() const;
 
+  /**
+   * @brief Return the underlying flex::RuntimeStream handle for this stream.
+   *
+   * Used by SpyreStreamGetError() (spyre_error.h) to query per-stream state
+   * without exposing flex internals through the pybind layer.
+   */
+  flex::RuntimeStream* getRuntimeHandle() const;
+
  private:
   flex::RuntimeStream* resolveRuntimeHandle() const;
   void copyAsyncImpl(void* cpu_ptr,

--- a/torch_spyre/csrc/spyre_stream.h
+++ b/torch_spyre/csrc/spyre_stream.h
@@ -68,12 +68,8 @@ class SpyreStream {
   // Conversions
   c10::Stream unwrap() const;
 
-  /**
-   * @brief Return the underlying flex::RuntimeStream handle for this stream.
-   *
-   * Used by SpyreStreamGetError() (spyre_error.h) to query per-stream state
-   * without exposing flex internals through the pybind layer.
-   */
+  // Returns the underlying flex::RuntimeStream handle. Used by
+  // SpyreStreamGetError().
   flex::RuntimeStream* getRuntimeHandle() const;
 
  private:

--- a/torch_spyre/csrc/spyre_stream.h
+++ b/torch_spyre/csrc/spyre_stream.h
@@ -68,12 +68,10 @@ class SpyreStream {
   // Conversions
   c10::Stream unwrap() const;
 
-  // Returns the underlying flex::RuntimeStream handle. Used by
-  // SpyreStreamGetError().
-  flex::RuntimeStream* getRuntimeHandle() const;
-
  private:
   flex::RuntimeStream* resolveRuntimeHandle() const;
+
+  friend SpyreStreamError SpyreStreamGetError(const SpyreStream& stream);
   void copyAsyncImpl(void* cpu_ptr,
                      const flex::CompositeAddress* device_address,
                      const DataConversionInfo* dci, bool host2device) const;

--- a/torch_spyre/csrc/spyre_stream.h
+++ b/torch_spyre/csrc/spyre_stream.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "module.h"
+#include "spyre_error.h"
 #include "spyre_kernel.h"
 
 namespace spyre {
@@ -68,10 +69,12 @@ class SpyreStream {
   // Conversions
   c10::Stream unwrap() const;
 
+  // Returns the error state of this stream without exposing the underlying
+  // flex::RuntimeStream handle to callers.
+  SpyreStreamError getError() const;
+
  private:
   flex::RuntimeStream* resolveRuntimeHandle() const;
-
-  friend SpyreStreamError SpyreStreamGetError(const SpyreStream& stream);
   void copyAsyncImpl(void* cpu_ptr,
                      const flex::CompositeAddress* device_address,
                      const DataConversionInfo* dci, bool host2device) const;


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [X] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Replaces the boolean _C.has_stream_error() with a richer typed API:

• SpyreStreamError — per-stream error enum (Success, StreamError; values 2–5 reserved for HardwareFault, Timeout, MemoryFault, CoreUnavailable pending flex-side typed error codes)
• SpyreDeviceState — device-level aggregate (Ok, NotInitialized, StreamError)
• SpyreStreamGetError(stream) — per-stream query backed by flex::RuntimeStream::needsShutdown()
• SpyreGetDeviceState() — process-wide roll-up via RuntimeContext::hasStreamError()
• SpyreStreamGetErrorString(error) — human-readable string for a SpyreStreamError value
All three functions are bound via pybind11 and stubbed in _C.pyi.

The pytest hook in conftest.py is updated to use get_device_state(); the skip reason now names the error class (e.g. "StreamError"). NotInitialized is explicitly treated as proceed — pre-init state no longer conflates with a healthy device.

#### Which issue(s) this PR is related to:

Fixes #3365 

#### Special notes for your reviewer:

Flex does not yet expose typed error codes on RuntimeStream (only a boolean shutdown_ flag). The fine-grained enum values (HardwareFault etc.) are documented as reserved comments in spyre_error.h and can be wired in once flex adds the detail. No pybind or Python changes would be needed at that point.

#### Does this PR introduce a user-facing change?

#### Additional note: 