### PR TITLE
Additional "structured" coarse tiling tests

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -14,21 +14,36 @@
 
 """End-to-end compilation tests for the coarse-tiling loop IR.
 
-These tests drive the full Spyre compilation pipeline (CustomPreSchedulingPasses
-→ scheduler → SpyreKernel codegen) and inspect the generated Python wrapper
-source to verify that LoopSpec entries appear when coarse tiling is active.
+This file has two sections:
 
-No Spyre hardware is required: torch.compile() exercises the full codegen path
-and run_and_get_code() captures the generated source without executing on device.
-launch_jobplan is mocked to prevent actual device execution.
+STRUCTURED TESTS (Groups 1-9)
+    Flat module-level tests using the run_coarse_tile_test() driver.
+    These are the primary test suite going forward — easy to read, copy,
+    and extend.  Each test declares its inputs via tensor() descriptors,
+    defines a plain fn(), and calls the driver with optional loopspec=
+    and correctness= flags.
 
-All coarse-tiling tests use the spyre_hint API (TestCoarseTileSpyreHints).
-Add new tests there using spyre_hint(num_tiles_per_dim=...) annotations.
+    Group 1: Basic tiling — abs/add on 2D tensors, varied sizes and tile counts
+    Group 2: 3D tensors — [A=512, B=256, C=256], all tiling combinations
+    Group 3: Pointwise op chains — abs(a+b)*c, exp(abs(...)), etc.
+    Group 4: Reductions — amin over 2D (all tiling combos) and 3D (all-dims)
+    Group 5: Mixed pointwise + reduction — add_min, reduce_both, softmax
+    Group 6: Restickify + coarse tiling — transpose inputs with tiling
+    Group 7: Copies — pre-allocated buffers, in-place accumulators, RMW
+    Group 8: Tiled ops with outside consumers
+    Group 9: Views — 1D sub-dim naming, reshape, view+transpose, unsqueeze
+
+    Tests marked loopspec=False, correctness=False are known broken and
+    skipped; see inline comments for root cause.
+
+ORIGINAL TESTS (below the boundary marker)
+    Original class-based tests preserved for coverage and reference, to be cleaned up in future.
 """
 
+import dataclasses
 import math
-import sys
 import os
+import sys
 import regex as re
 
 import pytest
@@ -36,21 +51,2247 @@ import torch
 import unittest
 from unittest.mock import patch as mock_patch
 
-from torch._inductor.test_case import TestCase as InductorTestCase
+from torch._inductor.test_case import TestCase as InductorTestCase, fresh_cache
 from torch._inductor.utils import run_and_get_code
 
 from torch_spyre._inductor import config
+from torch_spyre._inductor import spyre_hint
 import torch_spyre._inductor.wsr.propagate_named_dims as _pnd
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
-from utils_inductor import compare_with_cpu  # noqa: E402
+from utils_inductor import compare_with_cpu, _compile_and_run  # noqa: E402
+
+_declare_tensor_dim = _pnd.declare_tensor_dim
+_name_tensor_dims = _pnd.name_tensor_dims
 
 # Paths to mock for disabling actual device kernel execution.
 _LAUNCH_JOBPLAN = "torch_spyre.execution.kernel_runner.launch_jobplan"
 _PREPARE_KERNEL = "torch_spyre.execution.kernel_runner.prepare_kernel"
 
 
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class TensorSpec:
+    """Descriptor for a test input tensor.
+
+    name:       parameter name in fn — for readability only.
+    shape:      physical tensor shape passed to torch.randn.
+    dims:       named dim labels in order, passed to _name_tensor_dims.
+    named_dims: optional explicit {dim_name: size} dict for declaring dims.
+                Use when len(dims) > len(shape) — i.e. multiple logical dims
+                are fused into one physical dim (e.g. flat [B, S, H*D] input
+                named ["batch_size", "max_seqlen", "num_heads", "head_dim"]).
+                When absent, sizes are inferred by zipping dims with shape.
+    """
+
+    name: str
+    shape: tuple
+    dims: list
+    named_dims: dict | None = dataclasses.field(default=None)
+
+
+def tensor(name, *, shape, dims, named_dims=None):
+    """Shorthand constructor for TensorSpec."""
+    return TensorSpec(name=name, shape=shape, dims=dims, named_dims=named_dims)
+
+
+def run_coarse_tile_test(
+    fn,
+    inputs,
+    loopspec=True,
+    correctness=True,
+    atol=None,
+    rtol=None,
+    scale=0.01,
+):
+    """Compile fn on Spyre and check loopspec and/or correctness.
+
+    inputs: list of TensorSpec (from tensor(...)) — driver creates tensors,
+        declares dims, and calls _name_tensor_dims before each compile.
+
+    loopspec: True  — assert "LoopSpec(" appears in generated source.
+    correctness: True  — compare_with_cpu against CPU reference.
+    """
+    cpu_tensors = [torch.randn(s.shape, dtype=torch.float16) * scale for s in inputs]
+
+    def _setup_dims_and_dev_tensors():
+        _pnd.reset()
+        for spec in inputs:
+            if spec.named_dims is not None:
+                for dim, size in spec.named_dims.items():
+                    _declare_tensor_dim(dim, size)
+            else:
+                for dim, size in zip(spec.dims, spec.shape):
+                    _declare_tensor_dim(dim, size)
+        dev_tensors = [t.to("spyre") for t in cpu_tensors]
+        for spec, t in zip(inputs, dev_tensors):
+            _name_tensor_dims(t, spec.dims)
+        return dev_tensors
+
+    if loopspec:
+        with fresh_cache():
+            dev_tensors = _setup_dims_and_dev_tensors()
+            cfn = torch.compile(fn)
+            with (
+                mock_patch(_LAUNCH_JOBPLAN),
+                mock_patch(_PREPARE_KERNEL),
+                mock_patch("torch_spyre.execution.async_compile.subprocess.run"),
+            ):
+                _, source_codes = run_and_get_code(cfn, *dev_tensors)
+        assert len(source_codes) > 0
+        src = source_codes[0]
+        assert "LoopSpec(" in src, f"Expected LoopSpec( in generated source:\n{src}"
+
+    if correctness:
+        dev_tensors = _setup_dims_and_dev_tensors()
+        spyre_result = _compile_and_run(fn, dev_tensors, "spyre")
+        kwargs = {}
+        if atol is not None:
+            kwargs["atol"] = atol
+        if rtol is not None:
+            kwargs["rtol"] = rtol
+        compare_with_cpu(
+            fn, *cpu_tensors, target=spyre_result, run_eager=False, **kwargs
+        )
+
+
+# ---------------------------------------------------------------------------
+# Group 1: Test basic tiling with various sizes
+# ---------------------------------------------------------------------------
+
+
+def test_abs_256x256_A4():
+    """abs [256,256] tiled A÷4 → 64 elems/tile (1 stick)."""
+    inputs = [tensor("x", shape=(256, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return torch.abs(x)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_abs_256x256_B4():
+    """abs [256,256] tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [tensor("x", shape=(256, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return torch.abs(x)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_abs_256x256_A4_B4():
+    """abs [256,256] tiled A÷4 B÷4 → 64 elems/tile each (1 stick)."""
+    inputs = [tensor("x", shape=(256, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return torch.abs(x)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- add: scenario 1 — square 256×256, 1-stick tiles (64 elems/tile) ---
+
+
+def test_add_256x256_A4():
+    """add [256,256] tiled A÷4 → 64 elems/tile (1 stick)."""
+    inputs = [
+        tensor("x", shape=(256, 256), dims=["A", "B"]),
+        tensor("y", shape=(256, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_256x256_B4():
+    """add [256,256] tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [
+        tensor("x", shape=(256, 256), dims=["A", "B"]),
+        tensor("y", shape=(256, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_256x256_A4_B4():
+    """add [256,256] tiled A÷4 B÷4 → 64 elems/tile each (1 stick)."""
+    inputs = [
+        tensor("x", shape=(256, 256), dims=["A", "B"]),
+        tensor("y", shape=(256, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- add: scenario 2 — non-square 512×256, A>B, 2-stick A tiles ---
+
+
+def test_add_512x256_A4():
+    """add [512,256] tiled A÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_512x256_B4():
+    """add [512,256] tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_512x256_A4_B4():
+    """add [512,256] tiled A÷4 B÷4 → 128 and 64 elems/tile."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- add: scenario 3 — non-square 256×512, B>A, 2-stick B tiles ---
+
+
+def test_add_256x512_A4():
+    """add [256,512] tiled A÷4 → 64 elems/tile (1 stick)."""
+    inputs = [
+        tensor("x", shape=(256, 512), dims=["A", "B"]),
+        tensor("y", shape=(256, 512), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_256x512_B4():
+    """add [256,512] tiled B÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [
+        tensor("x", shape=(256, 512), dims=["A", "B"]),
+        tensor("y", shape=(256, 512), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_256x512_A4_B4():
+    """add [256,512] tiled A÷4 B÷4 → 64 and 128 elems/tile."""
+    inputs = [
+        tensor("x", shape=(256, 512), dims=["A", "B"]),
+        tensor("y", shape=(256, 512), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- add: scenario 4 — square 512×512, 2-stick tiles ---
+
+
+def test_add_512x512_A4():
+    """add [512,512] tiled A÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [
+        tensor("x", shape=(512, 512), dims=["A", "B"]),
+        tensor("y", shape=(512, 512), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_512x512_B4():
+    """add [512,512] tiled B÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [
+        tensor("x", shape=(512, 512), dims=["A", "B"]),
+        tensor("y", shape=(512, 512), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_512x512_A4_B4():
+    """add [512,512] tiled A÷4 B÷4 → 128 elems/tile each (2 sticks)."""
+    inputs = [
+        tensor("x", shape=(512, 512), dims=["A", "B"]),
+        tensor("y", shape=(512, 512), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- add: scenario 5 — asymmetric tile counts, same tile size ---
+
+
+def test_add_512x256_A4_B2():
+    """add [512,256] tiled A÷4 B÷2 → 128 elems/tile each, different counts."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 2}):
+                return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# ---------------------------------------------------------------------------
+# Group 2: 3D tensors — [A=512, B=256, C=256]
+# A÷4=128/tile (2 sticks), B÷2=128/tile (2 sticks, count=2), C÷4=64/tile (1 stick)
+# ---------------------------------------------------------------------------
+
+
+def test_add_3d_512x256x256_A4():
+    """add [512,256,256] tiled A÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [
+        tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("y", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_3d_512x256x256_B2():
+    """add [512,256,256] tiled B÷2 → 128 elems/tile (2 sticks, count=2)."""
+    inputs = [
+        tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("y", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"B": 2}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_3d_512x256x256_C4():
+    """add [512,256,256] tiled C÷4 → 64 elems/tile (1 stick)."""
+    inputs = [
+        tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("y", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"C": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_3d_512x256x256_A4_B2():
+    """add [512,256,256] tiled A÷4 B÷2 → 128+128 elems/tile."""
+    inputs = [
+        tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("y", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 2}):
+                return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_3d_512x256x256_A4_C4():
+    """add [512,256,256] tiled A÷4 C÷4 → 128+64 elems/tile."""
+    inputs = [
+        tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("y", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"C": 4}):
+                return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_3d_512x256x256_B2_C4():
+    """add [512,256,256] tiled B÷2 C÷4 → 128+64 elems/tile."""
+    inputs = [
+        tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("y", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"B": 2}):
+            with spyre_hint(num_tiles_per_dim={"C": 4}):
+                return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_3d_512x256x256_A4_B2_C4():
+    """add [512,256,256] tiled A÷4 B÷2 C÷4 → 128+128+64 elems/tile."""
+    inputs = [
+        tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("y", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 2}):
+                with spyre_hint(num_tiles_per_dim={"C": 4}):
+                    return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# ---------------------------------------------------------------------------
+# Group 3: pointwise op chains — [512x256], 3 tiling variants each
+# A÷4=128/tile (2 sticks), B÷4=64/tile (1 stick)
+# ---------------------------------------------------------------------------
+
+
+def test_abs_add_mul_512x256_A4():
+    """abs(a+b)*c on [512,256] tiled A÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+        tensor("c", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b, c):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return torch.abs(a + b) * c
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_abs_add_mul_512x256_B4():
+    """abs(a+b)*c on [512,256] tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+        tensor("c", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b, c):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return torch.abs(a + b) * c
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_abs_add_mul_512x256_A4_B4():
+    """abs(a+b)*c on [512,256] tiled A÷4 B÷4 → 128+64 elems/tile."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+        tensor("c", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b, c):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return torch.abs(a + b) * c
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_exp_abs_add_mul_512x256_A4():
+    """exp(abs((a+b)*c)) on [512,256] tiled A÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+        tensor("c", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b, c):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return torch.exp(torch.abs((a + b) * c))
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_exp_abs_add_mul_512x256_B4():
+    """exp(abs((a+b)*c)) on [512,256] tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+        tensor("c", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b, c):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return torch.exp(torch.abs((a + b) * c))
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_exp_abs_add_mul_512x256_A4_B4():
+    """exp(abs((a+b)*c)) on [512,256] tiled A÷4 B÷4 → 128+64 elems/tile."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+        tensor("c", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b, c):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return torch.exp(torch.abs((a + b) * c))
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# ---------------------------------------------------------------------------
+# Group 4: reductions (amin) — 2D all tiling combos, 3D all-dims tiling
+# 2D [512x256]: A÷4=128/tile, B÷4=64/tile
+# 3D [512x256x256]: A÷4=128/tile, B÷2=128/tile, C÷4=64/tile
+# ---------------------------------------------------------------------------
+
+
+def test_min_2d_512x256_reduce_dim0_A4():
+    """amin over dim=0 on [512,256] tiled A÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return x.amin(dim=0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_min_2d_512x256_reduce_dim0_B4():
+    """amin over dim=0 on [512,256] tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return x.amin(dim=0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_min_2d_512x256_reduce_dim0_A4_B4():
+    """amin over dim=0 on [512,256] tiled A÷4 B÷4 → 128+64 elems/tile."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return x.amin(dim=0)
+
+    run_coarse_tile_test(
+        fn, inputs, correctness=False
+    )  # nested tiling + reduction correctness bug
+
+
+def test_min_2d_512x256_reduce_dim1_A4():
+    """amin over dim=1 on [512,256] tiled A÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return x.amin(dim=1)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_min_2d_512x256_reduce_dim1_B4():
+    """amin over dim=1 on [512,256] tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return x.amin(dim=1)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_min_2d_512x256_reduce_dim1_A4_B4():
+    """amin over dim=1 on [512,256] tiled A÷4 B÷4 → 128+64 elems/tile."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return x.amin(dim=1)
+
+    run_coarse_tile_test(
+        fn, inputs, correctness=False
+    )  # nested tiling + reduction correctness bug
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_min_3d_512x256x256_reduce_dim0_A4_B2_C4():
+    """amin over dim=0 on [512,256,256] tiled A÷4 B÷2 C÷4."""
+    inputs = [tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 2}):
+                with spyre_hint(num_tiles_per_dim={"C": 4}):
+                    return x.amin(dim=0)
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # scheduler crash: inconsistent loop_count across reduction fill/combine nodes
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_min_3d_512x256x256_reduce_dim1_A4_B2_C4():
+    """amin over dim=1 on [512,256,256] tiled A÷4 B÷2 C÷4."""
+    inputs = [tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 2}):
+                with spyre_hint(num_tiles_per_dim={"C": 4}):
+                    return x.amin(dim=1)
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # scheduler crash: inconsistent loop_count across reduction fill/combine nodes
+
+
+def test_min_3d_512x256x256_reduce_dim2_A4_B2_C4():
+    """amin over dim=2 on [512,256,256] tiled A÷4 B÷2 C÷4."""
+    inputs = [tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 2}):
+                with spyre_hint(num_tiles_per_dim={"C": 4}):
+                    return x.amin(dim=2)
+
+    run_coarse_tile_test(
+        fn, inputs, correctness=False
+    )  # nested tiling + reduction correctness bug
+
+
+# ---------------------------------------------------------------------------
+# Group 5: mixed pointwise + reduction — add_min, reduce_both, softmax
+# add_min: min(a + abs(amin(b))) — 2D all 3 tiling variants × 2 reduction dims,
+#   3D all-dims tiling × 3 reduction dims
+# reduce_both: amin(a,dim) + amin(b,dim) — dense+dense and sparse+sparse, 3 tiling variants
+# softmax: decomposes into amax+pointwise+sum+pointwise — dim0 and dim1, 3 tiling variants each
+# ---------------------------------------------------------------------------
+
+
+def test_add_min_2d_512x256_reduce_dim0_A4():
+    """min(a + abs(amin(b, dim=0))) on [512,256] tiled A÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return a + torch.abs(b.amin(dim=0))
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_min_2d_512x256_reduce_dim0_B4():
+    """min(a + abs(amin(b, dim=0))) on [512,256] tiled B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return a + torch.abs(b.amin(dim=0))
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_min_2d_512x256_reduce_dim0_A4_B4():
+    """min(a + abs(amin(b, dim=0))) on [512,256] tiled A÷4 B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return a + torch.abs(b.amin(dim=0))
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_min_2d_512x256_reduce_dim1_A4():
+    """min(a + abs(amin(b, dim=1))) on [512,256] tiled A÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return a + torch.abs(b.amin(dim=1, keepdim=True))
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_min_2d_512x256_reduce_dim1_B4():
+    """min(a + abs(amin(b, dim=1))) on [512,256] tiled B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return a + torch.abs(b.amin(dim=1, keepdim=True))
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_min_2d_512x256_reduce_dim1_A4_B4():
+    """min(a + abs(amin(b, dim=1))) on [512,256] tiled A÷4 B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return a + torch.abs(b.amin(dim=1, keepdim=True))
+
+    run_coarse_tile_test(fn, inputs)
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_add_min_3d_512x256x256_reduce_dim0_A4_B2_C4():
+    """min(a + abs(amin(b, dim=0))) on [512,256,256] tiled A÷4 B÷2 C÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("b", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 2}):
+                with spyre_hint(num_tiles_per_dim={"C": 4}):
+                    return a + torch.abs(b.amin(dim=0))
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # scheduler crash: mixed loop counts in 3D nested tiling + reduction
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_add_min_3d_512x256x256_reduce_dim1_A4_B2_C4():
+    """min(a + abs(amin(b, dim=1))) on [512,256,256] tiled A÷4 B÷2 C÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("b", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 2}):
+                with spyre_hint(num_tiles_per_dim={"C": 4}):
+                    return a + torch.abs(b.amin(dim=1))
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # scheduler crash: mixed loop counts in 3D nested tiling + reduction
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_add_min_3d_512x256x256_reduce_dim2_A4_B2_C4():
+    """min(a + abs(amin(b, dim=2))) on [512,256,256] tiled A÷4 B÷2 C÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("b", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 2}):
+                with spyre_hint(num_tiles_per_dim={"C": 4}):
+                    return a + torch.abs(b.amin(dim=2))
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # scheduler crash: mixed loop counts in 3D nested tiling + reduction
+
+
+# dense+dense: both inputs reduce over dim=0 → [B] dense outputs, then add
+# sparse+sparse: both inputs reduce over dim=1 (stick) → [A] sparse outputs, then add
+
+
+def test_reduce_both_dense_add_2d_512x256_A4():
+    """amin(a,dim=0) + amin(b,dim=0) on [512,256] tiled A÷4 — dense+dense."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return a.amin(dim=0) + b.amin(dim=0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_reduce_both_dense_add_2d_512x256_B4():
+    """amin(a,dim=0) + amin(b,dim=0) on [512,256] tiled B÷4 — dense+dense."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return a.amin(dim=0) + b.amin(dim=0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_reduce_both_dense_add_2d_512x256_A4_B4():
+    """amin(a,dim=0) + amin(b,dim=0) on [512,256] tiled A÷4 B÷4 — dense+dense."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return a.amin(dim=0) + b.amin(dim=0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_reduce_both_sparse_add_2d_512x256_A4():
+    """amin(a,dim=1) + amin(b,dim=1) on [512,256] tiled A÷4 — sparse+sparse."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return a.amin(dim=1) + b.amin(dim=1)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_reduce_both_sparse_add_2d_512x256_B4():
+    """amin(a,dim=1) + amin(b,dim=1) on [512,256] tiled B÷4 — sparse+sparse."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return a.amin(dim=1) + b.amin(dim=1)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_reduce_both_sparse_add_2d_512x256_A4_B4():
+    """amin(a,dim=1) + amin(b,dim=1) on [512,256] tiled A÷4 B÷4 — sparse+sparse."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return a.amin(dim=1) + b.amin(dim=1)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# softmax decomposes into amax + pointwise + sum + pointwise — exercises
+# mixed reduction+pointwise tiling in a single op
+
+
+def test_softmax_2d_512x256_dim1_A4():
+    """softmax(x, dim=1) on [512,256] tiled A÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return torch.softmax(x, dim=1)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_softmax_2d_512x256_dim1_B4():
+    """softmax(x, dim=1) on [512,256] tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return torch.softmax(x, dim=1)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_softmax_2d_512x256_dim1_A4_B4():
+    """softmax(x, dim=1) on [512,256] tiled A÷4 B÷4."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return torch.softmax(x, dim=1)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_softmax_2d_512x256_dim0_A4():
+    """softmax(x, dim=0) on [512,256] tiled A÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return torch.softmax(x, dim=0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_softmax_2d_512x256_dim0_B4():
+    """softmax(x, dim=0) on [512,256] tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return torch.softmax(x, dim=0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_softmax_2d_512x256_dim0_A4_B4():
+    """softmax(x, dim=0) on [512,256] tiled A÷4 B÷4."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return torch.softmax(x, dim=0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# ---------------------------------------------------------------------------
+# Group 6: restickify + coarse tiling
+# a=[256,128], x=[128,256]: a.t() gives [128,256] same shape as x but
+# stick-incompatible — restickify is inserted before the add.
+# Named dims on the result shape [128, 256]: A=128, B=256.
+# A÷2=64/tile (1 stick), B÷4=64/tile (1 stick)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_add_256x128_A2():
+    """a.t() + x on [128,256] result, tiled A÷2 → 64 elems/tile (1 stick)."""
+    inputs = [
+        tensor("a", shape=(256, 128), dims=["B", "A"]),
+        tensor("x", shape=(128, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"A": 2}):
+            return a.t() + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_add_256x128_B4():
+    """a.t() + x on [128,256] result, tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [
+        tensor("a", shape=(256, 128), dims=["B", "A"]),
+        tensor("x", shape=(128, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return a.t() + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_add_256x128_A2_B4():
+    """a.t() + x on [128,256] result, tiled A÷2 B÷4 → 64 elems/tile each."""
+    inputs = [
+        tensor("a", shape=(256, 128), dims=["B", "A"]),
+        tensor("x", shape=(128, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"A": 2}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return a.t() + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+# 2D two-transpose: a.t() + b.t() + x
+# a=[256,128], b=[256,128], x=[128,256]; result [128,256]: A=128, B=256
+# A÷2=64/tile (1 stick), B÷4=64/tile (1 stick)
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_2t_add_256x128_A2():
+    """a.t()+b.t()+x on [128,256] result, tiled A÷2."""
+    inputs = [
+        tensor("a", shape=(256, 128), dims=["B", "A"]),
+        tensor("b", shape=(256, 128), dims=["B", "A"]),
+        tensor("x", shape=(128, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b, x):
+        with spyre_hint(num_tiles_per_dim={"A": 2}):
+            return a.t() + b.t() + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # d0+d1 stick expr bug: two restickified inputs produce unsupported stick expression
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_2t_add_256x128_B4():
+    """a.t()+b.t()+x on [128,256] result, tiled B÷4."""
+    inputs = [
+        tensor("a", shape=(256, 128), dims=["B", "A"]),
+        tensor("b", shape=(256, 128), dims=["B", "A"]),
+        tensor("x", shape=(128, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b, x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return a.t() + b.t() + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # d0+d1 stick expr bug
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_2t_add_256x128_A2_B4():
+    """a.t()+b.t()+x on [128,256] result, tiled A÷2 B÷4."""
+    inputs = [
+        tensor("a", shape=(256, 128), dims=["B", "A"]),
+        tensor("b", shape=(256, 128), dims=["B", "A"]),
+        tensor("x", shape=(128, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b, x):
+        with spyre_hint(num_tiles_per_dim={"A": 2}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return a.t() + b.t() + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # d0+d1 stick expr bug
+
+
+# 3D transpose: a.transpose(1,2) + x
+# a=[256,512,256], x=[256,256,512]; result [256,256,512]: A=256, B=256, C=512
+# A÷4=64/tile, B÷4=64/tile, C÷4=128/tile (2 sticks)
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_3d_transpose12_256x512x256_A4():
+    """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4."""
+    inputs = [
+        tensor("a", shape=(256, 512, 256), dims=["A", "C", "B"]),
+        tensor("x", shape=(256, 256, 512), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return a.transpose(1, 2) + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_3d_transpose12_256x512x256_B4():
+    """a.transpose(1,2)+x on [256,256,512] result, tiled B÷4."""
+    inputs = [
+        tensor("a", shape=(256, 512, 256), dims=["A", "C", "B"]),
+        tensor("x", shape=(256, 256, 512), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return a.transpose(1, 2) + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_3d_transpose12_256x512x256_C4():
+    """a.transpose(1,2)+x on [256,256,512] result, tiled C÷4."""
+    inputs = [
+        tensor("a", shape=(256, 512, 256), dims=["A", "C", "B"]),
+        tensor("x", shape=(256, 256, 512), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"C": 4}):
+            return a.transpose(1, 2) + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_3d_transpose12_256x512x256_A4_B4():
+    """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4 B÷4."""
+    inputs = [
+        tensor("a", shape=(256, 512, 256), dims=["A", "C", "B"]),
+        tensor("x", shape=(256, 256, 512), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return a.transpose(1, 2) + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_3d_transpose12_256x512x256_A4_C4():
+    """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4 C÷4."""
+    inputs = [
+        tensor("a", shape=(256, 512, 256), dims=["A", "C", "B"]),
+        tensor("x", shape=(256, 256, 512), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"C": 4}):
+                return a.transpose(1, 2) + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_3d_transpose12_256x512x256_B4_C4():
+    """a.transpose(1,2)+x on [256,256,512] result, tiled B÷4 C÷4."""
+    inputs = [
+        tensor("a", shape=(256, 512, 256), dims=["A", "C", "B"]),
+        tensor("x", shape=(256, 256, 512), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            with spyre_hint(num_tiles_per_dim={"C": 4}):
+                return a.transpose(1, 2) + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_3d_transpose12_256x512x256_A4_B4_C4():
+    """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4 B÷4 C÷4."""
+    inputs = [
+        tensor("a", shape=(256, 512, 256), dims=["A", "C", "B"]),
+        tensor("x", shape=(256, 256, 512), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                with spyre_hint(num_tiles_per_dim={"C": 4}):
+                    return a.transpose(1, 2) + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+# Matmul + transpose: x.t()@y and x@y.t()
+# x=[128,256], y=[128,256]; x.t()@y=[256,128]@[128,256]=[256,256]
+# x@y.t()=[128,256]@[256,128]=[128,128]
+# For x.t()@y result [256,256]: M=256, N=256; M÷4=64, N÷4=64
+# For x@y.t() result [128,128]: M=128, N=128; M÷2=64, N÷2=64
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_matmul_xt_y_256x128_M4():
+    """x.t()@y, result [256,256], tiled M÷4."""
+    inputs = [
+        tensor("x", shape=(128, 256), dims=["K", "M"]),
+        tensor("y", shape=(128, 256), dims=["K", "N"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"M": 4}):
+            return torch.matmul(x.t(), y)
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_matmul_xt_y_256x128_N4():
+    """x.t()@y, result [256,256], tiled N÷4."""
+    inputs = [
+        tensor("x", shape=(128, 256), dims=["K", "M"]),
+        tensor("y", shape=(128, 256), dims=["K", "N"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"N": 4}):
+            return torch.matmul(x.t(), y)
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_matmul_xt_y_256x128_M4_N4():
+    """x.t()@y, result [256,256], tiled M÷4 N÷4."""
+    inputs = [
+        tensor("x", shape=(128, 256), dims=["K", "M"]),
+        tensor("y", shape=(128, 256), dims=["K", "N"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"M": 4}):
+            with spyre_hint(num_tiles_per_dim={"N": 4}):
+                return torch.matmul(x.t(), y)
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_matmul_x_yt_128x256_M2():
+    """x@y.t(), result [128,128], tiled M÷2."""
+    inputs = [
+        tensor("x", shape=(128, 256), dims=["M", "K"]),
+        tensor("y", shape=(128, 256), dims=["N", "K"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"M": 2}):
+            return torch.matmul(x, y.t())
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_matmul_x_yt_128x256_N2():
+    """x@y.t(), result [128,128], tiled N÷2."""
+    inputs = [
+        tensor("x", shape=(128, 256), dims=["M", "K"]),
+        tensor("y", shape=(128, 256), dims=["N", "K"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"N": 2}):
+            return torch.matmul(x, y.t())
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_matmul_x_yt_128x256_M2_N2():
+    """x@y.t(), result [128,128], tiled M÷2 N÷2."""
+    inputs = [
+        tensor("x", shape=(128, 256), dims=["M", "K"]),
+        tensor("y", shape=(128, 256), dims=["N", "K"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"M": 2}):
+            with spyre_hint(num_tiles_per_dim={"N": 2}):
+                return torch.matmul(x, y.t())
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+# ---------------------------------------------------------------------------
+# Group 7: copies
+# Patterns: copy into pre-allocated buffer, in-place accumulation,
+# read-modify-write with correction factor, copy after reduction.
+# All on [512x256]: A÷4=128/tile (2 sticks), B÷4=64/tile (1 stick)
+# ---------------------------------------------------------------------------
+
+# --- copy into pre-allocated buffer: c.copy_(a + b) ---
+
+
+def test_copy_into_preallocated_512x256_A4():
+    """c.copy_(a+b) on [512,256] tiled A÷4 — result written into zeros buffer."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        c = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            c.copy_(a + b)
+        return c
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_into_preallocated_512x256_B4():
+    """c.copy_(a+b) on [512,256] tiled B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        c = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            c.copy_(a + b)
+        return c
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_into_preallocated_512x256_A4_B4():
+    """c.copy_(a+b) on [512,256] tiled A÷4 B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        c = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                c.copy_(a + b)
+        return c
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- in-place accumulation: acc.copy_(acc + x) ---
+
+
+def test_copy_inplace_accum_512x256_A4():
+    """acc.copy_(acc + x) on [512,256] tiled A÷4 — acc read and written inside loop."""
+    inputs = [
+        tensor("acc", shape=(512, 256), dims=["A", "B"]),
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(acc, x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            acc.copy_(acc + x)
+        return acc
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_inplace_accum_512x256_B4():
+    """acc.copy_(acc + x) on [512,256] tiled B÷4."""
+    inputs = [
+        tensor("acc", shape=(512, 256), dims=["A", "B"]),
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(acc, x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            acc.copy_(acc + x)
+        return acc
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_inplace_accum_512x256_A4_B4():
+    """acc.copy_(acc + x) on [512,256] tiled A÷4 B÷4."""
+    inputs = [
+        tensor("acc", shape=(512, 256), dims=["A", "B"]),
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(acc, x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                acc.copy_(acc + x)
+        return acc
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- read-modify-write with correction: acc.copy_(acc * scale + y) ---
+# flash attention accumulator pattern
+
+
+def test_copy_rmw_correction_512x256_A4():
+    """acc.copy_(acc * scale + y) on [512,256] tiled A÷4."""
+    inputs = [
+        tensor("acc", shape=(512, 256), dims=["A", "B"]),
+        tensor("scale", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(acc, scale, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            acc.copy_(acc * scale + y)
+        return acc
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_rmw_correction_512x256_B4():
+    """acc.copy_(acc * scale + y) on [512,256] tiled B÷4."""
+    inputs = [
+        tensor("acc", shape=(512, 256), dims=["A", "B"]),
+        tensor("scale", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(acc, scale, y):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            acc.copy_(acc * scale + y)
+        return acc
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_rmw_correction_512x256_A4_B4():
+    """acc.copy_(acc * scale + y) on [512,256] tiled A÷4 B÷4."""
+    inputs = [
+        tensor("acc", shape=(512, 256), dims=["A", "B"]),
+        tensor("scale", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(acc, scale, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                acc.copy_(acc * scale + y)
+        return acc
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- copy after reduction: out.copy_(x.amin(dim=0)) ---
+# copies sparse reduction result into a dense buffer
+
+
+def test_copy_after_reduction_512x256_A4():
+    """out.copy_(x.amin(dim=0)) on [512,256] tiled A÷4."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        out = torch.zeros(256, device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            out.copy_(x.amin(dim=0))
+        return out
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_after_reduction_512x256_B4():
+    """out.copy_(x.amin(dim=0)) on [512,256] tiled B÷4."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        out = torch.zeros(256, device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            out.copy_(x.amin(dim=0))
+        return out
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_after_reduction_512x256_A4_B4():
+    """out.copy_(x.amin(dim=0)) on [512,256] tiled A÷4 B÷4."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        out = torch.zeros(256, device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                out.copy_(x.amin(dim=0))
+        return out
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- copy + restickify: c.copy_(a.t() + b) ---
+# copy target receives a restickified input — tests copy layout after restickify
+
+
+@pytest.mark.skip(
+    reason="KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
+def test_copy_restickify_512x256_A4():
+    """c.copy_(a.t()+b) on [256,512] result tiled A÷4 — copy of restickified add."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["B", "A"]),
+        tensor("b", shape=(256, 512), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        c = torch.zeros(b.shape, device=b.device, dtype=b.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            c.copy_(a.t() + b)
+        return c
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(
+    reason="KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
+def test_copy_restickify_512x256_B4():
+    """c.copy_(a.t()+b) on [256,512] result tiled B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["B", "A"]),
+        tensor("b", shape=(256, 512), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        c = torch.zeros(b.shape, device=b.device, dtype=b.dtype)
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            c.copy_(a.t() + b)
+        return c
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381
+
+
+@pytest.mark.skip(
+    reason="KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
+def test_copy_restickify_512x256_A4_B4():
+    """c.copy_(a.t()+b) on [256,512] result tiled A÷4 B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["B", "A"]),
+        tensor("b", shape=(256, 512), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        c = torch.zeros(b.shape, device=b.device, dtype=b.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                c.copy_(a.t() + b)
+        return c
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381
+
+
+# --- nested copy + reduction: acc.copy_(acc * scale + x.amin(dim=1, keepdim=True)) ---
+# flash attention accumulator pattern: correction * running value + new contribution
+
+
+def test_copy_accum_with_reduction_512x256_A4():
+    """acc.copy_(acc * scale + x.amin(dim=1,keepdim=True)) tiled A÷4."""
+    inputs = [
+        tensor("acc", shape=(512, 256), dims=["A", "B"]),
+        tensor("scale", shape=(512, 1), dims=["A", "B"]),
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(acc, scale, x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            acc.copy_(acc * scale + x.amin(dim=1, keepdim=True))
+        return acc
+
+    run_coarse_tile_test(fn, inputs)
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_copy_accum_with_reduction_512x256_B4():
+    """acc.copy_(acc * scale + x.amin(dim=1,keepdim=True)) tiled B÷4."""
+    inputs = [
+        tensor("acc", shape=(512, 256), dims=["A", "B"]),
+        tensor("scale", shape=(512, 1), dims=["A", "B"]),
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(acc, scale, x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            acc.copy_(acc * scale + x.amin(dim=1, keepdim=True))
+        return acc
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 _insert_read_copy_ops IndexError when tiling B with unit-size B dim in scale
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_copy_accum_with_reduction_512x256_A4_B4():
+    """acc.copy_(acc * scale + x.amin(dim=1,keepdim=True)) tiled A÷4 B÷4."""
+    inputs = [
+        tensor("acc", shape=(512, 256), dims=["A", "B"]),
+        tensor("scale", shape=(512, 1), dims=["A", "B"]),
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(acc, scale, x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                acc.copy_(acc * scale + x.amin(dim=1, keepdim=True))
+        return acc
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 _insert_read_copy_ops IndexError when tiling B with unit-size B dim in scale
+
+
+# --- two copies in same hint scope: c1.copy_(a+b); c2.copy_(a*b) ---
+
+
+def test_copy_two_copies_same_scope_512x256_A4():
+    """Two copy_ ops in same hint scope tiled A÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        c1 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
+        c2 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            c1.copy_(a + b)
+            c2.copy_(a * b)
+        return c1, c2
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_two_copies_same_scope_512x256_B4():
+    """Two copy_ ops in same hint scope tiled B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        c1 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
+        c2 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            c1.copy_(a + b)
+            c2.copy_(a * b)
+        return c1, c2
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_two_copies_same_scope_512x256_A4_B4():
+    """Two copy_ ops in same hint scope tiled A÷4 B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        c1 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
+        c2 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                c1.copy_(a + b)
+                c2.copy_(a * b)
+        return c1, c2
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# ---------------------------------------------------------------------------
+# Group 8: tiled ops with outside consumers
+# Pattern: buffer initialized outside loop, written tile-by-tile inside,
+# then read again outside before returning.
+# All on [512x256]: A÷4=128/tile, B÷4=64/tile
+# ---------------------------------------------------------------------------
+
+# --- minimal: z = tiled(x+y); return z * 2.0 ---
+# The tiled op's output is a full-sized buffer consumed outside the loop.
+# Forces _allocate_full_buffer + correct stickification.
+
+
+def test_outside_consumer_pointwise_512x256_A4():
+    """z=tiled(x+y) consumed outside as z*2.0, tiled A÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            z = x + y
+        return z * 2.0
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_outside_consumer_pointwise_512x256_B4():
+    """z=tiled(x+y) consumed outside as z*2.0, tiled B÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            z = x + y
+        return z * 2.0
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_outside_consumer_pointwise_512x256_A4_B4():
+    """z=tiled(x+y) consumed outside as z*2.0, tiled A÷4 B÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                z = x + y
+        return z * 2.0
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- pattern: output=zeros outside; copy_ inside; read outside ---
+# output initialized outside, written tile-by-tile via copy_, divided outside.
+
+
+def test_outside_consumer_copy_then_read_512x256_A4():
+    """out=zeros; tiled out.copy_(x+y); return out/norm — tiled A÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+        tensor("norm", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y, norm):
+        out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            out.copy_(x + y)
+        return out / (torch.abs(norm) + 1.0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_outside_consumer_copy_then_read_512x256_B4():
+    """out=zeros; tiled out.copy_(x+y); return out/norm — tiled B÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+        tensor("norm", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y, norm):
+        out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            out.copy_(x + y)
+        return out / (torch.abs(norm) + 1.0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_outside_consumer_copy_then_read_512x256_A4_B4():
+    """out=zeros; tiled out.copy_(x+y); return out/norm — tiled A÷4 B÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+        tensor("norm", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y, norm):
+        out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                out.copy_(x + y)
+        return out / (torch.abs(norm) + 1.0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- two-accumulator flash pattern ---
+# Both output and denom initialized outside, updated inside, divided outside.
+# This is the minimal flash attention accumulator pattern.
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_outside_consumer_two_accum_512x256_A4():
+    """Flash-style: out=zeros, denom=zeros; tiled copy_; return out/denom — A÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("scale", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, scale):
+        out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
+        denom = torch.zeros(x.shape[0], device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            out.copy_(out * scale + x)
+            denom.copy_(denom + x.sum(dim=1))
+        return out / denom.unsqueeze(1)
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: infeasible restickify for 1D denom in mixed 1D/2D tiled scope
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_outside_consumer_two_accum_512x256_B4():
+    """Flash-style: out=zeros, denom=zeros; tiled copy_; return out/denom — B÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("scale", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, scale):
+        out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
+        denom = torch.zeros(x.shape[0], device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            out.copy_(out * scale + x)
+            denom.copy_(denom + x.sum(dim=1))
+        return out / denom.unsqueeze(1)
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: infeasible restickify for 1D denom in mixed 1D/2D tiled scope
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_outside_consumer_two_accum_512x256_A4_B4():
+    """Flash-style: out=zeros, denom=zeros; tiled copy_; return out/denom — A÷4 B÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("scale", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, scale):
+        out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
+        denom = torch.zeros(x.shape[0], device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                out.copy_(out * scale + x)
+                denom.copy_(denom + x.sum(dim=1))
+        return out / denom.unsqueeze(1)
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: infeasible restickify for 1D denom in mixed 1D/2D tiled scope
+
+
+# --- reduction inside loop, result consumed outside ---
+# s = tiled_amin(x, dim=0) → [256] dense; return s + bias
+# Tests _allocate_full_buffer for sparse reduction output with outside consumer.
+
+
+def test_outside_consumer_reduction_512x256_A4():
+    """s=tiled_amin(x,dim=0) consumed outside as s+bias, tiled A÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("bias", shape=(256,), dims=["B"]),
+    ]
+
+    def fn(x, bias):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            s = x.amin(dim=0)
+        return s + bias
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_outside_consumer_reduction_512x256_B4():
+    """s=tiled_amin(x,dim=0) consumed outside as s+bias, tiled B÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("bias", shape=(256,), dims=["B"]),
+    ]
+
+    def fn(x, bias):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            s = x.amin(dim=0)
+        return s + bias
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_outside_consumer_reduction_512x256_A4_B4():
+    """s=tiled_amin(x,dim=0) consumed outside as s+bias, tiled A÷4 B÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("bias", shape=(256,), dims=["B"]),
+    ]
+
+    def fn(x, bias):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                s = x.amin(dim=0)
+        return s + bias
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# ---------------------------------------------------------------------------
+# Group 9: views — reshape, 1D sub-dim, view+transpose, unsqueeze
+# Op inside fn is multiply (more numerically stable than add on fp16).
+# ---------------------------------------------------------------------------
+
+# --- 1D sub-dim naming: flat [Lq*D] tensor named with 2 sub-dims ---
+# Both outer (Lq÷2) and inner (D÷2) hints land on the single host dim.
+
+
+def test_view_1d_subdim_Lq2_D2():
+    """a*b on 1D [Lq*D] named ["Lq","D"], nested Lq÷2 / D÷2 on same host dim."""
+    Lq, D = 256, 128
+    inputs = [
+        tensor("a", shape=(Lq * D,), dims=["Lq", "D"]),
+        tensor("b", shape=(Lq * D,), dims=["Lq", "D"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"Lq": 2}):
+            with spyre_hint(num_tiles_per_dim={"D": 2}):
+                return a * b
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- named input directly viewed+transposed inside fn ---
+# Modeled after granite_flash_attention style views: flat [B,S,H*D] inputs viewed to 4D
+# then transposed. Named dims span the fused H*D dim.
+# B=2, S=256, H=4, D=64 → flat shape [2,256,256]; post-view+transpose [2,4,256,64]
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_view_named_input_view_transpose_H2():
+    """flat [B,S,H*D] view+transpose before hint scope, tiled H÷2."""
+    B, S, H, D = 2, 256, 8, 128
+    _nd = {"batch_size": B, "max_seqlen": S, "num_heads": H, "head_dim": D}
+    inputs = [
+        tensor(
+            "q",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen", "num_heads", "head_dim"],
+            named_dims=_nd,
+        ),
+        tensor(
+            "k",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen", "num_heads", "head_dim"],
+            named_dims=_nd,
+        ),
+    ]
+
+    def fn(q, k):
+        q = q.view(B, S, H, D).transpose(1, 2)
+        k = k.view(B, S, H, D).transpose(1, 2)
+        with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
+            return q * k
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: propagate_named_dims can't handle multi-var coord for fused dim after view+transpose
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_view_named_input_view_transpose_S4():
+    """flat [B,S,H*D] view+transpose before hint scope, tiled S÷4."""
+    B, S, H, D = 2, 256, 8, 128
+    _nd = {"batch_size": B, "max_seqlen": S, "num_heads": H, "head_dim": D}
+    inputs = [
+        tensor(
+            "q",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen", "num_heads", "head_dim"],
+            named_dims=_nd,
+        ),
+        tensor(
+            "k",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen", "num_heads", "head_dim"],
+            named_dims=_nd,
+        ),
+    ]
+
+    def fn(q, k):
+        q = q.view(B, S, H, D).transpose(1, 2)
+        k = k.view(B, S, H, D).transpose(1, 2)
+        with spyre_hint(num_tiles_per_dim={"max_seqlen": 4}):
+            return q * k
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: propagate_named_dims can't handle multi-var coord for fused dim after view+transpose
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_view_named_input_view_transpose_H2_S4():
+    """flat [B,S,H*D] view+transpose before hint scope, tiled H÷2 S÷4."""
+    B, S, H, D = 2, 256, 8, 128
+    _nd = {"batch_size": B, "max_seqlen": S, "num_heads": H, "head_dim": D}
+    inputs = [
+        tensor(
+            "q",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen", "num_heads", "head_dim"],
+            named_dims=_nd,
+        ),
+        tensor(
+            "k",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen", "num_heads", "head_dim"],
+            named_dims=_nd,
+        ),
+    ]
+
+    def fn(q, k):
+        q = q.view(B, S, H, D).transpose(1, 2)
+        k = k.view(B, S, H, D).transpose(1, 2)
+        with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
+            with spyre_hint(num_tiles_per_dim={"max_seqlen": 4}):
+                return q * k
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: Inductor fuses view+transpose into tiled op index expr, causing "reshape split a named dim" in propagate_named_dims
+
+
+# --- 4D input transposed then multiplied ---
+# Inputs already in 4D shape [B,H,S,D], transpose swaps non-stick dims.
+# B=2, S=256, H=4, D=64
+
+
+def test_view_4d_transpose_H2():
+    """x.view(B,S,H,D).transpose(1,2)*y tiled H÷2."""
+    B, S, H, D = 2, 256, 4, 64
+    _nd = {"batch_size": B, "max_seqlen_q": S, "num_heads": H, "head_dim": D}
+    inputs = [
+        tensor(
+            "x",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen_q", "num_heads", "head_dim"],
+            named_dims=_nd,
+        ),
+        tensor(
+            "y",
+            shape=(B, H, S, D),
+            dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"],
+            named_dims=_nd,
+        ),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
+            return x.view(B, S, H, D).transpose(1, 2) * y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_view_4d_transpose_S4():
+    """x.view(B,S,H,D).transpose(1,2)*y tiled S÷4."""
+    B, S, H, D = 2, 256, 4, 64
+    _nd = {"batch_size": B, "max_seqlen_q": S, "num_heads": H, "head_dim": D}
+    inputs = [
+        tensor(
+            "x",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen_q", "num_heads", "head_dim"],
+            named_dims=_nd,
+        ),
+        tensor(
+            "y",
+            shape=(B, H, S, D),
+            dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"],
+            named_dims=_nd,
+        ),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"max_seqlen_q": 4}):
+            return x.view(B, S, H, D).transpose(1, 2) * y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_view_4d_transpose_H2_S4():
+    """x.view(B,S,H,D).transpose(1,2)*y tiled H÷2 S÷4."""
+    B, S, H, D = 2, 256, 4, 64
+    _nd = {"batch_size": B, "max_seqlen_q": S, "num_heads": H, "head_dim": D}
+    inputs = [
+        tensor(
+            "x",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen_q", "num_heads", "head_dim"],
+            named_dims=_nd,
+        ),
+        tensor(
+            "y",
+            shape=(B, H, S, D),
+            dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"],
+            named_dims=_nd,
+        ),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
+            with spyre_hint(num_tiles_per_dim={"max_seqlen_q": 4}):
+                return x.view(B, S, H, D).transpose(1, 2) * y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- unsqueeze: a.unsqueeze(0) * b where b has the broadcast shape ---
+
+
+def test_view_unsqueeze_broadcast_A4():
+    """a.unsqueeze(0)*b: a=[256,256], b=[4,256,256], tiled A÷4."""
+    inputs = [
+        tensor("a", shape=(256, 256), dims=["A", "B"]),
+        tensor("b", shape=(4, 256, 256), dims=["N", "A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return a.unsqueeze(0) * b
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_view_unsqueeze_broadcast_B4():
+    """a.unsqueeze(0)*b: a=[256,256], b=[4,256,256], tiled B÷4."""
+    inputs = [
+        tensor("a", shape=(256, 256), dims=["A", "B"]),
+        tensor("b", shape=(4, 256, 256), dims=["N", "A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return a.unsqueeze(0) * b
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_view_unsqueeze_broadcast_A4_B4():
+    """a.unsqueeze(0)*b: a=[256,256], b=[4,256,256], tiled A÷4 B÷4."""
+    inputs = [
+        tensor("a", shape=(256, 256), dims=["A", "B"]),
+        tensor("b", shape=(4, 256, 256), dims=["N", "A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return a.unsqueeze(0) * b
+
+    run_coarse_tile_test(fn, inputs)
+
+
 # ===========================================================================
+# END OF STRUCTURED TESTS (Groups 1-9)
+# ===========================================================================
+# ORIGINAL TESTS — preserved for reference, being migrated to structured format.
+#
 # spyre_hint-driven coarse tiling
 # These tests verify that coarse tiling is driven automatically by
 # spyre_hint(num_tiles_per_dim=...) annotations.  Named tensor dimensions
@@ -571,15 +2812,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
     # Hint propagation into inserted restickify nodes
     # ------------------------------------------------------------------
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "The transposed input produces layouts where coarse-tiling rewrites "
-            "output buffer strides after restickify has already run, resulting in "
-            "a stick mismatch that raises in create_op_spec.  This will be fixed "
-            "by reordering the compiler passes so that restickify runs after "
-            "coarse-tiling (PR #3293)."
-        ),
+    @pytest.mark.skip(
+        reason="The transposed input produces layouts where coarse-tiling rewrites output buffer strides after restickify has already run, resulting in a stick mismatch that raises in create_op_spec."
     )
     @config.patch(
         {
@@ -692,7 +2926,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             fn, x, y, run_compile=True, run_eager=False, atol=0.01, rtol=0.01
         )
 
-    @unittest.expectedFailure
+    @pytest.mark.skip
     def test_hint_flash_attention(self):
         """Flash attention tiled over H (4 slices) via nested spyre_hints.
 
@@ -780,7 +3014,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
         )
 
-    @unittest.expectedFailure
+    @pytest.mark.skip
     def test_hint_flash_attention_v2(self):
         """Flash attention tiled over H (4 slices) via nested spyre_hints.
 
@@ -892,13 +3126,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             "allow_all_ops_in_lx_planning": True,
         }
     )
-    @pytest.mark.xfail(
-        strict=False,
-        reason=(
-            "flash attention v3/v4 not yet passing: Lk reduction-dim tiling is "
-            "disabled (see FIXME on kv_block_size), unrelated to carry "
-            "propagation"
-        ),
+    @pytest.mark.skip(
+        reason="flash attention v3/v4 not yet passing: Lk reduction-dim tiling is disabled (see FIXME on kv_block_size), unrelated to carry propagation"
     )
     def test_hint_flash_attention_v3(self):
         from torch_spyre._inductor import spyre_hint
@@ -1000,13 +3229,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
         )
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason=(
-            "flash attention v3/v4 not yet passing: Lk reduction-dim tiling is "
-            "disabled (see FIXME on kv_block_size), unrelated to carry "
-            "propagation"
-        ),
+    @pytest.mark.skip(
+        reason="flash attention v3/v4 not yet passing: Lk reduction-dim tiling is disabled (see FIXME on kv_block_size), unrelated to carry propagation"
     )
     def test_hint_flash_attention_v3_b2(self):
         """Same as flash_v3 but with B=2 and b_block_size=2 so B is nto tiled"""
@@ -1163,13 +3387,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
         )
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason=(
-            "flash attention v3/v4 not yet passing: unrelated "
-            "propagate_named_dims bug (num_heads layout dim has no loop "
-            "vars), not carry propagation"
-        ),
+    @pytest.mark.skip(
+        reason="flash attention v3/v4 not yet passing: unrelated propagate_named_dims bug (num_heads layout dim has no loop vars), not carry propagation"
     )
     def test_hint_flash_attention_v4(self):
         """This test attempts to replicate the standalone test_granite_attn.py with views
@@ -1316,7 +3535,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             "allow_all_ops_in_lx_planning": True,
         }
     )
-    @unittest.expectedFailure
+    @pytest.mark.skip
     def test_hint_flash_attention_loopspec(self):
         """Lk loop level not dropped when Lk-broadcast ops appear first in group.
 
@@ -1479,7 +3698,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             " by _stamp_group (group-wide is_reduction_level flag bug)",
         )
 
-    @unittest.expectedFailure
+    @pytest.mark.skip
     def test_hint_flash_attention_two_loop_levels(self):
         """Flash-attention graph: both H and Lk loop levels survive into codegen.
 
@@ -1588,7 +3807,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             " by _stamp_group (group-wide is_reduction_level flag bug)",
         )
 
-    @unittest.expectedFailure
+    @pytest.mark.skip
     def test_hint_flash_attention_two_loop_levels_v2(self):
         """Flash-attention graph: both H and Lq loop levels survive into codegen.
 
@@ -2045,7 +4264,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             "ignore_span_overflow_hints": False,
         }
     )
-    @unittest.expectedFailure
+    @pytest.mark.skip
     def test_span_overflow_mutation_case_external_input_layout_mismatch(self):
         """Originally a regression repro for the Case 2/"Case 3"
         layout-reconciliation gap; now an xfail for a separate, deeper,
@@ -2134,6 +4353,7 @@ class TestNamedDimsHint(InductorTestCase):
     def setUp(self):
         super().setUp()
         torch.manual_seed(0xAFFE)
+        _pnd.reset()
 
     @config.patch(
         {
@@ -2264,6 +4484,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
     def setUp(self):
         super().setUp()
         torch.manual_seed(0xAFFE)
+        _pnd.reset()
 
     def test_hint_tiled_reduction_sum_loopspec(self):
         """x.sum(dim=-1) tiled over D produces a LoopSpec with count 4."""
@@ -2459,6 +4680,7 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
     def setUp(self):
         super().setUp()
         torch.manual_seed(0xAFFE)
+        _pnd.reset()
 
     def test_hint_tiled_reduction_dim0_sum_correct(self):
         """x.sum(dim=0) tiled over B produces correct results."""
@@ -2523,6 +4745,7 @@ class TestCoarseTileMatmulKTilingE2E(InductorTestCase):
     def setUp(self):
         super().setUp()
         torch.manual_seed(0xAFFE)
+        _pnd.reset()
 
     def test_mm_k_tiled_correct(self):
         """2D mm [M,K] @ [K,N] tiled over K produces correct results."""
@@ -2638,6 +4861,7 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
     def setUp(self):
         super().setUp()
         torch.manual_seed(0xCAFE)
+        _pnd.reset()
 
     @pytest.mark.skip(
         reason=(
@@ -2853,7 +5077,7 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
 # ===========================================================================
 
 
-@pytest.mark.xfail(strict=True, reason="SpyreEmptyFallback / ct_fill STL bug")
+@pytest.mark.skip(reason="SpyreEmptyFallback / ct_fill STL bug")
 def test_tiled_in_place_accumulator():
     """Minimal reproducer for the SpyreEmptyFallback / ct_fill STL bug.
 
@@ -2953,9 +5177,8 @@ def test_sum_reduce_implicit_accumulator():
     torch.testing.assert_close(result, ref, atol=0.01, rtol=0.1)
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason="zeros with named_dims hint acquires wrong layout in tiled scope",
+@pytest.mark.skip(
+    reason="zeros with named_dims hint acquires wrong layout in tiled scope"
 )
 def test_zeros_named_dims_hint_correctness():
     """zeros with explicit named_dims hint inside a tiled scope should be correct.

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -14,21 +14,36 @@
 
 """End-to-end compilation tests for the coarse-tiling loop IR.
 
-These tests drive the full Spyre compilation pipeline (CustomPreSchedulingPasses
-→ scheduler → SpyreKernel codegen) and inspect the generated Python wrapper
-source to verify that LoopSpec entries appear when coarse tiling is active.
+This file has two sections:
 
-No Spyre hardware is required: torch.compile() exercises the full codegen path
-and run_and_get_code() captures the generated source without executing on device.
-launch_jobplan is mocked to prevent actual device execution.
+STRUCTURED TESTS (Groups 1-9)
+    Flat module-level tests using the run_coarse_tile_test() driver.
+    These are the primary test suite going forward — easy to read, copy,
+    and extend.  Each test declares its inputs via tensor() descriptors,
+    defines a plain fn(), and calls the driver with optional loopspec=
+    and correctness= flags.
 
-All coarse-tiling tests use the spyre_hint API (TestCoarseTileSpyreHints).
-Add new tests there using spyre_hint(num_tiles_per_dim=...) annotations.
+    Group 1: Basic tiling — abs/add on 2D tensors, varied sizes and tile counts
+    Group 2: 3D tensors — [A=512, B=256, C=256], all tiling combinations
+    Group 3: Pointwise op chains — abs(a+b)*c, exp(abs(...)), etc.
+    Group 4: Reductions — amin over 2D (all tiling combos) and 3D (all-dims)
+    Group 5: Mixed pointwise + reduction — add_min, reduce_both, softmax
+    Group 6: Restickify + coarse tiling — transpose inputs with tiling
+    Group 7: Copies — pre-allocated buffers, in-place accumulators, RMW
+    Group 8: Tiled ops with outside consumers — Avery's pattern
+    Group 9: Views — 1D sub-dim naming, reshape, view+transpose, unsqueeze
+
+    Tests marked loopspec=False, correctness=False are known broken and
+    skipped; see inline comments for root cause.
+
+ORIGINAL TESTS (below the boundary marker)
+    Original class-based tests preserved for coverage and reference, to be cleaned up in future.
 """
 
+import dataclasses
 import math
-import sys
 import os
+import sys
 import regex as re
 
 import pytest
@@ -36,21 +51,2247 @@ import torch
 import unittest
 from unittest.mock import patch as mock_patch
 
-from torch._inductor.test_case import TestCase as InductorTestCase
+from torch._inductor.test_case import TestCase as InductorTestCase, fresh_cache
 from torch._inductor.utils import run_and_get_code
 
 from torch_spyre._inductor import config
+from torch_spyre._inductor import spyre_hint
 import torch_spyre._inductor.wsr.propagate_named_dims as _pnd
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
-from utils_inductor import compare_with_cpu  # noqa: E402
+from utils_inductor import compare_with_cpu, _compile_and_run  # noqa: E402
+
+_declare_tensor_dim = _pnd.declare_tensor_dim
+_name_tensor_dims = _pnd.name_tensor_dims
 
 # Paths to mock for disabling actual device kernel execution.
 _LAUNCH_JOBPLAN = "torch_spyre.execution.kernel_runner.launch_jobplan"
 _PREPARE_KERNEL = "torch_spyre.execution.kernel_runner.prepare_kernel"
 
 
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class TensorSpec:
+    """Descriptor for a test input tensor.
+
+    name:       parameter name in fn — for readability only.
+    shape:      physical tensor shape passed to torch.randn.
+    dims:       named dim labels in order, passed to _name_tensor_dims.
+    named_dims: optional explicit {dim_name: size} dict for declaring dims.
+                Use when len(dims) > len(shape) — i.e. multiple logical dims
+                are fused into one physical dim (e.g. flat [B, S, H*D] input
+                named ["batch_size", "max_seqlen", "num_heads", "head_dim"]).
+                When absent, sizes are inferred by zipping dims with shape.
+    """
+
+    name: str
+    shape: tuple
+    dims: list
+    named_dims: dict | None = dataclasses.field(default=None)
+
+
+def tensor(name, *, shape, dims, named_dims=None):
+    """Shorthand constructor for TensorSpec."""
+    return TensorSpec(name=name, shape=shape, dims=dims, named_dims=named_dims)
+
+
+def run_coarse_tile_test(
+    fn,
+    inputs,
+    loopspec=True,
+    correctness=True,
+    atol=None,
+    rtol=None,
+    scale=0.01,
+):
+    """Compile fn on Spyre and check loopspec and/or correctness.
+
+    inputs: list of TensorSpec (from tensor(...)) — driver creates tensors,
+        declares dims, and calls _name_tensor_dims before each compile.
+
+    loopspec: True  — assert "LoopSpec(" appears in generated source.
+    correctness: True  — compare_with_cpu against CPU reference.
+    """
+    cpu_tensors = [torch.randn(s.shape, dtype=torch.float16) * scale for s in inputs]
+
+    def _setup_dims_and_dev_tensors():
+        _pnd.reset()
+        for spec in inputs:
+            if spec.named_dims is not None:
+                for dim, size in spec.named_dims.items():
+                    _declare_tensor_dim(dim, size)
+            else:
+                for dim, size in zip(spec.dims, spec.shape):
+                    _declare_tensor_dim(dim, size)
+        dev_tensors = [t.to("spyre") for t in cpu_tensors]
+        for spec, t in zip(inputs, dev_tensors):
+            _name_tensor_dims(t, spec.dims)
+        return dev_tensors
+
+    if loopspec:
+        with fresh_cache():
+            dev_tensors = _setup_dims_and_dev_tensors()
+            cfn = torch.compile(fn)
+            with (
+                mock_patch(_LAUNCH_JOBPLAN),
+                mock_patch(_PREPARE_KERNEL),
+                mock_patch("torch_spyre.execution.async_compile.subprocess.run"),
+            ):
+                _, source_codes = run_and_get_code(cfn, *dev_tensors)
+        assert len(source_codes) > 0
+        src = source_codes[0]
+        assert "LoopSpec(" in src, f"Expected LoopSpec( in generated source:\n{src}"
+
+    if correctness:
+        dev_tensors = _setup_dims_and_dev_tensors()
+        spyre_result = _compile_and_run(fn, dev_tensors, "spyre")
+        kwargs = {}
+        if atol is not None:
+            kwargs["atol"] = atol
+        if rtol is not None:
+            kwargs["rtol"] = rtol
+        compare_with_cpu(
+            fn, *cpu_tensors, target=spyre_result, run_eager=False, **kwargs
+        )
+
+
+# ---------------------------------------------------------------------------
+# Group 1: Test basic tiling with various sizes
+# ---------------------------------------------------------------------------
+
+
+def test_abs_256x256_A4():
+    """abs [256,256] tiled A÷4 → 64 elems/tile (1 stick)."""
+    inputs = [tensor("x", shape=(256, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return torch.abs(x)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_abs_256x256_B4():
+    """abs [256,256] tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [tensor("x", shape=(256, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return torch.abs(x)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_abs_256x256_A4_B4():
+    """abs [256,256] tiled A÷4 B÷4 → 64 elems/tile each (1 stick)."""
+    inputs = [tensor("x", shape=(256, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return torch.abs(x)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- add: scenario 1 — square 256×256, 1-stick tiles (64 elems/tile) ---
+
+
+def test_add_256x256_A4():
+    """add [256,256] tiled A÷4 → 64 elems/tile (1 stick)."""
+    inputs = [
+        tensor("x", shape=(256, 256), dims=["A", "B"]),
+        tensor("y", shape=(256, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_256x256_B4():
+    """add [256,256] tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [
+        tensor("x", shape=(256, 256), dims=["A", "B"]),
+        tensor("y", shape=(256, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_256x256_A4_B4():
+    """add [256,256] tiled A÷4 B÷4 → 64 elems/tile each (1 stick)."""
+    inputs = [
+        tensor("x", shape=(256, 256), dims=["A", "B"]),
+        tensor("y", shape=(256, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- add: scenario 2 — non-square 512×256, A>B, 2-stick A tiles ---
+
+
+def test_add_512x256_A4():
+    """add [512,256] tiled A÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_512x256_B4():
+    """add [512,256] tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_512x256_A4_B4():
+    """add [512,256] tiled A÷4 B÷4 → 128 and 64 elems/tile."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- add: scenario 3 — non-square 256×512, B>A, 2-stick B tiles ---
+
+
+def test_add_256x512_A4():
+    """add [256,512] tiled A÷4 → 64 elems/tile (1 stick)."""
+    inputs = [
+        tensor("x", shape=(256, 512), dims=["A", "B"]),
+        tensor("y", shape=(256, 512), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_256x512_B4():
+    """add [256,512] tiled B÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [
+        tensor("x", shape=(256, 512), dims=["A", "B"]),
+        tensor("y", shape=(256, 512), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_256x512_A4_B4():
+    """add [256,512] tiled A÷4 B÷4 → 64 and 128 elems/tile."""
+    inputs = [
+        tensor("x", shape=(256, 512), dims=["A", "B"]),
+        tensor("y", shape=(256, 512), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- add: scenario 4 — square 512×512, 2-stick tiles ---
+
+
+def test_add_512x512_A4():
+    """add [512,512] tiled A÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [
+        tensor("x", shape=(512, 512), dims=["A", "B"]),
+        tensor("y", shape=(512, 512), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_512x512_B4():
+    """add [512,512] tiled B÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [
+        tensor("x", shape=(512, 512), dims=["A", "B"]),
+        tensor("y", shape=(512, 512), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_512x512_A4_B4():
+    """add [512,512] tiled A÷4 B÷4 → 128 elems/tile each (2 sticks)."""
+    inputs = [
+        tensor("x", shape=(512, 512), dims=["A", "B"]),
+        tensor("y", shape=(512, 512), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- add: scenario 5 — asymmetric tile counts, same tile size ---
+
+
+def test_add_512x256_A4_B2():
+    """add [512,256] tiled A÷4 B÷2 → 128 elems/tile each, different counts."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 2}):
+                return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# ---------------------------------------------------------------------------
+# Group 2: 3D tensors — [A=512, B=256, C=256]
+# A÷4=128/tile (2 sticks), B÷2=128/tile (2 sticks, count=2), C÷4=64/tile (1 stick)
+# ---------------------------------------------------------------------------
+
+
+def test_add_3d_512x256x256_A4():
+    """add [512,256,256] tiled A÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [
+        tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("y", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_3d_512x256x256_B2():
+    """add [512,256,256] tiled B÷2 → 128 elems/tile (2 sticks, count=2)."""
+    inputs = [
+        tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("y", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"B": 2}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_3d_512x256x256_C4():
+    """add [512,256,256] tiled C÷4 → 64 elems/tile (1 stick)."""
+    inputs = [
+        tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("y", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"C": 4}):
+            return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_3d_512x256x256_A4_B2():
+    """add [512,256,256] tiled A÷4 B÷2 → 128+128 elems/tile."""
+    inputs = [
+        tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("y", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 2}):
+                return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_3d_512x256x256_A4_C4():
+    """add [512,256,256] tiled A÷4 C÷4 → 128+64 elems/tile."""
+    inputs = [
+        tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("y", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"C": 4}):
+                return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_3d_512x256x256_B2_C4():
+    """add [512,256,256] tiled B÷2 C÷4 → 128+64 elems/tile."""
+    inputs = [
+        tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("y", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"B": 2}):
+            with spyre_hint(num_tiles_per_dim={"C": 4}):
+                return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_3d_512x256x256_A4_B2_C4():
+    """add [512,256,256] tiled A÷4 B÷2 C÷4 → 128+128+64 elems/tile."""
+    inputs = [
+        tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("y", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 2}):
+                with spyre_hint(num_tiles_per_dim={"C": 4}):
+                    return x + y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# ---------------------------------------------------------------------------
+# Group 3: pointwise op chains — [512x256], 3 tiling variants each
+# A÷4=128/tile (2 sticks), B÷4=64/tile (1 stick)
+# ---------------------------------------------------------------------------
+
+
+def test_abs_add_mul_512x256_A4():
+    """abs(a+b)*c on [512,256] tiled A÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+        tensor("c", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b, c):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return torch.abs(a + b) * c
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_abs_add_mul_512x256_B4():
+    """abs(a+b)*c on [512,256] tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+        tensor("c", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b, c):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return torch.abs(a + b) * c
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_abs_add_mul_512x256_A4_B4():
+    """abs(a+b)*c on [512,256] tiled A÷4 B÷4 → 128+64 elems/tile."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+        tensor("c", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b, c):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return torch.abs(a + b) * c
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_exp_abs_add_mul_512x256_A4():
+    """exp(abs((a+b)*c)) on [512,256] tiled A÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+        tensor("c", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b, c):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return torch.exp(torch.abs((a + b) * c))
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_exp_abs_add_mul_512x256_B4():
+    """exp(abs((a+b)*c)) on [512,256] tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+        tensor("c", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b, c):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return torch.exp(torch.abs((a + b) * c))
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_exp_abs_add_mul_512x256_A4_B4():
+    """exp(abs((a+b)*c)) on [512,256] tiled A÷4 B÷4 → 128+64 elems/tile."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+        tensor("c", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b, c):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return torch.exp(torch.abs((a + b) * c))
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# ---------------------------------------------------------------------------
+# Group 4: reductions (amin) — 2D all tiling combos, 3D all-dims tiling
+# 2D [512x256]: A÷4=128/tile, B÷4=64/tile
+# 3D [512x256x256]: A÷4=128/tile, B÷2=128/tile, C÷4=64/tile
+# ---------------------------------------------------------------------------
+
+
+def test_min_2d_512x256_reduce_dim0_A4():
+    """amin over dim=0 on [512,256] tiled A÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return x.amin(dim=0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_min_2d_512x256_reduce_dim0_B4():
+    """amin over dim=0 on [512,256] tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return x.amin(dim=0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_min_2d_512x256_reduce_dim0_A4_B4():
+    """amin over dim=0 on [512,256] tiled A÷4 B÷4 → 128+64 elems/tile."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return x.amin(dim=0)
+
+    run_coarse_tile_test(
+        fn, inputs, correctness=False
+    )  # nested tiling + reduction correctness bug
+
+
+def test_min_2d_512x256_reduce_dim1_A4():
+    """amin over dim=1 on [512,256] tiled A÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return x.amin(dim=1)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_min_2d_512x256_reduce_dim1_B4():
+    """amin over dim=1 on [512,256] tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return x.amin(dim=1)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_min_2d_512x256_reduce_dim1_A4_B4():
+    """amin over dim=1 on [512,256] tiled A÷4 B÷4 → 128+64 elems/tile."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return x.amin(dim=1)
+
+    run_coarse_tile_test(
+        fn, inputs, correctness=False
+    )  # nested tiling + reduction correctness bug
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_min_3d_512x256x256_reduce_dim0_A4_B2_C4():
+    """amin over dim=0 on [512,256,256] tiled A÷4 B÷2 C÷4."""
+    inputs = [tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 2}):
+                with spyre_hint(num_tiles_per_dim={"C": 4}):
+                    return x.amin(dim=0)
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # scheduler crash: inconsistent loop_count across reduction fill/combine nodes
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_min_3d_512x256x256_reduce_dim1_A4_B2_C4():
+    """amin over dim=1 on [512,256,256] tiled A÷4 B÷2 C÷4."""
+    inputs = [tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 2}):
+                with spyre_hint(num_tiles_per_dim={"C": 4}):
+                    return x.amin(dim=1)
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # scheduler crash: inconsistent loop_count across reduction fill/combine nodes
+
+
+def test_min_3d_512x256x256_reduce_dim2_A4_B2_C4():
+    """amin over dim=2 on [512,256,256] tiled A÷4 B÷2 C÷4."""
+    inputs = [tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 2}):
+                with spyre_hint(num_tiles_per_dim={"C": 4}):
+                    return x.amin(dim=2)
+
+    run_coarse_tile_test(
+        fn, inputs, correctness=False
+    )  # nested tiling + reduction correctness bug
+
+
+# ---------------------------------------------------------------------------
+# Group 5: mixed pointwise + reduction — add_min, reduce_both, softmax
+# add_min: min(a + abs(amin(b))) — 2D all 3 tiling variants × 2 reduction dims,
+#   3D all-dims tiling × 3 reduction dims
+# reduce_both: amin(a,dim) + amin(b,dim) — dense+dense and sparse+sparse, 3 tiling variants
+# softmax: decomposes into amax+pointwise+sum+pointwise — dim0 and dim1, 3 tiling variants each
+# ---------------------------------------------------------------------------
+
+
+def test_add_min_2d_512x256_reduce_dim0_A4():
+    """min(a + abs(amin(b, dim=0))) on [512,256] tiled A÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return a + torch.abs(b.amin(dim=0))
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_min_2d_512x256_reduce_dim0_B4():
+    """min(a + abs(amin(b, dim=0))) on [512,256] tiled B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return a + torch.abs(b.amin(dim=0))
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_min_2d_512x256_reduce_dim0_A4_B4():
+    """min(a + abs(amin(b, dim=0))) on [512,256] tiled A÷4 B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return a + torch.abs(b.amin(dim=0))
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_min_2d_512x256_reduce_dim1_A4():
+    """min(a + abs(amin(b, dim=1))) on [512,256] tiled A÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return a + torch.abs(b.amin(dim=1, keepdim=True))
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_min_2d_512x256_reduce_dim1_B4():
+    """min(a + abs(amin(b, dim=1))) on [512,256] tiled B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return a + torch.abs(b.amin(dim=1, keepdim=True))
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_add_min_2d_512x256_reduce_dim1_A4_B4():
+    """min(a + abs(amin(b, dim=1))) on [512,256] tiled A÷4 B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return a + torch.abs(b.amin(dim=1, keepdim=True))
+
+    run_coarse_tile_test(fn, inputs)
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_add_min_3d_512x256x256_reduce_dim0_A4_B2_C4():
+    """min(a + abs(amin(b, dim=0))) on [512,256,256] tiled A÷4 B÷2 C÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("b", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 2}):
+                with spyre_hint(num_tiles_per_dim={"C": 4}):
+                    return a + torch.abs(b.amin(dim=0))
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # scheduler crash: mixed loop counts in 3D nested tiling + reduction
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_add_min_3d_512x256x256_reduce_dim1_A4_B2_C4():
+    """min(a + abs(amin(b, dim=1))) on [512,256,256] tiled A÷4 B÷2 C÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("b", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 2}):
+                with spyre_hint(num_tiles_per_dim={"C": 4}):
+                    return a + torch.abs(b.amin(dim=1))
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # scheduler crash: mixed loop counts in 3D nested tiling + reduction
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_add_min_3d_512x256x256_reduce_dim2_A4_B2_C4():
+    """min(a + abs(amin(b, dim=2))) on [512,256,256] tiled A÷4 B÷2 C÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256, 256), dims=["A", "B", "C"]),
+        tensor("b", shape=(512, 256, 256), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 2}):
+                with spyre_hint(num_tiles_per_dim={"C": 4}):
+                    return a + torch.abs(b.amin(dim=2))
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # scheduler crash: mixed loop counts in 3D nested tiling + reduction
+
+
+# dense+dense: both inputs reduce over dim=0 → [B] dense outputs, then add
+# sparse+sparse: both inputs reduce over dim=1 (stick) → [A] sparse outputs, then add
+
+
+def test_reduce_both_dense_add_2d_512x256_A4():
+    """amin(a,dim=0) + amin(b,dim=0) on [512,256] tiled A÷4 — dense+dense."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return a.amin(dim=0) + b.amin(dim=0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_reduce_both_dense_add_2d_512x256_B4():
+    """amin(a,dim=0) + amin(b,dim=0) on [512,256] tiled B÷4 — dense+dense."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return a.amin(dim=0) + b.amin(dim=0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_reduce_both_dense_add_2d_512x256_A4_B4():
+    """amin(a,dim=0) + amin(b,dim=0) on [512,256] tiled A÷4 B÷4 — dense+dense."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return a.amin(dim=0) + b.amin(dim=0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_reduce_both_sparse_add_2d_512x256_A4():
+    """amin(a,dim=1) + amin(b,dim=1) on [512,256] tiled A÷4 — sparse+sparse."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return a.amin(dim=1) + b.amin(dim=1)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_reduce_both_sparse_add_2d_512x256_B4():
+    """amin(a,dim=1) + amin(b,dim=1) on [512,256] tiled B÷4 — sparse+sparse."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return a.amin(dim=1) + b.amin(dim=1)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_reduce_both_sparse_add_2d_512x256_A4_B4():
+    """amin(a,dim=1) + amin(b,dim=1) on [512,256] tiled A÷4 B÷4 — sparse+sparse."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return a.amin(dim=1) + b.amin(dim=1)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# softmax decomposes into amax + pointwise + sum + pointwise — exercises
+# mixed reduction+pointwise tiling in a single op
+
+
+def test_softmax_2d_512x256_dim1_A4():
+    """softmax(x, dim=1) on [512,256] tiled A÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return torch.softmax(x, dim=1)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_softmax_2d_512x256_dim1_B4():
+    """softmax(x, dim=1) on [512,256] tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return torch.softmax(x, dim=1)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_softmax_2d_512x256_dim1_A4_B4():
+    """softmax(x, dim=1) on [512,256] tiled A÷4 B÷4."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return torch.softmax(x, dim=1)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_softmax_2d_512x256_dim0_A4():
+    """softmax(x, dim=0) on [512,256] tiled A÷4 → 128 elems/tile (2 sticks)."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return torch.softmax(x, dim=0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_softmax_2d_512x256_dim0_B4():
+    """softmax(x, dim=0) on [512,256] tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return torch.softmax(x, dim=0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_softmax_2d_512x256_dim0_A4_B4():
+    """softmax(x, dim=0) on [512,256] tiled A÷4 B÷4."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return torch.softmax(x, dim=0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# ---------------------------------------------------------------------------
+# Group 6: restickify + coarse tiling
+# a=[256,128], x=[128,256]: a.t() gives [128,256] same shape as x but
+# stick-incompatible — restickify is inserted before the add.
+# Named dims on the result shape [128, 256]: A=128, B=256.
+# A÷2=64/tile (1 stick), B÷4=64/tile (1 stick)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_add_256x128_A2():
+    """a.t() + x on [128,256] result, tiled A÷2 → 64 elems/tile (1 stick)."""
+    inputs = [
+        tensor("a", shape=(256, 128), dims=["B", "A"]),
+        tensor("x", shape=(128, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"A": 2}):
+            return a.t() + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_add_256x128_B4():
+    """a.t() + x on [128,256] result, tiled B÷4 → 64 elems/tile (1 stick)."""
+    inputs = [
+        tensor("a", shape=(256, 128), dims=["B", "A"]),
+        tensor("x", shape=(128, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return a.t() + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_add_256x128_A2_B4():
+    """a.t() + x on [128,256] result, tiled A÷2 B÷4 → 64 elems/tile each."""
+    inputs = [
+        tensor("a", shape=(256, 128), dims=["B", "A"]),
+        tensor("x", shape=(128, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"A": 2}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return a.t() + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+# 2D two-transpose: a.t() + b.t() + x
+# a=[256,128], b=[256,128], x=[128,256]; result [128,256]: A=128, B=256
+# A÷2=64/tile (1 stick), B÷4=64/tile (1 stick)
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_2t_add_256x128_A2():
+    """a.t()+b.t()+x on [128,256] result, tiled A÷2."""
+    inputs = [
+        tensor("a", shape=(256, 128), dims=["B", "A"]),
+        tensor("b", shape=(256, 128), dims=["B", "A"]),
+        tensor("x", shape=(128, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b, x):
+        with spyre_hint(num_tiles_per_dim={"A": 2}):
+            return a.t() + b.t() + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # d0+d1 stick expr bug: two restickified inputs produce unsupported stick expression
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_2t_add_256x128_B4():
+    """a.t()+b.t()+x on [128,256] result, tiled B÷4."""
+    inputs = [
+        tensor("a", shape=(256, 128), dims=["B", "A"]),
+        tensor("b", shape=(256, 128), dims=["B", "A"]),
+        tensor("x", shape=(128, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b, x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return a.t() + b.t() + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # d0+d1 stick expr bug
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_2t_add_256x128_A2_B4():
+    """a.t()+b.t()+x on [128,256] result, tiled A÷2 B÷4."""
+    inputs = [
+        tensor("a", shape=(256, 128), dims=["B", "A"]),
+        tensor("b", shape=(256, 128), dims=["B", "A"]),
+        tensor("x", shape=(128, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b, x):
+        with spyre_hint(num_tiles_per_dim={"A": 2}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return a.t() + b.t() + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # d0+d1 stick expr bug
+
+
+# 3D transpose: a.transpose(1,2) + x
+# a=[256,512,256], x=[256,256,512]; result [256,256,512]: A=256, B=256, C=512
+# A÷4=64/tile, B÷4=64/tile, C÷4=128/tile (2 sticks)
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_3d_transpose12_256x512x256_A4():
+    """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4."""
+    inputs = [
+        tensor("a", shape=(256, 512, 256), dims=["A", "C", "B"]),
+        tensor("x", shape=(256, 256, 512), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return a.transpose(1, 2) + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_3d_transpose12_256x512x256_B4():
+    """a.transpose(1,2)+x on [256,256,512] result, tiled B÷4."""
+    inputs = [
+        tensor("a", shape=(256, 512, 256), dims=["A", "C", "B"]),
+        tensor("x", shape=(256, 256, 512), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return a.transpose(1, 2) + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_3d_transpose12_256x512x256_C4():
+    """a.transpose(1,2)+x on [256,256,512] result, tiled C÷4."""
+    inputs = [
+        tensor("a", shape=(256, 512, 256), dims=["A", "C", "B"]),
+        tensor("x", shape=(256, 256, 512), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"C": 4}):
+            return a.transpose(1, 2) + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_3d_transpose12_256x512x256_A4_B4():
+    """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4 B÷4."""
+    inputs = [
+        tensor("a", shape=(256, 512, 256), dims=["A", "C", "B"]),
+        tensor("x", shape=(256, 256, 512), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return a.transpose(1, 2) + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_3d_transpose12_256x512x256_A4_C4():
+    """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4 C÷4."""
+    inputs = [
+        tensor("a", shape=(256, 512, 256), dims=["A", "C", "B"]),
+        tensor("x", shape=(256, 256, 512), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"C": 4}):
+                return a.transpose(1, 2) + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_3d_transpose12_256x512x256_B4_C4():
+    """a.transpose(1,2)+x on [256,256,512] result, tiled B÷4 C÷4."""
+    inputs = [
+        tensor("a", shape=(256, 512, 256), dims=["A", "C", "B"]),
+        tensor("x", shape=(256, 256, 512), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            with spyre_hint(num_tiles_per_dim={"C": 4}):
+                return a.transpose(1, 2) + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_3d_transpose12_256x512x256_A4_B4_C4():
+    """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4 B÷4 C÷4."""
+    inputs = [
+        tensor("a", shape=(256, 512, 256), dims=["A", "C", "B"]),
+        tensor("x", shape=(256, 256, 512), dims=["A", "B", "C"]),
+    ]
+
+    def fn(a, x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                with spyre_hint(num_tiles_per_dim={"C": 4}):
+                    return a.transpose(1, 2) + x
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+# Matmul + transpose: x.t()@y and x@y.t()
+# x=[128,256], y=[128,256]; x.t()@y=[256,128]@[128,256]=[256,256]
+# x@y.t()=[128,256]@[256,128]=[128,128]
+# For x.t()@y result [256,256]: M=256, N=256; M÷4=64, N÷4=64
+# For x@y.t() result [128,128]: M=128, N=128; M÷2=64, N÷2=64
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_matmul_xt_y_256x128_M4():
+    """x.t()@y, result [256,256], tiled M÷4."""
+    inputs = [
+        tensor("x", shape=(128, 256), dims=["K", "M"]),
+        tensor("y", shape=(128, 256), dims=["K", "N"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"M": 4}):
+            return torch.matmul(x.t(), y)
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_matmul_xt_y_256x128_N4():
+    """x.t()@y, result [256,256], tiled N÷4."""
+    inputs = [
+        tensor("x", shape=(128, 256), dims=["K", "M"]),
+        tensor("y", shape=(128, 256), dims=["K", "N"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"N": 4}):
+            return torch.matmul(x.t(), y)
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_matmul_xt_y_256x128_M4_N4():
+    """x.t()@y, result [256,256], tiled M÷4 N÷4."""
+    inputs = [
+        tensor("x", shape=(128, 256), dims=["K", "M"]),
+        tensor("y", shape=(128, 256), dims=["K", "N"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"M": 4}):
+            with spyre_hint(num_tiles_per_dim={"N": 4}):
+                return torch.matmul(x.t(), y)
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_matmul_x_yt_128x256_M2():
+    """x@y.t(), result [128,128], tiled M÷2."""
+    inputs = [
+        tensor("x", shape=(128, 256), dims=["M", "K"]),
+        tensor("y", shape=(128, 256), dims=["N", "K"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"M": 2}):
+            return torch.matmul(x, y.t())
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_matmul_x_yt_128x256_N2():
+    """x@y.t(), result [128,128], tiled N÷2."""
+    inputs = [
+        tensor("x", shape=(128, 256), dims=["M", "K"]),
+        tensor("y", shape=(128, 256), dims=["N", "K"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"N": 2}):
+            return torch.matmul(x, y.t())
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_restickify_matmul_x_yt_128x256_M2_N2():
+    """x@y.t(), result [128,128], tiled M÷2 N÷2."""
+    inputs = [
+        tensor("x", shape=(128, 256), dims=["M", "K"]),
+        tensor("y", shape=(128, 256), dims=["N", "K"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"M": 2}):
+            with spyre_hint(num_tiles_per_dim={"N": 2}):
+                return torch.matmul(x, y.t())
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+# ---------------------------------------------------------------------------
+# Group 7: copies
+# Patterns: copy into pre-allocated buffer, in-place accumulation,
+# read-modify-write with correction factor, copy after reduction.
+# All on [512x256]: A÷4=128/tile (2 sticks), B÷4=64/tile (1 stick)
+# ---------------------------------------------------------------------------
+
+# --- copy into pre-allocated buffer: c.copy_(a + b) ---
+
+
+def test_copy_into_preallocated_512x256_A4():
+    """c.copy_(a+b) on [512,256] tiled A÷4 — result written into zeros buffer."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        c = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            c.copy_(a + b)
+        return c
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_into_preallocated_512x256_B4():
+    """c.copy_(a+b) on [512,256] tiled B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        c = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            c.copy_(a + b)
+        return c
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_into_preallocated_512x256_A4_B4():
+    """c.copy_(a+b) on [512,256] tiled A÷4 B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        c = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                c.copy_(a + b)
+        return c
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- in-place accumulation: acc.copy_(acc + x) ---
+
+
+def test_copy_inplace_accum_512x256_A4():
+    """acc.copy_(acc + x) on [512,256] tiled A÷4 — acc read and written inside loop."""
+    inputs = [
+        tensor("acc", shape=(512, 256), dims=["A", "B"]),
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(acc, x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            acc.copy_(acc + x)
+        return acc
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_inplace_accum_512x256_B4():
+    """acc.copy_(acc + x) on [512,256] tiled B÷4."""
+    inputs = [
+        tensor("acc", shape=(512, 256), dims=["A", "B"]),
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(acc, x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            acc.copy_(acc + x)
+        return acc
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_inplace_accum_512x256_A4_B4():
+    """acc.copy_(acc + x) on [512,256] tiled A÷4 B÷4."""
+    inputs = [
+        tensor("acc", shape=(512, 256), dims=["A", "B"]),
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(acc, x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                acc.copy_(acc + x)
+        return acc
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- read-modify-write with correction: acc.copy_(acc * scale + y) ---
+# flash attention accumulator pattern
+
+
+def test_copy_rmw_correction_512x256_A4():
+    """acc.copy_(acc * scale + y) on [512,256] tiled A÷4."""
+    inputs = [
+        tensor("acc", shape=(512, 256), dims=["A", "B"]),
+        tensor("scale", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(acc, scale, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            acc.copy_(acc * scale + y)
+        return acc
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_rmw_correction_512x256_B4():
+    """acc.copy_(acc * scale + y) on [512,256] tiled B÷4."""
+    inputs = [
+        tensor("acc", shape=(512, 256), dims=["A", "B"]),
+        tensor("scale", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(acc, scale, y):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            acc.copy_(acc * scale + y)
+        return acc
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_rmw_correction_512x256_A4_B4():
+    """acc.copy_(acc * scale + y) on [512,256] tiled A÷4 B÷4."""
+    inputs = [
+        tensor("acc", shape=(512, 256), dims=["A", "B"]),
+        tensor("scale", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(acc, scale, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                acc.copy_(acc * scale + y)
+        return acc
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- copy after reduction: out.copy_(x.amin(dim=0)) ---
+# copies sparse reduction result into a dense buffer
+
+
+def test_copy_after_reduction_512x256_A4():
+    """out.copy_(x.amin(dim=0)) on [512,256] tiled A÷4."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        out = torch.zeros(256, device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            out.copy_(x.amin(dim=0))
+        return out
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_after_reduction_512x256_B4():
+    """out.copy_(x.amin(dim=0)) on [512,256] tiled B÷4."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        out = torch.zeros(256, device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            out.copy_(x.amin(dim=0))
+        return out
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_after_reduction_512x256_A4_B4():
+    """out.copy_(x.amin(dim=0)) on [512,256] tiled A÷4 B÷4."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        out = torch.zeros(256, device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                out.copy_(x.amin(dim=0))
+        return out
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- copy + restickify: c.copy_(a.t() + b) ---
+# copy target receives a restickified input — tests copy layout after restickify
+
+
+@pytest.mark.skip(
+    reason="KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
+def test_copy_restickify_512x256_A4():
+    """c.copy_(a.t()+b) on [256,512] result tiled A÷4 — copy of restickified add."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["B", "A"]),
+        tensor("b", shape=(256, 512), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        c = torch.zeros(b.shape, device=b.device, dtype=b.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            c.copy_(a.t() + b)
+        return c
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+
+
+@pytest.mark.skip(
+    reason="KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
+def test_copy_restickify_512x256_B4():
+    """c.copy_(a.t()+b) on [256,512] result tiled B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["B", "A"]),
+        tensor("b", shape=(256, 512), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        c = torch.zeros(b.shape, device=b.device, dtype=b.dtype)
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            c.copy_(a.t() + b)
+        return c
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381
+
+
+@pytest.mark.skip(
+    reason="KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
+def test_copy_restickify_512x256_A4_B4():
+    """c.copy_(a.t()+b) on [256,512] result tiled A÷4 B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["B", "A"]),
+        tensor("b", shape=(256, 512), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        c = torch.zeros(b.shape, device=b.device, dtype=b.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                c.copy_(a.t() + b)
+        return c
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381
+
+
+# --- nested copy + reduction: acc.copy_(acc * scale + x.amin(dim=1, keepdim=True)) ---
+# flash attention accumulator pattern: correction * running value + new contribution
+
+
+def test_copy_accum_with_reduction_512x256_A4():
+    """acc.copy_(acc * scale + x.amin(dim=1,keepdim=True)) tiled A÷4."""
+    inputs = [
+        tensor("acc", shape=(512, 256), dims=["A", "B"]),
+        tensor("scale", shape=(512, 1), dims=["A", "B"]),
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(acc, scale, x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            acc.copy_(acc * scale + x.amin(dim=1, keepdim=True))
+        return acc
+
+    run_coarse_tile_test(fn, inputs)
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_copy_accum_with_reduction_512x256_B4():
+    """acc.copy_(acc * scale + x.amin(dim=1,keepdim=True)) tiled B÷4."""
+    inputs = [
+        tensor("acc", shape=(512, 256), dims=["A", "B"]),
+        tensor("scale", shape=(512, 1), dims=["A", "B"]),
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(acc, scale, x):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            acc.copy_(acc * scale + x.amin(dim=1, keepdim=True))
+        return acc
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 _insert_read_copy_ops IndexError when tiling B with unit-size B dim in scale
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_copy_accum_with_reduction_512x256_A4_B4():
+    """acc.copy_(acc * scale + x.amin(dim=1,keepdim=True)) tiled A÷4 B÷4."""
+    inputs = [
+        tensor("acc", shape=(512, 256), dims=["A", "B"]),
+        tensor("scale", shape=(512, 1), dims=["A", "B"]),
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(acc, scale, x):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                acc.copy_(acc * scale + x.amin(dim=1, keepdim=True))
+        return acc
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: PR #3381 _insert_read_copy_ops IndexError when tiling B with unit-size B dim in scale
+
+
+# --- two copies in same hint scope: c1.copy_(a+b); c2.copy_(a*b) ---
+
+
+def test_copy_two_copies_same_scope_512x256_A4():
+    """Two copy_ ops in same hint scope tiled A÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        c1 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
+        c2 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            c1.copy_(a + b)
+            c2.copy_(a * b)
+        return c1, c2
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_two_copies_same_scope_512x256_B4():
+    """Two copy_ ops in same hint scope tiled B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        c1 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
+        c2 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            c1.copy_(a + b)
+            c2.copy_(a * b)
+        return c1, c2
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_two_copies_same_scope_512x256_A4_B4():
+    """Two copy_ ops in same hint scope tiled A÷4 B÷4."""
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(a, b):
+        c1 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
+        c2 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                c1.copy_(a + b)
+                c2.copy_(a * b)
+        return c1, c2
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# ---------------------------------------------------------------------------
+# Group 8: tiled ops with outside consumers
+# Pattern: buffer initialized outside loop, written tile-by-tile inside,
+# then read again outside before returning.
+# All on [512x256]: A÷4=128/tile, B÷4=64/tile
+# ---------------------------------------------------------------------------
+
+# --- minimal: z = tiled(x+y); return z * 2.0 ---
+# The tiled op's output is a full-sized buffer consumed outside the loop.
+# Forces _allocate_full_buffer + correct stickification.
+
+
+def test_outside_consumer_pointwise_512x256_A4():
+    """z=tiled(x+y) consumed outside as z*2.0, tiled A÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            z = x + y
+        return z * 2.0
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_outside_consumer_pointwise_512x256_B4():
+    """z=tiled(x+y) consumed outside as z*2.0, tiled B÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            z = x + y
+        return z * 2.0
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_outside_consumer_pointwise_512x256_A4_B4():
+    """z=tiled(x+y) consumed outside as z*2.0, tiled A÷4 B÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                z = x + y
+        return z * 2.0
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- Avery's pattern: output=zeros outside; copy_ inside; read outside ---
+# output initialized outside, written tile-by-tile via copy_, divided outside.
+
+
+def test_outside_consumer_copy_then_read_512x256_A4():
+    """out=zeros; tiled out.copy_(x+y); return out/norm — tiled A÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+        tensor("norm", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y, norm):
+        out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            out.copy_(x + y)
+        return out / (torch.abs(norm) + 1.0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_outside_consumer_copy_then_read_512x256_B4():
+    """out=zeros; tiled out.copy_(x+y); return out/norm — tiled B÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+        tensor("norm", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y, norm):
+        out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            out.copy_(x + y)
+        return out / (torch.abs(norm) + 1.0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_outside_consumer_copy_then_read_512x256_A4_B4():
+    """out=zeros; tiled out.copy_(x+y); return out/norm — tiled A÷4 B÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+        tensor("norm", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y, norm):
+        out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                out.copy_(x + y)
+        return out / (torch.abs(norm) + 1.0)
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- two-accumulator flash pattern ---
+# Both output and denom initialized outside, updated inside, divided outside.
+# This is the minimal flash attention accumulator pattern.
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_outside_consumer_two_accum_512x256_A4():
+    """Flash-style: out=zeros, denom=zeros; tiled copy_; return out/denom — A÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("scale", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, scale):
+        out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
+        denom = torch.zeros(x.shape[0], device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            out.copy_(out * scale + x)
+            denom.copy_(denom + x.sum(dim=1))
+        return out / denom.unsqueeze(1)
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: infeasible restickify for 1D denom in mixed 1D/2D tiled scope
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_outside_consumer_two_accum_512x256_B4():
+    """Flash-style: out=zeros, denom=zeros; tiled copy_; return out/denom — B÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("scale", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, scale):
+        out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
+        denom = torch.zeros(x.shape[0], device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            out.copy_(out * scale + x)
+            denom.copy_(denom + x.sum(dim=1))
+        return out / denom.unsqueeze(1)
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: infeasible restickify for 1D denom in mixed 1D/2D tiled scope
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_outside_consumer_two_accum_512x256_A4_B4():
+    """Flash-style: out=zeros, denom=zeros; tiled copy_; return out/denom — A÷4 B÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("scale", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, scale):
+        out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
+        denom = torch.zeros(x.shape[0], device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                out.copy_(out * scale + x)
+                denom.copy_(denom + x.sum(dim=1))
+        return out / denom.unsqueeze(1)
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: infeasible restickify for 1D denom in mixed 1D/2D tiled scope
+
+
+# --- reduction inside loop, result consumed outside ---
+# s = tiled_amin(x, dim=0) → [256] dense; return s + bias
+# Tests _allocate_full_buffer for sparse reduction output with outside consumer.
+
+
+def test_outside_consumer_reduction_512x256_A4():
+    """s=tiled_amin(x,dim=0) consumed outside as s+bias, tiled A÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("bias", shape=(256,), dims=["B"]),
+    ]
+
+    def fn(x, bias):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            s = x.amin(dim=0)
+        return s + bias
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_outside_consumer_reduction_512x256_B4():
+    """s=tiled_amin(x,dim=0) consumed outside as s+bias, tiled B÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("bias", shape=(256,), dims=["B"]),
+    ]
+
+    def fn(x, bias):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            s = x.amin(dim=0)
+        return s + bias
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_outside_consumer_reduction_512x256_A4_B4():
+    """s=tiled_amin(x,dim=0) consumed outside as s+bias, tiled A÷4 B÷4."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("bias", shape=(256,), dims=["B"]),
+    ]
+
+    def fn(x, bias):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                s = x.amin(dim=0)
+        return s + bias
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# ---------------------------------------------------------------------------
+# Group 9: views — reshape, 1D sub-dim, view+transpose, unsqueeze
+# Op inside fn is multiply (more numerically stable than add on fp16).
+# ---------------------------------------------------------------------------
+
+# --- 1D sub-dim naming: flat [Lq*D] tensor named with 2 sub-dims ---
+# Both outer (Lq÷2) and inner (D÷2) hints land on the single host dim.
+
+
+def test_view_1d_subdim_Lq2_D2():
+    """a*b on 1D [Lq*D] named ["Lq","D"], nested Lq÷2 / D÷2 on same host dim."""
+    Lq, D = 256, 128
+    inputs = [
+        tensor("a", shape=(Lq * D,), dims=["Lq", "D"]),
+        tensor("b", shape=(Lq * D,), dims=["Lq", "D"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"Lq": 2}):
+            with spyre_hint(num_tiles_per_dim={"D": 2}):
+                return a * b
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- named input directly viewed+transposed inside fn ---
+# Modeled after granite_flash_attention style views: flat [B,S,H*D] inputs viewed to 4D
+# then transposed. Named dims span the fused H*D dim.
+# B=2, S=256, H=4, D=64 → flat shape [2,256,256]; post-view+transpose [2,4,256,64]
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_view_named_input_view_transpose_H2():
+    """flat [B,S,H*D] view+transpose before hint scope, tiled H÷2."""
+    B, S, H, D = 2, 256, 8, 128
+    _nd = {"batch_size": B, "max_seqlen": S, "num_heads": H, "head_dim": D}
+    inputs = [
+        tensor(
+            "q",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen", "num_heads", "head_dim"],
+            named_dims=_nd,
+        ),
+        tensor(
+            "k",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen", "num_heads", "head_dim"],
+            named_dims=_nd,
+        ),
+    ]
+
+    def fn(q, k):
+        q = q.view(B, S, H, D).transpose(1, 2)
+        k = k.view(B, S, H, D).transpose(1, 2)
+        with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
+            return q * k
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: propagate_named_dims can't handle multi-var coord for fused dim after view+transpose
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_view_named_input_view_transpose_S4():
+    """flat [B,S,H*D] view+transpose before hint scope, tiled S÷4."""
+    B, S, H, D = 2, 256, 8, 128
+    _nd = {"batch_size": B, "max_seqlen": S, "num_heads": H, "head_dim": D}
+    inputs = [
+        tensor(
+            "q",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen", "num_heads", "head_dim"],
+            named_dims=_nd,
+        ),
+        tensor(
+            "k",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen", "num_heads", "head_dim"],
+            named_dims=_nd,
+        ),
+    ]
+
+    def fn(q, k):
+        q = q.view(B, S, H, D).transpose(1, 2)
+        k = k.view(B, S, H, D).transpose(1, 2)
+        with spyre_hint(num_tiles_per_dim={"max_seqlen": 4}):
+            return q * k
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: propagate_named_dims can't handle multi-var coord for fused dim after view+transpose
+
+
+@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+def test_view_named_input_view_transpose_H2_S4():
+    """flat [B,S,H*D] view+transpose before hint scope, tiled H÷2 S÷4."""
+    B, S, H, D = 2, 256, 8, 128
+    _nd = {"batch_size": B, "max_seqlen": S, "num_heads": H, "head_dim": D}
+    inputs = [
+        tensor(
+            "q",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen", "num_heads", "head_dim"],
+            named_dims=_nd,
+        ),
+        tensor(
+            "k",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen", "num_heads", "head_dim"],
+            named_dims=_nd,
+        ),
+    ]
+
+    def fn(q, k):
+        q = q.view(B, S, H, D).transpose(1, 2)
+        k = k.view(B, S, H, D).transpose(1, 2)
+        with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
+            with spyre_hint(num_tiles_per_dim={"max_seqlen": 4}):
+                return q * k
+
+    run_coarse_tile_test(
+        fn, inputs, loopspec=False, correctness=False
+    )  # KNOWN BROKEN: Inductor fuses view+transpose into tiled op index expr, causing "reshape split a named dim" in propagate_named_dims
+
+
+# --- 4D input transposed then multiplied ---
+# Inputs already in 4D shape [B,H,S,D], transpose swaps non-stick dims.
+# B=2, S=256, H=4, D=64
+
+
+def test_view_4d_transpose_H4():
+    """x.view(B,S,H,D).transpose(1,2)*y tiled H÷2."""
+    B, S, H, D = 2, 256, 4, 64
+    _nd = {"batch_size": B, "max_seqlen_q": S, "num_heads": H, "head_dim": D}
+    inputs = [
+        tensor(
+            "x",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen_q", "num_heads", "head_dim"],
+            named_dims=_nd,
+        ),
+        tensor(
+            "y",
+            shape=(B, H, S, D),
+            dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"],
+            named_dims=_nd,
+        ),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
+            return x.view(B, S, H, D).transpose(1, 2) * y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_view_4d_transpose_S4():
+    """x.view(B,S,H,D).transpose(1,2)*y tiled S÷4."""
+    B, S, H, D = 2, 256, 4, 64
+    _nd = {"batch_size": B, "max_seqlen_q": S, "num_heads": H, "head_dim": D}
+    inputs = [
+        tensor(
+            "x",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen_q", "num_heads", "head_dim"],
+            named_dims=_nd,
+        ),
+        tensor(
+            "y",
+            shape=(B, H, S, D),
+            dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"],
+            named_dims=_nd,
+        ),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"max_seqlen_q": 4}):
+            return x.view(B, S, H, D).transpose(1, 2) * y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_view_4d_transpose_H2_S4():
+    """x.view(B,S,H,D).transpose(1,2)*y tiled H÷2 S÷4."""
+    B, S, H, D = 2, 256, 4, 64
+    _nd = {"batch_size": B, "max_seqlen_q": S, "num_heads": H, "head_dim": D}
+    inputs = [
+        tensor(
+            "x",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen_q", "num_heads", "head_dim"],
+            named_dims=_nd,
+        ),
+        tensor(
+            "y",
+            shape=(B, H, S, D),
+            dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"],
+            named_dims=_nd,
+        ),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
+            with spyre_hint(num_tiles_per_dim={"max_seqlen_q": 4}):
+                return x.view(B, S, H, D).transpose(1, 2) * y
+
+    run_coarse_tile_test(fn, inputs)
+
+
+# --- unsqueeze: a.unsqueeze(0) * b where b has the broadcast shape ---
+
+
+def test_view_unsqueeze_broadcast_A4():
+    """a.unsqueeze(0)*b: a=[256,256], b=[4,256,256], tiled A÷4."""
+    inputs = [
+        tensor("a", shape=(256, 256), dims=["A", "B"]),
+        tensor("b", shape=(4, 256, 256), dims=["N", "A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            return a.unsqueeze(0) * b
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_view_unsqueeze_broadcast_B4():
+    """a.unsqueeze(0)*b: a=[256,256], b=[4,256,256], tiled B÷4."""
+    inputs = [
+        tensor("a", shape=(256, 256), dims=["A", "B"]),
+        tensor("b", shape=(4, 256, 256), dims=["N", "A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"B": 4}):
+            return a.unsqueeze(0) * b
+
+    run_coarse_tile_test(fn, inputs)
+
+
+def test_view_unsqueeze_broadcast_A4_B4():
+    """a.unsqueeze(0)*b: a=[256,256], b=[4,256,256], tiled A÷4 B÷4."""
+    inputs = [
+        tensor("a", shape=(256, 256), dims=["A", "B"]),
+        tensor("b", shape=(4, 256, 256), dims=["N", "A", "B"]),
+    ]
+
+    def fn(a, b):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return a.unsqueeze(0) * b
+
+    run_coarse_tile_test(fn, inputs)
+
+
 # ===========================================================================
+# END OF STRUCTURED TESTS (Groups 1-9)
+# ===========================================================================
+# ORIGINAL TESTS — preserved for reference, being migrated to structured format.
+#
 # spyre_hint-driven coarse tiling
 # These tests verify that coarse tiling is driven automatically by
 # spyre_hint(num_tiles_per_dim=...) annotations.  Named tensor dimensions
@@ -571,15 +2812,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
     # Hint propagation into inserted restickify nodes
     # ------------------------------------------------------------------
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "The transposed input produces layouts where coarse-tiling rewrites "
-            "output buffer strides after restickify has already run, resulting in "
-            "a stick mismatch that raises in create_op_spec.  This will be fixed "
-            "by reordering the compiler passes so that restickify runs after "
-            "coarse-tiling (PR #3293)."
-        ),
+    @pytest.mark.skip(
+        reason="The transposed input produces layouts where coarse-tiling rewrites output buffer strides after restickify has already run, resulting in a stick mismatch that raises in create_op_spec."
     )
     @config.patch(
         {
@@ -692,7 +2926,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             fn, x, y, run_compile=True, run_eager=False, atol=0.01, rtol=0.01
         )
 
-    @unittest.expectedFailure
+    @pytest.mark.skip
     def test_hint_flash_attention(self):
         """Flash attention tiled over H (4 slices) via nested spyre_hints.
 
@@ -780,7 +3014,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
         )
 
-    @unittest.expectedFailure
+    @pytest.mark.skip
     def test_hint_flash_attention_v2(self):
         """Flash attention tiled over H (4 slices) via nested spyre_hints.
 
@@ -892,13 +3126,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             "allow_all_ops_in_lx_planning": True,
         }
     )
-    @pytest.mark.xfail(
-        strict=False,
-        reason=(
-            "flash attention v3/v4 not yet passing: Lk reduction-dim tiling is "
-            "disabled (see FIXME on kv_block_size), unrelated to carry "
-            "propagation"
-        ),
+    @pytest.mark.skip(
+        reason="flash attention v3/v4 not yet passing: Lk reduction-dim tiling is disabled (see FIXME on kv_block_size), unrelated to carry propagation"
     )
     def test_hint_flash_attention_v3(self):
         from torch_spyre._inductor import spyre_hint
@@ -1000,13 +3229,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
         )
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason=(
-            "flash attention v3/v4 not yet passing: Lk reduction-dim tiling is "
-            "disabled (see FIXME on kv_block_size), unrelated to carry "
-            "propagation"
-        ),
+    @pytest.mark.skip(
+        reason="flash attention v3/v4 not yet passing: Lk reduction-dim tiling is disabled (see FIXME on kv_block_size), unrelated to carry propagation"
     )
     def test_hint_flash_attention_v3_b2(self):
         """Same as flash_v3 but with B=2 and b_block_size=2 so B is nto tiled"""
@@ -1163,13 +3387,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
         )
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason=(
-            "flash attention v3/v4 not yet passing: unrelated "
-            "propagate_named_dims bug (num_heads layout dim has no loop "
-            "vars), not carry propagation"
-        ),
+    @pytest.mark.skip(
+        reason="flash attention v3/v4 not yet passing: unrelated propagate_named_dims bug (num_heads layout dim has no loop vars), not carry propagation"
     )
     def test_hint_flash_attention_v4(self):
         """This test attempts to replicate the standalone test_granite_attn.py with views
@@ -1316,7 +3535,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             "allow_all_ops_in_lx_planning": True,
         }
     )
-    @unittest.expectedFailure
+    @pytest.mark.skip
     def test_hint_flash_attention_loopspec(self):
         """Lk loop level not dropped when Lk-broadcast ops appear first in group.
 
@@ -1479,7 +3698,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             " by _stamp_group (group-wide is_reduction_level flag bug)",
         )
 
-    @unittest.expectedFailure
+    @pytest.mark.skip
     def test_hint_flash_attention_two_loop_levels(self):
         """Flash-attention graph: both H and Lk loop levels survive into codegen.
 
@@ -1588,7 +3807,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             " by _stamp_group (group-wide is_reduction_level flag bug)",
         )
 
-    @unittest.expectedFailure
+    @pytest.mark.skip
     def test_hint_flash_attention_two_loop_levels_v2(self):
         """Flash-attention graph: both H and Lq loop levels survive into codegen.
 
@@ -2045,7 +4264,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             "ignore_span_overflow_hints": False,
         }
     )
-    @unittest.expectedFailure
+    @pytest.mark.skip
     def test_span_overflow_mutation_case_external_input_layout_mismatch(self):
         """Originally a regression repro for the Case 2/"Case 3"
         layout-reconciliation gap; now an xfail for a separate, deeper,
@@ -2134,6 +4353,7 @@ class TestNamedDimsHint(InductorTestCase):
     def setUp(self):
         super().setUp()
         torch.manual_seed(0xAFFE)
+        _pnd.reset()
 
     @config.patch(
         {
@@ -2264,6 +4484,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
     def setUp(self):
         super().setUp()
         torch.manual_seed(0xAFFE)
+        _pnd.reset()
 
     def test_hint_tiled_reduction_sum_loopspec(self):
         """x.sum(dim=-1) tiled over D produces a LoopSpec with count 4."""
@@ -2459,6 +4680,7 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
     def setUp(self):
         super().setUp()
         torch.manual_seed(0xAFFE)
+        _pnd.reset()
 
     def test_hint_tiled_reduction_dim0_sum_correct(self):
         """x.sum(dim=0) tiled over B produces correct results."""
@@ -2523,6 +4745,7 @@ class TestCoarseTileMatmulKTilingE2E(InductorTestCase):
     def setUp(self):
         super().setUp()
         torch.manual_seed(0xAFFE)
+        _pnd.reset()
 
     def test_mm_k_tiled_correct(self):
         """2D mm [M,K] @ [K,N] tiled over K produces correct results."""
@@ -2638,6 +4861,7 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
     def setUp(self):
         super().setUp()
         torch.manual_seed(0xCAFE)
+        _pnd.reset()
 
     @pytest.mark.skip(
         reason=(
@@ -2853,7 +5077,7 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
 # ===========================================================================
 
 
-@pytest.mark.xfail(strict=True, reason="SpyreEmptyFallback / ct_fill STL bug")
+@pytest.mark.skip(reason="SpyreEmptyFallback / ct_fill STL bug")
 def test_tiled_in_place_accumulator():
     """Minimal reproducer for the SpyreEmptyFallback / ct_fill STL bug.
 
@@ -2953,9 +5177,8 @@ def test_sum_reduce_implicit_accumulator():
     torch.testing.assert_close(result, ref, atol=0.01, rtol=0.1)
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason="zeros with named_dims hint acquires wrong layout in tiled scope",
+@pytest.mark.skip(
+    reason="zeros with named_dims hint acquires wrong layout in tiled scope"
 )
 def test_zeros_named_dims_hint_correctness():
     """zeros with explicit named_dims hint inside a tiled scope should be correct.


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR introduces 125 new "structured" tests for coarse tiling.  They are not gratuitous tests for testing sake, but small(ish) targeted tests that stress scenarios we know are relevant to coarse tiling.  They are organized into the following groups:

```
    Group 1: Basic tiling — abs/add on 2D tensors, varied sizes and tile counts
    Group 2: 3D tensors — [A=512, B=256, C=256], all tiling combinations
    Group 3: Pointwise op chains — abs(a+b)*c, exp(abs(...)), etc.
    Group 4: Reductions — amin over 2D (all tiling combos) and 3D (all-dims)
    Group 5: Mixed pointwise + reduction — add_min, reduce_both, softmax
    Group 6: Restickify + coarse tiling — transpose inputs with tiling
    Group 7: Copies — pre-allocated buffers, in-place accumulators, RMW
    Group 8: Tiled ops with outside consumers
    Group 9: Views — 1D sub-dim naming, reshape, view+transpose, unsqueeze
```

**Current Status**
125 new tests total, 34 skipped (known broken), 91 actually run.
37 disabled tests out of 125, in 5 categories:

1. PR #3381 regression (19): All restickify + coarse tiling tests fail with a StopIteration in insert_restickify — the new _insert_read_copy_ops from PR #3381 inserts buffers that restickify can't find in env. Affects all restickify groups including copy+restickify. Will unblock once PR #3381's interaction with restickify is fixed.
2. Reductions with nested tiling (7): Nested tiling on a single reduction produces wrong values (2D: A÷4+B÷4) or a scheduler crash (3D: inconsistent loop counts when tile counts differ, e.g. A÷4+B÷2+C÷4). Single-dim tiling of reductions passes.
3. Two-input restickify (3): a.t()+b.t()+x — two transposed inputs in the same op produces an unsupported d0+d1 stick expression.
4. Mixed 1D/2D tiled scope (3): Flash-style two-accumulator pattern where denom is 1D but out is 2D in the same hint scope — infeasible restickify for the 1D buffer.
5. View+transpose on named input (3): Flat [B,S,H*D] input directly view+transposed; Inductor fuses the view into the tiled op's index expression, causing propagate_named_dims to see a split named dim. Mitigated in flash_v4 by large tensor sizes that force materialization.
    
NOTE:
- Old failing tests were intentionally converted from xfail to skip.  These are large, slow tests that are known broken under active development.  We do not need to keep rerunning them to confirm they fail.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
