### PR TITLE
fix(distributed): fix import torch_spyre crash from spyre::broadcast_async schema ordering

### DIFF
--- a/torch_spyre/__init__.py
+++ b/torch_spyre/__init__.py
@@ -266,6 +266,11 @@ def _autoload():
     torch.utils.rename_privateuse1_backend(DEVICE_NAME)
     torch._register_device_module(DEVICE_NAME, make_spyre_module())
 
+    # Must run before torch_spyre._C loads anywhere below (ops.eager,
+    # decompositions both import it). _C's impl registration needs this
+    # module's schema to already exist, or import torch crashes.
+    from torch_spyre._inductor.distributed import spyre_library  # noqa: F401
+
     import torch_spyre.ops.eager  # noqa: F401
     from torch_spyre._inductor import _light_autoload
 

--- a/torch_spyre/_inductor/distributed/spyre_library.py
+++ b/torch_spyre/_inductor/distributed/spyre_library.py
@@ -8,23 +8,10 @@ import torch
 # This file only registers the abstract (fake/meta) kernels needed by torch.compile
 # for shape inference during tracing.
 
-# The op schema is defined here in Python -- NOT via a C++ TORCH_LIBRARY(spyre,
-# ...) def -- so it exists as soon as torch_spyre is imported. torch_spyre._C
-# (which holds the real PrivateUse1 kernels registered via
-# TORCH_LIBRARY_IMPL(spyre, PrivateUse1, ...) in spyre_distributed.cpp) is
-# loaded lazily on first real device use (see _SpyreImpl._lazy_init in
-# torch_spyre/__init__.py). register_fake() below requires the schema to
-# already exist, and this module is imported eagerly at autoload time -- so
-# defining the schema via C++ TORCH_LIBRARY would require _C to be loaded
-# before autoload finishes, breaking that lazy-load contract and making
-# `import torch` raise "operator spyre::broadcast_async does not exist".
-# "FRAGMENT" (rather than "DEF") avoids conflicting with other Library
-# handles that may also touch the "spyre" namespace (e.g. the
-# torch.library.custom_op declarations in customops.py).
-#
-# Module-level Library handle, kept alive for the lifetime of the process:
-# torch.library.Library uses weakref.finalize to call m.reset() on GC, which
-# would silently unregister the schema from the dispatcher.
+# Schema defined in Python, not C++: the C++ side only registers PrivateUse1
+# impls (spyre_distributed.cpp) and needs this schema to exist first.
+# torch_spyre/__init__.py imports this module before torch_spyre._C to
+# guarantee that order. Kept as a module-level var so it isn't GC'd.
 _spyre_distributed_lib = torch.library.Library("spyre", "FRAGMENT")
 _spyre_distributed_lib.define(
     "broadcast_async(Tensor input, int src_rank, str group_name) -> Tensor"

--- a/torch_spyre/_inductor/distributed/spyre_library.py
+++ b/torch_spyre/_inductor/distributed/spyre_library.py
@@ -8,6 +8,29 @@ import torch
 # This file only registers the abstract (fake/meta) kernels needed by torch.compile
 # for shape inference during tracing.
 
+# The op schema is defined here in Python -- NOT via a C++ TORCH_LIBRARY(spyre,
+# ...) def -- so it exists as soon as torch_spyre is imported. torch_spyre._C
+# (which holds the real PrivateUse1 kernels registered via
+# TORCH_LIBRARY_IMPL(spyre, PrivateUse1, ...) in spyre_distributed.cpp) is
+# loaded lazily on first real device use (see _SpyreImpl._lazy_init in
+# torch_spyre/__init__.py). register_fake() below requires the schema to
+# already exist, and this module is imported eagerly at autoload time -- so
+# defining the schema via C++ TORCH_LIBRARY would require _C to be loaded
+# before autoload finishes, breaking that lazy-load contract and making
+# `import torch` raise "operator spyre::broadcast_async does not exist".
+# "FRAGMENT" (rather than "DEF") avoids conflicting with other Library
+# handles that may also touch the "spyre" namespace (e.g. the
+# torch.library.custom_op declarations in customops.py).
+#
+# Module-level Library handle, kept alive for the lifetime of the process:
+# torch.library.Library uses weakref.finalize to call m.reset() on GC, which
+# would silently unregister the schema from the dispatcher.
+_spyre_distributed_lib = torch.library.Library("spyre", "FRAGMENT")
+_spyre_distributed_lib.define(
+    "broadcast_async(Tensor input, int src_rank, str group_name) -> Tensor"
+)
+_spyre_distributed_lib.define("wait_work(Tensor(a!) tensor) -> Tensor(a)")
+
 
 @torch.library.register_fake("spyre::broadcast_async")
 def _(x: torch.Tensor, src_rank: int = 0, group_name: str = "default") -> torch.Tensor:

--- a/torch_spyre/csrc/distributed/spyre_distributed.cpp
+++ b/torch_spyre/csrc/distributed/spyre_distributed.cpp
@@ -213,12 +213,8 @@ at::Tensor spyre_wait_work_impl(const at::Tensor& tensor) {
 
 }  // namespace spyre
 
-// The "broadcast_async"/"wait_work" op schemas are defined in Python
-// (torch_spyre/_inductor/distributed/spyre_library.py), not here, so they
-// exist as soon as torch_spyre is imported -- this extension module is only
-// loaded lazily on first real device use (see _SpyreImpl._lazy_init in
-// torch_spyre/__init__.py). Only the PrivateUse1 kernel implementations are
-// registered here, against the schema Python already defined.
+// Schemas for these ops are defined in Python (spyre_library.py), not here.
+// This only registers the PrivateUse1 implementations against that schema.
 TORCH_LIBRARY_IMPL(spyre, PrivateUse1, m) {
   m.impl("broadcast_async", &spyre::spyre_broadcast_async_impl);
   m.impl("wait_work", &spyre::spyre_wait_work_impl);

--- a/torch_spyre/csrc/distributed/spyre_distributed.cpp
+++ b/torch_spyre/csrc/distributed/spyre_distributed.cpp
@@ -213,15 +213,12 @@ at::Tensor spyre_wait_work_impl(const at::Tensor& tensor) {
 
 }  // namespace spyre
 
-// Define the spyre namespace and operations
-TORCH_LIBRARY(spyre, m) {
-  m.def(
-      "broadcast_async(Tensor input, int src_rank, str group_name) -> Tensor");
-  // wait_work mutates the tensor in-place (fills in the broadcasted data)
-  m.def("wait_work(Tensor(a!) tensor) -> Tensor(a)");
-}
-
-// Register the implementations with PyTorch's dispatcher
+// The "broadcast_async"/"wait_work" op schemas are defined in Python
+// (torch_spyre/_inductor/distributed/spyre_library.py), not here, so they
+// exist as soon as torch_spyre is imported -- this extension module is only
+// loaded lazily on first real device use (see _SpyreImpl._lazy_init in
+// torch_spyre/__init__.py). Only the PrivateUse1 kernel implementations are
+// registered here, against the schema Python already defined.
 TORCH_LIBRARY_IMPL(spyre, PrivateUse1, m) {
   m.impl("broadcast_async", &spyre::spyre_broadcast_async_impl);
   m.impl("wait_work", &spyre::spyre_wait_work_impl);


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

## Problem

## Problem

- All CI suites failed with "no tests collected" 

- Cause: `import torch` triggers `torch_spyre` autoload, which imports `torch_spyre.ops.eager` and `decompositions.py`  both load `torch_spyre._C` before `spyre_library.py` runs and calls `register_fake("spyre::broadcast_async")`. That call needs the op schema to already exist.

- The schema was only defined in C++, inside `_C`. So by the time `register_fake` ran, `_C` was already loaded but the schema still was not registered (stale build in CI), and `import torch` itself crashed, killing collection for every suite.


## Fix

- Define the `broadcast_async`/`wait_work` schema in Python (`spyre_library.py`), matching the pattern already used for other Spyre ops.
- Import that schema first in `torch_spyre/__init__.py`, before anything else can load `torch_spyre._C`  so the schema always exists before C++ registers its implementation.
