### PR TITLE
test(lx): guard LX producer/consumer core->slice agreement

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_index_b_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_index_b_config.yaml
@@ -37,4 +37,7 @@ test_suite_config:
             - LxPlanning.*::test_logsumexp_keepdim0_known_xfail.*_lx_planning_(pointwise|reduction)
             - LxPlanning.*::test_mean_3d_dim0_keepdim.*_lx_planning_(pointwise|reduction)
             - LxPlanning.*::test_index_copy_.*_lx_planning_(pointwise|reduction)
+            # Regression guard for LX producer/consumer core->slice agreement
+            # (#3374, #3387). Asserts both values and that the buffer stays in LX.
+            - LxPlanning.*::test_shared_input_two_reductions.*_lx_planning_(pointwise|reduction)
           mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_index_norm_eager_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_index_norm_eager_config.yaml
@@ -22,6 +22,9 @@ test_suite_config:
             # variant was collected in the reductions shard via substring match.
             - TestOps::test_mean_3d_dim0_keepdim
             - TestOps::test_index_copy_.*
+            # Regression guard for LX producer/consumer core->slice agreement
+            # (#3374, #3387). Asserts both values and that the buffer stays in LX.
+            - TestOps::test_shared_input_two_reductions.*
           mode: mandatory_success
         # Xfail for failing tests related to PR #2179 (FP32 reduction ops)
         - names:

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -29,6 +29,7 @@ from utils_inductor import (
     shapes2key,
 )
 import utils_inductor
+from torch._inductor.utils import run_and_get_code
 from torch_spyre._inductor.dtype_ops import DtypeOpTable
 from torch_spyre._inductor.constants import IDENTITY_OP
 
@@ -104,6 +105,25 @@ COMMON_REDUCTION_KEEPDIM_PARAM_SETS = {
     "pad_4d_dim_1": (1, cached_randn((3, 7, 9, 32), scale=0.1)),
     "pad_4d_dim_2": (2, cached_randn((3, 7, 9, 32), scale=0.1)),
     "pad_4d_dim_3": (3, cached_randn((3, 7, 9, 32), scale=0.1)),
+}
+
+
+# Shapes for the shared-input two-reduction regression (see
+# SHARED_INPUT_TWO_REDUCTION_PAIRS). The reduced dim is deliberately never the
+# trailing one: the hazard needs a *non-trailing* reduction, since only then do
+# the per-core work slices of the shared input carry more than one split dim.
+SHARED_INPUT_TWO_REDUCTION_PARAM_SETS = {
+    # The three geometries whose aminmax cases regressed on 2.13 before the
+    # producer-alignment fix (test_aminmax_keepdim{0,1}_aminmax_pad_{2,3,4}d_dim_0).
+    # Unaligned trailing dims put these on the SDSC padding path.
+    "pad_2d_dim_0": (0, cached_randn((63, 129), scale=0.1)),
+    "pad_3d_dim_0": (0, cached_randn((3, 7, 9), scale=0.1)),
+    "pad_4d_dim_0": (0, cached_randn((3, 7, 9, 32), scale=0.1)),
+    # Stick-aligned trailing dim, so the padding path is not involved.
+    "3d_dim_0": (0, cached_randn((3, 5, 256), scale=0.1)),
+    # Interior dim rather than dim 0, so the split that must agree is not the
+    # outermost one either.
+    "4d_dim_1": (1, cached_randn((6, 7, 12, 256), scale=0.1)),
 }
 
 
@@ -229,6 +249,58 @@ def _get_spyre_mode_support(op):
         op,
         {"compiled": True, "eager": True, "reason": None},
     )
+
+
+# How an LX-resident buffer appears in generated code, e.g. "allocation={'lx': 0}".
+_LX_ALLOCATION_MARKER = "allocation={'lx'"
+
+
+def _assert_keeps_lx_residency(fn, x, case):
+    """Assert the compiled graph still pins at least one buffer into LX.
+
+    Comparing values cannot detect a regression in
+    ``align_lx_producer_loop_order``: if an LX buffer's producer and consumers
+    stop agreeing on core->slice, ``demote_incoherent_lx_buffers`` clears the LX
+    allocation and the results come out correct anyway -- just served from HBM.
+    Residency is therefore the only observable that separates "aligned" from
+    "demoted", so assert it directly.
+
+    Measured on the shapes in SHARED_INPUT_TWO_REDUCTION_PARAM_SETS: with the
+    aligner in place every case keeps 3 LX allocations (4 for the three-consumer
+    pair); with it removed the pad_* cases drop to 0.
+    """
+    torch._dynamo.reset_code_caches()
+    torch._inductor.codecache.FxGraphCache.clear()
+    _, source_codes = run_and_get_code(
+        torch.compile(fn, dynamic=False), x.to(utils_inductor.DEVICE)
+    )
+    assert source_codes, f"{case}: no generated source captured"
+    assert source_codes[0].count(_LX_ALLOCATION_MARKER) > 0, (
+        f"{case}: no buffer left in LX. The values may still be correct, but an "
+        f"LX buffer whose users disagree on core->slice gets demoted to HBM -- so "
+        f"this is the signature of the producer/consumer loop-order alignment "
+        f"regressing (see align_lx_producer_loop_order, #3374/#3387)."
+    )
+
+
+# Pairs of reductions applied to the *same* input over the same dim. Each pair is
+# built from two separately-dispatched ops rather than from a single fused op such
+# as aminmax, so the graph shape under test survives any change to how a tuple
+# reduction decomposes.
+SHARED_INPUT_TWO_REDUCTION_PAIRS = {
+    # Closest analogue to aminmax, the op that originally surfaced this.
+    "amin_amax": lambda x, dim: (torch.amin(x, dim=dim), torch.amax(x, dim=dim)),
+    # Mixed reduction kinds: an accumulating reduction beside a comparing one.
+    "sum_amax": lambda x, dim: (torch.sum(x, dim=dim), torch.amax(x, dim=dim)),
+    "mean_amin": lambda x, dim: (torch.mean(x, dim=dim), torch.amin(x, dim=dim)),
+    # Three consumers, so a single mismatched pair cannot be masked by the other
+    # two happening to agree.
+    "amin_amax_sum": lambda x, dim: (
+        torch.amin(x, dim=dim),
+        torch.amax(x, dim=dim),
+        torch.sum(x, dim=dim),
+    ),
+}
 
 
 def _compare_op_with_cpu(fn, op, *args, **kwargs):
@@ -1147,6 +1219,23 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 "aminmax": torch.aminmax,
             },
             "param_sets": INDEX_REDUCTION_KEEPDIM_PARAM_SETS,
+        },
+        # Regression guard for the LX producer/consumer core->slice agreement
+        # (#3374, #3387). Two device reductions over one LX-pinned input reducing
+        # a non-trailing dim get a positional core->slice mapping from
+        # core_to_slice_mapping; if the clone that pins the input into LX walks it
+        # in a different dim order than the reductions read it, each core reads a
+        # slice another core wrote and the result is silently wrong. Through 2.12
+        # Inductor's loop_ordering_after_fusion happened to rewrite the clone into
+        # the consumers' order; 2.13 computes that reorder and discards it, which
+        # is what exposed it. aminmax was merely the first op to show it, so these
+        # cases assert the general shape.
+        (
+            "test_shared_input_two_reductions",
+            "test_shared_input_two_reductions_base",
+        ): {
+            "ops_dict": SHARED_INPUT_TWO_REDUCTION_PAIRS,
+            "param_sets": SHARED_INPUT_TWO_REDUCTION_PARAM_SETS,
         },
         ("test_vector_norm_keepdim0", "test_norm_keepdim0_cpu"): {
             "ops_dict": {
@@ -4979,6 +5068,25 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
 
     def test_tuple_reduce_keepdim1_cpu(self, op, dim, x):
         _compare_op_with_cpu(lambda x: op(x, dim=dim, keepdim=True), op, x)
+
+    def test_shared_input_two_reductions_base(self, op, dim, x):
+        """Two or more reductions over one shared input, reducing a non-trailing dim.
+
+        A wrong core->slice agreement shows up as values from another core's
+        slice, so this compares every output element rather than just a shape.
+
+        Compiled path only: LX planning is an Inductor-side pass, and Spyre eager
+        does not implement these reductions (they return NotImplemented).
+
+        Values are only half the guard -- see _assert_keeps_lx_residency for why
+        the LX allocation itself has to be asserted too.
+        """
+
+        def fn(t):
+            return op(t, dim)
+
+        self.compare_with_cpu(fn, x, run_eager=False, cpu_compile=True)
+        _assert_keeps_lx_residency(fn, x, self.id().rsplit(".", 1)[-1])
 
     def test_norm_keepdim0_cpu(self, op, ord, dim, x):
         _compare_op_with_cpu(lambda x: op(x, ord=ord, dim=dim, keepdim=False), op, x)


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

Test-only. No source changes.

#### What this PR does:

Adds a regression guard for the LX producer/consumer core->slice agreement fixed by `align_lx_producer_loop_order` (#3387, shipped inside the 2.13 upgrade `754839cc` / #3374).

20 parameterized cases - 60 instances once the LX-planning wraps are counted - each running two or more device reductions over one shared input while reducing a **non-trailing** dim. Per #3387 that is the whole hazard: *"any two device reductions over one LX-pinned input reducing a non-trailing dim are wrong."* `aminmax` was only the op that surfaced it, so the pairs are built from separately-dispatched ops (`amin`+`amax`, `sum`+`amax`, `mean`+`amin`, and a three-consumer case) rather than from `aminmax`, and so survive any change to how a tuple reduction decomposes.

**Each case asserts values against CPU *and* that the compiled graph still pins a buffer into LX.** The residency half is the load-bearing one, and it is the reason this PR exists in this shape: `demote_incoherent_lx_buffers` (#3378) clears `allocation["lx"]` when an LX buffer's users disagree on core->slice, so if the aligner regresses the values still come back **correct**, just served from HBM. A value-only test cannot see that happen. Residency is the only observable that separates "aligned" from "demoted".

#### Results

Verified in both directions on `main` @ `58f4ac2f`, on hardware:

| Configuration | Values | LX residency |
|---|---|---|
| `main` as-is | 20/20 pass | 3 allocations per case (4 for the three-consumer pair) |
| `align_lx_producer_loop_order` removed | still pass | **0 on every `pad_*` case** |
| align + demote both removed | 16 fail | -- |

With the assertion in place, removing the aligner fails 12 of 20 with a message naming the pass and the issues. Both wraps pass on `main`: 20 in `TestOps`, 40 under `LxPlanning`.

The three `pad_*_dim_0` geometries are the load-bearing cases - they reproduce the original `test_aminmax_keepdim{0,1}_aminmax_pad_{2,3,4}d_dim_0` signature and are what breaks when unprotected. `3d_dim_0` and `4d_dim_1` pass even fully unprotected and are breadth, not guards; they are kept deliberately and labelled as such.

Compiled path only: LX planning is an Inductor-side pass, and Spyre eager does not implement these reductions (they return `NotImplemented`).

Wired into the reduction shards for both the plain and LX-planning runs; `make check-all-configs` reports no missing coverage.

#### Which issue(s) this PR is related to:

Refs #2062, #3374, #3387

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No.

#### Additional note:
