### PR TITLE
docs: fix documentation drift against current codebase

### DIFF
--- a/docs/source/_ext/extract_graph.py
+++ b/docs/source/_ext/extract_graph.py
@@ -829,6 +829,7 @@ def build_graph(torch_spyre_root):
         (extract_custom_ops, root / "_inductor" / "customops.py"),
         (extract_fallbacks, root / "ops" / "fallbacks.py"),
         (extract_eager_kernels, root / "ops" / "eager.py"),
+        (extract_eager_kernels, root / "_inductor" / "customops.py"),
         (extract_passes, root / "_inductor" / "passes.py"),
     ]
 
@@ -880,7 +881,11 @@ def build_graph(torch_spyre_root):
         n, e = _run_file_extractor(extract_config, config_path, repo_root)
         all_nodes.extend(n)
         all_edges.extend(e)
-    for extra_config in [root / "__init__.py", root / "logging_config.py"]:
+    for extra_config in [
+        root / "__init__.py",
+        root / "logging_config.py",
+        root / "profiler" / "_ffdc.py",
+    ]:
         if extra_config.exists():
             n, e = _run_file_extractor(extract_config, extra_config, repo_root)
             all_nodes.extend(n)

--- a/docs/source/api/torch_spyre.rst
+++ b/docs/source/api/torch_spyre.rst
@@ -626,13 +626,16 @@ Environment Variables
    * - ``BUNDLE_SYMBOLIC_ARGS``
      - Emit LPDDR5 tensor addresses as runtime symbols rather than baked
        integers (default ``1``)
-   * - ``LX_BOUNDARY_CLONES``
-     - Insert boundary clones at LX scratchpad planning edges (default
-       ``0``)
    * - ``LAYOUT_SOLVER``
      - LX scratchpad layout solver strategy: ``greedy`` (default),
-       ``bestfit``, ``firstfit``, ``cpsat``.
+       ``bestfit``, ``firstfit``, ``cpsat``, ``simulated_annealing``.
        See :doc:`/compiler/scratchpad_planning`
+   * - ``SPYRE_INDUCTOR_ENABLE_REDUCTION_TILING``
+     - Enable reduction tiling in the pre-scheduling pipeline (default
+       ``1``)
+   * - ``SPYRE_LOG_PASSES``
+     - Comma-separated list of pass names after which to log the
+       op-spec IR at pipeline stage boundaries (default empty)
    * - ``MAX_BUCKETS``
      - Maximum number of work division buckets (default ``32``)
    * - ``MIN_DEFAULT_GRANULARITY``

--- a/docs/source/compiler/adding_operations.md
+++ b/docs/source/compiler/adding_operations.md
@@ -19,7 +19,7 @@ Canonical examples are `reciprocal` and `sigmoid`.
 ## Spyre-specific decompositions
 
 We define Spyre-specific decompositions in [decompositions.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/decompositions.py)
-using the `@register_spyre_decomposition` decorator.  Decompositions are graph transformations
+using the `@register_spyre_decompositions` decorator.  Decompositions are graph transformations
 that are performed before the graph is lowered to loop level IR.
 
 ## Spyre-specific lowerings

--- a/docs/source/compiler/architecture.md
+++ b/docs/source/compiler/architecture.md
@@ -34,7 +34,7 @@ A working knowledge of PyTorch's compilers is essential for understanding our fr
 Some useful resources are:
 + The [ASPLOS'24 paper on PyTorch2](https://docs.pytorch.org/assets/pytorch2-2.pdf)
 + The [ASPLOS'24 tutorial on PyTorch2](https://github.com/meta-pytorch/workshops/tree/master/ASPLOS_2024). In particular,
-the portion on [Inductor](https://github.com/pytorch/workshops/tree/master/ASPLOS_2024/inductor.pdf)
+the portion on [Inductor](https://github.com/meta-pytorch/workshops/blob/master/ASPLOS_2024/inductor.pdf)
 + General documentation on [torch.compiler](https://docs.pytorch.org/docs/stable/torch.compiler.html#)
 
 ## Front-end Compiler Overview

--- a/docs/source/compiler/coarse_tiling_loops.md
+++ b/docs/source/compiler/coarse_tiling_loops.md
@@ -616,7 +616,7 @@ Key observations:
   `device_tile_advance_expr` means `generate_bundle` addresses that
   `TensorArg` with a fixed, non-advancing address — no `affine.apply` per
   iteration — whether or not `per_tile_fixed` is actually set; see
-  `compute_ops.py`'s `_tensor_tiled_by_symbol`, which treats "no advance
+  `codegen/compute_ops.py`'s `_tensor_tiled_by_symbol`, which treats "no advance
   expression" and "`per_tile_fixed`" as the same "does not advance" case for
   `bundle.mlir` purposes. `op0`'s (`add`'s) own two inputs reuse the same
   fixed `a_tile`/`b_tile` `hbm_pool` addresses the read copies just wrote —
@@ -677,7 +677,7 @@ Key observations:
   it were too large, or scratchpad were otherwise full),
   `scratchpad_planning` would fall back to `allocation={'hbm_pool': ...}`
   instead — the same bulk-allocated HBM region
-  (`memory_planning.py`'s `INTERMEDIATES_SEGMENT`) that `a_tile`/`b_tile`/
+  (`constants.py`'s `INTERMEDIATES_SEGMENT`) that `a_tile`/`b_tile`/
   `c_tile` already use — and the buffer would still carry
   `per_tile_fixed=True`, since that flag reflects the loop-internal-scratch
   *lifetime* of the buffer, not which memory it happens to land in.
@@ -1386,7 +1386,7 @@ both already iterating per arg:
   (`supertile_count`) — `supertile_count` is host/op-level loop-structure
   metadata, not device-layout-derived, so it is legitimately the same
   across every arg of the op even though `tile_size` is not.
-- **`compute_ops.py`'s `generate_sdsc`** uses each tensor's own
+- **`codegen/compute_ops.py`'s `generate_sdsc`** uses each tensor's own
   `device_tile_advance_expr` to build `affine_strides` — the actual
   per-iteration advance for each nesting level. This is the one place in
   the whole pipeline that already iterates per level and per tensor arg,

--- a/docs/source/compiler/inductor_frontend.md
+++ b/docs/source/compiler/inductor_frontend.md
@@ -43,9 +43,9 @@ points, all registered in
 |----------------|-------|---------|
 | `CustomPreGradPasses` | Pre-grad FX graph | Reserved for graph rewrites before autograd partitioning. The pipeline is empty today. |
 | `CustomPrePasses` | Post-grad FX graph (early) | `collect_spyre_hints` snapshots `spyre_hint` annotations so they survive AOT re-tracing. |
-| `CustomPostPasses` | Post-grad FX graph (late) | Late post-grad rewrites: `recover_spyre_hints`, `mm_to_bmm_pass`, `mark_direct_unit_bmm_pass`, `bmm_unflatten_pass`. |
-| `CustomPreFusionPasses` | LoopLevelIR (pre-fusion) | Pre-fusion scheduler passes: `propagate_mutation_layouts`, `build_loop_scheduler_nodes`. |
-| `CustomPostFusionPasses` | LoopLevelIR (post-fusion) | Post-fusion scheduler passes: `hbm_pool_planning`, `spyre_fuse_nodes`. |
+| `CustomPostPasses` | Post-grad FX graph (late) | Late post-grad rewrites: `recover_spyre_hints`, `decompose_addmm`, `mm_to_bmm_pass`, `mark_direct_unit_bmm_pass`, `bmm_unflatten_pass`. |
+| `CustomPreFusionPasses` | LoopLevelIR (pre-fusion) | Pre-fusion scheduler passes: `propagate_mutation_layouts`, `align_lx_producer_loop_order`, `build_loop_scheduler_nodes`. |
+| `CustomPostFusionPasses` | LoopLevelIR (post-fusion) | Post-fusion scheduler passes: `demote_incoherent_lx_buffers`, `hbm_pool_planning`, `spyre_fuse_nodes`. |
 | `CustomPreSchedulingPasses` | LoopLevelIR (pre-scheduler) | The pre-scheduling pipeline that runs immediately before the Scheduler is constructed (wired in via a `GraphLowering._update_scheduler` monkey-patch in [`patches.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/patches.py)). The full step list is in [LoopLevelIR Passes](#looplevelir-passes) below. |
 
 ### FX Graph Passes
@@ -54,7 +54,7 @@ Transformations on the FX Graph tend to be simpler to implement, but happen befo
 layout of intermediate Tensors in device memory has been computed.  Therefore they need to be layout-agnostic.
 Some examples of passes that are appropriate to perform at this level are:
 + replacing constants with size 1 tensors
-+ normalizing matrix multiplies to add padding (also applied to `mm` and `bmm`)
++ normalizing 2D `mm` into 3D `bmm` (`mm_to_bmm_pass`)
 
 ### LoopLevelIR Passes
 
@@ -74,20 +74,21 @@ between `insert_restickify` and the hint-copy machinery (issue #3135).
 | 1 | `deadcode_elimination` | [deadcode_elimination.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/deadcode_elimination.py) | Drops unreachable ops. |
 | 2 | `propagate_named_dims` | [propagate_named_dims.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/wsr/propagate_named_dims.py) | Propagates `name_tensor_dims` annotations from inputs through the op graph. Runs pre-stickification — only needs host-side `FixedLayout`. |
 | 3 | `assign_dim_hints` | [propagate_named_dims.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/wsr/propagate_named_dims.py) | Lowers each `spyre_hint` scope to a per-op `DimHint` list. |
-| 4 | `_maybe_coarse_tile_hints` | [passes.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/passes.py) | Hint-driven half of coarse tiling: `reorder_unhinted_interlopers` + `hints_to_coarse_tile_groups` + `coarse_tile`. Runs on host-side `FixedLayout` only. |
+| 4 | `_maybe_coarse_tile_hints` | [passes.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/passes.py) | Gated by `config.ignore_wsr_hints` (`SPYRE_INDUCTOR_IGNORE_HINTS`). Hint-driven half of coarse tiling: `reorder_unhinted_interlopers` + `hints_to_coarse_tile_groups` + `coarse_tile`. Runs on host-side `FixedLayout` only. |
 | 5 | `split_multi_ops` | [split_multi_ops.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/split_multi_ops.py) | Splits multi-op loop bodies (e.g. type conversion + arithmetic) into separate single-op buffers and materializes constant args as `SpyreConstantFallback`. |
 | 6 | `propagate_spyre_tensor_layouts` | [propagate_layouts.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/propagate_layouts.py) | Stamps `FixedTiledLayout` on every `ComputedBuffer`. |
 | 7 | `validate_ops` | [split_multi_ops.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/split_multi_ops.py) | Checks that each op's inputs share the same `ElementArrangement`. Runs after layout propagation, when the `SpyreTensorLayout`s are available. |
 | 8 | `optimize_restickify_locations` | [optimize_restickify.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/optimize_restickify.py) | Moves restickify ops to better placements before the layout is finalized. |
 | 9 | `finalize_layouts` | [insert_restickify.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/insert_restickify.py) | Settles tile-structure decisions before any new restickify is inserted. |
 | 10 | `insert_restickify` | [insert_restickify.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/insert_restickify.py) | Adds explicit re-tile ops where adjacent ops disagree on layout. |
-| 11 | `insert_post_mutation_restickify` | [insert_restickify.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/insert_restickify.py) | Handles restickification for slice-mutation buffers. |
-| 12 | `insert_bmm_padding` | [padding.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/padding.py) | Pads `mm` and `bmm` operands to satisfy hardware alignment. |
-| 13 | `dedup_and_promote_constants` | [dedup_constants.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/dedup_constants.py) | Deduplicates identical constants and promotes shared ones. |
-| 14 | `_maybe_coarse_tile_span_overflow` | [passes.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/passes.py) | Span-overflow half of coarse tiling: `span_overflow_groups` + `coarse_tile`. Runs post-stickification — needs `FixedTiledLayout.device_layout` for physical span arithmetic. |
-| 15 | `span_reduction` | [work_division.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/work_division.py) | Reduces per-core access spans to fit the hardware memory budget. |
-| 16 | `cost_model_matmul_division` + `work_distribution` | [work_division.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/work_division.py) | The cost-model pass claims a subset of matmuls; `work_distribution` covers the rest. |
-| 17 | `scratchpad_planning` | [scratchpad/](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/scratchpad/) | Gated by `config.lx_planning`. Allocates the LX scratchpad. |
+| 11 | `enforce_indirect_access_layout` | [enforce_indirect_access_layout.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/enforce_indirect_access_layout.py) | Constrains the layout of tensors consumed by indirect (gather-style) access so the indexed dimension is addressable. |
+| 12 | `insert_post_mutation_restickify` | [insert_restickify.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/insert_restickify.py) | Handles restickification for slice-mutation buffers. |
+| 13 | `insert_bmm_padding` | [padding.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/padding.py) | Pads `mm` and `bmm` operands to satisfy hardware alignment. |
+| 14 | `dedup_and_promote_constants` | [dedup_constants.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/dedup_constants.py) | Deduplicates identical constants and promotes shared ones. |
+| 15 | `_maybe_coarse_tile_span_overflow` | [passes.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/passes.py) | Gated by `config.ignore_span_overflow_hints` (`SPYRE_INDUCTOR_IGNORE_SPAN_OVERFLOW_HINTS`, default on). Span-overflow half of coarse tiling: `span_overflow_groups` + `coarse_tile`. Runs post-stickification, so it needs `FixedTiledLayout.device_layout` for physical span arithmetic. |
+| 16 | `span_reduction` | [work_division.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/work_division.py) | Reduces per-core access spans to fit the hardware memory budget. |
+| 17 | `cost_model_matmul_division` + `work_distribution` | [work_division.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/work_division.py) | The cost-model pass claims a subset of matmuls; `work_distribution` covers the rest. |
+| 18 | `scratchpad_planning` | [scratchpad/](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/scratchpad/) | Gated by `config.lx_planning`. Allocates the LX scratchpad. |
 
 Once stickification has run, every `ComputedBuffer` carries a `FixedTiledLayout`, so the later passes can take device layout into account when making decisions.
 
@@ -243,7 +244,7 @@ using `@torch.library.custom_op`. Each custom op requires:
 
 ### Decompositions
 
-Spyre-specific decompositions are registered with `@register_spyre_decomposition`
+Spyre-specific decompositions are registered with `@register_spyre_decompositions`
 in
 [decompositions.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/decompositions.py).
 Decompositions transform complex ATen operations into simpler primitives
@@ -262,8 +263,8 @@ The headline modules above are the ones a contributor reaches for first. The fro
 
 | Module | Purpose |
 |---|---|
-| [`passes.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/passes.py) | The six extension-point classes, plus `_format_operations`, which renders the LoopLevelIR before and after the pre-scheduling pipeline. |
-| [`temp_passes.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/temp_passes.py) | Transitional FX-graph rewrites registered in `CustomPostPasses`: `mm_to_bmm_pass`, `mark_direct_unit_bmm_pass`, and `bmm_unflatten_pass`. The "temp" name reflects the plan to retire them as upstream Inductor evolves. |
+| [`passes.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/passes.py) | The six extension-point classes. It renders the LoopLevelIR before and after the pre-scheduling pipeline via `format_operations` (defined in `pass_utils.py`). |
+| [`temp_passes.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/temp_passes.py) | Transitional FX-graph rewrites registered in `CustomPostPasses`: `decompose_addmm`, `mm_to_bmm_pass`, `mark_direct_unit_bmm_pass`, and `bmm_unflatten_pass`. The "temp" name reflects the plan to retire them as upstream Inductor evolves. |
 | [`propagate_layouts.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/propagate_layouts.py) | `propagate_spyre_tensor_layouts` and `propagate_mutation_layouts`. Assigns `FixedTiledLayout` to every `ComputedBuffer`. |
 | [`split_multi_ops.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/split_multi_ops.py) | `split_multi_ops` and `validate_ops`. Splits multi-op loop bodies into single-op buffers (materializing constant args as `SpyreConstantFallback`) and validates that op inputs share the same `ElementArrangement`. |
 | [`optimize_restickify.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/optimize_restickify.py) | Optimizes restickify operations inserted by layout propagation. |
@@ -274,7 +275,9 @@ The headline modules above are the ones a contributor reaches for first. The fro
 | [`scratchpad/`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/scratchpad/) | `scratchpad_planning` and the layout-solver framework (`GreedyLayoutSolver`, `FirstFitLayoutSolver`, `BestFitLayoutSolver`). LX scratchpad allocation. |
 | [`propagate_hints.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/propagate_hints.py) | `spyre_hint` context manager, the `DimHint` dataclass, and `collect_spyre_hints` / `recover_spyre_hints` for surviving AOT re-tracing. |
 | [`propagate_named_dims.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/wsr/propagate_named_dims.py) | `declare_tensor_dim`, `name_tensor_dims`, `propagate_named_dims`, and `assign_dim_hints`. Propagates named-dim metadata through the op graph and lowers `spyre_hint` scopes to per-op `DimHint` lists. |
-| [`coarse_tile.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/wsr/coarse_tile.py) | `coarse_tile`, `hints_to_coarse_tile_groups`, `insert_tiling_propagation`, `reorder_unhinted_interlopers`, `span_overflow_groups`. Wraps each hint-derived group in nested counted loops and scales per-iteration ranges. |
+| [`coarse_tile.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/wsr/coarse_tile.py) | `coarse_tile`, `insert_tiling_propagation`. Wraps each hint-derived group in nested counted loops and scales per-iteration ranges. |
+| [`coarse_tile_hints.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/wsr/coarse_tile_hints.py) | `hints_to_coarse_tile_groups`, `reorder_unhinted_interlopers`. Derives coarse-tile groups from `spyre_hint` scopes and orders unhinted ops that sit between hinted ones. |
+| [`coarse_tile_span_overflow.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/wsr/coarse_tile_span_overflow.py) | `span_overflow_groups`. Derives coarse-tile groups for ops whose per-core span exceeds the hardware limit, using device layout. |
 | [`dedup_constants.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/dedup_constants.py) | `dedup_and_promote_constants`. Deduplicates identical constants in the LoopLevelIR. |
 | [`loop_info.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/loop_info.py) | `CoarseTileInfo`, `copy_op_metadata`. Per-op metadata stamped by `coarse_tile()` and consumed by the scheduler, kernel codegen, and buffer-propagation pass. |
 | [`dtype_ops.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/dtype_ops.py) | `DtypeOpTable`. Lookup table mapping PyTorch dtype pairs to Spyre hardware dtype-conversion operators. |
@@ -287,8 +290,10 @@ The headline modules above are the ones a contributor reaches for first. The fro
 | [`padding.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/padding.py) | `insert_bmm_padding`. Pads `mm` and `bmm` operands to satisfy hardware alignment. |
 | [`fusion.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/fusion.py) | `spyre_fuse_nodes`. Post-fusion scheduler pass. |
 | [`wrapper.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/wrapper.py) | `SpyrePythonWrapperCodegen`. The host-code generator that produces the Python wrapper around device kernels. |
-| [`codegen/`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/codegen/) | `superdsc.py` (`SDSCArgs`, `SDSCSpec`, `parse_op_spec`, `compile_op_spec`, `_get_core_to_slice_mapping`, `_get_padded_iteration_space`, `_get_op_dim_labels`), `compute_ops.py` (`generate_sdsc`), `bundle.py` (`generate_bundle`, emits `scf.for` for coarse-tiling `LoopSpec` trees). Translates `OpSpec` into SuperDSC JSON for the back-end compiler. |
-| [`config.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/config.py) | Spyre-specific Inductor configuration: `SENCORES`, `LX_PLANNING`, `DXP_LX_FRAC_AVAIL`. |
+| [`codegen/`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/codegen/) | `superdsc.py` (`SDSCArgs`, `SDSCSpec`, `parse_op_spec`, `compile_op_spec`, `_get_padded_iteration_space`, `_get_op_dim_labels`), `compute_ops.py` (`generate_sdsc`), `bundle.py` (`generate_bundle`, emits `scf.for` for coarse-tiling `LoopSpec` trees). Translates `OpSpec` into SuperDSC JSON for the back-end compiler. |
+| [`core_mapping.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/core_mapping.py) | `core_to_slice_mapping`. Maps `core_id` values to work-slice offsets during SuperDSC emission. |
+| [`enforce_indirect_access_layout.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/enforce_indirect_access_layout.py) | `enforce_indirect_access_layout`. Constrains the layout of tensors consumed by indirect (gather-style) access. |
+| [`config.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/config.py) | Spyre-specific Inductor configuration. The module attributes `sencores`, `lx_planning`, and `dxp_lx_frac_avail` are populated from the `SENCORES`, `LX_PLANNING`, and `DXP_LX_FRAC_AVAIL` environment variables. |
 | [`ir.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/ir.py) | `FixedTiledLayout`, `SpyreConstantFallback`, `SpyreEmptyFallback`, `SpyreReduction`. Core IR types used throughout the pre-scheduling pipeline. |
 | [`choices.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/choices.py) | Spyre-specific `InductorChoices` overrides (e.g. reduction split heuristics). |
 | [`errors.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/errors.py) | `Unsupported` exception class for ops or configurations not yet handled by the Spyre backend. |

--- a/docs/source/compiler/scratchpad_planning.md
+++ b/docs/source/compiler/scratchpad_planning.md
@@ -374,7 +374,8 @@ Once `layout.allocation["lx"]` is set:
 
 ## Solvers
 
-`config.layout_solver` (`"greedy" | "firstfit" | "bestfit" | "cpsat"`)
+`config.layout_solver`
+(`"greedy" | "firstfit" | "bestfit" | "cpsat" | "simulated_annealing"`)
 picks the solver; it defaults from the `LAYOUT_SOLVER` environment
 variable (falling back to `"greedy"`).
 
@@ -431,6 +432,18 @@ solver only *places* buffers on each op's pre-determined core division;
 with `co_optimizing_lx_planning` it is driven by the joint
 `CoOptimizingAllocator` (below), which additionally chooses each op's core
 division.
+
+### SimulatedAnnealingLayoutSolver
+
+`config.layout_solver = "simulated_annealing"` selects
+`SimulatedAnnealingLayoutSolver`, which takes a first-fit, best-fit, or
+greedy placement as the initial layout and then runs a simulated-annealing
+search over buffer orderings to reduce fragmentation. Each step reinserts a
+buffer and keeps or rejects the new ordering according to a cooling
+schedule, so the search can escape the local minima that trap the
+single-pass solvers. See
+[Simulated Annealing Layout Planner](simulated_annealing_layout.md) for the
+algorithm and the tunable schedule parameters.
 
 ## Co-optimization with work-distribution
 
@@ -600,21 +613,9 @@ The remaining `@expectedFailure` cases motivate the items in
 
 ## Future work
 
-The items below are not in-tree. They sit on top of the
-`MemoryPlanSolver` and `ScratchpadOptimizationPass` interfaces so they
-can be plugged in without disturbing the rest of the planner.
-
-### Non-greedy solvers
-
-Two non-greedy solver families are being prototyped on top of the same
-`MemoryPlanSolver` interface:
-
-- **Simulated Annealing** uses a first-fit or best-fit
-  allocation as the initial guess, then perturbs the order to escape
-  local minima.
-- **Integer Linear Programming** via OR-Tools formulates placement as a
-  2D bin-packing constraint and lets a general-purpose solver search
-  exhaustively for graphs small enough to be tractable.
+The extensions below build on the current co-optimization flow through the
+`MemoryPlanSolver` and `ScratchpadOptimizationPass` interfaces, so they can
+be added without disturbing the rest of the planner.
 
 ### Richer co-optimization
 

--- a/docs/source/compiler/scratchpad_planning.md
+++ b/docs/source/compiler/scratchpad_planning.md
@@ -88,7 +88,8 @@ measured result is fixed per-bundle overhead.
 
 The four stages map onto code under `torch_spyre/_inductor/scratchpad/`:
 LX-eligible op outputs (stage 2), in-place reuse (stage 3), and
-`CloneInputNodesPass` (stage 4).
+input-boundary cloning (stage 4), which `ScratchpadAllocator` performs
+inline via `_eligible_clone_inputs`, gated by `clone_at_graph_boundaries()`.
 
 ## Assumptions
 
@@ -133,19 +134,24 @@ after work division has stamped per-op core splits:
 
 ```
 deadcode_elimination
+propagate_named_dims                  # named-dimension metadata (pre-stickification)
+assign_dim_hints
+_maybe_coarse_tile_hints              # hint-driven coarse tiling, when hints produce groups
+split_multi_ops
 propagate_spyre_tensor_layouts        # assign FixedTiledLayout
+validate_ops
 optimize_restickify_locations
 finalize_layouts
 insert_restickify
+enforce_indirect_access_layout
+insert_post_mutation_restickify
 insert_bmm_padding
 dedup_and_promote_constants
-propagate_named_dims                  # named-dimension metadata
-assign_dim_hints
-coarse_tile                           # runs when hints produce groups
+_maybe_coarse_tile_span_overflow      # span-overflow coarse tiling (post-stickification)
 span_reduction                        # work-division: enforce 255.996 MiB span
 cost_model_matmul_division            # work-division: matmul cost model
 work_distribution                     # work-division: default distributor
-scratchpad_planning                   # ← THIS PASS, gated by config.lx_planning
+_maybe_scratchpad_planning            # ← THIS PASS, gated by config.lx_planning
 ```
 
 Two ordering constraints fix this slot:
@@ -193,8 +199,9 @@ the graph input and graph output, for `3MN` bytes total, a 62% reduction.
 
 **Stage 4, clone the input to LX.** The graph input is read by several
 ops. Without a clone each reader would re-fetch from HBM.
-`CloneInputNodesPass` detects multi-use inputs that fit in LX and inserts
-a `clone` op at the front of the graph. The clone reads HBM once and
+`ScratchpadAllocator._eligible_clone_inputs` detects multi-use inputs that
+fit in LX and inserts a `clone` op at the front of the graph, gated by
+`clone_at_graph_boundaries()`. The clone reads HBM once and
 writes LX; every subsequent op reads from LX. After stage 4 total HBM is
 `2MN`, the input read plus the output write, which is the theoretical
 minimum for this graph.
@@ -254,7 +261,7 @@ The relevant code lives under `torch_spyre/_inductor/scratchpad/`:
 
 | File | Responsibility |
 |---|---|
-| `passes.py` | `ScratchpadOptimizationPass` ABC, `CloneInputNodesPass` |
+| `passes.py` | `ScratchpadOptimizationPass` ABC, `_NameSwapHandler` |
 | `plan_solver.py` | `MemoryPlanSolver` ABC (declarative exclusion via `partition`/`excluded`), `LifetimeBoundBuffer` |
 | `greedy_solver.py` | `GreedyLayoutSolver` |
 | `firstfit_bestfit_solver.py` | `FirstFitLayoutSolver`, `BestFitLayoutSolver` |
@@ -269,9 +276,10 @@ scratchpad_planning(graph, allocator=ScratchpadAllocator())
 
 `ScratchpadAllocator` runs the following pipeline:
 
-1. **Pre-passes.** `CloneInputNodesPass` walks graph inputs and inserts a
-   `clone` for any HBM input that is read more than once *and* fits on
-   LX. The clone output becomes a fresh LX-eligible buffer.
+1. **Input-boundary cloning.** When `clone_at_graph_boundaries()` is set,
+   `_eligible_clone_inputs` walks graph inputs and inserts a `clone` for any
+   HBM input that is read more than once *and* fits on LX. The clone output
+   becomes a fresh LX-eligible buffer.
 2. **Buffer analysis.** `_generate_buffers` produces one
    `LifetimeBoundBuffer` per buffer — *including* the ones that may not
    reside. Nothing is filtered out; `ScratchpadAllocator._residency_reasons`
@@ -528,7 +536,7 @@ best-fit mitigate this by sorting all buffers up front before placing.
 
 ### No defragmentation
 
-`find_free_block` can locate holes between allocations but cannot
+`_find_free_block` can locate holes between allocations but cannot
 compact the address space. Allocate/deallocate cycles fragment LX.
 
 ### Co-optimization is still limited
@@ -645,9 +653,10 @@ Candidates under evaluation:
 - **Output node cloning.** Promote a producer to LX and clone to HBM
   only when an HBM-resident copy is required (draft PR
   [#2028](https://github.com/torch-spyre/torch-spyre/pull/2028)).
-- **Driving cloning from the solver.** `CloneInputNodesPass` currently
-  runs as a pre-pass with a heuristic. The longer-term plan is for the
-  solver to decide which clones pay off based on the global layout.
+- **Driving cloning from the solver.** Input-boundary cloning currently
+  runs inline in `ScratchpadAllocator` with a heuristic. The longer-term
+  plan is for the solver to decide which clones pay off based on the
+  global layout.
 
 ### Cross-core ring transfers
 

--- a/docs/source/compiler/span_overflow_hint_analysis.md
+++ b/docs/source/compiler/span_overflow_hint_analysis.md
@@ -14,12 +14,12 @@ errors.
 coarse tiling to run those ops in smaller output-range tiles.
 
 The planner does not mutate IR directly.  It computes a `SpanOverflowTilePlan`.
-The adapter in `coarse_tile.py` converts that plan into the same `DimHint` and
-coarse-tile group format used by manual `spyre_hint`.
+The adapter in `coarse_tile_span_overflow.py` converts that plan into the same
+`DimHint` and coarse-tile group format used by manual `spyre_hint`.
 
 ```text
 span_overflow_hint_analysis
-  -> coarse_tile.span_overflow_groups
+  -> coarse_tile_span_overflow.span_overflow_groups
   -> coarse_tile
   -> CountedLoopSchedulerNode
   -> LoopSpec codegen
@@ -719,7 +719,7 @@ synthetic `DimHint` per level.  `coarse_tile` then stamps a multi-level
 
 ## Adapter and Coarse Tiling
 
-`coarse_tile.span_overflow_groups(graph)`:
+`coarse_tile_span_overflow.span_overflow_groups(graph)`:
 
 1. skips auto groups if `config.ignore_wsr_hints` or
    `config.ignore_span_overflow_hints` is enabled;
@@ -787,11 +787,9 @@ pass with:
 SPYRE_INDUCTOR_IGNORE_SPAN_OVERFLOW_HINTS=0
 ```
 
-The broader working-set-reduction hint switch still suppresses this path:
-
-```python
-config.ignore_wsr_hints == True
-```
+The broader working-set-reduction hint switch also suppresses this path when
+set: `SPYRE_INDUCTOR_IGNORE_HINTS=1` (which populates `config.ignore_wsr_hints`,
+default off) disables both manual and automatic hints with one switch.
 
 User-authored `spyre_hint` groups take precedence per op.  Automatic hints are
 not added to ops that already carry user dim hints.
@@ -987,7 +985,8 @@ Current coverage includes:
 | File | Role |
 |---|---|
 | `torch_spyre/_inductor/wsr/span_overflow_hint_analysis.py` | Candidate collection, combo search, post-tile validation, tile-plan dataclasses |
-| `torch_spyre/_inductor/wsr/coarse_tile.py` | Adapter from tile plans to synthetic `DimHint`s; coarse-tile IR stamping |
+| `torch_spyre/_inductor/wsr/coarse_tile_span_overflow.py` | `span_overflow_groups`: adapter from tile plans to synthetic `DimHint`s |
+| `torch_spyre/_inductor/wsr/coarse_tile.py` | Coarse-tile IR stamping (`coarse_tile`, `CoarseTileInfo`) |
 | `torch_spyre/_inductor/passes.py` | Combines user hint groups and automatic span-overflow groups |
 | `torch_spyre/_inductor/propagate_layouts.py` | Preserves pointwise producer layouts from copy-back elision when automatic span-overflow is explicitly enabled |
 | `torch_spyre/_inductor/ir.py` | Spyre layout resize/reconstruction helpers |

--- a/docs/source/compiler/work_division_planning.md
+++ b/docs/source/compiler/work_division_planning.md
@@ -25,7 +25,7 @@ eligible op.**
 
 For each eligible op the planner runs three passes in order:
 
-1. **Pass 1, span reduction**, enforces the 256 MB per-core span limit.
+1. **Pass 1, span reduction**, enforces the 255.996 MiB per-core span limit.
    When a tensor's per-core span exceeds the limit, this pass commits
    the minimum splits needed to bring the span back under. When no
    tensor violates the limit, the pass leaves the op untouched.
@@ -481,8 +481,9 @@ commits the argmin. Pass 3 skips the op.
 When any planner selects a K-split, the SDSC emitter permutes physical
 core IDs so the cores collaborating on the K reduction occupy adjacent
 ring positions. The permutation is implemented in
-`_k_fast_core_to_slice_mapping` in `codegen/superdsc.py`, gated by
-`_should_use_k_fast_mapping`. It drops PSUM accumulation hops from
+`core_to_slice_mapping` in `core_mapping.py`, invoked from
+`codegen/superdsc.py` with a `contiguous_dim` argument, and gated by the
+`core_id_k_fast_emission` config flag. It drops PSUM accumulation hops from
 `m × n` to 1, which is what makes cross-core K reductions cheap at
 runtime. The flag `SPYRE_CORE_ID_K_FAST_EMISSION` (default on)
 controls this codegen-side permutation. The name is legacy from when

--- a/docs/source/compiler/working_set_reduction.md
+++ b/docs/source/compiler/working_set_reduction.md
@@ -344,12 +344,12 @@ A buffer that crosses the loop boundary and is *not* marked
 `per_tile_fixed` (see [`coarse_tiling_loops.md`](coarse_tiling_loops.md))
 advances its base address once per loop iteration, so its HBM pool
 allocation must be sized for every tile it will occupy across the loop's
-run, not just one. `memory_planning.py`'s `_advance_factor` computes this
-as the product of `loop_count` over the levels the buffer is tiled on;
-sizing it for a single tile would let the loop overrun into whatever buffer
-the allocator packed next to it. See
-[`coarse_tiling_loops.md`](coarse_tiling_loops.md) for the `accum_full` /
-`accum_tile` buffers this sizing matters most for.
+run, not just one. `hbm_pool_planning.py`'s `_compute_size_bytes` sizes each
+buffer from its full `FixedTiledLayout.device_layout.device_size`, which
+spans every tile the buffer occupies across the loop; sizing it for a single
+tile would let the loop overrun into whatever buffer the allocator packed
+next to it. See [`coarse_tiling_loops.md`](coarse_tiling_loops.md) for the
+`accum_full` / `accum_tile` buffers this sizing matters most for.
 
 ## Related documents
 

--- a/docs/source/rfcs/index.md
+++ b/docs/source/rfcs/index.md
@@ -16,14 +16,19 @@ and submit a pull request.
 | RFC | Title | Area |
 |-----|-------|------|
 | [0047](https://github.com/torch-spyre/rfcs/blob/main/0047-TiledTensors/0047-TiledTensorsRFC.md) | Tensors with Device-Specific Layouts | Tensor layouts |
+| [0099](https://github.com/torch-spyre/rfcs/blob/main/0099-MultiDevice/0099-MultiDeviceRFC.md) | Multi-Spyre Device Support in PyTorch | Distributed |
 | [0171](https://github.com/torch-spyre/rfcs/blob/main/0171-SpyreDevice/0171-SpyreDeviceRFC.md) | Spyre Device Construct in PyTorch | Device integration |
 | [0186](https://github.com/torch-spyre/rfcs/blob/main/0186-TestFrameworks/0186-TestFrameworks.md) | Test Frameworks | Testing |
 | [0601](https://github.com/torch-spyre/rfcs/blob/main/0601-SpyreProfilingToolkit/0601-SpyreProfilingToolkitRFC.md) | Spyre Profiling Toolkit | Profiling |
 | [0682](https://github.com/torch-spyre/rfcs/blob/main/0682-KtirSpec/0682-KtirSpecRFC.md) | Kernel Tile Intermediate Representation | Compiler IR |
+| [1069](https://github.com/torch-spyre/rfcs/blob/main/1069-SpyreTensorLayoutExtraction/1069-SpyreTensorLayoutExtraction.md) | SpyreTensorLayout Extraction via CPU Compilation | Tensor layouts |
 | [1287](https://github.com/torch-spyre/rfcs/blob/main/1287-SpyreTestFramework/1287-SpyreTestFrameworkRFC.md) | Test Suite Configuration for Upstream PyTorch Tests on OOT Devices | Testing |
 | [1358](https://github.com/torch-spyre/rfcs/blob/main/1358-CoarseTiling/1358-CoarseTiling.md) | Coarse Tiling | Compiler |
 | [1632](https://github.com/torch-spyre/rfcs/blob/main/1632-ModelEnablement/1632-ModelEnablement.md) | Model Enablement Tracking | Model enablement |
 | [1633](https://github.com/torch-spyre/rfcs/blob/main/1633-E2EModelPerf/1633-E2EModelPerf.md) | End-to-End Model Performance Testing | Performance |
+| [2676](https://github.com/torch-spyre/rfcs/blob/main/2676-SpyreMetricsApiExtension/2676-SpyreMetricsApiExtensionRFC.md) | Spyre Metrics API Extension Package | Profiling |
+| [2696](https://github.com/torch-spyre/rfcs/blob/main/2696-AiuSmiExtension/2696-AiuSmiExtensionRFC.md) | aiu-smi Extension Package | Profiling |
+| [2971](https://github.com/torch-spyre/rfcs/blob/main/2971-FP32ElementArrangement/2971-FP32ElementArrangementRFC.md) | FP32 Element Arrangement | Compiler |
 
 ## Summaries
 
@@ -35,6 +40,13 @@ cannot represent tiled tensors, and specifies the `SpyreTensorLayout` data
 structure that maps between PyTorch coordinates and Spyre device memory.
 
 See also: [Tensor Layouts](../user_guide/tensors_and_layouts.md)
+
+### RFC 0099 — Multi-Spyre Device Support in PyTorch
+
+Describes the additions required to bring a Spyre-based collective communication
+library into the PyTorch ecosystem. Specifies a module that implements the
+PyTorch distributed interfaces and registers as the default process group for
+Spyre devices, backed by an external Spyre communication library.
 
 ### RFC 0171 — Spyre Device Construct in PyTorch
 
@@ -72,6 +84,15 @@ memory and scratchpad in a hardware-independent form that DeepTools
 then lowers to device-specific code.
 
 See also: [Compiler Backend](../compiler/backend.md)
+
+### RFC 1069 — SpyreTensorLayout Extraction via CPU Compilation
+
+Proposes capturing the `SpyreTensorLayout` for each operation in a PyTorch model
+by compiling and running the model on the CPU. Using the CPU as a proxy for
+Spyre execution extracts the exact layouts expected on Spyre without requiring
+full operator support on the target backend.
+
+See also: [Tensor Layouts](../user_guide/tensors_and_layouts.md)
 
 ### RFC 1287 — Test Suite Configuration for Upstream PyTorch Tests on OOT Devices
 
@@ -112,3 +133,32 @@ dimensions — correctness against HuggingFace references, benchmarking
 (latency, throughput, TTFT, ITL), and quality evals (GSM8K, MMLU, and
 use-case-specific benchmarks) — leaning on upstream tooling such as
 `HfRunner`, `VLLMRunner`, `vllm bench`, and `lm-evaluation-harness`.
+
+### RFC 2676 — Spyre Metrics API Extension Package
+
+Proposes hosting `spyre-metrics-api` (Python import name `spyremetrics`) inside
+the torch-spyre repository under a top-level `extensions/` directory, as an
+independently packaged and versioned Python distribution. The package provides a
+public Python API for reading and parsing IBM Spyre performance metric files
+that contain hardware performance counters emitted by the Spyre runtime and
+driver layer. It abstracts the binary format, supports both PF- and VF-based
+metric formats, and exposes typed metric definitions with units and scaling.
+
+### RFC 2696 — aiu-smi Extension Package
+
+Proposes hosting `aiu-smi`, a performance monitoring tool for the IBM Spyre
+accelerator, inside the torch-spyre repository under the `extensions/`
+directory, as an independently packaged and versioned Python distribution.
+`aiu-smi` periodically reads Spyre metric data and prints per-device telemetry
+(power, temperature, busy percentage, PT-array utilization, memory bandwidth,
+reserved, active, and peak memory, host CPU and memory, and process mapping) in
+text or CSV form. It consumes the `spyre-metrics-api` extension.
+
+### RFC 2971 — FP32 Element Arrangement
+
+Specifies how widening a tensor's elements on device (16-bit `DL16` or `BF16` to
+32-bit `FP32`) leaves them staggered rather than in standard stick order: all
+values are correct, but within-stick position no longer matches logical order.
+The Inductor backend tracks this as an Element Arrangement (EA) per layout and
+gates op legality on it through `is_ea_compatible` and `validate_ops`. FP32 is
+ephemeral, never stored, and only a transient widening.

--- a/docs/source/runtime/index.md
+++ b/docs/source/runtime/index.md
@@ -48,7 +48,7 @@ to handle device management and synchronization.
 |---|---|
 | `AIU_WORLD_SIZE` | Overrides the visible device count. |
 | `SPYRE_DEVICES` | Comma-separated list of device indices to expose. |
-| `FLEX_DEVICE` | Selects the underlying flex runtime mode (PF or VF). |
+| `FLEX_DEVICE` | Selects the underlying flex runtime mode (`PF`, `VF`, or `MOCK`). |
 
 The count itself comes from `flex::getNumDevices`.
 
@@ -145,8 +145,9 @@ Physical-frame (PF) and virtual-frame (VF) execution are *not* allocator strateg
 
 | Mode | Selection | Description |
 |------|-----------|-------------|
-| PF (Physical Frame) | `FLEX_DEVICE` set to a PF device | Direct hardware execution path. |
-| VF (Virtual Frame) | `FLEX_DEVICE` set to a VF device | Virtualized hardware, used in multi-tenant deployments. |
+| PF (Physical Frame) | `FLEX_DEVICE=PF` | Direct hardware execution path. |
+| VF (Virtual Frame) | `FLEX_DEVICE=VF` | Virtualized hardware, used in multi-tenant deployments. |
+| MOCK | `FLEX_DEVICE=MOCK` | Software simulation with no hardware; device count comes from `AIU_WORLD_SIZE`. |
 
 ## Eager Operations
 

--- a/docs/source/runtime/memory_pressure_gc.md
+++ b/docs/source/runtime/memory_pressure_gc.md
@@ -8,8 +8,7 @@ references have been dropped but whose C++ storage has not yet been released.
 This page describes the Python-specific design: the GIL interaction, the
 lock-ordering contract, the per-call-site rules, and the free-threaded Python
 considerations. The underlying C++ callback contract (mutex release/re-acquire
-around any blocking work) is documented in
-[`flex/docs/lock_ordering.md`](https://github.com/torch-spyre/flex/blob/main/docs/lock_ordering.md).
+around any blocking work) is documented in `flex/docs/lock_ordering.md`.
 
 ## Why GC Can Free Device Memory
 

--- a/docs/source/user_guide/examples/index.md
+++ b/docs/source/user_guide/examples/index.md
@@ -27,6 +27,18 @@ common Torch-Spyre use cases.
 | `distributed/broadcast.py` | Broadcast collective on Spyre |
 | `distributed/gather.py` | Gather collective on Spyre |
 | `distributed/reduce.py` | Reduce collective on Spyre |
+| `broadcast_demo_multirank.py` | Multi-rank broadcast walkthrough with pre- and post-broadcast computation |
+
+## Scratchpad Planning Examples
+
+These scripts model the LX scratchpad layout solver in isolation and plot the
+resulting buffer layouts. They require `matplotlib` and `numpy`.
+
+| Script | Description |
+|--------|-------------|
+| `scratchpad/toy_layout.py` | Plot the layout for a fixed ordering of four buffers, with no annealing |
+| `scratchpad/random_buffers.py` | Compare first-fit against simulated-annealing quality on a set of random buffers |
+| `scratchpad/inplace_annealing.py` | Convergence study on an 18-buffer workload with in-place reuse |
 
 ## Provenance Audit
 

--- a/docs/source/user_guide/running_models.md
+++ b/docs/source/user_guide/running_models.md
@@ -45,11 +45,23 @@ Valid values: 1–32 (default: 32). See
 
 Full working examples are listed on the [Examples](examples/index.md)
 page. It has single-op scripts (`tensor_allocate.py`, `softmax.py`,
-`gelu.py`, `mean.py`, `mul.py`, `softplus.py`, `spyre_hints.py`) and a
+`gelu.py`, `mean.py`, `mul.py`, `softplus.py`, `spyre_hints.py`), a
 `distributed/` set covering the collective ops (allgather, allreduce,
-broadcast, gather, reduce, barrier). The scripts are under
+broadcast, gather, reduce, barrier) plus a multi-rank broadcast
+walkthrough, and a `scratchpad/` set that models the LX layout solver in
+isolation. The scripts are under
 [examples/](https://github.com/torch-spyre/torch-spyre/tree/main/docs/source/user_guide/examples).
 
 ## Troubleshooting
 
-> **TODO:** Document common errors and how to resolve them.
+When a model fails to compile or produces unexpected results, the following
+resources cover the common cases:
+
+- [Debugging](debugging/index.md) explains how to enable compiler logging,
+  dump Inductor artifacts, and inspect intermediate representations with
+  `TORCH_LOGS`, `TORCH_COMPILE_DEBUG`, and `TORCH_SPYRE_DEBUG`.
+- [Supported Operations](supported_operations.md) lists which operations run on
+  Spyre and which fall back to the CPU. An unsupported operation in the model
+  forces a graph break or a CPU fallback.
+- [Profiling](profiling/index.md) shows how to measure where time is spent once
+  a model runs correctly.

--- a/docs/source/user_guide/supported_operations.md
+++ b/docs/source/user_guide/supported_operations.md
@@ -18,11 +18,12 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch._scaled_mm` | | Y | Spyre | Compiled only; lowering in `_inductor/lowering.py` |
 | `torch.nn.functional.linear` | Y | Y | Spyre | Decomposed to `matmul` + `add` |
 | `torch.nn.functional.conv2d` | Y | Y | Spyre | Custom decomposition (`conv2d_via_bmm`); CPU fallback for the im2col step |
+| `torch.nn.functional.avg_pool2d` | | Y | Spyre | Compiled only; custom lowering |
 | **Activation Functions** | | | | |
 | `torch.nn.functional.softmax` | Y | Y | Spyre | |
 | `torch.nn.functional.layer_norm` | Y | Y | Spyre | Custom decomposition |
 | `torch.nn.functional.rms_norm` | Y | Y | Spyre | Custom decomposition |
-| `torch.nn.functional.gelu` | | Y | Spyre | Custom op + lowering |
+| `torch.nn.functional.gelu` | Y | Y | Spyre | Custom op + lowering; decomposition auto-registers a PrivateUse1 eager kernel |
 | `torch.nn.functional.silu` | Y | Y | Spyre | |
 | `torch.nn.functional.relu` | Y | Y | Spyre | |
 | `torch.nn.functional.sigmoid` | Y | Y | Spyre | |
@@ -68,10 +69,13 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.amax` | Y | Y | Spyre | |
 | `torch.amin` | | Y | Spyre | Custom decomposition |
 | `torch.prod` | | Y | Spyre | Requires `dim` argument; custom decomposition + lowering |
-| `torch.max` | Y | Y | Spyre | `max.dim` via custom decomposition |
-| `torch.min` | Y | Y | Spyre | `min.dim` via custom decomposition (fp16) |
+| `torch.max` | Y | Y | Spyre | `max.dim` via custom decomposition; int64 falls back to CPU |
+| `torch.min` | Y | Y | Spyre | `min.dim` via custom decomposition (fp16 eager); int64 falls back to CPU |
 | `torch.topk` | | Y | Spyre | Custom decomposition + custom ops (`spyre::topkvalue`, `spyre::topkindex`) |
-| `torch.linalg.vector_norm` | Y | | Spyre | Eager only |
+| `torch.linalg.vector_norm` | | Y | Spyre | Compiled only; eager misroutes the `ord` argument |
+| `torch.linalg.matrix_norm` | | Y | Spyre | Compiled only; eager misroutes the `ord` argument |
+| `torch.linalg.norm` | | Y | Spyre | Compiled only; eager misroutes the `ord` argument |
+| `torch.aminmax` | | Y | Spyre | Compiled only; eager not yet supported |
 | **View Ops** [^views] | | | | |
 | `torch.reshape` / `torch.view` | | Y | Spyre | Includes `_reshape_alias` (a C++ device view, not an Inductor lowering) |
 | `torch.transpose` | Y | Y | Spyre | |
@@ -100,13 +104,16 @@ see [Adding Operations](../compiler/adding_operations.md).
 | **In-place / Initialization** | | | | |
 | `torch.Tensor.fill_` | | Y | Spyre | Compiled only; eager kernel registered but not yet stable |
 | `torch.Tensor.normal_` | Y | Y | CPU fallback | Runs on CPU, result transferred back |
-| `torch.Tensor.uniform_` | Y | | Spyre | Eager only |
+| `torch.Tensor.uniform_` | Y | | CPU fallback | Eager only; random values generated on CPU, copied back |
 | `torch.Tensor.random_` | Y | | CPU fallback | Eager only; `from` overload |
 | `torch.is_nonzero` | | Y | Spyre | Compiled only |
+| **Indexing** | | | | |
+| `torch.embedding` | Y | Y | Spyre | Registered on the compiled path (`ops/eager.py`) |
+| `torch.index_select` | Y | Y | Spyre | Registered on the compiled path (`ops/eager.py`) |
 | **Utility** | | | | |
 | `torch.item` | Y | Y | Spyre | Copies to CPU, returns Python scalar |
+| `torch.Tensor.to` (dtype cast) | | Y | Spyre | Compiled only; eager dtype casts not yet supported |
 | **CPU Fallback** | | | | |
-| `torch.embedding` | Y | Y | CPU fallback | Runs on CPU, result transferred back |
 | `torch.arange` | Y | Y | CPU fallback | Runs on CPU, result transferred back |
 | `torch.sin` | Y | Y | CPU fallback | Runs on CPU, result transferred back |
 | `torch.cos` | Y | Y | CPU fallback | Runs on CPU, result transferred back |

--- a/docs/source/user_guide/supported_operations.md
+++ b/docs/source/user_guide/supported_operations.md
@@ -23,7 +23,7 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.nn.functional.softmax` | Y | Y | Spyre | |
 | `torch.nn.functional.layer_norm` | Y | Y | Spyre | Custom decomposition |
 | `torch.nn.functional.rms_norm` | Y | Y | Spyre | Custom decomposition |
-| `torch.nn.functional.gelu` | Y | Y | Spyre | Custom op + lowering; decomposition auto-registers a PrivateUse1 eager kernel |
+| `torch.nn.functional.gelu` | | Y | Spyre | Compiled only; the `spyre::gelu` custom op has no eager implementation |
 | `torch.nn.functional.silu` | Y | Y | Spyre | |
 | `torch.nn.functional.relu` | Y | Y | Spyre | |
 | `torch.nn.functional.sigmoid` | Y | Y | Spyre | |


### PR DESCRIPTION
## Summary

This audits the Sphinx documentation against the current torch-spyre code and corrects the drift found across the compiler, runtime, API reference, RFC index, user guide, and Knowledge Graph Explorer. Every change was verified against the sources on `origin/main`.

## What changed

**Supported operations**

- Corrects the reversed vector_norm Eager and Compiled columns (it is compiled-only), and adds matrix_norm, linalg.norm, and aminmax rows.
- Clarifies that gelu is compiled-only, since the `spyre::gelu` custom op has a pass-through body that returns None in eager mode.
- Adds an Indexing section for embedding and index_select, plus avg_pool2d and `Tensor.to`. Moves uniform_ to CPU fallback and notes the int64 fallbacks.

**Compiler**

- Fixes the `register_spyre_decompositions` decorator name.
- Aligns the extension-point, LoopLevelIR, and module-reference tables with `passes.py`, and corrects the file attributions for coarse tiling, scratchpad planning, working set reduction, span-overflow analysis, and work division. Several functions and classes that no longer exist in the code were removed from the docs.

**Runtime and API reference**

- Adds the `MOCK` flex mode to the FLEX_DEVICE tables.
- Removes the nonexistent `LX_BOUNDARY_CLONES` environment variable, adds `SPYRE_INDUCTOR_ENABLE_REDUCTION_TILING` and `SPYRE_LOG_PASSES`, and adds `simulated_annealing` to the `LAYOUT_SOLVER` options.

**RFC index**

- Adds the five missing RFCs (0099, 1069, 2676, 2696, 2971) with summaries, verified against the `torch-spyre/RFCs` repository.

**User guide**

- Lists the multi-rank broadcast and scratchpad examples.
- Replaces the running-models troubleshooting placeholder with pointers to the debugging, supported-operations, and profiling pages.

**Links**

- Repairs the ASPLOS workshop link and drops the broken external flex link.

**Knowledge Graph Explorer**

- The extractor now picks up the `copy_` and `overwrite` eager kernels from `customops.py` and the `USE_SPYRE_PROFILER` environment variable from `profiler/_ffdc.py`. The env var count in the Configuration view goes from 23 to 24.

## Testing

- `make html` builds with no link or toctree warnings.
- The pymarkdown, ruff-check, ruff-format, and import-regex pre-commit hooks pass on the changed files.

