### PR TITLE
fix(tests): delete _cls_<Class> alias so OOT wrapper doesn't leak the raw TestCase to pytest collection

### DIFF
--- a/tests/oot_framework/run_test.sh
+++ b/tests/oot_framework/run_test.sh
@@ -1116,6 +1116,15 @@ if '${cls}' in globals():
     del globals()['${cls}']
 "
     done
+    # injection_block also binds _cls_${cls} as its own module-level global for
+    # every class in NEEDS_INJECTION_CLASSES. It is still the raw TestCase, so
+    # pytest's unittest plugin collects it too unless it is deleted here.
+    for cls in "${NEEDS_INJECTION_CLASSES[@]}"; do
+        cleanup_block+="
+if '_cls_${cls}' in globals():
+    del globals()['_cls_${cls}']
+"
+    done
 
     # Separate quoted lists for restricted vs uncontrolled classes --
     # each is retrieved differently from the private module.


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

## Problem
- Wrapper cleanup deletes the bare class name (`TestDebugTrace`) but not the `_cls_TestDebugTrace` alias created during injection.
- Pytest collects `_cls_TestDebugTrace` as a duplicate `TestCase`, bypassing YAML `mode: skip` and failing on device-specific output.

## Fix
- Delete `_cls_${cls}` for every class in `NEEDS_INJECTION_CLASSES`, alongside the existing bare-name cleanup.


#### Which issue(s) this PR is related to:

Fixes https://github.com/pytorch/expecttest/issues/36
