### PR TITLE
fix(flex GIL): release GIL around FlexAllocator::allocate() to prevent memory-pressure deadlock 

### DIFF
--- a/docs/source/runtime/memory_pressure_gc.md
+++ b/docs/source/runtime/memory_pressure_gc.md
@@ -51,14 +51,21 @@ section for how this plays out in practice.
 |------|-------|
 | Python thread runs; GIL is already held | GIL ✓ |
 | Crosses the pybind11 boundary into C++ | GIL ✓ |
-| `SpyreAllocator::allocate()` → `FlexAllocator::allocate()` acquires `allocator_mutex_` | GIL ✓, mutex ✓ |
-| Normal allocation succeeds; mutex released | — |
+| `SpyreAllocator::allocate()` releases the GIL (`py::gil_scoped_release`) before calling `FlexAllocator::allocate()` | — |
+| `FlexAllocator::allocate()` acquires `allocator_mutex_` | mutex ✓ |
+| Normal allocation succeeds; mutex released; GIL re-acquired on return | — |
 
-**Lock order**: `GIL → allocator_mutex_`
+**Lock order**: neither lock is held at the same time as the other.
 
-**Why it is safe**: The GIL is *already held on entry* — it is never acquired
-while the mutex is held. If memory pressure fires, the callback releases the
-mutex before touching the GIL (Path 2 below).
+**Why it is safe**: `SpyreAllocator::allocate()` releases the GIL *before*
+calling into `FlexAllocator::allocate()`, so the calling Python thread never
+blocks inside the native allocation call while still holding the GIL. This
+matters because if memory pressure fires, whichever thread ends up running
+`memoryPressureCallback()` needs the GIL to call `PyGC_Collect()` (Path 2
+below) — if the original caller kept holding the GIL while blocked on
+`allocator_mutex_`, that acquire could never succeed, deadlocking the two
+threads against each other. Releasing the GIL up front removes that
+possibility entirely.
 
 ### Path 2 — Memory pressure callback
 
@@ -187,7 +194,7 @@ Any memory-pressure callback that acquires the GIL must:
 
 | Call-site context | Action required |
 |---|---|
-| From Python (GIL already held) | None — GIL is already held on entry; callback will release the mutex before re-acquiring the GIL. |
+| From Python (GIL already held) | None — `SpyreAllocator::allocate()` releases the GIL before entering `FlexAllocator::allocate()`; callback will release the mutex before re-acquiring the GIL. |
 | From C++ without GIL | None — callback acquires and releases the GIL internally. |
 | From C++ with GIL explicitly held | Ensure `allocator_mutex_` is not held when acquiring the GIL elsewhere in the same frame. |
 

--- a/torch_spyre/csrc/spyre_allocator.cpp
+++ b/torch_spyre/csrc/spyre_allocator.cpp
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <utility>
 
 #include "logging.h"
@@ -163,8 +164,26 @@ c10::DataPtr SpyreAllocator::allocate(
   auto flex_alloc = getFlexAllocator();
 
   // Allocate first-class raw storage via CompositeAddress.
-  flex::CompositeAddress composite_addr =
-      flex_alloc->allocate(nbytes, directive);
+  //
+  // If this thread holds the GIL, release it for the duration of this call.
+  // If FlexAllocator hits memory pressure it invokes memoryPressureCallback(),
+  // which must acquire the GIL to run PyGC_Collect(). If this (Python) thread
+  // kept holding the GIL while blocked here, that acquire could never
+  // succeed, inverting the documented allocator_mutex_ -> GIL lock order and
+  // deadlocking against whichever thread ends up running the callback. See
+  // docs/source/runtime/memory_pressure_gc.md.
+  //
+  // Some callers (e.g. TimestampCalibrator, compiled Inductor kernels, sendnn
+  // operations) invoke allocate() without holding the GIL at all;
+  // py::gil_scoped_release requires the GIL to be held on construction, so
+  // it is only used when PyGILState_Check() confirms that precondition.
+  flex::CompositeAddress composite_addr = [&]() {
+    std::optional<py::gil_scoped_release> release;
+    if (PyGILState_Check()) {
+      release.emplace();
+    }
+    return flex_alloc->allocate(nbytes, directive);
+  }();
 
   DEBUGINFO("allocated ", composite_addr);
   // FlexAllocator rounds up to DEVICE_ALIGNMENT (128 bytes), so the actual


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

## Problem
`torch.randn(device="spyre")` hung/deadlocked when multiple threads allocated memory at once (issue #3397). This happened because the allocating thread kept holding Python's GIL while blocked inside the native allocator, so the memory-pressure callback couldn't get the GIL back to run garbage collection.

## Fix
- Release the GIL before calling `FlexAllocator::allocate()`, so the GIL is always free for the pressure callback to run `PyGC_Collect()`.
- Only release it when actually held (checked via `PyGILState_Check()`), since some C++ callers invoke `allocate()` without the GIL at all.


#### Which issue(s) this PR is related to:

Fixes https://github.com/torch-spyre/torch-spyre/issues/3397

Before calling into the C++ allocator, the thread now lets go of the GIL first (only if it's actually holding it) so no matter what happens inside (even hitting memory pressure and needing to run garbage collection), the GIL is always available for whoever needs it, and nothing gets stuck waiting on itself.
