### PR TITLE
test(coarse_tile_e2e): tiled flash over H/Lq via divide-in-scope; un-skip 2 stale markers

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -2812,9 +2812,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
     # Hint propagation into inserted restickify nodes
     # ------------------------------------------------------------------
 
-    @pytest.mark.skip(
-        reason="The transposed input produces layouts where coarse-tiling rewrites output buffer strides after restickify has already run, resulting in a stick mismatch that raises in create_op_spec."
-    )
     @config.patch(
         {
             "lx_planning": True,
@@ -3022,6 +3019,18 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         explicit running-max (real_max) formulation that updates output and
         denominator in place via copy_.
 
+        Still xfailed.  The divide sits outside the tiled scopes, so
+        `output`/`denominator` get full buffers + copy ops; each copy writes its
+        target without reading it, nothing costs that pairing, and
+        finalize_layouts overwrites the target with the writer's layout ->
+        "restickify needed but infeasible for op='buf24' input='buf26'".
+
+        Not resolvable by layout choice: writer and consumer need mutually
+        unrestickifiable candidates (forcing either aborts or gives ~70% wrong).
+        {"Lq": 2} alone reproduces it.  See
+        test_hint_flash_attention_v2_divide_in_scope for the formulation that
+        works, which localizes this to the cross-loop-group copy path.
+
         Decision xfail: failing in CI (Actions run 30385154736, job
         90362755639) on PR #3293. We've decided to xfail the coarse tiling
         tests to allow us to merge to main -- deliberate decision to unblock
@@ -3118,6 +3127,111 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             atol=0.01,
             rtol=0.1,
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
+        )
+
+    def test_hint_flash_attention_v2_divide_in_scope(self):
+        """test_hint_flash_attention_v2 with the final divide INSIDE the scope.
+
+        Outside, `output`/`denominator` are read past the loop group, so both get a
+        full buffer + copy op whose target the divide (buf24) also reads; the copy
+        writes its target without reading it, so no edge costs that pairing and
+        finalize_layouts overwrites the target with the writer's layout, killing
+        buf24's solved edge.  Inside, only `result` crosses: one copy op, target
+        has no second consumer, nothing to invalidate.
+
+        Sound only because H/Lq are output dims (each tile's denominator is final).
+        Lk tiling still needs carry propagation -- #3198.
+
+        The LoopSpec assertion is load-bearing: without it this passes even if
+        tiling is silently skipped.
+        """
+        import math
+
+        from torch_spyre._inductor import spyre_hint
+
+        B, H, Lq, Lk, D = 1, 8, 256, 256, 64
+        block_size = 128
+
+        queries_t = torch.randn(B, H, Lq, D, dtype=torch.float16)
+        keys_t = torch.randn(B, H, Lk, D, dtype=torch.float16)
+        values_t = torch.randn(B, H, Lk, D, dtype=torch.float16)
+        causal = torch.tril(torch.ones(Lq, Lk, dtype=torch.bool))
+        mask_t = torch.zeros(1, 1, Lq, Lk, dtype=torch.float16)
+        mask_t.masked_fill_(~causal, float("-inf"))
+        lq_slices = Lq // block_size
+
+        def flash(queries, keys, values, mask):
+            scale = 1.0 / math.sqrt(math.sqrt(D))
+            output = torch.zeros_like(queries)
+            real_max = torch.full(
+                (B, H, Lq, 64),
+                float("-inf"),
+                device=queries.device,
+                dtype=torch.float16,
+            ).amax(dim=-1)
+            denominator = torch.zeros(
+                (B, H, Lq, 64),
+                device=queries.device,
+                dtype=torch.float16,
+            ).amax(dim=-1)
+            with spyre_hint(num_tiles_per_dim={"H": 4}):
+                with spyre_hint(num_tiles_per_dim={"Lq": lq_slices}):
+                    scaled_keys = keys * scale
+                    keys_T = scaled_keys.transpose(-1, -2)
+                    scores = torch.matmul(queries * scale, keys_T)
+                    scores = scores + mask
+
+                    block_max = torch.amax(scores, dim=-1)
+                    running_max = torch.maximum(real_max, block_max)
+
+                    exp_scores = torch.exp(scores - running_max.unsqueeze(-1))
+                    correction = torch.exp(real_max - running_max)
+
+                    denominator.copy_(denominator * correction + exp_scores.sum(dim=-1))
+                    output.copy_(
+                        output * correction.unsqueeze(-1)
+                        + torch.matmul(exp_scores, values)
+                    )
+                    real_max.copy_(running_max)
+
+                    # The one difference from test_hint_flash_attention_v2.
+                    result = output / denominator.unsqueeze(-1)
+            return result
+
+        ref = flash(queries_t, keys_t, values_t, mask_t)
+
+        queries_dev = queries_t.to("spyre")
+        keys_dev = keys_t.to("spyre")
+        values_dev = values_t.to("spyre")
+        mask_dev = mask_t.to("spyre")
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("H", H)
+        _declare_tensor_dim("Lq", Lq)
+        _declare_tensor_dim("Lk", Lk)
+        _declare_tensor_dim("D", D)
+        _name_tensor_dims(queries_dev, ["B", "H", "Lq", "D"])
+        _name_tensor_dims(keys_dev, ["B", "H", "Lk", "D"])
+        _name_tensor_dims(values_dev, ["B", "H", "Lk", "D"])
+        _name_tensor_dims(mask_dev, ["B", "H", "Lq", "Lk"])
+
+        cfn = torch.compile(flash)
+        result, source_codes = run_and_get_code(
+            cfn, queries_dev, keys_dev, values_dev, mask_dev
+        )
+        torch.testing.assert_close(
+            result.cpu(),
+            ref,
+            equal_nan=True,
+            atol=0.01,
+            rtol=0.1,
+            msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
+        )
+        # Both hint levels must survive into codegen (H=4 outer, Lq=2 inner).
+        self.assertEqual(
+            source_codes[0].count("LoopSpec("),
+            2,
+            "expected two nested LoopSpec entries (H then Lq); coarse tiling "
+            "must not be silently skipped",
         )
 
     @config.patch(
@@ -5077,13 +5191,10 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
 # ===========================================================================
 
 
-@pytest.mark.skip(reason="SpyreEmptyFallback / ct_fill STL bug")
 def test_tiled_in_place_accumulator():
-    """Minimal reproducer for the SpyreEmptyFallback / ct_fill STL bug.
+    """Regression test for the SpyreEmptyFallback / ct_fill STL bug.
 
-    CURRENT STATUS (to delete when reorder-passes-clean is merged)
-      - Fails on main
-      - Fails on reorder-passes-clean but passes with patch XYZ and SENCORES=1
+    Was xfailed pending reorder-passes-clean (#3293, #3377, #3381); passes now.
     """
     from torch_spyre._inductor import spyre_hint
 


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

**Buys correct, genuinely tiled flash over H and Lq — no compiler change.** One line moves; an abort becomes numerically exact with real nested `LoopSpec(4)`/`LoopSpec(2)`.

**Lk tiling stays unsupported and gates KV-streaming flash (#3198)** — needed whenever `Lk` is large, independent of prefill vs decode: `Lq_tile × Lk` (scores) and `Lk × D` (K/V) are both linear in `Lk`, so the phase only decides which binds first. Batch substitutes for `Lq` as a parallelism dim, never as a memory bound on `Lk`.

Test-only.

**1. Add `test_hint_flash_attention_v2_divide_in_scope`** — `test_hint_flash_attention_v2` with the divide moved inside the innermost scope:

```python
        return output / denominator.unsqueeze(-1)         # OUTSIDE -> aborts
            result = output / denominator.unsqueeze(-1)   # INSIDE  -> exact
```

Outside, `output`/`denominator` are read past the loop group, so both get a full buffer + copy op whose target the divide (`buf24`) also reads. The copy writes its target without reading it, so nothing costs that pairing: `buf26`/`buf24` commit candidate 0 (rank 6), the writer candidate 2 (rank 5), `finalize_layouts` overwrites the target with the writer's choice, and `buf24`'s solved edge dies — `restickify needed but infeasible for op='buf24' input='buf26'`. Inside, only `result` crosses: one copy op, no second consumer, nothing to invalidate. Two full buffers + two copies also become one.

**Not a fix for `test_hint_flash_attention_v2`**, which stays xfailed — the outside-divide form is the natural one and the aliased-writer conflict wants a compiler fix. Its docstring records that `{"Lq": 2}` alone reproduces and that no layout choice resolves it.

**2–3. Un-skip `test_hint_restickify_stays_in_group`** (stick mismatch in `create_op_spec`; fixed by the #3293 pass reorder) and **`test_tiled_in_place_accumulator`** ("SpyreEmptyFallback / ct_fill STL bug"; passes since #3293/#3377/#3381).

Out of scope, still xfailed/skipped:

| Defect | Tests | Tracking |
|---|---|---|
| aliased-writer conflict | `_v2`, `_two_loop_levels_v2` | no issue yet |
| Lk / carry propagation | `_loopspec`, `_two_loop_levels` | **#3198** |
| flash numerics, layout-independent (40.7/75.8/65.0/31.8%) | `flash_attention`, `_v3`, `_v3_b2`, `_v3_b2_minimal`, `_v4` | no issue yet |

#### Which issue(s) this PR is related to:

Related, none fixed: #3198, #3332, #3165, #3357.

#### Special notes for your reviewer:

Hardware at `ba8fd77` (torch 2.12.1), full-file runs: clean main **1 failed / 130 passed / 49 skipped** → with PR **0 failed / 134 passed / 47 skipped**.

- 3 of the +4 are this change. The 4th, and the vanished failure, is `test_nested_matmul_outer_M_inner_K_correct` flipping — **order-dependent, not fixed here**. Measure this file with full-file runs only.
- One shape (`B=1,H=8,Lq=256,Lk=256,D=64`); **no performance measured**.
- `LoopSpec` count asserted, so it can't pass with tiling silently skipped.
- torch 2.12.1 while `main` pins 2.13 (#3374); CI is authoritative.

#### Does this PR introduce a user-facing change?

No — tests only.
