### PR TITLE
Handle gather with single index P=1

### DIFF
--- a/tests/inductor/test_indirect_access_gather.py
+++ b/tests/inductor/test_indirect_access_gather.py
@@ -103,6 +103,14 @@ class _GatherScenarios(IndirectAccessTestCase):
         self.name_dims(i, {"P": P})
         return x, i
 
+    def _xi4d(self, P=32, dtype=torch.int32, A=8, B=4, C=8, D=64):
+        """Named (x[A,B,C,D], idx[P]) gather operands: 4-D value, 1-D index."""
+        x = self.to_spyre(torch.rand(A, B, C, D, dtype=torch.float16))
+        i = torch.randint(0, A, (P,), dtype=dtype).to("spyre")
+        self.name_dims(x, {"A": A, "B": B, "C": C, "D": D})
+        self.name_dims(i, {"P": P})
+        return x, i
+
     # -- core x[i].exp(): op-spec structure + detection (one compile) ------
     def test_gather_with_exp(self):
         """x[i].exp(): GATHER op spec with IndirectAccess on an input, a named
@@ -577,6 +585,231 @@ class _GatherScenarios(IndirectAccessTestCase):
         idx = torch.randint(0, V, (P,), dtype=torch.int32).to("spyre")
         self.name_dims(weight, {"V": V, "E": E})
         self.name_dims(idx, {"P": P})
+        self._stage_and_e2e(
+            lambda i, w: torch.nn.functional.embedding(i, w),
+            idx,
+            weight,
+            expect=GATHER_OP_SPEC,
+        )
+
+    # -- P=1 gather: comprehensive shape and rank coverage ----------------
+    # Verify that a single-element index (P=1) compiles and produces correct
+    # results across 2-D, 3-D, and 4-D value tensors with stick-aligned,
+    # non-stick-aligned, small, and large shapes.
+
+    # 2-D value tensor, P=1
+    def test_single_idx_2d_stick_aligned(self):
+        """P=1, 2-D value [64, 64] — both dims stick-aligned (1 stick per row)."""
+        x, i = self._xi(P=1, M=64, N=64)
+        self._stage_and_e2e(lambda x, i: x[i], x, i, expect=GATHER_OP_SPEC)
+
+    def test_single_idx_2d_non_stick_aligned(self):
+        """P=1, 2-D value [67, 100] — non-stick-aligned row width."""
+        x, i = self._xi(P=1, M=67, N=100)
+        self._stage_and_e2e(lambda x, i: x[i], x, i, expect=GATHER_OP_SPEC)
+
+    def test_single_idx_2d_multistick_row(self):
+        """P=1, 2-D value [128, 512] — 8 sticks per row."""
+        x, i = self._xi(P=1, M=128, N=512)
+        self._stage_and_e2e(lambda x, i: x[i], x, i, expect=GATHER_OP_SPEC)
+
+    def test_single_idx_2d_small(self):
+        """P=1, 2-D value [8, 64] — small table, 1 stick per row."""
+        x, i = self._xi(P=1, M=8, N=64)
+        self._stage_and_e2e(lambda x, i: x[i], x, i, expect=GATHER_OP_SPEC)
+
+    def test_single_idx_2d_int64_index(self):
+        """P=1, 2-D value, int64 index."""
+        x, i = self._xi(P=1, dtype=torch.int64)
+        self._stage_and_e2e(lambda x, i: x[i], x, i, expect=GATHER_OP_SPEC)
+
+    def test_single_idx_2d_with_exp(self):
+        """P=1, 2-D value, fused exp."""
+        x, i = self._xi(P=1)
+        self._stage_and_e2e(
+            lambda x, i: x[i].exp(), x, i, expect=GATHER_OP_SPEC, op="exp"
+        )
+
+    def test_single_idx_2d_with_tanh(self):
+        """P=1, 2-D value, fused tanh."""
+        x, i = self._xi(P=1)
+        self._stage_and_e2e(
+            lambda x, i: x[i].tanh(), x, i, expect=GATHER_OP_SPEC, op="tanh"
+        )
+
+    def test_single_idx_2d_embedding(self):
+        """P=1, torch.embedding — single token lookup."""
+        V, E = 256, 128
+        weight = self.to_spyre(torch.rand(V, E, dtype=torch.float16))
+        idx = torch.randint(0, V, (1,), dtype=torch.int32).to("spyre")
+        self.name_dims(weight, {"V": V, "E": E})
+        self.name_dims(idx, {"P": 1})
+        self._stage_and_e2e(
+            lambda w, i: torch.embedding(w, i), weight, idx, expect=GATHER_OP_SPEC
+        )
+
+    def test_single_idx_2d_index_select(self):
+        """P=1, torch.index_select, 2-D value."""
+        x, i = self._xi(P=1)
+        self._stage_and_e2e(
+            lambda x, i: torch.index_select(x, 0, i), x, i, expect=GATHER_OP_SPEC
+        )
+
+    # 3-D value tensor, P=1
+    def test_single_idx_3d_stick_aligned(self):
+        """P=1, 3-D value [32, 4, 128] — C stick-aligned (2 sticks per row)."""
+        x, i = self._xi3d(P=1, A=32, B=4, C=128)
+        self._stage_and_e2e(lambda x, i: x[i], x, i, expect=GATHER_OP_SPEC)
+
+    def test_single_idx_3d_non_stick_aligned(self):
+        """P=1, 3-D value [32, 4, 100] — C not stick-aligned."""
+        x, i = self._xi3d(P=1, A=32, B=4, C=100)
+        self._stage_and_e2e(lambda x, i: x[i], x, i, expect=GATHER_OP_SPEC)
+
+    def test_single_idx_3d_small(self):
+        """P=1, 3-D value [8, 2, 64] — small A and B, single-stick C."""
+        x, i = self._xi3d(P=1, A=8, B=2, C=64)
+        self._stage_and_e2e(lambda x, i: x[i], x, i, expect=GATHER_OP_SPEC)
+
+    def test_single_idx_3d_large(self):
+        """P=1, 3-D value [64, 16, 256] — large, 4 sticks per C."""
+        x, i = self._xi3d(P=1, A=64, B=16, C=256)
+        self._stage_and_e2e(lambda x, i: x[i], x, i, expect=GATHER_OP_SPEC)
+
+    def test_single_idx_3d_non_power_of_two(self):
+        """P=1, 3-D value [48, 6, 96] — non-power-of-two dims."""
+        x, i = self._xi3d(P=1, A=48, B=6, C=96)
+        self._stage_and_e2e(lambda x, i: x[i], x, i, expect=GATHER_OP_SPEC)
+
+    def test_single_idx_3d_int64_index(self):
+        """P=1, 3-D value, int64 index."""
+        x, i = self._xi3d(P=1, dtype=torch.int64)
+        self._stage_and_e2e(lambda x, i: x[i], x, i, expect=GATHER_OP_SPEC)
+
+    def test_single_idx_3d_with_exp(self):
+        """P=1, 3-D value, fused exp."""
+        x, i = self._xi3d(P=1)
+        self._stage_and_e2e(
+            lambda x, i: x[i].exp(), x, i, expect=GATHER_OP_SPEC, op="exp"
+        )
+
+    def test_single_idx_3d_with_tanh(self):
+        """P=1, 3-D value, fused tanh."""
+        x, i = self._xi3d(P=1)
+        self._stage_and_e2e(
+            lambda x, i: x[i].tanh(), x, i, expect=GATHER_OP_SPEC, op="tanh"
+        )
+
+    def test_single_idx_3d_index_select(self):
+        """P=1, torch.index_select, 3-D value."""
+        x, i = self._xi3d(P=1)
+        self._stage_and_e2e(
+            lambda x, i: torch.index_select(x, 0, i), x, i, expect=GATHER_OP_SPEC
+        )
+
+    def test_single_idx_3d_chained_unary(self):
+        """P=1, 3-D value, chained exp+tanh fused after gather."""
+        x, i = self._xi3d(P=1)
+        self._stage_and_e2e(lambda x, i: x[i].exp().tanh(), x, i, expect=GATHER_OP_SPEC)
+
+    def test_single_idx_3d_scalar_add(self):
+        """P=1, 3-D value, scalar add fused after gather."""
+        x, i = self._xi3d(P=1)
+        self._stage_and_e2e(lambda x, i: x[i] + 1.0, x, i, expect=GATHER_OP_SPEC)
+
+    # 4-D value tensor, P=1
+    def test_single_idx_4d_stick_aligned(self):
+        """P=1, 4-D value [8, 4, 8, 64] — D stick-aligned (1 stick per row)."""
+        x, i = self._xi4d(P=1, A=8, B=4, C=8, D=64)
+        self._stage_and_e2e(lambda x, i: x[i], x, i, expect=GATHER_OP_SPEC)
+
+    def test_single_idx_4d_non_stick_aligned(self):
+        """P=1, 4-D value [8, 4, 8, 100] — D not stick-aligned."""
+        x, i = self._xi4d(P=1, A=8, B=4, C=8, D=100)
+        self._stage_and_e2e(lambda x, i: x[i], x, i, expect=GATHER_OP_SPEC)
+
+    def test_single_idx_4d_multistick_row(self):
+        """P=1, 4-D value [8, 4, 4, 128] — D spans 2 sticks per row."""
+        x, i = self._xi4d(P=1, A=8, B=4, C=4, D=128)
+        self._stage_and_e2e(lambda x, i: x[i], x, i, expect=GATHER_OP_SPEC)
+
+    def test_single_idx_4d_small(self):
+        """P=1, 4-D value [4, 2, 2, 64] — small inner dims."""
+        x, i = self._xi4d(P=1, A=4, B=2, C=2, D=64)
+        self._stage_and_e2e(lambda x, i: x[i], x, i, expect=GATHER_OP_SPEC)
+
+    def test_single_idx_4d_int64_index(self):
+        """P=1, 4-D value, int64 index."""
+        x, i = self._xi4d(P=1, dtype=torch.int64)
+        self._stage_and_e2e(lambda x, i: x[i], x, i, expect=GATHER_OP_SPEC)
+
+    def test_single_idx_4d_with_exp(self):
+        """P=1, 4-D value, fused exp."""
+        x, i = self._xi4d(P=1)
+        self._stage_and_e2e(
+            lambda x, i: x[i].exp(), x, i, expect=GATHER_OP_SPEC, op="exp"
+        )
+
+    def test_single_idx_4d_with_tanh(self):
+        """P=1, 4-D value, fused tanh."""
+        x, i = self._xi4d(P=1)
+        self._stage_and_e2e(
+            lambda x, i: x[i].tanh(), x, i, expect=GATHER_OP_SPEC, op="tanh"
+        )
+
+    def test_single_idx_4d_index_select(self):
+        """P=1, torch.index_select, 4-D value."""
+        x, i = self._xi4d(P=1)
+        self._stage_and_e2e(
+            lambda x, i: torch.index_select(x, 0, i), x, i, expect=GATHER_OP_SPEC
+        )
+
+    def test_single_idx_4d_scalar_mul(self):
+        """P=1, 4-D value, scalar multiply fused after gather."""
+        x, i = self._xi4d(P=1)
+        self._stage_and_e2e(lambda x, i: x[i] * 2.0, x, i, expect=GATHER_OP_SPEC)
+
+    # P=1 embedding API variants
+    def test_single_idx_embedding_large_vocab(self):
+        """P=1, torch.embedding, large vocab (V=4096) with a multi-stick embedding dim."""
+        V, E = 4096, 512
+        weight = self.to_spyre(torch.rand(V, E, dtype=torch.float16))
+        idx = torch.randint(0, V, (1,), dtype=torch.int32).to("spyre")
+        self.name_dims(weight, {"V": V, "E": E})
+        self.name_dims(idx, {"P": 1})
+        self._stage_and_e2e(
+            lambda w, i: torch.embedding(w, i), weight, idx, expect=GATHER_OP_SPEC
+        )
+
+    def test_single_idx_embedding_non_aligned_dim(self):
+        """P=1, torch.embedding, embedding dim not stick-aligned (E=100)."""
+        V, E = 256, 100
+        weight = self.to_spyre(torch.rand(V, E, dtype=torch.float16))
+        idx = torch.randint(0, V, (1,), dtype=torch.int32).to("spyre")
+        self.name_dims(weight, {"V": V, "E": E})
+        self.name_dims(idx, {"P": 1})
+        self._stage_and_e2e(
+            lambda w, i: torch.embedding(w, i), weight, idx, expect=GATHER_OP_SPEC
+        )
+
+    def test_single_idx_embedding_int64(self):
+        """P=1, torch.embedding, int64 index — typical token id dtype."""
+        V, E = 256, 128
+        weight = self.to_spyre(torch.rand(V, E, dtype=torch.float16))
+        idx = torch.randint(0, V, (1,), dtype=torch.int64).to("spyre")
+        self.name_dims(weight, {"V": V, "E": E})
+        self.name_dims(idx, {"P": 1})
+        self._stage_and_e2e(
+            lambda w, i: torch.embedding(w, i), weight, idx, expect=GATHER_OP_SPEC
+        )
+
+    def test_single_idx_functional_embedding(self):
+        """P=1, torch.nn.functional.embedding — single token."""
+        V, E = 256, 128
+        weight = self.to_spyre(torch.rand(V, E, dtype=torch.float16))
+        idx = torch.randint(0, V, (1,), dtype=torch.int32).to("spyre")
+        self.name_dims(weight, {"V": V, "E": E})
+        self.name_dims(idx, {"P": 1})
         self._stage_and_e2e(
             lambda i, w: torch.nn.functional.embedding(i, w),
             idx,

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -497,11 +497,10 @@ def _collect_index_tensor_layouts(
 ) -> tuple[dict, dict]:
     """First pass: compute (dim_order, stick_dim) for each index tensor.
 
-    When ``gather_mb_injected`` is True (P < stick_size gather), any index
-    tensor whose device coordinates are all-constant (empty dim_order) gets its
-    layout overridden to ``([mb_sym], mb_sym)``.  This gives the KERNEL_IDX a
-    non-empty ``layoutDimOrder_`` so deeptools' allocate-node assertion is
-    satisfied without rewriting the FX graph.
+    For P=1 gathers the index tensor has all-constant coordinates (no loop
+    variables), so its natural dim_order is empty.  When ``gather_mb_injected``
+    is True, override the layout to ``([mb_sym], mb_sym)`` so the KERNEL_IDX
+    has a valid non-empty layout.
 
     Returns:
         index_tensor_layouts: dict mapping tensor_idx -> (dim_order, stick_dim)
@@ -514,8 +513,7 @@ def _collect_index_tensor_layouts(
         arg = op_spec.args[i]
         dim_order, stick_dim = _get_device_dim_order(arg, symbol_mapping)
         if gather_mb_injected and not dim_order:
-            # P < stick_size: all device coordinates are constants; substitute
-            # the synthesised mb dimension so the KERNEL_IDX has a valid layout.
+            # P=1: index tensor has all-constant coords; use the synthetic dim.
             dim_order = [mb_sym]
             stick_dim = mb_sym
         index_tensor_layouts[i] = (dim_order, stick_dim)
@@ -708,11 +706,8 @@ def _create_sdsc_tensors(
                 backGap[dim] = dev_dim_size - it_dim_size
                 strides[dim] = strides[dim] // dev_dim_size * it_dim_size
 
-        # Inject mb_sym for dtype-conversion ops and for the non-index tensors
-        # of P<stick_size gathers.  For P<stick_size gathers the KERNEL_IDX
-        # tensor already has mb_sym in its dim_order (set by
-        # _collect_index_tensor_layouts) and its strides were computed in the
-        # per-dim loop above, so skip re-injection for it.
+        # Prepend mb_sym to all tensors except the P=1 index tensor, which
+        # already has mb_sym set by _collect_index_tensor_layouts.
         is_gather_index = (
             gather_mb_injected and has_indirect_access and i in index_tensor_indices
         )
@@ -721,10 +716,7 @@ def _create_sdsc_tensors(
             scales[mb_sym] = 1
             strides[mb_sym] = _calculate_device_stride(0, arg.device_size)
             offsets[mb_sym] = 0
-            # For P<stick_size gather value tensors the KERNEL_IDX fetches
-            # exactly 1 row per mb iteration (matching what
-            # compute_indirect_max_dim_sizes returns for the P>=stick_size
-            # path).  For dtype-ops keep -1.
+            # P=1 gather value tensor fetches exactly 1 row per iteration.
             if gather_mb_injected and is_indirect_value_tensor(arg):
                 max_dim_sizes[mb_sym] = 1
             else:
@@ -1019,33 +1011,37 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
         work_slices = {mb_sym: 1, **work_slices}
         op_dim_order = [mb_sym] + op_dim_order
 
-    # P < stick_size gather: Inductor constant-folds the mb loop when P=1,
-    # leaving all-constant device coordinates on the index tensor.  deeptools
-    # requires a non-empty layoutDimOrder_ on every KERNEL_IDX allocate node.
-    # Inject a virtual mb dimension sized to stick_size (the index tensor's
-    # elems_per_stick) so the KERNEL_IDX gets [mb] as its layoutDimOrder_
-    # without any FX-level graph rewrite.  The value and output tensors pick up
-    # mb via the existing mb_sym injection in _create_sdsc_tensors.
+    # P=1 gather: when the index has only 1 element, Inductor eliminates the
+    # mb loop, leaving the index tensor with all-constant coordinates and no
+    # loop variable.  Inject a synthetic dim=1 so the KERNEL_IDX gets a valid
+    # non-empty layout, and the backend executes exactly one gather iteration.
     gather_mb_injected: bool = False
     if has_indirect_access and mb_sym is None:
         for idx in index_tensor_indices:
             idx_arg = op_spec.args[idx]
             idx_dim_order, _ = _get_device_dim_order(idx_arg, symbol_mapping)
             if not idx_dim_order:
-                # All-constant coords → P < stick_size. Synthesise mb = stick_size.
+                # All-constant coords → P=1. Use 1, not stick_size: stick_size
+                # iterations would overflow a 1-row output tensor.
                 stick_size = idx_arg.device_dtype.elems_per_stick()
-                mb_sym = Symbol(INPUT_DIM_LABELS[0])
-                sdsc_iteration_space = {mb_sym: stick_size, **sdsc_iteration_space}
+                # Pick the first label not already in op_dim_order to avoid
+                # collisions when a higher-rank gather has consumed "mb".
+                _existing_names = {s.name for s in op_dim_order}
+                _p1_label = next(
+                    lbl for lbl in INPUT_DIM_LABELS if lbl not in _existing_names
+                )
+                mb_sym = Symbol(_p1_label)
+                sdsc_iteration_space = {mb_sym: 1, **sdsc_iteration_space}
                 dim_splits = {mb_sym: 1, **dim_splits}
                 work_slices = {mb_sym: 1, **work_slices}
                 op_dim_order = [mb_sym] + op_dim_order
                 gather_mb_injected = True
                 logger.debug(
-                    "P<stick_size gather detected (index tensor %d, stick_size=%d): "
-                    "injecting virtual mb=%d into SDSC iteration space",
+                    "P=1 gather detected (index tensor %d, stick_size=%d): "
+                    "injecting virtual %s=1 into SDSC iteration space",
                     idx,
                     stick_size,
-                    stick_size,
+                    _p1_label,
                 )
                 break
 

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -492,8 +492,16 @@ def _collect_index_tensor_layouts(
     symbol_mapping: dict,
     index_tensor_indices: set[int],
     logger: object,
+    gather_mb_injected: bool = False,
+    mb_sym: Symbol | None = None,
 ) -> tuple[dict, dict]:
     """First pass: compute (dim_order, stick_dim) for each index tensor.
+
+    When ``gather_mb_injected`` is True (P < stick_size gather), any index
+    tensor whose device coordinates are all-constant (empty dim_order) gets its
+    layout overridden to ``([mb_sym], mb_sym)``.  This gives the KERNEL_IDX a
+    non-empty ``layoutDimOrder_`` so deeptools' allocate-node assertion is
+    satisfied without rewriting the FX graph.
 
     Returns:
         index_tensor_layouts: dict mapping tensor_idx -> (dim_order, stick_dim)
@@ -505,6 +513,11 @@ def _collect_index_tensor_layouts(
     for i in index_tensor_indices:
         arg = op_spec.args[i]
         dim_order, stick_dim = _get_device_dim_order(arg, symbol_mapping)
+        if gather_mb_injected and not dim_order:
+            # P < stick_size: all device coordinates are constants; substitute
+            # the synthesised mb dimension so the KERNEL_IDX has a valid layout.
+            dim_order = [mb_sym]
+            stick_dim = mb_sym
         index_tensor_layouts[i] = (dim_order, stick_dim)
         active_dims = {d for d in dim_order if d is not stick_dim}
         index_active_dims[i] = active_dims
@@ -523,6 +536,7 @@ def _create_sdsc_tensors(
     op_dim_order: list[Symbol],
     op_stick_dim: Symbol | None,
     mb_sym: Symbol | None = None,
+    gather_mb_injected: bool = False,
 ) -> tuple[list[SDSCArgs], dict, Symbol | None]:
     dims = list(iteration_space.keys())
     layouts: dict = {}
@@ -536,12 +550,19 @@ def _create_sdsc_tensors(
     }
     has_indirect_access = bool(index_tensor_indices)
 
-    # For indirect access: pre-compute index tensor layouts (first pass)
+    # For indirect access: pre-compute index tensor layouts (first pass).
+    # Pass gather_mb_injected so index tensors with all-constant coordinates get
+    # their layout overridden to ([mb_sym], mb_sym) instead of ([], None).
     index_tensor_layouts: dict[int, tuple[list, Any]] = {}
     index_active_dims: dict[int, set] = {}
     if has_indirect_access:
         index_tensor_layouts, index_active_dims = _collect_index_tensor_layouts(
-            op_spec, symbol_mapping, index_tensor_indices, logger
+            op_spec,
+            symbol_mapping,
+            index_tensor_indices,
+            logger,
+            gather_mb_injected=gather_mb_injected,
+            mb_sym=mb_sym,
         )
 
     missing_dim = None
@@ -687,12 +708,27 @@ def _create_sdsc_tensors(
                 backGap[dim] = dev_dim_size - it_dim_size
                 strides[dim] = strides[dim] // dev_dim_size * it_dim_size
 
-        if mb_sym is not None:
+        # Inject mb_sym for dtype-conversion ops and for the non-index tensors
+        # of P<stick_size gathers.  For P<stick_size gathers the KERNEL_IDX
+        # tensor already has mb_sym in its dim_order (set by
+        # _collect_index_tensor_layouts) and its strides were computed in the
+        # per-dim loop above, so skip re-injection for it.
+        is_gather_index = (
+            gather_mb_injected and has_indirect_access and i in index_tensor_indices
+        )
+        if mb_sym is not None and not is_gather_index:
             dim_order = [mb_sym] + dim_order
             scales[mb_sym] = 1
             strides[mb_sym] = _calculate_device_stride(0, arg.device_size)
             offsets[mb_sym] = 0
-            max_dim_sizes[mb_sym] = -1
+            # For P<stick_size gather value tensors the KERNEL_IDX fetches
+            # exactly 1 row per mb iteration (matching what
+            # compute_indirect_max_dim_sizes returns for the P>=stick_size
+            # path).  For dtype-ops keep -1.
+            if gather_mb_injected and is_indirect_value_tensor(arg):
+                max_dim_sizes[mb_sym] = 1
+            else:
+                max_dim_sizes[mb_sym] = -1
 
         effective_stick = op_stick_dim if stick_dim is None else stick_dim
         layout_labels = MATMUL_LAYOUT_LABELS if not use_op_dims else LAYOUT_LABELS
@@ -983,6 +1019,36 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
         work_slices = {mb_sym: 1, **work_slices}
         op_dim_order = [mb_sym] + op_dim_order
 
+    # P < stick_size gather: Inductor constant-folds the mb loop when P=1,
+    # leaving all-constant device coordinates on the index tensor.  deeptools
+    # requires a non-empty layoutDimOrder_ on every KERNEL_IDX allocate node.
+    # Inject a virtual mb dimension sized to stick_size (the index tensor's
+    # elems_per_stick) so the KERNEL_IDX gets [mb] as its layoutDimOrder_
+    # without any FX-level graph rewrite.  The value and output tensors pick up
+    # mb via the existing mb_sym injection in _create_sdsc_tensors.
+    gather_mb_injected: bool = False
+    if has_indirect_access and mb_sym is None:
+        for idx in index_tensor_indices:
+            idx_arg = op_spec.args[idx]
+            idx_dim_order, _ = _get_device_dim_order(idx_arg, symbol_mapping)
+            if not idx_dim_order:
+                # All-constant coords → P < stick_size. Synthesise mb = stick_size.
+                stick_size = idx_arg.device_dtype.elems_per_stick()
+                mb_sym = Symbol(INPUT_DIM_LABELS[0])
+                sdsc_iteration_space = {mb_sym: stick_size, **sdsc_iteration_space}
+                dim_splits = {mb_sym: 1, **dim_splits}
+                work_slices = {mb_sym: 1, **work_slices}
+                op_dim_order = [mb_sym] + op_dim_order
+                gather_mb_injected = True
+                logger.debug(
+                    "P<stick_size gather detected (index tensor %d, stick_size=%d): "
+                    "injecting virtual mb=%d into SDSC iteration space",
+                    idx,
+                    stick_size,
+                    stick_size,
+                )
+                break
+
     if op_stick_dim is None:
         if is_pool:
             # Pool op where C fits in one stick (e.g. C=1): the "out" (channel)
@@ -1015,6 +1081,7 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
         op_dim_order,
         op_stick_dim,
         mb_sym,
+        gather_mb_injected=gather_mb_injected,
     )
     if missing_dim is not None:
         # A dimension was added to the iteration space, update splits and work slices


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

**Issue:** P=1 gather (`x[i]` where `i.shape=[1]`) crashed the backend with an assertion failure — the index tensor ended up with an empty layout dimension order, which the backend does not allow.

**Root cause:** When there is only 1 index (P=1), Inductor eliminates the `mb` loop entirely, leaving the index tensor with all-constant device coordinates and no loop variable. With no loop variable, the index tensor's layout dimension order is empty, causing the backend to abort.

**Fix:** Inject a synthetic `dim=1` into the SDSC iteration space at the opspec level so the index tensor always gets a valid non-empty layout. Two additional correctness issues discovered and fixed along the way:

1. The synthetic dimension must be `size=1` (not `stick_size`) — otherwise the backend runs `stick_size` gather iterations on a 1-row output, producing wrong results.
2. For 3D+ value tensors the label `"mb"` is already consumed by an outer loop variable, so the synthetic dimension picks the first available label from `INPUT_DIM_LABELS` not already in use (`"x"` for 3D, `"y"` for 4D, etc.), avoiding a duplicate dimension crash.

**Test coverage:** 33 new `test_single_idx_*` tests added across:
- **2D, 3D, and 4D value tensors** — stick-aligned, non-stick-aligned, small, large, non-power-of-two shapes
- **int32 and int64 index dtypes**
- **All gather-family APIs**: `x[i]`, `torch.embedding`, `torch.nn.functional.embedding`, `torch.index_select`
- **Fused pointwise ops**: `exp`, `tanh`, chained `exp().tanh()`, scalar `add` and `mul`

#### Which issue(s) this PR is related to:
 
Related to #866
Fixes #3418

#### Special notes for your reviewer:

The injection block is guarded by `if not idx_dim_order` — only entered when the index tensor has all-constant coordinates (P=1). P≥2 paths are completely unaffected.

`test_advanced_indexing_single_row` (2D) and `test_advanced_indexing_3d_single_row` (3D) both previously crashed with the empty layout assertion — both are now passing with this fix.

#### Does this PR introduce a user-facing change?

`x[i]` with `i.shape=[1]` now compiles and produces correct results on Spyre for value tensors of any rank.