### PR TITLE
job_plan: gate correction HostCompute on prior-DMA completion (WAR under async)

### DIFF
--- a/tests/test_launch_jobplan.py
+++ b/tests/test_launch_jobplan.py
@@ -26,6 +26,7 @@ import torch._dynamo
 import torch_spyre
 
 from torch_spyre._inductor import config as _spyre_config
+from torch_spyre.execution import kernel_runner
 from test_prepare_kernel import TestPrepareKernel as tpk
 
 
@@ -143,6 +144,111 @@ class TestLaunchJobPlan(TestCase):
             with stream:
                 with pytest.raises(RuntimeError, match="Expect one DCI"):
                     torch_spyre._C.launch_jobplan(job_plan, [])
+
+
+class TestCorrectionBufferWarBarrier(TestCase):
+    """Regression guard for the reused correction-buffer WAR pipeline barrier.
+
+    The program-correction path emits a HostCompute step that writes a pinned
+    "correction" buffer, followed by an H2D that reads it. The JobPlan (and thus
+    the pinned buffer) is built once and reused across every launch of a compiled
+    op. Because flex dispatches the HostCompute callback INLINE on the caller
+    thread, the HostCompute step must carry ``pipeline_barrier=True`` so a later
+    launch's callback waits for the prior launch's H2D to finish reading the
+    buffer before overwriting it (cross-launch write-after-read; see flex #1479
+    and the ``JobPlanStepHostCompute`` constructor in job_plan.h).
+
+    This complements the mock-based ``test_pipeline_barrier_correction_sequence``
+    in test_prepare_kernel.py, which never compiles a real op and never exercises
+    reuse. Here we:
+
+      1. Compile a REAL correction-path op (BUNDLE_SYMBOLIC_ARGS=1, the process
+         default), so the JobPlan comes from the real compile -> prepare_kernel
+         path rather than a hand-built mock.
+      2. Launch it MORE THAN ONCE, so the same JobPlan and pinned correction
+         buffer are genuinely reused across iterations (the cross-launch reuse
+         the barrier protects).
+      3. Assert, on the JobPlan that is actually launched each iteration, that
+         the HostCompute step carries ``pipeline_barrier=True``.
+
+    Polarity as a regression guard: this PASSES on current (correct) code and
+    fails deterministically if a future change drops the barrier line
+    (job_plan.h:449) or stops emitting the HostCompute step. It does not depend
+    on reproducing the underlying data race numerically -- that race is timing
+    dependent and cannot be triggered reliably on real hardware, so a numeric
+    assertion would be a false guard (green even when the barrier is dropped).
+    """
+
+    NUM_ITERATIONS = 3
+
+    def test_reused_correction_buffer_keeps_barrier_across_launches(self):
+        torch._dynamo.reset()
+
+        captured = []
+        orig_launch = kernel_runner.launch_jobplan
+
+        def _spy(job_plan, args):
+            captured.append(job_plan)
+            return orig_launch(job_plan, args)
+
+        old_sym = os.environ.get("BUNDLE_SYMBOLIC_ARGS")
+        os.environ["BUNDLE_SYMBOLIC_ARGS"] = "1"
+        kernel_runner.launch_jobplan = _spy
+        try:
+            with _spyre_config.patch(bundle_symbolic_args=True):  # type: ignore[attr-defined]
+                torch.manual_seed(42)
+                compiled_fn = torch.compile(torch.abs, backend="inductor")
+                # Launch the SAME compiled fn multiple times so the JobPlan (and
+                # its pinned correction buffer) is reused across iterations.
+                for _ in range(self.NUM_ITERATIONS):
+                    x = torch.randn(64, dtype=torch.float16).to("spyre")
+                    compiled_fn(x).cpu()
+        finally:
+            kernel_runner.launch_jobplan = orig_launch
+            if old_sym is None:
+                os.environ.pop("BUNDLE_SYMBOLIC_ARGS", None)
+            else:
+                os.environ["BUNDLE_SYMBOLIC_ARGS"] = old_sym
+
+        # The compiled op must have launched on every iteration.
+        assert len(captured) >= self.NUM_ITERATIONS, (
+            f"expected >= {self.NUM_ITERATIONS} launches, got {len(captured)}"
+        )
+
+        # The correction path must reuse a single JobPlan across launches; that
+        # reuse is the whole reason the WAR barrier is needed. If each launch
+        # rebuilt the JobPlan (and buffer), there would be no cross-iteration
+        # hazard and this guard would be testing the wrong thing.
+        assert len({id(jp) for jp in captured}) == 1, (
+            "expected one reused JobPlan across launches, got "
+            f"{len({id(jp) for jp in captured})} distinct JobPlans; the "
+            "correction buffer is no longer reused, so the cross-iteration WAR "
+            "this test guards is not being exercised"
+        )
+
+        hostcompute_seen = 0
+        for job_plan in captured:
+            for idx in range(job_plan.num_steps()):
+                if job_plan.get_step_type(idx) != "HostCompute":
+                    continue
+                hostcompute_seen += 1
+                assert job_plan.get_step_pipeline_barrier(idx) is True, (
+                    f"HostCompute step {idx} must carry pipeline_barrier=True to "
+                    "close the cross-launch WAR on the reused pinned correction "
+                    "buffer (flex #1479). With the barrier dropped, flex runs the "
+                    "next launch's inline host callback while the prior launch's "
+                    "H2D is still reading the shared buffer, corrupting the "
+                    "correction data"
+                )
+
+        # Fail loudly rather than pass vacuously if the correction path stopped
+        # emitting a HostCompute step (e.g. a compiler change): then the barrier
+        # this test guards would silently no longer exist.
+        assert hostcompute_seen >= self.NUM_ITERATIONS, (
+            "no HostCompute step found on every launched JobPlan; the "
+            "program-correction path did not run, so the WAR barrier guard was "
+            "not exercised"
+        )
 
 
 def _build_d2h_jobplan(tmpdir: str, dev_ptr: int, size_bytes: int):

--- a/tests/test_prepare_kernel.py
+++ b/tests/test_prepare_kernel.py
@@ -576,7 +576,7 @@ class TestPrepareKernel:
         """Correction sequence: HostCompute=True, H2D=True, Compute=True.
 
         HostCompute carries the barrier to close the WAR hazard on the reused
-        pinned correction buffer (see flex #1306). H2D and Compute inherit the
+        pinned correction buffer (see flex #1479). H2D and Compute inherit the
         safe default True; Compute must also wait for H2D (RAW on the seg-7 region).
         """
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_prepare_kernel.py
+++ b/tests/test_prepare_kernel.py
@@ -573,11 +573,11 @@ class TestPrepareKernel:
             )
 
     def test_pipeline_barrier_correction_sequence(self):
-        """Correction sequence: HostCompute=False, H2D=True, Compute=True.
+        """Correction sequence: HostCompute=True, H2D=True, Compute=True.
 
-        HostCompute opts out (overlap-eligible: runs while prior device compute
-        is in flight). H2D and Compute inherit the safe default True. Compute
-        must wait for H2D to close the RAW hazard on the seg-7 correction region.
+        HostCompute carries the barrier to close the WAR hazard on the reused
+        pinned correction buffer (see flex #1306). H2D and Compute inherit the
+        safe default True; Compute must also wait for H2D (RAW on the seg-7 region).
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             spyrecode_dir = self.create_mock_spyrecode(
@@ -591,10 +591,11 @@ class TestPrepareKernel:
             assert job_plan.get_step_type(1) == "H2D"
             assert job_plan.get_step_type(2) == "Compute"
 
-            assert job_plan.get_step_pipeline_barrier(0) is False, (
-                "HostCompute step must carry pipeline_barrier=False to preserve "
-                "host/device overlap (correction callback runs while prior device "
-                "compute is still in flight)"
+            assert job_plan.get_step_pipeline_barrier(0) is True, (
+                "HostCompute step must carry pipeline_barrier=True to close the "
+                "WAR hazard on the reused pinned correction buffer: under flex's "
+                "inline caller-thread dispatch, the barrier makes the callback "
+                "wait for the prior iteration's H2D to drain before overwriting it"
             )
             assert job_plan.get_step_pipeline_barrier(1) is True, (
                 "H2D step must carry pipeline_barrier=True (safe default: "

--- a/torch_spyre/csrc/job_plan.h
+++ b/torch_spyre/csrc/job_plan.h
@@ -285,7 +285,7 @@ inline std::ostream& operator<<(std::ostream& os, const JobPlanStep& step) {
  * reused across launches. Within an iteration the HostCompute callback
  * completes (inline, on the caller thread) before its H2D is enqueued, so the
  * forward write-before-read holds; the cross-iteration WAR on the reused
- * buffer is closed by HostCompute's pipeline barrier (see flex #1306).
+ * buffer is closed by HostCompute's pipeline barrier (see flex #1479).
  */
 class JobPlanStepH2D final : public JobPlanStep {
  public:
@@ -415,9 +415,9 @@ class JobPlanStepCompute final : public JobPlanStep {
  * the buffer, and produces a RuntimeOperationHostCallback.
  *
  * The shared buffer is allocated once during PrepareKernel and reused across
- * launches. For tiled execution, the same buffer is reused across iterations —
- * FIFO ordering guarantees each iteration's H2D consumes the buffer before the
- * next iteration's HostCompute overwrites it.
+ * launches and across tiled iterations; the cross-iteration WAR on the reused
+ * buffer is closed by this step's pipeline barrier, not by FIFO (see flex
+ * #1479).
  */
 class JobPlanStepHostCompute final : public JobPlanStep {
  public:
@@ -439,7 +439,13 @@ class JobPlanStepHostCompute final : public JobPlanStep {
     // Gate on prior-stream completion: the shared pinned buffer is reused
     // across tiled iterations, so this write must wait for the previous
     // iteration's H2D to finish reading it (WAR). Under inline host dispatch,
-    // pipeline_barrier=false is unsafe. See flex #1306.
+    // pipeline_barrier=false is unsafe. See flex #1479.
+    //
+    // Precondition: this barrier closes the WAR only because HostCompute and
+    // its H2D share a stream today. The barrier drains the whole stream (all
+    // prior ops, including in-flight Compute), not just the prior H2D — correct
+    // and safe, just coarser than needed, at the cost of some HC/compute
+    // overlap. TODO: replace with a per-buffer dependency once available.
     pipeline_barrier_ = true;
   }
 

--- a/torch_spyre/csrc/job_plan.h
+++ b/torch_spyre/csrc/job_plan.h
@@ -256,8 +256,8 @@ class JobPlanStep {
 
  protected:
   // true by default: every step is a potential consumer that should wait for
-  // prior ops. Steps that are genuinely overlap-eligible (HostCompute) opt out
-  // explicitly.
+  // prior ops. A step opts out explicitly only when it is genuinely
+  // overlap-eligible.
   bool pipeline_barrier_ = true;
 };
 
@@ -282,8 +282,10 @@ inline std::ostream& operator<<(std::ostream& os, const JobPlanStep& step) {
  * When used for correction tensor DMA, the host_address points into a pinned
  * host buffer allocated during PrepareKernel and shared with the
  * JobPlanStepHostCompute that writes into it. The buffer is allocated once and
- * reused across launches — FIFO ordering within a stream guarantees the
- * HostCompute callback writes the buffer before the H2D reads it.
+ * reused across launches. Within an iteration the HostCompute callback
+ * completes (inline, on the caller thread) before its H2D is enqueued, so the
+ * forward write-before-read holds; the cross-iteration WAR on the reused
+ * buffer is closed by HostCompute's pipeline barrier (see flex #1306).
  */
 class JobPlanStepH2D final : public JobPlanStep {
  public:
@@ -434,7 +436,11 @@ class JobPlanStepHostCompute final : public JobPlanStep {
         output_buffer_(output_buffer),
         input_buffer_(input_buffer),
         ishape_(ishape) {
-    pipeline_barrier_ = false;  // host callbacks are overlap-eligible
+    // Gate on prior-stream completion: the shared pinned buffer is reused
+    // across tiled iterations, so this write must wait for the previous
+    // iteration's H2D to finish reading it (WAR). Under inline host dispatch,
+    // pipeline_barrier=false is unsafe. See flex #1306.
+    pipeline_barrier_ = true;
   }
 
   void construct(LaunchContext& ctx, const SpyreStream& stream) const override;


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->
JobPlanStepHostCompute now carries pipeline_barrier=true. The pinned correction buffer is reused across tiled iterations, so the callback's write must wait for the previous iteration's H2D to finish reading it. Under flex's inline caller-thread host dispatch, pipeline_barrier=false no longer serializes that ordering and would expose a write-after-read hazard. fix for flex 1306

Updates test_pipeline_barrier_correction_sequence to assert the new contract, and corrects two stale comments that described the old FIFO/overlap behavior.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->
part of #2878 
#### Special notes for your reviewer:
corresponding torch-spyre fix for WAR issue introduced by flex PR1479

#### Does this PR introduce a user-facing change?

#### Additional note:
