### PR TITLE
Don't LX allocate index or indirectly-accessed tensors

### DIFF
--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -247,7 +247,7 @@ class ScratchpadAllocator:
         the scratchpad and resolve from HBM instead.
         """
         if isinstance(op, ComputedBuffer):
-            writes = op.get_read_writes().writes
+            writes = op_read_writes(op).writes
             if any(isinstance(dep, MemoryDep) and dep.is_indirect() for dep in writes):
                 return True
         for u in uses:
@@ -257,7 +257,7 @@ class ScratchpadAllocator:
             index_names, _, _ = indirect_info_from_op(consumer)
             if name in index_names:
                 return True
-            reads = consumer.get_read_writes().reads
+            reads = op_read_writes(consumer).reads
             if any(
                 dep.name == name and isinstance(dep, MemoryDep) and dep.is_indirect()
                 for dep in reads

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -243,9 +243,7 @@ class ScratchpadAllocator:
         lifetime: as ``op``'s own indirect write (a Scatter target), or as a
         read/index operand of any consumer in ``uses``.
 
-        LX addresses are expressed as ``affine.apply`` symbols and cannot carry
-        the data-dependent offsets indirect (gather/scatter-style) access needs,
-        so both the index tensor and the tensor it indexes into must stay off
+        Both the index tensor and the tensor it indexes into must stay off
         the scratchpad and resolve from HBM instead.
         """
         if isinstance(op, ComputedBuffer):
@@ -323,8 +321,7 @@ class ScratchpadAllocator:
             return "extern kernel user"
         if self._is_index_or_indirectly_accessed(graph, name, uses, op):
             # Index tensors and the value tensors they index into are read via
-            # data-dependent (indirect) addressing, which LX's affine.apply
-            # addressing cannot express -- both must stay off the scratchpad.
+            # data-dependent (indirect) addressing, must stay in hbm.
             return "index tensor or indirectly accessed"
         if name in graph_output_names:
             # A graph output normally can't reside (the value must land back in

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -31,10 +31,12 @@ from torch._inductor.ir import (
     ReinterpretView,
 )
 from torch._inductor.graph import GraphLowering
+from torch._inductor.dependencies import MemoryDep
 
 from torch_spyre._inductor.pass_utils import (
     apply_splits_from_index_coeff,
     concretize_expr,
+    indirect_info_from_op,
     iteration_space_from_op,
     splits_by_index_coeff,
     op_read_writes,
@@ -229,6 +231,42 @@ class ScratchpadAllocator:
         ``LifetimeBoundBuffer.read_count``."""
         return max(0, len(uses) - 1)
 
+    @staticmethod
+    def _is_index_or_indirectly_accessed(
+        graph: GraphLowering,
+        name: str,
+        uses: list[int],
+        op: Optional[Operation],
+    ) -> bool:
+        """True if ``name`` is an index tensor, or is itself accessed
+        indirectly (a gather/scatter value tensor), on either side of its
+        lifetime: as ``op``'s own indirect write (a Scatter target), or as a
+        read/index operand of any consumer in ``uses``.
+
+        LX addresses are expressed as ``affine.apply`` symbols and cannot carry
+        the data-dependent offsets indirect (gather/scatter-style) access needs,
+        so both the index tensor and the tensor it indexes into must stay off
+        the scratchpad and resolve from HBM instead.
+        """
+        if isinstance(op, ComputedBuffer):
+            writes = op.get_read_writes().writes
+            if any(isinstance(dep, MemoryDep) and dep.is_indirect() for dep in writes):
+                return True
+        for u in uses:
+            consumer = graph.operations[u]
+            if not isinstance(consumer, ComputedBuffer):
+                continue
+            index_names, _, _ = indirect_info_from_op(consumer)
+            if name in index_names:
+                return True
+            reads = consumer.get_read_writes().reads
+            if any(
+                dep.name == name and isinstance(dep, MemoryDep) and dep.is_indirect()
+                for dep in reads
+            ):
+                return True
+        return False
+
     def _buffer_residency_reason(
         self,
         graph: GraphLowering,
@@ -283,6 +321,11 @@ class ScratchpadAllocator:
             return restickify
         if any(isinstance(graph.operations[u], ExternKernel) for u in uses):
             return "extern kernel user"
+        if self._is_index_or_indirectly_accessed(graph, name, uses, op):
+            # Index tensors and the value tensors they index into are read via
+            # data-dependent (indirect) addressing, which LX's affine.apply
+            # addressing cannot express -- both must stay off the scratchpad.
+            return "index tensor or indirectly accessed"
         if name in graph_output_names:
             # A graph output normally can't reside (the value must land back in
             # HBM), but with boundary cloning on it is pinned via an output clone
@@ -334,6 +377,8 @@ class ScratchpadAllocator:
             return "graph input (no clone)"
         if self._read_count(uses) == 0:
             return "no consumer reads it from LX"
+        if self._is_index_or_indirectly_accessed(graph, name, uses, None):
+            return "index tensor or indirectly accessed"
         if not GraphEditor.all_uses_are_rewritable(graph, uses):
             return "use is not rewritable to the clone"
         if buffer_not_read_in_full(graph, name):


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Index tensors and value tensors read/written via indirect (gather/scatter)
access cannot be in LX.
This PR adds _is_index_or_indirectly_accessed check to _buffer_residency_reason
and _input_residency_reason to exclude these from LX allocation and
keep them in HBM instead.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
