### PR TITLE
scratchpad: fix overlap after failed in-place reuse

### DIFF
--- a/tests/inductor/test_scratchpad_solver.py
+++ b/tests/inductor/test_scratchpad_solver.py
@@ -513,6 +513,18 @@ class ScoreOrderingTests:
         self.assertEqual(by_name["child"], 0)  # child reuses parent's slot
         self.assertIsNone(by_name["plain"])
 
+    def test_failed_inplace_reuse_does_not_overlap_live_parent(self):
+        parent = LifetimeBoundBuffer("parent", 20, [0, 4])
+        blocker = LifetimeBoundBuffer("blocker", 5, [5, 8])
+        child = LifetimeBoundBuffer("child", 10, [4, 8], in_place_parents=["parent"])
+
+        result = self.solve([parent, blocker, child], size=30)
+        by_name = {buffer.name: buffer.address for buffer in result}
+
+        self.assertEqual(by_name["parent"], 0)
+        self.assertEqual(by_name["blocker"], 0)
+        self.assertEqual(by_name["child"], 20)
+
     def test_write_first_buffer_placed_before_read_only(self):
         # Identical span (5) and use count (2). `writer`'s first use is a write
         # (first_use_is_read=False), so pinning it also saves the more expensive

--- a/torch_spyre/_inductor/scratchpad/firstfit_bestfit_solver.py
+++ b/torch_spyre/_inductor/scratchpad/firstfit_bestfit_solver.py
@@ -126,16 +126,19 @@ class FirstFitLayoutSolver(MemoryPlanSolver):
         self,
         buffer: LifetimeBoundBuffer,
         placed: list[LifetimeBoundBuffer],
+        *,
+        reuse_in_place_parents: bool = True,
     ) -> list[Gap]:
         """Build free gaps for buffer, annotated with valid in-place parent addresses.
 
         Pass 1: subtract address intervals of all already-placed buffers that overlap
-        buffer's lifetime, except declared in-place parents (their slots are candidates
-        for reuse, not conflicts).
+        buffer's lifetime. During the in-place attempt, declared parents are kept as
+        reuse candidates rather than conflicts. During ordinary fallback placement,
+        they are conflicts like every other live buffer.
         Pass 2: for each remaining gap, record which declared parents fit entirely within it.
         """
         gaps: list[Gap] = [Gap(0, self.limit)]
-        parent_names = set(buffer.in_place_parents)
+        parent_names = set(buffer.in_place_parents) if reuse_in_place_parents else set()
 
         for other in placed:
             if other.address is None:
@@ -225,6 +228,15 @@ class FirstFitLayoutSolver(MemoryPlanSolver):
                 buffer.address = names_to_addresses[parent]
                 names_to_addresses[buffer.name] = buffer.address
             else:
+                # Exact parent-slot reuse was not legal, usually because a third
+                # live buffer occupies part of that slot. Rebuild the ordinary
+                # gaps with the parent treated as a conflict; otherwise a shifted
+                # placement can partially overlap the still-live parent.
+                gaps = self._build_gaps(
+                    buffer,
+                    placed,
+                    reuse_in_place_parents=False,
+                )
                 gap = self._pick_gap(gaps, buffer.size)
                 if gap is not None:
                     buffer.address = round_up_to_alignment(gap.start, self.alignment)


### PR DESCRIPTION
## Summary

- Rebuild ordinary free gaps after an exact in-place parent reuse attempt fails.
- Treat the still-live parent as an occupied interval during fallback placement.
- Add a regression covering the prior partial-overlap failure in FirstFit and BestFit.

## Bug

`FirstFitLayoutSolver` and `BestFitLayoutSolver` omit declared in-place parents from the initial conflict set so a child may reuse a parent's exact address. If exact reuse was blocked, the old implementation reused those same gaps for ordinary placement. A shifted child could therefore overlap part of its still-live parent.

## Fix

The solvers still attempt exact parent-slot reuse first. If that attempt fails, they rebuild the gaps with `reuse_in_place_parents=False`, making every live parent an ordinary conflict before selecting a fallback address.

## Validation

- Regression runs through `ScoreOrderingTests` for both FirstFit and BestFit.
- The previous matrix's executed shards passed; one normalization shard was canceled by workflow concurrency.
- Rebased onto current `main` (`1d0b30a`) at `b55a4ad7`; the commit is GitHub-verified and DCO passes.
- A fresh full matrix is running on the signed head.
- Wheel builds, lint, DCO, test wiring, and OOT checks passed.
- `git diff --check` passed.

## Relationship to #2939

This extracts the independent allocator correctness fix identified during review of #2939. It has no dependency on LX relayout, DeepTools, or model policy.

Tracking: #3049