### PR TITLE
fix(csrc): update deeptools header include paths after upstream reorg

### DIFF
--- a/torch_spyre/csrc/job_plan.cpp
+++ b/torch_spyre/csrc/job_plan.cpp
@@ -24,7 +24,7 @@
 
 #include "spyre_allocator.h"
 #include "spyre_stream.h"
-#include "util/processSpyreCodeArtifacts.h"
+#include "spyrecode-host-functions/processSpyreCodeArtifacts.h"
 
 namespace spyre {
 

--- a/torch_spyre/csrc/job_plan.h
+++ b/torch_spyre/csrc/job_plan.h
@@ -28,7 +28,7 @@
 #include <variant>
 #include <vector>
 
-#include "util/spyrecode.h"
+#include "spyrecode-host-functions/spyrecode.h"
 
 namespace spyre {
 

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -21,8 +21,8 @@
 #include <pybind11/native_enum.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
-#include <util/sen_data_convert.h>
-#include <util/sendefs.h>
+#include <spyrecode-host-functions/sendataconvert/sen_data_convert.h>
+#include <util/sendefs/sendefs.h>
 
 #include <cstdlib>     // std::getenv
 #include <filesystem>  // NOLINT(build/c++17)

--- a/torch_spyre/csrc/module.h
+++ b/torch_spyre/csrc/module.h
@@ -18,7 +18,7 @@
 
 #include <pybind11/pybind11.h>
 #include <torch/csrc/utils/pybind.h>
-#include <util/sen_host_ops.h>
+#include <spyrecode-host-functions/sendataconvert/sen_host_ops.h>
 
 #include <flex/flex.hpp>
 #include <memory>

--- a/torch_spyre/csrc/module.h
+++ b/torch_spyre/csrc/module.h
@@ -17,8 +17,8 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
-#include <torch/csrc/utils/pybind.h>
 #include <spyrecode-host-functions/sendataconvert/sen_host_ops.h>
+#include <torch/csrc/utils/pybind.h>
 
 #include <flex/flex.hpp>
 #include <memory>

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -30,7 +30,7 @@
 #include "job_plan.h"
 #include "logging.h"
 #include "spyre_allocator.h"
-#include "util/spyrecode.h"
+#include "spyrecode-host-functions/spyrecode.h"
 
 namespace spyre {
 

--- a/torch_spyre/csrc/spyre_tensor_impl.h
+++ b/torch_spyre/csrc/spyre_tensor_impl.h
@@ -18,7 +18,7 @@
 
 #include <ATen/ATen.h>
 #include <c10/util/intrusive_ptr.h>
-#include <util/sendefs.h>
+#include <util/sendefs/sendefs.h>
 
 #include <functional>
 #include <optional>

--- a/torch_spyre/csrc/spyre_views.cpp
+++ b/torch_spyre/csrc/spyre_views.cpp
@@ -26,7 +26,7 @@
 #include <c10/util/ArrayRef.h>
 #include <torch/csrc/inductor/inductor_ops.h>
 #include <torch/library.h>
-#include <util/sen_data_convert.h>
+#include <spyrecode-host-functions/sendataconvert/sen_data_convert.h>
 
 #include <vector>
 

--- a/torch_spyre/csrc/spyre_views.cpp
+++ b/torch_spyre/csrc/spyre_views.cpp
@@ -24,9 +24,9 @@
 #include <c10/core/MemoryFormat.h>
 #include <c10/core/TensorOptions.h>
 #include <c10/util/ArrayRef.h>
+#include <spyrecode-host-functions/sendataconvert/sen_data_convert.h>
 #include <torch/csrc/inductor/inductor_ops.h>
 #include <torch/library.h>
-#include <spyrecode-host-functions/sendataconvert/sen_data_convert.h>
 
 #include <vector>
 

--- a/torch_spyre/csrc/types_mapping.h
+++ b/torch_spyre/csrc/types_mapping.h
@@ -19,7 +19,7 @@
 #include <c10/core/ScalarType.h>
 #include <c10/util/Exception.h>  // TORCH_WARN_ONCE
 #include <module.h>
-#include <util/sendefs.h>
+#include <util/sendefs/sendefs.h>
 
 #ifdef USE_FLEX_NAMESPACE
 #include <flex/datatype/flex_datatype.hpp>


### PR DESCRIPTION
## Summary
- deeptools reorganized several public headers on 2026-07-31 (commit `ca9739948e`, "[spyrecode-host-functions] move sen_host_ops DC stack + sen_const out of util"): `sen_host_ops.h`, `sen_data_convert.h`, and `spyrecode.h` moved from `util/` into `spyrecode-host-functions/{,sendataconvert/}`, and `sendefs.h` moved from `util/sendefs.h` to `util/sendefs/sendefs.h`.
- torch-spyre's `setup.py` adds a single flat `DEEPTOOLS_INSTALL_DIR/include` root (unlike flex's per-library `find_path` CMake resolution), so our hardcoded `#include <util/...>` paths broke on both amd64 and ppc64le CI as soon as deeptools' devel package picked up the reorg — compile failures like `util/sen_host_ops.h: No such file or directory`.
- This PR updates the 7 affected include lines across 6 files to match deeptools' current install layout. No logic changes.

## Test plan
- [x] Verified via grep that no stale `util/sen_host_ops.h`, `util/sen_data_convert.h`, `util/sendefs.h`, or `util/spyrecode.h` references remain.
- [ ] CI: relaunching `Spyre-Next/orchestrator` (amd64 + ppc64le) against this branch to confirm the build compiles.
