### PR TITLE
fix(ci): add integration-tests to push-to-clickhouse workflow_run triggers

### DIFF
--- a/.github/workflows/push-to-clickhouse.yaml
+++ b/.github/workflows/push-to-clickhouse.yaml
@@ -9,6 +9,7 @@ on:
       - upstream-pytorch-tests
       - model-ops-tests
       - tests # covers torch spyre tests
+      - integration-tests # amd64 arch_override dispatch target from spyre-frameworks
       # to add more workflows
     types: [completed]
   workflow_dispatch:
@@ -18,7 +19,7 @@ on:
         required: false
         default: ''
       workflow_name:
-        description: Workflow name (model-module-tests | upstream-tests | model-ops-tests )
+        description: Workflow name (model-module-tests | upstream-tests | model-ops-tests | integration-tests)
         required: false
         default: upstream-pytorch-tests
 


### PR DESCRIPTION
## Summary
- `push-to-clickhouse.yaml`'s `workflow_run` trigger list was missing `integration-tests` — the exact workflow spyre-frameworks' amd64 `arch_override` (`workflow: gha`) dispatches for torch-spyre-dev regression/smoke runs.
- Net effect: x86 test results have never landed in ClickHouse. Confirmed live: dev `spyre.test_runs` has 0 rows with `platform` referencing x86, vs. 2 rows already present for `ppc64le` (via the Jenkins/Power `pushJUnitXml` path in spyre-frameworks).

## Change
- Add `integration-tests` to the `workflow_run.workflows` trigger array.
- Add it to the `workflow_name` manual-dispatch input's description for consistency.

## Evidence
- `spyre-frameworks/pipelines/components/torch-spyre/config.yaml` arch_overrides route `amd64 -> workflow: gha`, `ppc64le/s390x -> jenkins_job`.
- Live query against the dev ClickHouse instance (`spyre.test_runs`) showed only `ppc64le` rows.

## Test plan
- [x] YAML syntax validated locally (`yaml.safe_load`).
- [ ] Next x86 `integration-tests` run on `main` should trigger this ingest job and land a row in `spyre.test_runs` with an x86-identifying `platform` value — will confirm once a run completes post-merge.
