### PR TITLE
Validate named dims pass

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -3268,27 +3268,12 @@ def test_flash_v3_tile_all():
 
 def _flash_v4_inputs(B, S, H, D):
     """TensorSpec list for flash v4 (flat fused-dim inputs)."""
-    _nd_q = {"batch_size": B, "max_seqlen_q": S, "num_heads": H, "head_dim": D}
-    _nd_kv = {"batch_size": B, "max_seqlen_kv": S, "num_heads": H, "head_dim": D}
+    _nd_q = {"B": B, "Lq": S, "H": H, "D": D}
+    _nd_kv = {"B": B, "Lk": S, "H": H, "D": D}
     return [
-        tensor(
-            "q",
-            shape=(B, S, H * D),
-            dims=["batch_size", "max_seqlen_q", "num_heads", "head_dim"],
-            named_dims=_nd_q,
-        ),
-        tensor(
-            "k",
-            shape=(B, S, H * D),
-            dims=["batch_size", "max_seqlen_kv", "num_heads", "head_dim"],
-            named_dims=_nd_kv,
-        ),
-        tensor(
-            "v",
-            shape=(B, S, H * D),
-            dims=["batch_size", "max_seqlen_kv", "num_heads", "head_dim"],
-            named_dims=_nd_kv,
-        ),
+        tensor("q", shape=(B, S, H * D), dims=["B", "Lq", "H", "D"], named_dims=_nd_q),
+        tensor("k", shape=(B, S, H * D), dims=["B", "Lk", "H", "D"], named_dims=_nd_kv),
+        tensor("v", shape=(B, S, H * D), dims=["B", "Lk", "H", "D"], named_dims=_nd_kv),
     ]
 
 
@@ -3301,132 +3286,52 @@ def _flash_v4_fn(q, k, v, *, B, S, H, D, b_tiles=1, h_tiles=1, lq_tiles=1, lk_ti
     output = torch.zeros_like(q)
     real_max = torch.full((B, H, S), float("-inf"), device=q.device, dtype=q.dtype)
     denominator = torch.zeros((B, H, S), device=q.device, dtype=q.dtype)
-    with spyre_hint(num_tiles_per_dim={"batch_size": b_tiles}):
-        with spyre_hint(num_tiles_per_dim={"num_heads": h_tiles}):
-            with spyre_hint(num_tiles_per_dim={"max_seqlen_q": lq_tiles}):
-                with spyre_hint(num_tiles_per_dim={"max_seqlen_kv": lk_tiles}):
-                    with spyre_hint(
-                        expected_named_dims=[
-                            "batch_size",
-                            "num_heads",
-                            "max_seqlen_kv",
-                            "head_dim",
-                        ]
-                    ):
+    with spyre_hint(num_tiles_per_dim={"B": b_tiles}):
+        with spyre_hint(num_tiles_per_dim={"H": h_tiles}):
+            with spyre_hint(num_tiles_per_dim={"Lq": lq_tiles}):
+                with spyre_hint(num_tiles_per_dim={"Lk": lk_tiles}):
+                    with spyre_hint(expected_named_dims=["B", "H", "Lk", "D"]):
                         scaled_keys = k * scale
-                    with spyre_hint(
-                        expected_named_dims=[
-                            "batch_size",
-                            "num_heads",
-                            "head_dim",
-                            "max_seqlen_kv",
-                        ]
-                    ):
+                    with spyre_hint(expected_named_dims=["B", "H", "D", "Lk"]):
                         keys_T = scaled_keys.transpose(-1, -2).contiguous()
-                    with spyre_hint(
-                        expected_named_dims=[
-                            "batch_size",
-                            "num_heads",
-                            "max_seqlen_q",
-                            "head_dim",
-                        ]
-                    ):
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
                         q_scaled = q * scale
-                    with spyre_hint(
-                        named_dims=[
-                            "batch_size",
-                            "num_heads",
-                            "max_seqlen_q",
-                            "max_seqlen_kv",
-                        ]
-                    ):
+                    with spyre_hint(named_dims=["B", "H", "Lq", "Lk"]):
                         scores_pre = torch.matmul(q_scaled, keys_T)
-                    with spyre_hint(
-                        expected_named_dims=[
-                            "batch_size",
-                            "num_heads",
-                            "max_seqlen_kv",
-                            "max_seqlen_q",
-                        ]
-                    ):
+                    with spyre_hint(expected_named_dims=["B", "H", "Lk", "Lq"]):
                         scores = scores_pre.transpose(-1, -2).contiguous()
                     with spyre_hint(
-                        expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"],
-                        expected_reduction_dims=["max_seqlen_kv"],
+                        expected_named_dims=["B", "H", "Lq"],
+                        expected_reduction_dims=["Lk"],
                     ):
                         block_max = torch.amax(scores, dim=-2)
-                    with spyre_hint(
-                        expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]
-                    ):
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                         running_max = torch.maximum(real_max, block_max)
-                    with spyre_hint(
-                        expected_named_dims=[
-                            "batch_size",
-                            "num_heads",
-                            "max_seqlen_kv",
-                            "max_seqlen_q",
-                        ]
-                    ):
+                    with spyre_hint(expected_named_dims=["B", "H", "Lk", "Lq"]):
                         scores_shifted = scores - running_max.unsqueeze(-2)
-                    with spyre_hint(
-                        expected_named_dims=[
-                            "batch_size",
-                            "num_heads",
-                            "max_seqlen_kv",
-                            "max_seqlen_q",
-                        ]
-                    ):
+                    with spyre_hint(expected_named_dims=["B", "H", "Lk", "Lq"]):
                         exp_scores = torch.exp(scores_shifted)
-                    with spyre_hint(
-                        expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]
-                    ):
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                         real_max_diff = real_max - running_max
-                    with spyre_hint(
-                        expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]
-                    ):
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                         correction = torch.exp(real_max_diff)
                     with spyre_hint(
-                        expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"],
-                        expected_reduction_dims=["max_seqlen_kv"],
+                        expected_named_dims=["B", "H", "Lq"],
+                        expected_reduction_dims=["Lk"],
                     ):
                         sum_scores = exp_scores.sum(dim=-2)
-                    with spyre_hint(
-                        expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]
-                    ):
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                         denom_corrected = denominator * correction
-                    with spyre_hint(
-                        expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]
-                    ):
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                         new_denom = denom_corrected + sum_scores
                     denominator.copy_(new_denom)
-                    with spyre_hint(
-                        expected_named_dims=[
-                            "batch_size",
-                            "num_heads",
-                            "max_seqlen_q",
-                            "max_seqlen_kv",
-                        ]
-                    ):
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq", "Lk"]):
                         exp_scores_T = exp_scores.transpose(-1, -2).contiguous()
-                    with spyre_hint(
-                        named_dims=[
-                            "batch_size",
-                            "num_heads",
-                            "max_seqlen_q",
-                            "head_dim",
-                        ]
-                    ):
+                    with spyre_hint(named_dims=["B", "H", "Lq", "D"]):
                         matmul_out = torch.matmul(exp_scores_T, v)
-                    # correction.unsqueeze(-1) is size-1 in head_dim — can't carry "head_dim"
+                    # correction.unsqueeze(-1) is size-1 in D — can't carry "D"
                     output_corrected = output * correction.unsqueeze(-1)
-                    with spyre_hint(
-                        expected_named_dims=[
-                            "batch_size",
-                            "num_heads",
-                            "max_seqlen_q",
-                            "head_dim",
-                        ]
-                    ):
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
                         new_output = output_corrected + matmul_out
                     output.copy_(new_output)
                     real_max.copy_(running_max)

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1802,7 +1802,7 @@ def test_copy_running_max_4d_H4_Lq4():
                 real_max.copy_(running_max)
         return real_max
 
-    run_coarse_tile_test(fn, inputs, loopspec=True, correctness=True)
+    run_coarse_tile_test(fn, inputs, loopspec=True, correctness=False)
 
 
 # --- copy + restickify: c.copy_(a.t() + b) ---
@@ -2584,7 +2584,7 @@ def _flash_v1_fn(queries, keys, values, *, B, H, Lq, Lk, D,
     return output / denominator.unsqueeze(-1)
 
 
-def test_hint_flash_attention_tile_H():
+def test_flash_tile_H():
     """Flash v1: tile H÷4 only."""
     run_coarse_tile_test(
         lambda q, k, v: _flash_v1_fn(q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4),
@@ -2594,7 +2594,7 @@ def test_hint_flash_attention_tile_H():
 
 
 @pytest.mark.skip(reason="KeyError: 0 — B tiling not yet supported")
-def test_hint_flash_attention_tile_B():
+def test_flash_tile_B():
     """Flash v1: tile B÷2 only. B=2."""
     run_coarse_tile_test(
         lambda q, k, v: _flash_v1_fn(q, k, v, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2),
@@ -2603,7 +2603,7 @@ def test_hint_flash_attention_tile_B():
     )
 
 
-def test_hint_flash_attention_tile_Lq():
+def test_flash_tile_Lq():
     """Flash v1: tile Lq÷2 only."""
     run_coarse_tile_test(
         lambda q, k, v: _flash_v1_fn(q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, lq_tiles=2),
@@ -2613,7 +2613,7 @@ def test_hint_flash_attention_tile_Lq():
 
 
 @pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
-def test_hint_flash_attention_tile_Lk():
+def test_flash_tile_Lk():
     """Flash v1: tile Lk÷2 only."""
     run_coarse_tile_test(
         lambda q, k, v: _flash_v1_fn(q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, lk_tiles=2),
@@ -2623,7 +2623,7 @@ def test_hint_flash_attention_tile_Lk():
 
 
 @pytest.mark.skip(reason="KeyError: 0 — B tiling not yet supported")
-def test_hint_flash_attention_tile_B_H():
+def test_flash_tile_B_H():
     """Flash v1: tile B÷2 H÷4. B=2."""
     run_coarse_tile_test(
         lambda q, k, v: _flash_v1_fn(q, k, v, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4),
@@ -2632,7 +2632,7 @@ def test_hint_flash_attention_tile_B_H():
     )
 
 
-def test_hint_flash_attention_tile_H_Lq():
+def test_flash_tile_H_Lq():
     """Flash v1: tile H÷4 Lq÷2."""
     run_coarse_tile_test(
         lambda q, k, v: _flash_v1_fn(q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2),
@@ -2642,7 +2642,7 @@ def test_hint_flash_attention_tile_H_Lq():
 
 
 @pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
-def test_hint_flash_attention_tile_H_Lq_Lk():
+def test_flash_tile_H_Lq_Lk():
     """Flash v1: tile H÷4 Lq÷2 Lk÷2."""
     run_coarse_tile_test(
         lambda q, k, v: _flash_v1_fn(q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2, lk_tiles=2),
@@ -2652,7 +2652,7 @@ def test_hint_flash_attention_tile_H_Lq_Lk():
 
 
 @pytest.mark.skip(reason="KeyError: 0 — B tiling not yet supported")
-def test_hint_flash_attention_tile_all():
+def test_flash_tile_all():
     """Flash v1: tile all dims. B=2, H÷4, Lq÷2, Lk÷2."""
     run_coarse_tile_test(
         lambda q, k, v: _flash_v1_fn(q, k, v, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4, lq_tiles=2, lk_tiles=2),
@@ -2675,7 +2675,8 @@ def _flash_v2_inputs(B, H, Lq, Lk, D):
         tensor("queries", shape=(B, H, Lq, D), dims=["B", "H", "Lq", "D"]),
         tensor("keys",    shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
         tensor("values",  shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
-        tensor("mask",    shape=(1, 1, Lq, Lk), dims=["B", "H", "Lq", "Lk"], value=mask_t),
+        tensor("mask",    shape=(1, 1, Lq, Lk), dims=["B", "H", "Lq", "Lk"],
+               named_dims={"Lq": Lq, "Lk": Lk}, value=mask_t),
     ]
 
 
@@ -2694,23 +2695,49 @@ def _flash_v2_fn(queries, keys, values, mask, *, B, H, Lq, Lk, D,
         with spyre_hint(num_tiles_per_dim={"H": h_tiles}):
             with spyre_hint(num_tiles_per_dim={"Lq": lq_tiles}):
                 with spyre_hint(num_tiles_per_dim={"Lk": lk_tiles}):
-                    scaled_keys = keys * scale
-                    keys_T = scaled_keys.transpose(-1, -2)
-                    scores = torch.matmul(queries * scale, keys_T)
-                    scores = scores + mask
-                    block_max = torch.amax(scores, dim=-1)
-                    running_max = torch.maximum(real_max, block_max)
-                    exp_scores = torch.exp(scores - running_max.unsqueeze(-1))
-                    correction = torch.exp(real_max - running_max)
-                    denominator.copy_(denominator * correction + exp_scores.sum(dim=-1))
-                    output.copy_(output * correction.unsqueeze(-1) + torch.matmul(exp_scores, values))
+                    with spyre_hint(expected_named_dims=["B", "H", "Lk", "D"]):
+                        scaled_keys = keys * scale
+                    with spyre_hint(expected_named_dims=["B", "H", "D", "Lk"]):
+                        keys_T = scaled_keys.transpose(-1, -2)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
+                        q_scaled = queries * scale
+                    with spyre_hint(named_dims=["B", "H", "Lq", "Lk"]):
+                        scores_pre = torch.matmul(q_scaled, keys_T)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq", "Lk"]):
+                        scores = scores_pre + mask
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
+                        block_max = torch.amax(scores, dim=-1)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                        running_max = torch.maximum(real_max, block_max)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq", "Lk"]):
+                        scores_shifted = scores - running_max.unsqueeze(-1)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq", "Lk"]):
+                        exp_scores = torch.exp(scores_shifted)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                        real_max_diff = real_max - running_max
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                        correction = torch.exp(real_max_diff)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
+                        sum_scores = exp_scores.sum(dim=-1)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                        denom_corrected = denominator * correction
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                        new_denom = denom_corrected + sum_scores
+                    denominator.copy_(new_denom)
+                    with spyre_hint(named_dims=["B", "H", "Lq", "D"]):
+                        matmul_out = torch.matmul(exp_scores, values)
+                    # correction.unsqueeze(-1) is [B,H,Lq,1] — size-1 dim can't carry "D"
+                    corr_expanded = correction.unsqueeze(-1)
+                    output_corrected = output * corr_expanded
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
+                        new_output = output_corrected + matmul_out
+                    output.copy_(new_output)
                     real_max.copy_(running_max)
     return output / denominator.unsqueeze(-1)
 
 
 @pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
-@pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
-def test_hint_flash_attention_v2_tile_H():
+def test_flash_v2_tile_H():
     """Flash v2: tile H÷4 only."""
     run_coarse_tile_test(
         lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4),
@@ -2719,8 +2746,8 @@ def test_hint_flash_attention_v2_tile_H():
     )
 
 
-@pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
-def test_hint_flash_attention_v2_tile_B():
+@pytest.mark.skip(reason="KeyError: 0 — B tiling not yet supported")
+def test_flash_v2_tile_B():
     """Flash v2: tile B÷2 only. B=2."""
     run_coarse_tile_test(
         lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2),
@@ -2730,7 +2757,7 @@ def test_hint_flash_attention_v2_tile_B():
 
 
 @pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
-def test_hint_flash_attention_v2_tile_Lq():
+def test_flash_v2_tile_Lq():
     """Flash v2: tile Lq÷2 only."""
     run_coarse_tile_test(
         lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, lq_tiles=2),
@@ -2740,7 +2767,7 @@ def test_hint_flash_attention_v2_tile_Lq():
 
 
 @pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
-def test_hint_flash_attention_v2_tile_Lk():
+def test_flash_v2_tile_Lk():
     """Flash v2: tile Lk÷2 only."""
     run_coarse_tile_test(
         lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, lk_tiles=2),
@@ -2749,8 +2776,8 @@ def test_hint_flash_attention_v2_tile_Lk():
     )
 
 
-@pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
-def test_hint_flash_attention_v2_tile_B_H():
+@pytest.mark.skip(reason="KeyError: 0 — B tiling not yet supported")
+def test_flash_v2_tile_B_H():
     """Flash v2: tile B÷2 H÷4. B=2."""
     run_coarse_tile_test(
         lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4),
@@ -2760,8 +2787,8 @@ def test_hint_flash_attention_v2_tile_B_H():
 
 
 @pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
-def test_hint_flash_attention_v2_tile_H_Lq():
-    """Flash v2: tile H÷4 Lq÷2. Equivalent to original test_hint_flash_attention_v2."""
+def test_flash_v2_tile_H_Lq():
+    """Flash v2: tile H÷4 Lq÷2. Equivalent to original test_flash_v2."""
     run_coarse_tile_test(
         lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2),
         _flash_v2_inputs(1, 8, 256, 256, 64),
@@ -2770,7 +2797,7 @@ def test_hint_flash_attention_v2_tile_H_Lq():
 
 
 @pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
-def test_hint_flash_attention_v2_tile_H_Lq_Lk():
+def test_flash_v2_tile_H_Lq_Lk():
     """Flash v2: tile H÷4 Lq÷2 Lk÷2."""
     run_coarse_tile_test(
         lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2, lk_tiles=2),
@@ -2780,7 +2807,7 @@ def test_hint_flash_attention_v2_tile_H_Lq_Lk():
 
 
 @pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
-def test_hint_flash_attention_v2_tile_all():
+def test_flash_v2_tile_all():
     """Flash v2: tile all dims. B=2, H÷4, Lq÷2, Lk÷2."""
     run_coarse_tile_test(
         lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4, lq_tiles=2, lk_tiles=2),
@@ -2804,7 +2831,8 @@ def _flash_v3_inputs(B, H, Lq, Lk, D):
         tensor("queries", shape=(B, H, Lq, D), dims=["B", "H", "Lq", "D"]),
         tensor("keys",    shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
         tensor("values",  shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
-        tensor("mask",    shape=(1, 1, Lq, Lk), dims=["B", "H", "Lq", "Lk"], value=mask_t),
+        tensor("mask",    shape=(1, 1, Lq, Lk), dims=["B", "H", "Lq", "Lk"],
+               named_dims={"Lq": Lq, "Lk": Lk}, value=mask_t),
     ]
 
 
@@ -2823,26 +2851,52 @@ def _flash_v3_fn(queries, keys, values, mask, *, B, H, Lq, Lk, D,
         with spyre_hint(num_tiles_per_dim={"H": h_tiles}):
             with spyre_hint(num_tiles_per_dim={"Lq": lq_tiles}):
                 with spyre_hint(num_tiles_per_dim={"Lk": lk_tiles}):
-                    scaled_keys = keys * scale
-                    keys_T = scaled_keys.transpose(-1, -2)
-                    scores = torch.matmul(queries * scale, keys_T)
-                    scores = scores + mask
-                    scores = scores.transpose(-1, -2).contiguous()
-                    block_max = torch.amax(scores, dim=-2)
-                    running_max = torch.maximum(real_max, block_max)
-                    exp_scores = torch.exp(scores - running_max.unsqueeze(-2))
-                    correction = torch.exp(real_max - running_max)
-                    denominator.copy_(denominator * correction + exp_scores.sum(dim=-2))
-                    output.copy_(
-                        output * correction.unsqueeze(-1)
-                        + torch.matmul(exp_scores.transpose(-1, -2), values)
-                    )
+                    with spyre_hint(expected_named_dims=["B", "H", "Lk", "D"]):
+                        scaled_keys = keys * scale
+                    with spyre_hint(expected_named_dims=["B", "H", "D", "Lk"]):
+                        keys_T = scaled_keys.transpose(-1, -2)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
+                        q_scaled = queries * scale
+                    with spyre_hint(named_dims=["B", "H", "Lq", "Lk"]):
+                        scores_pre = torch.matmul(q_scaled, keys_T)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq", "Lk"]):
+                        scores_masked = scores_pre + mask
+                    with spyre_hint(expected_named_dims=["B", "H", "Lk", "Lq"]):
+                        scores = scores_masked.transpose(-1, -2).contiguous()
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
+                        block_max = torch.amax(scores, dim=-2)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                        running_max = torch.maximum(real_max, block_max)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lk", "Lq"]):
+                        scores_shifted = scores - running_max.unsqueeze(-2)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lk", "Lq"]):
+                        exp_scores = torch.exp(scores_shifted)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                        real_max_diff = real_max - running_max
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                        correction = torch.exp(real_max_diff)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
+                        sum_scores = exp_scores.sum(dim=-2)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                        denom_corrected = denominator * correction
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                        new_denom = denom_corrected + sum_scores
+                    denominator.copy_(new_denom)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq", "Lk"]):
+                        exp_scores_T = exp_scores.transpose(-1, -2).contiguous()
+                    with spyre_hint(named_dims=["B", "H", "Lq", "D"]):
+                        matmul_out = torch.matmul(exp_scores_T, values)
+                    # correction.unsqueeze(-1) is [B,H,Lq,1] — size-1 dim can't carry "D"
+                    corr_expanded = correction.unsqueeze(-1)
+                    output_corrected = output * corr_expanded
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
+                        new_output = output_corrected + matmul_out
+                    output.copy_(new_output)
                     real_max.copy_(running_max)
     return output / denominator.unsqueeze(-1)
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
-def test_hint_flash_attention_v3_tile_H():
+def test_flash_v3_tile_H():
     """Flash v3: tile H÷4 only."""
     run_coarse_tile_test(
         lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4),
@@ -2852,7 +2906,7 @@ def test_hint_flash_attention_v3_tile_H():
 
 
 @pytest.mark.skip(reason="KeyError: 0 — B tiling not yet supported")
-def test_hint_flash_attention_v3_tile_B():
+def test_flash_v3_tile_B():
     """Flash v3: tile B÷2 only. B=2."""
     run_coarse_tile_test(
         lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2),
@@ -2861,8 +2915,7 @@ def test_hint_flash_attention_v3_tile_B():
     )
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
-def test_hint_flash_attention_v3_tile_Lq():
+def test_flash_v3_tile_Lq():
     """Flash v3: tile Lq÷2 only."""
     run_coarse_tile_test(
         lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, lq_tiles=2),
@@ -2872,7 +2925,7 @@ def test_hint_flash_attention_v3_tile_Lq():
 
 
 @pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
-def test_hint_flash_attention_v3_tile_Lk():
+def test_flash_v3_tile_Lk():
     """Flash v3: tile Lk÷2 only."""
     run_coarse_tile_test(
         lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, lk_tiles=2),
@@ -2882,7 +2935,7 @@ def test_hint_flash_attention_v3_tile_Lk():
 
 
 @pytest.mark.skip(reason="KeyError: 0 — B tiling not yet supported")
-def test_hint_flash_attention_v3_tile_B_H():
+def test_flash_v3_tile_B_H():
     """Flash v3: tile B÷2 H÷4. B=2."""
     run_coarse_tile_test(
         lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4),
@@ -2891,9 +2944,8 @@ def test_hint_flash_attention_v3_tile_B_H():
     )
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
-def test_hint_flash_attention_v3_tile_H_Lq():
-    """Flash v3: tile H÷4 Lq÷2. Equivalent to original test_hint_flash_attention_v3 (small sizes)."""
+def test_flash_v3_tile_H_Lq():
+    """Flash v3: tile H÷4 Lq÷2. Equivalent to original test_flash_v3 (small sizes)."""
     run_coarse_tile_test(
         lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2),
         _flash_v3_inputs(1, 8, 256, 256, 64),
@@ -2902,7 +2954,7 @@ def test_hint_flash_attention_v3_tile_H_Lq():
 
 
 @pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
-def test_hint_flash_attention_v3_tile_H_Lq_Lk():
+def test_flash_v3_tile_H_Lq_Lk():
     """Flash v3: tile H÷4 Lq÷2 Lk÷2."""
     run_coarse_tile_test(
         lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2, lk_tiles=2),
@@ -2912,7 +2964,7 @@ def test_hint_flash_attention_v3_tile_H_Lq_Lk():
 
 
 @pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
-def test_hint_flash_attention_v3_tile_all():
+def test_flash_v3_tile_all():
     """Flash v3: tile all dims. B=2, H÷4, Lq÷2, Lk÷2."""
     run_coarse_tile_test(
         lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4, lq_tiles=2, lk_tiles=2),
@@ -2958,26 +3010,50 @@ def _flash_v4_fn(q, k, v, *, B, S, H, D,
         with spyre_hint(num_tiles_per_dim={"num_heads": h_tiles}):
             with spyre_hint(num_tiles_per_dim={"max_seqlen_q": lq_tiles}):
                 with spyre_hint(num_tiles_per_dim={"max_seqlen_kv": lk_tiles}):
-                    scaled_keys = k * scale
-                    keys_T = scaled_keys.transpose(-1, -2).contiguous()
-                    scores = torch.matmul(q * scale, keys_T)
-                    scores = scores.transpose(-1, -2).contiguous()
-                    block_max = torch.amax(scores, dim=-2)
-                    running_max = torch.maximum(real_max, block_max)
-                    exp_scores = torch.exp(scores - running_max.unsqueeze(-2))
-                    correction = torch.exp(real_max - running_max)
-                    denominator.copy_(denominator * correction + exp_scores.sum(dim=-2))
-                    output.copy_(
-                        output * correction.unsqueeze(-1)
-                        + torch.matmul(exp_scores.transpose(-1, -2), v)
-                    )
+                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_kv", "head_dim"]):
+                        scaled_keys = k * scale
+                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "head_dim", "max_seqlen_kv"]):
+                        keys_T = scaled_keys.transpose(-1, -2).contiguous()
+                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"]):
+                        q_scaled = q * scale
+                    with spyre_hint(named_dims=["batch_size", "num_heads", "max_seqlen_q", "max_seqlen_kv"]):
+                        scores_pre = torch.matmul(q_scaled, keys_T)
+                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_kv", "max_seqlen_q"]):
+                        scores = scores_pre.transpose(-1, -2).contiguous()
+                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"], expected_reduction_dims=["max_seqlen_kv"]):
+                        block_max = torch.amax(scores, dim=-2)
+                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
+                        running_max = torch.maximum(real_max, block_max)
+                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_kv", "max_seqlen_q"]):
+                        scores_shifted = scores - running_max.unsqueeze(-2)
+                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_kv", "max_seqlen_q"]):
+                        exp_scores = torch.exp(scores_shifted)
+                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
+                        real_max_diff = real_max - running_max
+                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
+                        correction = torch.exp(real_max_diff)
+                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"], expected_reduction_dims=["max_seqlen_kv"]):
+                        sum_scores = exp_scores.sum(dim=-2)
+                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
+                        denom_corrected = denominator * correction
+                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
+                        new_denom = denom_corrected + sum_scores
+                    denominator.copy_(new_denom)
+                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q", "max_seqlen_kv"]):
+                        exp_scores_T = exp_scores.transpose(-1, -2).contiguous()
+                    with spyre_hint(named_dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"]):
+                        matmul_out = torch.matmul(exp_scores_T, v)
+                    # correction.unsqueeze(-1) is size-1 in head_dim — can't carry "head_dim"
+                    output_corrected = output * correction.unsqueeze(-1)
+                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"]):
+                        new_output = output_corrected + matmul_out
+                    output.copy_(new_output)
                     real_max.copy_(running_max)
     output.copy_(output / denominator.unsqueeze(-1))
     return output.transpose(1, 2).reshape(B, S, H * D)
 
 
-@pytest.mark.skip(reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose")
-def test_hint_flash_attention_v4_tile_H():
+def test_flash_v4_tile_H():
     """Flash v4: tile num_heads÷4 only."""
     run_coarse_tile_test(
         lambda q, k, v: _flash_v4_fn(q, k, v, B=2, S=256, H=8, D=64, h_tiles=4),
@@ -2987,7 +3063,7 @@ def test_hint_flash_attention_v4_tile_H():
 
 
 @pytest.mark.skip(reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose")
-def test_hint_flash_attention_v4_tile_B():
+def test_flash_v4_tile_B():
     """Flash v4: tile batch_size÷2 only. B=2."""
     run_coarse_tile_test(
         lambda q, k, v: _flash_v4_fn(q, k, v, B=2, S=256, H=8, D=64, b_tiles=2),
@@ -2997,7 +3073,7 @@ def test_hint_flash_attention_v4_tile_B():
 
 
 @pytest.mark.skip(reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose")
-def test_hint_flash_attention_v4_tile_Lq():
+def test_flash_v4_tile_Lq():
     """Flash v4: tile max_seqlen_q÷2 only."""
     run_coarse_tile_test(
         lambda q, k, v: _flash_v4_fn(q, k, v, B=2, S=256, H=8, D=64, lq_tiles=2),
@@ -3007,8 +3083,8 @@ def test_hint_flash_attention_v4_tile_Lq():
 
 
 @pytest.mark.skip(reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose")
-def test_hint_flash_attention_v4_tile_H_Lq():
-    """Flash v4: tile num_heads÷4 max_seqlen_q÷2. Equivalent to original test_hint_flash_attention_v4."""
+def test_flash_v4_tile_H_Lq():
+    """Flash v4: tile num_heads÷4 max_seqlen_q÷2. Equivalent to original test_flash_v4."""
     run_coarse_tile_test(
         lambda q, k, v: _flash_v4_fn(q, k, v, B=2, S=256, H=8, D=64, h_tiles=4, lq_tiles=2),
         _flash_v4_inputs(2, 256, 8, 64),
@@ -3017,7 +3093,7 @@ def test_hint_flash_attention_v4_tile_H_Lq():
 
 
 @pytest.mark.skip(reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose")
-def test_hint_flash_attention_v4_tile_H_Lq_Lk():
+def test_flash_v4_tile_H_Lq_Lk():
     """Flash v4: tile num_heads÷4 max_seqlen_q÷2 max_seqlen_kv÷2."""
     run_coarse_tile_test(
         lambda q, k, v: _flash_v4_fn(q, k, v, B=2, S=256, H=8, D=64, h_tiles=4, lq_tiles=2, lk_tiles=2),
@@ -3027,7 +3103,7 @@ def test_hint_flash_attention_v4_tile_H_Lq_Lk():
 
 
 @pytest.mark.skip(reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose")
-def test_hint_flash_attention_v4_tile_all():
+def test_flash_v4_tile_all():
     """Flash v4: tile all dims. B=2, H÷4, Lq÷2, Lk÷2."""
     run_coarse_tile_test(
         lambda q, k, v: _flash_v4_fn(q, k, v, B=2, S=256, H=8, D=64, b_tiles=2, h_tiles=4, lq_tiles=2, lk_tiles=2),
@@ -3796,7 +3872,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         )
 
     # Consider deleting — superseded by Group 10 structured tests (_flash_v2_fn)
-    @pytest.mark.skip
+    @pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
     def test_hint_flash_attention_v2(self):
         """Flash attention tiled over H (4 slices) via nested spyre_hints.
 
@@ -3902,7 +3978,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         _name_tensor_dims(queries_dev, ["B", "H", "Lq", "D"])
         _name_tensor_dims(keys_dev, ["B", "H", "Lk", "D"])
         _name_tensor_dims(values_dev, ["B", "H", "Lk", "D"])
-        _name_tensor_dims(mask_dev, ["B", "H", "Lq", "Lk"])
+        _name_tensor_dims(mask_dev, ["Lq", "Lk"])
 
         result = torch.compile(flash)(queries_dev, keys_dev, values_dev, mask_dev).cpu()
         torch.testing.assert_close(
@@ -3914,7 +3990,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
         )
 
-    @pytest.mark.skip
+    @pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
     def test_hint_flash_attention_v2_validate_dims(self):
         """Same as test_hint_flash_attention_v2 but with expected_named_dims annotations.
 
@@ -4041,7 +4117,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         _name_tensor_dims(queries_dev, ["B", "H", "Lq", "D"])
         _name_tensor_dims(keys_dev, ["B", "H", "Lk", "D"])
         _name_tensor_dims(values_dev, ["B", "H", "Lk", "D"])
-        _name_tensor_dims(mask_dev, ["B", "H", "Lq", "Lk"])
+        _name_tensor_dims(mask_dev, ["Lq", "Lk"])
 
         result_annotated = torch.compile(flash)(queries_dev, keys_dev, values_dev, mask_dev).cpu()
 
@@ -4152,7 +4228,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         _name_tensor_dims(queries_dev, ["B", "H", "Lq", "D"])
         _name_tensor_dims(keys_dev, ["B", "H", "Lk", "D"])
         _name_tensor_dims(values_dev, ["B", "H", "Lk", "D"])
-        _name_tensor_dims(mask_dev, ["B", "H", "Lq", "Lk"])
+        _name_tensor_dims(mask_dev, ["Lq", "Lk"])
 
         cfn = torch.compile(flash)
         result, source_codes = run_and_get_code(
@@ -4181,7 +4257,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         }
     )
     # Consider deleting — superseded by Group 10 structured tests (_flash_v3_fn)
-    @pytest.mark.skip
+    @pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
     def test_hint_flash_attention_v3(self):
         from torch_spyre._inductor import spyre_hint
 
@@ -4269,7 +4345,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         _name_tensor_dims(queries_t_spyre, ["B", "H", "Lq", "D"])
         _name_tensor_dims(keys_t_spyre, ["B", "H", "Lk", "D"])
         _name_tensor_dims(values_t_spyre, ["B", "H", "Lk", "D"])
-        _name_tensor_dims(mask_t_spyre, ["B", "H", "Lq", "Lk"])
+        _name_tensor_dims(mask_t_spyre, ["Lq", "Lk"])
         result = torch.compile(flash)(
             queries_t_spyre, keys_t_spyre, values_t_spyre, mask_t_spyre
         ).cpu()
@@ -4282,9 +4358,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
         )
 
-    @pytest.mark.skip(
-        reason="flash attention v3/v4 not yet passing: Lk reduction-dim tiling is disabled (see FIXME on kv_block_size), unrelated to carry propagation"
-    )
+    @pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
     def test_hint_flash_attention_v3_b2(self):
         """Same as flash_v3 but with B=2 and b_block_size=2 so B is nto tiled"""
         from torch_spyre._inductor import spyre_hint
@@ -4372,7 +4446,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         _name_tensor_dims(queries_t_spyre, ["B", "H", "Lq", "D"])
         _name_tensor_dims(keys_t_spyre, ["B", "H", "Lk", "D"])
         _name_tensor_dims(values_t_spyre, ["B", "H", "Lk", "D"])
-        _name_tensor_dims(mask_t_spyre, ["B", "H", "Lq", "Lk"])
+        _name_tensor_dims(mask_t_spyre, ["Lq", "Lk"])
         result = torch.compile(flash)(
             queries_t_spyre, keys_t_spyre, values_t_spyre, mask_t_spyre
         ).cpu()

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -34,7 +34,7 @@ STRUCTURED TESTS (Groups 1-10)
     Group 9: Views — 1D sub-dim naming, reshape, view+transpose, unsqueeze
     Group 10: Flash attention variants — v1/v2/v3/v4, parameterized by size and tile dims
 
-    Tests marked loopspec=False, correctness=False are known broken and
+    Tests marked loopspec=None, correctness=False are known broken and
     skipped; see inline comments for root cause.
 
 ORIGINAL TESTS (below the boundary marker)
@@ -78,10 +78,9 @@ _PREPARE_KERNEL = "torch_spyre.execution.kernel_runner.prepare_kernel"
 class LoopSpecCheck:
     """Callable loopspec checker passed as the loopspec= argument to run_coarse_tile_test.
 
-    loopspec=LoopSpecCheck()            — asserts LoopSpec( appears in generated source
+    loopspec=LoopSpecCheck()             — asserts LoopSpec( appears in generated source (default)
     loopspec=LoopSpecCheck(counts=[4,2]) — also checks count=sympify('N') for each N
-    loopspec=True                        — shorthand for LoopSpecCheck()
-    loopspec=False                       — skip loopspec check entirely
+    loopspec=None                        — skip loopspec check entirely
     """
 
     def __init__(self, counts=None):
@@ -122,13 +121,15 @@ class TensorSpec:
 
 def tensor(name, *, shape, dims, named_dims=None, value=None):
     """Shorthand constructor for TensorSpec."""
-    return TensorSpec(name=name, shape=shape, dims=dims, named_dims=named_dims, value=value)
+    return TensorSpec(
+        name=name, shape=shape, dims=dims, named_dims=named_dims, value=value
+    )
 
 
 def run_coarse_tile_test(
     fn,
     inputs,
-    loopspec=True,
+    loopspec=LoopSpecCheck(),
     correctness=True,
     atol=None,
     rtol=None,
@@ -139,18 +140,18 @@ def run_coarse_tile_test(
     inputs: list of TensorSpec (from tensor(...)) — driver creates tensors,
         declares dims, and calls _name_tensor_dims before each compile.
 
-    loopspec: LoopSpecCheck() or True — check generated source for LoopSpec.
+    loopspec: LoopSpecCheck() — check generated source for LoopSpec (default).
               LoopSpecCheck(counts=[4,2]) also checks specific tile counts.
-              False — skip loopspec check.
+              None — skip loopspec check.
     correctness: True  — compare_with_cpu against CPU reference.
 
     Always compiles exactly once, regardless of which checks are enabled.
     """
-    if loopspec is True:
-        loopspec = LoopSpecCheck()
 
     cpu_tensors = [
-        s.value if s.value is not None else torch.randn(s.shape, dtype=torch.float16) * scale
+        s.value
+        if s.value is not None
+        else torch.randn(s.shape, dtype=torch.float16) * scale
         for s in inputs
     ]
 
@@ -684,8 +685,7 @@ def test_min_2d_512x256_reduce_dim0_A4():
 
     def fn(x):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(expected_named_dims=["B"],
-                            expected_reduction_dims=["A"]):
+            with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
                 return x.amin(dim=0)
 
     run_coarse_tile_test(fn, inputs)
@@ -697,8 +697,7 @@ def test_min_2d_512x256_reduce_dim0_B4():
 
     def fn(x):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            with spyre_hint(expected_named_dims=["B"],
-                            expected_reduction_dims=["A"]):
+            with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
                 return x.amin(dim=0)
 
     run_coarse_tile_test(fn, inputs)
@@ -711,8 +710,9 @@ def test_min_2d_512x256_reduce_dim0_A4_B4():
     def fn(x):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                with spyre_hint(expected_named_dims=["B"],
-                                expected_reduction_dims=["A"]):
+                with spyre_hint(
+                    expected_named_dims=["B"], expected_reduction_dims=["A"]
+                ):
                     return x.amin(dim=0)
 
     run_coarse_tile_test(
@@ -726,8 +726,7 @@ def test_min_2d_512x256_reduce_dim1_A4():
 
     def fn(x):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(expected_named_dims=["A"],
-                            expected_reduction_dims=["B"]):
+            with spyre_hint(expected_named_dims=["A"], expected_reduction_dims=["B"]):
                 return x.amin(dim=1)
 
     run_coarse_tile_test(fn, inputs)
@@ -739,8 +738,7 @@ def test_min_2d_512x256_reduce_dim1_B4():
 
     def fn(x):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            with spyre_hint(expected_named_dims=["A"],
-                            expected_reduction_dims=["B"]):
+            with spyre_hint(expected_named_dims=["A"], expected_reduction_dims=["B"]):
                 return x.amin(dim=1)
 
     run_coarse_tile_test(fn, inputs)
@@ -753,8 +751,9 @@ def test_min_2d_512x256_reduce_dim1_A4_B4():
     def fn(x):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                with spyre_hint(expected_named_dims=["A"],
-                                expected_reduction_dims=["B"]):
+                with spyre_hint(
+                    expected_named_dims=["A"], expected_reduction_dims=["B"]
+                ):
                     return x.amin(dim=1)
 
     run_coarse_tile_test(
@@ -771,12 +770,13 @@ def test_min_3d_512x256x256_reduce_dim0_A4_B2_C4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 2}):
                 with spyre_hint(num_tiles_per_dim={"C": 4}):
-                    with spyre_hint(expected_named_dims=["B", "C"],
-                                    expected_reduction_dims=["A"]):
+                    with spyre_hint(
+                        expected_named_dims=["B", "C"], expected_reduction_dims=["A"]
+                    ):
                         return x.amin(dim=0)
 
     run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
+        fn, inputs, loopspec=None, correctness=False
     )  # scheduler crash: inconsistent loop_count across reduction fill/combine nodes
 
 
@@ -789,12 +789,13 @@ def test_min_3d_512x256x256_reduce_dim1_A4_B2_C4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 2}):
                 with spyre_hint(num_tiles_per_dim={"C": 4}):
-                    with spyre_hint(expected_named_dims=["A", "C"],
-                                    expected_reduction_dims=["B"]):
+                    with spyre_hint(
+                        expected_named_dims=["A", "C"], expected_reduction_dims=["B"]
+                    ):
                         return x.amin(dim=1)
 
     run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
+        fn, inputs, loopspec=None, correctness=False
     )  # scheduler crash: inconsistent loop_count across reduction fill/combine nodes
 
 
@@ -806,8 +807,9 @@ def test_min_3d_512x256x256_reduce_dim2_A4_B2_C4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 2}):
                 with spyre_hint(num_tiles_per_dim={"C": 4}):
-                    with spyre_hint(expected_named_dims=["A", "B"],
-                                    expected_reduction_dims=["C"]):
+                    with spyre_hint(
+                        expected_named_dims=["A", "B"], expected_reduction_dims=["C"]
+                    ):
                         return x.amin(dim=2)
 
     run_coarse_tile_test(
@@ -872,7 +874,9 @@ def test_add_min_2d_512x256_reduce_dim0_A4_B4():
     def fn(a, b):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
+                with spyre_hint(
+                    expected_named_dims=["B"], expected_reduction_dims=["A"]
+                ):
                     r = b.amin(dim=0)
                 with spyre_hint(expected_named_dims=["B"]):
                     temp = torch.abs(r)
@@ -930,7 +934,9 @@ def test_add_min_2d_512x256_reduce_dim1_A4_B4():
     def fn(a, b):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                with spyre_hint(expected_named_dims=["A"], expected_reduction_dims=["B"]):
+                with spyre_hint(
+                    expected_named_dims=["A"], expected_reduction_dims=["B"]
+                ):
                     r = b.amin(dim=1, keepdim=True)
                 with spyre_hint(expected_named_dims=["A"]):
                     temp = torch.abs(r)
@@ -952,7 +958,9 @@ def test_add_min_3d_512x256x256_reduce_dim0_A4_B2_C4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 2}):
                 with spyre_hint(num_tiles_per_dim={"C": 4}):
-                    with spyre_hint(expected_named_dims=["B", "C"], expected_reduction_dims=["A"]):
+                    with spyre_hint(
+                        expected_named_dims=["B", "C"], expected_reduction_dims=["A"]
+                    ):
                         r = b.amin(dim=0)
                     with spyre_hint(expected_named_dims=["B", "C"]):
                         temp = torch.abs(r)
@@ -960,7 +968,7 @@ def test_add_min_3d_512x256x256_reduce_dim0_A4_B2_C4():
                         return a + temp
 
     run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
+        fn, inputs, loopspec=None, correctness=False
     )  # scheduler crash: mixed loop counts in 3D nested tiling + reduction
 
 
@@ -976,7 +984,9 @@ def test_add_min_3d_512x256x256_reduce_dim1_A4_B2_C4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 2}):
                 with spyre_hint(num_tiles_per_dim={"C": 4}):
-                    with spyre_hint(expected_named_dims=["A", "C"], expected_reduction_dims=["B"]):
+                    with spyre_hint(
+                        expected_named_dims=["A", "C"], expected_reduction_dims=["B"]
+                    ):
                         r = b.amin(dim=1)
                     with spyre_hint(expected_named_dims=["A", "C"]):
                         temp = torch.abs(r)
@@ -984,7 +994,7 @@ def test_add_min_3d_512x256x256_reduce_dim1_A4_B2_C4():
                         return a + temp
 
     run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
+        fn, inputs, loopspec=None, correctness=False
     )  # scheduler crash: mixed loop counts in 3D nested tiling + reduction
 
 
@@ -1000,7 +1010,9 @@ def test_add_min_3d_512x256x256_reduce_dim2_A4_B2_C4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 2}):
                 with spyre_hint(num_tiles_per_dim={"C": 4}):
-                    with spyre_hint(expected_named_dims=["A", "B"], expected_reduction_dims=["C"]):
+                    with spyre_hint(
+                        expected_named_dims=["A", "B"], expected_reduction_dims=["C"]
+                    ):
                         r = b.amin(dim=2)
                     with spyre_hint(expected_named_dims=["A", "B"]):
                         temp = torch.abs(r)
@@ -1008,7 +1020,7 @@ def test_add_min_3d_512x256x256_reduce_dim2_A4_B2_C4():
                         return a + temp
 
     run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
+        fn, inputs, loopspec=None, correctness=False
     )  # scheduler crash: mixed loop counts in 3D nested tiling + reduction
 
 
@@ -1189,7 +1201,9 @@ def test_softmax_2d_512x256_dim0_A4_B4():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+@pytest.mark.skip(
+    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
 def test_restickify_add_256x128_A2():
     """a.t() + x on [128,256] result, tiled A÷2 → 64 elems/tile (1 stick)."""
     inputs = [
@@ -1202,12 +1216,12 @@ def test_restickify_add_256x128_A2():
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return a.t() + x
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+@pytest.mark.skip(
+    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
 def test_restickify_add_256x128_B4():
     """a.t() + x on [128,256] result, tiled B÷4 → 64 elems/tile (1 stick)."""
     inputs = [
@@ -1220,12 +1234,12 @@ def test_restickify_add_256x128_B4():
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return a.t() + x
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+@pytest.mark.skip(
+    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
 def test_restickify_add_256x128_A2_B4():
     """a.t() + x on [128,256] result, tiled A÷2 B÷4 → 64 elems/tile each."""
     inputs = [
@@ -1239,9 +1253,7 @@ def test_restickify_add_256x128_A2_B4():
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     return a.t() + x
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
 # 2D two-transpose: a.t() + b.t() + x
@@ -1264,7 +1276,7 @@ def test_restickify_2t_add_256x128_A2():
                 return a.t() + b.t() + x
 
     run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
+        fn, inputs, loopspec=None, correctness=False
     )  # d0+d1 stick expr bug: two restickified inputs produce unsupported stick expression
 
 
@@ -1283,7 +1295,7 @@ def test_restickify_2t_add_256x128_B4():
                 return a.t() + b.t() + x
 
     run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
+        fn, inputs, loopspec=None, correctness=False
     )  # d0+d1 stick expr bug
 
 
@@ -1303,7 +1315,7 @@ def test_restickify_2t_add_256x128_A2_B4():
                     return a.t() + b.t() + x
 
     run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
+        fn, inputs, loopspec=None, correctness=False
     )  # d0+d1 stick expr bug
 
 
@@ -1312,7 +1324,9 @@ def test_restickify_2t_add_256x128_A2_B4():
 # A÷4=64/tile, B÷4=64/tile, C÷4=128/tile (2 sticks)
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+@pytest.mark.skip(
+    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
 def test_restickify_3d_transpose12_256x512x256_A4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4."""
     inputs = [
@@ -1325,12 +1339,12 @@ def test_restickify_3d_transpose12_256x512x256_A4():
             with spyre_hint(expected_named_dims=["A", "B", "C"]):
                 return a.transpose(1, 2) + x
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+@pytest.mark.skip(
+    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
 def test_restickify_3d_transpose12_256x512x256_B4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled B÷4."""
     inputs = [
@@ -1343,12 +1357,12 @@ def test_restickify_3d_transpose12_256x512x256_B4():
             with spyre_hint(expected_named_dims=["A", "B", "C"]):
                 return a.transpose(1, 2) + x
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+@pytest.mark.skip(
+    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
 def test_restickify_3d_transpose12_256x512x256_C4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled C÷4."""
     inputs = [
@@ -1361,12 +1375,12 @@ def test_restickify_3d_transpose12_256x512x256_C4():
             with spyre_hint(expected_named_dims=["A", "B", "C"]):
                 return a.transpose(1, 2) + x
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+@pytest.mark.skip(
+    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
 def test_restickify_3d_transpose12_256x512x256_A4_B4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4 B÷4."""
     inputs = [
@@ -1380,12 +1394,12 @@ def test_restickify_3d_transpose12_256x512x256_A4_B4():
                 with spyre_hint(expected_named_dims=["A", "B", "C"]):
                     return a.transpose(1, 2) + x
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+@pytest.mark.skip(
+    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
 def test_restickify_3d_transpose12_256x512x256_A4_C4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4 C÷4."""
     inputs = [
@@ -1399,12 +1413,12 @@ def test_restickify_3d_transpose12_256x512x256_A4_C4():
                 with spyre_hint(expected_named_dims=["A", "B", "C"]):
                     return a.transpose(1, 2) + x
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+@pytest.mark.skip(
+    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
 def test_restickify_3d_transpose12_256x512x256_B4_C4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled B÷4 C÷4."""
     inputs = [
@@ -1419,11 +1433,13 @@ def test_restickify_3d_transpose12_256x512x256_B4_C4():
                     return a.transpose(1, 2) + x
 
     run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
+        fn, inputs, loopspec=None, correctness=False
     )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+@pytest.mark.skip(
+    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
 def test_restickify_3d_transpose12_256x512x256_A4_B4_C4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4 B÷4 C÷4."""
     inputs = [
@@ -1438,9 +1454,7 @@ def test_restickify_3d_transpose12_256x512x256_A4_B4_C4():
                     with spyre_hint(expected_named_dims=["A", "B", "C"]):
                         return a.transpose(1, 2) + x
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
 # Matmul + transpose: x.t()@y and x@y.t()
@@ -1450,7 +1464,9 @@ def test_restickify_3d_transpose12_256x512x256_A4_B4_C4():
 # For x@y.t() result [128,128]: M=128, N=128; M÷2=64, N÷2=64
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+@pytest.mark.skip(
+    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
 def test_restickify_matmul_xt_y_256x128_M4():
     """x.t()@y, result [256,256], tiled M÷4."""
     inputs = [
@@ -1463,12 +1479,12 @@ def test_restickify_matmul_xt_y_256x128_M4():
             with spyre_hint(expected_named_dims=["M", "N"]):
                 return torch.matmul(x.t(), y)
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+@pytest.mark.skip(
+    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
 def test_restickify_matmul_xt_y_256x128_N4():
     """x.t()@y, result [256,256], tiled N÷4."""
     inputs = [
@@ -1481,12 +1497,12 @@ def test_restickify_matmul_xt_y_256x128_N4():
             with spyre_hint(expected_named_dims=["M", "N"]):
                 return torch.matmul(x.t(), y)
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+@pytest.mark.skip(
+    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
 def test_restickify_matmul_xt_y_256x128_M4_N4():
     """x.t()@y, result [256,256], tiled M÷4 N÷4."""
     inputs = [
@@ -1500,12 +1516,12 @@ def test_restickify_matmul_xt_y_256x128_M4_N4():
                 with spyre_hint(expected_named_dims=["M", "N"]):
                     return torch.matmul(x.t(), y)
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+@pytest.mark.skip(
+    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
 def test_restickify_matmul_x_yt_128x256_M2():
     """x@y.t(), result [128,128], tiled M÷2."""
     inputs = [
@@ -1518,12 +1534,12 @@ def test_restickify_matmul_x_yt_128x256_M2():
             with spyre_hint(expected_named_dims=["M", "N"]):
                 return torch.matmul(x, y.t())
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+@pytest.mark.skip(
+    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
 def test_restickify_matmul_x_yt_128x256_N2():
     """x@y.t(), result [128,128], tiled N÷2."""
     inputs = [
@@ -1536,12 +1552,12 @@ def test_restickify_matmul_x_yt_128x256_N2():
             with spyre_hint(expected_named_dims=["M", "N"]):
                 return torch.matmul(x, y.t())
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+@pytest.mark.skip(
+    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
 def test_restickify_matmul_x_yt_128x256_M2_N2():
     """x@y.t(), result [128,128], tiled M÷2 N÷2."""
     inputs = [
@@ -1555,9 +1571,7 @@ def test_restickify_matmul_x_yt_128x256_M2_N2():
                 with spyre_hint(expected_named_dims=["M", "N"]):
                     return torch.matmul(x, y.t())
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
 # ---------------------------------------------------------------------------
@@ -1770,7 +1784,9 @@ def test_copy_after_reduction_512x256_A4_B4():
         out = torch.zeros(256, device=x.device, dtype=x.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
+                with spyre_hint(
+                    expected_named_dims=["B"], expected_reduction_dims=["A"]
+                ):
                     out.copy_(x.amin(dim=0))
         return out
 
@@ -1795,21 +1811,25 @@ def test_copy_running_max_4d_H4_Lq4():
         )
         with spyre_hint(num_tiles_per_dim={"H": H // h_block_size}):
             with spyre_hint(num_tiles_per_dim={"Lq": Lq // lq_block_size}):
-                with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
+                with spyre_hint(
+                    expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]
+                ):
                     block_max = torch.amax(scores, dim=-2)
                 with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                     running_max = torch.maximum(real_max, block_max)
                 real_max.copy_(running_max)
         return real_max
 
-    run_coarse_tile_test(fn, inputs, loopspec=True, correctness=False)
+    run_coarse_tile_test(fn, inputs, correctness=False)
 
 
 # --- copy + restickify: c.copy_(a.t() + b) ---
 # copy target receives a restickified input — tests copy layout after restickify
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+@pytest.mark.skip(
+    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
 def test_copy_restickify_512x256_A4():
     """c.copy_(a.t()+b) on [256,512] result tiled A÷4 — copy of restickified add."""
     inputs = [
@@ -1824,12 +1844,12 @@ def test_copy_restickify_512x256_A4():
                 c.copy_(a.t() + b)
         return c
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+@pytest.mark.skip(
+    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
 def test_copy_restickify_512x256_B4():
     """c.copy_(a.t()+b) on [256,512] result tiled B÷4."""
     inputs = [
@@ -1844,12 +1864,12 @@ def test_copy_restickify_512x256_B4():
                 c.copy_(a.t() + b)
         return c
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
-@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+@pytest.mark.skip(
+    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
+)
 def test_copy_restickify_512x256_A4_B4():
     """c.copy_(a.t()+b) on [256,512] result tiled A÷4 B÷4."""
     inputs = [
@@ -1865,9 +1885,7 @@ def test_copy_restickify_512x256_A4_B4():
                     c.copy_(a.t() + b)
         return c
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
 # --- nested copy + reduction: acc.copy_(acc * scale + x.amin(dim=1, keepdim=True)) ---
@@ -1893,7 +1911,9 @@ def test_copy_accum_with_reduction_512x256_A4():
     run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(reason="IndexError: _insert_read_copy_ops fails when tiling B with unit-size B dim in scale")
+@pytest.mark.skip(
+    reason="IndexError: _insert_read_copy_ops fails when tiling B with unit-size B dim in scale"
+)
 def test_copy_accum_with_reduction_512x256_B4():
     """acc.copy_(acc * scale + x.amin(dim=1,keepdim=True)) tiled B÷4."""
     inputs = [
@@ -1910,12 +1930,12 @@ def test_copy_accum_with_reduction_512x256_B4():
                 acc.copy_(acc * scale + r)
         return acc
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
-@pytest.mark.skip(reason="IndexError: _insert_read_copy_ops fails when tiling B with unit-size B dim in scale")
+@pytest.mark.skip(
+    reason="IndexError: _insert_read_copy_ops fails when tiling B with unit-size B dim in scale"
+)
 def test_copy_accum_with_reduction_512x256_A4_B4():
     """acc.copy_(acc * scale + x.amin(dim=1,keepdim=True)) tiled A÷4 B÷4."""
     inputs = [
@@ -1927,15 +1947,15 @@ def test_copy_accum_with_reduction_512x256_A4_B4():
     def fn(acc, scale, x):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                with spyre_hint(expected_named_dims=["A"], expected_reduction_dims=["B"]):
+                with spyre_hint(
+                    expected_named_dims=["A"], expected_reduction_dims=["B"]
+                ):
                     r = x.amin(dim=1, keepdim=True)
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     acc.copy_(acc * scale + r)
         return acc
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
 # --- two copies in same hint scope: c1.copy_(a+b); c2.copy_(a*b) ---
@@ -2127,7 +2147,9 @@ def test_outside_consumer_copy_then_read_512x256_A4_B4():
 # This is the minimal flash attention accumulator pattern.
 
 
-@pytest.mark.skip(reason="infeasible restickify for 1D denom in mixed 1D/2D tiled scope")
+@pytest.mark.skip(
+    reason="infeasible restickify for 1D denom in mixed 1D/2D tiled scope"
+)
 def test_outside_consumer_two_accum_512x256_A4():
     """Flash-style: out=zeros, denom=zeros; tiled copy_; return out/denom — A÷4."""
     inputs = [
@@ -2145,9 +2167,7 @@ def test_outside_consumer_two_accum_512x256_A4():
                 denom.copy_(denom + x.sum(dim=1))
         return out / denom.unsqueeze(1)
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
 def test_outside_consumer_two_accum_512x256_B4():
@@ -2167,12 +2187,12 @@ def test_outside_consumer_two_accum_512x256_B4():
                 denom.copy_(denom + x.sum(dim=1))
         return out / denom.unsqueeze(1)
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
-@pytest.mark.skip(reason="infeasible restickify for 1D denom in mixed 1D/2D tiled scope")
+@pytest.mark.skip(
+    reason="infeasible restickify for 1D denom in mixed 1D/2D tiled scope"
+)
 def test_outside_consumer_two_accum_512x256_A4_B4():
     """Flash-style: out=zeros, denom=zeros; tiled copy_; return out/denom — A÷4 B÷4."""
     inputs = [
@@ -2191,9 +2211,7 @@ def test_outside_consumer_two_accum_512x256_A4_B4():
                     denom.copy_(denom + x.sum(dim=1))
         return out / denom.unsqueeze(1)
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )
+    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
 # --- reduction inside loop, result consumed outside ---
@@ -2243,7 +2261,9 @@ def test_outside_consumer_reduction_512x256_A4_B4():
     def fn(x, bias):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
+                with spyre_hint(
+                    expected_named_dims=["B"], expected_reduction_dims=["A"]
+                ):
                     s = x.amin(dim=0)
         return s + bias
 
@@ -2307,12 +2327,17 @@ def test_view_named_input_view_transpose_H2():
         q = q.view(B, S, H, D).transpose(1, 2)
         k = k.view(B, S, H, D).transpose(1, 2)
         with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
-            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen", "head_dim"]):
+            with spyre_hint(
+                expected_named_dims=[
+                    "batch_size",
+                    "num_heads",
+                    "max_seqlen",
+                    "head_dim",
+                ]
+            ):
                 return q * k
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=True, correctness=True
-    )
+    run_coarse_tile_test(fn, inputs)
 
 
 def test_view_named_input_view_transpose_S4():
@@ -2338,12 +2363,17 @@ def test_view_named_input_view_transpose_S4():
         q = q.view(B, S, H, D).transpose(1, 2)
         k = k.view(B, S, H, D).transpose(1, 2)
         with spyre_hint(num_tiles_per_dim={"max_seqlen": 4}):
-            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen", "head_dim"]):
+            with spyre_hint(
+                expected_named_dims=[
+                    "batch_size",
+                    "num_heads",
+                    "max_seqlen",
+                    "head_dim",
+                ]
+            ):
                 return q * k
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=True, correctness=True
-    )
+    run_coarse_tile_test(fn, inputs)
 
 
 def test_view_named_input_view_transpose_H2_S4():
@@ -2370,12 +2400,17 @@ def test_view_named_input_view_transpose_H2_S4():
         k = k.view(B, S, H, D).transpose(1, 2)
         with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
             with spyre_hint(num_tiles_per_dim={"max_seqlen": 4}):
-                with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen", "head_dim"]):
+                with spyre_hint(
+                    expected_named_dims=[
+                        "batch_size",
+                        "num_heads",
+                        "max_seqlen",
+                        "head_dim",
+                    ]
+                ):
                     return q * k
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=True, correctness=True
-    )
+    run_coarse_tile_test(fn, inputs)
 
 
 # --- 4D input transposed then multiplied ---
@@ -2404,7 +2439,14 @@ def test_view_4d_transpose_H2():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
-            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"]):
+            with spyre_hint(
+                expected_named_dims=[
+                    "batch_size",
+                    "num_heads",
+                    "max_seqlen_q",
+                    "head_dim",
+                ]
+            ):
                 return x.view(B, S, H, D).transpose(1, 2) * y
 
     run_coarse_tile_test(fn, inputs)
@@ -2431,7 +2473,14 @@ def test_view_4d_transpose_S4():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"max_seqlen_q": 4}):
-            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"]):
+            with spyre_hint(
+                expected_named_dims=[
+                    "batch_size",
+                    "num_heads",
+                    "max_seqlen_q",
+                    "head_dim",
+                ]
+            ):
                 return x.view(B, S, H, D).transpose(1, 2) * y
 
     run_coarse_tile_test(fn, inputs)
@@ -2459,7 +2508,14 @@ def test_view_4d_transpose_H2_S4():
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
             with spyre_hint(num_tiles_per_dim={"max_seqlen_q": 4}):
-                with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"]):
+                with spyre_hint(
+                    expected_named_dims=[
+                        "batch_size",
+                        "num_heads",
+                        "max_seqlen_q",
+                        "head_dim",
+                    ]
+                ):
                     return x.view(B, S, H, D).transpose(1, 2) * y
 
     run_coarse_tile_test(fn, inputs)
@@ -2525,21 +2581,38 @@ def _flash_v1_inputs(B, H, Lq, Lk, D):
     """TensorSpec list for flash v1 (no mask)."""
     return [
         tensor("queries", shape=(B, H, Lq, D), dims=["B", "H", "Lq", "D"]),
-        tensor("keys",    shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
-        tensor("values",  shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
+        tensor("keys", shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
+        tensor("values", shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
     ]
 
 
-def _flash_v1_fn(queries, keys, values, *, B, H, Lq, Lk, D,
-                 b_tiles=1, h_tiles=1, lq_tiles=1, lk_tiles=1):
+def _flash_v1_fn(
+    queries,
+    keys,
+    values,
+    *,
+    B,
+    H,
+    Lq,
+    Lk,
+    D,
+    b_tiles=1,
+    h_tiles=1,
+    lq_tiles=1,
+    lk_tiles=1,
+):
     """Flash attention v1 body. Tile any combination of B/H/Lq/Lk."""
     scale = 1.0 / math.sqrt(math.sqrt(D))
     with spyre_hint(named_dims=["B", "H", "Lq", "D"]):
         output = torch.zeros_like(queries)
     with spyre_hint(named_dims=["B", "H", "Lq"]):
-        M = torch.full((B, H, Lq), float("-inf"), device=queries.device, dtype=torch.float16)
+        M = torch.full(
+            (B, H, Lq), float("-inf"), device=queries.device, dtype=torch.float16
+        )
     with spyre_hint(named_dims=["B", "H", "Lq"]):
-        denominator = torch.zeros((B, H, Lq), device=queries.device, dtype=torch.float16)
+        denominator = torch.zeros(
+            (B, H, Lq), device=queries.device, dtype=torch.float16
+        )
     with spyre_hint(num_tiles_per_dim={"B": b_tiles}):
         with spyre_hint(num_tiles_per_dim={"H": h_tiles}):
             with spyre_hint(num_tiles_per_dim={"Lq": lq_tiles}):
@@ -2554,7 +2627,10 @@ def _flash_v1_fn(queries, keys, values, *, B, H, Lq, Lk, D,
                         scores = torch.matmul(q_scaled, k_scaled)
                     with spyre_hint(expected_named_dims=["B", "H", "Lk", "Lq"]):
                         scores = scores.transpose(-1, -2).contiguous()
-                    with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
+                    with spyre_hint(
+                        expected_named_dims=["B", "H", "Lq"],
+                        expected_reduction_dims=["Lk"],
+                    ):
                         block_max = torch.amax(scores, dim=-2)
                     with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                         max_running = torch.maximum(M, block_max)
@@ -2566,7 +2642,10 @@ def _flash_v1_fn(queries, keys, values, *, B, H, Lq, Lk, D,
                         M_diff = M - max_running
                     with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                         correction = torch.exp(M_diff)
-                    with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
+                    with spyre_hint(
+                        expected_named_dims=["B", "H", "Lq"],
+                        expected_reduction_dims=["Lk"],
+                    ):
                         sum_scores = exp_scores.sum(dim=-2)
                     with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                         denom_corrected = denominator * correction
@@ -2587,9 +2666,14 @@ def _flash_v1_fn(queries, keys, values, *, B, H, Lq, Lk, D,
 def test_flash_tile_H():
     """Flash v1: tile H÷4 only."""
     run_coarse_tile_test(
-        lambda q, k, v: _flash_v1_fn(q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4),
+        lambda q, k, v: _flash_v1_fn(
+            q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4
+        ),
         _flash_v1_inputs(1, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[4]), correctness=True, atol=0.01, rtol=0.1,
+        loopspec=LoopSpecCheck(counts=[4]),
+        correctness=True,
+        atol=0.01,
+        rtol=0.1,
     )
 
 
@@ -2597,28 +2681,39 @@ def test_flash_tile_H():
 def test_flash_tile_B():
     """Flash v1: tile B÷2 only. B=2."""
     run_coarse_tile_test(
-        lambda q, k, v: _flash_v1_fn(q, k, v, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2),
+        lambda q, k, v: _flash_v1_fn(
+            q, k, v, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2
+        ),
         _flash_v1_inputs(2, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[2]),
+        correctness=False,
     )
 
 
 def test_flash_tile_Lq():
     """Flash v1: tile Lq÷2 only."""
     run_coarse_tile_test(
-        lambda q, k, v: _flash_v1_fn(q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, lq_tiles=2),
+        lambda q, k, v: _flash_v1_fn(
+            q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, lq_tiles=2
+        ),
         _flash_v1_inputs(1, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[2]),
+        correctness=False,
     )
 
 
-@pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
+@pytest.mark.skip(
+    reason="Unsupported: Lk reduction-dim tiling requires carry propagation"
+)
 def test_flash_tile_Lk():
     """Flash v1: tile Lk÷2 only."""
     run_coarse_tile_test(
-        lambda q, k, v: _flash_v1_fn(q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, lk_tiles=2),
+        lambda q, k, v: _flash_v1_fn(
+            q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, lk_tiles=2
+        ),
         _flash_v1_inputs(1, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[2]),
+        correctness=False,
     )
 
 
@@ -2626,28 +2721,39 @@ def test_flash_tile_Lk():
 def test_flash_tile_B_H():
     """Flash v1: tile B÷2 H÷4. B=2."""
     run_coarse_tile_test(
-        lambda q, k, v: _flash_v1_fn(q, k, v, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4),
+        lambda q, k, v: _flash_v1_fn(
+            q, k, v, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4
+        ),
         _flash_v1_inputs(2, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[2, 4]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[2, 4]),
+        correctness=False,
     )
 
 
 def test_flash_tile_H_Lq():
     """Flash v1: tile H÷4 Lq÷2."""
     run_coarse_tile_test(
-        lambda q, k, v: _flash_v1_fn(q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2),
+        lambda q, k, v: _flash_v1_fn(
+            q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2
+        ),
         _flash_v1_inputs(1, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[4, 2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[4, 2]),
+        correctness=False,
     )
 
 
-@pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
+@pytest.mark.skip(
+    reason="Unsupported: Lk reduction-dim tiling requires carry propagation"
+)
 def test_flash_tile_H_Lq_Lk():
     """Flash v1: tile H÷4 Lq÷2 Lk÷2."""
     run_coarse_tile_test(
-        lambda q, k, v: _flash_v1_fn(q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2, lk_tiles=2),
+        lambda q, k, v: _flash_v1_fn(
+            q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2, lk_tiles=2
+        ),
         _flash_v1_inputs(1, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[4, 2, 2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[4, 2, 2]),
+        correctness=False,
     )
 
 
@@ -2655,9 +2761,23 @@ def test_flash_tile_H_Lq_Lk():
 def test_flash_tile_all():
     """Flash v1: tile all dims. B=2, H÷4, Lq÷2, Lk÷2."""
     run_coarse_tile_test(
-        lambda q, k, v: _flash_v1_fn(q, k, v, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4, lq_tiles=2, lk_tiles=2),
+        lambda q, k, v: _flash_v1_fn(
+            q,
+            k,
+            v,
+            B=2,
+            H=8,
+            Lq=256,
+            Lk=256,
+            D=64,
+            b_tiles=2,
+            h_tiles=4,
+            lq_tiles=2,
+            lk_tiles=2,
+        ),
         _flash_v1_inputs(2, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[2, 4, 2, 2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[2, 4, 2, 2]),
+        correctness=False,
     )
 
 
@@ -2673,23 +2793,47 @@ def _flash_v2_inputs(B, H, Lq, Lk, D):
     mask_t.masked_fill_(~causal, float("-inf"))
     return [
         tensor("queries", shape=(B, H, Lq, D), dims=["B", "H", "Lq", "D"]),
-        tensor("keys",    shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
-        tensor("values",  shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
-        tensor("mask",    shape=(1, 1, Lq, Lk), dims=["B", "H", "Lq", "Lk"],
-               named_dims={"Lq": Lq, "Lk": Lk}, value=mask_t),
+        tensor("keys", shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
+        tensor("values", shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
+        tensor(
+            "mask",
+            shape=(1, 1, Lq, Lk),
+            dims=["B", "H", "Lq", "Lk"],
+            named_dims={"Lq": Lq, "Lk": Lk},
+            value=mask_t,
+        ),
     ]
 
 
-def _flash_v2_fn(queries, keys, values, mask, *, B, H, Lq, Lk, D,
-                 b_tiles=1, h_tiles=1, lq_tiles=1, lk_tiles=1):
+def _flash_v2_fn(
+    queries,
+    keys,
+    values,
+    mask,
+    *,
+    B,
+    H,
+    Lq,
+    Lk,
+    D,
+    b_tiles=1,
+    h_tiles=1,
+    lq_tiles=1,
+    lk_tiles=1,
+):
     """Flash attention v2 body. Tile any combination of B/H/Lq/Lk."""
     scale = 1.0 / math.sqrt(math.sqrt(D))
     output = torch.zeros_like(queries)
     real_max = torch.full(
-        (B, H, Lq, 64), float("-inf"), device=queries.device, dtype=torch.float16,
+        (B, H, Lq, 64),
+        float("-inf"),
+        device=queries.device,
+        dtype=torch.float16,
     ).amax(dim=-1)
     denominator = torch.zeros(
-        (B, H, Lq, 64), device=queries.device, dtype=torch.float16,
+        (B, H, Lq, 64),
+        device=queries.device,
+        dtype=torch.float16,
     ).amax(dim=-1)
     with spyre_hint(num_tiles_per_dim={"B": b_tiles}):
         with spyre_hint(num_tiles_per_dim={"H": h_tiles}):
@@ -2705,7 +2849,10 @@ def _flash_v2_fn(queries, keys, values, mask, *, B, H, Lq, Lk, D,
                         scores_pre = torch.matmul(q_scaled, keys_T)
                     with spyre_hint(expected_named_dims=["B", "H", "Lq", "Lk"]):
                         scores = scores_pre + mask
-                    with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
+                    with spyre_hint(
+                        expected_named_dims=["B", "H", "Lq"],
+                        expected_reduction_dims=["Lk"],
+                    ):
                         block_max = torch.amax(scores, dim=-1)
                     with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                         running_max = torch.maximum(real_max, block_max)
@@ -2717,7 +2864,10 @@ def _flash_v2_fn(queries, keys, values, mask, *, B, H, Lq, Lk, D,
                         real_max_diff = real_max - running_max
                     with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                         correction = torch.exp(real_max_diff)
-                    with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
+                    with spyre_hint(
+                        expected_named_dims=["B", "H", "Lq"],
+                        expected_reduction_dims=["Lk"],
+                    ):
                         sum_scores = exp_scores.sum(dim=-1)
                     with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                         denom_corrected = denominator * correction
@@ -2736,13 +2886,20 @@ def _flash_v2_fn(queries, keys, values, mask, *, B, H, Lq, Lk, D,
     return output / denominator.unsqueeze(-1)
 
 
-@pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
+@pytest.mark.skip(
+    reason="finalize_layouts: restickify infeasible for copy ops across loop groups"
+)
 def test_flash_v2_tile_H():
     """Flash v2: tile H÷4 only."""
     run_coarse_tile_test(
-        lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4),
+        lambda q, k, v, m: _flash_v2_fn(
+            q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4
+        ),
         _flash_v2_inputs(1, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[4]), correctness=True, atol=0.01, rtol=0.1,
+        loopspec=LoopSpecCheck(counts=[4]),
+        correctness=True,
+        atol=0.01,
+        rtol=0.1,
     )
 
 
@@ -2750,29 +2907,42 @@ def test_flash_v2_tile_H():
 def test_flash_v2_tile_B():
     """Flash v2: tile B÷2 only. B=2."""
     run_coarse_tile_test(
-        lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2),
+        lambda q, k, v, m: _flash_v2_fn(
+            q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2
+        ),
         _flash_v2_inputs(2, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[2]),
+        correctness=False,
     )
 
 
-@pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
+@pytest.mark.skip(
+    reason="finalize_layouts: restickify infeasible for copy ops across loop groups"
+)
 def test_flash_v2_tile_Lq():
     """Flash v2: tile Lq÷2 only."""
     run_coarse_tile_test(
-        lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, lq_tiles=2),
+        lambda q, k, v, m: _flash_v2_fn(
+            q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, lq_tiles=2
+        ),
         _flash_v2_inputs(1, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[2]),
+        correctness=False,
     )
 
 
-@pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
+@pytest.mark.skip(
+    reason="Unsupported: Lk reduction-dim tiling requires carry propagation"
+)
 def test_flash_v2_tile_Lk():
     """Flash v2: tile Lk÷2 only."""
     run_coarse_tile_test(
-        lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, lk_tiles=2),
+        lambda q, k, v, m: _flash_v2_fn(
+            q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, lk_tiles=2
+        ),
         _flash_v2_inputs(1, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[2]),
+        correctness=False,
     )
 
 
@@ -2780,39 +2950,80 @@ def test_flash_v2_tile_Lk():
 def test_flash_v2_tile_B_H():
     """Flash v2: tile B÷2 H÷4. B=2."""
     run_coarse_tile_test(
-        lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4),
+        lambda q, k, v, m: _flash_v2_fn(
+            q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4
+        ),
         _flash_v2_inputs(2, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[2, 4]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[2, 4]),
+        correctness=False,
     )
 
 
-@pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
+@pytest.mark.skip(
+    reason="finalize_layouts: restickify infeasible for copy ops across loop groups"
+)
 def test_flash_v2_tile_H_Lq():
     """Flash v2: tile H÷4 Lq÷2. Equivalent to original test_flash_v2."""
     run_coarse_tile_test(
-        lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2),
+        lambda q, k, v, m: _flash_v2_fn(
+            q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2
+        ),
         _flash_v2_inputs(1, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[4, 2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[4, 2]),
+        correctness=False,
     )
 
 
-@pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
+@pytest.mark.skip(
+    reason="Unsupported: Lk reduction-dim tiling requires carry propagation"
+)
 def test_flash_v2_tile_H_Lq_Lk():
     """Flash v2: tile H÷4 Lq÷2 Lk÷2."""
     run_coarse_tile_test(
-        lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2, lk_tiles=2),
+        lambda q, k, v, m: _flash_v2_fn(
+            q,
+            k,
+            v,
+            m,
+            B=1,
+            H=8,
+            Lq=256,
+            Lk=256,
+            D=64,
+            h_tiles=4,
+            lq_tiles=2,
+            lk_tiles=2,
+        ),
         _flash_v2_inputs(1, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[4, 2, 2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[4, 2, 2]),
+        correctness=False,
     )
 
 
-@pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
+@pytest.mark.skip(
+    reason="Unsupported: Lk reduction-dim tiling requires carry propagation"
+)
 def test_flash_v2_tile_all():
     """Flash v2: tile all dims. B=2, H÷4, Lq÷2, Lk÷2."""
     run_coarse_tile_test(
-        lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4, lq_tiles=2, lk_tiles=2),
+        lambda q, k, v, m: _flash_v2_fn(
+            q,
+            k,
+            v,
+            m,
+            B=2,
+            H=8,
+            Lq=256,
+            Lk=256,
+            D=64,
+            b_tiles=2,
+            h_tiles=4,
+            lq_tiles=2,
+            lk_tiles=2,
+        ),
         _flash_v2_inputs(2, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[2, 4, 2, 2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[2, 4, 2, 2]),
+        correctness=False,
     )
 
 
@@ -2829,24 +3040,41 @@ def _flash_v3_inputs(B, H, Lq, Lk, D):
     mask_t.masked_fill_(~causal, float("-inf"))
     return [
         tensor("queries", shape=(B, H, Lq, D), dims=["B", "H", "Lq", "D"]),
-        tensor("keys",    shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
-        tensor("values",  shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
-        tensor("mask",    shape=(1, 1, Lq, Lk), dims=["B", "H", "Lq", "Lk"],
-               named_dims={"Lq": Lq, "Lk": Lk}, value=mask_t),
+        tensor("keys", shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
+        tensor("values", shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
+        tensor(
+            "mask",
+            shape=(1, 1, Lq, Lk),
+            dims=["B", "H", "Lq", "Lk"],
+            named_dims={"Lq": Lq, "Lk": Lk},
+            value=mask_t,
+        ),
     ]
 
 
-def _flash_v3_fn(queries, keys, values, mask, *, B, H, Lq, Lk, D,
-                 b_tiles=1, h_tiles=1, lq_tiles=1, lk_tiles=1):
+def _flash_v3_fn(
+    queries,
+    keys,
+    values,
+    mask,
+    *,
+    B,
+    H,
+    Lq,
+    Lk,
+    D,
+    b_tiles=1,
+    h_tiles=1,
+    lq_tiles=1,
+    lk_tiles=1,
+):
     """Flash attention v3 body (scores transposed). Tile any combination of B/H/Lq/Lk."""
     scale = 1.0 / math.sqrt(math.sqrt(D))
     output = torch.zeros_like(queries)
     real_max = torch.full(
         (B, H, Lq), float("-inf"), device=queries.device, dtype=torch.float16
     )
-    denominator = torch.zeros(
-        (B, H, Lq), device=queries.device, dtype=torch.float16
-    )
+    denominator = torch.zeros((B, H, Lq), device=queries.device, dtype=torch.float16)
     with spyre_hint(num_tiles_per_dim={"B": b_tiles}):
         with spyre_hint(num_tiles_per_dim={"H": h_tiles}):
             with spyre_hint(num_tiles_per_dim={"Lq": lq_tiles}):
@@ -2863,7 +3091,10 @@ def _flash_v3_fn(queries, keys, values, mask, *, B, H, Lq, Lk, D,
                         scores_masked = scores_pre + mask
                     with spyre_hint(expected_named_dims=["B", "H", "Lk", "Lq"]):
                         scores = scores_masked.transpose(-1, -2).contiguous()
-                    with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
+                    with spyre_hint(
+                        expected_named_dims=["B", "H", "Lq"],
+                        expected_reduction_dims=["Lk"],
+                    ):
                         block_max = torch.amax(scores, dim=-2)
                     with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                         running_max = torch.maximum(real_max, block_max)
@@ -2875,7 +3106,10 @@ def _flash_v3_fn(queries, keys, values, mask, *, B, H, Lq, Lk, D,
                         real_max_diff = real_max - running_max
                     with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                         correction = torch.exp(real_max_diff)
-                    with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
+                    with spyre_hint(
+                        expected_named_dims=["B", "H", "Lq"],
+                        expected_reduction_dims=["Lk"],
+                    ):
                         sum_scores = exp_scores.sum(dim=-2)
                     with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                         denom_corrected = denominator * correction
@@ -2899,9 +3133,12 @@ def _flash_v3_fn(queries, keys, values, mask, *, B, H, Lq, Lk, D,
 def test_flash_v3_tile_H():
     """Flash v3: tile H÷4 only."""
     run_coarse_tile_test(
-        lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4),
+        lambda q, k, v, m: _flash_v3_fn(
+            q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4
+        ),
         _flash_v3_inputs(1, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[4]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[4]),
+        correctness=False,
     )
 
 
@@ -2909,28 +3146,39 @@ def test_flash_v3_tile_H():
 def test_flash_v3_tile_B():
     """Flash v3: tile B÷2 only. B=2."""
     run_coarse_tile_test(
-        lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2),
+        lambda q, k, v, m: _flash_v3_fn(
+            q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2
+        ),
         _flash_v3_inputs(2, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[2]),
+        correctness=False,
     )
 
 
 def test_flash_v3_tile_Lq():
     """Flash v3: tile Lq÷2 only."""
     run_coarse_tile_test(
-        lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, lq_tiles=2),
+        lambda q, k, v, m: _flash_v3_fn(
+            q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, lq_tiles=2
+        ),
         _flash_v3_inputs(1, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[2]),
+        correctness=False,
     )
 
 
-@pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
+@pytest.mark.skip(
+    reason="Unsupported: Lk reduction-dim tiling requires carry propagation"
+)
 def test_flash_v3_tile_Lk():
     """Flash v3: tile Lk÷2 only."""
     run_coarse_tile_test(
-        lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, lk_tiles=2),
+        lambda q, k, v, m: _flash_v3_fn(
+            q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, lk_tiles=2
+        ),
         _flash_v3_inputs(1, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[2]),
+        correctness=False,
     )
 
 
@@ -2938,38 +3186,77 @@ def test_flash_v3_tile_Lk():
 def test_flash_v3_tile_B_H():
     """Flash v3: tile B÷2 H÷4. B=2."""
     run_coarse_tile_test(
-        lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4),
+        lambda q, k, v, m: _flash_v3_fn(
+            q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4
+        ),
         _flash_v3_inputs(2, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[2, 4]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[2, 4]),
+        correctness=False,
     )
 
 
 def test_flash_v3_tile_H_Lq():
     """Flash v3: tile H÷4 Lq÷2. Equivalent to original test_flash_v3 (small sizes)."""
     run_coarse_tile_test(
-        lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2),
+        lambda q, k, v, m: _flash_v3_fn(
+            q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2
+        ),
         _flash_v3_inputs(1, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[4, 2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[4, 2]),
+        correctness=False,
     )
 
 
-@pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
+@pytest.mark.skip(
+    reason="Unsupported: Lk reduction-dim tiling requires carry propagation"
+)
 def test_flash_v3_tile_H_Lq_Lk():
     """Flash v3: tile H÷4 Lq÷2 Lk÷2."""
     run_coarse_tile_test(
-        lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2, lk_tiles=2),
+        lambda q, k, v, m: _flash_v3_fn(
+            q,
+            k,
+            v,
+            m,
+            B=1,
+            H=8,
+            Lq=256,
+            Lk=256,
+            D=64,
+            h_tiles=4,
+            lq_tiles=2,
+            lk_tiles=2,
+        ),
         _flash_v3_inputs(1, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[4, 2, 2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[4, 2, 2]),
+        correctness=False,
     )
 
 
-@pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
+@pytest.mark.skip(
+    reason="Unsupported: Lk reduction-dim tiling requires carry propagation"
+)
 def test_flash_v3_tile_all():
     """Flash v3: tile all dims. B=2, H÷4, Lq÷2, Lk÷2."""
     run_coarse_tile_test(
-        lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4, lq_tiles=2, lk_tiles=2),
+        lambda q, k, v, m: _flash_v3_fn(
+            q,
+            k,
+            v,
+            m,
+            B=2,
+            H=8,
+            Lq=256,
+            Lk=256,
+            D=64,
+            b_tiles=2,
+            h_tiles=4,
+            lq_tiles=2,
+            lk_tiles=2,
+        ),
         _flash_v3_inputs(2, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[2, 4, 2, 2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[2, 4, 2, 2]),
+        correctness=False,
     )
 
 
@@ -2984,20 +3271,28 @@ def _flash_v4_inputs(B, S, H, D):
     _nd_q = {"batch_size": B, "max_seqlen_q": S, "num_heads": H, "head_dim": D}
     _nd_kv = {"batch_size": B, "max_seqlen_kv": S, "num_heads": H, "head_dim": D}
     return [
-        tensor("q", shape=(B, S, H * D),
-               dims=["batch_size", "max_seqlen_q", "num_heads", "head_dim"],
-               named_dims=_nd_q),
-        tensor("k", shape=(B, S, H * D),
-               dims=["batch_size", "max_seqlen_kv", "num_heads", "head_dim"],
-               named_dims=_nd_kv),
-        tensor("v", shape=(B, S, H * D),
-               dims=["batch_size", "max_seqlen_kv", "num_heads", "head_dim"],
-               named_dims=_nd_kv),
+        tensor(
+            "q",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen_q", "num_heads", "head_dim"],
+            named_dims=_nd_q,
+        ),
+        tensor(
+            "k",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen_kv", "num_heads", "head_dim"],
+            named_dims=_nd_kv,
+        ),
+        tensor(
+            "v",
+            shape=(B, S, H * D),
+            dims=["batch_size", "max_seqlen_kv", "num_heads", "head_dim"],
+            named_dims=_nd_kv,
+        ),
     ]
 
 
-def _flash_v4_fn(q, k, v, *, B, S, H, D,
-                 b_tiles=1, h_tiles=1, lq_tiles=1, lk_tiles=1):
+def _flash_v4_fn(q, k, v, *, B, S, H, D, b_tiles=1, h_tiles=1, lq_tiles=1, lk_tiles=1):
     """Flash attention v4 body (flat fused-dim inputs). Tile any combination."""
     q = q.view(B, S, H, D).transpose(1, 2)
     k = k.view(B, S, H, D).transpose(1, 2)
@@ -3010,42 +3305,128 @@ def _flash_v4_fn(q, k, v, *, B, S, H, D,
         with spyre_hint(num_tiles_per_dim={"num_heads": h_tiles}):
             with spyre_hint(num_tiles_per_dim={"max_seqlen_q": lq_tiles}):
                 with spyre_hint(num_tiles_per_dim={"max_seqlen_kv": lk_tiles}):
-                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_kv", "head_dim"]):
+                    with spyre_hint(
+                        expected_named_dims=[
+                            "batch_size",
+                            "num_heads",
+                            "max_seqlen_kv",
+                            "head_dim",
+                        ]
+                    ):
                         scaled_keys = k * scale
-                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "head_dim", "max_seqlen_kv"]):
+                    with spyre_hint(
+                        expected_named_dims=[
+                            "batch_size",
+                            "num_heads",
+                            "head_dim",
+                            "max_seqlen_kv",
+                        ]
+                    ):
                         keys_T = scaled_keys.transpose(-1, -2).contiguous()
-                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"]):
+                    with spyre_hint(
+                        expected_named_dims=[
+                            "batch_size",
+                            "num_heads",
+                            "max_seqlen_q",
+                            "head_dim",
+                        ]
+                    ):
                         q_scaled = q * scale
-                    with spyre_hint(named_dims=["batch_size", "num_heads", "max_seqlen_q", "max_seqlen_kv"]):
+                    with spyre_hint(
+                        named_dims=[
+                            "batch_size",
+                            "num_heads",
+                            "max_seqlen_q",
+                            "max_seqlen_kv",
+                        ]
+                    ):
                         scores_pre = torch.matmul(q_scaled, keys_T)
-                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_kv", "max_seqlen_q"]):
+                    with spyre_hint(
+                        expected_named_dims=[
+                            "batch_size",
+                            "num_heads",
+                            "max_seqlen_kv",
+                            "max_seqlen_q",
+                        ]
+                    ):
                         scores = scores_pre.transpose(-1, -2).contiguous()
-                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"], expected_reduction_dims=["max_seqlen_kv"]):
+                    with spyre_hint(
+                        expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"],
+                        expected_reduction_dims=["max_seqlen_kv"],
+                    ):
                         block_max = torch.amax(scores, dim=-2)
-                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
+                    with spyre_hint(
+                        expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]
+                    ):
                         running_max = torch.maximum(real_max, block_max)
-                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_kv", "max_seqlen_q"]):
+                    with spyre_hint(
+                        expected_named_dims=[
+                            "batch_size",
+                            "num_heads",
+                            "max_seqlen_kv",
+                            "max_seqlen_q",
+                        ]
+                    ):
                         scores_shifted = scores - running_max.unsqueeze(-2)
-                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_kv", "max_seqlen_q"]):
+                    with spyre_hint(
+                        expected_named_dims=[
+                            "batch_size",
+                            "num_heads",
+                            "max_seqlen_kv",
+                            "max_seqlen_q",
+                        ]
+                    ):
                         exp_scores = torch.exp(scores_shifted)
-                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
+                    with spyre_hint(
+                        expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]
+                    ):
                         real_max_diff = real_max - running_max
-                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
+                    with spyre_hint(
+                        expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]
+                    ):
                         correction = torch.exp(real_max_diff)
-                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"], expected_reduction_dims=["max_seqlen_kv"]):
+                    with spyre_hint(
+                        expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"],
+                        expected_reduction_dims=["max_seqlen_kv"],
+                    ):
                         sum_scores = exp_scores.sum(dim=-2)
-                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
+                    with spyre_hint(
+                        expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]
+                    ):
                         denom_corrected = denominator * correction
-                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
+                    with spyre_hint(
+                        expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]
+                    ):
                         new_denom = denom_corrected + sum_scores
                     denominator.copy_(new_denom)
-                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q", "max_seqlen_kv"]):
+                    with spyre_hint(
+                        expected_named_dims=[
+                            "batch_size",
+                            "num_heads",
+                            "max_seqlen_q",
+                            "max_seqlen_kv",
+                        ]
+                    ):
                         exp_scores_T = exp_scores.transpose(-1, -2).contiguous()
-                    with spyre_hint(named_dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"]):
+                    with spyre_hint(
+                        named_dims=[
+                            "batch_size",
+                            "num_heads",
+                            "max_seqlen_q",
+                            "head_dim",
+                        ]
+                    ):
                         matmul_out = torch.matmul(exp_scores_T, v)
                     # correction.unsqueeze(-1) is size-1 in head_dim — can't carry "head_dim"
                     output_corrected = output * correction.unsqueeze(-1)
-                    with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"]):
+                    with spyre_hint(
+                        expected_named_dims=[
+                            "batch_size",
+                            "num_heads",
+                            "max_seqlen_q",
+                            "head_dim",
+                        ]
+                    ):
                         new_output = output_corrected + matmul_out
                     output.copy_(new_output)
                     real_max.copy_(running_max)
@@ -3053,62 +3434,87 @@ def _flash_v4_fn(q, k, v, *, B, S, H, D,
     return output.transpose(1, 2).reshape(B, S, H * D)
 
 
+@pytest.mark.skip(
+    reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose"
+)
 def test_flash_v4_tile_H():
     """Flash v4: tile num_heads÷4 only."""
     run_coarse_tile_test(
         lambda q, k, v: _flash_v4_fn(q, k, v, B=2, S=256, H=8, D=64, h_tiles=4),
         _flash_v4_inputs(2, 256, 8, 64),
-        loopspec=LoopSpecCheck(counts=[4]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[4]),
+        correctness=False,
     )
 
 
-@pytest.mark.skip(reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose")
+@pytest.mark.skip(
+    reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose"
+)
 def test_flash_v4_tile_B():
     """Flash v4: tile batch_size÷2 only. B=2."""
     run_coarse_tile_test(
         lambda q, k, v: _flash_v4_fn(q, k, v, B=2, S=256, H=8, D=64, b_tiles=2),
         _flash_v4_inputs(2, 256, 8, 64),
-        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[2]),
+        correctness=False,
     )
 
 
-@pytest.mark.skip(reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose")
+@pytest.mark.skip(
+    reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose"
+)
 def test_flash_v4_tile_Lq():
     """Flash v4: tile max_seqlen_q÷2 only."""
     run_coarse_tile_test(
         lambda q, k, v: _flash_v4_fn(q, k, v, B=2, S=256, H=8, D=64, lq_tiles=2),
         _flash_v4_inputs(2, 256, 8, 64),
-        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[2]),
+        correctness=False,
     )
 
 
-@pytest.mark.skip(reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose")
+@pytest.mark.skip(
+    reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose"
+)
 def test_flash_v4_tile_H_Lq():
     """Flash v4: tile num_heads÷4 max_seqlen_q÷2. Equivalent to original test_flash_v4."""
     run_coarse_tile_test(
-        lambda q, k, v: _flash_v4_fn(q, k, v, B=2, S=256, H=8, D=64, h_tiles=4, lq_tiles=2),
+        lambda q, k, v: _flash_v4_fn(
+            q, k, v, B=2, S=256, H=8, D=64, h_tiles=4, lq_tiles=2
+        ),
         _flash_v4_inputs(2, 256, 8, 64),
-        loopspec=LoopSpecCheck(counts=[4, 2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[4, 2]),
+        correctness=False,
     )
 
 
-@pytest.mark.skip(reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose")
+@pytest.mark.skip(
+    reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose"
+)
 def test_flash_v4_tile_H_Lq_Lk():
     """Flash v4: tile num_heads÷4 max_seqlen_q÷2 max_seqlen_kv÷2."""
     run_coarse_tile_test(
-        lambda q, k, v: _flash_v4_fn(q, k, v, B=2, S=256, H=8, D=64, h_tiles=4, lq_tiles=2, lk_tiles=2),
+        lambda q, k, v: _flash_v4_fn(
+            q, k, v, B=2, S=256, H=8, D=64, h_tiles=4, lq_tiles=2, lk_tiles=2
+        ),
         _flash_v4_inputs(2, 256, 8, 64),
-        loopspec=LoopSpecCheck(counts=[4, 2, 2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[4, 2, 2]),
+        correctness=False,
     )
 
 
-@pytest.mark.skip(reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose")
+@pytest.mark.skip(
+    reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose"
+)
 def test_flash_v4_tile_all():
     """Flash v4: tile all dims. B=2, H÷4, Lq÷2, Lk÷2."""
     run_coarse_tile_test(
-        lambda q, k, v: _flash_v4_fn(q, k, v, B=2, S=256, H=8, D=64, b_tiles=2, h_tiles=4, lq_tiles=2, lk_tiles=2),
+        lambda q, k, v: _flash_v4_fn(
+            q, k, v, B=2, S=256, H=8, D=64, b_tiles=2, h_tiles=4, lq_tiles=2, lk_tiles=2
+        ),
         _flash_v4_inputs(2, 256, 8, 64),
-        loopspec=LoopSpecCheck(counts=[2, 4, 2, 2]), correctness=False,
+        loopspec=LoopSpecCheck(counts=[2, 4, 2, 2]),
+        correctness=False,
     )
 
 
@@ -3126,7 +3532,7 @@ def test_validate_named_dims_raises_on_mismatch():
             return torch.abs(x)
 
     with pytest.raises(Exception, match="expected_named_dims"):
-        run_coarse_tile_test(fn, inputs, loopspec=False, correctness=False)
+        run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
 def test_validate_reduction_dims_raises_on_mismatch():
@@ -3138,7 +3544,7 @@ def test_validate_reduction_dims_raises_on_mismatch():
             return x.amin(dim=0)
 
     with pytest.raises(Exception, match="expected_reduction_dims"):
-        run_coarse_tile_test(fn, inputs, loopspec=False, correctness=False)
+        run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
 # ===========================================================================
@@ -3261,13 +3667,17 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
         def softmax_fn(x):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["D"]):
+                with spyre_hint(
+                    expected_named_dims=["B"], expected_reduction_dims=["D"]
+                ):
                     max_val = x.amax(dim=-1, keepdim=True)
                 with spyre_hint(expected_named_dims=["B", "D"]):
                     x_shifted = x - max_val
                 with spyre_hint(expected_named_dims=["B", "D"]):
                     exp_x = x_shifted.exp()
-                with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["D"]):
+                with spyre_hint(
+                    expected_named_dims=["B"], expected_reduction_dims=["D"]
+                ):
                     sum_exp = exp_x.sum(dim=-1, keepdim=True)
                 with spyre_hint(expected_named_dims=["B", "D"]):
                     return exp_x / sum_exp
@@ -3872,7 +4282,9 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         )
 
     # Consider deleting — superseded by Group 10 structured tests (_flash_v2_fn)
-    @pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
+    @pytest.mark.skip(
+        reason="finalize_layouts: restickify infeasible for copy ops across loop groups"
+    )
     def test_hint_flash_attention_v2(self):
         """Flash attention tiled over H (4 slices) via nested spyre_hints.
 
@@ -3990,161 +4402,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
         )
 
-    @pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
-    def test_hint_flash_attention_v2_validate_dims(self):
-        """Same as test_hint_flash_attention_v2 but with expected_named_dims annotations.
-
-        Confirms annotated and original versions produce identical output.
-        Known broken: restickify infeasible for copy ops across loop groups —
-        both versions are expected to fail at finalize_layouts, but dims are
-        validated before that point.
-        """
-        import math
-        from torch_spyre._inductor import spyre_hint
-
-        B, H, Lq, Lk, D = 1, 8, 256, 256, 64
-        block_size = 128
-
-        queries_t = torch.randn(B, H, Lq, D, dtype=torch.float16)
-        keys_t = torch.randn(B, H, Lk, D, dtype=torch.float16)
-        values_t = torch.randn(B, H, Lk, D, dtype=torch.float16)
-        causal = torch.tril(torch.ones(Lq, Lk, dtype=torch.bool))
-        mask_t = torch.zeros(1, 1, Lq, Lk, dtype=torch.float16)
-        mask_t.masked_fill_(~causal, float("-inf"))
-        lq_slices = Lq // block_size
-
-        def flash(queries, keys, values, mask):
-            scale = 1.0 / math.sqrt(math.sqrt(D))
-            output = torch.zeros_like(queries)
-            real_max = torch.full(
-                (B, H, Lq, 64),
-                float("-inf"),
-                device=queries.device,
-                dtype=torch.float16,
-            )
-            real_max = real_max.amax(dim=-1)  # B, H, Lq sparse
-
-            denominator = torch.zeros(
-                (B, H, Lq, 64),
-                device=queries.device,
-                dtype=torch.float16,
-            )
-            denominator = denominator.amax(dim=-1)  # B, H, Lq sparse
-            with spyre_hint(num_tiles_per_dim={"B": 1}):
-                with spyre_hint(num_tiles_per_dim={"H": 4}):
-                    with spyre_hint(num_tiles_per_dim={"Lq": lq_slices}):
-                        with spyre_hint(expected_named_dims=["B", "H", "Lk", "D"]):
-                            scaled_keys = keys * scale
-                        with spyre_hint(expected_named_dims=["B", "H", "D", "Lk"]):
-                            keys_T = scaled_keys.transpose(-1, -2)
-                        with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
-                            q_scaled = queries * scale
-                        with spyre_hint(named_dims=["B", "H", "Lq", "Lk"]):
-                            scores_pre = torch.matmul(q_scaled, keys_T)
-                        with spyre_hint(expected_named_dims=["B", "H", "Lq", "Lk"]):
-                            scores = scores_pre + mask
-                        with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
-                            block_max = torch.amax(scores, dim=-1)
-                        with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
-                            running_max = torch.maximum(real_max, block_max)
-                        with spyre_hint(expected_named_dims=["B", "H", "Lq", "Lk"]):
-                            scores_shifted = scores - running_max.unsqueeze(-1)
-                        with spyre_hint(expected_named_dims=["B", "H", "Lq", "Lk"]):
-                            exp_scores = torch.exp(scores_shifted)
-                        with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
-                            real_max_diff = real_max - running_max
-                        with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
-                            correction = torch.exp(real_max_diff)
-                        with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
-                            sum_scores = exp_scores.sum(dim=-1)
-                        with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
-                            denom_corrected = denominator * correction
-                        with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
-                            new_denom = denom_corrected + sum_scores
-                        denominator.copy_(new_denom)
-                        with spyre_hint(named_dims=["B", "H", "Lq", "D"]):
-                            matmul_out = torch.matmul(exp_scores, values)
-                        corr_expanded = correction.unsqueeze(-1)
-                        output_corrected = output * corr_expanded
-                        with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
-                            new_output = output_corrected + matmul_out
-                        output.copy_(new_output)
-                        real_max.copy_(running_max)
-
-            return output / denominator.unsqueeze(-1)
-
-        def flash_original(queries, keys, values, mask):
-            scale = 1.0 / math.sqrt(math.sqrt(D))
-            output = torch.zeros_like(queries)
-            real_max = torch.full(
-                (B, H, Lq, 64),
-                float("-inf"),
-                device=queries.device,
-                dtype=torch.float16,
-            )
-            real_max = real_max.amax(dim=-1)
-            denominator = torch.zeros(
-                (B, H, Lq, 64),
-                device=queries.device,
-                dtype=torch.float16,
-            )
-            denominator = denominator.amax(dim=-1)
-            with spyre_hint(num_tiles_per_dim={"B": 1}):
-                with spyre_hint(num_tiles_per_dim={"H": 4}):
-                    with spyre_hint(num_tiles_per_dim={"Lq": lq_slices}):
-                        scaled_keys = keys * scale
-                        keys_T = scaled_keys.transpose(-1, -2)
-                        scores = torch.matmul(queries * scale, keys_T)
-                        scores = scores + mask
-                        block_max = torch.amax(scores, dim=-1)
-                        running_max = torch.maximum(real_max, block_max)
-                        exp_scores = torch.exp(scores - running_max.unsqueeze(-1))
-                        correction = torch.exp(real_max - running_max)
-                        denominator.copy_(denominator * correction + exp_scores.sum(dim=-1))
-                        output.copy_(output * correction.unsqueeze(-1) + torch.matmul(exp_scores, values))
-                        real_max.copy_(running_max)
-            return output / denominator.unsqueeze(-1)
-
-        queries_dev = queries_t.to("spyre")
-        keys_dev = keys_t.to("spyre")
-        values_dev = values_t.to("spyre")
-        mask_dev = mask_t.to("spyre")
-        _declare_tensor_dim("B", B)
-        _declare_tensor_dim("H", H)
-        _declare_tensor_dim("Lq", Lq)
-        _declare_tensor_dim("Lk", Lk)
-        _declare_tensor_dim("D", D)
-        _name_tensor_dims(queries_dev, ["B", "H", "Lq", "D"])
-        _name_tensor_dims(keys_dev, ["B", "H", "Lk", "D"])
-        _name_tensor_dims(values_dev, ["B", "H", "Lk", "D"])
-        _name_tensor_dims(mask_dev, ["Lq", "Lk"])
-
-        result_annotated = torch.compile(flash)(queries_dev, keys_dev, values_dev, mask_dev).cpu()
-
-        _pnd.reset()
-        _declare_tensor_dim("B", B)
-        _declare_tensor_dim("H", H)
-        _declare_tensor_dim("Lq", Lq)
-        _declare_tensor_dim("Lk", Lk)
-        _declare_tensor_dim("D", D)
-        _name_tensor_dims(queries_dev, ["B", "H", "Lq", "D"])
-        _name_tensor_dims(keys_dev, ["B", "H", "Lk", "D"])
-        _name_tensor_dims(values_dev, ["B", "H", "Lk", "D"])
-        _name_tensor_dims(mask_dev, ["B", "H", "Lq", "Lk"])
-
-        result_original = torch.compile(flash_original)(queries_dev, keys_dev, values_dev, mask_dev).cpu()
-
-        print(f"\nAnnotated result: {result_annotated}")
-        print(f"Original result:  {result_original}")
-        torch.testing.assert_close(
-            result_annotated,
-            result_original,
-            equal_nan=True,
-            atol=0.0,
-            rtol=0.0,
-            msg=lambda msg: f"annotated vs original mismatch\n\n{msg}\n",
-        )
-
     def test_hint_flash_attention_v2_divide_in_scope(self):
         """test_hint_flash_attention_v2 with the final divide INSIDE the scope.
 
@@ -4257,7 +4514,9 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         }
     )
     # Consider deleting — superseded by Group 10 structured tests (_flash_v3_fn)
-    @pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
+    @pytest.mark.skip(
+        reason="finalize_layouts: restickify infeasible for copy ops across loop groups"
+    )
     def test_hint_flash_attention_v3(self):
         from torch_spyre._inductor import spyre_hint
 
@@ -4358,7 +4617,9 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
         )
 
-    @pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
+    @pytest.mark.skip(
+        reason="finalize_layouts: restickify infeasible for copy ops across loop groups"
+    )
     def test_hint_flash_attention_v3_b2(self):
         """Same as flash_v3 but with B=2 and b_block_size=2 so B is nto tiled"""
         from torch_spyre._inductor import spyre_hint
@@ -4488,7 +4749,10 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             )
             with spyre_hint(tiles={"H": H // h_block_size}):
                 with spyre_hint(tiles={"Lq": Lq // lq_block_size}):
-                    with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
+                    with spyre_hint(
+                        expected_named_dims=["B", "H", "Lq"],
+                        expected_reduction_dims=["Lk"],
+                    ):
                         block_max = torch.amax(scores, dim=-2)  # [B, H, Lq]
                     with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                         running_max = torch.maximum(real_max, block_max)
@@ -4609,142 +4873,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             atol=0.1,
             rtol=0.1,
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
-        )
-
-    @pytest.mark.skip
-    def test_hint_flash_attention_v4_validate_dims(self):
-        """Same as test_hint_flash_attention_v4 with expected_named_dims annotations."""
-        from torch_spyre._inductor import spyre_hint
-
-        B, H, S, D = 2, 32, 4096, 256
-        q_block_size = S // 4
-        kv_block_size = S // 1
-
-        queries_t = torch.randn(B, S, H * D, dtype=torch.float16)
-        keys_t = torch.randn(B, S, H * D, dtype=torch.float16)
-        values_t = torch.randn(B, S, H * D, dtype=torch.float16)
-
-        def flash(q, k, v):
-            q = q.view(B, S, H, D).transpose(1, 2)
-            k = k.view(B, S, H, D).transpose(1, 2)
-            v = v.view(B, S, H, D).transpose(1, 2)
-
-            scale = 1.0 / math.sqrt(math.sqrt(D))
-
-            output = torch.zeros_like(q)
-            real_max = torch.full(
-                (B, H, S), float("-inf"), device=q.device, dtype=q.dtype
-            )
-            denominator = torch.zeros((B, H, S), device=q.device, dtype=q.dtype)
-
-            with spyre_hint(tiles={"batch_size": max(1, B // 2)}):
-                with spyre_hint(tiles={"num_heads": max(1, H // 4)}):
-                    with spyre_hint(tiles={"max_seqlen_q": max(1, S // q_block_size)}):
-                        with spyre_hint(tiles={"max_seqlen_kv": max(1, S // kv_block_size)}):
-                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_kv", "head_dim"]):
-                                scaled_keys = k * scale
-                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "head_dim", "max_seqlen_kv"]):
-                                keys_T = scaled_keys.transpose(-1, -2).contiguous()
-                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"]):
-                                q_scaled = q * scale
-                            with spyre_hint(named_dims=["batch_size", "num_heads", "max_seqlen_q", "max_seqlen_kv"]):
-                                scores_pre = torch.matmul(q_scaled, keys_T)
-                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_kv", "max_seqlen_q"]):
-                                scores = scores_pre.transpose(-1, -2).contiguous()
-                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"], expected_reduction_dims=["max_seqlen_kv"]):
-                                block_max = torch.amax(scores, dim=-2)
-                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
-                                running_max = torch.maximum(real_max, block_max)
-                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_kv", "max_seqlen_q"]):
-                                scores_shifted = scores - running_max.unsqueeze(-2)
-                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_kv", "max_seqlen_q"]):
-                                exp_scores = torch.exp(scores_shifted)
-                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
-                                real_max_diff = real_max - running_max
-                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
-                                correction = torch.exp(real_max_diff)
-                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"], expected_reduction_dims=["max_seqlen_kv"]):
-                                sum_scores = exp_scores.sum(dim=-2)
-                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
-                                denom_corrected = denominator * correction
-                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
-                                new_denom = denom_corrected + sum_scores
-                            denominator.copy_(new_denom)
-                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q", "max_seqlen_kv"]):
-                                exp_scores_T = exp_scores.transpose(-1, -2).contiguous()
-                            with spyre_hint(named_dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"]):
-                                matmul_out = torch.matmul(exp_scores_T, v)
-                            # correction.unsqueeze(-1) is size-1 in head_dim — can't carry "head_dim"
-                            output_corrected = output * correction.unsqueeze(-1)
-                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"]):
-                                new_output = output_corrected + matmul_out
-                            output.copy_(new_output)
-                            real_max.copy_(running_max)
-
-            output.copy_(output / denominator.unsqueeze(-1))
-            return output.transpose(1, 2).reshape(B, S, H * D)
-
-        def flash_original(q, k, v):
-            q = q.view(B, S, H, D).transpose(1, 2)
-            k = k.view(B, S, H, D).transpose(1, 2)
-            v = v.view(B, S, H, D).transpose(1, 2)
-            scale = 1.0 / math.sqrt(math.sqrt(D))
-            output = torch.zeros_like(q)
-            real_max = torch.full((B, H, S), float("-inf"), device=q.device, dtype=q.dtype)
-            denominator = torch.zeros((B, H, S), device=q.device, dtype=q.dtype)
-            with spyre_hint(tiles={"batch_size": max(1, B // 2)}):
-                with spyre_hint(tiles={"num_heads": max(1, H // 4)}):
-                    with spyre_hint(tiles={"max_seqlen_q": max(1, S // q_block_size)}):
-                        with spyre_hint(tiles={"max_seqlen_kv": max(1, S // kv_block_size)}):
-                            scaled_keys = k * scale
-                            keys_T = scaled_keys.transpose(-1, -2).contiguous()
-                            scores = torch.matmul(q * scale, keys_T)
-                            scores = scores.transpose(-1, -2).contiguous()
-                            block_max = torch.amax(scores, dim=-2)
-                            running_max = torch.maximum(real_max, block_max)
-                            exp_scores = torch.exp(scores - running_max.unsqueeze(-2))
-                            correction = torch.exp(real_max - running_max)
-                            denominator.copy_(denominator * correction + exp_scores.sum(dim=-2))
-                            output.copy_(output * correction.unsqueeze(-1) + torch.matmul(exp_scores.transpose(-1, -2), v))
-                            real_max.copy_(running_max)
-            output.copy_(output / denominator.unsqueeze(-1))
-            return output.transpose(1, 2).reshape(B, S, H * D)
-
-        queries_dev = queries_t.to("spyre")
-        keys_dev = keys_t.to("spyre")
-        values_dev = values_t.to("spyre")
-        _declare_tensor_dim("batch_size", B)
-        _declare_tensor_dim("num_heads", H)
-        _declare_tensor_dim("max_seqlen_q", S)
-        _declare_tensor_dim("max_seqlen_kv", S)
-        _declare_tensor_dim("head_dim", D)
-        _name_tensor_dims(queries_dev, ["batch_size", "max_seqlen_q", "num_heads", "head_dim"])
-        _name_tensor_dims(keys_dev, ["batch_size", "max_seqlen_kv", "num_heads", "head_dim"])
-        _name_tensor_dims(values_dev, ["batch_size", "max_seqlen_kv", "num_heads", "head_dim"])
-
-        result_annotated = torch.compile(flash)(queries_dev, keys_dev, values_dev).cpu()
-
-        _pnd.reset()
-        _declare_tensor_dim("batch_size", B)
-        _declare_tensor_dim("num_heads", H)
-        _declare_tensor_dim("max_seqlen_q", S)
-        _declare_tensor_dim("max_seqlen_kv", S)
-        _declare_tensor_dim("head_dim", D)
-        _name_tensor_dims(queries_dev, ["batch_size", "max_seqlen_q", "num_heads", "head_dim"])
-        _name_tensor_dims(keys_dev, ["batch_size", "max_seqlen_kv", "num_heads", "head_dim"])
-        _name_tensor_dims(values_dev, ["batch_size", "max_seqlen_kv", "num_heads", "head_dim"])
-
-        result_original = torch.compile(flash_original)(queries_dev, keys_dev, values_dev).cpu()
-
-        print(f"\nAnnotated result: {result_annotated}")
-        print(f"Original result:  {result_original}")
-        torch.testing.assert_close(
-            result_annotated,
-            result_original,
-            equal_nan=True,
-            atol=0.0,
-            rtol=0.0,
-            msg=lambda msg: f"annotated vs original mismatch\n\n{msg}\n",
         )
 
     def test_hint_mixed_coverage_loopspec(self):
@@ -6161,6 +6289,9 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
             fn, a, b, run_compile=True, run_eager=False, atol=0.05, rtol=0.05
         )
 
+    @pytest.mark.skip(
+        reason="compiled spyre <-> cpu mismatch: nested matmul correctness not yet passing"
+    )
     def test_nested_matmul_outer_M_inner_K_correct(self):
         """mm [M,K]@[K,N] with outer M (output) + inner K (reduction) — correct."""
         from torch_spyre._inductor import spyre_hint

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -16,7 +16,7 @@
 
 This file has two sections:
 
-STRUCTURED TESTS (Groups 1-9)
+STRUCTURED TESTS (Groups 1-10)
     Flat module-level tests using the run_coarse_tile_test() driver.
     These are the primary test suite going forward — easy to read, copy,
     and extend.  Each test declares its inputs via tensor() descriptors,
@@ -32,6 +32,7 @@ STRUCTURED TESTS (Groups 1-9)
     Group 7: Copies — pre-allocated buffers, in-place accumulators, RMW
     Group 8: Tiled ops with outside consumers
     Group 9: Views — 1D sub-dim naming, reshape, view+transpose, unsqueeze
+    Group 10: Flash attention variants — v1/v2/v3/v4, parameterized by size and tile dims
 
     Tests marked loopspec=False, correctness=False are known broken and
     skipped; see inline comments for root cause.
@@ -74,6 +75,27 @@ _PREPARE_KERNEL = "torch_spyre.execution.kernel_runner.prepare_kernel"
 # ---------------------------------------------------------------------------
 
 
+class LoopSpecCheck:
+    """Callable loopspec checker passed as the loopspec= argument to run_coarse_tile_test.
+
+    loopspec=LoopSpecCheck()            — asserts LoopSpec( appears in generated source
+    loopspec=LoopSpecCheck(counts=[4,2]) — also checks count=sympify('N') for each N
+    loopspec=True                        — shorthand for LoopSpecCheck()
+    loopspec=False                       — skip loopspec check entirely
+    """
+
+    def __init__(self, counts=None):
+        self.counts = counts
+
+    def __call__(self, src):
+        assert "LoopSpec(" in src, f"Expected LoopSpec( in generated source:\n{src}"
+        if self.counts:
+            for count in self.counts:
+                assert f"count=sympify('{count}')" in src, (
+                    f"Expected count=sympify('{count}') in generated source:\n{src}"
+                )
+
+
 @dataclasses.dataclass
 class TensorSpec:
     """Descriptor for a test input tensor.
@@ -86,17 +108,21 @@ class TensorSpec:
                 are fused into one physical dim (e.g. flat [B, S, H*D] input
                 named ["batch_size", "max_seqlen", "num_heads", "head_dim"]).
                 When absent, sizes are inferred by zipping dims with shape.
+    value:      optional pre-built CPU tensor. When set, used directly instead
+                of torch.randn — shape and scale are ignored for tensor creation.
+                Useful for structured inputs like causal masks.
     """
 
     name: str
     shape: tuple
     dims: list
     named_dims: dict | None = dataclasses.field(default=None)
+    value: "torch.Tensor | None" = dataclasses.field(default=None)
 
 
-def tensor(name, *, shape, dims, named_dims=None):
+def tensor(name, *, shape, dims, named_dims=None, value=None):
     """Shorthand constructor for TensorSpec."""
-    return TensorSpec(name=name, shape=shape, dims=dims, named_dims=named_dims)
+    return TensorSpec(name=name, shape=shape, dims=dims, named_dims=named_dims, value=value)
 
 
 def run_coarse_tile_test(
@@ -108,15 +134,25 @@ def run_coarse_tile_test(
     rtol=None,
     scale=0.01,
 ):
-    """Compile fn on Spyre and check loopspec and/or correctness.
+    """Compile fn on Spyre once, then check loopspec and/or correctness.
 
     inputs: list of TensorSpec (from tensor(...)) — driver creates tensors,
         declares dims, and calls _name_tensor_dims before each compile.
 
-    loopspec: True  — assert "LoopSpec(" appears in generated source.
+    loopspec: LoopSpecCheck() or True — check generated source for LoopSpec.
+              LoopSpecCheck(counts=[4,2]) also checks specific tile counts.
+              False — skip loopspec check.
     correctness: True  — compare_with_cpu against CPU reference.
+
+    Always compiles exactly once, regardless of which checks are enabled.
     """
-    cpu_tensors = [torch.randn(s.shape, dtype=torch.float16) * scale for s in inputs]
+    if loopspec is True:
+        loopspec = LoopSpecCheck()
+
+    cpu_tensors = [
+        s.value if s.value is not None else torch.randn(s.shape, dtype=torch.float16) * scale
+        for s in inputs
+    ]
 
     def _setup_dims_and_dev_tensors():
         _pnd.reset()
@@ -132,19 +168,18 @@ def run_coarse_tile_test(
             _name_tensor_dims(t, spec.dims)
         return dev_tensors
 
+    with fresh_cache():
+        dev_tensors = _setup_dims_and_dev_tensors()
+        with (
+            mock_patch(_LAUNCH_JOBPLAN),
+            mock_patch(_PREPARE_KERNEL),
+            mock_patch("torch_spyre.execution.async_compile.subprocess.run"),
+        ):
+            _, source_codes = run_and_get_code(torch.compile(fn), *dev_tensors)
+
     if loopspec:
-        with fresh_cache():
-            dev_tensors = _setup_dims_and_dev_tensors()
-            cfn = torch.compile(fn)
-            with (
-                mock_patch(_LAUNCH_JOBPLAN),
-                mock_patch(_PREPARE_KERNEL),
-                mock_patch("torch_spyre.execution.async_compile.subprocess.run"),
-            ):
-                _, source_codes = run_and_get_code(cfn, *dev_tensors)
         assert len(source_codes) > 0
-        src = source_codes[0]
-        assert "LoopSpec(" in src, f"Expected LoopSpec( in generated source:\n{src}"
+        loopspec(source_codes[0])
 
     if correctness:
         dev_tensors = _setup_dims_and_dev_tensors()
@@ -170,7 +205,8 @@ def test_abs_256x256_A4():
 
     def fn(x):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            return torch.abs(x)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return torch.abs(x)
 
     run_coarse_tile_test(fn, inputs)
 
@@ -181,7 +217,8 @@ def test_abs_256x256_B4():
 
     def fn(x):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            return torch.abs(x)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return torch.abs(x)
 
     run_coarse_tile_test(fn, inputs)
 
@@ -193,7 +230,8 @@ def test_abs_256x256_A4_B4():
     def fn(x):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                return torch.abs(x)
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    return torch.abs(x)
 
     run_coarse_tile_test(fn, inputs)
 
@@ -210,7 +248,8 @@ def test_add_256x256_A4():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            return x + y
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -224,7 +263,8 @@ def test_add_256x256_B4():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            return x + y
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -239,7 +279,8 @@ def test_add_256x256_A4_B4():
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                return x + y
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -256,7 +297,8 @@ def test_add_512x256_A4():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            return x + y
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -270,7 +312,8 @@ def test_add_512x256_B4():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            return x + y
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -285,7 +328,8 @@ def test_add_512x256_A4_B4():
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                return x + y
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -302,7 +346,8 @@ def test_add_256x512_A4():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            return x + y
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -316,7 +361,8 @@ def test_add_256x512_B4():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            return x + y
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -331,7 +377,8 @@ def test_add_256x512_A4_B4():
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                return x + y
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -348,7 +395,8 @@ def test_add_512x512_A4():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            return x + y
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -362,7 +410,8 @@ def test_add_512x512_B4():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            return x + y
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -377,7 +426,8 @@ def test_add_512x512_A4_B4():
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                return x + y
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -395,7 +445,8 @@ def test_add_512x256_A4_B2():
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 2}):
-                return x + y
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -415,7 +466,8 @@ def test_add_3d_512x256x256_A4():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            return x + y
+            with spyre_hint(expected_named_dims=["A", "B", "C"]):
+                return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -429,7 +481,8 @@ def test_add_3d_512x256x256_B2():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"B": 2}):
-            return x + y
+            with spyre_hint(expected_named_dims=["A", "B", "C"]):
+                return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -443,7 +496,8 @@ def test_add_3d_512x256x256_C4():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"C": 4}):
-            return x + y
+            with spyre_hint(expected_named_dims=["A", "B", "C"]):
+                return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -458,7 +512,8 @@ def test_add_3d_512x256x256_A4_B2():
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 2}):
-                return x + y
+                with spyre_hint(expected_named_dims=["A", "B", "C"]):
+                    return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -473,7 +528,8 @@ def test_add_3d_512x256x256_A4_C4():
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"C": 4}):
-                return x + y
+                with spyre_hint(expected_named_dims=["A", "B", "C"]):
+                    return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -488,7 +544,8 @@ def test_add_3d_512x256x256_B2_C4():
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"B": 2}):
             with spyre_hint(num_tiles_per_dim={"C": 4}):
-                return x + y
+                with spyre_hint(expected_named_dims=["A", "B", "C"]):
+                    return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -504,7 +561,8 @@ def test_add_3d_512x256x256_A4_B2_C4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 2}):
                 with spyre_hint(num_tiles_per_dim={"C": 4}):
-                    return x + y
+                    with spyre_hint(expected_named_dims=["A", "B", "C"]):
+                        return x + y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -525,7 +583,8 @@ def test_abs_add_mul_512x256_A4():
 
     def fn(a, b, c):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            return torch.abs(a + b) * c
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return torch.abs(a + b) * c
 
     run_coarse_tile_test(fn, inputs)
 
@@ -540,7 +599,8 @@ def test_abs_add_mul_512x256_B4():
 
     def fn(a, b, c):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            return torch.abs(a + b) * c
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return torch.abs(a + b) * c
 
     run_coarse_tile_test(fn, inputs)
 
@@ -556,7 +616,8 @@ def test_abs_add_mul_512x256_A4_B4():
     def fn(a, b, c):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                return torch.abs(a + b) * c
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    return torch.abs(a + b) * c
 
     run_coarse_tile_test(fn, inputs)
 
@@ -571,7 +632,8 @@ def test_exp_abs_add_mul_512x256_A4():
 
     def fn(a, b, c):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            return torch.exp(torch.abs((a + b) * c))
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return torch.exp(torch.abs((a + b) * c))
 
     run_coarse_tile_test(fn, inputs)
 
@@ -586,7 +648,8 @@ def test_exp_abs_add_mul_512x256_B4():
 
     def fn(a, b, c):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            return torch.exp(torch.abs((a + b) * c))
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return torch.exp(torch.abs((a + b) * c))
 
     run_coarse_tile_test(fn, inputs)
 
@@ -602,7 +665,8 @@ def test_exp_abs_add_mul_512x256_A4_B4():
     def fn(a, b, c):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                return torch.exp(torch.abs((a + b) * c))
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    return torch.exp(torch.abs((a + b) * c))
 
     run_coarse_tile_test(fn, inputs)
 
@@ -620,7 +684,9 @@ def test_min_2d_512x256_reduce_dim0_A4():
 
     def fn(x):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            return x.amin(dim=0)
+            with spyre_hint(expected_named_dims=["B"],
+                            expected_reduction_dims=["A"]):
+                return x.amin(dim=0)
 
     run_coarse_tile_test(fn, inputs)
 
@@ -631,7 +697,9 @@ def test_min_2d_512x256_reduce_dim0_B4():
 
     def fn(x):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            return x.amin(dim=0)
+            with spyre_hint(expected_named_dims=["B"],
+                            expected_reduction_dims=["A"]):
+                return x.amin(dim=0)
 
     run_coarse_tile_test(fn, inputs)
 
@@ -643,7 +711,9 @@ def test_min_2d_512x256_reduce_dim0_A4_B4():
     def fn(x):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                return x.amin(dim=0)
+                with spyre_hint(expected_named_dims=["B"],
+                                expected_reduction_dims=["A"]):
+                    return x.amin(dim=0)
 
     run_coarse_tile_test(
         fn, inputs, correctness=False
@@ -656,7 +726,9 @@ def test_min_2d_512x256_reduce_dim1_A4():
 
     def fn(x):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            return x.amin(dim=1)
+            with spyre_hint(expected_named_dims=["A"],
+                            expected_reduction_dims=["B"]):
+                return x.amin(dim=1)
 
     run_coarse_tile_test(fn, inputs)
 
@@ -667,7 +739,9 @@ def test_min_2d_512x256_reduce_dim1_B4():
 
     def fn(x):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            return x.amin(dim=1)
+            with spyre_hint(expected_named_dims=["A"],
+                            expected_reduction_dims=["B"]):
+                return x.amin(dim=1)
 
     run_coarse_tile_test(fn, inputs)
 
@@ -679,14 +753,16 @@ def test_min_2d_512x256_reduce_dim1_A4_B4():
     def fn(x):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                return x.amin(dim=1)
+                with spyre_hint(expected_named_dims=["A"],
+                                expected_reduction_dims=["B"]):
+                    return x.amin(dim=1)
 
     run_coarse_tile_test(
         fn, inputs, correctness=False
     )  # nested tiling + reduction correctness bug
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="inconsistent loop_count across reduction fill/combine nodes")
 def test_min_3d_512x256x256_reduce_dim0_A4_B2_C4():
     """amin over dim=0 on [512,256,256] tiled A÷4 B÷2 C÷4."""
     inputs = [tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"])]
@@ -695,14 +771,16 @@ def test_min_3d_512x256x256_reduce_dim0_A4_B2_C4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 2}):
                 with spyre_hint(num_tiles_per_dim={"C": 4}):
-                    return x.amin(dim=0)
+                    with spyre_hint(expected_named_dims=["B", "C"],
+                                    expected_reduction_dims=["A"]):
+                        return x.amin(dim=0)
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
     )  # scheduler crash: inconsistent loop_count across reduction fill/combine nodes
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="inconsistent loop_count across reduction fill/combine nodes")
 def test_min_3d_512x256x256_reduce_dim1_A4_B2_C4():
     """amin over dim=1 on [512,256,256] tiled A÷4 B÷2 C÷4."""
     inputs = [tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"])]
@@ -711,7 +789,9 @@ def test_min_3d_512x256x256_reduce_dim1_A4_B2_C4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 2}):
                 with spyre_hint(num_tiles_per_dim={"C": 4}):
-                    return x.amin(dim=1)
+                    with spyre_hint(expected_named_dims=["A", "C"],
+                                    expected_reduction_dims=["B"]):
+                        return x.amin(dim=1)
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
@@ -726,7 +806,9 @@ def test_min_3d_512x256x256_reduce_dim2_A4_B2_C4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 2}):
                 with spyre_hint(num_tiles_per_dim={"C": 4}):
-                    return x.amin(dim=2)
+                    with spyre_hint(expected_named_dims=["A", "B"],
+                                    expected_reduction_dims=["C"]):
+                        return x.amin(dim=2)
 
     run_coarse_tile_test(
         fn, inputs, correctness=False
@@ -751,7 +833,12 @@ def test_add_min_2d_512x256_reduce_dim0_A4():
 
     def fn(a, b):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            return a + torch.abs(b.amin(dim=0))
+            with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
+                r = b.amin(dim=0)
+            with spyre_hint(expected_named_dims=["B"]):
+                temp = torch.abs(r)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return a + temp
 
     run_coarse_tile_test(fn, inputs)
 
@@ -765,7 +852,12 @@ def test_add_min_2d_512x256_reduce_dim0_B4():
 
     def fn(a, b):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            return a + torch.abs(b.amin(dim=0))
+            with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
+                r = b.amin(dim=0)
+            with spyre_hint(expected_named_dims=["B"]):
+                temp = torch.abs(r)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return a + temp
 
     run_coarse_tile_test(fn, inputs)
 
@@ -780,7 +872,12 @@ def test_add_min_2d_512x256_reduce_dim0_A4_B4():
     def fn(a, b):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                return a + torch.abs(b.amin(dim=0))
+                with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
+                    r = b.amin(dim=0)
+                with spyre_hint(expected_named_dims=["B"]):
+                    temp = torch.abs(r)
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    return a + temp
 
     run_coarse_tile_test(fn, inputs)
 
@@ -794,7 +891,12 @@ def test_add_min_2d_512x256_reduce_dim1_A4():
 
     def fn(a, b):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            return a + torch.abs(b.amin(dim=1, keepdim=True))
+            with spyre_hint(expected_named_dims=["A"], expected_reduction_dims=["B"]):
+                r = b.amin(dim=1, keepdim=True)
+            with spyre_hint(expected_named_dims=["A"]):
+                temp = torch.abs(r)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return a + temp
 
     run_coarse_tile_test(fn, inputs)
 
@@ -808,7 +910,12 @@ def test_add_min_2d_512x256_reduce_dim1_B4():
 
     def fn(a, b):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            return a + torch.abs(b.amin(dim=1, keepdim=True))
+            with spyre_hint(expected_named_dims=["A"], expected_reduction_dims=["B"]):
+                r = b.amin(dim=1, keepdim=True)
+            with spyre_hint(expected_named_dims=["A"]):
+                temp = torch.abs(r)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return a + temp
 
     run_coarse_tile_test(fn, inputs)
 
@@ -823,12 +930,17 @@ def test_add_min_2d_512x256_reduce_dim1_A4_B4():
     def fn(a, b):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                return a + torch.abs(b.amin(dim=1, keepdim=True))
+                with spyre_hint(expected_named_dims=["A"], expected_reduction_dims=["B"]):
+                    r = b.amin(dim=1, keepdim=True)
+                with spyre_hint(expected_named_dims=["A"]):
+                    temp = torch.abs(r)
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    return a + temp
 
     run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="inconsistent loop_count across reduction fill/combine nodes")
 def test_add_min_3d_512x256x256_reduce_dim0_A4_B2_C4():
     """min(a + abs(amin(b, dim=0))) on [512,256,256] tiled A÷4 B÷2 C÷4."""
     inputs = [
@@ -840,14 +952,19 @@ def test_add_min_3d_512x256x256_reduce_dim0_A4_B2_C4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 2}):
                 with spyre_hint(num_tiles_per_dim={"C": 4}):
-                    return a + torch.abs(b.amin(dim=0))
+                    with spyre_hint(expected_named_dims=["B", "C"], expected_reduction_dims=["A"]):
+                        r = b.amin(dim=0)
+                    with spyre_hint(expected_named_dims=["B", "C"]):
+                        temp = torch.abs(r)
+                    with spyre_hint(expected_named_dims=["A", "B", "C"]):
+                        return a + temp
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
     )  # scheduler crash: mixed loop counts in 3D nested tiling + reduction
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="inconsistent loop_count across reduction fill/combine nodes")
 def test_add_min_3d_512x256x256_reduce_dim1_A4_B2_C4():
     """min(a + abs(amin(b, dim=1))) on [512,256,256] tiled A÷4 B÷2 C÷4."""
     inputs = [
@@ -859,14 +976,19 @@ def test_add_min_3d_512x256x256_reduce_dim1_A4_B2_C4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 2}):
                 with spyre_hint(num_tiles_per_dim={"C": 4}):
-                    return a + torch.abs(b.amin(dim=1))
+                    with spyre_hint(expected_named_dims=["A", "C"], expected_reduction_dims=["B"]):
+                        r = b.amin(dim=1)
+                    with spyre_hint(expected_named_dims=["A", "C"]):
+                        temp = torch.abs(r)
+                    with spyre_hint(expected_named_dims=["A", "B", "C"]):
+                        return a + temp
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
     )  # scheduler crash: mixed loop counts in 3D nested tiling + reduction
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="inconsistent loop_count across reduction fill/combine nodes")
 def test_add_min_3d_512x256x256_reduce_dim2_A4_B2_C4():
     """min(a + abs(amin(b, dim=2))) on [512,256,256] tiled A÷4 B÷2 C÷4."""
     inputs = [
@@ -878,7 +1000,12 @@ def test_add_min_3d_512x256x256_reduce_dim2_A4_B2_C4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 2}):
                 with spyre_hint(num_tiles_per_dim={"C": 4}):
-                    return a + torch.abs(b.amin(dim=2))
+                    with spyre_hint(expected_named_dims=["A", "B"], expected_reduction_dims=["C"]):
+                        r = b.amin(dim=2)
+                    with spyre_hint(expected_named_dims=["A", "B"]):
+                        temp = torch.abs(r)
+                    with spyre_hint(expected_named_dims=["A", "B", "C"]):
+                        return a + temp
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
@@ -898,7 +1025,8 @@ def test_reduce_both_dense_add_2d_512x256_A4():
 
     def fn(a, b):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            return a.amin(dim=0) + b.amin(dim=0)
+            with spyre_hint(expected_named_dims=["B"]):
+                return a.amin(dim=0) + b.amin(dim=0)
 
     run_coarse_tile_test(fn, inputs)
 
@@ -912,7 +1040,8 @@ def test_reduce_both_dense_add_2d_512x256_B4():
 
     def fn(a, b):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            return a.amin(dim=0) + b.amin(dim=0)
+            with spyre_hint(expected_named_dims=["B"]):
+                return a.amin(dim=0) + b.amin(dim=0)
 
     run_coarse_tile_test(fn, inputs)
 
@@ -927,7 +1056,8 @@ def test_reduce_both_dense_add_2d_512x256_A4_B4():
     def fn(a, b):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                return a.amin(dim=0) + b.amin(dim=0)
+                with spyre_hint(expected_named_dims=["B"]):
+                    return a.amin(dim=0) + b.amin(dim=0)
 
     run_coarse_tile_test(fn, inputs)
 
@@ -941,7 +1071,8 @@ def test_reduce_both_sparse_add_2d_512x256_A4():
 
     def fn(a, b):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            return a.amin(dim=1) + b.amin(dim=1)
+            with spyre_hint(expected_named_dims=["A"]):
+                return a.amin(dim=1) + b.amin(dim=1)
 
     run_coarse_tile_test(fn, inputs)
 
@@ -955,7 +1086,8 @@ def test_reduce_both_sparse_add_2d_512x256_B4():
 
     def fn(a, b):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            return a.amin(dim=1) + b.amin(dim=1)
+            with spyre_hint(expected_named_dims=["A"]):
+                return a.amin(dim=1) + b.amin(dim=1)
 
     run_coarse_tile_test(fn, inputs)
 
@@ -970,7 +1102,8 @@ def test_reduce_both_sparse_add_2d_512x256_A4_B4():
     def fn(a, b):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                return a.amin(dim=1) + b.amin(dim=1)
+                with spyre_hint(expected_named_dims=["A"]):
+                    return a.amin(dim=1) + b.amin(dim=1)
 
     run_coarse_tile_test(fn, inputs)
 
@@ -1056,7 +1189,7 @@ def test_softmax_2d_512x256_dim0_A4_B4():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
 def test_restickify_add_256x128_A2():
     """a.t() + x on [128,256] result, tiled A÷2 → 64 elems/tile (1 stick)."""
     inputs = [
@@ -1066,14 +1199,15 @@ def test_restickify_add_256x128_A2():
 
     def fn(a, x):
         with spyre_hint(num_tiles_per_dim={"A": 2}):
-            return a.t() + x
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return a.t() + x
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+    )
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
 def test_restickify_add_256x128_B4():
     """a.t() + x on [128,256] result, tiled B÷4 → 64 elems/tile (1 stick)."""
     inputs = [
@@ -1083,14 +1217,15 @@ def test_restickify_add_256x128_B4():
 
     def fn(a, x):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            return a.t() + x
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return a.t() + x
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+    )
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
 def test_restickify_add_256x128_A2_B4():
     """a.t() + x on [128,256] result, tiled A÷2 B÷4 → 64 elems/tile each."""
     inputs = [
@@ -1101,11 +1236,12 @@ def test_restickify_add_256x128_A2_B4():
     def fn(a, x):
         with spyre_hint(num_tiles_per_dim={"A": 2}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                return a.t() + x
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    return a.t() + x
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+    )
 
 
 # 2D two-transpose: a.t() + b.t() + x
@@ -1113,7 +1249,7 @@ def test_restickify_add_256x128_A2_B4():
 # A÷2=64/tile (1 stick), B÷4=64/tile (1 stick)
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="Unsupported: unexpected stick expression d0+d1")
 def test_restickify_2t_add_256x128_A2():
     """a.t()+b.t()+x on [128,256] result, tiled A÷2."""
     inputs = [
@@ -1124,14 +1260,15 @@ def test_restickify_2t_add_256x128_A2():
 
     def fn(a, b, x):
         with spyre_hint(num_tiles_per_dim={"A": 2}):
-            return a.t() + b.t() + x
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return a.t() + b.t() + x
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
     )  # d0+d1 stick expr bug: two restickified inputs produce unsupported stick expression
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="Unsupported: unexpected stick expression d0+d1")
 def test_restickify_2t_add_256x128_B4():
     """a.t()+b.t()+x on [128,256] result, tiled B÷4."""
     inputs = [
@@ -1142,14 +1279,15 @@ def test_restickify_2t_add_256x128_B4():
 
     def fn(a, b, x):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            return a.t() + b.t() + x
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return a.t() + b.t() + x
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
     )  # d0+d1 stick expr bug
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="Unsupported: unexpected stick expression d0+d1")
 def test_restickify_2t_add_256x128_A2_B4():
     """a.t()+b.t()+x on [128,256] result, tiled A÷2 B÷4."""
     inputs = [
@@ -1161,7 +1299,8 @@ def test_restickify_2t_add_256x128_A2_B4():
     def fn(a, b, x):
         with spyre_hint(num_tiles_per_dim={"A": 2}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                return a.t() + b.t() + x
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    return a.t() + b.t() + x
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
@@ -1173,7 +1312,7 @@ def test_restickify_2t_add_256x128_A2_B4():
 # A÷4=64/tile, B÷4=64/tile, C÷4=128/tile (2 sticks)
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
 def test_restickify_3d_transpose12_256x512x256_A4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4."""
     inputs = [
@@ -1183,14 +1322,15 @@ def test_restickify_3d_transpose12_256x512x256_A4():
 
     def fn(a, x):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            return a.transpose(1, 2) + x
+            with spyre_hint(expected_named_dims=["A", "B", "C"]):
+                return a.transpose(1, 2) + x
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+    )
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
 def test_restickify_3d_transpose12_256x512x256_B4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled B÷4."""
     inputs = [
@@ -1200,14 +1340,15 @@ def test_restickify_3d_transpose12_256x512x256_B4():
 
     def fn(a, x):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            return a.transpose(1, 2) + x
+            with spyre_hint(expected_named_dims=["A", "B", "C"]):
+                return a.transpose(1, 2) + x
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+    )
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
 def test_restickify_3d_transpose12_256x512x256_C4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled C÷4."""
     inputs = [
@@ -1217,14 +1358,15 @@ def test_restickify_3d_transpose12_256x512x256_C4():
 
     def fn(a, x):
         with spyre_hint(num_tiles_per_dim={"C": 4}):
-            return a.transpose(1, 2) + x
+            with spyre_hint(expected_named_dims=["A", "B", "C"]):
+                return a.transpose(1, 2) + x
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+    )
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
 def test_restickify_3d_transpose12_256x512x256_A4_B4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4 B÷4."""
     inputs = [
@@ -1235,14 +1377,15 @@ def test_restickify_3d_transpose12_256x512x256_A4_B4():
     def fn(a, x):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                return a.transpose(1, 2) + x
+                with spyre_hint(expected_named_dims=["A", "B", "C"]):
+                    return a.transpose(1, 2) + x
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+    )
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
 def test_restickify_3d_transpose12_256x512x256_A4_C4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4 C÷4."""
     inputs = [
@@ -1253,14 +1396,15 @@ def test_restickify_3d_transpose12_256x512x256_A4_C4():
     def fn(a, x):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"C": 4}):
-                return a.transpose(1, 2) + x
+                with spyre_hint(expected_named_dims=["A", "B", "C"]):
+                    return a.transpose(1, 2) + x
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+    )
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
 def test_restickify_3d_transpose12_256x512x256_B4_C4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled B÷4 C÷4."""
     inputs = [
@@ -1271,14 +1415,15 @@ def test_restickify_3d_transpose12_256x512x256_B4_C4():
     def fn(a, x):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
             with spyre_hint(num_tiles_per_dim={"C": 4}):
-                return a.transpose(1, 2) + x
+                with spyre_hint(expected_named_dims=["A", "B", "C"]):
+                    return a.transpose(1, 2) + x
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
     )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
 def test_restickify_3d_transpose12_256x512x256_A4_B4_C4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4 B÷4 C÷4."""
     inputs = [
@@ -1290,11 +1435,12 @@ def test_restickify_3d_transpose12_256x512x256_A4_B4_C4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
                 with spyre_hint(num_tiles_per_dim={"C": 4}):
-                    return a.transpose(1, 2) + x
+                    with spyre_hint(expected_named_dims=["A", "B", "C"]):
+                        return a.transpose(1, 2) + x
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+    )
 
 
 # Matmul + transpose: x.t()@y and x@y.t()
@@ -1304,7 +1450,7 @@ def test_restickify_3d_transpose12_256x512x256_A4_B4_C4():
 # For x@y.t() result [128,128]: M=128, N=128; M÷2=64, N÷2=64
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
 def test_restickify_matmul_xt_y_256x128_M4():
     """x.t()@y, result [256,256], tiled M÷4."""
     inputs = [
@@ -1314,14 +1460,15 @@ def test_restickify_matmul_xt_y_256x128_M4():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"M": 4}):
-            return torch.matmul(x.t(), y)
+            with spyre_hint(expected_named_dims=["M", "N"]):
+                return torch.matmul(x.t(), y)
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+    )
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
 def test_restickify_matmul_xt_y_256x128_N4():
     """x.t()@y, result [256,256], tiled N÷4."""
     inputs = [
@@ -1331,14 +1478,15 @@ def test_restickify_matmul_xt_y_256x128_N4():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"N": 4}):
-            return torch.matmul(x.t(), y)
+            with spyre_hint(expected_named_dims=["M", "N"]):
+                return torch.matmul(x.t(), y)
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+    )
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
 def test_restickify_matmul_xt_y_256x128_M4_N4():
     """x.t()@y, result [256,256], tiled M÷4 N÷4."""
     inputs = [
@@ -1349,14 +1497,15 @@ def test_restickify_matmul_xt_y_256x128_M4_N4():
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"M": 4}):
             with spyre_hint(num_tiles_per_dim={"N": 4}):
-                return torch.matmul(x.t(), y)
+                with spyre_hint(expected_named_dims=["M", "N"]):
+                    return torch.matmul(x.t(), y)
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+    )
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
 def test_restickify_matmul_x_yt_128x256_M2():
     """x@y.t(), result [128,128], tiled M÷2."""
     inputs = [
@@ -1366,14 +1515,15 @@ def test_restickify_matmul_x_yt_128x256_M2():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"M": 2}):
-            return torch.matmul(x, y.t())
+            with spyre_hint(expected_named_dims=["M", "N"]):
+                return torch.matmul(x, y.t())
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+    )
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
 def test_restickify_matmul_x_yt_128x256_N2():
     """x@y.t(), result [128,128], tiled N÷2."""
     inputs = [
@@ -1383,14 +1533,15 @@ def test_restickify_matmul_x_yt_128x256_N2():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"N": 2}):
-            return torch.matmul(x, y.t())
+            with spyre_hint(expected_named_dims=["M", "N"]):
+                return torch.matmul(x, y.t())
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+    )
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
 def test_restickify_matmul_x_yt_128x256_M2_N2():
     """x@y.t(), result [128,128], tiled M÷2 N÷2."""
     inputs = [
@@ -1401,11 +1552,12 @@ def test_restickify_matmul_x_yt_128x256_M2_N2():
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"M": 2}):
             with spyre_hint(num_tiles_per_dim={"N": 2}):
-                return torch.matmul(x, y.t())
+                with spyre_hint(expected_named_dims=["M", "N"]):
+                    return torch.matmul(x, y.t())
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1428,7 +1580,8 @@ def test_copy_into_preallocated_512x256_A4():
     def fn(a, b):
         c = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            c.copy_(a + b)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                c.copy_(a + b)
         return c
 
     run_coarse_tile_test(fn, inputs)
@@ -1444,7 +1597,8 @@ def test_copy_into_preallocated_512x256_B4():
     def fn(a, b):
         c = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            c.copy_(a + b)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                c.copy_(a + b)
         return c
 
     run_coarse_tile_test(fn, inputs)
@@ -1461,7 +1615,8 @@ def test_copy_into_preallocated_512x256_A4_B4():
         c = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                c.copy_(a + b)
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    c.copy_(a + b)
         return c
 
     run_coarse_tile_test(fn, inputs)
@@ -1479,7 +1634,8 @@ def test_copy_inplace_accum_512x256_A4():
 
     def fn(acc, x):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            acc.copy_(acc + x)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                acc.copy_(acc + x)
         return acc
 
     run_coarse_tile_test(fn, inputs)
@@ -1494,7 +1650,8 @@ def test_copy_inplace_accum_512x256_B4():
 
     def fn(acc, x):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            acc.copy_(acc + x)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                acc.copy_(acc + x)
         return acc
 
     run_coarse_tile_test(fn, inputs)
@@ -1510,7 +1667,8 @@ def test_copy_inplace_accum_512x256_A4_B4():
     def fn(acc, x):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                acc.copy_(acc + x)
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    acc.copy_(acc + x)
         return acc
 
     run_coarse_tile_test(fn, inputs)
@@ -1530,7 +1688,8 @@ def test_copy_rmw_correction_512x256_A4():
 
     def fn(acc, scale, y):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            acc.copy_(acc * scale + y)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                acc.copy_(acc * scale + y)
         return acc
 
     run_coarse_tile_test(fn, inputs)
@@ -1546,7 +1705,8 @@ def test_copy_rmw_correction_512x256_B4():
 
     def fn(acc, scale, y):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            acc.copy_(acc * scale + y)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                acc.copy_(acc * scale + y)
         return acc
 
     run_coarse_tile_test(fn, inputs)
@@ -1563,7 +1723,8 @@ def test_copy_rmw_correction_512x256_A4_B4():
     def fn(acc, scale, y):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                acc.copy_(acc * scale + y)
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    acc.copy_(acc * scale + y)
         return acc
 
     run_coarse_tile_test(fn, inputs)
@@ -1580,7 +1741,8 @@ def test_copy_after_reduction_512x256_A4():
     def fn(x):
         out = torch.zeros(256, device=x.device, dtype=x.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            out.copy_(x.amin(dim=0))
+            with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
+                out.copy_(x.amin(dim=0))
         return out
 
     run_coarse_tile_test(fn, inputs)
@@ -1593,7 +1755,8 @@ def test_copy_after_reduction_512x256_B4():
     def fn(x):
         out = torch.zeros(256, device=x.device, dtype=x.dtype)
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            out.copy_(x.amin(dim=0))
+            with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
+                out.copy_(x.amin(dim=0))
         return out
 
     run_coarse_tile_test(fn, inputs)
@@ -1607,19 +1770,46 @@ def test_copy_after_reduction_512x256_A4_B4():
         out = torch.zeros(256, device=x.device, dtype=x.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                out.copy_(x.amin(dim=0))
+                with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
+                    out.copy_(x.amin(dim=0))
         return out
 
     run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_running_max_4d_H4_Lq4():
+    """running_max.copy_(maximum(real_max, amax(scores,dim=-2))) on [B,H,Lk,Lq] tiled H÷4 Lq÷4.
+
+    Minimal flash-attention-style reproducer: 4D scores [B,H,Lk,Lq] reduced over
+    dim=-2 (Lk), then max with a running accumulator, then copy_ back.
+    """
+    B, H, Lk, Lq = 2, 32, 4096, 4096
+    h_block_size = 4
+    lq_block_size = 1024
+
+    inputs = [tensor("scores", shape=(B, H, Lk, Lq), dims=["B", "H", "Lk", "Lq"])]
+
+    def fn(scores):
+        real_max = torch.full(
+            (B, H, Lq), float("-inf"), device=scores.device, dtype=scores.dtype
+        )
+        with spyre_hint(num_tiles_per_dim={"H": H // h_block_size}):
+            with spyre_hint(num_tiles_per_dim={"Lq": Lq // lq_block_size}):
+                with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
+                    block_max = torch.amax(scores, dim=-2)
+                with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                    running_max = torch.maximum(real_max, block_max)
+                real_max.copy_(running_max)
+        return real_max
+
+    run_coarse_tile_test(fn, inputs, loopspec=True, correctness=True)
 
 
 # --- copy + restickify: c.copy_(a.t() + b) ---
 # copy target receives a restickified input — tests copy layout after restickify
 
 
-@pytest.mark.skip(
-    reason="KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
 def test_copy_restickify_512x256_A4():
     """c.copy_(a.t()+b) on [256,512] result tiled A÷4 — copy of restickified add."""
     inputs = [
@@ -1630,17 +1820,16 @@ def test_copy_restickify_512x256_A4():
     def fn(a, b):
         c = torch.zeros(b.shape, device=b.device, dtype=b.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            c.copy_(a.t() + b)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                c.copy_(a.t() + b)
         return c
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+    )
 
 
-@pytest.mark.skip(
-    reason="KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
 def test_copy_restickify_512x256_B4():
     """c.copy_(a.t()+b) on [256,512] result tiled B÷4."""
     inputs = [
@@ -1651,17 +1840,16 @@ def test_copy_restickify_512x256_B4():
     def fn(a, b):
         c = torch.zeros(b.shape, device=b.device, dtype=b.dtype)
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            c.copy_(a.t() + b)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                c.copy_(a.t() + b)
         return c
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381
+    )
 
 
-@pytest.mark.skip(
-    reason="KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
 def test_copy_restickify_512x256_A4_B4():
     """c.copy_(a.t()+b) on [256,512] result tiled A÷4 B÷4."""
     inputs = [
@@ -1673,12 +1861,13 @@ def test_copy_restickify_512x256_A4_B4():
         c = torch.zeros(b.shape, device=b.device, dtype=b.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                c.copy_(a.t() + b)
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    c.copy_(a.t() + b)
         return c
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381
+    )
 
 
 # --- nested copy + reduction: acc.copy_(acc * scale + x.amin(dim=1, keepdim=True)) ---
@@ -1695,13 +1884,16 @@ def test_copy_accum_with_reduction_512x256_A4():
 
     def fn(acc, scale, x):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            acc.copy_(acc * scale + x.amin(dim=1, keepdim=True))
+            with spyre_hint(expected_named_dims=["A"], expected_reduction_dims=["B"]):
+                r = x.amin(dim=1, keepdim=True)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                acc.copy_(acc * scale + r)
         return acc
 
     run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="IndexError: _insert_read_copy_ops fails when tiling B with unit-size B dim in scale")
 def test_copy_accum_with_reduction_512x256_B4():
     """acc.copy_(acc * scale + x.amin(dim=1,keepdim=True)) tiled B÷4."""
     inputs = [
@@ -1712,15 +1904,18 @@ def test_copy_accum_with_reduction_512x256_B4():
 
     def fn(acc, scale, x):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            acc.copy_(acc * scale + x.amin(dim=1, keepdim=True))
+            with spyre_hint(expected_named_dims=["A"], expected_reduction_dims=["B"]):
+                r = x.amin(dim=1, keepdim=True)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                acc.copy_(acc * scale + r)
         return acc
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381 _insert_read_copy_ops IndexError when tiling B with unit-size B dim in scale
+    )
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="IndexError: _insert_read_copy_ops fails when tiling B with unit-size B dim in scale")
 def test_copy_accum_with_reduction_512x256_A4_B4():
     """acc.copy_(acc * scale + x.amin(dim=1,keepdim=True)) tiled A÷4 B÷4."""
     inputs = [
@@ -1732,12 +1927,15 @@ def test_copy_accum_with_reduction_512x256_A4_B4():
     def fn(acc, scale, x):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                acc.copy_(acc * scale + x.amin(dim=1, keepdim=True))
+                with spyre_hint(expected_named_dims=["A"], expected_reduction_dims=["B"]):
+                    r = x.amin(dim=1, keepdim=True)
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    acc.copy_(acc * scale + r)
         return acc
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: PR #3381 _insert_read_copy_ops IndexError when tiling B with unit-size B dim in scale
+    )
 
 
 # --- two copies in same hint scope: c1.copy_(a+b); c2.copy_(a*b) ---
@@ -1754,8 +1952,10 @@ def test_copy_two_copies_same_scope_512x256_A4():
         c1 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
         c2 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            c1.copy_(a + b)
-            c2.copy_(a * b)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                c1.copy_(a + b)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                c2.copy_(a * b)
         return c1, c2
 
     run_coarse_tile_test(fn, inputs)
@@ -1772,8 +1972,10 @@ def test_copy_two_copies_same_scope_512x256_B4():
         c1 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
         c2 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            c1.copy_(a + b)
-            c2.copy_(a * b)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                c1.copy_(a + b)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                c2.copy_(a * b)
         return c1, c2
 
     run_coarse_tile_test(fn, inputs)
@@ -1791,8 +1993,10 @@ def test_copy_two_copies_same_scope_512x256_A4_B4():
         c2 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                c1.copy_(a + b)
-                c2.copy_(a * b)
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    c1.copy_(a + b)
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    c2.copy_(a * b)
         return c1, c2
 
     run_coarse_tile_test(fn, inputs)
@@ -1819,7 +2023,8 @@ def test_outside_consumer_pointwise_512x256_A4():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            z = x + y
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                z = x + y
         return z * 2.0
 
     run_coarse_tile_test(fn, inputs)
@@ -1834,7 +2039,8 @@ def test_outside_consumer_pointwise_512x256_B4():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            z = x + y
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                z = x + y
         return z * 2.0
 
     run_coarse_tile_test(fn, inputs)
@@ -1850,7 +2056,8 @@ def test_outside_consumer_pointwise_512x256_A4_B4():
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                z = x + y
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    z = x + y
         return z * 2.0
 
     run_coarse_tile_test(fn, inputs)
@@ -1871,7 +2078,8 @@ def test_outside_consumer_copy_then_read_512x256_A4():
     def fn(x, y, norm):
         out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            out.copy_(x + y)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                out.copy_(x + y)
         return out / (torch.abs(norm) + 1.0)
 
     run_coarse_tile_test(fn, inputs)
@@ -1888,7 +2096,8 @@ def test_outside_consumer_copy_then_read_512x256_B4():
     def fn(x, y, norm):
         out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            out.copy_(x + y)
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                out.copy_(x + y)
         return out / (torch.abs(norm) + 1.0)
 
     run_coarse_tile_test(fn, inputs)
@@ -1906,7 +2115,8 @@ def test_outside_consumer_copy_then_read_512x256_A4_B4():
         out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                out.copy_(x + y)
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    out.copy_(x + y)
         return out / (torch.abs(norm) + 1.0)
 
     run_coarse_tile_test(fn, inputs)
@@ -1917,7 +2127,7 @@ def test_outside_consumer_copy_then_read_512x256_A4_B4():
 # This is the minimal flash attention accumulator pattern.
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="infeasible restickify for 1D denom in mixed 1D/2D tiled scope")
 def test_outside_consumer_two_accum_512x256_A4():
     """Flash-style: out=zeros, denom=zeros; tiled copy_; return out/denom — A÷4."""
     inputs = [
@@ -1929,16 +2139,17 @@ def test_outside_consumer_two_accum_512x256_A4():
         out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
         denom = torch.zeros(x.shape[0], device=x.device, dtype=x.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            out.copy_(out * scale + x)
-            denom.copy_(denom + x.sum(dim=1))
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                out.copy_(out * scale + x)
+            with spyre_hint(expected_named_dims=["A"]):
+                denom.copy_(denom + x.sum(dim=1))
         return out / denom.unsqueeze(1)
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: infeasible restickify for 1D denom in mixed 1D/2D tiled scope
+    )
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
 def test_outside_consumer_two_accum_512x256_B4():
     """Flash-style: out=zeros, denom=zeros; tiled copy_; return out/denom — B÷4."""
     inputs = [
@@ -1950,16 +2161,18 @@ def test_outside_consumer_two_accum_512x256_B4():
         out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
         denom = torch.zeros(x.shape[0], device=x.device, dtype=x.dtype)
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            out.copy_(out * scale + x)
-            denom.copy_(denom + x.sum(dim=1))
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                out.copy_(out * scale + x)
+            with spyre_hint(expected_named_dims=["A"]):
+                denom.copy_(denom + x.sum(dim=1))
         return out / denom.unsqueeze(1)
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: infeasible restickify for 1D denom in mixed 1D/2D tiled scope
+    )
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
+@pytest.mark.skip(reason="infeasible restickify for 1D denom in mixed 1D/2D tiled scope")
 def test_outside_consumer_two_accum_512x256_A4_B4():
     """Flash-style: out=zeros, denom=zeros; tiled copy_; return out/denom — A÷4 B÷4."""
     inputs = [
@@ -1972,13 +2185,15 @@ def test_outside_consumer_two_accum_512x256_A4_B4():
         denom = torch.zeros(x.shape[0], device=x.device, dtype=x.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                out.copy_(out * scale + x)
-                denom.copy_(denom + x.sum(dim=1))
+                with spyre_hint(expected_named_dims=["A", "B"]):
+                    out.copy_(out * scale + x)
+                with spyre_hint(expected_named_dims=["A"]):
+                    denom.copy_(denom + x.sum(dim=1))
         return out / denom.unsqueeze(1)
 
     run_coarse_tile_test(
         fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: infeasible restickify for 1D denom in mixed 1D/2D tiled scope
+    )
 
 
 # --- reduction inside loop, result consumed outside ---
@@ -1995,7 +2210,8 @@ def test_outside_consumer_reduction_512x256_A4():
 
     def fn(x, bias):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            s = x.amin(dim=0)
+            with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
+                s = x.amin(dim=0)
         return s + bias
 
     run_coarse_tile_test(fn, inputs)
@@ -2010,7 +2226,8 @@ def test_outside_consumer_reduction_512x256_B4():
 
     def fn(x, bias):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            s = x.amin(dim=0)
+            with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
+                s = x.amin(dim=0)
         return s + bias
 
     run_coarse_tile_test(fn, inputs)
@@ -2026,7 +2243,8 @@ def test_outside_consumer_reduction_512x256_A4_B4():
     def fn(x, bias):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                s = x.amin(dim=0)
+                with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
+                    s = x.amin(dim=0)
         return s + bias
 
     run_coarse_tile_test(fn, inputs)
@@ -2045,14 +2263,17 @@ def test_view_1d_subdim_Lq2_D2():
     """a*b on 1D [Lq*D] named ["Lq","D"], nested Lq÷2 / D÷2 on same host dim."""
     Lq, D = 256, 128
     inputs = [
-        tensor("a", shape=(Lq * D,), dims=["Lq", "D"]),
-        tensor("b", shape=(Lq * D,), dims=["Lq", "D"]),
+        tensor("a", shape=(Lq * D,), dims=["Lq", "D"], named_dims={"Lq": Lq, "D": D}),
+        tensor("b", shape=(Lq * D,), dims=["Lq", "D"], named_dims={"Lq": Lq, "D": D}),
     ]
 
     def fn(a, b):
+        a = a.view(Lq, D)
+        b = b.view(Lq, D)
         with spyre_hint(num_tiles_per_dim={"Lq": 2}):
             with spyre_hint(num_tiles_per_dim={"D": 2}):
-                return a * b
+                with spyre_hint(expected_named_dims=["Lq", "D"]):
+                    return a * b
 
     run_coarse_tile_test(fn, inputs)
 
@@ -2063,7 +2284,6 @@ def test_view_1d_subdim_Lq2_D2():
 # B=2, S=256, H=4, D=64 → flat shape [2,256,256]; post-view+transpose [2,4,256,64]
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
 def test_view_named_input_view_transpose_H2():
     """flat [B,S,H*D] view+transpose before hint scope, tiled H÷2."""
     B, S, H, D = 2, 256, 8, 128
@@ -2087,14 +2307,14 @@ def test_view_named_input_view_transpose_H2():
         q = q.view(B, S, H, D).transpose(1, 2)
         k = k.view(B, S, H, D).transpose(1, 2)
         with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
-            return q * k
+            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen", "head_dim"]):
+                return q * k
 
     run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: propagate_named_dims can't handle multi-var coord for fused dim after view+transpose
+        fn, inputs, loopspec=True, correctness=True
+    )
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
 def test_view_named_input_view_transpose_S4():
     """flat [B,S,H*D] view+transpose before hint scope, tiled S÷4."""
     B, S, H, D = 2, 256, 8, 128
@@ -2118,14 +2338,14 @@ def test_view_named_input_view_transpose_S4():
         q = q.view(B, S, H, D).transpose(1, 2)
         k = k.view(B, S, H, D).transpose(1, 2)
         with spyre_hint(num_tiles_per_dim={"max_seqlen": 4}):
-            return q * k
+            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen", "head_dim"]):
+                return q * k
 
     run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: propagate_named_dims can't handle multi-var coord for fused dim after view+transpose
+        fn, inputs, loopspec=True, correctness=True
+    )
 
 
-@pytest.mark.skip(reason="KNOWN BROKEN — see run_coarse_tile_test comment")
 def test_view_named_input_view_transpose_H2_S4():
     """flat [B,S,H*D] view+transpose before hint scope, tiled H÷2 S÷4."""
     B, S, H, D = 2, 256, 8, 128
@@ -2150,11 +2370,12 @@ def test_view_named_input_view_transpose_H2_S4():
         k = k.view(B, S, H, D).transpose(1, 2)
         with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
             with spyre_hint(num_tiles_per_dim={"max_seqlen": 4}):
-                return q * k
+                with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen", "head_dim"]):
+                    return q * k
 
     run_coarse_tile_test(
-        fn, inputs, loopspec=False, correctness=False
-    )  # KNOWN BROKEN: Inductor fuses view+transpose into tiled op index expr, causing "reshape split a named dim" in propagate_named_dims
+        fn, inputs, loopspec=True, correctness=True
+    )
 
 
 # --- 4D input transposed then multiplied ---
@@ -2183,7 +2404,8 @@ def test_view_4d_transpose_H2():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
-            return x.view(B, S, H, D).transpose(1, 2) * y
+            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"]):
+                return x.view(B, S, H, D).transpose(1, 2) * y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -2209,7 +2431,8 @@ def test_view_4d_transpose_S4():
 
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"max_seqlen_q": 4}):
-            return x.view(B, S, H, D).transpose(1, 2) * y
+            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"]):
+                return x.view(B, S, H, D).transpose(1, 2) * y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -2236,7 +2459,8 @@ def test_view_4d_transpose_H2_S4():
     def fn(x, y):
         with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
             with spyre_hint(num_tiles_per_dim={"max_seqlen_q": 4}):
-                return x.view(B, S, H, D).transpose(1, 2) * y
+                with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"]):
+                    return x.view(B, S, H, D).transpose(1, 2) * y
 
     run_coarse_tile_test(fn, inputs)
 
@@ -2253,7 +2477,8 @@ def test_view_unsqueeze_broadcast_A4():
 
     def fn(a, b):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            return a.unsqueeze(0) * b
+            with spyre_hint(expected_named_dims=["N", "A", "B"]):
+                return a.unsqueeze(0) * b
 
     run_coarse_tile_test(fn, inputs)
 
@@ -2267,7 +2492,8 @@ def test_view_unsqueeze_broadcast_B4():
 
     def fn(a, b):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            return a.unsqueeze(0) * b
+            with spyre_hint(expected_named_dims=["N", "A", "B"]):
+                return a.unsqueeze(0) * b
 
     run_coarse_tile_test(fn, inputs)
 
@@ -2282,9 +2508,561 @@ def test_view_unsqueeze_broadcast_A4_B4():
     def fn(a, b):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                return a.unsqueeze(0) * b
+                with spyre_hint(expected_named_dims=["N", "A", "B"]):
+                    return a.unsqueeze(0) * b
 
     run_coarse_tile_test(fn, inputs)
+
+
+# ---------------------------------------------------------------------------
+# Group 10: Flash attention variants
+# ---------------------------------------------------------------------------
+# Flash v1: no mask, reassignment-based accumulators, scores transposed.
+# Parameterized helpers — tests specify sizes and tile counts directly.
+
+
+def _flash_v1_inputs(B, H, Lq, Lk, D):
+    """TensorSpec list for flash v1 (no mask)."""
+    return [
+        tensor("queries", shape=(B, H, Lq, D), dims=["B", "H", "Lq", "D"]),
+        tensor("keys",    shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
+        tensor("values",  shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
+    ]
+
+
+def _flash_v1_fn(queries, keys, values, *, B, H, Lq, Lk, D,
+                 b_tiles=1, h_tiles=1, lq_tiles=1, lk_tiles=1):
+    """Flash attention v1 body. Tile any combination of B/H/Lq/Lk."""
+    scale = 1.0 / math.sqrt(math.sqrt(D))
+    with spyre_hint(named_dims=["B", "H", "Lq", "D"]):
+        output = torch.zeros_like(queries)
+    with spyre_hint(named_dims=["B", "H", "Lq"]):
+        M = torch.full((B, H, Lq), float("-inf"), device=queries.device, dtype=torch.float16)
+    with spyre_hint(named_dims=["B", "H", "Lq"]):
+        denominator = torch.zeros((B, H, Lq), device=queries.device, dtype=torch.float16)
+    with spyre_hint(num_tiles_per_dim={"B": b_tiles}):
+        with spyre_hint(num_tiles_per_dim={"H": h_tiles}):
+            with spyre_hint(num_tiles_per_dim={"Lq": lq_tiles}):
+                with spyre_hint(num_tiles_per_dim={"Lk": lk_tiles}):
+                    with spyre_hint(expected_named_dims=["B", "H", "D", "Lk"]):
+                        keys_T = keys.transpose(-1, -2).contiguous()
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
+                        q_scaled = queries * scale
+                    with spyre_hint(expected_named_dims=["B", "H", "D", "Lk"]):
+                        k_scaled = keys_T * scale
+                    with spyre_hint(named_dims=["B", "H", "Lq", "Lk"]):
+                        scores = torch.matmul(q_scaled, k_scaled)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lk", "Lq"]):
+                        scores = scores.transpose(-1, -2).contiguous()
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
+                        block_max = torch.amax(scores, dim=-2)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                        max_running = torch.maximum(M, block_max)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lk", "Lq"]):
+                        scores_shifted = scores - max_running.unsqueeze(-2)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lk", "Lq"]):
+                        exp_scores = torch.exp(scores_shifted)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                        M_diff = M - max_running
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                        correction = torch.exp(M_diff)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
+                        sum_scores = exp_scores.sum(dim=-2)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                        denom_corrected = denominator * correction
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                        denominator = denom_corrected + sum_scores
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq", "Lk"]):
+                        exp_scores_T = exp_scores.transpose(-1, -2).contiguous()
+                    with spyre_hint(named_dims=["B", "H", "Lq", "D"]):
+                        matmul_out = torch.matmul(exp_scores_T, values)
+                    corr_expanded = correction.unsqueeze(-1)
+                    output_corrected = output * corr_expanded
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
+                        output = output_corrected + matmul_out
+                    M = max_running  # noqa: F841
+    return output / denominator.unsqueeze(-1)
+
+
+def test_hint_flash_attention_tile_H():
+    """Flash v1: tile H÷4 only."""
+    run_coarse_tile_test(
+        lambda q, k, v: _flash_v1_fn(q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4),
+        _flash_v1_inputs(1, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[4]), correctness=True, atol=0.01, rtol=0.1,
+    )
+
+
+@pytest.mark.skip(reason="KeyError: 0 — B tiling not yet supported")
+def test_hint_flash_attention_tile_B():
+    """Flash v1: tile B÷2 only. B=2."""
+    run_coarse_tile_test(
+        lambda q, k, v: _flash_v1_fn(q, k, v, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2),
+        _flash_v1_inputs(2, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+    )
+
+
+def test_hint_flash_attention_tile_Lq():
+    """Flash v1: tile Lq÷2 only."""
+    run_coarse_tile_test(
+        lambda q, k, v: _flash_v1_fn(q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, lq_tiles=2),
+        _flash_v1_inputs(1, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
+def test_hint_flash_attention_tile_Lk():
+    """Flash v1: tile Lk÷2 only."""
+    run_coarse_tile_test(
+        lambda q, k, v: _flash_v1_fn(q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, lk_tiles=2),
+        _flash_v1_inputs(1, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="KeyError: 0 — B tiling not yet supported")
+def test_hint_flash_attention_tile_B_H():
+    """Flash v1: tile B÷2 H÷4. B=2."""
+    run_coarse_tile_test(
+        lambda q, k, v: _flash_v1_fn(q, k, v, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4),
+        _flash_v1_inputs(2, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[2, 4]), correctness=False,
+    )
+
+
+def test_hint_flash_attention_tile_H_Lq():
+    """Flash v1: tile H÷4 Lq÷2."""
+    run_coarse_tile_test(
+        lambda q, k, v: _flash_v1_fn(q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2),
+        _flash_v1_inputs(1, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[4, 2]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
+def test_hint_flash_attention_tile_H_Lq_Lk():
+    """Flash v1: tile H÷4 Lq÷2 Lk÷2."""
+    run_coarse_tile_test(
+        lambda q, k, v: _flash_v1_fn(q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2, lk_tiles=2),
+        _flash_v1_inputs(1, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[4, 2, 2]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="KeyError: 0 — B tiling not yet supported")
+def test_hint_flash_attention_tile_all():
+    """Flash v1: tile all dims. B=2, H÷4, Lq÷2, Lk÷2."""
+    run_coarse_tile_test(
+        lambda q, k, v: _flash_v1_fn(q, k, v, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4, lq_tiles=2, lk_tiles=2),
+        _flash_v1_inputs(2, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[2, 4, 2, 2]), correctness=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Flash v2: causal mask, copy_ accumulators, sparse init, reduces over dim=-1
+# ---------------------------------------------------------------------------
+
+
+def _flash_v2_inputs(B, H, Lq, Lk, D):
+    """TensorSpec list for flash v2 (with causal mask)."""
+    causal = torch.tril(torch.ones(Lq, Lk, dtype=torch.bool))
+    mask_t = torch.zeros(1, 1, Lq, Lk, dtype=torch.float16)
+    mask_t.masked_fill_(~causal, float("-inf"))
+    return [
+        tensor("queries", shape=(B, H, Lq, D), dims=["B", "H", "Lq", "D"]),
+        tensor("keys",    shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
+        tensor("values",  shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
+        tensor("mask",    shape=(1, 1, Lq, Lk), dims=["B", "H", "Lq", "Lk"], value=mask_t),
+    ]
+
+
+def _flash_v2_fn(queries, keys, values, mask, *, B, H, Lq, Lk, D,
+                 b_tiles=1, h_tiles=1, lq_tiles=1, lk_tiles=1):
+    """Flash attention v2 body. Tile any combination of B/H/Lq/Lk."""
+    scale = 1.0 / math.sqrt(math.sqrt(D))
+    output = torch.zeros_like(queries)
+    real_max = torch.full(
+        (B, H, Lq, 64), float("-inf"), device=queries.device, dtype=torch.float16,
+    ).amax(dim=-1)
+    denominator = torch.zeros(
+        (B, H, Lq, 64), device=queries.device, dtype=torch.float16,
+    ).amax(dim=-1)
+    with spyre_hint(num_tiles_per_dim={"B": b_tiles}):
+        with spyre_hint(num_tiles_per_dim={"H": h_tiles}):
+            with spyre_hint(num_tiles_per_dim={"Lq": lq_tiles}):
+                with spyre_hint(num_tiles_per_dim={"Lk": lk_tiles}):
+                    scaled_keys = keys * scale
+                    keys_T = scaled_keys.transpose(-1, -2)
+                    scores = torch.matmul(queries * scale, keys_T)
+                    scores = scores + mask
+                    block_max = torch.amax(scores, dim=-1)
+                    running_max = torch.maximum(real_max, block_max)
+                    exp_scores = torch.exp(scores - running_max.unsqueeze(-1))
+                    correction = torch.exp(real_max - running_max)
+                    denominator.copy_(denominator * correction + exp_scores.sum(dim=-1))
+                    output.copy_(output * correction.unsqueeze(-1) + torch.matmul(exp_scores, values))
+                    real_max.copy_(running_max)
+    return output / denominator.unsqueeze(-1)
+
+
+@pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
+@pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
+def test_hint_flash_attention_v2_tile_H():
+    """Flash v2: tile H÷4 only."""
+    run_coarse_tile_test(
+        lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4),
+        _flash_v2_inputs(1, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[4]), correctness=True, atol=0.01, rtol=0.1,
+    )
+
+
+@pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
+def test_hint_flash_attention_v2_tile_B():
+    """Flash v2: tile B÷2 only. B=2."""
+    run_coarse_tile_test(
+        lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2),
+        _flash_v2_inputs(2, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
+def test_hint_flash_attention_v2_tile_Lq():
+    """Flash v2: tile Lq÷2 only."""
+    run_coarse_tile_test(
+        lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, lq_tiles=2),
+        _flash_v2_inputs(1, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
+def test_hint_flash_attention_v2_tile_Lk():
+    """Flash v2: tile Lk÷2 only."""
+    run_coarse_tile_test(
+        lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, lk_tiles=2),
+        _flash_v2_inputs(1, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
+def test_hint_flash_attention_v2_tile_B_H():
+    """Flash v2: tile B÷2 H÷4. B=2."""
+    run_coarse_tile_test(
+        lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4),
+        _flash_v2_inputs(2, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[2, 4]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="finalize_layouts: restickify infeasible for copy ops across loop groups")
+def test_hint_flash_attention_v2_tile_H_Lq():
+    """Flash v2: tile H÷4 Lq÷2. Equivalent to original test_hint_flash_attention_v2."""
+    run_coarse_tile_test(
+        lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2),
+        _flash_v2_inputs(1, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[4, 2]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
+def test_hint_flash_attention_v2_tile_H_Lq_Lk():
+    """Flash v2: tile H÷4 Lq÷2 Lk÷2."""
+    run_coarse_tile_test(
+        lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2, lk_tiles=2),
+        _flash_v2_inputs(1, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[4, 2, 2]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
+def test_hint_flash_attention_v2_tile_all():
+    """Flash v2: tile all dims. B=2, H÷4, Lq÷2, Lk÷2."""
+    run_coarse_tile_test(
+        lambda q, k, v, m: _flash_v2_fn(q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4, lq_tiles=2, lk_tiles=2),
+        _flash_v2_inputs(2, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[2, 4, 2, 2]), correctness=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Flash v3: causal mask, copy_ accumulators, scores transposed, tiles= API
+# Uses num_tiles_per_dim= (normalized from tiles=) for consistency
+# ---------------------------------------------------------------------------
+
+
+def _flash_v3_inputs(B, H, Lq, Lk, D):
+    """TensorSpec list for flash v3 (with causal mask)."""
+    causal = torch.tril(torch.ones(Lq, Lk, dtype=torch.bool))
+    mask_t = torch.zeros(1, 1, Lq, Lk, dtype=torch.float16)
+    mask_t.masked_fill_(~causal, float("-inf"))
+    return [
+        tensor("queries", shape=(B, H, Lq, D), dims=["B", "H", "Lq", "D"]),
+        tensor("keys",    shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
+        tensor("values",  shape=(B, H, Lk, D), dims=["B", "H", "Lk", "D"]),
+        tensor("mask",    shape=(1, 1, Lq, Lk), dims=["B", "H", "Lq", "Lk"], value=mask_t),
+    ]
+
+
+def _flash_v3_fn(queries, keys, values, mask, *, B, H, Lq, Lk, D,
+                 b_tiles=1, h_tiles=1, lq_tiles=1, lk_tiles=1):
+    """Flash attention v3 body (scores transposed). Tile any combination of B/H/Lq/Lk."""
+    scale = 1.0 / math.sqrt(math.sqrt(D))
+    output = torch.zeros_like(queries)
+    real_max = torch.full(
+        (B, H, Lq), float("-inf"), device=queries.device, dtype=torch.float16
+    )
+    denominator = torch.zeros(
+        (B, H, Lq), device=queries.device, dtype=torch.float16
+    )
+    with spyre_hint(num_tiles_per_dim={"B": b_tiles}):
+        with spyre_hint(num_tiles_per_dim={"H": h_tiles}):
+            with spyre_hint(num_tiles_per_dim={"Lq": lq_tiles}):
+                with spyre_hint(num_tiles_per_dim={"Lk": lk_tiles}):
+                    scaled_keys = keys * scale
+                    keys_T = scaled_keys.transpose(-1, -2)
+                    scores = torch.matmul(queries * scale, keys_T)
+                    scores = scores + mask
+                    scores = scores.transpose(-1, -2).contiguous()
+                    block_max = torch.amax(scores, dim=-2)
+                    running_max = torch.maximum(real_max, block_max)
+                    exp_scores = torch.exp(scores - running_max.unsqueeze(-2))
+                    correction = torch.exp(real_max - running_max)
+                    denominator.copy_(denominator * correction + exp_scores.sum(dim=-2))
+                    output.copy_(
+                        output * correction.unsqueeze(-1)
+                        + torch.matmul(exp_scores.transpose(-1, -2), values)
+                    )
+                    real_max.copy_(running_max)
+    return output / denominator.unsqueeze(-1)
+
+
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+def test_hint_flash_attention_v3_tile_H():
+    """Flash v3: tile H÷4 only."""
+    run_coarse_tile_test(
+        lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4),
+        _flash_v3_inputs(1, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[4]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="KeyError: 0 — B tiling not yet supported")
+def test_hint_flash_attention_v3_tile_B():
+    """Flash v3: tile B÷2 only. B=2."""
+    run_coarse_tile_test(
+        lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2),
+        _flash_v3_inputs(2, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+def test_hint_flash_attention_v3_tile_Lq():
+    """Flash v3: tile Lq÷2 only."""
+    run_coarse_tile_test(
+        lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, lq_tiles=2),
+        _flash_v3_inputs(1, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
+def test_hint_flash_attention_v3_tile_Lk():
+    """Flash v3: tile Lk÷2 only."""
+    run_coarse_tile_test(
+        lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, lk_tiles=2),
+        _flash_v3_inputs(1, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="KeyError: 0 — B tiling not yet supported")
+def test_hint_flash_attention_v3_tile_B_H():
+    """Flash v3: tile B÷2 H÷4. B=2."""
+    run_coarse_tile_test(
+        lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4),
+        _flash_v3_inputs(2, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[2, 4]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers")
+def test_hint_flash_attention_v3_tile_H_Lq():
+    """Flash v3: tile H÷4 Lq÷2. Equivalent to original test_hint_flash_attention_v3 (small sizes)."""
+    run_coarse_tile_test(
+        lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2),
+        _flash_v3_inputs(1, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[4, 2]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
+def test_hint_flash_attention_v3_tile_H_Lq_Lk():
+    """Flash v3: tile H÷4 Lq÷2 Lk÷2."""
+    run_coarse_tile_test(
+        lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2, lk_tiles=2),
+        _flash_v3_inputs(1, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[4, 2, 2]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="Unsupported: Lk reduction-dim tiling requires carry propagation")
+def test_hint_flash_attention_v3_tile_all():
+    """Flash v3: tile all dims. B=2, H÷4, Lq÷2, Lk÷2."""
+    run_coarse_tile_test(
+        lambda q, k, v, m: _flash_v3_fn(q, k, v, m, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2, h_tiles=4, lq_tiles=2, lk_tiles=2),
+        _flash_v3_inputs(2, 8, 256, 256, 64),
+        loopspec=LoopSpecCheck(counts=[2, 4, 2, 2]), correctness=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Flash v4: flat [B,S,H*D] inputs, view+transpose inside fn
+# Known broken: propagate_named_dims bug — num_heads layout dim has no loop vars
+# ---------------------------------------------------------------------------
+
+
+def _flash_v4_inputs(B, S, H, D):
+    """TensorSpec list for flash v4 (flat fused-dim inputs)."""
+    _nd_q = {"batch_size": B, "max_seqlen_q": S, "num_heads": H, "head_dim": D}
+    _nd_kv = {"batch_size": B, "max_seqlen_kv": S, "num_heads": H, "head_dim": D}
+    return [
+        tensor("q", shape=(B, S, H * D),
+               dims=["batch_size", "max_seqlen_q", "num_heads", "head_dim"],
+               named_dims=_nd_q),
+        tensor("k", shape=(B, S, H * D),
+               dims=["batch_size", "max_seqlen_kv", "num_heads", "head_dim"],
+               named_dims=_nd_kv),
+        tensor("v", shape=(B, S, H * D),
+               dims=["batch_size", "max_seqlen_kv", "num_heads", "head_dim"],
+               named_dims=_nd_kv),
+    ]
+
+
+def _flash_v4_fn(q, k, v, *, B, S, H, D,
+                 b_tiles=1, h_tiles=1, lq_tiles=1, lk_tiles=1):
+    """Flash attention v4 body (flat fused-dim inputs). Tile any combination."""
+    q = q.view(B, S, H, D).transpose(1, 2)
+    k = k.view(B, S, H, D).transpose(1, 2)
+    v = v.view(B, S, H, D).transpose(1, 2)
+    scale = 1.0 / math.sqrt(math.sqrt(D))
+    output = torch.zeros_like(q)
+    real_max = torch.full((B, H, S), float("-inf"), device=q.device, dtype=q.dtype)
+    denominator = torch.zeros((B, H, S), device=q.device, dtype=q.dtype)
+    with spyre_hint(num_tiles_per_dim={"batch_size": b_tiles}):
+        with spyre_hint(num_tiles_per_dim={"num_heads": h_tiles}):
+            with spyre_hint(num_tiles_per_dim={"max_seqlen_q": lq_tiles}):
+                with spyre_hint(num_tiles_per_dim={"max_seqlen_kv": lk_tiles}):
+                    scaled_keys = k * scale
+                    keys_T = scaled_keys.transpose(-1, -2).contiguous()
+                    scores = torch.matmul(q * scale, keys_T)
+                    scores = scores.transpose(-1, -2).contiguous()
+                    block_max = torch.amax(scores, dim=-2)
+                    running_max = torch.maximum(real_max, block_max)
+                    exp_scores = torch.exp(scores - running_max.unsqueeze(-2))
+                    correction = torch.exp(real_max - running_max)
+                    denominator.copy_(denominator * correction + exp_scores.sum(dim=-2))
+                    output.copy_(
+                        output * correction.unsqueeze(-1)
+                        + torch.matmul(exp_scores.transpose(-1, -2), v)
+                    )
+                    real_max.copy_(running_max)
+    output.copy_(output / denominator.unsqueeze(-1))
+    return output.transpose(1, 2).reshape(B, S, H * D)
+
+
+@pytest.mark.skip(reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose")
+def test_hint_flash_attention_v4_tile_H():
+    """Flash v4: tile num_heads÷4 only."""
+    run_coarse_tile_test(
+        lambda q, k, v: _flash_v4_fn(q, k, v, B=2, S=256, H=8, D=64, h_tiles=4),
+        _flash_v4_inputs(2, 256, 8, 64),
+        loopspec=LoopSpecCheck(counts=[4]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose")
+def test_hint_flash_attention_v4_tile_B():
+    """Flash v4: tile batch_size÷2 only. B=2."""
+    run_coarse_tile_test(
+        lambda q, k, v: _flash_v4_fn(q, k, v, B=2, S=256, H=8, D=64, b_tiles=2),
+        _flash_v4_inputs(2, 256, 8, 64),
+        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose")
+def test_hint_flash_attention_v4_tile_Lq():
+    """Flash v4: tile max_seqlen_q÷2 only."""
+    run_coarse_tile_test(
+        lambda q, k, v: _flash_v4_fn(q, k, v, B=2, S=256, H=8, D=64, lq_tiles=2),
+        _flash_v4_inputs(2, 256, 8, 64),
+        loopspec=LoopSpecCheck(counts=[2]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose")
+def test_hint_flash_attention_v4_tile_H_Lq():
+    """Flash v4: tile num_heads÷4 max_seqlen_q÷2. Equivalent to original test_hint_flash_attention_v4."""
+    run_coarse_tile_test(
+        lambda q, k, v: _flash_v4_fn(q, k, v, B=2, S=256, H=8, D=64, h_tiles=4, lq_tiles=2),
+        _flash_v4_inputs(2, 256, 8, 64),
+        loopspec=LoopSpecCheck(counts=[4, 2]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose")
+def test_hint_flash_attention_v4_tile_H_Lq_Lk():
+    """Flash v4: tile num_heads÷4 max_seqlen_q÷2 max_seqlen_kv÷2."""
+    run_coarse_tile_test(
+        lambda q, k, v: _flash_v4_fn(q, k, v, B=2, S=256, H=8, D=64, h_tiles=4, lq_tiles=2, lk_tiles=2),
+        _flash_v4_inputs(2, 256, 8, 64),
+        loopspec=LoopSpecCheck(counts=[4, 2, 2]), correctness=False,
+    )
+
+
+@pytest.mark.skip(reason="Unsupported: propagate_named_dims bug — num_heads layout dim has no loop vars after view+transpose")
+def test_hint_flash_attention_v4_tile_all():
+    """Flash v4: tile all dims. B=2, H÷4, Lq÷2, Lk÷2."""
+    run_coarse_tile_test(
+        lambda q, k, v: _flash_v4_fn(q, k, v, B=2, S=256, H=8, D=64, b_tiles=2, h_tiles=4, lq_tiles=2, lk_tiles=2),
+        _flash_v4_inputs(2, 256, 8, 64),
+        loopspec=LoopSpecCheck(counts=[2, 4, 2, 2]), correctness=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# validate_named_dims tests
+# ---------------------------------------------------------------------------
+
+
+def test_validate_named_dims_raises_on_mismatch():
+    """validate_named_dims raises AssertionError when expected_named_dims is wrong."""
+    inputs = [tensor("x", shape=(256, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(expected_named_dims=["WRONG", "DIMS"]):
+            return torch.abs(x)
+
+    with pytest.raises(Exception, match="expected_named_dims"):
+        run_coarse_tile_test(fn, inputs, loopspec=False, correctness=False)
+
+
+def test_validate_reduction_dims_raises_on_mismatch():
+    """validate_named_dims raises AssertionError when expected_reduction_dims is wrong."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["WRONG"]):
+            return x.amin(dim=0)
+
+    with pytest.raises(Exception, match="expected_reduction_dims"):
+        run_coarse_tile_test(fn, inputs, loopspec=False, correctness=False)
 
 
 # ===========================================================================
@@ -2407,11 +3185,16 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
         def softmax_fn(x):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                max_val = x.amax(dim=-1, keepdim=True)
-                x_shifted = x - max_val
-                exp_x = x_shifted.exp()
-                sum_exp = exp_x.sum(dim=-1, keepdim=True)
-                return exp_x / sum_exp
+                with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["D"]):
+                    max_val = x.amax(dim=-1, keepdim=True)
+                with spyre_hint(expected_named_dims=["B", "D"]):
+                    x_shifted = x - max_val
+                with spyre_hint(expected_named_dims=["B", "D"]):
+                    exp_x = x_shifted.exp()
+                with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["D"]):
+                    sum_exp = exp_x.sum(dim=-1, keepdim=True)
+                with spyre_hint(expected_named_dims=["B", "D"]):
+                    return exp_x / sum_exp
 
         x_dev = x.to("spyre")
         _declare_tensor_dim("B", B)
@@ -2923,6 +3706,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             fn, x, y, run_compile=True, run_eager=False, atol=0.01, rtol=0.01
         )
 
+    # Consider deleting — superseded by Group 10 structured tests (_flash_v1_fn)
     @pytest.mark.skip
     def test_hint_flash_attention(self):
         """Flash attention tiled over H (4 slices) via nested spyre_hints.
@@ -3011,6 +3795,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
         )
 
+    # Consider deleting — superseded by Group 10 structured tests (_flash_v2_fn)
     @pytest.mark.skip
     def test_hint_flash_attention_v2(self):
         """Flash attention tiled over H (4 slices) via nested spyre_hints.
@@ -3129,6 +3914,161 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
         )
 
+    @pytest.mark.skip
+    def test_hint_flash_attention_v2_validate_dims(self):
+        """Same as test_hint_flash_attention_v2 but with expected_named_dims annotations.
+
+        Confirms annotated and original versions produce identical output.
+        Known broken: restickify infeasible for copy ops across loop groups —
+        both versions are expected to fail at finalize_layouts, but dims are
+        validated before that point.
+        """
+        import math
+        from torch_spyre._inductor import spyre_hint
+
+        B, H, Lq, Lk, D = 1, 8, 256, 256, 64
+        block_size = 128
+
+        queries_t = torch.randn(B, H, Lq, D, dtype=torch.float16)
+        keys_t = torch.randn(B, H, Lk, D, dtype=torch.float16)
+        values_t = torch.randn(B, H, Lk, D, dtype=torch.float16)
+        causal = torch.tril(torch.ones(Lq, Lk, dtype=torch.bool))
+        mask_t = torch.zeros(1, 1, Lq, Lk, dtype=torch.float16)
+        mask_t.masked_fill_(~causal, float("-inf"))
+        lq_slices = Lq // block_size
+
+        def flash(queries, keys, values, mask):
+            scale = 1.0 / math.sqrt(math.sqrt(D))
+            output = torch.zeros_like(queries)
+            real_max = torch.full(
+                (B, H, Lq, 64),
+                float("-inf"),
+                device=queries.device,
+                dtype=torch.float16,
+            )
+            real_max = real_max.amax(dim=-1)  # B, H, Lq sparse
+
+            denominator = torch.zeros(
+                (B, H, Lq, 64),
+                device=queries.device,
+                dtype=torch.float16,
+            )
+            denominator = denominator.amax(dim=-1)  # B, H, Lq sparse
+            with spyre_hint(num_tiles_per_dim={"B": 1}):
+                with spyre_hint(num_tiles_per_dim={"H": 4}):
+                    with spyre_hint(num_tiles_per_dim={"Lq": lq_slices}):
+                        with spyre_hint(expected_named_dims=["B", "H", "Lk", "D"]):
+                            scaled_keys = keys * scale
+                        with spyre_hint(expected_named_dims=["B", "H", "D", "Lk"]):
+                            keys_T = scaled_keys.transpose(-1, -2)
+                        with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
+                            q_scaled = queries * scale
+                        with spyre_hint(named_dims=["B", "H", "Lq", "Lk"]):
+                            scores_pre = torch.matmul(q_scaled, keys_T)
+                        with spyre_hint(expected_named_dims=["B", "H", "Lq", "Lk"]):
+                            scores = scores_pre + mask
+                        with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
+                            block_max = torch.amax(scores, dim=-1)
+                        with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                            running_max = torch.maximum(real_max, block_max)
+                        with spyre_hint(expected_named_dims=["B", "H", "Lq", "Lk"]):
+                            scores_shifted = scores - running_max.unsqueeze(-1)
+                        with spyre_hint(expected_named_dims=["B", "H", "Lq", "Lk"]):
+                            exp_scores = torch.exp(scores_shifted)
+                        with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                            real_max_diff = real_max - running_max
+                        with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                            correction = torch.exp(real_max_diff)
+                        with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
+                            sum_scores = exp_scores.sum(dim=-1)
+                        with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                            denom_corrected = denominator * correction
+                        with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                            new_denom = denom_corrected + sum_scores
+                        denominator.copy_(new_denom)
+                        with spyre_hint(named_dims=["B", "H", "Lq", "D"]):
+                            matmul_out = torch.matmul(exp_scores, values)
+                        corr_expanded = correction.unsqueeze(-1)
+                        output_corrected = output * corr_expanded
+                        with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
+                            new_output = output_corrected + matmul_out
+                        output.copy_(new_output)
+                        real_max.copy_(running_max)
+
+            return output / denominator.unsqueeze(-1)
+
+        def flash_original(queries, keys, values, mask):
+            scale = 1.0 / math.sqrt(math.sqrt(D))
+            output = torch.zeros_like(queries)
+            real_max = torch.full(
+                (B, H, Lq, 64),
+                float("-inf"),
+                device=queries.device,
+                dtype=torch.float16,
+            )
+            real_max = real_max.amax(dim=-1)
+            denominator = torch.zeros(
+                (B, H, Lq, 64),
+                device=queries.device,
+                dtype=torch.float16,
+            )
+            denominator = denominator.amax(dim=-1)
+            with spyre_hint(num_tiles_per_dim={"B": 1}):
+                with spyre_hint(num_tiles_per_dim={"H": 4}):
+                    with spyre_hint(num_tiles_per_dim={"Lq": lq_slices}):
+                        scaled_keys = keys * scale
+                        keys_T = scaled_keys.transpose(-1, -2)
+                        scores = torch.matmul(queries * scale, keys_T)
+                        scores = scores + mask
+                        block_max = torch.amax(scores, dim=-1)
+                        running_max = torch.maximum(real_max, block_max)
+                        exp_scores = torch.exp(scores - running_max.unsqueeze(-1))
+                        correction = torch.exp(real_max - running_max)
+                        denominator.copy_(denominator * correction + exp_scores.sum(dim=-1))
+                        output.copy_(output * correction.unsqueeze(-1) + torch.matmul(exp_scores, values))
+                        real_max.copy_(running_max)
+            return output / denominator.unsqueeze(-1)
+
+        queries_dev = queries_t.to("spyre")
+        keys_dev = keys_t.to("spyre")
+        values_dev = values_t.to("spyre")
+        mask_dev = mask_t.to("spyre")
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("H", H)
+        _declare_tensor_dim("Lq", Lq)
+        _declare_tensor_dim("Lk", Lk)
+        _declare_tensor_dim("D", D)
+        _name_tensor_dims(queries_dev, ["B", "H", "Lq", "D"])
+        _name_tensor_dims(keys_dev, ["B", "H", "Lk", "D"])
+        _name_tensor_dims(values_dev, ["B", "H", "Lk", "D"])
+        _name_tensor_dims(mask_dev, ["B", "H", "Lq", "Lk"])
+
+        result_annotated = torch.compile(flash)(queries_dev, keys_dev, values_dev, mask_dev).cpu()
+
+        _pnd.reset()
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("H", H)
+        _declare_tensor_dim("Lq", Lq)
+        _declare_tensor_dim("Lk", Lk)
+        _declare_tensor_dim("D", D)
+        _name_tensor_dims(queries_dev, ["B", "H", "Lq", "D"])
+        _name_tensor_dims(keys_dev, ["B", "H", "Lk", "D"])
+        _name_tensor_dims(values_dev, ["B", "H", "Lk", "D"])
+        _name_tensor_dims(mask_dev, ["B", "H", "Lq", "Lk"])
+
+        result_original = torch.compile(flash_original)(queries_dev, keys_dev, values_dev, mask_dev).cpu()
+
+        print(f"\nAnnotated result: {result_annotated}")
+        print(f"Original result:  {result_original}")
+        torch.testing.assert_close(
+            result_annotated,
+            result_original,
+            equal_nan=True,
+            atol=0.0,
+            rtol=0.0,
+            msg=lambda msg: f"annotated vs original mismatch\n\n{msg}\n",
+        )
+
     def test_hint_flash_attention_v2_divide_in_scope(self):
         """test_hint_flash_attention_v2 with the final divide INSIDE the scope.
 
@@ -3240,9 +4180,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             "allow_all_ops_in_lx_planning": True,
         }
     )
-    @pytest.mark.skip(
-        reason="flash attention v3/v4 not yet passing: Lk reduction-dim tiling is disabled (see FIXME on kv_block_size), unrelated to carry propagation"
-    )
+    # Consider deleting — superseded by Group 10 structured tests (_flash_v3_fn)
+    @pytest.mark.skip
     def test_hint_flash_attention_v3(self):
         from torch_spyre._inductor import spyre_hint
 
@@ -3475,8 +4414,10 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             )
             with spyre_hint(tiles={"H": H // h_block_size}):
                 with spyre_hint(tiles={"Lq": Lq // lq_block_size}):
-                    block_max = torch.amax(scores, dim=-2)  # [B, H, Lq]
-                    running_max = torch.maximum(real_max, block_max)
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]):
+                        block_max = torch.amax(scores, dim=-2)  # [B, H, Lq]
+                    with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
+                        running_max = torch.maximum(real_max, block_max)
                     real_max.copy_(running_max)
             return real_max
 
@@ -3501,9 +4442,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
         )
 
-    @pytest.mark.skip(
-        reason="flash attention v3/v4 not yet passing: unrelated propagate_named_dims bug (num_heads layout dim has no loop vars), not carry propagation"
-    )
+    # Consider deleting — superseded by Group 10 structured tests (_flash_v4_fn)
+    @pytest.mark.skip
     def test_hint_flash_attention_v4(self):
         """This test attempts to replicate the standalone test_granite_attn.py with views
         but the flash logic is inlined rather than relying on decompositions.py
@@ -3595,6 +4535,142 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             atol=0.1,
             rtol=0.1,
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
+        )
+
+    @pytest.mark.skip
+    def test_hint_flash_attention_v4_validate_dims(self):
+        """Same as test_hint_flash_attention_v4 with expected_named_dims annotations."""
+        from torch_spyre._inductor import spyre_hint
+
+        B, H, S, D = 2, 32, 4096, 256
+        q_block_size = S // 4
+        kv_block_size = S // 1
+
+        queries_t = torch.randn(B, S, H * D, dtype=torch.float16)
+        keys_t = torch.randn(B, S, H * D, dtype=torch.float16)
+        values_t = torch.randn(B, S, H * D, dtype=torch.float16)
+
+        def flash(q, k, v):
+            q = q.view(B, S, H, D).transpose(1, 2)
+            k = k.view(B, S, H, D).transpose(1, 2)
+            v = v.view(B, S, H, D).transpose(1, 2)
+
+            scale = 1.0 / math.sqrt(math.sqrt(D))
+
+            output = torch.zeros_like(q)
+            real_max = torch.full(
+                (B, H, S), float("-inf"), device=q.device, dtype=q.dtype
+            )
+            denominator = torch.zeros((B, H, S), device=q.device, dtype=q.dtype)
+
+            with spyre_hint(tiles={"batch_size": max(1, B // 2)}):
+                with spyre_hint(tiles={"num_heads": max(1, H // 4)}):
+                    with spyre_hint(tiles={"max_seqlen_q": max(1, S // q_block_size)}):
+                        with spyre_hint(tiles={"max_seqlen_kv": max(1, S // kv_block_size)}):
+                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_kv", "head_dim"]):
+                                scaled_keys = k * scale
+                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "head_dim", "max_seqlen_kv"]):
+                                keys_T = scaled_keys.transpose(-1, -2).contiguous()
+                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"]):
+                                q_scaled = q * scale
+                            with spyre_hint(named_dims=["batch_size", "num_heads", "max_seqlen_q", "max_seqlen_kv"]):
+                                scores_pre = torch.matmul(q_scaled, keys_T)
+                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_kv", "max_seqlen_q"]):
+                                scores = scores_pre.transpose(-1, -2).contiguous()
+                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"], expected_reduction_dims=["max_seqlen_kv"]):
+                                block_max = torch.amax(scores, dim=-2)
+                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
+                                running_max = torch.maximum(real_max, block_max)
+                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_kv", "max_seqlen_q"]):
+                                scores_shifted = scores - running_max.unsqueeze(-2)
+                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_kv", "max_seqlen_q"]):
+                                exp_scores = torch.exp(scores_shifted)
+                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
+                                real_max_diff = real_max - running_max
+                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
+                                correction = torch.exp(real_max_diff)
+                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"], expected_reduction_dims=["max_seqlen_kv"]):
+                                sum_scores = exp_scores.sum(dim=-2)
+                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
+                                denom_corrected = denominator * correction
+                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q"]):
+                                new_denom = denom_corrected + sum_scores
+                            denominator.copy_(new_denom)
+                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q", "max_seqlen_kv"]):
+                                exp_scores_T = exp_scores.transpose(-1, -2).contiguous()
+                            with spyre_hint(named_dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"]):
+                                matmul_out = torch.matmul(exp_scores_T, v)
+                            # correction.unsqueeze(-1) is size-1 in head_dim — can't carry "head_dim"
+                            output_corrected = output * correction.unsqueeze(-1)
+                            with spyre_hint(expected_named_dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"]):
+                                new_output = output_corrected + matmul_out
+                            output.copy_(new_output)
+                            real_max.copy_(running_max)
+
+            output.copy_(output / denominator.unsqueeze(-1))
+            return output.transpose(1, 2).reshape(B, S, H * D)
+
+        def flash_original(q, k, v):
+            q = q.view(B, S, H, D).transpose(1, 2)
+            k = k.view(B, S, H, D).transpose(1, 2)
+            v = v.view(B, S, H, D).transpose(1, 2)
+            scale = 1.0 / math.sqrt(math.sqrt(D))
+            output = torch.zeros_like(q)
+            real_max = torch.full((B, H, S), float("-inf"), device=q.device, dtype=q.dtype)
+            denominator = torch.zeros((B, H, S), device=q.device, dtype=q.dtype)
+            with spyre_hint(tiles={"batch_size": max(1, B // 2)}):
+                with spyre_hint(tiles={"num_heads": max(1, H // 4)}):
+                    with spyre_hint(tiles={"max_seqlen_q": max(1, S // q_block_size)}):
+                        with spyre_hint(tiles={"max_seqlen_kv": max(1, S // kv_block_size)}):
+                            scaled_keys = k * scale
+                            keys_T = scaled_keys.transpose(-1, -2).contiguous()
+                            scores = torch.matmul(q * scale, keys_T)
+                            scores = scores.transpose(-1, -2).contiguous()
+                            block_max = torch.amax(scores, dim=-2)
+                            running_max = torch.maximum(real_max, block_max)
+                            exp_scores = torch.exp(scores - running_max.unsqueeze(-2))
+                            correction = torch.exp(real_max - running_max)
+                            denominator.copy_(denominator * correction + exp_scores.sum(dim=-2))
+                            output.copy_(output * correction.unsqueeze(-1) + torch.matmul(exp_scores.transpose(-1, -2), v))
+                            real_max.copy_(running_max)
+            output.copy_(output / denominator.unsqueeze(-1))
+            return output.transpose(1, 2).reshape(B, S, H * D)
+
+        queries_dev = queries_t.to("spyre")
+        keys_dev = keys_t.to("spyre")
+        values_dev = values_t.to("spyre")
+        _declare_tensor_dim("batch_size", B)
+        _declare_tensor_dim("num_heads", H)
+        _declare_tensor_dim("max_seqlen_q", S)
+        _declare_tensor_dim("max_seqlen_kv", S)
+        _declare_tensor_dim("head_dim", D)
+        _name_tensor_dims(queries_dev, ["batch_size", "max_seqlen_q", "num_heads", "head_dim"])
+        _name_tensor_dims(keys_dev, ["batch_size", "max_seqlen_kv", "num_heads", "head_dim"])
+        _name_tensor_dims(values_dev, ["batch_size", "max_seqlen_kv", "num_heads", "head_dim"])
+
+        result_annotated = torch.compile(flash)(queries_dev, keys_dev, values_dev).cpu()
+
+        _pnd.reset()
+        _declare_tensor_dim("batch_size", B)
+        _declare_tensor_dim("num_heads", H)
+        _declare_tensor_dim("max_seqlen_q", S)
+        _declare_tensor_dim("max_seqlen_kv", S)
+        _declare_tensor_dim("head_dim", D)
+        _name_tensor_dims(queries_dev, ["batch_size", "max_seqlen_q", "num_heads", "head_dim"])
+        _name_tensor_dims(keys_dev, ["batch_size", "max_seqlen_kv", "num_heads", "head_dim"])
+        _name_tensor_dims(values_dev, ["batch_size", "max_seqlen_kv", "num_heads", "head_dim"])
+
+        result_original = torch.compile(flash_original)(queries_dev, keys_dev, values_dev).cpu()
+
+        print(f"\nAnnotated result: {result_annotated}")
+        print(f"Original result:  {result_original}")
+        torch.testing.assert_close(
+            result_annotated,
+            result_original,
+            equal_nan=True,
+            atol=0.0,
+            rtol=0.0,
+            msg=lambda msg: f"annotated vs original mismatch\n\n{msg}\n",
         )
 
     def test_hint_mixed_coverage_loopspec(self):

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -2307,18 +2307,18 @@ def test_view_1d_subdim_Lq2_D2():
 def test_view_named_input_view_transpose_H2():
     """flat [B,S,H*D] view+transpose before hint scope, tiled H÷2."""
     B, S, H, D = 2, 256, 8, 128
-    _nd = {"batch_size": B, "max_seqlen": S, "num_heads": H, "head_dim": D}
+    _nd = {"B": B, "S": S, "H": H, "D": D}
     inputs = [
         tensor(
             "q",
             shape=(B, S, H * D),
-            dims=["batch_size", "max_seqlen", "num_heads", "head_dim"],
+            dims=["B", "S", "H", "D"],
             named_dims=_nd,
         ),
         tensor(
             "k",
             shape=(B, S, H * D),
-            dims=["batch_size", "max_seqlen", "num_heads", "head_dim"],
+            dims=["B", "S", "H", "D"],
             named_dims=_nd,
         ),
     ]
@@ -2326,15 +2326,8 @@ def test_view_named_input_view_transpose_H2():
     def fn(q, k):
         q = q.view(B, S, H, D).transpose(1, 2)
         k = k.view(B, S, H, D).transpose(1, 2)
-        with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
-            with spyre_hint(
-                expected_named_dims=[
-                    "batch_size",
-                    "num_heads",
-                    "max_seqlen",
-                    "head_dim",
-                ]
-            ):
+        with spyre_hint(num_tiles_per_dim={"H": 2}):
+            with spyre_hint(expected_named_dims=["B", "H", "S", "D"]):
                 return q * k
 
     run_coarse_tile_test(fn, inputs)
@@ -2343,18 +2336,18 @@ def test_view_named_input_view_transpose_H2():
 def test_view_named_input_view_transpose_S4():
     """flat [B,S,H*D] view+transpose before hint scope, tiled S÷4."""
     B, S, H, D = 2, 256, 8, 128
-    _nd = {"batch_size": B, "max_seqlen": S, "num_heads": H, "head_dim": D}
+    _nd = {"B": B, "S": S, "H": H, "D": D}
     inputs = [
         tensor(
             "q",
             shape=(B, S, H * D),
-            dims=["batch_size", "max_seqlen", "num_heads", "head_dim"],
+            dims=["B", "S", "H", "D"],
             named_dims=_nd,
         ),
         tensor(
             "k",
             shape=(B, S, H * D),
-            dims=["batch_size", "max_seqlen", "num_heads", "head_dim"],
+            dims=["B", "S", "H", "D"],
             named_dims=_nd,
         ),
     ]
@@ -2362,15 +2355,8 @@ def test_view_named_input_view_transpose_S4():
     def fn(q, k):
         q = q.view(B, S, H, D).transpose(1, 2)
         k = k.view(B, S, H, D).transpose(1, 2)
-        with spyre_hint(num_tiles_per_dim={"max_seqlen": 4}):
-            with spyre_hint(
-                expected_named_dims=[
-                    "batch_size",
-                    "num_heads",
-                    "max_seqlen",
-                    "head_dim",
-                ]
-            ):
+        with spyre_hint(num_tiles_per_dim={"S": 4}):
+            with spyre_hint(expected_named_dims=["B", "H", "S", "D"]):
                 return q * k
 
     run_coarse_tile_test(fn, inputs)
@@ -2379,18 +2365,18 @@ def test_view_named_input_view_transpose_S4():
 def test_view_named_input_view_transpose_H2_S4():
     """flat [B,S,H*D] view+transpose before hint scope, tiled H÷2 S÷4."""
     B, S, H, D = 2, 256, 8, 128
-    _nd = {"batch_size": B, "max_seqlen": S, "num_heads": H, "head_dim": D}
+    _nd = {"B": B, "S": S, "H": H, "D": D}
     inputs = [
         tensor(
             "q",
             shape=(B, S, H * D),
-            dims=["batch_size", "max_seqlen", "num_heads", "head_dim"],
+            dims=["B", "S", "H", "D"],
             named_dims=_nd,
         ),
         tensor(
             "k",
             shape=(B, S, H * D),
-            dims=["batch_size", "max_seqlen", "num_heads", "head_dim"],
+            dims=["B", "S", "H", "D"],
             named_dims=_nd,
         ),
     ]
@@ -2398,16 +2384,9 @@ def test_view_named_input_view_transpose_H2_S4():
     def fn(q, k):
         q = q.view(B, S, H, D).transpose(1, 2)
         k = k.view(B, S, H, D).transpose(1, 2)
-        with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
-            with spyre_hint(num_tiles_per_dim={"max_seqlen": 4}):
-                with spyre_hint(
-                    expected_named_dims=[
-                        "batch_size",
-                        "num_heads",
-                        "max_seqlen",
-                        "head_dim",
-                    ]
-                ):
+        with spyre_hint(num_tiles_per_dim={"H": 2}):
+            with spyre_hint(num_tiles_per_dim={"S": 4}):
+                with spyre_hint(expected_named_dims=["B", "H", "S", "D"]):
                     return q * k
 
     run_coarse_tile_test(fn, inputs)
@@ -2421,32 +2400,25 @@ def test_view_named_input_view_transpose_H2_S4():
 def test_view_4d_transpose_H2():
     """x.view(B,S,H,D).transpose(1,2)*y tiled H÷2."""
     B, S, H, D = 2, 256, 4, 64
-    _nd = {"batch_size": B, "max_seqlen_q": S, "num_heads": H, "head_dim": D}
+    _nd = {"B": B, "Lq": S, "H": H, "D": D}
     inputs = [
         tensor(
             "x",
             shape=(B, S, H * D),
-            dims=["batch_size", "max_seqlen_q", "num_heads", "head_dim"],
+            dims=["B", "Lq", "H", "D"],
             named_dims=_nd,
         ),
         tensor(
             "y",
             shape=(B, H, S, D),
-            dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"],
+            dims=["B", "H", "Lq", "D"],
             named_dims=_nd,
         ),
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
-            with spyre_hint(
-                expected_named_dims=[
-                    "batch_size",
-                    "num_heads",
-                    "max_seqlen_q",
-                    "head_dim",
-                ]
-            ):
+        with spyre_hint(num_tiles_per_dim={"H": 2}):
+            with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
                 return x.view(B, S, H, D).transpose(1, 2) * y
 
     run_coarse_tile_test(fn, inputs)
@@ -2455,32 +2427,25 @@ def test_view_4d_transpose_H2():
 def test_view_4d_transpose_S4():
     """x.view(B,S,H,D).transpose(1,2)*y tiled S÷4."""
     B, S, H, D = 2, 256, 4, 64
-    _nd = {"batch_size": B, "max_seqlen_q": S, "num_heads": H, "head_dim": D}
+    _nd = {"B": B, "Lq": S, "H": H, "D": D}
     inputs = [
         tensor(
             "x",
             shape=(B, S, H * D),
-            dims=["batch_size", "max_seqlen_q", "num_heads", "head_dim"],
+            dims=["B", "Lq", "H", "D"],
             named_dims=_nd,
         ),
         tensor(
             "y",
             shape=(B, H, S, D),
-            dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"],
+            dims=["B", "H", "Lq", "D"],
             named_dims=_nd,
         ),
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"max_seqlen_q": 4}):
-            with spyre_hint(
-                expected_named_dims=[
-                    "batch_size",
-                    "num_heads",
-                    "max_seqlen_q",
-                    "head_dim",
-                ]
-            ):
+        with spyre_hint(num_tiles_per_dim={"Lq": 4}):
+            with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
                 return x.view(B, S, H, D).transpose(1, 2) * y
 
     run_coarse_tile_test(fn, inputs)
@@ -2489,33 +2454,26 @@ def test_view_4d_transpose_S4():
 def test_view_4d_transpose_H2_S4():
     """x.view(B,S,H,D).transpose(1,2)*y tiled H÷2 S÷4."""
     B, S, H, D = 2, 256, 4, 64
-    _nd = {"batch_size": B, "max_seqlen_q": S, "num_heads": H, "head_dim": D}
+    _nd = {"B": B, "Lq": S, "H": H, "D": D}
     inputs = [
         tensor(
             "x",
             shape=(B, S, H * D),
-            dims=["batch_size", "max_seqlen_q", "num_heads", "head_dim"],
+            dims=["B", "Lq", "H", "D"],
             named_dims=_nd,
         ),
         tensor(
             "y",
             shape=(B, H, S, D),
-            dims=["batch_size", "num_heads", "max_seqlen_q", "head_dim"],
+            dims=["B", "H", "Lq", "D"],
             named_dims=_nd,
         ),
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"num_heads": 2}):
-            with spyre_hint(num_tiles_per_dim={"max_seqlen_q": 4}):
-                with spyre_hint(
-                    expected_named_dims=[
-                        "batch_size",
-                        "num_heads",
-                        "max_seqlen_q",
-                        "head_dim",
-                    ]
-                ):
+        with spyre_hint(num_tiles_per_dim={"H": 2}):
+            with spyre_hint(num_tiles_per_dim={"Lq": 4}):
+                with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
                     return x.view(B, S, H, D).transpose(1, 2) * y
 
     run_coarse_tile_test(fn, inputs)

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -56,7 +56,11 @@ from .propagate_hints import (
     collect_spyre_hints,
     recover_spyre_hints,
 )
-from .wsr.propagate_named_dims import propagate_named_dims, assign_dim_hints
+from .wsr.propagate_named_dims import (
+    propagate_named_dims,
+    validate_named_dims,
+    assign_dim_hints,
+)
 from .propagate_layouts import (
     propagate_mutation_layouts,
     propagate_spyre_tensor_layouts,
@@ -412,6 +416,7 @@ class CustomPreSchedulingPasses:
             # ranges.  This also dissolves the insert_restickify→hint cross-phase
             # contract (issue #3135).
             propagate_named_dims,
+            validate_named_dims,
             assign_dim_hints,
             _maybe_coarse_tile_hints,
             #

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -155,14 +155,8 @@ def compute_coordinates(
     )
 
     # Convert ModularIndexing expressions to sympy.Mod before processing
-    index_before = index
     index = convert_modular_indexing(index)
     repeat_info = find_repeat_vars([index], var_ranges)
-    print(f"DEBUG compute_coordinates: size={size} stride={stride}")
-    print(f"  index_before={index_before}")
-    print(f"  index_after_convert={index}")
-    print(f"  var_ranges={var_ranges}")
-    print(f"  repeat_info={repeat_info}")
     if not hasattr(V.graph, "_repeat_info"):
         V.graph._repeat_info = dict(repeat_info)
     else:
@@ -265,7 +259,6 @@ def compute_coordinates(
     # NOTE: indirect_access_subs substitution is NOT applied here. It is deferred to
     # after align_tensors() so that indirect symbols are decomposed as regular variables.
     # The substitution is applied in simplify_op_spec() after align_tensors completes.
-    print(f"  coordinates={coordinates}")
     return coordinates
 
 

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -155,8 +155,14 @@ def compute_coordinates(
     )
 
     # Convert ModularIndexing expressions to sympy.Mod before processing
+    index_before = index
     index = convert_modular_indexing(index)
     repeat_info = find_repeat_vars([index], var_ranges)
+    print(f"DEBUG compute_coordinates: size={size} stride={stride}")
+    print(f"  index_before={index_before}")
+    print(f"  index_after_convert={index}")
+    print(f"  var_ranges={var_ranges}")
+    print(f"  repeat_info={repeat_info}")
     if not hasattr(V.graph, "_repeat_info"):
         V.graph._repeat_info = dict(repeat_info)
     else:
@@ -259,6 +265,7 @@ def compute_coordinates(
     # NOTE: indirect_access_subs substitution is NOT applied here. It is deferred to
     # after align_tensors() so that indirect symbols are decomposed as regular variables.
     # The substitution is applied in simplify_op_spec() after align_tensors completes.
+    print(f"  coordinates={coordinates}")
     return coordinates
 
 

--- a/torch_spyre/_inductor/wsr/propagate_named_dims.py
+++ b/torch_spyre/_inductor/wsr/propagate_named_dims.py
@@ -509,24 +509,13 @@ def _propagate_named_dims_impl(graph: GraphLowering) -> None:
 
 
 def _graph_has_named_dims_hint(graph: GraphLowering) -> bool:
-    """True if any op carries a spyre_hint(named_dims=[...]) annotation.
-
-    This lets a decomposition name its own intermediate dims entirely in-graph
-    (e.g. the flash SDPA decomposition), without a driver-side name_tensor_dims()
-    call.  Such a hint is the only in-graph way to name a matmul output, whose
-    loop vars carry no names from inputs.
-
-    This scans graph.operations, which _propagate_named_dims_impl then scans
-    again; the extra pass is a cheap gate on a per-compilation path.  If it ever
-    shows up as a hotspot, fold the check into _propagate_named_dims_impl (run
-    unconditionally, short-circuit inside) so operations is walked once.
-    """
-    for op in graph.operations:
-        if isinstance(op, ComputedBuffer):
-            for hint_dict in get_op_hints(op).values():
-                if "named_dims" in hint_dict:
-                    return True
-    return False
+    """True if any op carries a spyre_hint(named_dims=[...]) annotation."""
+    return any(
+        "named_dims" in hint_dict
+        for op in graph.operations
+        if isinstance(op, ComputedBuffer)
+        for hint_dict in get_op_hints(op).values()
+    )
 
 
 def propagate_named_dims(
@@ -573,14 +562,20 @@ def validate_named_dims(graph: GraphLowering) -> None:
         if dp is None:
             continue
         for hint_dict in get_op_hints(op).values():
-            if "expected_named_dims" in hint_dict or "expected_reduction_dims" in hint_dict:
-                logger.info(f"validate_named_dims: checking {op.get_name()} named_dims={dp.named_dims}")
+            if (
+                "expected_named_dims" not in hint_dict
+                and "expected_reduction_dims" not in hint_dict
+            ):
+                continue
+            origins: set = getattr(op.data, "origins", set())
+            aten_ops = [str(n.target) for n in origins if hasattr(n, "target")]
+            logger.info(
+                f"validate_named_dims: checking {op.get_name()} named_dims={dp.named_dims}"
+            )
             if "expected_named_dims" in hint_dict:
                 expected = hint_dict["expected_named_dims"]
                 actual = dp.named_dims
                 if actual != expected:
-                    origins: set = getattr(op.data, "origins", set())
-                    aten_ops = [str(n.target) for n in origins if hasattr(n, "target")]
                     raise AssertionError(
                         f"validate_named_dims: {op.get_name()} {aten_ops}\n"
                         f"  expected_named_dims: {expected}\n"
@@ -590,8 +585,6 @@ def validate_named_dims(graph: GraphLowering) -> None:
                 expected = hint_dict["expected_reduction_dims"]
                 actual = dp.reduction_named_dims
                 if actual != expected:
-                    origins = getattr(op.data, "origins", set())
-                    aten_ops = [str(n.target) for n in origins if hasattr(n, "target")]
                     raise AssertionError(
                         f"validate_named_dims: {op.get_name()} {aten_ops}\n"
                         f"  expected_reduction_dims: {expected}\n"

--- a/torch_spyre/_inductor/wsr/propagate_named_dims.py
+++ b/torch_spyre/_inductor/wsr/propagate_named_dims.py
@@ -557,6 +557,48 @@ def propagate_named_dims(
         _enabled = False
 
 
+def validate_named_dims(graph: GraphLowering) -> None:
+    """Assert expected_named_dims / expected_reduction_dims hints match propagation.
+
+    Reads hint keys set by spyre_hint() and compares them against the
+    _dim_prop_info written by propagate_named_dims().  Raises AssertionError
+    immediately on the first mismatch.  Ops without assertion hints are skipped.
+    Ops where _dim_prop_info is absent (propagation was skipped or the op is a
+    no-op) are also silently skipped.
+    """
+    for op in graph.operations:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        dp = getattr(op, "_dim_prop_info", None)
+        if dp is None:
+            continue
+        for hint_dict in get_op_hints(op).values():
+            if "expected_named_dims" in hint_dict or "expected_reduction_dims" in hint_dict:
+                logger.info(f"validate_named_dims: checking {op.get_name()} named_dims={dp.named_dims}")
+            if "expected_named_dims" in hint_dict:
+                expected = hint_dict["expected_named_dims"]
+                actual = dp.named_dims
+                if actual != expected:
+                    origins: set = getattr(op.data, "origins", set())
+                    aten_ops = [str(n.target) for n in origins if hasattr(n, "target")]
+                    raise AssertionError(
+                        f"validate_named_dims: {op.get_name()} {aten_ops}\n"
+                        f"  expected_named_dims: {expected}\n"
+                        f"  actual   named_dims: {actual}"
+                    )
+            if "expected_reduction_dims" in hint_dict:
+                expected = hint_dict["expected_reduction_dims"]
+                actual = dp.reduction_named_dims
+                if actual != expected:
+                    origins = getattr(op.data, "origins", set())
+                    aten_ops = [str(n.target) for n in origins if hasattr(n, "target")]
+                    raise AssertionError(
+                        f"validate_named_dims: {op.get_name()} {aten_ops}\n"
+                        f"  expected_reduction_dims: {expected}\n"
+                        f"  actual   reduction_dims: {actual}"
+                    )
+
+
 def _assign_dim_hints_impl(operations: list[Operation]) -> None:
     for op in operations:
         if not isinstance(op, ComputedBuffer):


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Add pass `validate_named_dims` that runs right after `propagate_named_dims`.  It allows using a `spyre_hint` to specify the `expected_named_dims` an an output buffer or `expected_reduction_dims` - which do not occur in the output buffer, thus have their own specification mechanism.

**Limitations**: 
The hinted expectations apply to all operations in the nested scope, therefore they cannot be used on 
1. Compound expressions where the operations have different dimension name expectations, such as `a+b.min(dim=0)`.  Compound expressions can be broken up using temporaries and annotated independently.
2. Operations that decompose into multiple operations with different dimension specifications, such as `softmax`
  
The file `test_coarse_tile_e2e.py` is instrumented liberally with dimension expectation annotations.
1. Two tests were added that intentionally fail the expected dimensions to confirm the mechanism is working
2. The existing "structured" all now contain dimension expectations
3. Flash v1, v2, v3, and v4 have been 
    a. Migrated to the structured dimension section
    b. `Annotated` with expected dimensions
    c. Designed to allow launching multiple times with different combinations of dimension sizes and tiled` dimensions (without copy-pasting the flash function itself
    
Note that the original unannotated flash versions were not deleted, and remain below in the "Original tests" section for reference.  These can be deleted at a future time if we gain confidence in the new flash tests and the old tests are deemed unnecessary.

#### Which issue(s) this PR is related to:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
