### PR TITLE
Add perf-tests Makefile target for spyre-perf-suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,18 @@ TEST_CONFIGS ?= tests/configs/torch_spyre_tests
 #                       D2D copies (used as the default in integration-tests.yaml,
 #                       triggered by those upstream repos)
 #   full             — everything (core + LX-planning); default for `make tests`
+#   perf             — spyre-perf-suite benchmark (shells out, not a pytest
+#                      config suite); writes report.xml into RESULTS_DIR
 #   suite_<group>    — all configs inside the <group>/ sub-directory
 #                      (e.g. suite_inductor, suite_tensors)
 #   <label>          — any arbitrary label defined in test_suite_config.labels
 # Empty / unset defaults to "full" (all configs under TEST_CONFIGS).
 TEST_TYPE ?= full
+
+# Where TEST_TYPE=perf writes its benchmark report. Flat /tmp/results so the CI
+# ClickHouse push step (ingest_xml.py globs *.xml non-recursively) finds it
+# alongside every other suite's JUnit XML, with no per-suite subdirectory.
+RESULTS_DIR ?= /tmp/results
 
 # Path to the OOT config checker script (relative to repo root)
 CHECK_SCRIPT  := tests/scripts/check_oot_configs.py
@@ -56,8 +63,21 @@ precommit: ## Run all pre-commit hooks against every file
 # ---------------------------------------------------------------------------
 
 .PHONY: tests
-tests: ## Run torch spyre tests. Narrow scope with TEST_TYPE=smoke|core|full|suite_<group>. TEST_CONFIGS may point at a config directory (filtered by TEST_TYPE) or a single config yaml file (run directly).
-ifneq ($(wildcard $(TEST_CONFIGS)/.),)
+tests: ## Run torch spyre tests. Narrow scope with TEST_TYPE=smoke|core|full|perf|suite_<group>. TEST_CONFIGS may point at a config directory (filtered by TEST_TYPE) or a single config yaml file (run directly).
+# TEST_TYPE=perf is a benchmark mode, not a pytest-config suite: it does not
+# run the OOT config machinery below. It shells out to the installed
+# spyre-perf-suite console script (a wheel dependency of the dev image) and
+# writes report.xml into RESULTS_DIR. Keeping it a mode of `tests` lets CI call
+# it through the same `make tests TEST_TYPE=...` entry point as every other
+# suite, so no new Makefile target or Jenkins wiring is needed.
+ifeq ($(TEST_TYPE),perf)
+	@mkdir -p "$(RESULTS_DIR)"
+	spyre-perf-suite --no-experimental --stacks torch-spyre \
+		--report "$(RESULTS_DIR)/report.txt"
+	@test -f "$(RESULTS_DIR)/report.xml" || \
+		{ echo "ERROR: spyre-perf-suite did not emit $(RESULTS_DIR)/report.xml" >&2; \
+		  exit 1; }
+else ifneq ($(wildcard $(TEST_CONFIGS)/.),)
 	$(eval _PATHS := $(shell python3 $(FILTER_SCRIPT) \
 		--config-dir $(TEST_CONFIGS) \
 		--test-type "$(TEST_TYPE)" \


### PR DESCRIPTION
## What

Adds a `perf-tests` Makefile target that runs the installed `spyre-perf-suite` benchmark and writes JUnit XML under `RESULTS_DIR`.

This is the runnable producer half of the perf-benchmark scaffolding. The CI dispatch and preset scheduling live in spyre-frameworks (companion PR: the `mode: perf` cell already forward-declared for torch-spyre in #528, plus the ClickHouse push wiring).

## Details

```makefile
RESULTS_DIR ?= /tmp/results/benchmark-results

perf-tests:
	@mkdir -p "$(RESULTS_DIR)"
	spyre-perf-suite --no-experimental --stacks torch-spyre \
		--report "$(RESULTS_DIR)/report.txt"
	@test -f "$(RESULTS_DIR)/report.xml" || { ... exit 1; }
```

- `RESULTS_DIR` defaults to `/tmp/results/benchmark-results` to match the `run:` command in the spyre-frameworks perf cell.
- `spyre-perf-suite` auto-writes the JUnit XML next to `--report`, with `classname="spyre_perf_suite.benchmark"`, which is the schema the existing `.github/scripts/ingest_xml.py` benchmark branch keys on (tables `benchmark_runs` / `perf_benchmarks`).
- `--stacks torch-spyre` only (sendnn availability in the dev image is unverified; a `torch-spyre sendnn` opt-in is a follow-up).
- No `--jobs` (the multi-card driver is on an unpushed `spyre-perf-suite` branch, not in the published wheel).
- A guard fails the target if `report.xml` is missing.

## Notes / assumptions

- The `spyre-perf-suite` console script must be on `$PATH` in the `torch-spyre-dev` image (the wheel is baked in via the spyre-frameworks config deps). If it is not, fall back to `python run_benchmark.py`.
- The spyre-frameworks perf cell is `gating: "unstable"`, so until this target exists the forward-declared `run: make perf-tests` is inert, and a failing run only marks the pipeline UNSTABLE.

## Validation

`make -n perf-tests` expands correctly; `make help` lists the new target. On-hardware validation (`make perf-tests` on an x86 Spyre dev image, then assert `report.xml` exists with the benchmark classname) is part of the end-to-end test run tracked with the spyre-frameworks PR.
