### PR TITLE
fix(tests): don't abort the run when the -m probe collects no tests

### DIFF
--- a/tests/oot_framework/run_test.sh
+++ b/tests/oot_framework/run_test.sh
@@ -2534,10 +2534,12 @@ for i in "${!RUN_FILES[@]}"; do
             fi
         done
 
+        # `|| _probe_exit=$?` is required: exit 5 (nothing collected) is the
+        # expected signal here, and under `set -e` a bare subshell would abort
+        # the whole run before the exit code could be inspected.
         _probe_exit=0
         (cd "$run_dir" && python3 -m pytest "$run_basename" \
-            "${_PROBE_ARGS[@]}" --collect-only -q 2>/dev/null)
-        _probe_exit=$?
+            "${_PROBE_ARGS[@]}" --collect-only -q 2>/dev/null) || _probe_exit=$?
 
         if [[ $_probe_exit -eq 5 ]]; then
             # 0 tests match this marker in this file — strip -m from args.


### PR DESCRIPTION
## Problem

On the ppc64le regression leg, `make tests` died with:

```
make: *** [Makefile:63: tests] Error 5
```

736 tests had passed, **zero had failed**, and yet the job was marked failed — with no failing test to point at, no warning, and no indication that anything had been skipped. The remaining ~32 inductor test files in the config were silently never run.

## Root cause

The `-m` marker pre-flight in `tests/oot_framework/run_test.sh`:

```bash
_probe_exit=0
(cd "$run_dir" && python3 -m pytest "$run_basename" \
    "${_PROBE_ARGS[@]}" --collect-only -q 2>/dev/null)
_probe_exit=$?
```

Exit 5 ("no tests collected") is precisely the signal this probe exists to detect — it strips the `-m` flag so the file's tests run unfiltered. But the script runs under `set -euo pipefail`, and a bare subshell in statement position triggers errexit on any non-zero status. So the script aborted at the subshell and `_probe_exit=$?` was never reached.

Because the abort happened mid-loop, everything downstream was skipped too:
- the exit-5 handler's `WARNING: no tests collected` message
- the per-file result summary
- the final `Done. Overall exit code:` line

which is why the failure presented as a bare `Error 5` with no diagnostics.

Reduced:

```bash
$ bash -c 'set -euo pipefail; _p=0; ( exit 5 ); _p=$?; echo "reached $_p"'
$ echo $?
5          # 'reached' never prints
```

Trigger in this repo: `tests/inductor/test_inductor_ops_lx_planning.py` collects no tests under the regression marker filter (it derives its cases from `inductor.test_inductor_ops`), so it hits the exit-5 path and takes the whole run down with it.

## Fix

Append `|| _probe_exit=$?` so the subshell's status is captured instead of tripping errexit, letting the existing strip-the-`-m` logic proceed as designed.

Verified the three relevant cases all survive and preserve the code:

```
input=0 -> probe=0 (survived)
input=5 -> probe=5 (survived)
input=1 -> probe=1 (survived)
```

`bash -n` on the modified script passes. Audited the rest of the file for the same bare-subshell-then-`$?` pattern — this was the only occurrence.

## Impact

Two bugs in one: the suite aborted early (masking ~32 files' worth of coverage) **and** did so without any diagnostic output. Both are fixed by capturing the exit code.