### PR TITLE
Split reorder_unhinted_interlopers as a separate toplevel pass

### DIFF
--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -310,6 +310,15 @@ def _runs(*passes: Callable) -> Callable[[Callable], Callable]:
 
 @_runs(
     reorder_unhinted_interlopers,
+)
+def _maybe_reorder_unhinted_interlopers(graph: GraphLowering) -> None:
+    """Move unhinted ComputedBuffer ops that interrupt hint-group runs."""
+    if config.ignore_wsr_hints:
+        return
+    reorder_unhinted_interlopers(graph)
+
+
+@_runs(
     hints_to_coarse_tile_groups,
     validate_coarse_tile_groups,
     coarse_tile,
@@ -322,7 +331,6 @@ def _maybe_coarse_tile_hints(graph: GraphLowering) -> None:
     """
     if config.ignore_wsr_hints:
         return
-    reorder_unhinted_interlopers(graph)
     groups = hints_to_coarse_tile_groups(graph)
     if not groups:
         return
@@ -418,6 +426,7 @@ class CustomPreSchedulingPasses:
             propagate_named_dims,
             validate_named_dims,
             assign_dim_hints,
+            _maybe_reorder_unhinted_interlopers,
             _maybe_coarse_tile_hints,
             #
             # Tensor Layout (Stickification)


### PR DESCRIPTION
#### What type of PR is this?

- [X] cleanup

#### What this PR does:

This PR splits `reorder_unhinted_interlopers` as a separate toplevel pass making it easy to log the output separately from the rest of the working set reduction transformation.

#### Does this PR introduce a user-facing change?

No
