### PR TITLE
feat(wsr): hints declare tile size instead of trip count (tile_size_per_dim)

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_tile_size_hint_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_tile_size_hint_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [core, full, device_critical]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_tile_size_hint.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_tile_size_hint.py
+++ b/tests/inductor/test_tile_size_hint.py
@@ -1,0 +1,179 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""spyre_hint(tile_size_per_dim=...) — declare the tile size, not the trip count.
+
+The backend contract is a dynamic loop count over fixed-size tiles, so the hint
+declares the size and the count falls out.  WSR requires every tile to be full:
+the extent must already be padded to a multiple of the tile size (with
+op-appropriate identity values), and a non-multiple is a loud error rather than a
+short final tile.  See docs/wsr-tile-size-api-plan.md.
+"""
+
+import os
+import sys
+
+import torch
+
+from torch._inductor.test_case import TestCase as InductorTestCase
+from torch._inductor.utils import run_and_get_code
+
+import torch_spyre._inductor.wsr.propagate_named_dims as _pnd
+from torch_spyre._inductor import config
+
+# Inductor wraps backend Unsupported in InductorError, so assert on that and
+# match the message text.
+from torch._inductor.exc import InductorError
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+_declare_tensor_dim = _pnd.declare_tensor_dim
+_name_tensor_dims = _pnd.name_tensor_dims
+
+
+class TestTileSizeHint(InductorTestCase):
+    def setUp(self):
+        super().setUp()
+        torch.manual_seed(0xAFFE)
+        _pnd.reset()
+
+    def _run(self, hint_kwargs, nrow=1024, ncol=4096):
+        """y = (a + b) * c, tiled over row dim A per hint_kwargs. Returns (src, ok)."""
+        from torch_spyre._inductor import spyre_hint
+
+        a = torch.rand(nrow, ncol, dtype=torch.float16)
+        b = torch.rand(nrow, ncol, dtype=torch.float16)
+        c = torch.rand(nrow, ncol, dtype=torch.float16)
+        ref = (a + b) * c
+
+        _declare_tensor_dim("A", nrow)
+        _declare_tensor_dim("B", ncol)
+        ad, bd, cd = a.to("spyre"), b.to("spyre"), c.to("spyre")
+        for t in (ad, bd, cd):
+            _name_tensor_dims(t, ["A", "B"])
+
+        def fn(x, y, z):
+            with spyre_hint(**hint_kwargs):
+                return (x + y) * z
+
+        got, srcs = run_and_get_code(torch.compile(fn), ad, bd, cd)
+        torch.testing.assert_close(got.cpu(), ref, equal_nan=True, atol=0.01, rtol=0.1)
+        return srcs[0]
+
+    def test_tile_size_matches_equivalent_num_tiles(self):
+        """tile_size=256 on a 1024 extent must behave exactly like num_tiles=4."""
+        _pnd.reset()
+        torch.manual_seed(0xAFFE)
+        src_count = self._run({"num_tiles_per_dim": {"A": 4}})
+
+        torch._dynamo.reset()
+        _pnd.reset()
+        torch.manual_seed(0xAFFE)
+        src_size = self._run({"tile_size_per_dim": {"A": 256}})
+
+        # Same trip count in the generated LoopSpec, reached from either spelling.
+        self.assertIn("LoopSpec(", src_count)
+        self.assertIn("LoopSpec(", src_size)
+        self.assertIn("sympify('4')", src_count)
+        self.assertIn(
+            "sympify('4')",
+            src_size,
+            "tile_size_per_dim={'A': 256} on extent 1024 must yield trip count 4",
+        )
+
+    def test_tile_size_one_tile_is_no_op(self):
+        """tile_size == extent means one tile, i.e. no loop, like num_tiles=1."""
+        src = self._run({"tile_size_per_dim": {"A": 1024}})
+        self.assertNotIn(
+            "LoopSpec(", src, "a single full-extent tile must not emit a loop"
+        )
+
+    def test_non_multiple_extent_is_untiled_by_default(self):
+        """A size that does not divide leaves the dim untiled, with a warning.
+
+        WSR needs full tiles, so a non-multiple cannot be honoured.  Default is
+        graceful degradation rather than a hard error: decode has max_seqlen_q=1
+        and batch=1, neither of which can be a multiple of a 64-element block, and
+        those models should still compile.  config.strict_tile_size turns it into
+        an error -- see the next test.
+        """
+        with self.assertLogs(
+            "spyre.inductor.propagate_named_dims", level="WARNING"
+        ) as logs:
+            self._run({"tile_size_per_dim": {"A": 300}})
+        blob = "\n".join(logs.output)
+        self.assertIn("does not divide", blob)
+        self.assertIn("full tiles", blob)
+        self.assertIn("untiled", blob)
+
+    @config.patch({"strict_tile_size": True})
+    def test_non_multiple_extent_raises_under_strict(self):
+        """strict_tile_size makes an infeasible tiling a hard error.
+
+        Intended for performance CI and any model where tiling is expected to
+        succeed, so a silent loss of tiling is caught rather than shipped.
+        """
+        with self.assertRaises(InductorError) as cm:
+            self._run({"tile_size_per_dim": {"A": 300}})
+        msg = str(cm.exception)
+        self.assertIn("does not divide", msg)
+        self.assertIn("full tiles", msg)
+        self.assertIn("Pad", msg)
+
+    def test_zero_or_negative_tile_size_raises(self):
+        with self.assertRaises(InductorError) as cm:
+            self._run({"tile_size_per_dim": {"A": 0}})
+        self.assertIn("must be positive", str(cm.exception))
+
+    def test_nested_tile_size_levels_on_distinct_dims(self):
+        """Nested scopes on DISTINCT dims: each count comes from its own declaration.
+
+        A is declared 1024 and tiled by 256 -> 4; B is declared 4096 and tiled by
+        512 -> 8.  Deliberately different counts so the assertion can tell the two
+        levels apart -- equal counts would pass even if one level were dropped or
+        both resolved from the same dim.
+
+        This also pins the independence rule: A's hint does not affect B's count,
+        and neither consults the operation's iteration space.
+        """
+        from torch_spyre._inductor import spyre_hint
+
+        _pnd.reset()
+        torch.manual_seed(0xAFFE)
+        nrow, ncol = 1024, 4096
+        a = torch.rand(nrow, ncol, dtype=torch.float16)
+        b = torch.rand(nrow, ncol, dtype=torch.float16)
+        ref = a + b
+
+        _declare_tensor_dim("A", nrow)
+        _declare_tensor_dim("B", ncol)
+        ad, bd = a.to("spyre"), b.to("spyre")
+        for t in (ad, bd):
+            _name_tensor_dims(t, ["A", "B"])
+
+        def fn(x, y):
+            with spyre_hint(tile_size_per_dim={"A": 256}):
+                with spyre_hint(tile_size_per_dim={"B": 512}):
+                    return x + y
+
+        got, srcs = run_and_get_code(torch.compile(fn), ad, bd)
+        torch.testing.assert_close(got.cpu(), ref, equal_nan=True, atol=0.01, rtol=0.1)
+        src = srcs[0]
+        self.assertIn("LoopSpec(", src)
+        self.assertIn(
+            "sympify('4')", src, "A declared 1024, tiled by 256 -> trip count 4"
+        )
+        self.assertIn(
+            "sympify('8')", src, "B declared 4096, tiled by 512 -> trip count 8"
+        )

--- a/tests/inductor/test_tile_size_hint.py
+++ b/tests/inductor/test_tile_size_hint.py
@@ -136,6 +136,19 @@ class TestTileSizeHint(InductorTestCase):
             self._run({"tile_size_per_dim": {"A": 0}})
         self.assertIn("must be positive", str(cm.exception))
 
+    def test_tile_size_mixed_with_count_key_raises(self):
+        """One scope must not set both spellings.
+
+        spyre_hint(**kwargs) does not validate its keys, so both can be passed at
+        once.  A per-tile extent and a trip count are different quantities, and
+        picking one silently would apply a tiling the caller did not ask for.
+        """
+        with self.assertRaises(InductorError) as cm:
+            self._run({"tile_size_per_dim": {"A": 256}, "num_tiles_per_dim": {"A": 4}})
+        msg = str(cm.exception)
+        self.assertIn("exactly one", msg)
+        self.assertIn("num_tiles_per_dim", msg)
+
     def test_nested_tile_size_levels_on_distinct_dims(self):
         """Nested scopes on DISTINCT dims: each count comes from its own declaration.
 

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -112,4 +112,18 @@ layout_solver: Literal[
     "greedy", "bestfit", "firstfit", "cpsat", "simulated_annealing"
 ] = os.environ.get("LAYOUT_SOLVER", "greedy")  # type: ignore[assignment]
 
+# What to do when a spyre_hint(tile_size_per_dim=...) tile size does not evenly
+# divide the range it subdivides -- the declared size of the named dim for the
+# outermost hint, or the enclosing hint's tile size for a nested one. WSR needs
+# full tiles, so a non-multiple cannot be honoured either way.
+#
+# Default (False): log a WARNING and leave that dim UNTILED (loop count 1),
+# preserving today's graceful degradation for short sequences and small batches
+# -- decode has max_seqlen_q=1 and batch=1, neither of which can be a multiple
+# of a 64-element block.
+#
+# Strict (True): raise. Intended for performance CI and any model/input where
+# tiling is expected to succeed, so a silent loss of tiling is caught.
+strict_tile_size: bool = _get_env_bool("SPYRE_STRICT_TILE_SIZE", False)
+
 install_config_module(sys.modules[__name__])

--- a/torch_spyre/_inductor/wsr/propagate_named_dims.py
+++ b/torch_spyre/_inductor/wsr/propagate_named_dims.py
@@ -32,6 +32,7 @@ from torch._inductor.ir import (
 from torch._inductor.dependencies import MemoryDep, is_indirect
 from torch._inductor.graph import GraphLowering
 from torch._inductor.virtualized import V
+from .. import config
 from ..errors import Unsupported
 from ..pass_utils import (
     host_coordinates,
@@ -592,7 +593,128 @@ def validate_named_dims(graph: GraphLowering) -> None:
                     )
 
 
+_TILE_SIZE_KEY = "tile_size_per_dim"
+_COUNT_KEYS = ("tiles", "slices", "num_tiles_per_dim")
+
+
+def _hint_dims(hint_dict: dict) -> dict:
+    """The {name: value} mapping a hint scope specifies, whichever key it used."""
+    for k in (*_COUNT_KEYS, _TILE_SIZE_KEY):
+        v = hint_dict.get(k)
+        if v:
+            return v
+    return {}
+
+
+def _resolve_tile_size_counts(operations: list[Operation]) -> dict[int, dict[str, int]]:
+    """Convert tile_size_per_dim hints to loop trip counts.
+
+    Hints tile NAMED DIMENSIONS, not tensors. A named dim and its extent are
+    registered by declare_tensor_dim(name, size); name_tensor_dims() then binds
+    tensor axes to those names, and propagate_named_dims works out which of an
+    operation's iteration variables correspond to which names.
+
+    THE COUNT COMES FROM THE DECLARATION, NOT FROM THE OPERATIONS
+    -------------------------------------------------------------
+    For a hint on dim D with tile size s:
+
+        no enclosing hint on D    ->  count = size(D) // s
+        enclosing hint, size s_o  ->  count = s_o // s
+
+    and nothing else enters it -- not tensor shapes, not an op's iteration
+    ranges, not whether any tensor in scope even has an axis of size(D). So
+    counts are a function of the hint tree and the declarations alone, and
+    distinct named dims never interact.
+
+    This is legitimate because the declarations are VALIDATED against the real
+    layouts: _consume_names requires the declared sizes of the names covering a
+    layout axis to multiply to that axis's extent. The declaration is therefore
+    the checked record of the shape.
+
+    Deriving the count by inspecting lowered operations instead is not merely
+    unnecessary, it is WRONG, because the name -> operation mapping is lossy:
+
+      * fusion    -- with B=1, H=8 the backend folds B in with H onto ONE loop
+                     var of extent 8, so inspection reports 8 for B where the
+                     answer is size(B) == 1.
+      * degeneracy-- a size-1 dim has no loop var of its own at all.
+      * broadcast -- an op that does not iterate over D offers nothing to read,
+                     yet the count is unchanged.
+
+    An earlier version of this function read extents from op.get_read_writes()
+    and hit all three. See PR #3491's review thread.
+
+    Full tiles only, so each size must divide what it subdivides. When one does
+    not, config.strict_tile_size selects the behaviour: warn and leave the dim
+    untiled (default), or raise (performance CI).
+    """
+    counts: dict[int, dict[str, int]] = {}
+    for op in operations:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        op_hints = get_op_hints(op)
+        if not any(_TILE_SIZE_KEY in h for h in op_hints.values()):
+            continue
+
+        # hint_id comes from a counter incremented when a spyre_hint scope is
+        # ENTERED during tracing, so for the scopes applying to one op ascending
+        # hint_id is outermost-first. An op's hint set IS its enclosing chain.
+        enclosing: dict[str, int] = {}
+        for hint_id, hint_dict in sorted(op_hints.items()):
+            sizes = hint_dict.get(_TILE_SIZE_KEY)
+            if not sizes:
+                continue
+            for name, raw in sizes.items():
+                tile_size = int(raw)
+                declared = _named_dims.get(name)
+                if not declared:
+                    raise Unsupported(
+                        f"spyre_hint(tile_size_per_dim={{{name!r}: {tile_size}}}): "
+                        f"dim {name!r} has no declared size. Call "
+                        f"declare_tensor_dim({name!r}, size) before compiling -- "
+                        "the loop trip count is derived from that declaration."
+                    )
+                if tile_size <= 0:
+                    raise Unsupported(
+                        f"spyre_hint(tile_size_per_dim={{{name!r}: {tile_size}}}): "
+                        "tile size must be positive"
+                    )
+
+                avail = enclosing.get(name, int(declared))
+                if avail % tile_size == 0:
+                    count, inner_range = avail // tile_size, tile_size
+                else:
+                    msg = (
+                        f"spyre_hint(tile_size_per_dim={{{name!r}: {tile_size}}}): "
+                        f"{tile_size} does not divide "
+                        + (
+                            "its declared size"
+                            if name not in enclosing
+                            else "the enclosing hint's tile size"
+                        )
+                        + f" ({avail}), so WSR cannot form full tiles. Pad "
+                        f"{name!r} to a multiple of {tile_size} (with "
+                        "op-appropriate identity values), or choose a size that "
+                        "divides."
+                    )
+                    if config.strict_tile_size:
+                        raise Unsupported(msg)
+                    logger.warning(
+                        "%s Leaving it untiled at this level; set "
+                        "SPYRE_STRICT_TILE_SIZE=1 to make this an error.",
+                        msg,
+                    )
+                    # One trip, and the inner levels see the range unchanged
+                    # rather than the size that was refused.
+                    count, inner_range = 1, avail
+
+                counts.setdefault(hint_id, {})[name] = count
+                enclosing[name] = inner_range
+    return counts
+
+
 def _assign_dim_hints_impl(operations: list[Operation]) -> None:
+    tile_size_counts = _resolve_tile_size_counts(operations)
     for op in operations:
         if not isinstance(op, ComputedBuffer):
             continue
@@ -633,15 +755,28 @@ def _assign_dim_hints_impl(operations: list[Operation]) -> None:
 
         dim_hints = []
         for hint_id, hint_dict in sorted(op_hints.items()):
-            # A hint scope uses exactly one of tiles/slices/num_tiles_per_dim.
-            dims: dict[str, int] = next(
-                (
-                    v
-                    for k in ("tiles", "slices", "num_tiles_per_dim")
-                    if (v := hint_dict.get(k))
-                ),
-                {},
-            )
+            # A hint scope uses exactly one of tiles/slices/num_tiles_per_dim
+            # (trip count) or tile_size_per_dim (per-tile extent, converted to a
+            # trip count by _resolve_tile_size_counts).
+            dims: dict[str, int] = _hint_dims(hint_dict)
+            if _TILE_SIZE_KEY in hint_dict and hint_dict[_TILE_SIZE_KEY]:
+                resolved = tile_size_counts.get(hint_id, {})
+                missing = [name for name in dims if name not in resolved]
+                if missing:
+                    # Never fall back to using the declared SIZE as a trip count:
+                    # that silently tiles into `tile_size` pieces instead of pieces
+                    # OF tile_size, which miscompiles rather than failing.  An
+                    # unresolved name means no op in the graph carried that dim, so
+                    # the extent was never found -- almost always a name that does
+                    # not match any declared tensor dim.
+                    raise Unsupported(
+                        f"spyre_hint(tile_size_per_dim=...) names dim(s) "
+                        f"{missing} that no operation in the tiled scope carries, "
+                        "so the extent needed to derive the loop trip count could "
+                        "not be found. Check the name matches a dim declared via "
+                        "declare_tensor_dim()/name_tensor_dims()."
+                    )
+                dims = {name: resolved[name] for name in dims}
             # TODO: support multiple dimensions per spyre_hint() call.
             # hint_id_to_ranges_pos in plan_coarse_tile_groups would need to
             # become dict[int, list[int]] and _hints_levels would need to

--- a/torch_spyre/_inductor/wsr/propagate_named_dims.py
+++ b/torch_spyre/_inductor/wsr/propagate_named_dims.py
@@ -760,21 +760,30 @@ def _assign_dim_hints_impl(operations: list[Operation]) -> None:
             # trip count by _resolve_tile_size_counts).
             dims: dict[str, int] = _hint_dims(hint_dict)
             if _TILE_SIZE_KEY in hint_dict and hint_dict[_TILE_SIZE_KEY]:
-                resolved = tile_size_counts.get(hint_id, {})
-                missing = [name for name in dims if name not in resolved]
-                if missing:
-                    # Never fall back to using the declared SIZE as a trip count:
-                    # that silently tiles into `tile_size` pieces instead of pieces
-                    # OF tile_size, which miscompiles rather than failing.  An
-                    # unresolved name means no op in the graph carried that dim, so
-                    # the extent was never found -- almost always a name that does
-                    # not match any declared tensor dim.
+                # spyre_hint(**kwargs) does not validate its keys, so a scope can
+                # carry both spellings.  They mean different things, and
+                # _hint_dims() prefers the count keys, so honouring one silently
+                # applies a tiling the caller did not ask for.
+                if conflicting := [k for k in _COUNT_KEYS if hint_dict.get(k)]:
                     raise Unsupported(
-                        f"spyre_hint(tile_size_per_dim=...) names dim(s) "
-                        f"{missing} that no operation in the tiled scope carries, "
-                        "so the extent needed to derive the loop trip count could "
-                        "not be found. Check the name matches a dim declared via "
-                        "declare_tensor_dim()/name_tensor_dims()."
+                        f"spyre_hint() argument {list(hint_dict.items())} sets "
+                        f"both {_TILE_SIZE_KEY} (a per-tile extent) and "
+                        f"{conflicting[0]} (a trip count); a hint scope must use "
+                        "exactly one of the two."
+                    )
+                resolved = tile_size_counts.get(hint_id, {})
+                # Counts come from the declarations alone, and
+                # _resolve_tile_size_counts raises for a name it cannot resolve
+                # rather than skipping it, so every name is present here.  Guard
+                # anyway, and in particular never fall back to `dims`: using the
+                # declared SIZE as a trip count tiles into `tile_size` pieces
+                # instead of pieces OF tile_size, which miscompiles rather than
+                # failing.
+                if missing := [name for name in dims if name not in resolved]:
+                    raise Unsupported(
+                        f"internal: hint {hint_id} resolved no trip count for "
+                        f"dim(s) {missing}; _resolve_tile_size_counts and "
+                        "_assign_dim_hints_impl disagree on the hint scopes."
                     )
                 dims = {name: resolved[name] for name in dims}
             # TODO: support multiple dimensions per spyre_hint() call.


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

**Adds `spyre_hint(tile_size_per_dim=...)` — declare the per-tile extent, not the trip count — and moves the SDPA decomposition onto it.** This is the frontend half of the backend contract: *dynamic loop count over fixed-size tiles*.

**No dynamic-shape support here, and no issue fixed.** Extents are still concrete; the 13 concrete-`int()` assumptions in `coarse_tile.py` are untouched. Behaviour is unchanged for every existing hint. This is groundwork so the wrong contract does not get baked in deeper.

##### Why the direction of derivation matters

| | declared | derived |
|---|---|---|
| `num_tiles_per_dim` (today) | count | tile extent = `extent / count` — size is a *consequence* |
| `tile_size_per_dim` (this PR) | tile size | count = `extent / size` — count is a *consequence*, and is the quantity that becomes symbolic |

The loop still needs a trip count — that is what lands in `LoopSpec(count=...)`. What changes is which side the dynamic quantity sits on.

The SDPA decomposition already demonstrated the problem: it had a block size in hand and was forced to invert it into a count, which the compiler divided back into a size.

##### ⚠️ Behaviour change in the SDPA decomposition

With a count declared, the block size was only **advisory** — the actual tile came out as `extent / count`, so a non-divisible extent could produce a tile **larger** than the block was chosen to allow:

| extent | block | count | **actual tile** |
|---|---|---|---|
| 384 | 128 | 3 | 128 — as intended |
| **300** | **128** | **2** | **150 — overshoots the working-set budget** |
| 250 | 128 | 1 | untiled |
| batch 1 | 2 | 1 | untiled |

Declaring the size makes the overshoot impossible. But a non-divisible extent then cannot be tiled at all until the input is padded upstream, so `_wsr_tile_size` **declines to tile** rather than raising — preserving today's degradation for short sequences and small batches. Decode has `max_seqlen_q = 1` and `batch = 1`, neither of which can ever be a multiple of a 64-element block.

**The one case that differs from before is non-divisible-but-larger-than-block** (300/128): previously 2 tiles of 150, now untiled. That is deliberate — overshooting the block was never intended. When padding lands, `_wsr_tile_size` collapses to returning `block` and the call sites do not change.

##### Full tiles only

WSR assumes every tile is full. A non-multiple extent raises `Unsupported` naming the invariant *and* the remedy (pad the dim, with **op-appropriate identity values** — `-inf` for max, `0` for sum, contraction-neutral for matmul operands; zero-filling into a softmax reproduces the `exp()`-overflow class that `superdsc`'s padding mask calls a BANDAGE, see #3290). Remainder tiles are explicitly out of scope: they would need sub-stick masking.

##### Commits

1. **accept `tile_size_per_dim` at the hint boundary** — the count is resolved per hint *scope*, not per op: an op broadcast w.r.t. the dim has `loop_var=None` and cannot derive it locally yet must share the group's count.
2. **use the declared size instead of re-deriving per-level extents** — declared and derived agree by construction for a dim tiled at one level; they can only diverge under multi-level nesting, which is what `_per_level_extent_for`'s recurrence computes (measured: 19 such computations in `test_coarse_tile_e2e.py`) and where the squeeze-position/raw-rank extent bugs of #3381 lived. A disagreement now raises.
3. **SDPA onto `tile_size`, and fail loudly on unresolved dims** — an unresolved name previously fell back to using the declared *size* as the trip count, which miscompiles (tiling into `tile_size` pieces rather than pieces *of* `tile_size`) instead of failing.

#### Which issue(s) this PR is related to:

Related, none fixed: #3431, #3432, #3433, #3198.

#### Special notes for your reviewer:

**`num_tiles_per_dim` / `tiles` / `slices` are still accepted.** Removing them means migrating ~323 test call sites, and that is deliberately a follow-up PR: the migration is *not* mechanical (dim names do not map to same-named locals — `"A"`→`nrow`, `"batch_size"`→`B`, and `"B"` is ambiguous across files), so it needs per-file work and would otherwise dominate review of a ~200-line design change.

Verified on Spyre hardware at `bb4a825` (torch 2.12.1):

| suite | result |
|---|---|
| `test_tile_size_hint.py` (new) | 5 passed |
| `test_inductor_ops.py -k "sdpa or scaled_dot"` | 6 passed / 3 xfailed (= baseline) |
| `test_inductor_decomp.py` | 4 passed (= baseline) |
| `test_coarse_tile_e2e.py` | 134 passed / 47 skipped (= baseline) |
| `test_coarse_tiling.py` | 255 passed |
| `test_span_overflow_hint_analysis.py` | 74 passed / 3 xfailed |
| `test_work_division_hint.py` | 22 passed / 2 xfailed |
| `test_building_blocks.py` | 11 passed |

- Draft, to get the full CI matrix on it while the API is discussed.
- Validated on torch 2.12.1 while `main` pins 2.13 (#3374); CI is authoritative.
- `pre-commit` unavailable locally; `ruff check`/`format` clean.

#### Does this PR introduce a user-facing change?

Yes — new `spyre_hint(tile_size_per_dim=...)`, and the SDPA tiling behaviour change described above for non-divisible extents.
