### PR TITLE
Add buffer name to format_operations output

### DIFF
--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1791,6 +1791,7 @@ def format_operations(operations: list[Operation]) -> str:
     for op in operations:
         buf.write(f"{op.get_operation_name()}: {type(op).__name__}")
         if isinstance(op, ComputedBuffer):
+            buf.write(f"\n  buffer={op.get_name()}")
             buf.write(f"\n  layout={op.layout}")
             if allocation := getattr(op.layout, "allocation", None):
                 buf.write(f"\n  allocation={allocation}")


### PR DESCRIPTION
#### What type of PR is this?

- [X] feature

#### What this PR does:

This PR adds the output buffer name to the output of `format_operations`, which is useful for logging/debugging purposes since the body of the op only includes the names of the input buffers.

#### Does this PR introduce a user-facing change?

No