### PR TITLE
Replace op and op id with buffer name in coarse tiling

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -79,7 +79,6 @@ from torch_spyre._inductor.wsr.coarse_tile import (
     _divide_ranges,
     _full_buffer_read_deps,
     _insert_read_copy_ops,
-    _replace_group_op,
     _rescale_index,
     _retile_load_index_from_strides,
     _should_patch_retiled_load_indexes,
@@ -901,29 +900,6 @@ class TestShouldPatchRetiledLoadIndexes(unittest.TestCase):
         self.assertTrue(result)
 
 
-class TestReplaceGroupOp(unittest.TestCase):
-    """Unit tests for keeping coarse-tile group op references current."""
-
-    def test_replaces_by_identity(self):
-        old_op = _make_op(_make_pointwise([4]), "old")
-        new_op = _make_op(_make_pointwise([4]), "new")
-        group_ops = [old_op]
-
-        _replace_group_op(group_ops, old_op, new_op)
-
-        self.assertIs(group_ops[0], new_op)
-
-    def test_replaces_by_operation_name_when_identity_changed(self):
-        stale_op = _make_op(_make_pointwise([4]), "old")
-        current_op = _make_op(_make_pointwise([4]), "old")
-        new_op = _make_op(_make_pointwise([4]), "new")
-        group_ops = [stale_op]
-
-        _replace_group_op(group_ops, current_op, new_op)
-
-        self.assertIs(group_ops[0], new_op)
-
-
 # ===========================================================================
 # 1. LoopSpec data structure and codegen serialization
 # ===========================================================================
@@ -1439,7 +1415,7 @@ class TestCoarseTile(unittest.TestCase):
         op_computed = _make_hinted_op(data, "op0", hints=((0, 0),))
         coarse_tile(
             _graph([op_extern, op_computed]),
-            [([op_extern, op_computed], [(0, Integer(2))])],
+            [([op_computed.get_name()], [(0, Integer(2))])],
         )
         self.assertEqual(op_computed.loop_info.loop_group_id, (0,))
         self.assertEqual(data.ranges[0], Integer(8))
@@ -1449,7 +1425,7 @@ class TestCoarseTile(unittest.TestCase):
         n = Symbol("N", positive=True)
         data = _make_pointwise([n])
         op = _make_hinted_op(data, "op0", hints=((0, 0),))
-        coarse_tile(_graph([op]), [([op], [(0, k)])])
+        coarse_tile(_graph([op]), [([op.get_name()], [(0, k)])])
         self.assertEqual(op.loop_info.loop_count, [k])
         self.assertEqual(simplify(data.ranges[0] - n / k), 0)
 
@@ -1461,7 +1437,10 @@ class TestCoarseTile(unittest.TestCase):
         op1 = _make_hinted_op(d1, "op1", hints=((0, 0),))
         op2 = _make_hinted_op(d2, "op2", hints=((0, 0),))
         with self.assertRaises(RuntimeError):
-            coarse_tile(_graph([op0, op1, op2]), [([op0, op2], [(0, Integer(4))])])
+            coarse_tile(
+                _graph([op0, op1, op2]),
+                [([op0.get_name(), op2.get_name()], [(0, Integer(4))])],
+            )
 
     def test_op_not_in_operations_raises(self):
         data = _make_pointwise([Integer(32)])
@@ -1470,7 +1449,9 @@ class TestCoarseTile(unittest.TestCase):
             _make_pointwise([Integer(8)]), "unknown", hints=((0, 0),)
         )
         with self.assertRaises(RuntimeError):
-            coarse_tile(_graph([op_known]), [([op_unknown], [(0, Integer(2))])])
+            coarse_tile(
+                _graph([op_known]), [([op_unknown.get_name()], [(0, Integer(2))])]
+            )
 
 
 class TestCoarseTileNested(unittest.TestCase):
@@ -1489,7 +1470,9 @@ class TestCoarseTileNested(unittest.TestCase):
     def test_nested_spec_stamps_list_attributes(self):
         data = _make_pointwise([Integer(256), Integer(128)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 1)))
-        coarse_tile(_graph([op]), [([op], [(1, Integer(4)), (2, Integer(2))])])
+        coarse_tile(
+            _graph([op]), [([op.get_name()], [(1, Integer(4)), (2, Integer(2))])]
+        )
         self.assertEqual(op.loop_info.loop_group_id, (0, 0))
         self.assertEqual(op.loop_info.loop_count, [Integer(4), Integer(2)])
         self.assertEqual(op.loop_info.loop_tiled_dims, [[0], [1]])
@@ -1497,14 +1480,18 @@ class TestCoarseTileNested(unittest.TestCase):
     def test_nested_spec_divides_ranges_both_levels(self):
         data = _make_pointwise([Integer(256), Integer(128)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 1)))
-        coarse_tile(_graph([op]), [([op], [(1, Integer(4)), (2, Integer(2))])])
+        coarse_tile(
+            _graph([op]), [([op.get_name()], [(1, Integer(4)), (2, Integer(2))])]
+        )
         self.assertEqual(data.ranges[0], Integer(64))
         self.assertEqual(data.ranges[1], Integer(64))
 
     def test_nested_spec_outer_only_divides_outer_dim(self):
         data = _make_pointwise([Integer(32), Integer(64), Integer(16)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 1)))
-        coarse_tile(_graph([op]), [([op], [(1, Integer(4)), (2, Integer(8))])])
+        coarse_tile(
+            _graph([op]), [([op.get_name()], [(1, Integer(4)), (2, Integer(8))])]
+        )
         self.assertEqual(data.ranges[0], Integer(8))
         self.assertEqual(data.ranges[1], Integer(8))
         self.assertEqual(data.ranges[2], Integer(16))
@@ -1518,8 +1505,8 @@ class TestCoarseTileNested(unittest.TestCase):
         coarse_tile(
             _graph([op0, op1]),
             [
-                ([op0], [(1, Integer(4))]),
-                ([op1], [(2, Integer(4)), (3, Integer(2))]),
+                ([op0.get_name()], [(1, Integer(4))]),
+                ([op1.get_name()], [(2, Integer(4)), (3, Integer(2))]),
             ],
         )
         self.assertEqual(op0.loop_info.loop_group_id, (0,))
@@ -1536,7 +1523,9 @@ class TestCoarseTileNested(unittest.TestCase):
     def test_nested_same_dim_different_counts(self):
         data = _make_pointwise([Integer(256)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 0)))
-        coarse_tile(_graph([op]), [([op], [(1, Integer(4)), (2, Integer(2))])])
+        coarse_tile(
+            _graph([op]), [([op.get_name()], [(1, Integer(4)), (2, Integer(2))])]
+        )
         self.assertEqual(data.ranges[0], Integer(32))
         self.assertEqual(op.loop_info.loop_count, [Integer(4), Integer(2)])
         self.assertEqual(op.loop_info.loop_tiled_dims, [[0], [0]])
@@ -1572,21 +1561,20 @@ class TestCoarseTileNested(unittest.TestCase):
         zero-mutation test plus this test's confirmation that stamping still
         happens by the time coarse_tile() returns.
         """
-        from torch._inductor.ir import ComputedBuffer
 
         d0 = _make_pointwise([Integer(64), Integer(32)])
         d1 = _make_pointwise([Integer(128), Integer(64)])
         op0 = _make_hinted_op(d0, "op0", hints=((1, 0),))
         op1 = _make_hinted_op(d1, "op1", hints=((2, 0), (3, 1)))
-        groups = [
-            ([op0], [(1, Integer(4))]),
-            ([op1], [(2, Integer(4)), (3, Integer(2))]),
-        ]
-        coarse_tile(_graph([op0, op1]), groups)
-        for group_ops, _ in groups:
-            for op in group_ops:
-                if isinstance(op, ComputedBuffer):
-                    self.assertIsNotNone(getattr(op, "loop_info", None))
+        coarse_tile(
+            _graph([op0, op1]),
+            [
+                ([op0.get_name()], [(1, Integer(4))]),
+                ([op1.get_name()], [(2, Integer(4)), (3, Integer(2))]),
+            ],
+        )
+        for op in (op0, op1):
+            self.assertIsNotNone(getattr(op, "loop_info", None))
 
 
 class TestCoarseTileTiledDimsPerRead(unittest.TestCase):
@@ -1646,7 +1634,7 @@ class TestCoarseTileTiledDimsPerRead(unittest.TestCase):
             hints=((1, 0), (2, 1)),
         )
         levels = [(1, Integer(2)), (2, Integer(4))]
-        plan = plan_coarse_tile_groups([op], [([op], levels)])
+        plan = plan_coarse_tile_groups([op], [([op.get_name()], levels)])
         _apply_plan([op], (0, 0), levels, {op.get_operation_name(): 0}, plan)
         # Output: dim 0 tiled at level 0 (K=2 outer, extent 512 = 1024/2);
         # dim 1 tiled at level 1 (M=4 inner, extent 1024 = 4096/4). Neither
@@ -1677,7 +1665,7 @@ class TestCoarseTileTiledDimsPerRead(unittest.TestCase):
             hints=((1, 0), (2, 1)),
         )
         levels = [(1, Integer(2)), (2, Integer(4))]
-        plan = plan_coarse_tile_groups([op], [([op], levels)])
+        plan = plan_coarse_tile_groups([op], [([op.get_name()], levels)])
         _apply_plan([op], (0, 0), levels, {op.get_operation_name(): 0}, plan)
         broadcast_tiled_dims = op.loop_info.tiled_dims_per_read[1]
         # Broadcast along dim 0 (stride 0): b's index never depends on d0,
@@ -1701,7 +1689,7 @@ class TestCoarseTileTiledDimsPerRead(unittest.TestCase):
             hints=((1, 0), (2, 1)),
         )
         levels = [(1, Integer(2)), (2, Integer(4))]
-        plan = plan_coarse_tile_groups([op], [([op], levels)])
+        plan = plan_coarse_tile_groups([op], [([op.get_name()], levels)])
         _apply_plan([op], (0, 0), levels, {op.get_operation_name(): 0}, plan)
         # Input's read index is 16*d0 + d1: d0 (output dim 0, extent 4 --
         # 8 rows / K=2 outer steps) tiled at level 0; d1 (reduction dim,
@@ -1727,7 +1715,7 @@ class TestCoarseTileTiledDimsPerRead(unittest.TestCase):
             hints=((1, 0), (2, 2)),
         )
         levels = [(1, Integer(2)), (2, Integer(4))]
-        plan = plan_coarse_tile_groups([op], [([op], levels)])
+        plan = plan_coarse_tile_groups([op], [([op.get_name()], levels)])
         _apply_plan([op], (0, 0), levels, {op.get_operation_name(): 0}, plan)
         # Level 0 (hint 1, count=2) tiles dim 0, extent 4 (8 rows / 2 steps);
         # level 1 (hint 2, count=4) tiles dim 2, extent 8 (32 cols / 4
@@ -1760,7 +1748,7 @@ class TestCoarseTileTiledDimsPerRead(unittest.TestCase):
             hints=((1, 0), (2, 1)),
         )
         levels = [(1, Integer(2)), (2, Integer(4))]
-        plan = plan_coarse_tile_groups([op], [([op], levels)])
+        plan = plan_coarse_tile_groups([op], [([op.get_name()], levels)])
         _apply_plan([op], (0, 0), levels, {op.get_operation_name(): 0}, plan)
         expected = [[(0, Integer(512))], [(1, Integer(1024))]]
         self.assertEqual(len(op.loop_info.tiled_dims_per_read), 2)
@@ -1797,7 +1785,9 @@ class TestCoarseTileTiledDimsPerRead(unittest.TestCase):
         ]
         pre_loop_info = [getattr(o, "loop_info", None) for o in group_ops]
 
-        plan = plan_coarse_tile_groups(group_ops, [(group_ops, levels)])
+        plan = plan_coarse_tile_groups(
+            group_ops, [([op.get_name() for op in group_ops], levels)]
+        )
 
         post_ranges = [
             tuple(o.data.ranges) for o in group_ops if isinstance(o, ComputedBuffer)
@@ -1805,11 +1795,10 @@ class TestCoarseTileTiledDimsPerRead(unittest.TestCase):
         post_loop_info = [getattr(o, "loop_info", None) for o in group_ops]
         self.assertEqual(pre_ranges, post_ranges)
         self.assertEqual(pre_loop_info, post_loop_info)
-        # plan is keyed by id(op), not op itself: ir.Operation/ComputedBuffer
-        # are (eq=True, unsafe_hash=False) dataclasses, so Python sets their
-        # __hash__ to None and they cannot be used as dict keys directly.
         self.assertTrue(
-            all(id(o) in plan for o in group_ops if isinstance(o, ComputedBuffer))
+            all(
+                o.get_name() in plan for o in group_ops if isinstance(o, ComputedBuffer)
+            )
         )
 
     def test_plan_raises_unsupported_when_reduction_tiling_disabled(self):
@@ -1836,7 +1825,9 @@ class TestCoarseTileTiledDimsPerRead(unittest.TestCase):
             with self.assertRaisesRegex(
                 Unsupported, "disabled via enable_reduction_tiling"
             ):
-                plan_coarse_tile_groups(group_ops, [(group_ops, levels)])
+                plan_coarse_tile_groups(
+                    group_ops, [([op.get_name() for op in group_ops], levels)]
+                )
 
     def test_plan_raises_unsupported_for_carry(self):
         """Planning raises Unsupported for an op requiring carry propagation.
@@ -1934,7 +1925,9 @@ class TestCoarseTileTiledDimsPerRead(unittest.TestCase):
         levels = [(1, Integer(4))]
 
         with self.assertRaisesRegex(Unsupported, "requiring carry propagation"):
-            plan_coarse_tile_groups(group_ops, [(group_ops, levels)])
+            plan_coarse_tile_groups(
+                group_ops, [([op.get_name() for op in group_ops], levels)]
+            )
 
 
 def _make_fixed_flag_op(
@@ -6376,7 +6369,10 @@ def _run_htctg_and_capture_log(ops):
     from torch_spyre._inductor.wsr.coarse_tile_hints import hints_to_coarse_tile_groups
     import torch_spyre._inductor.wsr.coarse_tile_hints as coarse_tile_hints_mod
 
-    graph = SimpleNamespace(operations=list(ops))
+    graph = SimpleNamespace(
+        operations=list(ops),
+        name_to_buffer={op.get_name(): op for op in ops},
+    )
 
     # Temporarily force the module-level hints_logger to INFO so the logging
     # block inside hints_to_coarse_tile_groups actually runs.

--- a/tests/inductor/test_span_overflow_hint_analysis.py
+++ b/tests/inductor/test_span_overflow_hint_analysis.py
@@ -228,7 +228,7 @@ def _manual_h_hint_group(op, hint_id=1, split_count=_E2E_SPLIT_COUNT):
         hint_id=hint_id,
     )
     op.dim_hints = [hint]
-    return [([op], [(hint_id, sympy.Integer(split_count))])]
+    return [([op.get_name()], [(hint_id, sympy.Integer(split_count))])]
 
 
 def _scheduler_node_for_op(op, name):
@@ -271,7 +271,7 @@ class TestSpanOverflowGroups(InductorTestCase):
             groups = _run_span_overflow_groups(op)
 
         self.assertEqual(len(groups), 1)
-        self.assertIs(groups[0][0][0], op)
+        self.assertEqual(groups[0][0][0], op.get_name())
 
     def test_overflow_reduction_output_returns_one_group(self):
         op = _reduction_op(_E2E_SHAPE)
@@ -280,7 +280,7 @@ class TestSpanOverflowGroups(InductorTestCase):
             groups = _run_span_overflow_groups(op)
 
         self.assertEqual(len(groups), 1)
-        self.assertIs(groups[0][0][0], op)
+        self.assertEqual(groups[0][0][0], op.get_name())
         self.assertFalse(op.dim_hints[0].is_reduction)
 
     def test_scalar_reduction_skipped(self):
@@ -299,7 +299,7 @@ class TestSpanOverflowGroups(InductorTestCase):
 
         self.assertEqual(len(groups), 1)
         ops_list, levels = groups[0]
-        self.assertEqual(ops_list, [op])
+        self.assertEqual(ops_list, [op.get_name()])
         self.assertEqual(len(levels), 1)
         hint_id, count = levels[0]
         self.assertEqual(hint_id, _SPAN_OVERFLOW_HINT_ID)
@@ -319,7 +319,7 @@ class TestSpanOverflowGroups(InductorTestCase):
                 groups = _apply_span_overflow(_graph([op0, op1]))
 
         self.assertEqual(len(groups), 1)
-        self.assertEqual(groups[0][0], [op0, op1])
+        self.assertEqual(groups[0][0], [op0.get_name(), op1.get_name()])
         self.assertEqual(groups[0][1][0][0], _SPAN_OVERFLOW_HINT_ID)
         self.assertEqual(op0.dim_hints[0].hint_id, _SPAN_OVERFLOW_HINT_ID)
         self.assertEqual(op1.dim_hints[0].hint_id, _SPAN_OVERFLOW_HINT_ID)
@@ -353,7 +353,7 @@ class TestSpanOverflowGroups(InductorTestCase):
                 groups = _apply_span_overflow(_graph([op0, op1]))
 
         self.assertEqual(len(groups), 1)
-        self.assertEqual(groups[0][0], [op0, op1])
+        self.assertEqual(groups[0][0], [op0.get_name(), op1.get_name()])
         self.assertEqual(op0.dim_hints[0].hint_id, op1.dim_hints[0].hint_id)
 
     def _chained_pointwise_ops(self, shape1=_E2E_SHAPE):
@@ -425,7 +425,7 @@ class TestSpanOverflowGroups(InductorTestCase):
             groups = _apply_span_overflow(_graph([op0, op1]))
 
         self.assertEqual(len(groups), 1)
-        self.assertEqual(groups[0][0], [op0, op1])
+        self.assertEqual(groups[0][0], [op0.get_name(), op1.get_name()])
         self.assertEqual(op0.dim_hints[0].hint_id, op1.dim_hints[0].hint_id)
         # op1 adopted op0's split (5), not its own independently-searched one (11).
         self.assertEqual(op0.dim_hints[0].split_count, 5)
@@ -488,7 +488,7 @@ class TestSpanOverflowGroups(InductorTestCase):
             groups = _apply_span_overflow(_graph([producer, matmul]))
 
         self.assertEqual(len(groups), 1)
-        self.assertEqual(groups[0][0], [producer, matmul])
+        self.assertEqual(groups[0][0], [producer.get_name(), matmul.get_name()])
         # Synchronized: shared hint_id and split, each on its own loop_var.
         self.assertEqual(producer.dim_hints[0].hint_id, matmul.dim_hints[0].hint_id)
         self.assertEqual(producer.dim_hints[0].split_count, 5)
@@ -613,7 +613,7 @@ class TestSpanOverflowGroups(InductorTestCase):
             groups = _apply_span_overflow(_graph([producer, reduction]))
 
         self.assertEqual(len(groups), 1)
-        self.assertEqual(groups[0][0], [producer, reduction])
+        self.assertEqual(groups[0][0], [producer.get_name(), reduction.get_name()])
         self.assertEqual(producer.dim_hints[0].hint_id, reduction.dim_hints[0].hint_id)
         self.assertEqual(producer.dim_hints[0].split_count, 5)
         self.assertEqual(reduction.dim_hints[0].split_count, 5)
@@ -947,7 +947,9 @@ class TestSpanOverflowGroups(InductorTestCase):
 
         # One synchronized group containing the weight producer and the matmul.
         self.assertEqual(len(groups), 1)
-        self.assertEqual(groups[0][0], [restickify_weight, lm_head_bmm])
+        self.assertEqual(
+            groups[0][0], [restickify_weight.get_name(), lm_head_bmm.get_name()]
+        )
         self.assertEqual(
             restickify_weight.dim_hints[0].hint_id, lm_head_bmm.dim_hints[0].hint_id
         )
@@ -1074,7 +1076,7 @@ class TestSpanOverflowGroups(InductorTestCase):
                 groups = _apply_span_overflow(_graph([hinted_op, unhinted_op]))
 
         self.assertEqual(len(groups), 1)
-        self.assertEqual(groups[0][0], [unhinted_op])
+        self.assertEqual(groups[0][0], [unhinted_op.get_name()])
         self.assertEqual(getattr(hinted_op, "dim_hints")[0].hint_id, 1)
 
     def test_ignore_wsr_hints_config_suppresses_groups(self):
@@ -1693,7 +1695,7 @@ class TestSpanOverflowPointwisePlannerAndAdapter(InductorTestCase):
 
         self.assertEqual(len(groups), 1)
         group_ops, levels = groups[0]
-        self.assertEqual(group_ops, [op])
+        self.assertEqual(group_ops, [op.get_name()])
         self.assertEqual(levels[0][1], sympy.Integer(_E2E_SPLIT_COUNT))
         self.assertEqual(len(op.dim_hints), 1)
         self.assertEqual(op.dim_hints[0].split_count, _E2E_SPLIT_COUNT)

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -32,7 +32,7 @@ except ImportError:
 
 
 from torch._inductor.graph import GraphLowering
-from torch._inductor.ir import Operation
+from torch._inductor.ir import ComputedBuffer, Operation
 from torch._inductor.scheduler import BaseSchedulerNode
 
 from .logging_utils import get_inductor_logger
@@ -334,8 +334,12 @@ def _maybe_coarse_tile_hints(graph: GraphLowering) -> None:
     groups = hints_to_coarse_tile_groups(graph)
     if not groups:
         return
-    op_order = {id(op): idx for idx, op in enumerate(graph.operations)}
-    groups.sort(key=lambda group: op_order.get(id(group[0][0]), len(op_order)))
+    op_order = {
+        op.get_name(): idx
+        for idx, op in enumerate(graph.operations)
+        if isinstance(op, ComputedBuffer)
+    }
+    groups.sort(key=lambda group: op_order.get(group[0][0], len(op_order)))
     validate_coarse_tile_groups(groups)
     coarse_tile(graph, groups=groups)
 
@@ -373,8 +377,12 @@ def _maybe_coarse_tile_span_overflow(graph: GraphLowering) -> None:
         if hasattr(op, "loop_info") and op.loop_info is not None
     ]
     group_idx_offset = max(used_ids, default=-1) + 1
-    op_order = {id(op): idx for idx, op in enumerate(graph.operations)}
-    groups.sort(key=lambda group: op_order.get(id(group[0][0]), len(op_order)))
+    op_order = {
+        op.get_name(): idx
+        for idx, op in enumerate(graph.operations)
+        if isinstance(op, ComputedBuffer)
+    }
+    groups.sort(key=lambda group: op_order.get(group[0][0], len(op_order)))
     validate_coarse_tile_groups(groups)
     coarse_tile(graph, groups=groups, group_idx_offset=group_idx_offset)
 

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -1428,46 +1428,28 @@ def coarse_tile(
     plan = plan_coarse_tile_groups(operations, groups)
 
     # Transformation: apply the plan. Only reached if planning didn't raise.
-    def _buf_name_to_op(
-        name_to_buf: dict[str, ComputedBuffer], buf_name: str
-    ) -> Operation | None:
-        op = name_to_buf.get(buf_name)
-        if op is None:
-            try:
-                op = V.graph.name_to_buffer.get(buf_name)
-            except Exception:
-                pass
-        return op
-
     def _resolve_group(
         group_buffer_names: list[str],
-        name_to_buf: dict[str, ComputedBuffer],
-        op_to_position: dict[str, int],
         group_id: tuple[int, ...] | None = None,
     ) -> list[Operation]:
         result = []
         for buf_name in group_buffer_names:
-            op = _buf_name_to_op(name_to_buf, buf_name)
+            op = next(
+                (
+                    o
+                    for o in operations
+                    if isinstance(o, ComputedBuffer) and o.get_name() == buf_name
+                ),
+                None,
+            )
             if op is None:
                 raise RuntimeError(
                     f"coarse_tile: buffer {buf_name!r} (group {group_id}) "
                     "is not in the operations list"
                 )
-            op_name = op.get_operation_name()
-            if op_name not in op_to_position:
-                raise RuntimeError(
-                    f"coarse_tile: operation {op_name!r} for buffer {buf_name!r} "
-                    f"(group {group_id}) is not in the operations list"
-                )
-            result.append(operations[op_to_position[op_name]])
+            result.append(op)
         return result
 
-    op_to_position: dict[str, int] = {
-        op.get_operation_name(): i for i, op in enumerate(operations)
-    }
-    name_to_buf: dict[str, ComputedBuffer] = {
-        op.get_name(): op for op in operations if isinstance(op, ComputedBuffer)
-    }
     retiled_infos_by_group: list[
         tuple[tuple[int, ...], list[str], dict[str, _RetiledBufferInfo]]
     ] = []
@@ -1475,19 +1457,14 @@ def coarse_tile(
         groups, start=group_idx_offset
     ):
         group_id: tuple[int, ...] = (group_idx,)
-        group_ops = _resolve_group(
-            group_buffer_names, name_to_buf, op_to_position, group_id
-        )
+        group_ops = _resolve_group(group_buffer_names, group_id)
         name_map = _replace_constant_fill_predecessors(
             group_ops, levels, operations, group_id
         )
-        op_to_position = {op.get_operation_name(): i for i, op in enumerate(operations)}
-        name_to_buf = {
-            op.get_name(): op for op in operations if isinstance(op, ComputedBuffer)
+        group_ops = _resolve_group(group_buffer_names, group_id)
+        op_to_position: dict[str, int] = {
+            op.get_operation_name(): i for i, op in enumerate(operations)
         }
-        group_ops = _resolve_group(
-            group_buffer_names, name_to_buf, op_to_position, group_id
-        )
         stamped_group_id = group_id + (0,) * (len(levels) - 1)
         retiled_infos = _apply_plan(
             group_ops, stamped_group_id, levels, op_to_position, plan
@@ -1500,12 +1477,8 @@ def coarse_tile(
     insert_tiling_propagation(operations, groups)
     _zero_fixed_tile_advance_exprs(operations)
 
-    op_to_position = {op.get_operation_name(): i for i, op in enumerate(operations)}
-    name_to_buf = {
-        op.get_name(): op for op in operations if isinstance(op, ComputedBuffer)
-    }
     for group_id, group_buffer_names, retiled_infos in retiled_infos_by_group:
-        group_ops = _resolve_group(group_buffer_names, name_to_buf, op_to_position)
+        group_ops = _resolve_group(group_buffer_names)
         _patch_retiled_load_indexes(group_id, group_ops, retiled_infos, operations)
 
 
@@ -1582,31 +1555,21 @@ def insert_tiling_propagation(
     bundle.py handles the per-iteration address offset for both the tiled
     op and the inserted copy op.
     """
-    name_to_pos = {
-        op.get_name(): i
-        for i, op in enumerate(operations)
-        if isinstance(op, ComputedBuffer)
-    }
     for group_buffer_names, _ in groups:
         for buf_name in group_buffer_names:
-            pos = name_to_pos.get(buf_name)
-            if pos is None:
-                continue
-            op = operations[pos]
-            if not isinstance(op, ComputedBuffer):
+            op = next(
+                (
+                    o
+                    for o in operations
+                    if isinstance(o, ComputedBuffer) and o.get_name() == buf_name
+                ),
+                None,
+            )
+            if op is None:
                 continue
             if not isinstance(op.data, (Pointwise, Reduction)):
                 continue
             _propagate_tiled_op(op, operations)
-            # _propagate_tiled_op may replace op with a new ComputedBuffer
-            # under the same buffer name via replace_computed_buffer_body.
-            # Re-index so the next buf_name lookup in this group finds the
-            # current object, not the stale pre-rewrite one.
-            name_to_pos = {
-                o.get_name(): i
-                for i, o in enumerate(operations)
-                if isinstance(o, ComputedBuffer)
-            }
 
 
 def _validate_reduction_tiling(op: ComputedBuffer) -> None:

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -121,9 +121,10 @@ def validate_coarse_tile_groups(groups: list[tuple]) -> None:
     different tiles in an unsynchronized fashion.
     """
     hint_id_to_group: dict[int, int] = {}
-    for group_idx, (group_ops, _levels) in enumerate(groups):
+    for group_idx, (group_buffer_names, _levels) in enumerate(groups):
         group_hint_ids: set[int] = set()
-        for op in group_ops:
+        for buf_name in group_buffer_names:
+            op = V.graph.name_to_buffer.get(buf_name)
             for h in getattr(op, "dim_hints", []):
                 group_hint_ids.add(h.hint_id)
         for hint_id in group_hint_ids:
@@ -187,7 +188,7 @@ def _clear_cache(obj: object, key: str) -> None:
 def plan_coarse_tile_groups(
     operations: list[Operation],
     groups: list[tuple],
-) -> dict[int, CoarseTileInfo]:
+) -> dict[str, CoarseTileInfo]:
     """Decide every op's coarse-tiling attributes without mutating the IR.
 
     Performs the per-op decision logic (hint-to-position lookup, per-level
@@ -198,24 +199,24 @@ def plan_coarse_tile_groups(
     _planned_tile_extents_per_level, reading op.data.ranges/reduction_ranges
     as they exist before any mutation.
 
-    Returns a dict mapping each tiled op's ``id(op)`` to its planned
-    CoarseTileInfo. Keyed by ``id(op)`` rather than ``op`` itself because
-    ir.Operation/ComputedBuffer are (unsafe_hash=False, eq=True) dataclasses
-    -- Python therefore sets their __hash__ to None, so they cannot be used
-    directly as dict keys (confirmed: ``{ComputedBuffer(...): 1}`` raises
-    ``TypeError: unhashable type``). ``id(op)`` still gives exact identity
-    semantics (the same object passed in via ``groups``, unmodified), and
-    matches the existing ``{id(op): ...}`` convention already used for
-    op-identity dicts elsewhere in this codebase (see
-    ``torch_spyre/_inductor/passes.py``'s ``op_order`` dicts).
+    Returns a dict mapping each tiled op's buffer name (``op.get_name()``) to
+    its planned CoarseTileInfo. Groups only ever contain ComputedBuffers, and
+    ``replace_computed_buffer_body`` preserves ``name``, so the buffer name is
+    stable across IR rewrites and safe as a dict key.
 
     Untiled/skipped ops (non-ComputedBuffer) have no entry.
     """
-    plan: dict[int, CoarseTileInfo] = {}
-    for group_idx, (group_ops, levels) in enumerate(groups):
+    name_to_buf: dict[str, ComputedBuffer] = {
+        op.get_name(): op for op in operations if isinstance(op, ComputedBuffer)
+    }
+    plan: dict[str, CoarseTileInfo] = {}
+    for group_idx, (group_buffer_names, levels) in enumerate(groups):
         group_id: tuple[int, ...] = (group_idx,)
         nested_group_id: tuple[int, ...] = group_id + (0,) * (len(levels) - 1)
         counts = [count for _, count in levels]
+        group_ops: list[Operation] = [
+            name_to_buf[n] for n in group_buffer_names if n in name_to_buf
+        ]
         group_reduction_tiled_levels = _group_reduction_tiled_levels_in_group(
             group_ops, levels
         )
@@ -282,7 +283,7 @@ def plan_coarse_tile_groups(
                 else []
             )
 
-            plan[id(op)] = CoarseTileInfo(
+            plan[op.get_name()] = CoarseTileInfo(
                 loop_group_id=nested_group_id,
                 loop_count=counts,
                 loop_tiled_dims=op_tiled_dims,
@@ -998,15 +999,15 @@ def _apply_plan(
     stamped_group_id: tuple[int, ...],
     levels: list[tuple],
     op_to_position: dict[str, int],
-    plan: dict[int, CoarseTileInfo],
+    plan: dict[str, CoarseTileInfo],
 ) -> dict[str, _RetiledBufferInfo]:
     """Apply planning's decisions: divide ranges and stamp loop_info.
 
     This is transformation's mutation step. All decisions (which
     dims/reduction levels are tiled, per CoarseTileInfo.tiled_dims_per_read /
     output_tiled_dims) already exist in
-    `plan` (keyed by id(op) -- Operation/ComputedBuffer are unhashable, see
-    plan_coarse_tile_groups) -- this function only performs the IR mutation
+    `plan` (keyed by op.get_name() -- see plan_coarse_tile_groups) -- this
+    function only performs the IR mutation
     _divide_ranges/_divide_reduction_ranges and the loop_info attribute
     assignment, using the plan's values instead of recomputing them.
 
@@ -1027,7 +1028,7 @@ def _apply_plan(
     for op in ops:
         if not isinstance(op, ComputedBuffer):
             continue
-        info = plan.get(id(op))
+        info = plan.get(op.get_name())
         if info is None:
             continue
 
@@ -1427,29 +1428,84 @@ def coarse_tile(
     plan = plan_coarse_tile_groups(operations, groups)
 
     # Transformation: apply the plan. Only reached if planning didn't raise.
+    def _buf_name_to_op(
+        name_to_buf: dict[str, ComputedBuffer], buf_name: str
+    ) -> Operation | None:
+        op = name_to_buf.get(buf_name)
+        if op is None:
+            try:
+                op = V.graph.name_to_buffer.get(buf_name)
+            except Exception:
+                pass
+        return op
+
+    def _resolve_group(
+        group_buffer_names: list[str],
+        name_to_buf: dict[str, ComputedBuffer],
+        op_to_position: dict[str, int],
+        group_id: tuple[int, ...] | None = None,
+    ) -> list[Operation]:
+        result = []
+        for buf_name in group_buffer_names:
+            op = _buf_name_to_op(name_to_buf, buf_name)
+            if op is None:
+                raise RuntimeError(
+                    f"coarse_tile: buffer {buf_name!r} (group {group_id}) "
+                    "is not in the operations list"
+                )
+            op_name = op.get_operation_name()
+            if op_name not in op_to_position:
+                raise RuntimeError(
+                    f"coarse_tile: operation {op_name!r} for buffer {buf_name!r} "
+                    f"(group {group_id}) is not in the operations list"
+                )
+            result.append(operations[op_to_position[op_name]])
+        return result
+
     op_to_position: dict[str, int] = {
         op.get_operation_name(): i for i, op in enumerate(operations)
     }
+    name_to_buf: dict[str, ComputedBuffer] = {
+        op.get_name(): op for op in operations if isinstance(op, ComputedBuffer)
+    }
     retiled_infos_by_group: list[
-        tuple[tuple[int, ...], list[Operation], dict[str, _RetiledBufferInfo]]
+        tuple[tuple[int, ...], list[str], dict[str, _RetiledBufferInfo]]
     ] = []
-    for group_idx, (group_ops, levels) in enumerate(groups, start=group_idx_offset):
+    for group_idx, (group_buffer_names, levels) in enumerate(
+        groups, start=group_idx_offset
+    ):
         group_id: tuple[int, ...] = (group_idx,)
+        group_ops = _resolve_group(
+            group_buffer_names, name_to_buf, op_to_position, group_id
+        )
         name_map = _replace_constant_fill_predecessors(
             group_ops, levels, operations, group_id
         )
         op_to_position = {op.get_operation_name(): i for i, op in enumerate(operations)}
+        name_to_buf = {
+            op.get_name(): op for op in operations if isinstance(op, ComputedBuffer)
+        }
+        group_ops = _resolve_group(
+            group_buffer_names, name_to_buf, op_to_position, group_id
+        )
         stamped_group_id = group_id + (0,) * (len(levels) - 1)
         retiled_infos = _apply_plan(
             group_ops, stamped_group_id, levels, op_to_position, plan
         )
         _apply_fill_name_swap(group_ops, name_map, operations)
-        retiled_infos_by_group.append((stamped_group_id, group_ops, retiled_infos))
+        retiled_infos_by_group.append(
+            (stamped_group_id, group_buffer_names, retiled_infos)
+        )
 
     insert_tiling_propagation(operations, groups)
     _zero_fixed_tile_advance_exprs(operations)
 
-    for group_id, group_ops, retiled_infos in retiled_infos_by_group:
+    op_to_position = {op.get_operation_name(): i for i, op in enumerate(operations)}
+    name_to_buf = {
+        op.get_name(): op for op in operations if isinstance(op, ComputedBuffer)
+    }
+    for group_id, group_buffer_names, retiled_infos in retiled_infos_by_group:
+        group_ops = _resolve_group(group_buffer_names, name_to_buf, op_to_position)
         _patch_retiled_load_indexes(group_id, group_ops, retiled_infos, operations)
 
 
@@ -1526,35 +1582,31 @@ def insert_tiling_propagation(
     bundle.py handles the per-iteration address offset for both the tiled
     op and the inserted copy op.
     """
-    for group_ops, _ in groups:
-        for idx, op in enumerate(group_ops):
+    name_to_pos = {
+        op.get_name(): i
+        for i, op in enumerate(operations)
+        if isinstance(op, ComputedBuffer)
+    }
+    for group_buffer_names, _ in groups:
+        for buf_name in group_buffer_names:
+            pos = name_to_pos.get(buf_name)
+            if pos is None:
+                continue
+            op = operations[pos]
             if not isinstance(op, ComputedBuffer):
                 continue
             if not isinstance(op.data, (Pointwise, Reduction)):
                 continue
             _propagate_tiled_op(op, operations)
-            # _propagate_tiled_op (and the copy-op insertion it may
-            # delegate to) can replace op with a new ComputedBuffer object
-            # spliced into `operations` under the same name (see
-            # replace_computed_buffer_body).  group_ops is a separate list
-            # snapshotted before this loop runs, so it must be kept in sync
-            # here — otherwise a later pass reading group_ops (e.g.
-            # _patch_retiled_load_indexes) sees the stale pre-rewrite object
-            # and clobbers the rewrite when it reconstructs from it.  Look
-            # up the current object in `operations` itself (already the
-            # authoritative post-replacement list) rather than V.graph --
-            # this pass runs from CustomPreSchedulingPasses, and unit tests
-            # that call coarse_tile() directly never install a real V.graph.
-            current = next(
-                (
-                    o
-                    for o in operations
-                    if isinstance(o, ComputedBuffer) and o.get_name() == op.get_name()
-                ),
-                None,
-            )
-            if current is not None and current is not op:
-                group_ops[idx] = current
+            # _propagate_tiled_op may replace op with a new ComputedBuffer
+            # under the same buffer name via replace_computed_buffer_body.
+            # Re-index so the next buf_name lookup in this group finds the
+            # current object, not the stale pre-rewrite one.
+            name_to_pos = {
+                o.get_name(): i
+                for i, o in enumerate(operations)
+                if isinstance(o, ComputedBuffer)
+            }
 
 
 def _validate_reduction_tiling(op: ComputedBuffer) -> None:
@@ -3186,17 +3238,6 @@ def _should_patch_retiled_load_indexes(
     return any(_reads_buffer(op, name) for name in retiled_names)
 
 
-def _replace_group_op(
-    group_ops: list[Operation], old_op: Operation, new_op: Operation
-) -> None:
-    """Keep the tiling group list in sync after replacing a ComputedBuffer body."""
-    old_name = old_op.get_operation_name()
-    for idx, group_op in enumerate(group_ops):
-        if group_op is old_op or group_op.get_operation_name() == old_name:
-            group_ops[idx] = new_op
-            return
-
-
 def _patch_retiled_load_indexes(
     group_id: tuple[int, ...],
     group_ops: list[Operation],
@@ -3239,7 +3280,6 @@ def _patch_retiled_load_indexes(
             pass_name="coarse_tile",
             reason="rewrite retiled load indexes",
         )
-        _replace_group_op(group_ops, op, new_op)
         V.graph.name_to_buffer[new_op.get_name()] = new_op
 
 

--- a/torch_spyre/_inductor/wsr/coarse_tile_hints.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile_hints.py
@@ -280,7 +280,7 @@ def hints_to_coarse_tile_groups(graph: GraphLowering) -> list[tuple]:
         if current_ops and current_key is not None:
             levels = _hints_levels(current_ops)
             if levels:
-                groups.append((current_ops, levels))
+                groups.append(([op.get_name() for op in current_ops], levels))
             else:
                 hints_logger.warning(
                     "spyre_hint on [%s]: no op iterates over the hinted dimension "
@@ -308,17 +308,18 @@ def hints_to_coarse_tile_groups(graph: GraphLowering) -> list[tuple]:
     if hints_logger.isEnabledFor(logging.INFO):
         # Build an interleaved view: walk operations in order, emit group boundaries
         # and ungrouped ops so the reader can see what breaks each consecutive run.
-        grouped_to_group_idx = {id(o): i for i, g in enumerate(groups) for o in g[0]}
+        grouped_to_group_idx = {name: i for i, g in enumerate(groups) for name in g[0]}
         # Pre-compute hint descriptions per group — get_op_hints is called once per
         # group rather than once per op in the group.
         group_hint_descs: dict[int, str] = {}
-        for g_idx, (group_ops, _group_levels) in enumerate(groups):
+        for g_idx, (group_buffer_names, _group_levels) in enumerate(groups):
             # Collect all DimHints across the group, keyed by hint_id.
             # Prefer a hint whose loop_var is not None (op actually iterates
             # that dim) over a broadcast hint (loop_var=None), so that the
             # representative name/count reflects a real iteration.
             best: dict[int, "DimHint"] = {}
-            for gop in group_ops:
+            for gname in group_buffer_names:
+                gop = graph.name_to_buffer.get(gname)
                 for h in getattr(gop, "dim_hints", []):
                     if h.hint_id not in best or best[h.hint_id].loop_var is None:
                         best[h.hint_id] = h
@@ -336,7 +337,7 @@ def hints_to_coarse_tile_groups(graph: GraphLowering) -> list[tuple]:
         for o in operations:
             if not isinstance(o, ComputedBuffer):
                 continue
-            op_group_idx = grouped_to_group_idx.get(id(o))
+            op_group_idx = grouped_to_group_idx.get(o.get_name())
             if op_group_idx is None:
                 hints = getattr(o, "dim_hints", [])
                 if hints:

--- a/torch_spyre/_inductor/wsr/coarse_tile_span_overflow.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile_span_overflow.py
@@ -315,19 +315,19 @@ def span_overflow_groups(
             )
         ]
 
-        group_ops: list[Operation] = []
+        group_buffer_names: list[str] = []
         for grouped_op, dims in current_group:
             dim_hint_assignments.append(
                 (grouped_op, _dims_to_hints(grouped_op, dims, hint_ids))
             )
-            group_ops.append(grouped_op)
+            group_buffer_names.append(grouped_op.get_name())
             auto_tiled_producers.add(grouped_op.get_name())
 
-        groups.append((group_ops, levels))
+        groups.append((group_buffer_names, levels))
         logger.debug(
             "[span-overflow groups] created group_index=%d ops=%s levels=%s",
             len(groups) - 1,
-            [op.get_name() for op in group_ops],
+            group_buffer_names,
             levels,
         )
         current_group = []
@@ -549,7 +549,7 @@ def span_overflow_groups(
                 hint_ids, signature
             )
         ]
-        groups.append(([op], levels))
+        groups.append(([op.get_name()], levels))
         auto_tiled_producers.add(op.get_name())
         logger.debug(
             "[span-overflow groups] created group_index=%d op=%s levels=%s",


### PR DESCRIPTION
#### What type of PR is this?

- [X] cleanup

#### What this PR does:

This PR replaces the use of `Operation` ids `id(op)` in coarse tiling plans with `ComputedBuffer` names `op.get_name()` and replaces operations in tiling groups with buffer names.

`ComputedBuffer` names are guaranteed to be unique and mappable back to operations via `V.graph.get_buffer`. This PR removes the need for consistently updating both the whole graph and the tiling groups when replacing an op by another op.

#### Does this PR introduce a user-facing change?

No