### PR TITLE
feat(ci): surface integration/regression tier into ClickHouse test_runs

### DIFF
--- a/.github/scripts/ingest_xml.py
+++ b/.github/scripts/ingest_xml.py
@@ -610,7 +610,11 @@ def main():
     parser.add_argument("--run-id", default="")
     parser.add_argument("--triggered-at", default="")
     parser.add_argument("--pr-number", default="")
-    parser.add_argument("--trigger-type", default="", help="Suite tier that produced this run, e.g. integration | regression | smoke | full")
+    parser.add_argument(
+        "--trigger-type",
+        default="",
+        help="Suite tier that produced this run, e.g. regression | integration | unit | smoke",
+    )
     args = parser.parse_args()
 
     if args.xml_file:

--- a/.github/scripts/ingest_xml.py
+++ b/.github/scripts/ingest_xml.py
@@ -496,6 +496,7 @@ def insert_run(client, run_id: str, run: dict, args):
                 run["errors"],
                 run["xpass"],
                 run["duration_s"],
+                getattr(args, "trigger_type", "") or "unknown",
             ]
         ],
         column_names=[
@@ -517,6 +518,7 @@ def insert_run(client, run_id: str, run: dict, args):
             "errors",
             "xpass",
             "duration_s",
+            "trigger_type",
         ],
     )
 
@@ -608,6 +610,7 @@ def main():
     parser.add_argument("--run-id", default="")
     parser.add_argument("--triggered-at", default="")
     parser.add_argument("--pr-number", default="")
+    parser.add_argument("--trigger-type", default="", help="Suite tier that produced this run, e.g. integration | regression | smoke | full")
     args = parser.parse_args()
 
     if args.xml_file:

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -140,6 +140,7 @@ jobs:
       }}
     outputs:
       matrix: ${{ steps.filter.outputs.matrix }}
+      resolved_test_type: ${{ steps.filter.outputs.resolved_test_type }}
     steps:
       # NORMAL: sparse-checkout the configs from github.com at the requested ref.
       - if: ${{ !inputs.prebaked_image }}
@@ -155,6 +156,8 @@ jobs:
 
       - name: Filter configs by TEST_TYPE
         id: filter
+        env:
+          RAW_TEST_TYPE: ${{ inputs.test_type || 'full' }}
         run: |
           # Prebaked: read the configs baked in the dev image; else the checkout cwd.
           # cd into the source root so every path below stays repo-relative and
@@ -167,10 +170,24 @@ jobs:
           fi
           matrix=$(python3 tests/oot_framework/utils/filter_configs.py \
             --config-dir tests/configs/torch_spyre_tests \
-            --test-type "${{ inputs.test_type || 'full' }}" \
+            --test-type "${RAW_TEST_TYPE}" \
             --runner-map .github/runner_overrides.yaml \
             --format matrix-json)
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+          # Everything downstream of this job (TORCH_SPYRE_TEST_TYPE env var, the
+          # test_multi_spyre distributed-suite gate) compares test_type by literal
+          # string, bypassing filter_configs.py's own alias resolution -- resolve
+          # once here via the same source of truth so unit/integration/regression
+          # behave identically everywhere, not just in the label-matching path.
+          resolved=$(python3 -c "
+          import sys
+          sys.path.insert(0, 'tests/oot_framework/utils')
+          from filter_configs import resolve_test_type
+          import os
+          print(resolve_test_type(os.environ['RAW_TEST_TYPE'].strip()))
+          ")
+          echo "resolved_test_type=$resolved" >> "$GITHUB_OUTPUT"
 
   # ---------------------------------------------------------------------------
   # Job 0b: build torch-spyre ONCE
@@ -262,7 +279,7 @@ jobs:
       # GitHub Actions sets CI=true which causes pytest inductor tests to fail.
       # Explicitly clear it.
       CI: ''
-      TORCH_SPYRE_TEST_TYPE: ${{ inputs.test_type || 'full' }}
+      TORCH_SPYRE_TEST_TYPE: ${{ needs.generate_matrix.outputs.resolved_test_type }}
 
     strategy:
       fail-fast: false
@@ -372,7 +389,7 @@ jobs:
   # ---------------------------------------------------------------------------
   test_multi_spyre:
     name: ${{ matrix.suite.name }}
-    needs: build_torch_spyre
+    needs: [generate_matrix, build_torch_spyre]
     # Run for distributed-including test_types AND only when the single build
     # succeeded or was skipped (RPM path). A failed build skips this job too.
     # The leading `!cancelled() &&` is REQUIRED (see the `test` job above):
@@ -380,10 +397,10 @@ jobs:
     # this job on the RPM path, where build_torch_spyre is intentionally skipped.
     if: >-
       !cancelled() &&
-      (inputs.test_type == '' ||
-       inputs.test_type == 'full' ||
-       inputs.test_type == 'device_critical' ||
-       inputs.test_type == 'suite_distributed') &&
+      (needs.generate_matrix.outputs.resolved_test_type == '' ||
+       needs.generate_matrix.outputs.resolved_test_type == 'full' ||
+       needs.generate_matrix.outputs.resolved_test_type == 'device_critical' ||
+       needs.generate_matrix.outputs.resolved_test_type == 'suite_distributed') &&
       (needs.build_torch_spyre.result == 'success' ||
        needs.build_torch_spyre.result == 'skipped')
     runs-on:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,5 +1,9 @@
 name: integration-tests
 run-name: integration-tests (${{ inputs.test_type || 'device_critical' }})
+# NOTE: run-name intentionally shows the RAW input (pre-alias-resolution) since
+# GHA's run-name: expression can't reference a job output -- the config.yaml-facing
+# aliases (integration/regression) still show up correctly for callers using them,
+# and push-to-clickhouse.yaml's trigger_type ends up with whichever value was passed.
 
 # ---------------------------------------------------------------------------
 # Triggered by commits in upstream dependant repos (deeptools, flex, etc.) via
@@ -75,11 +79,15 @@ on:
       test_type:
         description: >-
           Suite subset to run: smoke | core | full | device_critical |
-          suite_<group> | <label>. Default: device_critical (configs whose
+          suite_<group> | <label> -- or the tier aliases integration
+          (= device_critical) | regression (= full), for callers (e.g.
+          spyre-frameworks config.yaml) that speak in tier names rather than
+          label names. Default: device_critical (configs whose
           test_suite_config.labels cover the device-layer surfaces flex and
           deeptools/dxp_standalone exercise most -- streams, job launch
           plans, codegen, LX/scratchpad planning, tensor layout,
-          allocator/GC, D2D copies). Pass "full" to run every config.
+          allocator/GC, D2D copies). Pass "full" (or "regression") to run
+          every config.
         required: false
         type: string
         default: device_critical
@@ -125,12 +133,37 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
+  # config.yaml (spyre-frameworks) and other CI callers speak in tier names
+  # (integration/regression), not test-suite label names. Resolve those aliases
+  # to the actual test_suite_config.labels values here -- device_critical/full
+  # keep their existing, more specific meaning everywhere else (Makefile,
+  # filter_configs.py, the ~40 tests/configs/**/*_config.yaml label lists), only
+  # this entry point accepts the tier-name spelling too.
+  # ---------------------------------------------------------------------------
+  resolve-test-type:
+    name: Resolve test_type alias
+    runs-on: ubuntu-latest
+    outputs:
+      test_type: ${{ steps.resolve.outputs.test_type }}
+    steps:
+      - name: Resolve
+        id: resolve
+        run: |
+          case "${{ inputs.test_type }}" in
+            integration) RESOLVED=device_critical ;;
+            regression)  RESOLVED=full ;;
+            '')          RESOLVED=device_critical ;;
+            *)           RESOLVED="${{ inputs.test_type }}" ;;
+          esac
+          echo "test_type=${RESOLVED}" >> "${GITHUB_OUTPUT}"
+
+  # ---------------------------------------------------------------------------
   # Run the test matrix, defaulting to the device_critical subset -- same
   # default as the "run-tests" job in torch_spyre_tests.yaml. Callers can
-  # still request test_type=full for complete coverage.
+  # still request test_type=full (or its alias, regression) for complete coverage.
   # ---------------------------------------------------------------------------
   run-tests:
-    needs: provenance
+    needs: [provenance, resolve-test-type]
     uses: ./.github/workflows/_test_matrix.yaml
     with:
       runner_label: linux
@@ -139,7 +172,7 @@ jobs:
       checkout_pytorch: false
       ref: ${{ inputs.ref || '' }}
       repository: ${{ inputs.repository || '' }}
-      test_type: ${{ inputs.test_type || 'device_critical' }}
+      test_type: ${{ needs.resolve-test-type.outputs.test_type }}
       prebaked_image: ${{ inputs.prebaked_image }}
 
   # ----------------------------------------------------------------------------------

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,9 +1,9 @@
 name: integration-tests
 run-name: integration-tests (${{ inputs.test_type || 'device_critical' }})
-# NOTE: run-name intentionally shows the RAW input (pre-alias-resolution) since
-# GHA's run-name: expression can't reference a job output -- the config.yaml-facing
-# aliases (integration/regression) still show up correctly for callers using them,
-# and push-to-clickhouse.yaml's trigger_type ends up with whichever value was passed.
+# NOTE: run-name intentionally shows the RAW, user-facing input (before
+# filter_configs.py resolves unit/integration/regression to core/device_critical/
+# full) -- this is also what push-to-clickhouse.yaml's trigger_type ends up
+# recording, so ClickHouse sees the tier name callers actually asked for.
 
 # ---------------------------------------------------------------------------
 # Triggered by commits in upstream dependant repos (deeptools, flex, etc.) via
@@ -79,13 +79,13 @@ on:
       test_type:
         description: >-
           Suite subset to run: smoke | core | full | device_critical |
-          suite_<group> | <label> -- or the tier aliases integration
-          (= device_critical) | regression (= full), for callers (e.g.
-          spyre-frameworks config.yaml) that speak in tier names rather than
-          label names. Default: device_critical (configs whose
-          test_suite_config.labels cover the device-layer surfaces flex and
-          deeptools/dxp_standalone exercise most -- streams, job launch
-          plans, codegen, LX/scratchpad planning, tensor layout,
+          suite_<group> | <label> -- or the user-facing tier aliases unit
+          (= core) | integration (= device_critical) | regression (= full),
+          for callers (e.g. spyre-frameworks config.yaml) that speak in tier
+          names rather than label names. Default: device_critical (configs
+          whose test_suite_config.labels cover the device-layer surfaces
+          flex and deeptools/dxp_standalone exercise most -- streams, job
+          launch plans, codegen, LX/scratchpad planning, tensor layout,
           allocator/GC, D2D copies). Pass "full" (or "regression") to run
           every config.
         required: false
@@ -133,37 +133,16 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
-  # config.yaml (spyre-frameworks) and other CI callers speak in tier names
-  # (integration/regression), not test-suite label names. Resolve those aliases
-  # to the actual test_suite_config.labels values here -- device_critical/full
-  # keep their existing, more specific meaning everywhere else (Makefile,
-  # filter_configs.py, the ~40 tests/configs/**/*_config.yaml label lists), only
-  # this entry point accepts the tier-name spelling too.
-  # ---------------------------------------------------------------------------
-  resolve-test-type:
-    name: Resolve test_type alias
-    runs-on: ubuntu-latest
-    outputs:
-      test_type: ${{ steps.resolve.outputs.test_type }}
-    steps:
-      - name: Resolve
-        id: resolve
-        run: |
-          case "${{ inputs.test_type }}" in
-            integration) RESOLVED=device_critical ;;
-            regression)  RESOLVED=full ;;
-            '')          RESOLVED=device_critical ;;
-            *)           RESOLVED="${{ inputs.test_type }}" ;;
-          esac
-          echo "test_type=${RESOLVED}" >> "${GITHUB_OUTPUT}"
-
-  # ---------------------------------------------------------------------------
   # Run the test matrix, defaulting to the device_critical subset -- same
   # default as the "run-tests" job in torch_spyre_tests.yaml. Callers can
-  # still request test_type=full (or its alias, regression) for complete coverage.
+  # still request test_type=full (or its alias, regression) for complete
+  # coverage. Tier aliases (unit/integration/regression) are resolved inside
+  # _test_matrix.yaml's generate_matrix job -- the single choke point every
+  # test_type caller (Makefile, Jenkins, GHA) passes through -- so the raw
+  # input is forwarded unchanged here.
   # ---------------------------------------------------------------------------
   run-tests:
-    needs: [provenance, resolve-test-type]
+    needs: provenance
     uses: ./.github/workflows/_test_matrix.yaml
     with:
       runner_label: linux
@@ -172,7 +151,7 @@ jobs:
       checkout_pytorch: false
       ref: ${{ inputs.ref || '' }}
       repository: ${{ inputs.repository || '' }}
-      test_type: ${{ needs.resolve-test-type.outputs.test_type }}
+      test_type: ${{ inputs.test_type || 'device_critical' }}
       prebaked_image: ${{ inputs.prebaked_image }}
 
   # ----------------------------------------------------------------------------------

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,4 +1,5 @@
 name: integration-tests
+run-name: integration-tests (${{ inputs.test_type || 'device_critical' }})
 
 # ---------------------------------------------------------------------------
 # Triggered by commits in upstream dependant repos (deeptools, flex, etc.) via

--- a/.github/workflows/push-to-clickhouse.yaml
+++ b/.github/workflows/push-to-clickhouse.yaml
@@ -76,6 +76,10 @@ jobs:
       TRIGGERING_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
       TRIGGERING_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
       TRIGGERING_AT: ${{ github.event.workflow_run.created_at || '' }}
+      # display_title carries "integration-tests (<test_type>)" via that workflow's
+      # run-name: — this is the only way a workflow_run-triggered job can recover the
+      # original dispatch tier (integration/regression/smoke/etc) without an extra API call.
+      TRIGGERING_DISPLAY_TITLE: ${{ github.event.workflow_run.display_title || '' }}
 
 
     steps:
@@ -175,6 +179,16 @@ jobs:
       # Parse each XML file and insert rows into ClickHouse.
       # The Python script is in .github/scripts/ingest_xml.py (see below).
       # ---------------------------------------------------------------------------
+      - name: Extract suite tier from display title
+        id: extract-tier
+        run: |
+          # display_title is "integration-tests (full)" / "integration-tests (device_critical)" / etc.
+          # Fall back to empty (ingest_xml.py defaults it to 'unknown') for manual workflow_dispatch
+          # re-ingests or older runs whose display_title predates this convention.
+          TIER=$(echo "${TRIGGERING_DISPLAY_TITLE}" | sed -n 's/.*(\(.*\))\s*$/\1/p')
+          echo "Resolved tier: ${TIER:-<none>}"
+          echo "tier=${TIER}" >> "${GITHUB_OUTPUT}"
+
       - name: Ingest XML files into ClickHouse
         run: |
           source .venv/bin/activate
@@ -185,7 +199,8 @@ jobs:
             --sha      "${TRIGGERING_SHA}" \
             --run-id   "${TRIGGERING_RUN_ID}" \
             --triggered-at "${TRIGGERING_AT}" \
-            --pr-number    "${{ steps.resolve-pr.outputs.pr_number }}"
+            --pr-number    "${{ steps.resolve-pr.outputs.pr_number }}" \
+            --trigger-type "${{ steps.extract-tier.outputs.tier }}"
         env:
           # PROD INSTANCE
           CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ TEST_CONFIGS ?= tests/configs/torch_spyre_tests
 #   suite_<group>    — all configs inside the <group>/ sub-directory
 #                      (e.g. suite_inductor, suite_tensors)
 #   <label>          — any arbitrary label defined in test_suite_config.labels
+#
+# User-facing tier aliases (resolved by filter_configs.py, so every caller of
+# this Makefile target sees them too): unit=core, integration=device_critical,
+# regression=full.
 # Empty / unset defaults to "full" (all configs under TEST_CONFIGS).
 TEST_TYPE ?= full
 

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ TEST_CONFIGS ?= tests/configs/torch_spyre_tests
 # User-facing tier aliases (resolved by filter_configs.py, so every caller of
 # this Makefile target sees them too): unit=core, integration=device_critical,
 # regression=full.
-# Empty / unset defaults to "full" (all configs under TEST_CONFIGS).
-TEST_TYPE ?= full
+# Empty / unset defaults to "regression" (= full: all configs under TEST_CONFIGS).
+TEST_TYPE ?= regression
 
 # Where TEST_TYPE=perf writes its benchmark report. Flat /tmp/results so the CI
 # ClickHouse push step (ingest_xml.py globs *.xml non-recursively) finds it

--- a/tests/oot_framework/utils/filter_configs.py
+++ b/tests/oot_framework/utils/filter_configs.py
@@ -33,6 +33,19 @@ Selection rules
   <other>            Treated as an arbitrary label name; matches configs
                      whose labels array contains the value.
 
+User-facing tier aliases
+-------------------------
+Every caller (Makefile, GHA _test_matrix.yaml, Jenkins, config.yaml) resolves
+--test-type through this one script, so the alias mapping lives here once and
+every caller sees it consistently:
+  "unit"          -> "core"
+  "integration"   -> "device_critical"
+  "regression"    -> "full"
+  "smoke"         -> "smoke" (already the canonical spelling, no change)
+These are the names meant for humans/CI configs to type; device_critical/full/
+core keep their existing, more specific meaning as the actual label vocabulary
+tests/configs/**/*.yaml declares.
+
 Configs with no labels field default to ["full"] (backward compatible) --
 they run under "full" but are excluded from every narrower test_type
 (smoke, core, device_critical, suite_<group>, custom labels). Every config
@@ -127,6 +140,22 @@ def _load_runner_map(runner_map_path: str) -> dict:
     return {k: str(v) for k, v in data.items()}
 
 
+# User-facing tier name -> actual test_suite_config.labels vocabulary. Single
+# source of truth: every caller (Makefile, _test_matrix.yaml, Jenkins,
+# config.yaml) shells out to this script, so resolving here is sufficient --
+# no caller needs its own copy of this mapping.
+TEST_TYPE_ALIASES = {
+    "unit": "core",
+    "integration": "device_critical",
+    "regression": "full",
+}
+
+
+def resolve_test_type(test_type: str) -> str:
+    """Resolve a user-facing tier alias to its underlying label/value."""
+    return TEST_TYPE_ALIASES.get(test_type, test_type)
+
+
 def _matches(labels: list, config_path: Path, test_type: str) -> bool:
     """Return True if *config_path* should be included for *test_type*."""
     if not test_type or test_type == "full":
@@ -162,8 +191,9 @@ def main() -> None:
         default="full",
         metavar="TYPE",
         help=(
-            "Selection type: smoke | core | full | suite_<group> | <label>. "
-            "Default: full (all configs)."
+            "Selection type: smoke | core | full | device_critical | "
+            "suite_<group> | <label> -- or the user-facing tier aliases "
+            "unit | integration | regression. Default: full (all configs)."
         ),
     )
     ap.add_argument(
@@ -191,7 +221,7 @@ def main() -> None:
     if not config_dir.is_dir():
         sys.exit(f"ERROR: --config-dir does not exist: {config_dir}")
 
-    test_type = args.test_type.strip()
+    test_type = resolve_test_type(args.test_type.strip())
 
     runner_map: dict = {}
     if args.runner_map:


### PR DESCRIPTION
## Summary
- `integration-tests.yaml`'s `test_type` dispatch input (device_critical/full/smoke/core)
  was invisible downstream — no `run-name:` was set, so every run showed as the static
  string `integration-tests`, and `push-to-clickhouse.yaml` (workflow_run-triggered) had
  no way to recover the original dispatch tier.
- Net effect: every `test_runs` row landed with no way to tell an integration run from a
  regression run apart.
- Add `run-name: integration-tests (${{ inputs.test_type }})`, parse the tier out of
  `display_title` in `push-to-clickhouse.yaml`, and thread it into `ingest_xml.py`'s
  existing (previously always-empty) `trigger_type` column — no schema change, since
  `spyre-dashboard` already has this column with an unused filter on it
  (`backend/routes/test_coverage.py`'s `/scheduled-runs` endpoint).

## Test plan
- [x] YAML syntax validated (`yaml.safe_load`)
- [x] `ingest_xml.py` compiles (`py_compile`)
- [ ] Manually trigger `integration-tests.yaml` with `test_type=full` and `test_type=smoke`,
      confirm `display_title` shows the tier and two distinct `trigger_type` values land in
      ClickHouse `test_runs`
