### PR TITLE
test(scratchpad): run hashseed determinism checks concurrently

### DIFF
--- a/tests/inductor/test_scratchpad_solver.py
+++ b/tests/inductor/test_scratchpad_solver.py
@@ -19,6 +19,7 @@ import os
 import subprocess
 import sys
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from unittest import TestCase
 
 from torch_spyre._inductor import config
@@ -446,6 +447,9 @@ print("RESULT " + json.dumps({{x.name: x.address for x in bufs}}))
 """
 
 
+_DETERMINISM_HASHSEEDS = range(5)
+
+
 def _run_determinism_snippet(hashseed, solver_class_name, solver_module):
     env = dict(
         os.environ,
@@ -461,11 +465,32 @@ def _run_determinism_snippet(hashseed, solver_class_name, solver_module):
         text=True,
         env=env,
         cwd=_REPO_ROOT,
-        timeout=60,
+        timeout=120,
     )
     assert p.returncode == 0, p.stderr
     line = next(ln for ln in p.stdout.splitlines() if ln.startswith("RESULT "))
     return json.loads(line[len("RESULT ") :])
+
+
+def _run_determinism_snippets(solver_class_name, solver_module):
+    """Run the snippet once per hash seed, all subprocesses concurrently.
+
+    Each subprocess pays ~6s importing torch and the Inductor stack (the
+    snippet imports ``torch_spyre._inductor``, whose ``__init__`` pulls in
+    ``torch._inductor.graph``), so running them sequentially costs that import
+    once per seed. The work is entirely inside ``subprocess.run``, so threads
+    release the GIL and wall time collapses to roughly a single import.
+    Returns the results in seed order.
+    """
+    with ThreadPoolExecutor(max_workers=len(_DETERMINISM_HASHSEEDS)) as pool:
+        return list(
+            pool.map(
+                lambda seed: _run_determinism_snippet(
+                    seed, solver_class_name, solver_module
+                ),
+                _DETERMINISM_HASHSEEDS,
+            )
+        )
 
 
 class ScoreOrderingTests:
@@ -542,15 +567,12 @@ class ScoreOrderingTests:
 
     def test_inplace_parent_choice_is_hashseed_independent(self):
         """Placement must not depend on PYTHONHASHSEED (set-iteration order)."""
-        solver_class_name = self.solver_class.__name__
-        solver_module = self.solver_class.__module__
-        base = _run_determinism_snippet(0, solver_class_name, solver_module)
-        for hashseed in range(1, 10):
-            self.assertEqual(
-                _run_determinism_snippet(hashseed, solver_class_name, solver_module),
-                base,
-                f"PYTHONHASHSEED={hashseed}",
-            )
+        results = _run_determinism_snippets(
+            self.solver_class.__name__, self.solver_class.__module__
+        )
+        base = results[0]
+        for hashseed, result in zip(_DETERMINISM_HASHSEEDS, results):
+            self.assertEqual(result, base, f"PYTHONHASHSEED={hashseed}")
 
 
 class TestFirstFitLayoutSolver(ScoreOrderingTests, BaseLayoutSolverTests, TestCase):


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Cuts `test_inplace_parent_choice_is_hashseed_independent` from ~57s to ~7s per
test method by running its subprocesses concurrently.

The test guards a real property — in-place parent selection must not depend on
set-iteration order — and it needs a fresh interpreter per seed, because
`PYTHONHASHSEED` only takes effect at startup. But it spawned 11 interpreters
*sequentially*: one baseline at seed 0, then seeds 1–9. Each one paid the full
cost of importing torch and the Inductor stack before it reached the solver,
because the snippet imports `torch_spyre._inductor`, whose `__init__` pulls in
`.patches` → `torch._inductor.graph` → dynamo → sympy. That import, not the
solver, was essentially the entire runtime.

The `-X importtime` breakdown, best-of-3 with a warm page cache:

| statement | wall |
|---|---|
| `pass` | 0.03s |
| `import torch` | 1.72s |
| `import torch_spyre` | 1.71s |
| `import torch_spyre._inductor` | **5.27s** |
| the snippet's actual imports | **5.51s** |

Note that `torch_spyre._inductor` costs more than torch itself does — the
`.patches` import adds ~3.6s on top. (`TORCH_DEVICE_BACKEND_AUTOLOAD=0`, which
the test already sets, does not help here: it disables torch auto-importing
torch_spyre via entry point, the opposite direction from what this snippet
does.)

Since the cost sits inside `subprocess.run`, threads release the GIL and the
seeds can all run at once. This PR:

- adds `_run_determinism_snippets()`, which fans the seeds out over a
  `ThreadPoolExecutor` and returns results in seed order;
- compares every result against the first, rather than running seed 0
  separately as a baseline;
- drops the seed count from 10 to 5;
- raises the per-subprocess timeout from 60s to 120s, since concurrent imports
  contend for I/O and CPU.

Wall time now collapses to roughly a single import. The check lives on the
`ScoreOrderingTests` mixin, which three solver suites inherit, so the file-level
saving is the one that matters:

| | before | after |
|---|---|---|
| one test method | 56.8s | ~6.8s |
| all three suites (`-k hashseed`) | ~170s | 20.3s |

#### Which issue(s) this PR is related to:

None — noticed while profiling the scratchpad solver test suite.

#### Special notes for your reviewer:

Reducing 10 seeds to 5 does trim coverage in principle. In practice set-iteration
order for the snippet's three buffer names changes under essentially any seed
perturbation, so a genuine ordering dependency surfaces within the first seed or
two; 10 bought little over 5.

I verified the assertion still bites rather than passing vacuously, by stubbing
`_run_determinism_snippet` to return a different placement for seed 3 — the test
fails and correctly reports `PYTHONHASHSEED=3`. Worth confirming, since the loop
now compares `results[0]` against itself on the first iteration.

One caveat on the timeout: on a cold page cache I measured a *single* import as
high as 43s wall (the venv here is on GPFS over NFS, so these imports are
I/O-bound — user time held steady at ~5.7s throughout). 120s held comfortably in
my runs, but if this test ever flakes in CI on a cold cache, that timeout is the
knob.

#### Does this PR introduce a user-facing change?

No. Test-only change; no library code touched.

#### Additional note:

`pre-commit run --files tests/inductor/test_scratchpad_solver.py` passes (ruff,
ruff format, mypy).
