### PR TITLE
feat(ci): replace(skip) native GHA tests when `integration-test` label routes PR through spyre-frameworks regression suite (jenkins)

### DIFF
--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -100,10 +100,13 @@ jobs:
   #
   # Only runs when `changes.code_changed == 'true'`. For docs-only PRs the
   # reusable workflow is never invoked — no hardware runners are consumed.
+  # Also skipped when `integration-test` is labeled -- spyre-framework handles it
   # ---------------------------------------------------------------------------
   run-tests:
     needs: changes
-    if: needs.changes.outputs.code_changed == 'true'
+    if: |
+      needs.changes.outputs.code_changed == 'true' &&
+      !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'integration-test'))
     uses: ./.github/workflows/_test_matrix.yaml
     with:
       runner_label: linux
@@ -130,12 +133,16 @@ jobs:
   #   run-tests result = success -> all suites passed      -> green
   #   run-tests result = skipped -> docs-only PR, no tests -> green (instant)
   #   run-tests result = failure -> one or more suites bad -> red   (blocks merge)
+  #
+  # For an `integration-test`-labeled PR this job doesn't run at all
   # ---------------------------------------------------------------------------
   run-spyre-unit-tests:
     name: Run Spyre unit tests
     runs-on: ubuntu-latest
     needs: [changes, run-tests]
-    if: always()
+    if: |
+      always() &&
+      !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'integration-test'))
     steps:
       - name: Evaluate test results
         run: |-

--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -69,7 +69,10 @@ jobs:
   build:
     name: Build torch-spyre wheel (once)
     needs: changes
-    if: needs.changes.outputs.code_changed == 'true'
+    # Also skipped when `integration-test` is labeled -- Jenkins handles it instead
+    if: |
+      needs.changes.outputs.code_changed == 'true' &&
+      !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'integration-test'))
     # Compile-only: needs the backend image + SDK toolchain but NO physical Spyre
     # card, so it targets the cardless spyre_pf_x0 pool and leaves card runners
     # for the test jobs.


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

Skip native GHA (torch spyre and upstream) tests on `integration-test`-labeled PRs since Jenkins already covers them and mirrors the result onto the same required check.