### PR TITLE
scratchpad: protect the in-place parent's footprint at the handoff tick

### DIFF
--- a/tests/inductor/test_scratchpad_solver.py
+++ b/tests/inductor/test_scratchpad_solver.py
@@ -130,6 +130,74 @@ def _addr_overlap(a, b) -> bool:
     return a.address < b.address + b.size and b.address < a.address + a.size
 
 
+def _in_place_descendants(buffers) -> dict[str, set[str]]:
+    """name -> every name reachable by following in-place edges downward.
+
+    A slot can be handed down a chain (``a -> b -> c``), and every solver
+    supports that, so legality has to be judged transitively: ``a`` and ``c``
+    sharing one base is the chain working as intended, not an overlap. Siblings
+    are deliberately *not* related here -- two children of one parent are in the
+    same component but neither inherits from the other, so they may not share.
+    """
+    children: dict[str, list[str]] = {}
+    for b in buffers:
+        for parent in b.in_place_parents:
+            children.setdefault(parent, []).append(b.name)
+
+    descendants: dict[str, set[str]] = {}
+
+    def walk(name: str) -> set[str]:
+        if name in descendants:
+            return descendants[name]
+        descendants[name] = set()  # placeholder, so a malformed cycle terminates
+        reached: set[str] = set()
+        for child in children.get(name, ()):
+            reached.add(child)
+            reached |= walk(child)
+        descendants[name] = reached
+        return reached
+
+    for b in buffers:
+        walk(b.name)
+    return descendants
+
+
+def _assert_legal_layout(test, result, size, alignment):
+    """Assert the layout is *physically* legal, whatever the solver's policy.
+
+    Every placed buffer is aligned and inside capacity, and no two buffers live
+    at a common tick may share an address. An in-place chain is exempt only at
+    *equal* addresses -- that one shared base is the whole point of the handoff
+    tick. A child that failed exact reuse and landed part-way into its parent, a
+    second child taking a slot already handed off, or a third buffer given the
+    parent's footprint above the child's, is corrupted data rather than a
+    heuristic choice, so each is checked like any other pair.
+
+    Which buffers reside is a policy question each solver answers differently;
+    this is the part none of them may get wrong, so it is asserted on every
+    layout every suite produces rather than per test.
+    """
+    placed = [b for b in result if b.address is not None]
+    for b in placed:
+        test.assertEqual(b.address % alignment, 0, f"{b.name} misaligned")
+        test.assertLessEqual(b.address + b.size, size, f"{b.name} exceeds capacity")
+    descendants = _in_place_descendants(result)
+    for i, a in enumerate(placed):
+        for c in placed[i + 1 :]:
+            if not _lifetimes_overlap(a, c):
+                continue
+            inherits = c.name in descendants[a.name] or a.name in descendants[c.name]
+            if inherits and a.address == c.address:
+                continue  # sanctioned handoff: same base, down one chain
+            test.assertFalse(
+                _addr_overlap(a, c),
+                f"{a.name}[{a.address},{a.address + a.size}) and "
+                f"{c.name}[{c.address},{c.address + c.size}) overlap in memory "
+                f"while both live at tick {max(a.start_time, c.start_time)}"
+                + (" (in-place chain, differing bases)" if inherits else ""),
+            )
+
+
 class BaseLayoutSolverTests:
     solver_class: type[MemoryPlanSolver] = None  # type: ignore[assignment]
 
@@ -146,7 +214,11 @@ class BaseLayoutSolverTests:
 
     def solve(self, buffers, size=LARGE_SIZE, alignment=1):
         self.last_solver = self.solver_class(size, alignment)
-        return self.last_solver.plan_layout(buffers)
+        result = self.last_solver.plan_layout(buffers)
+        # Checked here, not in check_result: several tests call solve() directly
+        # and assert addresses themselves, and legality holds for those too.
+        _assert_legal_layout(self, result, size, alignment)
+        return result
 
     def check_result(self, result, expected_addresses, size, alignment):
         """Assert the solved layout matches the heuristic-solver expectation.
@@ -210,6 +282,85 @@ class BaseLayoutSolverTests:
 
         self.assertIsNone(result["parent"].address)
         self.assertIsNotNone(result["child"].address)
+
+    # -- the in-place handoff contract, run against every solver -------------
+    #
+    # A child may take over its parent's slot, but only at the parent's exact
+    # base, and only the low `child.size` bytes of it. The parent is still live
+    # for the handoff tick and the bytes above the child still hold parent data
+    # read on that tick, so that remainder belongs to nobody else until the
+    # parent's lifetime ends.
+
+    def test_live_parent_footprint_not_reused_at_handoff(self):
+        # `child` takes over the low 5 bytes of a 40-byte parent. `stranger`
+        # enters at the handoff tick, so it may not be handed any of the
+        # remaining 35 -- and `child` itself may not sit part-way into the
+        # parent. `_assert_legal_layout` in solve() is the real assertion; the
+        # checks below name the specific pair for a readable failure.
+        parent = self.make_buffer("parent", 40, [0])
+        child = self.make_buffer("child", 5, [0, 2], in_place_parents=["parent"])
+        stranger = self.make_buffer("stranger", 20, [0, 1])
+        result = {b.name: b for b in self.solve([parent, child, stranger], size=120)}
+
+        p = result["parent"]
+        if p.address is None:
+            self.skipTest("parent spilled; nothing to protect")
+        for name in ("child", "stranger"):
+            b = result[name]
+            if b.address is None or not _lifetimes_overlap(p, b):
+                continue
+            if name == "child" and b.address == p.address:
+                continue  # sanctioned exact reuse
+            self.assertFalse(
+                _addr_overlap(p, b),
+                f"{name}[{b.address},{b.address + b.size}) lands inside live "
+                f"parent[{p.address},{p.address + p.size}) at the handoff tick",
+            )
+
+    def test_second_child_does_not_take_a_handed_off_slot(self):
+        # Two children declare the same parent. A slot is handed off once, so at
+        # most one of them may inherit the parent's base -- whichever the solver's
+        # ordering prefers. The other has to be placed on its own: those bytes now
+        # belong to the first child, and the rest still belongs to the parent for
+        # the handoff tick.
+        parent = self.make_buffer("parent", 40, [0])
+        first = self.make_buffer("first", 20, [0, 2], in_place_parents=["parent"])
+        second = self.make_buffer("second", 5, [0], in_place_parents=["parent"])
+        result = {b.name: b for b in self.solve([parent, first, second], size=120)}
+
+        placed = [b for b in result.values() if b.address is not None]
+        self.assertEqual(len(placed), 3, "all three fit in 120 bytes")
+        inheritors = [
+            name
+            for name in ("first", "second")
+            if result[name].address == result["parent"].address
+        ]
+        self.assertLessEqual(
+            len(inheritors),
+            1,
+            f"{inheritors} all sit at the parent's base; the slot is handed off once",
+        )
+
+    def test_in_place_merge_stays_within_capacity(self):
+        # Tight capacity (three alignment units) around a single in-place pair.
+        # The pair legally shares one base, but everything stacked around it must
+        # still end below capacity: a solver -- or a post-pass that slides merged
+        # units down -- has to spill rather than hand out an address that runs
+        # past the limit.
+        buffers = [
+            self.make_buffer("stacked", 20, [0, 2]),
+            self.make_buffer("late", 5, [6]),
+            self.make_buffer("parent", 20, [0]),
+            self.make_buffer("child", 5, [0, 2, 5, 6], in_place_parents=["parent"]),
+        ]
+        for b in self.solve(buffers, size=30, alignment=10):
+            if b.address is not None:
+                self.assertLessEqual(
+                    b.address + b.size,
+                    30,
+                    f"{b.name}[{b.address},{b.address + b.size}) runs past the "
+                    f"30-byte scratchpad",
+                )
 
     def test_simple_layout(self):
         # Three non-overlapping buffers fill memory sequentially.
@@ -583,24 +734,10 @@ def _assert_legal_packing(test, result, expected_addresses, size, alignment):
     solver minimises HBM traffic.
     """
     placed = [b for b in result if b.address is not None]
-    # A legal packing: every placed buffer is aligned and within capacity.
-    for b in placed:
-        test.assertEqual(b.address % alignment, 0, f"{b.name} misaligned")
-        test.assertLessEqual(b.address + b.size, size, f"{b.name} exceeds capacity")
-    # No two lifetime-overlapping buffers may share addresses, except in-place
-    # pairs, which intentionally share storage for the single tick their
-    # lifetimes touch.
-    for a in placed:
-        for c in placed:
-            if a.name == c.name:
-                continue
-            if not _lifetimes_overlap(a, c):
-                continue
-            if a.name in c.in_place_parents or c.name in a.in_place_parents:
-                continue
-            test.assertFalse(
-                _addr_overlap(a, c), f"{a.name} and {c.name} overlap in memory"
-            )
+    # Aligned, within capacity, and no address shared between buffers live at a
+    # common tick -- in-place pairs included, which are legal only at the single
+    # shared base they were merged at.
+    _assert_legal_layout(test, result, size, alignment)
     # Below one alignment unit of capacity the solver's unit model rounds to
     # zero and can't represent any placement, so the count comparison does not
     # apply.
@@ -677,7 +814,9 @@ class JointDivisionSolverTests(BaseLayoutSolverTests):
         )
         self.last_solver = self.solver_class(size, alignment)
         result = self.last_solver.plan_layout_and_core_divisions(buffers + [sink])
-        return [b for b in result if b.name != "__sink__"]
+        result = [b for b in result if b.name != "__sink__"]
+        _assert_legal_layout(self, result, size, alignment)
+        return result
 
     def check_result(self, result, expected_addresses, size, alignment):
         _assert_legal_packing(self, result, expected_addresses, size, alignment)
@@ -981,7 +1120,9 @@ class TestCpSatPlacementOnly(BaseLayoutSolverTests, TestCase):
             # and the solver cannot represent any placement.
             return buffers
         self.last_solver = self.solver_class(size, alignment)
-        return self.last_solver.plan_layout(buffers)
+        result = self.last_solver.plan_layout(buffers)
+        _assert_legal_layout(self, result, size, alignment)
+        return result
 
     def check_result(self, result, expected_addresses, size, alignment):
         _assert_legal_packing(self, result, expected_addresses, size, alignment)

--- a/torch_spyre/_inductor/scratchpad/greedy_solver.py
+++ b/torch_spyre/_inductor/scratchpad/greedy_solver.py
@@ -34,6 +34,11 @@ class GreedyLayoutSolver(MemoryPlanSolver):
         # `usage` tracks live placements during planning. It is specific to the
         # greedy time-stepping algorithm; the gap-based solvers don't use it.
         self.usage: list[LifetimeBoundBuffer] = []
+        # Names of parents whose slot has already been handed to an in-place
+        # child. A slot is handed off once: from the handoff on it belongs to
+        # that child, so a second child declaring the same parent must be placed
+        # on its own slot instead of landing on top of the first.
+        self.reused_parents: set[str] = set()
 
     def _get_lowest_addr_in_use(self):
         return min(
@@ -46,6 +51,27 @@ class GreedyLayoutSolver(MemoryPlanSolver):
             (rec.address + rec.size for rec in self.usage if rec.address is not None),
             default=0,
         )
+
+    def _occupied_spans(self) -> list[tuple[int, int]]:
+        """Merged ``[start, end)`` address spans currently in use.
+
+        An in-place handoff keeps both the dying parent and its child in
+        ``usage`` at the same address for the tick their lifetimes share, so
+        entries can nest. Merging the spans first means the gap scan cannot read
+        a shared slot as two abutting ones and hand out an address that is still
+        inside the parent.
+        """
+        merged: list[list[int]] = []
+        for lo, hi in sorted(
+            (rec.address, rec.address + rec.size)
+            for rec in self.usage
+            if rec.address is not None
+        ):
+            if merged and lo <= merged[-1][1]:
+                merged[-1][1] = max(merged[-1][1], hi)
+            else:
+                merged.append([lo, hi])
+        return [(lo, hi) for lo, hi in merged]
 
     def _find_free_block(self, size_needed: int) -> Optional[int]:
         assert all(x.address is not None for x in self.usage)
@@ -62,15 +88,10 @@ class GreedyLayoutSolver(MemoryPlanSolver):
             return address
 
         # Search for a gap between existing allocations
-        self.usage.sort(key=lambda x: (x.address is None, x.address))
-        for i in range(len(self.usage) - 1):
-            assert (current_address := self.usage[i].address) is not None
-            assert (next_address := self.usage[i + 1].address) is not None
-            frag_st = (
-                math.ceil((current_address + self.usage[i].size) / self.alignment)
-                * self.alignment
-            )
-            if next_address - frag_st >= size_needed:
+        occupied = self._occupied_spans()
+        for (_, span_end), (next_start, _) in zip(occupied, occupied[1:]):
+            frag_st = math.ceil(span_end / self.alignment) * self.alignment
+            if next_start - frag_st >= size_needed:
                 return frag_st
 
         return None
@@ -78,11 +99,18 @@ class GreedyLayoutSolver(MemoryPlanSolver):
     def _try_allocate(self, buffer: LifetimeBoundBuffer):
         # Check if the current buffer can be in-placed
         for in_place_opt in buffer.in_place_parents:
+            if in_place_opt in self.reused_parents:
+                continue
             matched_obj = next((u for u in self.usage if u.name == in_place_opt), None)
             if matched_obj is not None and buffer.size <= matched_obj.size:
                 buffer.address = matched_obj.address
                 self.usage.append(buffer)
-                self.usage.remove(matched_obj)
+                # The parent stays in `usage` until its own end_time. It is still
+                # live for the handoff tick, and the child covers only the low
+                # `buffer.size` bytes of its slot, so the footprint above that is
+                # still holding the parent's data and is not free for anyone
+                # else. `_try_deallocate` drops the parent at the right tick.
+                self.reused_parents.add(in_place_opt)
                 return None
 
         # Decide where to allocate the block from
@@ -147,6 +175,7 @@ class GreedyLayoutSolver(MemoryPlanSolver):
             return list(buffers)
 
         self.usage = []
+        self.reused_parents = set()
 
         # Walk through all transition points in chronological order.
         # Include end_time + 1 so deallocation fires even when no other

--- a/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
+++ b/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
@@ -31,10 +31,12 @@ constraint model over :class:`CoreDivisionBuffer`s:
 * **Placement** is a global ``AddNoOverlap2D`` over optional rectangles
   (``[start_time, end_time) x [offset, offset + eff_size)``, present iff
   resident). In-place reuse (``in_place_parents`` -> per-edge ``merge_vars``) is
-  encoded by *shortening the parent's lifetime* by the single handoff tick when
+  encoded by *shortening the child's lifetime* by the single handoff tick when
   the merge fires, so the parent and its in-place child abut in time and may
   legally share an offset; the single-tick-overlap invariant
-  (``_assert_in_place_relationships``) makes this exact (``_add_no_overlap_2d``).
+  (``_assert_in_place_relationships``) makes this exact. The parent keeps its
+  full lifetime, so the footprint above a smaller child stays protected on the
+  handoff tick (``_add_no_overlap_2d``).
 * **Objective** (two-phase lexicographic, in ``_run``). *Residency is the hard
   priority.* Phase 1 minimizes total **HBM transfer traffic** via
   ``spill_cost(b) * (1 - in_buffer)`` -- the *differential* traffic a spill adds
@@ -52,7 +54,10 @@ constraint model over :class:`CoreDivisionBuffer`s:
   spill.
 
 After the solve, ``_justify`` slides each in-place-merged placement unit down to
-the lowest free address, squeezing out float gaps without raising the peak.
+the lowest free address, squeezing out float gaps the search leaves. It coarsens
+a merged unit to one rectangle over the union of its members' lifetimes, which is
+conservative enough that the squeeze can occasionally need more room than the
+solver's own answer; when it would not fit, the solver's offsets are kept.
 
 The same model also serves plain :class:`LifetimeBoundBuffer`s via
 ``plan_layout`` (the ``MemoryPlanSolver`` contract the placement-only allocator
@@ -74,7 +79,7 @@ import logging
 import os
 from collections.abc import Sequence
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Generic, Optional, TypeVar, cast
 import torch
 
 
@@ -520,8 +525,8 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
         """In-place reuse as a relaxation of the no-overlap constraint: each
         parent->child edge gets a merge bool that, when active, pins the pair to
         one shared base. Rather than lifting a pairwise no-overlap, an active
-        merge *shortens the parent's lifetime by the single handoff tick* it
-        shares with the child (``_assert_in_place_relationships`` guarantees the
+        merge *shortens the child's lifetime by the single handoff tick* it
+        shares with the parent (``_assert_in_place_relationships`` guarantees the
         overlap is exactly that one tick): the two then become time-adjacent
         rectangles that may legally sit at the same offset under the global 2D
         no-overlap (see ``_add_no_overlap_2d``). Chains are induced transitively
@@ -531,7 +536,7 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
         M = self._capacity_units
 
         # A storage slot is handed off linearly, so a buffer reuses at most one
-        # parent and is reused by at most one child. ``outgoing`` also drives the
+        # parent and is reused by at most one child. ``incoming`` also drives the
         # lifetime shortening in ``_add_no_overlap_2d``.
         incoming: dict[str, list] = {}
         outgoing: dict[str, list] = {}
@@ -558,13 +563,13 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
             # if a buffer is resident its top must be below the peak usage.
             model.add(sb.offset + sb.eff_size <= M).OnlyEnforceIf(sb.in_buffer)
 
-        self._add_no_overlap_2d(model, bufs, outgoing)
+        self._add_no_overlap_2d(model, bufs, incoming)
 
     def _add_no_overlap_2d(
         self,
         model: "cp_model.CpModel",
         bufs: dict[str, _LifetimeBufferWithCpVars],
-        outgoing: dict[str, list],
+        incoming: dict[str, list],
     ) -> None:
         """Global 2D no-overlap: each resident buffer is an optional rectangle
         ``[start_time, end_time) x [offset, offset + eff_size)`` and no two may
@@ -572,40 +577,48 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
         presence (``in_buffer``), so spilled buffers drop out for free.
 
         In-place reuse is handled *inside* this constraint rather than by
-        relaxing it: an active outgoing merge shortens the parent's time
-        interval by the single handoff tick it shares with the child
-        (``end -> end - 1``). The parent and child then abut in time at the same
-        offset (pinned equal by the merge), which the 2D constraint accepts as
-        non-overlapping -- so the child legally reuses the parent's slot. With no
-        active merge the parent keeps its full lifetime and the shared-offset
+        relaxing it: an active incoming merge shortens the child's time interval
+        by the single handoff tick it shares with the parent
+        (``start -> start + 1``). The parent and child then abut in time at the
+        same offset (pinned equal by the merge), which the 2D constraint accepts
+        as non-overlapping -- so the child legally reuses the parent's slot. With
+        no active merge the child keeps its full lifetime and the shared-offset
         placement is correctly forbidden, exactly as the pairwise encoding did.
 
-        The handoff tick stays protected because the child's interval covers it
-        at the shared offset; the merge ``eff_size`` equality means there is no
-        footprint gap. ``AddAtMostOne`` on the outgoing edges bounds the
-        shortening at one tick (a degenerate zero-width parent box is ignored by
-        the 2D propagator, which is fine -- the child holds the slot)."""
+        It is the *child* that gives up the tick, never the parent: the parent's
+        rectangle has to keep covering the handoff tick at full footprint. The
+        child may be smaller than its parent (the placement-only model only
+        requires ``child.size <= parent.size``), and the bytes above the child
+        are still holding parent data that is read on that tick, so they are not
+        free for a third buffer. Shortening the parent instead would expose them
+        -- and a parent whose whole lifetime is that one tick would drop out of
+        the propagator entirely, exposing its full slot.
+
+        ``AddAtMostOne`` on the incoming edges bounds the shortening at one tick.
+        A child whose entire lifetime is the handoff tick degenerates to a
+        zero-width box the 2D propagator ignores, which is safe here: the tick is
+        covered by the parent's box, whose footprint contains the child's at the
+        shared offset."""
         x_intervals = []
         y_intervals = []
         for sb in bufs.values():
-            outs = outgoing.get(sb.name, [])
-            if outs:
-                # at most one outgoing merge is active (AddAtMostOne), so the
-                # sum is 0 or 1: shorten the parent by the handoff tick exactly
-                # when it hands its slot to an in-place child.
-                end_var = model.new_int_var(
-                    sb.start_time, sb.end_time, f"end_{sb.name}"
+            ins = incoming.get(sb.name, [])
+            if ins:
+                # at most one incoming merge is active (AddAtMostOne), so the
+                # sum is 0 or 1: shorten the child by the handoff tick exactly
+                # when it takes over a parent's slot.
+                start_var = model.new_int_var(
+                    sb.start_time, sb.end_time, f"start_{sb.name}"
                 )
-                model.add(end_var == sb.end_time - sum(outs))
-                x_size: object = end_var - sb.start_time
-                x_end: object = end_var
+                model.add(start_var == sb.start_time + sum(ins))
+                x_start: object = start_var
+                x_size: object = sb.end_time - start_var
             else:
-                end_var = sb.end_time
+                x_start = sb.start_time
                 x_size = sb.end_time - sb.start_time
-                x_end = sb.end_time
             x_intervals.append(
                 model.new_optional_interval_var(
-                    sb.start_time, x_size, x_end, sb.in_buffer, f"x_{sb.name}"
+                    x_start, x_size, sb.end_time, sb.in_buffer, f"x_{sb.name}"
                 )
             )
             # An interval's ``end`` must be affine (a single var), so the address
@@ -670,14 +683,16 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
         ``address`` (in alignment units, as the solver works them; the caller
         scales to bytes). A spilled buffer gets ``address = None``. When
         bottom_justify is set, each in-place-merged placement unit is slid down
-        to the lowest free address (preserving merges, never raising the
-        peak)."""
+        to the lowest free address (preserving merges); if that squeeze cannot
+        keep every unit inside capacity the solver's own offsets are kept, since
+        those are always legal."""
         by_name = {name: sb.buffer for name, sb in bufs.items()}
         spilled = {
             name for name, sb in bufs.items() if not solver.BooleanValue(sb.in_buffer)
         }
         footprint = {name: sb.footprint(solver) for name, sb in bufs.items()}
 
+        offsets: Optional[dict[str, int]] = None
         if self._bottom_justify:
             # A placement unit is a connected component of active merge edges: its
             # members share one base (the merge equalities), so the component
@@ -710,8 +725,9 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
                 )
                 for names in components.values()
             ]
-            offsets = self._justify(units)
-        else:
+            offsets = self._justify(units, self._capacity_units)
+
+        if offsets is None:
             offsets = {
                 name: solver.Value(sb.offset)
                 for name, sb in bufs.items()
@@ -728,12 +744,23 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
         return by_name
 
     @staticmethod
-    def _justify(units: list[_PlacementUnit]) -> dict[str, int]:
+    def _justify(
+        units: list[_PlacementUnit], capacity: int
+    ) -> Optional[dict[str, int]]:
         """Slide each placement unit down to the lowest free address. Processing
         in current-base order and giving each the lowest non-conflicting slot
-        preserves the relative stacking, so the peak never increases -- it only
-        squeezes out the float gaps the search leaves. Returns a name -> address
-        map."""
+        preserves the relative stacking, so it mostly squeezes out the float gaps
+        the search leaves. Returns a name -> address map, or ``None`` if the
+        result would not fit in ``capacity``.
+
+        A merged unit is coarsened to one rectangle spanning the union of its
+        members' lifetimes at their largest footprint, which is conservative: it
+        can make two units conflict here that did not conflict in the model, and
+        the bump that resolves that conflict can push a unit's top past capacity.
+        The caller then keeps the solver's own offsets, which the model
+        constrained to fit. Returning ``None`` rather than clamping keeps this a
+        pure optimisation -- it never decides residency, and never hands back an
+        address outside the scratchpad."""
         placed: list[_PlacementUnit] = []
         offsets = {}
         for u in sorted(units, key=lambda u: (u.original_offset, u.start_time)):
@@ -752,6 +779,8 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
                     break  # fits in the gap below this obstacle
                 if base < hi:
                     base = hi  # otherwise bump above it
+            if base + u.footprint > capacity:
+                return None
             u.justified_offset = base
             placed.append(u)
             for n in u.members:


### PR DESCRIPTION
## Summary

Extends #3438 to the remaining solvers, and adds the invariant that would have caught all of it.

#3438 fixed a FirstFit/BestFit issue where an in-place child that failed exact parent-slot reuse landed part-way inside its still-live parent. The underlying rule is broader than that one path, and two other solvers broke it in their own ways — including Greedy, the `LAYOUT_SOLVER` default.

The rule all five now apply: **a child may take over its parent's slot only at the parent's exact base, and only the low `child.size` bytes of it. The parent keeps the rest until its own lifetime ends, and a slot is handed off exactly once.**

## Greedy (`greedy_solver.py`)

`_try_allocate` removed the parent from `usage` the moment a child reused its slot, so the footprint above the child read as free while the parent was still live for the handoff tick:

```
parent    40 live=[0,1) addr=0
child      5 live=[0,3) addr=0     <- in-place, legal
stranger  20 live=[0,2) addr=5     <- inside parent[0,40) at tick 0
```

Three coupled changes: the parent stays in `usage` until its own `end_time`; a slot is handed to at most one child (a second child previously landed on top of the first); and address spans are merged before the gap scan. The last is required by the first — the pairwise scan assumed non-overlapping `usage` entries, so a nested parent/child pair would read as two abutting allocations and yield an address inside the parent.

## CP-SAT (`ilp_solver_ortools.py`)

Two independent issues.

`_add_no_overlap_2d` shortened the **parent's** rectangle by the handoff tick. The placement-only model only requires `child.size <= parent.size`, so the bytes above a smaller child went unprotected on that tick — and a parent whose whole lifetime *was* that tick dropped out of the 2D propagator entirely, exposing its full slot. It now shortens the child's start instead: the parent keeps covering the tick at full footprint, and a degenerate zero-width child is safe becausethe parent's box contains it at the shared offset.

`_justify` coarsens a merged unit to one rectangle over the union of its members' lifetimes at their largest footprint, which can manufacture conflicts the model did not have. The bump resolving them had no capacity guard, so it silently returned addresses past the limit (e.g. `[20,40)` in a 30-byte pad, 10/10 reruns). It now returns `None` and the caller keeps the solver's own offsets, which the model constrained to fit — justification stays a pure optimization that never decides residency.

## The invariant (`tests/inductor/test_scratchpad_solver.py`)

Nothing checked that a layout was physically legal. `check_result` compared exact addresses, and `_assert_legal_packing` — the invariant the CP-SAT suites use — exempted declared in-place pairs from the overlap check unconditionally, so it accepted a child sitting part-way inside its parent. Neither #3438's issue nor the two above were visible to the suite.

`_assert_legal_layout` (aligned, within capacity, no address shared between buffers live at a common tick) is asserted inside all three `solve()` overrides rather than in `check_result`, because several tests call `solve()` directly and assert addresses themselves. `_assert_legal_packing` delegates to it.

Legality is judged over in-place **chains**, not single edges: a slot can be handed down `a -> b -> c` and all three legally share one base, so `_in_place_descendants` exempts inheritance at equal addresses. Siblings are deliberately not related that way — two children of one parent are in the same component but neither inherits from the other, so they may not share.

Three shared cases in `BaseLayoutSolverTests` exercise the shapes, so all six suites run them: a third buffer entering at the handoff tick, a second child claiming an already handed-off slot, and an in-place merge under capacity pressure.
