### PR TITLE
feat(ci): add a trunk tier alias for push-to-main CI

### DIFF
--- a/.github/workflows/model_ops_tests.yaml
+++ b/.github/workflows/model_ops_tests.yaml
@@ -1,5 +1,8 @@
 name: model-ops-tests
 
+# One of torch-spyre's four "trunk" (push-to-main) workflows -- see
+# torch_spyre_tests.yaml, upstream_tests.yaml, upstream_tests_beta.yaml for
+# the others. No test_type input here, so no trunk wiring beyond this label.
 on:
   # Run automatically on every merge to main
   push:

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -1,5 +1,9 @@
 name: tests
 
+# One of torch-spyre's four "trunk" (push-to-main) workflows -- see
+# model_ops_tests.yaml, upstream_tests.yaml, upstream_tests_beta.yaml for the
+# others. A push run passes test_type: trunk (below) so it's distinguishable
+# from a manually-dispatched full run once tier-tagging reaches ClickHouse.
 on:
   push:
     branches: [main]
@@ -117,7 +121,7 @@ jobs:
       rpm_location: ${{ inputs.rpm_location || '' }}
       rpm_names: ${{ inputs.rpm_names || '' }}
       build_torch_spyre: ${{ inputs.build_torch_spyre == true }}
-      test_type: ${{ inputs.test_type || 'full' }}
+      test_type: ${{ inputs.test_type || (github.event_name == 'push' && 'trunk' || 'full') }}
 
   # ---------------------------------------------------------------------------
   # Job 3: run-spyre-unit-tests (required check gate)

--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -1,5 +1,8 @@
 name: upstream-pytorch-tests
 
+# One of torch-spyre's four "trunk" (push-to-main) workflows -- see
+# torch_spyre_tests.yaml, model_ops_tests.yaml, upstream_tests_beta.yaml for
+# the others. No test_type input here, so no trunk wiring beyond this label.
 on:
   # Run automatically on every merge to main
   push:

--- a/.github/workflows/upstream_tests_beta.yaml
+++ b/.github/workflows/upstream_tests_beta.yaml
@@ -1,5 +1,8 @@
 name: upstream-pytorch-tests-beta
 
+# One of torch-spyre's four "trunk" (push-to-main) workflows -- see
+# torch_spyre_tests.yaml, model_ops_tests.yaml, upstream_tests.yaml for the
+# others. No test_type input here, so no trunk wiring beyond this label.
 on:
   # Run automatically on every merge to main
   push:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,12 @@ TEST_CONFIGS ?= tests/configs/torch_spyre_tests
 #                       LX/scratchpad planning, tensor layout, allocator/GC,
 #                       D2D copies (used as the default in integration-tests.yaml,
 #                       triggered by those upstream repos)
-#   full             — everything (core + LX-planning); default for `make tests`
+#   full             — everything (core + LX-planning) under TEST_CONFIGS;
+#                      default for `make tests`
+#   trunk            — full, run across every suite directory CI's four
+#                      push-to-main workflows cover (see TRUNK_CONFIG_DIRS),
+#                      not just TEST_CONFIGS -- so `make tests TEST_TYPE=trunk`
+#                      matches what actually runs on a push to main
 #   perf             — spyre-perf-suite benchmark (shells out, not a pytest
 #                      config suite); writes report.xml into RESULTS_DIR
 #   suite_<group>    — all configs inside the <group>/ sub-directory
@@ -29,6 +34,14 @@ TEST_CONFIGS ?= tests/configs/torch_spyre_tests
 # regression=full.
 # Empty / unset defaults to "regression" (= full: all configs under TEST_CONFIGS).
 TEST_TYPE ?= regression
+
+# Suite directories covered by torch-spyre's four trunk (push-to-main)
+# workflows -- torch_spyre_tests.yaml, model_ops_tests.yaml,
+# upstream_tests.yaml, upstream_tests_beta.yaml, in that order. TEST_TYPE=trunk
+# scans all of them (each filtered to "full") instead of just TEST_CONFIGS, so
+# a local trunk run exercises the same configs the push workflows do
+# collectively. Update this list if a trunk workflow's config directory moves.
+TRUNK_CONFIG_DIRS := tests/configs/torch_spyre_tests tests/configs/model_ops_tests tests/configs/upstream_tests tests/configs/upstream_tests_beta
 
 # Where TEST_TYPE=perf writes its benchmark report. Flat /tmp/results so the CI
 # ClickHouse push step (ingest_xml.py globs *.xml non-recursively) finds it
@@ -67,7 +80,7 @@ precommit: ## Run all pre-commit hooks against every file
 # ---------------------------------------------------------------------------
 
 .PHONY: tests
-tests: ## Run torch spyre tests. Narrow scope with TEST_TYPE=smoke|core|full|perf|suite_<group>. TEST_CONFIGS may point at a config directory (filtered by TEST_TYPE) or a single config yaml file (run directly).
+tests: ## Run torch spyre tests. Narrow scope with TEST_TYPE=smoke|core|full|trunk|perf|suite_<group>. TEST_CONFIGS may point at a config directory (filtered by TEST_TYPE) or a single config yaml file (run directly); ignored when TEST_TYPE=trunk (see TRUNK_CONFIG_DIRS).
 # TEST_TYPE=perf is a benchmark mode, not a pytest-config suite: it does not
 # run the OOT config machinery below. It shells out to the installed
 # spyre-perf-suite console script (a wheel dependency of the dev image) and
@@ -81,6 +94,15 @@ ifeq ($(TEST_TYPE),perf)
 	@test -f "$(RESULTS_DIR)/report.xml" || \
 		{ echo "ERROR: spyre-perf-suite did not emit $(RESULTS_DIR)/report.xml" >&2; \
 		  exit 1; }
+else ifeq ($(TEST_TYPE),trunk)
+	$(eval _PATHS := $(shell for d in $(TRUNK_CONFIG_DIRS); do \
+		python3 $(FILTER_SCRIPT) --config-dir "$$d" --test-type full --format paths; \
+	done))
+	@if [ -z "$(_PATHS)" ]; then \
+		echo "ERROR: no configs matched TEST_TYPE=trunk under TRUNK_CONFIG_DIRS ($(TRUNK_CONFIG_DIRS))" >&2; \
+		exit 1; \
+	fi
+	@TORCH_SPYRE_TEST_TYPE="$(TEST_TYPE)" bash tests/run_test.sh $(_PATHS) $(PYTEST_ARGS)
 else ifneq ($(wildcard $(TEST_CONFIGS)/.),)
 	$(eval _PATHS := $(shell python3 $(FILTER_SCRIPT) \
 		--config-dir $(TEST_CONFIGS) \

--- a/tests/oot_framework/utils/filter_configs.py
+++ b/tests/oot_framework/utils/filter_configs.py
@@ -41,6 +41,7 @@ every caller sees it consistently:
   "unit"          -> "core"
   "integration"   -> "device_critical"
   "regression"    -> "full"
+  "trunk"         -> "full" (push-to-main CI; same coverage as full)
   "smoke"         -> "smoke" (already the canonical spelling, no change)
 These are the names meant for humans/CI configs to type; device_critical/full/
 core keep their existing, more specific meaning as the actual label vocabulary
@@ -148,6 +149,7 @@ TEST_TYPE_ALIASES = {
     "unit": "core",
     "integration": "device_critical",
     "regression": "full",
+    "trunk": "full",
 }
 
 


### PR DESCRIPTION
## Summary
- Add `"trunk": "full"` to `TEST_TYPE_ALIASES` in `filter_configs.py` so push-triggered runs can be tagged distinctly from a manually-dispatched `full` run.
- Label all four push-to-main workflows (`torch_spyre_tests.yaml`, `model_ops_tests.yaml`, `upstream_tests.yaml`, `upstream_tests_beta.yaml`) as trunk collectively via header comments.
- `torch_spyre_tests.yaml` passes `test_type: trunk` on push (the only one of the four with a `test_type` input to wire).

## Test plan
- [x] `resolve_test_type("trunk")` returns `"full"` (verified locally)
- [x] YAML syntax of all four edited workflow files validated