### PR TITLE
ci(perf): route TEST_TYPE=perf to a dedicated benchmark job

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -388,7 +388,7 @@ jobs:
           retention-days: 10
 
   # ---------------------------------------------------------------------------
-  # Job 1b: perf benchmark  (test_type=perf only)
+  # Job 1b: perf benchmark  (test_type=perf only, never per-PR)
   #
   # perf is a benchmark MODE of `make tests`, not an OOT pytest-config suite, so
   # it never appears in the config-driven `test` matrix above (generate_matrix
@@ -397,12 +397,20 @@ jobs:
   # report.xml into RESULTS_DIR. This job runs that single benchmark step on a
   # card runner and uploads the report as report.xml (same artifact contract as
   # the matrix suites, so report_empty_suites and any XML ingest pick it up).
+  #
+  # POLICY: perf is a weekly-only suite -- it must NEVER run on a per-PR trigger
+  # (it is expensive and holds a scarce card runner). The `github.event_name !=
+  # pull_request` guard below is the hard stop: even if a pull_request path
+  # forwarded test_type=perf, this job stays skipped. The weekly/scheduled and
+  # orchestrator paths reach here via workflow_dispatch/schedule, not
+  # pull_request, so they are unaffected.
   # ---------------------------------------------------------------------------
   perf:
     name: Perf benchmark
     needs: [generate_matrix, build_torch_spyre]
     if: >-
       !cancelled() &&
+      github.event_name != 'pull_request' &&
       needs.generate_matrix.outputs.resolved_test_type == 'perf' &&
       (needs.build_torch_spyre.result == 'success' ||
        needs.build_torch_spyre.result == 'skipped')

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -395,8 +395,8 @@ jobs:
   # emits an empty matrix for perf). `make tests TEST_TYPE=perf` shells out to
   # the spyre-perf-suite console script baked into the dev image and writes
   # report.xml into RESULTS_DIR. This job runs that single benchmark step on a
-  # card runner and uploads the report as report.xml (same artifact contract as
-  # the matrix suites, so report_empty_suites and any XML ingest pick it up).
+  # card runner. The reports are not uploaded as artifacts; the results are
+  # consumed only by the ClickHouse ingest path.
   #
   # POLICY: perf is a weekly-only suite -- it must NEVER run on a per-PR trigger
   # (it is expensive and holds a scarce card runner). The `github.event_name !=
@@ -476,23 +476,15 @@ jobs:
           source "${VENV}/bin/activate"
           make -C "${SRC_DIR}" tests TEST_TYPE=perf RESULTS_DIR="${RESULTS_DIR}"
 
-      - name: Upload perf report
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: report.xml
-          path: ${{ env.RESULTS_DIR }}/report.xml
-          if-no-files-found: warn
-          retention-days: 10
-
-      - name: Upload perf report (human-readable)
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: report.txt
-          path: ${{ env.RESULTS_DIR }}/report.txt
-          if-no-files-found: warn
-          retention-days: 10
+      # The benchmark reports are not uploaded as workflow artifacts; the
+      # results are consumed only by the ClickHouse ingest path.
+      - name: Confirm perf report was produced
+        run: |
+          # Fail if the benchmark did not write its report. Do not echo the
+          # report contents to the build log.
+          test -f "${RESULTS_DIR}/report.xml" \
+            || { echo "::error::perf run did not produce report.xml"; exit 1; }
+          echo "perf report written to \${RESULTS_DIR} (not uploaded)"
 
   # ---------------------------------------------------------------------------
   # Job 2: Multi-Spyre test matrix
@@ -637,7 +629,7 @@ jobs:
   report_empty_suites:
     name: Report empty test suites
     runs-on: ubuntu-latest
-    needs: [generate_matrix, test, test_multi_spyre, perf]
+    needs: [generate_matrix, test, test_multi_spyre]
     if: always()
 
     steps:

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -168,6 +168,20 @@ jobs:
           else
             pip install pyyaml --quiet
           fi
+
+          # perf is NOT an OOT pytest-config suite: it is a benchmark mode of
+          # `make tests` (TEST_TYPE=perf shells out to spyre-perf-suite; see the
+          # Makefile `ifeq ($(TEST_TYPE),perf)` branch). It carries no
+          # test_suite_config.labels, so the config filter below would always
+          # return an empty matrix. Route it to the dedicated `perf` job instead:
+          # emit an empty matrix (the `test` matrix job is then skipped) and pin
+          # resolved_test_type=perf so the downstream perf gate fires.
+          if [ "${RAW_TEST_TYPE}" = "perf" ]; then
+            echo "matrix={\"suite\":[]}" >> "$GITHUB_OUTPUT"
+            echo "resolved_test_type=perf" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           matrix=$(python3 tests/oot_framework/utils/filter_configs.py \
             --config-dir tests/configs/torch_spyre_tests \
             --test-type "${RAW_TEST_TYPE}" \
@@ -374,6 +388,105 @@ jobs:
           retention-days: 10
 
   # ---------------------------------------------------------------------------
+  # Job 1b: perf benchmark  (test_type=perf only)
+  #
+  # perf is a benchmark MODE of `make tests`, not an OOT pytest-config suite, so
+  # it never appears in the config-driven `test` matrix above (generate_matrix
+  # emits an empty matrix for perf). `make tests TEST_TYPE=perf` shells out to
+  # the spyre-perf-suite console script baked into the dev image and writes
+  # report.xml into RESULTS_DIR. This job runs that single benchmark step on a
+  # card runner and uploads the report as report.xml (same artifact contract as
+  # the matrix suites, so report_empty_suites and any XML ingest pick it up).
+  # ---------------------------------------------------------------------------
+  perf:
+    name: Perf benchmark
+    needs: [generate_matrix, build_torch_spyre]
+    if: >-
+      !cancelled() &&
+      needs.generate_matrix.outputs.resolved_test_type == 'perf' &&
+      (needs.build_torch_spyre.result == 'success' ||
+       needs.build_torch_spyre.result == 'skipped')
+    runs-on:
+      - x86_64
+      - spyre_pf_x1
+      - ${{ inputs.runner_label }}
+      - ${{ inputs.image_label }}
+    timeout-minutes: 120
+    env:
+      # Flat results dir, matching the Makefile default and PR #3452. The suite
+      # writes both report.txt and report.xml here.
+      RESULTS_DIR: ${{ github.workspace }}/perf-results
+    steps:
+      - name: Checkout composite actions
+        if: ${{ !inputs.prebaked_image }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+
+      - name: Expose baked composite actions in the workspace
+        if: ${{ inputs.prebaked_image }}
+        run: ln -sfn "${PREBAKED_TORCH_SPYRE_DIR}/.github" "${GITHUB_WORKSPACE}/.github"
+
+      - if: ${{ !inputs.prebaked_image }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: torch-spyre
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
+          repository: ${{ inputs.repository || github.event.pull_request.head.repo.full_name || github.repository }}
+
+      - uses: ./.github/actions/gather-runner-info
+        with:
+          verbose: 'true'
+          torch_spyre_dir: ${{ inputs.prebaked_image && env.PREBAKED_TORCH_SPYRE_DIR || 'torch-spyre' }}
+
+      - name: Install prebuilt torch-spyre
+        if: ${{ !inputs.prebaked_image && needs.build_torch_spyre.result == 'success' }}
+        uses: ./.github/actions/install-prebuilt-torch-spyre
+
+      - name: Run perf benchmark (make tests TEST_TYPE=perf)
+        run: |
+          # Prebaked: run FROM the baked source dir + its SHARED venv at
+          # $HOME/.venv; normal: the checkout ('torch-spyre') + local '.venv'.
+          if [ "${{ inputs.prebaked_image }}" = "true" ]; then
+            SRC_DIR="${PREBAKED_TORCH_SPYRE_DIR}"
+            VENV="${PREBAKED_VENV_PATH}"
+          else
+            SRC_DIR="torch-spyre"
+            VENV="torch-spyre/.venv"
+          fi
+          mkdir -p "${RESULTS_DIR}"
+          # Refresh AIU setup so the benchmark sees the card topology, mirroring
+          # the matrix suites' pre_run. set +u because the script reads unset
+          # vars; a failed refresh must abort before the benchmark runs.
+          set +u
+          unset _IBM_AIU_SETUP
+          rm -rf /tmp/etc/ibm/spyre/topo.json
+          source /etc/profile.d/ibm-aiu-setup.sh || exit 1
+          set -u
+          # shellcheck disable=SC1091
+          source "${VENV}/bin/activate"
+          make -C "${SRC_DIR}" tests TEST_TYPE=perf RESULTS_DIR="${RESULTS_DIR}"
+
+      - name: Upload perf report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: report.xml
+          path: ${{ env.RESULTS_DIR }}/report.xml
+          if-no-files-found: warn
+          retention-days: 10
+
+      - name: Upload perf report (human-readable)
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: report.txt
+          path: ${{ env.RESULTS_DIR }}/report.txt
+          if-no-files-found: warn
+          retention-days: 10
+
+  # ---------------------------------------------------------------------------
   # Job 2: Multi-Spyre test matrix
   #
   # Only runs for test_type values that include the distributed suite:
@@ -516,7 +629,7 @@ jobs:
   report_empty_suites:
     name: Report empty test suites
     runs-on: ubuntu-latest
-    needs: [generate_matrix, test, test_multi_spyre]
+    needs: [generate_matrix, test, test_multi_spyre, perf]
     if: always()
 
     steps:


### PR DESCRIPTION
## Summary

Fixes the amd64 GHA `perf` leg that fails at matrix generation (seen in
orchestrator #1026 / component-build #6021). Two independent problems, both
addressed here:

1. **`ImportError: cannot import name 'resolve_test_type'`.** The reusable
   `_test_matrix.yaml` runs from `main` and imports `resolve_test_type` from
   `filter_configs.py`, but that function did not exist on the older branch this
   started from. Resynced with `main`, which carries the function.

2. **`WARNING: no configs matched TEST_TYPE='perf'`.** `perf` is a benchmark
   mode of `make tests` (`TEST_TYPE=perf` shells out to `spyre-perf-suite` and
   writes `report.xml`; see the Makefile `ifeq ($(TEST_TYPE),perf)` branch), not
   an OOT pytest-config suite. It carries no `test_suite_config.labels`, so
   `_test_matrix.yaml`'s config filter always returned an empty matrix for perf
   and no job ever ran the benchmark.

## Changes to `_test_matrix.yaml`

- **`generate_matrix`**: short-circuit `test_type=perf` before the config
  filter. Emit an empty matrix and `resolved_test_type=perf`. No config lookup,
  no crash. The config-driven `test` matrix job then skips (empty `suite` list).
- **New `perf` job**: gated on `resolved_test_type == 'perf'`. Runs
  `make tests TEST_TYPE=perf` on a card runner (`spyre_pf_x1`), mirroring the
  prebaked-image pattern used by the `test` job (symlink the baked `.github`,
  use `PREBAKED_TORCH_SPYRE_DIR` + `PREBAKED_VENV_PATH`, refresh AIU setup).
- **Weekly-only, never per-PR.** The perf job carries a hard
  `github.event_name != 'pull_request'` guard, so perf can never run on a
  per-PR trigger even if a `pull_request` path forwarded `test_type=perf`. It
  is reachable only via the weekly/scheduled and orchestrator paths
  (`workflow_dispatch` / `schedule`). perf is expensive and holds a scarce card
  runner, so this keeps it off the per-PR path by design.
- **Results handling.** The perf job does not upload the benchmark reports as
  workflow artifacts; the results are consumed only by the ClickHouse ingest
  path. A presence check fails the job if `report.xml` was not written. `perf`
  is dropped from `report_empty_suites` `needs` since it produces no XML
  artifact for that job.

## Validation

- `pre-commit run --files .github/workflows/_test_matrix.yaml`: **actionlint
  PASSED, yamlfmt PASSED**.
- The `perf` suite itself is known-good: it runs clean on real hardware
  (`PERF_EXIT=0`, full report) via `make tests TEST_TYPE=perf`. This PR only
  wires that entry point into the GHA path.
- On this PR's own run, the `Perf benchmark` job is SKIPPED (correct: this PR
  runs `full` and is a `pull_request` event).
