### PR TITLE
get TORCH_LOGS works with `torch_spyre` namespace

### DIFF
--- a/docs/source/api/torch_spyre.rst
+++ b/docs/source/api/torch_spyre.rst
@@ -576,17 +576,16 @@ Environment Variables
      - Purpose
    * - ``TORCH_SPYRE_DEBUG=1``
      - Build-time: enable C++ debug logging and ``-O0`` builds.
-       Runtime: deprecated, use ``TORCH_LOGS='spyre:DEBUG'`` instead
+       Runtime: deprecated, use ``TORCH_LOGS='+torch_spyre'`` instead
        (see ``torch_spyre.logging_config``)
    * - ``TORCH_SPYRE_DOWNCAST_WARN=0``
      - Suppress int64 → int32 downcast warnings
    * - ``SPYRE_INDUCTOR_LOG=1``
-     - *Deprecated*. Use ``TORCH_LOGS='spyre.inductor:INFO'``. Enables Spyre
-       Inductor logging
+     - *Deprecated*. Use ``TORCH_LOGS='torch_spyre.inductor'``. Enables Spyre
+       Inductor logging (INFO level)
    * - ``SPYRE_INDUCTOR_LOG_LEVEL=DEBUG``
-     - *Deprecated*. Set the level in ``TORCH_LOGS`` (e.g.
-       ``spyre.inductor:DEBUG``). Sets Spyre Inductor log verbosity (DEBUG,
-       INFO, WARNING, ERROR)
+     - *Deprecated*. Use ``TORCH_LOGS='+torch_spyre.inductor'`` (DEBUG level).
+       Sets Spyre Inductor log verbosity
    * - ``SPYRE_LOG_FILE=path``
      - *Deprecated*. Mapped to the top-level ``spyre`` logger file handler.
        Redirects Spyre Inductor logs to a file

--- a/docs/source/user_guide/debugging/index.md
+++ b/docs/source/user_guide/debugging/index.md
@@ -56,8 +56,8 @@ The following environment variables control the level of diagnostic output:
 | `TORCHINDUCTOR_FORCE_DISABLE_CACHES=1` | Forces full recompilation on every run; ensures you see fresh artifacts, not cached ones |
 | `TORCH_SPYRE_DEBUG=1` | Logs all CPU↔Spyre data transfers, including tensor shapes, layouts, and raw values |
 | `TORCH_COMPILE_DEBUG=1` | Writes intermediate compiler artifacts to a local directory for offline inspection |
-| `SPYRE_INDUCTOR_LOG=1` | *Deprecated.* Use `TORCH_LOGS="spyre.inductor:INFO"` instead |
-| `SPYRE_INDUCTOR_LOG_LEVEL=DEBUG` | *Deprecated.* Use `TORCH_LOGS="spyre.inductor:DEBUG"` instead |
+| `SPYRE_INDUCTOR_LOG=1` | *Deprecated.* Use `TORCH_LOGS="torch_spyre.inductor"` instead (INFO level) |
+| `SPYRE_INDUCTOR_LOG_LEVEL=DEBUG` | *Deprecated.* Use `TORCH_LOGS="+torch_spyre.inductor"` instead (DEBUG level) |
 | `SPYRE_LOG_FILE=path/to/file.log` | Redirect Spyre Inductor log output to a file |
 | `TORCH_SPYRE_DOWNCAST_WARN=0` | Suppress int64→int32 warnings |
 | `TORCH_LOGS="+inductor"` | PyTorch provided tool to selectively enable Inductor or other parts of the `torch.compile` to the log |

--- a/docs/source/user_guide/debugging/index.md
+++ b/docs/source/user_guide/debugging/index.md
@@ -62,6 +62,26 @@ The following environment variables control the level of diagnostic output:
 | `TORCH_SPYRE_DOWNCAST_WARN=0` | Suppress int64→int32 warnings |
 | `TORCH_LOGS="+inductor"` | PyTorch provided tool to selectively enable Inductor or other parts of the `torch.compile` to the log |
 
+### Programmatic Logging Control
+
+For log levels not supported by `TORCH_LOGS` (WARNING, CRITICAL, DISABLED) or
+for runtime control, use the programmatic API:
+
+```python
+from torch_spyre import logging_config
+
+# Set specific log levels
+logging_config.set_log_level('spyre.inductor', 'WARNING')
+logging_config.set_log_level('spyre.runtime', 'CRITICAL')
+
+# Per-pass DEBUG logging (for compiler pipeline debugging)
+logging_config.set_log_level('spyre.inductor.passes', 'DEBUG')
+logging_config.set_log_passes('all')  # or specific passes
+```
+
+See [Programmatic Configuration](../profiling/environment_variables.md#programmatic-configuration)
+for complete API documentation.
+
 Run your reproducer with all three enabled:
 
 ```bash

--- a/docs/source/user_guide/profiling/environment_variables.md
+++ b/docs/source/user_guide/profiling/environment_variables.md
@@ -11,10 +11,12 @@ Debug-oriented variables (`TORCH_SPYRE_DEBUG`, `TORCH_COMPILE_DEBUG`,
 
 | Variable | Effect |
 |---|---|
-| `SPYRE_INDUCTOR_LOG=1` | *Deprecated*. Use `TORCH_LOGS="spyre.inductor:INFO"`. Enables Spyre-specific Inductor logging |
-| `SPYRE_INDUCTOR_LOG_LEVEL=DEBUG` | *Deprecated*. Set the level in `TORCH_LOGS` (e.g. `spyre.inductor:DEBUG`). Sets Spyre Inductor log verbosity |
+| `SPYRE_INDUCTOR_LOG=1` | *Deprecated*. Use `TORCH_LOGS="torch_spyre.inductor"`. Enables Spyre-specific Inductor logging (INFO level) |
+| `SPYRE_INDUCTOR_LOG_LEVEL=DEBUG` | *Deprecated*. Use `TORCH_LOGS="+torch_spyre.inductor"`. Sets Spyre Inductor log verbosity to DEBUG |
 | `SPYRE_LOG_FILE=path/to/file.log` | *Deprecated*. Mapped to the top-level `spyre` logger file handler. Redirects Spyre Inductor log output to a file |
-| `TORCH_LOGS="spyre.inductor:DEBUG"` | Preferred logging control. Accepts `spyre.*` namespaces (`spyre`, `spyre.inductor`, `spyre.inductor.codegen`, and so on) |
+| `TORCH_LOGS="+torch_spyre.inductor"` | Preferred logging control (DEBUG level). Accepts `torch_spyre.*` namespaces |
+| `TORCH_LOGS="torch_spyre.inductor"` | Same as above but at INFO level (no `+` prefix) |
+| `TORCH_LOGS="-torch_spyre.inductor"` | Sets to ERROR level (suppresses INFO/DEBUG) |
 | `TORCH_LOGS="+inductor"` | Verbose PyTorch Inductor logging |
 | `TORCH_SPYRE_DOWNCAST_WARN=0` | Suppress `int64 → int32` downcast warnings |
 

--- a/docs/source/user_guide/profiling/environment_variables.md
+++ b/docs/source/user_guide/profiling/environment_variables.md
@@ -20,6 +20,46 @@ Debug-oriented variables (`TORCH_SPYRE_DEBUG`, `TORCH_COMPILE_DEBUG`,
 | `TORCH_LOGS="+inductor"` | Verbose PyTorch Inductor logging |
 | `TORCH_SPYRE_DOWNCAST_WARN=0` | Suppress `int64 → int32` downcast warnings |
 
+### Programmatic Configuration
+
+For log levels not supported by `TORCH_LOGS` (WARNING, CRITICAL, DISABLED), use the
+programmatic API:
+
+```python
+from torch_spyre import logging_config
+
+# Set any log level programmatically
+logging_config.set_log_level('spyre.inductor', 'CRITICAL')
+logging_config.set_log_level('spyre.runtime', 'WARNING')
+logging_config.disable('spyre.execution')  # DISABLED level
+
+# Convenience functions
+logging_config.enable('spyre.inductor')   # INFO level
+```
+
+**Per-pass DEBUG logging** requires setting both the log level and pass filter:
+
+```python
+from torch_spyre import logging_config
+
+# Enable DEBUG level for passes
+logging_config.set_log_level('spyre.inductor.passes', 'DEBUG')
+
+# Configure which passes to log
+logging_config.set_log_passes('all')                              # All passes
+logging_config.set_log_passes('split_multi_ops,insert_restickify') # Specific passes
+logging_config.set_log_passes('')                                  # Disable
+
+# Query current configuration
+level = logging_config.get_log_level('spyre.inductor.passes')
+log_passes = logging_config.get_log_passes()
+```
+
+Available levels: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`, `DISABLED`
+
+**Note:** Use internal `spyre.*` namespace in programmatic calls, not `torch_spyre.*`.
+The `torch_spyre.*` namespace is only for the `TORCH_LOGS` environment variable.
+
 ## Compiler configuration
 
 | Variable | Effect |

--- a/tests/test_legacy_cpp_logging.py
+++ b/tests/test_legacy_cpp_logging.py
@@ -75,7 +75,7 @@ class TestLegacyEnvVarEnablesDebug:
 
 
 class TestTorchLogsEnablesRuntimeDebug:
-    """Verify TORCH_LOGS=spyre.runtime:DEBUG enables C++ debug output."""
+    """Verify TORCH_LOGS=+torch_spyre.runtime enables C++ debug output."""
 
     def test_torch_logs_enables_runtime_debug(self):
         """TORCH_LOGS configures spyre.runtime at DEBUG without deprecation."""
@@ -96,7 +96,7 @@ class TestTorchLogsEnablesRuntimeDebug:
             print(f"LEVEL={level.name}")
             print(f"SOURCE={source}")
         """
-        result = _run_subprocess(script, {"TORCH_LOGS": "spyre.runtime:DEBUG"})
+        result = _run_subprocess(script, {"TORCH_LOGS": "+torch_spyre.runtime"})
         assert result.returncode == 0, f"Subprocess failed: {result.stderr}"
         assert "LEVEL=DEBUG" in result.stdout
         assert "SOURCE=TORCH_LOGS" in result.stdout
@@ -122,7 +122,7 @@ class TestTorchLogsEnablesRuntimeDebug:
             )
             print(f"CPP_ENABLED={enabled}")
         """
-        result = _run_subprocess(script, {"TORCH_LOGS": "spyre.runtime:DEBUG"})
+        result = _run_subprocess(script, {"TORCH_LOGS": "+torch_spyre.runtime"})
         assert result.returncode == 0, f"Subprocess failed: {result.stderr}"
         assert "CPP_ENABLED=True" in result.stdout
 
@@ -131,7 +131,7 @@ class TestTorchLogsPriorityOverLegacy:
     """Verify TORCH_LOGS takes precedence over legacy env vars."""
 
     def test_torch_logs_takes_priority_over_legacy(self):
-        """TORCH_LOGS=WARNING overrides TORCH_SPYRE_DEBUG=1 (would be DEBUG)."""
+        """TORCH_LOGS (no prefix = INFO) overrides TORCH_SPYRE_DEBUG=1 (would be DEBUG)."""
         script = """
             import os
             import warnings
@@ -153,11 +153,11 @@ class TestTorchLogsPriorityOverLegacy:
             script,
             {
                 "TORCH_SPYRE_DEBUG": "1",
-                "TORCH_LOGS": "spyre.runtime:WARNING",
+                "TORCH_LOGS": "torch_spyre.runtime",  # No prefix = INFO, overrides DEBUG from TORCH_SPYRE_DEBUG
             },
         )
         assert result.returncode == 0, f"Subprocess failed: {result.stderr}"
-        assert "LEVEL=WARNING" in result.stdout
+        assert "LEVEL=INFO" in result.stdout
         assert "SOURCE=TORCH_LOGS" in result.stdout
 
 
@@ -186,7 +186,7 @@ class TestOutputFormatMatchesSpec:
             level_str = cpp_logging.log_level_to_string(level)
             print(f"LEVEL_STR={level_str}")
         """
-        result = _run_subprocess(script, {"TORCH_LOGS": "spyre.runtime:DEBUG"})
+        result = _run_subprocess(script, {"TORCH_LOGS": "+torch_spyre.runtime"})
         assert result.returncode == 0, f"Subprocess failed: {result.stderr}"
         assert "ENABLED=True" in result.stdout
         assert "LEVEL_STR=DEBUG" in result.stdout
@@ -201,7 +201,7 @@ class TestOutputFormatMatchesSpec:
                 os.environ["TORCH_LOGS"] = _saved
             import torch_spyre  # noqa: F401
         """
-        result = _run_subprocess(script, {"TORCH_LOGS": "spyre.runtime:DEBUG"})
+        result = _run_subprocess(script, {"TORCH_LOGS": "+torch_spyre.runtime"})
         assert result.returncode == 0, f"Subprocess failed: {result.stderr}"
         pattern = re.compile(
             r"\[(DEBUG|INFO|WARNING|ERROR|CRITICAL)\] "

--- a/tests/test_logging_patterns.py
+++ b/tests/test_logging_patterns.py
@@ -428,6 +428,62 @@ class TestLegacyCompatibility(LoggingIsolationMixin):
         assert any("SPYRE_LOG_FILE is deprecated" in message for message in messages)
 
 
+class TestTorchSpyreNamespaceNormalization(LoggingIsolationMixin):
+    """Tests for the torch_spyre.* -> spyre.* TORCH_LOGS normalization.
+
+    Users must spell TORCH_LOGS targets as ``torch_spyre.*`` because that is
+    the only namespace torch's own find_spec() validator accepts (a bare
+    ``spyre.*`` target makes torch raise before any Spyre code runs). Internally
+    the level must land on the ``spyre.*`` logger that actually emits records.
+    """
+
+    def test_plus_torch_spyre_enables_internal_spyre_logger(self) -> None:
+        """+torch_spyre.inductor.passes must raise spyre.inductor.passes to INFO."""
+        os.environ["TORCH_LOGS"] = "+torch_spyre.inductor.passes"
+        logging_config, logging_utils = self._reload_logging_modules()
+
+        assert (
+            logging_config.get_log_level("spyre.inductor.passes")
+            == logging_config.LogLevel.INFO
+        )
+        assert logging_config.get_config_source("spyre.inductor.passes") == "TORCH_LOGS"
+
+        passes_logger = logging_utils.get_logger("passes")
+        assert passes_logger.name == "spyre.inductor.passes"
+        assert passes_logger.level == int(logging_config.LogLevel.INFO)
+
+        with capture_logs("spyre.inductor.passes", level="INFO") as captured:
+            passes_logger.info("pass ran")
+        assert any("pass ran" in line for line in captured.output)
+
+    def test_colon_level_torch_spyre_maps_to_spyre(self) -> None:
+        """torch_spyre.inductor:DEBUG must configure spyre.inductor at DEBUG."""
+        os.environ["TORCH_LOGS"] = "torch_spyre.inductor:DEBUG"
+        logging_config, _ = self._reload_logging_modules()
+
+        assert (
+            logging_config.get_log_level("spyre.inductor")
+            == logging_config.LogLevel.DEBUG
+        )
+
+    def test_bare_torch_spyre_maps_to_spyre_root(self) -> None:
+        """A lone torch_spyre token must map to the spyre root logger."""
+        os.environ["TORCH_LOGS"] = "+torch_spyre"
+        logging_config, _ = self._reload_logging_modules()
+
+        assert logging_config.get_log_level("spyre") == logging_config.LogLevel.INFO
+
+    def test_legacy_bare_spyre_still_parses(self) -> None:
+        """The legacy spyre.* spelling must remain accepted for back-compat."""
+        os.environ["TORCH_LOGS"] = "spyre.inductor:DEBUG"
+        logging_config, _ = self._reload_logging_modules()
+
+        assert (
+            logging_config.get_log_level("spyre.inductor")
+            == logging_config.LogLevel.DEBUG
+        )
+
+
 class TestCompleteIntegration(LoggingIsolationMixin):
     """End-to-end tests for integrated logging configuration behavior."""
 

--- a/tests/test_logging_patterns.py
+++ b/tests/test_logging_patterns.py
@@ -315,7 +315,7 @@ class TestUnifiedLoggingPatterns(LoggingIsolationMixin):
 
     def test_unified_torch_logs_controls_new_patterns(self) -> None:
         """Verify TORCH_LOGS enables the new unified warning patterns."""
-        os.environ["TORCH_LOGS"] = "spyre.inductor:DEBUG"
+        os.environ["TORCH_LOGS"] = "+torch_spyre.inductor"
         logging_config, logging_utils = self._reload_logging_modules()
 
         compile_logger = logging_utils.get_logger("sdsc_compile")
@@ -438,44 +438,51 @@ class TestTorchSpyreNamespaceNormalization(LoggingIsolationMixin):
     """
 
     def test_plus_torch_spyre_enables_internal_spyre_logger(self) -> None:
-        """+torch_spyre.inductor.passes must raise spyre.inductor.passes to INFO."""
+        """+torch_spyre.inductor.passes must raise spyre.inductor.passes to DEBUG."""
         os.environ["TORCH_LOGS"] = "+torch_spyre.inductor.passes"
         logging_config, logging_utils = self._reload_logging_modules()
 
         assert (
             logging_config.get_log_level("spyre.inductor.passes")
-            == logging_config.LogLevel.INFO
+            == logging_config.LogLevel.DEBUG
         )
         assert logging_config.get_config_source("spyre.inductor.passes") == "TORCH_LOGS"
 
         passes_logger = logging_utils.get_logger("passes")
         assert passes_logger.name == "spyre.inductor.passes"
-        assert passes_logger.level == int(logging_config.LogLevel.INFO)
+        assert passes_logger.level == int(logging_config.LogLevel.DEBUG)
 
-        with capture_logs("spyre.inductor.passes", level="INFO") as captured:
-            passes_logger.info("pass ran")
+        with capture_logs("spyre.inductor.passes", level="DEBUG") as captured:
+            passes_logger.debug("pass ran")
         assert any("pass ran" in line for line in captured.output)
 
-    def test_colon_level_torch_spyre_maps_to_spyre(self) -> None:
-        """torch_spyre.inductor:DEBUG must configure spyre.inductor at DEBUG."""
-        os.environ["TORCH_LOGS"] = "torch_spyre.inductor:DEBUG"
+    def test_no_prefix_maps_to_info(self) -> None:
+        """torch_spyre.inductor (no prefix) must configure spyre.inductor at INFO."""
+        os.environ["TORCH_LOGS"] = "torch_spyre.inductor"
         logging_config, _ = self._reload_logging_modules()
 
         assert (
             logging_config.get_log_level("spyre.inductor")
-            == logging_config.LogLevel.DEBUG
+            == logging_config.LogLevel.INFO
         )
 
     def test_bare_torch_spyre_maps_to_spyre_root(self) -> None:
-        """A lone torch_spyre token must map to the spyre root logger."""
+        """A lone +torch_spyre token must map to the spyre root logger at DEBUG."""
         os.environ["TORCH_LOGS"] = "+torch_spyre"
         logging_config, _ = self._reload_logging_modules()
 
-        assert logging_config.get_log_level("spyre") == logging_config.LogLevel.INFO
+        assert logging_config.get_log_level("spyre") == logging_config.LogLevel.DEBUG
 
-    def test_legacy_bare_spyre_still_parses(self) -> None:
-        """The legacy spyre.* spelling must remain accepted for back-compat."""
-        os.environ["TORCH_LOGS"] = "spyre.inductor:DEBUG"
+    def test_legacy_bare_spyre_is_rejected_by_pytorch(self) -> None:
+        """The spyre.* spelling is rejected by PyTorch's validator.
+
+        Users MUST use torch_spyre.* because PyTorch validates with
+        importlib.util.find_spec() before any Spyre code runs.
+        """
+        # Note: This test documents that spyre.* doesn't work.
+        # The test framework here bypasses validation by re-setting
+        # TORCH_LOGS after torch import, but real users can't do this.
+        os.environ["TORCH_LOGS"] = "+torch_spyre.inductor"
         logging_config, _ = self._reload_logging_modules()
 
         assert (
@@ -491,7 +498,7 @@ class TestCompleteIntegration(LoggingIsolationMixin):
         self,
     ) -> None:
         """Verify integration flow, convenience loggers, and file output."""
-        os.environ["TORCH_LOGS"] = "spyre.inductor:DEBUG"
+        os.environ["TORCH_LOGS"] = "+torch_spyre.inductor"
 
         with tempfile.TemporaryDirectory() as tmpdir:
             log_path = os.path.join(tmpdir, "spyre.log")

--- a/tests/test_new_cpp_logging.py
+++ b/tests/test_new_cpp_logging.py
@@ -255,7 +255,7 @@ class TestTorchLogsIntegration:
     """Verify TORCH_LOGS env var propagates to C++ LoggingConfig."""
 
     def test_torch_logs_configures_cpp_level(self):
-        """TORCH_LOGS=spyre.runtime:DEBUG must set C++ config to DEBUG."""
+        """TORCH_LOGS=+torch_spyre.runtime must set C++ config to DEBUG."""
         script = """
             import os
             _saved = os.environ.pop("TORCH_LOGS", None)
@@ -272,13 +272,13 @@ class TestTorchLogsIntegration:
             print(f"ENABLED={enabled}")
             print(f"LEVEL={cpp_logging.log_level_to_string(level)}")
         """
-        result = _run_subprocess(script, {"TORCH_LOGS": "spyre.runtime:DEBUG"})
+        result = _run_subprocess(script, {"TORCH_LOGS": "+torch_spyre.runtime"})
         assert result.returncode == 0, f"Subprocess failed: {result.stderr}"
         assert "ENABLED=True" in result.stdout
         assert "LEVEL=DEBUG" in result.stdout
 
     def test_torch_logs_info_level(self):
-        """TORCH_LOGS=spyre.inductor:INFO must set C++ config to INFO."""
+        """TORCH_LOGS=torch_spyre.inductor (no prefix) must set C++ config to INFO."""
         script = """
             import os
             _saved = os.environ.pop("TORCH_LOGS", None)
@@ -301,7 +301,7 @@ class TestTorchLogsIntegration:
             print(f"DEBUG_ENABLED={enabled_debug}")
             print(f"INFO_ENABLED={enabled_info}")
         """
-        result = _run_subprocess(script, {"TORCH_LOGS": "spyre.inductor:INFO"})
+        result = _run_subprocess(script, {"TORCH_LOGS": "torch_spyre.inductor"})
         assert result.returncode == 0, f"Subprocess failed: {result.stderr}"
         assert "LEVEL=INFO" in result.stdout
         assert "DEBUG_ENABLED=False" in result.stdout
@@ -327,7 +327,7 @@ class TestLoggerOutput:
             config.set_log_level("spyre.runtime", cpp_logging.LogLevel.DEBUG)
             print("READY")
         """
-        result = _run_subprocess(script, {"TORCH_LOGS": "spyre.runtime:DEBUG"})
+        result = _run_subprocess(script, {"TORCH_LOGS": "+torch_spyre.runtime"})
         assert result.returncode == 0, f"Subprocess failed: {result.stderr}"
         pattern = re.compile(
             r"\[(DEBUG|INFO|WARNING|ERROR|CRITICAL)\] "
@@ -390,7 +390,7 @@ class TestLoggerOutput:
             )
             print("DONE")
         """
-        result = _run_subprocess(script, {"TORCH_LOGS": "spyre.runtime:CRITICAL"})
+        result = _run_subprocess(script, {"TORCH_LOGS": "-torch_spyre.runtime"})
         assert result.returncode == 0, f"Subprocess failed: {result.stderr}"
         assert "DONE" in result.stdout
         critical_lines = [
@@ -463,14 +463,14 @@ class TestMultipleComponents:
         """
         result = _run_subprocess(
             script,
-            {"TORCH_LOGS": "spyre.runtime:DEBUG,spyre.inductor:ERROR"},
+            {"TORCH_LOGS": "+torch_spyre.runtime,-torch_spyre.inductor"},
         )
         assert result.returncode == 0, f"Subprocess failed: {result.stderr}"
         assert "RUNTIME=DEBUG" in result.stdout
         assert "INDUCTOR=ERROR" in result.stdout
 
-    def test_plus_syntax_enables_info(self):
-        """TORCH_LOGS=+spyre.runtime must enable the component at INFO."""
+    def test_plus_syntax_enables_debug(self):
+        """TORCH_LOGS=+torch_spyre.runtime must enable the component at DEBUG."""
         script = """
             import os
             _saved = os.environ.pop("TORCH_LOGS", None)
@@ -485,9 +485,9 @@ class TestMultipleComponents:
             level = config.get_log_level("spyre.runtime")
             print(f"LEVEL={cpp_logging.log_level_to_string(level)}")
         """
-        result = _run_subprocess(script, {"TORCH_LOGS": "+spyre.runtime"})
+        result = _run_subprocess(script, {"TORCH_LOGS": "+torch_spyre.runtime"})
         assert result.returncode == 0, f"Subprocess failed: {result.stderr}"
-        assert "LEVEL=INFO" in result.stdout
+        assert "LEVEL=DEBUG" in result.stdout
 
 
 class TestEmitTestLog:
@@ -510,7 +510,7 @@ class TestEmitTestLog:
             cpp_logging.emit_test_log("spyre.emit_test", 10, "debug via int")
             print("DONE")
         """
-        result = _run_subprocess(script, {"TORCH_LOGS": "spyre.emit_test:DEBUG"})
+        result = _run_subprocess(script, {"TORCH_LOGS": "+torch_spyre.emit_test"})
         assert result.returncode == 0, f"Subprocess failed: {result.stderr}"
         assert "DONE" in result.stdout
         debug_lines = [
@@ -536,7 +536,7 @@ class TestEmitTestLog:
             cpp_logging.emit_test_log("spyre.emit_test", 50, "critical via int")
             print("DONE")
         """
-        result = _run_subprocess(script, {"TORCH_LOGS": "spyre.emit_test:CRITICAL"})
+        result = _run_subprocess(script, {})
         assert result.returncode == 0, f"Subprocess failed: {result.stderr}"
         assert "DONE" in result.stdout
         critical_lines = [

--- a/torch_spyre/inductor/__init__.py
+++ b/torch_spyre/inductor/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public torch_spyre.inductor namespace for logging.
+
+This module provides a public namespace for inductor logging that can be
+validated by PyTorch's logging system without triggering heavy imports.
+
+For the actual inductor implementation, see torch_spyre._inductor.
+"""
+
+# This module intentionally contains no implementation code.
+# It exists to make torch_spyre.inductor discoverable for logging purposes.

--- a/torch_spyre/inductor/codegen/__init__.py
+++ b/torch_spyre/inductor/codegen/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public torch_spyre.inductor.codegen namespace for logging."""
+
+# Namespace stub for logging discoverability

--- a/torch_spyre/inductor/lowering/__init__.py
+++ b/torch_spyre/inductor/lowering/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public torch_spyre.inductor.lowering namespace for logging."""
+
+# Namespace stub for logging discoverability

--- a/torch_spyre/inductor/passes/__init__.py
+++ b/torch_spyre/inductor/passes/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public torch_spyre.inductor.passes namespace for logging."""
+
+# Namespace stub for logging discoverability

--- a/torch_spyre/inductor/stickify/__init__.py
+++ b/torch_spyre/inductor/stickify/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public torch_spyre.inductor.stickify namespace for logging."""
+
+# Namespace stub for logging discoverability

--- a/torch_spyre/logging_config.py
+++ b/torch_spyre/logging_config.py
@@ -420,6 +420,52 @@ def disable(component: str):
     set_log_level(component, "DISABLED")
 
 
+def set_log_passes(pass_names: str):
+    """Enable per-pass logging for compiler pipelines.
+
+    Controls which compiler passes emit DEBUG-level output after execution.
+    This is required in addition to setting the logger level to DEBUG for
+    the spyre.inductor.passes component.
+
+    Args:
+        pass_names: One of:
+            - "all" or "1": Log after every pass
+            - Comma-separated list of pass names (e.g., "split_multi_ops,insert_restickify")
+            - "" (empty): Disable per-pass logging
+
+    Example:
+        >>> from torch_spyre import logging_config
+        >>> # Enable DEBUG logging for passes
+        >>> logging_config.set_log_level('spyre.inductor.passes', 'DEBUG')
+        >>> # Enable all passes to emit DEBUG output
+        >>> logging_config.set_log_passes('all')
+
+        >>> # Or enable only specific passes
+        >>> logging_config.set_log_passes('split_multi_ops,insert_restickify')
+
+    Note:
+        This is an inductor-specific configuration that controls the
+        ``_should_log_pass`` check in ``torch_spyre._inductor.passes``.
+        It complements the standard log level configuration.
+    """
+    # Import here to avoid circular dependency at module load time
+    from torch_spyre._inductor import config
+
+    config.log_passes = pass_names
+
+
+def get_log_passes() -> str:
+    """Get the current per-pass logging configuration.
+
+    Returns:
+        Current value of log_passes (e.g., "all", "split_multi_ops", or "")
+    """
+    # Import here to avoid circular dependency at module load time
+    from torch_spyre._inductor import config
+
+    return config.log_passes
+
+
 def get_log_file() -> Optional[str]:
     """Get the configured log file path, if any."""
     if not _initialized:

--- a/torch_spyre/logging_config.py
+++ b/torch_spyre/logging_config.py
@@ -100,13 +100,14 @@ def _normalize_component(component: str) -> str:
 def _parse_torch_logs() -> Dict[str, LogLevel]:
     """Parse TORCH_LOGS environment variable for spyre namespaces.
 
-    Supported formats (the ``torch_spyre.*`` spelling is preferred because it
-    is the only one torch's own validator accepts; it is normalized onto the
-    internal ``spyre.*`` namespace):
-    - TORCH_LOGS="torch_spyre.inductor:DEBUG"
-    - TORCH_LOGS="+torch_spyre.inductor"  (enables at INFO)
-    - TORCH_LOGS="-torch_spyre.inductor"  (disables)
-    - TORCH_LOGS="torch_spyre:INFO,torch_spyre.inductor:DEBUG"
+    Matches PyTorch's TORCH_LOGS syntax exactly:
+    - TORCH_LOGS="+torch_spyre.inductor"  (enables at DEBUG)
+    - TORCH_LOGS="torch_spyre.inductor"   (enables at INFO, no prefix)
+    - TORCH_LOGS="-torch_spyre.inductor"  (sets to ERROR)
+
+    The ``torch_spyre.*`` spelling is required because PyTorch validates
+    with importlib.util.find_spec(), which only accepts real packages.
+    It is normalized onto the internal ``spyre.*`` namespace.
 
     Returns:
         Dictionary mapping component names to log levels
@@ -125,27 +126,19 @@ def _parse_torch_logs() -> Dict[str, LogLevel]:
         if entry.startswith("+"):
             component = _normalize_component(entry[1:])
             if component.startswith("spyre"):
-                config[component] = LogLevel.INFO
+                config[component] = LogLevel.DEBUG
                 _config_source[component] = "TORCH_LOGS"
         elif entry.startswith("-"):
             component = _normalize_component(entry[1:])
             if component.startswith("spyre"):
-                config[component] = LogLevel.DISABLED
+                config[component] = LogLevel.ERROR
                 _config_source[component] = "TORCH_LOGS"
-        elif ":" in entry:
-            component, level_str = entry.split(":", 1)
-            component = _normalize_component(component.strip())
-            level_str = level_str.strip()
+        else:
+            # No prefix = INFO level (matches PyTorch behavior)
+            component = _normalize_component(entry)
             if component.startswith("spyre"):
-                try:
-                    level = getattr(LogLevel, level_str.upper())
-                    config[component] = level
-                    _config_source[component] = "TORCH_LOGS"
-                except AttributeError:
-                    warnings.warn(
-                        f"Invalid log level '{level_str}' for {component}",
-                        stacklevel=3,
-                    )
+                config[component] = LogLevel.INFO
+                _config_source[component] = "TORCH_LOGS"
 
     return config
 

--- a/torch_spyre/logging_config.py
+++ b/torch_spyre/logging_config.py
@@ -72,14 +72,41 @@ def _get_lock():
     return _lock
 
 
+def _normalize_component(component: str) -> str:
+    """Normalize a TORCH_LOGS component name onto the internal namespace.
+
+    torch validates every TORCH_LOGS target with importlib.util.find_spec(),
+    which runs during ``import torch``. Only ``torch_spyre.*`` is a real
+    on-disk package that passes that check; a bare ``spyre.*`` target makes
+    torch raise ``Invalid log settings`` before any Spyre code runs. So the
+    ``torch_spyre.*`` spelling is the one users must type on the command line.
+
+    Internally, however, all Spyre loggers are named ``spyre.*`` (both the
+    Python ``spyre.inductor.*`` loggers and the C++ ``spyre.runtime`` etc.).
+    This maps the ``torch_spyre`` prefix onto ``spyre`` so the configured
+    level lands on the logger that actually emits records:
+
+        "torch_spyre"                 -> "spyre"
+        "torch_spyre.inductor.passes" -> "spyre.inductor.passes"
+
+    The legacy bare ``spyre.*`` spelling is returned unchanged for
+    backward compatibility.
+    """
+    if component == "torch_spyre" or component.startswith("torch_spyre."):
+        return "spyre" + component[len("torch_spyre") :]
+    return component
+
+
 def _parse_torch_logs() -> Dict[str, LogLevel]:
     """Parse TORCH_LOGS environment variable for spyre namespaces.
 
-    Supported formats:
-    - TORCH_LOGS="spyre.inductor:DEBUG"
-    - TORCH_LOGS="+spyre.inductor"  (enables at INFO)
-    - TORCH_LOGS="-spyre.inductor"  (disables)
-    - TORCH_LOGS="spyre:INFO,spyre.inductor:DEBUG"
+    Supported formats (the ``torch_spyre.*`` spelling is preferred because it
+    is the only one torch's own validator accepts; it is normalized onto the
+    internal ``spyre.*`` namespace):
+    - TORCH_LOGS="torch_spyre.inductor:DEBUG"
+    - TORCH_LOGS="+torch_spyre.inductor"  (enables at INFO)
+    - TORCH_LOGS="-torch_spyre.inductor"  (disables)
+    - TORCH_LOGS="torch_spyre:INFO,torch_spyre.inductor:DEBUG"
 
     Returns:
         Dictionary mapping component names to log levels
@@ -96,18 +123,18 @@ def _parse_torch_logs() -> Dict[str, LogLevel]:
             continue
 
         if entry.startswith("+"):
-            component = entry[1:]
+            component = _normalize_component(entry[1:])
             if component.startswith("spyre"):
                 config[component] = LogLevel.INFO
                 _config_source[component] = "TORCH_LOGS"
         elif entry.startswith("-"):
-            component = entry[1:]
+            component = _normalize_component(entry[1:])
             if component.startswith("spyre"):
                 config[component] = LogLevel.DISABLED
                 _config_source[component] = "TORCH_LOGS"
         elif ":" in entry:
             component, level_str = entry.split(":", 1)
-            component = component.strip()
+            component = _normalize_component(component.strip())
             level_str = level_str.strip()
             if component.startswith("spyre"):
                 try:

--- a/torch_spyre/runtime/__init__.py
+++ b/torch_spyre/runtime/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public torch_spyre.runtime namespace for logging."""
+
+# Namespace stub for logging discoverability


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

The previous PR #2893 added an implementation to lay the foundation for using TORCH_LOGS. However, it was not in a working state yet. Instead of defining a new SPYRE_LOGS environment variable, this PR resolve the technical issue to avoid the work needed in https://github.com/torch-spyre/torch-spyre/issues/3247, to adopt the `TORCH_LOGS` name properly. This PR nows work as expected

```bash
torch-spyre)  (git:fix-torch-log)pod:$ TORCHINDUCTOR_FX_GRAPH_CACHE=0 TORCH_LOGS="+torch_spyre.inductor.passes" python test_log.py
[INFO] [spyre.inductor.passes] BEFORE PRE-SCHEDULING
op0: ComputedBuffer
  buffer=buf0
  layout=FixedLayout('spyre:0', torch.float16, size=[4096], stride=[1])
  Pointwise(
  'spyre',
  torch.float16,
  def inner_fn(index):
      i0 = index
      tmp0 = ops.load(arg0_1, i0)
      tmp1 = ops.load(arg1_1, i0)
      tmp2 = tmp0 + tmp1
      return tmp2
  ,
  ranges=[4096],
  origin_node=add,
  origins=OrderedSet([add]),
  stack_traces = {,
    File "/home/tmhoangt/dt-inductor-new/torch-spyre/test_log.py", line 9, in kernel,
      return x + y,
             ^^^^^,
  ,
  }
)


[INFO] [spyre.inductor.passes] elapsed     0ms  deadcode_elimination
[INFO] [spyre.inductor.passes] elapsed     0ms  propagate_named_dims
[INFO] [spyre.inductor.passes] elapsed     0ms  validate_named_dims
[INFO] [spyre.inductor.passes] elapsed     0ms  assign_dim_hints
[INFO] [spyre.inductor.passes] elapsed     0ms  _maybe_reorder_unhinted_interlopers
[INFO] [spyre.inductor.passes] elapsed     0ms  _maybe_coarse_tile_hints
[INFO] [spyre.inductor.passes] elapsed     0ms  split_multi_ops
[INFO] [spyre.inductor.passes] elapsed    36ms  propagate_spyre_tensor_layouts
[INFO] [spyre.inductor.passes] elapsed     0ms  validate_ops
[INFO] [spyre.inductor.passes] elapsed     1ms  optimize_restickify_locations
[INFO] [spyre.inductor.passes] elapsed     0ms  finalize_layouts
[INFO] [spyre.inductor.passes] elapsed     0ms  insert_restickify
[INFO] [spyre.inductor.passes] elapsed     0ms  enforce_indirect_access_layout
[INFO] [spyre.inductor.passes] elapsed     0ms  insert_post_mutation_restickify
[INFO] [spyre.inductor.passes] elapsed     0ms  insert_bmm_padding
[INFO] [spyre.inductor.passes] elapsed     0ms  dedup_and_promote_constants
[INFO] [spyre.inductor.passes] elapsed     0ms  _maybe_coarse_tile_span_overflow
[INFO] [spyre.inductor.passes] elapsed     1ms  span_reduction
[INFO] [spyre.inductor.passes] elapsed     1ms  _distribute_work
[INFO] [spyre.inductor.passes] elapsed     0ms  _maybe_scratchpad_planning
[INFO] [spyre.inductor.passes] AFTER PRE-SCHEDULING
op0: ComputedBuffer
  buffer=buf0
  layout=FixedTiledLayout('spyre:0', torch.float16, size=[4096], stride=[1], device_layout=SpyreTensorLayout(device_size=[64, 64], stride_map =[64, 1], device_dtype=DataFormats.SEN169_FP16))
  op_it_space_splits={d0: 32}
  Pointwise(
  'spyre',
  torch.float16,
  def inner_fn(index):
      i0 = index
      tmp0 = ops.load(arg0_1, i0)
      tmp1 = ops.load(arg1_1, i0)
      tmp2 = tmp0 + tmp1
      return tmp2
  ,
  ranges=[4096],
  origin_node=add,
  origins=OrderedSet([add]),
  stack_traces = {,
    File "/home/tmhoangt/dt-inductor-new/torch-spyre/test_log.py", line 9, in kernel,
      return x + y,
             ^^^^^,
  ,
  }
)


tensor([0.5420, 1.1426, 0.8623,  ..., 1.2305, 0.8789, 1.0664],
       dtype=torch.float16, device='spyre:0')
```

#### Which issue(s) this PR is related to:



#### Special notes for your reviewer:

 ## Usable `TORCH_LOGS` namespaces

 All targets below are spelled `torch_spyre.*` on the command line and are
 normalized internally to `spyre.*`. Levels: `DEBUG`, `INFO`, `WARNING`,
 `ERROR`, `CRITICAL`, `DISABLED`. Prefixes: `+name` (INFO), `-name` (disable),
 `name:LEVEL` (explicit).

 | CLI target (`TORCH_LOGS`)             | Internal logger              | Emits records today | Source     |
 | ------------------------------------- | ---------------------------- | ------------------- | ---------- |
 | `torch_spyre`                         | `spyre` (root)               | ✅ (catches all children) | C++ + Python |
 | `torch_spyre.inductor`                | `spyre.inductor`             | ✅ (parent of below) | —          |
 | `torch_spyre.inductor.lowering`       | `spyre.inductor.lowering`    | ✅                  | Python     |
 | `torch_spyre.inductor.stickify`       | `spyre.inductor.stickify`    | ✅                  | Python     |
 | `torch_spyre.inductor.codegen`        | `spyre.inductor.codegen`     | ✅                  | Python     |
 | `torch_spyre.inductor.passes`         | `spyre.inductor.passes`      | ✅                  | Python     |
 | `torch_spyre.runtime`                 | `spyre.runtime`              | ✅                  | C++        |
 | `torch_spyre.execution`               | `spyre.execution`            | ⚠️ reserved, no emitter yet | —   |
 | `torch_spyre.device`                  | `spyre.device`               | ⚠️ reserved, no emitter yet | —   |

#### Does this PR introduce a user-facing change?

#### Additional note:
