### PR TITLE
fix(insert_restickify): handle synthetic coarse_tile nodes in restickify

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1201,9 +1201,6 @@ def test_softmax_2d_512x256_dim0_A4_B4():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skip(
-    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
 def test_restickify_add_256x128_A2():
     """a.t() + x on [128,256] result, tiled A÷2 → 64 elems/tile (1 stick)."""
     inputs = [
@@ -1216,12 +1213,9 @@ def test_restickify_add_256x128_A2():
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return a.t() + x
 
-    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
+    run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(
-    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
 def test_restickify_add_256x128_B4():
     """a.t() + x on [128,256] result, tiled B÷4 → 64 elems/tile (1 stick)."""
     inputs = [
@@ -1237,9 +1231,6 @@ def test_restickify_add_256x128_B4():
     run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
-@pytest.mark.skip(
-    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
 def test_restickify_add_256x128_A2_B4():
     """a.t() + x on [128,256] result, tiled A÷2 B÷4 → 64 elems/tile each."""
     inputs = [
@@ -1253,7 +1244,7 @@ def test_restickify_add_256x128_A2_B4():
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     return a.t() + x
 
-    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
+    run_coarse_tile_test(fn, inputs)
 
 
 # 2D two-transpose: a.t() + b.t() + x
@@ -1275,9 +1266,7 @@ def test_restickify_2t_add_256x128_A2():
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return a.t() + b.t() + x
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=None, correctness=False
-    )  # d0+d1 stick expr bug: two restickified inputs produce unsupported stick expression
+    run_coarse_tile_test(fn, inputs)
 
 
 @pytest.mark.skip(reason="Unsupported: unexpected stick expression d0+d1")
@@ -1294,9 +1283,7 @@ def test_restickify_2t_add_256x128_B4():
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return a.t() + b.t() + x
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=None, correctness=False
-    )  # d0+d1 stick expr bug
+    run_coarse_tile_test(fn, inputs)
 
 
 @pytest.mark.skip(reason="Unsupported: unexpected stick expression d0+d1")
@@ -1314,9 +1301,7 @@ def test_restickify_2t_add_256x128_A2_B4():
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     return a.t() + b.t() + x
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=None, correctness=False
-    )  # d0+d1 stick expr bug
+    run_coarse_tile_test(fn, inputs)  # d0+d1 stick expr bug
 
 
 # 3D transpose: a.transpose(1,2) + x
@@ -1324,9 +1309,6 @@ def test_restickify_2t_add_256x128_A2_B4():
 # A÷4=64/tile, B÷4=64/tile, C÷4=128/tile (2 sticks)
 
 
-@pytest.mark.skip(
-    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
 def test_restickify_3d_transpose12_256x512x256_A4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4."""
     inputs = [
@@ -1339,12 +1321,9 @@ def test_restickify_3d_transpose12_256x512x256_A4():
             with spyre_hint(expected_named_dims=["A", "B", "C"]):
                 return a.transpose(1, 2) + x
 
-    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
+    run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(
-    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
 def test_restickify_3d_transpose12_256x512x256_B4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled B÷4."""
     inputs = [
@@ -1357,12 +1336,9 @@ def test_restickify_3d_transpose12_256x512x256_B4():
             with spyre_hint(expected_named_dims=["A", "B", "C"]):
                 return a.transpose(1, 2) + x
 
-    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
+    run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(
-    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
 def test_restickify_3d_transpose12_256x512x256_C4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled C÷4."""
     inputs = [
@@ -1375,12 +1351,9 @@ def test_restickify_3d_transpose12_256x512x256_C4():
             with spyre_hint(expected_named_dims=["A", "B", "C"]):
                 return a.transpose(1, 2) + x
 
-    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
+    run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(
-    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
 def test_restickify_3d_transpose12_256x512x256_A4_B4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4 B÷4."""
     inputs = [
@@ -1394,12 +1367,9 @@ def test_restickify_3d_transpose12_256x512x256_A4_B4():
                 with spyre_hint(expected_named_dims=["A", "B", "C"]):
                     return a.transpose(1, 2) + x
 
-    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
+    run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(
-    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
 def test_restickify_3d_transpose12_256x512x256_A4_C4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4 C÷4."""
     inputs = [
@@ -1413,12 +1383,9 @@ def test_restickify_3d_transpose12_256x512x256_A4_C4():
                 with spyre_hint(expected_named_dims=["A", "B", "C"]):
                     return a.transpose(1, 2) + x
 
-    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
+    run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(
-    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
 def test_restickify_3d_transpose12_256x512x256_B4_C4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled B÷4 C÷4."""
     inputs = [
@@ -1432,14 +1399,9 @@ def test_restickify_3d_transpose12_256x512x256_B4_C4():
                 with spyre_hint(expected_named_dims=["A", "B", "C"]):
                     return a.transpose(1, 2) + x
 
-    run_coarse_tile_test(
-        fn, inputs, loopspec=None, correctness=False
-    )  # KNOWN BROKEN: PR #3381 insert_restickify env lookup fails for coarse_tile_read_copy buffers
+    run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(
-    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
 def test_restickify_3d_transpose12_256x512x256_A4_B4_C4():
     """a.transpose(1,2)+x on [256,256,512] result, tiled A÷4 B÷4 C÷4."""
     inputs = [
@@ -1454,7 +1416,7 @@ def test_restickify_3d_transpose12_256x512x256_A4_B4_C4():
                     with spyre_hint(expected_named_dims=["A", "B", "C"]):
                         return a.transpose(1, 2) + x
 
-    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
+    run_coarse_tile_test(fn, inputs)
 
 
 # Matmul + transpose: x.t()@y and x@y.t()
@@ -1464,9 +1426,6 @@ def test_restickify_3d_transpose12_256x512x256_A4_B4_C4():
 # For x@y.t() result [128,128]: M=128, N=128; M÷2=64, N÷2=64
 
 
-@pytest.mark.skip(
-    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
 def test_restickify_matmul_xt_y_256x128_M4():
     """x.t()@y, result [256,256], tiled M÷4."""
     inputs = [
@@ -1479,12 +1438,9 @@ def test_restickify_matmul_xt_y_256x128_M4():
             with spyre_hint(expected_named_dims=["M", "N"]):
                 return torch.matmul(x.t(), y)
 
-    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
+    run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(
-    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
 def test_restickify_matmul_xt_y_256x128_N4():
     """x.t()@y, result [256,256], tiled N÷4."""
     inputs = [
@@ -1497,12 +1453,9 @@ def test_restickify_matmul_xt_y_256x128_N4():
             with spyre_hint(expected_named_dims=["M", "N"]):
                 return torch.matmul(x.t(), y)
 
-    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
+    run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(
-    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
 def test_restickify_matmul_xt_y_256x128_M4_N4():
     """x.t()@y, result [256,256], tiled M÷4 N÷4."""
     inputs = [
@@ -1516,12 +1469,9 @@ def test_restickify_matmul_xt_y_256x128_M4_N4():
                 with spyre_hint(expected_named_dims=["M", "N"]):
                     return torch.matmul(x.t(), y)
 
-    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
+    run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(
-    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
 def test_restickify_matmul_x_yt_128x256_M2():
     """x@y.t(), result [128,128], tiled M÷2."""
     inputs = [
@@ -1534,12 +1484,9 @@ def test_restickify_matmul_x_yt_128x256_M2():
             with spyre_hint(expected_named_dims=["M", "N"]):
                 return torch.matmul(x, y.t())
 
-    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
+    run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(
-    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
 def test_restickify_matmul_x_yt_128x256_N2():
     """x@y.t(), result [128,128], tiled N÷2."""
     inputs = [
@@ -1552,12 +1499,9 @@ def test_restickify_matmul_x_yt_128x256_N2():
             with spyre_hint(expected_named_dims=["M", "N"]):
                 return torch.matmul(x, y.t())
 
-    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
+    run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(
-    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
 def test_restickify_matmul_x_yt_128x256_M2_N2():
     """x@y.t(), result [128,128], tiled M÷2 N÷2."""
     inputs = [
@@ -1571,7 +1515,7 @@ def test_restickify_matmul_x_yt_128x256_M2_N2():
                 with spyre_hint(expected_named_dims=["M", "N"]):
                     return torch.matmul(x, y.t())
 
-    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
+    run_coarse_tile_test(fn, inputs)
 
 
 # ---------------------------------------------------------------------------
@@ -1827,9 +1771,6 @@ def test_copy_running_max_4d_H4_Lq4():
 # copy target receives a restickified input — tests copy layout after restickify
 
 
-@pytest.mark.skip(
-    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
 def test_copy_restickify_512x256_A4():
     """c.copy_(a.t()+b) on [256,512] result tiled A÷4 — copy of restickified add."""
     inputs = [
@@ -1847,9 +1788,6 @@ def test_copy_restickify_512x256_A4():
     run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
-@pytest.mark.skip(
-    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
 def test_copy_restickify_512x256_B4():
     """c.copy_(a.t()+b) on [256,512] result tiled B÷4."""
     inputs = [
@@ -1867,9 +1805,6 @@ def test_copy_restickify_512x256_B4():
     run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
 
 
-@pytest.mark.skip(
-    reason="StopIteration: insert_restickify env lookup fails for coarse_tile_read_copy buffers"
-)
 def test_copy_restickify_512x256_A4_B4():
     """c.copy_(a.t()+b) on [256,512] result tiled A÷4 B÷4."""
     inputs = [

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1301,7 +1301,7 @@ def test_restickify_2t_add_256x128_A2_B4():
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     return a.t() + b.t() + x
 
-    run_coarse_tile_test(fn, inputs)  
+    run_coarse_tile_test(fn, inputs)
 
 
 # 3D transpose: a.transpose(1,2) + x

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1228,7 +1228,7 @@ def test_restickify_add_256x128_B4():
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return a.t() + x
 
-    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
+    run_coarse_tile_test(fn, inputs)
 
 
 def test_restickify_add_256x128_A2_B4():
@@ -1301,7 +1301,7 @@ def test_restickify_2t_add_256x128_A2_B4():
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     return a.t() + b.t() + x
 
-    run_coarse_tile_test(fn, inputs)  # d0+d1 stick expr bug
+    run_coarse_tile_test(fn, inputs)  
 
 
 # 3D transpose: a.transpose(1,2) + x

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -29,6 +29,7 @@ from torch._inductor.ir import (
     ComputedBuffer,
     FixedLayout,
     InputBuffer,
+    IRNode,
     MutationLayoutSHOULDREMOVE,
     Operation,
     ReinterpretView,
@@ -94,7 +95,16 @@ def _create_restickify_node(
     Inserts a spyre.restickify call into the FX graph, lowers it via
     graph_lowering.run_node(), and assigns the target layout.  Returns
     (old_buffer_name, new_computed_buffer).
+
+    For synthetically-created buffers that have no FX node (e.g.
+    coarse_tile_read_copy_* buffers created by coarse_tile.py), the FX env
+    lookup is skipped and lower_restickify is called directly with a TensorBox
+    wrapping the ComputedBuffer.
     """
+    from .lowering import (
+        lower_restickify,
+    )  # deferred: lowering.py imports insert_restickify at module level
+
     arg_name = restick_arg_info["arg_name"]
 
     graph_lowering = V.graph
@@ -114,12 +124,48 @@ def _create_restickify_node(
 
     # Search env by buffer name to find the FX node to pass to restickify.
     fx_arg_node = next(
-        fx_node
-        for fx_node, tb in graph_lowering.env.items()
-        if isinstance(fx_node, torch.fx.Node)
-        and isinstance(tb, TensorBox)
-        and tb.get_name() == arg_name
+        (
+            fx_node
+            for fx_node, tb in graph_lowering.env.items()
+            if isinstance(fx_node, torch.fx.Node)
+            and isinstance(tb, TensorBox)
+            and tb.get_name() == arg_name
+        ),
+        None,
     )
+
+    if fx_arg_node is None:
+        # Synthetically-created buffers (e.g. coarse_tile_read_copy_*) have no
+        # FX node. Build a TensorBox from the buffer and call lower_restickify
+        # directly; realize() inside lower_restickify registers the output in
+        # graph.buffers and graph.operations.
+        arg_buf = graph_lowering.get_buffer(arg_name)
+        assert isinstance(arg_buf, ComputedBuffer), (
+            f"_create_restickify_node: buffer {arg_name!r} not found in env and is "
+            f"{type(arg_buf).__name__}, not ComputedBuffer — cannot restickify"
+        )
+        arg_tb = TensorBox(StorageBox(arg_buf))
+        # Insert a synthetic FX node for origins — downstream code (e.g.
+        # _single_arg_op_layout in propagate_layouts.py) requires non-empty origins.
+        first_compute_node = next(n for n in fx_graph.nodes if n.op != "placeholder")
+        with fx_graph.inserting_before(first_compute_node):
+            restick_fx_node = fx_graph.create_node(
+                "call_function", torch.ops.spyre.restickify.default, ()
+            )
+        with (
+            IRNode.current_origins(OrderedSet([restick_fx_node])),
+            V.set_current_node(restick_fx_node),
+        ):
+            restick_tb = lower_restickify(arg_tb)
+        restick_buff = restick_tb.data.data  # TensorBox -> StorageBox -> ComputedBuffer
+        assert isinstance(restick_buff, ComputedBuffer), (
+            f"Expected ComputedBuffer, got {type(restick_buff).__name__}"
+        )
+        restick_buff.origins = OrderedSet([restick_fx_node])
+        graph_lowering.env[restick_fx_node] = restick_tb
+        restick_buff.layout = restick_arg_info["target_layout"]
+        return arg_name, restick_buff
+
     # Insert at a valid position in the FX graph; the operations list order is
     # authoritative pre-scheduler, not position in the FX graph.
     first_compute_node = next(n for n in fx_graph.nodes if n.op != "placeholder")


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

When restickify is applied during coarse tiling, the input buffer is sometimes a synthetic `coarse_tile_read_copy_*` buffer created on-the-fly by the coarse tile pass. These buffers have no corresponding FX graph node, so the existing env lookup in `_create_restickify_node` raised `StopIteration`.

The fix detects when the env lookup returns nothing and falls back to lowering the restickify directly from the buffer, creating a synthetic FX node for bookkeeping purposes only.

This unblocks 20 Group 6 tests covering restickify combined with coarse tiling: transpose+add, matmul with transposed operands, and copy with restickified inputs.

## Testing

All previously-skipped Group 6 restickify + coarse tiling tests are re-enabled.


#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
