### PR TITLE
feat(clickhouse): rename run_id to results_id in ingest_xml.py

### DIFF
--- a/.github/scripts/ingest_xml.py
+++ b/.github/scripts/ingest_xml.py
@@ -249,7 +249,9 @@ def insert_benchmark_run(client, run_id: int, results_id: str, run_meta: dict) -
     )
 
 
-def insert_perf_benchmarks(client, results_id: str, benchmarks: list[dict]) -> None:
+def insert_perf_benchmarks(
+    client, run_id: str, results_id: str, benchmarks: list[dict]
+) -> None:
     if not benchmarks:
         return
     client.insert(
@@ -257,6 +259,7 @@ def insert_perf_benchmarks(client, results_id: str, benchmarks: list[dict]) -> N
         [
             [
                 b["benchmark_id"],
+                run_id,
                 results_id,
                 b["record_type"],
                 b["operation_name"],
@@ -280,6 +283,7 @@ def insert_perf_benchmarks(client, results_id: str, benchmarks: list[dict]) -> N
         ],
         column_names=[
             "benchmark_id",
+            "run_id",
             "results_id",
             "record_type",
             "operation_name",
@@ -486,6 +490,7 @@ def insert_run(client, results_id: str, run: dict, args):
         [
             [
                 results_id,
+                results_id,
                 args.workflow,
                 run["suite_name"],
                 run["filename"],
@@ -507,6 +512,7 @@ def insert_run(client, results_id: str, run: dict, args):
             ]
         ],
         column_names=[
+            "run_id",
             "results_id",
             "workflow",
             "suite_name",
@@ -538,6 +544,7 @@ def insert_cases(client, results_id: str, cases: list[dict], workflow: str = "")
         [
             [
                 results_id,
+                results_id,
                 c["case_id"],
                 c["classname"],
                 c["name"],
@@ -552,6 +559,7 @@ def insert_cases(client, results_id: str, cases: list[dict], workflow: str = "")
             for c in cases
         ],
         column_names=[
+            "run_id",
             "results_id",
             "case_id",
             "classname",
@@ -570,6 +578,7 @@ def insert_cases(client, results_id: str, cases: list[dict], workflow: str = "")
 def insert_properties(client, results_id: str, cases: list[dict]):
     rows = [
         {
+            "run_id": results_id,
             "results_id": results_id,
             "case_id": c["case_id"],
             "prop_name": pname,
@@ -584,6 +593,7 @@ def insert_properties(client, results_id: str, cases: list[dict]):
             "run_properties",
             [
                 [
+                    r["run_id"],
                     r["results_id"],
                     r["case_id"],
                     r["prop_name"],
@@ -593,6 +603,7 @@ def insert_properties(client, results_id: str, cases: list[dict]):
                 for r in rows
             ],
             column_names=[
+                "run_id",
                 "results_id",
                 "case_id",
                 "prop_name",
@@ -671,14 +682,14 @@ def main():
                 )
                 continue
 
-            # benchmark_runs.run_id (legacy UInt64) is kept alongside results_id during the
-            # transition window — drop run_id once every reader is off it.
+            # run_id is kept alongside results_id on every table during the transition
+            # window (readers still on run_id) — drop run_id once all readers migrate.
             run_id = uuid.uuid4().int >> 64  # positive 64-bit int
             results_id = str(uuid.uuid4())
             print(f"  results_id={results_id}  benchmarks={len(benchmarks)}")
 
             insert_benchmark_run(client, run_id, results_id, run_meta)
-            insert_perf_benchmarks(client, results_id, benchmarks)
+            insert_perf_benchmarks(client, run_id, results_id, benchmarks)
 
             total_benchmarks += len(benchmarks)
             print(f"  Inserted {len(benchmarks)} benchmark rows")

--- a/.github/scripts/ingest_xml.py
+++ b/.github/scripts/ingest_xml.py
@@ -239,7 +239,13 @@ def insert_benchmark_run(client, run_id: int, results_id: str, run_meta: dict) -
                 run_meta["created_at"].replace(tzinfo=None),
             ]
         ],
-        column_names=["run_id", "results_id", "source_file", "version_info", "created_at"],
+        column_names=[
+            "run_id",
+            "results_id",
+            "source_file",
+            "version_info",
+            "created_at",
+        ],
     )
 
 

--- a/.github/scripts/ingest_xml.py
+++ b/.github/scripts/ingest_xml.py
@@ -227,22 +227,23 @@ def parse_benchmark_xml(xml_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def insert_benchmark_run(client, run_id: int, run_meta: dict) -> None:
+def insert_benchmark_run(client, run_id: int, results_id: str, run_meta: dict) -> None:
     client.insert(
         "benchmark_runs",
         [
             [
                 run_id,
+                results_id,
                 run_meta["source_file"],
                 run_meta.get("version_info"),
                 run_meta["created_at"].replace(tzinfo=None),
             ]
         ],
-        column_names=["run_id", "source_file", "version_info", "created_at"],
+        column_names=["run_id", "results_id", "source_file", "version_info", "created_at"],
     )
 
 
-def insert_perf_benchmarks(client, run_id: int, benchmarks: list[dict]) -> None:
+def insert_perf_benchmarks(client, results_id: str, benchmarks: list[dict]) -> None:
     if not benchmarks:
         return
     client.insert(
@@ -250,7 +251,7 @@ def insert_perf_benchmarks(client, run_id: int, benchmarks: list[dict]) -> None:
         [
             [
                 b["benchmark_id"],
-                run_id,
+                results_id,
                 b["record_type"],
                 b["operation_name"],
                 b["config_name"],
@@ -273,7 +274,7 @@ def insert_perf_benchmarks(client, run_id: int, benchmarks: list[dict]) -> None:
         ],
         column_names=[
             "benchmark_id",
-            "run_id",
+            "results_id",
             "record_type",
             "operation_name",
             "config_name",
@@ -473,12 +474,12 @@ def get_client():
     )
 
 
-def insert_run(client, run_id: str, run: dict, args):
+def insert_run(client, results_id: str, run: dict, args):
     client.insert(
         "test_runs",
         [
             [
-                run_id,
+                results_id,
                 args.workflow,
                 run["suite_name"],
                 run["filename"],
@@ -500,7 +501,7 @@ def insert_run(client, run_id: str, run: dict, args):
             ]
         ],
         column_names=[
-            "run_id",
+            "results_id",
             "workflow",
             "suite_name",
             "filename",
@@ -523,14 +524,14 @@ def insert_run(client, run_id: str, run: dict, args):
     )
 
 
-def insert_cases(client, run_id: str, cases: list[dict], workflow: str = ""):
+def insert_cases(client, results_id: str, cases: list[dict], workflow: str = ""):
     if not cases:
         return
     client.insert(
         "test_cases",
         [
             [
-                run_id,
+                results_id,
                 c["case_id"],
                 c["classname"],
                 c["name"],
@@ -545,7 +546,7 @@ def insert_cases(client, run_id: str, cases: list[dict], workflow: str = ""):
             for c in cases
         ],
         column_names=[
-            "run_id",
+            "results_id",
             "case_id",
             "classname",
             "name",
@@ -560,10 +561,10 @@ def insert_cases(client, run_id: str, cases: list[dict], workflow: str = ""):
     )
 
 
-def insert_properties(client, run_id: str, cases: list[dict]):
+def insert_properties(client, results_id: str, cases: list[dict]):
     rows = [
         {
-            "run_id": run_id,
+            "results_id": results_id,
             "case_id": c["case_id"],
             "prop_name": pname,
             "prop_value": pvalue,
@@ -577,7 +578,7 @@ def insert_properties(client, run_id: str, cases: list[dict]):
             "run_properties",
             [
                 [
-                    r["run_id"],
+                    r["results_id"],
                     r["case_id"],
                     r["prop_name"],
                     r["prop_value"],
@@ -586,7 +587,7 @@ def insert_properties(client, run_id: str, cases: list[dict]):
                 for r in rows
             ],
             column_names=[
-                "run_id",
+                "results_id",
                 "case_id",
                 "prop_name",
                 "prop_value",
@@ -664,12 +665,14 @@ def main():
                 )
                 continue
 
-            # benchmark_runs.run_id is UInt64 — use a random 64-bit int
+            # benchmark_runs.run_id (legacy UInt64) is kept alongside results_id during the
+            # transition window — drop run_id once every reader is off it.
             run_id = uuid.uuid4().int >> 64  # positive 64-bit int
-            print(f"  run_id={run_id}  benchmarks={len(benchmarks)}")
+            results_id = str(uuid.uuid4())
+            print(f"  results_id={results_id}  benchmarks={len(benchmarks)}")
 
-            insert_benchmark_run(client, run_id, run_meta)
-            insert_perf_benchmarks(client, run_id, benchmarks)
+            insert_benchmark_run(client, run_id, results_id, run_meta)
+            insert_perf_benchmarks(client, results_id, benchmarks)
 
             total_benchmarks += len(benchmarks)
             print(f"  Inserted {len(benchmarks)} benchmark rows")
@@ -693,18 +696,18 @@ def main():
                 print(f"  Already ingested — skipping {run['filename']}")
                 continue
 
-            run_id = str(uuid.uuid4())
+            results_id = str(uuid.uuid4())
             print(
-                f"  run_id={run_id}  tests={run['total_tests']}  "
+                f"  results_id={results_id}  tests={run['total_tests']}  "
                 f"passed={run['passed']}  failed={run['failed']}  "
                 f"xpass={run['xpass']}  xfail={run['xfail']}  skipped={run['skipped']}"
             )
 
-            insert_run(client, run_id, run, args)
+            insert_run(client, results_id, run, args)
 
             existing_cases = client.query(
                 "SELECT count() FROM test_cases tc "
-                "INNER JOIN test_runs tr ON tc.run_id = tr.run_id "
+                "INNER JOIN test_runs tr ON tc.results_id = tr.results_id "
                 "WHERE tr.gha_run_id = {gha_run_id:UInt64} AND tr.filename = {filename:String}",
                 parameters={
                     "gha_run_id": int(args.run_id or 0),
@@ -714,15 +717,15 @@ def main():
             if existing_cases.result_rows[0][0] > 0:
                 print("  Cases already exist — skipping case+property inserts")
             else:
-                insert_cases(client, run_id, cases, workflow=args.workflow)
+                insert_cases(client, results_id, cases, workflow=args.workflow)
                 existing_props = client.query(
-                    "SELECT count() FROM run_properties WHERE run_id = {run_id:String}",
-                    parameters={"run_id": run_id},
+                    "SELECT count() FROM run_properties WHERE results_id = {results_id:String}",
+                    parameters={"results_id": results_id},
                 )
                 if existing_props.result_rows[0][0] > 0:
                     print("  Properties already exist — skipping property insert")
                 else:
-                    insert_properties(client, run_id, cases)
+                    insert_properties(client, results_id, cases)
 
             total_cases += len(cases)
             print(

--- a/.github/scripts/ingest_xml.py
+++ b/.github/scripts/ingest_xml.py
@@ -484,6 +484,25 @@ def get_client():
     )
 
 
+# Tables written to during the run_id -> results_id migration; each needs a
+# String results_id column added once, alongside the pre-existing run_id.
+_RESULTS_ID_TABLES = [
+    "benchmark_runs",
+    "perf_benchmarks",
+    "test_runs",
+    "test_cases",
+    "run_properties",
+]
+
+
+def ensure_results_id_columns(client):
+    """Add a String results_id column to migration tables if it doesn't exist yet."""
+    for table in _RESULTS_ID_TABLES:
+        client.command(
+            f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS results_id String AFTER run_id"
+        )
+
+
 def insert_run(client, results_id: str, run: dict, args):
     client.insert(
         "test_runs",
@@ -652,6 +671,7 @@ def main():
         f"{os.environ['CLICKHOUSE_HOST']}:{os.environ.get('CLICKHOUSE_PORT', 443)} ..."
     )
     client = get_client()
+    ensure_results_id_columns(client)
     client.command("SELECT 1")
     print("Connected.\n")
 


### PR DESCRIPTION
## What

Why `results_id`: on `benchmark_runs`/`perf_benchmarks`, `run_id` was never a real uuid — it's
`UInt64` (`uuid.uuid4().int >> 64`, a random int workaround, since these tables predate the
`String` id convention). `results_id` gives those two tables their first genuine `String` uuid.
On `test_runs`/`test_cases`/`run_properties`, `run_id` was already a proper `String` uuid
(`str(uuid.uuid4())`) — there, `results_id` is purely a naming-consistency rename, not a type fix.

This PR is now purely additive, not a rename, on all 5 tables:
- `test_runs`/`test_cases`/`run_properties`: `run_id` keeps being written (unchanged, still the
  same uuid string), and `results_id` is written alongside it with that same value.
- `benchmark_runs`/`perf_benchmarks`: the legacy `run_id` (`UInt64`) is untouched; `results_id`
  is added as the new, correctly-typed `String` uuid.

`args.run_id` (the `--run-id` CLI flag / GHA run id, written to the `gha_run_id` column) is
unrelated and untouched.

## Schema migration — now self-service, no coordination needed

The script calls `ensure_results_id_columns()` on startup, which runs
`ALTER TABLE ... ADD COLUMN IF NOT EXISTS results_id String AFTER run_id` on all 5 tables before
any insert. It's idempotent and safe to re-run, so:
- No manual DDL needs to land ahead of/alongside this PR.
- No coordinated `spyre-dashboard` PR is required for this change to merge — existing dashboard
  queries against `run_id` keep working untouched, since `run_id` is still written everywhere.
  `spyre-dashboard` can move to `results_id` on its own schedule once ready.

One thing to confirm: the CI ClickHouse credentials need `ALTER TABLE` privilege (not just
`INSERT`/`SELECT`) for `ensure_results_id_columns()` to succeed — worth checking the service
account's grants before merge.

## Acceptance

After a staging run touching both suites:
```sql
SELECT run_id, results_id FROM spyre.test_runs ORDER BY triggered_at DESC LIMIT 1;
SELECT run_id, results_id FROM spyre.benchmark_runs ORDER BY created_at DESC LIMIT 1;
```
`results_id` returns a non-empty uuid string, `run_id` returns its original (unchanged) value.
