### PR TITLE
ci(perf): perf ClickHouse inline ingest — E2E test branch

### DIFF
--- a/.github/actions/ingest-xml-to-clickhouse/action.yml
+++ b/.github/actions/ingest-xml-to-clickhouse/action.yml
@@ -1,0 +1,185 @@
+name: Ingest JUnit XML into ClickHouse
+description: >
+  Parse JUnit/benchmark XML files in a directory and insert their rows into
+  ClickHouse via .github/scripts/ingest_xml.py. This is the SINGLE ingest
+  implementation shared by two callers: the push-to-clickhouse.yaml
+  workflow_run job (which downloads uploaded artifacts first) and the perf job
+  in _test_matrix.yaml (which pushes its report.xml INLINE on the card runner,
+  because on a public repo benchmark numbers must not be uploaded as
+  world-readable artifacts). Secrets cannot reach a composite action, so the
+  caller passes the ClickHouse connection as plain inputs.
+
+inputs:
+  xml-dir:
+    description: Directory to glob for *.xml (non-recursive). Empty = skip.
+    required: false
+    default: ''
+  workflow:
+    description: Workflow name recorded against the rows.
+    required: false
+    default: ''
+  branch:
+    description: Branch recorded against the rows.
+    required: false
+    default: ''
+  sha:
+    description: Commit sha recorded against the rows.
+    required: false
+    default: ''
+  run-id:
+    description: Triggering run id recorded against the rows.
+    required: false
+    default: ''
+  triggered-at:
+    description: Trigger timestamp recorded against the rows (may be empty).
+    required: false
+    default: ''
+  pr-number:
+    description: PR number associated with the rows (empty on non-PR runs).
+    required: false
+    default: ''
+  trigger-type:
+    description: Suite tier (e.g. perf | regression | integration | smoke).
+    required: false
+    default: ''
+  torch-spyre-dir:
+    description: >
+      Directory that already holds a checkout containing
+      .github/scripts/ingest_xml.py (e.g. the prebaked dev image source dir or
+      a per-job checkout). When set and the script is found there, the action
+      reuses it instead of a redundant sparse-checkout. Empty = always
+      sparse-checkout the script into the workspace.
+    required: false
+    default: ''
+  clickhouse-host:
+    description: ClickHouse host. Empty = skip the whole ingest (clean no-op).
+    required: false
+    default: ''
+  clickhouse-port:
+    description: ClickHouse port (default 443 inside the script).
+    required: false
+    default: ''
+  clickhouse-user:
+    description: ClickHouse user (default "default" inside the script).
+    required: false
+    default: ''
+  clickhouse-pass:
+    description: ClickHouse password.
+    required: false
+    default: ''
+  clickhouse-db:
+    description: ClickHouse database (default "spyre" inside the script).
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    # ingest_xml.py get_client() reads CLICKHOUSE_HOST/PASS as REQUIRED env
+    # (a KeyError, not a clean skip, when absent), and an empty --xml-dir hits
+    # sys.exit(1). So the no-op gate MUST live here: when the connection or the
+    # dir is not configured, set configured=false and every later step is a
+    # no-op. This is what lets a caller without ClickHouse secrets (or a run
+    # with no XML) pass cleanly.
+    - name: Gate on ClickHouse config and XML dir
+      id: gate
+      shell: bash
+      env:
+        CH_HOST: ${{ inputs.clickhouse-host }}
+        XML_DIR: ${{ inputs.xml-dir }}
+      run: |
+        if [ -z "${CH_HOST}" ]; then
+          echo "::notice::ClickHouse host not configured — skipping ingest."
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        elif [ -z "${XML_DIR}" ]; then
+          echo "::notice::No xml-dir provided — skipping ingest."
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    # The ingest script lives under .github/scripts (a different path than the
+    # .github/actions the perf job already checks out). Reuse an on-disk copy
+    # when the caller has one (perf card runner: prebaked image or a per-job
+    # checkout); otherwise fall back to a sparse-checkout, which reproduces the
+    # push-to-clickhouse.yaml caller's original behavior (it has no product
+    # checkout).
+    - name: Locate ingest script (on disk)
+      id: locate
+      if: steps.gate.outputs.configured == 'true'
+      shell: bash
+      env:
+        TS_DIR: ${{ inputs.torch-spyre-dir }}
+      run: |
+        REL=.github/scripts/ingest_xml.py
+        FOUND=""
+        for base in "${TS_DIR}" "${GITHUB_WORKSPACE}"; do
+          [ -n "${base}" ] || continue
+          if [ -f "${base}/${REL}" ]; then
+            FOUND="${base}/${REL}"
+            break
+          fi
+        done
+        if [ -n "${FOUND}" ]; then
+          echo "Found ingest script at ${FOUND}"
+          echo "INGEST_SCRIPT=${FOUND}" >> "$GITHUB_ENV"
+          echo "need-checkout=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "Ingest script not on disk — will sparse-checkout."
+          echo "need-checkout=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Checkout ingest script (fallback)
+      if: steps.gate.outputs.configured == 'true' && steps.locate.outputs.need-checkout == 'true'
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        sparse-checkout: |
+          .github/scripts/ingest_xml.py
+        sparse-checkout-cone-mode: false
+
+    - name: Set ingest script path (fallback)
+      if: steps.gate.outputs.configured == 'true' && steps.locate.outputs.need-checkout == 'true'
+      shell: bash
+      run: echo "INGEST_SCRIPT=${GITHUB_WORKSPACE}/.github/scripts/ingest_xml.py" >> "$GITHUB_ENV"
+
+    - name: Install uv
+      if: steps.gate.outputs.configured == 'true'
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+    - name: Setup venv and dependencies
+      if: steps.gate.outputs.configured == 'true'
+      shell: bash
+      run: |
+        # Create the ingest venv in the workspace, NOT the baked shared venv, so
+        # the ingest deps never perturb the dev image's torch-spyre environment.
+        uv venv
+        source .venv/bin/activate
+        uv pip install requests clickhouse-driver clickhouse-connect lxml regex
+
+    - name: Ingest XML files into ClickHouse
+      if: steps.gate.outputs.configured == 'true'
+      shell: bash
+      env:
+        CLICKHOUSE_HOST: ${{ inputs.clickhouse-host }}
+        CLICKHOUSE_PASS: ${{ inputs.clickhouse-pass }}
+        # Port/user/db are optional. Only export them when non-empty: the script
+        # reads PORT via int(os.environ.get("CLICKHOUSE_PORT", 443)), so an
+        # empty-string value would break int(""), and empty user/db would
+        # override the script's sensible defaults ("default" / "spyre").
+        CH_PORT_IN: ${{ inputs.clickhouse-port }}
+        CH_USER_IN: ${{ inputs.clickhouse-user }}
+        CH_DB_IN: ${{ inputs.clickhouse-db }}
+      run: |
+        source .venv/bin/activate
+        [ -n "${CH_PORT_IN}" ] && export CLICKHOUSE_PORT="${CH_PORT_IN}"
+        [ -n "${CH_USER_IN}" ] && export CLICKHOUSE_USER="${CH_USER_IN}"
+        [ -n "${CH_DB_IN}" ] && export CLICKHOUSE_DB="${CH_DB_IN}"
+        python3 "${INGEST_SCRIPT}" \
+          --xml-dir "${{ inputs.xml-dir }}" \
+          --workflow "${{ inputs.workflow }}" \
+          --branch "${{ inputs.branch }}" \
+          --sha "${{ inputs.sha }}" \
+          --run-id "${{ inputs.run-id }}" \
+          --triggered-at "${{ inputs.triggered-at }}" \
+          --pr-number "${{ inputs.pr-number }}" \
+          --trigger-type "${{ inputs.trigger-type }}"

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -388,7 +388,7 @@ jobs:
           retention-days: 10
 
   # ---------------------------------------------------------------------------
-  # Job 1b: perf benchmark  (test_type=perf only)
+  # Job 1b: perf benchmark  (test_type=perf only, never per-PR)
   #
   # perf is a benchmark MODE of `make tests`, not an OOT pytest-config suite, so
   # it never appears in the config-driven `test` matrix above (generate_matrix
@@ -397,12 +397,20 @@ jobs:
   # report.xml into RESULTS_DIR. This job runs that single benchmark step on a
   # card runner and uploads the report as report.xml (same artifact contract as
   # the matrix suites, so report_empty_suites and any XML ingest pick it up).
+  #
+  # POLICY: perf is a weekly-only suite -- it must NEVER run on a per-PR trigger
+  # (it is expensive and holds a scarce card runner). The `github.event_name !=
+  # pull_request` guard below is the hard stop: even if a pull_request path
+  # forwarded test_type=perf, this job stays skipped. The weekly/scheduled and
+  # orchestrator paths reach here via workflow_dispatch/schedule, not
+  # pull_request, so they are unaffected.
   # ---------------------------------------------------------------------------
   perf:
     name: Perf benchmark
     needs: [generate_matrix, build_torch_spyre]
     if: >-
       !cancelled() &&
+      github.event_name != 'pull_request' &&
       needs.generate_matrix.outputs.resolved_test_type == 'perf' &&
       (needs.build_torch_spyre.result == 'success' ||
        needs.build_torch_spyre.result == 'skipped')

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -395,8 +395,8 @@ jobs:
   # emits an empty matrix for perf). `make tests TEST_TYPE=perf` shells out to
   # the spyre-perf-suite console script baked into the dev image and writes
   # report.xml into RESULTS_DIR. This job runs that single benchmark step on a
-  # card runner and uploads the report as report.xml (same artifact contract as
-  # the matrix suites, so report_empty_suites and any XML ingest pick it up).
+  # card runner. The reports are not uploaded as artifacts; the results are
+  # consumed only by the ClickHouse ingest path.
   #
   # POLICY: perf is a weekly-only suite -- it must NEVER run on a per-PR trigger
   # (it is expensive and holds a scarce card runner). The `github.event_name !=
@@ -476,23 +476,15 @@ jobs:
           source "${VENV}/bin/activate"
           make -C "${SRC_DIR}" tests TEST_TYPE=perf RESULTS_DIR="${RESULTS_DIR}"
 
-      - name: Upload perf report
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: report.xml
-          path: ${{ env.RESULTS_DIR }}/report.xml
-          if-no-files-found: warn
-          retention-days: 10
-
-      - name: Upload perf report (human-readable)
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: report.txt
-          path: ${{ env.RESULTS_DIR }}/report.txt
-          if-no-files-found: warn
-          retention-days: 10
+      # The benchmark reports are not uploaded as workflow artifacts; the
+      # results are consumed only by the ClickHouse ingest path.
+      - name: Confirm perf report was produced
+        run: |
+          # Fail if the benchmark did not write its report. Do not echo the
+          # report contents to the build log.
+          test -f "${RESULTS_DIR}/report.xml" \
+            || { echo "::error::perf run did not produce report.xml"; exit 1; }
+          echo "perf report written to \${RESULTS_DIR} (not uploaded)"
 
   # ---------------------------------------------------------------------------
   # Job 2: Multi-Spyre test matrix
@@ -637,7 +629,7 @@ jobs:
   report_empty_suites:
     name: Report empty test suites
     runs-on: ubuntu-latest
-    needs: [generate_matrix, test, test_multi_spyre, perf]
+    needs: [generate_matrix, test, test_multi_spyre]
     if: always()
 
     steps:

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -168,6 +168,20 @@ jobs:
           else
             pip install pyyaml --quiet
           fi
+
+          # perf is NOT an OOT pytest-config suite: it is a benchmark mode of
+          # `make tests` (TEST_TYPE=perf shells out to spyre-perf-suite; see the
+          # Makefile `ifeq ($(TEST_TYPE),perf)` branch). It carries no
+          # test_suite_config.labels, so the config filter below would always
+          # return an empty matrix. Route it to the dedicated `perf` job instead:
+          # emit an empty matrix (the `test` matrix job is then skipped) and pin
+          # resolved_test_type=perf so the downstream perf gate fires.
+          if [ "${RAW_TEST_TYPE}" = "perf" ]; then
+            echo "matrix={\"suite\":[]}" >> "$GITHUB_OUTPUT"
+            echo "resolved_test_type=perf" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           matrix=$(python3 tests/oot_framework/utils/filter_configs.py \
             --config-dir tests/configs/torch_spyre_tests \
             --test-type "${RAW_TEST_TYPE}" \
@@ -374,6 +388,105 @@ jobs:
           retention-days: 10
 
   # ---------------------------------------------------------------------------
+  # Job 1b: perf benchmark  (test_type=perf only)
+  #
+  # perf is a benchmark MODE of `make tests`, not an OOT pytest-config suite, so
+  # it never appears in the config-driven `test` matrix above (generate_matrix
+  # emits an empty matrix for perf). `make tests TEST_TYPE=perf` shells out to
+  # the spyre-perf-suite console script baked into the dev image and writes
+  # report.xml into RESULTS_DIR. This job runs that single benchmark step on a
+  # card runner and uploads the report as report.xml (same artifact contract as
+  # the matrix suites, so report_empty_suites and any XML ingest pick it up).
+  # ---------------------------------------------------------------------------
+  perf:
+    name: Perf benchmark
+    needs: [generate_matrix, build_torch_spyre]
+    if: >-
+      !cancelled() &&
+      needs.generate_matrix.outputs.resolved_test_type == 'perf' &&
+      (needs.build_torch_spyre.result == 'success' ||
+       needs.build_torch_spyre.result == 'skipped')
+    runs-on:
+      - x86_64
+      - spyre_pf_x1
+      - ${{ inputs.runner_label }}
+      - ${{ inputs.image_label }}
+    timeout-minutes: 120
+    env:
+      # Flat results dir, matching the Makefile default and PR #3452. The suite
+      # writes both report.txt and report.xml here.
+      RESULTS_DIR: ${{ github.workspace }}/perf-results
+    steps:
+      - name: Checkout composite actions
+        if: ${{ !inputs.prebaked_image }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+
+      - name: Expose baked composite actions in the workspace
+        if: ${{ inputs.prebaked_image }}
+        run: ln -sfn "${PREBAKED_TORCH_SPYRE_DIR}/.github" "${GITHUB_WORKSPACE}/.github"
+
+      - if: ${{ !inputs.prebaked_image }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: torch-spyre
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
+          repository: ${{ inputs.repository || github.event.pull_request.head.repo.full_name || github.repository }}
+
+      - uses: ./.github/actions/gather-runner-info
+        with:
+          verbose: 'true'
+          torch_spyre_dir: ${{ inputs.prebaked_image && env.PREBAKED_TORCH_SPYRE_DIR || 'torch-spyre' }}
+
+      - name: Install prebuilt torch-spyre
+        if: ${{ !inputs.prebaked_image && needs.build_torch_spyre.result == 'success' }}
+        uses: ./.github/actions/install-prebuilt-torch-spyre
+
+      - name: Run perf benchmark (make tests TEST_TYPE=perf)
+        run: |
+          # Prebaked: run FROM the baked source dir + its SHARED venv at
+          # $HOME/.venv; normal: the checkout ('torch-spyre') + local '.venv'.
+          if [ "${{ inputs.prebaked_image }}" = "true" ]; then
+            SRC_DIR="${PREBAKED_TORCH_SPYRE_DIR}"
+            VENV="${PREBAKED_VENV_PATH}"
+          else
+            SRC_DIR="torch-spyre"
+            VENV="torch-spyre/.venv"
+          fi
+          mkdir -p "${RESULTS_DIR}"
+          # Refresh AIU setup so the benchmark sees the card topology, mirroring
+          # the matrix suites' pre_run. set +u because the script reads unset
+          # vars; a failed refresh must abort before the benchmark runs.
+          set +u
+          unset _IBM_AIU_SETUP
+          rm -rf /tmp/etc/ibm/spyre/topo.json
+          source /etc/profile.d/ibm-aiu-setup.sh || exit 1
+          set -u
+          # shellcheck disable=SC1091
+          source "${VENV}/bin/activate"
+          make -C "${SRC_DIR}" tests TEST_TYPE=perf RESULTS_DIR="${RESULTS_DIR}"
+
+      - name: Upload perf report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: report.xml
+          path: ${{ env.RESULTS_DIR }}/report.xml
+          if-no-files-found: warn
+          retention-days: 10
+
+      - name: Upload perf report (human-readable)
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: report.txt
+          path: ${{ env.RESULTS_DIR }}/report.txt
+          if-no-files-found: warn
+          retention-days: 10
+
+  # ---------------------------------------------------------------------------
   # Job 2: Multi-Spyre test matrix
   #
   # Only runs for test_type values that include the distributed suite:
@@ -516,7 +629,7 @@ jobs:
   report_empty_suites:
     name: Report empty test suites
     runs-on: ubuntu-latest
-    needs: [generate_matrix, test, test_multi_spyre]
+    needs: [generate_matrix, test, test_multi_spyre, perf]
     if: always()
 
     steps:

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -107,6 +107,25 @@ on:
         type: boolean
         default: false
 
+    secrets:
+      # ClickHouse connection for the perf job's inline benchmark ingest. The
+      # perf report.xml is written on the card runner and is NOT uploaded as an
+      # artifact (benchmark numbers must not become world-readable on a public
+      # repo), so it cannot ride the push-to-clickhouse.yaml artifact-download
+      # path the way the matrix suites do. Instead the perf job pushes it inline.
+      # All optional: a caller that omits them (or a non-perf run) simply skips
+      # the inline push, leaving every existing caller byte-for-byte unchanged.
+      CLICKHOUSE_HOST:
+        required: false
+      CLICKHOUSE_PORT:
+        required: false
+      CLICKHOUSE_USER:
+        required: false
+      CLICKHOUSE_PASS:
+        required: false
+      CLICKHOUSE_DB:
+        required: false
+
 defaults:
   run:
     shell: bash
@@ -424,6 +443,10 @@ jobs:
       # Flat results dir, matching the Makefile default and PR #3452. The suite
       # writes both report.txt and report.xml here.
       RESULTS_DIR: ${{ github.workspace }}/perf-results
+      # Mapped to env so the inline-ingest step can gate on it: secrets cannot be
+      # used in a step `if:`. Empty (caller passed no ClickHouse secrets) => the
+      # ingest step is skipped and the perf run still succeeds.
+      CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
     steps:
       - name: Checkout composite actions
         if: ${{ !inputs.prebaked_image }}
@@ -485,6 +508,35 @@ jobs:
           test -f "${RESULTS_DIR}/report.xml" \
             || { echo "::error::perf run did not produce report.xml"; exit 1; }
           echo "perf report written to \${RESULTS_DIR} (not uploaded)"
+
+      # Push the perf report to ClickHouse INLINE on this card runner. The
+      # report is never uploaded as a workflow artifact (public repo: artifacts
+      # are world-readable and benchmark numbers must stay private), so it
+      # cannot ride the push-to-clickhouse.yaml artifact-download path the
+      # matrix suites use. The composite action is the SAME ingest
+      # implementation that workflow reuses, so there is one code path, not two.
+      # Gated on CLICKHOUSE_HOST: a caller that passes no ClickHouse secrets
+      # skips the push and the perf run still succeeds.
+      - name: Ingest perf report into ClickHouse (inline, no artifact)
+        if: ${{ env.CLICKHOUSE_HOST != '' }}
+        uses: ./.github/actions/ingest-xml-to-clickhouse
+        with:
+          xml-dir: ${{ env.RESULTS_DIR }}
+          workflow: ${{ github.workflow }}
+          branch: ${{ inputs.ref || github.event.pull_request.head.sha || github.ref_name }}
+          sha: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
+          run-id: ${{ github.run_id }}
+          triggered-at: ''
+          # perf never runs on pull_request (see the job `if:` above), so there
+          # is no PR to associate; leave empty.
+          pr-number: ''
+          trigger-type: perf
+          torch-spyre-dir: ${{ inputs.prebaked_image && env.PREBAKED_TORCH_SPYRE_DIR || 'torch-spyre' }}
+          clickhouse-host: ${{ secrets.CLICKHOUSE_HOST }}
+          clickhouse-port: ${{ secrets.CLICKHOUSE_PORT }}
+          clickhouse-user: ${{ secrets.CLICKHOUSE_USER }}
+          clickhouse-pass: ${{ secrets.CLICKHOUSE_PASS }}
+          clickhouse-db: ${{ secrets.CLICKHOUSE_DB }}
 
   # ---------------------------------------------------------------------------
   # Job 2: Multi-Spyre test matrix

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -100,6 +100,17 @@ on:
         required: false
         type: boolean
         default: true
+      clickhouse_env:
+        description: >-
+          Which ClickHouse instance the perf job's inline ingest writes to:
+          "dev" (the CLICKHOUSE_*_DEV secret set) or "prod" (the CLICKHOUSE_*
+          set). Defaults to dev so a manual/test dispatch never writes to the
+          production perf tables by accident. The scheduled/orchestrator
+          production perf run passes prod explicitly. A no-op when the selected
+          secret set is unset (the perf ingest step self-skips on empty host).
+        required: false
+        type: string
+        default: dev
 
 concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.pull_request.html_url) || (github.event_name == 'workflow_dispatch'
@@ -156,12 +167,19 @@ jobs:
     # ClickHouse connection for the perf job's inline benchmark ingest. Passed
     # explicitly (not `secrets: inherit`) so only what _test_matrix declares is
     # forwarded. Absent on a repo without these secrets => perf ingest no-ops.
+    #
+    # clickhouse_env selects the instance HERE (the only place both secret sets
+    # are readable): dev -> the *_DEV set, prod -> the plain set. _test_matrix
+    # stays instance-agnostic; it just receives "the ClickHouse to use". A secret
+    # context key must be a literal name, so this is a per-name ternary rather
+    # than a computed `secrets[...]` lookup. An unset selected secret forwards as
+    # empty and the perf ingest step self-skips.
     secrets:
-      CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
-      CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT }}
-      CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
-      CLICKHOUSE_PASS: ${{ secrets.CLICKHOUSE_PASS }}
-      CLICKHOUSE_DB: ${{ secrets.CLICKHOUSE_DB }}
+      CLICKHOUSE_HOST: ${{ inputs.clickhouse_env == 'prod' && secrets.CLICKHOUSE_HOST || secrets.CLICKHOUSE_HOST_DEV }}
+      CLICKHOUSE_PORT: ${{ inputs.clickhouse_env == 'prod' && secrets.CLICKHOUSE_PORT || secrets.CLICKHOUSE_PORT_DEV }}
+      CLICKHOUSE_USER: ${{ inputs.clickhouse_env == 'prod' && secrets.CLICKHOUSE_USER || secrets.CLICKHOUSE_USER_DEV }}
+      CLICKHOUSE_PASS: ${{ inputs.clickhouse_env == 'prod' && secrets.CLICKHOUSE_PASS || secrets.CLICKHOUSE_PASS_DEV }}
+      CLICKHOUSE_DB: ${{ inputs.clickhouse_env == 'prod' && secrets.CLICKHOUSE_DB || secrets.CLICKHOUSE_DB_DEV }}
 
   # ----------------------------------------------------------------------------------
   # Fan-in gate job which is similar to run-spyre-unit-tests in torch_spyre_tests.yaml

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -153,6 +153,15 @@ jobs:
       repository: ${{ inputs.repository || '' }}
       test_type: ${{ inputs.test_type || 'device_critical' }}
       prebaked_image: ${{ inputs.prebaked_image }}
+    # ClickHouse connection for the perf job's inline benchmark ingest. Passed
+    # explicitly (not `secrets: inherit`) so only what _test_matrix declares is
+    # forwarded. Absent on a repo without these secrets => perf ingest no-ops.
+    secrets:
+      CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
+      CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT }}
+      CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
+      CLICKHOUSE_PASS: ${{ secrets.CLICKHOUSE_PASS }}
+      CLICKHOUSE_DB: ${{ secrets.CLICKHOUSE_DB }}
 
   # ----------------------------------------------------------------------------------
   # Fan-in gate job which is similar to run-spyre-unit-tests in torch_spyre_tests.yaml

--- a/.github/workflows/push-to-clickhouse.yaml
+++ b/.github/workflows/push-to-clickhouse.yaml
@@ -90,27 +90,18 @@ jobs:
           which python3
           python3 --version
 
-      - name: Checkout (for the ingest script)
+      # Check out the local composite action (and the ingest script it runs).
+      # The uv/venv/deps/ingest steps that used to live here inline now live in
+      # .github/actions/ingest-xml-to-clickhouse, shared with the perf job's
+      # inline push so there is one ingest implementation. `uses: ./...`
+      # resolves against the workspace, so the action tree must be present.
+      - name: Checkout (for the composite action and ingest script)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           sparse-checkout: |
+            .github/actions
             .github/scripts/ingest_xml.py
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-
-      - name: setup venv
-        run: |
-          pwd
-          ls -la
-          uv venv
-          source .venv/bin/activate
-          echo "VIRTUAL_ENV $VIRTUAL_ENV"
-
-      - name: Install Python dependencies
-        run: |
-          source .venv/bin/activate
-          uv pip install requests clickhouse-driver clickhouse-connect lxml regex
+          sparse-checkout-cone-mode: false
 
       - name: Install gh CLI
         run: |
@@ -132,10 +123,12 @@ jobs:
           echo "pr_number=${PR}" >> "${GITHUB_OUTPUT}"
 
       # ---------------------------------------------------------------------------
-      # Download all XML artifacts produced by the triggering run.
-      # Each matrix job uploads one artifact named after its config file, e.g.
-      #   granite_3_3_8b_instruct_spyre.xml
-      #   test_view_ops_config.xml
+      # Download every artifact from the triggering run and unzip it. Artifact
+      # *names* carry no file extension (only the file inside the zip does), so
+      # filtering must happen post-unzip by actual filename, not by artifact
+      # name — a `select(.name | endswith(".xml"))` here dropped every artifact.
+      # The ingest step globs *.xml in the unzip dir, so non-XML files that come
+      # along are simply ignored.
       # ---------------------------------------------------------------------------
       - name: List artifacts from triggering run
         id: list-artifacts
@@ -144,7 +137,7 @@ jobs:
         run: |
           ARTIFACTS=$(gh api \
             "/repos/${{ github.repository }}/actions/runs/${TRIGGERING_RUN_ID}/artifacts" \
-            --jq '[.artifacts[] | select(.name | endswith(".xml")) | {id: .id, name: .name}]')
+            --jq '[.artifacts[] | {id: .id, name: .name}]')
           echo "artifacts=$ARTIFACTS" >> "$GITHUB_OUTPUT"
           echo "Found artifacts:"
           echo "$ARTIFACTS" | python3 -c "import json,sys; [print(' •', a['name']) for a in json.load(sys.stdin)]"
@@ -189,25 +182,27 @@ jobs:
           echo "Resolved tier: ${TIER:-<none>}"
           echo "tier=${TIER}" >> "${GITHUB_OUTPUT}"
 
+      # Delegate the venv+deps+ingest to the shared composite action (the same
+      # one the perf job uses for its inline push). The ClickHouse connection
+      # comes from this job's env block above (DEV vs PROD toggle lives there);
+      # no product checkout exists here, so the action sparse-checks-out the
+      # script itself when torch-spyre-dir is not passed.
       - name: Ingest XML files into ClickHouse
-        run: |
-          source .venv/bin/activate
-          python3 .github/scripts/ingest_xml.py \
-            --xml-dir xml_artifacts \
-            --workflow "${TRIGGERING_WORKFLOW}" \
-            --branch   "${TRIGGERING_BRANCH}" \
-            --sha      "${TRIGGERING_SHA}" \
-            --run-id   "${TRIGGERING_RUN_ID}" \
-            --triggered-at "${TRIGGERING_AT}" \
-            --pr-number    "${{ steps.resolve-pr.outputs.pr_number }}" \
-            --trigger-type "${{ steps.extract-tier.outputs.tier }}"
-        env:
-          # PROD INSTANCE
-          CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
-          CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT }}
-          CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
-          CLICKHOUSE_PASS: ${{ secrets.CLICKHOUSE_PASS }}
-          CLICKHOUSE_DB: ${{ secrets.CLICKHOUSE_DB }}
+        uses: ./.github/actions/ingest-xml-to-clickhouse
+        with:
+          xml-dir: xml_artifacts
+          workflow: ${{ env.TRIGGERING_WORKFLOW }}
+          branch: ${{ env.TRIGGERING_BRANCH }}
+          sha: ${{ env.TRIGGERING_SHA }}
+          run-id: ${{ env.TRIGGERING_RUN_ID }}
+          triggered-at: ${{ env.TRIGGERING_AT }}
+          pr-number: ${{ steps.resolve-pr.outputs.pr_number }}
+          trigger-type: ${{ steps.extract-tier.outputs.tier }}
+          clickhouse-host: ${{ env.CLICKHOUSE_HOST }}
+          clickhouse-port: ${{ env.CLICKHOUSE_PORT }}
+          clickhouse-user: ${{ env.CLICKHOUSE_USER }}
+          clickhouse-pass: ${{ env.CLICKHOUSE_PASS }}
+          clickhouse-db: ${{ env.CLICKHOUSE_DB }}
 
       - name: Summary
         if: always()

--- a/.github/workflows/runtests_nightly.yaml
+++ b/.github/workflows/runtests_nightly.yaml
@@ -50,6 +50,15 @@ jobs:
       rpm_location: ${{ inputs.rpm_location || '' }}
       rpm_names: ${{ inputs.rpm_names || '' }}
       build_torch_spyre: ${{ inputs.build_torch_spyre == true }}
+    # ClickHouse connection for the perf job's inline ingest. Nightly is
+    # schedule-triggered (never pull_request), so a nightly test_type=perf run
+    # can ingest here. Forwarded explicitly, matching the other callers.
+    secrets:
+      CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
+      CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT }}
+      CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
+      CLICKHOUSE_PASS: ${{ secrets.CLICKHOUSE_PASS }}
+      CLICKHOUSE_DB: ${{ secrets.CLICKHOUSE_DB }}
 
   # ---------------------------------------------------------------------------
   # Job 2: run-spyre-unit-tests (fan-in gate)

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -125,6 +125,15 @@ jobs:
       rpm_names: ${{ inputs.rpm_names || '' }}
       build_torch_spyre: ${{ inputs.build_torch_spyre == true }}
       test_type: ${{ inputs.test_type || (github.event_name == 'push' && 'trunk' || 'full') }}
+    # ClickHouse connection for the perf job's inline ingest (a no-op here in
+    # practice: perf is non-PR-gated and this workflow's test_type is never
+    # perf). Forwarded for consistency with the other _test_matrix callers.
+    secrets:
+      CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
+      CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT }}
+      CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
+      CLICKHOUSE_PASS: ${{ secrets.CLICKHOUSE_PASS }}
+      CLICKHOUSE_DB: ${{ secrets.CLICKHOUSE_DB }}
 
   # ---------------------------------------------------------------------------
   # Job 3: run-spyre-unit-tests (required check gate)


### PR DESCRIPTION
## What this is

The perf-benchmark ClickHouse ingest work from #3519, plus its inline-ingest
follow-up, targeted at the `perf-test` branch so it can be run end-to-end
(dispatch -> card runner -> ClickHouse) **before** it merges to `main`.

Base `perf-test` is at the pre-perf commit, so this PR carries the full series:

1. `ci(perf): route TEST_TYPE=perf to a dedicated benchmark job` — perf as a
   benchmark MODE of `make tests`, its own `perf` job in `_test_matrix.yaml`.
2. `ci(perf): restrict perf job to non-PR (weekly-only) triggers` — hard
   `github.event_name != 'pull_request'` guard.
3. `ci(perf): do not upload benchmark reports as workflow artifacts` — the
   report stays on the runner (public repo: artifacts are world-readable).
4. `ci(perf): ingest perf report.xml into ClickHouse inline via a shared action`
   — because the report is not an artifact, the `push-to-clickhouse.yaml`
   artifact-download path cannot reach it, so the perf job pushes it INLINE via
   a new shared composite action `.github/actions/ingest-xml-to-clickhouse`,
   which is the SAME ingest implementation `push-to-clickhouse.yaml` now uses
   (one code path, not two). Also ports the `endswith(".xml")` artifact-filter
   fix (matching hf-adapters#285 / spyre-inference#466).
5. `ci(perf): add clickhouse_env dev/prod selector to integration-tests` —
   `integration-tests.yaml` gains a `clickhouse_env` dispatch input
   (**default `dev`**) so a manual/pre-merge run writes to the DEV instance,
   never the production perf tables, unless `prod` is passed explicitly.

## How to test it end-to-end (needs canonical secrets + card runner)

After merging this into `perf-test`, dispatch against that ref so GitHub loads
these workflow definitions (a reusable workflow resolves from the ref the
top-level workflow runs at, not from a checkout input):

```
gh workflow run integration-tests.yaml \
  --repo torch-spyre/torch-spyre \
  --ref perf-test \
  -f test_type=perf \
  -f prebaked_image=true \
  -f clickhouse_env=dev
```

Requires on canonical: the `CLICKHOUSE_*_DEV` secret set (for `clickhouse_env=dev`),
and the shared `spyre_pf_x1` card-runner pool. A missing selected secret set
forwards as empty and the perf ingest step self-skips (the perf run still
passes), so it is safe to dry-run.

### What to verify
- **perf job scheduled** on `spyre_pf_x1`; "Confirm perf report was produced" passes.
- **Ingest step** ("Ingest perf report into ClickHouse (inline, no artifact)")
  logs the benchmark-XML detection and an "Inserted N rows".
- **DEV ClickHouse** `benchmark_runs` / `perf_benchmarks` has rows for this
  `run_id` (dedup is on `source_file`, so re-runs are exactly-once).
- **No artifact**: `gh api /repos/torch-spyre/torch-spyre/actions/runs/<id>/artifacts`
  shows no `report`/`report.xml` entry.

Do not merge into `main` from here: this is the pre-merge test branch. Once the
DEV run lands rows in the correct format, #3519 comes out of draft on `main`.
