### PR TITLE
ci(perf): dev/prod selector for manual push-to-clickhouse re-ingest

### DIFF
--- a/.github/workflows/push-to-clickhouse.yaml
+++ b/.github/workflows/push-to-clickhouse.yaml
@@ -22,6 +22,16 @@ on:
         description: Workflow name (model-module-tests | upstream-tests | model-ops-tests | integration-tests)
         required: false
         default: upstream-pytorch-tests
+      clickhouse_env:
+        description: >-
+          ClickHouse instance for a MANUAL re-ingest: "prod" (the CLICKHOUSE_*
+          secret set) or "dev" (the CLICKHOUSE_*_DEV set). Default prod. Lets a
+          manual re-ingest target dev WITHOUT editing this file and pushing to
+          main (see the env block below). The automatic workflow_run path always
+          uses prod: for a workflow_run event this input is empty, so the env
+          ternary falls through to the prod secret set.
+        required: false
+        default: prod
 
 concurrency:
   # Allow at most one ingest per triggering run (re-runs queue behind)
@@ -56,19 +66,18 @@ jobs:
       #   CLICKHOUSE_DB     e.g. spyre
       # ---------------------------------------------------------------------------
 
-      # DEV INSTANCE
-      # CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST_DEV }}
-      # CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT_DEV }}
-      # CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER_DEV }}
-      # CLICKHOUSE_PASS: ${{ secrets.CLICKHOUSE_PASS_DEV }}
-      # CLICKHOUSE_DB: ${{ secrets.CLICKHOUSE_DB_DEV }}
-
-      # PROD INSTANCE
-      CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
-      CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT }}
-      CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
-      CLICKHOUSE_PASS: ${{ secrets.CLICKHOUSE_PASS }}
-      CLICKHOUSE_DB: ${{ secrets.CLICKHOUSE_DB }}
+      # Instance selected by the clickhouse_env input: "dev" -> the *_DEV secret
+      # set, anything else (incl. "prod" and the empty value a workflow_run event
+      # sends) -> the plain PROD set. The `!= 'dev'` test (not `== 'prod'`) is
+      # deliberate: it keeps the AUTOMATIC workflow_run path on prod, since that
+      # event carries no input. A secret context key must be a literal name, so
+      # this is a per-name ternary, not a computed `secrets[...]` lookup. This is
+      # what lets a manual DEV re-ingest happen with no edit+push to main.
+      CLICKHOUSE_HOST: ${{ inputs.clickhouse_env != 'dev' && secrets.CLICKHOUSE_HOST || secrets.CLICKHOUSE_HOST_DEV }}
+      CLICKHOUSE_PORT: ${{ inputs.clickhouse_env != 'dev' && secrets.CLICKHOUSE_PORT || secrets.CLICKHOUSE_PORT_DEV }}
+      CLICKHOUSE_USER: ${{ inputs.clickhouse_env != 'dev' && secrets.CLICKHOUSE_USER || secrets.CLICKHOUSE_USER_DEV }}
+      CLICKHOUSE_PASS: ${{ inputs.clickhouse_env != 'dev' && secrets.CLICKHOUSE_PASS || secrets.CLICKHOUSE_PASS_DEV }}
+      CLICKHOUSE_DB: ${{ inputs.clickhouse_env != 'dev' && secrets.CLICKHOUSE_DB || secrets.CLICKHOUSE_DB_DEV }}
 
       # Metadata about the triggering run
       TRIGGERING_RUN_ID: ${{ github.event.workflow_run.id || inputs.gha_run_id }}


### PR DESCRIPTION
## What this is

Follow-up to #3536 (already merged into `perf-test`). Addresses the ergonomics
point Anubhav raised: a workflow that hardcodes the plain `secrets.CLICKHOUSE_*`
(PROD) names has to be edited and pushed to `main` every time you want a DEV
re-ingest. `push-to-clickhouse.yaml` still had that shape (DEV block commented
out).

Adds a `clickhouse_env` `workflow_dispatch` input (**default `prod`**) and
selects the secret set from it with a per-name ternary:

```
CLICKHOUSE_HOST: ${{ inputs.clickhouse_env != 'dev' && secrets.CLICKHOUSE_HOST || secrets.CLICKHOUSE_HOST_DEV }}
```

The test is `!= 'dev'` (not `== 'prod'`) on purpose: the AUTOMATIC
`workflow_run` trigger carries no input, so an empty value must still resolve to
the PROD set. So:

- automatic `workflow_run` ingest -> **prod** (unchanged behaviour)
- manual `workflow_dispatch` with `clickhouse_env=dev` -> **dev**, no edit + push

Mirrors the `clickhouse_env` selector `integration-tests.yaml` already uses for
the perf job's inline ingest (merged in #3536).

## Scope / safety
- One file, `push-to-clickhouse.yaml`. actionlint clean.
- Does NOT change the perf E2E: the perf job uploads no artifact, so this
  `workflow_run` path ingests no perf rows regardless.
- Secret context keys must be literals, so this is a per-name ternary, not a
  computed `secrets[...]` lookup.

Base `perf-test` so it rides the same pre-merge test branch as #3536.
