### PR TITLE
Fix eager-mode matmul crash on 4D batched tensors (#3489)

### DIFF
--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -86,6 +86,7 @@ register_torch_compile_kernel(
         aten.bitwise_not,
         aten.logical_not,
         aten.bmm,
+        aten.matmul,
         aten.cat,
         aten.div,
         aten.exp,


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes a crash in torch.matmul on large 4D batched float16 tensors in eager mode. The op crashed dxp_standalone with DtException: Immediate value out of boundary (SIGABRT), while the same call worked fine under torch.compile(backend="inductor").

Root cause: aten.matmul was never registered as a Spyre kernel — only aten.mm and aten.bmm were (torch_spyre/ops/eager.py). Without its own kernel, torch.matmul falls back to PyTorch's default decomposition, which runs eagerly: expand → reshape(to 3D) → bmm → view. Because these steps execute as real ops (not as FX graph nodes), the batch dimensions get flattened (e.g. [2, 2] → [4]) before Inductor ever sees the graph.

This matters because a separate pass, _unflatten_bmm_batch_dims, is designed to undo exactly this flattening and restore the batch structure — but it only works on FX graph nodes. Since the flattening already happened as real ops in eager mode, there's nothing left for it to match, so it never fires.

With the batch dims flattened into one axis instead of two, the compiler's work_division pass has one fewer way to split the tensor across cores. For most shapes this doesn't matter, but for this specific shape, the best possible split without that second axis needs 512 MB per core — exactly double the 256 MB hardware limit. The overflow check only logs a warning instead of stopping compilation, so the oversized kernel reaches the hardware verifier anyway, which aborts.

torch.compile mode doesn't hit this because Dynamo traces the whole call before decomposition runs, so the flattening shows up as graph nodes, _unflatten_bmm_batch_dims catches it, and the batch structure is restored — keeping both axes available for splitting.

This isn't a new regression — aten.matmul has never been registered directly, per git history. Confirmed empirically too: shrinking the same shape to 1/4 size (N=16384) succeeds on the identical eager code path; only the larger shape crosses the 256 MB limit.

#### Which issue(s) this PR is related to:

Fixes #3489

#### Special notes for your reviewer:

This is a one-line fix — adding aten.matmul to the register_torch_compile_kernel([...]) list in eager.py, using the exact same registration mechanism already in place for aten.mm and aten.bmm. Verified via torch._C._dispatch_dump('aten::matmul') that this correctly installs a PrivateUse1 kernel where none existed before, and that CompositeImplicitAutograd no longer intercepts matmul calls on Spyre tensors.

Note: torch.bmm called directly on an already-3D batch tensor (not reached via matmul's decomposition) is not fixed by this change and can still hit the same 256 MB span limit — that's inherent to bmm's 3D-only signature. Separately, warn_if_per_core_overflow only logs CRITICAL and never raises, which is why this surfaces as a hardware SIGABRT rather than a catchable Python exception; that's a pre-existing gap worth addressing separately so future span violations fail cleanly instead of crashing the process.


####Testing::


```
import torch
import torch_spyre

DEVICE = "spyre"
DTYPE = torch.float16

torch.manual_seed(0xAFFE)
a = torch.randn(2, 2, 2048, 2048, dtype=DTYPE).to(DEVICE)
b = torch.randn(2, 2, 2048, 65536, dtype=DTYPE).to(DEVICE)

out = torch.matmul(a, b)
```


####Results:
```
tensor([[[[ 115.2500,    7.8281,  100.2500,  ...,   52.8750,   16.9688,
             -9.2812],
          [  -8.9688,   -7.7109,   -4.9062,  ...,  -37.5000,    4.0781,
             30.4375],
          [  23.3438,  110.7500,  -21.7812,  ...,   44.6250,   14.3906,
             26.8750],
          ...,
          [  50.5625,  -19.0312,   50.0625,  ...,  112.1250,   59.6250,
            -43.5000],
          [ -39.0000,   81.3750,   44.5625,  ...,    3.8125,  -66.8750,
             -5.7031],
          [  25.4688,   45.0000,   53.0000,  ...,  -32.6875,  -58.0000,
            -50.5000]],

         [[  27.5938,  -73.2500,   16.2188,  ...,    2.4688,   25.0938,
            -39.3750],
          [ -33.6250,  -26.0000,   20.7188,  ..., -108.3750,   20.1562,
             -4.1094],
          [ -57.0000,    1.6406,  -91.7500,  ...,    2.5625,   29.1250,
              0.7500],
          ...,
          [  43.7500,  -25.5312,   92.8750,  ...,    1.0312,   -1.9141,
             -3.0000],
          [  35.0625,    7.6250,  -13.3438,  ...,  -27.3438,   51.7500,
            -23.9375],
          [  41.9375,    1.3125,  -48.3750,  ...,   26.8750,    4.8594,
             37.0000]]],


        [[[ -39.0000,  -14.6406,   39.0000,  ...,    7.6328,   38.6250,
            -46.0000],
          [   2.7344,   30.5938,    6.9062,  ...,    2.1406,  -56.5000,
            -73.6250],
          [  61.4375,  -47.3750,    1.5449,  ...,   76.2500,  -19.2812,
            -42.3125],
          ...,
          [   3.9766,  -16.0938,  -13.7969,  ...,  -35.0000,   61.1875,
            -70.7500],
          [  16.1562,    9.0312,    5.0156,  ...,  -28.8438,   16.3125,
             31.5000],
          [  39.5625,  -12.7500,  -15.6719,  ...,  -50.3125,  -24.1562,
             52.8750]],

         [[  34.5000,  -35.4375,  -54.6250,  ...,   73.6250,   38.1250,
             27.7812],
          [  -9.9375,  -18.1562,   10.1406,  ...,   39.7500,   86.2500,
            -50.5000],
          [ -10.3281,  -48.8125,  -11.0000,  ...,  -48.9375,  -39.3750,
             29.1562],
          ...,
          [  13.3594,   27.2500,  -41.2500,  ...,   -9.1094,    6.5312,
             52.1875],
          [  52.3750,   -2.6250,  -61.5000,  ...,   40.0000,   -2.7461,
             16.9062],
          [  24.8438,    8.8125,  -14.3906,  ...,  -19.1250,    7.6562,
             48.6875]]]], dtype=torch.float16, device='spyre:0')

```

#### Does this PR introduce a user-facing change?

#### Additional note:
