### PR TITLE
Add missing tests to test config

### DIFF
--- a/tests/configs/torch_spyre_tests/test_spyre_profiler_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_spyre_profiler_config.yaml
@@ -16,3 +16,7 @@ test_suite_config:
             - TestSpyreProfiler::test_event_list
             - TestSpyreProfiler::test_profiler_timestamp_consistency
           mode: mandatory_success
+        - names:
+            - TestMemoryProfilerTimeline::test_memory_timeline_no_id_spyre
+            - TestMemoryProfilerTimeline::test_memory_timeline_no_id_cpu
+          mode: mandatory_success


### PR DESCRIPTION
#### What type of PR is this?

- [X] bug

#### What this PR does:

This PR addresses a regression in #2958 that introduced new tests without updating the test configuration accordingly.