### PR TITLE
fix(inductor): reject reversed index terms and support Tensor.flip

### DIFF
--- a/docs/source/user_guide/supported_operations.md
+++ b/docs/source/user_guide/supported_operations.md
@@ -91,6 +91,7 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.repeat` | | Y | Spyre | Compiled only. `repeat.out` is available as a CPU fallback |
 | `torch.unbind` | Y | Y | Spyre | |
 | `torch.Tensor.unfold` | Y | Y | Spyre | View op |
+| `torch.flip` | Y | Y | Spyre | Custom decomposition to `index_select` gathers; reversing the last (stick) dimension is unsupported and raises |
 | `torch.split` | | Y | Spyre | Compiled only (lowers via `aten.slice`) |
 | `torch.expand` | | Y | Spyre | Compiled only; supported when followed by a materializing op (e.g. `clone`, `contiguous`). Used internally by `ones`, `pad`, and SDPA decompositions |
 | `torch.narrow` / `torch.select` | | Y | Spyre | Compiled only; basic slicing works (see `test_slice` / `test_split`); broader `narrow`/`select` coverage in development |

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_shape_b_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_shape_b_config.yaml
@@ -17,6 +17,9 @@ test_suite_config:
         - names:
             # shape ops
             - TestOps::test_flatten.*
+            # flip: non-stick dims reverse via index_select; the stick-dim
+            # cases are strict xfails inside the test itself
+            - TestOps::test_flip.*
             - TestOps::test_permute.*
             - TestOps::test_unbind.*
             - TestOps::test_size_one.*

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1314,6 +1314,28 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             ),
             "expect_fail": ["49159x4096"],
         },
+        # Reversal along a non-stick dim works; the stick (last) dim needs a
+        # gather along the stick dimension, which the backend cannot do, and
+        # a rank-1 flip is always a stick-dim flip. Before issue #3558 the
+        # dim-0 cases compiled clean and returned the last slice broadcast
+        # over the whole axis.
+        ("test_flip", "test_flip_cpu"): {
+            "param_sets": {
+                "2d_dim_0": ([0], cached_randn((67, 256))),
+                "2d_dim_neg2": ([-2], cached_randn((67, 256))),
+                "2d_dim_0_aligned": ([0], cached_randn((64, 256))),
+                "3d_dim_0": ([0], cached_randn((3, 5, 256))),
+                "3d_dim_1": ([1], cached_randn((3, 5, 256))),
+                "3d_dim_0_1": ([0, 1], cached_randn((3, 5, 256))),
+                "4d_dim_0_2": ([0, 2], cached_randn((2, 3, 5, 256))),
+                "2d_size1_dim_0": ([0], cached_randn((1, 256))),
+                "2d_no_dims": ([], cached_randn((67, 256))),
+                # Stick-dim reversals: unsupported, but must fail loudly.
+                "2d_dim_1_stick": ([1], cached_randn((67, 256))),
+                "1d_stick": ([0], cached_randn((256,))),
+            },
+            "expect_fail": ["2d_dim_1_stick", "1d_stick"],
+        },
         ("test_transpose_2d", "test_transpose_2d_cpu"): {
             "param_sets": {
                 "dim_0_2": (
@@ -5567,6 +5589,13 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
     def test_t_2d_contiguous_cpu(self, x):
         # Note: .contiguous() causes issues with eager mode, see https://github.com/torch-spyre/torch-spyre/issues/1149
         self.compare_with_cpu(lambda x: x.t().contiguous(), x, run_eager=False)
+
+    @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
+    def test_flip_cpu(self, dims, x):
+        # Spyre decomposes aten.flip into index_select gathers with a
+        # descending index (see spyre_flip); the arange building that index
+        # falls back to CPU, hence the filtered FallbackWarning.
+        self.compare_with_cpu(lambda x: torch.flip(x, dims), x)
 
     def test_transpose_2d_cpu(self, dim0: int, dim1: int, x):
         self.compare_with_cpu(lambda x: torch.transpose(x, dim0, dim1), x)

--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -256,6 +256,48 @@ class TestUnrepresentableStickCandidates(TestCase):
         d2 = sympy.Symbol("d2", integer=True, nonnegative=True)
         self.assertEqual(device_coordinates(good, dep, None)[-1].free_symbols, {d2})
 
+    def test_reversed_dim_rejected(self):
+        # prims.rev / Tensor.flip(0) on a (4, 64) tensor reads
+        # x[64*(3 - p0) + p1], i.e. p0 carries a negative coefficient.  No
+        # device coordinate can walk a dim backwards, and the term used to be
+        # dropped silently, leaving coord=3 for every p0 (issue #3558).
+        with self.assertRaisesRegex(Unsupported, "runs backwards"):
+            compute_coordinates(
+                [4, 64],
+                [64, 1],
+                {p0: 4, p1: 64},
+                192 - 64 * p0 + p1,
+            )
+
+        # Same for a reversal of the innermost (stick) dim.
+        with self.assertRaisesRegex(Unsupported, "runs backwards"):
+            compute_coordinates(
+                [4, 64],
+                [64, 1],
+                {p0: 4, p1: 64},
+                64 * p0 - p1 + 63,
+            )
+
+        # The guard keys off the direction of travel, not the sign of ``step``:
+        # an ascending term whose ``step`` is dragged negative by a constant
+        # folded into it must still be accepted.
+        cx = compute_coordinates(
+            [4, 64],
+            [64, 1],
+            {p0: 4, p1: 64},
+            64 * p0 + p1 - 5,
+        )
+        self.assertEqual(len(cx), 2)
+
+        # The ordinary ascending access is untouched.
+        cx = compute_coordinates(
+            [4, 64],
+            [64, 1],
+            {p0: 4, p1: 64},
+            64 * p0 + p1,
+        )
+        self.assertEqual(cx, [p0, p1])
+
     def test_check_supported_input_sticks_tolerates_mixed_list(self):
         # arg with one unrepresentable candidate and one valid one: the guard
         # must not raise (it previously aborted the whole compile).

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -837,6 +837,52 @@ def spyre_quantize_weight_fp8_with_scale(
     return torch.ops.spyre.qfp8wt(x_clamped)
 
 
+@register_spyre_decompositions([torch.ops.aten.flip.default])
+def spyre_flip(input: torch.Tensor, dims: Sequence[int]) -> torch.Tensor:
+    """Reverse ``input`` along each dim in ``dims`` using gathers.
+
+    Inductor's default decomposition of ``aten.flip`` is ``prims.rev``, whose
+    index expression walks the reversed dim backwards (``N - 1 - i``). Device
+    coordinates can only ascend, so that form is not lowerable on Spyre —
+    ``compute_coordinates`` rejects it. The same reversal expressed as an
+    ``index_select`` with a descending index tensor is an ordinary gather,
+    which the backend does support: the descending order lives in the index
+    *values* rather than in the access pattern.
+
+    Registering the aten op also installs the PrivateUse1 kernel, so this is
+    what eager ``Tensor.flip`` dispatches to as well (there is no
+    ``aten::flip`` kernel for Spyre otherwise).
+    """
+    # Replacing the op means aten.flip's own argument validation no longer
+    # runs, so repeat it here rather than silently accepting a program aten
+    # rejects. Out-of-range dims still raise from ``size()`` below.
+    seen: set[int] = set()
+    for dim in dims:
+        normalized = dim + input.dim() if dim < 0 else dim
+        if normalized in seen:
+            raise RuntimeError(
+                f"dim {normalized} appears multiple times in the list of dims"
+            )
+        seen.add(normalized)
+
+    out = input
+    reversed_any = False
+    for dim in dims:
+        # A 0-d tensor accepts flip(0) and is its own reversal; ``size(0)``
+        # would raise on it, so skip before asking.
+        size = 1 if input.dim() == 0 else out.size(dim)
+        if size <= 1:
+            # A dim of size 0 or 1 is its own reversal; index_select would
+            # still work, but skipping avoids an empty/degenerate gather.
+            continue
+        index = torch.arange(size - 1, -1, -1, device=out.device, dtype=torch.int32)
+        out = torch.index_select(out, dim, index)
+        reversed_any = True
+    # aten.flip always returns a fresh tensor; clone so the no-op case does
+    # not alias its input.
+    return out if reversed_any else out.clone()
+
+
 @register_spyre_decompositions([torch.ops.aten.prod.dim_int])
 def spyre_prod_dim_int(
     input: torch.Tensor, dim: int, keepdim: bool = False

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -151,6 +151,10 @@ def compute_coordinates(
     may contain symbolic expressions (e.g. a dynamic batch dimension); the
     algorithm concretizes range values only for comparison logic, while the
     output coordinate expressions remain symbolic.
+
+    Raises ``Unsupported`` if ``index`` walks a dimension backwards (a loop
+    variable with a negative coefficient, as produced by ``prims.rev``): a
+    device coordinate can only ascend.
     """
     assert all(isinstance(s, (int, sympy.Integer)) for s in stride), (
         f"compute_coordinates requires concrete strides, got {stride}"
@@ -185,6 +189,26 @@ def compute_coordinates(
         # TODO(issue#1373): replace with sympy predicates to avoid concretization.
         concrete_step = _concretize_for_cmp(step)
         concrete_limit = _concretize_for_cmp(limit)
+
+        # ``limit`` below ``step`` means the access walks the dimension
+        # backwards (the index carries a term like ``N - 1 - var``, as
+        # ``prims.rev`` / ``Tensor.flip`` produces).  Every dim test below
+        # compares a non-negative ``stride[dim]`` against ``concrete_step``, so
+        # a descending term can match no dim and would be dropped from
+        # ``coordinates`` entirely -- silently yielding the coordinate for
+        # ``var == 0`` at every iteration.  Device coordinates can only ascend,
+        # so reject it loudly instead (see issue #3558).
+        #
+        # Testing ``limit - step`` rather than ``step``'s sign isolates the
+        # direction from any additive constant folded into both: for a term
+        # ``a*var + b`` over range ``R``, ``limit - step == a*(R - 1)``, so the
+        # comparison sees ``a``'s sign alone.
+        if concrete_limit < concrete_step:
+            raise Unsupported(
+                f"index term for {var} runs backwards (step {step}, limit "
+                f"{limit}): reversed traversal of a tensor dimension cannot "
+                f"be expressed as a device coordinate"
+            )
 
         # find primary dim with largest stride less than or equal to step
         primary_stride = 0


### PR DESCRIPTION
Fixes #3558.

## The issue

`Tensor.flip(0)` on a rank >= 2 tensor compiled clean under `torch.compile` and returned the last slice broadcast over the whole axis instead of a reversal.

## Root cause

Not a hole in the layout guard. `compute_coordinates` (`_inductor/views.py`) maps an index expression onto device coordinates by matching each loop variable's step against the dimension strides, which are non-negative:

```python
if st <= concrete_step and st > primary_stride:    # never: st > 0 > step
elif st > concrete_step and st < concrete_limit:   # never: limit is negative
```

`flip(0)` on `(4,64)` reads `x[64*(3 - c0) + c1]`. The constant offset `192` is stripped first (correctly becoming the `+3`), then `c0` arrives with `step = -64`, `limit = -256`, matches no dimension, and is **dropped from the coordinate list without a word**. The emitted OpSpec shows it: input `device_coordinates=[0, floor(c1/32), z0 + 3, Mod(c1,32)]`, where `z0` is a size-1 axis — so dim 0 is pinned at `3` for every iteration.

`flip(1)` and rank-1 `flip(0)` already raised only incidentally: those reverse the *stick* dimension, which trips a different check first.

## Changes

**`views.py` — close the hole.** `add_term` raises `Unsupported` when a term travels backwards, so no descending access can be silently dropped again. The test is `limit < step` rather than `step < 0`: for a term `a*var + b` over range `R`, `limit - step == a*(R - 1)`, so it sees the coefficient's sign alone. That is narrower than a sign test (an ascending term whose `step` is dragged negative by a constant is still accepted) and wider (it also catches a reversed stick dim, where `step` stays positive).

**`decompositions.py` — make flip work.** Rather than only turning wrong answers into an error, `aten.flip` now decomposes to `index_select` with a descending index. The reversal moves into the index *values* instead of the access pattern, which is an ordinary gather the backend supports. Registering the aten op also installs the PrivateUse1 kernel, so eager `Tensor.flip` works too (previously `NotImplementedError` — there was no `aten::flip` kernel for Spyre at all). It repeats aten's duplicate-dim validation, which replacing the op would otherwise skip.

## Results

Verified on a real card. The reporter's repro script from the issue passes verbatim (2 passed); every `WRONG` row became `ok`:

| case | before | after |
|---|---|---|
| `(4,64).flip(0)`, `(2,64)`, `(3,64)`, `(2,4,64)` | silently wrong | **exact** |
| `(2,4,64).flip(1)`, `flip([0,1])`, `(3,5,64).flip([0,1])` | silently wrong | **exact** |
| eager `(4,64).flip(0)` | `NotImplementedError` | **exact** |
| `(4,64).flip(1)`, `(64,).flip(0)`, `fliplr` — stick dim | InductorError | InductorError (still unsupported, still loud) |

Reversing the last dimension needs a gather along the stick dimension, which the backend cannot do, so those still raise — the issue's stated fallback ask.

## Tests

- `tests/tensor/test_coordinates.py::test_reversed_dim_rejected` — unit test for the guard, including that an ascending term with a negative additive constant is still accepted.
- `tests/inductor/test_inductor_ops.py` — 11 `test_flip_*` cases (dim 0/1, rank 2–4, multi-dim, negative dim, size-1 dim, empty dims). Each runs compiled *and* eager against CPU. The two stick-dim cases are strict `expect_fail`, so whoever enables stick-dim gather is told to update them.
- Docs: `supported_operations.md` row added.