### PR TITLE
Support rescaling scaled_mm output

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -398,20 +398,25 @@ _SCALED_MM_SHAPES = [
 
 # scale_a, scale_b
 _SCALED_MM_PARAMS = [
-    (1.0, 1.0),
+    (1.0, 1.0, 0.0),   # unit scales, no bias — baseline
+    (2.0, 1.0, 0.0),   # non-unit scale_a
+    (1.0, 3.0, 0.0),   # non-unit scale_b
+    (2.0, 3.0, 0.0),   # both non-unit scales
+    (1.0, 1.0, 5.0),   # unit scales with bias
+    (2.0, 3.0, 0.5),   # non-unit scales with bias
 ]
 
 SCALED_MM_TESTS = {
-    f"{shapes2key([shape])}_{sa}_{sb}": (
+    f"{shapes2key([shape])}_{sa}_{sb}_{b}": (
         torch.rand((shape[0], shape[1]), dtype=torch.float16),
         torch.rand((shape[1], shape[2]), dtype=torch.float16),
         torch.tensor(sa, dtype=torch.float16),
         torch.tensor(sb, dtype=torch.float16),
+        torch.tensor(b, dtype=torch.float16),
     )
     for shape in _SCALED_MM_SHAPES
-    for sa, sb in _SCALED_MM_PARAMS
+    for sa, sb, b in _SCALED_MM_PARAMS
 }
-
 FP32_EPS = torch.finfo(torch.float32).eps  # 1.1920928955078125e-07
 FP16_EPS = torch.finfo(torch.float16).eps  # 0.0009765625
 
@@ -6741,17 +6746,17 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             run_eager=False,
         )
 
-    def test_fp8_scaled_mm_cpu(self, a, b, scale_a, scale_b):
+    def test_fp8_scaled_mm_cpu(self, a, b, scale_a, scale_b, bias):
         """Test _scaled_mm with FP8 inputs."""
 
-        def spyre_fn(a, b, scale_a, scale_b):
+        def spyre_fn(a, b, scale_a, scale_b, bias):
             q_a = torch.ops.spyre.quantize_fp8_with_scale(a, scale_a)
             q_b = torch.ops.spyre.quantize_weight_fp8_with_scale(b, scale_b)
             return torch.ops.aten._scaled_mm(
-                q_a, q_b, scale_a=None, scale_b=None, bias=None, out_dtype=torch.float16
+                q_a, q_b, scale_a=scale_a, scale_b=scale_b, bias=bias, out_dtype=torch.float16
             )
 
-        def pytorch_fn(a, b, scale_a, scale_b):
+        def pytorch_fn(a, b, scale_a, scale_b, bias):
             q_a = (
                 (a / scale_a)
                 .clamp(-448.0, 448.0)
@@ -6764,10 +6769,10 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 .to(torch.float8_e4m3fn)
                 .to(torch.float16)
             )
-            return (q_a @ q_b) * (scale_a * scale_b)
+            return (q_a @ q_b) * (scale_a * scale_b) + bias
 
         compare_with_pytorch(
-            spyre_fn, pytorch_fn, a, b, scale_a, scale_b, atol=0.1, rtol=0.1
+            spyre_fn, pytorch_fn, a, b, scale_a, scale_b, bias, atol=0.1, rtol=0.1
         )
 
     def test_is_nonzero_cpu(self, *args):

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -398,12 +398,12 @@ _SCALED_MM_SHAPES = [
 
 # scale_a, scale_b
 _SCALED_MM_PARAMS = [
-    (1.0, 1.0, 0.0),   # unit scales, no bias — baseline
-    (2.0, 1.0, 0.0),   # non-unit scale_a
-    (1.0, 3.0, 0.0),   # non-unit scale_b
-    (2.0, 3.0, 0.0),   # both non-unit scales
-    (1.0, 1.0, 5.0),   # unit scales with bias
-    (2.0, 3.0, 0.5),   # non-unit scales with bias
+    (1.0, 1.0, 0.0),  # unit scales, no bias — baseline
+    (2.0, 1.0, 0.0),  # non-unit scale_a
+    (1.0, 3.0, 0.0),  # non-unit scale_b
+    (2.0, 3.0, 0.0),  # both non-unit scales
+    (1.0, 1.0, 5.0),  # unit scales with bias
+    (2.0, 3.0, 0.5),  # non-unit scales with bias
 ]
 
 SCALED_MM_TESTS = {
@@ -6753,7 +6753,12 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             q_a = torch.ops.spyre.quantize_fp8_with_scale(a, scale_a)
             q_b = torch.ops.spyre.quantize_weight_fp8_with_scale(b, scale_b)
             return torch.ops.aten._scaled_mm(
-                q_a, q_b, scale_a=scale_a, scale_b=scale_b, bias=bias, out_dtype=torch.float16
+                q_a,
+                q_b,
+                scale_a=scale_a,
+                scale_b=scale_b,
+                bias=bias,
+                out_dtype=torch.float16,
             )
 
         def pytorch_fn(a, b, scale_a, scale_b, bias):

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -716,8 +716,8 @@ def _(input: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
     return torch.empty(input.size(), dtype=torch.float16, device=input.device)
 
 
-@torch.library.custom_op("spyre::fp8_scaled_mm", mutates_args=(), device_types="spyre")
-def fp8_scaled_mm(
+@torch.library.custom_op("spyre::scaled_mm", mutates_args=(), device_types="spyre")
+def scaled_mm(
     mat1: torch.Tensor, mat2: torch.Tensor, out_dtype: torch.dtype = None
 ) -> torch.Tensor:  # type: ignore[empty-body]
     """
@@ -731,7 +731,7 @@ def fp8_scaled_mm(
     pass
 
 
-@fp8_scaled_mm.register_fake
+@scaled_mm.register_fake
 def _(
     mat1: torch.Tensor, mat2: torch.Tensor, out_dtype: torch.dtype = None
 ) -> torch.Tensor:

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -716,6 +716,29 @@ def _(input: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
     return torch.empty(input.size(), dtype=torch.float16, device=input.device)
 
 
+@torch.library.custom_op("spyre::fp8_scaled_mm", mutates_args=(), device_types="spyre")
+def fp8_scaled_mm(
+    mat1: torch.Tensor, mat2: torch.Tensor, out_dtype: torch.dtype = None
+) -> torch.Tensor:  # type: ignore[empty-body]
+    """
+    Raw FP8 matrix multiplication, with no scaling or bias applied.
+
+    Scaling (scale_a, scale_b) and bias are intentionally NOT applied here -
+    they're applied afterward at the decomposition level by scaled_mm_decomp,
+    mirroring how dequantize_fp8_with_scale keeps its FP8->FP16 conversion
+    separate from the subsequent scale multiply.
+    """
+    pass
+
+
+@fp8_scaled_mm.register_fake
+def _(
+    mat1: torch.Tensor, mat2: torch.Tensor, out_dtype: torch.dtype = None
+) -> torch.Tensor:
+    output_shape = [mat1.shape[0], mat2.shape[-1]]
+    return mat1.new_empty(output_shape, dtype=out_dtype or torch.float16)
+
+
 @torch.library.custom_op(
     "spyre::quantize_weight_fp8_with_scale", mutates_args=(), device_types="spyre"
 )

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -799,7 +799,7 @@ def scaled_mm_decomp(
 ) -> torch.Tensor:
     """
     Decompose _scaled_mm into:
-    1. Raw FP8 matmul via spyre.fp8_scaled_mm (no scale/bias applied)
+    1. Raw FP8 matmul via spyre.scaled_mm (no scale/bias applied)
     2. Multiply by scale_a, if present
     3. Multiply by scale_b, if present
     4. Add bias, if present
@@ -809,7 +809,7 @@ def scaled_mm_decomp(
     separation dequantize_fp8_with_scale_decomp uses for its FP8->FP16
     conversion.
     """
-    result = torch.ops.spyre.fp8_scaled_mm(mat1, mat2, out_dtype=out_dtype)
+    result = torch.ops.spyre.scaled_mm(mat1, mat2, out_dtype=out_dtype)
 
     if scale_a is not None:
         result = result * scale_a

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -34,11 +34,14 @@ import torch._decomp as decomp
 
 from .constants import DEVICE_NAME, FP8_E4M3FN_MAX, FP8_E4M3FN_MIN
 from .errors import Unsupported
+from .logging_utils import get_inductor_logger
 
 from . import customops  # noqa: F401
 from . import spyre_hint
 from torch_spyre._C import DataFormats, get_device_dtype
 import torch_spyre._inductor.customops  # noqa: F401
+
+logger = get_inductor_logger("decompositions")
 
 
 # Determine the float dtype for bool at module load time (not during tracing)
@@ -781,6 +784,46 @@ def dequantize_fp8_with_scale_decomp(
     """
     x_fp16 = input.to(torch.float16)
     return x_fp16 * scale
+
+
+@register_spyre_decompositions([torch.ops.aten._scaled_mm.default])
+def scaled_mm_decomp(
+    mat1: torch.Tensor,
+    mat2: torch.Tensor,
+    scale_a: torch.Tensor = None,
+    scale_b: torch.Tensor = None,
+    bias: torch.Tensor = None,
+    scale_result: torch.Tensor = None,
+    out_dtype: torch.dtype = None,
+    use_fast_accum: bool = False,
+) -> torch.Tensor:
+    """
+    Decompose _scaled_mm into:
+    1. Raw FP8 matmul via spyre.fp8_scaled_mm (no scale/bias applied)
+    2. Multiply by scale_a, if present
+    3. Multiply by scale_b, if present
+    4. Add bias, if present
+
+    This decomposition is executed during compilation and keeps scale/bias
+    arithmetic out of lower_scaled_mm's matmul lowering - the same
+    separation dequantize_fp8_with_scale_decomp uses for its FP8->FP16
+    conversion.
+    """
+    result = torch.ops.spyre.fp8_scaled_mm(mat1, mat2, out_dtype=out_dtype)
+
+    if scale_a is not None:
+        result = result * scale_a
+    if scale_b is not None:
+        result = result * scale_b
+    if bias is not None:
+        result = result + bias
+
+    if scale_result is not None:
+        logger.warning("scale_result parameter in _scaled_mm is not yet supported")
+    if use_fast_accum:
+        logger.warning("use_fast_accum parameter in _scaled_mm is not yet supported")
+
+    return result
 
 
 @register_spyre_decompositions([torch.ops.aten.where.ScalarOther])

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -330,7 +330,7 @@ def _ensure_synthetic_origin(result, target, args: tuple) -> None:
     buf.origins = OrderedSet([fx_node])
 
 
-@register_spyre_lowering(torch.ops.aten._scaled_mm.default)
+@register_spyre_lowering(torch.ops.aten._scaled_mm.default, type_promotion_kind=None)
 def lower_scaled_mm(
     mat1,
     mat2,
@@ -341,16 +341,6 @@ def lower_scaled_mm(
     out_dtype=None,
     use_fast_accum=False,
 ):
-    if scale_a is not None:
-        raise Unsupported("scale_a parameter in _scaled_mm is not yet supported")
-    if scale_b is not None:
-        raise Unsupported("scale_b parameter in _scaled_mm is not yet supported")
-    if bias is not None:
-        raise Unsupported("bias parameter in _scaled_mm is not yet supported")
-    if scale_result is not None:
-        raise Unsupported("scale_result parameter in _scaled_mm is not yet supported")
-    if use_fast_accum:
-        raise Unsupported("use_fast_accum parameter in _scaled_mm is not yet supported")
 
     mat1.realize()
     mat2.realize()
@@ -417,6 +407,29 @@ def lower_scaled_mm(
     )
 
     result.realize()
+
+    # Apply activation scale
+    if scale_a is not None:
+        scale_a.realize()
+        result = lowering.mul(result, scale_a)
+        result.realize()
+
+    # Apply weight scale
+    if scale_b is not None:
+        scale_b.realize()
+        result = lowering.mul(result, scale_b)
+        result.realize()
+
+    # Apply bias
+    if bias is not None:
+        bias.realize()
+        result = lowering.add(result, bias)
+        result.realize()
+
+    if scale_result is not None:
+        logger.warning("scale_result parameter in _scaled_mm is not yet supported")
+    if use_fast_accum:
+        logger.warning("use_fast_accum parameter in _scaled_mm is not yet supported")
 
     if logger.isEnabledFor(logging.DEBUG):
         result_buf = V.graph.get_buffer(result.get_name())

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -330,16 +330,11 @@ def _ensure_synthetic_origin(result, target, args: tuple) -> None:
     buf.origins = OrderedSet([fx_node])
 
 
-@register_spyre_lowering(torch.ops.aten._scaled_mm.default, type_promotion_kind=None)
-def lower_scaled_mm(
+@register_spyre_lowering(torch.ops.spyre.fp8_scaled_mm.default)
+def lower_fp8_scaled_mm(
     mat1,
     mat2,
-    scale_a=None,
-    scale_b=None,
-    bias=None,
-    scale_result=None,
     out_dtype=None,
-    use_fast_accum=False,
 ):
     mat1.realize()
     mat2.realize()
@@ -407,33 +402,10 @@ def lower_scaled_mm(
 
     result.realize()
 
-    # Apply activation scale
-    if scale_a is not None:
-        scale_a.realize()
-        result = lowering.mul(result, scale_a)
-        result.realize()
-
-    # Apply weight scale
-    if scale_b is not None:
-        scale_b.realize()
-        result = lowering.mul(result, scale_b)
-        result.realize()
-
-    # Apply bias
-    if bias is not None:
-        bias.realize()
-        result = lowering.add(result, bias)
-        result.realize()
-
-    if scale_result is not None:
-        logger.warning("scale_result parameter in _scaled_mm is not yet supported")
-    if use_fast_accum:
-        logger.warning("use_fast_accum parameter in _scaled_mm is not yet supported")
-
     if logger.isEnabledFor(logging.DEBUG):
         result_buf = V.graph.get_buffer(result.get_name())
         logger.debug(
-            f"_scaled_mm (FP8): mat1{[int(s) for s in mat1_size]} @ mat2{[int(s) for s in mat2_size]} "
+            f"fp8_scaled_mm: mat1{[int(s) for s in mat1_size]} @ mat2{[int(s) for s in mat2_size]} "
             f"-> {[int(s) for s in result_buf.get_size()]}, "
             f"mat1_dtype={mat1_dtype}, mat2_dtype={mat2_dtype}, out_dtype={output_dtype}"
         )

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -330,8 +330,8 @@ def _ensure_synthetic_origin(result, target, args: tuple) -> None:
     buf.origins = OrderedSet([fx_node])
 
 
-@register_spyre_lowering(torch.ops.spyre.fp8_scaled_mm.default)
-def lower_fp8_scaled_mm(
+@register_spyre_lowering(torch.ops.spyre.scaled_mm.default)
+def lower_scaled_mm(
     mat1,
     mat2,
     out_dtype=None,
@@ -405,7 +405,7 @@ def lower_fp8_scaled_mm(
     if logger.isEnabledFor(logging.DEBUG):
         result_buf = V.graph.get_buffer(result.get_name())
         logger.debug(
-            f"fp8_scaled_mm: mat1{[int(s) for s in mat1_size]} @ mat2{[int(s) for s in mat2_size]} "
+            f"scaled_mm: mat1{[int(s) for s in mat1_size]} @ mat2{[int(s) for s in mat2_size]} "
             f"-> {[int(s) for s in result_buf.get_size()]}, "
             f"mat1_dtype={mat1_dtype}, mat2_dtype={mat2_dtype}, out_dtype={output_dtype}"
         )

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -341,7 +341,6 @@ def lower_scaled_mm(
     out_dtype=None,
     use_fast_accum=False,
 ):
-
     mat1.realize()
     mat2.realize()
     mat1_loader = mat1.make_loader()


### PR DESCRIPTION


Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds support for applying FP8 scaling factors and bias in aten._scaled_mm lowering.

Previously, lower_scaled_mm raised Unsupported when scale_a, scale_b, or bias were provided, preventing FP8 workflows from supplying runtime-computed scaling factors.

This PR:

- Removes Unsupported exceptions for scale_a, scale_b, and bias
- Applies scale_a and scale_b as post-matmul multiplications on the result tensor
- Applies bias as a post-matmul addition
- Replaces hard failures for scale_result and use_fast_accum with warnings to preserve forward compatibility

The resulting computation is:

result = (mat1 @ mat2) * scale_a * scale_b + bias

#### Which issue(s) this PR is related to:

Prerequisite for end-to-end FP8 dynamic quantization inference on Spyre. Related to the broader FP8 integration work alongside #2286 (FP8 scaled MM SDSC codegen) and #2401 (FP8 quantization/dequantization ops).


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

Yes. FP8 workflows using torch._scaled_mm with dynamic scale_a/scale_b will no longer fail at compile time with Unsupported. Users can now call spyre.compute_fp8_scale(tensor) to compute a per-tensor FP8 scale and pass it through to _scaled_mm.

#### Additional note:
