### PR TITLE
Remove per_tile_fixed in favor of loop_info as sole source of truth

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -3840,7 +3840,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         )
 
     # ------------------------------------------------------------------
-    # Loop-invariant (broadcast) op gets per_tile_fixed=True
+    # Loop-invariant (broadcast) op's own write does not advance
     # ------------------------------------------------------------------
 
     @config.patch(
@@ -3849,14 +3849,25 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             "allow_all_ops_in_lx_planning": True,
         }
     )
-    def test_loop_invariant_op_per_tile_fixed_in_sdsc(self):
-        """A loop-invariant ComputedBuffer inside a coarse-tile group must have
-        per_tile_fixed=True in the generated SDSC source, so the unroller does
+    def test_loop_invariant_op_write_does_not_advance_in_sdsc(self):
+        """A loop-invariant ComputedBuffer's own write inside a coarse-tile
+        group must never get a device_tile_advance_expr, so the unroller does
         not advance its address.
 
         torch.full lowers to a scalar-fill ComputedBuffer with no loop var matching
         the hinted dim.  Its loop_tiled_dims are all-empty, making it loop-invariant
-        w.r.t. the tiling.  finalize_layouts must stamp per_tile_fixed=True on it.
+        w.r.t. the tiling, so its own write's TensorArg carries no
+        device_tile_advance_expr at all (that field is only present on
+        references that actually advance per tile).
+
+        There is no per-TensorArg identifying token in the debug dump today
+        to isolate the fill's own write in isolation (out of scope to add
+        one here), so this asserts a stable *count* of
+        device_tile_advance_expr occurrences across the whole kernel instead:
+        the fill's own write is fixed (0 occurrences), its read by the tiled
+        add advances (1), the add's own write to the copy-out target advances
+        (1), and the final write-back copy-out advances (1) -- 3 total, with
+        none attributable to the fill's own write.
         """
         from torch_spyre._inductor import spyre_hint
 
@@ -3882,10 +3893,32 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         ):
             _, source_codes = run_and_get_code(cfn, x_dev)
         src = source_codes[0]
-        self.assertIn(
-            "per_tile_fixed=True",
+        fill_op_match = re.search(
+            r"ir_chain=\('full_default', '(\w+)'\).*?args=\[\s*"
+            r"TensorArg\((?:(?!TensorArg\().)*?\),\s*"
+            r"TensorArg\(((?:(?!TensorArg\().)*?)\)\s*\]",
             src,
-            "Loop-invariant (scalar-fill) buffer must have per_tile_fixed=True in SDSC",
+            re.DOTALL,
+        )
+        self.assertTrue(
+            fill_op_match,
+            "Expected to find the torch.full fill's OpSpec (ir_chain "
+            "'full_default') with its own write as the second TensorArg",
+        )
+        self.assertNotIn(
+            "device_tile_advance_expr",
+            fill_op_match.group(2),
+            "The loop-invariant fill's own write must not advance per tile, "
+            f"got: {fill_op_match.group(2)}",
+        )
+        self.assertEqual(
+            src.count("device_tile_advance_expr="),
+            3,
+            "Expected exactly 3 advancing references in this kernel (the "
+            "fill's read by the tiled add, the add's own write, and the "
+            "final copy-out) -- if this changes, some other reference's "
+            "fixed/advancing status changed too; investigate rather than "
+            "just updating the count.",
         )
 
     # ------------------------------------------------------------------
@@ -5273,14 +5306,19 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         # device layouts for H (e.g. the read-copy ops keep H outermost, while
         # op0/coarse_tile_copy_buf0's own layouts place H just before the D
         # stick) -- so the *value* of the coefficient is not the same across
-        # every op. What must hold for every op is that the coefficient equals
+        # every op, and even the *symbol name* for H's tiled iteration
+        # variable differs per op (c0 for ops using the shared/global
+        # iteration space, d0 for the read-copy ops' own local iteration
+        # space). What must hold for every op is that the coefficient equals
         # H's per-tile extent (8 // 2 == 4) times *that op's own*
         # device-element stride for H, derived structurally from its
         # device_size/device_coordinates (the device dim whose coordinate
-        # expression is exactly the tiled iteration symbol c0). The original
-        # bug instead advanced by a coefficient tied to Lq's extent/stride,
-        # which this per-op recomputation catches regardless of which layout
-        # a given op happens to commit to.
+        # expression is exactly that op's own tiled iteration symbol -- the
+        # first key of its own iteration_space dict, which always has H's
+        # per-tile extent of 4). The original bug instead advanced by a
+        # coefficient tied to Lq's extent/stride, which this per-op
+        # recomputation catches regardless of which layout or symbol family a
+        # given op happens to commit to.
 
         tiled_syms_matches = re.findall(r"tiled_symbols=\[(\[.*?\])\]", src, re.DOTALL)
         self.assertTrue(
@@ -5295,19 +5333,34 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             f"Expected a minted _tile_adv_* symbol in tiled_symbols, "
             f"got: {tiled_syms_matches}",
         )
-        tensor_arg_matches = re.findall(
-            r"TensorArg\((?:(?!TensorArg\().)*?"
-            r"device_size=\[([^\]]*)\],\s*"
-            r"device_coordinates=\[([^\]]*)\],(?:(?!TensorArg\().)*?"
-            r"device_tile_advance_expr=sympify\('([^']*)'\),",
+        op_spec_blocks = re.findall(
+            r"iteration_space=\{sympify\('(\w+)'\): \(sympify\('4'\), 1\).*?"
+            r"args=\[(.*?)\n\s*\]\n",
             src,
             re.DOTALL,
         )
         self.assertTrue(
+            op_spec_blocks,
+            "Expected an OpSpec with H's per-tile extent (4) as its first "
+            "iteration_space entry in generated source",
+        )
+        tensor_arg_matches = []
+        for h_sym, args_block in op_spec_blocks:
+            for device_size_str, coords_str, advance_expr in re.findall(
+                r"device_size=\[([^\]]*)\],\s*"
+                r"device_coordinates=\[([^\]]*)\],(?:(?!TensorArg\().)*?"
+                r"device_tile_advance_expr=sympify\('([^']*)'\),",
+                args_block,
+                re.DOTALL,
+            ):
+                tensor_arg_matches.append(
+                    (h_sym, device_size_str, coords_str, advance_expr)
+                )
+        self.assertTrue(
             tensor_arg_matches,
             "Expected TensorArg(...device_tile_advance_expr=...) in generated source",
         )
-        for device_size_str, coords_str, advance_expr in tensor_arg_matches:
+        for h_sym, device_size_str, coords_str, advance_expr in tensor_arg_matches:
             embedded_syms = re.findall(r"_tile_adv_\w+_lvl\d+", advance_expr)
             self.assertTrue(
                 embedded_syms,
@@ -5316,10 +5369,10 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             )
             device_size = [int(x.strip()) for x in device_size_str.split(",")]
             coord_exprs = re.findall(r"sympify\('([^']*)'\)", coords_str)
-            tiled_dim_positions = [i for i, c in enumerate(coord_exprs) if c == "c0"]
+            tiled_dim_positions = [i for i, c in enumerate(coord_exprs) if c == h_sym]
             self.assertTrue(
                 tiled_dim_positions,
-                f"Expected H's tiled iteration symbol c0 to appear bare in "
+                f"Expected H's tiled iteration symbol {h_sym} to appear bare in "
                 f"device_coordinates, got: {coord_exprs}",
             )
             device_stride = 1
@@ -6293,14 +6346,17 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
             "Expected tile-sized accum TensorArg with lx allocation for nested M+K tiling",
         )
 
-    def test_nested_matmul_accum_tile_per_tile_fixed_in_sdsc(self):
-        """Accumulator tile buffer in nested outer-M + inner-K reduction must have
-        per_tile_fixed=True in the generated SDSC source.
+    def test_nested_matmul_accum_tile_write_does_not_advance_in_sdsc(self):
+        """Accumulator tile buffer in nested outer-M + inner-K reduction must never
+        get a device_tile_advance_expr referencing the inner K-loop, so the
+        unroller does not advance its base address across inner iterations.
 
-        The accum_tile buffer is loop-internal to the inner K-loop, so the unroller
-        must not advance its base address across inner iterations.  This requires
-        _pending_per_tile_fixed to be set by _propagate_tiled_reduction_op (pre-
-        stickify path) and consumed by finalize_layouts.
+        The accum_tile buffer is loop-internal to the inner K-loop: it is read
+        and written every inner iteration by the combine op, but must stay at a
+        single fixed address throughout that loop (only the outer M-loop may
+        move it). This mirrors test_tile_accum_copy_advances_per_outer_tile's
+        unit-test-granularity check (no affine.apply referencing the inner loop
+        var) at full e2e granularity.
         """
         from torch_spyre._inductor import spyre_hint
 
@@ -6329,10 +6385,30 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
             _, source_codes = run_and_get_code(cfn, a_dev, b_dev)
         self.assertTrue(len(source_codes) > 0)
         src = source_codes[0]
-        self.assertIn(
-            "per_tile_fixed=True",
+
+        # The combine op (the inner-K-loop "add" that reads and writes the
+        # accum_tile buffer every inner iteration) is identified by its
+        # ir_chain -- its args list contains the accum_tile buffer twice
+        # (once as a read, once as the mutation-write). Neither reference
+        # may carry a device_tile_advance_expr: the accum_tile's address
+        # must stay fixed across the inner K-loop.
+        combine_op_match = re.search(
+            r"ir_chain=\('mm', 'coarse_tile_combine_\w+'\).*?"
+            r"args=\[(.*?)\n\s*\]\n",
             src,
-            "Nested-reduction accum_tile must have per_tile_fixed=True in SDSC",
+            re.DOTALL,
+        )
+        self.assertTrue(
+            combine_op_match,
+            "Expected to find the combine op's OpSpec (ir_chain "
+            "'coarse_tile_combine_*') in generated source",
+        )
+        combine_args = combine_op_match.group(1)
+        self.assertNotIn(
+            "device_tile_advance_expr",
+            combine_args,
+            "The accum_tile's read/write inside the combine op must not "
+            f"advance per inner-K-tile, got args: {combine_args}",
         )
 
 

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1937,132 +1937,6 @@ class TestCoarseTileTiledDimsPerRead(unittest.TestCase):
             plan_coarse_tile_groups(group_ops, [(group_ops, levels)])
 
 
-def _make_fixed_flag_op(
-    name,
-    tiled_dims_per_read,
-    output_tiled_dims,
-    pending_per_tile_fixed=False,
-    layout_per_tile_fixed=False,
-    read_names=(),
-):
-    """Return a ComputedBuffer mock carrying loop_info + a fixed-tile signal.
-
-    Mirrors _make_tiled_op/_make_consumer_op's MagicMock(spec=...) pattern
-    (see _make_rw_with_reads above) so isinstance(op, ComputedBuffer) and
-    isinstance(dep, MemoryDep) both hold without needing real IR.
-    """
-    from torch._inductor.ir import ComputedBuffer, FixedLayout, Pointwise
-
-    data = MagicMock(spec=Pointwise)
-    data.ranges = [Integer(16)]
-
-    op = MagicMock(spec=ComputedBuffer)
-    op.data = data
-    op.get_operation_name.return_value = name
-    op.get_name.return_value = name
-    op.loop_info = CoarseTileInfo(
-        loop_group_id=(0,),
-        loop_count=[Integer(4)],
-        loop_tiled_dims=[[0]],
-        tiled_dims_per_read=[list(entry) for entry in tiled_dims_per_read],
-        output_tiled_dims=list(output_tiled_dims),
-    )
-    op.get_read_writes.return_value = _make_rw_with_reads(*read_names)
-    if layout_per_tile_fixed:
-        layout = MagicMock(spec=FixedLayout)
-        layout.per_tile_fixed = True
-        op.layout = layout
-    else:
-        op.layout = MagicMock(spec=FixedLayout)
-        del op.layout.per_tile_fixed
-    if pending_per_tile_fixed:
-        op._pending_per_tile_fixed = True
-    else:
-        del op._pending_per_tile_fixed
-    op.origins = OrderedSet()
-    return op
-
-
-class TestZeroFixedTileAdvanceExprs(unittest.TestCase):
-    """Unit tests for _zero_fixed_tile_advance_exprs."""
-
-    def test_no_fixed_ops_is_noop(self):
-        from torch_spyre._inductor.wsr.coarse_tile import _zero_fixed_tile_advance_exprs
-
-        op = _make_fixed_flag_op(
-            "op0",
-            tiled_dims_per_read=[[[(0, Integer(4))]]],
-            output_tiled_dims=[[(0, Integer(4))]],
-        )
-        _zero_fixed_tile_advance_exprs([op])
-        self.assertEqual(op.loop_info.tiled_dims_per_read[0], [[(0, Integer(4))]])
-        self.assertEqual(op.loop_info.output_tiled_dims, [[(0, Integer(4))]])
-
-    def test_pending_per_tile_fixed_zeros_own_output(self):
-        from torch_spyre._inductor.wsr.coarse_tile import _zero_fixed_tile_advance_exprs
-
-        op = _make_fixed_flag_op(
-            "op0",
-            tiled_dims_per_read=[],
-            output_tiled_dims=[[(0, Integer(4))]],
-            pending_per_tile_fixed=True,
-        )
-        _zero_fixed_tile_advance_exprs([op])
-        self.assertEqual(op.loop_info.output_tiled_dims, [])
-
-    def test_committed_layout_per_tile_fixed_zeros_own_output(self):
-        from torch_spyre._inductor.wsr.coarse_tile import _zero_fixed_tile_advance_exprs
-
-        op = _make_fixed_flag_op(
-            "op0",
-            tiled_dims_per_read=[],
-            output_tiled_dims=[[(0, Integer(4))]],
-            layout_per_tile_fixed=True,
-        )
-        _zero_fixed_tile_advance_exprs([op])
-        self.assertEqual(op.loop_info.output_tiled_dims, [])
-
-    def test_reader_of_fixed_buffer_has_its_read_advance_zeroed(self):
-        from torch_spyre._inductor.wsr.coarse_tile import _zero_fixed_tile_advance_exprs
-
-        fixed_op = _make_fixed_flag_op(
-            "fixed0",
-            tiled_dims_per_read=[],
-            output_tiled_dims=[[(0, Integer(4))]],
-            pending_per_tile_fixed=True,
-        )
-        reader = _make_fixed_flag_op(
-            "reader0",
-            tiled_dims_per_read=[[[(0, Integer(4))]], [[(0, Integer(8))]]],
-            output_tiled_dims=[[(0, Integer(8))]],
-            read_names=["fixed0", "other_buf"],
-        )
-        _zero_fixed_tile_advance_exprs([fixed_op, reader])
-        # fixed0's own read entry (index 0, matching read_names[0]) is
-        # dropped to an empty per-level list; other_buf's (index 1) is
-        # untouched.
-        self.assertEqual(reader.loop_info.tiled_dims_per_read[0], [])
-        self.assertEqual(reader.loop_info.tiled_dims_per_read[1], [[(0, Integer(8))]])
-        # reader's own output is unaffected -- reader0 itself isn't fixed.
-        self.assertEqual(reader.loop_info.output_tiled_dims, [[(0, Integer(8))]])
-
-    def test_op_without_loop_info_is_skipped(self):
-        from torch_spyre._inductor.wsr.coarse_tile import _zero_fixed_tile_advance_exprs
-
-        fixed_op = _make_fixed_flag_op(
-            "fixed0",
-            tiled_dims_per_read=[],
-            output_tiled_dims=[],
-            pending_per_tile_fixed=True,
-        )
-        no_loop_info_op = _make_fixed_flag_op(
-            "other0", tiled_dims_per_read=[], output_tiled_dims=[]
-        )
-        del no_loop_info_op.loop_info
-        # Must not raise despite the second op having no loop_info at all.
-        _zero_fixed_tile_advance_exprs([fixed_op, no_loop_info_op])
-
-
 # ===========================================================================
 # 3. CountedLoopSchedulerNode and build_loop_scheduler_nodes
 # ===========================================================================
@@ -3738,7 +3612,7 @@ class TestGenerateBundleAffineLoopPath(unittest.TestCase):
 
     Key invariants:
       - ops tiled only by the inner loop var emit affine.apply with that var only
-      - ops not tiled (per_tile_fixed or fixed address) emit no affine.apply
+      - ops not tiled (fixed address, no advancing dims) emit no affine.apply
       - the copy op (outer-B tiled) emits affine.apply with the outer loop var
     """
 
@@ -3959,7 +3833,7 @@ class TestGenerateBundleAffineLoopPath(unittest.TestCase):
                     [],
                 )
             elif i == 2:
-                # combine: inside outer>inner, per_tile_fixed accum_tile, not tiled.
+                # combine: inside outer>inner, accum_tile address fixed, not tiled.
                 return _make_tiled_json(idx, sym_id), [0x3000], [[{}, {}]], []
             else:
                 # copy: inside outer loop only; accum_full tiled at outer level (level 0).
@@ -3994,7 +3868,7 @@ class TestGenerateBundleAffineLoopPath(unittest.TestCase):
         )
 
     def test_tile_accum_fill_no_affine_apply(self):
-        """fill op (per_tile_fixed output) must not get an affine.apply."""
+        """fill op (fixed, non-advancing output) must not get an affine.apply."""
         mlir = self._bundle(
             self._make_tile_accum_specs(),
             self._fake_tile_accum(self._GRP3_K_STRIDE, self._GRP3_B_STRIDE),
@@ -4487,10 +4361,11 @@ class TestCoarseTileBufferPropagation(unittest.TestCase):
         # Both real inputs get their own read copy.
         self.assertEqual(len(read_copy_ops), 2)
         # The tiled op itself never becomes a MutationLayoutSHOULDREMOVE --
-        # it keeps its own tile-sized layout and is marked per_tile_fixed
-        # instead, mirroring the Case 1 path.
+        # it keeps its own tile-sized layout, and its own write no longer
+        # advances (the copy-out op above drains it every iteration
+        # instead), mirroring the Case 1 path.
         self.assertNotIsInstance(final_op.layout, MutationLayoutSHOULDREMOVE)
-        self.assertTrue(getattr(final_op, "_pending_per_tile_fixed", False))
+        self.assertEqual(final_op.loop_info.output_tiled_dims, [])
 
 
 def _make_cross_group_producer_read_fixture():
@@ -4965,6 +4840,109 @@ class TestInsertReadCopyOps(unittest.TestCase):
             ElementArrangement.STANDARD,
         )
         self.assertEqual(copy_buf.layout.device_layout, expected_device_layout)
+
+
+class TestIsReadAdvancingAnywhere(unittest.TestCase):
+    """A buffer with a fixed write can still be barred from LX by a reader.
+
+    ``_is_tiled_advancing`` only asks whether a buffer's own *producing*
+    write advances; it says nothing about whether some other op *reads*
+    that buffer via a reference that advances across the reader's own
+    coarse-tile loop (e.g. a full HBM buffer with a fixed write, copied
+    into a nested tile every outer iteration -- exactly the shape
+    ``_make_full_buffer_read_fixture`` already builds for
+    ``_insert_read_copy_ops``'s own tests). ``compute_ops.py``'s
+    ``is_tiled_lx`` check applies to every ``TensorArg`` -- reads and the
+    write -- so missing this at allocation time only defers the same
+    ``NotImplementedError`` to codegen. This class exercises
+    ``_get_buffer_user_deps`` + ``_is_read_advancing_anywhere`` together,
+    against real IR and real ``MemoryDep`` objects (via
+    ``_make_full_buffer_read_fixture``), not mocks.
+    """
+
+    def setUp(self):
+        gm = fx.symbolic_trace(lambda: None)
+        self._graph_ctx = V.set_graph_handler(GraphLowering(gm))
+        self._graph_ctx.__enter__()
+
+    def tearDown(self):
+        self._graph_ctx.__exit__(None, None, None)
+
+    def test_advancing_copy_in_read_detected(self):
+        from torch_spyre._inductor.scratchpad.utils import (
+            _get_buffer_user_deps,
+            _is_read_advancing_anywhere,
+        )
+
+        tiled_op, full_deps, operations = _make_full_buffer_read_fixture()
+        self.assertEqual(len(full_deps), 1)
+        full_buf = V.graph.get_buffer(full_deps[0].name)
+        # full_buf itself has no loop_info -- its write is fixed (it is
+        # never produced inside a coarse-tile loop). tiled_op reads it via
+        # an advancing copy-in: dim 0 divided across tiled_op's own outer
+        # loop (matches the fixture's loop_count=[8] over dim 0).
+        tiled_op.loop_info.tiled_dims_per_read = [[[(0, Integer(8))]]]
+
+        fake_graph = SimpleNamespace(operations=operations)
+        buf_user_deps = _get_buffer_user_deps(fake_graph)
+        self.assertTrue(_is_read_advancing_anywhere(full_buf.get_name(), buf_user_deps))
+
+    def test_fixed_copy_in_read_not_detected(self):
+        """Same shape, but the reader's copy-in is fixed (not advancing):
+        the dep has no tiled levels at all (empty outer list)."""
+        from torch_spyre._inductor.scratchpad.utils import (
+            _get_buffer_user_deps,
+            _is_read_advancing_anywhere,
+        )
+
+        tiled_op, full_deps, operations = _make_full_buffer_read_fixture()
+        full_buf = V.graph.get_buffer(full_deps[0].name)
+        tiled_op.loop_info.tiled_dims_per_read = [[]]
+
+        fake_graph = SimpleNamespace(operations=operations)
+        buf_user_deps = _get_buffer_user_deps(fake_graph)
+        self.assertFalse(
+            _is_read_advancing_anywhere(full_buf.get_name(), buf_user_deps)
+        )
+
+    def test_fixed_copy_in_read_with_empty_levels_not_detected(self):
+        """Fixed can also show up as a non-empty outer list whose every
+        per-level entry is itself empty -- e.g. tiled_op has one loop level
+        that does not divide any dim this dep's index depends on.
+        _general_tile_advance's own per-level loop (`if not
+        dim_extent_pairs: continue`) never contributes a term for such a
+        level, so this must be treated as fixed too, not merely "has some
+        levels" (regression coverage: an earlier version of this check used
+        a shallow `if tiled_dims_per_read[dep_idx]:` truthiness test, which
+        wrongly treated [[]] as advancing since the outer list is
+        non-empty)."""
+        from torch_spyre._inductor.scratchpad.utils import (
+            _get_buffer_user_deps,
+            _is_read_advancing_anywhere,
+        )
+
+        tiled_op, full_deps, operations = _make_full_buffer_read_fixture()
+        full_buf = V.graph.get_buffer(full_deps[0].name)
+        tiled_op.loop_info.tiled_dims_per_read = [[[]]]
+
+        fake_graph = SimpleNamespace(operations=operations)
+        buf_user_deps = _get_buffer_user_deps(fake_graph)
+        self.assertFalse(
+            _is_read_advancing_anywhere(full_buf.get_name(), buf_user_deps)
+        )
+
+    def test_unrelated_buffer_not_detected(self):
+        from torch_spyre._inductor.scratchpad.utils import (
+            _get_buffer_user_deps,
+            _is_read_advancing_anywhere,
+        )
+
+        tiled_op, full_deps, operations = _make_full_buffer_read_fixture()
+        tiled_op.loop_info.tiled_dims_per_read = [[[(0, Integer(8))]]]
+
+        fake_graph = SimpleNamespace(operations=operations)
+        buf_user_deps = _get_buffer_user_deps(fake_graph)
+        self.assertFalse(_is_read_advancing_anywhere("no_such_buffer", buf_user_deps))
 
 
 class TestRescaleIndex(unittest.TestCase):

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -521,6 +521,9 @@ def _tensor_tiled_by_symbol(tensor, sym) -> bool:
     contains a minted symbol's term when this tensor genuinely advances
     at that level, so the coefficient check alone is both necessary and
     sufficient for minted symbols.
+
+    This is the sole test for whether a reference advances -- callers do
+    not pre-filter by any other per-tensor flag.
     """
     if sym in tensor.strides and tensor.scales.get(sym, 1) <= 0:
         return False
@@ -730,9 +733,10 @@ def generate_sdsc(
                 # affine.apply can never target an LX address today. A tiled
                 # (advancing) lx tensor therefore has no way to express its
                 # per-iteration address change in this preserved-loop path.
-                # per_tile_fixed lx tensors are fine: they don't advance, same as
-                # non-tiled tensors, so [{}] * n_levels is correct either way.
-                is_tiled_lx = tensor.per_tile_fixed is False and any(
+                # A non-advancing reference has no term in
+                # device_tile_advance_expr, which _tensor_tiled_by_symbol
+                # already detects directly.
+                is_tiled_lx = any(
                     _tensor_tiled_by_symbol(tensor, s)
                     for level_syms in tiled_symbols
                     for s in level_syms
@@ -875,27 +879,26 @@ def generate_sdsc(
             # whose stride describes element layout within one tile, not the advance
             # between tiles.  Tiling by a reduction-dim symbol would incorrectly
             # advance the base address of a pool output past its single allocated slot.
-            # per_tile_fixed tensors (tile-local scratch reused every iteration, see
-            # unroll.py) never advance either, regardless of allocation type.
+            # A tile-local scratch tensor reused every iteration (see unroll.py)
+            # never advances either -- it simply has no term in
+            # device_tile_advance_expr, which _tensor_tiled_by_symbol already
+            # detects directly.
             per_level_strides: list[dict] = []
             any_tiled = False
-            if not tensor.per_tile_fixed:
-                for level_idx, level_syms in enumerate(tiled_symbols):
-                    tensor_tiled_at_level = [
-                        s for s in level_syms if _tensor_tiled_by_symbol(tensor, s)
-                    ]
-                    strides_for_level: dict = {}
-                    for s in tensor_tiled_at_level:
-                        coeff = (
-                            coeff_through_floor(tensor.device_tile_advance_expr, s)
-                            if tensor.device_tile_advance_expr is not None
-                            else 0
-                        )
-                        strides_for_level[s] = int(coeff) * nb
-                        any_tiled = True
-                    per_level_strides.append(strides_for_level)
-            else:
-                per_level_strides = [{} for _ in tiled_symbols]
+            for level_idx, level_syms in enumerate(tiled_symbols):
+                tensor_tiled_at_level = [
+                    s for s in level_syms if _tensor_tiled_by_symbol(tensor, s)
+                ]
+                strides_for_level: dict = {}
+                for s in tensor_tiled_at_level:
+                    coeff = (
+                        coeff_through_floor(tensor.device_tile_advance_expr, s)
+                        if tensor.device_tile_advance_expr is not None
+                        else 0
+                    )
+                    strides_for_level[s] = int(coeff) * nb
+                    any_tiled = True
+                per_level_strides.append(strides_for_level)
             if not any_tiled:
                 # Non-tiled HBM: register per-core addresses.
                 for c in range(sdsc_spec.num_cores):

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -74,7 +74,6 @@ class SDSCArgs:
     arg_index: int = -1
     is_index_tensor: bool = False
     related_value_tensor_idx: int = -1
-    per_tile_fixed: bool = False
     device_tile_advance_expr: Expr | None = None
 
     def __str__(self) -> str:
@@ -800,7 +799,6 @@ def _create_sdsc_tensors(
                 arg_index=arg.arg_index,
                 is_index_tensor=is_idx_tensor,
                 related_value_tensor_idx=related_val_idx,
-                per_tile_fixed=arg.per_tile_fixed,
                 device_tile_advance_expr=arg.device_tile_advance_expr,
             )
         )

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -278,29 +278,16 @@ def finalize_layouts(graph: GraphLowering) -> None:
         if op_layouts and not isinstance(op.layout, MutationLayoutSHOULDREMOVE):
             stl = committed if cost_fn else op_layouts[0]
             op.layout = _fixed_tiled(op.layout, cast(SpyreTensorLayout, stl))
-            # Mark loop-invariant tiled ops: per_tile_fixed so the unroller
-            # reuses the same base address every tile iteration.  A tiled op is
-            # loop-invariant when its CoarseTileInfo has no tiled dims at any
-            # level (all loop_tiled_dims and loop_tiled_reduction_dims entries
-            # are empty).  The loop-internal and tiled-reduction-scratch cases
-            # are handled later in _propagate_tiled_op /
-            # _propagate_tiled_reduction_op once consumer analysis is available.
+            # Tiled-reduction scratch: propagate the reduction op's device
+            # layout to accum_full so fill, combine, and copy all agree on
+            # the device coordinate system.
             loop_info = getattr(op, "loop_info", None)
             if loop_info is not None and isinstance(op.layout, FixedTiledLayout):
-                all_tiled_dims_empty = all(
-                    not dims for dims in loop_info.loop_tiled_dims
-                )
                 all_tiled_rdims_empty = all(
                     not dims
                     for dims in getattr(loop_info, "loop_tiled_reduction_dims", [])
                 )
-                if all_tiled_dims_empty and all_tiled_rdims_empty:
-                    op.layout.per_tile_fixed = True
-                # Tiled-reduction scratch: inner level tiles a reduction dim.
-                # The op's output is a per-tile accumulation buffer reused
-                # every inner-loop iteration.
-                elif not all_tiled_rdims_empty:
-                    op.layout.per_tile_fixed = True
+                if not all_tiled_rdims_empty:
                     # Propagate the reduction op's device layout to accum_full.
                     # Pre-stickify, _allocate_full_buffer assigned accum_full a
                     # generic layout; we now overwrite it with the same STL as
@@ -332,18 +319,6 @@ def finalize_layouts(graph: GraphLowering) -> None:
                                 accum_layout, op.layout.device_layout
                             )
 
-            # Loop-internal buffers: _propagate_tiled_op sets _pending_per_tile_fixed
-            # when the layout is still FixedLayout (pre-stickify).  Transfer that
-            # deferred flag now that we have the committed FixedTiledLayout.
-            if getattr(op, "_pending_per_tile_fixed", False):
-                assert isinstance(op.layout, FixedTiledLayout), (
-                    f"{op.get_name()} has _pending_per_tile_fixed but layout is "
-                    f"{type(op.layout).__name__} — expected FixedTiledLayout "
-                    "after finalize_layouts committed"
-                )
-                op.layout.per_tile_fixed = True
-                del op._pending_per_tile_fixed  # type: ignore[attr-defined]
-
         # For each input edge, schedule a restickify if the input's committed STL
         # is incompatible with what this op requires on that edge.
         if not cost_fn:
@@ -372,9 +347,6 @@ def finalize_layouts(graph: GraphLowering) -> None:
                         accum_layout.size,
                         accum_layout.stride,
                         committed,
-                    )
-                    new_layout.per_tile_fixed = getattr(
-                        accum_layout, "per_tile_fixed", False
                     )
                     mut_target_buf.layout = new_layout
             elif isinstance(mut_target_buf, SpyreEmptyFallback) and committed is None:
@@ -418,13 +390,6 @@ def finalize_layouts(graph: GraphLowering) -> None:
                     f"target_stl.stride_map={list(target_stl.stride_map)}"
                 )
             restick_target = _fixed_tiled(in_layout, restick_stl)
-            # restick_target's buffer is created fresh by _create_restickify_node
-            # and consumed only by op's own inner_fn (see
-            # insert_restickify_on_node_inputs) — it can never have outside-loop
-            # consumers, so it is always safe to inherit in_layout's per_tile_fixed:
-            # if the source address doesn't advance across iterations, this private
-            # single-consumer copy of it doesn't need to either.
-            restick_target.per_tile_fixed = getattr(in_layout, "per_tile_fixed", False)
             logger.info(
                 f"Injecting restickify on {op.get_name()} input {edge.dep.name}: "
                 f"{list(in_stl.stride_map)} -> {list(target_stl.stride_map)}"

--- a/torch_spyre/_inductor/ir.py
+++ b/torch_spyre/_inductor/ir.py
@@ -98,7 +98,6 @@ class FixedTiledLayout(FixedLayout):
         super().__init__(device, dtype, size, stride)
         self.device_layout: SpyreTensorLayout = device_layout
         self.allocation: dict[str, Any] = {}
-        self.per_tile_fixed: bool = False
 
     def __str__(self) -> str:
         device_index_str = "" if self.device.index is None else f":{self.device.index}"

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -96,9 +96,6 @@ _SPYRE_METADATA_ATTRS = (
     "_restickify_plan",
     "_input_layout_overrides",
     "_emit_set_layout",
-    # Deferred per_tile_fixed flag: set by coarse_tile._propagate_tiled_op when
-    # the layout is FixedLayout (pre-stickify); consumed by finalize_layouts.
-    "_pending_per_tile_fixed",
     # Links a tiled reduction op to its accumulation buffer; set by
     # coarse_tile._propagate_tiled_reduction_op, read by finalize_layouts in
     # insert_restickify.py to overwrite accum_full's generic layout.

--- a/torch_spyre/_inductor/op_spec.py
+++ b/torch_spyre/_inductor/op_spec.py
@@ -173,7 +173,6 @@ class TensorArg:
     device_size: list[int]
     device_coordinates: list[Expr]
     allocation: Any
-    per_tile_fixed: bool = False
     name: str | None = None
     device_tile_advance_expr: Expr | None = None
     element_arrangement: ElementArrangement = dataclasses.field(

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1808,8 +1808,6 @@ def format_operations(operations: list[Operation]) -> str:
                 buf.write(f"\n  dim_hints={dim_hints}")
             if loop_info := getattr(op, "loop_info", None):
                 buf.write(f"\n  loop_info={loop_info}")
-            if pending_per_tile_fixed := getattr(op, "_pending_per_tile_fixed", None):
-                buf.write(f"\n  _pending_per_tile_fixed={pending_per_tile_fixed}")
             buf.write(f"\n  {op.data}")
         buf.write("\n\n")
     return buf.getvalue()

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -30,8 +30,8 @@ from torch._inductor.ir import (
     Reduction,
     ReinterpretView,
 )
-from torch._inductor.graph import GraphLowering
 from torch._inductor.dependencies import MemoryDep
+from torch._inductor.graph import GraphLowering
 
 from torch_spyre._inductor.pass_utils import (
     apply_splits_from_index_coeff,
@@ -76,6 +76,8 @@ from torch_spyre._inductor.scratchpad.utils import (
     buffer_not_read_in_full,
     get_ncores_for_buffers,
     _is_tiled_advancing,
+    _is_read_advancing_anywhere,
+    _get_buffer_user_deps,
     _would_produce_lx_back_gap,
     OP_OUTPUT_GOOD_FOR_LX_REUSE,
 )
@@ -278,6 +280,7 @@ class ScratchpadAllocator:
         ncores: dict[str, int],
         ncores_reasons: dict[str, str],
         division_is_fixed: bool,
+        buf_user_deps: dict[str, list[tuple[Operation, MemoryDep]]],
     ) -> Optional[str]:
         """The first check ``name`` fails, or ``None`` if it clears them all.
 
@@ -298,6 +301,8 @@ class ScratchpadAllocator:
                 division was committed upstream and a mismatch between a buffer's
                 users is fatal. False on the joint path, where the solver chooses
                 the division and its slicing gate decides instead.
+            buf_user_deps: every buffer's ``(op, dep)`` users, from
+                :func:`_get_buffer_user_deps`, for the read-side advancing check.
         """
         if op is None or not self._op_output_good_for_lx_reuse(op):
             return "op not allowed"
@@ -308,12 +313,15 @@ class ScratchpadAllocator:
             return "unsized (no device layout)"
         if name in mutated_buffers:
             return "mutation target"
-        if _is_tiled_advancing(op):
+        if _is_tiled_advancing(op) or _is_read_advancing_anywhere(name, buf_user_deps):
             # LX addresses cannot be expressed as affine.apply symbols today (see
             # compute_ops.py's is_tiled_lx check), so a buffer whose address
             # advances per coarse-tile iteration must stay in HBM, where that is
-            # supported.
-            return "tiled (advancing), not per_tile_fixed"
+            # supported -- whether the advance is on this buffer's own write
+            # (_is_tiled_advancing) or on some other op's read of it
+            # (_is_read_advancing_anywhere, e.g. a fixed-write full buffer
+            # copied into a nested tile every outer iteration).
+            return "tiled (advancing)"
         restickify = self._restickify_barrier(graph, name, uses)
         if restickify is not None:
             return restickify
@@ -429,6 +437,7 @@ class ScratchpadAllocator:
             ncores, ncores_reasons = get_ncores_for_buffers(graph)
         ncores = ncores or {}
         ncores_reasons = ncores_reasons or {}
+        buf_user_deps = _get_buffer_user_deps(graph)
         return {
             name: self._buffer_residency_reason(
                 graph,
@@ -441,6 +450,7 @@ class ScratchpadAllocator:
                 ncores=ncores,
                 ncores_reasons=ncores_reasons,
                 division_is_fixed=division_is_fixed,
+                buf_user_deps=buf_user_deps,
             )
             for name in names
         }

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -220,21 +220,73 @@ def _is_tiled_advancing(op: Operation) -> bool:
 
     LX addresses are never registered as ``affine.apply`` symbols in the SDSC
     JSON (see ``compute_ops.py``'s ``is_tiled_lx`` check), so a buffer that
-    advances per loop iteration (tiled, and not ``per_tile_fixed``) has no way
-    to express its address change if pinned to LX. This mirrors that check,
-    but at IR time via ``loop_info`` instead of the later per-tensor strides
-    representation, letting the allocator exclude such buffers from LX
-    candidacy up front instead of crashing at codegen time.
+    advances per loop iteration has no way to express its address change if
+    pinned to LX. This derives the same answer ``is_tiled_lx`` derives, but
+    earlier (at IR/allocation time) and directly from ``loop_info``, letting
+    the allocator exclude such buffers from LX candidacy up front instead of
+    crashing at codegen time.
+
+    Note this checks ``output_tiled_dims`` -- whether *this op's own write*
+    advances -- not ``loop_tiled_dims``, which only says the op is tiled at
+    all. A loop-internal buffer (e.g. drained by a copy op every iteration)
+    can be tiled yet have its own write pinned at a fixed address; such a
+    buffer is LX-eligible.
     """
     layout = getattr(op, "layout", None)
-    if not isinstance(layout, FixedTiledLayout) or layout.per_tile_fixed:
+    if not isinstance(layout, FixedTiledLayout):
         return False
     loop_info = getattr(op, "loop_info", None)
     if loop_info is None:
         return False
-    return any(dims for dims in loop_info.loop_tiled_dims) or any(
-        dims for dims in getattr(loop_info, "loop_tiled_reduction_dims", [])
-    )
+    return any(dims for dims in loop_info.output_tiled_dims)
+
+
+def _is_read_advancing_anywhere(
+    name: str, buf_user_deps: dict[str, list[tuple[Operation, MemoryDep]]]
+) -> bool:
+    """True if some op reads buffer ``name`` via an advancing reference.
+
+    ``_is_tiled_advancing`` only asks whether ``name``'s own *producing*
+    write advances -- it says nothing about whether some other, unrelated
+    op *reads* ``name`` via a reference that advances across that reader's
+    own coarse-tile loop (e.g. a full HBM buffer with a fixed write, copied
+    into a nested tile every outer iteration). ``SpyreKernel.
+    _general_tile_advance`` derives a read reference's
+    ``device_tile_advance_expr`` from the *consuming* op's own
+    ``loop_info.tiled_dims_per_read``, not from the producer's
+    ``output_tiled_dims`` -- so a reader can advance even when the
+    producer's own write is fixed. ``compute_ops.py``'s ``is_tiled_lx``
+    check applies to every ``TensorArg`` (read and write) at codegen time,
+    so missing this at allocation time defers the same
+    ``NotImplementedError`` to codegen instead of routing the buffer to
+    HBM up front.
+
+    Mirrors ``_general_tile_advance``'s own positional dep-index matching:
+    for each reader op, ``name``'s occurrences among that op's
+    ``MemoryDep`` reads are matched in order to
+    ``loop_info.tiled_dims_per_read`` by position.
+    """
+    for reader_op, dep in buf_user_deps.get(name, []):
+        loop_info = getattr(reader_op, "loop_info", None)
+        if loop_info is None:
+            continue
+        read_deps = [
+            d for d in op_read_writes(reader_op).reads if isinstance(d, MemoryDep)
+        ]
+        if dep not in read_deps:
+            continue  # dep is name's write on this op, not a read
+        dep_idx = read_deps.index(dep)
+        if dep_idx >= len(loop_info.tiled_dims_per_read):
+            continue
+        # Mirrors _general_tile_advance's own per-level loop: a dep whose
+        # outer per-level list is non-empty but every level's own
+        # (dim, extent) list is empty (e.g. [[], []]) still advances by
+        # zero -- _general_tile_advance's `if not dim_extent_pairs:
+        # continue` never contributes a term for such a level, so the
+        # resulting device_tile_advance_expr is None, not merely small.
+        if any(loop_info.tiled_dims_per_read[dep_idx]):
+            return True
+    return False
 
 
 def _writes_at_constant_offset(op: Operation) -> bool:

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -762,7 +762,6 @@ class SpyreKernel(Kernel[CSEVariable]):
             tensor.layout.device_layout.device_size,
             device_coords,
             tensor.layout.allocation,
-            per_tile_fixed=getattr(tensor.layout, "per_tile_fixed", False),
             element_arrangement=tensor.layout.device_layout.element_arrangement,
             name=opspec_name,
             device_tile_advance_expr=device_tile_advance_expr,
@@ -1428,8 +1427,6 @@ def _codegen_op_spec_list(specs, buf: IndentedBuffer, sympy_str) -> None:
                                 + "],"
                             )
                             buf.writeline(f"allocation={arg.allocation!r},")
-                            if arg.per_tile_fixed:
-                                buf.writeline("per_tile_fixed=True,")
                             if arg.name is not None:
                                 buf.writeline(f"name={arg.name!r},")
                             if arg.device_tile_advance_expr is not None:

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -1123,56 +1123,9 @@ def coarse_tile(
         retiled_infos_by_group.append((stamped_group_id, group_ops, retiled_infos))
 
     insert_tiling_propagation(operations, groups)
-    _zero_fixed_tile_advance_exprs(operations)
 
     for group_id, group_ops, retiled_infos in retiled_infos_by_group:
         _patch_retiled_load_indexes(group_id, group_ops, retiled_infos, operations)
-
-
-def _zero_fixed_tile_advance_exprs(operations: list[Operation]) -> None:
-    """Drop tiled_dims_per_read / output_tiled_dims entries for fixed tiles.
-
-    A per-tile-fixed buffer (flagged by insert_tiling_propagation, above, via
-    either the pre-stickify _pending_per_tile_fixed or an already-committed
-    post-stickify FixedTiledLayout.per_tile_fixed) is reused in place every
-    tile iteration -- it never actually advances, regardless of what its
-    dependency's index arithmetic would otherwise compute. Drop that
-    dependency's tiled-dim entries entirely (an empty per-level list has the
-    same effect as a zero advance expr did before this plan: no dims to
-    substitute means no advance), both for the op's own output (if its own
-    buffer is fixed) and for any op reading a fixed buffer as an input.
-
-    This is the only place tiled_dims_per_read/output_tiled_dims reads
-    per_tile_fixed/_pending_per_tile_fixed -- a deliberate one-way bridge
-    kept isolated here so it can be deleted once a later stage derives
-    per_tile_fixed from a zero advance expr instead of the reverse.
-    """
-    fixed_names = {
-        op.get_name()
-        for op in operations
-        if isinstance(op, ComputedBuffer)
-        and (
-            getattr(op, "_pending_per_tile_fixed", False)
-            or getattr(op.layout, "per_tile_fixed", False)
-        )
-    }
-    if not fixed_names:
-        return
-
-    for op in operations:
-        loop_info = getattr(op, "loop_info", None)
-        if loop_info is None:
-            continue
-        if op.get_name() in fixed_names:
-            loop_info.output_tiled_dims = []
-        if not loop_info.tiled_dims_per_read:
-            continue
-        reads = [
-            dep for dep in op.get_read_writes().reads if isinstance(dep, MemoryDep)
-        ]
-        for i, dep in enumerate(reads):
-            if dep.name in fixed_names:
-                loop_info.tiled_dims_per_read[i] = []
 
 
 # ---------------------------------------------------------------------------
@@ -1231,6 +1184,50 @@ def insert_tiling_propagation(
             )
             if current is not None and current is not op:
                 group_ops[idx] = current
+
+    _zero_reads_of_fixed_buffers(operations)
+
+
+def _zero_reads_of_fixed_buffers(operations: list[Operation]) -> None:
+    """Zero tiled_dims_per_read entries for reads of now-fixed buffers.
+
+    The per-op loop above (_propagate_tiled_op /
+    _propagate_tiled_reduction_op) zeroes a buffer's own
+    output_tiled_dims once that buffer is known to be loop-internal
+    scratch reused in place every iteration (no outside consumers, not a
+    graph output). But a sibling op *reading* that buffer inside the same
+    loop was planned before this was known, so its tiled_dims_per_read
+    entry for that read may still carry the stale, non-empty extent from
+    plan_coarse_tile_groups. SpyreKernel._general_tile_advance matches
+    tiled_dims_per_read to get_read_writes().reads purely positionally, so
+    a fixed buffer's readers must have that entry zeroed too, exactly
+    mirroring the now-fixed buffer's own write. This is a genuine second
+    pass over `operations` (not folded into the per-op loop above) because
+    a reader can be visited before its dependency is determined to be
+    fixed -- group_ops is processed in source order, and "is buf1 fixed"
+    is only known once buf1 itself has been propagated.
+    """
+    fixed_names = {
+        op.get_name()
+        for op in operations
+        if isinstance(op, ComputedBuffer)
+        and (loop_info := getattr(op, "loop_info", None)) is not None
+        and any(dims for dims in loop_info.loop_tiled_dims)
+        and not any(dims for dims in loop_info.output_tiled_dims)
+    }
+    if not fixed_names:
+        return
+
+    for op in operations:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        loop_info = getattr(op, "loop_info", None)
+        if loop_info is None or not loop_info.tiled_dims_per_read:
+            continue
+        reads = [d for d in op.get_read_writes().reads if isinstance(d, MemoryDep)]
+        for i, dep in enumerate(reads):
+            if dep.name in fixed_names and loop_info.tiled_dims_per_read[i]:
+                loop_info.tiled_dims_per_read[i] = []
 
 
 def _validate_reduction_tiling(op: ComputedBuffer) -> None:
@@ -1301,6 +1298,12 @@ def _propagate_tiled_op(
     full_deps = _full_buffer_read_deps(op)
     if full_deps:
         op = _insert_read_copy_ops(op, full_deps, operations)
+        # _insert_read_copy_ops may rebuild op.loop_info via
+        # dataclasses.replace (to give it fresh tiled_dims_per_read for the
+        # swapped-in copy reads), which detaches it from the loop_info
+        # object captured above -- re-fetch so every mutation below lands
+        # on the object actually reachable from the (possibly-replaced) op.
+        loop_info = getattr(op, "loop_info", None)
 
     if isinstance(op.data, Reduction):
         _validate_reduction_tiling(op)
@@ -1326,24 +1329,16 @@ def _propagate_tiled_op(
 
     if not outside_consumers and not is_graph_output:
         # Loop-internal: the buffer is a per-tile scratch region reused every
-        # iteration.  Mark it so the unroller does not advance its base address.
-        if isinstance(op.layout, FixedTiledLayout):
-            # Post-stickify (span-overflow path): layout is already FixedTiledLayout.
-            op.layout.per_tile_fixed = True
-        else:
-            # Pre-stickify (hint path): layout is FixedLayout.  Defer to
-            # finalize_layouts which sees the committed FixedTiledLayout and can
-            # set the flag then.  MutationLayoutSHOULDREMOVE only appears in
-            # the post-stickify span-overflow path and is handled by the branch
-            # above (it would not reach this else).
-            op._pending_per_tile_fixed = True  # type: ignore[attr-defined]
+        # iteration.  Its own write must not advance at any level.
+        loop_info.output_tiled_dims = []
         return
 
     # Reconstruct the original (pre-division) ranges.
     full_ranges = _compute_full_ranges(op)
 
-    # Insert the full buffer before the first op in the same outermost loop group
-    # so it doesn't split the group's contiguous run in the operations list.
+    # Insert the full buffer before the first op in the same outermost
+    # loop group so it doesn't split the group's contiguous run in the
+    # operations list.
     outer_key = loop_group_id[0]
     group_start_idx = next(
         i
@@ -1370,11 +1365,8 @@ def _propagate_tiled_op(
     _insert_copy_op(op, full_buf, operations)
     # The tiled op's own buffer is always loop-internal scratch here: it is
     # fully drained by the copy op inserted above before the next iteration
-    # overwrites it.
-    if isinstance(op.layout, FixedTiledLayout):
-        op.layout.per_tile_fixed = True
-    else:
-        op._pending_per_tile_fixed = True  # type: ignore[attr-defined]
+    # overwrites it, so its own write must not advance at any level.
+    loop_info.output_tiled_dims = []
 
     # Patch outside consumers and graph outputs to read full_buf.
     full_name = full_buf.get_name()
@@ -1699,10 +1691,10 @@ def _insert_copy_op(
     # DIFFERENT extents, because they address differently sized buffers:
     #
     # READS re-read tiled_op's already-divided per-tile buffer, which is
-    # per_tile_fixed scratch reused in place every iteration -- it does not
-    # move, so it must not advance at any level (the copy op is not itself
-    # re-divided). See _fixed_level_extents for why "not advance" means
-    # omitting the dim, not giving it extent 1.
+    # scratch reused in place every iteration -- it does not move, so it
+    # must not advance at any level (the copy op is not itself re-divided).
+    # See _fixed_level_extents for why "not advance" means omitting the
+    # dim, not giving it extent 1.
     tiled_op_info = tiled_op.loop_info  # type: ignore[attr-defined]
     read_level_extents = _fixed_level_extents(tiled_op_info.loop_tiled_dims)
     # The WRITE targets full_buf, which is NOT divided, so its store base must
@@ -2142,7 +2134,7 @@ def _insert_read_copy_ops(
         # advances a whole tile; here, the copy's READ (of full_buf) advances
         # a whole tile per iteration and its WRITE (to this copy's own
         # freshly allocated, tile-sized buffer) must not advance -- the copy
-        # buffer is per_tile_fixed scratch reused in place, it does not move.
+        # buffer is scratch reused in place, it does not move.
         # See _fixed_level_extents for why "must not advance" means omitting
         # the dim, not giving it extent 1.
         #
@@ -2272,8 +2264,8 @@ def _insert_read_copy_ops(
     # planned when this op's own reads were full_buf directly -- whole-tile
     # advance, correct at plan time. But new_op's actual reads (per
     # get_read_writes(), re-derived from the now-patched inner_fn) are the
-    # copy buffers for every swapped name: per_tile_fixed scratch reused in
-    # place every iteration, which must not advance, exactly like
+    # copy buffers for every swapped name: scratch reused in place every
+    # iteration, which must not advance, exactly like
     # _insert_copy_op's own read side. SpyreKernel._general_tile_advance
     # matches tiled_dims_per_read to get_read_writes().reads purely
     # positionally (see loop_info.py's docstring), so every entry
@@ -2321,8 +2313,17 @@ def _insert_combine_op(
 
     The combine op reads both the partial result (tiled_op) and the current
     accumulation buffer and writes the combined value back into accum_buf via
-    MutationLayoutSHOULDREMOVE.  It carries the same loop_info as tiled_op
-    so the scheduler places it inside the same CountedLoopSchedulerNode.
+    MutationLayoutSHOULDREMOVE.  It carries tiled_op's loop_group_id/
+    loop_count/loop_tiled_dims/loop_tiled_reduction_dims (so the scheduler
+    places it inside the same CountedLoopSchedulerNode), but its own
+    freshly-derived tiled_dims_per_read/output_tiled_dims -- combine_buf's
+    two reads and one write don't correspond positionally to tiled_op's own
+    reads/write, and both accum_buf and tiled_op's output are scratch that
+    never advances across the inner tiled loop, so reusing tiled_op.loop_info
+    wholesale attributed tiled_op's own output-tiling shape to accum_buf's
+    mutation-write instead (this previously surfaced as a spurious
+    advancing-lx NotImplementedError once a since-removed per-buffer
+    per_tile_fixed flag that had been masking it was taken away).
     """
     from torch._inductor.virtualized import ops as vops
 
@@ -2366,7 +2367,34 @@ def _insert_combine_op(
     )
     combine_buf.origins = tiled_op.origins
     combine_buf.operation_name = combine_name
-    combine_buf.loop_info = tiled_op.loop_info  # type: ignore[attr-defined]
+
+    # Both reads (tiled_op's partial output, accum_buf itself) and the
+    # mutation-write (into accum_buf) are per-tile-fixed scratch that never
+    # advances across the inner tiled loop -- all-empty per-level extents at
+    # every level, same convention _insert_copy_op's read side uses.
+    tiled_op_info = tiled_op.loop_info  # type: ignore[attr-defined]
+    fixed_level_extents = _fixed_level_extents(tiled_op_info.loop_tiled_dims)
+    combine_reads = [
+        dep for dep in combine_buf.get_read_writes().reads if isinstance(dep, MemoryDep)
+    ]
+    combine_writes = [
+        dep
+        for dep in combine_buf.get_read_writes().writes
+        if isinstance(dep, MemoryDep)
+    ]
+    tiled_dims_per_read = [
+        _tiled_dims_for_dep(dep, fixed_level_extents) for dep in combine_reads
+    ]
+    output_tiled_dims = (
+        _tiled_dims_for_dep(combine_writes[0], fixed_level_extents)
+        if combine_writes
+        else []
+    )
+    combine_buf.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
+        tiled_op_info,
+        tiled_dims_per_read=tiled_dims_per_read,
+        output_tiled_dims=output_tiled_dims,
+    )
     V.graph.name_to_buffer[combine_name] = combine_buf
 
     tiled_idx = operations.index(tiled_op)
@@ -2384,9 +2412,9 @@ def _insert_reduction_copy_op(
 ) -> None:
     """Insert a copy op that writes accum_tile → accum_full at the outer loop level.
 
-    Reads accum_tile (per_tile_fixed=True, never advances) and writes into
-    accum_full via MutationLayoutSHOULDREMOVE.  Carries outer_loop_info so
-    the unroller advances accum_full per outer output-dim tile.
+    Reads accum_tile (never advances) and writes into accum_full via
+    MutationLayoutSHOULDREMOVE.  Carries outer_loop_info so the unroller
+    advances accum_full per outer output-dim tile.
 
     By default inserts immediately after tiled_op (or its combine op, if
     any) — correct when nothing else in the inner loop group depends on
@@ -2491,8 +2519,8 @@ def _propagate_tiled_reduction_op(
       3. Insert a combine op (inside the inner loop, same loop_info as the
          tiled reduction op) that merges each tile's partial result into the
          accumulation buffer using the reduction's combining fn.
-      4. Mark the tiled reduction op's output as per_tile_fixed (inner-loop
-         scratch, not advanced between inner iterations).
+      4. Mark the tiled reduction op's output as inner-loop scratch (not
+         advanced between inner iterations).
       5. Patch outside consumers and graph outputs to read the accumulation
          buffer.
     """
@@ -2525,7 +2553,10 @@ def _propagate_tiled_reduction_op(
 
     if is_nested:
         # Nested case: allocate separate tile-sized and full-sized buffers.
-        # accum_tile (per_tile_fixed=True) stays inside the inner K-loop;
+        # accum_tile stays inside the inner K-loop (never advances there --
+        # its only readers are the combine op and the outer copy op, both of
+        # which build their own correct tiled_dims_per_read/output_tiled_dims
+        # from their own loop_info, so accum_tile itself needs no flag);
         # accum_full accumulates across outer B-tiles via a copy op.
         accum_full = _allocate_full_buffer(
             op, full_output_ranges, operations, group_start_idx
@@ -2534,15 +2565,6 @@ def _propagate_tiled_reduction_op(
         accum_tile = _allocate_full_buffer(
             op, per_tile_ranges, operations, group_start_idx_after_full
         )
-        if isinstance(accum_tile.layout, FixedTiledLayout):
-            # Post-stickify (span-overflow path): set directly.
-            accum_tile.layout.per_tile_fixed = True
-        else:
-            # Pre-stickify (hint path): layout is FixedLayout; defer to
-            # finalize_layouts.  In the span-overflow path this branch is
-            # unreachable because _allocate_full_buffer returns FixedTiledLayout
-            # when the original layout is already FixedTiledLayout.
-            accum_tile._pending_per_tile_fixed = True  # type: ignore[attr-defined]
         fill_target = accum_tile
         combine_target = accum_tile
     else:
@@ -2616,12 +2638,11 @@ def _propagate_tiled_reduction_op(
             op, accum_tile, accum_full, fill_loop_info, operations
         )
 
-    # Mark the tiled reduction op's per-tile scratch as stationary.
-    # Pre-stickify: op.layout is FixedLayout; per_tile_fixed will be set by
-    # finalize_layouts (which inspects CoarseTileInfo) once stickification runs.
-    # Post-stickify (span-overflow path): op.layout is already FixedTiledLayout.
-    if isinstance(op.layout, FixedTiledLayout):
-        op.layout.per_tile_fixed = True
+    # The tiled reduction op's own write is per-tile scratch: it is drained by
+    # the combine op every inner iteration and never read directly by the
+    # outer copy op (which reads accum_tile instead), so it must not advance
+    # at any level.
+    loop_info.output_tiled_dims = []
 
     # Record the accumulation buffer name so finalize_layouts can propagate
     # the reduction op's post-stickify device layout to accum_full.  Pre-stickify,


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Removes `FixedTiledLayout.per_tile_fixed` / `_pending_per_tile_fixed` from
the coarse-tiling compiler pass, in favor of `loop_info` as the sole source
of truth for "does this buffer's address advance across a coarse-tile
loop?"

`per_tile_fixed` was a boolean stamped on a tensor's layout (post-stickify)
or transiently on the op itself (pre-stickify), duplicating at buffer
granularity a question that is really per-reference: does *this specific
read or write* advance? That answer already exists per-op, per-level in
`CoarseTileInfo.tiled_dims_per_read` / `output_tiled_dims`
(`loop_info.py`), and per-reference in `TensorArg.device_tile_advance_expr`
(built directly from that data in `SpyreKernel._general_tile_advance`).
`per_tile_fixed` is deleted so "fixed vs. advancing" has exactly one source
of truth, consulted directly wherever a decision is made.

Removing the flag required first fixing two real gaps it had been masking:

- `_insert_combine_op` wholesale-reused its tiled op's `loop_info` instead
  of building its own per-reference `tiled_dims_per_read`/
  `output_tiled_dims`. `SpyreKernel`'s positional lookup indexed into this
  purely by list position, so it silently attributed the wrong op's data to
  the combine op's own reads. Fixed by deriving `combine_buf`'s own
  `tiled_dims_per_read`/`output_tiled_dims` at construction time, the same
  way `_insert_copy_op`/`_insert_reduction_copy_op` already do.
- `_is_tiled_advancing` (LX scratchpad residency) only checked a buffer's
  own producing write, never whether any *reader* accessed it via an
  advancing copy-in. A buffer with a fixed write could still be placed in
  LX today and only crash later, at codegen time, if some other tiled op
  read it advancingly. Fixed by adding a sibling check,
  `_is_read_advancing_anywhere` (`scratchpad/utils.py`), using the same
  positional matching `_general_tile_advance` already relies on.

Both fixes land independently of the flag removal and are verified by the
full coarse-tile regression suite.

#### Which issue(s) this PR is related to:

N/A — internal cleanup, no tracked issue.

#### Special notes for your reviewer:

- This branch was rebased onto the current `main` after upstream PR #3496
  ("Delete constant fills handling code from coarse tiling") landed and
  removed code this branch had originally also modified (a fix for an
  output-dim-tiled carry-accumulator bug in flash-attention's constant-fill
  hoisting). That fix depended entirely on the machinery #3496 deleted, so
  it was dropped during the rebase rather than reconciled — resolving in
  favor of upstream, per direct instruction. Verified post-rebase that
  `test_hint_flash_attention_v2_divide_in_scope` still passes: upstream's
  own removal of the hoisting mechanism independently avoids the bug this
  branch used to work around.
- 13 files changed, 439 insertions(+), 346 deletions(-).
- Full regression (`test_coarse_tiling.py` + `test_coarse_tile_e2e.py` +
  `test_building_blocks.py`): 411 passed, 68 skipped, 0 failed.
- `pre-commit run --all-files`: clean.
- Repo-wide grep for `per_tile_fixed`/`_pending_per_tile_fixed` after this
  change: exactly one hit, an intentional historical-context comment in
  `coarse_tile.py` documenting why `_insert_combine_op` needed its own
  `loop_info` (see above).
- The separate, still-unimplemented reduction-tiled (Lk) carry case
  (`test_flash_tile_Lk`, `test_flash_tile_H_Lq_Lk`) is deliberately left
  untouched and remains skipped with its existing reason string.

#### Does this PR introduce a user-facing change?

No. This is an internal compiler-pass refactor with no change to supported
ops, public APIs, or numerical results.

#### Additional note: