### PR TITLE
test(wsr): migrate the remaining convertible hint sites (282/293)

### DIFF
--- a/docs/source/user_guide/examples/spyre_hints.py
+++ b/docs/source/user_guide/examples/spyre_hints.py
@@ -25,8 +25,10 @@ d = torch.rand(64, 256, dtype=torch.float16)  # M N
 
 
 def f(a, b, c, d):
-    with spyre_hint(tiles={"K": 2}):
-        with spyre_hint(tiles={"M": 4}):
+    # tile_size_per_dim declares the PER-TILE extent, not the number of tiles:
+    # K=128 in tiles of 64 (2 tiles), M=64 in tiles of 16 (4 tiles).
+    with spyre_hint(tile_size_per_dim={"K": 64}):
+        with spyre_hint(tile_size_per_dim={"M": 16}):
             x = a + b
         y = x @ c
     return y + d

--- a/docs/tools/capture_coarse_tile_ir.py
+++ b/docs/tools/capture_coarse_tile_ir.py
@@ -81,13 +81,13 @@ def main() -> None:
         "--outer-tiles",
         type=int,
         default=2,
-        help="num_tiles_per_dim for the outer spyre_hint (dim A). Default: 2.",
+        help="Number of tiles for the outer spyre_hint (dim A). Default: 2.",
     )
     parser.add_argument(
         "--inner-tiles",
         type=int,
         default=4,
-        help="num_tiles_per_dim for the inner spyre_hint (dim B). Default: 4.",
+        help="Number of tiles for the inner spyre_hint (dim B). Default: 4.",
     )
     parser.add_argument(
         "--size-a", type=int, default=1024, help="Size of dim A. Default: 1024."
@@ -114,11 +114,14 @@ def main() -> None:
     for t in (a_dev, b_dev, c_dev):
         _name_tensor_dims(t, ["A", "B"])
 
-    outer_tiles, inner_tiles = args.outer_tiles, args.inner_tiles
+    # The CLI takes tile COUNTS, but spyre_hint declares the per-tile EXTENT,
+    # so convert here at the hint boundary.
+    outer_size = args.size_a // args.outer_tiles
+    inner_size = args.size_b // args.inner_tiles
 
     def fn(a, b, c):
-        with spyre_hint(num_tiles_per_dim={"A": outer_tiles}):
-            with spyre_hint(num_tiles_per_dim={"B": inner_tiles}):
+        with spyre_hint(tile_size_per_dim={"A": outer_size}):
+            with spyre_hint(tile_size_per_dim={"B": inner_size}):
                 y = a + b
                 z = y * c
                 return z

--- a/tests/configs/torch_spyre_tests/inductor/test_tile_size_hint_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_tile_size_hint_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [core, full, device_critical]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_tile_size_hint.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_building_blocks.py
+++ b/tests/inductor/test_building_blocks.py
@@ -306,7 +306,7 @@ class TestBuildingBlocks(unittest.TestCase):
             # abs is a plain SchedulerNode; neg inside the hint becomes a
             # CountedLoopSchedulerNode.  The two must fuse into one bundle.
             y = torch.abs(x)
-            with sh(num_tiles_per_dim={"T": 2}):
+            with sh(tile_size_per_dim={"T": 64}):
                 return torch.neg(y)
 
         cfn = torch.compile(fn)
@@ -338,7 +338,7 @@ class TestBuildingBlocks(unittest.TestCase):
         _pnd.name_tensor_dims(x_dev, ["T", "D"])
 
         def fn(x):
-            with sh(num_tiles_per_dim={"T": 2}):
+            with sh(tile_size_per_dim={"T": 64}):
                 return x + x
 
         captured_op_specs = []

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1809,8 +1809,8 @@ def test_copy_running_max_4d_H4_Lq4():
         real_max = torch.full(
             (B, H, Lq), float("-inf"), device=scores.device, dtype=scores.dtype
         )
-        with spyre_hint(num_tiles_per_dim={"H": H // h_block_size}):
-            with spyre_hint(num_tiles_per_dim={"Lq": Lq // lq_block_size}):
+        with spyre_hint(tile_size_per_dim={"H": h_block_size}):
+            with spyre_hint(tile_size_per_dim={"Lq": lq_block_size}):
                 with spyre_hint(
                     expected_named_dims=["B", "H", "Lq"], expected_reduction_dims=["Lk"]
                 ):
@@ -2576,6 +2576,13 @@ def _flash_v1_fn(
         denominator = torch.zeros(
             (B, H, Lq), device=queries.device, dtype=torch.float16
         )
+    # These stay on num_tiles_per_dim deliberately.  A tile SIZE must be given in
+    # the units of the LOOP VAR the dim lands on, and that grouping is
+    # shape-dependent: with B=1 the backend folds B in with H onto one loop var
+    # of extent B*H, so "B" would need (B//b_tiles)*H rather than B//b_tiles --
+    # and in _flash_v4_fn both Lq and Lk come from S.  A helper parameterised
+    # over many shapes cannot write that as a fixed expression.  A COUNT is
+    # invariant to which loop var a name lands on; a size is not.  See #3520.
     with spyre_hint(num_tiles_per_dim={"B": b_tiles}):
         with spyre_hint(num_tiles_per_dim={"H": h_tiles}):
             with spyre_hint(num_tiles_per_dim={"Lq": lq_tiles}):
@@ -2798,6 +2805,13 @@ def _flash_v2_fn(
         device=queries.device,
         dtype=torch.float16,
     ).amax(dim=-1)
+    # These stay on num_tiles_per_dim deliberately.  A tile SIZE must be given in
+    # the units of the LOOP VAR the dim lands on, and that grouping is
+    # shape-dependent: with B=1 the backend folds B in with H onto one loop var
+    # of extent B*H, so "B" would need (B//b_tiles)*H rather than B//b_tiles --
+    # and in _flash_v4_fn both Lq and Lk come from S.  A helper parameterised
+    # over many shapes cannot write that as a fixed expression.  A COUNT is
+    # invariant to which loop var a name lands on; a size is not.  See #3520.
     with spyre_hint(num_tiles_per_dim={"B": b_tiles}):
         with spyre_hint(num_tiles_per_dim={"H": h_tiles}):
             with spyre_hint(num_tiles_per_dim={"Lq": lq_tiles}):
@@ -2991,8 +3005,8 @@ def test_flash_v2_tile_all():
 
 
 # ---------------------------------------------------------------------------
-# Flash v3: causal mask, copy_ accumulators, scores transposed, tiles= API
-# Uses num_tiles_per_dim= (normalized from tiles=) for consistency
+# Flash v3: causal mask, copy_ accumulators, scores transposed
+# Declares tile_size_per_dim= (per-tile extent), like every other site here
 # ---------------------------------------------------------------------------
 
 
@@ -3038,6 +3052,13 @@ def _flash_v3_fn(
         (B, H, Lq), float("-inf"), device=queries.device, dtype=torch.float16
     )
     denominator = torch.zeros((B, H, Lq), device=queries.device, dtype=torch.float16)
+    # These stay on num_tiles_per_dim deliberately.  A tile SIZE must be given in
+    # the units of the LOOP VAR the dim lands on, and that grouping is
+    # shape-dependent: with B=1 the backend folds B in with H onto one loop var
+    # of extent B*H, so "B" would need (B//b_tiles)*H rather than B//b_tiles --
+    # and in _flash_v4_fn both Lq and Lk come from S.  A helper parameterised
+    # over many shapes cannot write that as a fixed expression.  A COUNT is
+    # invariant to which loop var a name lands on; a size is not.  See #3520.
     with spyre_hint(num_tiles_per_dim={"B": b_tiles}):
         with spyre_hint(num_tiles_per_dim={"H": h_tiles}):
             with spyre_hint(num_tiles_per_dim={"Lq": lq_tiles}):
@@ -3249,6 +3270,13 @@ def _flash_v4_fn(q, k, v, *, B, S, H, D, b_tiles=1, h_tiles=1, lq_tiles=1, lk_ti
     output = torch.zeros_like(q)
     real_max = torch.full((B, H, S), float("-inf"), device=q.device, dtype=q.dtype)
     denominator = torch.zeros((B, H, S), device=q.device, dtype=q.dtype)
+    # These stay on num_tiles_per_dim deliberately.  A tile SIZE must be given in
+    # the units of the LOOP VAR the dim lands on, and that grouping is
+    # shape-dependent: with B=1 the backend folds B in with H onto one loop var
+    # of extent B*H, so "B" would need (B//b_tiles)*H rather than B//b_tiles --
+    # and in _flash_v4_fn both Lq and Lk come from S.  A helper parameterised
+    # over many shapes cannot write that as a fixed expression.  A COUNT is
+    # invariant to which loop var a name lands on; a size is not.  See #3520.
     with spyre_hint(num_tiles_per_dim={"B": b_tiles}):
         with spyre_hint(num_tiles_per_dim={"H": h_tiles}):
             with spyre_hint(num_tiles_per_dim={"Lq": lq_tiles}):
@@ -3681,13 +3709,15 @@ class TestCoarseTileSpyreHints(InductorTestCase):
           B=256 → 4 tiles of 64 rows each.  Iteration space per tile: [64, D].
 
         op_b = neg(y): tensor named ["B0","B1","D0","D1"] with B0×B1=B and
-          D0×D1=D.  Outer hint num_tiles_per_dim={"B0": 4} tiles dim 0 (c0,
-          range 256) into 4.  Inner hint num_tiles_per_dim={"D0": 4} tiles
-          dim 1 (c1, range 128) into 4.  Iteration space per tile: [64, 32].
-          These two stay on num_tiles_per_dim: B0/D0 are sub-dims of a fused
-          host dim, so their declared extents are the split factors (4), not
-          the host ranges (256/128), and a tile size derived from them would
-          not describe the host tile.
+          D0×D1=D.  Outer hint tiles dim 0 (c0, range 256) into 4, inner hint
+          tiles dim 1 (c1, range 128) into 4.  Iteration space per tile:
+          [64, 32].
+
+          A tile SIZE for a sub-dim name must be in HOST-dim units, which for a
+          sub-dim decomposition is just the sibling's extent: B0×B1=256 split
+          into B0=4 parts is B1=64 rows per tile.  Deriving it from B0's own
+          declared extent would give 4//4 = 1 -- a count of B0 steps per tile,
+          not an extent of anything the backend divides.
 
         Both ops form separate groups → ≥2 LoopSpec entries, each with
         count=sympify('4').
@@ -3720,8 +3750,12 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         def fn(x, y):
             with spyre_hint(tile_size_per_dim={"B": 64}):
                 out_x = torch.abs(x)
-            with spyre_hint(num_tiles_per_dim={"B0": 4}):
-                with spyre_hint(num_tiles_per_dim={"D0": 4}):
+            # Host-dim units: B0xB1=B split into B0=4 parts is B1 rows per tile,
+            # and likewise D1 cols.  Deriving from B0's own declared extent (4)
+            # would give 4//4 = 1, a count of B0 steps rather than an extent --
+            # see the docstring and #3520.
+            with spyre_hint(tile_size_per_dim={"B0": B1}):
+                with spyre_hint(tile_size_per_dim={"D0": D1}):
                     out_y = torch.neg(y)
             return out_x, out_y
 
@@ -4073,7 +4107,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         # The Lk hint was previously a no-op (dropped by _hints_levels bug fixed
         # on this branch).  Now that Lk tiling is correctly applied, the result
         # is numerically wrong (~90% element mismatch).  Investigate and fix
-        # before re-adding spyre_hint(num_tiles_per_dim={"Lk": lk_slices}).
+        # before re-adding spyre_hint(tile_size_per_dim={"Lk": <per-tile Lk extent>}).
 
         Decision xfail: failing in CI (Actions run 30385154736, job
         90362755639) on PR #3293. We've decided to xfail the coarse tiling
@@ -4085,14 +4119,12 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         from torch_spyre._inductor import spyre_hint
 
         B, H, Lq, Lk, D = 1, 8, 256, 256, 64
-        block_size = 128
 
         queries_t = torch.randn(B, H, Lq, D, dtype=torch.float16)
         keys_t = torch.randn(B, H, Lk, D, dtype=torch.float16)
         values_t = torch.randn(B, H, Lk, D, dtype=torch.float16)
 
         scale = 1.0 / math.sqrt(math.sqrt(D))
-        lk_slices = Lk // block_size  # noqa: F841 — used in commented-out Lk hint
 
         def flash(queries, keys, values):
             with spyre_hint(named_dims=["B", "H", "Lq", "D"]):
@@ -4113,7 +4145,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             ):  # 3 nested scopes exercises multi-hint logic
                 with spyre_hint(tile_size_per_dim={"H": 2}):
                     # TODO: re-enable once numerical error with Lk tiling is fixed
-                    # with spyre_hint(num_tiles_per_dim={"Lk": lk_slices}):
+                    # with spyre_hint(tile_size_per_dim={"Lk": <per-tile Lk extent>}):
                     keys_T = keys.transpose(-1, -2).contiguous()
                     scores = torch.matmul(queries * scale, keys_T * scale)
                     scores = scores.transpose(-1, -2).contiguous()
@@ -4194,7 +4226,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         causal = torch.tril(torch.ones(Lq, Lk, dtype=torch.bool))
         mask_t = torch.zeros(1, 1, Lq, Lk, dtype=torch.float16)
         mask_t.masked_fill_(~causal, float("-inf"))
-        lq_slices = Lq // block_size
 
         def flash(queries, keys, values, mask):
             scale = 1.0 / math.sqrt(math.sqrt(D))
@@ -4217,7 +4248,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                 tile_size_per_dim={"B": 1}
             ):  # 3 nested scopes exercises multi-hint logic
                 with spyre_hint(tile_size_per_dim={"H": 2}):
-                    with spyre_hint(num_tiles_per_dim={"Lq": lq_slices}):
+                    with spyre_hint(tile_size_per_dim={"Lq": block_size}):
                         scaled_keys = keys * scale  # B, H, Lk, D
                         keys_T = scaled_keys.transpose(-1, -2)  # B, H, D, Lk
                         scores = torch.matmul(queries * scale, keys_T)  # B, H, Lq, Lk
@@ -4303,7 +4334,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         causal = torch.tril(torch.ones(Lq, Lk, dtype=torch.bool))
         mask_t = torch.zeros(1, 1, Lq, Lk, dtype=torch.float16)
         mask_t.masked_fill_(~causal, float("-inf"))
-        lq_slices = Lq // block_size
 
         def flash(queries, keys, values, mask):
             scale = 1.0 / math.sqrt(math.sqrt(D))
@@ -4320,7 +4350,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                 dtype=torch.float16,
             ).amax(dim=-1)
             with spyre_hint(tile_size_per_dim={"H": 2}):
-                with spyre_hint(num_tiles_per_dim={"Lq": lq_slices}):
+                with spyre_hint(tile_size_per_dim={"Lq": block_size}):
                     scaled_keys = keys * scale
                     keys_T = scaled_keys.transpose(-1, -2)
                     scores = torch.matmul(queries * scale, keys_T)
@@ -4425,10 +4455,10 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                 (B, H, Lq), device=queries.device, dtype=torch.float16
             )
 
-            with spyre_hint(tiles={"B": B // b_block_size}):
-                with spyre_hint(tiles={"H": H // h_block_size}):
-                    with spyre_hint(tiles={"Lq": Lq // q_block_size}):
-                        with spyre_hint(tiles={"Lk": Lk // kv_block_size}):
+            with spyre_hint(tile_size_per_dim={"B": b_block_size}):
+                with spyre_hint(tile_size_per_dim={"H": h_block_size}):
+                    with spyre_hint(tile_size_per_dim={"Lq": q_block_size}):
+                        with spyre_hint(tile_size_per_dim={"Lk": kv_block_size}):
                             # with spyre_hint(work_div={"H": 4, "Lq": 8, "Lk": 8}):
                             scaled_keys = keys * scale  # B, H, Lk, D
                             keys_T = scaled_keys.transpose(-1, -2)  # B, H, D, Lk
@@ -4529,10 +4559,10 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                 (B, H, Lq), device=queries.device, dtype=torch.float16
             )
 
-            with spyre_hint(tiles={"B": B // b_block_size}):
-                with spyre_hint(tiles={"H": H // h_block_size}):
-                    with spyre_hint(tiles={"Lq": Lq // q_block_size}):
-                        with spyre_hint(tiles={"Lk": Lk // kv_block_size}):
+            with spyre_hint(tile_size_per_dim={"B": b_block_size}):
+                with spyre_hint(tile_size_per_dim={"H": h_block_size}):
+                    with spyre_hint(tile_size_per_dim={"Lq": q_block_size}):
+                        with spyre_hint(tile_size_per_dim={"Lk": kv_block_size}):
                             scaled_keys = keys * scale  # B, H, Lk, D
                             keys_T = scaled_keys.transpose(-1, -2)  # B, H, D, Lk
                             scores = torch.matmul(
@@ -4619,8 +4649,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             real_max = torch.full(
                 (B, H, Lq), float("-inf"), device=scores.device, dtype=scores.dtype
             )
-            with spyre_hint(tiles={"H": H // h_block_size}):
-                with spyre_hint(tiles={"Lq": Lq // lq_block_size}):
+            with spyre_hint(tile_size_per_dim={"H": h_block_size}):
+                with spyre_hint(tile_size_per_dim={"Lq": lq_block_size}):
                     with spyre_hint(
                         expected_named_dims=["B", "H", "Lq"],
                         expected_reduction_dims=["Lk"],
@@ -4691,11 +4721,11 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             )
             denominator = torch.zeros((B, H, S), device=q.device, dtype=q.dtype)
 
-            with spyre_hint(tiles={"batch_size": max(1, B // 2)}):
-                with spyre_hint(tiles={"num_heads": max(1, H // 4)}):
-                    with spyre_hint(tiles={"max_seqlen_q": max(1, S // q_block_size)}):
+            with spyre_hint(tile_size_per_dim={"batch_size": 2}):
+                with spyre_hint(tile_size_per_dim={"num_heads": 4}):
+                    with spyre_hint(tile_size_per_dim={"max_seqlen_q": q_block_size}):
                         with spyre_hint(
-                            tiles={"max_seqlen_kv": max(1, S // kv_block_size)}
+                            tile_size_per_dim={"max_seqlen_kv": kv_block_size}
                         ):
                             scaled_keys = k * scale
                             keys_T = scaled_keys.transpose(-1, -2).contiguous()
@@ -4830,7 +4860,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         B, H, Lq, Lk, D = 1, 8, 256, 256, 64
         block_size = 128
         scale = 1.0 / math.sqrt(math.sqrt(D))
-        lk_slices = Lk // block_size  # 2
 
         queries_t = torch.randn(B, H, Lq, D, dtype=torch.float16)
         keys_t = torch.randn(B, H, Lk, D, dtype=torch.float16)
@@ -4865,7 +4894,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                 )
             with spyre_hint(tile_size_per_dim={"B": 1}):
                 with spyre_hint(tile_size_per_dim={"H": 2}):
-                    with spyre_hint(num_tiles_per_dim={"Lk": lk_slices}):
+                    with spyre_hint(tile_size_per_dim={"Lk": block_size}):
                         keys_T = keys.transpose(-1, -2).contiguous()
                         scores = torch.matmul(queries * scale, keys_T * scale)
                         scores = scores.transpose(-1, -2).contiguous()
@@ -4991,7 +5020,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         B, H, Lq, Lk, D = 1, 8, 256, 256, 64
         block_size = 128
         scale = 1.0 / math.sqrt(math.sqrt(D))
-        lk_slices = Lk // block_size  # 2
 
         queries_t = torch.randn(B, H, Lq, D, dtype=torch.float16)
         keys_t = torch.randn(B, H, Lk, D, dtype=torch.float16)
@@ -5024,7 +5052,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                 )
             with spyre_hint(tile_size_per_dim={"B": 1}):
                 with spyre_hint(tile_size_per_dim={"H": 2}):
-                    with spyre_hint(num_tiles_per_dim={"Lk": lk_slices}):
+                    with spyre_hint(tile_size_per_dim={"Lk": block_size}):
                         keys_T = keys.transpose(-1, -2).contiguous()
                         scores = torch.matmul(queries * scale, keys_T * scale)
                         scores = scores.transpose(-1, -2).contiguous()
@@ -5096,7 +5124,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
         B, H, Lq, Lk, D = 1, 8, 256, 256, 64
         block_size = 128
-        lq_slices = Lq // block_size  # 2
 
         queries_t = torch.randn(B, H, Lq, D, dtype=torch.float16)
         keys_t = torch.randn(B, H, Lk, D, dtype=torch.float16)
@@ -5136,7 +5163,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             denominator = denominator.amax(dim=-1)  # B, H, Lq sparse
             with spyre_hint(tile_size_per_dim={"B": 1}):
                 with spyre_hint(tile_size_per_dim={"H": 2}):
-                    with spyre_hint(num_tiles_per_dim={"Lq": lq_slices}):
+                    with spyre_hint(tile_size_per_dim={"Lq": block_size}):
                         scaled_keys = keys * scale  # B, H, Lk, D
                         keys_T = scaled_keys.transpose(-1, -2)  # B, H, D, Lk
                         scores = torch.matmul(queries * scale, keys_T)  # B, H, Lq, Lk
@@ -6363,7 +6390,6 @@ def test_tiled_in_place_accumulator():
     _pnd.reset()
 
     B, H, Lq, D = 1, 8, 256, 64
-    lq_slices = Lq // 128
 
     x_t = torch.randn(B, H, Lq, D, dtype=torch.float16)
     scale_t = torch.randn(B, H, Lq, 1, dtype=torch.float16)
@@ -6373,7 +6399,7 @@ def test_tiled_in_place_accumulator():
 
     def fn(x, scale, acc):
         with spyre_hint(tile_size_per_dim={"H": 2}):
-            with spyre_hint(num_tiles_per_dim={"Lq": lq_slices}):
+            with spyre_hint(tile_size_per_dim={"Lq": 128}):
                 block_max = torch.amax(x, dim=-1, keepdim=True)
                 acc.copy_(acc + block_max * scale)
         return acc

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -205,7 +205,7 @@ def test_abs_256x256_A4():
     inputs = [tensor("x", shape=(256, 256), dims=["A", "B"])]
 
     def fn(x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return torch.abs(x)
 
@@ -217,7 +217,7 @@ def test_abs_256x256_B4():
     inputs = [tensor("x", shape=(256, 256), dims=["A", "B"])]
 
     def fn(x):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return torch.abs(x)
 
@@ -229,8 +229,8 @@ def test_abs_256x256_A4_B4():
     inputs = [tensor("x", shape=(256, 256), dims=["A", "B"])]
 
     def fn(x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 64}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     return torch.abs(x)
 
@@ -248,7 +248,7 @@ def test_add_256x256_A4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return x + y
 
@@ -263,7 +263,7 @@ def test_add_256x256_B4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return x + y
 
@@ -278,8 +278,8 @@ def test_add_256x256_A4_B4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 64}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     return x + y
 
@@ -297,7 +297,7 @@ def test_add_512x256_A4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return x + y
 
@@ -312,7 +312,7 @@ def test_add_512x256_B4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return x + y
 
@@ -327,8 +327,8 @@ def test_add_512x256_A4_B4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     return x + y
 
@@ -346,7 +346,7 @@ def test_add_256x512_A4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return x + y
 
@@ -361,7 +361,7 @@ def test_add_256x512_B4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 128}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return x + y
 
@@ -376,8 +376,8 @@ def test_add_256x512_A4_B4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 64}):
+            with spyre_hint(tile_size_per_dim={"B": 128}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     return x + y
 
@@ -395,7 +395,7 @@ def test_add_512x512_A4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return x + y
 
@@ -410,7 +410,7 @@ def test_add_512x512_B4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 128}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return x + y
 
@@ -425,8 +425,8 @@ def test_add_512x512_A4_B4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 128}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     return x + y
 
@@ -444,8 +444,8 @@ def test_add_512x256_A4_B2():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 2}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 128}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     return x + y
 
@@ -466,7 +466,7 @@ def test_add_3d_512x256x256_A4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["A", "B", "C"]):
                 return x + y
 
@@ -481,7 +481,7 @@ def test_add_3d_512x256x256_B2():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"B": 2}):
+        with spyre_hint(tile_size_per_dim={"B": 128}):
             with spyre_hint(expected_named_dims=["A", "B", "C"]):
                 return x + y
 
@@ -496,7 +496,7 @@ def test_add_3d_512x256x256_C4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"C": 4}):
+        with spyre_hint(tile_size_per_dim={"C": 64}):
             with spyre_hint(expected_named_dims=["A", "B", "C"]):
                 return x + y
 
@@ -511,8 +511,8 @@ def test_add_3d_512x256x256_A4_B2():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 2}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 128}):
                 with spyre_hint(expected_named_dims=["A", "B", "C"]):
                     return x + y
 
@@ -527,8 +527,8 @@ def test_add_3d_512x256x256_A4_C4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"C": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"C": 64}):
                 with spyre_hint(expected_named_dims=["A", "B", "C"]):
                     return x + y
 
@@ -543,8 +543,8 @@ def test_add_3d_512x256x256_B2_C4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"B": 2}):
-            with spyre_hint(num_tiles_per_dim={"C": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 128}):
+            with spyre_hint(tile_size_per_dim={"C": 64}):
                 with spyre_hint(expected_named_dims=["A", "B", "C"]):
                     return x + y
 
@@ -559,9 +559,9 @@ def test_add_3d_512x256x256_A4_B2_C4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 2}):
-                with spyre_hint(num_tiles_per_dim={"C": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 128}):
+                with spyre_hint(tile_size_per_dim={"C": 64}):
                     with spyre_hint(expected_named_dims=["A", "B", "C"]):
                         return x + y
 
@@ -583,7 +583,7 @@ def test_abs_add_mul_512x256_A4():
     ]
 
     def fn(a, b, c):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return torch.abs(a + b) * c
 
@@ -599,7 +599,7 @@ def test_abs_add_mul_512x256_B4():
     ]
 
     def fn(a, b, c):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return torch.abs(a + b) * c
 
@@ -615,8 +615,8 @@ def test_abs_add_mul_512x256_A4_B4():
     ]
 
     def fn(a, b, c):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     return torch.abs(a + b) * c
 
@@ -632,7 +632,7 @@ def test_exp_abs_add_mul_512x256_A4():
     ]
 
     def fn(a, b, c):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return torch.exp(torch.abs((a + b) * c))
 
@@ -648,7 +648,7 @@ def test_exp_abs_add_mul_512x256_B4():
     ]
 
     def fn(a, b, c):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return torch.exp(torch.abs((a + b) * c))
 
@@ -664,8 +664,8 @@ def test_exp_abs_add_mul_512x256_A4_B4():
     ]
 
     def fn(a, b, c):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     return torch.exp(torch.abs((a + b) * c))
 
@@ -684,7 +684,7 @@ def test_min_2d_512x256_reduce_dim0_A4():
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
 
     def fn(x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
                 return x.amin(dim=0)
 
@@ -696,7 +696,7 @@ def test_min_2d_512x256_reduce_dim0_B4():
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
 
     def fn(x):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
                 return x.amin(dim=0)
 
@@ -708,8 +708,8 @@ def test_min_2d_512x256_reduce_dim0_A4_B4():
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
 
     def fn(x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(
                     expected_named_dims=["B"], expected_reduction_dims=["A"]
                 ):
@@ -725,7 +725,7 @@ def test_min_2d_512x256_reduce_dim1_A4():
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
 
     def fn(x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["A"], expected_reduction_dims=["B"]):
                 return x.amin(dim=1)
 
@@ -737,7 +737,7 @@ def test_min_2d_512x256_reduce_dim1_B4():
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
 
     def fn(x):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["A"], expected_reduction_dims=["B"]):
                 return x.amin(dim=1)
 
@@ -749,8 +749,8 @@ def test_min_2d_512x256_reduce_dim1_A4_B4():
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
 
     def fn(x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(
                     expected_named_dims=["A"], expected_reduction_dims=["B"]
                 ):
@@ -767,9 +767,9 @@ def test_min_3d_512x256x256_reduce_dim0_A4_B2_C4():
     inputs = [tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"])]
 
     def fn(x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 2}):
-                with spyre_hint(num_tiles_per_dim={"C": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 128}):
+                with spyre_hint(tile_size_per_dim={"C": 64}):
                     with spyre_hint(
                         expected_named_dims=["B", "C"], expected_reduction_dims=["A"]
                     ):
@@ -786,9 +786,9 @@ def test_min_3d_512x256x256_reduce_dim1_A4_B2_C4():
     inputs = [tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"])]
 
     def fn(x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 2}):
-                with spyre_hint(num_tiles_per_dim={"C": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 128}):
+                with spyre_hint(tile_size_per_dim={"C": 64}):
                     with spyre_hint(
                         expected_named_dims=["A", "C"], expected_reduction_dims=["B"]
                     ):
@@ -804,9 +804,9 @@ def test_min_3d_512x256x256_reduce_dim2_A4_B2_C4():
     inputs = [tensor("x", shape=(512, 256, 256), dims=["A", "B", "C"])]
 
     def fn(x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 2}):
-                with spyre_hint(num_tiles_per_dim={"C": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 128}):
+                with spyre_hint(tile_size_per_dim={"C": 64}):
                     with spyre_hint(
                         expected_named_dims=["A", "B"], expected_reduction_dims=["C"]
                     ):
@@ -834,7 +834,7 @@ def test_add_min_2d_512x256_reduce_dim0_A4():
     ]
 
     def fn(a, b):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
                 r = b.amin(dim=0)
             with spyre_hint(expected_named_dims=["B"]):
@@ -853,7 +853,7 @@ def test_add_min_2d_512x256_reduce_dim0_B4():
     ]
 
     def fn(a, b):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
                 r = b.amin(dim=0)
             with spyre_hint(expected_named_dims=["B"]):
@@ -872,8 +872,8 @@ def test_add_min_2d_512x256_reduce_dim0_A4_B4():
     ]
 
     def fn(a, b):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(
                     expected_named_dims=["B"], expected_reduction_dims=["A"]
                 ):
@@ -894,7 +894,7 @@ def test_add_min_2d_512x256_reduce_dim1_A4():
     ]
 
     def fn(a, b):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["A"], expected_reduction_dims=["B"]):
                 r = b.amin(dim=1, keepdim=True)
             with spyre_hint(expected_named_dims=["A"]):
@@ -913,7 +913,7 @@ def test_add_min_2d_512x256_reduce_dim1_B4():
     ]
 
     def fn(a, b):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["A"], expected_reduction_dims=["B"]):
                 r = b.amin(dim=1, keepdim=True)
             with spyre_hint(expected_named_dims=["A"]):
@@ -932,8 +932,8 @@ def test_add_min_2d_512x256_reduce_dim1_A4_B4():
     ]
 
     def fn(a, b):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(
                     expected_named_dims=["A"], expected_reduction_dims=["B"]
                 ):
@@ -955,9 +955,9 @@ def test_add_min_3d_512x256x256_reduce_dim0_A4_B2_C4():
     ]
 
     def fn(a, b):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 2}):
-                with spyre_hint(num_tiles_per_dim={"C": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 128}):
+                with spyre_hint(tile_size_per_dim={"C": 64}):
                     with spyre_hint(
                         expected_named_dims=["B", "C"], expected_reduction_dims=["A"]
                     ):
@@ -981,9 +981,9 @@ def test_add_min_3d_512x256x256_reduce_dim1_A4_B2_C4():
     ]
 
     def fn(a, b):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 2}):
-                with spyre_hint(num_tiles_per_dim={"C": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 128}):
+                with spyre_hint(tile_size_per_dim={"C": 64}):
                     with spyre_hint(
                         expected_named_dims=["A", "C"], expected_reduction_dims=["B"]
                     ):
@@ -1007,9 +1007,9 @@ def test_add_min_3d_512x256x256_reduce_dim2_A4_B2_C4():
     ]
 
     def fn(a, b):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 2}):
-                with spyre_hint(num_tiles_per_dim={"C": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 128}):
+                with spyre_hint(tile_size_per_dim={"C": 64}):
                     with spyre_hint(
                         expected_named_dims=["A", "B"], expected_reduction_dims=["C"]
                     ):
@@ -1036,7 +1036,7 @@ def test_reduce_both_dense_add_2d_512x256_A4():
     ]
 
     def fn(a, b):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["B"]):
                 return a.amin(dim=0) + b.amin(dim=0)
 
@@ -1051,7 +1051,7 @@ def test_reduce_both_dense_add_2d_512x256_B4():
     ]
 
     def fn(a, b):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["B"]):
                 return a.amin(dim=0) + b.amin(dim=0)
 
@@ -1066,8 +1066,8 @@ def test_reduce_both_dense_add_2d_512x256_A4_B4():
     ]
 
     def fn(a, b):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(expected_named_dims=["B"]):
                     return a.amin(dim=0) + b.amin(dim=0)
 
@@ -1082,7 +1082,7 @@ def test_reduce_both_sparse_add_2d_512x256_A4():
     ]
 
     def fn(a, b):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["A"]):
                 return a.amin(dim=1) + b.amin(dim=1)
 
@@ -1097,7 +1097,7 @@ def test_reduce_both_sparse_add_2d_512x256_B4():
     ]
 
     def fn(a, b):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["A"]):
                 return a.amin(dim=1) + b.amin(dim=1)
 
@@ -1112,8 +1112,8 @@ def test_reduce_both_sparse_add_2d_512x256_A4_B4():
     ]
 
     def fn(a, b):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(expected_named_dims=["A"]):
                     return a.amin(dim=1) + b.amin(dim=1)
 
@@ -1129,7 +1129,7 @@ def test_softmax_2d_512x256_dim1_A4():
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
 
     def fn(x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             return torch.softmax(x, dim=1)
 
     run_coarse_tile_test(fn, inputs)
@@ -1140,7 +1140,7 @@ def test_softmax_2d_512x256_dim1_B4():
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
 
     def fn(x):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             return torch.softmax(x, dim=1)
 
     run_coarse_tile_test(fn, inputs)
@@ -1151,8 +1151,8 @@ def test_softmax_2d_512x256_dim1_A4_B4():
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
 
     def fn(x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 return torch.softmax(x, dim=1)
 
     run_coarse_tile_test(fn, inputs)
@@ -1163,7 +1163,7 @@ def test_softmax_2d_512x256_dim0_A4():
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
 
     def fn(x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             return torch.softmax(x, dim=0)
 
     run_coarse_tile_test(fn, inputs)
@@ -1174,7 +1174,7 @@ def test_softmax_2d_512x256_dim0_B4():
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
 
     def fn(x):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             return torch.softmax(x, dim=0)
 
     run_coarse_tile_test(fn, inputs)
@@ -1185,8 +1185,8 @@ def test_softmax_2d_512x256_dim0_A4_B4():
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
 
     def fn(x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 return torch.softmax(x, dim=0)
 
     run_coarse_tile_test(fn, inputs)
@@ -1212,7 +1212,7 @@ def test_restickify_add_256x128_A2():
     ]
 
     def fn(a, x):
-        with spyre_hint(num_tiles_per_dim={"A": 2}):
+        with spyre_hint(tile_size_per_dim={"A": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return a.t() + x
 
@@ -1230,7 +1230,7 @@ def test_restickify_add_256x128_B4():
     ]
 
     def fn(a, x):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return a.t() + x
 
@@ -1248,8 +1248,8 @@ def test_restickify_add_256x128_A2_B4():
     ]
 
     def fn(a, x):
-        with spyre_hint(num_tiles_per_dim={"A": 2}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 64}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     return a.t() + x
 
@@ -1271,7 +1271,7 @@ def test_restickify_2t_add_256x128_A2():
     ]
 
     def fn(a, b, x):
-        with spyre_hint(num_tiles_per_dim={"A": 2}):
+        with spyre_hint(tile_size_per_dim={"A": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return a.t() + b.t() + x
 
@@ -1290,7 +1290,7 @@ def test_restickify_2t_add_256x128_B4():
     ]
 
     def fn(a, b, x):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return a.t() + b.t() + x
 
@@ -1309,8 +1309,8 @@ def test_restickify_2t_add_256x128_A2_B4():
     ]
 
     def fn(a, b, x):
-        with spyre_hint(num_tiles_per_dim={"A": 2}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 64}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     return a.t() + b.t() + x
 
@@ -1335,7 +1335,7 @@ def test_restickify_3d_transpose12_256x512x256_A4():
     ]
 
     def fn(a, x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 64}):
             with spyre_hint(expected_named_dims=["A", "B", "C"]):
                 return a.transpose(1, 2) + x
 
@@ -1353,7 +1353,7 @@ def test_restickify_3d_transpose12_256x512x256_B4():
     ]
 
     def fn(a, x):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["A", "B", "C"]):
                 return a.transpose(1, 2) + x
 
@@ -1371,7 +1371,7 @@ def test_restickify_3d_transpose12_256x512x256_C4():
     ]
 
     def fn(a, x):
-        with spyre_hint(num_tiles_per_dim={"C": 4}):
+        with spyre_hint(tile_size_per_dim={"C": 128}):
             with spyre_hint(expected_named_dims=["A", "B", "C"]):
                 return a.transpose(1, 2) + x
 
@@ -1389,8 +1389,8 @@ def test_restickify_3d_transpose12_256x512x256_A4_B4():
     ]
 
     def fn(a, x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 64}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(expected_named_dims=["A", "B", "C"]):
                     return a.transpose(1, 2) + x
 
@@ -1408,8 +1408,8 @@ def test_restickify_3d_transpose12_256x512x256_A4_C4():
     ]
 
     def fn(a, x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"C": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 64}):
+            with spyre_hint(tile_size_per_dim={"C": 128}):
                 with spyre_hint(expected_named_dims=["A", "B", "C"]):
                     return a.transpose(1, 2) + x
 
@@ -1427,8 +1427,8 @@ def test_restickify_3d_transpose12_256x512x256_B4_C4():
     ]
 
     def fn(a, x):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
-            with spyre_hint(num_tiles_per_dim={"C": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
+            with spyre_hint(tile_size_per_dim={"C": 128}):
                 with spyre_hint(expected_named_dims=["A", "B", "C"]):
                     return a.transpose(1, 2) + x
 
@@ -1448,9 +1448,9 @@ def test_restickify_3d_transpose12_256x512x256_A4_B4_C4():
     ]
 
     def fn(a, x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
-                with spyre_hint(num_tiles_per_dim={"C": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 64}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
+                with spyre_hint(tile_size_per_dim={"C": 128}):
                     with spyre_hint(expected_named_dims=["A", "B", "C"]):
                         return a.transpose(1, 2) + x
 
@@ -1475,7 +1475,7 @@ def test_restickify_matmul_xt_y_256x128_M4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"M": 4}):
+        with spyre_hint(tile_size_per_dim={"M": 64}):
             with spyre_hint(expected_named_dims=["M", "N"]):
                 return torch.matmul(x.t(), y)
 
@@ -1493,7 +1493,7 @@ def test_restickify_matmul_xt_y_256x128_N4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"N": 4}):
+        with spyre_hint(tile_size_per_dim={"N": 64}):
             with spyre_hint(expected_named_dims=["M", "N"]):
                 return torch.matmul(x.t(), y)
 
@@ -1511,8 +1511,8 @@ def test_restickify_matmul_xt_y_256x128_M4_N4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"M": 4}):
-            with spyre_hint(num_tiles_per_dim={"N": 4}):
+        with spyre_hint(tile_size_per_dim={"M": 64}):
+            with spyre_hint(tile_size_per_dim={"N": 64}):
                 with spyre_hint(expected_named_dims=["M", "N"]):
                     return torch.matmul(x.t(), y)
 
@@ -1530,7 +1530,7 @@ def test_restickify_matmul_x_yt_128x256_M2():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"M": 2}):
+        with spyre_hint(tile_size_per_dim={"M": 64}):
             with spyre_hint(expected_named_dims=["M", "N"]):
                 return torch.matmul(x, y.t())
 
@@ -1548,7 +1548,7 @@ def test_restickify_matmul_x_yt_128x256_N2():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"N": 2}):
+        with spyre_hint(tile_size_per_dim={"N": 64}):
             with spyre_hint(expected_named_dims=["M", "N"]):
                 return torch.matmul(x, y.t())
 
@@ -1566,8 +1566,8 @@ def test_restickify_matmul_x_yt_128x256_M2_N2():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"M": 2}):
-            with spyre_hint(num_tiles_per_dim={"N": 2}):
+        with spyre_hint(tile_size_per_dim={"M": 64}):
+            with spyre_hint(tile_size_per_dim={"N": 64}):
                 with spyre_hint(expected_named_dims=["M", "N"]):
                     return torch.matmul(x, y.t())
 
@@ -1593,7 +1593,7 @@ def test_copy_into_preallocated_512x256_A4():
 
     def fn(a, b):
         c = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 c.copy_(a + b)
         return c
@@ -1610,7 +1610,7 @@ def test_copy_into_preallocated_512x256_B4():
 
     def fn(a, b):
         c = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 c.copy_(a + b)
         return c
@@ -1627,8 +1627,8 @@ def test_copy_into_preallocated_512x256_A4_B4():
 
     def fn(a, b):
         c = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     c.copy_(a + b)
         return c
@@ -1647,7 +1647,7 @@ def test_copy_inplace_accum_512x256_A4():
     ]
 
     def fn(acc, x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 acc.copy_(acc + x)
         return acc
@@ -1663,7 +1663,7 @@ def test_copy_inplace_accum_512x256_B4():
     ]
 
     def fn(acc, x):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 acc.copy_(acc + x)
         return acc
@@ -1679,8 +1679,8 @@ def test_copy_inplace_accum_512x256_A4_B4():
     ]
 
     def fn(acc, x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     acc.copy_(acc + x)
         return acc
@@ -1701,7 +1701,7 @@ def test_copy_rmw_correction_512x256_A4():
     ]
 
     def fn(acc, scale, y):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 acc.copy_(acc * scale + y)
         return acc
@@ -1718,7 +1718,7 @@ def test_copy_rmw_correction_512x256_B4():
     ]
 
     def fn(acc, scale, y):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 acc.copy_(acc * scale + y)
         return acc
@@ -1735,8 +1735,8 @@ def test_copy_rmw_correction_512x256_A4_B4():
     ]
 
     def fn(acc, scale, y):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     acc.copy_(acc * scale + y)
         return acc
@@ -1754,7 +1754,7 @@ def test_copy_after_reduction_512x256_A4():
 
     def fn(x):
         out = torch.zeros(256, device=x.device, dtype=x.dtype)
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
                 out.copy_(x.amin(dim=0))
         return out
@@ -1768,7 +1768,7 @@ def test_copy_after_reduction_512x256_B4():
 
     def fn(x):
         out = torch.zeros(256, device=x.device, dtype=x.dtype)
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
                 out.copy_(x.amin(dim=0))
         return out
@@ -1782,8 +1782,8 @@ def test_copy_after_reduction_512x256_A4_B4():
 
     def fn(x):
         out = torch.zeros(256, device=x.device, dtype=x.dtype)
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(
                     expected_named_dims=["B"], expected_reduction_dims=["A"]
                 ):
@@ -1839,7 +1839,7 @@ def test_copy_restickify_512x256_A4():
 
     def fn(a, b):
         c = torch.zeros(b.shape, device=b.device, dtype=b.dtype)
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 c.copy_(a.t() + b)
         return c
@@ -1859,7 +1859,7 @@ def test_copy_restickify_512x256_B4():
 
     def fn(a, b):
         c = torch.zeros(b.shape, device=b.device, dtype=b.dtype)
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 128}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 c.copy_(a.t() + b)
         return c
@@ -1879,8 +1879,8 @@ def test_copy_restickify_512x256_A4_B4():
 
     def fn(a, b):
         c = torch.zeros(b.shape, device=b.device, dtype=b.dtype)
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 64}):
+            with spyre_hint(tile_size_per_dim={"B": 128}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     c.copy_(a.t() + b)
         return c
@@ -1901,7 +1901,7 @@ def test_copy_accum_with_reduction_512x256_A4():
     ]
 
     def fn(acc, scale, x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["A"], expected_reduction_dims=["B"]):
                 r = x.amin(dim=1, keepdim=True)
             with spyre_hint(expected_named_dims=["A", "B"]):
@@ -1923,7 +1923,7 @@ def test_copy_accum_with_reduction_512x256_B4():
     ]
 
     def fn(acc, scale, x):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["A"], expected_reduction_dims=["B"]):
                 r = x.amin(dim=1, keepdim=True)
             with spyre_hint(expected_named_dims=["A", "B"]):
@@ -1945,8 +1945,8 @@ def test_copy_accum_with_reduction_512x256_A4_B4():
     ]
 
     def fn(acc, scale, x):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(
                     expected_named_dims=["A"], expected_reduction_dims=["B"]
                 ):
@@ -1971,7 +1971,7 @@ def test_copy_two_copies_same_scope_512x256_A4():
     def fn(a, b):
         c1 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
         c2 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 c1.copy_(a + b)
             with spyre_hint(expected_named_dims=["A", "B"]):
@@ -1991,7 +1991,7 @@ def test_copy_two_copies_same_scope_512x256_B4():
     def fn(a, b):
         c1 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
         c2 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 c1.copy_(a + b)
             with spyre_hint(expected_named_dims=["A", "B"]):
@@ -2011,8 +2011,8 @@ def test_copy_two_copies_same_scope_512x256_A4_B4():
     def fn(a, b):
         c1 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
         c2 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     c1.copy_(a + b)
                 with spyre_hint(expected_named_dims=["A", "B"]):
@@ -2042,7 +2042,7 @@ def test_outside_consumer_pointwise_512x256_A4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 z = x + y
         return z * 2.0
@@ -2058,7 +2058,7 @@ def test_outside_consumer_pointwise_512x256_B4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 z = x + y
         return z * 2.0
@@ -2074,8 +2074,8 @@ def test_outside_consumer_pointwise_512x256_A4_B4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     z = x + y
         return z * 2.0
@@ -2097,7 +2097,7 @@ def test_outside_consumer_copy_then_read_512x256_A4():
 
     def fn(x, y, norm):
         out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 out.copy_(x + y)
         return out / (torch.abs(norm) + 1.0)
@@ -2115,7 +2115,7 @@ def test_outside_consumer_copy_then_read_512x256_B4():
 
     def fn(x, y, norm):
         out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 out.copy_(x + y)
         return out / (torch.abs(norm) + 1.0)
@@ -2133,8 +2133,8 @@ def test_outside_consumer_copy_then_read_512x256_A4_B4():
 
     def fn(x, y, norm):
         out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     out.copy_(x + y)
         return out / (torch.abs(norm) + 1.0)
@@ -2160,7 +2160,7 @@ def test_outside_consumer_two_accum_512x256_A4():
     def fn(x, scale):
         out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
         denom = torch.zeros(x.shape[0], device=x.device, dtype=x.dtype)
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 out.copy_(out * scale + x)
             with spyre_hint(expected_named_dims=["A"]):
@@ -2180,7 +2180,7 @@ def test_outside_consumer_two_accum_512x256_B4():
     def fn(x, scale):
         out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
         denom = torch.zeros(x.shape[0], device=x.device, dtype=x.dtype)
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["A", "B"]):
                 out.copy_(out * scale + x)
             with spyre_hint(expected_named_dims=["A"]):
@@ -2203,8 +2203,8 @@ def test_outside_consumer_two_accum_512x256_A4_B4():
     def fn(x, scale):
         out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
         denom = torch.zeros(x.shape[0], device=x.device, dtype=x.dtype)
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     out.copy_(out * scale + x)
                 with spyre_hint(expected_named_dims=["A"]):
@@ -2227,7 +2227,7 @@ def test_outside_consumer_reduction_512x256_A4():
     ]
 
     def fn(x, bias):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
             with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
                 s = x.amin(dim=0)
         return s + bias
@@ -2243,7 +2243,7 @@ def test_outside_consumer_reduction_512x256_B4():
     ]
 
     def fn(x, bias):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
                 s = x.amin(dim=0)
         return s + bias
@@ -2259,8 +2259,8 @@ def test_outside_consumer_reduction_512x256_A4_B4():
     ]
 
     def fn(x, bias):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 128}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(
                     expected_named_dims=["B"], expected_reduction_dims=["A"]
                 ):
@@ -2326,7 +2326,7 @@ def test_view_named_input_view_transpose_H2():
     def fn(q, k):
         q = q.view(B, S, H, D).transpose(1, 2)
         k = k.view(B, S, H, D).transpose(1, 2)
-        with spyre_hint(num_tiles_per_dim={"H": 2}):
+        with spyre_hint(tile_size_per_dim={"H": 4}):
             with spyre_hint(expected_named_dims=["B", "H", "S", "D"]):
                 return q * k
 
@@ -2355,7 +2355,7 @@ def test_view_named_input_view_transpose_S4():
     def fn(q, k):
         q = q.view(B, S, H, D).transpose(1, 2)
         k = k.view(B, S, H, D).transpose(1, 2)
-        with spyre_hint(num_tiles_per_dim={"S": 4}):
+        with spyre_hint(tile_size_per_dim={"S": 64}):
             with spyre_hint(expected_named_dims=["B", "H", "S", "D"]):
                 return q * k
 
@@ -2384,8 +2384,8 @@ def test_view_named_input_view_transpose_H2_S4():
     def fn(q, k):
         q = q.view(B, S, H, D).transpose(1, 2)
         k = k.view(B, S, H, D).transpose(1, 2)
-        with spyre_hint(num_tiles_per_dim={"H": 2}):
-            with spyre_hint(num_tiles_per_dim={"S": 4}):
+        with spyre_hint(tile_size_per_dim={"H": 4}):
+            with spyre_hint(tile_size_per_dim={"S": 64}):
                 with spyre_hint(expected_named_dims=["B", "H", "S", "D"]):
                     return q * k
 
@@ -2417,7 +2417,7 @@ def test_view_4d_transpose_H2():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"H": 2}):
+        with spyre_hint(tile_size_per_dim={"H": 2}):
             with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
                 return x.view(B, S, H, D).transpose(1, 2) * y
 
@@ -2444,7 +2444,7 @@ def test_view_4d_transpose_S4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"Lq": 4}):
+        with spyre_hint(tile_size_per_dim={"Lq": 64}):
             with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
                 return x.view(B, S, H, D).transpose(1, 2) * y
 
@@ -2471,8 +2471,8 @@ def test_view_4d_transpose_H2_S4():
     ]
 
     def fn(x, y):
-        with spyre_hint(num_tiles_per_dim={"H": 2}):
-            with spyre_hint(num_tiles_per_dim={"Lq": 4}):
+        with spyre_hint(tile_size_per_dim={"H": 2}):
+            with spyre_hint(tile_size_per_dim={"Lq": 64}):
                 with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
                     return x.view(B, S, H, D).transpose(1, 2) * y
 
@@ -2490,7 +2490,7 @@ def test_view_unsqueeze_broadcast_A4():
     ]
 
     def fn(a, b):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 64}):
             with spyre_hint(expected_named_dims=["N", "A", "B"]):
                 return a.unsqueeze(0) * b
 
@@ -2505,7 +2505,7 @@ def test_view_unsqueeze_broadcast_B4():
     ]
 
     def fn(a, b):
-        with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"B": 64}):
             with spyre_hint(expected_named_dims=["N", "A", "B"]):
                 return a.unsqueeze(0) * b
 
@@ -2520,8 +2520,8 @@ def test_view_unsqueeze_broadcast_A4_B4():
     ]
 
     def fn(a, b):
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+        with spyre_hint(tile_size_per_dim={"A": 64}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(expected_named_dims=["N", "A", "B"]):
                     return a.unsqueeze(0) * b
 
@@ -3417,7 +3417,7 @@ def test_validate_reduction_dims_raises_on_mismatch():
 #
 # spyre_hint-driven coarse tiling
 # These tests verify that coarse tiling is driven automatically by
-# spyre_hint(num_tiles_per_dim=...) annotations.  Named tensor dimensions
+# spyre_hint(tile_size_per_dim=...) annotations.  Named tensor dimensions
 # must be declared and annotated on device tensors for the hint resolver to
 # map dimension names to loop variables.
 # ===========================================================================
@@ -3428,7 +3428,7 @@ _name_tensor_dims = _pnd.name_tensor_dims
 
 
 class TestCoarseTileSpyreHints(InductorTestCase):
-    """Coarse tiling driven by spyre_hint(num_tiles_per_dim=...) annotations."""
+    """Coarse tiling driven by spyre_hint(tile_size_per_dim=...) annotations."""
 
     def setUp(self):
         super().setUp()
@@ -3468,7 +3468,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         }
     )
     def test_hint_single_group_pointwise(self):
-        """spyre_hint(num_tiles_per_dim={"A": 4}) tiles a pointwise abs into 4 iterations."""
+        """spyre_hint(tile_size_per_dim={"A": 64}) tiles a pointwise abs into 4 iterations."""
         from torch_spyre._inductor import spyre_hint
 
         # 256 rows × 128 cols.  Tiling the outermost dim by 4 → 64 rows/iter.
@@ -3476,7 +3476,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         x = torch.randn(A, B, dtype=torch.float16)
 
         def fn(x):
-            with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(tile_size_per_dim={"A": 64}):
                 return torch.abs(x)
 
         x_dev = x.to("spyre")
@@ -3529,7 +3529,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         x = torch.randn(B, D, dtype=torch.float16)
 
         def softmax_fn(x):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 with spyre_hint(
                     expected_named_dims=["B"], expected_reduction_dims=["D"]
                 ):
@@ -3584,7 +3584,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
     def test_hint_nested_loop_with_scratchpad(self):
         """Design-doc small example: y=a+b; z=y*c with nested K=2×M=4 hints.
 
-        This is the canonical spyre_hint(num_tiles_per_dim=...) version of the
+        This is the canonical spyre_hint(tile_size_per_dim=...) version of the
         small example from docs/source/compiler/coarse_tiling_loops.md.
 
         Shape [1024, 4096], outer hint tiles A-dim by 2 (512 rows/iter),
@@ -3609,8 +3609,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         c = torch.randn(A, B, dtype=torch.float16)
 
         def fn(a, b, c):
-            with spyre_hint(num_tiles_per_dim={"A": 2}):
-                with spyre_hint(num_tiles_per_dim={"B": 4}):
+            with spyre_hint(tile_size_per_dim={"A": 512}):
+                with spyre_hint(tile_size_per_dim={"B": 1024}):
                     y = a + b
                     z = y * c
                     return z
@@ -3672,13 +3672,17 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         Uses sub-dimension naming to map a [B, D] tensor's physical dims to
         named sub-dims, then tiles each op independently:
 
-        op_a = abs(x): hint num_tiles_per_dim={"B": 4} tiles dim 0 only.
+        op_a = abs(x): hint tile_size_per_dim={"B": 64} tiles dim 0 only.
           B=256 → 4 tiles of 64 rows each.  Iteration space per tile: [64, D].
 
         op_b = neg(y): tensor named ["B0","B1","D0","D1"] with B0×B1=B and
           D0×D1=D.  Outer hint num_tiles_per_dim={"B0": 4} tiles dim 0 (c0,
           range 256) into 4.  Inner hint num_tiles_per_dim={"D0": 4} tiles
           dim 1 (c1, range 128) into 4.  Iteration space per tile: [64, 32].
+          These two stay on num_tiles_per_dim: B0/D0 are sub-dims of a fused
+          host dim, so their declared extents are the split factors (4), not
+          the host ranges (256/128), and a tile size derived from them would
+          not describe the host tile.
 
         Both ops form separate groups → ≥2 LoopSpec entries, each with
         count=sympify('4').
@@ -3709,7 +3713,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         _name_tensor_dims(y_dev, ["B0", "B1", "D0", "D1"])
 
         def fn(x, y):
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+            with spyre_hint(tile_size_per_dim={"B": 64}):
                 out_x = torch.abs(x)
             with spyre_hint(num_tiles_per_dim={"B0": 4}):
                 with spyre_hint(num_tiles_per_dim={"D0": 4}):
@@ -3758,9 +3762,9 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
         def fn(x, y):
             # Two independent pointwise ops: each becomes its own group.
-            with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(tile_size_per_dim={"A": 64}):
                 out_x = torch.abs(x)
-            with spyre_hint(num_tiles_per_dim={"A": 8}):
+            with spyre_hint(tile_size_per_dim={"A": 32}):
                 out_y = torch.neg(y)
             return out_x, out_y
 
@@ -3812,7 +3816,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         x = torch.randn(M, K, dtype=torch.float16)
 
         def fn(x):
-            with spyre_hint(num_tiles_per_dim={"M": 4}):
+            with spyre_hint(tile_size_per_dim={"M": 64}):
                 # torch.full produces a scalar-fill with no M/K loop dim mapping.
                 bias = torch.full(x.shape, 0.5, dtype=x.dtype, device=x.device)
                 return x + bias
@@ -3868,7 +3872,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         _name_tensor_dims(x_dev, ["M", "K"])
 
         def fn(x):
-            with spyre_hint(num_tiles_per_dim={"M": 4}):
+            with spyre_hint(tile_size_per_dim={"M": 64}):
                 # torch.full produces a scalar-fill ComputedBuffer with no M-dim
                 # loop var — its loop_tiled_dims are all empty (loop-invariant).
                 bias = torch.full(x.shape, 0.5, dtype=x.dtype, device=x.device)
@@ -3912,7 +3916,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         y = torch.randn(K, N, dtype=torch.float16) * 0.01
 
         def fn(x, y):
-            with spyre_hint(num_tiles_per_dim={"M": 4}):
+            with spyre_hint(tile_size_per_dim={"M": 32}):
                 return torch.matmul(x, y)
 
         x_dev = x.to("spyre")
@@ -3967,7 +3971,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         scale = torch.randn(M, dtype=torch.float16)
 
         def fn(x, scale):
-            with spyre_hint(num_tiles_per_dim={"M": 4}):
+            with spyre_hint(tile_size_per_dim={"M": 64}):
                 # transpose + contiguous forces a restickify on x before the mul
                 x_t = x.transpose(0, 1).contiguous().transpose(0, 1)
                 return x_t * scale.unsqueeze(-1)
@@ -4006,7 +4010,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         }
     )
     def test_hint_softmax_row_tiling(self):
-        """spyre_hint(num_tiles_per_dim={"NROW": 4}) tiles softmax over the row dimension.
+        """spyre_hint(tile_size_per_dim={"NROW": 4096}) tiles softmax over the row dim.
 
         NCOL=4096 gives 64 sticks/row.  Row-tiling this shape exercises the
         multi-stick device_size[1] invariant: a per-tile device_size bug that
@@ -4024,7 +4028,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
         def fn(x, dim=-1):
             _name_tensor_dims(x, ["NROW", "NCOL"])
-            with spyre_hint(num_tiles_per_dim={"NROW": 4}):
+            with spyre_hint(tile_size_per_dim={"NROW": 4096}):
                 return torch.softmax(x, dim)
 
         compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=0.02, rtol=0.1)
@@ -4034,7 +4038,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
     # ------------------------------------------------------------------
 
     def test_hint_matmul_row_tiling(self):
-        """spyre_hint(num_tiles_per_dim={"M": 4}) tiles matmul over the row (M) dimension."""
+        """spyre_hint(tile_size_per_dim={"M": 64}) tiles matmul over the row (M) dim."""
         from torch_spyre._inductor import spyre_hint
 
         M, K, N = 256, 128, 64
@@ -4048,7 +4052,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         def fn(x, y):
             _name_tensor_dims(x, ["M", "K"])
             _name_tensor_dims(y, ["K", "N"])
-            with spyre_hint(num_tiles_per_dim={"M": 4}):
+            with spyre_hint(tile_size_per_dim={"M": 64}):
                 return x @ y
 
         compare_with_cpu(
@@ -4100,9 +4104,9 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                     (B, H, Lq), device=queries.device, dtype=torch.float16
                 )
             with spyre_hint(
-                num_tiles_per_dim={"B": 1}
+                tile_size_per_dim={"B": 1}
             ):  # 3 nested scopes exercises multi-hint logic
-                with spyre_hint(num_tiles_per_dim={"H": 4}):
+                with spyre_hint(tile_size_per_dim={"H": 2}):
                     # TODO: re-enable once numerical error with Lk tiling is fixed
                     # with spyre_hint(num_tiles_per_dim={"Lk": lk_slices}):
                     keys_T = keys.transpose(-1, -2).contiguous()
@@ -4205,9 +4209,9 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             )
             denominator = denominator.amax(dim=-1)  # B, H, Lq sparse
             with spyre_hint(
-                num_tiles_per_dim={"B": 1}
+                tile_size_per_dim={"B": 1}
             ):  # 3 nested scopes exercises multi-hint logic
-                with spyre_hint(num_tiles_per_dim={"H": 4}):
+                with spyre_hint(tile_size_per_dim={"H": 2}):
                     with spyre_hint(num_tiles_per_dim={"Lq": lq_slices}):
                         scaled_keys = keys * scale  # B, H, Lk, D
                         keys_T = scaled_keys.transpose(-1, -2)  # B, H, D, Lk
@@ -4310,7 +4314,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                 device=queries.device,
                 dtype=torch.float16,
             ).amax(dim=-1)
-            with spyre_hint(num_tiles_per_dim={"H": 4}):
+            with spyre_hint(tile_size_per_dim={"H": 2}):
                 with spyre_hint(num_tiles_per_dim={"Lq": lq_slices}):
                     scaled_keys = keys * scale
                     keys_T = scaled_keys.transpose(-1, -2)
@@ -4767,8 +4771,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         _name_tensor_dims(y_dev, ["A", "B", "D"])
 
         def fn(x, y):
-            with spyre_hint(num_tiles_per_dim={"A": 2}):
-                with spyre_hint(num_tiles_per_dim={"B": 4}):
+            with spyre_hint(tile_size_per_dim={"A": 64}):
+                with spyre_hint(tile_size_per_dim={"B": 2}):
                     # abs_x has shape [A, D], unsqueeze to [A, 1, D] for broadcast
                     abs_x = torch.abs(x).unsqueeze(1)
                     return abs_x + y
@@ -4854,8 +4858,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                     device=queries.device,
                     dtype=torch.float16,
                 )
-            with spyre_hint(num_tiles_per_dim={"B": 1}):
-                with spyre_hint(num_tiles_per_dim={"H": 4}):
+            with spyre_hint(tile_size_per_dim={"B": 1}):
+                with spyre_hint(tile_size_per_dim={"H": 2}):
                     with spyre_hint(num_tiles_per_dim={"Lk": lk_slices}):
                         keys_T = keys.transpose(-1, -2).contiguous()
                         scores = torch.matmul(queries * scale, keys_T * scale)
@@ -4917,7 +4921,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         _name_tensor_dims(x_dev, ["H", "Lq", "Lk"])
 
         def fn(x):
-            with spyre_hint(num_tiles_per_dim={"Lk": 2}):
+            with spyre_hint(tile_size_per_dim={"Lk": 64}):
                 # Op1: pointwise — Lk is an output dim
                 y = x * 2.0
                 # Op2: reduction over Lk — Lk is a reduction dim
@@ -5013,8 +5017,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                 denominator = torch.zeros(
                     (B, H, Lq), device=queries.device, dtype=torch.float16
                 )
-            with spyre_hint(num_tiles_per_dim={"B": 1}):
-                with spyre_hint(num_tiles_per_dim={"H": 4}):
+            with spyre_hint(tile_size_per_dim={"B": 1}):
+                with spyre_hint(tile_size_per_dim={"H": 2}):
                     with spyre_hint(num_tiles_per_dim={"Lk": lk_slices}):
                         keys_T = keys.transpose(-1, -2).contiguous()
                         scores = torch.matmul(queries * scale, keys_T * scale)
@@ -5125,8 +5129,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                 dtype=torch.float16,
             )
             denominator = denominator.amax(dim=-1)  # B, H, Lq sparse
-            with spyre_hint(num_tiles_per_dim={"B": 1}):
-                with spyre_hint(num_tiles_per_dim={"H": 4}):
+            with spyre_hint(tile_size_per_dim={"B": 1}):
+                with spyre_hint(tile_size_per_dim={"H": 2}):
                     with spyre_hint(num_tiles_per_dim={"Lq": lq_slices}):
                         scaled_keys = keys * scale  # B, H, Lk, D
                         keys_T = scaled_keys.transpose(-1, -2)  # B, H, D, Lk
@@ -5181,7 +5185,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         )
 
     def test_hint_h_tiling_elementwise(self):
-        """spyre_hint(num_tiles_per_dim={"H": 2}) tiles elementwise multiply over the H dimension.
+        """spyre_hint(tile_size_per_dim={"H": 4}) tiles elementwise multiply over H.
 
         Regression test for a bug in per-tile byte-stride computation where
         per-tile HBM base addresses advanced by the wrong amount when the tiled
@@ -5196,7 +5200,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         V = torch.randn(B, H, Lk, D, dtype=torch.float16)
 
         def fn(q, v):
-            with spyre_hint(num_tiles_per_dim={"H": 2}):
+            with spyre_hint(tile_size_per_dim={"H": 4}):
                 return q * v
 
         ref = fn(Q, V)
@@ -5247,7 +5251,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         _name_tensor_dims(V_dev, ["B", "H", "Lq", "D"])
 
         def fn(q, v):
-            with spyre_hint(num_tiles_per_dim={"H": 2}):
+            with spyre_hint(tile_size_per_dim={"H": 4}):
                 return q * v
 
         cfn = torch.compile(fn)
@@ -5345,7 +5349,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
     def test_hint_row_tiling_multi_stick_pointwise_correct(self):
         """Row-tiling a multi-stick pointwise chain produces correct output.
 
-        y = a + b; z = y * c on [1024, 4096] fp16 with num_tiles_per_dim={"A": 2}.
+        y = a + b; z = y * c on [1024, 4096] fp16 with tile_size_per_dim={"A": 512}.
         This is the minimal reproducer for the _tile_device_size bug: with 64
         sticks/row, shrinking device_size[1] from 1024 to 512 corrupts the
         inter-stick-group stride, producing wrong values in the second tile.
@@ -5368,7 +5372,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             _name_tensor_dims(a, ["A", "B"])
             _name_tensor_dims(b, ["A", "B"])
             _name_tensor_dims(c, ["A", "B"])
-            with spyre_hint(num_tiles_per_dim={"A": 2}):
+            with spyre_hint(tile_size_per_dim={"A": 512}):
                 y = a + b
                 z = y * c
                 return z
@@ -5406,7 +5410,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         def fn(x, y):
             _name_tensor_dims(x, ["A", "B"])
             _name_tensor_dims(y, ["A", "B"])
-            with spyre_hint(num_tiles_per_dim={"A": 2}):
+            with spyre_hint(tile_size_per_dim={"A": 64}):
                 z = x + y  # tiled op
             return z * 2.0  # outside consumer -- forces _allocate_full_buffer
 
@@ -5427,8 +5431,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             _name_tensor_dims(a, ["Lq", "D"])
             _name_tensor_dims(b, ["Lq", "D"])
             c = torch.full((Lq, D), 0, device=a.device, dtype=torch.float16)
-            with spyre_hint(num_tiles_per_dim={"Lq": 2}):
-                with spyre_hint(num_tiles_per_dim={"D": 2}):
+            with spyre_hint(tile_size_per_dim={"Lq": 128}):
+                with spyre_hint(tile_size_per_dim={"D": 64}):
                     c.copy_(a + b)
             return c
 
@@ -5457,7 +5461,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         divergent-stick-dim case being a separate, pre-existing,
         out-of-scope gap -- confirmed by direct repro, not exercised here;
         tracked as https://github.com/torch-spyre/torch-spyre/issues/3332).
-        Nesting num_tiles_per_dim={"Lq": 2} outer / {"B": 2} inner tiles two
+        Nesting tile_size_per_dim={"Lq": 128} outer / {"B": 2} inner tiles two
         non-stick dims, each with a distinct per-arg device_coordinates walk.
         """
         from torch_spyre._C import SpyreTensorLayout
@@ -5480,8 +5484,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             _name_tensor_dims(a, ["B", "Lq", "D"])
             _name_tensor_dims(b, ["B", "Lq", "D"])
             c = torch.full((B, Lq, D), 0, device=a.device, dtype=torch.float16)
-            with spyre_hint(num_tiles_per_dim={"Lq": 2}):
-                with spyre_hint(num_tiles_per_dim={"B": 2}):
+            with spyre_hint(tile_size_per_dim={"Lq": 128}):
+                with spyre_hint(tile_size_per_dim={"B": 2}):
                     c.copy_(a + b)
             return c
 
@@ -5635,7 +5639,7 @@ class TestNamedDimsHint(InductorTestCase):
         M, K = 256, 64
 
         def fn(x):
-            with spyre_hint(slices={"M": 4}, named_dims=["M", "K"]):
+            with spyre_hint(tile_size_per_dim={"M": 64}, named_dims=["M", "K"]):
                 bias = torch.full(x.shape, 0.5, dtype=x.dtype, device=x.device)
             return x + bias
 
@@ -5670,7 +5674,7 @@ class TestNamedDimsHint(InductorTestCase):
         M, K = 128, 64
 
         def fn(x):
-            with spyre_hint(slices={"M": 2}, named_dims=["M", "K"]):
+            with spyre_hint(tile_size_per_dim={"M": 64}, named_dims=["M", "K"]):
                 buf = torch.full_like(x, 2.0)
             return x + buf
 
@@ -5713,7 +5717,7 @@ class TestNamedDimsHint(InductorTestCase):
         M, K = 256, 64
 
         def fn(x):
-            with spyre_hint(slices={"M": 4}, named_dims=["M", "K"]):
+            with spyre_hint(tile_size_per_dim={"M": 64}, named_dims=["M", "K"]):
                 bias = torch.full(x.shape, 0.5, dtype=x.dtype, device=x.device)
             return x + bias
 
@@ -5759,7 +5763,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         _name_tensor_dims(x_dev, ["B", "D"])
 
         def fn(x):
-            with spyre_hint(num_tiles_per_dim={"D": 4}):
+            with spyre_hint(tile_size_per_dim={"D": 128}):
                 return x.sum(dim=-1)
 
         cfn = torch.compile(fn)
@@ -5785,7 +5789,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
 
         def fn(x):
             _name_tensor_dims(x, ["B", "D"])
-            with spyre_hint(num_tiles_per_dim={"D": 4}):
+            with spyre_hint(tile_size_per_dim={"D": 128}):
                 return x.sum(dim=-1)
 
         # atol=0.05: fp16 sum over 512 elements scaled by 0.1 accumulates ~0.05 error.
@@ -5807,7 +5811,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         _name_tensor_dims(b_dev, ["K", "N"])
 
         def fn(a, b):
-            with spyre_hint(num_tiles_per_dim={"K": 4}):
+            with spyre_hint(tile_size_per_dim={"K": 128}):
                 return a @ b
 
         cfn = torch.compile(fn)
@@ -5836,7 +5840,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         def fn(a, b):
             _name_tensor_dims(a, ["M", "K"])
             _name_tensor_dims(b, ["K", "N"])
-            with spyre_hint(num_tiles_per_dim={"K": 4}):
+            with spyre_hint(tile_size_per_dim={"K": 128}):
                 return a @ b
 
         compare_with_cpu(
@@ -5855,7 +5859,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         _name_tensor_dims(x_dev, ["B", "D"])
 
         def fn(x):
-            with spyre_hint(num_tiles_per_dim={"D": 4}):
+            with spyre_hint(tile_size_per_dim={"D": 128}):
                 return x.amax(dim=-1)
 
         cfn = torch.compile(fn)
@@ -5881,7 +5885,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
 
         def fn(x):
             _name_tensor_dims(x, ["B", "D"])
-            with spyre_hint(num_tiles_per_dim={"D": 4}):
+            with spyre_hint(tile_size_per_dim={"D": 128}):
                 return x.amax(dim=-1)
 
         compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=1e-3, rtol=1e-3)
@@ -5898,7 +5902,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         _name_tensor_dims(x_dev, ["B", "D"])
 
         def fn(x):
-            with spyre_hint(num_tiles_per_dim={"D": 4}):
+            with spyre_hint(tile_size_per_dim={"D": 128}):
                 return x.amin(dim=-1)
 
         cfn = torch.compile(fn)
@@ -5924,7 +5928,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
 
         def fn(x):
             _name_tensor_dims(x, ["B", "D"])
-            with spyre_hint(num_tiles_per_dim={"D": 4}):
+            with spyre_hint(tile_size_per_dim={"D": 128}):
                 return x.amin(dim=-1)
 
         compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=1e-3, rtol=1e-3)
@@ -5955,7 +5959,7 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
 
         def fn(x):
             _name_tensor_dims(x, ["B", "D"])
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+            with spyre_hint(tile_size_per_dim={"B": 128}):
                 return x.sum(dim=0)
 
         compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=0.05, rtol=0.05)
@@ -5972,7 +5976,7 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
 
         def fn(x):
             _name_tensor_dims(x, ["B", "D"])
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+            with spyre_hint(tile_size_per_dim={"B": 128}):
                 return x.amax(dim=0)
 
         compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=1e-3, rtol=1e-3)
@@ -5989,7 +5993,7 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
 
         def fn(x):
             _name_tensor_dims(x, ["B", "D"])
-            with spyre_hint(num_tiles_per_dim={"B": 4}):
+            with spyre_hint(tile_size_per_dim={"B": 128}):
                 return x.amin(dim=0)
 
         compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=1e-3, rtol=1e-3)
@@ -6022,7 +6026,7 @@ class TestCoarseTileMatmulKTilingE2E(InductorTestCase):
         def fn(a, b):
             _name_tensor_dims(a, ["M", "K"])
             _name_tensor_dims(b, ["K", "N"])
-            with spyre_hint(num_tiles_per_dim={"K": 4}):
+            with spyre_hint(tile_size_per_dim={"K": 128}):
                 return torch.mm(a, b)
 
         compare_with_cpu(
@@ -6044,7 +6048,7 @@ class TestCoarseTileMatmulKTilingE2E(InductorTestCase):
         def fn(a, b):
             _name_tensor_dims(a, ["B", "M", "K"])
             _name_tensor_dims(b, ["B", "K", "N"])
-            with spyre_hint(num_tiles_per_dim={"K": 4}):
+            with spyre_hint(tile_size_per_dim={"K": 128}):
                 return torch.bmm(a, b)
 
         compare_with_cpu(
@@ -6066,7 +6070,7 @@ class TestCoarseTileMatmulKTilingE2E(InductorTestCase):
         def fn(a, b):
             _name_tensor_dims(a, ["B", "M", "K"])
             _name_tensor_dims(b, ["K", "N"])
-            with spyre_hint(num_tiles_per_dim={"K": 4}):
+            with spyre_hint(tile_size_per_dim={"K": 128}):
                 return torch.matmul(a, b)
 
         compare_with_cpu(
@@ -6089,7 +6093,7 @@ class TestCoarseTileMatmulKTilingE2E(InductorTestCase):
         _name_tensor_dims(b_dev, ["K", "N"])
 
         def fn(a, b):
-            with spyre_hint(num_tiles_per_dim={"K": 4}):
+            with spyre_hint(tile_size_per_dim={"K": 128}):
                 return torch.mm(a, b)
 
         cfn = torch.compile(fn)
@@ -6150,8 +6154,8 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
         def fn(a, b):
             _name_tensor_dims(a, ["B", "M", "K"])
             _name_tensor_dims(b, ["B", "K", "N"])
-            with spyre_hint(num_tiles_per_dim={"B": 2}):
-                with spyre_hint(num_tiles_per_dim={"K": 4}):
+            with spyre_hint(tile_size_per_dim={"B": 2}):
+                with spyre_hint(tile_size_per_dim={"K": 128}):
                     return torch.bmm(a, b)
 
         compare_with_cpu(
@@ -6175,8 +6179,8 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
         def fn(a, b):
             _name_tensor_dims(a, ["M", "K"])
             _name_tensor_dims(b, ["K", "N"])
-            with spyre_hint(num_tiles_per_dim={"M": 2}):
-                with spyre_hint(num_tiles_per_dim={"K": 4}):
+            with spyre_hint(tile_size_per_dim={"M": 64}):
+                with spyre_hint(tile_size_per_dim={"K": 128}):
                     return torch.mm(a, b)
 
         compare_with_cpu(
@@ -6199,8 +6203,8 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
         _name_tensor_dims(b_dev, ["K", "N"])
 
         def fn(a, b):
-            with spyre_hint(num_tiles_per_dim={"M": 2}):
-                with spyre_hint(num_tiles_per_dim={"K": 4}):
+            with spyre_hint(tile_size_per_dim={"M": 64}):
+                with spyre_hint(tile_size_per_dim={"K": 128}):
                     return torch.mm(a, b)
 
         cfn = torch.compile(fn)
@@ -6233,8 +6237,8 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
         _name_tensor_dims(b_dev, ["K", "N"])
 
         def fn(a, b):
-            with spyre_hint(num_tiles_per_dim={"M": 2}):
-                with spyre_hint(num_tiles_per_dim={"K": 4}):
+            with spyre_hint(tile_size_per_dim={"M": 64}):
+                with spyre_hint(tile_size_per_dim={"K": 128}):
                     return torch.mm(a, b)
 
         cfn = torch.compile(fn)
@@ -6274,8 +6278,8 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
         _name_tensor_dims(b_dev, ["K", "N"])
 
         def fn(a, b):
-            with spyre_hint(num_tiles_per_dim={"M": 2}):
-                with spyre_hint(num_tiles_per_dim={"K": 4}):
+            with spyre_hint(tile_size_per_dim={"M": 64}):
+                with spyre_hint(tile_size_per_dim={"K": 128}):
                     return torch.mm(a, b)
 
         cfn = torch.compile(fn)
@@ -6316,8 +6320,8 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
         _name_tensor_dims(b_dev, ["K", "N"])
 
         def fn(a, b):
-            with spyre_hint(num_tiles_per_dim={"M": 2}):
-                with spyre_hint(num_tiles_per_dim={"K": 4}):
+            with spyre_hint(tile_size_per_dim={"M": 64}):
+                with spyre_hint(tile_size_per_dim={"K": 128}):
                     return torch.mm(a, b)
 
         cfn = torch.compile(fn)
@@ -6361,7 +6365,7 @@ def test_tiled_in_place_accumulator():
     acc_t = torch.zeros(B, H, Lq, D, dtype=torch.float16)
 
     def fn(x, scale, acc):
-        with spyre_hint(num_tiles_per_dim={"H": 4}):
+        with spyre_hint(tile_size_per_dim={"H": 2}):
             with spyre_hint(num_tiles_per_dim={"Lq": lq_slices}):
                 block_max = torch.amax(x, dim=-1, keepdim=True)
                 acc.copy_(acc + block_max * scale)
@@ -6396,7 +6400,7 @@ def test_sum_reduce_with_explicit_zero_accumulator():
 
     def f(a):
         z = torch.zeros(B, device=a.device, dtype=torch.float16)
-        with spyre_hint(num_tiles_per_dim={"A": 2}):
+        with spyre_hint(tile_size_per_dim={"A": 512}):
             y = torch.sum(a, dim=0)
             z += y
         return z
@@ -6423,7 +6427,7 @@ def test_sum_reduce_implicit_accumulator():
     a_t = torch.randn(A, B, dtype=torch.float16) * 0.01
 
     def f_implicit(a):
-        with spyre_hint(num_tiles_per_dim={"A": 2}):
+        with spyre_hint(tile_size_per_dim={"A": 512}):
             z = torch.sum(a, dim=0)
         return z
 
@@ -6460,7 +6464,7 @@ def test_zeros_named_dims_hint_correctness():
     def f(x, cval):
         with spyre_hint(named_dims=["B", "H", "Lq"]):
             denom_named = torch.zeros((B, H, Lq), device=x.device, dtype=torch.float16)
-        with spyre_hint(num_tiles_per_dim={"H": 4}):
+        with spyre_hint(tile_size_per_dim={"H": 2}):
             corr = torch.exp(cval)
             denom_likecval = torch.zeros_like(cval)
             s_simple = x.sum(dim=-2)

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -2290,8 +2290,13 @@ def test_view_1d_subdim_Lq2_D2():
     def fn(a, b):
         a = a.view(Lq, D)
         b = b.view(Lq, D)
-        with spyre_hint(num_tiles_per_dim={"Lq": 2}):
-            with spyre_hint(num_tiles_per_dim={"D": 2}):
+        # The view() above means the op sees a 2-D [Lq, D] iteration space, so
+        # despite the flat 1-D input these are ORDINARY per-dim tile sizes --
+        # not the absolute host-dim extents the truly-flat
+        # test_hint_nested_tiling_copy_mutation_flat needs.  D is not carried by
+        # any loop var here, so its count comes from the declared extent.
+        with spyre_hint(tile_size_per_dim={"Lq": Lq // 2}):
+            with spyre_hint(tile_size_per_dim={"D": D // 2}):
                 with spyre_hint(expected_named_dims=["Lq", "D"]):
                     return a * b
 
@@ -5516,8 +5521,10 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             _name_tensor_dims(a, ["Lq", "D"])
             _name_tensor_dims(b, ["Lq", "D"])
             c = torch.full([Lq * D], 0, device=a.device, dtype=torch.float16)
-            with spyre_hint(num_tiles_per_dim={"Lq": 2}):
-                with spyre_hint(num_tiles_per_dim={"D": 2}):
+            # Absolute HOST-dim extents; inner divides outer.  See
+            # test_view_1d_subdim_Lq2_D2 for the same pairing.
+            with spyre_hint(tile_size_per_dim={"Lq": (Lq // 2) * D}):
+                with spyre_hint(tile_size_per_dim={"D": (Lq // 2) * (D // 2)}):
                     c.copy_(a + b)
             return c
 

--- a/tests/inductor/test_span_overflow_hint_analysis.py
+++ b/tests/inductor/test_span_overflow_hint_analysis.py
@@ -2381,7 +2381,8 @@ class TestSpanOverflowPointwiseCodegen(InductorTestCase):
             return x + y
 
         def manual_hint_fn(x, y):
-            with spyre_hint(num_tiles_per_dim={"SO_H": 5}):
+            # SO_H = shape[1] = 20 -> 5 tiles of 4
+            with spyre_hint(tile_size_per_dim={"SO_H": 4}):
                 return x + y
 
         _pnd.declare_tensor_dim("SO_B", shape[0])

--- a/tests/inductor/test_tile_size_hint.py
+++ b/tests/inductor/test_tile_size_hint.py
@@ -1,0 +1,121 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""spyre_hint(tile_size_per_dim=...) — declare the tile size, not the trip count.
+
+The backend contract is a dynamic loop count over fixed-size tiles, so the hint
+declares the size and the count falls out.  WSR requires every tile to be full:
+the extent must already be padded to a multiple of the tile size (with
+op-appropriate identity values), and a non-multiple is a loud error rather than a
+short final tile.  See docs/wsr-tile-size-api-plan.md.
+"""
+
+import os
+import sys
+
+import pytest
+import torch
+
+from torch._inductor.test_case import TestCase as InductorTestCase
+from torch._inductor.utils import run_and_get_code
+
+import torch_spyre._inductor.wsr.propagate_named_dims as _pnd
+
+# Inductor wraps backend Unsupported in InductorError, so assert on that and
+# match the message text.
+from torch._inductor.exc import InductorError
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+_declare_tensor_dim = _pnd.declare_tensor_dim
+_name_tensor_dims = _pnd.name_tensor_dims
+
+
+class TestTileSizeHint(InductorTestCase):
+    def setUp(self):
+        super().setUp()
+        torch.manual_seed(0xAFFE)
+        _pnd.reset()
+
+    def _run(self, hint_kwargs, nrow=1024, ncol=4096):
+        """y = (a + b) * c, tiled over row dim A per hint_kwargs. Returns (src, ok)."""
+        from torch_spyre._inductor import spyre_hint
+
+        a = torch.rand(nrow, ncol, dtype=torch.float16)
+        b = torch.rand(nrow, ncol, dtype=torch.float16)
+        c = torch.rand(nrow, ncol, dtype=torch.float16)
+        ref = (a + b) * c
+
+        _declare_tensor_dim("A", nrow)
+        _declare_tensor_dim("B", ncol)
+        ad, bd, cd = a.to("spyre"), b.to("spyre"), c.to("spyre")
+        for t in (ad, bd, cd):
+            _name_tensor_dims(t, ["A", "B"])
+
+        def fn(x, y, z):
+            with spyre_hint(**hint_kwargs):
+                return (x + y) * z
+
+        got, srcs = run_and_get_code(torch.compile(fn), ad, bd, cd)
+        torch.testing.assert_close(got.cpu(), ref, equal_nan=True, atol=0.01, rtol=0.1)
+        return srcs[0]
+
+    def test_tile_size_matches_equivalent_num_tiles(self):
+        """tile_size=256 on a 1024 extent must behave exactly like num_tiles=4."""
+        _pnd.reset()
+        torch.manual_seed(0xAFFE)
+        src_count = self._run({"num_tiles_per_dim": {"A": 4}})
+
+        torch._dynamo.reset()
+        _pnd.reset()
+        torch.manual_seed(0xAFFE)
+        src_size = self._run({"tile_size_per_dim": {"A": 256}})
+
+        # Same trip count in the generated LoopSpec, reached from either spelling.
+        self.assertIn("LoopSpec(", src_count)
+        self.assertIn("LoopSpec(", src_size)
+        self.assertIn("sympify('4')", src_count)
+        self.assertIn(
+            "sympify('4')",
+            src_size,
+            "tile_size_per_dim={'A': 256} on extent 1024 must yield trip count 4",
+        )
+
+    def test_tile_size_one_tile_is_no_op(self):
+        """tile_size == extent means one tile, i.e. no loop, like num_tiles=1."""
+        src = self._run({"tile_size_per_dim": {"A": 1024}})
+        self.assertNotIn(
+            "LoopSpec(", src, "a single full-extent tile must not emit a loop"
+        )
+
+    def test_non_multiple_extent_raises_naming_the_padding_invariant(self):
+        """Extent not a multiple of tile size is a loud error, not a short tile."""
+        with self.assertRaises(InductorError) as cm:
+            self._run({"tile_size_per_dim": {"A": 300}})
+        msg = str(cm.exception)
+        self.assertIn("not a multiple", msg)
+        self.assertIn("full tiles", msg)
+        self.assertIn("pad", msg)
+
+    def test_zero_or_negative_tile_size_raises(self):
+        with self.assertRaises(InductorError) as cm:
+            self._run({"tile_size_per_dim": {"A": 0}})
+        self.assertIn("must be positive", str(cm.exception))
+
+    @pytest.mark.skip(
+        reason="P2: nested tile_size levels on distinct dims — needs the declared "
+        "size carried through CoarseTileInfo rather than re-derived"
+    )
+    def test_nested_tile_size_levels(self):
+        pass

--- a/tests/inductor/test_tile_size_hint.py
+++ b/tests/inductor/test_tile_size_hint.py
@@ -24,7 +24,6 @@ short final tile.  See docs/wsr-tile-size-api-plan.md.
 import os
 import sys
 
-import pytest
 import torch
 
 from torch._inductor.test_case import TestCase as InductorTestCase
@@ -113,9 +112,38 @@ class TestTileSizeHint(InductorTestCase):
             self._run({"tile_size_per_dim": {"A": 0}})
         self.assertIn("must be positive", str(cm.exception))
 
-    @pytest.mark.skip(
-        reason="P2: nested tile_size levels on distinct dims — needs the declared "
-        "size carried through CoarseTileInfo rather than re-derived"
-    )
     def test_nested_tile_size_levels(self):
-        pass
+        """Nested tile_size scopes on distinct dims: both levels reach codegen.
+
+        This is the P2 path -- declared sizes are used instead of
+        _per_level_extent_for's inner-count recurrence.  A dim tiled at a single
+        level has declared == derived by construction, so nesting is the only
+        place the two can disagree; _planned_tile_extents_per_level asserts if
+        they do.
+        """
+        from torch_spyre._inductor import spyre_hint
+
+        nrow, ncol = 1024, 4096
+        a = torch.rand(nrow, ncol, dtype=torch.float16)
+        b = torch.rand(nrow, ncol, dtype=torch.float16)
+        ref = a + b
+
+        _declare_tensor_dim("A", nrow)
+        _declare_tensor_dim("B", ncol)
+        ad, bd = a.to("spyre"), b.to("spyre")
+        for t in (ad, bd):
+            _name_tensor_dims(t, ["A", "B"])
+
+        def fn(x, y):
+            # A: 1024 / 256 = 4 tiles;  B: 4096 / 1024 = 4 tiles
+            with spyre_hint(tile_size_per_dim={"A": 256}):
+                with spyre_hint(tile_size_per_dim={"B": 1024}):
+                    return x + y
+
+        got, srcs = run_and_get_code(torch.compile(fn), ad, bd)
+        torch.testing.assert_close(got.cpu(), ref, equal_nan=True, atol=0.01, rtol=0.1)
+        self.assertEqual(
+            srcs[0].count("LoopSpec("),
+            2,
+            "both nested tile_size levels must survive into codegen",
+        )

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -399,7 +399,7 @@ class TestNamedWorkDivisionHint(InductorTestCase):
         _name_tensor_dims(x, ["M", "N"])
 
         def fn(x):
-            with spyre_hint(tiles={"M": 4}):
+            with spyre_hint(tile_size_per_dim={"M": 32}):
                 return torch.abs(x)
 
         with (
@@ -427,7 +427,7 @@ class TestNamedWorkDivisionHint(InductorTestCase):
         _name_tensor_dims(x, ["M", "N"])
 
         def fn(x):
-            with spyre_hint(tiles={"M": 4}, work_div={"N": 2}):
+            with spyre_hint(tile_size_per_dim={"M": 32}, work_div={"N": 2}):
                 return torch.abs(x)
 
         with (

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -364,6 +364,41 @@ def spyre_linear(
     return out
 
 
+def _wsr_tile_size(extent: int, block: int) -> int:
+    """Per-tile extent for ``extent`` at the requested ``block``, or no tiling.
+
+    WSR now takes the tile SIZE (spyre_hint(tile_size_per_dim=...)) rather than a
+    trip count, because the backend runs a dynamic loop count over fixed-size
+    tiles.  Full tiles are required, so ``extent`` must be a multiple of ``block``.
+
+    ============================ BEHAVIOUR CHANGE ============================
+    The previous spelling was ``tiles={dim: max(1, extent // block)}`` -- a trip
+    COUNT derived from the block, which meant the block size was only advisory
+    and the ACTUAL tile came out as ``extent / count``:
+
+        extent=384 block=128 -> count 3 -> tile 128   (as intended)
+        extent=300 block=128 -> count 2 -> tile 150   <-- LARGER than requested
+        extent=250 block=128 -> count 1 -> no tiling
+        batch=1    block=2   -> count 1 -> no tiling
+
+    So a non-divisible extent could silently produce a tile bigger than the
+    working-set budget the block was chosen to respect -- the opposite of what
+    WSR is for.  Declaring the size makes that impossible, but it also means a
+    non-divisible extent cannot be tiled at all until the input is padded (with
+    op-appropriate identity values) upstream.
+
+    Until that padding exists this declines to tile rather than erroring, which
+    preserves today's graceful degradation for short sequences and small batches.
+    The one case that differs from before is non-divisible-but-larger-than-block
+    (300/128 above): previously 2 tiles of 150, now untiled.  That is deliberate
+    -- overshooting the block was never intended.
+    =========================================================================
+    """
+    if block <= 0 or extent <= 0:
+        return max(1, extent)
+    return block if extent % block == 0 else extent
+
+
 @register_spyre_decompositions(
     [torch.ops.aten._scaled_dot_product_fused_attention_overrideable.default]
 )
@@ -444,13 +479,19 @@ def spyre__sdpa_overrideable(
             max_seqlen_q, max_seqlen_kv, query.dtype, query.device
         )
 
-    with spyre_hint(tiles={"batch_size": max(1, batch_size // 2)}):
-        with spyre_hint(tiles={"num_heads": max(1, num_heads // 4)}):
+    # Declared per-tile extents (not trip counts) -- see _wsr_tile_size for the
+    # behaviour change this carries for non-divisible extents.
+    with spyre_hint(tile_size_per_dim={"batch_size": _wsr_tile_size(batch_size, 2)}):
+        with spyre_hint(tile_size_per_dim={"num_heads": _wsr_tile_size(num_heads, 4)}):
             with spyre_hint(
-                tiles={"max_seqlen_q": max(1, max_seqlen_q // q_block_size)}
+                tile_size_per_dim={
+                    "max_seqlen_q": _wsr_tile_size(max_seqlen_q, q_block_size)
+                }
             ):
                 with spyre_hint(
-                    tiles={"max_seqlen_kv": max(1, max_seqlen_kv // kv_block_size)}
+                    tile_size_per_dim={
+                        "max_seqlen_kv": _wsr_tile_size(max_seqlen_kv, kv_block_size)
+                    }
                 ):
                     with spyre_hint(
                         work_div={"num_heads": 4, "max_seqlen_q": 8, "max_seqlen_kv": 8}

--- a/torch_spyre/_inductor/propagate_hints.py
+++ b/torch_spyre/_inductor/propagate_hints.py
@@ -39,6 +39,12 @@ class DimHint:
     # None when op is broadcast w.r.t. this hint scope
     is_reduction: bool
     hint_id: int = 0  # the _hint_N counter value identifying the scope
+    # Declared per-tile extent from spyre_hint(tile_size_per_dim=...), when the
+    # scope was specified that way.  split_count above is then derived from it
+    # (extent // tile_size).  Carried so downstream passes can use the DECLARED
+    # size rather than re-deriving it -- see _planned_tile_extents_per_level,
+    # whose inner-count recurrence is the only place the two can disagree.
+    tile_size: "int | None" = None
 
 
 # op.dim_hints: list[DimHint]

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -269,8 +269,36 @@ def plan_coarse_tile_groups(
                         f"op {op.get_name()}"
                     )
 
+            # Declared per-tile extents from spyre_hint(tile_size_per_dim=...),
+            # parallel to `levels`, keyed the same way per_level_output is:
+            # output dims by ranges position, reduction dims offset by
+            # len(data.ranges).  Empty where the scope used a trip count instead.
+            hint_tile_size = {
+                h.hint_id: h.tile_size
+                for h in getattr(op, "dim_hints", [])
+                if getattr(h, "tile_size", None)
+            }
+            declared_sizes: list[dict[int, int]] = []
+            if hint_tile_size:
+                n_out = len(op.data.ranges) if hasattr(op.data, "ranges") else 0
+                for hint_id, _count in levels:
+                    sizes: dict[int, int] = {}
+                    ts = hint_tile_size.get(hint_id)
+                    if ts is not None:
+                        opos = hint_id_to_ranges_pos.get(hint_id)
+                        rpos = hint_id_to_reduction_ranges_pos.get(hint_id)
+                        if opos is not None:
+                            sizes[opos] = ts
+                        if rpos is not None:
+                            sizes[n_out + rpos] = ts
+                    declared_sizes.append(sizes)
+
             per_level_extents = _planned_tile_extents_per_level(
-                op, op_tiled_dims, op_tiled_reduction_dims, levels
+                op,
+                op_tiled_dims,
+                op_tiled_reduction_dims,
+                levels,
+                declared_sizes or None,
             )
 
             tiled_dims_per_read = [
@@ -312,6 +340,7 @@ def _planned_tile_extents_per_level(
     op_tiled_dims: list[list[int]],
     op_tiled_reduction_dims: list[list[int]],
     levels: list[tuple],
+    declared_sizes: "list[dict[int, int]] | None" = None,
 ) -> list[dict[int, Expr]]:
     """Per-level (not merged) tile extents, outermost-first.
 
@@ -393,6 +422,32 @@ def _planned_tile_extents_per_level(
         level_extents = _per_level_extent_for(final_extent, op_tiled_reduction_dims, d)
         for level_idx, extent in level_extents.items():
             per_level_output[level_idx][dim_key] = extent
+
+    # Where spyre_hint(tile_size_per_dim=...) DECLARED the per-tile extent, use it
+    # instead of the value _per_level_extent_for just derived.  The two agree by
+    # construction when a dim is tiled at a single level (extent // count ==
+    # tile_size); they can only diverge where a dim is tiled at more than one
+    # level, which is exactly what the inner-count recurrence above computes and
+    # where its squeeze/raw-rank handling has misfired before.  Preferring the
+    # declaration removes that inference; a mismatch means the declaration and
+    # the trip count disagree, which is a bug in the conversion, so assert.
+    if declared_sizes:
+        for level_idx, per_dim in enumerate(declared_sizes):
+            if level_idx >= len(per_level_output):
+                continue
+            for d, size in (per_dim or {}).items():
+                if d not in per_level_output[level_idx]:
+                    continue
+                derived = per_level_output[level_idx][d]
+                if isinstance(derived, (int, sympy.Integer)) and int(derived) != int(
+                    size
+                ):
+                    raise RuntimeError(
+                        f"coarse_tile: op {op.get_name()!r} level {level_idx} dim {d}: "
+                        f"declared tile_size {size} disagrees with derived extent "
+                        f"{derived} -- tile_size/trip-count conversion is inconsistent"
+                    )
+                per_level_output[level_idx][d] = sympy.Integer(int(size))
 
     return per_level_output
 

--- a/torch_spyre/_inductor/wsr/propagate_named_dims.py
+++ b/torch_spyre/_inductor/wsr/propagate_named_dims.py
@@ -716,9 +716,22 @@ def _assign_dim_hints_impl(operations: list[Operation]) -> None:
             dims: dict[str, int] = _hint_dims(hint_dict)
             if _TILE_SIZE_KEY in hint_dict and hint_dict[_TILE_SIZE_KEY]:
                 resolved = tile_size_counts.get(hint_id, {})
-                dims = {
-                    name: resolved[name] for name in dims if name in resolved
-                } or dims
+                missing = [name for name in dims if name not in resolved]
+                if missing:
+                    # Never fall back to using the declared SIZE as a trip count:
+                    # that silently tiles into `tile_size` pieces instead of pieces
+                    # OF tile_size, which miscompiles rather than failing.  An
+                    # unresolved name means no op in the graph carried that dim, so
+                    # the extent was never found -- almost always a name that does
+                    # not match any declared tensor dim.
+                    raise Unsupported(
+                        f"spyre_hint(tile_size_per_dim=...) names dim(s) "
+                        f"{missing} that no operation in the tiled scope carries, "
+                        "so the extent needed to derive the loop trip count could "
+                        "not be found. Check the name matches a dim declared via "
+                        "declare_tensor_dim()/name_tensor_dims()."
+                    )
+                dims = {name: resolved[name] for name in dims}
             # TODO: support multiple dimensions per spyre_hint() call.
             # hint_id_to_ranges_pos in plan_coarse_tile_groups would need to
             # become dict[int, list[int]] and _hints_levels would need to

--- a/torch_spyre/_inductor/wsr/propagate_named_dims.py
+++ b/torch_spyre/_inductor/wsr/propagate_named_dims.py
@@ -640,31 +640,116 @@ def _resolve_tile_size_counts(operations: list[Operation]) -> dict[int, dict[str
             for nm in names:
                 name_to_sym[nm] = sym
 
-        for hint_id, hint_dict in op_hints.items():
+        # Collect this op's tile_size levels OUTERMOST-FIRST.  hint_id comes from
+        # a counter incremented when a spyre_hint scope is entered during
+        # tracing, so ascending hint_id is ascending nesting depth.  Ordering is
+        # load-bearing below, which is why this is sorted (the previous
+        # unordered pass was only safe because every level divided the same
+        # extent).
+        levels: list[tuple[int, str, int, sympy.Symbol]] = []
+        for hint_id, hint_dict in sorted(op_hints.items()):
+            sizes = hint_dict.get(_TILE_SIZE_KEY)
+            if not sizes:
+                continue
+            for name, tile_size in sizes.items():
+                sym = name_to_sym.get(name)
+                if sym is None or not extents.get(sym):
+                    continue  # this op does not carry the dim; another will
+                levels.append((hint_id, name, int(tile_size), sym))
+
+        # Levels that land on the SAME loop var divide CUMULATIVELY: the
+        # outermost divides the host extent, and each inner level divides the
+        # tile the level above it produced -- not the host extent again.  This
+        # is what makes nesting work when several named dims share one host dim
+        # (e.g. a flat shape=(Lq*D,) named ["Lq","D"], hinted at two levels):
+        # sizes are absolute host-dim extents, so consecutive division recovers
+        # each level's own trip count.  For a dim tiled at a single level, or for
+        # levels on distinct loop vars, `remaining` is just the host extent and
+        # this is identical to the previous behaviour.
+        remaining: dict[sympy.Symbol, int] = {}
+        claimed_by: dict[sympy.Symbol, tuple[int, str]] = {}
+        for hint_id, name, tile_size, sym in levels:
+            # Cumulative division walks NESTING levels, so two names of the SAME
+            # scope landing on one loop var is not a chain -- treating it as one
+            # would divide twice for a single level.  It is also ambiguous (which
+            # of the two is the outer split?), so refuse rather than pick.
+            prev = claimed_by.get(sym)
+            if prev is not None and prev[0] == hint_id:
+                raise Unsupported(
+                    f"spyre_hint(tile_size_per_dim=...): dims {prev[1]!r} and "
+                    f"{name!r} in the same hint scope share one host dim, so "
+                    "their tile sizes cannot both be applied at this level. "
+                    "Tile them in nested scopes instead, outermost first, with "
+                    "each inner size dividing the enclosing one."
+                )
+            claimed_by[sym] = (hint_id, name)
+            avail = remaining.get(sym, extents[sym])
+            if tile_size <= 0:
+                raise Unsupported(
+                    f"spyre_hint(tile_size_per_dim={{{name!r}: {tile_size}}}): "
+                    "tile size must be positive"
+                )
+            if avail % tile_size != 0:
+                enclosing = (
+                    "the host extent"
+                    if sym not in remaining
+                    else "the tile its enclosing hint scope produces"
+                )
+                raise Unsupported(
+                    f"spyre_hint(tile_size_per_dim={{{name!r}: {tile_size}}}): "
+                    f"dim {name!r} divides {avail} ({enclosing}), which is not a "
+                    f"multiple of the tile size. WSR requires full tiles -- pad "
+                    f"{name!r} to a multiple of {tile_size} (with op-appropriate "
+                    "identity values) before the tiled scope. Note tile sizes for "
+                    "dims sharing one host dim are absolute host-dim extents, so "
+                    "an inner size must divide the enclosing one."
+                )
+            # The count belongs to the hint SCOPE, so leave a value another op
+            # already resolved in place -- but still advance `remaining`, or the
+            # rest of this op's chain would divide the wrong quantity.
+            if counts.get(hint_id, {}).get(name) is None:
+                counts.setdefault(hint_id, {})[name] = avail // tile_size
+            remaining[sym] = tile_size
+
+    # Second pass: a hinted dim that NO op carries as a loop var has no range to
+    # read an extent from, so the size -> count conversion above never fires for
+    # it.  The count spelling never needed an extent, which is why
+    # num_tiles_per_dim works for such dims today.  The DECLARED extent
+    # (declare_tensor_dim) is a legitimate second source -- unlike falling back
+    # to using the tile SIZE as the count, which would tile into `tile_size`
+    # pieces instead of pieces OF tile_size, i.e. miscompile.
+    #
+    # Deliberately a separate pass, run only where pass 1 left a gap, so a range
+    # derived from real op ranges always wins and the result does not depend on
+    # the order `operations` happens to be in.
+    for op in operations:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        for hint_id, hint_dict in sorted(get_op_hints(op).items()):
             sizes = hint_dict.get(_TILE_SIZE_KEY)
             if not sizes:
                 continue
             for name, tile_size in sizes.items():
                 if counts.get(hint_id, {}).get(name) is not None:
                     continue
-                sym = name_to_sym.get(name)
-                extent = extents.get(sym) if sym is not None else None
-                if not extent:
-                    continue  # this op does not carry the dim; another will
-                if int(tile_size) <= 0:
+                declared = _named_dims.get(name)
+                if not declared:
+                    continue  # genuinely unknown -- the caller's check raises
+                tile_size = int(tile_size)
+                if tile_size <= 0:
                     raise Unsupported(
                         f"spyre_hint(tile_size_per_dim={{{name!r}: {tile_size}}}): "
                         "tile size must be positive"
                     )
-                if extent % int(tile_size) != 0:
+                if int(declared) % tile_size != 0:
                     raise Unsupported(
                         f"spyre_hint(tile_size_per_dim={{{name!r}: {tile_size}}}): "
-                        f"dim {name!r} has extent {extent}, which is not a multiple "
-                        f"of the tile size. WSR requires full tiles -- pad {name!r} "
-                        f"to a multiple of {tile_size} (with op-appropriate identity "
-                        "values) before the tiled scope."
+                        f"dim {name!r} has declared extent {declared}, which is not "
+                        f"a multiple of the tile size. WSR requires full tiles -- "
+                        f"pad {name!r} to a multiple of {tile_size} (with "
+                        "op-appropriate identity values) before the tiled scope."
                     )
-                counts.setdefault(hint_id, {})[name] = extent // int(tile_size)
+                counts.setdefault(hint_id, {})[name] = int(declared) // tile_size
     return counts
 
 

--- a/torch_spyre/_inductor/wsr/propagate_named_dims.py
+++ b/torch_spyre/_inductor/wsr/propagate_named_dims.py
@@ -617,6 +617,30 @@ def _resolve_tile_size_counts(operations: list[Operation]) -> dict[int, dict[str
     convenience: WSR assumes every tile is full (see
     docs/wsr-tile-size-api-plan.md), so a non-multiple extent means the caller did
     not pad, and the failure must be loud rather than a short final tile.
+
+    THE CONTRACT FOR DIMS THAT SHARE A LOOP VAR
+    -------------------------------------------
+    Several named dims can land on ONE loop var -- a flat shape=(Lq*D,) named
+    ["Lq","D"], or a [B,H,...] tensor where B=1 is degenerate and the backend
+    folds B in with H onto a loop var of extent B*H. For those, a tile SIZE is
+    read in the units of the LOOP VAR, i.e. **absolute host-dim extents**,
+    outermost-first, each inner size dividing the enclosing one. So for
+    ["B","H"] with B=1, H=8 (loop var extent 8), "B" is 8 (do not tile) and NOT
+    B // b_tiles == 1 -- the latter is a count of B steps, not an extent of
+    anything this divides.
+
+    That ambiguity is not detectable in general: a host-unit size of 1 is
+    perfectly legal (extent-many tiles of one element), so it cannot be told
+    apart from a per-dim 1 that was meant as something else. What IS checkable is
+    the alignment below -- a size for one name of a fused group must be a
+    multiple of the product of its INNER siblings' extents, because that name can
+    only cut the host range at multiples of what sits inside it. That rejects the
+    common mistake (per-dim units) while accepting every valid host-unit size.
+
+    A COUNT is invariant to which loop var a name lands on; a SIZE is not. Where
+    the grouping depends on the shape -- e.g. a test helper parameterised over
+    many shapes -- the count spelling is the only one that can be written as a
+    fixed expression. See tests/inductor/test_coarse_tile_e2e.py's flash helpers.
     """
     counts: dict[int, dict[str, int]] = {}
     for op in operations:
@@ -683,6 +707,39 @@ def _resolve_tile_size_counts(operations: list[Operation]) -> dict[int, dict[str
                     "each inner size dividing the enclosing one."
                 )
             claimed_by[sym] = (hint_id, name)
+
+            # Alignment check for a dim sharing its loop var with others: the
+            # size is in LOOP-VAR units, and this name can only cut the host
+            # range at multiples of what sits inside it, so it must be a multiple
+            # of the product of its INNER siblings' extents.  Rejects the common
+            # mistake of passing per-dim units (["B","H"], B=1, H=8: a "B" of 1
+            # is not a multiple of 8) without touching any valid host-unit size.
+            # Skipped when a sibling's extent is not declared -- then there is
+            # nothing to compute the stride from.
+            group = dp.loop_var_dims.get(sym) or []
+            if len(group) > 1 and name in group:
+                inner = 1
+                known = True
+                for sib in group[group.index(name) + 1 :]:
+                    sz = _named_dims.get(sib)
+                    if not sz:
+                        known = False
+                        break
+                    inner *= int(sz)
+                if known and inner > 1 and tile_size % inner != 0:
+                    raise Unsupported(
+                        f"spyre_hint(tile_size_per_dim={{{name!r}: {tile_size}}}): "
+                        f"dim {name!r} shares one loop var with {group}, so its "
+                        f"tile size is an ABSOLUTE extent in that loop var's "
+                        f"units and must be a multiple of {inner} (the product of "
+                        f"the extents inside it: {group[group.index(name) + 1 :]}). "
+                        f"{tile_size} is not. A per-dim size such as "
+                        f"extent // count is the wrong quantity here -- use the "
+                        f"product over the whole group, a hinted name "
+                        f"contributing extent // count and an unhinted one its "
+                        f"full extent."
+                    )
+
             avail = remaining.get(sym, extents[sym])
             if tile_size <= 0:
                 raise Unsupported(

--- a/torch_spyre/_inductor/wsr/propagate_named_dims.py
+++ b/torch_spyre/_inductor/wsr/propagate_named_dims.py
@@ -592,7 +592,84 @@ def validate_named_dims(graph: GraphLowering) -> None:
                     )
 
 
+_TILE_SIZE_KEY = "tile_size_per_dim"
+_COUNT_KEYS = ("tiles", "slices", "num_tiles_per_dim")
+
+
+def _hint_dims(hint_dict: dict) -> dict:
+    """The {name: value} mapping a hint scope specifies, whichever key it used."""
+    for k in (*_COUNT_KEYS, _TILE_SIZE_KEY):
+        v = hint_dict.get(k)
+        if v:
+            return v
+    return {}
+
+
+def _resolve_tile_size_counts(operations: list[Operation]) -> dict[int, dict[str, int]]:
+    """Convert tile_size_per_dim hints to trip counts, per hint scope.
+
+    The trip count is a property of the hint SCOPE, not of one op: an op that is
+    broadcast w.r.t. the hinted dim has loop_var=None and cannot derive the count
+    locally, yet must share the group's count. So resolve it once here from any op
+    that does carry the dim, and hand the same value to every op in the scope.
+
+    Requires extent % tile_size == 0. That is the padding invariant, not a
+    convenience: WSR assumes every tile is full (see
+    docs/wsr-tile-size-api-plan.md), so a non-multiple extent means the caller did
+    not pad, and the failure must be loud rather than a short final tile.
+    """
+    counts: dict[int, dict[str, int]] = {}
+    for op in operations:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        dp = getattr(op, "_dim_prop_info", None)
+        if not (dp and dp.loop_var_dims):
+            continue
+        op_hints = get_op_hints(op)
+        if not any(_TILE_SIZE_KEY in h for h in op_hints.values()):
+            continue
+
+        rw = op.get_read_writes()
+        extents = {
+            sym: int(v)
+            for dep in [*rw.reads, *rw.writes]
+            for sym, v in dep.ranges.items()
+        }
+        name_to_sym: dict[str, sympy.Symbol] = {}
+        for sym, names in dp.loop_var_dims.items():
+            for nm in names:
+                name_to_sym[nm] = sym
+
+        for hint_id, hint_dict in op_hints.items():
+            sizes = hint_dict.get(_TILE_SIZE_KEY)
+            if not sizes:
+                continue
+            for name, tile_size in sizes.items():
+                if counts.get(hint_id, {}).get(name) is not None:
+                    continue
+                sym = name_to_sym.get(name)
+                extent = extents.get(sym) if sym is not None else None
+                if not extent:
+                    continue  # this op does not carry the dim; another will
+                if int(tile_size) <= 0:
+                    raise Unsupported(
+                        f"spyre_hint(tile_size_per_dim={{{name!r}: {tile_size}}}): "
+                        "tile size must be positive"
+                    )
+                if extent % int(tile_size) != 0:
+                    raise Unsupported(
+                        f"spyre_hint(tile_size_per_dim={{{name!r}: {tile_size}}}): "
+                        f"dim {name!r} has extent {extent}, which is not a multiple "
+                        f"of the tile size. WSR requires full tiles -- pad {name!r} "
+                        f"to a multiple of {tile_size} (with op-appropriate identity "
+                        "values) before the tiled scope."
+                    )
+                counts.setdefault(hint_id, {})[name] = extent // int(tile_size)
+    return counts
+
+
 def _assign_dim_hints_impl(operations: list[Operation]) -> None:
+    tile_size_counts = _resolve_tile_size_counts(operations)
     for op in operations:
         if not isinstance(op, ComputedBuffer):
             continue
@@ -633,15 +710,15 @@ def _assign_dim_hints_impl(operations: list[Operation]) -> None:
 
         dim_hints = []
         for hint_id, hint_dict in sorted(op_hints.items()):
-            # A hint scope uses exactly one of tiles/slices/num_tiles_per_dim.
-            dims: dict[str, int] = next(
-                (
-                    v
-                    for k in ("tiles", "slices", "num_tiles_per_dim")
-                    if (v := hint_dict.get(k))
-                ),
-                {},
-            )
+            # A hint scope uses exactly one of tiles/slices/num_tiles_per_dim
+            # (trip count) or tile_size_per_dim (per-tile extent, converted to a
+            # trip count by _resolve_tile_size_counts).
+            dims: dict[str, int] = _hint_dims(hint_dict)
+            if _TILE_SIZE_KEY in hint_dict and hint_dict[_TILE_SIZE_KEY]:
+                resolved = tile_size_counts.get(hint_id, {})
+                dims = {
+                    name: resolved[name] for name in dims if name in resolved
+                } or dims
             # TODO: support multiple dimensions per spyre_hint() call.
             # hint_id_to_ranges_pos in plan_coarse_tile_groups would need to
             # become dict[int, list[int]] and _hints_levels would need to

--- a/torch_spyre/_inductor/wsr/propagate_named_dims.py
+++ b/torch_spyre/_inductor/wsr/propagate_named_dims.py
@@ -729,6 +729,7 @@ def _assign_dim_hints_impl(operations: list[Operation]) -> None:
                     f"{len(dims)} dimensions; only one is currently allowed per "
                     f"spyre_hint() call (not yet implemented)"
                 )
+            declared = hint_dict.get(_TILE_SIZE_KEY) or {}
             for name, count in dims.items():
                 sym = coord_for_name.get(name)
                 dim_hints.append(
@@ -738,6 +739,7 @@ def _assign_dim_hints_impl(operations: list[Operation]) -> None:
                         loop_var=sym,
                         is_reduction=name in reduction_dims,
                         hint_id=hint_id,
+                        tile_size=declared.get(name),
                     )
                 )
         op.dim_hints = dim_hints  # type: ignore[attr-defined]


### PR DESCRIPTION
> **Stacked on #3511** (which is stacked on #3491), so it carries their commits.
> Review only the last commit. Merge order: #3491 → #3511 → this.

Takes the migration to **282 of 293** sites. Verified on hardware (pod pf2, torch 2.13):
all six WSR suites at baseline — `test_coarse_tile_e2e.py` 146 passed / 68 skipped,
`test_coarse_tiling.py` 255, `test_span_overflow_hint_analysis.py` 74/3xf,
`test_work_division_hint.py` 22/2xf, `test_building_blocks.py` 11, `test_tile_size_hint.py` 5.

## Converted (29)

Nearly all were the same inversion `_wsr_tile_size` already fixed: the caller knows the block
size and divides by it to get a count, so the conversion is **algebraic** —
`count = X // Y` ⟹ `tile_size = Y`, no divisibility arithmetic needed.

Includes the **user-facing** `docs/source/user_guide/examples/spyre_hints.py` and
`docs/tools/capture_coarse_tile_ir.py` (the CLI keeps its count flags and converts at the
hint boundary).

## Not converted (16), and this is the interesting part

The `_flash_v1_fn`..`_flash_v4_fn` helpers keep `num_tiles_per_dim`. A tile SIZE is read in
the units of the **loop var** the dim lands on, and that grouping is **shape-dependent** —
measured, not assumed:

```
test_flash_tile_H, op buf4:
  loop_var_dims = {'d0': ['B','H'], 'd1': ['Lq'], 'd2': ['D']}
  extents       = {'d0': 8,         'd1': 256,    'd2': 64}
```

With `B=1` the backend folds `B` in with `H` onto one loop var of extent `B*H`, so `"B"` needs
`(B//b_tiles)*H`, not `B//b_tiles`. `_flash_v4_fn` draws both `Lq` and `Lk` from `S`. A helper
parameterised over many shapes cannot write that as a fixed expression.

**A count is invariant to which loop var a name lands on; a size is not.**

⇒ **`num_tiles_per_dim` cannot simply be removed**, which the plan assumed. See #3491's thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)