### PR TITLE
fix(scratchpad): make uses a list of distinct op indices, and require in-place parents to be read

### DIFF
--- a/tests/inductor/test_perm_layout_solver.py
+++ b/tests/inductor/test_perm_layout_solver.py
@@ -56,6 +56,13 @@ def _random_buffers(rng, n, horizon=12, max_size=200, inplace_prob=0.25):
             parent_i = rng.randrange(child_i)
             parent = buffers[parent_i]
             child = buffers[child_i]
+            if parent.read_count == 0:
+                # A write-only parent has nothing to hand over, so the pair is
+                # not expressible at all (see ``assert_in_place_parent_is_read``).
+                # Drawing one is possible because a base buffer may land on a
+                # single-tick lifetime; skip rather than reshaping the parent,
+                # which could invalidate a pair already wired to it.
+                continue
             # The child is defined at the parent's last live tick, so that
             # parent.end_time == child.start_time + 1. Its own read has to fall
             # strictly after that write, both because uses is strictly increasing
@@ -233,6 +240,33 @@ class SkeletonTestsMixin(MixinBase):
             self.make_plan(buffers, [0, 0], capacity=128)
         with self.assertRaises(AssertionError):
             self.make_plan(buffers, [0], capacity=128)
+
+    def test_write_only_in_place_parent_rejected(self):
+        # "a" is a computed buffer whose only use is its write, so it is never
+        # read and has no storage to hand over; "b" declaring it as an in-place
+        # parent is not expressible. Rejected while resolving declared pairs, so
+        # it fires for both concrete plans.
+        parent = LifetimeBoundBuffer("a", 64, [0])
+        child = LifetimeBoundBuffer("b", 64, [0, 2], in_place_parents=["a"])
+        with self.assertRaises(AssertionError):
+            self.make_plan([parent, child], [0, 1], capacity=256)
+
+    def test_single_use_input_in_place_parent_allowed(self):
+        # The same shape is legal when the parent is a graph input: all its uses
+        # are reads, so one use still means a genuine read before the handoff.
+        parent = LifetimeBoundBuffer("a", 64, [0], first_use_is_read=True)
+        child = LifetimeBoundBuffer("b", 64, [0, 2], in_place_parents=["a"])
+        plan = self.make_plan([parent, child], [0, 1], capacity=256)
+        self.assertEqual(plan._inplace_partners, [{1}, {0}])
+
+    def test_in_place_chain_allowed(self):
+        # Chains are explicitly supported: "b" is both a child of "a" and the
+        # parent of "c". Every parent here has a read, so nothing is rejected.
+        a = LifetimeBoundBuffer("a", 64, [0, 2])
+        b = LifetimeBoundBuffer("b", 64, [2, 4], in_place_parents=["a"])
+        c = LifetimeBoundBuffer("c", 64, [4, 6], in_place_parents=["b"])
+        plan = self.make_plan([a, b, c], [0, 1, 2], capacity=256)
+        self.assertEqual(plan._inplace_partners, [{1}, {0, 2}, {1}])
 
     def test_align_up(self):
         buffers = [_buf("a", 64, 0, 1)]
@@ -493,9 +527,19 @@ class ContactProfileTests(TestCase):
         the same ``_placement_decision`` as the full earlier-overlapping set.
 
         Placement reads neither capacity nor alignment, so the equivalence is
-        independent of both and one of each suffices. ~40k configs, well under
-        a second. The heavier validation (n up to 4, larger sizes, live swap
-        propagation) lives in StressTests and the one-off exhaustive sweep.
+        independent of both and one of each suffices. ~82k configs, 33k of them
+        carrying an in-place edge, in a few seconds. The heavier validation
+        (n up to 4, larger sizes, live swap propagation) lives in StressTests
+        and the one-off exhaustive sweep.
+
+        ``horizon`` is 4 rather than 3 because requiring the parent to be read
+        costs every in-place pair a tick: the parent must be written and then
+        read before it hands over, so the earliest legal handoff is tick 1 and
+        the earliest a child can start is 1, where it used to be 0.  (A child
+        starting at 0 has no legal parent at any horizon -- that one is inherent
+        to the rule, not a horizon effect.)  At horizon 3 there is no longer room
+        for the shifted pairs and the wirings carrying an in-place edge collapse
+        from 29k to 8k; horizon 4 gives them the tick back, at 33k.
         """
 
         def contact_cands(plan, z):
@@ -512,17 +556,26 @@ class ContactProfileTests(TestCase):
             pz = plan.position[z]
             return [w for w in plan.overlap_dict[z] if plan.position[w] < pz]
 
-        horizon = 3
+        horizon = 4
         lifetimes = [(s, e) for s in range(horizon) for e in range(s + 1, horizon + 1)]
         for n in (2, 3):
             for life in itertools.product(lifetimes, repeat=n):
                 starts = [s for s, _ in life]
                 ends = [e for _, e in life]
                 # in-place parent options: any other buffer whose lifetime makes
-                # it a geometrically valid parent (parent.end == child.start + 1).
+                # it a geometrically valid parent (parent.end == child.start + 1)
+                # *and* that is read before the handoff. A single-tick parent has
+                # only its write, so it has nothing to hand over and the pair is
+                # not expressible (see ``assert_in_place_parent_is_read``).
                 parent_opts = [
                     [None]
-                    + [j for j in range(n) if j != i and ends[j] == starts[i] + 1]
+                    + [
+                        j
+                        for j in range(n)
+                        if j != i
+                        and ends[j] == starts[i] + 1
+                        and ends[j] - starts[j] > 1
+                    ]
                     for i in range(n)
                 ]
                 for sizes in itertools.product((1, 2), repeat=n):

--- a/tests/inductor/test_perm_layout_solver.py
+++ b/tests/inductor/test_perm_layout_solver.py
@@ -56,10 +56,13 @@ def _random_buffers(rng, n, horizon=12, max_size=200, inplace_prob=0.25):
             parent_i = rng.randrange(child_i)
             parent = buffers[parent_i]
             child = buffers[child_i]
-            if parent.end_time > child.end_time:
-                child.uses = [parent.end_time - 1]
-            else:
-                child.uses = [parent.end_time - 1, child.end_time - 1]
+            # The child is defined at the parent's last live tick, so that
+            # parent.end_time == child.start_time + 1. Its own read has to fall
+            # strictly after that write, both because uses is strictly increasing
+            # and so that the child can itself act as an in-place parent; extend
+            # by a tick when the child's own end is too early to supply one.
+            handoff = parent.end_time - 1
+            child.uses = [handoff, max(child.end_time - 1, handoff + 1)]
             child.size = rng.randint(1, parent.size)
             child.in_place_parents = [parent.name]
     return buffers
@@ -178,10 +181,15 @@ def _above_named(plan, name):
 
 
 def _buf(name, size, start, end, in_place_parents=None):
+    # A lifetime of [start, end) is expressed as a write at start and a read at
+    # end - 1. When end == start + 1 those are the same operation, so the buffer
+    # has a single use: uses carries one distinct index per accessing op (see
+    # LifetimeBoundBuffer), and such a buffer is written without being read.
+    uses = [start] if end - 1 == start else [start, end - 1]
     return LifetimeBoundBuffer(
         name=name,
         size=size,
-        uses=[start, end - 1],
+        uses=uses,
         in_place_parents=in_place_parents or [],
     )
 
@@ -307,7 +315,10 @@ class ReferencePlacementTests(TestCase):
         buffers = [_buf("a", 64, 0, 1), _buf("b", 64, 2, 3), _buf("c", 64, 4, 5)]
         plan = self.plan(buffers, [0, 1, 2])
         self.assertEqual([_addr(plan, n) for n in "abc"], [0, 0, 0])
-        self.assertEqual(plan.quality(), 480)  # 2.5 * (64 + 64 + 64)
+        # Each buffer lives for a single tick, so it has one use (its write) and
+        # weight 1 + 0.5. Contrast test_overlapping_lifetimes_stack, whose
+        # two-tick buffers carry a write and a read and so weigh 2 + 0.5.
+        self.assertEqual(plan.quality(), 288)  # 1.5 * (64 + 64 + 64)
 
     def test_overlapping_lifetimes_stack(self):
         buffers = [_buf("a", 64, 0, 2), _buf("b", 50, 1, 3)]

--- a/tests/inductor/test_scratchpad_solver.py
+++ b/tests/inductor/test_scratchpad_solver.py
@@ -581,6 +581,20 @@ class BaseLayoutSolverTests:
         with self.assertRaises(AssertionError):
             _assert_in_place_relationships([p, c])
 
+    def test_uses_must_be_strictly_increasing(self):
+        # One distinct index per accessing op. A repeat would describe a buffer
+        # written and read by the same operation, i.e. with a single live tick,
+        # and would make read_count overstate the reads.
+        with self.assertRaises(AssertionError):
+            LifetimeBoundBuffer("P", 20, [3, 3])
+        with self.assertRaises(AssertionError):
+            LifetimeBoundBuffer("P", 20, [4, 3])
+        LifetimeBoundBuffer("P", 20, [3, 4])  # fine
+        LifetimeBoundBuffer("P", 20, [3])  # fine
+        # Empty is allowed: buffers may be registered before their uses are
+        # known and filled in afterwards.
+        LifetimeBoundBuffer("P", 20, [])
+
 
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 
@@ -589,7 +603,8 @@ import json
 from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
 from {solver_module} import {solver_class}
 def b(n, s, st, en, ipp=None):
-    return LifetimeBoundBuffer(name=n, size=s, uses=[st, en - 1], in_place_parents=ipp or [])
+    uses = [st] if en - 1 == st else [st, en - 1]
+    return LifetimeBoundBuffer(name=n, size=s, uses=uses, in_place_parents=ipp or [])
 # c has two in-place parents at distinct addresses, both in-place candidates for
 # its gap -> _build_gaps' iteration order decides in_place_parents[0].
 bufs = [b("pA", 100, 0, 3), b("pB", 80, 1, 3), b("c", 50, 2, 5, ["pA", "pB"])]

--- a/tests/inductor/test_scratchpad_solver.py
+++ b/tests/inductor/test_scratchpad_solver.py
@@ -646,6 +646,24 @@ class BaseLayoutSolverTests:
         # known and filled in afterwards.
         LifetimeBoundBuffer("P", 20, [])
 
+    def test_read_count_counts_every_use_of_a_read_first_buffer(self):
+        # A computed buffer's first use is its producing write, so only the later
+        # uses are reads. A graph input (first_use_is_read) is read at every use,
+        # including the first -- that read is the clone-in, which is still a read
+        # of the buffer even though pinning cannot save it (the cost models
+        # discount it themselves; see CpSat's ``spill_cost``).
+        self.assertEqual(LifetimeBoundBuffer("C", 20, [3, 5, 8]).read_count, 2)
+        self.assertEqual(LifetimeBoundBuffer("C", 20, [3]).read_count, 0)
+        inp = LifetimeBoundBuffer("I", 20, [3, 5, 8], first_use_is_read=True)
+        self.assertEqual(inp.read_count, 3)
+        single = LifetimeBoundBuffer("I", 20, [3], first_use_is_read=True)
+        self.assertEqual(single.read_count, 1)
+        # Empty uses is a transient registration state, not a negative count.
+        self.assertEqual(LifetimeBoundBuffer("E", 20, []).read_count, 0)
+        self.assertEqual(
+            LifetimeBoundBuffer("E", 20, [], first_use_is_read=True).read_count, 0
+        )
+
     def test_repeated_index_cannot_pass_as_a_read(self):
         # The in-place rule tests for a use strictly after the first rather than
         # relying on read_count, so a buffer whose uses were mutated into a

--- a/tests/inductor/test_scratchpad_solver.py
+++ b/tests/inductor/test_scratchpad_solver.py
@@ -292,15 +292,47 @@ class BaseLayoutSolverTests:
     # read on that tick, so that remainder belongs to nobody else until the
     # parent's lifetime ends.
 
-    def test_live_parent_footprint_not_reused_at_handoff(self):
-        # `child` takes over the low 5 bytes of a 40-byte parent. `stranger`
-        # enters at the handoff tick, so it may not be handed any of the
-        # remaining 35 -- and `child` itself may not sit part-way into the
-        # parent. `_assert_legal_layout` in solve() is the real assertion; the
-        # checks below name the specific pair for a readable failure.
+    def test_write_only_in_place_parent_is_rejected(self):
+        # Whether the pair is expressible at all, before any question of where
+        # it lands. A computed parent whose only use is its write has nothing to
+        # hand over, so every solver must reject it rather than place the child
+        # over data nothing consumes.
+        #
+        # The two solver families check this at different points -- the gap-based
+        # and ILP solvers in ``_assert_in_place_relationships``, the
+        # permutation-based ones (which simulated annealing drives) in
+        # ``_compute_inplace_partners`` -- and they share no base class, so
+        # running one case against all of them is what pins the coverage.
+        # Matched on the message: ``solve`` also asserts layout legality, and a
+        # bare ``assertRaises`` would accept that unrelated failure as a pass.
         parent = self.make_buffer("parent", 40, [0])
-        child = self.make_buffer("child", 5, [0, 2], in_place_parents=["parent"])
-        stranger = self.make_buffer("stranger", 20, [0, 1])
+        child = self.make_buffer("child", 40, [0, 2], in_place_parents=["parent"])
+        with self.assertRaisesRegex(
+            AssertionError, "computed buffer that is never read"
+        ):
+            self.solve([parent, child], size=120)
+
+    def test_single_use_in_place_parent_allowed_for_an_input(self):
+        # The same shape is legal when the parent is a graph input: every use of
+        # one is a read, so the single use is a genuine read before the handoff.
+        # The contrast shows the rejection above keys on the missing read rather
+        # than on ``len(uses) == 1``. Only that it solves is asserted -- an input
+        # parent has no producer write to save and its one read is the clone-in,
+        # so a cost-driven solver may legitimately decline to place it.
+        parent = self.make_buffer("parent", 40, [0], first_use_is_read=True)
+        child = self.make_buffer("child", 40, [0, 2], in_place_parents=["parent"])
+        self.solve([parent, child], size=120)
+
+    def test_live_parent_footprint_not_reused_at_handoff(self):
+        # `child` takes over the low 5 bytes of a 40-byte parent at tick 1, the
+        # parent's read. `stranger` enters at that handoff tick, so it may not be
+        # handed any of the remaining 35 -- and `child` itself may not sit
+        # part-way into the parent. `_assert_legal_layout` in solve() is the real
+        # assertion; the checks below name the specific pair for a readable
+        # failure.
+        parent = self.make_buffer("parent", 40, [0, 1])
+        child = self.make_buffer("child", 5, [1, 3], in_place_parents=["parent"])
+        stranger = self.make_buffer("stranger", 20, [1, 2])
         result = {b.name: b for b in self.solve([parent, child, stranger], size=120)}
 
         p = result["parent"]
@@ -324,9 +356,9 @@ class BaseLayoutSolverTests:
         # ordering prefers. The other has to be placed on its own: those bytes now
         # belong to the first child, and the rest still belongs to the parent for
         # the handoff tick.
-        parent = self.make_buffer("parent", 40, [0])
-        first = self.make_buffer("first", 20, [0, 2], in_place_parents=["parent"])
-        second = self.make_buffer("second", 5, [0], in_place_parents=["parent"])
+        parent = self.make_buffer("parent", 40, [0, 1])
+        first = self.make_buffer("first", 20, [1, 3], in_place_parents=["parent"])
+        second = self.make_buffer("second", 5, [1], in_place_parents=["parent"])
         result = {b.name: b for b in self.solve([parent, first, second], size=120)}
 
         placed = [b for b in result.values() if b.address is not None]
@@ -351,8 +383,8 @@ class BaseLayoutSolverTests:
         buffers = [
             self.make_buffer("stacked", 20, [0, 2]),
             self.make_buffer("late", 5, [6]),
-            self.make_buffer("parent", 20, [0]),
-            self.make_buffer("child", 5, [0, 2, 5, 6], in_place_parents=["parent"]),
+            self.make_buffer("parent", 20, [0, 1]),
+            self.make_buffer("child", 5, [1, 2, 5, 6], in_place_parents=["parent"]),
         ]
         for b in self.solve(buffers, size=30, alignment=10):
             if b.address is not None:
@@ -581,6 +613,25 @@ class BaseLayoutSolverTests:
         with self.assertRaises(AssertionError):
             _assert_in_place_relationships([p, c])
 
+    def test_assert_rejects_write_only_computed_parent(self):
+        # P's single use is its write, so it is never read: C would take over
+        # storage holding data nothing consumes, and the two would come alive on
+        # the same tick. P.end_time == C.start_time + 1 still holds, so only the
+        # read-count invariant rejects this.
+        p = LifetimeBoundBuffer("P", 20, [3])
+        c = LifetimeBoundBuffer("C", 15, [3, 8], in_place_parents=["P"])
+        self.assertEqual(p.end_time, c.start_time + 1)
+        with self.assertRaises(AssertionError):
+            _assert_in_place_relationships([p, c])
+
+    def test_assert_allows_single_use_input_parent(self):
+        # A graph input's single use is a read, so handing its storage over is
+        # legitimate; first_use_is_read is what distinguishes it from the
+        # computed buffer above.
+        p = LifetimeBoundBuffer("P", 20, [3], first_use_is_read=True)
+        c = LifetimeBoundBuffer("C", 15, [3, 8], in_place_parents=["P"])
+        _assert_in_place_relationships([p, c])
+
     def test_uses_must_be_strictly_increasing(self):
         # One distinct index per accessing op. A repeat would describe a buffer
         # written and read by the same operation, i.e. with a single live tick,
@@ -594,6 +645,28 @@ class BaseLayoutSolverTests:
         # Empty is allowed: buffers may be registered before their uses are
         # known and filled in afterwards.
         LifetimeBoundBuffer("P", 20, [])
+
+    def test_repeated_index_cannot_pass_as_a_read(self):
+        # The in-place rule tests for a use strictly after the first rather than
+        # relying on read_count, so a buffer whose uses were mutated into a
+        # repeat after construction still cannot be an in-place parent.
+        #
+        # The mutation rewrites uses[0] only, leaving end_time untouched, so the
+        # handoff geometry still lines up afterwards. That is what makes the read
+        # rule the assertion under test: end_time == uses[-1] + 1, so a mutation
+        # that moved the tail would trip the abutment check first and this would
+        # pass without ever reaching the rule it is named for. Matched on the
+        # message for the same reason.
+        p = LifetimeBoundBuffer("P", 20, [2, 3])
+        c = LifetimeBoundBuffer("C", 15, [3, 8], in_place_parents=["P"])
+        _assert_in_place_relationships([p, c])  # baseline: accepted
+        p.uses = [3, 3]  # bypasses __post_init__
+        self.assertEqual(p.end_time, c.start_time + 1)  # geometry still holds
+        self.assertEqual(p.read_count, 1)  # read_count is fooled...
+        with self.assertRaisesRegex(  # ...the invariant is not
+            AssertionError, "computed buffer that is never read"
+        ):
+            _assert_in_place_relationships([p, c])
 
 
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
@@ -1063,7 +1136,20 @@ class TestCpSatJointDivision(JointDivisionSolverTests, TestCase):
         # zero-width time interval, which the 2D propagator ignores -- the child
         # still holds the shared slot. The merge must fire (capacity fits only
         # one 100-byte buffer) and the child must reuse the parent's address.
-        gp = CoreDivisionBuffer("gp", 100, [0], core_divisions=_whole())  # end_time=1
+        #
+        # ``gp`` has to be an input clone (``first_use_is_read``) rather than a
+        # computed buffer: a computed buffer's lone use is its write, so it is
+        # never read and cannot hand storage over at all -- forbidden by
+        # ``_assert_in_place_relationships``. A clone read exactly once is the
+        # real shape of a single-use in-place parent. The flag does reach
+        # ``spill_cost`` -- it is read there unconditionally -- but cancels: it
+        # raises ``read_count`` by one and is discounted by one, so the cost is
+        # 100 with it or without it. (``boundary`` decides only ``is_intermediate``,
+        # and ``CoreDivisionBuffer`` tracks that independently of the flag.) So
+        # the flag leaves the zero-width interval under test.
+        gp = CoreDivisionBuffer(
+            "gp", 100, [0], first_use_is_read=True, core_divisions=_whole()
+        )  # end_time=1
         c = CoreDivisionBuffer(
             "c",
             100,

--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -29,6 +29,8 @@ from torch._inductor.graph import GraphLowering
 from torch_spyre._inductor.passes import CustomPreSchedulingPasses
 from torch_spyre._inductor import passes
 from torch_spyre._inductor import config as ts_inductor_config
+from torch_spyre._inductor.pass_utils import op_read_writes
+from torch_spyre._inductor.scratchpad.utils import calculate_liveness
 
 try:
     from ortools.sat.python import cp_model  # noqa: F401
@@ -1095,6 +1097,56 @@ class TestIntermediatePartialReadNotPinned(BaseTestScratchpadUsage):
             rtol=0.1,
             msg="sliced intermediate miscompiled — is the partial-read guard present?",
         )
+
+
+class TestLivenessIndicesAreDistinct(BaseTestScratchpadUsage):
+    """``calculate_liveness`` records one distinct op index per accessing op.
+
+    ``rw.reads | rw.writes`` is a set of *dependencies*, not of names, so an op
+    touching one buffer through two index expressions contributes two deps naming
+    it; appending per dep would repeat that op's index. The repeat is invisible to
+    ``start_time``/``end_time``, inflates ``read_count``, and would let a buffer
+    written and read by the same op pass as an in-place parent -- so
+    ``calculate_liveness`` collapses it and
+    :class:`LifetimeBoundBuffer` asserts the result is strictly increasing.
+
+    That assertion is exercised elsewhere over hand-built lists, which proves it
+    fires but not that the producer satisfies it. Only a real lowering can show
+    that, which is what this test does.
+    """
+
+    def test_fused_slice_input_has_one_use_per_op(self):
+        seen: dict[str, list[int]] = {}
+        multi_dep: list[str] = []
+
+        def visitor(graph: GraphLowering) -> None:
+            seen.update(calculate_liveness(graph))
+            for op in graph.operations:
+                rw = op_read_writes(op)
+                names = [dep.name for dep in rw.reads | rw.writes]
+                multi_dep.extend(n for n in set(names) if names.count(n) > 1)
+
+        def fn(x):
+            # One fused add reading x at offset 0 and at offset 512: two deps on
+            # the same buffer from a single op, the shape the dedup exists for.
+            return x[:, 0:512] + x[:, 512:1024]
+
+        with self.pre_scheduling_iterating_pass(visitor):
+            # (64, 1024) matches the shape ``_input_read_at_multiple_offsets_is_correct``
+            # already drives this same expression with, so the two-deps lowering is
+            # known to hold for it.
+            torch.compile(fn, fullgraph=True)(self.rand_device((64, 1024))).to("cpu")
+
+        self.assertTrue(seen, "liveness visitor never ran")
+        # The scenario must still produce the two-deps-one-buffer shape, else the
+        # check below is free for every buffer and covers nothing.
+        self.assertTrue(
+            multi_dep, "no op read one buffer through two deps in this scenario"
+        )
+        for name, uses in seen.items():
+            # Distinct *and* ascending in one assertion: exactly what
+            # LifetimeBoundBuffer requires of ``uses``.
+            self.assertEqual(uses, sorted(set(uses)), name)
 
 
 class TestCpSatAllocatorFallback(

--- a/tests/inductor/test_simulated_annealing.py
+++ b/tests/inductor/test_simulated_annealing.py
@@ -57,9 +57,20 @@ def _random_buffers(rng, n, horizon=12, max_size=200):
         if rng.random() < 0.25:
             parent = buffers[rng.randrange(child_i)]
             child = buffers[child_i]
-            new_start = parent.uses[-1]
-            new_last = max(child.uses[-1], parent.uses[-1])
-            child.uses = [new_start] if new_start == new_last else [new_start, new_last]
+            if parent.read_count == 0:
+                # A write-only parent has nothing to hand over, so the pair is
+                # not expressible at all (see ``assert_in_place_parent_is_read``).
+                # Drawing one is possible because a base buffer may land on a
+                # single-tick lifetime; skip rather than reshaping the parent,
+                # which could invalidate a pair already wired to it.
+                continue
+            # The child is defined at the parent's last live tick. Its own read
+            # has to fall strictly after that write, both because uses is
+            # strictly increasing and so that the child can itself be drawn as a
+            # parent later in this loop; extend by a tick when the child's own
+            # end is too early to supply one.
+            handoff = parent.uses[-1]
+            child.uses = [handoff, max(child.uses[-1], handoff + 1)]
             child.size = rng.randint(1, parent.size)
             child.in_place_parents = [parent.name]
     return buffers

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -229,8 +229,11 @@ class ScratchpadAllocator:
     def _read_count(uses: list[int]) -> int:
         """Reads residency would serve from LX. The first use is never one of
         them: it is either the producer's write (an intermediate) or the clone-in
-        read a graph input cannot avoid. Mirrors
-        ``LifetimeBoundBuffer.read_count``."""
+        read a graph input cannot avoid.
+
+        Deliberately not ``LifetimeBoundBuffer.read_count``, which counts the
+        buffer's reads and so includes an input's clone-in; this is the savings,
+        which discounts it in both cases (as ``spill_cost`` does)."""
         return max(0, len(uses) - 1)
 
     @staticmethod
@@ -1844,7 +1847,10 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                     output_name,
                     size,
                     uses,
-                    first_use_is_read=True,
+                    # An op output is a computed buffer: ``uses[0]`` is the
+                    # producing write, as on the placement path above. (Only the
+                    # input-clone loop above sets this True.)
+                    first_use_is_read=False,
                     in_place_parents=parents,
                     core_divisions=buf_divisions,
                     parents=parent_proj,

--- a/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
+++ b/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
@@ -207,13 +207,18 @@ class _LifetimeBufferWithCpVars(Generic[_BufT]):
     # ------------------------------ residency ------------------------------
     def spill_cost(self) -> int:
         """Differential HBM traffic a spill adds over residency: the reads
-        residency would have served from LX (``read_count``, computed by the
-        allocator) plus the producer's write, which residency turns into a free
-        LX write. A graph input has no producer write to save; a graph output's
-        write-out is unavoidable either way, so it too cancels. Both cases are
-        exactly ``boundary != Intermediate`` -- for a plain
-        :class:`LifetimeBoundBuffer`, whose boundary is not tracked,
-        ``first_use_is_read`` marks the same distinction for inputs."""
+        residency would have served from LX plus the producer's write, which
+        residency turns into a free LX write. A graph input has no producer write
+        to save; a graph output's write-out is unavoidable either way, so it too
+        cancels. Both cases are exactly ``boundary != Intermediate`` -- for a
+        plain :class:`LifetimeBoundBuffer`, whose boundary is not tracked,
+        ``first_use_is_read`` marks the same distinction for inputs.
+
+        An input's first read is the clone-in that pinning cannot avoid, so it is
+        not one of the reads residency serves and is discounted from
+        ``read_count`` (which counts the buffer's reads, not the savings). For a
+        computed buffer the first use is the write and ``read_count`` already
+        excludes it, hence the discount is keyed on ``first_use_is_read``."""
         b = self.buffer
         boundary = getattr(b, "boundary", None)
         is_intermediate = (
@@ -221,7 +226,8 @@ class _LifetimeBufferWithCpVars(Generic[_BufT]):
             if boundary is not None
             else not b.first_use_is_read
         )
-        return (b.read_count + (1 if is_intermediate else 0)) * b.size
+        reads_served = b.read_count - (1 if b.first_use_is_read else 0)
+        return (reads_served + (1 if is_intermediate else 0)) * b.size
 
     def constrain_residency(self, model, kids, bufs) -> None:
         """Placement-only: any buffer may reside, so there is no slicing gate."""

--- a/torch_spyre/_inductor/scratchpad/permutation_layout.py
+++ b/torch_spyre/_inductor/scratchpad/permutation_layout.py
@@ -32,7 +32,10 @@ import heapq
 import math
 
 from torch_spyre._inductor.scratchpad.contact_profile import Profile
-from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
+from torch_spyre._inductor.scratchpad.plan_solver import (
+    LifetimeBoundBuffer,
+    assert_in_place_parent_is_read,
+)
 
 
 def buffer_quality(buf: LifetimeBoundBuffer) -> float:
@@ -239,6 +242,15 @@ class PermutationBasedLayoutSolverBase(ABC):
             for pname in buf.in_place_parents:
                 parent = self._name_to_idx.get(pname)
                 if parent is not None:
+                    # A write-only computed parent has nothing to hand over, so
+                    # the pair is not expressible rather than merely unprofitable.
+                    # Checked here because this is the one place that resolves
+                    # declared pairs. The other two in-place invariants asserted
+                    # by ``_assert_in_place_relationships`` are placement-time
+                    # gates here rather than preconditions -- an oversized child
+                    # is simply not placed in-place, see ``_can_inplace`` -- so
+                    # asserting them would reject plans this solver handles.
+                    assert_in_place_parent_is_read(self.buffers[parent], buf.name)
                     partners[child].add(parent)
                     partners[parent].add(child)
         return partners

--- a/torch_spyre/_inductor/scratchpad/plan_solver.py
+++ b/torch_spyre/_inductor/scratchpad/plan_solver.py
@@ -58,10 +58,11 @@ class LifetimeBoundBuffer:
 
     Both properties of ``uses`` are asserted in ``__post_init__``.  Strictness
     is what makes ``read_count`` trustworthy: one entry per accessing op means
-    ``read_count == 0`` is exactly "written, never read", which the in-place
-    invariants rely on (see :func:`assert_in_place_parent_is_read`).  A repeated
-    index would describe a buffer written and read by the same op, i.e. with a
-    single live tick, and would let such a buffer pass as an in-place parent.
+    that for a computed buffer ``read_count == 0`` is exactly "written, never
+    read", which the in-place invariants rely on (see
+    :func:`assert_in_place_parent_is_read`).  A repeated index would describe a
+    buffer written and read by the same op, i.e. with a single live tick, and
+    would let such a buffer pass as an in-place parent.
 
     ``start_time`` and ``end_time`` are convenience properties derived from
     ``uses``: ``uses[0]`` and ``uses[-1] + 1`` respectively.
@@ -94,10 +95,18 @@ class LifetimeBoundBuffer:
 
     @property
     def read_count(self) -> int:
-        """Number of reads: every use but the first, which is the producing
-        write for a computed buffer.  Exact because ``uses`` holds one distinct
-        index per accessing op."""
-        return max(0, len(self.uses) - 1)
+        """Number of reads.  For a computed buffer the first use is the producing
+        write, so every use but that one is a read; when ``first_use_is_read``
+        (a graph input) every use is a read.  Exact because ``uses`` holds one
+        distinct index per accessing op.
+
+        This counts the buffer's reads, not the reads residency would save: an
+        input's first read is the clone-in that pinning cannot avoid, so a cost
+        model has to discount it separately (see
+        :meth:`_LifetimeBufferWithCpVars.spill_cost`).  The ``max`` only guards
+        the transient empty-``uses`` state described in :meth:`__post_init__`.
+        """
+        return max(0, len(self.uses) - (0 if self.first_use_is_read else 1))
 
     @property
     def start_time(self) -> int:

--- a/torch_spyre/_inductor/scratchpad/plan_solver.py
+++ b/torch_spyre/_inductor/scratchpad/plan_solver.py
@@ -193,6 +193,37 @@ class CoreDivisionBuffer(LifetimeBoundBuffer):
         )
 
 
+def assert_in_place_parent_is_read(
+    parent: "LifetimeBoundBuffer", child_name: str
+) -> None:
+    """Assert an in-place parent's storage is read before it is handed over.
+
+    The child takes the parent's storage over at the parent's last use, so that
+    use has to be a read. For a computed buffer the first use is the write, so a
+    single use means the buffer is written and never read -- handing it to a
+    child would overwrite data nothing ever consumed, and it would make parent
+    and child come alive on the same tick while sharing storage. Graph inputs are
+    exempt: all their uses are reads, so one use is enough.
+
+    Split out of :func:`_assert_in_place_relationships` because the
+    permutation-based layout solvers enforce this one invariant on its own. For
+    them the other two are placement-time gates rather than preconditions: a
+    child that outgrows its parent, or a pair whose lifetimes do not abut, is
+    simply not placed in-place (see ``_can_inplace``), so asserting either here
+    would reject inputs those solvers handle correctly.
+    """
+    # Tested as "a use strictly after the first" rather than via ``read_count``:
+    # the two agree whenever ``uses`` is strictly increasing, but ``uses`` is
+    # validated at construction and can be mutated afterwards, and this way a
+    # repeated index cannot pass as a read.
+    has_read_after_write = len(parent.uses) > 1 and parent.uses[-1] > parent.uses[0]
+    assert parent.first_use_is_read or has_read_after_write, (
+        f"In-place parent {parent.name} is a computed buffer that is never read "
+        f"(uses={parent.uses}), so it cannot hand its storage to child "
+        f"{child_name}"
+    )
+
+
 def _assert_in_place_relationships(
     buffers: Sequence["LifetimeBoundBuffer"],
 ) -> None:
@@ -206,6 +237,7 @@ def _assert_in_place_relationships(
                     f"In-place parent {parent_name}.end_time={parent.end_time} must equal "
                     f"child {child.name}.start_time+1={child.start_time + 1}"
                 )
+                assert_in_place_parent_is_read(parent, child.name)
                 # With core_divisions ``size`` is the *total* footprint, so a static
                 # size check doesn't apply; the per-core match is enforced against the
                 # chosen division in ``CpSatLayoutSolver._add_inplace_relaxation``. Only

--- a/torch_spyre/_inductor/scratchpad/plan_solver.py
+++ b/torch_spyre/_inductor/scratchpad/plan_solver.py
@@ -45,13 +45,23 @@ class LifetimeBoundBuffer:
     """
     Defines the data fields required for a plan solver.
 
-    ``uses`` is the sorted list of operation indices at which the buffer is
-    accessed (as returned by ``calculate_liveness``).  It must be non-empty:
-    the ``start_time``/``end_time`` properties index into it and the
-    FirstFit/BestFit scoring divides by ``len(uses)``, so callers must only
-    construct buffers for names that are actually used.  ``first_use_is_read``
-    is True for graph inputs (all accesses are reads) and False for computed
-    buffers (first access is a write, all subsequent accesses are reads).
+    ``uses`` is the strictly increasing list of operation indices at which the
+    buffer is accessed (as returned by ``calculate_liveness``).  It is normally
+    non-empty, and callers that read ``start_time``/``end_time`` require that,
+    since those properties index into it; the FirstFit/BestFit scoring divides
+    by ``len(uses)`` plus a write bonus, which is non-zero for a computed buffer
+    even when ``uses`` is empty.  Emptiness is nevertheless allowed at
+    construction -- see :meth:`__post_init__` for the registration state that
+    needs it.  ``first_use_is_read`` is True for graph inputs (all accesses are
+    reads) and False for computed buffers (first access is a write, all
+    subsequent accesses are reads).
+
+    Both properties of ``uses`` are asserted in ``__post_init__``.  Strictness
+    is what makes ``read_count`` trustworthy: one entry per accessing op means
+    ``read_count == 0`` is exactly "written, never read", which the in-place
+    invariants rely on (see :func:`assert_in_place_parent_is_read`).  A repeated
+    index would describe a buffer written and read by the same op, i.e. with a
+    single live tick, and would let such a buffer pass as an in-place parent.
 
     ``start_time`` and ``end_time`` are convenience properties derived from
     ``uses``: ``uses[0]`` and ``uses[-1] + 1`` respectively.
@@ -67,9 +77,26 @@ class LifetimeBoundBuffer:
     # or solver logic paths.
     residency_reason: Optional[str] = None
 
+    def __post_init__(self) -> None:
+        # Not also asserted non-empty: buffers are sometimes registered before
+        # their uses are known and filled in afterwards (see
+        # ``make_buffer_registry`` in tests/inductor/test_scratchpad_patterns.py),
+        # and an empty list is vacuously strictly increasing. Callers that read
+        # ``start_time``/``end_time`` still require a non-empty list.
+        #
+        # This runs at construction only, so it does not see later mutation of
+        # ``uses``; the in-place invariants therefore test the property they need
+        # directly rather than inferring it from ``read_count``.
+        assert all(a < b for a, b in zip(self.uses, self.uses[1:])), (
+            f"buffer {self.name} has uses={self.uses}, which is not strictly "
+            "increasing; uses carries one distinct index per accessing operation"
+        )
+
     @property
     def read_count(self) -> int:
-        """Reports the number of reads base on the number of uses."""
+        """Number of reads: every use but the first, which is the producing
+        write for a computed buffer.  Exact because ``uses`` holds one distinct
+        index per accessing op."""
         return max(0, len(self.uses) - 1)
 
     @property

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -86,10 +86,21 @@ def calculate_liveness(graph: GraphLowering) -> dict[str, list[int]]:
     at which that buffer is accessed (read or written).  Graph inputs are seeded with
     an empty list; unused inputs remain empty.
 
+    Indices are *distinct*: one entry per accessing operation, not per access.
+    ``rw.reads | rw.writes`` is a set of dependencies rather than of names, so an
+    op that touches one buffer through two different index expressions -- e.g. the
+    fused ``x[:, 0:512] + x[:, 512:1024]``, which reads ``arg0_1`` at
+    ``1024*d0 + d1`` and at ``1024*d0 + d1 + 512`` -- contributes two deps naming
+    it, and appending per dep would repeat that op's index.  A repeat is not
+    meaningful here (``start_time``/``end_time`` bracket the list and cannot see
+    it) and it inflates ``read_count``, so it is dropped.  This is what lets
+    :class:`~torch_spyre._inductor.scratchpad.plan_solver.LifetimeBoundBuffer`
+    require strictly increasing ``uses``, and makes ``read_count == 0`` mean
+    exactly "written but never read".
+
     Note: previously, unused graph inputs did not appear in the returned dict at
-    all.  Now they appear with an empty list.  Callers that skip buffers with
-    ``len(uses) <= 1`` (e.g. ``_build_bound_buffers``) will still skip unused inputs
-    correctly, since ``len([]) == 0 <= 1``."""
+    all.  Now they appear with an empty list, and ``_build_bound_buffers`` skips
+    them on ``not uses``."""
     liveness: dict[str, list[int]] = {}
     for input_name in graph.graph_input_names:
         liveness[input_name] = []
@@ -97,9 +108,10 @@ def calculate_liveness(graph: GraphLowering) -> dict[str, list[int]]:
         rw = op_read_writes(op)
         for mem_dep in rw.reads | rw.writes:
             buf_name = mem_dep.name
-            if buf_name not in liveness:
-                liveness[buf_name] = []
-            liveness[buf_name].append(i)
+            uses = liveness.setdefault(buf_name, [])
+            # Ops are walked in order, so only the tail can repeat i.
+            if not uses or uses[-1] != i:
+                uses.append(i)
     return liveness
 
 

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -96,7 +96,7 @@ def calculate_liveness(graph: GraphLowering) -> dict[str, list[int]]:
     it) and it inflates ``read_count``, so it is dropped.  This is what lets
     :class:`~torch_spyre._inductor.scratchpad.plan_solver.LifetimeBoundBuffer`
     require strictly increasing ``uses``, and makes ``read_count == 0`` mean
-    exactly "written but never read".
+    exactly "written but never read" for a computed buffer.
 
     Note: previously, unused graph inputs did not appear in the returned dict at
     all.  Now they appear with an empty list, and ``_build_bound_buffers`` skips


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

While doing unrelated work, I found that there are two invariants that I need
in order to reason correctly about layout solving, and indeed they hold for
real graphs, but you can only determine that by examining the whole inductor
code base. Simply *asserting* these properties makes it so that we can reason
about these buffers *locally*. I also found three minor bugs that live in the
same code, so it makes sense to fix them at the same time. Here are (first)
the three bugs and (then) the two assertions:

**1. `calculate_liveness` counted accesses, not accessing ops.**

`rw.reads | rw.writes` is a set of *dependencies*, not of names, so an op that
touches one buffer through two different index expressions contributes two deps
naming it, and the old loop appended that op's index once per dep:

```python
def fn(x):
    return x[:, 0:512] + x[:, 512:1024]   # one fused ComputedBuffer

# reads: ['1024*d0 + d1', '1024*d0 + d1 + 512']  -> two deps, same name
# arg0_1 uses: [0, 0]                            <- op 0 counted twice
```

Measured across the scratchpad compile suites: **18 of 601 buffers** were
affected, all graph inputs of this shape — though that is what this corpus
happened to hold, not a property of the shape. A computed buffer read at two
offsets dedups identically; `buffer_not_read_in_full` bars both kinds from
residency for the same reason, which is why the placements come out unchanged
either way (see below).

A repeat is invisible to `start_time`/`end_time`, which only bracket the list,
but it inflates `read_count`. `uses` now carries one distinct index per
accessing operation, which is what its docstring already claimed.

**2. The `read_count` property disregarded `first_use_is_read`.**

It returned `max(0, len(uses) - 1)` unconditionally, which drops a read for
every graph input: a buffer with `first_use_is_read` has no producing write in
`uses`, so *all* of its uses are reads. It is now
`len(uses) - (0 if first_use_is_read else 1)`.

The one production consumer is adjusted so the cost model comes out numerically
unchanged. CpSat's `spill_cost` wants the reads residency *saves*, which
excludes an input's unavoidable clone-in; it now discounts that read explicitly
instead of getting it for free from the old, wrong `read_count`.
`ScratchpadAllocator._read_count` is deliberately left alone: it measures the
savings, not the reads, so excluding the first use is correct there. Both
docstrings now say which of the two quantities they are.

**3. `_build_cd_bound_buffers` marked computed op outputs as read-first.**

It passed `first_use_is_read=True` for op outputs, which are computed buffers
whose `uses[0]` is the producing write — the placement-path builder already
passes `False`. This was inert while `read_count` ignored the flag, which is
presumably how it survived; fixed in the same commit as (2), because that is
the commit that makes it live. Left alone, it would have inflated `read_count`
for every joint-path intermediate.

**4. `LifetimeBoundBuffer` asserts `uses` is strictly increasing.**

That makes `read_count` exact rather than approximate, so for a computed buffer
`read_count == 0` means precisely "written, never read". (The qualifier matters
after (2): for a graph input every use is a read, so `read_count == 0` there
means only that `uses` is empty.)

Deliberately *not* also asserted non-empty: buffers are sometimes registered
before their uses are known and filled in afterwards (see
`make_buffer_registry` in the pattern tests), and an empty list is vacuously
strictly increasing.

**5. An in-place parent must actually be read.**

The child takes the parent's storage over at the parent's last use, so that use
has to be a read. A computed buffer's first use is its write, so one with no
later use is written and never read: handing it to a child would overwrite data
nothing consumes, and would make parent and child come alive on the same tick
while sharing a slot. Graph inputs are exempt, since all their uses are reads.

This is the invariant that the duplicate index was quietly defeating — a buffer
with `uses=[3, 3]` reported `read_count == 1` and passed, despite having a
single live tick.

Asserted in the two places that resolve declared in-place pairs independently:

- `_assert_in_place_relationships`, alongside the existing in-place invariants,
  covering the greedy, first-fit/best-fit and ILP solvers;
- `_compute_inplace_partners` on `PermutationBasedLayoutSolverBase`, covering
  both the reference and the incremental permutation solvers.

Only this invariant is shared between them. For the permutation solvers the
other two are placement-time gates rather than preconditions — a child that
outgrows its parent, or a pair whose lifetimes do not abut, is simply not placed
in-place (see `_can_inplace`) — so asserting either there would reject inputs
those solvers handle correctly.

#### Which issue(s) this PR is related to:

Split out of the exploration behind #3363. No issue filed — the duplicate index
was found by instrumenting `calculate_liveness` while chasing an unrelated
in-place question.

#### Special notes for your reviewer:

**The one behavioural change is a quality score.** Test helpers fabricated
one-tick lifetimes as `[t, t]`. Since `end_time == uses[-1] + 1`, a one-tick
lifetime has exactly one use, so they now emit `[t]`. Dropping the phantom use
takes such a buffer's weight from 2.5 to 1.5, which is why
`test_disjoint_lifetimes_all_at_zero` now expects 288 rather than 480. The
neighbouring `test_overlapping_lifetimes_stack` still expects 285, because its
two-tick buffers genuinely carry a write and a read — that contrast is the
check that only genuinely-single-tick buffers moved.

**Deduping cannot change an LX placement decision.** All 18 affected buffers are
already barred from residency with `residency_reason="partial/offset read"`, via
`buffer_not_read_in_full`, which is reached from the non-input residency path
too. A barred buffer is not placed whatever its quality score. I could not
construct a duplicate-`uses` shape that was *not* barred: distinct index
expressions on one buffer are essentially always an offset or partial read,
which is exactly what that guard rejects (`x * x` and `exp(x) + x` produce no
duplicate at all, since identical index expressions collapse in the dep set).
Correspondingly, `test_scratchpad_use.py` and `test_scratchpad_patterns.py` come
out byte-identical before and after.

**`calculate_liveness` is now covered end to end.** Nothing under `tests/`
imported it before this PR, so the distinctness invariant was only guarded by
`LifetimeBoundBuffer.__post_init__` over hand-built lists — which proves the
assertion fires, not that the producer satisfies it. `TestLivenessIndicesAreDistinct`
drives the fused-slice lowering from the docstring through a real compile and
checks the indices it returns. It also asserts the two-deps precondition, so it
cannot start passing vacuously if lowering stops producing that shape.

**Why the in-place condition is spelled `uses[-1] > uses[0]` and not
`read_count > 0`.** The two agree whenever `uses` is strictly increasing, but
that is validated in `__post_init__` and `uses` can be mutated afterwards —
both the pattern-test registry and the random generator do exactly that. Testing
the property directly means a repeated index can never pass as a read;
`test_repeated_index_cannot_pass_as_a_read` pins that down.

**Generators stop offering write-only parents**, now that those are not
representable. There are two independent `_random_buffers`. Both skip a parent
with no read, and the exhaustive contact sweep requires a parent to be read
rather than merely to line up geometrically. The simulated-annealing one needed
a second fix: it collapsed a child to a single use when the parent's handoff
tick was already the child's last, and its loop can draw an earlier child as a
later pair's parent — so a buffer legally built as a child came back as a
write-only parent. Both now leave the child a use strictly after the handoff. The
CpSat degenerate-case test built one, so its parent becomes an input clone
(`first_use_is_read`) — which is also the real shape of a single-use in-place
parent, since the allocator marks input clones that way and wires them up as
in-place parents. It leaves the zero-width interval that test was written for
intact, because the flag does not reach the solver: `CoreDivisionBuffer` tracks
`boundary`, which takes precedence.

**Every solver is pinned to reject a write-only in-place parent.**
`test_write_only_in_place_parent_is_rejected` sits in `BaseLayoutSolverTests`, so
it runs against greedy, first-fit, best-fit, simulated annealing and both CP-SAT
modes; `test_write_only_in_place_parent_rejected` in the perm suite covers the
reference and incremental solvers via `SkeletonTestsMixin`. That is all eight:
six from `BaseLayoutSolverTests`, two from the perm suite.
It matches on the assertion message, since `solve()` also asserts layout
legality and a bare `assertRaises` would take that unrelated failure for a pass;
neutering the assertion fails all six classes. A companion case admits the same
shape with an *input* parent, so the rejection is visibly keyed on the missing
read rather than on `len(uses) == 1`.

There is no single base class to hoist the check into: `MemoryPlanSolver` and
`PermutationBasedLayoutSolverBase` are independent ABCs, and the permutation
solvers take their buffers in the constructor rather than through `plan_layout`.
`SimulatedAnnealingLayoutSolver` shows why that matters — it *is* a
`MemoryPlanSolver`, but it is a shim over a `PermutationBasedLayoutSolver` and
never calls `_assert_in_place_relationships`. Hence one shared implementation,
`assert_in_place_parent_is_read`, called from the two pair-resolution sites.

**Rebasing onto current `main` brought in three tests that (5) rejects.**
`test_live_parent_footprint_not_reused_at_handoff`,
`test_second_child_does_not_take_a_handed_off_slot` and
`test_in_place_merge_stays_within_capacity` live in `BaseLayoutSolverTests` and
run against all six solver classes, so this was 18 failures. Each gave its
in-place parent `uses=[0]` purely to line the geometry up. Every pair now starts
a tick later, so the parent is written at 0 and read at 1 and the handoff lands
on that read — which is what the section comment above them already describes
("the bytes above the child still hold parent data read on that tick"). The
lifetimes overlap exactly as before, shifted.

Marking those parents `first_use_is_read` instead would have been the smaller
diff, but it breaks two of the three: for a plain `LifetimeBoundBuffer` there is
no `boundary`, so that flag drives `is_intermediate` *and* the clone-in discount
in `spill_cost`, taking a single-use parent's cost from `size` to zero. CpSat
placement-only then has no reason to place the parent, so
`test_second_child_does_not_take_a_handed_off_slot` fails on "all three fit in
120 bytes" and `test_live_parent_footprint_not_reused_at_handoff` goes vacuous
via its own `skipTest("parent spilled; nothing to protect")` guard. The joint
and heuristic classes hide this, since `CoreDivisionBuffer.boundary` takes
precedence — which is why the same move *is* right for the CpSat degenerate-case
test above.

#### Does this PR introduce a user-facing change?

No. Internal invariants and liveness bookkeeping only.

`read_count`'s meaning does change — it now counts a graph input's reads rather
than under-reporting them by one — but its only production consumer, CpSat's
`spill_cost`, was adjusted in the same commit to discount the clone-in
explicitly, so the objective is numerically identical. The quality-score change
above is confined to solver scoring for single-tick buffers and, per the
analysis above, does not move a placement.

#### Additional note:

Re-verified at the branch tip, rebased onto `main` at `193d8a1a`:

| Suite | Result |
|---|---|
| `tests/inductor/test_perm_layout_solver.py` | 80 passed, 4 skipped |
| `tests/inductor/test_simulated_annealing.py` | 17 passed, 1 skipped (18 under `TORCH_SPYRE_STRESS_SCRATCHPAD=1`) |
| `tests/inductor/test_scratchpad_solver.py` | 248 passed, 6 subtests |
| `tests/inductor/test_scratchpad_patterns.py` | 24 passed, 11 xfailed |
| `tests/inductor/test_scratchpad_use.py` | 120 passed, 8 subtests |
| `tests/inductor/test_lx_inplace_layout.py` | 1 passed |
| `tests/test_allocator_e2e.py` | 10 passed |
| `tests/tensor/` | 154 passed, 1 skipped |

The stack is green commit by commit, not just at the tip: the handoff-contract
fix above is folded into the commit that introduces the assertion rather than
appended, so no revision in between is broken.

