### PR TITLE
EA Restore Customop

### DIFF
--- a/tests/inductor/test_ea_bidirectional_conversion.py
+++ b/tests/inductor/test_ea_bidirectional_conversion.py
@@ -183,27 +183,9 @@ def test_bidirectional_roundtrip_fp32_start(device):
     print("✓ FP32→FP16→FP32 roundtrip works")
 
 
-# ---------------------------------------------------------------------------
-# stagger_to_standard_ea
-# ---------------------------------------------------------------------------
-
-
 def _stagger_fn(x):
-    """fp32 → fp16(staggered) → stagger_to_standard_ea → standard EA fp16.
-
-    For 3-D+ inputs, flatten to 2-D before the op (stagger_to_standard_ea is
-    proven correct for 1-D / 2-D; higher-rank staggered tensors must be
-    flattened first because their physical device-dim interleaving makes
-    reshape(-1, N) give the correct row mapping only when done while staggered).
-    """
-    staggered = x.to(torch.float16)
-    orig_shape = list(staggered.shape)
-    n = orig_shape[-1]
-    if staggered.dim() > 2:
-        m = staggered.numel() // n
-        result = torch.ops.spyre.stagger_to_standard_ea(staggered.reshape(m, n))
-        return result.reshape(orig_shape)
-    return torch.ops.spyre.stagger_to_standard_ea(staggered)
+    """fp32 → fp16(staggered) → stagger_to_standard_ea → standard EA fp16."""
+    return torch.ops.spyre.stagger_to_standard_ea(x.to(torch.float16))
 
 
 @pytest.mark.parametrize(
@@ -252,3 +234,6 @@ def test_stagger_to_standard_ea(x):
     spyre_result = compiled_fn(x.to("spyre"))
     ea = get_spyre_tensor_layout(spyre_result).element_arrangement
     assert ea == ElementArrangement.STANDARD, f"Expected STANDARD EA, got {ea}"
+
+
+# Made with Bob

--- a/tests/inductor/test_ea_bidirectional_conversion.py
+++ b/tests/inductor/test_ea_bidirectional_conversion.py
@@ -183,4 +183,72 @@ def test_bidirectional_roundtrip_fp32_start(device):
     print("✓ FP32→FP16→FP32 roundtrip works")
 
 
-# Made with Bob
+# ---------------------------------------------------------------------------
+# stagger_to_standard_ea
+# ---------------------------------------------------------------------------
+
+
+def _stagger_fn(x):
+    """fp32 → fp16(staggered) → stagger_to_standard_ea → standard EA fp16.
+
+    For 3-D+ inputs, flatten to 2-D before the op (stagger_to_standard_ea is
+    proven correct for 1-D / 2-D; higher-rank staggered tensors must be
+    flattened first because their physical device-dim interleaving makes
+    reshape(-1, N) give the correct row mapping only when done while staggered).
+    """
+    staggered = x.to(torch.float16)
+    orig_shape = list(staggered.shape)
+    n = orig_shape[-1]
+    if staggered.dim() > 2:
+        m = staggered.numel() // n
+        result = torch.ops.spyre.stagger_to_standard_ea(staggered.reshape(m, n))
+        return result.reshape(orig_shape)
+    return torch.ops.spyre.stagger_to_standard_ea(staggered)
+
+
+@pytest.mark.parametrize(
+    "x",
+    [
+        # 1-D: stick-aligned
+        torch.randn(64, dtype=torch.float32),
+        torch.randn(128, dtype=torch.float32),
+        # 1-D: non-stick-aligned (padded to 64-multiple)
+        torch.nn.functional.pad(torch.randn(44, dtype=torch.float32), (0, 20)),
+        # 2-D: stick-aligned
+        torch.randn(4, 64, dtype=torch.float32),
+        torch.randn(7, 128, dtype=torch.float32),
+        # 2-D: non-stick-aligned (padded)
+        torch.nn.functional.pad(torch.randn(7, 44, dtype=torch.float32), (0, 20)),
+        # 3-D: stick-aligned
+        torch.randn(2, 4, 64, dtype=torch.float32),
+        torch.randn(3, 5, 128, dtype=torch.float32),
+        # 3-D: non-stick-aligned (padded)
+        torch.nn.functional.pad(torch.randn(2, 4, 44, dtype=torch.float32), (0, 20)),
+        # 4-D: stick-aligned
+        torch.randn(2, 3, 4, 64, dtype=torch.float32),
+        torch.randn(2, 3, 4, 128, dtype=torch.float32),
+        # 4-D: non-stick-aligned (padded)
+        torch.nn.functional.pad(torch.randn(2, 3, 4, 44, dtype=torch.float32), (0, 20)),
+    ],
+)
+@pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
+def test_stagger_to_standard_ea(x):
+    """stagger_to_standard_ea restores standard EA after fp32→fp16 (fp32todl16).
+
+    Verifies:
+      1. Output values match a plain x.to(fp16) on CPU (logical correctness).
+      2. Output EA is STANDARD (layout correctness).
+    """
+    expected = x.to(torch.float16)
+
+    compiled_fn = torch.compile(_stagger_fn, backend="inductor")
+
+    # 1. Value correctness: Spyre result matches CPU fp16 cast.
+    # fp32→fp16 rounding differs slightly (Spyre uses DF16); use fp16 tolerances.
+    result = compiled_fn(x.to("spyre")).cpu()
+    torch.testing.assert_close(result, expected, atol=1e-2, rtol=1e-2)
+
+    # 2. Layout correctness: output EA must be STANDARD.
+    spyre_result = compiled_fn(x.to("spyre"))
+    ea = get_spyre_tensor_layout(spyre_result).element_arrangement
+    assert ea == ElementArrangement.STANDARD, f"Expected STANDARD EA, got {ea}"

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -781,6 +781,69 @@ def _(
     return torch.empty(1, 1, seqlen_q, seqlen_kv, dtype=dtype, device=device)
 
 
+@torch.library.custom_op(
+    "spyre::stagger_to_standard_ea", mutates_args=(), device_types="spyre"
+)
+def stagger_to_standard_ea(x: torch.Tensor) -> torch.Tensor:
+    """Restore standard Element Arrangement (EA) from staggered EA.
+
+    The fp32todl16 conversion reorders elements when converting fp32 to fp16,
+    producing staggered EA in the output.  This op applies mm(x, P.t()) to
+    permute the last dimension back to standard EA so downstream ops see a
+    normal fp16 tensor.
+
+    The permutation matrix P encodes the hardware fp32→fp16 stagger pattern.
+    Each fp16 stick (64 elements) staggers independently:
+        stick_base = (phys // 64) * 64
+        local_phys = phys % 64
+        k, w = local_phys // 8, local_phys % 8
+        local_logical = k*4 + w            if w < 4
+                      = k*4 + (w-4) + 32   otherwise   (32 = fp16_stick // 2)
+        logical = stick_base + local_logical
+
+    ``half`` is always 32 (half of one fp16 stick), independent of N.
+    N = x.shape[-1] must be a multiple of 64.
+
+    P is built on CPU and transferred to the device.  It is determined solely
+    by N, so it is constant for a given tensor width and can be reused across
+    ops (lt, eq, etc.) that produce the same stagger pattern.
+
+    Input:  fp16 tensor with staggered EA, any shape [..., N]
+    Output: fp16 tensor with standard EA, same shape [..., N]
+    """
+    n = x.shape[-1]
+    device = x.device
+
+    # Build N×N permutation matrix on CPU, transfer to device.
+    # Each fp16 stick (64 elements) staggers independently with half=32.
+    FP16_STICK = 64
+    half = FP16_STICK // 2  # 32 — fixed, independent of n
+    P = torch.zeros(n, n, dtype=torch.float16, device="cpu")
+    for phys_j in range(n):
+        stick_base = (phys_j // FP16_STICK) * FP16_STICK
+        local_phys = phys_j % FP16_STICK
+        k, w = local_phys // 8, local_phys % 8
+        local_logical = k * 4 + w if w < 4 else k * 4 + (w - 4) + half
+        P[stick_base + local_logical, phys_j] = 1.0
+    P = P.to(device=device)
+
+    # Reshape to 2D for mm, then restore original shape.
+    # Callers are expected to pass a 1-D or 2-D tensor; higher-rank inputs
+    # should be flattened to 2-D before calling this op.
+    orig_shape = list(x.shape)
+    if x.dim() == 1:
+        result = torch.mm(x.unsqueeze(0), P.t()).squeeze(0)
+    else:
+        m = x.numel() // n
+        result = torch.mm(x.reshape(m, n), P.t()).reshape(orig_shape)
+    return result
+
+
+@stagger_to_standard_ea.register_fake
+def _(x: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(x)
+
+
 @torch.library.custom_op("spyre::prod_dim_int", mutates_args=(), device_types="spyre")
 def prod_dim_int(input: torch.Tensor, dim: int, keepdim: bool = False) -> torch.Tensor:
     pass

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -827,15 +827,13 @@ def stagger_to_standard_ea(x: torch.Tensor) -> torch.Tensor:
         P[stick_base + local_logical, phys_j] = 1.0
     P = P.to(device=device)
 
-    # Reshape to 2D for mm, then restore original shape.
-    # Callers are expected to pass a 1-D or 2-D tensor; higher-rank inputs
-    # should be flattened to 2-D before calling this op.
+    # Flatten all dims except the last into a single batch dim for mm,
+    # then restore the original shape.  This works for any rank >= 1:
+    # the stagger pattern only affects the last (stick) dimension, so
+    # flattening leading dims produces the correct row ordering for mm.
     orig_shape = list(x.shape)
-    if x.dim() == 1:
-        result = torch.mm(x.unsqueeze(0), P.t()).squeeze(0)
-    else:
-        m = x.numel() // n
-        result = torch.mm(x.reshape(m, n), P.t()).reshape(orig_shape)
+    m = x.numel() // n
+    result = torch.mm(x.reshape(m, n), P.t()).reshape(orig_shape)
     return result
 
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds a custom op that restores standard Element Arrangement (EA) after fp32→fp16 (fp32todl16) conversions. The fp32todl16 hardware instruction reorders elements within each 64-element stick, producing a staggered physical layout. While most fp upcast/downcast patterns (e.g. RMSNorm) do not require EA restoration since regular ops can operate correctly on staggered tensors, some patterns do — specifically when fp32 is used as an internal representation for integer values and the result needs to be combined with another fp16 tensor that expects standard EA.

The op builds an N×N permutation matrix P on CPU (N = last dim, must be a multiple of 64) and transfers it to Spyre as a graph constant, so it is built once at compile time rather than at runtime. It then applies mm(x, P.t()) on Spyre to permute the last dimension back to standard EA. Since each fp16 stick staggers independently with the same pattern, P is a 64×64 one-hot permutation matrix encoding the stagger pattern; for N > 64, the same permutation is applied independently to each 64-element stick.

<img width="1678" height="1402" alt="image" src="https://github.com/user-attachments/assets/ae8f2ca0-b409-44b2-bc5c-dff200e07b29" />

The op internally flattens all leading dimensions into a single batch dim before the matrix multiply and restores the original shape afterwards, so it accepts tensors of any rank. The last dimension must be a multiple of 64; padding should be filled before EA restore if needed. This is an interim solution pending hardware DDL support for direct EA conversion 


#### Which issue(s) this PR is related to:

Fixes #3423 
