### PR TITLE
coarse tile: split and decompose the plan / execute stages

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -4252,7 +4252,10 @@ class TestCoarseTileBufferPropagation(unittest.TestCase):
         from torch._subclasses.fake_tensor import FakeTensorMode
 
         from torch_spyre._inductor.lowering import enable_spyre_lowerings
-        from torch_spyre._inductor.wsr.coarse_tile import _propagate_tiled_op
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _insert_all_read_copy_ops,
+            _propagate_tiled_op,
+        )
 
         # _allocate_full_buffer lowers a real spyre.empty FX node via
         # V.graph.run_node(), which needs V.fake_mode (GraphLowering.fake_mode
@@ -4317,32 +4320,47 @@ class TestCoarseTileBufferPropagation(unittest.TestCase):
         # V.graph.buffers, not an independent list, for that removal to find it.
         operations = V.graph.buffers
         operations.extend([tiled_op, consumer])
+        original_op = tiled_op
 
+        # Read copy-ins are now Pass 1 (_insert_all_read_copy_ops), a
+        # standalone pass that runs before insert_tiling_propagation /
+        # _propagate_tiled_op even in production -- call it directly here
+        # rather than folding its effect into _propagate_tiled_op.
         with patch(
             "torch_spyre._inductor.wsr.coarse_tile._graph_output_names",
             return_value=set(),
         ):
+            _insert_all_read_copy_ops(operations)
+            # Pass 1 may have spliced a replacement for "op0" into
+            # operations -- re-resolve by name before calling
+            # _propagate_tiled_op, exactly as insert_tiling_propagation's
+            # own loop now does.
+            tiled_op = next(
+                o
+                for o in operations
+                if isinstance(o, ComputedBuffer) and o.get_name() == "op0"
+            )
             _propagate_tiled_op(tiled_op, operations)
 
-        # tiled_op's own two inputs are real, full-size, untiled InputBuffers
+        # original_op's two inputs are real, full-size, untiled InputBuffers
         # read at a tile-scoped index -- _full_buffer_read_deps now flags
-        # both, so _insert_read_copy_ops replaces tiled_op with a new
-        # ComputedBuffer (same name, "op0") before the write-side copy-op
-        # logic below even runs. Look the final op up by name rather than
-        # using the now-stale tiled_op reference.
+        # both, so Pass 1's _insert_all_read_copy_ops replaces original_op
+        # with a new ComputedBuffer (same name, "op0") before the write-side
+        # copy-op logic even runs. Look the final op up by name rather than
+        # using the now-stale original_op reference.
         final_op = V.graph.name_to_buffer["op0"]
         # name_to_buffer is only half the story: replace_computed_buffer_body
-        # must also have swapped the stale tiled_op out of operations (==
+        # must also have swapped the stale original_op out of operations (==
         # V.graph.buffers, see the comment above where it's assigned) for
         # later scheduling to see the new op instead of the old one. Checked
         # by identity (`is`), not `in`/`==`: ComputedBuffer is a frozen
         # dataclass, so `==` compares field values rather than object
-        # identity, and tiled_op/final_op share the same (in-place-mutated)
+        # identity, and original_op/final_op share the same (in-place-mutated)
         # `.data` and layout -- they compare equal to each other even though
         # only final_op is the live object, which makes assertIn/assertNotIn
         # pass regardless of whether the swap actually happened.
         self.assertTrue(any(op is final_op for op in operations))
-        self.assertFalse(any(op is tiled_op for op in operations))
+        self.assertFalse(any(op is original_op for op in operations))
 
         write_copy_ops = [
             op

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -30,7 +30,7 @@ Covers six areas, each in its own class group:
      (TestGenerateBundleMlir, TestFindUnimplemented,
       TestGenerateBundleMlirSnapshot, TestGenerateBundleMlirWithAffineStrides,
       TestGenerateBundleNestedTiling, TestGenerateBundleAffineLoopPath)
-  6. Buffer propagation: consumer analysis helpers for insert_tiling_propagation
+  6. Buffer propagation: consumer analysis helpers for tiling propagation
      (TestCoarseTileBufferPropagation)
 
 No Spyre device or backend compiler is required.
@@ -1607,10 +1607,10 @@ class TestCoarseTileTiledDimsPerRead(unittest.TestCase):
 
     These tests call plan_coarse_tile_groups + _apply_plan directly rather
     than the full coarse_tile() entry point.  coarse_tile() unconditionally
-    also runs insert_tiling_propagation after stamping every group, which
-    for a Reduction op with an actually-tiled reduction dim drives
-    _propagate_tiled_reduction_op -> _allocate_full_buffer ->
-    graph_lowering.run_node() on a synthesized spyre.empty FX node -- real
+    also runs the reduction-machinery pass (_insert_all_reduction_ops) after
+    stamping every group, which for a Reduction op with an actually-tiled
+    reduction dim drives _propagate_tiled_reduction_op -> _allocate_full_buffer
+    -> graph_lowering.run_node() on a synthesized spyre.empty FX node -- real
     FX-dispatch/lowering machinery this lightweight harness does not
     provide (confirmed live: raises LoweringException /
     "'NullHandler' object does not support the context manager protocol").
@@ -4063,7 +4063,7 @@ def _make_inside_consumer_op(name, reads_buf, loop_group_id):
 
 
 class TestCoarseTileBufferPropagation(unittest.TestCase):
-    """Tests for insert_tiling_propagation — consumer analysis helpers."""
+    """Tests for tiling propagation — consumer analysis helpers."""
 
     def setUp(self):
         # Only test_case2_condition_now_produces_copy_op below needs a real
@@ -4236,10 +4236,11 @@ class TestCoarseTileBufferPropagation(unittest.TestCase):
         (_allocate_full_buffer, _insert_copy_op, _patch_consumers) all touch
         real ComputedBuffer/V.graph machinery (qualify_name, run_node,
         replace_computed_buffer_body), which MagicMock-based ops used
-        elsewhere in this file cannot satisfy. insert_tiling_propagation
-        itself takes a pre-grouped ``groups`` list that plan_coarse_tile_groups
-        would normally produce; calling _propagate_tiled_op directly is the
-        cheaper, equivalent way to reach exactly the code this task changed.
+        elsewhere in this file cannot satisfy. Pass 3
+        (_insert_all_write_copy_ops) itself takes the already-stamped
+        `operations` list that _apply_plan would normally produce; calling
+        _propagate_tiled_op directly is the cheaper, equivalent way to reach
+        exactly the code this task changed.
         """
         from torch._inductor.ir import (
             ComputedBuffer,
@@ -5278,7 +5279,7 @@ def _make_tiled_reduction_op(
 
 
 class TestCoarseTileReductionPropagation(unittest.TestCase):
-    """Tests for insert_tiling_propagation Reduction support."""
+    """Tests for tiling propagation Reduction support."""
 
     def test_reduction_tiled_reduction_dim_nested_ok(self):
         from torch_spyre._inductor.wsr.coarse_tile import (

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -4368,6 +4368,185 @@ class TestCoarseTileBufferPropagation(unittest.TestCase):
         self.assertEqual(final_op.loop_info.output_tiled_dims, [])
 
 
+class TestPlanTilingPropagation(unittest.TestCase):
+    """Cross-check: _plan_tiling_propagation's kind decision must match what
+    _propagate_tiled_op / _propagate_tiled_reduction_op actually do today.
+
+    This is the load-bearing regression net for Stage 2: it validates the
+    front-loaded planning decision against current (still transformation-
+    driving) behavior, before Stage 3 ever makes transformation consume the
+    new field. Built with the same mock-based fixtures
+    (_make_tiled_op/_make_consumer_op/_make_inside_consumer_op/
+    _make_tiled_reduction_op) TestCoarseTileBufferPropagation already uses
+    for its plain _find_outside_consumers/_full_buffer_read_deps checks --
+    _plan_tiling_propagation's own helpers are direct planning-time analogs
+    of those same functions.
+    """
+
+    def _plan_for(self, op, group_ops=None):
+        from torch_spyre._inductor.wsr.coarse_tile import _plan_tiling_propagation
+
+        group_ops = group_ops if group_ops is not None else [op]
+        info = op.loop_info
+        plan = {id(op): info}
+        levels = [(0, c) for c in info.loop_count]
+        with patch(
+            "torch_spyre._inductor.wsr.coarse_tile._graph_output_names",
+            return_value=set(),
+        ):
+            _plan_tiling_propagation(group_ops, [(group_ops, levels)], plan)
+        return info.propagation
+
+    def test_loop_invariant_matches_no_tiled_dims(self):
+        """All loop_tiled_dims empty -> loop_internal, matching
+        _propagate_tiled_op's `all(not dims ...)` fast-path return."""
+        op = _make_tiled_op("op0", [Integer(16)], (0,), [Integer(4)], [[]])
+        propagation = self._plan_for(op)
+        self.assertEqual(propagation.kind, "loop_internal")
+        self.assertEqual(propagation.full_read_deps, ())
+
+    def test_no_outside_consumers_matches_loop_internal(self):
+        """Tiled with no outside consumers/graph output -> loop_internal,
+        matching _propagate_tiled_op zeroing output_tiled_dims and
+        returning without a copy op."""
+        op = _make_tiled_op("op0", [Integer(16)], (0,), [Integer(4)], [[0]])
+        propagation = self._plan_for(op)
+        self.assertEqual(propagation.kind, "loop_internal")
+        self.assertEqual(propagation.outside_consumer_names, ())
+        self.assertFalse(propagation.is_graph_output)
+
+    def test_outside_consumer_matches_copy_out(self):
+        """Tiled with an outside consumer -> copy_out, matching
+        _propagate_tiled_op's _allocate_full_buffer/_insert_copy_op path."""
+        tiled = _make_tiled_op("op0", [Integer(16)], (0,), [Integer(4)], [[0]])
+        consumer = _make_consumer_op("out0", "op0")
+        propagation = self._plan_for(tiled, group_ops=[tiled, consumer])
+        self.assertEqual(propagation.kind, "copy_out")
+        self.assertEqual(propagation.outside_consumer_names, ("out0",))
+        self.assertEqual(propagation.full_ranges, [Integer(64)])
+
+    def test_inside_consumer_only_matches_loop_internal(self):
+        """An inside-loop-group consumer alone doesn't force copy_out --
+        matches _propagate_tiled_op's outside_consumers check, which
+        _find_outside_consumers already excludes same-outer-group readers
+        from."""
+        tiled = _make_tiled_op("op0", [Integer(16)], (0,), [Integer(4)], [[0]])
+        inside = _make_inside_consumer_op("op1", "op0", (0,))
+        propagation = self._plan_for(tiled, group_ops=[tiled, inside])
+        self.assertEqual(propagation.kind, "loop_internal")
+
+    def test_graph_output_matches_copy_out(self):
+        """A graph-output buffer -> copy_out even with no other consumers,
+        matching _propagate_tiled_op's is_graph_output branch."""
+        from torch_spyre._inductor.wsr.coarse_tile import _plan_tiling_propagation
+
+        op = _make_tiled_op("op0", [Integer(16)], (0,), [Integer(4)], [[0]])
+        info = op.loop_info
+        plan = {id(op): info}
+        levels = [(0, Integer(4))]
+        with patch(
+            "torch_spyre._inductor.wsr.coarse_tile._graph_output_names",
+            return_value={"op0"},
+        ):
+            _plan_tiling_propagation([op], [([op], levels)], plan)
+        propagation = info.propagation
+        self.assertEqual(propagation.kind, "copy_out")
+        self.assertTrue(propagation.is_graph_output)
+
+    def test_tiled_reduction_matches_reduction_kind(self):
+        """A Reduction op tiling a reduction dim -> kind="reduction", with
+        the same identity/nesting decisions _propagate_tiled_reduction_op
+        computes."""
+        op = _make_tiled_reduction_op(
+            "red0",
+            ranges=[Integer(128)],
+            reduction_ranges=[Integer(256)],
+            reduction_type="sum",
+            loop_group_id=(0,),
+            loop_count=[Integer(4)],
+            loop_tiled_dims=[[]],
+        )
+        op.loop_info.loop_tiled_reduction_dims = [[0]]
+        propagation = self._plan_for(op)
+        self.assertEqual(propagation.kind, "reduction")
+        self.assertIsNotNone(propagation.reduction)
+        self.assertEqual(propagation.reduction.reduction_type, "sum")
+        self.assertEqual(propagation.reduction.identity, 0)
+        self.assertFalse(propagation.reduction.is_nested)
+        self.assertIsNone(propagation.reduction.outer_fill_loop_info)
+
+    def test_nested_tiled_reduction_matches_is_nested(self):
+        """Nested output+reduction tiling -> reduction plan with
+        is_nested=True and a trimmed outer_fill_loop_info, matching
+        _compute_fill_loop_info's non-None nested case."""
+        op = _make_tiled_reduction_op(
+            "red0",
+            ranges=[Integer(64)],
+            reduction_ranges=[Integer(256)],
+            reduction_type="max",
+            loop_group_id=(0, 0),
+            loop_count=[Integer(2), Integer(4)],
+            loop_tiled_dims=[[0], []],
+        )
+        op.loop_info.loop_tiled_reduction_dims = [[], [0]]
+        propagation = self._plan_for(op)
+        self.assertEqual(propagation.kind, "reduction")
+        self.assertTrue(propagation.reduction.is_nested)
+        self.assertEqual(propagation.reduction.identity, float("-inf"))
+        outer_info = propagation.reduction.outer_fill_loop_info
+        self.assertIsNotNone(outer_info)
+        self.assertEqual(outer_info.loop_group_id, (0,))
+        self.assertEqual(outer_info.loop_count, [Integer(2)])
+        self.assertEqual(outer_info.loop_tiled_dims, [[0]])
+
+    def test_reader_before_producer_still_zeroes_fixed_read(self):
+        """Reader-before-producer ordering in group_ops must not matter.
+
+        producer (op0) is tiled with no outside consumers -> loop_internal,
+        i.e. "fixed": its own write never advances. reader (op1) is inside
+        the same loop group and reads op0; op1's tiled_dims_per_read entry
+        for op0 is planted here exactly as plan_coarse_tile_groups would
+        have left it *before* op0's fixed status was known (non-empty,
+        mirroring the stale entry _zero_reads_of_fixed_buffers used to
+        correct after the fact at transformation time). op1 is placed
+        BEFORE op0 in group_ops -- the ordering
+        _zero_reads_of_fixed_buffers existed to work around, since
+        source-order visitation would see op1 before op0 is known to be
+        fixed. _plan_tiling_propagation must still zero op1's entry for
+        op0, because it computes every op's kind up front before its own
+        fixed-buffer zeroing pass runs -- there is no visitation-order
+        hazard left to trigger.
+        """
+        from torch_spyre._inductor.wsr.coarse_tile import _plan_tiling_propagation
+
+        producer = _make_tiled_op("op0", [Integer(16)], (0,), [Integer(4)], [[0]])
+        reader = _make_inside_consumer_op("op1", "op0", (0,))
+        # Simulate plan_coarse_tile_groups's pre-zeroing output: op1 read op0
+        # while op0's own tiled dims were still extent-4-tiled at level 0.
+        reader.loop_info.tiled_dims_per_read = [[[(0, Integer(4))]]]
+        group_ops = [reader, producer]
+        plan = {id(reader): reader.loop_info, id(producer): producer.loop_info}
+        levels = [(0, Integer(4))]
+        # reader is in `plan`, so _plan_tiling_propagation's main loop
+        # processes it too, which resolves its "op0" read via
+        # V.graph.get_buffer -- give it a minimal graph mock rather than a
+        # real GraphLowering, since these are MagicMock IR objects, not
+        # objects a real graph handler has ever registered.
+        mock_graph = MagicMock()
+        mock_graph.get_buffer.return_value = producer
+        with (
+            patch(
+                "torch_spyre._inductor.wsr.coarse_tile._graph_output_names",
+                return_value=set(),
+            ),
+            V.set_graph_handler(mock_graph),
+        ):
+            _plan_tiling_propagation(group_ops, [(group_ops, levels)], plan)
+
+        self.assertEqual(producer.loop_info.propagation.kind, "loop_internal")
+        self.assertEqual(reader.loop_info.tiled_dims_per_read, [[]])
+
+
 def _make_cross_group_producer_read_fixture():
     """Like _make_full_buffer_read_fixture, but the producer is a plain
     ComputedBuffer in a different loop group, not a SpyreEmptyFallback.
@@ -5068,7 +5247,9 @@ class TestCoarseTileReductionPropagation(unittest.TestCase):
     """Tests for insert_tiling_propagation Reduction support."""
 
     def test_reduction_tiled_reduction_dim_nested_ok(self):
-        from torch_spyre._inductor.wsr.coarse_tile import _validate_reduction_tiling
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _validate_planned_reduction_tiling,
+        )
 
         # Nested: outer tiles output dim, inner tiles reduction dim — now supported
         op = _make_tiled_reduction_op(
@@ -5081,10 +5262,14 @@ class TestCoarseTileReductionPropagation(unittest.TestCase):
             loop_tiled_dims=[[0], []],
         )
         op.loop_info.loop_tiled_reduction_dims = [[], [0]]
-        _validate_reduction_tiling(op)  # must not raise
+        _validate_planned_reduction_tiling(
+            op, op.loop_info.loop_tiled_dims, op.loop_info.loop_tiled_reduction_dims
+        )  # must not raise
 
     def test_reduction_output_dim_tiled_ok(self):
-        from torch_spyre._inductor.wsr.coarse_tile import _validate_reduction_tiling
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _validate_planned_reduction_tiling,
+        )
 
         # ranges=[M], reduction_ranges=[K]; tiled_dim=0 is an output dim → no error
         op = _make_tiled_reduction_op(
@@ -5097,7 +5282,9 @@ class TestCoarseTileReductionPropagation(unittest.TestCase):
             loop_tiled_dims=[[0]],
         )
         # output-dim-only tiling should not raise
-        _validate_reduction_tiling(op)
+        _validate_planned_reduction_tiling(
+            op, op.loop_info.loop_tiled_dims, op.loop_info.loop_tiled_reduction_dims
+        )
 
     def test_nested_fill_gets_outer_loop_info(self):
         """Fill op gets outer-level loop_info for nested output+reduction tiling."""
@@ -5179,9 +5366,11 @@ class TestComputeFillLoopInfo(unittest.TestCase):
         self.assertEqual(result.loop_tiled_reduction_dims, [[]])
 
 
-class TestValidateReductionTiling(unittest.TestCase):
-    """Tests for _validate_reduction_tiling: raising on unsupported cases,
-    passing on supported ones."""
+class TestValidatePlannedReductionTiling(unittest.TestCase):
+    """Tests for _validate_planned_reduction_tiling: raising on unsupported
+    cases, passing on supported ones. Called from plan_coarse_tile_groups
+    (planning time) with the op's own per-level tiled-dims lists, before any
+    loop_info is stamped."""
 
     def _make_op(self, loop_tiled_dims, loop_tiled_reduction_dims):
         from torch._inductor.ir import ComputedBuffer, Reduction
@@ -5203,43 +5392,52 @@ class TestValidateReductionTiling(unittest.TestCase):
 
     def test_pure_reduction_tile_ok(self):
         """Single level, only reduction dim tiled — Stage 1 supported case."""
-        from torch_spyre._inductor.wsr.coarse_tile import _validate_reduction_tiling
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _validate_planned_reduction_tiling,
+        )
 
         op = self._make_op(loop_tiled_dims=[[]], loop_tiled_reduction_dims=[[0]])
-        _validate_reduction_tiling(op)  # must not raise
+        _validate_planned_reduction_tiling(op, [[]], [[0]])  # must not raise
 
     def test_pure_output_tile_ok(self):
         """Single level, only output dim tiled — existing supported case."""
-        from torch_spyre._inductor.wsr.coarse_tile import _validate_reduction_tiling
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _validate_planned_reduction_tiling,
+        )
 
         op = self._make_op(loop_tiled_dims=[[0]], loop_tiled_reduction_dims=[[]])
-        _validate_reduction_tiling(op)  # must not raise
+        _validate_planned_reduction_tiling(op, [[0]], [[]])  # must not raise
 
-    def test_no_loop_info_ok(self):
-        """Op with no loop_info is not tiled — no error."""
+    def test_no_tiled_dims_ok(self):
+        """No dims tiled at all — no error."""
         from torch._inductor.ir import ComputedBuffer, Reduction
-        from torch_spyre._inductor.wsr.coarse_tile import _validate_reduction_tiling
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _validate_planned_reduction_tiling,
+        )
 
         data = MagicMock(spec=Reduction)
         data.ranges = [Integer(128)]
         data.reduction_ranges = [Integer(256)]
         op = MagicMock(spec=ComputedBuffer)
         op.data = data
-        op.loop_info = None
-        _validate_reduction_tiling(op)  # must not raise
+        _validate_planned_reduction_tiling(op, [[]], [[]])  # must not raise
 
     def test_mixed_same_level_raises(self):
         """Both output and reduction dim tiled at the same level — Stage 2, raises."""
-        from torch_spyre._inductor.wsr.coarse_tile import _validate_reduction_tiling
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _validate_planned_reduction_tiling,
+        )
 
         op = self._make_op(loop_tiled_dims=[[0]], loop_tiled_reduction_dims=[[0]])
         with self.assertRaises(Unsupported, msg="mixed same-level should raise"):
-            _validate_reduction_tiling(op)
+            _validate_planned_reduction_tiling(op, [[0]], [[0]])
 
     def test_mixed_different_levels_allowed(self):
         """Outer output-dim tiling + inner reduction-dim tiling — now supported."""
         from torch._inductor.ir import ComputedBuffer, Reduction
-        from torch_spyre._inductor.wsr.coarse_tile import _validate_reduction_tiling
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _validate_planned_reduction_tiling,
+        )
 
         data = MagicMock(spec=Reduction)
         data.ranges = [Integer(128)]
@@ -5248,19 +5446,17 @@ class TestValidateReductionTiling(unittest.TestCase):
         op = MagicMock(spec=ComputedBuffer)
         op.data = data
         op.get_name.return_value = "test_op"
-        op.loop_info = CoarseTileInfo(
-            loop_group_id=(0, 0),
-            loop_count=[Integer(2), Integer(4)],
-            loop_tiled_dims=[[0], []],
-            loop_tiled_reduction_dims=[[], [0]],
-        )
+        tiled_dims = [[0], []]
+        tiled_rdims = [[], [0]]
         # Must not raise: outer output-dim + inner reduction-dim is now supported.
-        _validate_reduction_tiling(op)
+        _validate_planned_reduction_tiling(op, tiled_dims, tiled_rdims)
 
     def test_multiple_reduction_dims_same_level_raises(self):
         """Multiple reduction dims tiled at one level — Stage 2, raises."""
         from torch._inductor.ir import ComputedBuffer, Reduction
-        from torch_spyre._inductor.wsr.coarse_tile import _validate_reduction_tiling
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _validate_planned_reduction_tiling,
+        )
 
         data = MagicMock(spec=Reduction)
         data.ranges = [Integer(128)]
@@ -5268,19 +5464,15 @@ class TestValidateReductionTiling(unittest.TestCase):
         op = MagicMock(spec=ComputedBuffer)
         op.data = data
         op.get_name.return_value = "test_op"
-        op.loop_info = CoarseTileInfo(
-            loop_group_id=(0,),
-            loop_count=[Integer(4)],
-            loop_tiled_dims=[[]],
-            loop_tiled_reduction_dims=[[0, 1]],
-        )
         with self.assertRaises(Unsupported, msg="multiple reduction dims should raise"):
-            _validate_reduction_tiling(op)
+            _validate_planned_reduction_tiling(op, [[]], [[0, 1]])
 
     def test_stick_dim_reduction_tiling_allowed(self):
         """Tiling a reduction over the stick dimension is now supported."""
         from torch._inductor.ir import ComputedBuffer, Reduction
-        from torch_spyre._inductor.wsr.coarse_tile import _validate_reduction_tiling
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _validate_planned_reduction_tiling,
+        )
 
         data = MagicMock(spec=Reduction)
         data.ranges = [Integer(64)]  # [B] output
@@ -5289,14 +5481,8 @@ class TestValidateReductionTiling(unittest.TestCase):
         op = MagicMock(spec=ComputedBuffer)
         op.data = data
         op.get_name.return_value = "test_sum"
-        op.loop_info = CoarseTileInfo(
-            loop_group_id=(0,),
-            loop_count=[Integer(4)],
-            loop_tiled_dims=[[]],
-            loop_tiled_reduction_dims=[[0]],
-        )
         # Must not raise: stick-dim reduction tiling is now supported.
-        _validate_reduction_tiling(op)
+        _validate_planned_reduction_tiling(op, [[]], [[0]])
 
 
 class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -4434,7 +4434,6 @@ class TestPlanTilingPropagation(unittest.TestCase):
         op = _make_tiled_op("op0", [Integer(16)], (0,), [Integer(4)], [[]])
         propagation = self._plan_for(op)
         self.assertEqual(propagation.kind, "loop_internal")
-        self.assertEqual(propagation.full_read_deps, ())
 
     def test_no_outside_consumers_matches_loop_internal(self):
         """Tiled with no outside consumers/graph output -> loop_internal,

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -4435,8 +4435,12 @@ class TestPlanTilingPropagation(unittest.TestCase):
 
     def test_outside_consumer_matches_copy_out(self):
         """Tiled with an outside consumer -> copy_out, matching
-        _propagate_tiled_op's _allocate_full_buffer/_insert_copy_op path."""
-        tiled = _make_tiled_op("op0", [Integer(16)], (0,), [Integer(4)], [[0]])
+        _propagate_tiled_op's _allocate_full_buffer/_insert_copy_op path.
+
+        Planning runs before _apply_plan divides op.data.ranges, so the
+        fixture's ranges are already the full (pre-division) size here --
+        full_ranges is expected to come back unchanged."""
+        tiled = _make_tiled_op("op0", [Integer(64)], (0,), [Integer(4)], [[0]])
         consumer = _make_consumer_op("out0", "op0")
         propagation = self._plan_for(tiled, group_ops=[tiled, consumer])
         self.assertEqual(propagation.kind, "copy_out")

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -4252,6 +4252,7 @@ class TestCoarseTileBufferPropagation(unittest.TestCase):
         from torch._subclasses.fake_tensor import FakeTensorMode
 
         from torch_spyre._inductor.lowering import enable_spyre_lowerings
+        from torch_spyre._inductor.loop_info import PropagationPlan
         from torch_spyre._inductor.wsr.coarse_tile import (
             _insert_all_read_copy_ops,
             _propagate_tiled_op,
@@ -4323,9 +4324,9 @@ class TestCoarseTileBufferPropagation(unittest.TestCase):
         original_op = tiled_op
 
         # Read copy-ins are now Pass 1 (_insert_all_read_copy_ops), a
-        # standalone pass that runs before insert_tiling_propagation /
-        # _propagate_tiled_op even in production -- call it directly here
-        # rather than folding its effect into _propagate_tiled_op.
+        # standalone pass that runs before Pass 3 / _propagate_tiled_op even
+        # in production -- call it directly here rather than folding its
+        # effect into _propagate_tiled_op.
         with patch(
             "torch_spyre._inductor.wsr.coarse_tile._graph_output_names",
             return_value=set(),
@@ -4333,14 +4334,25 @@ class TestCoarseTileBufferPropagation(unittest.TestCase):
             _insert_all_read_copy_ops(operations)
             # Pass 1 may have spliced a replacement for "op0" into
             # operations -- re-resolve by name before calling
-            # _propagate_tiled_op, exactly as insert_tiling_propagation's
+            # _propagate_tiled_op, exactly as _insert_all_write_copy_ops'
             # own loop now does.
             tiled_op = next(
                 o
                 for o in operations
                 if isinstance(o, ComputedBuffer) and o.get_name() == "op0"
             )
-            _propagate_tiled_op(tiled_op, operations)
+            # _propagate_tiled_op (Pass 3) now consumes a precomputed
+            # PropagationPlan instead of deriving it itself -- full_ranges
+            # is the pre-division full shape (8 * loop_count 8 == 64),
+            # matching what the old in-function _compute_full_ranges call
+            # used to compute from the tile-sized op.data.ranges.
+            propagation = PropagationPlan(
+                kind="copy_out",
+                full_ranges=[Integer(64)],
+                outside_consumer_names=("out0",),
+                is_graph_output=False,
+            )
+            _propagate_tiled_op(tiled_op, propagation, operations)
 
         # original_op's two inputs are real, full-size, untiled InputBuffers
         # read at a tile-scoped index -- _full_buffer_read_deps now flags

--- a/tests/inductor/test_span_overflow_hint_analysis.py
+++ b/tests/inductor/test_span_overflow_hint_analysis.py
@@ -1716,15 +1716,11 @@ class TestSpanOverflowPointwisePlannerAndAdapter(InductorTestCase):
         self.assertEqual(op.dim_hints[0].loop_var, sympy.Symbol("h"))
         self.assertEqual(groups[0][1][0][1], sympy.Integer(_E2E_SPLIT_COUNT))
 
-    @patch("torch_spyre._inductor.wsr.coarse_tile.insert_tiling_propagation")
     @patch(
         "torch_spyre._inductor.wsr.coarse_tile_span_overflow.op_out_coords",
         _out_coords_for_bhld,
     )
-    def test_coarse_tile_consumes_auto_group_and_stamps_op(
-        self,
-        _mock_insert_tiling_propagation,
-    ):
+    def test_coarse_tile_consumes_auto_group_and_stamps_op(self):
         op = _pointwise_op(_E2E_SHAPE)
 
         with config.patch({"sencores": 4, "ignore_span_overflow_hints": False}):
@@ -2143,31 +2139,28 @@ class TestSpanOverflowLargeShapeContract(InductorTestCase):
             "torch_spyre._inductor.wsr.coarse_tile_span_overflow.op_out_coords",
             _out_coords_for_bhld,
         ):
-            with patch(
-                "torch_spyre._inductor.wsr.coarse_tile.insert_tiling_propagation"
-            ):
-                with config.patch({"sencores": 4, "ignore_span_overflow_hints": False}):
-                    # Layer 2: adapter emits the same group shape as user hints.
-                    auto_graph = _graph([auto_op])
-                    auto_groups = _apply_span_overflow(auto_graph)
-                    manual_graph = _graph([manual_op])
-                    manual_groups = _manual_h_hint_group(manual_op)
+            with config.patch({"sencores": 4, "ignore_span_overflow_hints": False}):
+                # Layer 2: adapter emits the same group shape as user hints.
+                auto_graph = _graph([auto_op])
+                auto_groups = _apply_span_overflow(auto_graph)
+                manual_graph = _graph([manual_op])
+                manual_groups = _manual_h_hint_group(manual_op)
 
-                    self.assertEqual(len(auto_groups), 1)
-                    self.assertEqual(len(manual_groups), 1)
-                    self.assertEqual(auto_groups[0][1][0][1], sympy.Integer(5))
-                    self.assertEqual(manual_groups[0][1][0][1], sympy.Integer(5))
-                    self.assertEqual(auto_groups[0][1][0][1], sympy.Integer(5))
-                    self.assertEqual(manual_groups[0][1][0][1], sympy.Integer(5))
-                    # Span-overflow tiling is always an output dim (never reduction).
-                    self.assertFalse(auto_op.dim_hints[0].is_reduction)
-                    self.assertFalse(manual_op.dim_hints[0].is_reduction)
-                    self.assertEqual(auto_op.dim_hints[0].loop_var, sympy.Symbol("h"))
-                    self.assertEqual(manual_op.dim_hints[0].loop_var, sympy.Symbol("h"))
+                self.assertEqual(len(auto_groups), 1)
+                self.assertEqual(len(manual_groups), 1)
+                self.assertEqual(auto_groups[0][1][0][1], sympy.Integer(5))
+                self.assertEqual(manual_groups[0][1][0][1], sympy.Integer(5))
+                self.assertEqual(auto_groups[0][1][0][1], sympy.Integer(5))
+                self.assertEqual(manual_groups[0][1][0][1], sympy.Integer(5))
+                # Span-overflow tiling is always an output dim (never reduction).
+                self.assertFalse(auto_op.dim_hints[0].is_reduction)
+                self.assertFalse(manual_op.dim_hints[0].is_reduction)
+                self.assertEqual(auto_op.dim_hints[0].loop_var, sympy.Symbol("h"))
+                self.assertEqual(manual_op.dim_hints[0].loop_var, sympy.Symbol("h"))
 
-                    # Layer 3: coarse_tile stamps identical per-tile IR shape.
-                    coarse_tile(auto_graph, auto_groups)
-                    coarse_tile(manual_graph, manual_groups)
+                # Layer 3: coarse_tile stamps identical per-tile IR shape.
+                coarse_tile(auto_graph, auto_groups)
+                coarse_tile(manual_graph, manual_groups)
 
         self.assertEqual(list(auto_op.data.ranges), _E2E_TILE_SHAPE)
         self.assertEqual(list(manual_op.data.ranges), _E2E_TILE_SHAPE)

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -21,12 +21,97 @@ and consumed by the scheduler, kernel codegen, and buffer-propagation pass.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import sympy
 
 if TYPE_CHECKING:
+    from torch._inductor.dependencies import MemoryDep
     from torch._inductor.ir import ComputedBuffer
+
+
+@dataclass(frozen=True)
+class ReductionPlan:
+    """Planned shape/identity/nesting data for a tiled-reduction op.
+
+    Computed once during planning (``_plan_tiling_propagation``) from pure
+    functions of already-known shape data, and consumed by transformation's
+    reduction-machinery pass to build the actual accumulator/fill/combine
+    buffers -- the objects themselves don't exist until then, only the
+    decisions about their shape/identity/nesting front-load.
+
+    Attributes
+    ----------
+    reduction_type:
+        ``op.data.reduction_type`` (e.g. ``"sum"``, ``"max"``).
+    identity:
+        Monoid identity value for ``reduction_type``, from
+        ``_reduction_identity_value``.
+    is_nested:
+        True when an outer level tiles an output dim and an inner level
+        tiles a reduction dim, requiring separate tile-sized and full-sized
+        accumulators (see ``_compute_fill_loop_info``). False for a flat
+        (reduction-dim-only) tiling.
+    full_output_ranges:
+        Full (pre-outer-division) output shape for the accumulation buffer,
+        from ``_compute_full_ranges``.
+    per_tile_ranges:
+        Per-outer-tile output shape (``op.data.ranges`` at planning time).
+    outer_fill_loop_info:
+        ``CoarseTileInfo`` covering only the outer output-dim levels, to
+        stamp on the fill op for a nested tiling (``_compute_fill_loop_info``).
+        ``None`` for a flat tiling, where the fill runs once before all loops.
+    """
+
+    reduction_type: str
+    identity: float | int
+    is_nested: bool
+    full_output_ranges: list[sympy.Expr]
+    per_tile_ranges: list[sympy.Expr]
+    outer_fill_loop_info: "CoarseTileInfo | None"
+
+
+@dataclass(frozen=True)
+class PropagationPlan:
+    """Decision for how a tiled op's result crosses its loop boundary.
+
+    Computed once during planning (``_plan_tiling_propagation``) and
+    consumed by transformation's fixed pass sequence, which only acts on
+    these decisions -- it never makes new ones.
+
+    Attributes
+    ----------
+    kind:
+        ``"loop_internal"``: the op's own buffer is scratch reused every
+        iteration; its write must not advance at any level.
+        ``"copy_out"``: the op's result is consumed outside its loop group
+        (or is a graph output) and needs a full-sized buffer + copy op.
+        ``"reduction"``: the op is a Reduction tiled over a reduction dim;
+        see ``reduction`` for the accumulator/fill/combine shape decisions.
+    full_ranges:
+        Full (pre-division) iteration ranges for the copy-out's full buffer.
+        Only set when ``kind == "copy_out"``.
+    reduction:
+        Shape/identity/nesting decisions for the reduction machinery. Only
+        set when ``kind == "reduction"``.
+    outside_consumer_names:
+        Names (not object references -- see ``_find_outside_consumers``, and
+        the module docstring on name stability) of ComputedBuffers outside
+        this op's own outermost loop group that read this op's result.
+    is_graph_output:
+        True if this op's buffer name appears in the graph's output names.
+    full_read_deps:
+        This op's own ``MemoryDep`` reads whose producer lies outside this
+        op's own loop group (``_full_buffer_read_deps``) -- independent of
+        ``kind``, since an op of any kind may need read-side copy-ins.
+    """
+
+    kind: Literal["loop_internal", "copy_out", "reduction"]
+    full_ranges: list[sympy.Expr] | None = None
+    reduction: ReductionPlan | None = None
+    outside_consumer_names: tuple[str, ...] = ()
+    is_graph_output: bool = False
+    full_read_deps: tuple["MemoryDep", ...] = ()
 
 
 @dataclass
@@ -73,6 +158,10 @@ class CoarseTileInfo:
     output_tiled_dims:
         The analogous per-level ``(op_dim_index, extent)`` list for this
         op's own write dependency. Defaults to ``[]`` (no levels tiled).
+    propagation:
+        Planned decision for how this op's result crosses its loop
+        boundary, computed by ``_plan_tiling_propagation``. ``None`` until
+        that planning stage runs (or for ops it doesn't cover).
     """
 
     loop_group_id: tuple[int, ...]
@@ -83,6 +172,7 @@ class CoarseTileInfo:
         default_factory=list
     )
     output_tiled_dims: list[list[tuple[int, sympy.Expr]]] = field(default_factory=list)
+    propagation: "PropagationPlan | None" = None
 
 
 # ---------------------------------------------------------------------------

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -53,14 +53,20 @@ class ReductionPlan:
         accumulators (see ``_compute_fill_loop_info``). False for a flat
         (reduction-dim-only) tiling.
     full_output_ranges:
-        Full (pre-outer-division) output shape for the accumulation buffer,
-        from ``_compute_full_ranges``.
+        Full (pre-division) output shape for the accumulation buffer --
+        planning runs before ``_apply_plan`` divides ``op.data.ranges``, so
+        this is just ``op.data.ranges`` at planning time, unchanged.
     per_tile_ranges:
-        Per-outer-tile output shape (``op.data.ranges`` at planning time).
+        Per-outer-tile output shape: ``op.data.ranges`` at planning time with
+        every tiled dim divided by its ``loop_count`` (mirrors the division
+        ``_divide_ranges`` performs later, in place, during transformation).
     outer_fill_loop_info:
         ``CoarseTileInfo`` covering only the outer output-dim levels, to
         stamp on the fill op for a nested tiling (``_compute_fill_loop_info``).
         ``None`` for a flat tiling, where the fill runs once before all loops.
+        Its ``loop_group_id`` is planning-time, pre-offset numbering --
+        transformation must re-slice it from the op's own real, stamped
+        ``loop_group_id`` before use (see ``_propagate_tiled_reduction_op``).
     """
 
     reduction_type: str

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -26,7 +26,6 @@ from typing import TYPE_CHECKING, Literal
 import sympy
 
 if TYPE_CHECKING:
-    from torch._inductor.dependencies import MemoryDep
     from torch._inductor.ir import ComputedBuffer
 
 
@@ -106,10 +105,6 @@ class PropagationPlan:
         this op's own outermost loop group that read this op's result.
     is_graph_output:
         True if this op's buffer name appears in the graph's output names.
-    full_read_deps:
-        This op's own ``MemoryDep`` reads whose producer lies outside this
-        op's own loop group (``_full_buffer_read_deps``) -- independent of
-        ``kind``, since an op of any kind may need read-side copy-ins.
     """
 
     kind: Literal["loop_internal", "copy_out", "reduction"]
@@ -117,7 +112,6 @@ class PropagationPlan:
     reduction: ReductionPlan | None = None
     outside_consumer_names: tuple[str, ...] = ()
     is_graph_output: bool = False
-    full_read_deps: tuple["MemoryDep", ...] = ()
 
 
 @dataclass

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -1408,10 +1408,8 @@ def coarse_tile(
     plan = plan_coarse_tile_groups(operations, groups)
 
     # Planning continued: decide every op's propagation kind (loop-internal
-    # / copy-out / reduction) with zero mutation. Transformation doesn't
-    # consume this yet (still uses its own equivalent, interleaved logic) --
-    # this is purely additive until the cross-check test below is joined by
-    # the Stage 3 migration.
+    # / copy-out / reduction) with zero mutation, consumed by Pass 1/2/3
+    # below.
     _plan_tiling_propagation(operations, groups, plan)
 
     # Transformation: apply the plan. Only reached if planning didn't raise.
@@ -1436,13 +1434,38 @@ def coarse_tile(
     # Pass 2: reduction machinery (accumulator/fill/combine), using each
     # op's now-stamped loop_info.propagation.reduction. Must run after Pass
     # 1 (a tiled-reduction op may itself have needed a read copy-in) and
-    # before insert_tiling_propagation, which no longer dispatches reduction
-    # ops at all -- Pass 2 is their sole handler.
+    # before Pass 3 -- a reduction op is never also copy_out (the plan's
+    # kind routes each op to exactly one).
     _insert_all_reduction_ops(operations)
+
+    # Pass 3: write copy-outs (full buffer + copy op + outside-consumer/
+    # graph-output patching), using each op's now-stamped
+    # loop_info.propagation.full_ranges/outside_consumer_names/
+    # is_graph_output. Must run after Pass 1/2 -- _allocate_full_buffer/
+    # _insert_copy_op read op's *current* reads/loader/layout.
+    _insert_all_write_copy_ops(operations)
 
     insert_tiling_propagation(operations, groups)
 
+    # Pass 1/2/3 (all above) may have spliced a replacement ComputedBuffer
+    # into `operations` under the same name for any op in a group's
+    # `group_ops` snapshot (taken before those passes ran, back when
+    # retiled_infos_by_group was built) -- e.g. a read copy-in redirect
+    # (Pass 1) or a copy-out's output_tiled_dims zeroing that happens to
+    # accompany a body rewrite. _patch_retiled_load_indexes must see each
+    # op's *current* inner_fn/loop_info to decide whether it still needs
+    # patching, so re-resolve every entry by name from `operations` (the
+    # authoritative post-replacement list) before calling it -- the same
+    # by-name resync idiom used throughout this module (see PropagationPlan's
+    # docstring on name stability).
+    name_to_op = {
+        op.get_name(): op for op in operations if isinstance(op, ComputedBuffer)
+    }
     for group_id, group_ops, retiled_infos in retiled_infos_by_group:
+        for idx, op in enumerate(group_ops):
+            if not isinstance(op, ComputedBuffer):
+                continue
+            group_ops[idx] = name_to_op.get(op.get_name(), op)
         _patch_retiled_load_indexes(group_id, group_ops, retiled_infos, operations)
 
 
@@ -1455,98 +1478,18 @@ def insert_tiling_propagation(
     operations: list[Operation],
     groups: list[tuple],
 ) -> None:
-    """Insert full-sized buffers and copy/mutation ops for tiled ops.
+    """Zero fixed-buffer readers' tiled_dims_per_read entries.
 
-    Handles Pointwise and Reduction ComputedBuffers.  For Reductions, tiled
-    dims that fall in the reduction_ranges index range raise RuntimeError.
-
-    For each eligible ComputedBuffer in a tiling group, if its result is
-    consumed by any operation outside the loop (different loop_group_id or
-    absent) or is a graph output, this pass ensures the outside consumer sees
-    the complete result: allocate a full-sized buffer, then insert a copy op
-    (same loop_group_id, same loop_tiled_dims) that writes each tile into the
-    correct slice of the full buffer.  Patch outside consumers to read the
-    full buffer.  This applies uniformly regardless of whether the tiled
-    op's output is also consumed inside the loop.
-
-    The existing tiled_symbols / affine.apply machinery in SpyreKernel and
-    bundle.py handles the per-iteration address offset for both the tiled
-    op and the inserted copy op.
+    Pass 2 (_insert_all_reduction_ops) and Pass 3 (_insert_all_write_copy_ops)
+    -- both run before this -- already handle every tiled op's own
+    boundary-crossing (reduction machinery, or full-buffer allocation +
+    copy-out + outside-consumer/graph-output patching). All that remains
+    here is _zero_reads_of_fixed_buffers, kept as its own pass because "is
+    buf1 fixed" depends on Pass 3 having already zeroed buf1's own
+    output_tiled_dims, which a sibling reader of buf1 cannot know until
+    then regardless of visitation order.
     """
-    for group_ops, _ in groups:
-        for idx, op in enumerate(group_ops):
-            if not isinstance(op, ComputedBuffer):
-                continue
-            if not isinstance(op.data, (Pointwise, Reduction)):
-                continue
-            # Reduction ops tiled over a reduction dim were already fully
-            # handled by Pass 2 (_insert_all_reduction_ops), which runs
-            # before this loop -- its own consumer-patching already redirects
-            # every outside reader/graph-output away from op's name, so a
-            # second dispatch here would be redundant at best. Detect via
-            # loop_info.propagation.kind rather than re-deriving
-            # has_tiled_reduction, since group_ops may be stale (see the
-            # resolve-by-name step below) -- checking the *current* object's
-            # already-computed plan is simpler and always correct.
-            current_propagation = getattr(
-                getattr(op, "loop_info", None), "propagation", None
-            )
-            if (
-                current_propagation is not None
-                and current_propagation.kind == "reduction"
-            ):
-                continue
-            # _insert_all_read_copy_ops (Pass 1) may already have spliced a
-            # replacement for op into `operations` under the same name, if
-            # op read a full-size cross-loop-group buffer directly.
-            # group_ops is a stale pre-Pass-1 snapshot, so resolve the
-            # current object by name before calling _propagate_tiled_op --
-            # otherwise it would operate on the discarded pre-copy-in op
-            # whose reads still point at the un-copied full buffer.
-            op = next(
-                (
-                    o
-                    for o in operations
-                    if isinstance(o, ComputedBuffer) and o.get_name() == op.get_name()
-                ),
-                op,
-            )
-            # Write the Pass-1-resolved object back into group_ops immediately
-            # -- not just after _propagate_tiled_op returns (see the resync
-            # below). group_ops is shared with retiled_infos_by_group, read
-            # later by _patch_retiled_load_indexes; _propagate_tiled_op may
-            # mutate op.loop_info *in place* (no replacement object) for
-            # e.g. the loop-internal/copy-out output_tiled_dims zeroing, in
-            # which case the after-the-fact "current is not op" check below
-            # never fires, leaving group_ops[idx] pointing at the discarded
-            # pre-Pass-1 object forever -- exactly the object
-            # _patch_retiled_load_indexes would later reconstruct from,
-            # silently discarding the zeroing.
-            group_ops[idx] = op
-            _propagate_tiled_op(op, operations)
-            # _propagate_tiled_op (and the copy-op insertion it may
-            # delegate to) can replace op with a new ComputedBuffer object
-            # spliced into `operations` under the same name (see
-            # replace_computed_buffer_body).  group_ops is a separate list
-            # snapshotted before this loop runs, so it must be kept in sync
-            # here — otherwise a later pass reading group_ops (e.g.
-            # _patch_retiled_load_indexes) sees the stale pre-rewrite object
-            # and clobbers the rewrite when it reconstructs from it.  Look
-            # up the current object in `operations` itself (already the
-            # authoritative post-replacement list) rather than V.graph --
-            # this pass runs from CustomPreSchedulingPasses, and unit tests
-            # that call coarse_tile() directly never install a real V.graph.
-            current = next(
-                (
-                    o
-                    for o in operations
-                    if isinstance(o, ComputedBuffer) and o.get_name() == op.get_name()
-                ),
-                None,
-            )
-            if current is not None and current is not op:
-                group_ops[idx] = current
-
+    del groups  # unused now that Pass 3 covers every group's own ops
     _zero_reads_of_fixed_buffers(operations)
 
 
@@ -1639,46 +1582,58 @@ def _validate_planned_reduction_tiling(
             )
 
 
+def _insert_all_write_copy_ops(operations: list[Operation]) -> None:
+    """Pass 3: build full buffer + copy-out for every planned copy-out op.
+
+    Transformation's Pass 3 (see the plan/execute split design). Every op
+    was already stamped by _apply_plan with a loop_info carrying
+    .propagation, computed by _plan_tiling_propagation -- this pass only
+    consumes that decision (kind == "copy_out" and its accompanying
+    full_ranges/outside_consumer_names/is_graph_output data), it makes no
+    new ones. A "loop_internal" op needs nothing here: planning already
+    determined it has no outside consumers, so its output_tiled_dims is
+    left as _apply_plan stamped it (a loop-internal op's write is never
+    tiled -- see _plan_tiling_propagation).
+
+    Must run after Pass 1 (_insert_all_read_copy_ops) and Pass 2
+    (_insert_all_reduction_ops) -- a copy-out op may itself have needed a
+    read copy-in, and _allocate_full_buffer/_insert_copy_op read op's
+    *current* reads/loader/layout.
+    """
+    for op in list(operations):
+        if not isinstance(op, ComputedBuffer):
+            continue
+        loop_info = getattr(op, "loop_info", None)
+        propagation = getattr(loop_info, "propagation", None)
+        if propagation is None or propagation.kind != "copy_out":
+            continue
+        _propagate_tiled_op(op, propagation, operations)
+
+
 def _propagate_tiled_op(
     op: ComputedBuffer,
+    propagation: PropagationPlan,
     operations: list[Operation],
 ) -> None:
-    """Handle buffer propagation for a single tiled Pointwise or Reduction op."""
-    # Read copy-ins (for a tiled op reading a full-size cross-loop-group
-    # buffer directly -- see _full_buffer_read_deps) are handled up front by
-    # Pass 1 (_insert_all_read_copy_ops), before insert_tiling_propagation's
-    # loop ever calls this function. By the time op reaches here, its reads
-    # already target the inserted copy buffers, so op.loop_info is already
-    # the final, post-copy-in one -- no re-fetch needed.
-    #
-    # Reduction ops tiled over a reduction dim are handled entirely by Pass 2
-    # (_insert_all_reduction_ops), which also runs before
-    # insert_tiling_propagation's loop calls this function -- op.data is
-    # never a Reduction with a tiled reduction dim by the time control
-    # reaches here.
-    loop_info = getattr(op, "loop_info", None)
-
-    if loop_info is None:
-        return
+    """Allocate a full buffer + copy-out for a single planned copy-out op."""
+    loop_info = op.loop_info
     loop_group_id = loop_info.loop_group_id
-
     buf_name = op.get_name()
-    outside_consumers, is_graph_output = _find_outside_consumers(
-        buf_name, loop_group_id, operations
-    )
 
-    # If no dims were tiled (loop_tiled_dims all empty), the op is loop-invariant.
-    if all(not dims for dims in loop_info.loop_tiled_dims):
-        return
+    # Resolve planning-time consumer names to their current objects --
+    # Pass 1/2 may have spliced replacements into `operations` under the
+    # same names since planning ran (see PropagationPlan's docstring on
+    # name stability).
+    outside_consumers = [
+        o
+        for o in operations
+        if isinstance(o, ComputedBuffer)
+        and o.get_name() in propagation.outside_consumer_names
+    ]
+    is_graph_output = propagation.is_graph_output
 
-    if not outside_consumers and not is_graph_output:
-        # Loop-internal: the buffer is a per-tile scratch region reused every
-        # iteration.  Its own write must not advance at any level.
-        loop_info.output_tiled_dims = []
-        return
-
-    # Reconstruct the original (pre-division) ranges.
-    full_ranges = _compute_full_ranges(op)
+    full_ranges = propagation.full_ranges
+    assert full_ranges is not None, "full_ranges must be planned for copy_out ops"
 
     # Insert the full buffer before the first op in the same outermost
     # loop group so it doesn't split the group's contiguous run in the

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -1400,6 +1400,12 @@ def coarse_tile(
         )
         retiled_infos_by_group.append((stamped_group_id, group_ops, retiled_infos))
 
+    # Pass 1: read copy-ins, using each op's now-stamped
+    # loop_info.propagation.full_read_deps. Must complete before
+    # insert_tiling_propagation's Reduction/copy-out dispatch runs, which
+    # reads each op's *current* reads/loader.
+    _insert_all_read_copy_ops(operations)
+
     insert_tiling_propagation(operations, groups)
 
     for group_id, group_ops, retiled_infos in retiled_infos_by_group:
@@ -1439,6 +1445,33 @@ def insert_tiling_propagation(
                 continue
             if not isinstance(op.data, (Pointwise, Reduction)):
                 continue
+            # _insert_all_read_copy_ops (Pass 1) may already have spliced a
+            # replacement for op into `operations` under the same name, if
+            # op read a full-size cross-loop-group buffer directly.
+            # group_ops is a stale pre-Pass-1 snapshot, so resolve the
+            # current object by name before calling _propagate_tiled_op --
+            # otherwise it would operate on the discarded pre-copy-in op
+            # whose reads still point at the un-copied full buffer.
+            op = next(
+                (
+                    o
+                    for o in operations
+                    if isinstance(o, ComputedBuffer) and o.get_name() == op.get_name()
+                ),
+                op,
+            )
+            # Write the Pass-1-resolved object back into group_ops immediately
+            # -- not just after _propagate_tiled_op returns (see the resync
+            # below). group_ops is shared with retiled_infos_by_group, read
+            # later by _patch_retiled_load_indexes; _propagate_tiled_op may
+            # mutate op.loop_info *in place* (no replacement object) for
+            # e.g. the loop-internal/copy-out output_tiled_dims zeroing, in
+            # which case the after-the-fact "current is not op" check below
+            # never fires, leaving group_ops[idx] pointing at the discarded
+            # pre-Pass-1 object forever -- exactly the object
+            # _patch_retiled_load_indexes would later reconstruct from,
+            # silently discarding the zeroing.
+            group_ops[idx] = op
             _propagate_tiled_op(op, operations)
             # _propagate_tiled_op (and the copy-op insertion it may
             # delegate to) can replace op with a new ComputedBuffer object
@@ -1560,28 +1593,13 @@ def _propagate_tiled_op(
     operations: list[Operation],
 ) -> None:
     """Handle buffer propagation for a single tiled Pointwise or Reduction op."""
+    # Read copy-ins (for a tiled op reading a full-size cross-loop-group
+    # buffer directly -- see _full_buffer_read_deps) are handled up front by
+    # Pass 1 (_insert_all_read_copy_ops), before insert_tiling_propagation's
+    # loop ever calls this function. By the time op reaches here, its reads
+    # already target the inserted copy buffers, so op.loop_info is already
+    # the final, post-copy-in one -- no re-fetch needed.
     loop_info = getattr(op, "loop_info", None)
-
-    # A tiled op — Pointwise or Reduction, loop-internal or not — may read a
-    # buffer produced outside its own outer loop group directly (e.g. a
-    # SpyreEmptyFallback accumulator, or the output of an earlier, different
-    # coarse-tile group's own copy op).  That buffer's layout was fixed by a
-    # different loop group's (or no loop group's) constraints, sized to its
-    # own full extent, while this op's own candidates are sized to its tile
-    # — the two can never be stick-compatible.  Insert a tile-sized read copy
-    # for each such input before doing anything else (mirrors the write-side
-    # _insert_copy_op fix, but on the read side).  This must run before the
-    # Reduction/has_tiled_reduction branch below, since
-    # _propagate_tiled_reduction_op never touches op's own reads.
-    full_deps = _full_buffer_read_deps(op)
-    if full_deps:
-        op = _insert_read_copy_ops(op, full_deps, operations)
-        # _insert_read_copy_ops may rebuild op.loop_info via
-        # dataclasses.replace (to give it fresh tiled_dims_per_read for the
-        # swapped-in copy reads), which detaches it from the loop_info
-        # object captured above -- re-fetch so every mutation below lands
-        # on the object actually reachable from the (possibly-replaced) op.
-        loop_info = getattr(op, "loop_info", None)
 
     if isinstance(op.data, Reduction):
         # Unsupported reduction-tiling shapes are already rejected during
@@ -2577,6 +2595,45 @@ def _insert_read_copy_ops(
             new_loop_info, tiled_dims_per_read=new_tiled_dims_per_read
         )
     return new_op
+
+
+def _insert_all_read_copy_ops(operations: list[Operation]) -> None:
+    """Pass 1: insert read-copy-ins for every tiled op reading a full buffer.
+
+    Transformation's Pass 1 (see the plan/execute split design). Every op
+    was already stamped by _apply_plan with a loop_info, so
+    _full_buffer_read_deps(op) is available -- but it must be recomputed
+    fresh here, not read off loop_info.propagation.full_read_deps: that
+    planning-time value was computed from op.get_read_writes() *before*
+    _apply_plan's _divide_ranges/_divide_reduction_ranges divided op's own
+    ranges, so its MemoryDep.index/size expressions are keyed to the
+    pre-division (full-sized) iteration space. _insert_read_copy_ops sizes
+    and indexes the inserted copy directly from dep.index/dep.size (see its
+    docstring), so a stale pre-division dep would size/index the copy
+    against the wrong (full, not tile) extent -- silent wrong-code, exactly
+    the hazard CLAUDE.md's "wrap, never reconstruct" convention warns about
+    for stale symbolic index expressions. _full_buffer_read_deps(op),
+    called here on the current post-division op, is the fresh equivalent.
+    propagation.full_read_deps still has value elsewhere (e.g. as a planning-
+    time cross-check of *which* reads are full-buffer reads -- a static
+    topology fact, unaffected by division), but its dep objects themselves
+    must never be handed to a transformation-time mutation like
+    _insert_read_copy_ops.
+
+    Must run after every group's _apply_plan (so op.loop_info is stamped)
+    and before insert_tiling_propagation's Reduction/copy-out dispatch,
+    which reads an op's *current* reads/loader -- copy-ins must be applied
+    before that machinery is built, not interleaved with it.
+    """
+    for op in list(operations):
+        if not isinstance(op, ComputedBuffer):
+            continue
+        if not isinstance(op.data, (Pointwise, Reduction)):
+            continue
+        full_deps = _full_buffer_read_deps(op)
+        if not full_deps:
+            continue
+        _insert_read_copy_ops(op, full_deps, operations)
 
 
 # ---------------------------------------------------------------------------

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -1492,8 +1492,7 @@ def coarse_tile(
 
     # Pass 1: read copy-ins, using each op's now-stamped
     # loop_info.propagation.full_read_deps. Must complete before Pass 2 and
-    # insert_tiling_propagation's copy-out dispatch run, both of which read
-    # each op's *current* reads/loader.
+    # Pass 3 run, both of which read each op's *current* reads/loader.
     _insert_all_read_copy_ops(operations)
 
     # Pass 2: reduction machinery (accumulator/fill/combine), using each
@@ -1509,10 +1508,6 @@ def coarse_tile(
     # is_graph_output. Must run after Pass 1/2 -- _allocate_full_buffer/
     # _insert_copy_op read op's *current* reads/loader/layout.
     _insert_all_write_copy_ops(operations)
-
-    # No-op: kept only as a mock/patch point for span-overflow tests. See
-    # insert_tiling_propagation's docstring.
-    insert_tiling_propagation(operations, groups)
 
     # Checkpoint 5 wants each op's *planned* kind by name -- snapshot that
     # now, before the resync loop below overwrites `group_ops` (the same
@@ -1611,23 +1606,6 @@ def _log_propagation_self_check(
 # ---------------------------------------------------------------------------
 # Buffer propagation pass
 # ---------------------------------------------------------------------------
-
-
-def insert_tiling_propagation(
-    operations: list[Operation],
-    groups: list[tuple],
-) -> None:
-    """No-op: retained only as a mock/patch point for span-overflow tests.
-
-    Pass 1 (_insert_all_read_copy_ops), Pass 2 (_insert_all_reduction_ops),
-    and Pass 3 (_insert_all_write_copy_ops) -- all run before this -- now
-    handle every tiled op's own boundary-crossing, and
-    _plan_tiling_propagation's planning-time
-    _zero_reads_of_fixed_buffers_planned already zeroes fixed-buffer
-    readers' tiled_dims_per_read entries before _apply_plan ever stamps
-    loop_info, so no transformation-time equivalent is needed.
-    """
-    del operations, groups
 
 
 def _validate_planned_reduction_tiling(
@@ -2743,9 +2721,9 @@ def _insert_all_read_copy_ops(operations: list[Operation]) -> None:
     _insert_read_copy_ops.
 
     Must run after every group's _apply_plan (so op.loop_info is stamped)
-    and before insert_tiling_propagation's Reduction/copy-out dispatch,
-    which reads an op's *current* reads/loader -- copy-ins must be applied
-    before that machinery is built, not interleaved with it.
+    and before Pass 2/3's Reduction/copy-out dispatch, which reads an op's
+    *current* reads/loader -- copy-ins must be applied before that
+    machinery is built, not interleaved with it.
     """
     for op in list(operations):
         if not isinstance(op, ComputedBuffer):
@@ -2970,8 +2948,8 @@ def _insert_all_reduction_ops(operations: list[Operation]) -> None:
     Must run after Pass 1 (_insert_all_read_copy_ops) -- a tiled-reduction
     op may itself have needed a read copy-in, and this pass's accumulator/
     fill/combine construction reads op's *current* reads/loader -- and
-    before insert_tiling_propagation, which no longer dispatches reduction
-    ops at all now that this pass is their sole handler.
+    before Pass 3, since a reduction op is never also copy_out (the plan's
+    kind routes each op to exactly one).
     """
     for op in list(operations):
         if not isinstance(op, ComputedBuffer):
@@ -3413,9 +3391,9 @@ def _patch_retiled_load_indexes(
 
     # Only ops that were already in the group when _apply_plan ran can hold a
     # stale (pre-divide) coefficient for a retiled buffer.  Ops inserted later
-    # by insert_tiling_propagation (e.g. _insert_copy_op's copy_buf) read the
-    # retiled buffer's already-updated layout directly, so rewriting them here
-    # would double-apply the stride correction (see issue found while fixing
+    # by Pass 1/2/3 (e.g. _insert_copy_op's copy_buf) read the retiled
+    # buffer's already-updated layout directly, so rewriting them here would
+    # double-apply the stride correction (see issue found while fixing
     # test_hint_restickify_stays_in_group).
     retiled_names = set(rewrites_by_name)
     for op in list(group_ops):

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -380,16 +380,43 @@ def _compute_full_ranges_planned(
 ) -> list[Expr]:
     """Planning-time analog of _compute_full_ranges.
 
-    Same computation, but takes op's planned CoarseTileInfo directly (op has
-    no .loop_info attribute yet at planning time) instead of reading it off
-    the op.
+    _compute_full_ranges reconstructs the pre-division ranges from op.data
+    .ranges, which by the time transformation calls it has already been
+    divided by _divide_ranges. Planning runs *before* _apply_plan/
+    _divide_ranges, so op.data.ranges is already the undivided, full shape
+    here -- return it unchanged rather than multiplying by loop_count again
+    (which would double the extent of every tiled dim).
     """
-    full_ranges = list(op.data.ranges)
+    return list(op.data.ranges)
+
+
+def _compute_per_tile_ranges_planned(
+    op: ComputedBuffer, info: CoarseTileInfo
+) -> list[Expr]:
+    """Compute op's post-division (per-tile) output ranges without mutating.
+
+    Mirrors the arithmetic _divide_ranges performs in place, but reads
+    pre-mutation op.data.ranges (planning runs before _apply_plan) and
+    returns a fresh list instead of writing through op.data/op.layout. A dim
+    tiled at more than one level is divided by every such level's count, matching
+    _divide_ranges being called once per level in the transformation loop.
+    """
+    ranges = list(op.data.ranges)
     for count, dims in zip(info.loop_count, info.loop_tiled_dims):
         for d in dims:
-            if 0 <= d < len(full_ranges):
-                full_ranges[d] = sympy.simplify(full_ranges[d] * count)
-    return full_ranges
+            if 0 <= d < len(ranges):
+                r = ranges[d]
+                if isinstance(r, (int, sympy.Integer)) and isinstance(
+                    count, (int, sympy.Integer)
+                ):
+                    assert int(r) % int(count) == 0, (
+                        f"coarse_tile: op {op.get_name()!r} loop var d{d} range "
+                        f"{r} is not divisible by loop_count {count}."
+                    )
+                    ranges[d] = sympy.Integer(int(r) // int(count))
+                else:
+                    ranges[d] = sympy.simplify(sympy.sympify(r) / sympy.sympify(count))
+    return ranges
 
 
 def _compute_fill_loop_info_planned(
@@ -479,7 +506,7 @@ def _plan_tiling_propagation(
             if isinstance(op.data, Reduction) and has_tiled_reduction:
                 reduction_type = op.data.reduction_type
                 identity = _reduction_identity_value(reduction_type, op.get_dtype())
-                per_tile_ranges = list(op.data.ranges)
+                per_tile_ranges = _compute_per_tile_ranges_planned(op, info)
                 full_output_ranges = _compute_full_ranges_planned(op, info)
                 outer_fill_loop_info = _compute_fill_loop_info_planned(info)
                 reduction_plan = ReductionPlan(
@@ -1401,10 +1428,17 @@ def coarse_tile(
         retiled_infos_by_group.append((stamped_group_id, group_ops, retiled_infos))
 
     # Pass 1: read copy-ins, using each op's now-stamped
-    # loop_info.propagation.full_read_deps. Must complete before
-    # insert_tiling_propagation's Reduction/copy-out dispatch runs, which
-    # reads each op's *current* reads/loader.
+    # loop_info.propagation.full_read_deps. Must complete before Pass 2 and
+    # insert_tiling_propagation's copy-out dispatch run, both of which read
+    # each op's *current* reads/loader.
     _insert_all_read_copy_ops(operations)
+
+    # Pass 2: reduction machinery (accumulator/fill/combine), using each
+    # op's now-stamped loop_info.propagation.reduction. Must run after Pass
+    # 1 (a tiled-reduction op may itself have needed a read copy-in) and
+    # before insert_tiling_propagation, which no longer dispatches reduction
+    # ops at all -- Pass 2 is their sole handler.
+    _insert_all_reduction_ops(operations)
 
     insert_tiling_propagation(operations, groups)
 
@@ -1444,6 +1478,23 @@ def insert_tiling_propagation(
             if not isinstance(op, ComputedBuffer):
                 continue
             if not isinstance(op.data, (Pointwise, Reduction)):
+                continue
+            # Reduction ops tiled over a reduction dim were already fully
+            # handled by Pass 2 (_insert_all_reduction_ops), which runs
+            # before this loop -- its own consumer-patching already redirects
+            # every outside reader/graph-output away from op's name, so a
+            # second dispatch here would be redundant at best. Detect via
+            # loop_info.propagation.kind rather than re-deriving
+            # has_tiled_reduction, since group_ops may be stale (see the
+            # resolve-by-name step below) -- checking the *current* object's
+            # already-computed plan is simpler and always correct.
+            current_propagation = getattr(
+                getattr(op, "loop_info", None), "propagation", None
+            )
+            if (
+                current_propagation is not None
+                and current_propagation.kind == "reduction"
+            ):
                 continue
             # _insert_all_read_copy_ops (Pass 1) may already have spliced a
             # replacement for op into `operations` under the same name, if
@@ -1599,18 +1650,13 @@ def _propagate_tiled_op(
     # loop ever calls this function. By the time op reaches here, its reads
     # already target the inserted copy buffers, so op.loop_info is already
     # the final, post-copy-in one -- no re-fetch needed.
+    #
+    # Reduction ops tiled over a reduction dim are handled entirely by Pass 2
+    # (_insert_all_reduction_ops), which also runs before
+    # insert_tiling_propagation's loop calls this function -- op.data is
+    # never a Reduction with a tiled reduction dim by the time control
+    # reaches here.
     loop_info = getattr(op, "loop_info", None)
-
-    if isinstance(op.data, Reduction):
-        # Unsupported reduction-tiling shapes are already rejected during
-        # planning (_validate_planned_reduction_tiling, called from
-        # plan_coarse_tile_groups) -- no need to re-check here.
-        has_tiled_reduction = loop_info is not None and any(
-            dims for dims in getattr(loop_info, "loop_tiled_reduction_dims", [])
-        )
-        if has_tiled_reduction:
-            _propagate_tiled_reduction_op(op, operations)
-            return
 
     if loop_info is None:
         return
@@ -2514,10 +2560,20 @@ def _insert_read_copy_ops(
             if copy_writes
             else []
         )
+        # copy_buf is its own op, not tiled_op under another name -- it must
+        # not inherit tiled_op_info.propagation. That plan was computed for
+        # tiled_op's own boundary-crossing decision (kind may be "reduction"
+        # or "copy_out"); copy_buf is purely scratch, reused in place and
+        # never read outside this loop group, so its own kind is always
+        # "loop_internal". Leaving propagation unreplaced here previously let
+        # a "reduction"-kind plan leak onto this Pointwise passthrough buffer,
+        # causing Pass 2 (_insert_all_reduction_ops) to misdispatch it into
+        # _propagate_tiled_reduction_op.
         copy_buf.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
             tiled_op_info,
             tiled_dims_per_read=tiled_dims_per_read,
             output_tiled_dims=output_tiled_dims,
+            propagation=PropagationPlan(kind="loop_internal"),
         )
 
         V.graph.name_to_buffer[copy_name] = copy_buf
@@ -2835,6 +2891,31 @@ def _compute_fill_loop_info(op: ComputedBuffer) -> "CoarseTileInfo | None":
     )
 
 
+def _insert_all_reduction_ops(operations: list[Operation]) -> None:
+    """Pass 2: build reduction machinery for every planned reduction op.
+
+    Transformation's Pass 2 (see the plan/execute split design). Every op
+    was already stamped by _apply_plan with a loop_info carrying
+    .propagation, computed by _plan_tiling_propagation -- this pass only
+    consumes that decision (kind == "reduction" and its accompanying
+    ReductionPlan shape/identity/nesting data), it makes no new ones.
+
+    Must run after Pass 1 (_insert_all_read_copy_ops) -- a tiled-reduction
+    op may itself have needed a read copy-in, and this pass's accumulator/
+    fill/combine construction reads op's *current* reads/loader -- and
+    before insert_tiling_propagation, which no longer dispatches reduction
+    ops at all now that this pass is their sole handler.
+    """
+    for op in list(operations):
+        if not isinstance(op, ComputedBuffer):
+            continue
+        loop_info = getattr(op, "loop_info", None)
+        propagation = getattr(loop_info, "propagation", None)
+        if propagation is None or propagation.kind != "reduction":
+            continue
+        _propagate_tiled_reduction_op(op, operations)
+
+
 def _propagate_tiled_reduction_op(
     op: ComputedBuffer,
     operations: list[Operation],
@@ -2843,10 +2924,10 @@ def _propagate_tiled_reduction_op(
 
     Strategy: fill-initialize + per-tile combine.
       1. Allocate a HBM accumulation buffer sized to the full
-         (pre-outer-division) output shape (_compute_full_ranges), so that
-         address advancement across outer tiles writes each tile into the
-         correct slice.  For flat (reduction-only) tiling this equals
-         op.data.ranges.
+         (pre-outer-division) output shape (planned as
+         reduction.full_output_ranges), so that address advancement across
+         outer tiles writes each tile into the correct slice.  For flat
+         (reduction-only) tiling this equals op.data.ranges.
       2. Insert a fill op that writes the reduction's identity value into the
          accumulation buffer.  For flat reduction tiling the fill has no
          loop_info and runs before all loops.  For nested tiling (outer
@@ -2863,17 +2944,17 @@ def _propagate_tiled_reduction_op(
     """
     loop_info = op.loop_info
     loop_group_id = loop_info.loop_group_id
-    reduction_type = op.data.reduction_type
-    identity = _reduction_identity_value(reduction_type, op.get_dtype())
+    reduction_plan = loop_info.propagation.reduction
+    identity = reduction_plan.identity
 
     # Per-outer-tile output shape (ranges after any outer tiling divided them).
-    per_tile_ranges = list(op.data.ranges)
+    per_tile_ranges = reduction_plan.per_tile_ranges
 
     # Accumulation buffer uses the full (pre-outer-division) output shape so
     # that address advancement across outer output-dim tiles writes each tile's
     # result into the correct slice.  For reduction-dim-only tiling there is no
     # outer division, so full == per-tile.
-    full_output_ranges = _compute_full_ranges(op)
+    full_output_ranges = reduction_plan.full_output_ranges
 
     # Insert HBM buffer before the first op in the loop group.
     outer_key = loop_group_id[0]
@@ -2885,8 +2966,22 @@ def _propagate_tiled_reduction_op(
         == outer_key
     )
 
-    fill_loop_info = _compute_fill_loop_info(op)
-    is_nested = fill_loop_info is not None
+    fill_loop_info = reduction_plan.outer_fill_loop_info
+    is_nested = reduction_plan.is_nested
+
+    if fill_loop_info is not None:
+        # outer_fill_loop_info was built at planning time, before _apply_plan
+        # stamped op's real, offset-adjusted loop_group_id -- its own
+        # loop_group_id is still the pre-offset internal numbering
+        # plan_coarse_tile_groups used only for its own bookkeeping (see
+        # coarse_tile()'s comment on group_idx_offset). Re-slice from
+        # op.loop_info's now-real loop_group_id so the fill/copy ops this
+        # function stamps with fill_loop_info end up in the same outer group
+        # as every other op here, not a stale, potentially colliding one.
+        fill_loop_info = dataclasses.replace(
+            fill_loop_info,
+            loop_group_id=loop_group_id[: len(fill_loop_info.loop_count)],
+        )
 
     if is_nested:
         # Nested case: allocate separate tile-sized and full-sized buffers.

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -346,39 +346,6 @@ def _find_outside_consumers_planned(
     return consumer_names, is_graph_output
 
 
-def _full_buffer_read_deps_planned(
-    op: ComputedBuffer,
-    info: CoarseTileInfo,
-    name_to_group_outer_key: dict[str, int],
-) -> list[MemoryDep]:
-    """Planning-time analog of _full_buffer_read_deps.
-
-    Same decision, but takes op's planned CoarseTileInfo directly (op has no
-    .loop_info attribute yet at planning time) and looks up each read
-    dependency's producer outer loop-group key from name_to_group_outer_key
-    instead of a not-yet-stamped op.loop_info attribute.
-    """
-    from ..ir import SpyreEmptyFallback  # deferred: avoids circular import
-
-    outer_key = info.loop_group_id[0]
-    reads = [d for d in op.get_read_writes().reads if isinstance(d, MemoryDep)]
-    result = []
-    for d in reads:
-        buf = V.graph.get_buffer(d.name)
-        unwrapped = buf
-        if isinstance(unwrapped, TensorBox):
-            unwrapped = unwrapped.data
-        if isinstance(unwrapped, StorageBox):
-            unwrapped = unwrapped.data
-        if isinstance(unwrapped, (SpyreEmptyFallback, InputBuffer)):
-            result.append(d)
-        elif isinstance(unwrapped, ComputedBuffer):
-            producer_outer_key = name_to_group_outer_key.get(unwrapped.get_name())
-            if producer_outer_key is None or producer_outer_key != outer_key:
-                result.append(d)
-    return result
-
-
 def _compute_full_ranges_planned(
     op: ComputedBuffer, info: CoarseTileInfo
 ) -> list[Expr]:
@@ -474,9 +441,9 @@ def _plan_tiling_propagation(
     Untiled/skipped ops (no entry in `plan`) are left untouched.
     """
     # Every candidate consumer/producer's outer loop-group key, built once
-    # up front so _find_outside_consumers_planned / _full_buffer_read_deps_planned
-    # don't each re-derive it per candidate. Keyed by name (not id(op)) to
-    # match _reads_buffer/_graph_output_names' own name-based buffer lookup.
+    # up front so _find_outside_consumers_planned doesn't re-derive it per
+    # candidate. Keyed by name (not id(op)) to match _reads_buffer/
+    # _graph_output_names' own name-based buffer lookup.
     # Prefer this call's own plan (the freshest data, for ops this call is
     # about to stamp); fall back to a real, already-stamped loop_info
     # attribute for ops outside this plan (e.g. from an earlier coarse_tile()
@@ -502,10 +469,6 @@ def _plan_tiling_propagation(
             if info is None:
                 continue
 
-            full_read_deps = tuple(
-                _full_buffer_read_deps_planned(op, info, name_to_group_outer_key)
-            )
-
             has_tiled_reduction = any(info.loop_tiled_reduction_dims)
             if isinstance(op.data, Reduction) and has_tiled_reduction:
                 reduction_type = op.data.reduction_type
@@ -530,15 +493,11 @@ def _plan_tiling_propagation(
                     reduction=reduction_plan,
                     outside_consumer_names=tuple(consumer_names),
                     is_graph_output=is_graph_output,
-                    full_read_deps=full_read_deps,
                 )
                 continue
 
             if all(not dims for dims in info.loop_tiled_dims):
-                info.propagation = PropagationPlan(
-                    kind="loop_internal",
-                    full_read_deps=full_read_deps,
-                )
+                info.propagation = PropagationPlan(kind="loop_internal")
                 continue
 
             buf_name = op.get_name()
@@ -546,10 +505,7 @@ def _plan_tiling_propagation(
                 buf_name, info.loop_group_id, operations, name_to_group_outer_key
             )
             if not consumer_names and not is_graph_output:
-                info.propagation = PropagationPlan(
-                    kind="loop_internal",
-                    full_read_deps=full_read_deps,
-                )
+                info.propagation = PropagationPlan(kind="loop_internal")
                 continue
 
             full_ranges = _compute_full_ranges_planned(op, info)
@@ -558,7 +514,6 @@ def _plan_tiling_propagation(
                 full_ranges=full_ranges,
                 outside_consumer_names=tuple(consumer_names),
                 is_graph_output=is_graph_output,
-                full_read_deps=full_read_deps,
             )
 
     _zero_reads_of_fixed_buffers_planned(operations, plan)
@@ -1490,9 +1445,9 @@ def coarse_tile(
         )
         retiled_infos_by_group.append((stamped_group_id, group_ops, retiled_infos))
 
-    # Pass 1: read copy-ins, using each op's now-stamped
-    # loop_info.propagation.full_read_deps. Must complete before Pass 2 and
-    # Pass 3 run, both of which read each op's *current* reads/loader.
+    # Pass 1: read copy-ins, recomputing each op's full-buffer read deps
+    # fresh (post-division). Must complete before Pass 2 and Pass 3 run,
+    # both of which read each op's *current* reads/loader.
     _insert_all_read_copy_ops(operations)
 
     # Pass 2: reduction machinery (accumulator/fill/combine), using each
@@ -2702,23 +2657,17 @@ def _insert_all_read_copy_ops(operations: list[Operation]) -> None:
 
     Transformation's Pass 1 (see the plan/execute split design). Every op
     was already stamped by _apply_plan with a loop_info, so
-    _full_buffer_read_deps(op) is available -- but it must be recomputed
-    fresh here, not read off loop_info.propagation.full_read_deps: that
-    planning-time value was computed from op.get_read_writes() *before*
-    _apply_plan's _divide_ranges/_divide_reduction_ranges divided op's own
-    ranges, so its MemoryDep.index/size expressions are keyed to the
-    pre-division (full-sized) iteration space. _insert_read_copy_ops sizes
-    and indexes the inserted copy directly from dep.index/dep.size (see its
-    docstring), so a stale pre-division dep would size/index the copy
-    against the wrong (full, not tile) extent -- silent wrong-code, exactly
-    the hazard CLAUDE.md's "wrap, never reconstruct" convention warns about
-    for stale symbolic index expressions. _full_buffer_read_deps(op),
-    called here on the current post-division op, is the fresh equivalent.
-    propagation.full_read_deps still has value elsewhere (e.g. as a planning-
-    time cross-check of *which* reads are full-buffer reads -- a static
-    topology fact, unaffected by division), but its dep objects themselves
-    must never be handed to a transformation-time mutation like
-    _insert_read_copy_ops.
+    _full_buffer_read_deps(op) is available -- and it must be computed here,
+    not at planning time: op.get_read_writes() before _apply_plan's
+    _divide_ranges/_divide_reduction_ranges divided op's own ranges would
+    key each MemoryDep's index/size expressions to the pre-division
+    (full-sized) iteration space. _insert_read_copy_ops sizes and indexes
+    the inserted copy directly from dep.index/dep.size (see its docstring),
+    so a pre-division dep would size/index the copy against the wrong
+    (full, not tile) extent -- silent wrong-code, exactly the hazard
+    CLAUDE.md's "wrap, never reconstruct" convention warns about for stale
+    symbolic index expressions. _full_buffer_read_deps(op), called here on
+    the current post-division op, avoids that hazard entirely.
 
     Must run after every group's _apply_plan (so op.loop_info is stamped)
     and before Pass 2/3's Reduction/copy-out dispatch, which reads an op's

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -1514,6 +1514,21 @@ def coarse_tile(
     # insert_tiling_propagation's docstring.
     insert_tiling_propagation(operations, groups)
 
+    # Checkpoint 5 wants each op's *planned* kind by name -- snapshot that
+    # now, before the resync loop below overwrites `group_ops` (the same
+    # list objects `groups` holds references to) with post-transformation
+    # replacement objects, which would make the id(op)-keyed `plan` lookup
+    # miss every replaced op.
+    predicted_kind_by_name: dict[str, str] = {
+        op.get_name(): info.propagation.kind
+        for group_ops, _levels in groups
+        for op in group_ops
+        if isinstance(op, ComputedBuffer)
+        and (info := plan.get(id(op))) is not None
+        and info.propagation is not None
+        and info.propagation.kind in ("copy_out", "reduction")
+    }
+
     # Pass 1/2/3 (all above) may have spliced a replacement ComputedBuffer
     # into `operations` under the same name for any op in a group's
     # `group_ops` snapshot (taken before those passes ran, back when
@@ -1535,61 +1550,61 @@ def coarse_tile(
             group_ops[idx] = name_to_op.get(op.get_name(), op)
         _patch_retiled_load_indexes(group_id, group_ops, retiled_infos, operations)
 
-    _log_propagation_self_check(operations, plan)
+    _log_propagation_self_check(operations, predicted_kind_by_name)
 
 
 def _log_propagation_self_check(
     operations: list[Operation],
-    plan: dict[int, CoarseTileInfo],
+    predicted_kind_by_name: dict[str, str],
 ) -> None:
-    """Checkpoint 5: cross-check actual new-op counts against the plan.
+    """Checkpoint 5: per-op cross-check of actual new buffers against the plan.
 
-    Tally new op names by the prefix each pass's worker uses
-    (coarse_tile_copy_*/coarse_tile_read_copy_*/coarse_tile_combine_*/
-    coarse_tile_fill_*) and compare against checkpoint 1's predicted
-    copy_out/reduction counts -- a cheap correctness assertion that the
-    fixed pass sequence actually did what planning decided it would.
+    For every op the plan routed to "copy_out" or "reduction", check by name
+    that the buffers its kind requires actually exist in `operations`:
+    copy_out needs a "coarse_tile_copy_{name}"; reduction needs both a
+    "coarse_tile_fill_{name}" and a "coarse_tile_combine_{name}" (nested
+    reduction additionally needs a "coarse_tile_reduce_copy_{name}", but that
+    is not checked here since a missing outer-level copy would already
+    surface as wrong numerics, not a silently-dropped buffer). This is a
+    per-op existence check rather than a plan-vs-actual aggregate tally,
+    because a coarse count comparison (e.g. counting fill buffers alone as a
+    proxy for "reduction machinery is complete") cannot distinguish "combine
+    op silently dropped" from "no bug" -- the count of fill buffers alone is
+    unaffected by a missing combine op.
     """
     if not logger.isEnabledFor(logging.DEBUG):
         return
-    predicted_copy_out = 0
-    predicted_reduction = 0
-    for info in plan.values():
-        if info.propagation is None:
-            continue
-        if info.propagation.kind == "copy_out":
-            predicted_copy_out += 1
-        elif info.propagation.kind == "reduction":
-            predicted_reduction += 1
+    existing_names = {
+        op.get_name() for op in operations if isinstance(op, ComputedBuffer)
+    }
+    mismatches = []
+    for name, kind in predicted_kind_by_name.items():
+        if kind == "copy_out":
+            required = [f"coarse_tile_copy_{name}"]
+        else:
+            required = [f"coarse_tile_fill_{name}", f"coarse_tile_combine_{name}"]
+        missing = [r for r in required if r not in existing_names]
+        if missing:
+            mismatches.append((name, kind, missing))
 
-    actual_copy_out = 0
-    actual_reduction = 0
-    for op in operations:
-        if not isinstance(op, ComputedBuffer):
-            continue
-        name = op.get_name()
-        if name.startswith("coarse_tile_copy_"):
-            actual_copy_out += 1
-        elif name.startswith("coarse_tile_fill_"):
-            actual_reduction += 1
-
+    predicted_copy_out = sum(
+        1 for k in predicted_kind_by_name.values() if k == "copy_out"
+    )
+    predicted_reduction = sum(
+        1 for k in predicted_kind_by_name.values() if k == "reduction"
+    )
     logger.debug(
-        "coarse_tile: self-check predicted copy_out=%d reduction=%d, "
-        "actual copy_out=%d reduction=%d",
+        "coarse_tile: self-check predicted copy_out=%d reduction=%d, %d mismatches",
         predicted_copy_out,
         predicted_reduction,
-        actual_copy_out,
-        actual_reduction,
+        len(mismatches),
     )
-    if actual_copy_out != predicted_copy_out or actual_reduction != predicted_reduction:
+    if mismatches:
         logger.warning(
-            "coarse_tile: propagation self-check mismatch -- planned "
-            "copy_out=%d reduction=%d but transformation produced "
-            "copy_out=%d reduction=%d",
-            predicted_copy_out,
-            predicted_reduction,
-            actual_copy_out,
-            actual_reduction,
+            "coarse_tile: propagation self-check mismatch -- %d op(s) "
+            "missing their planned buffers: %s",
+            len(mismatches),
+            mismatches,
         )
 
 

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -39,9 +39,12 @@ tiled dimension from its ``loop_var`` in ``dim_hints``.
 
 Each ``ops`` list must be a contiguous sub-sequence of ``operations``.
 
-After stamping, ``coarse_tile`` calls ``insert_tiling_propagation`` to allocate
-full-sized output buffers and insert copy/mutation ops for Pointwise operations
-whose results are consumed outside the loop.
+After stamping, ``coarse_tile`` runs a fixed sequence of passes --
+``_insert_all_read_copy_ops``, ``_insert_all_reduction_ops``,
+``_insert_all_write_copy_ops`` -- that allocate full-sized output buffers and
+insert copy/mutation/reduction ops for tiled operations whose results are
+consumed outside the loop, all driven by the ``PropagationPlan`` each op's
+``loop_info`` already carries from planning.
 
 Before touching any ``inner_fn``/``layout``/``MutationLayoutSHOULDREMOVE``
 rewiring in this file, read "Appendix: How IR rewiring works, and why it's
@@ -566,13 +569,18 @@ def _zero_reads_of_fixed_buffers_planned(
 ) -> None:
     """Planning-time analog of _zero_reads_of_fixed_buffers.
 
-    A buffer is "fixed" once _plan_tiling_propagation (just above, in the
-    same call) has decided kind == "loop_internal" for a tiled op (loop
-    _propagate_tiled_op's own equivalent zeroing at loop_info.output_tiled_dims
-    = [] for the same case, plus _propagate_tiled_reduction_op's own
-    unconditional zeroing for any tiled-reduction op -- reduction accumulator
-    buffers are never read by name in the tiled_dims_per_read sense, so they
-    need no separate reader-side zeroing here). Unlike the deleted
+    A buffer is "fixed" -- its own tiled write never advances, because
+    something else drains/replaces it every iteration -- once
+    _plan_tiling_propagation (just above, in the same call) has decided any
+    kind at all for a tiled op: "loop_internal" (nothing advances it),
+    "copy_out" (the Pass 3 copy op drains it), or "reduction" (the Pass 2
+    combine op drains it, and _propagate_tiled_reduction_op zeroes it
+    unconditionally). The reduction case matters here even though the
+    accumulator buffer itself is never read by name: a tiled-reduction op's
+    *own* buffer (e.g. an amax result feeding a same-loop subtraction, as in
+    softmax) IS commonly read by name by a sibling op in the same group, and
+    that sibling's tiled_dims_per_read entry for it must be zeroed exactly
+    like the loop_internal/copy_out cases. Unlike the deleted
     transformation-time pass, every op's kind is already known for the
     whole plan at this point (computed above, before any mutation), so
     there is no reader-before-producer ordering hazard to work around --
@@ -585,7 +593,6 @@ def _zero_reads_of_fixed_buffers_planned(
         if isinstance(op, ComputedBuffer)
         and (info := plan.get(id(op))) is not None
         and info.propagation is not None
-        and info.propagation.kind == "loop_internal"
         and any(dims for dims in info.loop_tiled_dims)
     }
     if not fixed_names:
@@ -1445,6 +1452,8 @@ def coarse_tile(
     # _insert_copy_op read op's *current* reads/loader/layout.
     _insert_all_write_copy_ops(operations)
 
+    # No-op: kept only as a mock/patch point for span-overflow tests. See
+    # insert_tiling_propagation's docstring.
     insert_tiling_propagation(operations, groups)
 
     # Pass 1/2/3 (all above) may have spliced a replacement ComputedBuffer
@@ -1478,61 +1487,17 @@ def insert_tiling_propagation(
     operations: list[Operation],
     groups: list[tuple],
 ) -> None:
-    """Zero fixed-buffer readers' tiled_dims_per_read entries.
+    """No-op: retained only as a mock/patch point for span-overflow tests.
 
-    Pass 2 (_insert_all_reduction_ops) and Pass 3 (_insert_all_write_copy_ops)
-    -- both run before this -- already handle every tiled op's own
-    boundary-crossing (reduction machinery, or full-buffer allocation +
-    copy-out + outside-consumer/graph-output patching). All that remains
-    here is _zero_reads_of_fixed_buffers, kept as its own pass because "is
-    buf1 fixed" depends on Pass 3 having already zeroed buf1's own
-    output_tiled_dims, which a sibling reader of buf1 cannot know until
-    then regardless of visitation order.
+    Pass 1 (_insert_all_read_copy_ops), Pass 2 (_insert_all_reduction_ops),
+    and Pass 3 (_insert_all_write_copy_ops) -- all run before this -- now
+    handle every tiled op's own boundary-crossing, and
+    _plan_tiling_propagation's planning-time
+    _zero_reads_of_fixed_buffers_planned already zeroes fixed-buffer
+    readers' tiled_dims_per_read entries before _apply_plan ever stamps
+    loop_info, so no transformation-time equivalent is needed.
     """
-    del groups  # unused now that Pass 3 covers every group's own ops
-    _zero_reads_of_fixed_buffers(operations)
-
-
-def _zero_reads_of_fixed_buffers(operations: list[Operation]) -> None:
-    """Zero tiled_dims_per_read entries for reads of now-fixed buffers.
-
-    The per-op loop above (_propagate_tiled_op /
-    _propagate_tiled_reduction_op) zeroes a buffer's own
-    output_tiled_dims once that buffer is known to be loop-internal
-    scratch reused in place every iteration (no outside consumers, not a
-    graph output). But a sibling op *reading* that buffer inside the same
-    loop was planned before this was known, so its tiled_dims_per_read
-    entry for that read may still carry the stale, non-empty extent from
-    plan_coarse_tile_groups. SpyreKernel._general_tile_advance matches
-    tiled_dims_per_read to get_read_writes().reads purely positionally, so
-    a fixed buffer's readers must have that entry zeroed too, exactly
-    mirroring the now-fixed buffer's own write. This is a genuine second
-    pass over `operations` (not folded into the per-op loop above) because
-    a reader can be visited before its dependency is determined to be
-    fixed -- group_ops is processed in source order, and "is buf1 fixed"
-    is only known once buf1 itself has been propagated.
-    """
-    fixed_names = {
-        op.get_name()
-        for op in operations
-        if isinstance(op, ComputedBuffer)
-        and (loop_info := getattr(op, "loop_info", None)) is not None
-        and any(dims for dims in loop_info.loop_tiled_dims)
-        and not any(dims for dims in loop_info.output_tiled_dims)
-    }
-    if not fixed_names:
-        return
-
-    for op in operations:
-        if not isinstance(op, ComputedBuffer):
-            continue
-        loop_info = getattr(op, "loop_info", None)
-        if loop_info is None or not loop_info.tiled_dims_per_read:
-            continue
-        reads = [d for d in op.get_read_writes().reads if isinstance(d, MemoryDep)]
-        for i, dep in enumerate(reads):
-            if dep.name in fixed_names and loop_info.tiled_dims_per_read[i]:
-                loop_info.tiled_dims_per_read[i] = []
+    del operations, groups
 
 
 def _validate_planned_reduction_tiling(

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 
 
 import dataclasses
+import logging
 from collections import Counter
 from typing import NamedTuple
 
@@ -612,6 +613,62 @@ def _zero_reads_of_fixed_buffers_planned(
         for i, dep in enumerate(reads):
             if dep.name in fixed_names and info.tiled_dims_per_read[i]:
                 info.tiled_dims_per_read[i] = []
+
+
+def _log_propagation_plan(
+    groups: list[tuple],
+    plan: dict[int, CoarseTileInfo],
+) -> None:
+    """Checkpoint 1: log the complete plan before any transformation runs.
+
+    Most valuable of the five checkpoints (see the plan/execute split
+    design's "Logging checkpoints" section) because it is inspectable even
+    if transformation later crashes -- every op's kind is already decided
+    here, with zero mutation.
+    """
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
+    for group_idx, (group_ops, _levels) in enumerate(groups):
+        tally: dict[str, int] = {"loop_internal": 0, "copy_out": 0, "reduction": 0}
+        for op in group_ops:
+            if not isinstance(op, ComputedBuffer):
+                continue
+            info = plan.get(id(op))
+            propagation = info.propagation if info is not None else None
+            if propagation is None:
+                continue
+            tally[propagation.kind] += 1
+            if propagation.kind == "copy_out":
+                logger.debug(
+                    "coarse_tile: plan group=%d %s kind=copy_out "
+                    "full_ranges=%s consumers=%s graph_output=%s",
+                    group_idx,
+                    op.get_name(),
+                    propagation.full_ranges,
+                    propagation.outside_consumer_names,
+                    propagation.is_graph_output,
+                )
+            elif propagation.kind == "reduction":
+                reduction = propagation.reduction
+                logger.debug(
+                    "coarse_tile: plan group=%d %s kind=reduction "
+                    "reduction_type=%s is_nested=%s consumers=%s "
+                    "graph_output=%s",
+                    group_idx,
+                    op.get_name(),
+                    reduction.reduction_type if reduction else None,
+                    reduction.is_nested if reduction else None,
+                    propagation.outside_consumer_names,
+                    propagation.is_graph_output,
+                )
+        logger.debug(
+            "coarse_tile: plan group=%d tally loop_internal=%d copy_out=%d "
+            "reduction=%d",
+            group_idx,
+            tally["loop_internal"],
+            tally["copy_out"],
+            tally["reduction"],
+        )
 
 
 def _planned_tile_extents_per_level(
@@ -1418,6 +1475,7 @@ def coarse_tile(
     # / copy-out / reduction) with zero mutation, consumed by Pass 1/2/3
     # below.
     _plan_tiling_propagation(operations, groups, plan)
+    _log_propagation_plan(groups, plan)
 
     # Transformation: apply the plan. Only reached if planning didn't raise.
     retiled_infos_by_group: list[
@@ -1476,6 +1534,63 @@ def coarse_tile(
                 continue
             group_ops[idx] = name_to_op.get(op.get_name(), op)
         _patch_retiled_load_indexes(group_id, group_ops, retiled_infos, operations)
+
+    _log_propagation_self_check(operations, plan)
+
+
+def _log_propagation_self_check(
+    operations: list[Operation],
+    plan: dict[int, CoarseTileInfo],
+) -> None:
+    """Checkpoint 5: cross-check actual new-op counts against the plan.
+
+    Tally new op names by the prefix each pass's worker uses
+    (coarse_tile_copy_*/coarse_tile_read_copy_*/coarse_tile_combine_*/
+    coarse_tile_fill_*) and compare against checkpoint 1's predicted
+    copy_out/reduction counts -- a cheap correctness assertion that the
+    fixed pass sequence actually did what planning decided it would.
+    """
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
+    predicted_copy_out = 0
+    predicted_reduction = 0
+    for info in plan.values():
+        if info.propagation is None:
+            continue
+        if info.propagation.kind == "copy_out":
+            predicted_copy_out += 1
+        elif info.propagation.kind == "reduction":
+            predicted_reduction += 1
+
+    actual_copy_out = 0
+    actual_reduction = 0
+    for op in operations:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        name = op.get_name()
+        if name.startswith("coarse_tile_copy_"):
+            actual_copy_out += 1
+        elif name.startswith("coarse_tile_fill_"):
+            actual_reduction += 1
+
+    logger.debug(
+        "coarse_tile: self-check predicted copy_out=%d reduction=%d, "
+        "actual copy_out=%d reduction=%d",
+        predicted_copy_out,
+        predicted_reduction,
+        actual_copy_out,
+        actual_reduction,
+    )
+    if actual_copy_out != predicted_copy_out or actual_reduction != predicted_reduction:
+        logger.warning(
+            "coarse_tile: propagation self-check mismatch -- planned "
+            "copy_out=%d reduction=%d but transformation produced "
+            "copy_out=%d reduction=%d",
+            predicted_copy_out,
+            predicted_reduction,
+            actual_copy_out,
+            actual_reduction,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1639,7 +1754,16 @@ def _propagate_tiled_op(
     if is_graph_output:
         _patch_graph_outputs(buf_name, full_buf)
 
-    logger.debug("coarse_tile: propagated %s → %s (copy)", buf_name, full_name)
+    logger.debug(
+        "coarse_tile: write copy-out %s -> %s old_stride=%s new_stride=%s "
+        "consumers=%s graph_output=%s",
+        buf_name,
+        full_name,
+        old_stride,
+        tuple(full_buf.layout.stride),
+        [c.get_name() for c in outside_consumers],
+        is_graph_output,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -2508,6 +2632,13 @@ def _insert_read_copy_ops(
         # tile_strides, so _NameSwapHandler rescales the index's coefficients
         # from full_strides to tile_strides at call time (_rescale_index).
         name_map[dep.name] = (copy_name, full_strides, tile_strides)
+        logger.debug(
+            "coarse_tile: read copy-in %s -> %s (full_strides=%s tile_strides=%s)",
+            dep.name,
+            copy_name,
+            full_strides,
+            tile_strides,
+        )
 
     # Patch tiled_op's inner_fn once with the full name_map (wrap, not
     # reconstruct — see _NameSwapHandler docstring).  Rebuild via
@@ -2621,7 +2752,7 @@ def _insert_combine_op(
     tiled_op: ComputedBuffer,
     accum_buf: ComputedBuffer,
     operations: list[Operation],
-) -> None:
+) -> str:
     """Insert a pointwise combine op that accumulates tiled_op into accum_buf.
 
     The combine op reads both the partial result (tiled_op) and the current
@@ -2712,6 +2843,7 @@ def _insert_combine_op(
 
     tiled_idx = operations.index(tiled_op)
     operations.insert(tiled_idx + 1, combine_buf)
+    return combine_name
 
 
 def _insert_reduction_copy_op(
@@ -2980,7 +3112,7 @@ def _propagate_tiled_reduction_op(
     operations.insert(fill_target_idx + 2, fill_buf)
 
     # Insert combine op after the tiled reduction op (inside the loop).
-    _insert_combine_op(op, combine_target, operations)
+    combine_name = _insert_combine_op(op, combine_target, operations)
 
     # For nested case, insert a copy op at the outer loop level that writes
     # accum_tile → accum_full, advancing accum_full across outer output tiles.
@@ -3017,11 +3149,12 @@ def _propagate_tiled_reduction_op(
         _patch_graph_outputs(buf_name, accum_full)
 
     logger.debug(
-        "coarse_tile: tiled reduction %s → accum_full %s (fill=%s, identity=%s, "
-        "nested=%s)",
+        "coarse_tile: tiled reduction %s -> accum_full %s (fill=%s, combine=%s, "
+        "identity=%s, nested=%s)",
         buf_name,
         accum_name,
         fill_name,
+        combine_name,
         identity,
         is_nested,
     )

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -90,7 +90,7 @@ from .. import config
 from ..constants import BATCH_MATMUL_OP
 from ..errors import Unsupported
 from ..logging_utils import get_inductor_logger
-from ..loop_info import CoarseTileInfo, copy_op_metadata
+from ..loop_info import CoarseTileInfo, PropagationPlan, ReductionPlan, copy_op_metadata
 from ..pass_utils import op_out_coords, host_coordinates, indirect_sizes_from_op
 from ..ir import FixedTiledLayout, SpyreConstantFallback, _resize_device_layout
 
@@ -259,6 +259,11 @@ def plan_coarse_tile_groups(
                     "(disabled via enable_reduction_tiling)"
                 )
 
+            if has_tiled_reduction:
+                _validate_planned_reduction_tiling(
+                    op, op_tiled_dims, op_tiled_reduction_dims
+                )
+
             if _plan_is_loop_invariant_at_reduction_levels(
                 op, op_tiled_dims, group_reduction_tiled_levels
             ):
@@ -304,6 +309,275 @@ def plan_coarse_tile_groups(
             )
 
     return plan
+
+
+def _find_outside_consumers_planned(
+    buf_name: str,
+    group_loop_id: tuple[int, ...],
+    operations: list[Operation],
+    name_to_group_outer_key: dict[str, int],
+) -> tuple[list[str], bool]:
+    """Planning-time analog of _find_outside_consumers.
+
+    Same decision (does any op outside buf_name's own outermost loop group
+    read it, or is it a graph output), but returns consumer *names* instead
+    of objects (planning is zero-mutation, so there's no reason to carry
+    object references past this stage -- see PropagationPlan's docstring on
+    name stability), and looks up each candidate's outer loop-group key from
+    name_to_group_outer_key (built once by the caller from the planned
+    CoarseTileInfo dict) instead of a not-yet-stamped op.loop_info attribute.
+    """
+    outer_key = group_loop_id[0]
+    consumer_names: list[str] = []
+    for op in operations:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        if not _reads_buffer(op, buf_name):
+            continue
+        candidate_outer_key = name_to_group_outer_key.get(op.get_name())
+        if candidate_outer_key is None or candidate_outer_key != outer_key:
+            consumer_names.append(op.get_name())
+
+    is_graph_output = buf_name in _graph_output_names()
+    return consumer_names, is_graph_output
+
+
+def _full_buffer_read_deps_planned(
+    op: ComputedBuffer,
+    info: CoarseTileInfo,
+    name_to_group_outer_key: dict[str, int],
+) -> list[MemoryDep]:
+    """Planning-time analog of _full_buffer_read_deps.
+
+    Same decision, but takes op's planned CoarseTileInfo directly (op has no
+    .loop_info attribute yet at planning time) and looks up each read
+    dependency's producer outer loop-group key from name_to_group_outer_key
+    instead of a not-yet-stamped op.loop_info attribute.
+    """
+    from ..ir import SpyreEmptyFallback  # deferred: avoids circular import
+
+    outer_key = info.loop_group_id[0]
+    reads = [d for d in op.get_read_writes().reads if isinstance(d, MemoryDep)]
+    result = []
+    for d in reads:
+        buf = V.graph.get_buffer(d.name)
+        unwrapped = buf
+        if isinstance(unwrapped, TensorBox):
+            unwrapped = unwrapped.data
+        if isinstance(unwrapped, StorageBox):
+            unwrapped = unwrapped.data
+        if isinstance(unwrapped, (SpyreEmptyFallback, InputBuffer)):
+            result.append(d)
+        elif isinstance(unwrapped, ComputedBuffer):
+            producer_outer_key = name_to_group_outer_key.get(unwrapped.get_name())
+            if producer_outer_key is None or producer_outer_key != outer_key:
+                result.append(d)
+    return result
+
+
+def _compute_full_ranges_planned(
+    op: ComputedBuffer, info: CoarseTileInfo
+) -> list[Expr]:
+    """Planning-time analog of _compute_full_ranges.
+
+    Same computation, but takes op's planned CoarseTileInfo directly (op has
+    no .loop_info attribute yet at planning time) instead of reading it off
+    the op.
+    """
+    full_ranges = list(op.data.ranges)
+    for count, dims in zip(info.loop_count, info.loop_tiled_dims):
+        for d in dims:
+            if 0 <= d < len(full_ranges):
+                full_ranges[d] = sympy.simplify(full_ranges[d] * count)
+    return full_ranges
+
+
+def _compute_fill_loop_info_planned(
+    info: CoarseTileInfo,
+) -> CoarseTileInfo | None:
+    """Planning-time analog of _compute_fill_loop_info.
+
+    Same computation, but takes op's planned CoarseTileInfo directly.
+    """
+    tiled_rdims = info.loop_tiled_reduction_dims
+
+    outer_counts: list[sympy.Expr] = []
+    outer_tiled_dims: list[list[int]] = []
+    outer_tiled_rdims: list[list[int]] = []
+    for dims, _rdims, count in zip(info.loop_tiled_dims, tiled_rdims, info.loop_count):
+        if dims:  # non-empty output-dim list → this is an output-dim level
+            outer_counts.append(count)
+            outer_tiled_dims.append(dims)
+            outer_tiled_rdims.append([])
+
+    if not outer_counts:
+        return None  # flat: fill runs before all loops
+
+    outer_gid = info.loop_group_id[: len(outer_counts)]
+    return CoarseTileInfo(
+        loop_group_id=outer_gid,
+        loop_count=outer_counts,
+        loop_tiled_dims=outer_tiled_dims,
+        loop_tiled_reduction_dims=outer_tiled_rdims,
+        tiled_dims_per_read=[],
+        output_tiled_dims=[],
+    )
+
+
+def _plan_tiling_propagation(
+    operations: list[Operation],
+    groups: list[tuple],
+    plan: dict[int, CoarseTileInfo],
+) -> None:
+    """Decide how every tiled op's result crosses its loop boundary.
+
+    Mirrors _propagate_tiled_op / _propagate_tiled_reduction_op's decision
+    logic exactly, but makes zero mutation: it only reads op.data.ranges/
+    op.get_read_writes() (unmutated at this point -- _apply_plan hasn't run
+    yet) and each op's already-computed planned CoarseTileInfo (looked up by
+    id(op) in `plan`), and stores the result on that same CoarseTileInfo's
+    new `propagation` field.
+
+    Called right after plan_coarse_tile_groups's own per-op loop, over the
+    same `groups`/`plan` -- same zero-mutation contract, same id(op) keying.
+    Untiled/skipped ops (no entry in `plan`) are left untouched.
+    """
+    # Every candidate consumer/producer's outer loop-group key, built once
+    # up front so _find_outside_consumers_planned / _full_buffer_read_deps_planned
+    # don't each re-derive it per candidate. Keyed by name (not id(op)) to
+    # match _reads_buffer/_graph_output_names' own name-based buffer lookup.
+    # Prefer this call's own plan (the freshest data, for ops this call is
+    # about to stamp); fall back to a real, already-stamped loop_info
+    # attribute for ops outside this plan (e.g. from an earlier coarse_tile()
+    # call on the same graph, or already-processed groups within a chained
+    # call) -- exactly the candidates _find_outside_consumers/
+    # _full_buffer_read_deps consult via getattr(op, "loop_info", None) at
+    # transformation time.
+    name_to_group_outer_key: dict[str, int] = {}
+    for op in operations:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        info = plan.get(id(op))
+        if info is None:
+            info = getattr(op, "loop_info", None)
+        if info is not None:
+            name_to_group_outer_key[op.get_name()] = info.loop_group_id[0]
+
+    for group_ops, _levels in groups:
+        for op in group_ops:
+            if not isinstance(op, ComputedBuffer):
+                continue
+            info = plan.get(id(op))
+            if info is None:
+                continue
+
+            full_read_deps = tuple(
+                _full_buffer_read_deps_planned(op, info, name_to_group_outer_key)
+            )
+
+            has_tiled_reduction = any(info.loop_tiled_reduction_dims)
+            if isinstance(op.data, Reduction) and has_tiled_reduction:
+                reduction_type = op.data.reduction_type
+                identity = _reduction_identity_value(reduction_type, op.get_dtype())
+                per_tile_ranges = list(op.data.ranges)
+                full_output_ranges = _compute_full_ranges_planned(op, info)
+                outer_fill_loop_info = _compute_fill_loop_info_planned(info)
+                reduction_plan = ReductionPlan(
+                    reduction_type=reduction_type,
+                    identity=identity,
+                    is_nested=outer_fill_loop_info is not None,
+                    full_output_ranges=full_output_ranges,
+                    per_tile_ranges=per_tile_ranges,
+                    outer_fill_loop_info=outer_fill_loop_info,
+                )
+                buf_name = op.get_name()
+                consumer_names, is_graph_output = _find_outside_consumers_planned(
+                    buf_name, info.loop_group_id, operations, name_to_group_outer_key
+                )
+                info.propagation = PropagationPlan(
+                    kind="reduction",
+                    reduction=reduction_plan,
+                    outside_consumer_names=tuple(consumer_names),
+                    is_graph_output=is_graph_output,
+                    full_read_deps=full_read_deps,
+                )
+                continue
+
+            if all(not dims for dims in info.loop_tiled_dims):
+                info.propagation = PropagationPlan(
+                    kind="loop_internal",
+                    full_read_deps=full_read_deps,
+                )
+                continue
+
+            buf_name = op.get_name()
+            consumer_names, is_graph_output = _find_outside_consumers_planned(
+                buf_name, info.loop_group_id, operations, name_to_group_outer_key
+            )
+            if not consumer_names and not is_graph_output:
+                info.propagation = PropagationPlan(
+                    kind="loop_internal",
+                    full_read_deps=full_read_deps,
+                )
+                continue
+
+            full_ranges = _compute_full_ranges_planned(op, info)
+            info.propagation = PropagationPlan(
+                kind="copy_out",
+                full_ranges=full_ranges,
+                outside_consumer_names=tuple(consumer_names),
+                is_graph_output=is_graph_output,
+                full_read_deps=full_read_deps,
+            )
+
+    _zero_reads_of_fixed_buffers_planned(operations, plan)
+
+
+def _zero_reads_of_fixed_buffers_planned(
+    operations: list[Operation],
+    plan: dict[int, CoarseTileInfo],
+) -> None:
+    """Planning-time analog of _zero_reads_of_fixed_buffers.
+
+    A buffer is "fixed" once _plan_tiling_propagation (just above, in the
+    same call) has decided kind == "loop_internal" for a tiled op (loop
+    _propagate_tiled_op's own equivalent zeroing at loop_info.output_tiled_dims
+    = [] for the same case, plus _propagate_tiled_reduction_op's own
+    unconditional zeroing for any tiled-reduction op -- reduction accumulator
+    buffers are never read by name in the tiled_dims_per_read sense, so they
+    need no separate reader-side zeroing here). Unlike the deleted
+    transformation-time pass, every op's kind is already known for the
+    whole plan at this point (computed above, before any mutation), so
+    there is no reader-before-producer ordering hazard to work around --
+    this always sees the complete, final fixed set on its one and only
+    pass.
+    """
+    fixed_names = {
+        op.get_name()
+        for op in operations
+        if isinstance(op, ComputedBuffer)
+        and (info := plan.get(id(op))) is not None
+        and info.propagation is not None
+        and info.propagation.kind == "loop_internal"
+        and any(dims for dims in info.loop_tiled_dims)
+    }
+    if not fixed_names:
+        return
+
+    for op in operations:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        info = plan.get(id(op))
+        if info is None:
+            continue
+        if op.get_name() in fixed_names and any(info.output_tiled_dims):
+            info.output_tiled_dims = []
+        if not info.tiled_dims_per_read:
+            continue
+        reads = [d for d in op.get_read_writes().reads if isinstance(d, MemoryDep)]
+        for i, dep in enumerate(reads):
+            if dep.name in fixed_names and info.tiled_dims_per_read[i]:
+                info.tiled_dims_per_read[i] = []
 
 
 def _planned_tile_extents_per_level(
@@ -1106,10 +1380,14 @@ def coarse_tile(
     # info.loop_group_id via _apply_plan before it's ever read back out.
     plan = plan_coarse_tile_groups(operations, groups)
 
+    # Planning continued: decide every op's propagation kind (loop-internal
+    # / copy-out / reduction) with zero mutation. Transformation doesn't
+    # consume this yet (still uses its own equivalent, interleaved logic) --
+    # this is purely additive until the cross-check test below is joined by
+    # the Stage 3 migration.
+    _plan_tiling_propagation(operations, groups, plan)
+
     # Transformation: apply the plan. Only reached if planning didn't raise.
-    op_to_position: dict[str, int] = {
-        op.get_operation_name(): i for i, op in enumerate(operations)
-    }
     retiled_infos_by_group: list[
         tuple[tuple[int, ...], list[Operation], dict[str, _RetiledBufferInfo]]
     ] = []
@@ -1230,7 +1508,11 @@ def _zero_reads_of_fixed_buffers(operations: list[Operation]) -> None:
                 loop_info.tiled_dims_per_read[i] = []
 
 
-def _validate_reduction_tiling(op: ComputedBuffer) -> None:
+def _validate_planned_reduction_tiling(
+    op: ComputedBuffer,
+    tiled_dims: list[list[int]],
+    tiled_rdims: list[list[int]],
+) -> None:
     """Raise Unsupported for unsupported Reduction tiling configurations.
 
     Supported:
@@ -1244,16 +1526,12 @@ def _validate_reduction_tiling(op: ComputedBuffer) -> None:
     not an internal invariant violation):
       - Mixed output+reduction tiling at the same nesting level.
       - Multiple reduction range indices tiled at one level.
+
+    Called from plan_coarse_tile_groups (planning time): tiled_dims /
+    tiled_rdims are the op's own per-level lists computed there, before any
+    loop_info is stamped -- this check is a pure function of already-known
+    shape data, so it doesn't need to wait for transformation to run.
     """
-    data = op.data
-    assert isinstance(data, Reduction)
-    loop_info = getattr(op, "loop_info", None)
-    if loop_info is None:
-        return
-
-    tiled_dims = loop_info.loop_tiled_dims
-    tiled_rdims = getattr(loop_info, "loop_tiled_reduction_dims", [])
-
     # Pad both lists to the same length so zip covers all levels.
     n = max(len(tiled_dims), len(tiled_rdims))
     tiled_dims_padded = tiled_dims + [[]] * (n - len(tiled_dims))
@@ -1306,7 +1584,9 @@ def _propagate_tiled_op(
         loop_info = getattr(op, "loop_info", None)
 
     if isinstance(op.data, Reduction):
-        _validate_reduction_tiling(op)
+        # Unsupported reduction-tiling shapes are already rejected during
+        # planning (_validate_planned_reduction_tiling, called from
+        # plan_coarse_tile_groups) -- no need to re-check here.
         has_tiled_reduction = loop_info is not None and any(
             dims for dims in getattr(loop_info, "loop_tiled_reduction_dims", [])
         )

--- a/torch_spyre/_inductor/wsr/coarse_tile_span_overflow.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile_span_overflow.py
@@ -356,11 +356,11 @@ def span_overflow_groups(
         plan = plan_span_overflow_tile(op, config.sencores)
         if plan is None:
             # op needs no coarse tiling of its own.  It's always safe to leave
-            # it outside any loop: insert_tiling_propagation's outside-consumer
-            # path (coarse_tile.py) already patches consumers of a tiled
-            # producer to read a full, reassembled buffer, and
-            # plan_span_overflow_tile returning None here means that op's own
-            # full-size reads/writes are already known not to overflow.
+            # it outside any loop: Pass 3's outside-consumer path
+            # (coarse_tile.py) already patches consumers of a tiled producer
+            # to read a full, reassembled buffer, and plan_span_overflow_tile
+            # returning None here means that op's own full-size reads/writes
+            # are already known not to overflow.
             logger.debug("[span-overflow groups] op=%s no auto plan", op.get_name())
             flush_current_group()
             continue


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://g
ithub.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Splits `coarse_tile.py`'s tiling-propagation logic into a clean
plan/execute pipeline, matching the pattern already used by
`plan_coarse_tile_groups` / `_apply_plan` for tiling decisions.

Previously, `insert_tiling_propagation` → `_propagate_tiled_op` /
`_propagate_tiled_reduction_op` interleaved decision-making ("should this
op's result cross its loop boundary, and how?") with mutation (allocating
buffers, splicing them into `operations`) in one big per-op dispatcher.
This required an object-identity resync hack (`group_ops[idx] = current`)
after every call, and a forced second graph-wide pass
(`_zero_reads_of_fixed_buffers`) purely to work around visitation-order
dependence in the old code.

Staged as eight commits:

1. **Stages 1-2** (`2da42034`) — delete a dead `op_to_position` prebuild,
   hoist `_validate_reduction_tiling`'s `Unsupported` raises into planning,
   and add `PropagationPlan`/`ReductionPlan` to `loop_info.py` plus
   `_plan_tiling_propagation`, which front-loads every op's `kind`
   (`loop_internal` / `copy_out` / `reduction`) and the shape/identity data
   needed to execute it — all before any mutation runs.
2. **Stage 3a** (`b84d9aae`) — extract Pass 1 (read copy-ins) into a
   standalone `_insert_all_read_copy_ops`, run once for all ops.
3. **Stage 3b** (`f5668a39`) — extract Pass 2 (reduction machinery:
   accumulator/fill/combine) into `_insert_all_reduction_ops`.
4. **Stage 3c** (`a17ce2d7`) — extract Pass 3 (write copy-outs) into
   `_insert_all_write_copy_ops`, and delete the old per-op resync hack now
   that each pass re-resolves "current object for name X" fresh from
   `operations` instead of carrying stale references across mutation
   boundaries.
5. **Stage 3d** (`d9857249`) — delete `_zero_reads_of_fixed_buffers`
   entirely; the planning-time `kind` lookup makes "is this buffer fixed"
   a precomputed fact rather than an emergent, order-dependent one.
6. **Stage 4** (`7f670904`) — add five logging checkpoints spanning the
   full pipeline (post-planning plan dump, then one per pass, then a
   self-check comparing planned vs. actual new-op counts) so a single
   `TORCH_LOGS`/`SPYRE_INDUCTOR_LOG` capture tells the complete
   plan-then-execute story in order.
7. **Review fix** (`097315ee`) — code review on this PR flagged that
   Stage 4's self-check (checkpoint 5) was a coarse aggregate tally that
   couldn't actually catch its stated target (a silently-dropped combine
   op wouldn't move the fill-buffer count at all). Replaced with a
   per-op, by-name existence check: for every op the plan routed to
   `copy_out`/`reduction`, verify the buffers its kind requires actually
   exist in `operations`. Making the check per-op surfaced a real latent
   bug in the checkpoint itself — it looked up each op's predicted kind
   via `plan.get(id(op))`, but the resync loop immediately before
   checkpoint 5 overwrites `group_ops` in place with post-transformation
   replacement objects (the same list objects `groups` holds references
   to), so every replaced op's `id()` no longer matched a `plan` key by
   checkpoint-5 time. Fixed by snapshotting `predicted_kind_by_name` from
   `groups`/`plan` before that resync loop runs.
8. **Cleanup** (`59e488ab`) — the same review raised the question of
   whether `insert_tiling_propagation`'s no-op status was meant to be
   permanent API surface, kept solely for two `@patch` mock points in
   span-overflow tests. Investigated and confirmed those patches were
   inert (Passes 1-3 already run unconditionally before that call), so
   deleted the wrapper, its call site, and both mock points, updating
   the handful of comments elsewhere that used it as a pipeline-ordering
   landmark to name the actual pass instead.

Transformation is now a fixed, non-interleaved sequence of passes that
only *consumes* planning's decisions — it never makes new ones.

Two real, pre-existing bugs were found and fixed along the way (see commit
messages for `f5668a39`, `a17ce2d7`, `d9857249` for full root-cause
writeups):

- A `copy_buf` produced by the read-copy-in pass was inheriting its source
  op's `PropagationPlan` wholesale via a bulk `dataclasses.replace`,
  causing Pass 2 to misdispatch it.
- `_patch_retiled_load_indexes` was reading a `group_ops` snapshot
  captured before Pass 1/2/3 ran; deleting the old resync hack without a
  replacement broke two tests until each pass's mutations were re-resolved
  by name immediately before that call.
- `_zero_reads_of_fixed_buffers_planned`'s `fixed_names` set excluded
  `kind == "reduction"` ops, but a tiled-reduction op's own buffer (e.g.
  softmax's amax result) can be read by name by a sibling op in the same
  loop group, exactly like `copy_out`/`loop_internal` buffers — fixed by
  dropping the `kind` filter entirely.

A pre-existing, order-dependent test failure
(`test_copy_after_reduction_512x256_A4_B4`, fails alone but passes with
its siblings) was found during verification but confirmed present on the
pre-Stage-3b baseline too — out of scope for this PR, not fixed here. Not
yet filed as a tracked issue; currently documented only in this repo's own
session notes.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

- Eight commits are each independently reviewable and were each verified
  with the full `test_coarse_tiling.py` + `test_coarse_tile_e2e.py` suite
  before landing (see individual commit messages for per-stage results).
- Final verification for the full branch:
  `test_coarse_tiling.py` + `test_coarse_tile_e2e.py` +
  `test_span_overflow_hint_analysis.py` + `test_building_blocks.py`: 512
  passed, 49 skipped, 3 xfailed.
  `pre-commit run --all-files`: clean.
- Stage 4's logging checkpoints are pure `logger.debug` additions with no
  behavioral effect on non-debug runs; verified functional by setting
  `SPYRE_INDUCTOR_LOG=1 SPYRE_INDUCTOR_LOG_LEVEL=DEBUG` before process
  start (torch.compile's async-compile subprocess workers re-read env
  vars independently at startup, so in-process log-level changes made
  after workers spawn don't reach them — this is a pre-existing
  characteristic of the logging infrastructure, not new in this PR).
- `insert_tiling_propagation` (the no-op wrapper kept only for two
  span-overflow `@patch` mock points) has been deleted (`59e488ab`) —
  confirmed both patches were inert (Passes 1-3 already ran
  unconditionally before that call), so removing it and its mock points
  changes no observable behavior. A couple of stale comments/docstrings
  describing pre-plan/execute-split mechanics in
  `docs/source/compiler/coarse_tiling_loops.md`/`inductor_frontend.md`
  and two test docstrings in `test_coarse_tiling.py` still mention the
  old name — left as a separate, out-of-scope doc-accuracy follow-up
  (the docs need a fuller rewrite of the buffer-propagation section, not
  a find-replace).

#### Does this PR introduce a user-facing change?

No. This is an internal refactor of the coarse-tiling compiler pass with
no change to supported operations, generated code behavior, or the public
API. The new logging checkpoints are opt-in via existing `TORCH_LOGS`/
`SPYRE_INDUCTOR_LOG` mechanisms.

#### Additional note: