### PR TITLE
Emit KTIR for a pointwise op

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_opspec_utils_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_opspec_utils_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [core, full]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_opspec_utils.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_ktir_emitter.py
+++ b/tests/inductor/test_ktir_emitter.py
@@ -1,0 +1,130 @@
+# Copyright 2025-2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Golden-text snapshot test for the OpSpec->KTIR emitter (``generate_ktir``).
+
+Self-contained: it builds the ``add`` OpSpec directly (no live Inductor graph,
+no compiler run) and asserts the emitter's canonical MLIR text.
+Skipped only where ``mlir_ktdp`` is not installed.
+"""
+
+import unittest
+
+import sympy
+
+from torch_spyre._C import DataFormats
+from torch_spyre._inductor.op_spec import OpSpec, TensorArg
+
+
+def _mlir_ktdp_available() -> bool:
+    """True when mlir_ktdp is built with the func/arith dialect Python bindings."""
+    try:
+        from mlir_ktdp import ir  # noqa: F401
+        from mlir_ktdp.dialects import arith, func, ktdp  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+# The canonical KTIR text ``generate_ktir`` emits for a single pointwise ``add``
+# over a [512, 1024] fp16 tensor stickified to device shape [16, 512, 64].
+_EXPECTED_ADD_KTIR = """\
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#set = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 15 >= 0, d1 >= 0, -d1 + 511 >= 0, d2 >= 0, -d2 + 63 >= 0)>
+module {
+  func.func @ktir_fused_add_0(%arg0: index, %arg1: index, %arg2: index) attributes {grid = [1]} {
+    %c0 = arith.constant 0 : index
+    %0 = ktdp.construct_memory_view %arg0, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %1 = ktdp.construct_memory_view %arg1, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %2 = ktdp.construct_memory_view %arg2, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %3 = ktdp.construct_access_tile %0[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    %4 = ktdp.load %3 : <16x512x64xindex> -> tensor<16x512x64xf16>
+    %5 = ktdp.construct_access_tile %1[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    %6 = ktdp.load %5 : <16x512x64xindex> -> tensor<16x512x64xf16>
+    %7 = arith.addf %4, %6 : tensor<16x512x64xf16>
+    %8 = ktdp.construct_access_tile %2[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    ktdp.store %7, %8 : tensor<16x512x64xf16>, <16x512x64xindex>
+    return
+  }
+}
+"""
+
+
+def _add_op_specs() -> list:
+    """Finished OpSpec list for ``a + b`` at device shape [16, 512, 64] fp16.
+
+    This mirrors what the SuperDSC frontend produces for a pointwise ``a + b``:
+    two HBM inputs and one HBM output, each addressed at the identity
+    coordinates ``(d0, d1, d2)`` over the stickified device shape.
+    """
+    d0, d1, d2 = sympy.symbols("d0 d1 d2")
+    coords = [d0, d1, d2]
+    size = [16, 512, 64]
+
+    def arg(is_input: bool, index: int, name: str) -> TensorArg:
+        return TensorArg(
+            is_input=is_input,
+            arg_index=index,
+            device_dtype=DataFormats.SEN169_FP16,
+            device_size=list(size),
+            device_coordinates=list(coords),
+            allocation={"hbm": None},
+            name=name,
+        )
+
+    return [
+        OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space={d0: (16, 1), d1: (512, 1), d2: (64, 1)},
+            args=[
+                arg(True, 0, "arg0"),
+                arg(True, 1, "arg1"),
+                arg(False, 2, "buf0"),
+            ],
+            op_info={},
+        )
+    ]
+
+
+@unittest.skipUnless(
+    _mlir_ktdp_available(),
+    "mlir_ktdp with func/arith dialect bindings is not installed",
+)
+class TestKtirEmitter(unittest.TestCase):
+    def test_pointwise_add_golden(self):
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        emitted = generate_ktir("ktir_fused_add_0", _add_op_specs())
+        self.assertEqual(emitted, _EXPECTED_ADD_KTIR)
+
+    def test_reduction_unsupported(self):
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        specs = _add_op_specs()
+        specs[0].is_reduction = True
+        with self.assertRaises(NotImplementedError):
+            generate_ktir("ktir_fused_add_0", specs)
+
+    def test_non_add_unsupported(self):
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        specs = _add_op_specs()
+        specs[0].op = "mul"
+        with self.assertRaises(NotImplementedError):
+            generate_ktir("ktir_fused_mul_0", specs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/inductor/test_ktir_emitter.py
+++ b/tests/inductor/test_ktir_emitter.py
@@ -20,6 +20,7 @@ Skipped only where ``mlir_ktdp`` is not installed.
 """
 
 import unittest
+from unittest import mock
 
 import sympy
 
@@ -98,6 +99,10 @@ def _add_op_specs() -> list:
     ]
 
 
+# The emitter only supports the single-core (SENCORES=1) grid so far; pin it so
+# these tests exercise their intended guards rather than the multi-core guard,
+# which would otherwise fire first on the default SENCORES=32.
+@mock.patch("torch_spyre._inductor.config.sencores", 1)
 @unittest.skipUnless(
     _mlir_ktdp_available(),
     "mlir_ktdp with func/arith dialect bindings is not installed",
@@ -124,6 +129,17 @@ class TestKtirEmitter(unittest.TestCase):
         specs[0].op = "mul"
         with self.assertRaises(NotImplementedError):
             generate_ktir("ktir_fused_mul_0", specs)
+
+
+class TestKtirCapabilityGuards(unittest.TestCase):
+    """Guards that fire before the mlir_ktdp import, so they need no dialect."""
+
+    @mock.patch("torch_spyre._inductor.config.sencores", 2)
+    def test_multicore_unsupported(self):
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        with self.assertRaises(NotImplementedError):
+            generate_ktir("ktir_fused_add_0", _add_op_specs())
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_opspec_utils.py
+++ b/tests/inductor/test_opspec_utils.py
@@ -1,0 +1,199 @@
+# Copyright 2025-2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the pure OpSpec-reading helpers in ``opspec_utils``.
+
+These helpers (buffer identity, row-major strides, device-dim classification,
+reshape/broadcast alignment) are pure sympy/int computations with no MLIR
+emission, so this suite runs in CI without ``mlir_ktdp`` installed -- unlike
+``test_ktir_emitter`` which pins the emitted MLIR text and skips without it.
+"""
+
+import unittest
+
+import sympy
+from torch.utils._sympy.functions import FloorDiv
+
+from torch_spyre._C import DataFormats
+from torch_spyre._inductor.codegen.opspec_utils import (
+    _DIM_BARE,
+    _DIM_CONST,
+    _DIM_OUTER_STICK,
+    _DIM_WITHIN_STICK,
+    _align_reshape_plan,
+    _buf_id,
+    _dim_info,
+    _iteration_space_key,
+    _row_major_strides,
+)
+from torch_spyre._inductor.op_spec import OpSpec, TensorArg
+
+
+def _arg(name, arg_index=0) -> TensorArg:
+    """Minimal TensorArg; only ``name`` matters for ``_buf_id``."""
+    return TensorArg(
+        is_input=True,
+        arg_index=arg_index,
+        device_dtype=DataFormats.SEN169_FP16,
+        device_size=[64],
+        device_coordinates=[sympy.Symbol("d0")],
+        allocation={"hbm": None},
+        name=name,
+    )
+
+
+class TestRowMajorStrides(unittest.TestCase):
+    def test_rank3(self):
+        self.assertEqual(_row_major_strides([16, 512, 64]), [32768, 64, 1])
+
+    def test_rank1(self):
+        self.assertEqual(_row_major_strides([64]), [1])
+
+    def test_rank2(self):
+        self.assertEqual(_row_major_strides([8, 3]), [3, 1])
+
+
+class TestBufId(unittest.TestCase):
+    def test_name_is_identity(self):
+        self.assertEqual(_buf_id(_arg("buf0")), "buf0")
+
+    def test_same_name_same_id_across_input_output(self):
+        # An intermediate appearing as both input and output (arg_index sentinel
+        # -1 either side) must key on the shared name, not arg_index.
+        as_in = _arg("buf7", arg_index=-1)
+        as_out = _arg("buf7", arg_index=-1)
+        self.assertEqual(_buf_id(as_in), _buf_id(as_out))
+
+    def test_none_name_raises_value_error(self):
+        # Missing name is a broken internal invariant, not a capability gap:
+        # ValueError, not NotImplementedError.
+        with self.assertRaises(ValueError):
+            _buf_id(_arg(None))
+
+
+class TestDimInfo(unittest.TestCase):
+    def test_const_dim(self):
+        self.assertEqual(_dim_info(sympy.Integer(1)), (_DIM_CONST, None))
+
+    def test_bare_symbol(self):
+        d0 = sympy.Symbol("d0")
+        self.assertEqual(_dim_info(d0), (_DIM_BARE, d0))
+
+    def test_within_stick(self):
+        d0 = sympy.Symbol("d0")
+        kind, sym = _dim_info(sympy.Mod(d0, 64))
+        self.assertEqual(kind, _DIM_WITHIN_STICK)
+        self.assertEqual(sym, d0)
+
+    def test_outer_stick(self):
+        d0 = sympy.Symbol("d0")
+        kind, sym = _dim_info(FloorDiv(d0, 64))
+        self.assertEqual(kind, _DIM_OUTER_STICK)
+        self.assertEqual(sym, d0)
+
+    def test_multi_symbol_raises(self):
+        d0, d1 = sympy.symbols("d0 d1")
+        with self.assertRaises(NotImplementedError):
+            _dim_info(d0 * 8 + d1)
+
+    def test_single_symbol_unknown_form_raises(self):
+        # A single-symbol coordinate that is neither bare, within-stick, nor
+        # outer-stick (e.g. ``2*d0 + 1``) must raise, not fall through.
+        d0 = sympy.Symbol("d0")
+        with self.assertRaises(NotImplementedError):
+            _dim_info(2 * d0 + 1)
+
+
+class TestIterationSpaceKey(unittest.TestCase):
+    def test_order_independent(self):
+        d0, d1 = sympy.symbols("d0 d1")
+        spec_a = OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space={d0: (16, 1), d1: (512, 1)},
+            args=[],
+            op_info={},
+        )
+        spec_b = OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space={d1: (512, 1), d0: (16, 1)},
+            args=[],
+            op_info={},
+        )
+        self.assertEqual(_iteration_space_key(spec_a), _iteration_space_key(spec_b))
+
+    def test_distinct_ranges_differ(self):
+        d0 = sympy.Symbol("d0")
+        spec_a = OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space={d0: (16, 1)},
+            args=[],
+            op_info={},
+        )
+        spec_b = OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space={d0: (32, 1)},
+            args=[],
+            op_info={},
+        )
+        self.assertNotEqual(_iteration_space_key(spec_a), _iteration_space_key(spec_b))
+
+
+class TestAlignReshapePlan(unittest.TestCase):
+    def test_identity_returns_none(self):
+        d0, d1 = sympy.symbols("d0 d1")
+        self.assertIsNone(_align_reshape_plan([d0, d1], [16, 64], [d0, d1], [16, 64]))
+
+    def test_broadcast_unmatched_output_axis(self):
+        # Input [a, within] aligned into output [a, b, within]: the output's
+        # ``b`` axis has no input counterpart, so it reshapes to extent 1 and
+        # then broadcasts to the output block.
+        a, b, c = sympy.symbols("a b c")
+        plan = _align_reshape_plan(
+            [a, sympy.Mod(c, 64)],
+            [16, 64],
+            [a, b, sympy.Mod(c, 64)],
+            [16, 8, 64],
+        )
+        self.assertEqual(plan, ([16, 1, 64], [16, 8, 64]))
+
+    def test_transpose_raises(self):
+        # Matched input axes in decreasing order -> would need a permute.
+        a, b, c = sympy.symbols("a b c")
+        with self.assertRaises(NotImplementedError):
+            _align_reshape_plan(
+                [b, a, sympy.Mod(c, 64)],
+                [2, 3, 64],
+                [a, b, sympy.Mod(c, 64)],
+                [3, 2, 64],
+            )
+
+    def test_dropped_extent_raises(self):
+        # An input axis with extent > 1 that no output axis matches would lose
+        # data -> needs a cross-stick transpose (restickify), not a reshape.
+        a, d, c = sympy.symbols("a d c")
+        with self.assertRaises(NotImplementedError):
+            _align_reshape_plan(
+                [a, sympy.Mod(c, 64)],
+                [4, 64],
+                [d, sympy.Mod(c, 64)],
+                [4, 64],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/check_test_coverage.sh
+++ b/tests/scripts/check_test_coverage.sh
@@ -54,6 +54,10 @@ TESTS_DIR="${REPO_ROOT}/tests"
 # (e.g. shared test harness helpers, not standalone test suites).
 IGNORED_TEST_FILES=(
   "models/test_model_ops.py"   # base class / helper — not a standalone test suite
+  # Golden IR suite: requires the dialect-packaged mlir_ktdp build, which no CI
+  # lane provides, so it is skip-only in CI. Revisit when a KTIR/mlir_ktdp lane
+  # exists.
+  "inductor/test_ktir_emitter.py"
 )
 
 # ── Ignore list: config files ─────────────────────────────────────────────────

--- a/torch_spyre/_inductor/codegen/ktir.py
+++ b/torch_spyre/_inductor/codegen/ktir.py
@@ -1,0 +1,296 @@
+# Copyright 2025-2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpSpec -> KTIR emitter.
+
+``generate_ktir`` is an OpSpec consumer: it consumes the finished
+``list[OpSpec | LoopSpec]`` kernel contract (the same contract the SDSC bundle
+emitter ``generate_bundle`` consumes) and emits **KTDP-dialect MLIR** directly.
+The module is built with the ``mlir_ktdp`` Python builders, so the returned
+``str(module)`` is canonical, verifier-checked MLIR that the golden snapshot
+test consumes without drift.
+
+It uses the OpSpec-reading helpers from ``opspec_utils`` to adapt the OpSpec
+information to generate_ktir.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from torch_spyre._C import DataFormats
+from torch_spyre._inductor.codegen.opspec_utils import (
+    _align_reshape_plan,
+    _buf_id,
+    _row_major_strides,
+)
+from torch_spyre._inductor.op_spec import LoopSpec, OpSpec, TensorArg, UnimplementedOp
+
+# Pointwise op name -> the ``arith`` float builder that implements it.  Only
+# ``add`` is wired up so far; other ops raise before reaching here.
+_ARITH_FLOAT_OP = {"add": "AddFOp"}
+
+
+def _mlir_elt_type(ir, device_dtype: DataFormats):
+    """The ``mlir_ktdp.ir`` element type for a Spyre device dtype.
+
+    ``ir`` is the lazily-imported ``mlir_ktdp.ir`` module (the file never
+    imports it at top level, so it stays importable where the dialect build is
+    absent).  The two fp16 device formats both map to ``f16``; extend this map
+    (never fall through silently) as new dtypes are supported.
+    """
+    # Direct type-builder references (not name strings) resolved here, where
+    # ``ir`` is in scope.
+    mapping = {
+        DataFormats.IEEE_FP16: ir.F16Type,
+        DataFormats.SEN169_FP16: ir.F16Type,
+        DataFormats.IEEE_FP32: ir.F32Type,
+        DataFormats.BFLOAT16: ir.BF16Type,
+    }
+    builder = mapping.get(device_dtype)
+    if builder is None:
+        raise NotImplementedError(
+            f"OpSpec->KTIR: unsupported device dtype {device_dtype!r}"
+        )
+    return builder.get()
+
+
+def generate_ktir(
+    kernel_name: str,
+    specs: Sequence[OpSpec | LoopSpec | UnimplementedOp],
+) -> str:
+    """Build a KTDP-dialect MLIR module for ``specs`` and return ``str(module)``.
+
+    ``specs`` is the finished OpSpec kernel contract (the same value
+    ``call_kernel`` passes positionally to ``.run(...)``).  Func parameters are
+    the unique operand buffers in ascending ``arg_index`` order so the emitted
+    signature matches that positional binding.
+    """
+    # ``mlir_ktdp`` is imported lazily so the module stays importable (and the
+    # golden test can skip) where the dialect-packaged mlir_ktdp is not built.
+    from mlir_ktdp import ir
+    from mlir_ktdp.dialects import arith, func, ktdp
+
+    op_specs = _collect_pointwise_op_specs(specs)
+
+    # Ordered unique operand buffers -> func parameter position.  Ascending
+    # arg_index matches the positional order call_kernel passes to .run(...),
+    # so the emitted func signature lines up with that binding.
+    ordered_args: dict[object, TensorArg] = {}
+    for spec in op_specs:
+        for arg in spec.args:
+            ordered_args.setdefault(_buf_id(arg), arg)
+    param_args = sorted(ordered_args.values(), key=lambda a: a.arg_index)
+    param_index = {_buf_id(a): i for i, a in enumerate(param_args)}
+
+    with ir.Context() as ctx, ir.Location.unknown():
+        ktdp.register_dialects(ctx)
+        index_t = ir.IndexType.get()
+
+        module = ir.Module.create()
+        with ir.InsertionPoint(module.body):
+            fn_type = ir.FunctionType.get([index_t] * len(param_args), [])
+            fn = func.FuncOp(kernel_name, fn_type)
+            # Single-core (SENCORES=1) grid; work-division scaling is future work.
+            i64 = ir.IntegerType.get_signless(64)
+            fn.attributes["grid"] = ir.ArrayAttr.get([ir.IntegerAttr.get(i64, 1)])
+            block = fn.add_entry_block()
+            block_args = list(block.arguments)
+
+            with ir.InsertionPoint(block):
+                c0 = arith.ConstantOp(index_t, 0)
+
+                # One memory view per unique buffer, in param order.
+                memory_views: dict[object, ir.Value] = {}
+                for arg in param_args:
+                    bid = _buf_id(arg)
+                    memory_views[bid] = _emit_memory_view(
+                        ir, ktdp, arg, block_args[param_index[bid]]
+                    )
+
+                for spec in op_specs:
+                    _emit_pointwise_op(ir, ktdp, arith, spec, memory_views, c0)
+
+                func.ReturnOp([])
+
+        return str(module)
+
+
+def _collect_pointwise_op_specs(
+    specs: Sequence[OpSpec | LoopSpec | UnimplementedOp],
+) -> list[OpSpec]:
+    """Validate ``specs`` and return the flat list of pointwise ``OpSpec``s.
+
+    Rejects everything outside the supported scope with an explicit
+    ``NotImplementedError``.
+    """
+    op_specs: list[OpSpec] = []
+    for entry in specs:
+        if isinstance(entry, UnimplementedOp):
+            raise NotImplementedError(f"OpSpec->KTIR: unimplemented op {entry.op!r}")
+        if isinstance(entry, LoopSpec):
+            raise NotImplementedError(
+                "OpSpec->KTIR: counted loops (LoopSpec) are not supported yet"
+            )
+        if not isinstance(entry, OpSpec):
+            raise NotImplementedError(
+                f"OpSpec->KTIR: unexpected spec entry {type(entry).__name__}"
+            )
+        if entry.is_reduction:
+            raise NotImplementedError("OpSpec->KTIR: reductions are not supported yet")
+        if entry.op not in _ARITH_FLOAT_OP:
+            raise NotImplementedError(
+                f"OpSpec->KTIR: op {entry.op!r} is not supported yet "
+                "(only pointwise 'add')"
+            )
+        op_specs.append(entry)
+    if not op_specs:
+        raise NotImplementedError("OpSpec->KTIR: no OpSpec to emit")
+    return op_specs
+
+
+def _emit_memory_view(ir, ktdp, arg: TensorArg, offset):
+    """Emit ``ktdp.construct_memory_view`` for one buffer, return its SSA value."""
+    sizes = [int(s) for s in arg.device_size]
+    strides = _row_major_strides(sizes)
+    memref_t = ir.MemRefType.get(sizes, _mlir_elt_type(ir, arg.device_dtype))
+    coord_set = _coordinate_set_attr(ir, sizes)
+    # No Python builder is exposed for the ``spyre_memory_space`` enum attribute
+    # (only the ktdp *types* have getters), so this small enum literal is the one
+    # unavoidable textual attribute.
+    memory_space = ir.Attribute.parse("#ktdp.spyre_memory_space<HBM>")
+    # All extents are static -> empty dynamic size/stride operand lists.
+    return ktdp.construct_memory_view(
+        memref_t,
+        offset,
+        [],
+        [],
+        sizes,
+        strides,
+        memory_space,
+        coord_set,
+    )
+
+
+def _emit_pointwise_op(ir, ktdp, arith, spec: OpSpec, memory_views, c0):
+    """Emit the load / compute / store sequence for one pointwise ``OpSpec``."""
+    inputs = [a for a in spec.args if a.is_input]
+    outputs = [a for a in spec.args if not a.is_input]
+    if len(outputs) != 1:
+        raise NotImplementedError(
+            f"OpSpec->KTIR: expected exactly one output, got {len(outputs)}"
+        )
+    if len(inputs) != 2:
+        raise NotImplementedError(
+            f"OpSpec->KTIR: 'add' expects two inputs, got {len(inputs)}"
+        )
+    out = outputs[0]
+
+    out_extents = [int(s) for s in out.device_size]
+    for arg in inputs:
+        # In-place (input buffer aliases the output) is not supported yet.
+        if _buf_id(arg) == _buf_id(out):
+            raise NotImplementedError(
+                "OpSpec->KTIR: in-place ops (input aliases output) not supported"
+            )
+        # Reject broadcast / transpose operands: only operands whose device
+        # axes already match the output tile exactly are supported.
+        plan = _align_reshape_plan(
+            list(arg.device_coordinates),
+            [int(s) for s in arg.device_size],
+            list(out.device_coordinates),
+            out_extents,
+        )
+        if plan is not None:
+            raise NotImplementedError(
+                "OpSpec->KTIR: broadcast / reshape operands not supported yet"
+            )
+
+    # Every operand buffer must be a func parameter (register-threaded fused
+    # intermediates are not supported yet).
+    for arg in spec.args:
+        if _buf_id(arg) not in memory_views:
+            raise NotImplementedError(
+                "OpSpec->KTIR: fused intermediates (register threading) "
+                "not supported yet"
+            )
+
+    loaded = [
+        _emit_load(ir, ktdp, arg, memory_views[_buf_id(arg)], c0) for arg in inputs
+    ]
+
+    builder = getattr(arith, _ARITH_FLOAT_OP[spec.op])
+    result = builder(loaded[0], loaded[1])
+
+    _emit_store(ir, ktdp, out, memory_views[_buf_id(out)], result, c0)
+
+
+def _emit_access_tile(ir, ktdp, arg: TensorArg, memory_view, c0):
+    """Emit ``ktdp.construct_access_tile`` for ``arg``, return its SSA value."""
+    sizes = [int(s) for s in arg.device_size]
+    rank = len(sizes)
+    at_t = ktdp.AccessTileType.get(sizes, ir.IndexType.get())
+    identity = ir.AffineMapAttr.get(ir.AffineMap.get_identity(rank))
+    tile_set = _coordinate_set_attr(ir, sizes)
+    return ktdp.construct_access_tile(
+        at_t,
+        memory_view,
+        identity,
+        [c0] * rank,
+        [],
+        tile_set,
+        identity,
+    )
+
+
+def _emit_load(ir, ktdp, arg: TensorArg, memory_view, c0):
+    """Emit an access tile + ``ktdp.load`` for an input ``arg``."""
+    sizes = [int(s) for s in arg.device_size]
+    tensor_t = ir.RankedTensorType.get(sizes, _mlir_elt_type(ir, arg.device_dtype))
+    tile = _emit_access_tile(ir, ktdp, arg, memory_view, c0)
+    return ktdp.load(tensor_t, tile)
+
+
+def _emit_store(ir, ktdp, arg: TensorArg, memory_view, value, c0):
+    """Emit an access tile + ``ktdp.store`` of ``value`` into output ``arg``."""
+    tile = _emit_access_tile(ir, ktdp, arg, memory_view, c0)
+    ktdp.store(value, tile)
+
+
+# ---------------------------------------------------------------------------
+# Attribute builders
+# ---------------------------------------------------------------------------
+
+
+def _coordinate_set_attr(ir, sizes: list[int]):
+    """Per-dim bounding integer set ``(0 <= d_i <= size_i - 1)`` as an attribute.
+
+    Built with ``ir.IntegerSet`` from ``AffineExpr`` constraints (no textual
+    round-trip): for each dim ``i`` two inequalities ``d_i >= 0`` and
+    ``-d_i + (size_i - 1) >= 0``, matching the ``affine_set`` MLIR prints.
+    """
+    exprs = []
+    eq_flags: list[bool] = []
+    for i, s in enumerate(sizes):
+        dim = ir.AffineExpr.get_dim(i)
+        # d_i >= 0
+        exprs.append(dim)
+        eq_flags.append(False)
+        # -d_i + (size_i - 1) >= 0
+        neg_dim = ir.AffineExpr.get_mul(ir.AffineExpr.get_constant(-1), dim)
+        upper = ir.AffineExpr.get_add(neg_dim, ir.AffineExpr.get_constant(int(s) - 1))
+        exprs.append(upper)
+        eq_flags.append(False)
+    integer_set = ir.IntegerSet.get(len(sizes), 0, exprs, eq_flags)
+    return ir.IntegerSetAttr.get(integer_set)

--- a/torch_spyre/_inductor/codegen/ktir.py
+++ b/torch_spyre/_inductor/codegen/ktir.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from torch_spyre._C import DataFormats
+from torch_spyre._inductor import config as _spyre_config
 from torch_spyre._inductor.codegen.opspec_utils import (
     _align_reshape_plan,
     _buf_id,
@@ -77,21 +78,39 @@ def generate_ktir(
     the unique operand buffers in ascending ``arg_index`` order so the emitted
     signature matches that positional binding.
     """
+    # Pure capability checks first, before the mlir_ktdp import: they need no
+    # dialect build, so an unsupported request fails fast (and is testable)
+    # whether or not mlir_ktdp is installed.
+    #
+    # Multi-core work division is future work; the grid below is hard-coded to a
+    # single core, so reject anything else rather than silently emitting a
+    # single-core grid on a multi-core request.
+    if _spyre_config.sencores != 1:
+        raise NotImplementedError(
+            "OpSpec->KTIR: multi-core work division is not supported yet "
+            f"(SENCORES={_spyre_config.sencores}, only 1 is supported)"
+        )
+    op_specs = _collect_pointwise_op_specs(specs)
+
     # ``mlir_ktdp`` is imported lazily so the module stays importable (and the
     # golden test can skip) where the dialect-packaged mlir_ktdp is not built.
     from mlir_ktdp import ir
     from mlir_ktdp.dialects import arith, func, ktdp
 
-    op_specs = _collect_pointwise_op_specs(specs)
-
     # Ordered unique operand buffers -> func parameter position.  Ascending
     # arg_index matches the positional order call_kernel passes to .run(...),
-    # so the emitted func signature lines up with that binding.
+    # so the emitted func signature lines up with that binding.  Only real
+    # external buffers (arg_index >= 0) become func parameters; register-threaded
+    # fused intermediates carry the -1 sentinel and are threaded as SSA values,
+    # never bound positionally.
     ordered_args: dict[object, TensorArg] = {}
     for spec in op_specs:
         for arg in spec.args:
             ordered_args.setdefault(_buf_id(arg), arg)
-    param_args = sorted(ordered_args.values(), key=lambda a: a.arg_index)
+    param_args = sorted(
+        (a for a in ordered_args.values() if a.arg_index >= 0),
+        key=lambda a: a.arg_index,
+    )
     param_index = {_buf_id(a): i for i, a in enumerate(param_args)}
 
     with ir.Context() as ctx, ir.Location.unknown():

--- a/torch_spyre/_inductor/codegen/opspec_utils.py
+++ b/torch_spyre/_inductor/codegen/opspec_utils.py
@@ -1,0 +1,208 @@
+# Copyright 2025-2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpSpec-reading helpers.
+
+The KTIR emitter consumes the *finished* ``OpSpec`` list and must agree on the
+"decision / arithmetic" it implies: buffer identity, row-major strides,
+iteration-space grouping, and reshape / broadcast alignment of pointwise
+operands.  Those computations are **pure** (sympy / int over the ``op_specs``)
+-- no backend emission primitives, no MLIR builder, no live Inductor kernel
+state -- so they live here as plain functions rather than as base-class methods.
+"""
+
+from __future__ import annotations
+
+import sympy
+from torch._inductor.virtualized import V
+from torch.utils._sympy.functions import ModularIndexing
+
+from torch_spyre._inductor.op_spec import OpSpec, TensorArg
+
+
+def _size_hint(expr) -> int:
+    """Concrete size hint for an iteration-space range expression."""
+    if isinstance(expr, (int, sympy.Integer)):
+        return int(expr)
+    return int(V.graph.sizevars.size_hint(expr))
+
+
+def _row_major_strides(device_size: list[int]) -> list[int]:
+    """Row-major (C-contiguous) strides for a device-size list."""
+    n = len(device_size)
+    strides = [1] * n
+    for i in range(n - 2, -1, -1):
+        strides[i] = strides[i + 1] * int(device_size[i + 1])
+    return strides
+
+
+def _buf_id(arg: TensorArg) -> str:
+    """Stable identity of the buffer an op arg refers to, for register threading.
+
+    Keys on the op-spec ``name`` (the buffer name): unique per buffer and
+    identical whether the buffer appears as an input or an output, so a
+    fused-away intermediate threads its register value without aliasing.
+    ``arg_index`` cannot serve as the identity -- distinct fused-away
+    intermediates all carry the unassigned sentinel ``-1``.
+
+    ``name`` must therefore be populated on every projected op arg (see
+    ``create_tensor_arg``).  A ``None`` name means an unnamed arg reached
+    projection, which would silently alias on ``-1``; raise loudly instead of
+    falling back.
+    """
+    if arg.name is None:
+        raise ValueError(
+            "_buf_id: TensorArg.name is None -- every projected op arg must "
+            "carry a buffer name for register-threading identity (arg_index is "
+            "-1 for fused intermediates and cannot disambiguate them)"
+        )
+    return arg.name
+
+
+def _iteration_space_key(spec: OpSpec) -> tuple:
+    """Hashable canonical form of ``spec.iteration_space`` for grouping.
+
+    Two ops fuse iff this key matches: same symbols, same ranges, and same
+    work divisions.  Symbols/ranges are compared by their string form so the
+    key is order-independent and hashable.
+    """
+    return tuple(
+        sorted(
+            (str(sym), str(rng), int(div))
+            for sym, (rng, div) in spec.iteration_space.items()
+        )
+    )
+
+
+# Device-dim coordinate kinds, used to align pointwise operands whose device
+# axes are ordered differently from the op's output tile (broadcast alignment).
+_DIM_CONST = "const"  # no iteration-space symbol (an inserted / broadcast dim)
+_DIM_BARE = "bare"  # coord == sym (a non-stick dim)
+_DIM_WITHIN_STICK = "within_stick"  # coord == sym % stick  (within-stick lanes)
+_DIM_OUTER_STICK = "outer_stick"  # coord == sym // stick (outer-stick chunks)
+
+
+def _dim_info(coord: sympy.Expr) -> tuple[str, sympy.Symbol | None]:
+    """Classify a device-dim coordinate as ``(kind, sym)``.
+
+    Two device axes are the "same" logical dim iff they share a ``(kind, sym)``
+    -- e.g. a weight's ``sym // stick`` outer-stick axis matches an output's
+    ``sym // stick`` axis even when they sit at different positions.  A ``const``
+    dim (extent 1, no symbol) carries no data and is dropped / broadcast.
+
+    A coordinate carrying more than one iteration symbol (a single physical axis
+    that folds two logical dims, e.g. ``a*8 + b``) is not a simple device axis.
+    No legal reshape produces one today -- a plain reshape is a pure view whose
+    strides stay stick-aligned (single symbol per axis), and a within-stick fold
+    is rejected earlier at layout selection (the within-stick dim must be a full
+    64-element stick).  Raise loudly rather than carrying a dead classification:
+    if this fires, a new frontend construct reached alignment and both this
+    helper and ``_align_reshape_plan`` need real multi-symbol support.
+    """
+    syms = coord.free_symbols
+    if not syms:
+        return (_DIM_CONST, None)
+    if len(syms) > 1:
+        raise NotImplementedError(
+            f"OpSpec alignment: device coordinate {coord!r} folds multiple "
+            f"iteration symbols {syms} into one physical axis; no supported "
+            "reshape produces this, so multi-symbol alignment is not implemented"
+        )
+    sym = next(iter(syms))
+    if isinstance(coord, sympy.Symbol):
+        return (_DIM_BARE, sym)
+    if isinstance(coord, (sympy.Mod, ModularIndexing)):
+        return (_DIM_WITHIN_STICK, sym)
+    return (_DIM_OUTER_STICK, sym)
+
+
+def _align_reshape_plan(
+    in_coords: list[sympy.Expr],
+    in_block: list[int],
+    out_coords: list[sympy.Expr],
+    out_block: list[int],
+) -> tuple[list[int], list[int] | None] | None:
+    """Plan to reshape + broadcast a pointwise operand tile into the op's output
+    device-axis order.
+
+    A pointwise op's operands may carry their device axes in a different order
+    (and rank) from the output tile: a per-row reduction result broadcasts over
+    the outer-stick dim, a channel weight broadcasts over the row dim, etc.
+    Elementwise broadcast typically only auto-aligns *leading* unit dims, so a
+    misaligned operand (outer-stick where the output has rows) must be reshaped
+    to the output order first.
+
+    Each output device axis is matched to an input axis by ``(kind, sym)`` (see
+    ``_dim_info``); the within-stick axis maps last -> last.  Unmatched output
+    axes get extent 1 (to be broadcast).  Returns ``(reshape_to, broadcast_to)``
+    -- reshape the operand to ``reshape_to`` (skip if it already equals
+    ``in_block``) then broadcast to ``broadcast_to`` (``None`` to skip).
+    Returns ``None`` when the operand already matches the output (fast path:
+    no reshape / broadcast emitted, keeping simple kernels byte-identical).
+
+    Raises ``NotImplementedError`` for a cross-stick transpose (an input axis
+    with extent > 1 that no output axis matches, or matched axes that would need
+    a permute) -- that needs a restickify, not a reshape.
+    """
+    in_block = [int(b) for b in in_block]
+    out_block = [int(b) for b in out_block]
+    if list(in_coords) == list(out_coords) and in_block == out_block:
+        return None
+
+    in_info = [_dim_info(c) for c in in_coords]
+    in_rank = len(in_coords)
+    out_rank = len(out_coords)
+
+    reshape_to = [1] * out_rank
+    used: set[int] = set()
+    # Within-stick lanes: the last input axis always maps to the last output axis.
+    reshape_to[out_rank - 1] = in_block[in_rank - 1]
+    used.add(in_rank - 1)
+    matched_seq: list[int] = []  # input axes matched to output axes, in out order
+    for o in range(out_rank - 1):
+        okind, osym = _dim_info(out_coords[o])
+        if okind == _DIM_CONST:
+            continue
+        for a in range(in_rank - 1):
+            if a in used:
+                continue
+            if in_info[a] == (okind, osym):
+                used.add(a)
+                reshape_to[o] = in_block[a]
+                matched_seq.append(a)
+                break
+
+    # A pure reshape preserves the row-major element order: the matched input
+    # axes must appear in increasing order.  If not, the operand would need a
+    # transpose (restickify) to align -- not supported on this path.
+    if any(matched_seq[i] >= matched_seq[i + 1] for i in range(len(matched_seq) - 1)):
+        raise NotImplementedError(
+            "OpSpec alignment: pointwise operand needs a transpose (restickify) "
+            "to align device axes; not supported yet"
+        )
+    prod_in = 1
+    for b in in_block:
+        prod_in *= b
+    prod_reshape = 1
+    for b in reshape_to:
+        prod_reshape *= b
+    if prod_in != prod_reshape:
+        # An input axis with extent > 1 was dropped -> real data would be lost;
+        # aligning it needs a cross-stick transpose (restickify).
+        raise NotImplementedError(
+            "OpSpec alignment: pointwise operand needs a cross-stick transpose "
+            "(restickify) to align device axes; not supported yet"
+        )
+    broadcast_to = out_block if reshape_to != out_block else None
+    return (reshape_to, broadcast_to)

--- a/torch_spyre/_inductor/codegen/opspec_utils.py
+++ b/torch_spyre/_inductor/codegen/opspec_utils.py
@@ -20,13 +20,19 @@ iteration-space grouping, and reshape / broadcast alignment of pointwise
 operands.  Those computations are **pure** (sympy / int over the ``op_specs``)
 -- no backend emission primitives, no MLIR builder, no live Inductor kernel
 state -- so they live here as plain functions rather than as base-class methods.
+
+They are therefore **emitter-agnostic**: they read the ``OpSpec`` contract
+without emitting any target IR, so one set can serve every OpSpec consumer.  The
+KTIR emitter is simply the first such consumer (hence the KTIR references
+below); future emitters are intended to share them, which is why the module is
+named for the ``OpSpec`` it reads rather than for KTIR.
 """
 
 from __future__ import annotations
 
 import sympy
 from torch._inductor.virtualized import V
-from torch.utils._sympy.functions import ModularIndexing
+from torch.utils._sympy.functions import FloorDiv, ModularIndexing
 
 from torch_spyre._inductor.op_spec import OpSpec, TensorArg
 
@@ -62,6 +68,9 @@ def _buf_id(arg: TensorArg) -> str:
     falling back.
     """
     if arg.name is None:
+        # ValueError (not NotImplementedError): under TORCH_SPYRE_KTIR=1
+        # create_tensor_arg always populates the name, so a None here is a
+        # broken internal invariant, not an unsupported-capability case.
         raise ValueError(
             "_buf_id: TensorArg.name is None -- every projected op arg must "
             "carry a buffer name for register-threading identity (arg_index is "
@@ -124,7 +133,18 @@ def _dim_info(coord: sympy.Expr) -> tuple[str, sympy.Symbol | None]:
         return (_DIM_BARE, sym)
     if isinstance(coord, (sympy.Mod, ModularIndexing)):
         return (_DIM_WITHIN_STICK, sym)
-    return (_DIM_OUTER_STICK, sym)
+    if isinstance(coord, FloorDiv):
+        return (_DIM_OUTER_STICK, sym)
+    # A single-symbol coordinate that is none of the known device-axis forms
+    # (e.g. ``2*d0 + 1``) is not a plain outer-stick chunk index.  Raise loudly
+    # rather than silently classifying it as outer-stick -- same policy as the
+    # multi-symbol case above; a later increment that legitimately produces such
+    # a coordinate must extend this classifier explicitly.
+    raise NotImplementedError(
+        f"OpSpec alignment: single-symbol device coordinate {coord!r} is not a "
+        "bare symbol, within-stick (Mod/ModularIndexing), or outer-stick "
+        "(FloorDiv) form; classification is not implemented"
+    )
 
 
 def _align_reshape_plan(

--- a/torch_spyre/_inductor/codegen/opspec_utils.py
+++ b/torch_spyre/_inductor/codegen/opspec_utils.py
@@ -31,17 +31,9 @@ named for the ``OpSpec`` it reads rather than for KTIR.
 from __future__ import annotations
 
 import sympy
-from torch._inductor.virtualized import V
 from torch.utils._sympy.functions import FloorDiv, ModularIndexing
 
 from torch_spyre._inductor.op_spec import OpSpec, TensorArg
-
-
-def _size_hint(expr) -> int:
-    """Concrete size hint for an iteration-space range expression."""
-    if isinstance(expr, (int, sympy.Integer)):
-        return int(expr)
-    return int(V.graph.sizevars.size_hint(expr))
 
 
 def _row_major_strides(device_size: list[int]) -> list[int]:

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -27,6 +27,12 @@ hbm_pool_planning: bool = _get_env_bool("HBM_POOL_PLANNING", True)
 
 global_stick_optimizer: bool = os.environ.get("GLOBAL_STICK_OPTIMIZER", "1") == "1"
 
+# Opt-in OpSpec->KTIR emitter (experimental, #3380). When enabled the scheduler
+# emits ``async_compile.ktir(...)`` instead of the SDSC bundle, and
+# ``create_tensor_arg`` populates the op-spec buffer name so the emitter has a
+# stable per-buffer identity. Inert by default: the SDSC/flex path is unchanged.
+ktir_emitter: bool = os.environ.get("TORCH_SPYRE_KTIR", "0") == "1"
+
 allow_all_ops_in_lx_planning: bool = False
 
 dxp_lx_frac_avail: float = float(os.environ.get("DXP_LX_FRAC_AVAIL", "0.2"))

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from typing import Sequence, Union
 
 import sympy
@@ -712,10 +713,11 @@ class SuperDSCScheduling(BaseScheduling):
             kernel_name = wrapper.src_to_kernel[src_code]
         else:
             fused_name = get_fused_kernel_name(node_schedule, "original_aten")
-            kernel_name = "_".join(["sdsc", fused_name, wrapper.next_kernel_suffix()])
+            method = "ktir" if os.getenv("TORCH_SPYRE_KTIR") == "1" else "sdsc"
+            kernel_name = "_".join([method, fused_name, wrapper.next_kernel_suffix()])
             wrapper.src_to_kernel[src_code] = kernel_name
             buf = IndentedBuffer()
-            buf.writeline(f"async_compile.sdsc('{kernel_name}',")
+            buf.writeline(f"async_compile.{method}('{kernel_name}',")
             with buf.indent():
                 buf.splice(f"{src_code}")
             buf.writeline(")")

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from typing import Sequence, Union
 
 import sympy
@@ -713,7 +712,7 @@ class SuperDSCScheduling(BaseScheduling):
             kernel_name = wrapper.src_to_kernel[src_code]
         else:
             fused_name = get_fused_kernel_name(node_schedule, "original_aten")
-            method = "ktir" if os.getenv("TORCH_SPYRE_KTIR") == "1" else "sdsc"
+            method = "ktir" if _spyre_config.ktir_emitter else "sdsc"
             kernel_name = "_".join([method, fused_name, wrapper.next_kernel_suffix()])
             wrapper.src_to_kernel[src_code] = kernel_name
             buf = IndentedBuffer()

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from dataclasses import dataclass, field
 from typing import Any, Callable, Self, Sequence, Tuple, Union
 from abc import ABC
@@ -733,6 +734,15 @@ class SpyreKernel(Kernel[CSEVariable]):
         tensor: TensorAccess,
         opspec_name: "str | None" = None,
     ) -> TensorArg:
+        # OpSpec->KTIR needs a stable per-buffer identity for register-threaded
+        # fused intermediates (all arg_index == -1): _buf_id keys on TensorArg.name,
+        # which is serialized into the emitted op-spec literal and read back by
+        # generate_ktir.  The SDSC/flex literal identifies buffers by arg_index +
+        # allocation address and only needs name for gather indices, so populate it
+        # from the buffer name only under TORCH_SPYRE_KTIR=1 -- leaving the default
+        # SDSC literal byte-identical.
+        if opspec_name is None and os.getenv("TORCH_SPYRE_KTIR") == "1":
+            opspec_name = name
         it_space = iteration_space(self.current_node)
         # With dynamic=True the host index may contain symbolic strides
         # (e.g. x0*s1+x1).  Concretize size symbols so normalize_coordinates

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from dataclasses import dataclass, field
 from typing import Any, Callable, Self, Sequence, Tuple, Union
 from abc import ABC
@@ -739,9 +738,10 @@ class SpyreKernel(Kernel[CSEVariable]):
         # which is serialized into the emitted op-spec literal and read back by
         # generate_ktir.  The SDSC/flex literal identifies buffers by arg_index +
         # allocation address and only needs name for gather indices, so populate it
-        # from the buffer name only under TORCH_SPYRE_KTIR=1 -- leaving the default
+        # from the buffer name only when the KTIR emitter is enabled
+        # (config.ktir_emitter, i.e. TORCH_SPYRE_KTIR=1) -- leaving the default
         # SDSC literal byte-identical.
-        if opspec_name is None and os.getenv("TORCH_SPYRE_KTIR") == "1":
+        if opspec_name is None and _spyre_config.ktir_emitter:
             opspec_name = name
         it_space = iteration_space(self.current_node)
         # With dynamic=True the host index may contain symbolic strides

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -96,3 +96,35 @@ class SpyreAsyncCompile(AsyncCompile):
                 raise
 
         return SpyreSDSCKernelRunner(kernel_name, output_dir)
+
+    def ktir(
+        self, kernel_name: str, specs: Sequence[OpSpec | LoopSpec | UnimplementedOp]
+    ):
+        """Emit KTDP-dialect MLIR for ``specs`` (OpSpec->KTIR path).
+
+        Mirrors ``sdsc`` but emits KTIR directly instead of an SDSC bundle.
+        Device execution is not wired yet: the emitted KTIR is persisted to
+        disk for inspection and this raises ``NotImplementedError``.
+        """
+        unimp = find_unimplemented(list(specs))
+        if unimp is not None:
+            logger.warning(
+                f"WARNING: Compiling unimplemented {unimp.op} to runtime exception"
+            )
+            return SpyreUnimplementedRunner(kernel_name, unimp.op)
+
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        # Persist the emitted KTIR as a text file in the same per-kernel output
+        # dir as sdsc's bundle.
+        output_dir = get_output_dir(kernel_name)
+        ktir_path = os.path.join(output_dir, f"{kernel_name}.ktir")
+        with open(ktir_path, "w") as fh:
+            fh.write(generate_ktir(kernel_name, specs))
+        logger.debug("OpSpec->KTIR: wrote %s", ktir_path)
+
+        raise NotImplementedError(
+            "OpSpec->KTIR: device execution is not wired yet; the emitted KTIR "
+            f"was written to {ktir_path} for inspection. Execution lands in a "
+            "later PR."
+        )

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -115,12 +115,16 @@ class SpyreAsyncCompile(AsyncCompile):
 
         from torch_spyre._inductor.codegen.ktir import generate_ktir
 
+        # Emit before opening the file: if generate_ktir raises we must not
+        # leave a truncated/empty .ktir behind.
+        ktir_text = generate_ktir(kernel_name, specs)
+
         # Persist the emitted KTIR as a text file in the same per-kernel output
         # dir as sdsc's bundle.
         output_dir = get_output_dir(kernel_name)
         ktir_path = os.path.join(output_dir, f"{kernel_name}.ktir")
         with open(ktir_path, "w") as fh:
-            fh.write(generate_ktir(kernel_name, specs))
+            fh.write(ktir_text)
         logger.debug("OpSpec->KTIR: wrote %s", ktir_path)
 
         raise NotImplementedError(


### PR DESCRIPTION
This is the first PR to emit KTIRs. This new emitter emits a KTIR reflecting the content of OpSpecs. This first PR only supports a single pointwise op to simplify the code and ease the code review.

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds `generate_ktir` (`torch_spyre/_inductor/codegen/ktir.py`), a new Inductor
emitter that builds a **KTDP-dialect MLIR module directly from the finished
`OpSpec` list** — a sibling of the SDSC emitter (`generate_bundle`), emitted
from the same self-contained specs in `async_compile` with no live kernel state.
The module is built with the `mlir_ktdp` builder API and serialized to KTIR
text.

Scope of this first increment is deliberately narrow — a single pointwise op
(`add`), single-core (`SENCORES=1`) grid. Everything outside that scope
(reductions, loops/`LoopSpec`, matmul, broadcast/reshape operands, in-place,
fused/register-threaded intermediates, non-`add` ops, unsupported dtypes) raises
an explicit `NotImplementedError`, so the supported surface is unambiguous and
easy to review.

Wiring:

- `scheduler.py` — selects `method = "ktir"` (vs `"sdsc"`) when
  `TORCH_SPYRE_KTIR=1`, and emits `async_compile.ktir(...)`.
- `execution/async_compile.py` — adds a `ktir()` method mirroring `sdsc()`.
- `_inductor/codegen/opspec_utils.py` — OpSpec-reading helpers used by the
  emitter (buffer identity, row-major strides, pointwise operand alignment).
- `spyre_kernel.py` — under `TORCH_SPYRE_KTIR=1` only, populates `TensorArg.name`
  so `_buf_id` has a stable per-buffer identity.

#### Which issue(s) this PR is related to:

Related to #3380

#### Special notes for your reviewer:

- **Gated and inert by default.** All new behavior is behind
  `TORCH_SPYRE_KTIR=1`. When it is unset, the scheduler selects `sdsc` and the
  `spyre_kernel.py` hunk is skipped, so the existing SDSC/flex path is
  unchanged. Verified: with the env var unset, `add.py` still dispatches
  `async_compile.sdsc(...)`.
- **Device execution is deferred.** The `ktir()` method emits the module, writes
  it to `<output_dir>/<kernel>.ktir` for inspection, and then raises
  `NotImplementedError`. Running it on device or ktir-cpu lands in a later PR.
- **`opspec_utils.py` is the pointwise subset** of a larger helper module; only
  the helpers the pointwise emitter needs are included here. Later increments
  add the loop / reduction / matmul / gather helpers.
- **Test:** `tests/inductor/test_ktir_emitter.py` is a self-contained
  golden-string test (skips when `mlir_ktdp` is unavailable) — it pins the exact
  emitted MLIR for pointwise `add` and asserts reductions / non-`add` ops raise.

#### Does this PR introduce a user-facing change?

Adds an opt-in, experimental `TORCH_SPYRE_KTIR=1` code path. It has no effect
unless explicitly enabled, and does not yet execute on device.

#### Additional note:

First of an ordered series building out the OpSpec→KTIR emitter (#3380): pointwise → fuse + work-division → dbo compilation & execution → ktir-cpu execution → loop → reduction → matmul → indirect access → dynamic symbols.
