### PR TITLE
feat(oot framework): allow model ops sample tag markers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -398,9 +398,9 @@ def pytest_configure(config):
             for test_entry in file_entry.get("tests", []):
                 for tag in test_entry.get("tags", []):
                     tags.add(tag)
-                for op_item in (
-                    test_entry.get("edits", {}).get("ops", {}).get("include", [])
-                ):
+                edits = test_entry.get("edits") or {}
+                ops = edits.get("ops") or {}
+                for op_item in ops.get("include") or []:
                     for tag in op_item.get("tags", []):
                         tags.add(tag)
         for tag in sorted(tags):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -398,6 +398,11 @@ def pytest_configure(config):
             for test_entry in file_entry.get("tests", []):
                 for tag in test_entry.get("tags", []):
                     tags.add(tag)
+                for op_item in (
+                    test_entry.get("edits", {}).get("ops", {}).get("include", [])
+                ):
+                    for tag in op_item.get("tags", []):
+                        tags.add(tag)
         for tag in sorted(tags):
             config.addinivalue_line(
                 "markers",

--- a/tests/oot_framework/oot_upstream_patcher.py
+++ b/tests/oot_framework/oot_upstream_patcher.py
@@ -757,6 +757,16 @@ class _OOTOpMarkerPatcher:
                             test_wrapper
                         )
 
+                    # ModelOpInfo (tests/models/test_model_ops_v2.py) carries the
+                    # per-sample `edits.ops.include[].tags` from the YAML config
+                    # (e.g. "torch.nn.functional.embedding.1_spyre"). Apply each
+                    # as its own mark so a single sample can be selected with
+                    # `-m <tag>`, the same way op__/dtype__ select by op/dtype.
+                    # Plain upstream OpInfo objects have no `op_tags` attribute,
+                    # so this is a no-op for every other @ops-based test suite.
+                    for op_tag in getattr(op, "op_tags", None) or []:
+                        test_wrapper = pytest.mark.__getattr__(op_tag)(test_wrapper)
+
                 if dtype is not None:
                     dtype_safe = re.sub(
                         r"[^a-zA-Z0-9_]", "_", str(dtype).replace("torch.", "")


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

## Problem
- `edits.ops.include[].tags` in model-ops YAML configs (e.g. `torch.nn.functional.embedding.1_spyre`) were runtime-only labels, only used for the `[TAGS = ...]` report line and JUnit XML sidecar.

- These tags were never attached as pytest marks, so no `-m` expression could select an individual sample --- only the coarser `op__<name>` marker (whole op, index stripped) was selectable.

## Feature
- `_OOTOpMarkerPatcher` now applies each `ModelOpInfo.op_tags` entry as its own pytest mark alongside the existing `op__`/`dtype__` marks, enabling `-m "torch.nn.functional.embedding.1_spyre"` to select a single sample.


### Validation:

```bash
bash tests/run_test.sh tests/configs/model_ops_tests/granite-3.3-8b-instruct_spyre.yaml -v -m "torch.nn.functional.embedding.1_spyre" --collect-only -q
```

now correctly collect test by ops.include.tags

<img width="2076" height="276" alt="image" src="https://github.com/user-attachments/assets/9341b1a2-fe7f-404d-a307-bd0f58bd1b11" />

