### PR TITLE
test: small reproducer that catches coarse tiling dim order errors

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1518,6 +1518,29 @@ def test_restickify_matmul_x_yt_128x256_M2_N2():
     run_coarse_tile_test(fn, inputs)
 
 
+def test_restickify_pointwise_unsqueeze_mul_Lq2():
+    """pointwise result unsqueezed and multiplied with 4D tensor, tiled Lq÷2.
+
+    Minimal reproducer for ReinterpretView staleness: a 3D pointwise result
+    [H,Lq] goes through unsqueeze(-1) creating a ReinterpretView [H,Lq,1]
+    whose FixedLayout captures pre-divide Lq strides. The multiply consumer
+    reads it with a stale stride coefficient after _divide_ranges tiles Lq.
+    """
+    H, Lq, D = 8, 128, 64
+    inputs = [
+        tensor("x", shape=(H, Lq), dims=["H", "Lq"]),
+        tensor("y", shape=(H, Lq), dims=["H", "Lq"]),
+        tensor("z", shape=(H, Lq, D), dims=["H", "Lq", "D"]),
+    ]
+
+    def fn(x, y, z):
+        with spyre_hint(num_tiles_per_dim={"Lq": 2}):
+            c = torch.exp(x - y)  # [H, Lq] pointwise
+            return z * c.unsqueeze(-1)  # [H, Lq, D]
+
+    run_coarse_tile_test(fn, inputs)
+
+
 # ---------------------------------------------------------------------------
 # Group 7: copies
 # Patterns: copy into pre-allocated buffer, in-place accumulation,


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds test tests/inductor/test_coarse_tile_e2e.py::test_restickify_pointwise_unsqueeze_mul_Lq2

This new test currently passes on main, but will help block incorrect fixes to other currently skipped tests (like tests/inductor/test_coarse_tile_e2e.py::test_restickify_2t_add_256x128_A2).  Ie, this new test fails if you try to fix the currently skipped restickify tests with invalid solutions.


#### Which issue(s) this PR is related to:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
