### PR TITLE
ci(perf): resolve inline ingest action in prebaked mode

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -448,16 +448,29 @@ jobs:
       # ingest step is skipped and the perf run still succeeds.
       CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
     steps:
+      # ALWAYS sparse-checkout .github from the workflow ref, in BOTH prebaked
+      # and normal mode. `uses: ./.github/actions/*` resolves the action
+      # DEFINITION against $GITHUB_WORKSPACE/.github before any step of that
+      # action runs, so a composite action added on this branch must be present
+      # in the workspace even when the benchmark runs from a prebaked image. The
+      # matrix jobs symlink the baked .github instead, which is fine there because
+      # they only use actions old enough to be in every image; the perf job is the
+      # one that references a NEWER action (ingest-xml-to-clickhouse), so a symlink
+      # to an older baked .github fails to resolve it ("Can't find action.yml ...
+      # Did you forget to run actions/checkout"). A fresh sparse-checkout of just
+      # .github is tiny, is owned by the disposable runner workspace (a separate
+      # dir from PREBAKED_TORCH_SPYRE_DIR, so the baked tree is never mutated), and
+      # always carries the current actions + the .github/scripts the ingest action
+      # reads. The benchmark itself still runs from the baked source dir
+      # (PREBAKED_TORCH_SPYRE_DIR) below, so prebaked provenance for the RUN is
+      # unchanged.
       - name: Checkout composite actions
-        if: ${{ !inputs.prebaked_image }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          sparse-checkout: .github/actions
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
+          repository: ${{ inputs.repository || github.event.pull_request.head.repo.full_name || github.repository }}
+          sparse-checkout: .github
           sparse-checkout-cone-mode: false
-
-      - name: Expose baked composite actions in the workspace
-        if: ${{ inputs.prebaked_image }}
-        run: ln -sfn "${PREBAKED_TORCH_SPYRE_DIR}/.github" "${GITHUB_WORKSPACE}/.github"
 
       - if: ${{ !inputs.prebaked_image }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Problem

The perf job runs the benchmark from a prebaked dev image. In that mode it symlinked the baked `.github` into the workspace instead of checking it out. A composite action added on this branch (`ingest-xml-to-clickhouse`) is absent from an older baked image, so `uses: ./.github/actions/ingest-xml-to-clickhouse` could not load its action definition:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'.../.github/actions/ingest-xml-to-clickhouse'.
Did you forget to run actions/checkout before running your local action?
```

The benchmark itself ran and wrote its `report.xml`, but the report never reached ClickHouse because the action could not be loaded.

## Fix

Always sparse-checkout `.github` from the workflow ref in the perf job, in both prebaked and normal mode, so the current composite actions and the ingest script are present regardless of the baked image age. This replaces the baked-`.github` symlink in the perf job only.

- The benchmark still runs from the prebaked source dir (`PREBAKED_TORCH_SPYRE_DIR`), so the run's provenance is unchanged.
- The workspace is a disposable runner-owned dir separate from the baked source tree, so the baked tree is never mutated.
- The matrix jobs keep the symlink path unchanged (they only use actions that are old enough to be in every image).

## Validation

- `pre-commit` (actionlint + yamlfmt) passes on the changed file.
- Single file, perf job only: 19 insertions, 6 deletions.