### PR TITLE
Claude skills inductor scoped

### DIFF
--- a/torch_spyre/_inductor/.claude/skills/inductor-overview/SKILL.md
+++ b/torch_spyre/_inductor/.claude/skills/inductor-overview/SKILL.md
@@ -14,13 +14,66 @@ For repo-wide context (Spyre hardware, device registration, general
 compilation pipeline overview), see the top-level `project-overview` skill
 first if you haven't already.
 
-## Scope of this skill
+## Debugging a compilation
 
-This is scaffolding. Fill in sections below as inductor-specific guidance
-accumulates — pass ordering rules, `OpSpec`/`LoopSpec` contract conventions,
-coarse-tiling invariants, scratchpad/LX planning conventions, etc. Prefer
-linking to `docs/source/compiler/` for material that's already documented
-there rather than duplicating it here.
+Inductor caches compiled artifacts under `/tmp/torchinductor_<user>/` in
+two layers, and only one of them is cleared by `FxGraphCache.clear()`. If
+a pass change doesn't seem to take effect — wrong `LoopSpec`/wrapper
+structure persists — suspect the stale wrapper-`.py` cache layer before
+your code. See
+[`references/debugging-compiled-artifacts.md`](references/debugging-compiled-artifacts.md)
+for the cache-layer breakdown and where to find generated SDSC/superdsc
+JSON, MLIR bundles, and `output_code.py` for a given compilation.
+
+## Layout and stride semantics
+
+`stride_map`, `device_stride`, and `pytorch_stride` measure three
+different things and are easy to conflate — and different ops in the same
+kernel can legitimately commit to different device layouts for the same
+logical dimension (not a bug). See
+[`references/layout-and-stride-semantics.md`](references/layout-and-stride-semantics.md)
+for worked before/after-restickify examples and the general formula for
+computing `stride_map` from a device dim's coordinate expression.
+
+## Terminology: `hbm_pool` is not scratchpad
+
+`allocation={'hbm_pool': ...}` in generated `TensorArg`/`OpSpec` output
+means a bulk-allocated **HBM** region (`memory_planning.py`'s
+`INTERMEDIATES_SEGMENT`) for tensors used within a single kernel — it is
+*not* scratchpad. Only `allocation={'lx': ...}` is actual on-chip
+scratchpad memory. (`hbm_pool` was renamed from the older key name `pool`;
+if you see `'pool'` in older docs or history, it refers to the same thing.)
+Buffers in `lx` are `per_tile_fixed=True` (pinned address, no
+`affine.apply` needed); `hbm_pool` buffers are ordinary HBM addresses that
+still need per-iteration `affine.apply` addressing like any other HBM
+operand.
+
+## `WrapperHandler` swaps must account for stride, not just name
+
+CLAUDE.md's "wrap, never reconstruct" rule for `ComputedBuffer.inner_fn`
+covers *why* to use a `WrapperHandler`. The failure mode to watch for once
+you're using one: a plain `NameSwapHandler`-style rename forwards a
+consumer's load index **unmodified**. That's correct when the old and new
+buffers are addressing-equivalent, but silently computes wrong addresses
+when they have different strides for the same dimension (e.g. redirecting
+a consumer from a tile-local scratch buffer to a full-size buffer after
+promoting the consumer's own iteration space). `_patch_consumers` in
+`wsr/coarse_tile.py` hit exactly this bug historically and now carries the
+fix as its documented pattern: it computes a stride-coefficient rewrite
+map (`_stride_rewrite_map`) and applies it via
+`_retile_load_index_from_strides`/`_NameAndIndexSwapHandler` whenever the
+old and new buffer strides differ, falling back to plain `NameSwapHandler`
+only when they don't. Any new pass that swaps a buffer name/identity under
+a consumer's `inner_fn` should check whether this applies — a bare rename
+is only safe when the swap is addressing-equivalent.
+
+## Test execution conventions
+
+Never run Spyre tests in parallel (the device is exclusive to one
+process), and don't run the full `tests/` suite locally as a pre-push
+check — CI covers it. See
+[`references/testing-conventions.md`](references/testing-conventions.md)
+for the specific suites to run locally instead.
 
 ## Adding to this skill
 

--- a/torch_spyre/_inductor/.claude/skills/inductor-overview/SKILL.md
+++ b/torch_spyre/_inductor/.claude/skills/inductor-overview/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: inductor-overview
+description: "Guidance specific to torch_spyre/_inductor: compilation pipeline internals, pass ordering, and conventions for code changes in this subtree. Use when working on files under torch_spyre/_inductor/."
+---
+
+# torch_spyre/_inductor Guidance
+
+This skill is scoped to `torch_spyre/_inductor/` and is discovered
+automatically by Claude Code for work under this subtree, independent of the
+top-level `.claude/skills/` directory. It is owned and maintained by the
+CODEOWNERS of this subtree.
+
+For repo-wide context (Spyre hardware, device registration, general
+compilation pipeline overview), see the top-level `project-overview` skill
+first if you haven't already.
+
+## Scope of this skill
+
+This is scaffolding. Fill in sections below as inductor-specific guidance
+accumulates — pass ordering rules, `OpSpec`/`LoopSpec` contract conventions,
+coarse-tiling invariants, scratchpad/LX planning conventions, etc. Prefer
+linking to `docs/source/compiler/` for material that's already documented
+there rather than duplicating it here.
+
+## Adding to this skill
+
+- Keep guidance specific to `torch_spyre/_inductor/` here. Repo-wide
+  conventions (license headers, commit signing, `import regex`, line length)
+  stay in the top-level `CLAUDE.md` — don't duplicate them.
+- Follow the top-level `CLAUDE.md` conventions for `SKILL.md` frontmatter:
+  a quoted single-line `description`, not a multi-line `>-` block scalar.
+- Companion reference files for this skill (decision trees, checklists,
+  templates) belong alongside this file, under
+  `torch_spyre/_inductor/.claude/skills/inductor-overview/`.

--- a/torch_spyre/_inductor/.claude/skills/inductor-overview/SKILL.md
+++ b/torch_spyre/_inductor/.claude/skills/inductor-overview/SKILL.md
@@ -43,10 +43,18 @@ means a bulk-allocated **HBM** region (`memory_planning.py`'s
 *not* scratchpad. Only `allocation={'lx': ...}` is actual on-chip
 scratchpad memory. (`hbm_pool` was renamed from the older key name `pool`;
 if you see `'pool'` in older docs or history, it refers to the same thing.)
-Buffers in `lx` are `per_tile_fixed=True` (pinned address, no
-`affine.apply` needed); `hbm_pool` buffers are ordinary HBM addresses that
-still need per-iteration `affine.apply` addressing like any other HBM
-operand.
+Whether a buffer's address is pinned (no `affine.apply` needed) or needs
+per-iteration `affine.apply` addressing is determined by
+`loop_info.output_tiled_dims`/`tiled_dims_per_read` and
+`TensorArg.device_tile_advance_expr` — not a standalone flag. (An older
+`per_tile_fixed` boolean duplicated this decision and was removed; if you
+see it mentioned in older docs or history, it's the same "pinned vs.
+advancing" distinction now derived from `loop_info`/
+`device_tile_advance_expr` directly.) `lx` buffers are typically pinned;
+`hbm_pool` buffers are ordinary HBM addresses that usually still need
+per-iteration addressing like any other HBM operand — but check
+`loop_info`/`device_tile_advance_expr` for the specific buffer rather than
+assuming from the allocation kind alone.
 
 ## `WrapperHandler` swaps must account for stride, not just name
 
@@ -77,11 +85,5 @@ for the specific suites to run locally instead.
 
 ## Adding to this skill
 
-- Keep guidance specific to `torch_spyre/_inductor/` here. Repo-wide
-  conventions (license headers, commit signing, `import regex`, line length)
-  stay in the top-level `CLAUDE.md` — don't duplicate them.
-- Follow the top-level `CLAUDE.md` conventions for `SKILL.md` frontmatter:
-  a quoted single-line `description`, not a multi-line `>-` block scalar.
-- Companion reference files for this skill (decision trees, checklists,
-  templates) belong alongside this file, under
-  `torch_spyre/_inductor/.claude/skills/inductor-overview/`.
+Follow the top-level `CLAUDE.md` conventions for `SKILL.md` frontmatter:
+a quoted single-line `description`, not a multi-line `>-` block scalar.

--- a/torch_spyre/_inductor/.claude/skills/inductor-overview/references/debugging-compiled-artifacts.md
+++ b/torch_spyre/_inductor/.claude/skills/inductor-overview/references/debugging-compiled-artifacts.md
@@ -1,0 +1,73 @@
+# Debugging compiled artifacts
+
+## Two cache layers, and why clearing one isn't enough
+
+Inductor's on-disk cache under `/tmp/torchinductor_<user>/` has two layers
+that get conflated:
+
+1. **`fxgraph/`** — the FX graph cache, keyed by pass UUID hashes. Cleared
+   by `torch._inductor.codecache.FxGraphCache.clear()`.
+2. **Compiled wrapper `.py` files**, stored in two-character subdirectories
+   (e.g. `yl/cylvm3....py`). These are the actual generated Python wrapper
+   modules. `FxGraphCache.clear()` does **not** clear this layer — if a
+   matching wrapper file is still on disk, Inductor imports it directly and
+   skips codegen entirely.
+
+If you change a compiler pass and a test still shows the old `LoopSpec`
+nesting, iteration space, or wrapper structure despite the change, suspect
+a stale layer-2 wrapper file before suspecting your code. Symptoms look
+like "my pass isn't running" even when it is.
+
+**Force a true full recompile:**
+
+```bash
+rm -rf /tmp/torchinductor_<user>/
+```
+
+Clearing only `fxgraph/` (`rm -rf /tmp/torchinductor_<user>/fxgraph/`) is
+not sufficient when the wrapper-file layer is what's stale.
+
+`output_code.py` (see below) is ground truth for what the *current* source
+actually produces — if it disagrees with what a test run just did, that's
+the cache, not a bug in your pass.
+
+## Where to find generated artifacts
+
+Set `TORCH_COMPILE_DEBUG=1` to get a full dump per compilation under:
+
+```
+torch_compile_debug/run_<timestamp>-pid_<pid>/torchinductor/<graph_name>/output_code.py
+```
+
+`output_code.py` is the generated Python wrapper — the single most useful
+artifact for confirming what codegen actually produced, independent of any
+cache question.
+
+The generated SuperDSC bundle (MLIR passed to the back-end compiler) lives
+under the Inductor cache itself:
+
+```
+/tmp/torchinductor_<user>/inductor-spyre/sdsc_<op names>_<hash>/bundle.mlir
+```
+
+The directory name is derived from the fused op names in that kernel, so
+it's greppable by op name when you're not sure which hash directory to
+look in.
+
+For a full worked example of what a coarse-tiled kernel's generated
+`OpSpec` (Python wrapper source) and `bundle.mlir` actually look like side
+by side, see the "Generated OpSpec" and "Generated `bundle.mlir`" sections
+in
+[`docs/source/compiler/coarse_tiling_loops.md`](../../../../../docs/source/compiler/coarse_tiling_loops.md).
+
+## Provenance tracking
+
+`SpyreGraphTransformObserver` (`provenance.py`) tracks whether passes drop
+buffer origin/provenance info across the pass pipeline. It's disabled by
+default; enable with `INDUCTOR_PROVENANCE=1`, or it follows
+`TORCH_COMPILE_DEBUG=1` when `INDUCTOR_PROVENANCE` is unset. Set
+`INDUCTOR_PROVENANCE=0` to force it off explicitly. See
+[`docs/source/compiler/adding_operations.md`](../../../../../docs/source/compiler/adding_operations.md)
+for the full contract (`SOURCELESS_CREATION_PASSES`,
+`INTENTIONAL_PROVENANCE_REMAP_PASSES`,
+`INTENTIONAL_PROVENANCE_REMOVAL_PASSES`).

--- a/torch_spyre/_inductor/.claude/skills/inductor-overview/references/debugging-compiled-artifacts.md
+++ b/torch_spyre/_inductor/.claude/skills/inductor-overview/references/debugging-compiled-artifacts.md
@@ -58,7 +58,7 @@ For a full worked example of what a coarse-tiled kernel's generated
 `OpSpec` (Python wrapper source) and `bundle.mlir` actually look like side
 by side, see the "Generated OpSpec" and "Generated `bundle.mlir`" sections
 in
-[`docs/source/compiler/coarse_tiling_loops.md`](../../../../../docs/source/compiler/coarse_tiling_loops.md).
+[`docs/source/compiler/coarse_tiling_loops.md`](../../../../../../docs/source/compiler/coarse_tiling_loops.md).
 
 ## Provenance tracking
 
@@ -66,8 +66,12 @@ in
 buffer origin/provenance info across the pass pipeline. It's disabled by
 default; enable with `INDUCTOR_PROVENANCE=1`, or it follows
 `TORCH_COMPILE_DEBUG=1` when `INDUCTOR_PROVENANCE` is unset. Set
-`INDUCTOR_PROVENANCE=0` to force it off explicitly. See
-[`docs/source/compiler/adding_operations.md`](../../../../../docs/source/compiler/adding_operations.md)
+`INDUCTOR_PROVENANCE=0` to force it off explicitly. `INDUCTOR_PROVENANCE`
+itself is parsed by upstream PyTorch Inductor's config layer, not by
+torch-spyre — torch-spyre's `provenance.py` only reads the resulting
+`trace.provenance_tracking_level` config value, so `grep INDUCTOR_PROVENANCE
+torch_spyre/` turning up nothing is expected. See
+[`docs/source/compiler/adding_operations.md`](../../../../../../docs/source/compiler/adding_operations.md)
 for the full contract (`SOURCELESS_CREATION_PASSES`,
 `INTENTIONAL_PROVENANCE_REMAP_PASSES`,
 `INTENTIONAL_PROVENANCE_REMOVAL_PASSES`).

--- a/torch_spyre/_inductor/.claude/skills/inductor-overview/references/layout-and-stride-semantics.md
+++ b/torch_spyre/_inductor/.claude/skills/inductor-overview/references/layout-and-stride-semantics.md
@@ -1,0 +1,89 @@
+# Layout and stride semantics
+
+For the full tiled-tensor layout specification, see
+[`docs/source/user_guide/tensors_and_layouts.md`](../../../../../docs/source/user_guide/tensors_and_layouts.md).
+This file covers the `stride_map` concept specifically, which trips people
+up because it's easy to conflate with `device_stride`.
+
+## `stride_map` vs `device_stride` vs `pytorch_stride`
+
+- `pytorch_stride` — the tensor's ordinary PyTorch logical-memory strides
+  (row-major unless it's a transposed view).
+- `device_size` / `device_stride` — the shape/strides of the *device
+  buffer*, one entry per physical device dimension. `device_stride` is
+  always row-major-by-construction over `device_size`
+  (`device_stride[i] = prod(device_size[i+1:])`) — this holds for **any**
+  `device_size` array; it is a definitional consequence of row-major
+  layout, not a sortedness property of `device_size`'s raw values. A
+  `device_size` like `[256, 1, 1, 8, 64]` is not "corrupted" just because
+  the numbers aren't monotonically decreasing.
+- `stride_map[j]` — how far stepping +1 along **device dim j** moves you in
+  **PyTorch logical memory**. This is a completely different axis from
+  `device_stride`, which measures distance in the device buffer. If the
+  host tensor's strides aren't row-major (e.g. a transposed view),
+  `stride_map` won't be decreasing either — its order is a property of the
+  host tensor's strides, independent of the device buffer's own
+  (always-row-major) physical layout.
+
+General rule for computing `stride_map[j]` from a device dim's coordinate
+expression over pytorch dim `p`:
+
+| Device dim role | Coordinate expr example | `stride_map[j]` |
+|---|---|---|
+| inner stick | `Mod(p, 64)` | `pytorch_stride[p]` |
+| outer stick tile | `floor(p / 64)` | `64 * pytorch_stride[p]` |
+| non-stick | `floor(p)` | `pytorch_stride[p]` |
+
+### Worked example: `[128, 256]` row-major, cols = stick (before restickify)
+
+```
+pytorch_size:    [128, 256]
+pytorch_stride:  [256, 1]
+device_size:     [4, 128, 64]
+device_stride:   [8192, 64, 1]
+stride_map:      [64, 256, 1]
+```
+
+| dim | coord expr | size | dev_stride | stride_map |
+|---|---|---|---|---|
+| 0 | `floor(p1/64)` | 4 | 8192 | 64 |
+| 1 | `floor(p0)` | 128 | 64 | 256 |
+| 2 | `Mod(p1, 64)` | 64 | 1 | 1 |
+
+The stick is `Mod(p1, 64)` — the pytorch column, since `pytorch_stride[1] = 1`.
+
+### Worked example: same tensor, rows = stick (after restickify)
+
+`pytorch_size`/`pytorch_stride` are unchanged — only the device-side
+tiling choice changes:
+
+```
+device_size:     [2, 256, 64]
+device_stride:   [16384, 64, 1]
+stride_map:      [16384, 1, 256]
+```
+
+| dim | coord expr | size | dev_stride | stride_map |
+|---|---|---|---|---|
+| 0 | `floor(p0/64)` | 2 | 16384 | 16384 |
+| 1 | `floor(p1)` | 256 | 64 | 1 |
+| 2 | `Mod(p0, 64)` | 64 | 1 | 256 |
+
+The stick is now `Mod(p0, 64)` — the pytorch row.
+
+## Gotcha: layouts are per-op, not kernel-wide
+
+Different ops in the same compiled kernel can legitimately commit to
+different, mutually inconsistent device layouts for the *same logical
+tensor dimension* — e.g. dim H can be device-outermost for one op's input
+and device-near-innermost for another op's output/copy in the same fused
+kernel. **This is valid, not a bug.** Don't assume a single canonical
+layout holds kernel-wide when you're investigating a
+`device_tile_advance_expr` (or any device-layout-derived value) mismatch
+between two ops — check whether they've actually committed to the same
+layout before treating a discrepancy as a bug.
+
+To recover "where is logical dim X in this op's device layout" for a given
+generated `OpSpec`, look at `device_coordinates` and find the position
+whose coordinate expression equals the bare iteration-space symbol for X
+— don't assume a fixed dim ordering across ops.

--- a/torch_spyre/_inductor/.claude/skills/inductor-overview/references/layout-and-stride-semantics.md
+++ b/torch_spyre/_inductor/.claude/skills/inductor-overview/references/layout-and-stride-semantics.md
@@ -1,7 +1,7 @@
 # Layout and stride semantics
 
 For the full tiled-tensor layout specification, see
-[`docs/source/user_guide/tensors_and_layouts.md`](../../../../../docs/source/user_guide/tensors_and_layouts.md).
+[`docs/source/user_guide/tensors_and_layouts.md`](../../../../../../docs/source/user_guide/tensors_and_layouts.md).
 This file covers the `stride_map` concept specifically, which trips people
 up because it's easy to conflate with `device_stride`.
 

--- a/torch_spyre/_inductor/.claude/skills/inductor-overview/references/testing-conventions.md
+++ b/torch_spyre/_inductor/.claude/skills/inductor-overview/references/testing-conventions.md
@@ -1,0 +1,34 @@
+# Testing conventions for `_inductor` work
+
+## Never run Spyre tests in parallel
+
+Loading `torch_spyre` gives the process **exclusive access to the Spyre
+device** until it exits. A second process that also loads `torch_spyre`
+cannot acquire the device and will fail or hang.
+
+Always run pytest as a single sequential process. Never use `-n`,
+`-n auto`, `pytest-xdist`, or any other parallel/distributed test runner
+for any suite in this repo — including in CI-adjacent local scripts.
+
+## Local regression scope before pushing
+
+The full `tests/` suite is slow to run locally and CI already covers it in
+parallel infrastructure that isn't subject to the single-device
+constraint above. For a local "did I break anything nearby" pass on
+`_inductor` changes, you don't need the full suite — run:
+
+- `tests/inductor/test_building_blocks.py` — always. It exercises the core
+  op/lowering paths broadly enough to catch most collateral damage
+  regardless of which pass you touched.
+- The test file(s) that correspond to the specific pass/module you
+  modified, if one exists — e.g. touching `wsr/coarse_tile.py` warrants
+  `tests/inductor/test_coarse_tile_e2e.py`, `test_coarse_tiling.py`; a
+  scratchpad allocator change warrants whatever exercises
+  `torch_spyre/_inductor/scratchpad/`, etc. Match by name/import, not by
+  habit — don't run a fixed list left over from someone else's feature
+  work.
+- `pre-commit run --all-files`
+
+Don't run the entire `tests/` tree as a pre-push check — it's redundant
+with what CI already runs on push, and the wall-clock cost isn't worth it
+for local iteration.


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [ ] feature
- [x] documentation
- [ ] cleanup

#### What this PR does:

Fills in the `torch_spyre/_inductor/.claude/skills/inductor-overview`
skill scaffold (added in #91ea7249) with inductor-debugging knowledge
that had previously only existed in personal notes, so it's visible to
anyone working in this subtree via Claude Code's directory-scoped skill
discovery.

Adds:

- **`SKILL.md`** — five short sections: debugging a compilation, layout
  and stride semantics, the `hbm_pool`-vs-`lx` terminology trap, the
  `WrapperHandler`/`NameSwapHandler` stride-rescale pitfall, and test
  execution conventions. Each links out to a reference file or to
  `docs/source/compiler/` rather than duplicating existing docs.
- **`references/debugging-compiled-artifacts.md`** — Inductor's two
  distinct on-disk cache layers under `/tmp/torchinductor_<user>/`
  (`fxgraph/` vs. compiled wrapper `.py` files) and why clearing only
  one can leave a stale wrapper masking a pass change; where to find
  `output_code.py`, the generated SDSC bundle (`bundle.mlir`), and the
  provenance-observer env vars.
- **`references/layout-and-stride-semantics.md`** — `stride_map` vs.
  `device_stride` vs. `pytorch_stride`, worked before/after-restickify
  examples, and the gotcha that different ops in the same kernel can
  validly commit to different device layouts for the same logical
  dimension.
- **`references/testing-conventions.md`** — never run Spyre tests in
  parallel (exclusive device access); for local regression checks,
  always include `test_building_blocks.py` plus whichever test file
  corresponds to the pass/module actually touched, rather than a fixed
  suite list.

No source code changes.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

- The case study referenced for the `NameSwapHandler` stride-rescale
  pitfall (`_patch_consumers` in `wsr/coarse_tile.py`) is already fixed
  in current code (`_stride_rewrite_map`/`_retile_load_index_from_strides`)
  — this PR documents it as a resolved pattern to watch for in new
  passes, not an open bug.
- `SKILL.md` files are excluded from the PyMarkdown pre-commit hook
  (`.claude/skills/.*` exclusion in `.pre-commit-config.yaml`), so no
  lint output is expected from that hook on these files.

#### Does this PR introduce a user-facing change?

No — this only affects Claude Code's skill discovery for contributors
working under `torch_spyre/_inductor/`. No runtime or compiler behavior
changes.

#### Additional note: