### PR TITLE
Run emitted KTIR via the dbo backend behind TORCH_SPYRE_DBO

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,8 @@ Test sub-suites:
 | `TORCH_LOGS="+inductor"` | Verbose Inductor logging |
 | `TORCH_COMPILE_DEBUG=1` | Dump Inductor debug artifacts |
 | `TORCH_SPYRE_DOWNCAST_WARN=0` | Suppress int64→int32 downcast warnings |
+| `TORCH_SPYRE_KTIR=1` | Select the OpSpec→KTIR emitter instead of SDSC (experimental; emission-only unless `TORCH_SPYRE_DBO=1`) |
+| `TORCH_SPYRE_DBO=1` | Compile the emitted KTIR via the `dbo` backend and run it (requires `TORCH_SPYRE_KTIR=1`) |
 
 ## Spyre Hardware Basics
 

--- a/tests/configs/torch_spyre_tests/inductor/test_opspec_utils_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_opspec_utils_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [core, full]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_opspec_utils.py
+      unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_async_compile_ktir_dbo_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_async_compile_ktir_dbo_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [core, full]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/test_async_compile_ktir_dbo.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_ktir_emitter.py
+++ b/tests/inductor/test_ktir_emitter.py
@@ -1,0 +1,130 @@
+# Copyright 2025-2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Golden-text snapshot test for the OpSpec->KTIR emitter (``generate_ktir``).
+
+Self-contained: it builds the ``add`` OpSpec directly (no live Inductor graph,
+no compiler run) and asserts the emitter's canonical MLIR text.
+Skipped only where ``mlir_ktdp`` is not installed.
+"""
+
+import unittest
+
+import sympy
+
+from torch_spyre._C import DataFormats
+from torch_spyre._inductor.op_spec import OpSpec, TensorArg
+
+
+def _mlir_ktdp_available() -> bool:
+    """True when mlir_ktdp is built with the func/arith dialect Python bindings."""
+    try:
+        from mlir_ktdp import ir  # noqa: F401
+        from mlir_ktdp.dialects import arith, func, ktdp  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+# The canonical KTIR text ``generate_ktir`` emits for a single pointwise ``add``
+# over a [512, 1024] fp16 tensor stickified to device shape [16, 512, 64].
+_EXPECTED_ADD_KTIR = """\
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#set = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 15 >= 0, d1 >= 0, -d1 + 511 >= 0, d2 >= 0, -d2 + 63 >= 0)>
+module {
+  func.func @ktir_fused_add_0(%arg0: index, %arg1: index, %arg2: index) attributes {grid = [1]} {
+    %c0 = arith.constant 0 : index
+    %0 = ktdp.construct_memory_view %arg0, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %1 = ktdp.construct_memory_view %arg1, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %2 = ktdp.construct_memory_view %arg2, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %3 = ktdp.construct_access_tile %0[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    %4 = ktdp.load %3 : <16x512x64xindex> -> tensor<16x512x64xf16>
+    %5 = ktdp.construct_access_tile %1[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    %6 = ktdp.load %5 : <16x512x64xindex> -> tensor<16x512x64xf16>
+    %7 = arith.addf %4, %6 : tensor<16x512x64xf16>
+    %8 = ktdp.construct_access_tile %2[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    ktdp.store %7, %8 : tensor<16x512x64xf16>, <16x512x64xindex>
+    return
+  }
+}
+"""
+
+
+def _add_op_specs() -> list:
+    """Finished OpSpec list for ``a + b`` at device shape [16, 512, 64] fp16.
+
+    This mirrors what the SuperDSC frontend produces for a pointwise ``a + b``:
+    two HBM inputs and one HBM output, each addressed at the identity
+    coordinates ``(d0, d1, d2)`` over the stickified device shape.
+    """
+    d0, d1, d2 = sympy.symbols("d0 d1 d2")
+    coords = [d0, d1, d2]
+    size = [16, 512, 64]
+
+    def arg(is_input: bool, index: int, name: str) -> TensorArg:
+        return TensorArg(
+            is_input=is_input,
+            arg_index=index,
+            device_dtype=DataFormats.SEN169_FP16,
+            device_size=list(size),
+            device_coordinates=list(coords),
+            allocation={"hbm": None},
+            name=name,
+        )
+
+    return [
+        OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space={d0: (16, 1), d1: (512, 1), d2: (64, 1)},
+            args=[
+                arg(True, 0, "arg0"),
+                arg(True, 1, "arg1"),
+                arg(False, 2, "buf0"),
+            ],
+            op_info={},
+        )
+    ]
+
+
+@unittest.skipUnless(
+    _mlir_ktdp_available(),
+    "mlir_ktdp with func/arith dialect bindings is not installed",
+)
+class TestKtirEmitter(unittest.TestCase):
+    def test_pointwise_add_golden(self):
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        emitted = generate_ktir("ktir_fused_add_0", _add_op_specs())
+        self.assertEqual(emitted, _EXPECTED_ADD_KTIR)
+
+    def test_reduction_unsupported(self):
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        specs = _add_op_specs()
+        specs[0].is_reduction = True
+        with self.assertRaises(NotImplementedError):
+            generate_ktir("ktir_fused_add_0", specs)
+
+    def test_non_add_unsupported(self):
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        specs = _add_op_specs()
+        specs[0].op = "mul"
+        with self.assertRaises(NotImplementedError):
+            generate_ktir("ktir_fused_mul_0", specs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/inductor/test_ktir_emitter.py
+++ b/tests/inductor/test_ktir_emitter.py
@@ -30,10 +30,17 @@ from torch_spyre._inductor.op_spec import LoopSpec, OpSpec, TensorArg
 
 
 def _mlir_ktdp_available() -> bool:
-    """True when mlir_ktdp is built with the func/arith dialect Python bindings."""
+    """True when mlir_ktdp is built with the dialect Python bindings the emitter
+    needs (func/arith/ktdp plus linalg/tensor for the pointwise named ops)."""
     try:
         from mlir_ktdp import ir  # noqa: F401
-        from mlir_ktdp.dialects import arith, func, ktdp  # noqa: F401
+        from mlir_ktdp.dialects import (  # noqa: F401
+            arith,
+            func,
+            ktdp,
+            linalg,
+            tensor,
+        )
     except ImportError:
         return False
     return True
@@ -183,17 +190,18 @@ module {
     %4 = ktdp.load %3 : <16x512x64xindex> -> tensor<16x512x64xf16>
     %5 = ktdp.construct_access_tile %1[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
     %6 = ktdp.load %5 : <16x512x64xindex> -> tensor<16x512x64xf16>
-    %7 = arith.addf %4, %6 : tensor<16x512x64xf16>
-    %8 = ktdp.construct_access_tile %2[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
-    ktdp.store %7, %8 : tensor<16x512x64xf16>, <16x512x64xindex>
+    %7 = tensor.empty() : tensor<16x512x64xf16>
+    %8 = linalg.add ins(%4, %6 : tensor<16x512x64xf16>, tensor<16x512x64xf16>) outs(%7 : tensor<16x512x64xf16>) -> tensor<16x512x64xf16>
+    %9 = ktdp.construct_access_tile %2[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    ktdp.store %8, %9 : tensor<16x512x64xf16>, <16x512x64xindex>
     return
   }
 }
 """
 
 
-# ``(a + b) + c``: buf0 threads from the first addf straight into the second
-# (%8 feeds %11) -- no memory view / access tile / load / store for it.
+# ``(a + b) + c``: buf0 threads from the first linalg.add straight into the
+# second (%9 feeds %13) -- no memory view / access tile / load / store for it.
 _EXPECTED_FUSED_CHAIN_KTIR = """\
 #map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #set = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 15 >= 0, d1 >= 0, -d1 + 511 >= 0, d2 >= 0, -d2 + 63 >= 0)>
@@ -208,20 +216,22 @@ module {
     %5 = ktdp.load %4 : <16x512x64xindex> -> tensor<16x512x64xf16>
     %6 = ktdp.construct_access_tile %1[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
     %7 = ktdp.load %6 : <16x512x64xindex> -> tensor<16x512x64xf16>
-    %8 = arith.addf %5, %7 : tensor<16x512x64xf16>
-    %9 = ktdp.construct_access_tile %2[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
-    %10 = ktdp.load %9 : <16x512x64xindex> -> tensor<16x512x64xf16>
-    %11 = arith.addf %8, %10 : tensor<16x512x64xf16>
-    %12 = ktdp.construct_access_tile %3[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
-    ktdp.store %11, %12 : tensor<16x512x64xf16>, <16x512x64xindex>
+    %8 = tensor.empty() : tensor<16x512x64xf16>
+    %9 = linalg.add ins(%5, %7 : tensor<16x512x64xf16>, tensor<16x512x64xf16>) outs(%8 : tensor<16x512x64xf16>) -> tensor<16x512x64xf16>
+    %10 = ktdp.construct_access_tile %2[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    %11 = ktdp.load %10 : <16x512x64xindex> -> tensor<16x512x64xf16>
+    %12 = tensor.empty() : tensor<16x512x64xf16>
+    %13 = linalg.add ins(%9, %11 : tensor<16x512x64xf16>, tensor<16x512x64xf16>) outs(%12 : tensor<16x512x64xf16>) -> tensor<16x512x64xf16>
+    %14 = ktdp.construct_access_tile %3[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    ktdp.store %13, %14 : tensor<16x512x64xf16>, <16x512x64xindex>
     return
   }
 }
 """
 
 
-# ``(a + b) * (c + d)``: buf0 (%9) and buf1 (%14) both thread into the mulf
-# (%15) with no materialization; only buf2 (%arg4) is stored.
+# ``(a + b) * (c + d)``: buf0 (%10) and buf1 (%16) both thread into the
+# linalg.mul (%18) with no materialization; only buf2 (%arg4) is stored.
 _EXPECTED_FUSED_ADD_MUL_KTIR = """\
 #map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #set = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 15 >= 0, d1 >= 0, -d1 + 511 >= 0, d2 >= 0, -d2 + 63 >= 0)>
@@ -237,15 +247,18 @@ module {
     %6 = ktdp.load %5 : <16x512x64xindex> -> tensor<16x512x64xf16>
     %7 = ktdp.construct_access_tile %1[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
     %8 = ktdp.load %7 : <16x512x64xindex> -> tensor<16x512x64xf16>
-    %9 = arith.addf %6, %8 : tensor<16x512x64xf16>
-    %10 = ktdp.construct_access_tile %2[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
-    %11 = ktdp.load %10 : <16x512x64xindex> -> tensor<16x512x64xf16>
-    %12 = ktdp.construct_access_tile %3[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
-    %13 = ktdp.load %12 : <16x512x64xindex> -> tensor<16x512x64xf16>
-    %14 = arith.addf %11, %13 : tensor<16x512x64xf16>
-    %15 = arith.mulf %9, %14 : tensor<16x512x64xf16>
-    %16 = ktdp.construct_access_tile %4[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
-    ktdp.store %15, %16 : tensor<16x512x64xf16>, <16x512x64xindex>
+    %9 = tensor.empty() : tensor<16x512x64xf16>
+    %10 = linalg.add ins(%6, %8 : tensor<16x512x64xf16>, tensor<16x512x64xf16>) outs(%9 : tensor<16x512x64xf16>) -> tensor<16x512x64xf16>
+    %11 = ktdp.construct_access_tile %2[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    %12 = ktdp.load %11 : <16x512x64xindex> -> tensor<16x512x64xf16>
+    %13 = ktdp.construct_access_tile %3[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    %14 = ktdp.load %13 : <16x512x64xindex> -> tensor<16x512x64xf16>
+    %15 = tensor.empty() : tensor<16x512x64xf16>
+    %16 = linalg.add ins(%12, %14 : tensor<16x512x64xf16>, tensor<16x512x64xf16>) outs(%15 : tensor<16x512x64xf16>) -> tensor<16x512x64xf16>
+    %17 = tensor.empty() : tensor<16x512x64xf16>
+    %18 = linalg.mul ins(%10, %16 : tensor<16x512x64xf16>, tensor<16x512x64xf16>) outs(%17 : tensor<16x512x64xf16>) -> tensor<16x512x64xf16>
+    %19 = ktdp.construct_access_tile %4[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    ktdp.store %18, %19 : tensor<16x512x64xf16>, <16x512x64xindex>
     return
   }
 }
@@ -274,11 +287,12 @@ module {
     %7 = arith.muli %3, %c16_0 : index
     %8 = ktdp.construct_access_tile %1[%c0, %7, %c0] {access_tile_order = #map, access_tile_set = #set1} : memref<16x512x64xf16> -> !ktdp.access_tile<16x16x64xindex>
     %9 = ktdp.load %8 : <16x16x64xindex> -> tensor<16x16x64xf16>
-    %10 = arith.addf %6, %9 : tensor<16x16x64xf16>
+    %10 = tensor.empty() : tensor<16x16x64xf16>
+    %11 = linalg.add ins(%6, %9 : tensor<16x16x64xf16>, tensor<16x16x64xf16>) outs(%10 : tensor<16x16x64xf16>) -> tensor<16x16x64xf16>
     %c16_1 = arith.constant 16 : index
-    %11 = arith.muli %3, %c16_1 : index
-    %12 = ktdp.construct_access_tile %2[%c0, %11, %c0] {access_tile_order = #map, access_tile_set = #set1} : memref<16x512x64xf16> -> !ktdp.access_tile<16x16x64xindex>
-    ktdp.store %10, %12 : tensor<16x16x64xf16>, <16x16x64xindex>
+    %12 = arith.muli %3, %c16_1 : index
+    %13 = ktdp.construct_access_tile %2[%c0, %12, %c0] {access_tile_order = #map, access_tile_set = #set1} : memref<16x512x64xf16> -> !ktdp.access_tile<16x16x64xindex>
+    ktdp.store %11, %13 : tensor<16x16x64xf16>, <16x16x64xindex>
     return
   }
 }

--- a/tests/inductor/test_ktir_emitter.py
+++ b/tests/inductor/test_ktir_emitter.py
@@ -20,6 +20,7 @@ Skipped only where ``mlir_ktdp`` is not installed.
 """
 
 import unittest
+from unittest import mock
 
 import sympy
 
@@ -98,6 +99,10 @@ def _add_op_specs() -> list:
     ]
 
 
+# The emitter only supports the single-core (SENCORES=1) grid so far; pin it so
+# these tests exercise their intended guards rather than the multi-core guard,
+# which would otherwise fire first on the default SENCORES=32.
+@mock.patch("torch_spyre._inductor.config.sencores", 1)
 @unittest.skipUnless(
     _mlir_ktdp_available(),
     "mlir_ktdp with func/arith dialect bindings is not installed",
@@ -124,6 +129,17 @@ class TestKtirEmitter(unittest.TestCase):
         specs[0].op = "mul"
         with self.assertRaises(NotImplementedError):
             generate_ktir("ktir_fused_mul_0", specs)
+
+
+class TestKtirCapabilityGuards(unittest.TestCase):
+    """Guards that fire before the mlir_ktdp import, so they need no dialect."""
+
+    @mock.patch("torch_spyre._inductor.config.sencores", 2)
+    def test_multicore_unsupported(self):
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        with self.assertRaises(NotImplementedError):
+            generate_ktir("ktir_fused_add_0", _add_op_specs())
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_ktir_emitter.py
+++ b/tests/inductor/test_ktir_emitter.py
@@ -14,18 +14,19 @@
 
 """Golden-text snapshot test for the OpSpec->KTIR emitter (``generate_ktir``).
 
-Self-contained: it builds the ``add`` OpSpec directly (no live Inductor graph,
-no compiler run) and asserts the emitter's canonical MLIR text.
-Skipped only where ``mlir_ktdp`` is not installed.
+Self-contained: it builds the OpSpecs directly (no live Inductor graph, no
+compiler run) and asserts the emitter's canonical MLIR text for a single
+pointwise ``add``, a fused pointwise chain (register-threaded intermediates),
+and a work-divided pointwise ``add`` (multi-core grid).  Skipped only where
+``mlir_ktdp`` is not installed.
 """
 
 import unittest
-from unittest import mock
 
 import sympy
 
 from torch_spyre._C import DataFormats
-from torch_spyre._inductor.op_spec import OpSpec, TensorArg
+from torch_spyre._inductor.op_spec import LoopSpec, OpSpec, TensorArg
 
 
 def _mlir_ktdp_available() -> bool:
@@ -36,6 +37,135 @@ def _mlir_ktdp_available() -> bool:
     except ImportError:
         return False
     return True
+
+
+# Device shape [16, 512, 64] fp16 (a [512, 1024] logical tensor stickified).
+_D0, _D1, _D2 = sympy.symbols("d0 d1 d2")
+_COORDS = [_D0, _D1, _D2]
+_SIZE = [16, 512, 64]
+
+
+def _arg(is_input: bool, index: int, name: str) -> TensorArg:
+    """A TensorArg at the identity coordinates over the [16, 512, 64] shape.
+
+    ``index < 0`` marks a fused-away intermediate (no assigned arg slot); such a
+    buffer is register-threaded rather than materialized to a func parameter.
+    """
+    return TensorArg(
+        is_input=is_input,
+        arg_index=index,
+        device_dtype=DataFormats.SEN169_FP16,
+        device_size=list(_SIZE),
+        device_coordinates=list(_COORDS),
+        allocation={"hbm": None},
+        name=name,
+    )
+
+
+def _it_space(divs=(1, 1, 1)) -> dict:
+    """Iteration space over (d0, d1, d2) with per-dim work divisions ``divs``."""
+    return {
+        _D0: (_SIZE[0], divs[0]),
+        _D1: (_SIZE[1], divs[1]),
+        _D2: (_SIZE[2], divs[2]),
+    }
+
+
+def _add_op_specs() -> list:
+    """Finished OpSpec list for ``a + b`` (two HBM inputs, one HBM output)."""
+    return [
+        OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space=_it_space(),
+            args=[_arg(True, 0, "arg0"), _arg(True, 1, "arg1"), _arg(False, 2, "buf0")],
+            op_info={},
+        )
+    ]
+
+
+def _fused_chain_op_specs() -> list:
+    """``(a + b) + c``: the first add's output is a fused-away intermediate.
+
+    ``buf0`` (arg_index -1) is produced by the first add and consumed by the
+    second; it must be register-threaded, never materialized to HBM.
+    """
+    return [
+        OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space=_it_space(),
+            args=[
+                _arg(True, 0, "arg0"),
+                _arg(True, 1, "arg1"),
+                _arg(False, -1, "buf0"),
+            ],
+            op_info={},
+        ),
+        OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space=_it_space(),
+            args=[
+                _arg(True, -1, "buf0"),
+                _arg(True, 2, "arg2"),
+                _arg(False, 3, "buf1"),
+            ],
+            op_info={},
+        ),
+    ]
+
+
+def _fused_add_mul_op_specs() -> list:
+    """``(a + b) * (c + d)``: two fused-away intermediates + a ``mul``."""
+    return [
+        OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space=_it_space(),
+            args=[
+                _arg(True, 0, "arg0"),
+                _arg(True, 1, "arg1"),
+                _arg(False, -1, "buf0"),
+            ],
+            op_info={},
+        ),
+        OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space=_it_space(),
+            args=[
+                _arg(True, 2, "arg2"),
+                _arg(True, 3, "arg3"),
+                _arg(False, -1, "buf1"),
+            ],
+            op_info={},
+        ),
+        OpSpec(
+            op="mul",
+            is_reduction=False,
+            iteration_space=_it_space(),
+            args=[
+                _arg(True, -1, "buf0"),
+                _arg(True, -1, "buf1"),
+                _arg(False, 4, "buf2"),
+            ],
+            op_info={},
+        ),
+    ]
+
+
+def _work_divided_add_op_specs() -> list:
+    """``a + b`` with the d1 axis split across 32 cores (512 // 32 = 16)."""
+    return [
+        OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space=_it_space((1, 32, 1)),
+            args=[_arg(True, 0, "arg0"), _arg(True, 1, "arg1"), _arg(False, 2, "buf0")],
+            op_info={},
+        )
+    ]
 
 
 # The canonical KTIR text ``generate_ktir`` emits for a single pointwise ``add``
@@ -62,57 +192,131 @@ module {
 """
 
 
-def _add_op_specs() -> list:
-    """Finished OpSpec list for ``a + b`` at device shape [16, 512, 64] fp16.
-
-    This mirrors what the SuperDSC frontend produces for a pointwise ``a + b``:
-    two HBM inputs and one HBM output, each addressed at the identity
-    coordinates ``(d0, d1, d2)`` over the stickified device shape.
-    """
-    d0, d1, d2 = sympy.symbols("d0 d1 d2")
-    coords = [d0, d1, d2]
-    size = [16, 512, 64]
-
-    def arg(is_input: bool, index: int, name: str) -> TensorArg:
-        return TensorArg(
-            is_input=is_input,
-            arg_index=index,
-            device_dtype=DataFormats.SEN169_FP16,
-            device_size=list(size),
-            device_coordinates=list(coords),
-            allocation={"hbm": None},
-            name=name,
-        )
-
-    return [
-        OpSpec(
-            op="add",
-            is_reduction=False,
-            iteration_space={d0: (16, 1), d1: (512, 1), d2: (64, 1)},
-            args=[
-                arg(True, 0, "arg0"),
-                arg(True, 1, "arg1"),
-                arg(False, 2, "buf0"),
-            ],
-            op_info={},
-        )
-    ]
+# ``(a + b) + c``: buf0 threads from the first addf straight into the second
+# (%8 feeds %11) -- no memory view / access tile / load / store for it.
+_EXPECTED_FUSED_CHAIN_KTIR = """\
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#set = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 15 >= 0, d1 >= 0, -d1 + 511 >= 0, d2 >= 0, -d2 + 63 >= 0)>
+module {
+  func.func @ktir_fused_add_add_0(%arg0: index, %arg1: index, %arg2: index, %arg3: index) attributes {grid = [1]} {
+    %c0 = arith.constant 0 : index
+    %0 = ktdp.construct_memory_view %arg0, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %1 = ktdp.construct_memory_view %arg1, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %2 = ktdp.construct_memory_view %arg2, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %3 = ktdp.construct_memory_view %arg3, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %4 = ktdp.construct_access_tile %0[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    %5 = ktdp.load %4 : <16x512x64xindex> -> tensor<16x512x64xf16>
+    %6 = ktdp.construct_access_tile %1[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    %7 = ktdp.load %6 : <16x512x64xindex> -> tensor<16x512x64xf16>
+    %8 = arith.addf %5, %7 : tensor<16x512x64xf16>
+    %9 = ktdp.construct_access_tile %2[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    %10 = ktdp.load %9 : <16x512x64xindex> -> tensor<16x512x64xf16>
+    %11 = arith.addf %8, %10 : tensor<16x512x64xf16>
+    %12 = ktdp.construct_access_tile %3[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    ktdp.store %11, %12 : tensor<16x512x64xf16>, <16x512x64xindex>
+    return
+  }
+}
+"""
 
 
-# The emitter only supports the single-core (SENCORES=1) grid so far; pin it so
-# these tests exercise their intended guards rather than the multi-core guard,
-# which would otherwise fire first on the default SENCORES=32.
-@mock.patch("torch_spyre._inductor.config.sencores", 1)
+# ``(a + b) * (c + d)``: buf0 (%9) and buf1 (%14) both thread into the mulf
+# (%15) with no materialization; only buf2 (%arg4) is stored.
+_EXPECTED_FUSED_ADD_MUL_KTIR = """\
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#set = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 15 >= 0, d1 >= 0, -d1 + 511 >= 0, d2 >= 0, -d2 + 63 >= 0)>
+module {
+  func.func @ktir_fused_add_add_mul_0(%arg0: index, %arg1: index, %arg2: index, %arg3: index, %arg4: index) attributes {grid = [1]} {
+    %c0 = arith.constant 0 : index
+    %0 = ktdp.construct_memory_view %arg0, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %1 = ktdp.construct_memory_view %arg1, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %2 = ktdp.construct_memory_view %arg2, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %3 = ktdp.construct_memory_view %arg3, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %4 = ktdp.construct_memory_view %arg4, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %5 = ktdp.construct_access_tile %0[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    %6 = ktdp.load %5 : <16x512x64xindex> -> tensor<16x512x64xf16>
+    %7 = ktdp.construct_access_tile %1[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    %8 = ktdp.load %7 : <16x512x64xindex> -> tensor<16x512x64xf16>
+    %9 = arith.addf %6, %8 : tensor<16x512x64xf16>
+    %10 = ktdp.construct_access_tile %2[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    %11 = ktdp.load %10 : <16x512x64xindex> -> tensor<16x512x64xf16>
+    %12 = ktdp.construct_access_tile %3[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    %13 = ktdp.load %12 : <16x512x64xindex> -> tensor<16x512x64xf16>
+    %14 = arith.addf %11, %13 : tensor<16x512x64xf16>
+    %15 = arith.mulf %9, %14 : tensor<16x512x64xf16>
+    %16 = ktdp.construct_access_tile %4[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    ktdp.store %15, %16 : tensor<16x512x64xf16>, <16x512x64xindex>
+    return
+  }
+}
+"""
+
+
+# ``a + b`` split over 32 cores on d1: grid = [32], a flat get_compute_tile_id,
+# per-core base ``id * 16`` on the d1 axis, per-core access tiles of shape
+# [16, 16, 64] under the shrunk #set1; the memory views stay full [16, 512, 64].
+_EXPECTED_WORK_DIVIDED_KTIR = """\
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#set = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 15 >= 0, d1 >= 0, -d1 + 511 >= 0, d2 >= 0, -d2 + 63 >= 0)>
+#set1 = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 15 >= 0, d1 >= 0, -d1 + 15 >= 0, d2 >= 0, -d2 + 63 >= 0)>
+module {
+  func.func @ktir_fused_add_0(%arg0: index, %arg1: index, %arg2: index) attributes {grid = [32]} {
+    %c0 = arith.constant 0 : index
+    %0 = ktdp.construct_memory_view %arg0, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %1 = ktdp.construct_memory_view %arg1, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %2 = ktdp.construct_memory_view %arg2, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %3 = ktdp.get_compute_tile_id : index
+    %c16 = arith.constant 16 : index
+    %4 = arith.muli %3, %c16 : index
+    %5 = ktdp.construct_access_tile %0[%c0, %4, %c0] {access_tile_order = #map, access_tile_set = #set1} : memref<16x512x64xf16> -> !ktdp.access_tile<16x16x64xindex>
+    %6 = ktdp.load %5 : <16x16x64xindex> -> tensor<16x16x64xf16>
+    %c16_0 = arith.constant 16 : index
+    %7 = arith.muli %3, %c16_0 : index
+    %8 = ktdp.construct_access_tile %1[%c0, %7, %c0] {access_tile_order = #map, access_tile_set = #set1} : memref<16x512x64xf16> -> !ktdp.access_tile<16x16x64xindex>
+    %9 = ktdp.load %8 : <16x16x64xindex> -> tensor<16x16x64xf16>
+    %10 = arith.addf %6, %9 : tensor<16x16x64xf16>
+    %c16_1 = arith.constant 16 : index
+    %11 = arith.muli %3, %c16_1 : index
+    %12 = ktdp.construct_access_tile %2[%c0, %11, %c0] {access_tile_order = #map, access_tile_set = #set1} : memref<16x512x64xf16> -> !ktdp.access_tile<16x16x64xindex>
+    ktdp.store %10, %12 : tensor<16x16x64xf16>, <16x16x64xindex>
+    return
+  }
+}
+"""
+
+
 @unittest.skipUnless(
     _mlir_ktdp_available(),
     "mlir_ktdp with func/arith dialect bindings is not installed",
 )
 class TestKtirEmitter(unittest.TestCase):
     def test_pointwise_add_golden(self):
+        """Single pointwise add, single core -- the pointwise-PR baseline."""
         from torch_spyre._inductor.codegen.ktir import generate_ktir
 
         emitted = generate_ktir("ktir_fused_add_0", _add_op_specs())
         self.assertEqual(emitted, _EXPECTED_ADD_KTIR)
+
+    def test_fused_chain_golden(self):
+        """``(a + b) + c``: the intermediate is register-threaded, not stored."""
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        emitted = generate_ktir("ktir_fused_add_add_0", _fused_chain_op_specs())
+        self.assertEqual(emitted, _EXPECTED_FUSED_CHAIN_KTIR)
+
+    def test_fused_add_mul_golden(self):
+        """``(a + b) * (c + d)``: two threaded intermediates + a ``mul``."""
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        emitted = generate_ktir("ktir_fused_add_add_mul_0", _fused_add_mul_op_specs())
+        self.assertEqual(emitted, _EXPECTED_FUSED_ADD_MUL_KTIR)
+
+    def test_work_divided_add_golden(self):
+        """Pointwise add split across 32 cores on the d1 axis."""
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        emitted = generate_ktir("ktir_fused_add_0", _work_divided_add_op_specs())
+        self.assertEqual(emitted, _EXPECTED_WORK_DIVIDED_KTIR)
 
     def test_reduction_unsupported(self):
         from torch_spyre._inductor.codegen.ktir import generate_ktir
@@ -122,24 +326,22 @@ class TestKtirEmitter(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             generate_ktir("ktir_fused_add_0", specs)
 
-    def test_non_add_unsupported(self):
+    def test_unsupported_op(self):
+        """A pointwise op outside the wired-up set (e.g. ``sub``) must raise."""
         from torch_spyre._inductor.codegen.ktir import generate_ktir
 
         specs = _add_op_specs()
-        specs[0].op = "mul"
+        specs[0].op = "sub"
         with self.assertRaises(NotImplementedError):
-            generate_ktir("ktir_fused_mul_0", specs)
+            generate_ktir("ktir_fused_sub_0", specs)
 
-
-class TestKtirCapabilityGuards(unittest.TestCase):
-    """Guards that fire before the mlir_ktdp import, so they need no dialect."""
-
-    @mock.patch("torch_spyre._inductor.config.sencores", 2)
-    def test_multicore_unsupported(self):
+    def test_loopspec_unsupported(self):
+        """A counted loop (``LoopSpec``) is out of scope and must raise."""
         from torch_spyre._inductor.codegen.ktir import generate_ktir
 
+        specs = [LoopSpec(count=4, body=_add_op_specs())]
         with self.assertRaises(NotImplementedError):
-            generate_ktir("ktir_fused_add_0", _add_op_specs())
+            generate_ktir("ktir_loop_0", specs)
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_opspec_utils.py
+++ b/tests/inductor/test_opspec_utils.py
@@ -1,0 +1,199 @@
+# Copyright 2025-2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the pure OpSpec-reading helpers in ``opspec_utils``.
+
+These helpers (buffer identity, row-major strides, device-dim classification,
+reshape/broadcast alignment) are pure sympy/int computations with no MLIR
+emission, so this suite runs in CI without ``mlir_ktdp`` installed -- unlike
+``test_ktir_emitter`` which pins the emitted MLIR text and skips without it.
+"""
+
+import unittest
+
+import sympy
+from torch.utils._sympy.functions import FloorDiv
+
+from torch_spyre._C import DataFormats
+from torch_spyre._inductor.codegen.opspec_utils import (
+    _DIM_BARE,
+    _DIM_CONST,
+    _DIM_OUTER_STICK,
+    _DIM_WITHIN_STICK,
+    _align_reshape_plan,
+    _buf_id,
+    _dim_info,
+    _iteration_space_key,
+    _row_major_strides,
+)
+from torch_spyre._inductor.op_spec import OpSpec, TensorArg
+
+
+def _arg(name, arg_index=0) -> TensorArg:
+    """Minimal TensorArg; only ``name`` matters for ``_buf_id``."""
+    return TensorArg(
+        is_input=True,
+        arg_index=arg_index,
+        device_dtype=DataFormats.SEN169_FP16,
+        device_size=[64],
+        device_coordinates=[sympy.Symbol("d0")],
+        allocation={"hbm": None},
+        name=name,
+    )
+
+
+class TestRowMajorStrides(unittest.TestCase):
+    def test_rank3(self):
+        self.assertEqual(_row_major_strides([16, 512, 64]), [32768, 64, 1])
+
+    def test_rank1(self):
+        self.assertEqual(_row_major_strides([64]), [1])
+
+    def test_rank2(self):
+        self.assertEqual(_row_major_strides([8, 3]), [3, 1])
+
+
+class TestBufId(unittest.TestCase):
+    def test_name_is_identity(self):
+        self.assertEqual(_buf_id(_arg("buf0")), "buf0")
+
+    def test_same_name_same_id_across_input_output(self):
+        # An intermediate appearing as both input and output (arg_index sentinel
+        # -1 either side) must key on the shared name, not arg_index.
+        as_in = _arg("buf7", arg_index=-1)
+        as_out = _arg("buf7", arg_index=-1)
+        self.assertEqual(_buf_id(as_in), _buf_id(as_out))
+
+    def test_none_name_raises_value_error(self):
+        # Missing name is a broken internal invariant, not a capability gap:
+        # ValueError, not NotImplementedError.
+        with self.assertRaises(ValueError):
+            _buf_id(_arg(None))
+
+
+class TestDimInfo(unittest.TestCase):
+    def test_const_dim(self):
+        self.assertEqual(_dim_info(sympy.Integer(1)), (_DIM_CONST, None))
+
+    def test_bare_symbol(self):
+        d0 = sympy.Symbol("d0")
+        self.assertEqual(_dim_info(d0), (_DIM_BARE, d0))
+
+    def test_within_stick(self):
+        d0 = sympy.Symbol("d0")
+        kind, sym = _dim_info(sympy.Mod(d0, 64))
+        self.assertEqual(kind, _DIM_WITHIN_STICK)
+        self.assertEqual(sym, d0)
+
+    def test_outer_stick(self):
+        d0 = sympy.Symbol("d0")
+        kind, sym = _dim_info(FloorDiv(d0, 64))
+        self.assertEqual(kind, _DIM_OUTER_STICK)
+        self.assertEqual(sym, d0)
+
+    def test_multi_symbol_raises(self):
+        d0, d1 = sympy.symbols("d0 d1")
+        with self.assertRaises(NotImplementedError):
+            _dim_info(d0 * 8 + d1)
+
+    def test_single_symbol_unknown_form_raises(self):
+        # A single-symbol coordinate that is neither bare, within-stick, nor
+        # outer-stick (e.g. ``2*d0 + 1``) must raise, not fall through.
+        d0 = sympy.Symbol("d0")
+        with self.assertRaises(NotImplementedError):
+            _dim_info(2 * d0 + 1)
+
+
+class TestIterationSpaceKey(unittest.TestCase):
+    def test_order_independent(self):
+        d0, d1 = sympy.symbols("d0 d1")
+        spec_a = OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space={d0: (16, 1), d1: (512, 1)},
+            args=[],
+            op_info={},
+        )
+        spec_b = OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space={d1: (512, 1), d0: (16, 1)},
+            args=[],
+            op_info={},
+        )
+        self.assertEqual(_iteration_space_key(spec_a), _iteration_space_key(spec_b))
+
+    def test_distinct_ranges_differ(self):
+        d0 = sympy.Symbol("d0")
+        spec_a = OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space={d0: (16, 1)},
+            args=[],
+            op_info={},
+        )
+        spec_b = OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space={d0: (32, 1)},
+            args=[],
+            op_info={},
+        )
+        self.assertNotEqual(_iteration_space_key(spec_a), _iteration_space_key(spec_b))
+
+
+class TestAlignReshapePlan(unittest.TestCase):
+    def test_identity_returns_none(self):
+        d0, d1 = sympy.symbols("d0 d1")
+        self.assertIsNone(_align_reshape_plan([d0, d1], [16, 64], [d0, d1], [16, 64]))
+
+    def test_broadcast_unmatched_output_axis(self):
+        # Input [a, within] aligned into output [a, b, within]: the output's
+        # ``b`` axis has no input counterpart, so it reshapes to extent 1 and
+        # then broadcasts to the output block.
+        a, b, c = sympy.symbols("a b c")
+        plan = _align_reshape_plan(
+            [a, sympy.Mod(c, 64)],
+            [16, 64],
+            [a, b, sympy.Mod(c, 64)],
+            [16, 8, 64],
+        )
+        self.assertEqual(plan, ([16, 1, 64], [16, 8, 64]))
+
+    def test_transpose_raises(self):
+        # Matched input axes in decreasing order -> would need a permute.
+        a, b, c = sympy.symbols("a b c")
+        with self.assertRaises(NotImplementedError):
+            _align_reshape_plan(
+                [b, a, sympy.Mod(c, 64)],
+                [2, 3, 64],
+                [a, b, sympy.Mod(c, 64)],
+                [3, 2, 64],
+            )
+
+    def test_dropped_extent_raises(self):
+        # An input axis with extent > 1 that no output axis matches would lose
+        # data -> needs a cross-stick transpose (restickify), not a reshape.
+        a, d, c = sympy.symbols("a d c")
+        with self.assertRaises(NotImplementedError):
+            _align_reshape_plan(
+                [a, sympy.Mod(c, 64)],
+                [4, 64],
+                [d, sympy.Mod(c, 64)],
+                [4, 64],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/inductor/test_opspec_utils.py
+++ b/tests/inductor/test_opspec_utils.py
@@ -33,6 +33,8 @@ from torch_spyre._inductor.codegen.opspec_utils import (
     _DIM_WITHIN_STICK,
     _align_reshape_plan,
     _buf_id,
+    _decompose_work_divisions,
+    _device_block_shape,
     _dim_info,
     _iteration_space_key,
     _row_major_strides,
@@ -193,6 +195,93 @@ class TestAlignReshapePlan(unittest.TestCase):
                 [d, sympy.Mod(c, 64)],
                 [4, 64],
             )
+
+
+class TestDecomposeWorkDivisions(unittest.TestCase):
+    def test_no_division(self):
+        # Every symbol has div == 1: nothing splits, single-core grid.
+        d0, d1 = sympy.symbols("d0 d1")
+        work, total = _decompose_work_divisions({d0: (16, 1), d1: (512, 1)})
+        self.assertEqual(work, [])
+        self.assertEqual(total, 1)
+
+    def test_single_divided_symbol(self):
+        # One divided axis owns the whole flat grid: inner_cores == 1.
+        d0, d1 = sympy.symbols("d0 d1")
+        work, total = _decompose_work_divisions({d0: (16, 1), d1: (512, 32)})
+        self.assertEqual(work, [(d1, 32, 1)])
+        self.assertEqual(total, 32)
+
+    def test_multiple_divided_symbols_mixed_radix(self):
+        # Two divided axes: the flat index is mixed-radix, innermost (last in
+        # iteration order) first, so d1 gets inner_cores 1 and d0 gets 4.
+        d0, d1 = sympy.symbols("d0 d1")
+        work, total = _decompose_work_divisions({d0: (16, 2), d1: (512, 4)})
+        self.assertEqual(work, [(d1, 4, 1), (d0, 2, 4)])
+        self.assertEqual(total, 8)
+
+    def test_undivided_axis_between_divided_is_skipped(self):
+        # A div == 1 axis contributes no core portion even when it sits between
+        # two divided axes.
+        d0, d1, d2 = sympy.symbols("d0 d1 d2")
+        work, total = _decompose_work_divisions(
+            {d0: (16, 2), d1: (512, 1), d2: (64, 4)}
+        )
+        self.assertEqual(work, [(d2, 4, 1), (d0, 2, 4)])
+        self.assertEqual(total, 8)
+
+
+def _arg_nd(sizes, coords) -> TensorArg:
+    """TensorArg with explicit device sizes/coordinates for block-shape tests."""
+    return TensorArg(
+        is_input=True,
+        arg_index=0,
+        device_dtype=DataFormats.SEN169_FP16,
+        device_size=sizes,
+        device_coordinates=coords,
+        allocation={"hbm": None},
+        name="buf0",
+    )
+
+
+class TestDeviceBlockShape(unittest.TestCase):
+    def test_undivided_returns_full_shape(self):
+        c0, c1, c2 = sympy.symbols("c0 c1 c2")
+        arg = _arg_nd([16, 512, 64], [c0, c1, sympy.Mod(c2, 64)])
+        self.assertEqual(_device_block_shape(arg, {}), [16, 512, 64])
+
+    def test_divided_outer_dim(self):
+        # c1 divided by 32 -> that dim shrinks; the within-stick last dim and
+        # the undivided c0 dim stay full.
+        c0, c1, c2 = sympy.symbols("c0 c1 c2")
+        arg = _arg_nd([16, 512, 64], [c0, c1, sympy.Mod(c2, 64)])
+        self.assertEqual(_device_block_shape(arg, {c1: 32}), [16, 16, 64])
+
+    def test_within_stick_never_divided(self):
+        # Even if the last dim's symbol carries a divisor, the within-stick dim
+        # stays at its full device size.
+        c0, c1, c2 = sympy.symbols("c0 c1 c2")
+        arg = _arg_nd([16, 512, 64], [c0, c1, sympy.Mod(c2, 64)])
+        self.assertEqual(_device_block_shape(arg, {c2: 2}), [16, 512, 64])
+
+    def test_outer_stick_dim_divided(self):
+        # An outer-stick coordinate (c0 // 64) carries one symbol and divides.
+        c0, c2 = sympy.symbols("c0 c2")
+        arg = _arg_nd([16, 64], [FloorDiv(c0, 64), sympy.Mod(c2, 64)])
+        self.assertEqual(_device_block_shape(arg, {c0: 2}), [8, 64])
+
+    def test_constant_axis_left_full(self):
+        # A broadcast axis carries a constant coordinate (no symbols): no
+        # divisor applies, so it keeps its full size.
+        c2 = sympy.Symbol("c2")
+        arg = _arg_nd([8, 64], [sympy.Integer(1), sympy.Mod(c2, 64)])
+        self.assertEqual(_device_block_shape(arg, {}), [8, 64])
+
+    def test_multi_symbol_axis_raises(self):
+        c0, c1, c2 = sympy.symbols("c0 c1 c2")
+        arg = _arg_nd([128, 64], [c0 * 8 + c1, sympy.Mod(c2, 64)])
+        with self.assertRaises(NotImplementedError):
+            _device_block_shape(arg, {c0: 2})
 
 
 if __name__ == "__main__":

--- a/tests/scripts/check_test_coverage.sh
+++ b/tests/scripts/check_test_coverage.sh
@@ -54,6 +54,10 @@ TESTS_DIR="${REPO_ROOT}/tests"
 # (e.g. shared test harness helpers, not standalone test suites).
 IGNORED_TEST_FILES=(
   "models/test_model_ops.py"   # base class / helper — not a standalone test suite
+  # Golden IR suite: requires the dialect-packaged mlir_ktdp build, which no CI
+  # lane provides, so it is skip-only in CI. Revisit when a KTIR/mlir_ktdp lane
+  # exists.
+  "inductor/test_ktir_emitter.py"
 )
 
 # ── Ignore list: config files ─────────────────────────────────────────────────

--- a/tests/test_async_compile_ktir_dbo.py
+++ b/tests/test_async_compile_ktir_dbo.py
@@ -1,0 +1,139 @@
+# Copyright 2025-2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CI-safe wiring test for the ``dbo`` backend on the OpSpec->KTIR path.
+
+Exercises ``SpyreAsyncCompile.ktir`` without a real ``dbo-opt`` binary or a
+device: ``generate_ktir`` is stubbed to a fixed string, ``subprocess.run`` is
+recorded (and fabricates the ``spyreCodeDir`` dbo would produce), and
+``prepare_kernel`` is stubbed so the shared ``SpyreSDSCKernelRunner`` constructs
+without hardware.  Asserts the ``TORCH_SPYRE_DBO`` gate, the exact ``dbo-opt``
+command line, and that the compiled path returns the SDSC runner.
+"""
+
+import os
+import unittest
+from unittest import mock
+
+import sympy
+
+from torch_spyre._C import DataFormats
+from torch_spyre._inductor.op_spec import OpSpec, TensorArg
+from torch_spyre.execution import async_compile as ac
+from torch_spyre.execution import kernel_runner
+from torch_spyre.execution.kernel_runner import SpyreSDSCKernelRunner
+
+_D0, _D1, _D2 = sympy.symbols("d0 d1 d2")
+_SIZE = [16, 512, 64]
+
+
+def _arg(is_input: bool, index: int, name: str) -> TensorArg:
+    return TensorArg(
+        is_input=is_input,
+        arg_index=index,
+        device_dtype=DataFormats.SEN169_FP16,
+        device_size=list(_SIZE),
+        device_coordinates=[_D0, _D1, _D2],
+        allocation={"hbm": None},
+        name=name,
+    )
+
+
+def _add_specs() -> list:
+    """OpSpec list for ``a + b`` (two HBM inputs, one HBM output)."""
+    return [
+        OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space={
+                _D0: (_SIZE[0], 1),
+                _D1: (_SIZE[1], 1),
+                _D2: (_SIZE[2], 1),
+            },
+            args=[_arg(True, 0, "arg0"), _arg(True, 1, "arg1"), _arg(False, 2, "buf0")],
+            op_info={},
+        )
+    ]
+
+
+class KtirDboWiringTest(unittest.TestCase):
+    def setUp(self):
+        # Isolate the two switches this path reads.
+        self._saved = {
+            k: os.environ.get(k) for k in ("TORCH_SPYRE_KTIR", "TORCH_SPYRE_DBO")
+        }
+        os.environ.pop("TORCH_SPYRE_DBO", None)
+        # generate_ktir is imported lazily inside ktir(); stub it so the test
+        # needs neither mlir_ktdp nor a live graph.
+        self._gen = mock.patch(
+            "torch_spyre._inductor.codegen.ktir.generate_ktir",
+            return_value="module {}\n",
+        )
+        self._gen.start()
+
+    def tearDown(self):
+        self._gen.stop()
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_dbo_unset_emits_then_raises(self):
+        """Without TORCH_SPYRE_DBO the KTIR is written but execution is deferred."""
+        os.environ.pop("TORCH_SPYRE_DBO", None)
+        with mock.patch.object(ac.subprocess, "run") as run:
+            with self.assertRaises(NotImplementedError):
+                ac.SpyreAsyncCompile().ktir("ktir_add_0", _add_specs())
+            run.assert_not_called()
+
+    def test_dbo_set_invokes_dbo_opt_and_returns_runner(self):
+        """With TORCH_SPYRE_DBO=1, dbo-opt is invoked and the SDSC runner returned."""
+        os.environ["TORCH_SPYRE_DBO"] = "1"
+
+        recorded = {}
+
+        def fake_run(cmd, check):
+            recorded["cmd"] = cmd
+            recorded["check"] = check
+            # Fabricate the spyreCodeDir dbo-opt would export so the runner's
+            # prepare_kernel target exists (its body is stubbed below anyway).
+            export = next(a for a in cmd if a.startswith("--export-dir="))
+            export_dir = export.split("=", 1)[1]
+            os.makedirs(os.path.join(export_dir, "spyreCodeDir"), exist_ok=True)
+
+        with (
+            mock.patch.object(ac.subprocess, "run", side_effect=fake_run),
+            mock.patch.object(kernel_runner, "prepare_kernel", return_value=object()),
+        ):
+            runner = ac.SpyreAsyncCompile().ktir("ktir_add_0", _add_specs())
+
+        self.assertIsInstance(runner, SpyreSDSCKernelRunner)
+        cmd = recorded["cmd"]
+        self.assertTrue(recorded["check"])
+        self.assertEqual(cmd[0], "dbo-opt")
+        self.assertIn("--from-ktir", cmd)
+        self.assertIn("--kEmitSpyreCode", cmd)
+        # --export-dir points at the per-kernel output dir; the input .ktir and
+        # the runner's code_dir both live there.
+        export_arg = next(a for a in cmd if a.startswith("--export-dir="))
+        output_dir = export_arg.split("=", 1)[1]
+        ktir_path = cmd[-1]
+        self.assertEqual(runner.code_dir, output_dir)
+        self.assertEqual(ktir_path, os.path.join(output_dir, "ktir_add_0.ktir"))
+        self.assertTrue(os.path.isfile(ktir_path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torch_spyre/_inductor/codegen/ktir.py
+++ b/torch_spyre/_inductor/codegen/ktir.py
@@ -40,8 +40,13 @@ from torch_spyre._inductor.codegen.opspec_utils import (
 )
 from torch_spyre._inductor.op_spec import LoopSpec, OpSpec, TensorArg, UnimplementedOp
 
-# Pointwise op name -> the ``arith`` float builder that implements it.
-_ARITH_FLOAT_OP = {"add": "AddFOp", "mul": "MulFOp"}
+# Pointwise op name -> the ``linalg`` named op that implements it.
+# TENTATIVE (dbo workaround): dbo-opt's construct-three-stage-pipeline
+# requires linalg named ops (linalg.add / linalg.mul) rather than
+# arith scalar-on-tensor ops (arith.addf / arith.mulf).  The test
+# fixtures under dataflow-scheduler/test/.../ConstructThreeStagePipeline/
+# all use linalg ops; arith.addf on tensors is not handled.
+_LINALG_OP = {"add": "add", "mul": "mul"}
 
 
 def _val(x):
@@ -95,7 +100,7 @@ def generate_ktir(
     # ``mlir_ktdp`` is imported lazily so the module stays importable (and the
     # golden test can skip) where the dialect-packaged mlir_ktdp is not built.
     from mlir_ktdp import ir
-    from mlir_ktdp.dialects import arith, func, ktdp
+    from mlir_ktdp.dialects import arith, func, ktdp, linalg, tensor
 
     # Fused ops must share one iteration space (same grid / work-division); the
     # register-threaded intermediate between them has the same extents as the
@@ -182,6 +187,8 @@ def generate_ktir(
                         ir,
                         ktdp,
                         arith,
+                        linalg,
+                        tensor,
                         spec,
                         memory_views,
                         produced,
@@ -218,10 +225,10 @@ def _collect_pointwise_op_specs(
             )
         if entry.is_reduction:
             raise NotImplementedError("OpSpec->KTIR: reductions are not supported yet")
-        if entry.op not in _ARITH_FLOAT_OP:
+        if entry.op not in _LINALG_OP:
             raise NotImplementedError(
                 f"OpSpec->KTIR: op {entry.op!r} is not supported yet "
-                f"(only pointwise {sorted(_ARITH_FLOAT_OP)})"
+                f"(only pointwise {sorted(_LINALG_OP)})"
             )
         op_specs.append(entry)
     if not op_specs:
@@ -256,6 +263,8 @@ def _emit_pointwise_op(
     ir,
     ktdp,
     arith,
+    linalg,
+    tensor,
     spec: OpSpec,
     memory_views,
     produced,
@@ -332,8 +341,15 @@ def _emit_pointwise_op(
                 "(cross-group HBM intermediates are not supported yet)"
             )
 
-    builder = getattr(arith, _ARITH_FLOAT_OP[spec.op])
-    result = _val(builder(loaded[0], loaded[1]))
+    # TENTATIVE: emit linalg named op + tensor.empty() outs, matching the
+    # pattern the dataflow-scheduler test fixtures use.
+    block = _device_block_shape(out, divisor_of)
+    elt_t = _mlir_elt_type(ir, out.device_dtype)
+    tensor_t = ir.RankedTensorType.get(block, elt_t)
+    empty = _val(tensor.EmptyOp(block, elt_t))
+    linalg_op_name = _LINALG_OP[spec.op]
+    linalg_builder = getattr(linalg, linalg_op_name)
+    result = _val(linalg_builder(*loaded, outs=[empty], result_tensors=[tensor_t]))
 
     out_bid = _buf_id(out)
     if out_bid in memory_views:

--- a/torch_spyre/_inductor/codegen/ktir.py
+++ b/torch_spyre/_inductor/codegen/ktir.py
@@ -1,0 +1,296 @@
+# Copyright 2025-2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpSpec -> KTIR emitter.
+
+``generate_ktir`` is an OpSpec consumer: it consumes the finished
+``list[OpSpec | LoopSpec]`` kernel contract (the same contract the SDSC bundle
+emitter ``generate_bundle`` consumes) and emits **KTDP-dialect MLIR** directly.
+The module is built with the ``mlir_ktdp`` Python builders, so the returned
+``str(module)`` is canonical, verifier-checked MLIR that the golden snapshot
+test consumes without drift.
+
+It uses the OpSpec-reading helpers from ``opspec_utils`` to adapt the OpSpec
+information to generate_ktir.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from torch_spyre._C import DataFormats
+from torch_spyre._inductor.codegen.opspec_utils import (
+    _align_reshape_plan,
+    _buf_id,
+    _row_major_strides,
+)
+from torch_spyre._inductor.op_spec import LoopSpec, OpSpec, TensorArg, UnimplementedOp
+
+# Pointwise op name -> the ``arith`` float builder that implements it.  Only
+# ``add`` is wired up so far; other ops raise before reaching here.
+_ARITH_FLOAT_OP = {"add": "AddFOp"}
+
+
+def _mlir_elt_type(ir, device_dtype: DataFormats):
+    """The ``mlir_ktdp.ir`` element type for a Spyre device dtype.
+
+    ``ir`` is the lazily-imported ``mlir_ktdp.ir`` module (the file never
+    imports it at top level, so it stays importable where the dialect build is
+    absent).  The two fp16 device formats both map to ``f16``; extend this map
+    (never fall through silently) as new dtypes are supported.
+    """
+    # Direct type-builder references (not name strings) resolved here, where
+    # ``ir`` is in scope.
+    mapping = {
+        DataFormats.IEEE_FP16: ir.F16Type,
+        DataFormats.SEN169_FP16: ir.F16Type,
+        DataFormats.IEEE_FP32: ir.F32Type,
+        DataFormats.BFLOAT16: ir.BF16Type,
+    }
+    builder = mapping.get(device_dtype)
+    if builder is None:
+        raise NotImplementedError(
+            f"OpSpec->KTIR: unsupported device dtype {device_dtype!r}"
+        )
+    return builder.get()
+
+
+def generate_ktir(
+    kernel_name: str,
+    specs: Sequence[OpSpec | LoopSpec | UnimplementedOp],
+) -> str:
+    """Build a KTDP-dialect MLIR module for ``specs`` and return ``str(module)``.
+
+    ``specs`` is the finished OpSpec kernel contract (the same value
+    ``call_kernel`` passes positionally to ``.run(...)``).  Func parameters are
+    the unique operand buffers in ascending ``arg_index`` order so the emitted
+    signature matches that positional binding.
+    """
+    # ``mlir_ktdp`` is imported lazily so the module stays importable (and the
+    # golden test can skip) where the dialect-packaged mlir_ktdp is not built.
+    from mlir_ktdp import ir
+    from mlir_ktdp.dialects import arith, func, ktdp
+
+    op_specs = _collect_pointwise_op_specs(specs)
+
+    # Ordered unique operand buffers -> func parameter position.  Ascending
+    # arg_index matches the positional order call_kernel passes to .run(...),
+    # so the emitted func signature lines up with that binding.
+    ordered_args: dict[object, TensorArg] = {}
+    for spec in op_specs:
+        for arg in spec.args:
+            ordered_args.setdefault(_buf_id(arg), arg)
+    param_args = sorted(ordered_args.values(), key=lambda a: a.arg_index)
+    param_index = {_buf_id(a): i for i, a in enumerate(param_args)}
+
+    with ir.Context() as ctx, ir.Location.unknown():
+        ktdp.register_dialects(ctx)
+        index_t = ir.IndexType.get()
+
+        module = ir.Module.create()
+        with ir.InsertionPoint(module.body):
+            fn_type = ir.FunctionType.get([index_t] * len(param_args), [])
+            fn = func.FuncOp(kernel_name, fn_type)
+            # Single-core (SENCORES=1) grid; work-division scaling is future work.
+            i64 = ir.IntegerType.get_signless(64)
+            fn.attributes["grid"] = ir.ArrayAttr.get([ir.IntegerAttr.get(i64, 1)])
+            block = fn.add_entry_block()
+            block_args = list(block.arguments)
+
+            with ir.InsertionPoint(block):
+                c0 = arith.ConstantOp(index_t, 0)
+
+                # One memory view per unique buffer, in param order.
+                memory_views: dict[object, ir.Value] = {}
+                for arg in param_args:
+                    bid = _buf_id(arg)
+                    memory_views[bid] = _emit_memory_view(
+                        ir, ktdp, arg, block_args[param_index[bid]]
+                    )
+
+                for spec in op_specs:
+                    _emit_pointwise_op(ir, ktdp, arith, spec, memory_views, c0)
+
+                func.ReturnOp([])
+
+        return str(module)
+
+
+def _collect_pointwise_op_specs(
+    specs: Sequence[OpSpec | LoopSpec | UnimplementedOp],
+) -> list[OpSpec]:
+    """Validate ``specs`` and return the flat list of pointwise ``OpSpec``s.
+
+    Rejects everything outside the supported scope with an explicit
+    ``NotImplementedError``.
+    """
+    op_specs: list[OpSpec] = []
+    for entry in specs:
+        if isinstance(entry, UnimplementedOp):
+            raise NotImplementedError(f"OpSpec->KTIR: unimplemented op {entry.op!r}")
+        if isinstance(entry, LoopSpec):
+            raise NotImplementedError(
+                "OpSpec->KTIR: counted loops (LoopSpec) are not supported yet"
+            )
+        if not isinstance(entry, OpSpec):
+            raise NotImplementedError(
+                f"OpSpec->KTIR: unexpected spec entry {type(entry).__name__}"
+            )
+        if entry.is_reduction:
+            raise NotImplementedError("OpSpec->KTIR: reductions are not supported yet")
+        if entry.op not in _ARITH_FLOAT_OP:
+            raise NotImplementedError(
+                f"OpSpec->KTIR: op {entry.op!r} is not supported yet "
+                "(only pointwise 'add')"
+            )
+        op_specs.append(entry)
+    if not op_specs:
+        raise NotImplementedError("OpSpec->KTIR: no OpSpec to emit")
+    return op_specs
+
+
+def _emit_memory_view(ir, ktdp, arg: TensorArg, offset):
+    """Emit ``ktdp.construct_memory_view`` for one buffer, return its SSA value."""
+    sizes = [int(s) for s in arg.device_size]
+    strides = _row_major_strides(sizes)
+    memref_t = ir.MemRefType.get(sizes, _mlir_elt_type(ir, arg.device_dtype))
+    coord_set = _coordinate_set_attr(ir, sizes)
+    # No Python builder is exposed for the ``spyre_memory_space`` enum attribute
+    # (only the ktdp *types* have getters), so this small enum literal is the one
+    # unavoidable textual attribute.
+    memory_space = ir.Attribute.parse("#ktdp.spyre_memory_space<HBM>")
+    # All extents are static -> empty dynamic size/stride operand lists.
+    return ktdp.construct_memory_view(
+        memref_t,
+        offset,
+        [],
+        [],
+        sizes,
+        strides,
+        memory_space,
+        coord_set,
+    )
+
+
+def _emit_pointwise_op(ir, ktdp, arith, spec: OpSpec, memory_views, c0):
+    """Emit the load / compute / store sequence for one pointwise ``OpSpec``."""
+    inputs = [a for a in spec.args if a.is_input]
+    outputs = [a for a in spec.args if not a.is_input]
+    if len(outputs) != 1:
+        raise NotImplementedError(
+            f"OpSpec->KTIR: expected exactly one output, got {len(outputs)}"
+        )
+    if len(inputs) != 2:
+        raise NotImplementedError(
+            f"OpSpec->KTIR: 'add' expects two inputs, got {len(inputs)}"
+        )
+    out = outputs[0]
+
+    out_extents = [int(s) for s in out.device_size]
+    for arg in inputs:
+        # In-place (input buffer aliases the output) is not supported yet.
+        if _buf_id(arg) == _buf_id(out):
+            raise NotImplementedError(
+                "OpSpec->KTIR: in-place ops (input aliases output) not supported"
+            )
+        # Reject broadcast / transpose operands: only operands whose device
+        # axes already match the output tile exactly are supported.
+        plan = _align_reshape_plan(
+            list(arg.device_coordinates),
+            [int(s) for s in arg.device_size],
+            list(out.device_coordinates),
+            out_extents,
+        )
+        if plan is not None:
+            raise NotImplementedError(
+                "OpSpec->KTIR: broadcast / reshape operands not supported yet"
+            )
+
+    # Every operand buffer must be a func parameter (register-threaded fused
+    # intermediates are not supported yet).
+    for arg in spec.args:
+        if _buf_id(arg) not in memory_views:
+            raise NotImplementedError(
+                "OpSpec->KTIR: fused intermediates (register threading) "
+                "not supported yet"
+            )
+
+    loaded = [
+        _emit_load(ir, ktdp, arg, memory_views[_buf_id(arg)], c0) for arg in inputs
+    ]
+
+    builder = getattr(arith, _ARITH_FLOAT_OP[spec.op])
+    result = builder(loaded[0], loaded[1])
+
+    _emit_store(ir, ktdp, out, memory_views[_buf_id(out)], result, c0)
+
+
+def _emit_access_tile(ir, ktdp, arg: TensorArg, memory_view, c0):
+    """Emit ``ktdp.construct_access_tile`` for ``arg``, return its SSA value."""
+    sizes = [int(s) for s in arg.device_size]
+    rank = len(sizes)
+    at_t = ktdp.AccessTileType.get(sizes, ir.IndexType.get())
+    identity = ir.AffineMapAttr.get(ir.AffineMap.get_identity(rank))
+    tile_set = _coordinate_set_attr(ir, sizes)
+    return ktdp.construct_access_tile(
+        at_t,
+        memory_view,
+        identity,
+        [c0] * rank,
+        [],
+        tile_set,
+        identity,
+    )
+
+
+def _emit_load(ir, ktdp, arg: TensorArg, memory_view, c0):
+    """Emit an access tile + ``ktdp.load`` for an input ``arg``."""
+    sizes = [int(s) for s in arg.device_size]
+    tensor_t = ir.RankedTensorType.get(sizes, _mlir_elt_type(ir, arg.device_dtype))
+    tile = _emit_access_tile(ir, ktdp, arg, memory_view, c0)
+    return ktdp.load(tensor_t, tile)
+
+
+def _emit_store(ir, ktdp, arg: TensorArg, memory_view, value, c0):
+    """Emit an access tile + ``ktdp.store`` of ``value`` into output ``arg``."""
+    tile = _emit_access_tile(ir, ktdp, arg, memory_view, c0)
+    ktdp.store(value, tile)
+
+
+# ---------------------------------------------------------------------------
+# Attribute builders
+# ---------------------------------------------------------------------------
+
+
+def _coordinate_set_attr(ir, sizes: list[int]):
+    """Per-dim bounding integer set ``(0 <= d_i <= size_i - 1)`` as an attribute.
+
+    Built with ``ir.IntegerSet`` from ``AffineExpr`` constraints (no textual
+    round-trip): for each dim ``i`` two inequalities ``d_i >= 0`` and
+    ``-d_i + (size_i - 1) >= 0``, matching the ``affine_set`` MLIR prints.
+    """
+    exprs = []
+    eq_flags: list[bool] = []
+    for i, s in enumerate(sizes):
+        dim = ir.AffineExpr.get_dim(i)
+        # d_i >= 0
+        exprs.append(dim)
+        eq_flags.append(False)
+        # -d_i + (size_i - 1) >= 0
+        neg_dim = ir.AffineExpr.get_mul(ir.AffineExpr.get_constant(-1), dim)
+        upper = ir.AffineExpr.get_add(neg_dim, ir.AffineExpr.get_constant(int(s) - 1))
+        exprs.append(upper)
+        eq_flags.append(False)
+    integer_set = ir.IntegerSet.get(len(sizes), 0, exprs, eq_flags)
+    return ir.IntegerSetAttr.get(integer_set)

--- a/torch_spyre/_inductor/codegen/ktir.py
+++ b/torch_spyre/_inductor/codegen/ktir.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from torch_spyre._C import DataFormats
+from torch_spyre._inductor import config as _spyre_config
 from torch_spyre._inductor.codegen.opspec_utils import (
     _align_reshape_plan,
     _buf_id,
@@ -77,21 +78,39 @@ def generate_ktir(
     the unique operand buffers in ascending ``arg_index`` order so the emitted
     signature matches that positional binding.
     """
+    # Pure capability checks first, before the mlir_ktdp import: they need no
+    # dialect build, so an unsupported request fails fast (and is testable)
+    # whether or not mlir_ktdp is installed.
+    #
+    # Multi-core work division is future work; the grid below is hard-coded to a
+    # single core, so reject anything else rather than silently emitting a
+    # single-core grid on a multi-core request.
+    if _spyre_config.sencores != 1:
+        raise NotImplementedError(
+            "OpSpec->KTIR: multi-core work division is not supported yet "
+            f"(SENCORES={_spyre_config.sencores}, only 1 is supported)"
+        )
+    op_specs = _collect_pointwise_op_specs(specs)
+
     # ``mlir_ktdp`` is imported lazily so the module stays importable (and the
     # golden test can skip) where the dialect-packaged mlir_ktdp is not built.
     from mlir_ktdp import ir
     from mlir_ktdp.dialects import arith, func, ktdp
 
-    op_specs = _collect_pointwise_op_specs(specs)
-
     # Ordered unique operand buffers -> func parameter position.  Ascending
     # arg_index matches the positional order call_kernel passes to .run(...),
-    # so the emitted func signature lines up with that binding.
+    # so the emitted func signature lines up with that binding.  Only real
+    # external buffers (arg_index >= 0) become func parameters; register-threaded
+    # fused intermediates carry the -1 sentinel and are threaded as SSA values,
+    # never bound positionally.
     ordered_args: dict[object, TensorArg] = {}
     for spec in op_specs:
         for arg in spec.args:
             ordered_args.setdefault(_buf_id(arg), arg)
-    param_args = sorted(ordered_args.values(), key=lambda a: a.arg_index)
+    param_args = sorted(
+        (a for a in ordered_args.values() if a.arg_index >= 0),
+        key=lambda a: a.arg_index,
+    )
     param_index = {_buf_id(a): i for i, a in enumerate(param_args)}
 
     with ir.Context() as ctx, ir.Location.unknown():

--- a/torch_spyre/_inductor/codegen/ktir.py
+++ b/torch_spyre/_inductor/codegen/ktir.py
@@ -30,17 +30,26 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from torch_spyre._C import DataFormats
-from torch_spyre._inductor import config as _spyre_config
 from torch_spyre._inductor.codegen.opspec_utils import (
     _align_reshape_plan,
     _buf_id,
+    _decompose_work_divisions,
+    _device_block_shape,
+    _iteration_space_key,
     _row_major_strides,
 )
 from torch_spyre._inductor.op_spec import LoopSpec, OpSpec, TensorArg, UnimplementedOp
 
-# Pointwise op name -> the ``arith`` float builder that implements it.  Only
-# ``add`` is wired up so far; other ops raise before reaching here.
-_ARITH_FLOAT_OP = {"add": "AddFOp"}
+# Pointwise op name -> the ``arith`` float builder that implements it.
+_ARITH_FLOAT_OP = {"add": "AddFOp", "mul": "MulFOp"}
+
+
+def _val(x):
+    """The SSA ``Value`` of a builder result.
+
+    Return the result of x if x is not a SSA value (e.g., ``OpView``).
+    """
+    return x.result if hasattr(x, "result") else x
 
 
 def _mlir_elt_type(ir, device_dtype: DataFormats):
@@ -78,24 +87,30 @@ def generate_ktir(
     the unique operand buffers in ascending ``arg_index`` order so the emitted
     signature matches that positional binding.
     """
-    # Pure capability checks first, before the mlir_ktdp import: they need no
-    # dialect build, so an unsupported request fails fast (and is testable)
-    # whether or not mlir_ktdp is installed.
-    #
-    # Multi-core work division is future work; the grid below is hard-coded to a
-    # single core, so reject anything else rather than silently emitting a
-    # single-core grid on a multi-core request.
-    if _spyre_config.sencores != 1:
-        raise NotImplementedError(
-            "OpSpec->KTIR: multi-core work division is not supported yet "
-            f"(SENCORES={_spyre_config.sencores}, only 1 is supported)"
-        )
+    # Validate scope before the mlir_ktdp import: these checks need no dialect
+    # build, so an unsupported request fails fast (and is testable) whether or
+    # not mlir_ktdp is installed.
     op_specs = _collect_pointwise_op_specs(specs)
 
     # ``mlir_ktdp`` is imported lazily so the module stays importable (and the
     # golden test can skip) where the dialect-packaged mlir_ktdp is not built.
     from mlir_ktdp import ir
     from mlir_ktdp.dialects import arith, func, ktdp
+
+    # Fused ops must share one iteration space (same grid / work-division); the
+    # register-threaded intermediate between them has the same extents as the
+    # output.  Differing spaces (mixed work-division within one node) are not
+    # supported yet.
+    it_space = op_specs[0].iteration_space
+    it_key = _iteration_space_key(op_specs[0])
+    for spec in op_specs[1:]:
+        if _iteration_space_key(spec) != it_key:
+            raise NotImplementedError(
+                "OpSpec->KTIR: fused ops with differing iteration spaces "
+                "(mixed work-division) are not supported yet"
+            )
+    work_divisions, total_cores = _decompose_work_divisions(it_space)
+    divisor_of = {sym: div for sym, div, _inner in work_divisions}
 
     # Ordered unique operand buffers -> func parameter position.  Ascending
     # arg_index matches the positional order call_kernel passes to .run(...),
@@ -121,9 +136,10 @@ def generate_ktir(
         with ir.InsertionPoint(module.body):
             fn_type = ir.FunctionType.get([index_t] * len(param_args), [])
             fn = func.FuncOp(kernel_name, fn_type)
-            # Single-core (SENCORES=1) grid; work-division scaling is future work.
             i64 = ir.IntegerType.get_signless(64)
-            fn.attributes["grid"] = ir.ArrayAttr.get([ir.IntegerAttr.get(i64, 1)])
+            fn.attributes["grid"] = ir.ArrayAttr.get(
+                [ir.IntegerAttr.get(i64, total_cores)]
+            )
             block = fn.add_entry_block()
             block_args = list(block.arguments)
 
@@ -138,8 +154,42 @@ def generate_ktir(
                         ir, ktdp, arg, block_args[param_index[bid]]
                     )
 
+                # Per-core offset from the flat grid id for each work-divided
+                # symbol.  Nothing is emitted when total_cores == 1, so the
+                # single-core path stays byte-identical to the pointwise PR.
+                core_offset: dict[object, ir.Value] = {}
+                if total_cores > 1:
+                    tile_id = ktdp.get_compute_tile_id([index_t])
+                    for sym, div, inner_cores in work_divisions:
+                        idx = tile_id
+                        if inner_cores > 1:
+                            idx = _val(
+                                arith.DivUIOp(
+                                    idx, arith.ConstantOp(index_t, inner_cores)
+                                )
+                            )
+                        if inner_cores * div != total_cores:
+                            idx = _val(
+                                arith.RemUIOp(idx, arith.ConstantOp(index_t, div))
+                            )
+                        core_offset[sym] = idx
+
+                # SSA value threaded from each producer to its consumers; a
+                # fused-away intermediate is recorded here instead of stored.
+                produced: dict[object, ir.Value] = {}
                 for spec in op_specs:
-                    _emit_pointwise_op(ir, ktdp, arith, spec, memory_views, c0)
+                    _emit_pointwise_op(
+                        ir,
+                        ktdp,
+                        arith,
+                        spec,
+                        memory_views,
+                        produced,
+                        core_offset,
+                        divisor_of,
+                        c0,
+                        index_t,
+                    )
 
                 func.ReturnOp([])
 
@@ -171,7 +221,7 @@ def _collect_pointwise_op_specs(
         if entry.op not in _ARITH_FLOAT_OP:
             raise NotImplementedError(
                 f"OpSpec->KTIR: op {entry.op!r} is not supported yet "
-                "(only pointwise 'add')"
+                f"(only pointwise {sorted(_ARITH_FLOAT_OP)})"
             )
         op_specs.append(entry)
     if not op_specs:
@@ -202,8 +252,25 @@ def _emit_memory_view(ir, ktdp, arg: TensorArg, offset):
     )
 
 
-def _emit_pointwise_op(ir, ktdp, arith, spec: OpSpec, memory_views, c0):
-    """Emit the load / compute / store sequence for one pointwise ``OpSpec``."""
+def _emit_pointwise_op(
+    ir,
+    ktdp,
+    arith,
+    spec: OpSpec,
+    memory_views,
+    produced,
+    core_offset,
+    divisor_of,
+    c0,
+    index_t,
+):
+    """Emit the load / compute / store sequence for one pointwise ``OpSpec``.
+
+    An input whose buffer was produced earlier in this kernel is
+    register-threaded (its SSA value is reused, no load is emitted); an output
+    that is a fused-away intermediate (``arg_index < 0``, no memory view) is
+    only recorded in ``produced`` and never stored.
+    """
     inputs = [a for a in spec.args if a.is_input]
     outputs = [a for a in spec.args if not a.is_input]
     if len(outputs) != 1:
@@ -212,7 +279,7 @@ def _emit_pointwise_op(ir, ktdp, arith, spec: OpSpec, memory_views, c0):
         )
     if len(inputs) != 2:
         raise NotImplementedError(
-            f"OpSpec->KTIR: 'add' expects two inputs, got {len(inputs)}"
+            f"OpSpec->KTIR: {spec.op!r} expects two inputs, got {len(inputs)}"
         )
     out = outputs[0]
 
@@ -236,54 +303,127 @@ def _emit_pointwise_op(ir, ktdp, arith, spec: OpSpec, memory_views, c0):
                 "OpSpec->KTIR: broadcast / reshape operands not supported yet"
             )
 
-    # Every operand buffer must be a func parameter (register-threaded fused
-    # intermediates are not supported yet).
-    for arg in spec.args:
-        if _buf_id(arg) not in memory_views:
+    loaded = []
+    for arg in inputs:
+        bid = _buf_id(arg)
+        if bid in produced:
+            # Register-threaded fused intermediate: reuse the producer's value.
+            loaded.append(produced[bid])
+        elif bid in memory_views:
+            loaded.append(
+                _emit_load(
+                    ir,
+                    ktdp,
+                    arith,
+                    arg,
+                    memory_views[bid],
+                    core_offset,
+                    divisor_of,
+                    c0,
+                    index_t,
+                )
+            )
+        else:
+            # Neither a func parameter nor produced earlier: a cross-group HBM
+            # intermediate that a single KTIR kernel cannot thread.  Fail loud.
             raise NotImplementedError(
-                "OpSpec->KTIR: fused intermediates (register threading) "
-                "not supported yet"
+                "OpSpec->KTIR: operand buffer is neither a func parameter nor a "
+                "register-threaded intermediate produced earlier in this kernel "
+                "(cross-group HBM intermediates are not supported yet)"
             )
 
-    loaded = [
-        _emit_load(ir, ktdp, arg, memory_views[_buf_id(arg)], c0) for arg in inputs
-    ]
-
     builder = getattr(arith, _ARITH_FLOAT_OP[spec.op])
-    result = builder(loaded[0], loaded[1])
+    result = _val(builder(loaded[0], loaded[1]))
 
-    _emit_store(ir, ktdp, out, memory_views[_buf_id(out)], result, c0)
+    out_bid = _buf_id(out)
+    if out_bid in memory_views:
+        _emit_store(
+            ir,
+            ktdp,
+            arith,
+            out,
+            memory_views[out_bid],
+            result,
+            core_offset,
+            divisor_of,
+            c0,
+            index_t,
+        )
+    # Record for any downstream consumer (a real output may be read back too).
+    produced[out_bid] = result
 
 
-def _emit_access_tile(ir, ktdp, arg: TensorArg, memory_view, c0):
-    """Emit ``ktdp.construct_access_tile`` for ``arg``, return its SSA value."""
-    sizes = [int(s) for s in arg.device_size]
-    rank = len(sizes)
-    at_t = ktdp.AccessTileType.get(sizes, ir.IndexType.get())
+def _emit_tile_offsets(arith, arg: TensorArg, block, core_offset, c0, index_t):
+    """Per-device-axis base offset for ``arg``'s per-core access-tile slice.
+
+    A device axis divided across cores starts at
+    ``core_offset(sym) * block[k]`` (the per-core extent on that axis); an
+    undivided axis -- and the within-stick (last) axis, which is never divided
+    -- starts at 0.
+    """
+    coords = arg.device_coordinates
+    last = len(block) - 1
+    offsets = []
+    for k, coord in enumerate(coords):
+        syms = set() if k == last else coord.free_symbols
+        sym = next(iter(syms)) if len(syms) == 1 else None
+        if sym is not None and sym in core_offset:
+            extent = arith.ConstantOp(index_t, block[k])
+            offsets.append(arith.MulIOp(core_offset[sym], extent))
+        else:
+            offsets.append(c0)
+    return offsets
+
+
+def _emit_access_tile(
+    ir, ktdp, arith, arg: TensorArg, memory_view, core_offset, divisor_of, c0, index_t
+):
+    """Emit ``ktdp.construct_access_tile`` for ``arg``'s per-core slice."""
+    block = _device_block_shape(arg, divisor_of)
+    rank = len(block)
+    at_t = ktdp.AccessTileType.get(block, ir.IndexType.get())
     identity = ir.AffineMapAttr.get(ir.AffineMap.get_identity(rank))
-    tile_set = _coordinate_set_attr(ir, sizes)
+    tile_set = _coordinate_set_attr(ir, block)
+    offsets = _emit_tile_offsets(arith, arg, block, core_offset, c0, index_t)
     return ktdp.construct_access_tile(
         at_t,
         memory_view,
         identity,
-        [c0] * rank,
+        offsets,
         [],
         tile_set,
         identity,
     )
 
 
-def _emit_load(ir, ktdp, arg: TensorArg, memory_view, c0):
-    """Emit an access tile + ``ktdp.load`` for an input ``arg``."""
-    sizes = [int(s) for s in arg.device_size]
-    tensor_t = ir.RankedTensorType.get(sizes, _mlir_elt_type(ir, arg.device_dtype))
-    tile = _emit_access_tile(ir, ktdp, arg, memory_view, c0)
+def _emit_load(
+    ir, ktdp, arith, arg: TensorArg, memory_view, core_offset, divisor_of, c0, index_t
+):
+    """Emit a per-core access tile + ``ktdp.load`` for an input ``arg``."""
+    block = _device_block_shape(arg, divisor_of)
+    tensor_t = ir.RankedTensorType.get(block, _mlir_elt_type(ir, arg.device_dtype))
+    tile = _emit_access_tile(
+        ir, ktdp, arith, arg, memory_view, core_offset, divisor_of, c0, index_t
+    )
     return ktdp.load(tensor_t, tile)
 
 
-def _emit_store(ir, ktdp, arg: TensorArg, memory_view, value, c0):
-    """Emit an access tile + ``ktdp.store`` of ``value`` into output ``arg``."""
-    tile = _emit_access_tile(ir, ktdp, arg, memory_view, c0)
+def _emit_store(
+    ir,
+    ktdp,
+    arith,
+    arg: TensorArg,
+    memory_view,
+    value,
+    core_offset,
+    divisor_of,
+    c0,
+    index_t,
+):
+    """Emit a per-core access tile + ``ktdp.store`` of ``value`` into ``arg``."""
+    tile = _emit_access_tile(
+        ir, ktdp, arith, arg, memory_view, core_offset, divisor_of, c0, index_t
+    )
     ktdp.store(value, tile)
 
 

--- a/torch_spyre/_inductor/codegen/opspec_utils.py
+++ b/torch_spyre/_inductor/codegen/opspec_utils.py
@@ -1,0 +1,208 @@
+# Copyright 2025-2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpSpec-reading helpers.
+
+The KTIR emitter consumes the *finished* ``OpSpec`` list and must agree on the
+"decision / arithmetic" it implies: buffer identity, row-major strides,
+iteration-space grouping, and reshape / broadcast alignment of pointwise
+operands.  Those computations are **pure** (sympy / int over the ``op_specs``)
+-- no backend emission primitives, no MLIR builder, no live Inductor kernel
+state -- so they live here as plain functions rather than as base-class methods.
+"""
+
+from __future__ import annotations
+
+import sympy
+from torch._inductor.virtualized import V
+from torch.utils._sympy.functions import ModularIndexing
+
+from torch_spyre._inductor.op_spec import OpSpec, TensorArg
+
+
+def _size_hint(expr) -> int:
+    """Concrete size hint for an iteration-space range expression."""
+    if isinstance(expr, (int, sympy.Integer)):
+        return int(expr)
+    return int(V.graph.sizevars.size_hint(expr))
+
+
+def _row_major_strides(device_size: list[int]) -> list[int]:
+    """Row-major (C-contiguous) strides for a device-size list."""
+    n = len(device_size)
+    strides = [1] * n
+    for i in range(n - 2, -1, -1):
+        strides[i] = strides[i + 1] * int(device_size[i + 1])
+    return strides
+
+
+def _buf_id(arg: TensorArg) -> str:
+    """Stable identity of the buffer an op arg refers to, for register threading.
+
+    Keys on the op-spec ``name`` (the buffer name): unique per buffer and
+    identical whether the buffer appears as an input or an output, so a
+    fused-away intermediate threads its register value without aliasing.
+    ``arg_index`` cannot serve as the identity -- distinct fused-away
+    intermediates all carry the unassigned sentinel ``-1``.
+
+    ``name`` must therefore be populated on every projected op arg (see
+    ``create_tensor_arg``).  A ``None`` name means an unnamed arg reached
+    projection, which would silently alias on ``-1``; raise loudly instead of
+    falling back.
+    """
+    if arg.name is None:
+        raise ValueError(
+            "_buf_id: TensorArg.name is None -- every projected op arg must "
+            "carry a buffer name for register-threading identity (arg_index is "
+            "-1 for fused intermediates and cannot disambiguate them)"
+        )
+    return arg.name
+
+
+def _iteration_space_key(spec: OpSpec) -> tuple:
+    """Hashable canonical form of ``spec.iteration_space`` for grouping.
+
+    Two ops fuse iff this key matches: same symbols, same ranges, and same
+    work divisions.  Symbols/ranges are compared by their string form so the
+    key is order-independent and hashable.
+    """
+    return tuple(
+        sorted(
+            (str(sym), str(rng), int(div))
+            for sym, (rng, div) in spec.iteration_space.items()
+        )
+    )
+
+
+# Device-dim coordinate kinds, used to align pointwise operands whose device
+# axes are ordered differently from the op's output tile (broadcast alignment).
+_DIM_CONST = "const"  # no iteration-space symbol (an inserted / broadcast dim)
+_DIM_BARE = "bare"  # coord == sym (a non-stick dim)
+_DIM_WITHIN_STICK = "within_stick"  # coord == sym % stick  (within-stick lanes)
+_DIM_OUTER_STICK = "outer_stick"  # coord == sym // stick (outer-stick chunks)
+
+
+def _dim_info(coord: sympy.Expr) -> tuple[str, sympy.Symbol | None]:
+    """Classify a device-dim coordinate as ``(kind, sym)``.
+
+    Two device axes are the "same" logical dim iff they share a ``(kind, sym)``
+    -- e.g. a weight's ``sym // stick`` outer-stick axis matches an output's
+    ``sym // stick`` axis even when they sit at different positions.  A ``const``
+    dim (extent 1, no symbol) carries no data and is dropped / broadcast.
+
+    A coordinate carrying more than one iteration symbol (a single physical axis
+    that folds two logical dims, e.g. ``a*8 + b``) is not a simple device axis.
+    No legal reshape produces one today -- a plain reshape is a pure view whose
+    strides stay stick-aligned (single symbol per axis), and a within-stick fold
+    is rejected earlier at layout selection (the within-stick dim must be a full
+    64-element stick).  Raise loudly rather than carrying a dead classification:
+    if this fires, a new frontend construct reached alignment and both this
+    helper and ``_align_reshape_plan`` need real multi-symbol support.
+    """
+    syms = coord.free_symbols
+    if not syms:
+        return (_DIM_CONST, None)
+    if len(syms) > 1:
+        raise NotImplementedError(
+            f"OpSpec alignment: device coordinate {coord!r} folds multiple "
+            f"iteration symbols {syms} into one physical axis; no supported "
+            "reshape produces this, so multi-symbol alignment is not implemented"
+        )
+    sym = next(iter(syms))
+    if isinstance(coord, sympy.Symbol):
+        return (_DIM_BARE, sym)
+    if isinstance(coord, (sympy.Mod, ModularIndexing)):
+        return (_DIM_WITHIN_STICK, sym)
+    return (_DIM_OUTER_STICK, sym)
+
+
+def _align_reshape_plan(
+    in_coords: list[sympy.Expr],
+    in_block: list[int],
+    out_coords: list[sympy.Expr],
+    out_block: list[int],
+) -> tuple[list[int], list[int] | None] | None:
+    """Plan to reshape + broadcast a pointwise operand tile into the op's output
+    device-axis order.
+
+    A pointwise op's operands may carry their device axes in a different order
+    (and rank) from the output tile: a per-row reduction result broadcasts over
+    the outer-stick dim, a channel weight broadcasts over the row dim, etc.
+    Elementwise broadcast typically only auto-aligns *leading* unit dims, so a
+    misaligned operand (outer-stick where the output has rows) must be reshaped
+    to the output order first.
+
+    Each output device axis is matched to an input axis by ``(kind, sym)`` (see
+    ``_dim_info``); the within-stick axis maps last -> last.  Unmatched output
+    axes get extent 1 (to be broadcast).  Returns ``(reshape_to, broadcast_to)``
+    -- reshape the operand to ``reshape_to`` (skip if it already equals
+    ``in_block``) then broadcast to ``broadcast_to`` (``None`` to skip).
+    Returns ``None`` when the operand already matches the output (fast path:
+    no reshape / broadcast emitted, keeping simple kernels byte-identical).
+
+    Raises ``NotImplementedError`` for a cross-stick transpose (an input axis
+    with extent > 1 that no output axis matches, or matched axes that would need
+    a permute) -- that needs a restickify, not a reshape.
+    """
+    in_block = [int(b) for b in in_block]
+    out_block = [int(b) for b in out_block]
+    if list(in_coords) == list(out_coords) and in_block == out_block:
+        return None
+
+    in_info = [_dim_info(c) for c in in_coords]
+    in_rank = len(in_coords)
+    out_rank = len(out_coords)
+
+    reshape_to = [1] * out_rank
+    used: set[int] = set()
+    # Within-stick lanes: the last input axis always maps to the last output axis.
+    reshape_to[out_rank - 1] = in_block[in_rank - 1]
+    used.add(in_rank - 1)
+    matched_seq: list[int] = []  # input axes matched to output axes, in out order
+    for o in range(out_rank - 1):
+        okind, osym = _dim_info(out_coords[o])
+        if okind == _DIM_CONST:
+            continue
+        for a in range(in_rank - 1):
+            if a in used:
+                continue
+            if in_info[a] == (okind, osym):
+                used.add(a)
+                reshape_to[o] = in_block[a]
+                matched_seq.append(a)
+                break
+
+    # A pure reshape preserves the row-major element order: the matched input
+    # axes must appear in increasing order.  If not, the operand would need a
+    # transpose (restickify) to align -- not supported on this path.
+    if any(matched_seq[i] >= matched_seq[i + 1] for i in range(len(matched_seq) - 1)):
+        raise NotImplementedError(
+            "OpSpec alignment: pointwise operand needs a transpose (restickify) "
+            "to align device axes; not supported yet"
+        )
+    prod_in = 1
+    for b in in_block:
+        prod_in *= b
+    prod_reshape = 1
+    for b in reshape_to:
+        prod_reshape *= b
+    if prod_in != prod_reshape:
+        # An input axis with extent > 1 was dropped -> real data would be lost;
+        # aligning it needs a cross-stick transpose (restickify).
+        raise NotImplementedError(
+            "OpSpec alignment: pointwise operand needs a cross-stick transpose "
+            "(restickify) to align device axes; not supported yet"
+        )
+    broadcast_to = out_block if reshape_to != out_block else None
+    return (reshape_to, broadcast_to)

--- a/torch_spyre/_inductor/codegen/opspec_utils.py
+++ b/torch_spyre/_inductor/codegen/opspec_utils.py
@@ -20,13 +20,19 @@ iteration-space grouping, and reshape / broadcast alignment of pointwise
 operands.  Those computations are **pure** (sympy / int over the ``op_specs``)
 -- no backend emission primitives, no MLIR builder, no live Inductor kernel
 state -- so they live here as plain functions rather than as base-class methods.
+
+They are therefore **emitter-agnostic**: they read the ``OpSpec`` contract
+without emitting any target IR, so one set can serve every OpSpec consumer.  The
+KTIR emitter is simply the first such consumer (hence the KTIR references
+below); future emitters are intended to share them, which is why the module is
+named for the ``OpSpec`` it reads rather than for KTIR.
 """
 
 from __future__ import annotations
 
 import sympy
 from torch._inductor.virtualized import V
-from torch.utils._sympy.functions import ModularIndexing
+from torch.utils._sympy.functions import FloorDiv, ModularIndexing
 
 from torch_spyre._inductor.op_spec import OpSpec, TensorArg
 
@@ -62,6 +68,9 @@ def _buf_id(arg: TensorArg) -> str:
     falling back.
     """
     if arg.name is None:
+        # ValueError (not NotImplementedError): under TORCH_SPYRE_KTIR=1
+        # create_tensor_arg always populates the name, so a None here is a
+        # broken internal invariant, not an unsupported-capability case.
         raise ValueError(
             "_buf_id: TensorArg.name is None -- every projected op arg must "
             "carry a buffer name for register-threading identity (arg_index is "
@@ -124,7 +133,18 @@ def _dim_info(coord: sympy.Expr) -> tuple[str, sympy.Symbol | None]:
         return (_DIM_BARE, sym)
     if isinstance(coord, (sympy.Mod, ModularIndexing)):
         return (_DIM_WITHIN_STICK, sym)
-    return (_DIM_OUTER_STICK, sym)
+    if isinstance(coord, FloorDiv):
+        return (_DIM_OUTER_STICK, sym)
+    # A single-symbol coordinate that is none of the known device-axis forms
+    # (e.g. ``2*d0 + 1``) is not a plain outer-stick chunk index.  Raise loudly
+    # rather than silently classifying it as outer-stick -- same policy as the
+    # multi-symbol case above; a later increment that legitimately produces such
+    # a coordinate must extend this classifier explicitly.
+    raise NotImplementedError(
+        f"OpSpec alignment: single-symbol device coordinate {coord!r} is not a "
+        "bare symbol, within-stick (Mod/ModularIndexing), or outer-stick "
+        "(FloorDiv) form; classification is not implemented"
+    )
 
 
 def _align_reshape_plan(

--- a/torch_spyre/_inductor/codegen/opspec_utils.py
+++ b/torch_spyre/_inductor/codegen/opspec_utils.py
@@ -31,17 +31,9 @@ named for the ``OpSpec`` it reads rather than for KTIR.
 from __future__ import annotations
 
 import sympy
-from torch._inductor.virtualized import V
 from torch.utils._sympy.functions import FloorDiv, ModularIndexing
 
 from torch_spyre._inductor.op_spec import OpSpec, TensorArg
-
-
-def _size_hint(expr) -> int:
-    """Concrete size hint for an iteration-space range expression."""
-    if isinstance(expr, (int, sympy.Integer)):
-        return int(expr)
-    return int(V.graph.sizevars.size_hint(expr))
 
 
 def _row_major_strides(device_size: list[int]) -> list[int]:

--- a/torch_spyre/_inductor/codegen/opspec_utils.py
+++ b/torch_spyre/_inductor/codegen/opspec_utils.py
@@ -218,3 +218,72 @@ def _align_reshape_plan(
         )
     broadcast_to = out_block if reshape_to != out_block else None
     return (reshape_to, broadcast_to)
+
+
+# ---------------------------------------------------------------------------
+# Pointwise work-division helpers
+# ---------------------------------------------------------------------------
+
+
+def _device_block_shape(
+    arg: TensorArg,
+    divisor_of: dict[sympy.Symbol, int],
+) -> list[int]:
+    """Per-core ``block_shape`` for the access tile.
+
+    Divides each non-within-stick device dim by the core divisor
+    (``divisor_of``, this group's iteration-space work divisions) of the
+    single OpSpec symbol on that dim's coordinate.  Each non-within-stick
+    device dim carries exactly one iteration symbol -- a bare ``c_i`` or an
+    outer-stick ``c_i // stick`` -- so exactly one divisor applies per dim; a
+    constant (broadcast) axis carries none and is left at full size.  The last
+    device dim is the within-stick dim: always the full ``device_size[-1]``
+    (64 fp16 / 32 fp32 / 128 int8), never divided across cores.
+    """
+    device_size = [int(s) for s in arg.device_size]
+    coords = arg.device_coordinates
+    last = len(device_size) - 1
+
+    block: list[int] = []
+    for k, coord in enumerate(coords):
+        if k == last:
+            block.append(device_size[k])
+            continue
+        size = device_size[k]
+        syms = coord.free_symbols
+        if len(syms) > 1:
+            raise NotImplementedError(
+                f"OpSpec: device dim {k} coordinate {coord!r} folds multiple "
+                f"iteration symbols {syms}; work-division of a multi-symbol "
+                "axis is not supported"
+            )
+        divisor = divisor_of.get(next(iter(syms)), 1) if syms else 1
+        block.append(max(1, size // max(1, divisor)))
+    return block
+
+
+def _decompose_work_divisions(
+    iteration_space: dict[sympy.Symbol, tuple[sympy.Expr, int]],
+) -> tuple[list[tuple[sympy.Symbol, int, int]], int]:
+    """Decompose the iteration-space work divisions into per-symbol core
+    portions of the 1D core grid.
+
+    The core grid is 1D: a single flat core index in ``[0, total_cores)``.
+    Each work-divided symbol (``div > 1``) owns one slice of its iteration
+    range, and the flat index is read as a mixed-radix number over those
+    symbols, innermost (last in iteration order) first.  Returns
+    ``(work_divisions, total_cores)`` where ``work_divisions`` is a list of
+    ``(sym, div, inner_cores)`` **innermost-first** -- the core portion of
+    ``sym`` is ``(core_id // inner_cores) % div`` -- and ``total_cores`` is the
+    product of every ``div`` (``1`` when nothing is divided).
+    """
+    split = [(s, div) for s, (_rng, div) in iteration_space.items() if div > 1]
+    total_cores = 1
+    for _s, div in split:
+        total_cores *= div
+    work_divisions: list[tuple[sympy.Symbol, int, int]] = []
+    inner_cores = 1
+    for sym, div in reversed(split):  # innermost first
+        work_divisions.append((sym, div, inner_cores))
+        inner_cores *= div
+    return work_divisions, total_cores

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -27,6 +27,12 @@ hbm_pool_planning: bool = _get_env_bool("HBM_POOL_PLANNING", True)
 
 global_stick_optimizer: bool = os.environ.get("GLOBAL_STICK_OPTIMIZER", "1") == "1"
 
+# Opt-in OpSpec->KTIR emitter (experimental, #3380). When enabled the scheduler
+# emits ``async_compile.ktir(...)`` instead of the SDSC bundle, and
+# ``create_tensor_arg`` populates the op-spec buffer name so the emitter has a
+# stable per-buffer identity. Inert by default: the SDSC/flex path is unchanged.
+ktir_emitter: bool = os.environ.get("TORCH_SPYRE_KTIR", "0") == "1"
+
 allow_all_ops_in_lx_planning: bool = False
 
 dxp_lx_frac_avail: float = float(os.environ.get("DXP_LX_FRAC_AVAIL", "0.2"))

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from typing import Sequence, Union
 
 import sympy
@@ -712,10 +713,11 @@ class SuperDSCScheduling(BaseScheduling):
             kernel_name = wrapper.src_to_kernel[src_code]
         else:
             fused_name = get_fused_kernel_name(node_schedule, "original_aten")
-            kernel_name = "_".join(["sdsc", fused_name, wrapper.next_kernel_suffix()])
+            method = "ktir" if os.getenv("TORCH_SPYRE_KTIR") == "1" else "sdsc"
+            kernel_name = "_".join([method, fused_name, wrapper.next_kernel_suffix()])
             wrapper.src_to_kernel[src_code] = kernel_name
             buf = IndentedBuffer()
-            buf.writeline(f"async_compile.sdsc('{kernel_name}',")
+            buf.writeline(f"async_compile.{method}('{kernel_name}',")
             with buf.indent():
                 buf.splice(f"{src_code}")
             buf.writeline(")")

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from typing import Sequence, Union
 
 import sympy
@@ -713,7 +712,7 @@ class SuperDSCScheduling(BaseScheduling):
             kernel_name = wrapper.src_to_kernel[src_code]
         else:
             fused_name = get_fused_kernel_name(node_schedule, "original_aten")
-            method = "ktir" if os.getenv("TORCH_SPYRE_KTIR") == "1" else "sdsc"
+            method = "ktir" if _spyre_config.ktir_emitter else "sdsc"
             kernel_name = "_".join([method, fused_name, wrapper.next_kernel_suffix()])
             wrapper.src_to_kernel[src_code] = kernel_name
             buf = IndentedBuffer()

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from dataclasses import dataclass, field
 from typing import Any, Callable, Self, Sequence, Tuple, Union
 from abc import ABC
@@ -733,6 +734,15 @@ class SpyreKernel(Kernel[CSEVariable]):
         tensor: TensorAccess,
         opspec_name: "str | None" = None,
     ) -> TensorArg:
+        # OpSpec->KTIR needs a stable per-buffer identity for register-threaded
+        # fused intermediates (all arg_index == -1): _buf_id keys on TensorArg.name,
+        # which is serialized into the emitted op-spec literal and read back by
+        # generate_ktir.  The SDSC/flex literal identifies buffers by arg_index +
+        # allocation address and only needs name for gather indices, so populate it
+        # from the buffer name only under TORCH_SPYRE_KTIR=1 -- leaving the default
+        # SDSC literal byte-identical.
+        if opspec_name is None and os.getenv("TORCH_SPYRE_KTIR") == "1":
+            opspec_name = name
         it_space = iteration_space(self.current_node)
         # With dynamic=True the host index may contain symbolic strides
         # (e.g. x0*s1+x1).  Concretize size symbols so normalize_coordinates

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from dataclasses import dataclass, field
 from typing import Any, Callable, Self, Sequence, Tuple, Union
 from abc import ABC
@@ -739,9 +738,10 @@ class SpyreKernel(Kernel[CSEVariable]):
         # which is serialized into the emitted op-spec literal and read back by
         # generate_ktir.  The SDSC/flex literal identifies buffers by arg_index +
         # allocation address and only needs name for gather indices, so populate it
-        # from the buffer name only under TORCH_SPYRE_KTIR=1 -- leaving the default
+        # from the buffer name only when the KTIR emitter is enabled
+        # (config.ktir_emitter, i.e. TORCH_SPYRE_KTIR=1) -- leaving the default
         # SDSC literal byte-identical.
-        if opspec_name is None and os.getenv("TORCH_SPYRE_KTIR") == "1":
+        if opspec_name is None and _spyre_config.ktir_emitter:
             opspec_name = name
         it_space = iteration_space(self.current_node)
         # With dynamic=True the host index may contain symbolic strides

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -96,3 +96,35 @@ class SpyreAsyncCompile(AsyncCompile):
                 raise
 
         return SpyreSDSCKernelRunner(kernel_name, output_dir)
+
+    def ktir(
+        self, kernel_name: str, specs: Sequence[OpSpec | LoopSpec | UnimplementedOp]
+    ):
+        """Emit KTDP-dialect MLIR for ``specs`` (OpSpec->KTIR path).
+
+        Mirrors ``sdsc`` but emits KTIR directly instead of an SDSC bundle.
+        Device execution is not wired yet: the emitted KTIR is persisted to
+        disk for inspection and this raises ``NotImplementedError``.
+        """
+        unimp = find_unimplemented(list(specs))
+        if unimp is not None:
+            logger.warning(
+                f"WARNING: Compiling unimplemented {unimp.op} to runtime exception"
+            )
+            return SpyreUnimplementedRunner(kernel_name, unimp.op)
+
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        # Persist the emitted KTIR as a text file in the same per-kernel output
+        # dir as sdsc's bundle.
+        output_dir = get_output_dir(kernel_name)
+        ktir_path = os.path.join(output_dir, f"{kernel_name}.ktir")
+        with open(ktir_path, "w") as fh:
+            fh.write(generate_ktir(kernel_name, specs))
+        logger.debug("OpSpec->KTIR: wrote %s", ktir_path)
+
+        raise NotImplementedError(
+            "OpSpec->KTIR: device execution is not wired yet; the emitted KTIR "
+            f"was written to {ktir_path} for inspection. Execution lands in a "
+            "later PR."
+        )

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -115,12 +115,16 @@ class SpyreAsyncCompile(AsyncCompile):
 
         from torch_spyre._inductor.codegen.ktir import generate_ktir
 
+        # Emit before opening the file: if generate_ktir raises we must not
+        # leave a truncated/empty .ktir behind.
+        ktir_text = generate_ktir(kernel_name, specs)
+
         # Persist the emitted KTIR as a text file in the same per-kernel output
         # dir as sdsc's bundle.
         output_dir = get_output_dir(kernel_name)
         ktir_path = os.path.join(output_dir, f"{kernel_name}.ktir")
         with open(ktir_path, "w") as fh:
-            fh.write(generate_ktir(kernel_name, specs))
+            fh.write(ktir_text)
         logger.debug("OpSpec->KTIR: wrote %s", ktir_path)
 
         raise NotImplementedError(

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -103,8 +103,12 @@ class SpyreAsyncCompile(AsyncCompile):
         """Emit KTDP-dialect MLIR for ``specs`` (OpSpec->KTIR path).
 
         Mirrors ``sdsc`` but emits KTIR directly instead of an SDSC bundle.
-        Device execution is not wired yet: the emitted KTIR is persisted to
-        disk for inspection and this raises ``NotImplementedError``.
+        The emitted KTIR is always persisted to disk for inspection. When
+        ``TORCH_SPYRE_DBO=1`` it is then compiled by the ``dbo`` backend
+        (``dbo-opt``), which writes a ``spyreCodeDir`` in the same layout the
+        SDSC path produces, so the resulting kernel is loaded and run by the
+        shared ``SpyreSDSCKernelRunner``. Without that switch, device execution
+        stays deferred and this raises ``NotImplementedError``.
         """
         unimp = find_unimplemented(list(specs))
         if unimp is not None:
@@ -127,8 +131,38 @@ class SpyreAsyncCompile(AsyncCompile):
             fh.write(ktir_text)
         logger.debug("OpSpec->KTIR: wrote %s", ktir_path)
 
-        raise NotImplementedError(
-            "OpSpec->KTIR: device execution is not wired yet; the emitted KTIR "
-            f"was written to {ktir_path} for inspection. Execution lands in a "
-            "later PR."
-        )
+        if os.getenv("TORCH_SPYRE_DBO") != "1":
+            raise NotImplementedError(
+                "OpSpec->KTIR: device execution is gated behind "
+                "TORCH_SPYRE_DBO=1; the emitted KTIR was written to "
+                f"{ktir_path} for inspection. Set TORCH_SPYRE_DBO=1 to compile "
+                "and run it via the dbo backend."
+            )
+
+        # Compile the emitted KTIR with the dbo backend. `--export-dir` receives
+        # the same per-kernel output dir; dbo-opt writes
+        # `<output_dir>/spyreCodeDir/{spyrecode.json, init_binary.bin}`, which is
+        # exactly the layout SpyreSDSCKernelRunner loads via prepare_kernel.
+        with torch.profiler.record_function(f"dbo-opt:{kernel_name}"):
+            try:
+                subprocess.run(
+                    [
+                        "dbo-opt",
+                        "--from-ktir",
+                        f"--export-dir={output_dir}",
+                        "--kEmitSpyreCode",
+                        ktir_path,
+                    ],
+                    check=True,
+                )
+            except Exception as exc:
+                try_collect(
+                    exc,
+                    logger=logger,
+                    failure_category=CATEGORY_COMPILE,
+                    kernel_name=kernel_name,
+                    code_dir=output_dir,
+                )
+                raise
+
+        return SpyreSDSCKernelRunner(kernel_name, output_dir)


### PR DESCRIPTION
This is the third PR in the OpSpec→KTIR series. It closes the loop for the first time: the emitted KTIR is compiled by the `dbo` backend (`dbo-opt`) and run, instead of being written to disk and then raising `NotImplementedError`. It mirrors how the existing SDSC path shells out to `dxp_standalone`.

> [!IMPORTANT]
> **Merge is blocked by #3577 and #3579.** This PR is stacked on the fusion / work-division emitter (#3579), which is itself stacked on the pointwise emitter (#3577). Because neither is on `main` yet, this PR is opened against `main` and its diff therefore currently includes #3577's and #3579's commits as well as this increment. Review only the dbo increment (the `dbo` execution wiring plus the `linalg` emitter change); the pointwise and fusion / work-division commits belong to #3577 and #3579. Do not merge until both land, after which this branch will be rebased onto `main` so the diff reduces to just the dbo delta.

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Wires the `dbo` backend into the OpSpec→KTIR path behind a new `TORCH_SPYRE_DBO=1` switch. The KTIR path is still selected by `TORCH_SPYRE_KTIR=1`; `TORCH_SPYRE_DBO` is a sub-switch inside `async_compile.ktir`:

- `TORCH_SPYRE_KTIR=1` alone → emit `<output_dir>/<kernel>.ktir`, then raise `NotImplementedError` (unchanged emission-only behavior from #3577 / #3579; the golden tests stay valid).
- `TORCH_SPYRE_KTIR=1` + `TORCH_SPYRE_DBO=1` → emit the KTIR, then run `dbo-opt --from-ktir --export-dir=<output_dir> --kEmitSpyreCode <output_dir>/<kernel>.ktir`, and return a runnable kernel.

The key observation is that `dbo-opt --kEmitSpyreCode` exports `<output_dir>/spyreCodeDir/{spyrecode.json, init_binary.bin}` — byte-for-byte the layout the existing `SpyreSDSCKernelRunner` already loads via `prepare_kernel(code_dir + "/spyreCodeDir")`. So this PR reuses that runner and adds **no new runner class**; the `dbo-opt` invocation mirrors the `dxp_standalone` block in `sdsc()` (profiler region + FFDC `try_collect` on failure).

This PR also adds **`linalg` named-op emission**. To feed `dbo-opt`, `generate_ktir` now emits `linalg.add` / `linalg.mul` (each with a `tensor.empty()` out) instead of `arith.addf` / `arith.mulf`. This is required by dbo-opt's construct-three-stage-pipeline pass, which only rewrites `ktdp.load` → `ktdf.read_from_fifo` for linalg named ops; an `arith` scalar-on-tensor op leaves a stale `ktdp.load` that fails the verifier (dataflow-scheduler#65). The four golden snapshots are regenerated to the linalg output, and the `mlir_ktdp` availability guard now also requires the `linalg` / `tensor` dialect bindings the emitter imports.

Files changed:

- `torch_spyre/execution/async_compile.py` — replace the unconditional `raise` at the end of `ktir()` with the `TORCH_SPYRE_DBO` branch: run `dbo-opt` and return `SpyreSDSCKernelRunner`, else keep the deferred-execution raise.
- `torch_spyre/_inductor/codegen/ktir.py` — emit `linalg.add` / `linalg.mul` with `tensor.empty()` outs instead of `arith.addf` / `arith.mulf`.
- `tests/inductor/test_ktir_emitter.py` — regenerate the four golden snapshots to the linalg output; widen the `mlir_ktdp` availability guard to also require the `linalg` / `tensor` bindings.
- `tests/test_async_compile_ktir_dbo.py` — CI-safe wiring test (stubs `generate_ktir`, `subprocess.run`, `prepare_kernel`): asserts the exact `dbo-opt` command line, the returned runner type, and that `TORCH_SPYRE_DBO` unset still raises.
- `CLAUDE.md` — document `TORCH_SPYRE_KTIR` and `TORCH_SPYRE_DBO`.

#### Which issue(s) this PR is related to:

Related to #3380

#### Special notes for your reviewer:

- **Gated and inert by default.** With `TORCH_SPYRE_KTIR` unset the scheduler selects `sdsc` and this path is never reached; with `TORCH_SPYRE_KTIR=1` but `TORCH_SPYRE_DBO` unset the behavior is byte-identical to #3579 (emit then raise).
- **Emitter change: linalg named ops.** `generate_ktir` now emits `linalg.add` / `linalg.mul` (with `tensor.empty()` outs) rather than `arith.addf` / `arith.mulf`, so dbo-opt's construct-three-stage-pipeline can lower them (dataflow-scheduler#65). The golden tests are regenerated to match; the emitter's structure (memory views, access tiles, register-threaded intermediates, work division) is otherwise unchanged.
- **`dbo-opt` is resolved from `PATH` by bare name**, exactly like `dxp_standalone` (no binary-path resolver exists to mirror).

#### Does this PR introduce a user-facing change?

Adds the opt-in `TORCH_SPYRE_DBO=1` switch (requires `TORCH_SPYRE_KTIR=1`). It has no effect unless both are set.

#### Additional note:

Third of an ordered series building out the OpSpec→KTIR emitter (#3380): pointwise → fuse + work-division → **dbo compilation & execution** → ktir-cpu execution → loop → reduction → matmul → indirect access → dynamic symbols.

There are two branches for the dbo path; they differ only in how each buffer's HBM base address reaches the emitted KTIR:

- [`feature/opspec-ktir-dbo`](https://github.com/tnakaike/torch-spyre/tree/feature/opspec-ktir-dbo) (this PR): dbo + linalg + **symbolic addresses**. The emitted func takes one `index` argument per buffer and `construct_memory_view` uses it as the base — the same symbolic-address form the SDSC path uses.
- [`tentative/ktir-dbo-constant-addresses`](https://github.com/tnakaike/torch-spyre/tree/tentative/ktir-dbo-constant-addresses): dbo + linalg + **constant addresses**. Same as the above branch plus a temporary dbo-opt workaround — a zero-arg func with each buffer's HBM base materialized as an `arith.constant`. This compiles and runs end-to-end through dbo-opt today.
