### PR TITLE
feat(ci): reap TEST_PID's process group on every attempt end and not just on stalled processes

### DIFF
--- a/.github/actions/run-test-suite/action.yml
+++ b/.github/actions/run-test-suite/action.yml
@@ -127,11 +127,11 @@ runs:
           attempt=$(( attempt + 1 ))
           echo "=== Attempt ${attempt}/${MAX_ATTEMPTS}: ${{ inputs.suite_name }} ==="
 
-          # Clean up the previous attempt's process group only if it's still alive.
-          if [[ -n "$TEST_PID" ]] && kill -0 -- "-$TEST_PID" 2>/dev/null; then
-            echo "Previous attempt's process group (PGID ${TEST_PID}) still alive — cleaning up"
-            kill -STOP -- "-$TEST_PID" 2>/dev/null || true
-            kill -KILL -- "-$TEST_PID" 2>/dev/null || true
+          # Clean up the previous attempt's leader PID or its process group, whichever is still alive.
+          if [[ -n "$TEST_PID" ]] && { kill -0 -- "$TEST_PID" 2>/dev/null || kill -0 -- "-$TEST_PID" 2>/dev/null; }; then
+            echo "Previous attempt's process (PID/PGID ${TEST_PID}) still alive — cleaning up"
+            kill -STOP -- "$TEST_PID" "-$TEST_PID" 2>/dev/null || true
+            kill -KILL -- "$TEST_PID" "-$TEST_PID" 2>/dev/null || true
           fi
 
           LOG_FILE="$(mktemp /tmp/test_output_XXXXXX.log)"

--- a/.github/actions/run-test-suite/action.yml
+++ b/.github/actions/run-test-suite/action.yml
@@ -120,9 +120,19 @@ runs:
         # Set by stall_watcher when it kills a hung attempt; read after `wait`
         # to make the next attempt add -n1 (pytest-xdist worker isolation).
         _STALLED_LAST_ATTEMPT=0
+        # Previous attempt's TEST_PID (also its PGID, via `set -m`); empty
+        # until the first attempt has run.
+        TEST_PID=""
         while [[ $attempt -lt $MAX_ATTEMPTS ]]; do
           attempt=$(( attempt + 1 ))
           echo "=== Attempt ${attempt}/${MAX_ATTEMPTS}: ${{ inputs.suite_name }} ==="
+
+          # Clean up the previous attempt's process group only if it's still alive.
+          if [[ -n "$TEST_PID" ]] && kill -0 -- "-$TEST_PID" 2>/dev/null; then
+            echo "Previous attempt's process group (PGID ${TEST_PID}) still alive — cleaning up"
+            kill -STOP -- "-$TEST_PID" 2>/dev/null || true
+            kill -KILL -- "-$TEST_PID" 2>/dev/null || true
+          fi
 
           LOG_FILE="$(mktemp /tmp/test_output_XXXXXX.log)"
           STALL_FLAG="$(mktemp /tmp/stall_flag_XXXXXX.tmp)"
@@ -218,12 +228,6 @@ runs:
           touch "${STALL_FLAG}.done"
           kill "$WATCHER_PID" 2>/dev/null || true
           wait "$WATCHER_PID" 2>/dev/null || true
-
-          # Reap TEST_PID's whole process group on every attempt end (stall,
-          # test failure/error, or pass alike), since surviving xdist workers
-          # can keep the Spyre device open and cause "device busy" on retry.
-          kill -STOP -- "-$TEST_PID" 2>/dev/null || true
-          kill -KILL -- "-$TEST_PID" 2>/dev/null || true
 
           kill "$TEE_PID" 2>/dev/null || true
           wait "$TEE_PID" 2>/dev/null || true

--- a/.github/actions/run-test-suite/action.yml
+++ b/.github/actions/run-test-suite/action.yml
@@ -219,6 +219,12 @@ runs:
           kill "$WATCHER_PID" 2>/dev/null || true
           wait "$WATCHER_PID" 2>/dev/null || true
 
+          # Reap TEST_PID's whole process group on every attempt end (stall,
+          # test failure/error, or pass alike), since surviving xdist workers
+          # can keep the Spyre device open and cause "device busy" on retry.
+          kill -STOP -- "-$TEST_PID" 2>/dev/null || true
+          kill -KILL -- "-$TEST_PID" 2>/dev/null || true
+
           kill "$TEE_PID" 2>/dev/null || true
           wait "$TEE_PID" 2>/dev/null || true
           rm -f "$FIFO"


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

### Summary
- Previously the test process group was only force-killed (STOP+KILL) when the stall watcher detected a hang; a plain test failure/error could leave xdist worker descendants alive, holding the Spyre device open and causing "device busy" on the next retry.
- Now the group is reaped unconditionally right after `wait "$TEST_PID"` on every attempt (pass, stall, or failure alike), before the loop's `sleep 10` and next retry iteration.


The check now signals both the leader PID and its process group  whichever is still alive  instead of only the process group, so a leftover parent isn't missed alongside leftover children.
