### PR TITLE
:zap: lazy-load libaiupti to avoid telemetry overhead

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -170,13 +170,24 @@ if COMPILE_AIUPTI:  # Include kineto and libaiupti headers
     KINETO_INCLUDE_DIR = Path(torch.__path__[0]) / "include" / "kineto"
     INCLUDE_DIRS += [KINETO_INCLUDE_DIR]
 
-    # On default system install, aiupti is installed in runtime folders
+    # On default system install, aiupti headers are in runtime folders
     if os.environ.get("LIBAIUPTI_INSTALL_DIR", "") != "":
         LIBAIUPTI_DIR = Path(os.environ["LIBAIUPTI_INSTALL_DIR"])
-        LIBRARY_DIRS += [LIBAIUPTI_DIR / "lib"]
         INCLUDE_DIRS += [LIBAIUPTI_DIR / "include"]
 
-    LIBRARIES.insert(-1, "aiupti")  # Build dependency on flex
+    # NB: libaiupti is intentionally NOT linked as a DT_NEEDED dependency of
+    # _C. Loading it arms the flex runtime's per-op telemetry, adding a fixed
+    # per-dispatch cost to every aten op (a large regression under eager
+    # execution). Instead it is linked only by the standalone _aiupti_shim
+    # extension (built below), which _C dlopen's lazily on the first profiler
+    # session (see AiuptiLibrary). libaiupti therefore stays unloaded — and
+    # telemetry dormant — until a trace is requested. `dl` provides
+    # dlopen/dlsym for that lazy load.
+    LIBRARIES.append("dl")
+
+    LIBAIUPTI_LIBRARY_DIRS = list(LIBRARY_DIRS)
+    if os.environ.get("LIBAIUPTI_INSTALL_DIR", "") != "":
+        LIBAIUPTI_LIBRARY_DIRS = [LIBAIUPTI_DIR / "lib"] + LIBAIUPTI_LIBRARY_DIRS
 
 if use_spyre_ccl:
     LIBRARIES.append("spyre_comms")
@@ -232,8 +243,13 @@ if __name__ == "__main__":
         from torch.utils.cpp_extension import BuildExtension, CppExtension
 
         sources = list(CSRC_DIR.glob("*.cpp"))
+        # The shim is built as its own extension (see below); it must not be
+        # compiled into _C, or _C would link libaiupti as a DT_NEEDED dep.
+        shim_source = PROFILER_SRC_DIR / "AiuptiShim.cpp"
         profiler_sources = (
-            list(PROFILER_SRC_DIR.glob("*.cpp")) if COMPILE_AIUPTI else []
+            [p for p in PROFILER_SRC_DIR.glob("*.cpp") if p != shim_source]
+            if COMPILE_AIUPTI
+            else []
         )
         distributed_sources = (
             list(DISTRIBUTED_SRC_DIR.glob("*.cpp")) if use_spyre_ccl else []
@@ -277,6 +293,25 @@ if __name__ == "__main__":
                 ],
             ),
         ]
+
+        if COMPILE_AIUPTI:
+            # Standalone shim that links libaiupti. _C dlopen's this on the
+            # first profiler session so libaiupti is not loaded at import time
+            # (see the DT_NEEDED note above and AiuptiLibrary).
+            ext_modules.append(
+                CppExtension(
+                    name=f"{PACKAGE_NAME}._aiupti_shim",
+                    sources=[shim_source.relative_to(ROOT_DIR).as_posix()],
+                    include_dirs=[str(p) for p in INCLUDE_DIRS],
+                    library_dirs=[str(p) for p in LIBAIUPTI_LIBRARY_DIRS],
+                    libraries=["aiupti"],
+                    extra_compile_args={"cxx": EXTRA_CXX_FLAGS},
+                    define_macros=base_define_macros
+                    + [
+                        ("MODULE_NAME", f'"{PACKAGE_NAME}._aiupti_shim"'),
+                    ],
+                )
+            )
 
         BUILD_DIR = ROOT_DIR / "build"
 

--- a/setup.py
+++ b/setup.py
@@ -176,13 +176,15 @@ if COMPILE_AIUPTI:  # Include kineto and libaiupti headers
         INCLUDE_DIRS += [LIBAIUPTI_DIR / "include"]
 
     # NB: libaiupti is intentionally NOT linked as a DT_NEEDED dependency of
-    # _C. Loading it arms the flex runtime's per-op telemetry, adding a fixed
-    # per-dispatch cost to every aten op (a large regression under eager
-    # execution). Instead it is linked only by the standalone _aiupti_shim
-    # extension (built below), which _C dlopen's lazily on the first profiler
-    # session (see AiuptiLibrary). libaiupti therefore stays unloaded — and
-    # telemetry dormant — until a trace is requested. `dl` provides
-    # dlopen/dlsym for that lazy load.
+    # _C. Loaded at process startup (as a DT_NEEDED) it arms the flex runtime's
+    # per-op telemetry, adding a fixed per-dispatch cost to every aten op (a
+    # large regression under eager execution); loading it later via dlopen,
+    # after flex is initialized, does not. Instead it is linked only by the
+    # standalone _aiupti_shim extension (built below), which _C dlopen's lazily
+    # on the first profiler session (see AiuptiLibrary). libaiupti therefore
+    # stays unloaded — and telemetry dormant — until a trace is requested, and
+    # a run that never profiles never loads it. `dl` provides dlopen/dlsym for
+    # that lazy load.
     LIBRARIES.append("dl")
 
     LIBAIUPTI_LIBRARY_DIRS = list(LIBRARY_DIRS)

--- a/torch_spyre/csrc/profiler/AiuptiActivityApi.cpp
+++ b/torch_spyre/csrc/profiler/AiuptiActivityApi.cpp
@@ -20,6 +20,8 @@
 
 #include <c10/util/Logging.h>
 
+#include "AiuptiLibrary.h"
+
 #include <cassert>
 #include <chrono>
 #include <cstdlib>
@@ -75,7 +77,8 @@ static bool nextActivityRecord(uint8_t* buffer, size_t valid_size,
                                Pti_Activity*& record) {
 #ifdef HAS_AIUPTI
   AIUpti_ResultTypes status =
-      aiuptiActivityGetNextRecord(buffer, valid_size, &record);
+      AiuptiLibrary::singleton().activityGetNextRecord(buffer, valid_size,
+                                                       &record);
   if (status != AIUpti_ResultTypes::AIUPTI_SUCCESS) {
     record = nullptr;
   }
@@ -129,7 +132,7 @@ AiuptiActivityApi::activityBuffers() {
 
 #ifdef HAS_AIUPTI
   std::chrono::time_point<std::chrono::system_clock> t1;
-  AIUPTI_CALL(aiuptiFlushAllActivities());
+  AIUPTI_CALL(AiuptiLibrary::singleton().flushAllActivities());
 #endif
 
   std::lock_guard<std::mutex> guard(mutex_);
@@ -178,7 +181,7 @@ void AiuptiActivityApi::clearActivities() {
   //   }
   // }
 #ifdef HAS_AIUPTI
-  AIUPTI_CALL(aiuptiFlushAllActivities());
+  AIUPTI_CALL(AiuptiLibrary::singleton().flushAllActivities());
 #endif
   // TODO(mamaral): verify
   // std::lock_guard<std::mutex> guard(mutex_);
@@ -214,7 +217,8 @@ void AiuptiActivityApi::bufferCompleted(uint8_t* buffer, size_t size,
   // often)
   if (VLOG_IS_ON(1)) {
     size_t dropped = 0;
-    AIUPTI_CALL(aiuptiActivityGetNumDroppedRecords(&dropped));
+    AIUPTI_CALL(
+        AiuptiLibrary::singleton().activityGetNumDroppedRecords(&dropped));
     if (dropped != 0)
       LOG(WARNING) << "Dropped " << dropped << " activity records";
   }
@@ -224,33 +228,33 @@ void AiuptiActivityApi::bufferCompleted(uint8_t* buffer, size_t size,
 void AiuptiActivityApi::enableAiuptiActivities(
     const std::set<libkineto::ActivityType>& selected_activities) {
 #ifdef HAS_AIUPTI
-  AIUPTI_CALL(aiuptiActivityRegisterCallbacks(bufferRequestedTrampoline,
-                                              bufferCompletedTrampoline));
+  AIUPTI_CALL(AiuptiLibrary::singleton().activityRegisterCallbacks(
+      bufferRequestedTrampoline, bufferCompletedTrampoline));
   bool activityEnabled = false;
   externalCorrelationEnabled_ = false;
   for (const auto& activity : selected_activities) {
     if (activity == libkineto::ActivityType::GPU_MEMCPY) {
-      AIUPTI_CALL(aiuptiActivityEnable(AIUPTI_ACTIVITY_KIND_MEMCPY));
-      AIUPTI_CALL(aiuptiActivityEnable(AIUPTI_ACTIVITY_KIND_MEMCPY2));
-      AIUPTI_CALL(aiuptiActivityEnable(AIUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_MEMCPY));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_MEMCPY2));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
       activityEnabled = true;
     }
     if (activity == libkineto::ActivityType::GPU_MEMSET) {
       // memset requires memory be also enabled
-      AIUPTI_CALL(aiuptiActivityEnable(AIUPTI_ACTIVITY_KIND_MEMORY));
-      AIUPTI_CALL(aiuptiActivityEnable(AIUPTI_ACTIVITY_KIND_MEMSET));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_MEMORY));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_MEMSET));
       activityEnabled = true;
     }
     if (activity == libkineto::ActivityType::CONCURRENT_KERNEL) {
-      AIUPTI_CALL(aiuptiActivityEnable(AIUPTI_ACTIVITY_KIND_CMPT));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_CMPT));
       activityEnabled = true;
     }
     if (activity == libkineto::ActivityType::PRIVATEUSE1_RUNTIME) {
-      AIUPTI_CALL(aiuptiActivityEnable(AIUPTI_ACTIVITY_KIND_RUNTIME));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_RUNTIME));
       activityEnabled = true;
     }
     if (activity == libkineto::ActivityType::PRIVATEUSE1_DRIVER) {
-      AIUPTI_CALL(aiuptiActivityEnable(AIUPTI_ACTIVITY_KIND_DRIVER));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_DRIVER));
       activityEnabled = true;
     }
   }
@@ -261,14 +265,14 @@ void AiuptiActivityApi::enableAiuptiActivities(
   if (activityEnabled == false) {
     const char* env_value = std::getenv("ProfilerActivity");
     if (env_value != nullptr && std::string(env_value) == "PrivateUse1") {
-      AIUPTI_CALL(aiuptiActivityEnable(AIUPTI_ACTIVITY_KIND_MEMCPY));
-      AIUPTI_CALL(aiuptiActivityEnable(AIUPTI_ACTIVITY_KIND_MEMCPY2));
-      AIUPTI_CALL(aiuptiActivityEnable(AIUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
-      AIUPTI_CALL(aiuptiActivityEnable(AIUPTI_ACTIVITY_KIND_MEMORY));
-      AIUPTI_CALL(aiuptiActivityEnable(AIUPTI_ACTIVITY_KIND_MEMSET));
-      AIUPTI_CALL(aiuptiActivityEnable(AIUPTI_ACTIVITY_KIND_CMPT));
-      AIUPTI_CALL(aiuptiActivityEnable(AIUPTI_ACTIVITY_KIND_RUNTIME));
-      AIUPTI_CALL(aiuptiActivityEnable(AIUPTI_ACTIVITY_KIND_DRIVER));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_MEMCPY));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_MEMCPY2));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_MEMORY));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_MEMSET));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_CMPT));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_RUNTIME));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_DRIVER));
     }
   }
 
@@ -284,26 +288,26 @@ void AiuptiActivityApi::disablePtiActivities(
   bool activityDisabled = false;
   for (const auto& activity : selected_activities) {
     if (activity == libkineto::ActivityType::GPU_MEMCPY) {
-      AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_MEMCPY));
-      AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_MEMCPY2));
-      AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_MEMCPY));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_MEMCPY2));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
       activityDisabled = true;
     }
     if (activity == libkineto::ActivityType::GPU_MEMSET) {
-      AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_MEMORY));
-      AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_MEMSET));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_MEMORY));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_MEMSET));
       activityDisabled = true;
     }
     if (activity == libkineto::ActivityType::CONCURRENT_KERNEL) {
-      AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_CMPT));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_CMPT));
       activityDisabled = true;
     }
     if (activity == libkineto::ActivityType::PRIVATEUSE1_RUNTIME) {
-      AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_RUNTIME));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_RUNTIME));
       activityDisabled = true;
     }
     if (activity == libkineto::ActivityType::PRIVATEUSE1_DRIVER) {
-      AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_DRIVER));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_DRIVER));
       activityDisabled = true;
     }
   }
@@ -311,14 +315,14 @@ void AiuptiActivityApi::disablePtiActivities(
   if (activityDisabled == false) {
     const char* env_value = std::getenv("ProfilerActivity");
     if (env_value != nullptr && std::string(env_value) == "PrivateUse1") {
-      AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_MEMCPY));
-      AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_MEMCPY2));
-      AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
-      AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_MEMORY));
-      AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_MEMSET));
-      AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_CMPT));
-      AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_RUNTIME));
-      AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_DRIVER));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_MEMCPY));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_MEMCPY2));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_MEMORY));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_MEMSET));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_CMPT));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_RUNTIME));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_DRIVER));
     }
   }
   externalCorrelationEnabled_ = false;

--- a/torch_spyre/csrc/profiler/AiuptiActivityApi.cpp
+++ b/torch_spyre/csrc/profiler/AiuptiActivityApi.cpp
@@ -20,8 +20,6 @@
 
 #include <c10/util/Logging.h>
 
-#include "AiuptiLibrary.h"
-
 #include <cassert>
 #include <chrono>
 #include <cstdlib>
@@ -31,6 +29,8 @@
 #include <string>
 #include <thread>
 #include <utility>
+
+#include "AiuptiLibrary.h"
 
 namespace KINETO_NAMESPACE {
 
@@ -76,9 +76,8 @@ void AiuptiActivityApi::popCorrelationID(CorrelationFlowType type) {
 static bool nextActivityRecord(uint8_t* buffer, size_t valid_size,
                                Pti_Activity*& record) {
 #ifdef HAS_AIUPTI
-  AIUpti_ResultTypes status =
-      AiuptiLibrary::singleton().activityGetNextRecord(buffer, valid_size,
-                                                       &record);
+  AIUpti_ResultTypes status = AiuptiLibrary::singleton().activityGetNextRecord(
+      buffer, valid_size, &record);
   if (status != AIUpti_ResultTypes::AIUPTI_SUCCESS) {
     record = nullptr;
   }
@@ -234,27 +233,35 @@ void AiuptiActivityApi::enableAiuptiActivities(
   externalCorrelationEnabled_ = false;
   for (const auto& activity : selected_activities) {
     if (activity == libkineto::ActivityType::GPU_MEMCPY) {
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_MEMCPY));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_MEMCPY2));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(
+          AIUPTI_ACTIVITY_KIND_MEMCPY));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(
+          AIUPTI_ACTIVITY_KIND_MEMCPY2));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(
+          AIUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
       activityEnabled = true;
     }
     if (activity == libkineto::ActivityType::GPU_MEMSET) {
       // memset requires memory be also enabled
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_MEMORY));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_MEMSET));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(
+          AIUPTI_ACTIVITY_KIND_MEMORY));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(
+          AIUPTI_ACTIVITY_KIND_MEMSET));
       activityEnabled = true;
     }
     if (activity == libkineto::ActivityType::CONCURRENT_KERNEL) {
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_CMPT));
+      AIUPTI_CALL(
+          AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_CMPT));
       activityEnabled = true;
     }
     if (activity == libkineto::ActivityType::PRIVATEUSE1_RUNTIME) {
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_RUNTIME));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(
+          AIUPTI_ACTIVITY_KIND_RUNTIME));
       activityEnabled = true;
     }
     if (activity == libkineto::ActivityType::PRIVATEUSE1_DRIVER) {
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_DRIVER));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(
+          AIUPTI_ACTIVITY_KIND_DRIVER));
       activityEnabled = true;
     }
   }
@@ -265,14 +272,22 @@ void AiuptiActivityApi::enableAiuptiActivities(
   if (activityEnabled == false) {
     const char* env_value = std::getenv("ProfilerActivity");
     if (env_value != nullptr && std::string(env_value) == "PrivateUse1") {
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_MEMCPY));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_MEMCPY2));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_MEMORY));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_MEMSET));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_CMPT));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_RUNTIME));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_DRIVER));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(
+          AIUPTI_ACTIVITY_KIND_MEMCPY));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(
+          AIUPTI_ACTIVITY_KIND_MEMCPY2));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(
+          AIUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(
+          AIUPTI_ACTIVITY_KIND_MEMORY));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(
+          AIUPTI_ACTIVITY_KIND_MEMSET));
+      AIUPTI_CALL(
+          AiuptiLibrary::singleton().activityEnable(AIUPTI_ACTIVITY_KIND_CMPT));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(
+          AIUPTI_ACTIVITY_KIND_RUNTIME));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityEnable(
+          AIUPTI_ACTIVITY_KIND_DRIVER));
     }
   }
 
@@ -288,26 +303,34 @@ void AiuptiActivityApi::disablePtiActivities(
   bool activityDisabled = false;
   for (const auto& activity : selected_activities) {
     if (activity == libkineto::ActivityType::GPU_MEMCPY) {
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_MEMCPY));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_MEMCPY2));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(
+          AIUPTI_ACTIVITY_KIND_MEMCPY));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(
+          AIUPTI_ACTIVITY_KIND_MEMCPY2));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(
+          AIUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
       activityDisabled = true;
     }
     if (activity == libkineto::ActivityType::GPU_MEMSET) {
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_MEMORY));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_MEMSET));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(
+          AIUPTI_ACTIVITY_KIND_MEMORY));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(
+          AIUPTI_ACTIVITY_KIND_MEMSET));
       activityDisabled = true;
     }
     if (activity == libkineto::ActivityType::CONCURRENT_KERNEL) {
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_CMPT));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(
+          AIUPTI_ACTIVITY_KIND_CMPT));
       activityDisabled = true;
     }
     if (activity == libkineto::ActivityType::PRIVATEUSE1_RUNTIME) {
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_RUNTIME));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(
+          AIUPTI_ACTIVITY_KIND_RUNTIME));
       activityDisabled = true;
     }
     if (activity == libkineto::ActivityType::PRIVATEUSE1_DRIVER) {
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_DRIVER));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(
+          AIUPTI_ACTIVITY_KIND_DRIVER));
       activityDisabled = true;
     }
   }
@@ -315,14 +338,22 @@ void AiuptiActivityApi::disablePtiActivities(
   if (activityDisabled == false) {
     const char* env_value = std::getenv("ProfilerActivity");
     if (env_value != nullptr && std::string(env_value) == "PrivateUse1") {
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_MEMCPY));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_MEMCPY2));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_MEMORY));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_MEMSET));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_CMPT));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_RUNTIME));
-      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(AIUPTI_ACTIVITY_KIND_DRIVER));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(
+          AIUPTI_ACTIVITY_KIND_MEMCPY));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(
+          AIUPTI_ACTIVITY_KIND_MEMCPY2));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(
+          AIUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(
+          AIUPTI_ACTIVITY_KIND_MEMORY));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(
+          AIUPTI_ACTIVITY_KIND_MEMSET));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(
+          AIUPTI_ACTIVITY_KIND_CMPT));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(
+          AIUPTI_ACTIVITY_KIND_RUNTIME));
+      AIUPTI_CALL(AiuptiLibrary::singleton().activityDisable(
+          AIUPTI_ACTIVITY_KIND_DRIVER));
     }
   }
   externalCorrelationEnabled_ = false;

--- a/torch_spyre/csrc/profiler/AiuptiLibrary.cpp
+++ b/torch_spyre/csrc/profiler/AiuptiLibrary.cpp
@@ -68,9 +68,8 @@ const AiuptiLibrary& AiuptiLibrary::singleton() {
     // deferred until a profiler session actually starts.
     void* handle = dlopen(path.c_str(), RTLD_NOW | RTLD_GLOBAL);
     if (handle == nullptr) {
-      throw std::runtime_error(
-          std::string("Failed to load ") + path +
-          " for AIU profiling: " + dlerror());
+      throw std::runtime_error(std::string("Failed to load ") + path +
+                               " for AIU profiling: " + dlerror());
     }
     auto resolveFn =
         reinterpret_cast<ResolveFn>(dlsym(handle, "ts_aiupti_resolve"));
@@ -92,9 +91,8 @@ const AiuptiLibrary& AiuptiLibrary::singleton() {
     lib.activityGetNumDroppedRecords =
         reinterpret_cast<decltype(lib.activityGetNumDroppedRecords)>(
             resolve(resolveFn, "aiuptiActivityGetNumDroppedRecords"));
-    lib.flushAllActivities =
-        reinterpret_cast<decltype(lib.flushAllActivities)>(
-            resolve(resolveFn, "aiuptiFlushAllActivities"));
+    lib.flushAllActivities = reinterpret_cast<decltype(lib.flushAllActivities)>(
+        resolve(resolveFn, "aiuptiFlushAllActivities"));
   });
   return lib;
 }

--- a/torch_spyre/csrc/profiler/AiuptiLibrary.cpp
+++ b/torch_spyre/csrc/profiler/AiuptiLibrary.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 The Torch-Spyre Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "AiuptiLibrary.h"
+
+#ifdef HAS_AIUPTI
+
+#include <dlfcn.h>
+
+#include <mutex>
+#include <stdexcept>
+#include <string>
+
+namespace KINETO_NAMESPACE {
+
+namespace {
+
+using ResolveFn = void* (*)(const char*);
+
+// Locate _aiupti_shim.so next to the _C extension that this code is linked
+// into. dladdr on a symbol from this translation unit yields the path of _C,
+// whose directory also contains the shim.
+std::string shimPath() {
+  Dl_info info;
+  if (dladdr(reinterpret_cast<void*>(&shimPath), &info) == 0 ||
+      info.dli_fname == nullptr) {
+    throw std::runtime_error(
+        "Failed to locate the torch_spyre extension directory for AIU "
+        "profiling (dladdr failed)");
+  }
+  std::string path(info.dli_fname);
+  auto slash = path.find_last_of('/');
+  std::string dir = (slash == std::string::npos) ? "." : path.substr(0, slash);
+  return dir + "/_aiupti_shim.so";
+}
+
+void* resolve(ResolveFn resolveFn, const char* name) {
+  void* sym = resolveFn(name);
+  if (sym == nullptr) {
+    throw std::runtime_error(
+        std::string("_aiupti_shim could not resolve libaiupti symbol '") +
+        name + "'");
+  }
+  return sym;
+}
+
+}  // namespace
+
+const AiuptiLibrary& AiuptiLibrary::singleton() {
+  static AiuptiLibrary lib;
+  static std::once_flag once;
+  std::call_once(once, [&]() {
+    std::string path = shimPath();
+    // Loading the shim pulls libaiupti in as its DT_NEEDED dependency; this is
+    // the point at which flex per-op telemetry is armed, which is why it is
+    // deferred until a profiler session actually starts.
+    void* handle = dlopen(path.c_str(), RTLD_NOW | RTLD_GLOBAL);
+    if (handle == nullptr) {
+      throw std::runtime_error(
+          std::string("Failed to load ") + path +
+          " for AIU profiling: " + dlerror());
+    }
+    auto resolveFn =
+        reinterpret_cast<ResolveFn>(dlsym(handle, "ts_aiupti_resolve"));
+    if (resolveFn == nullptr) {
+      throw std::runtime_error(
+          std::string("_aiupti_shim is missing ts_aiupti_resolve: ") +
+          dlerror());
+    }
+    lib.activityRegisterCallbacks =
+        reinterpret_cast<decltype(lib.activityRegisterCallbacks)>(
+            resolve(resolveFn, "aiuptiActivityRegisterCallbacks"));
+    lib.activityEnable = reinterpret_cast<decltype(lib.activityEnable)>(
+        resolve(resolveFn, "aiuptiActivityEnable"));
+    lib.activityDisable = reinterpret_cast<decltype(lib.activityDisable)>(
+        resolve(resolveFn, "aiuptiActivityDisable"));
+    lib.activityGetNextRecord =
+        reinterpret_cast<decltype(lib.activityGetNextRecord)>(
+            resolve(resolveFn, "aiuptiActivityGetNextRecord"));
+    lib.activityGetNumDroppedRecords =
+        reinterpret_cast<decltype(lib.activityGetNumDroppedRecords)>(
+            resolve(resolveFn, "aiuptiActivityGetNumDroppedRecords"));
+    lib.flushAllActivities =
+        reinterpret_cast<decltype(lib.flushAllActivities)>(
+            resolve(resolveFn, "aiuptiFlushAllActivities"));
+  });
+  return lib;
+}
+
+}  // namespace KINETO_NAMESPACE
+
+#endif  // HAS_AIUPTI

--- a/torch_spyre/csrc/profiler/AiuptiLibrary.cpp
+++ b/torch_spyre/csrc/profiler/AiuptiLibrary.cpp
@@ -63,9 +63,11 @@ const AiuptiLibrary& AiuptiLibrary::singleton() {
   static std::once_flag once;
   std::call_once(once, [&]() {
     std::string path = shimPath();
-    // Loading the shim pulls libaiupti in as its DT_NEEDED dependency; this is
-    // the point at which flex per-op telemetry is armed, which is why it is
-    // deferred until a profiler session actually starts.
+    // Loading the shim pulls libaiupti in as its DT_NEEDED dependency. Doing
+    // this lazily (on the first profiler session, after flex is initialized)
+    // rather than linking it into _C keeps libaiupti from being mapped at
+    // startup, which is what would arm flex's per-op telemetry. See
+    // AiuptiLibrary.h.
     void* handle = dlopen(path.c_str(), RTLD_NOW | RTLD_GLOBAL);
     if (handle == nullptr) {
       throw std::runtime_error(std::string("Failed to load ") + path +

--- a/torch_spyre/csrc/profiler/AiuptiLibrary.h
+++ b/torch_spyre/csrc/profiler/AiuptiLibrary.h
@@ -24,13 +24,15 @@ namespace KINETO_NAMESPACE {
 // Lazily-resolved entry points into libaiupti.so.
 //
 // libaiupti is deliberately NOT linked as a DT_NEEDED dependency of
-// torch_spyre._C. Merely loading it into the process arms the flex runtime's
-// per-op telemetry path, which adds a fixed per-dispatch cost to every aten
-// op. Under eager execution (CompilationMode.NONE) each op is its own tiny
-// graph, so that cost is paid ~once per op per token and dominates the forward
-// pass. By resolving these symbols via dlopen/dlsym on the first profiler
-// session rather than at import, libaiupti stays unloaded — and telemetry
-// dormant — until a trace is actually requested.
+// torch_spyre._C. Loaded at process startup (as a DT_NEEDED, or via
+// LD_PRELOAD) it arms the flex runtime's per-op telemetry path, which adds a
+// fixed per-dispatch cost to every aten op. Under eager execution
+// (CompilationMode.NONE) each op is its own tiny graph, so that cost is paid
+// ~once per op per token and dominates the forward pass. Loading it later —
+// via dlopen after flex is already initialized — does not arm that path. By
+// dlopen'ing on the first profiler session instead of linking at startup,
+// libaiupti is never mapped early in a normal run: telemetry stays dormant
+// until a trace is requested, and a run that never profiles never loads it.
 struct AiuptiLibrary {
   decltype(&aiuptiActivityRegisterCallbacks) activityRegisterCallbacks =
       nullptr;

--- a/torch_spyre/csrc/profiler/AiuptiLibrary.h
+++ b/torch_spyre/csrc/profiler/AiuptiLibrary.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 The Torch-Spyre Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#ifdef HAS_AIUPTI
+
+#include <libaiupti/aiupti_activity.h>
+
+namespace KINETO_NAMESPACE {
+
+// Lazily-resolved entry points into libaiupti.so.
+//
+// libaiupti is deliberately NOT linked as a DT_NEEDED dependency of
+// torch_spyre._C. Merely loading it into the process arms the flex runtime's
+// per-op telemetry path, which adds a fixed per-dispatch cost to every aten
+// op. Under eager execution (CompilationMode.NONE) each op is its own tiny
+// graph, so that cost is paid ~once per op per token and dominates the forward
+// pass. By resolving these symbols via dlopen/dlsym on the first profiler
+// session rather than at import, libaiupti stays unloaded — and telemetry
+// dormant — until a trace is actually requested.
+struct AiuptiLibrary {
+  decltype(&aiuptiActivityRegisterCallbacks) activityRegisterCallbacks =
+      nullptr;
+  decltype(&aiuptiActivityEnable) activityEnable = nullptr;
+  decltype(&aiuptiActivityDisable) activityDisable = nullptr;
+  decltype(&aiuptiActivityGetNextRecord) activityGetNextRecord = nullptr;
+  decltype(&aiuptiActivityGetNumDroppedRecords) activityGetNumDroppedRecords =
+      nullptr;
+  decltype(&aiuptiFlushAllActivities) flushAllActivities = nullptr;
+
+  // Resolves and caches the library handle and symbols on first call. Throws
+  // std::runtime_error if libaiupti.so cannot be loaded or a symbol is
+  // missing. The handle is intentionally never dlclose'd: once a profiling
+  // session loads libaiupti, it stays resident for the process lifetime.
+  static const AiuptiLibrary& singleton();
+};
+
+}  // namespace KINETO_NAMESPACE
+
+#endif  // HAS_AIUPTI

--- a/torch_spyre/csrc/profiler/AiuptiShim.cpp
+++ b/torch_spyre/csrc/profiler/AiuptiShim.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 The Torch-Spyre Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Thin resolver shim over libaiupti.
+//
+// This translation unit is compiled into a standalone shared library
+// (torch_spyre/_aiupti_shim.so) that links libaiupti as a DT_NEEDED
+// dependency. torch_spyre._C deliberately does NOT link libaiupti: merely
+// loading it into the process arms the flex runtime's per-op telemetry, which
+// adds a fixed per-dispatch cost to every aten op and dominates the forward
+// pass under eager execution. The profiler dlopen's this shim on the first
+// trace request (pulling libaiupti in at that point) and resolves the aiupti
+// entry points through the single `extern "C"` function below.
+//
+// Taking the address of each aiupti function here forces the compiler to emit
+// correctly-mangled references, so we never hardcode C++ mangled names in
+// dlsym calls.
+
+#include <cstring>
+
+#include <libaiupti/aiupti_activity.h>
+
+extern "C" void* ts_aiupti_resolve(const char* name) {
+  if (std::strcmp(name, "aiuptiActivityRegisterCallbacks") == 0)
+    return reinterpret_cast<void*>(&aiuptiActivityRegisterCallbacks);
+  if (std::strcmp(name, "aiuptiActivityEnable") == 0)
+    return reinterpret_cast<void*>(&aiuptiActivityEnable);
+  if (std::strcmp(name, "aiuptiActivityDisable") == 0)
+    return reinterpret_cast<void*>(&aiuptiActivityDisable);
+  if (std::strcmp(name, "aiuptiActivityGetNextRecord") == 0)
+    return reinterpret_cast<void*>(&aiuptiActivityGetNextRecord);
+  if (std::strcmp(name, "aiuptiActivityGetNumDroppedRecords") == 0)
+    return reinterpret_cast<void*>(&aiuptiActivityGetNumDroppedRecords);
+  if (std::strcmp(name, "aiuptiFlushAllActivities") == 0)
+    return reinterpret_cast<void*>(&aiuptiFlushAllActivities);
+  return nullptr;
+}

--- a/torch_spyre/csrc/profiler/AiuptiShim.cpp
+++ b/torch_spyre/csrc/profiler/AiuptiShim.cpp
@@ -29,9 +29,9 @@
 // correctly-mangled references, so we never hardcode C++ mangled names in
 // dlsym calls.
 
-#include <cstring>
-
 #include <libaiupti/aiupti_activity.h>
+
+#include <cstring>
 
 extern "C" void* ts_aiupti_resolve(const char* name) {
   if (std::strcmp(name, "aiuptiActivityRegisterCallbacks") == 0)

--- a/torch_spyre/csrc/profiler/AiuptiShim.cpp
+++ b/torch_spyre/csrc/profiler/AiuptiShim.cpp
@@ -18,12 +18,13 @@
 //
 // This translation unit is compiled into a standalone shared library
 // (torch_spyre/_aiupti_shim.so) that links libaiupti as a DT_NEEDED
-// dependency. torch_spyre._C deliberately does NOT link libaiupti: merely
-// loading it into the process arms the flex runtime's per-op telemetry, which
-// adds a fixed per-dispatch cost to every aten op and dominates the forward
-// pass under eager execution. The profiler dlopen's this shim on the first
-// trace request (pulling libaiupti in at that point) and resolves the aiupti
-// entry points through the single `extern "C"` function below.
+// dependency. torch_spyre._C deliberately does NOT link libaiupti: loaded at
+// process startup it arms the flex runtime's per-op telemetry, which adds a
+// fixed per-dispatch cost to every aten op and dominates the forward pass
+// under eager execution. The profiler dlopen's this shim on the first trace
+// request — after flex is initialized, which is late enough not to arm that
+// path — and resolves the aiupti entry points through the single `extern "C"`
+// function below.
 //
 // Taking the address of each aiupti function here forces the compiler to emit
 // correctly-mangled references, so we never hardcode C++ mangled names in


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Compiling the AIU profiler in by default (`USE_SPYRE_PROFILER=1`) links `libaiupti` as a `DT_NEEDED` dependency of `_C`, so `ld.so` maps it **at process startup**, before any Python runs. Loading libaiupti *that early* — as a `DT_NEEDED` or via `LD_PRELOAD`, before the flex runtime initializes — arms flex's per-dispatch telemetry path, adding a **fixed ~1.1 ms cost to every aten op dispatch** — even when no `torch.profiler.profile` session is active. Under `CompilationMode.NONE` (every aten op is its own tiny compiled graph, ~90 dispatches per decode token) this is ~100 ms of pure overhead on top of ~43 ms of real compute → the observed warning-free, fallback-free ~3× forward-pass slowdown.

**Fix:** stop hard-linking libaiupti into `_C`. Keep the profiler compiled in, but load libaiupti lazily (via a small `extern "C"` shim) on the first profiler session — i.e. *after* flex is already initialized, which is late enough that arming never happens. No session ⇒ libaiupti never loads ⇒ zero per-op cost; a session ⇒ it loads late and profiling works, still with no per-op penalty (verified — see below).

---

## Root cause: "compiled in" is coupled to "loaded early + armed"

- All of torch-spyre's profiler C++ is **session-gated**: `pushCorrelationID`/`popCorrelationID` early-return unless `externalCorrelationEnabled_`; `aiuptiActivityEnable(...)` runs only in `AiuptiActivityProfilerSession::start()`; `configure()` is called by kineto only for an active trace. `REGISTER_PRIVATEUSE1_PROFILER` just registers a lazy factory. `HAS_AIUPTI` appears only in `csrc/profiler/` — no hooks in the op-dispatch path. **No torch-spyre code runs per-op without a session.** So the ~1.1 ms/op cost is not our code — it is the flex runtime's own telemetry.
- The aiupti activity API (`aiuptiActivityEnable/Disable/RegisterCallbacks`) is exported by **`libflex.so`** (the runtime); `libaiupti.so` is the entry point. `setup.py` hard-links it (`LIBRARIES.insert(-1, "aiupti")`) → `libaiupti` becomes a `DT_NEEDED` dependency of `_C`, so `ld.so` maps it **at process startup**, before `import torch_spyre` runs and before flex initializes.
- It is the **early** load that does the damage: libaiupti mapped before flex init arms flex's per-dispatch telemetry path (the ~1.1 ms/op cost), even though torch-spyre never calls `aiuptiActivityEnable` outside a session. No runtime env master-gate exists (only `AIUPTI_ENABLE_METRICS` / `AIUPTI_METRIC_PATH`). Loading the *same* library *late* — via `dlopen` after flex is initialized — does **not** arm the path: a late load adds zero per-op cost and profiling still collects correctly (measured; see Validation). This is the whole reason the lazy-load fix works rather than merely relocating the cost.

## The cost is per-dispatch (fixed, independent of op size)

Per-op breakdown (`per_op_microbench.py`, profiler OFF vs ON, both on `ca01efe`):

| op | OFF ms/op | ON ms/op | Δ ms | ratio | # aten ops |
|---|---|---|---|---|---|
| add (tiny) | 0.296 | 1.404 | 🔴 +1.11 | 4.75× | 1 |
| mul (tiny) | 0.298 | 1.408 | 🔴 +1.11 | 4.72× | 1 |
| o-proj 4096×4096 | 0.543 | 1.659 | 🔴 +1.12 | 3.05× | 1 |
| qkv 4096×6144 | 0.636 | 1.779 | 🔴 +1.14 | 2.80× | 1 |
| down 12800×4096 | 1.070 | 2.137 | 🔴 +1.07 | 2.00× | 1 |
| gate_up 4096×25600 | 2.091 | 3.224 | 🔴 +1.13 | 1.54× | 1 |
| lm_head 4096×51200 | 3.285 | 4.379 | 🔴 +1.09 | 1.33× | 1 |
| silu (tiny) | 0.576 | 2.798 | +2.22 | 4.86× | 2 (sigmoid+mul) |
| rms_norm (tiny) | 1.940 | 9.036 | +7.10 | 4.66× | ~6 |

Every single-op row pays the same ~1.1 ms regardless of FLOPs (a 4096×4096 matmul costs the same delta as a scalar `add`). Composite ops scale with op **count**, not work: `silu` (2 ops) = +2.22 ≈ 2×1.1; `rms_norm` (~6 ops) = +7.1 ≈ 6×1.1. This is a **per-op-dispatch cost** (CUPTI-style "telemetry armed ⇒ per-launch callback"), not a slower kernel. (This table was captured with the profiler ON = the old `DT_NEEDED`/early-load build, so telemetry was armed.)

## Why spyre-inference sees it and the torch-spyre team doesn't

spyre-inference runs with `CompilationMode.NONE` — torch-spyre executes *every aten op as its own tiny compiled graph*, so a batch-1 decode step is ~90 separate device dispatches. At ~1.1 ms each that is ~100 ms of pure dispatch overhead on top of ~43 ms of real compute → ~142 ms. A maintainer testing a *fully-compiled* model (one graph for the whole forward) pays the fixed cost once and sees nothing.

Confirmed by fusing the whole forward into a single `torch.compile` graph (full 2×2 on `ca01efe`, microbench decode step, tokens=1, 4 layers):

| | eager (~90 per-op dispatches) | compiled (single graph) |
|---|---|---|
| profiler OFF | 41.89 ms | 17.56 ms |
| profiler ON | 🔴 140.69 ms | ✅ 19.74 ms |
| profiler penalty | 🔴 3.36× (+99 ms) | ✅ 1.12× (+2.2 ms) |

Compiling collapses the penalty from **+99 ms to +2.2 ms** (the residual is the few remaining graph launches). Decisive: the cost is fixed *per device dispatch*, so eager/per-op execution pays it ~90× per token while a fused graph pays it ~once.

## Mechanism confirmation (bisection + build-flag toggle)

First bad commit isolated by bisecting the 26-commit range `88964c0..ca01efe` — indices 9 (fast) and 10 (slow) are adjacent with nothing between:

| torch-spyre rev | build flag | median_ms | note |
|---|---|---|---|
| `88964c0` (baseline) | default | 43.24 | ✅ fast (profiler not present) |
| `ca01efe` (bump) | default (`USE_SPYRE_PROFILER=1`) | 142.12 | 🔴 slow (profiler compiled in) |
| `ca01efe` (bump) | `USE_SPYRE_PROFILER=0` | 43.15 | ✅ fast — full recovery |

Disabling the compiled-in profiler recovers 100% of the loss.

---

## Fix: lazy-load libaiupti via an `extern "C"` shim

Goal: keep the profiler **compiled in** (`USE_SPYRE_PROFILER=1`) but stop paying the per-op cost when no profiler is running. No load ⇒ no arming.

**Changes:**

- **New `AiuptiLibrary.{h,cpp}`** — a lazily-`dlopen`'d function-pointer table for the 6 aiupti symbols (`activityRegisterCallbacks`, `activityEnable`, `activityDisable`, `activityGetNextRecord`, `activityGetNumDroppedRecords`, `flushAllActivities`). Resolved on first use via `std::call_once`; the typed pointers use `decltype(&aiupti…)` so the call sites stay type-safe.
- **`AiuptiActivityApi.cpp`** — all 6 direct calls routed through `AiuptiLibrary::singleton()`. First call happens in `enableAiuptiActivities()` (session start), so nothing loads at import.
- **New `AiuptiShim.cpp` → `torch_spyre/_aiupti_shim.so`** — a standalone extension that links `-laiupti` at build time (so the compiler emits correctly-mangled references — no hardcoded names) and exposes a single unmangled `void* ts_aiupti_resolve(const char*)` returning `&aiupti…` by name. `AiuptiLibrary::singleton()` locates the shim next to `_C.so` via `dladdr`, `dlopen`s it (pulling libaiupti in as the shim's `DT_NEEDED` at that moment), `dlsym`s `ts_aiupti_resolve`, and populates the 6 typed pointers.
- **`setup.py`** — dropped `LIBRARIES.insert(-1, "aiupti")` so libaiupti is no longer a `DT_NEEDED` of `_C`; kept the header include dir, `HAS_AIUPTI`, `USE_KINETO`, and the profiler sources; added `dl` for `dlopen`/`dlsym`. libaiupti is now linked *only* by the shim extension.

> **Why a shim rather than plain `dlsym`?** libaiupti declares its API with C++ linkage (no `extern "C"`), so its exports are name-mangled (e.g. `_Z31aiuptiActivityRegisterCallbacksPFvPPhPmS1_EPFvS_mmE`). Hardcoding the mangled strings in `dlsym` calls is brittle to any signature change; the shim lets the compiler emit the mangled references and exposes stable unmangled entry points instead.

## Validation

Local wheel built with `USE_SPYRE_PROFILER=1`, installed into the spyre-inference venv:

| check | result |
|---|---|
| `_C.so` DT_NEEDED lists libaiupti | ✅ no (delinked) |
| `_aiupti_shim.so` DT_NEEDED lists libaiupti | ✅ yes |
| `_aiupti_shim.so` exports `ts_aiupti_resolve` | ✅ yes (unmangled, no hardcoded mangled names) |
| profiler compiled in (aiupti symbols in `_C.so`) | ✅ yes (112, `HAS_AIUPTI`) |
| libaiupti loaded at import / after a normal forward pass | ✅ no (dormant) |
| idle perf, eager microbench | ✅ 43.08 ms median (baseline; was ~140 ms profiler-linked) |
| libaiupti loaded after a `profile()` session | ✅ yes (shim dlopen'd on demand) |
| per-op cost after a late `dlopen` of libaiupti | ✅ unchanged (0.29 ms → 0.29 ms) — a late load never arms telemetry |
| profiler session runs without error | ✅ yes; 215 `key_averages` entries, SPYRE activity captured (1.85 ms) |
| captured trace vs old always-armed build | ✅ equivalent — identical event counts (65 / 233 / 46 / 12), durations and CPU→device alignment overlap within jitter; only intended difference is the removed per-op cost |

**Net:** profiler available at build time, **zero per-op penalty when idle**, and profiling still works on demand — with **no hardcoded mangled names** (the shim owns the libaiupti linkage).

> The functional profiling check here is a smoke test on a single host; a full trace-content assertion should run in torch-spyre CI (note the pre-existing libaiupti #114 ABI caveat in `tests/profiler/test_spyre_profiler.py`, unrelated to this change).




#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

I haven't written C/C++ in decades, this is all my good friend Claude's work.

#### Does this PR introduce a user-facing change?

Hopefully just the performance improvement when _not_ profiling

#### Additional note:
