### PR TITLE
coarse tiling: optional read copy

### DIFF
--- a/docs/source/compiler/coarse_tiling_loops.md
+++ b/docs/source/compiler/coarse_tiling_loops.md
@@ -1253,53 +1253,6 @@ separate copy op takes `MutationLayoutSHOULDREMOVE(full_buf)`." The code's
 treatment. The single operative treatment corresponds to the doc's Case 2 row
 above.
 
-**Revisited and re-deferred (2026-08-08): skipping the copy for
-span-overflow.** The span-overflow coarse-tiling path
-(`coarse_tile_span_overflow.py`) runs post-stickify and is intentionally
-narrow in scope — at most one loop level, at most one reduction per loop —
-which raised the question of whether that narrowness makes it safe to skip
-the copy op in at least some cases, avoiding the HBM round-trip. Three
-candidates were investigated and all three were rejected or deferred
-without becoming implemented:
-
-1. **Rely on `_resize_device_layout` preserving compatibility.** The
-   full buffer's device layout is derived from the tiled op's own
-   already-input-reconciled output layout by resizing it
-   (`_resize_device_layout`/`_stick_host_dim`), so perhaps that derivation
-   preserves enough structure to stay compatible with the op's inputs.
-   Rejected: `_resize_device_layout` preserves dim order and which host dim
-   is the stick, but *recomputes* `stride_map`/`device_size` for the new
-   size, and compatibility (`stick_compatible`, reached via
-   `device_coordinates`/`compute_coordinates`) depends on a size-dependent
-   coordinate-derivation step, not just dim order. Resizing does not
-   provably preserve compatibility.
-2. **Skip only when the tiled op has zero external-to-group reads.** If
-   every one of an op's reads is satisfied by sibling ops in the same
-   coarse-tile group (no graph inputs, no other-group outputs), there is
-   structurally nothing external to reconcile the full buffer's layout
-   against, so direct-write would be safe. Confirmed this shape is
-   non-vacuous in the grouping logic (`_plan_tiling_propagation` classifies
-   `copy_out` purely by output/consumer criteria, independent of an op's own
-   reads, and `span_overflow_groups`'s multi-op pointwise-run logic does not
-   require every op in a run to read an external buffer) and is exercised by
-   mocked-IR unit tests (`test_span_overflow_hint_analysis.py`'s
-   `test_chained_compatible_pointwise_ops_produce_one_group` and
-   `test_chained_pointwise_ops_conform_to_producer_split`). But no
-   end-to-end test compiling a real torch program through genuine
-   span-overflow triggering produces this shape — every real multi-op chain
-   found (e.g. `abs(a+b)*c`) has its last op read an additional external
-   tensor, and single-op programs are the norm. Deferred as unproven against
-   real workloads, not rejected as impossible.
-3. **Explicit per-edge compatibility re-check.** Reuse the same mechanism
-   `finalize_layouts` uses (`edge.layout(in_stl, target_stl)` via
-   `EdgeCostMap`) to re-derive `device_coordinates` for the full buffer's
-   actual resized layout against each of the tiled op's input edges, after
-   `_allocate_full_buffer` runs, and skip the copy only if every edge is
-   still compatible. This is well-scoped and would live entirely on the
-   post-stickify path. Deferred, not rejected — the most promising direction
-   for a follow-up, should a real workload surface case 2's shape or
-   otherwise justify the added complexity.
-
 **Case 1** is where most of the working-set-reduction win comes from.  An
 intermediate like `y` in the small example flows from one tiled op to
 another without ever leaving scratchpad.  `per_tile_fixed` is set on the

--- a/docs/source/compiler/coarse_tiling_loops.md
+++ b/docs/source/compiler/coarse_tiling_loops.md
@@ -31,7 +31,7 @@ what constraints forced each choice — see the companion RFC
 
 - [Design Overview](#design-overview)
 - [Small Example](#small-example)
-- [Layer 1 — IR pass & `coarse_tile_pre_stickify()`/`coarse_tile_post_stickify()` API](#layer-1--pre-scheduling-ir-pass)
+- [Layer 1 — IR pass & `coarse_tile()` API](#layer-1--pre-scheduling-ir-pass)
   - [`reorder_unhinted_interlopers`](#reorder_unhinted_interlopers-pre-grouping-pass)
   - [Groups derivation and placement](#groups-derivation-and-placement-in-custompreschedulingpasses)
 - [Layer 2 — `CountedLoopSchedulerNode`](#layer-2--countedloopschedulernode)
@@ -128,12 +128,10 @@ hand-editing; see `docs/tools/README.md` for usage.
 
 ### What the coarse-tiling pass stamps
 
-The coarse-tile entry points (`coarse_tile_pre_stickify`/
-`coarse_tile_post_stickify`) see this as a nested group spec and stamp a
-single `loop_info: CoarseTileInfo` attribute on **both** `ir.Operation`
-objects. This is the real, captured value of `buf0`'s (`y = a + b`'s)
-`loop_info` immediately after the call runs, before any later pass touches
-it:
+`coarse_tile()` sees this as a nested group spec and stamps a single
+`loop_info: CoarseTileInfo` attribute on **both** `ir.Operation` objects. This
+is the real, captured value of `buf0`'s (`y = a + b`'s) `loop_info`
+immediately after `coarse_tile()` runs, before any later pass touches it:
 
 ```python
 from torch_spyre._inductor.loop_info import CoarseTileInfo
@@ -342,8 +340,7 @@ Key points:
   for how that layout redirects without changing the loop's per-tile
   `Pointwise.ranges`.
 - **`tiled_dims_per_read` and `output_tiled_dims` are already visible here**,
-  not just at the moment the coarse-tile entry point first stamps them (see
-  [What the
+  not just at the moment `coarse_tile()` first stamps them (see [What the
   coarse-tiling pass stamps](#what-the-coarse-tiling-pass-stamps) above) —
   they survive `span_reduction`, `work_distribution`, and
   `scratchpad_planning` unchanged, since none of those passes touch
@@ -926,60 +923,39 @@ bypass this:
 object.__setattr__(data, "ranges", ranges)
 ```
 
-### Public API: `coarse_tile_pre_stickify()` / `coarse_tile_post_stickify()`
+### Public API: `coarse_tile()`
 
 ```python
-def coarse_tile_pre_stickify(
-    graph: GraphLowering,
-    groups: list[tuple],
-    group_idx_offset: int = 0,
-) -> None:
-
-def coarse_tile_post_stickify(
+def coarse_tile(
     graph: GraphLowering,
     groups: list[tuple],
     group_idx_offset: int = 0,
 ) -> None:
 ```
 
-There are two public entry points with identical signatures.
-`coarse_tile_pre_stickify` is used for hint-driven groups, stamped before
-stickification; `coarse_tile_post_stickify` is used for span-overflow
-groups, stamped after stickification (once every op's device layout is
-already committed, a read-copy would only produce an HBM-to-HBM copy with
-no layout-reconciliation benefit). Both delegate to a shared private
-driver, `_coarse_tile_common(graph, groups, group_idx_offset,
-run_read_copies)`, passing `run_read_copies=True`/`False` respectively —
-the only difference between the two entry points is whether Pass 1 (read
-copy-ins, `_insert_all_read_copy_ops`) runs; Pass 2
-(`_insert_all_reduction_ops`) and Pass 3 (`_insert_all_write_copy_ops`) run
-either way.
-
 `groups` is a pre-computed list of group tuples produced by
-`hints_to_coarse_tile_groups` (for `coarse_tile_pre_stickify`) or
-`span_overflow_groups` (for `coarse_tile_post_stickify`).  Each `ops` list
-must be a contiguous sub-sequence of `graph.operations`; a gap indicates a
-data-flow dependency crossing the group boundary and raises `RuntimeError`.
-The full `GraphLowering` is required (not just the operations list) because
+`hints_to_coarse_tile_groups`.  Each `ops` list must be a contiguous
+sub-sequence of `graph.operations`; a gap indicates a data-flow dependency
+crossing the group boundary and raises `RuntimeError`.  The full
+`GraphLowering` is required (not just the operations list) because
 `insert_tiling_propagation` calls `V.graph` APIs to allocate new buffers.
-`group_idx_offset` lets a caller make a second `coarse_tile_pre_stickify`/
-`coarse_tile_post_stickify` call on the same graph (e.g. hint-driven groups
-stamped pre-stickification, followed by a later span-overflow-driven call)
-without the new call's group IDs colliding with IDs already stamped by the
-earlier one.
+`group_idx_offset` lets a caller make a second `coarse_tile()` call on the
+same graph (e.g. hint-driven groups stamped pre-stickification, followed by
+a later span-overflow-driven call) without the new call's group IDs
+colliding with IDs already stamped by the earlier one.
 
-`_coarse_tile_common` itself is a thin plan-then-transform driver: it calls
+`coarse_tile()` itself is a thin plan-then-transform driver: it calls
 `plan_coarse_tile_groups(operations, groups)` exactly once, up front, for
 every group in the list.  Planning does zero IR mutation — it only decides
 each op's tiling attributes and raises `Unsupported` if any op in any group
 can't be tiled (see "Sequential recurrences are rejected at planning time"
-below).  Only if that single planning call succeeds does
-`_coarse_tile_common` move on to transformation: it loops over `groups`
-again and calls `_apply_plan` once per group to perform the actual IR
-mutation, followed by `insert_tiling_propagation`,
-`_zero_fixed_tile_advance_exprs`, and `_patch_retiled_load_indexes`.  There
-is no per-group interleaving of planning and mutation — every group is
-planned before any group is transformed.
+below).  Only if that single planning call succeeds does `coarse_tile()`
+move on to transformation: it loops over `groups` again and calls
+`_apply_plan` once per group to perform the actual IR mutation, followed by
+`insert_tiling_propagation`, `_zero_fixed_tile_advance_exprs`, and
+`_patch_retiled_load_indexes`.  There is no per-group interleaving of
+planning and mutation — every group is planned before any group is
+transformed.
 
 Each group tuple has the form:
 
@@ -1007,9 +983,9 @@ they are derived per-op inside `plan_coarse_tile_groups` by consulting each
 op's `DimHint.loop_var`.
 
 `plan_coarse_tile_groups` always receives this canonical list-of-pairs
-representation; for hint-driven groups it is built by `_hints_levels()`
-inside `hints_to_coarse_tile_groups` in `coarse_tile.py` before
-`coarse_tile_pre_stickify` plans and then transforms each group.
+representation; it is built by `_hints_levels()` inside
+`hints_to_coarse_tile_groups` in `coarse_tile.py` before `coarse_tile()`
+plans and then transforms each group.
 
 ### `reorder_unhinted_interlopers`: pre-grouping pass
 
@@ -1183,7 +1159,7 @@ for buffer lifetime analysis.
 
 ### Buffer propagation: `insert_tiling_propagation`
 
-`_coarse_tile_common` calls `insert_tiling_propagation(operations, groups)`
+`coarse_tile()` calls `insert_tiling_propagation(operations, groups)`
 immediately after stamping all loop attributes.  Its job is to ensure that
 any op whose result is consumed **outside** the loop (or is a graph output)
 exposes a complete, fully-sized buffer to its consumers.  Ops whose outputs
@@ -1646,13 +1622,13 @@ is rejected outright, before any IR mutation happens.
 
 **Detection, not propagation.** `plan_coarse_tile_groups` (the planning
 phase — see
-[Public API: `coarse_tile_pre_stickify()`/`coarse_tile_post_stickify()`](#public-api-coarse_tile_pre_stickify-coarse_tile_post_stickify))
-calls `_seed_buffer_for_carry` on every op that is loop-invariant at the
-group's reduction-tiled level(s) (`_plan_is_loop_invariant_at_reduction_levels`
+[Public API: `coarse_tile()`](#public-api-coarse_tile)) calls
+`_seed_buffer_for_carry` on every op that is loop-invariant at the group's
+reduction-tiled level(s) (`_plan_is_loop_invariant_at_reduction_levels`
 gates this call). If `_seed_buffer_for_carry` identifies `op` as the
 carry-producing step of such a recurrence, planning raises `Unsupported`
-immediately — `_coarse_tile_common` never reaches the transformation phase
-for that group, and no buffers are allocated or rewired for the recurrence.
+immediately — `coarse_tile()` never reaches the transformation phase for
+that group, and no buffers are allocated or rewired for the recurrence.
 `_seed_buffer_for_carry` exists purely to answer "does this op need a
 pattern we don't support," not to drive any propagation; there is no
 `accum_tile`/`carry_prev` machinery, no copy-in/copy-out placement, and no
@@ -2064,8 +2040,7 @@ LoopSpec(
 
 `OpSpec.tiled_symbols` is populated by `SpyreKernel.create_op_spec`: it
 reads `loop_info.loop_tiled_dims` (a `list[list[int]]`) from the
-`ir.Operation` (stamped by `coarse_tile_pre_stickify`/
-`coarse_tile_post_stickify`), and for each loop level
+`ir.Operation` (stamped by `coarse_tile()`), and for each loop level
 selects the symbols at those indices from the scheduler-level
 `iteration_space` dict.  The result is stored innermost-first.
 `MemoryDep.ranges` preserves the `data.ranges` ordering, so this positional
@@ -2164,7 +2139,7 @@ landed.
 |---|---|
 | `torch_spyre/_inductor/loop_info.py` | Layer 1: `CoarseTileInfo` dataclass; `copy_op_metadata` |
 | `torch_spyre/_inductor/wsr/coarse_tile_hints.py` | `reorder_unhinted_interlopers()` reorders interlopers before grouping |
-| `torch_spyre/_inductor/wsr/coarse_tile.py` | Layer 1: `coarse_tile_pre_stickify()`/`coarse_tile_post_stickify()` stamp `loop_info` and rewrite ranges; `insert_tiling_propagation` handles the data perimeter |
+| `torch_spyre/_inductor/wsr/coarse_tile.py` | Layer 1: `coarse_tile()` stamps `loop_info` and rewrites ranges; `insert_tiling_propagation` handles the data perimeter |
 | `torch_spyre/_inductor/insert_restickify.py` | Commits deferred `_pending_per_tile_fixed` flags in `finalize_layouts`; derives a restickify buffer's own `per_tile_fixed` from the *consuming* op's `loop_info` rather than inheriting the source layout's flag, needed when the restickify buffer takes over an advancing accumulator's role (the nested output-dim + reduction-dim tiling copy-out into `accum_tile`, `_insert_reduction_copy_op`) |
 | `torch_spyre/_inductor/scheduler.py` | Layer 2: `CountedLoopSchedulerNode`, `build_loop_scheduler_nodes`, `_codegen_counted_loop`, `_regroup_by_outer_loop_key` |
 | `torch_spyre/_inductor/op_spec.py` | Layer 3: `LoopSpec` and `OpSpec` dataclasses |
@@ -2173,8 +2148,8 @@ landed.
 | `torch_spyre/_inductor/passes.py` | Wires all passes into `CustomPreSchedulingPasses` and `CustomPreFusionPasses` |
 | `torch_spyre/_inductor/propagate_hints.py` | `spyre_hint()` context manager; `DimHint`; hint collection/recovery across AOT re-tracing |
 | `torch_spyre/_inductor/wsr/propagate_named_dims.py` | `propagate_named_dims()` and `assign_dim_hints()`: attach `dim_hints` to `ir.Operation` objects |
-| `torch_spyre/_inductor/wsr/coarse_tile_hints.py` | `hints_to_coarse_tile_groups()`: converts `dim_hints` into `coarse_tile_pre_stickify()` group tuples |
-| `torch_spyre/_inductor/wsr/coarse_tile.py` | `coarse_tile_pre_stickify()`/`coarse_tile_post_stickify()` entry points |
+| `torch_spyre/_inductor/wsr/coarse_tile_hints.py` | `hints_to_coarse_tile_groups()`: converts `dim_hints` into `coarse_tile()` group tuples |
+| `torch_spyre/_inductor/wsr/coarse_tile.py` | `coarse_tile()` entry point |
 | `tests/inductor/test_coarse_tiling.py` | Unit tests: IR pass, propagation, scheduler node, bundle MLIR output |
 | `tests/inductor/test_coarse_tile_e2e.py` | End-to-end compilation tests |
 
@@ -2425,8 +2400,8 @@ and they are staged deliberately rather than combined:
 2. **`_patch_retiled_load_indexes`** fixes a different problem: *other* ops
    whose captured load index still carries the pre-tiling stride
    coefficient for a buffer that has since been re-tiled. This is driven
-   exactly once, at the very end of `_coarse_tile_common`, after every group
-   in the call has been processed — not per-group. `_stride_rewrite_map`
+   exactly once, at the very end of `coarse_tile()`, after every group in
+   the call has been processed — not per-group. `_stride_rewrite_map`
    (in `coarse_tile.py`) builds the substitution from old to new
    stride coefficients; `_retile_load_index_from_strides`
    (in `coarse_tile.py`) checks that the load index is affine and

--- a/docs/source/compiler/coarse_tiling_loops.md
+++ b/docs/source/compiler/coarse_tiling_loops.md
@@ -1253,6 +1253,53 @@ separate copy op takes `MutationLayoutSHOULDREMOVE(full_buf)`." The code's
 treatment. The single operative treatment corresponds to the doc's Case 2 row
 above.
 
+**Revisited and re-deferred (2026-08-08): skipping the copy for
+span-overflow.** The span-overflow coarse-tiling path
+(`coarse_tile_span_overflow.py`) runs post-stickify and is intentionally
+narrow in scope — at most one loop level, at most one reduction per loop —
+which raised the question of whether that narrowness makes it safe to skip
+the copy op in at least some cases, avoiding the HBM round-trip. Three
+candidates were investigated and all three were rejected or deferred
+without becoming implemented:
+
+1. **Rely on `_resize_device_layout` preserving compatibility.** The
+   full buffer's device layout is derived from the tiled op's own
+   already-input-reconciled output layout by resizing it
+   (`_resize_device_layout`/`_stick_host_dim`), so perhaps that derivation
+   preserves enough structure to stay compatible with the op's inputs.
+   Rejected: `_resize_device_layout` preserves dim order and which host dim
+   is the stick, but *recomputes* `stride_map`/`device_size` for the new
+   size, and compatibility (`stick_compatible`, reached via
+   `device_coordinates`/`compute_coordinates`) depends on a size-dependent
+   coordinate-derivation step, not just dim order. Resizing does not
+   provably preserve compatibility.
+2. **Skip only when the tiled op has zero external-to-group reads.** If
+   every one of an op's reads is satisfied by sibling ops in the same
+   coarse-tile group (no graph inputs, no other-group outputs), there is
+   structurally nothing external to reconcile the full buffer's layout
+   against, so direct-write would be safe. Confirmed this shape is
+   non-vacuous in the grouping logic (`_plan_tiling_propagation` classifies
+   `copy_out` purely by output/consumer criteria, independent of an op's own
+   reads, and `span_overflow_groups`'s multi-op pointwise-run logic does not
+   require every op in a run to read an external buffer) and is exercised by
+   mocked-IR unit tests (`test_span_overflow_hint_analysis.py`'s
+   `test_chained_compatible_pointwise_ops_produce_one_group` and
+   `test_chained_pointwise_ops_conform_to_producer_split`). But no
+   end-to-end test compiling a real torch program through genuine
+   span-overflow triggering produces this shape — every real multi-op chain
+   found (e.g. `abs(a+b)*c`) has its last op read an additional external
+   tensor, and single-op programs are the norm. Deferred as unproven against
+   real workloads, not rejected as impossible.
+3. **Explicit per-edge compatibility re-check.** Reuse the same mechanism
+   `finalize_layouts` uses (`edge.layout(in_stl, target_stl)` via
+   `EdgeCostMap`) to re-derive `device_coordinates` for the full buffer's
+   actual resized layout against each of the tiled op's input edges, after
+   `_allocate_full_buffer` runs, and skip the copy only if every edge is
+   still compatible. This is well-scoped and would live entirely on the
+   post-stickify path. Deferred, not rejected — the most promising direction
+   for a follow-up, should a real workload surface case 2's shape or
+   otherwise justify the added complexity.
+
 **Case 1** is where most of the working-set-reduction win comes from.  An
 intermediate like `y` in the small example flows from one tiled op to
 another without ever leaving scratchpad.  `per_tile_fixed` is set on the

--- a/docs/source/compiler/coarse_tiling_loops.md
+++ b/docs/source/compiler/coarse_tiling_loops.md
@@ -31,7 +31,7 @@ what constraints forced each choice — see the companion RFC
 
 - [Design Overview](#design-overview)
 - [Small Example](#small-example)
-- [Layer 1 — IR pass & `coarse_tile()` API](#layer-1--pre-scheduling-ir-pass)
+- [Layer 1 — IR pass & `coarse_tile_pre_stickify()`/`coarse_tile_post_stickify()` API](#layer-1--pre-scheduling-ir-pass)
   - [`reorder_unhinted_interlopers`](#reorder_unhinted_interlopers-pre-grouping-pass)
   - [Groups derivation and placement](#groups-derivation-and-placement-in-custompreschedulingpasses)
 - [Layer 2 — `CountedLoopSchedulerNode`](#layer-2--countedloopschedulernode)
@@ -128,10 +128,12 @@ hand-editing; see `docs/tools/README.md` for usage.
 
 ### What the coarse-tiling pass stamps
 
-`coarse_tile()` sees this as a nested group spec and stamps a single
-`loop_info: CoarseTileInfo` attribute on **both** `ir.Operation` objects. This
-is the real, captured value of `buf0`'s (`y = a + b`'s) `loop_info`
-immediately after `coarse_tile()` runs, before any later pass touches it:
+The coarse-tile entry points (`coarse_tile_pre_stickify`/
+`coarse_tile_post_stickify`) see this as a nested group spec and stamp a
+single `loop_info: CoarseTileInfo` attribute on **both** `ir.Operation`
+objects. This is the real, captured value of `buf0`'s (`y = a + b`'s)
+`loop_info` immediately after the call runs, before any later pass touches
+it:
 
 ```python
 from torch_spyre._inductor.loop_info import CoarseTileInfo
@@ -340,7 +342,8 @@ Key points:
   for how that layout redirects without changing the loop's per-tile
   `Pointwise.ranges`.
 - **`tiled_dims_per_read` and `output_tiled_dims` are already visible here**,
-  not just at the moment `coarse_tile()` first stamps them (see [What the
+  not just at the moment the coarse-tile entry point first stamps them (see
+  [What the
   coarse-tiling pass stamps](#what-the-coarse-tiling-pass-stamps) above) —
   they survive `span_reduction`, `work_distribution`, and
   `scratchpad_planning` unchanged, since none of those passes touch
@@ -923,39 +926,60 @@ bypass this:
 object.__setattr__(data, "ranges", ranges)
 ```
 
-### Public API: `coarse_tile()`
+### Public API: `coarse_tile_pre_stickify()` / `coarse_tile_post_stickify()`
 
 ```python
-def coarse_tile(
+def coarse_tile_pre_stickify(
+    graph: GraphLowering,
+    groups: list[tuple],
+    group_idx_offset: int = 0,
+) -> None:
+
+def coarse_tile_post_stickify(
     graph: GraphLowering,
     groups: list[tuple],
     group_idx_offset: int = 0,
 ) -> None:
 ```
 
-`groups` is a pre-computed list of group tuples produced by
-`hints_to_coarse_tile_groups`.  Each `ops` list must be a contiguous
-sub-sequence of `graph.operations`; a gap indicates a data-flow dependency
-crossing the group boundary and raises `RuntimeError`.  The full
-`GraphLowering` is required (not just the operations list) because
-`insert_tiling_propagation` calls `V.graph` APIs to allocate new buffers.
-`group_idx_offset` lets a caller make a second `coarse_tile()` call on the
-same graph (e.g. hint-driven groups stamped pre-stickification, followed by
-a later span-overflow-driven call) without the new call's group IDs
-colliding with IDs already stamped by the earlier one.
+There are two public entry points with identical signatures.
+`coarse_tile_pre_stickify` is used for hint-driven groups, stamped before
+stickification; `coarse_tile_post_stickify` is used for span-overflow
+groups, stamped after stickification (once every op's device layout is
+already committed, a read-copy would only produce an HBM-to-HBM copy with
+no layout-reconciliation benefit). Both delegate to a shared private
+driver, `_coarse_tile_common(graph, groups, group_idx_offset,
+run_read_copies)`, passing `run_read_copies=True`/`False` respectively —
+the only difference between the two entry points is whether Pass 1 (read
+copy-ins, `_insert_all_read_copy_ops`) runs; Pass 2
+(`_insert_all_reduction_ops`) and Pass 3 (`_insert_all_write_copy_ops`) run
+either way.
 
-`coarse_tile()` itself is a thin plan-then-transform driver: it calls
+`groups` is a pre-computed list of group tuples produced by
+`hints_to_coarse_tile_groups` (for `coarse_tile_pre_stickify`) or
+`span_overflow_groups` (for `coarse_tile_post_stickify`).  Each `ops` list
+must be a contiguous sub-sequence of `graph.operations`; a gap indicates a
+data-flow dependency crossing the group boundary and raises `RuntimeError`.
+The full `GraphLowering` is required (not just the operations list) because
+`insert_tiling_propagation` calls `V.graph` APIs to allocate new buffers.
+`group_idx_offset` lets a caller make a second `coarse_tile_pre_stickify`/
+`coarse_tile_post_stickify` call on the same graph (e.g. hint-driven groups
+stamped pre-stickification, followed by a later span-overflow-driven call)
+without the new call's group IDs colliding with IDs already stamped by the
+earlier one.
+
+`_coarse_tile_common` itself is a thin plan-then-transform driver: it calls
 `plan_coarse_tile_groups(operations, groups)` exactly once, up front, for
 every group in the list.  Planning does zero IR mutation — it only decides
 each op's tiling attributes and raises `Unsupported` if any op in any group
 can't be tiled (see "Sequential recurrences are rejected at planning time"
-below).  Only if that single planning call succeeds does `coarse_tile()`
-move on to transformation: it loops over `groups` again and calls
-`_apply_plan` once per group to perform the actual IR mutation, followed by
-`insert_tiling_propagation`, `_zero_fixed_tile_advance_exprs`, and
-`_patch_retiled_load_indexes`.  There is no per-group interleaving of
-planning and mutation — every group is planned before any group is
-transformed.
+below).  Only if that single planning call succeeds does
+`_coarse_tile_common` move on to transformation: it loops over `groups`
+again and calls `_apply_plan` once per group to perform the actual IR
+mutation, followed by `insert_tiling_propagation`,
+`_zero_fixed_tile_advance_exprs`, and `_patch_retiled_load_indexes`.  There
+is no per-group interleaving of planning and mutation — every group is
+planned before any group is transformed.
 
 Each group tuple has the form:
 
@@ -983,9 +1007,9 @@ they are derived per-op inside `plan_coarse_tile_groups` by consulting each
 op's `DimHint.loop_var`.
 
 `plan_coarse_tile_groups` always receives this canonical list-of-pairs
-representation; it is built by `_hints_levels()` inside
-`hints_to_coarse_tile_groups` in `coarse_tile.py` before `coarse_tile()`
-plans and then transforms each group.
+representation; for hint-driven groups it is built by `_hints_levels()`
+inside `hints_to_coarse_tile_groups` in `coarse_tile.py` before
+`coarse_tile_pre_stickify` plans and then transforms each group.
 
 ### `reorder_unhinted_interlopers`: pre-grouping pass
 
@@ -1159,7 +1183,7 @@ for buffer lifetime analysis.
 
 ### Buffer propagation: `insert_tiling_propagation`
 
-`coarse_tile()` calls `insert_tiling_propagation(operations, groups)`
+`_coarse_tile_common` calls `insert_tiling_propagation(operations, groups)`
 immediately after stamping all loop attributes.  Its job is to ensure that
 any op whose result is consumed **outside** the loop (or is a graph output)
 exposes a complete, fully-sized buffer to its consumers.  Ops whose outputs
@@ -1622,13 +1646,13 @@ is rejected outright, before any IR mutation happens.
 
 **Detection, not propagation.** `plan_coarse_tile_groups` (the planning
 phase — see
-[Public API: `coarse_tile()`](#public-api-coarse_tile)) calls
-`_seed_buffer_for_carry` on every op that is loop-invariant at the group's
-reduction-tiled level(s) (`_plan_is_loop_invariant_at_reduction_levels`
+[Public API: `coarse_tile_pre_stickify()`/`coarse_tile_post_stickify()`](#public-api-coarse_tile_pre_stickify-coarse_tile_post_stickify))
+calls `_seed_buffer_for_carry` on every op that is loop-invariant at the
+group's reduction-tiled level(s) (`_plan_is_loop_invariant_at_reduction_levels`
 gates this call). If `_seed_buffer_for_carry` identifies `op` as the
 carry-producing step of such a recurrence, planning raises `Unsupported`
-immediately — `coarse_tile()` never reaches the transformation phase for
-that group, and no buffers are allocated or rewired for the recurrence.
+immediately — `_coarse_tile_common` never reaches the transformation phase
+for that group, and no buffers are allocated or rewired for the recurrence.
 `_seed_buffer_for_carry` exists purely to answer "does this op need a
 pattern we don't support," not to drive any propagation; there is no
 `accum_tile`/`carry_prev` machinery, no copy-in/copy-out placement, and no
@@ -2040,7 +2064,8 @@ LoopSpec(
 
 `OpSpec.tiled_symbols` is populated by `SpyreKernel.create_op_spec`: it
 reads `loop_info.loop_tiled_dims` (a `list[list[int]]`) from the
-`ir.Operation` (stamped by `coarse_tile()`), and for each loop level
+`ir.Operation` (stamped by `coarse_tile_pre_stickify`/
+`coarse_tile_post_stickify`), and for each loop level
 selects the symbols at those indices from the scheduler-level
 `iteration_space` dict.  The result is stored innermost-first.
 `MemoryDep.ranges` preserves the `data.ranges` ordering, so this positional
@@ -2139,7 +2164,7 @@ landed.
 |---|---|
 | `torch_spyre/_inductor/loop_info.py` | Layer 1: `CoarseTileInfo` dataclass; `copy_op_metadata` |
 | `torch_spyre/_inductor/wsr/coarse_tile_hints.py` | `reorder_unhinted_interlopers()` reorders interlopers before grouping |
-| `torch_spyre/_inductor/wsr/coarse_tile.py` | Layer 1: `coarse_tile()` stamps `loop_info` and rewrites ranges; `insert_tiling_propagation` handles the data perimeter |
+| `torch_spyre/_inductor/wsr/coarse_tile.py` | Layer 1: `coarse_tile_pre_stickify()`/`coarse_tile_post_stickify()` stamp `loop_info` and rewrite ranges; `insert_tiling_propagation` handles the data perimeter |
 | `torch_spyre/_inductor/insert_restickify.py` | Commits deferred `_pending_per_tile_fixed` flags in `finalize_layouts`; derives a restickify buffer's own `per_tile_fixed` from the *consuming* op's `loop_info` rather than inheriting the source layout's flag, needed when the restickify buffer takes over an advancing accumulator's role (the nested output-dim + reduction-dim tiling copy-out into `accum_tile`, `_insert_reduction_copy_op`) |
 | `torch_spyre/_inductor/scheduler.py` | Layer 2: `CountedLoopSchedulerNode`, `build_loop_scheduler_nodes`, `_codegen_counted_loop`, `_regroup_by_outer_loop_key` |
 | `torch_spyre/_inductor/op_spec.py` | Layer 3: `LoopSpec` and `OpSpec` dataclasses |
@@ -2148,8 +2173,8 @@ landed.
 | `torch_spyre/_inductor/passes.py` | Wires all passes into `CustomPreSchedulingPasses` and `CustomPreFusionPasses` |
 | `torch_spyre/_inductor/propagate_hints.py` | `spyre_hint()` context manager; `DimHint`; hint collection/recovery across AOT re-tracing |
 | `torch_spyre/_inductor/wsr/propagate_named_dims.py` | `propagate_named_dims()` and `assign_dim_hints()`: attach `dim_hints` to `ir.Operation` objects |
-| `torch_spyre/_inductor/wsr/coarse_tile_hints.py` | `hints_to_coarse_tile_groups()`: converts `dim_hints` into `coarse_tile()` group tuples |
-| `torch_spyre/_inductor/wsr/coarse_tile.py` | `coarse_tile()` entry point |
+| `torch_spyre/_inductor/wsr/coarse_tile_hints.py` | `hints_to_coarse_tile_groups()`: converts `dim_hints` into `coarse_tile_pre_stickify()` group tuples |
+| `torch_spyre/_inductor/wsr/coarse_tile.py` | `coarse_tile_pre_stickify()`/`coarse_tile_post_stickify()` entry points |
 | `tests/inductor/test_coarse_tiling.py` | Unit tests: IR pass, propagation, scheduler node, bundle MLIR output |
 | `tests/inductor/test_coarse_tile_e2e.py` | End-to-end compilation tests |
 
@@ -2400,8 +2425,8 @@ and they are staged deliberately rather than combined:
 2. **`_patch_retiled_load_indexes`** fixes a different problem: *other* ops
    whose captured load index still carries the pre-tiling stride
    coefficient for a buffer that has since been re-tiled. This is driven
-   exactly once, at the very end of `coarse_tile()`, after every group in
-   the call has been processed — not per-group. `_stride_rewrite_map`
+   exactly once, at the very end of `_coarse_tile_common`, after every group
+   in the call has been processed — not per-group. `_stride_rewrite_map`
    (in `coarse_tile.py`) builds the substitution from old to new
    stride coefficients; `_retile_load_index_from_strides`
    (in `coarse_tile.py`) checks that the load index is affine and

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1472,6 +1472,43 @@ class TestCoarseTile(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             coarse_tile(_graph([op_known]), [([op_unknown], [(0, Integer(2))])])
 
+    def test_insert_read_copies_false_skips_pass_1(self):
+        """insert_read_copies=False must skip both planning and execution
+        of Pass 1 -- a full-buffer boundary read stays a direct read of the
+        full buffer, not redirected to a copy."""
+        from torch._inductor.ir import ComputedBuffer
+
+        gm = fx.symbolic_trace(lambda: None)
+        graph_ctx = V.set_graph_handler(GraphLowering(gm))
+        graph_ctx.__enter__()
+        try:
+            tiled_op, full_deps, operations = _make_full_buffer_read_fixture()
+            self.assertEqual(len(full_deps), 1)
+            full_buf_name = full_deps[0].name
+
+            groups = [([tiled_op], [(0, Integer(8))])]
+            self._run(operations, groups, insert_read_copies=False)
+
+            # No new copy op was inserted: still exactly the original two ops.
+            self.assertEqual(len(operations), 2)
+            loaded_names = []
+
+            class _Recorder:
+                def load(self, name, index):
+                    loaded_names.append(name)
+                    return 0.0
+
+            final_op = next(
+                o
+                for o in operations
+                if isinstance(o, ComputedBuffer) and o.get_name() == "tiled_op0"
+            )
+            with V.set_ops_handler(_Recorder()):
+                final_op.data.inner_fn([sympy.Integer(0) for _ in final_op.data.ranges])
+            self.assertIn(full_buf_name, loaded_names)
+        finally:
+            graph_ctx.__exit__(None, None, None)
+
 
 class TestCoarseTileNested(unittest.TestCase):
     """Verify that the nested group format [(hint_id, K1), ...] works."""
@@ -4256,6 +4293,7 @@ class TestCoarseTileBufferPropagation(unittest.TestCase):
         from torch_spyre._inductor.loop_info import PropagationPlan
         from torch_spyre._inductor.wsr.coarse_tile import (
             _insert_all_read_copy_ops,
+            _plan_read_copies,
             _propagate_tiled_op,
         )
 
@@ -4332,7 +4370,8 @@ class TestCoarseTileBufferPropagation(unittest.TestCase):
             "torch_spyre._inductor.wsr.coarse_tile._graph_output_names",
             return_value=set(),
         ):
-            _insert_all_read_copy_ops(operations)
+            read_copy_plans = _plan_read_copies(operations, [((0,), [tiled_op], {})])
+            _insert_all_read_copy_ops(operations, read_copy_plans)
             # Pass 1 may have spliced a replacement for "op0" into
             # operations -- re-resolve by name before calling
             # _propagate_tiled_op, exactly as _insert_all_write_copy_ops'
@@ -4916,6 +4955,153 @@ class TestReadCopyPlanDataclasses(unittest.TestCase):
         self.assertEqual(plan.entries, (entry,))
         with self.assertRaises(Exception):
             plan.entries = ()
+
+
+class TestInsertAllReadCopyOps(unittest.TestCase):
+    """_insert_all_read_copy_ops executes a precomputed ReadCopyPlan."""
+
+    def setUp(self):
+        gm = fx.symbolic_trace(lambda: None)
+        self._graph_ctx = V.set_graph_handler(GraphLowering(gm))
+        self._graph_ctx.__enter__()
+
+    def tearDown(self):
+        self._graph_ctx.__exit__(None, None, None)
+
+    def test_shared_read_produces_one_copy_for_two_consumers(self):
+        from torch._inductor.ir import ComputedBuffer
+
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _insert_all_read_copy_ops,
+            _plan_read_copies,
+        )
+
+        op_a, op_b, full_buf, operations = _make_two_op_shared_read_fixture()
+        retiled_infos_by_group = [((0,), [op_a, op_b], {})]
+        plans = _plan_read_copies(operations, retiled_infos_by_group)
+
+        _insert_all_read_copy_ops(operations, plans)
+
+        # Exactly one new copy op was inserted: full_buf, copy, op_a, op_b.
+        self.assertEqual(len(operations), 4)
+        copy_buf = operations[1]
+        self.assertIsInstance(copy_buf, ComputedBuffer)
+        self.assertIs(operations[0], full_buf)
+
+        # Both consumers were repointed at the SAME copy buffer name, not
+        # two independent copies.
+        new_op_a = next(
+            o
+            for o in operations
+            if isinstance(o, ComputedBuffer) and o.get_name() == "op_a"
+        )
+        new_op_b = next(
+            o
+            for o in operations
+            if isinstance(o, ComputedBuffer) and o.get_name() == "op_b"
+        )
+
+        class _Recorder(list):
+            def load(self, name, index):
+                self.append(name)
+                return 0.0
+
+        # _Recorder(loaded_by_a) would build a *new* list initialized from
+        # loaded_by_a's (empty) contents, not an alias of it -- appends
+        # inside .load() would then land on the _Recorder instance, not on
+        # loaded_by_a, leaving loaded_by_a permanently empty regardless of
+        # what inner_fn loads. Use each _Recorder instance itself as both
+        # the installed handler and the assertion target.
+        loaded_by_a = _Recorder()
+        loaded_by_b = _Recorder()
+
+        with V.set_ops_handler(loaded_by_a):
+            new_op_a.data.inner_fn([sympy.Integer(0) for _ in new_op_a.data.ranges])
+        with V.set_ops_handler(loaded_by_b):
+            new_op_b.data.inner_fn([sympy.Integer(0) for _ in new_op_b.data.ranges])
+
+        self.assertEqual(loaded_by_a, [copy_buf.get_name()])
+        self.assertEqual(loaded_by_b, [copy_buf.get_name()])
+        self.assertNotIn(full_buf.get_name(), loaded_by_a)
+        self.assertNotIn(full_buf.get_name(), loaded_by_b)
+
+    def test_transposed_read_gets_its_own_copy(self):
+        """a+b+a.t()-style: two reads of the same buffer with different
+        index expressions must NOT share a copy."""
+        from torch._inductor.ir import (
+            ComputedBuffer,
+            FixedLayout,
+            Pointwise,
+            StorageBox,
+            TensorBox,
+        )
+
+        from torch_spyre._inductor.ir import SpyreEmptyFallback
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _insert_all_read_copy_ops,
+            _plan_read_copies,
+        )
+
+        device = torch.device("cpu")
+        dtype = torch.float32
+
+        full_buf = SpyreEmptyFallback(
+            torch.ops.spyre.empty.default, [8, 8], device, dtype
+        )
+        full_buf.layout = FixedLayout(device, dtype, [8, 8], [8, 1])
+        full_box = TensorBox(StorageBox(full_buf))
+
+        def inner_fn(index):
+            i, j = index
+            plain = full_box.make_loader()([i, j])
+            transposed = full_box.make_loader()([j, i])
+            return plain + transposed
+
+        pw = Pointwise.create(
+            device=device,
+            dtype=dtype,
+            inner_fn=inner_fn,
+            ranges=[Integer(8), Integer(8)],
+        )
+        pw_data = pw.data.data
+        tiled_op = ComputedBuffer(
+            name="tiled_op0",
+            layout=FixedLayout(device, dtype, [Integer(8), Integer(8)], None),
+            data=pw_data,
+        )
+        tiled_op.operation_name = "tiled_op0"
+        tiled_op.origins = OrderedSet()
+        tiled_op.loop_info = CoarseTileInfo(
+            loop_group_id=(0,), loop_count=[Integer(1)], loop_tiled_dims=[[]]
+        )
+        V.graph.name_to_buffer["tiled_op0"] = tiled_op
+
+        operations = [full_buf, tiled_op]
+        retiled_infos_by_group = [((0,), [tiled_op], {})]
+        plans = _plan_read_copies(operations, retiled_infos_by_group)
+
+        self.assertEqual(len(plans[(0,)].entries), 2)
+
+        _insert_all_read_copy_ops(operations, plans)
+
+        copy_bufs = [
+            op
+            for op in operations
+            if isinstance(op, ComputedBuffer) and op.get_name() != "tiled_op0"
+        ]
+        self.assertEqual(len(copy_bufs), 2)
+
+    def test_disable_flag_skips_everything(self):
+        """An empty read_copy_plans dict (the insert_read_copies=False case)
+        leaves operations untouched."""
+        from torch_spyre._inductor.wsr.coarse_tile import _insert_all_read_copy_ops
+
+        op_a, op_b, full_buf, operations = _make_two_op_shared_read_fixture()
+        before = list(operations)
+
+        _insert_all_read_copy_ops(operations, {})
+
+        self.assertEqual(operations, before)
 
 
 class TestInsertReadCopyOps(unittest.TestCase):

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -5322,6 +5322,119 @@ class TestInsertAllReadCopyOps(unittest.TestCase):
 
         self.assertEqual(operations, before)
 
+    def test_one_consumer_patched_across_two_entries(self):
+        """op_a reads buf_x (shared with op_b) and buf_y (shared with op_c):
+        op_a appears in TWO different ReadCopyEntry.consumer_op_names within
+        the same plan. Each entry's consumer loop rebuilds op_a in place via
+        replace_computed_buffer_body, so the second entry to patch op_a must
+        resolve it by name through a freshly-rebuilt name_to_op, not through
+        a stale object reference captured before the first entry's patch --
+        exactly the object-identity hazard _NameSwapHandler/
+        replace_computed_buffer_body exist to guard against. Confirms both
+        patches land on the final op_a object (it loads both copies, never
+        the original full buffers)."""
+        from torch._inductor.ir import (
+            ComputedBuffer,
+            FixedLayout,
+            Pointwise,
+            StorageBox,
+            TensorBox,
+        )
+
+        from torch_spyre._inductor.ir import SpyreEmptyFallback
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _insert_all_read_copy_ops,
+            _plan_read_copies,
+        )
+
+        device = torch.device("cpu")
+        dtype = torch.float32
+
+        def _make_full(name):
+            buf = SpyreEmptyFallback(
+                torch.ops.spyre.empty.default, [8, 8], device, dtype
+            )
+            buf.layout = FixedLayout(device, dtype, [8, 8], [8, 1])
+            buf.name = name
+            V.graph.name_to_buffer[name] = buf
+            return buf
+
+        buf_x = _make_full("buf_x")
+        buf_y = _make_full("buf_y")
+        box_x = TensorBox(StorageBox(buf_x))
+        box_y = TensorBox(StorageBox(buf_y))
+
+        def _make_op(name, boxes):
+            def inner_fn(index):
+                total = boxes[0].make_loader()(index)
+                for box in boxes[1:]:
+                    total = total + box.make_loader()(index)
+                return total
+
+            pw = Pointwise.create(
+                device=device,
+                dtype=dtype,
+                inner_fn=inner_fn,
+                ranges=[Integer(8), Integer(8)],
+            )
+            pw_data = pw.data.data
+            op = ComputedBuffer(
+                name=name,
+                layout=FixedLayout(device, dtype, [Integer(8), Integer(8)], None),
+                data=pw_data,
+            )
+            op.operation_name = name
+            op.origins = OrderedSet()
+            op.loop_info = CoarseTileInfo(
+                loop_group_id=(0,), loop_count=[Integer(1)], loop_tiled_dims=[[]]
+            )
+            V.graph.name_to_buffer[name] = op
+            return op
+
+        # op_a reads both buf_x and buf_y; op_b only buf_x; op_c only buf_y.
+        op_a = _make_op("op_a", [box_x, box_y])
+        op_b = _make_op("op_b", [box_x])
+        op_c = _make_op("op_c", [box_y])
+        operations = [buf_x, buf_y, op_a, op_b, op_c]
+        retiled_infos_by_group = [((0,), [op_a, op_b, op_c], {})]
+
+        plans = _plan_read_copies(operations, retiled_infos_by_group)
+        entries_by_name = {e.dep.name: e for e in plans[(0,)].entries}
+        self.assertEqual(set(entries_by_name), {"buf_x", "buf_y"})
+        self.assertIn("op_a", entries_by_name["buf_x"].consumer_op_names)
+        self.assertIn("op_a", entries_by_name["buf_y"].consumer_op_names)
+
+        _insert_all_read_copy_ops(operations, plans)
+
+        final_op_a = next(
+            o
+            for o in operations
+            if isinstance(o, ComputedBuffer) and o.get_name() == "op_a"
+        )
+
+        class _Recorder(list):
+            def load(self, name, index):
+                self.append(name)
+                return 0.0
+
+            def add(self, a, b):
+                return 0.0
+
+        loaded = _Recorder()
+        with V.set_ops_handler(loaded):
+            final_op_a.data.inner_fn([sympy.Integer(0) for _ in final_op_a.data.ranges])
+
+        copy_names = {
+            op.get_name()
+            for op in operations
+            if isinstance(op, ComputedBuffer)
+            and op.get_name().startswith("coarse_tile_read_copy_")
+        }
+        self.assertEqual(len(copy_names), 2)
+        self.assertEqual(set(loaded), copy_names)
+        self.assertNotIn("buf_x", loaded)
+        self.assertNotIn("buf_y", loaded)
+
 
 class TestInsertReadCopyOps(unittest.TestCase):
     """_insert_read_copy_ops always materializes a real copy, never a view.

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1423,12 +1423,6 @@ class TestCoarseTile(unittest.TestCase):
     def tearDown(self):
         self._patch.stop()
 
-    def _run(self, all_ops, groups, **kwargs):
-        if kwargs.pop("insert_read_copies", True):
-            coarse_tile_pre_stickify(_graph(all_ops), groups, **kwargs)
-        else:
-            coarse_tile_post_stickify(_graph(all_ops), groups, **kwargs)
-
     def test_empty_groups_list_is_noop(self):
         data = _make_pointwise([Integer(32)])
         op = _make_op(data, "op0")
@@ -1480,8 +1474,8 @@ class TestCoarseTile(unittest.TestCase):
                 _graph([op_known]), [([op_unknown], [(0, Integer(2))])]
             )
 
-    def test_insert_read_copies_false_skips_pass_1(self):
-        """insert_read_copies=False must skip both planning and execution
+    def test_post_stickify_skips_pass_1(self):
+        """coarse_tile_post_stickify must skip both planning and execution
         of Pass 1 -- a full-buffer boundary read stays a direct read of the
         full buffer, not redirected to a copy."""
         from torch._inductor.ir import ComputedBuffer
@@ -1495,7 +1489,7 @@ class TestCoarseTile(unittest.TestCase):
             full_buf_name = full_deps[0].name
 
             groups = [([tiled_op], [(0, Integer(8))])]
-            self._run(operations, groups, insert_read_copies=False)
+            coarse_tile_post_stickify(_graph(operations), groups)
 
             # No new copy op was inserted: still exactly the original two ops.
             self.assertEqual(len(operations), 2)
@@ -1594,7 +1588,7 @@ class TestCoarseTile(unittest.TestCase):
             operations = [op_a, op_b]
             groups = [([op_a, op_b], [(0, Integer(8))])]
 
-            self._run(operations, groups)
+            coarse_tile_pre_stickify(_graph(operations), groups)
 
             copy_ops = [
                 op

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -4799,6 +4799,94 @@ def _make_full_buffer_read_fixture():
     return tiled_op, full_deps, operations
 
 
+def _make_two_op_shared_read_fixture():
+    """Two tiled ops in the same group both read full_buf at the SAME index
+    expression (mirrors "a+b*a": two reads of "a" with identical indexing,
+    just from two different consuming ops instead of one op's two reads).
+
+    Returns (op_a, op_b, full_buf, operations) with loop_info already
+    stamped on both ops, ready to pass into _plan_read_copies via a single
+    retiled_infos_by_group-style entry:
+    [((0,), [op_a, op_b], {})].
+    """
+    from torch._inductor.ir import (
+        ComputedBuffer,
+        FixedLayout,
+        Pointwise,
+        StorageBox,
+        TensorBox,
+    )
+
+    from torch_spyre._inductor.ir import SpyreEmptyFallback
+
+    device = torch.device("cpu")
+    dtype = torch.float32
+
+    full_buf = SpyreEmptyFallback(
+        torch.ops.spyre.empty.default, [64, 128], device, dtype
+    )
+    full_buf.layout = FixedLayout(device, dtype, [64, 128], [128, 1])
+    full_box = TensorBox(StorageBox(full_buf))
+
+    def _make_reader(name):
+        def inner_fn(index):
+            return full_box.make_loader()(index)
+
+        pw = Pointwise.create(
+            device=device,
+            dtype=dtype,
+            inner_fn=inner_fn,
+            ranges=[Integer(8), Integer(128)],
+        )
+        pw_data = pw.data.data
+        op = ComputedBuffer(
+            name=name,
+            layout=FixedLayout(device, dtype, [Integer(8), Integer(128)], None),
+            data=pw_data,
+        )
+        op.operation_name = name
+        op.origins = OrderedSet()
+        op.loop_info = CoarseTileInfo(
+            loop_group_id=(0,), loop_count=[Integer(8)], loop_tiled_dims=[[0]]
+        )
+        V.graph.name_to_buffer[name] = op
+        return op
+
+    op_a = _make_reader("op_a")
+    op_b = _make_reader("op_b")
+    operations = [full_buf, op_a, op_b]
+    return op_a, op_b, full_buf, operations
+
+
+class TestPlanReadCopies(unittest.TestCase):
+    """_plan_read_copies groups equivalent cross-group reads within a group."""
+
+    def setUp(self):
+        gm = fx.symbolic_trace(lambda: None)
+        self._graph_ctx = V.set_graph_handler(GraphLowering(gm))
+        self._graph_ctx.__enter__()
+
+    def tearDown(self):
+        self._graph_ctx.__exit__(None, None, None)
+
+    def test_two_ops_same_index_share_one_entry(self):
+        from torch_spyre._inductor.wsr.coarse_tile import _plan_read_copies
+
+        op_a, op_b, full_buf, operations = _make_two_op_shared_read_fixture()
+        retiled_infos_by_group = [((0,), [op_a, op_b], {})]
+
+        plans = _plan_read_copies(operations, retiled_infos_by_group)
+
+        self.assertIn((0,), plans)
+        plan = plans[(0,)]
+        self.assertEqual(len(plan.entries), 1)
+        entry = plan.entries[0]
+        self.assertEqual(entry.dep.name, full_buf.get_name())
+        self.assertEqual(entry.insert_before_op_name, "op_a")
+        self.assertEqual(entry.sizing_op_name, "op_a")
+        self.assertEqual(set(entry.consumer_op_names), {"op_a", "op_b"})
+
+
 class TestReadCopyPlanDataclasses(unittest.TestCase):
     """ReadCopyEntry/ReadCopyPlan are plain frozen dataclasses (Task 1)."""
 

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -5320,6 +5320,77 @@ class TestInsertAllReadCopyOps(unittest.TestCase):
         ]
         self.assertEqual(len(copy_bufs), 2)
 
+    def test_offset_read_gets_its_own_copy(self):
+        """a+shift(a)-style: two reads of the same buffer with identical
+        per-var index coefficients but a different constant offset must
+        NOT share a copy -- dep.index.coeff(v) is blind to the constant
+        term, so a naive key would wrongly merge these (see coarse_tile.py
+        issue where a merged-in consumer's real offset differs from the
+        sizing op's, producing wrong/out-of-bounds data)."""
+        from torch._inductor.ir import (
+            ComputedBuffer,
+            FixedLayout,
+            Pointwise,
+            StorageBox,
+            TensorBox,
+        )
+
+        from torch_spyre._inductor.ir import SpyreEmptyFallback
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _insert_all_read_copy_ops,
+            _plan_read_copies,
+        )
+
+        device = torch.device("cpu")
+        dtype = torch.float32
+
+        # 8x9 so a +1 column offset stays in bounds for all j in [0, 8).
+        full_buf = SpyreEmptyFallback(
+            torch.ops.spyre.empty.default, [8, 9], device, dtype
+        )
+        full_buf.layout = FixedLayout(device, dtype, [8, 9], [9, 1])
+        full_box = TensorBox(StorageBox(full_buf))
+
+        def inner_fn(index):
+            i, j = index
+            plain = full_box.make_loader()([i, j])
+            shifted = full_box.make_loader()([i, j + 1])
+            return plain + shifted
+
+        pw = Pointwise.create(
+            device=device,
+            dtype=dtype,
+            inner_fn=inner_fn,
+            ranges=[Integer(8), Integer(8)],
+        )
+        pw_data = pw.data.data
+        tiled_op = ComputedBuffer(
+            name="tiled_op0",
+            layout=FixedLayout(device, dtype, [Integer(8), Integer(8)], None),
+            data=pw_data,
+        )
+        tiled_op.operation_name = "tiled_op0"
+        tiled_op.origins = OrderedSet()
+        tiled_op.loop_info = CoarseTileInfo(
+            loop_group_id=(0,), loop_count=[Integer(1)], loop_tiled_dims=[[]]
+        )
+        V.graph.name_to_buffer["tiled_op0"] = tiled_op
+
+        operations = [full_buf, tiled_op]
+        retiled_infos_by_group = [((0,), [tiled_op], {})]
+        plans = _plan_read_copies(operations, retiled_infos_by_group)
+
+        self.assertEqual(len(plans[(0,)].entries), 2)
+
+        _insert_all_read_copy_ops(operations, plans)
+
+        copy_bufs = [
+            op
+            for op in operations
+            if isinstance(op, ComputedBuffer) and op.get_name() != "tiled_op0"
+        ]
+        self.assertEqual(len(copy_bufs), 2)
+
     def test_disable_flag_skips_everything(self):
         """An empty read_copy_plans dict (the insert_read_copies=False case)
         leaves operations untouched."""

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1509,6 +1509,95 @@ class TestCoarseTile(unittest.TestCase):
         finally:
             graph_ctx.__exit__(None, None, None)
 
+    def test_end_to_end_shares_one_copy_across_group(self):
+        """Full coarse_tile() entry point: two hint-driven ops in one group
+        both reading the same full InputBuffer at the same index must end
+        up sharing exactly one inserted read-copy op.
+
+        This closes the loop that Tasks 2/3/6/7's direct
+        _plan_read_copies/_insert_all_read_copy_ops tests don't cover: it
+        is the only test that also runs coarse_tile()'s later by-name
+        resync loop (_patch_retiled_load_indexes, near the end of
+        coarse_tile()'s body), which could in principle silently break
+        Pass 1's sharing if it replaced an op object Pass 1 already
+        consumed by name.
+        """
+        from torch._inductor.ir import (
+            ComputedBuffer,
+            FixedLayout,
+            InputBuffer,
+            Pointwise,
+            StorageBox,
+            TensorBox,
+        )
+        from torch_spyre._inductor.propagate_hints import DimHint
+
+        gm = fx.symbolic_trace(lambda: None)
+        graph_ctx = V.set_graph_handler(GraphLowering(gm))
+        graph_ctx.__enter__()
+        try:
+            device = torch.device("cpu")
+            dtype = torch.float32
+
+            # One real, full-size InputBuffer shared by both ops below --
+            # unlike _make_real_pointwise_op (which allocates a fresh
+            # InputBuffer per op), both readers here load the exact same
+            # buffer object at the exact same index, so _plan_read_copies
+            # should key them into a single ReadCopyEntry.
+            shared_input = InputBuffer(
+                name="shared_in", layout=FixedLayout(device, dtype, [64], [1])
+            )
+            V.graph.name_to_buffer["shared_in"] = shared_input
+            shared_box = TensorBox(StorageBox(shared_input))
+
+            def _make_reader(name):
+                def inner_fn(index):
+                    return shared_box.make_loader()(index)
+
+                pw = Pointwise.create(
+                    device=device,
+                    dtype=dtype,
+                    inner_fn=inner_fn,
+                    ranges=[Integer(64)],
+                )
+                pw_data = pw.data.data  # TensorBox -> StorageBox -> Pointwise
+                op = ComputedBuffer(
+                    name=name,
+                    layout=FixedLayout(device, dtype, [Integer(64)], None),
+                    data=pw_data,
+                )
+                op.operation_name = name
+                op.origins = OrderedSet()
+                V.graph.name_to_buffer[name] = op
+                op._test_out_coords = [sympy.Symbol("c0")]
+                op.dim_hints = [
+                    DimHint(
+                        dim_names=["dim0"],
+                        split_count=1,
+                        loop_var=sympy.Symbol("c0"),
+                        is_reduction=False,
+                        hint_id=0,
+                    )
+                ]
+                return op
+
+            op_a = _make_reader("op_a")
+            op_b = _make_reader("op_b")
+            operations = [op_a, op_b]
+            groups = [([op_a, op_b], [(0, Integer(8))])]
+
+            self._run(operations, groups)
+
+            copy_ops = [
+                op
+                for op in operations
+                if isinstance(op, ComputedBuffer)
+                and op.get_name().startswith("coarse_tile_read_copy_")
+            ]
+            self.assertEqual(len(copy_ops), 1)
+        finally:
+            graph_ctx.__exit__(None, None, None)
+
 
 class TestCoarseTileNested(unittest.TestCase):
     """Verify that the nested group format [(hint_id, K1), ...] works."""

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -4799,6 +4799,37 @@ def _make_full_buffer_read_fixture():
     return tiled_op, full_deps, operations
 
 
+class TestReadCopyPlanDataclasses(unittest.TestCase):
+    """ReadCopyEntry/ReadCopyPlan are plain frozen dataclasses (Task 1)."""
+
+    def test_read_copy_entry_and_plan_construct_and_are_frozen(self):
+        from torch._inductor.dependencies import MemoryDep
+        from torch_spyre._inductor.loop_info import ReadCopyEntry, ReadCopyPlan
+
+        dep = MemoryDep(
+            name="a",
+            index=sympy.Integer(0),
+            var_names=(),
+            size=(),
+        )
+        entry = ReadCopyEntry(
+            copy_name="coarse_tile_read_copy_group0_a_0",
+            dep=dep,
+            insert_before_op_name="op0",
+            sizing_op_name="op0",
+            consumer_op_names=("op0", "op1"),
+        )
+        self.assertEqual(entry.copy_name, "coarse_tile_read_copy_group0_a_0")
+        self.assertEqual(entry.consumer_op_names, ("op0", "op1"))
+        with self.assertRaises(Exception):
+            entry.copy_name = "other"  # frozen -> raises FrozenInstanceError
+
+        plan = ReadCopyPlan(entries=(entry,))
+        self.assertEqual(plan.entries, (entry,))
+        with self.assertRaises(Exception):
+            plan.entries = ()
+
+
 class TestInsertReadCopyOps(unittest.TestCase):
     """_insert_read_copy_ops always materializes a real copy, never a view.
 

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -84,7 +84,8 @@ from torch_spyre._inductor.wsr.coarse_tile import (
     _retile_load_index_from_strides,
     _should_patch_retiled_load_indexes,
     _stride_rewrite_map,
-    coarse_tile,
+    coarse_tile_post_stickify,
+    coarse_tile_pre_stickify,
     plan_coarse_tile_groups,
 )
 from torch_spyre._inductor.op_spec import LoopSpec, OpSpec, TensorArg, UnimplementedOp
@@ -1423,13 +1424,16 @@ class TestCoarseTile(unittest.TestCase):
         self._patch.stop()
 
     def _run(self, all_ops, groups, **kwargs):
-        coarse_tile(_graph(all_ops), groups, **kwargs)
+        if kwargs.pop("insert_read_copies", True):
+            coarse_tile_pre_stickify(_graph(all_ops), groups, **kwargs)
+        else:
+            coarse_tile_post_stickify(_graph(all_ops), groups, **kwargs)
 
     def test_empty_groups_list_is_noop(self):
         data = _make_pointwise([Integer(32)])
         op = _make_op(data, "op0")
         original = list(data.ranges)
-        coarse_tile(_graph([op]), [])
+        coarse_tile_pre_stickify(_graph([op]), [])
         self.assertFalse(hasattr(op, "loop_info") and op.loop_info != MagicMock())
         self.assertEqual(data.ranges, original)
 
@@ -1437,7 +1441,7 @@ class TestCoarseTile(unittest.TestCase):
         op_extern = _make_non_computed_op("extern0")
         data = _make_pointwise([Integer(16)])
         op_computed = _make_hinted_op(data, "op0", hints=((0, 0),))
-        coarse_tile(
+        coarse_tile_pre_stickify(
             _graph([op_extern, op_computed]),
             [([op_extern, op_computed], [(0, Integer(2))])],
         )
@@ -1449,7 +1453,7 @@ class TestCoarseTile(unittest.TestCase):
         n = Symbol("N", positive=True)
         data = _make_pointwise([n])
         op = _make_hinted_op(data, "op0", hints=((0, 0),))
-        coarse_tile(_graph([op]), [([op], [(0, k)])])
+        coarse_tile_pre_stickify(_graph([op]), [([op], [(0, k)])])
         self.assertEqual(op.loop_info.loop_count, [k])
         self.assertEqual(simplify(data.ranges[0] - n / k), 0)
 
@@ -1461,7 +1465,9 @@ class TestCoarseTile(unittest.TestCase):
         op1 = _make_hinted_op(d1, "op1", hints=((0, 0),))
         op2 = _make_hinted_op(d2, "op2", hints=((0, 0),))
         with self.assertRaises(RuntimeError):
-            coarse_tile(_graph([op0, op1, op2]), [([op0, op2], [(0, Integer(4))])])
+            coarse_tile_pre_stickify(
+                _graph([op0, op1, op2]), [([op0, op2], [(0, Integer(4))])]
+            )
 
     def test_op_not_in_operations_raises(self):
         data = _make_pointwise([Integer(32)])
@@ -1470,7 +1476,9 @@ class TestCoarseTile(unittest.TestCase):
             _make_pointwise([Integer(8)]), "unknown", hints=((0, 0),)
         )
         with self.assertRaises(RuntimeError):
-            coarse_tile(_graph([op_known]), [([op_unknown], [(0, Integer(2))])])
+            coarse_tile_pre_stickify(
+                _graph([op_known]), [([op_unknown], [(0, Integer(2))])]
+            )
 
     def test_insert_read_copies_false_skips_pass_1(self):
         """insert_read_copies=False must skip both planning and execution
@@ -1615,7 +1623,9 @@ class TestCoarseTileNested(unittest.TestCase):
     def test_nested_spec_stamps_list_attributes(self):
         data = _make_pointwise([Integer(256), Integer(128)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 1)))
-        coarse_tile(_graph([op]), [([op], [(1, Integer(4)), (2, Integer(2))])])
+        coarse_tile_pre_stickify(
+            _graph([op]), [([op], [(1, Integer(4)), (2, Integer(2))])]
+        )
         self.assertEqual(op.loop_info.loop_group_id, (0, 0))
         self.assertEqual(op.loop_info.loop_count, [Integer(4), Integer(2)])
         self.assertEqual(op.loop_info.loop_tiled_dims, [[0], [1]])
@@ -1623,14 +1633,18 @@ class TestCoarseTileNested(unittest.TestCase):
     def test_nested_spec_divides_ranges_both_levels(self):
         data = _make_pointwise([Integer(256), Integer(128)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 1)))
-        coarse_tile(_graph([op]), [([op], [(1, Integer(4)), (2, Integer(2))])])
+        coarse_tile_pre_stickify(
+            _graph([op]), [([op], [(1, Integer(4)), (2, Integer(2))])]
+        )
         self.assertEqual(data.ranges[0], Integer(64))
         self.assertEqual(data.ranges[1], Integer(64))
 
     def test_nested_spec_outer_only_divides_outer_dim(self):
         data = _make_pointwise([Integer(32), Integer(64), Integer(16)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 1)))
-        coarse_tile(_graph([op]), [([op], [(1, Integer(4)), (2, Integer(8))])])
+        coarse_tile_pre_stickify(
+            _graph([op]), [([op], [(1, Integer(4)), (2, Integer(8))])]
+        )
         self.assertEqual(data.ranges[0], Integer(8))
         self.assertEqual(data.ranges[1], Integer(8))
         self.assertEqual(data.ranges[2], Integer(16))
@@ -1641,7 +1655,7 @@ class TestCoarseTileNested(unittest.TestCase):
         d1 = _make_pointwise([Integer(128), Integer(64)])
         op0 = _make_hinted_op(d0, "op0", hints=((1, 0),))
         op1 = _make_hinted_op(d1, "op1", hints=((2, 0), (3, 1)))
-        coarse_tile(
+        coarse_tile_pre_stickify(
             _graph([op0, op1]),
             [
                 ([op0], [(1, Integer(4))]),
@@ -1662,7 +1676,9 @@ class TestCoarseTileNested(unittest.TestCase):
     def test_nested_same_dim_different_counts(self):
         data = _make_pointwise([Integer(256)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 0)))
-        coarse_tile(_graph([op]), [([op], [(1, Integer(4)), (2, Integer(2))])])
+        coarse_tile_pre_stickify(
+            _graph([op]), [([op], [(1, Integer(4)), (2, Integer(2))])]
+        )
         self.assertEqual(data.ranges[0], Integer(32))
         self.assertEqual(op.loop_info.loop_count, [Integer(4), Integer(2)])
         self.assertEqual(op.loop_info.loop_tiled_dims, [[0], [0]])
@@ -1708,7 +1724,7 @@ class TestCoarseTileNested(unittest.TestCase):
             ([op0], [(1, Integer(4))]),
             ([op1], [(2, Integer(4)), (3, Integer(2))]),
         ]
-        coarse_tile(_graph([op0, op1]), groups)
+        coarse_tile_pre_stickify(_graph([op0, op1]), groups)
         for group_ops, _ in groups:
             for op in group_ops:
                 if isinstance(op, ComputedBuffer):

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -4925,6 +4925,62 @@ class TestPlanReadCopies(unittest.TestCase):
         self.assertEqual(entry.sizing_op_name, "op_a")
         self.assertEqual(set(entry.consumer_op_names), {"op_a", "op_b"})
 
+    def test_same_op_two_reads_same_index_collapse_to_one_entry(self):
+        """a+b*a: one op reading buffer 'a' twice at the identical index
+        must plan exactly one ReadCopyEntry, consumed once by that op."""
+        from torch._inductor.ir import (
+            ComputedBuffer,
+            FixedLayout,
+            Pointwise,
+            StorageBox,
+            TensorBox,
+        )
+
+        from torch_spyre._inductor.ir import SpyreEmptyFallback
+        from torch_spyre._inductor.wsr.coarse_tile import _plan_read_copies
+
+        device = torch.device("cpu")
+        dtype = torch.float32
+
+        full_buf = SpyreEmptyFallback(
+            torch.ops.spyre.empty.default, [8, 8], device, dtype
+        )
+        full_buf.layout = FixedLayout(device, dtype, [8, 8], [8, 1])
+        full_box = TensorBox(StorageBox(full_buf))
+
+        def inner_fn(index):
+            a1 = full_box.make_loader()(index)
+            a2 = full_box.make_loader()(index)
+            return a1 + a2
+
+        pw = Pointwise.create(
+            device=device,
+            dtype=dtype,
+            inner_fn=inner_fn,
+            ranges=[Integer(8), Integer(8)],
+        )
+        pw_data = pw.data.data
+        tiled_op = ComputedBuffer(
+            name="tiled_op0",
+            layout=FixedLayout(device, dtype, [Integer(8), Integer(8)], None),
+            data=pw_data,
+        )
+        tiled_op.operation_name = "tiled_op0"
+        tiled_op.origins = OrderedSet()
+        tiled_op.loop_info = CoarseTileInfo(
+            loop_group_id=(0,), loop_count=[Integer(1)], loop_tiled_dims=[[]]
+        )
+        V.graph.name_to_buffer["tiled_op0"] = tiled_op
+
+        operations = [full_buf, tiled_op]
+        retiled_infos_by_group = [((0,), [tiled_op], {})]
+
+        plans = _plan_read_copies(operations, retiled_infos_by_group)
+
+        self.assertEqual(len(plans[(0,)].entries), 1)
+        entry = plans[(0,)].entries[0]
+        self.assertEqual(entry.consumer_op_names, ("tiled_op0",))
+
 
 class TestReadCopyPlanDataclasses(unittest.TestCase):
     """ReadCopyEntry/ReadCopyPlan are plain frozen dataclasses (Task 1)."""

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -4981,6 +4981,80 @@ class TestPlanReadCopies(unittest.TestCase):
         entry = plans[(0,)].entries[0]
         self.assertEqual(entry.consumer_op_names, ("tiled_op0",))
 
+    def test_partial_sharing_two_entries_different_consumers(self):
+        """op_a reads shared_buf + only_a; op_b reads shared_buf + only_b.
+        Expect two ReadCopyEntry objects: one shared (consumers = op_a,
+        op_b), one each for only_a/only_b (consumers = just that op)."""
+        from torch._inductor.ir import (
+            ComputedBuffer,
+            FixedLayout,
+            Pointwise,
+            StorageBox,
+            TensorBox,
+        )
+
+        from torch_spyre._inductor.ir import SpyreEmptyFallback
+        from torch_spyre._inductor.wsr.coarse_tile import _plan_read_copies
+
+        device = torch.device("cpu")
+        dtype = torch.float32
+
+        def _make_full(name, size):
+            buf = SpyreEmptyFallback(torch.ops.spyre.empty.default, size, device, dtype)
+            buf.layout = FixedLayout(device, dtype, size, [size[1], 1])
+            buf.name = name
+            V.graph.name_to_buffer[name] = buf
+            return buf
+
+        shared_buf = _make_full("shared_buf", [8, 8])
+        only_a_buf = _make_full("only_a_buf", [8, 8])
+        only_b_buf = _make_full("only_b_buf", [8, 8])
+
+        shared_box = TensorBox(StorageBox(shared_buf))
+        only_a_box = TensorBox(StorageBox(only_a_buf))
+        only_b_box = TensorBox(StorageBox(only_b_buf))
+
+        def _make_reader(name, extra_box):
+            def inner_fn(index):
+                return shared_box.make_loader()(index) + extra_box.make_loader()(index)
+
+            pw = Pointwise.create(
+                device=device,
+                dtype=dtype,
+                inner_fn=inner_fn,
+                ranges=[Integer(8), Integer(8)],
+            )
+            pw_data = pw.data.data
+            op = ComputedBuffer(
+                name=name,
+                layout=FixedLayout(device, dtype, [Integer(8), Integer(8)], None),
+                data=pw_data,
+            )
+            op.operation_name = name
+            op.origins = OrderedSet()
+            op.loop_info = CoarseTileInfo(
+                loop_group_id=(0,), loop_count=[Integer(1)], loop_tiled_dims=[[]]
+            )
+            V.graph.name_to_buffer[name] = op
+            return op
+
+        op_a = _make_reader("op_a", only_a_box)
+        op_b = _make_reader("op_b", only_b_box)
+        operations = [shared_buf, only_a_buf, only_b_buf, op_a, op_b]
+        retiled_infos_by_group = [((0,), [op_a, op_b], {})]
+
+        plans = _plan_read_copies(operations, retiled_infos_by_group)
+
+        entries_by_name = {e.dep.name: e for e in plans[(0,)].entries}
+        self.assertEqual(
+            set(entries_by_name), {"shared_buf", "only_a_buf", "only_b_buf"}
+        )
+        self.assertEqual(
+            set(entries_by_name["shared_buf"].consumer_op_names), {"op_a", "op_b"}
+        )
+        self.assertEqual(entries_by_name["only_a_buf"].consumer_op_names, ("op_a",))
+        self.assertEqual(entries_by_name["only_b_buf"].consumer_op_names, ("op_b",))
+
 
 class TestReadCopyPlanDataclasses(unittest.TestCase):
     """ReadCopyEntry/ReadCopyPlan are plain frozen dataclasses (Task 1)."""

--- a/tests/inductor/test_span_overflow_hint_analysis.py
+++ b/tests/inductor/test_span_overflow_hint_analysis.py
@@ -58,7 +58,7 @@ from torch_spyre._inductor import config
 from torch_spyre._inductor.constants import BATCH_MATMUL_OP, RESTICKIFY_OP
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.propagate_hints import DimHint
-from torch_spyre._inductor.wsr.coarse_tile import coarse_tile
+from torch_spyre._inductor.wsr.coarse_tile import coarse_tile_post_stickify
 from torch_spyre._inductor.wsr.coarse_tile_span_overflow import (
     _SPAN_OVERFLOW_HINT_ID,
     span_overflow_groups,
@@ -1726,7 +1726,7 @@ class TestSpanOverflowPointwisePlannerAndAdapter(InductorTestCase):
         with config.patch({"sencores": 4, "ignore_span_overflow_hints": False}):
             graph = _graph([op])
             groups = _apply_span_overflow(graph)
-            coarse_tile(graph, groups)
+            coarse_tile_post_stickify(graph, groups)
 
         self.assertEqual(list(op.data.ranges), _E2E_TILE_SHAPE)
         self.assertEqual(list(op.layout.size), _E2E_TILE_SHAPE)
@@ -2159,8 +2159,8 @@ class TestSpanOverflowLargeShapeContract(InductorTestCase):
                 self.assertEqual(manual_op.dim_hints[0].loop_var, sympy.Symbol("h"))
 
                 # Layer 3: coarse_tile stamps identical per-tile IR shape.
-                coarse_tile(auto_graph, auto_groups)
-                coarse_tile(manual_graph, manual_groups)
+                coarse_tile_post_stickify(auto_graph, auto_groups)
+                coarse_tile_post_stickify(manual_graph, manual_groups)
 
         self.assertEqual(list(auto_op.data.ranges), _E2E_TILE_SHAPE)
         self.assertEqual(list(manual_op.data.ranges), _E2E_TILE_SHAPE)

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Literal
 import sympy
 
 if TYPE_CHECKING:
+    from torch._inductor.dependencies import MemoryDep
     from torch._inductor.ir import ComputedBuffer
 
 
@@ -112,6 +113,56 @@ class PropagationPlan:
     reduction: ReductionPlan | None = None
     outside_consumer_names: tuple[str, ...] = ()
     is_graph_output: bool = False
+
+
+@dataclass(frozen=True)
+class ReadCopyEntry:
+    """One shared copy to insert for a cross-group buffer read.
+
+    Attributes
+    ----------
+    copy_name:
+        Qualified name to assign the inserted copy ComputedBuffer.
+    dep:
+        The canonical MemoryDep (buffer name + index + var_names + size)
+        every equivalent read in the group shares -- the same object one of
+        the consuming ops' own full_deps produced, used to size/index the
+        copy exactly as _insert_read_copy_ops does today.
+    insert_before_op_name:
+        get_operation_name() of the first (operations order) consuming op
+        in the group -- where the copy is inserted.
+    sizing_op_name:
+        get_operation_name() of the op supplying tiled_op.loop_info for
+        the copy's own read/write-level-extent computation (the first
+        consuming op, per the sizing-invariant in the design doc).
+    consumer_op_names:
+        Names of every op in the group that must have this dep's buffer
+        name patched (via _NameSwapHandler) to load from copy_name instead.
+    """
+
+    copy_name: str
+    dep: "MemoryDep"
+    insert_before_op_name: str
+    sizing_op_name: str
+    consumer_op_names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ReadCopyPlan:
+    """Per-group plan for Pass 1 (read-copy insertion).
+
+    Computed once during planning (_plan_read_copies, run after every
+    group's _apply_plan) and consumed by a slimmed _insert_all_read_copy_ops
+    that only executes these decisions.
+
+    Attributes
+    ----------
+    entries:
+        One ReadCopyEntry per distinct (buffer name, canonical index expr)
+        pair read cross-group by at least one op in this group.
+    """
+
+    entries: tuple["ReadCopyEntry", ...]
 
 
 @dataclass

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -351,6 +351,11 @@ def _maybe_coarse_tile_span_overflow(graph: GraphLowering) -> None:
     Requires FixedTiledLayout (device_layout) on all ops.
     hint-driven groups (hints_to_coarse_tile_groups) are intentionally
     absent: they have already run pre-stickification.
+
+    Passes insert_read_copies=False: layout propagation has already
+    committed every op's device layout by this point, so a read-copy here
+    would only produce an HBM-to-HBM copy with no layout-reconciliation
+    benefit.
     """
     if config.ignore_span_overflow_hints:
         return
@@ -376,7 +381,12 @@ def _maybe_coarse_tile_span_overflow(graph: GraphLowering) -> None:
     op_order = {id(op): idx for idx, op in enumerate(graph.operations)}
     groups.sort(key=lambda group: op_order.get(id(group[0][0]), len(op_order)))
     validate_coarse_tile_groups(groups)
-    coarse_tile(graph, groups=groups, group_idx_offset=group_idx_offset)
+    coarse_tile(
+        graph,
+        groups=groups,
+        group_idx_offset=group_idx_offset,
+        insert_read_copies=False,
+    )
 
 
 @_runs(cost_model_matmul_division, work_distribution)

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -91,7 +91,7 @@ from .scheduler import (
 from .constants import DEVICE_NAME
 from .deadcode_elimination import deadcode_elimination
 from .dedup_constants import dedup_and_promote_constants
-from .wsr.coarse_tile import coarse_tile
+from .wsr.coarse_tile import coarse_tile_post_stickify, coarse_tile_pre_stickify
 from .split_multi_ops import split_multi_ops, validate_ops
 
 
@@ -321,7 +321,7 @@ def _maybe_reorder_unhinted_interlopers(graph: GraphLowering) -> None:
 @_runs(
     hints_to_coarse_tile_groups,
     validate_coarse_tile_groups,
-    coarse_tile,
+    coarse_tile_pre_stickify,
 )
 def _maybe_coarse_tile_hints(graph: GraphLowering) -> None:
     """Hint-driven coarse tiling only.  Runs PRE-stickification.
@@ -337,13 +337,13 @@ def _maybe_coarse_tile_hints(graph: GraphLowering) -> None:
     op_order = {id(op): idx for idx, op in enumerate(graph.operations)}
     groups.sort(key=lambda group: op_order.get(id(group[0][0]), len(op_order)))
     validate_coarse_tile_groups(groups)
-    coarse_tile(graph, groups=groups)
+    coarse_tile_pre_stickify(graph, groups=groups)
 
 
 @_runs(
     span_overflow_groups,
     validate_coarse_tile_groups,
-    coarse_tile,
+    coarse_tile_post_stickify,
 )
 def _maybe_coarse_tile_span_overflow(graph: GraphLowering) -> None:
     """Span-overflow coarse tiling only.  Runs POST-stickification.
@@ -352,7 +352,7 @@ def _maybe_coarse_tile_span_overflow(graph: GraphLowering) -> None:
     hint-driven groups (hints_to_coarse_tile_groups) are intentionally
     absent: they have already run pre-stickification.
 
-    Passes insert_read_copies=False: layout propagation has already
+    Uses coarse_tile_post_stickify: layout propagation has already
     committed every op's device layout by this point, so a read-copy here
     would only produce an HBM-to-HBM copy with no layout-reconciliation
     benefit.
@@ -364,9 +364,9 @@ def _maybe_coarse_tile_span_overflow(graph: GraphLowering) -> None:
         return
     # span_overflow_groups is a pure planning step: it decides each op's
     # dim_hints but does not set them.  Apply them now, before
-    # validate_coarse_tile_groups/coarse_tile run, since dim_hints is an
-    # input those consume (via plan_coarse_tile_groups's hint lookups), not
-    # something they produce.
+    # validate_coarse_tile_groups/coarse_tile_post_stickify run, since
+    # dim_hints is an input those consume (via plan_coarse_tile_groups's
+    # hint lookups), not something they produce.
     for op, dim_hints in dim_hint_assignments:
         op.dim_hints = dim_hints  # type: ignore[attr-defined]
     # Compute offset to avoid loop_group_id collision with any hint-driven
@@ -381,11 +381,10 @@ def _maybe_coarse_tile_span_overflow(graph: GraphLowering) -> None:
     op_order = {id(op): idx for idx, op in enumerate(graph.operations)}
     groups.sort(key=lambda group: op_order.get(id(group[0][0]), len(op_order)))
     validate_coarse_tile_groups(groups)
-    coarse_tile(
+    coarse_tile_post_stickify(
         graph,
         groups=groups,
         group_idx_offset=group_idx_offset,
-        insert_read_copies=False,
     )
 
 

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -102,7 +102,8 @@ def _loop_count(node: BaseSchedulerNode, depth: int) -> sympy.Expr:
     """Return the loop_count for ``depth`` from the ir.Operation inside node.
 
     ``loop_count`` on the ir.Operation is a list of trip counts, one per
-    nesting level from outermost to innermost (stamped by coarse_tile()).
+    nesting level from outermost to innermost (stamped by
+    coarse_tile_pre_stickify()/coarse_tile_post_stickify()).
     ``depth`` is the absolute nesting depth being queried (0 = outermost).
 
     For a flat (depth-1) op, ``loop_count = [K]`` and only depth 0 is valid.

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -2771,13 +2771,14 @@ def _plan_read_copies(
                 # same logical tensor dim through these two different
                 # fields and still correctly share one copy -- the plan
                 # doesn't need loop_tiled_dims to build the copy either way.
-                assert other_info.loop_count == sizing_info.loop_count, (
-                    "_plan_read_copies: ops in the same coarse-tile group "
-                    f"disagree on loop_count ({other_op.get_name()!r} vs "
-                    f"{sizing_op.get_name()!r} sizing this shared copy of "
-                    f"{key[0]!r}) -- ops in one group must share trip counts "
-                    "by construction."
-                )
+                if other_info.loop_count != sizing_info.loop_count:
+                    raise Unsupported(
+                        "_plan_read_copies: ops in the same coarse-tile "
+                        f"group disagree on loop_count ({other_op.get_name()!r} "
+                        f"vs {sizing_op.get_name()!r} sizing this shared copy "
+                        f"of {key[0]!r}) -- ops in one group must share trip "
+                        "counts by construction."
+                    )
             group_tag = "_".join(str(i) for i in stamped_group_id)
             copy_name = V.graph.qualify_name(
                 f"coarse_tile_read_copy_{group_tag}_{key[0]}_{n}"

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -1400,6 +1400,7 @@ def coarse_tile(
     graph: GraphLowering,
     groups: list[tuple],
     group_idx_offset: int = 0,
+    insert_read_copies: bool = True,
 ) -> None:
     """Plan then transform: stamp loop_group_id / loop_count and scale ranges.
 
@@ -1418,6 +1419,13 @@ def coarse_tile(
         when making a second ``coarse_tile`` call on the same graph so that
         the new group IDs do not collide with IDs already stamped by an
         earlier call (e.g. hint-driven groups stamped pre-stickification).
+    insert_read_copies:
+        When False, skip both planning and insertion of Pass 1's read
+        copy-ins entirely. Set False by _maybe_coarse_tile_span_overflow
+        (passes.py): at that post-stickify call site, every op's device
+        layout is already committed by layout propagation, so a read-copy
+        buys no layout reconciliation and would only produce an HBM-to-HBM
+        copy with no benefit.
     """
     operations = graph.operations
 
@@ -1452,10 +1460,15 @@ def coarse_tile(
         )
         retiled_infos_by_group.append((stamped_group_id, group_ops, retiled_infos))
 
-    # Pass 1: read copy-ins, recomputing each op's full-buffer read deps
-    # fresh (post-division). Must complete before Pass 2 and Pass 3 run,
-    # both of which read each op's *current* reads/loader.
-    _insert_all_read_copy_ops(operations)
+    # Pass 1: read copy-ins. _plan_read_copies runs here (after every
+    # group's _apply_plan above, not alongside _plan_tiling_propagation)
+    # because it needs op.loop_info stamped and ranges already divided --
+    # see _plan_read_copies's own docstring. Skipped entirely when
+    # insert_read_copies is False (e.g. the post-stickify call site, where
+    # layout propagation already ran and a read-copy buys nothing).
+    if insert_read_copies:
+        read_copy_plans = _plan_read_copies(operations, retiled_infos_by_group)
+        _insert_all_read_copy_ops(operations, read_copy_plans)
 
     # Pass 2: reduction machinery (accumulator/fill/combine), using each
     # op's now-stamped loop_info.propagation.reduction. Must run after Pass
@@ -2247,38 +2260,31 @@ def _rescale_index(
     return new_index
 
 
-def _insert_read_copy_ops(
-    tiled_op: ComputedBuffer,
-    full_deps: list[MemoryDep],
+def _insert_one_read_copy(
+    sizing_op: ComputedBuffer,
+    dep: MemoryDep,
+    copy_name: str,
     operations: list[Operation],
-) -> ComputedBuffer:
-    """Insert, before tiled_op, one tile-sized copy op per full-size real input.
+) -> str:
+    """Build and insert one tile-sized copy op for a single full-buffer read.
 
-    tiled_op reads one or more full-size cross-loop-group buffers directly
-    (see _full_buffer_read_deps).  Those buffers get exactly one candidate
-    layout (sized to the full buffer), while tiled_op's own candidates are
-    sized to its tile — the two can never be stick-compatible under
-    AllSameNode.  Mirroring _insert_copy_op's write-side fix: for each
-    such input, insert a copy op that reads the full buffer's current tile
-    slice (same index expression tiled_op already uses, same loop_info so
-    the per-iteration base address advances identically) and writes it into
-    a fresh tile-sized buffer.  tiled_op's own inner_fn is then patched
-    (WrapperHandler, not reconstructed — see _NameSwapHandler) to read the
-    copy instead of the full buffer.
+    sizing_op reads (or is the first of a group of ops that all read) a
+    full-size cross-loop-group buffer directly (see _full_buffer_read_deps).
+    That buffer gets exactly one candidate layout (sized to the full
+    buffer), while sizing_op's own candidates are sized to its tile — the
+    two can never be stick-compatible under AllSameNode.  Mirroring
+    _insert_copy_op's write-side fix: insert a copy op that reads the full
+    buffer's current tile slice (same index expression dep already
+    describes, same loop_info as sizing_op so the per-iteration base
+    address advances identically) and writes it into a fresh tile-sized
+    buffer.
 
     The copy's own ranges/index must match dep (dep.var_names/dep.size), not
-    tiled_op.data.ranges: for a Reduction, the read spans output dims plus
+    sizing_op.data.ranges: for a Reduction, the read spans output dims plus
     the reduction dim, so dep's iteration space has more vars than the op's
     own output-shaped ranges.  The copy buffer's own layout gets fresh
     contiguous tile-local strides (it is a physically smaller allocation
     than full_buf, not an aliased view of it — see tile_strides below).
-    tiled_op's own read index, however, was computed against full_buf's
-    full-sized layout (dep.index, affine in dep.var_names) and no longer
-    resolves to a valid offset into the smaller copy buffer.  _NameSwapHandler
-    is therefore handed both full_strides (dep.index's own per-dimension
-    coefficients) and tile_strides alongside the copy's name, and rescales
-    the index's coefficients when it retargets the load — see
-    _NameSwapHandler and _rescale_index.
 
     Mirrors _allocate_full_buffer's isinstance(orig_layout, FixedTiledLayout)
     branch: when full_buf already carries a FixedTiledLayout (post-stickify
@@ -2288,314 +2294,292 @@ def _insert_read_copy_ops(
     Otherwise (pre-stickify call site) the copy gets a plain FixedLayout, and
     stickification (which runs later) fills device_layout in normally.
 
-    Returns the reconstructed ComputedBuffer that replaces tiled_op in
-    operations (see replace_computed_buffer_body below) — callers must
-    rebind their own reference since the original tiled_op object is stale
-    after this call.
+    Returns the inserted copy buffer's name (copy_buf.get_name()) -- callers
+    patch consumers separately via _patch_consumer_to_read_copy.
     """
-    name_map: dict[str, tuple[str, list[Expr], list[Expr]]] = {}
-    tiled_idx = operations.index(tiled_op)
+    sizing_idx = operations.index(sizing_op)
+    full_buf = V.graph.get_buffer(dep.name)
+    # Graph inputs come back TensorBox(StorageBox(InputBuffer))-wrapped
+    # (see graph_inputs); get_dtype() resolves to self.dtype via IRNode
+    # and is not delegated by TensorBox/StorageBox, so it raises
+    # AttributeError on the wrapper -- unwrap to the real Buffer first.
+    # get_name()/.layout are delegating and would work either way, but
+    # unwrap once so every full_buf.* access below is on the real node.
+    if isinstance(full_buf, TensorBox):
+        full_buf = full_buf.data
+    if isinstance(full_buf, StorageBox):
+        full_buf = full_buf.data
 
-    # A single tiled_op can read the same full buffer through two distinct
-    # MemoryDeps (e.g. two different index expressions into the same
-    # buffer). _NameSwapHandler retargets loads by buffer *name* only, so
-    # only one copy op per unique name can ever be addressed -- keep the
-    # first dep per name and drop the rest, rather than silently
-    # overwriting name_map's entry for that name later (which would
-    # rescale every load of that name using only the last dep's
-    # full_strides/tile_strides, and leave the earlier, now-unreachable
-    # copy ops dead in `operations`). Safe only because every dep for a
-    # given name reads the same underlying buffer with the same full-size
-    # layout, so full_strides/tile_strides do not depend on which such dep
-    # was kept -- assert that invariant so a future violation fails loudly.
-    deduped_deps: dict[str, MemoryDep] = {}
-    for dep in full_deps:
-        if dep.name in deduped_deps:
-            prior = deduped_deps[dep.name]
-            assert prior.var_names == dep.var_names and prior.index == dep.index, (
-                f"_insert_read_copy_ops: {dep.name!r} is read via two "
-                "MemoryDeps with different index expressions "
-                f"({prior.index} vs {dep.index}); a single copy op keyed by "
-                "buffer name cannot serve both -- _NameSwapHandler needs to "
-                "become index-aware to support this."
-            )
-            continue
-        deduped_deps[dep.name] = dep
+    tile_ranges = list(dep.size)
+    # Fresh contiguous row-major strides for the copy buffer's own
+    # tile-sized shape (mirrors _allocate_full_buffer's strides loop) --
+    # NOT dep.index's own coefficients, which are strides into full_buf's
+    # full-sized layout (e.g. a row stride of the full row width) and
+    # would describe the freshly allocated, tile-sized copy buffer as if
+    # it shared the full buffer's physical layout.
+    tile_strides: list[Expr] = []
+    stride: Expr = sympy.Integer(1)
+    for s in reversed(tile_ranges):
+        tile_strides.insert(0, stride)
+        stride = stride * s
 
-    for dep in deduped_deps.values():
-        full_buf = V.graph.get_buffer(dep.name)
-        # Graph inputs come back TensorBox(StorageBox(InputBuffer))-wrapped
-        # (see graph_inputs); get_dtype() resolves to self.dtype via IRNode
-        # and is not delegated by TensorBox/StorageBox, so it raises
-        # AttributeError on the wrapper -- unwrap to the real Buffer first.
-        # get_name()/.layout are delegating and would work either way, but
-        # unwrap once so every full_buf.* access below is on the real node.
-        if isinstance(full_buf, TensorBox):
-            full_buf = full_buf.data
-        if isinstance(full_buf, StorageBox):
-            full_buf = full_buf.data
+    def _copy_inner_fn(idx, _dep=dep, _full_name=full_buf.get_name()):
+        subs = dict(zip(_dep.var_names, idx))
+        flat_index = sympy_subs(_dep.index, subs)
+        return V.ops.load(_full_name, flat_index)
 
-        tile_ranges = list(dep.size)
-        # Fresh contiguous row-major strides for the copy buffer's own
-        # tile-sized shape (mirrors _allocate_full_buffer's strides loop) --
-        # NOT dep.index's own coefficients, which are strides into full_buf's
-        # full-sized layout (e.g. a row stride of the full row width) and
-        # would describe the freshly allocated, tile-sized copy buffer as if
-        # it shared the full buffer's physical layout.
-        tile_strides: list[Expr] = []
-        stride: Expr = sympy.Integer(1)
-        for s in reversed(tile_ranges):
-            tile_strides.insert(0, stride)
-            stride = stride * s
-
-        # dep.index's own per-dimension coefficients (full_buf's strides),
-        # in the same dep.var_names order as tile_strides -- used by
-        # _NameSwapHandler/_rescale_index to retarget tiled_op's read index
-        # at call time, whatever free variables that particular trace uses.
-        full_strides = [dep.index.coeff(v) for v in dep.var_names]
-
-        def _copy_inner_fn(idx, _dep=dep, _full_name=full_buf.get_name()):
-            subs = dict(zip(_dep.var_names, idx))
-            flat_index = sympy_subs(_dep.index, subs)
-            return V.ops.load(_full_name, flat_index)
-
-        # Construct under tiled_op's origins so data.origins is non-empty —
-        # _single_arg_op_layout (propagate_layouts.py) unconditionally
-        # dereferences next(iter(data.origins)) for ordinary (non-mutation)
-        # Pointwise ops.  IRNode.origins is populated at construction time
-        # from IRNode._current_origins, so it must be set via this context
-        # manager rather than assigned after the fact (assigning
-        # copy_buf.origins below only sets the ComputedBuffer's own origins,
-        # not copy_data's).
-        with IRNode.current_origins(tiled_op.origins):
-            copy_data = Pointwise(
-                device=tiled_op.get_device(),
-                dtype=full_buf.get_dtype(),
-                inner_fn=_copy_inner_fn,
-                ranges=tile_ranges,
-            )
-        copy_name = V.graph.qualify_name(
-            f"coarse_tile_read_copy_{tiled_op.get_name()}_{dep.name}"
+    # Construct under sizing_op's origins so data.origins is non-empty —
+    # _single_arg_op_layout (propagate_layouts.py) unconditionally
+    # dereferences next(iter(data.origins)) for ordinary (non-mutation)
+    # Pointwise ops.  IRNode.origins is populated at construction time
+    # from IRNode._current_origins, so it must be set via this context
+    # manager rather than assigned after the fact (assigning
+    # copy_buf.origins below only sets the ComputedBuffer's own origins,
+    # not copy_data's).
+    with IRNode.current_origins(sizing_op.origins):
+        copy_data = Pointwise(
+            device=sizing_op.get_device(),
+            dtype=full_buf.get_dtype(),
+            inner_fn=_copy_inner_fn,
+            ranges=tile_ranges,
         )
 
-        # Mirror _allocate_full_buffer's isinstance(orig_layout, FixedTiledLayout)
-        # branch: on the post-stickify call site (_maybe_coarse_tile_span_overflow),
-        # full_buf already carries a FixedTiledLayout, and every sibling op at
-        # this pipeline stage (span_reduction, work_distribution, LX scratchpad
-        # planning) expects a copy op to carry one too. On the pre-stickify call
-        # site (_maybe_coarse_tile_hints), full_buf is a plain FixedLayout and
-        # stickification (which runs later) fills device_layout in normally, so
-        # a plain FixedLayout on the copy is correct there.
-        full_layout = full_buf.layout
-        copy_layout: FixedLayout | FixedTiledLayout
-        if isinstance(full_layout, FixedTiledLayout):
-            full_size_ints = [int(s) for s in full_layout.size]
-            # tile_ranges (== list(dep.size)) is dep's *squeezed* size --
-            # extract_read_writes drops unit-size dims, so tile_ranges is
-            # one shorter per unit dim in full_buf's own raw size and no
-            # longer lines up positionally with full_size_ints.
-            # _resize_device_layout indexes new_host_size exclusively by
-            # positions derived from old_host_size (matched_host/pstar), so
-            # it requires equal rank -- reinsert a 1 at each raw position
-            # full_layout.size squeezed out, undoing the same squeeze
-            # applied to tiled_op's own ranges elsewhere in this function
-            # (see squeeze_pos above).
-            tile_size_ints = []
-            it_idx = 0
-            for s in full_size_ints:
-                if s == 1:
-                    tile_size_ints.append(1)
-                else:
-                    tile_size_ints.append(int(tile_ranges[it_idx]))
-                    it_idx += 1
-            assert it_idx == len(tile_ranges), (
-                f"_insert_read_copy_ops: could not align squeezed tile_ranges="
-                f"{tile_ranges} to full_size_ints={full_size_ints} for "
-                f"{dep.name!r}"
-            )
-            # Authoritative stick host dim from coordinate identity (issue
-            # #3116); None falls back to size-based inference inside
-            # _resize_device_layout.
-            stick_hd = _stick_host_dim(full_buf, full_layout.device_layout)
-            try:
-                device_layout = _resize_device_layout(
-                    full_layout.device_layout,
-                    full_size_ints,
-                    tile_size_ints,
-                    stick_host_dim=stick_hd,
-                )
-            except RuntimeError:
-                # Non-standard device layout (e.g. post-restickify HBM strides
-                # that don't correspond to contiguous host strides).  Fall
-                # back to a default row-major allocation, preserving
-                # element_arrangement -- same fallback _allocate_full_buffer
-                # uses for its own grow-direction resize failures.
-                logger.debug(
-                    "_insert_read_copy_ops: _resize_device_layout could not "
-                    "classify %r (full_size=%s tile_size=%s); using "
-                    "row-major fallback",
-                    full_layout.device_layout,
-                    full_size_ints,
-                    tile_size_ints,
-                )
-                # Row-major fallback describes the freshly allocated,
-                # squeezed-rank copy buffer directly (unlike the
-                # reconstruction above, it has no need for full_buf's raw
-                # rank) -- use tile_ranges/tile_strides, not the
-                # full-buf-rank-padded tile_size_ints.
-                squeezed_size_ints = [int(s) for s in tile_ranges]
-                device_layout = SpyreTensorLayout(
-                    squeezed_size_ints,
-                    [int(s) for s in tile_strides],
-                    full_buf.get_dtype(),
-                    list(range(len(squeezed_size_ints))),
-                    full_layout.device_layout.element_arrangement,
-                )
-            copy_layout = FixedTiledLayout(
-                tiled_op.get_device(),
-                full_buf.get_dtype(),
-                tile_ranges,
-                tile_strides,
-                device_layout,
-            )
-        else:
-            copy_layout = FixedLayout(
-                tiled_op.get_device(),
-                full_buf.get_dtype(),
-                tile_ranges,
-                tile_strides,
-            )
-        copy_buf = ComputedBuffer(name=copy_name, layout=copy_layout, data=copy_data)
-        copy_buf.origins = tiled_op.origins
-        copy_buf.operation_name = copy_name
-        copy_op_metadata(tiled_op, copy_buf)
-
-        # Fresh per-level tiled-dim decisions for copy_buf's own read/write —
-        # mirroring _insert_copy_op's read/write split (see its comment), but
-        # with the roles swapped: there, the copy's READ (of tiled_op's
-        # per-tile scratch) must not advance and its WRITE (to full_buf)
-        # advances a whole tile; here, the copy's READ (of full_buf) advances
-        # a whole tile per iteration and its WRITE (to this copy's own
-        # freshly allocated, tile-sized buffer) must not advance -- the copy
-        # buffer is scratch reused in place, it does not move.
-        # See _fixed_level_extents for why "must not advance" means omitting
-        # the dim, not giving it extent 1.
-        #
-        # Reusing tiled_op.loop_info verbatim here (as an earlier version of
-        # this function did) is wrong for a different reason than
-        # _insert_copy_op's original bug: it is not just the wrong extent, it
-        # is tiled_dims_per_read/output_tiled_dims computed for tiled_op's own
-        # reads/write (by then patched to read the copy buffers, not
-        # full_buf) applied positionally to copy_buf's own reads/write (of
-        # full_buf and of copy_buf's own output) via
-        # SpyreKernel._general_tile_advance's positional dep-index lookup —
-        # a semantic mismatch, not merely a magnitude one.
-        tiled_op_info = tiled_op.loop_info  # type: ignore[attr-defined]
-        copy_ranges = list(copy_data.ranges)
-        # tiled_op_info.loop_tiled_dims's dim keys are raw positional indices
-        # into tiled_op.data.ranges (see CoarseTileInfo's docstring), which
-        # may include unit-size (==1) dims (e.g. a unit B in BHLD). But
-        # copy_ranges (== list(dep.size), dep being tiled_op's own *squeezed*
-        # MemoryDep -- see extract_read_writes -> index_vars_squeeze) has
-        # already dropped those unit dims, so copy_ranges is one shorter per
-        # squeezed-out dim and its positions no longer line up with
-        # loop_tiled_dims's raw numbering. Map each raw dim to its squeezed
-        # position (mirroring SpyreKernel._host_dim_to_index_symbol's own
-        # squeeze arithmetic) before indexing copy_ranges.
-        squeeze_pos: dict[int, int] = {}
+    # Mirror _allocate_full_buffer's isinstance(orig_layout, FixedTiledLayout)
+    # branch: on the post-stickify call site (_maybe_coarse_tile_span_overflow),
+    # full_buf already carries a FixedTiledLayout, and every sibling op at
+    # this pipeline stage (span_reduction, work_distribution, LX scratchpad
+    # planning) expects a copy op to carry one too. On the pre-stickify call
+    # site (_maybe_coarse_tile_hints), full_buf is a plain FixedLayout and
+    # stickification (which runs later) fills device_layout in normally, so
+    # a plain FixedLayout on the copy is correct there.
+    full_layout = full_buf.layout
+    copy_layout: FixedLayout | FixedTiledLayout
+    if isinstance(full_layout, FixedTiledLayout):
+        full_size_ints = [int(s) for s in full_layout.size]
+        # tile_ranges (== list(dep.size)) is dep's *squeezed* size --
+        # extract_read_writes drops unit-size dims, so tile_ranges is
+        # one shorter per unit dim in full_buf's own raw size and no
+        # longer lines up positionally with full_size_ints.
+        # _resize_device_layout indexes new_host_size exclusively by
+        # positions derived from old_host_size (matched_host/pstar), so
+        # it requires equal rank -- reinsert a 1 at each raw position
+        # full_layout.size squeezed out, undoing the same squeeze
+        # applied to sizing_op's own ranges elsewhere in this function
+        # (see squeeze_pos below).
+        tile_size_ints = []
         it_idx = 0
-        for host_idx, r in enumerate(tiled_op.data.ranges):
-            if int(r) != 1:
-                squeeze_pos[host_idx] = it_idx
+        for s in full_size_ints:
+            if s == 1:
+                tile_size_ints.append(1)
+            else:
+                tile_size_ints.append(int(tile_ranges[it_idx]))
                 it_idx += 1
-        write_level_extents = _fixed_level_extents(tiled_op_info.loop_tiled_dims)
-        read_level_extents: list[dict[int, Expr]] = [
-            {} for _ in tiled_op_info.loop_tiled_dims
-        ]
-        for d in {d for level in tiled_op_info.loop_tiled_dims for d in level}:
-            levels_tiling_d = [
-                i for i, dims in enumerate(tiled_op_info.loop_tiled_dims) if d in dims
-            ]
-            # The dict key must be a raw positional index into copy_buf's own
-            # data.ranges (what SpyreKernel._host_dim_to_index_symbol will
-            # later squeeze again when it runs against copy_buf) -- i.e. the
-            # squeezed position computed above, not tiled_op's raw d.
-            copy_dim = squeeze_pos[d]
-            running = sympy.sympify(copy_ranges[copy_dim])
-            for level_idx in reversed(levels_tiling_d):
-                read_level_extents[level_idx][copy_dim] = running
-                running = running * tiled_op_info.loop_count[level_idx]
-        reduction_squeeze_pos: dict[int, int] = {}
-        red_it_idx = 0
-        reduction_ranges = getattr(tiled_op.data, "reduction_ranges", None) or []
-        for host_idx, r in enumerate(reduction_ranges):
-            if int(r) != 1:
-                reduction_squeeze_pos[host_idx] = red_it_idx
-                red_it_idx += 1
-        for d in {
-            d for level in tiled_op_info.loop_tiled_reduction_dims for d in level
-        }:
-            levels_tiling_d = [
-                i
-                for i, dims in enumerate(tiled_op_info.loop_tiled_reduction_dims)
-                if d in dims
-            ]
-            copy_dim_key = it_idx + reduction_squeeze_pos[d]
-            running = sympy.sympify(copy_ranges[copy_dim_key])
-            for level_idx in reversed(levels_tiling_d):
-                read_level_extents[level_idx][copy_dim_key] = running
-                running = running * tiled_op_info.loop_count[level_idx]
-        copy_reads = [
-            r for r in copy_buf.get_read_writes().reads if isinstance(r, MemoryDep)
-        ]
-        copy_writes = [
-            w for w in copy_buf.get_read_writes().writes if isinstance(w, MemoryDep)
-        ]
-        tiled_dims_per_read = [
-            _tiled_dims_for_dep(r, read_level_extents) for r in copy_reads
-        ]
-        output_tiled_dims = (
-            _tiled_dims_for_dep(copy_writes[0], write_level_extents)
-            if copy_writes
-            else []
+        assert it_idx == len(tile_ranges), (
+            f"_insert_one_read_copy: could not align squeezed tile_ranges="
+            f"{tile_ranges} to full_size_ints={full_size_ints} for "
+            f"{dep.name!r}"
         )
-        # copy_buf is its own op, not tiled_op under another name -- it must
-        # not inherit tiled_op_info.propagation. That plan was computed for
-        # tiled_op's own boundary-crossing decision (kind may be "reduction"
-        # or "copy_out"); copy_buf is purely scratch, reused in place and
-        # never read outside this loop group, so its own kind is always
-        # "loop_internal". Leaving propagation unreplaced here previously let
-        # a "reduction"-kind plan leak onto this Pointwise passthrough buffer,
-        # causing Pass 2 (_insert_all_reduction_ops) to misdispatch it into
-        # _propagate_tiled_reduction_op.
-        copy_buf.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
-            tiled_op_info,
-            tiled_dims_per_read=tiled_dims_per_read,
-            output_tiled_dims=output_tiled_dims,
-            propagation=PropagationPlan(kind="loop_internal"),
+        # Authoritative stick host dim from coordinate identity (issue
+        # #3116); None falls back to size-based inference inside
+        # _resize_device_layout.
+        stick_hd = _stick_host_dim(full_buf, full_layout.device_layout)
+        try:
+            device_layout = _resize_device_layout(
+                full_layout.device_layout,
+                full_size_ints,
+                tile_size_ints,
+                stick_host_dim=stick_hd,
+            )
+        except RuntimeError:
+            # Non-standard device layout (e.g. post-restickify HBM strides
+            # that don't correspond to contiguous host strides).  Fall
+            # back to a default row-major allocation, preserving
+            # element_arrangement -- same fallback _allocate_full_buffer
+            # uses for its own grow-direction resize failures.
+            logger.debug(
+                "_insert_one_read_copy: _resize_device_layout could not "
+                "classify %r (full_size=%s tile_size=%s); using "
+                "row-major fallback",
+                full_layout.device_layout,
+                full_size_ints,
+                tile_size_ints,
+            )
+            # Row-major fallback describes the freshly allocated,
+            # squeezed-rank copy buffer directly (unlike the
+            # reconstruction above, it has no need for full_buf's raw
+            # rank) -- use tile_ranges/tile_strides, not the
+            # full-buf-rank-padded tile_size_ints.
+            squeezed_size_ints = [int(s) for s in tile_ranges]
+            device_layout = SpyreTensorLayout(
+                squeezed_size_ints,
+                [int(s) for s in tile_strides],
+                full_buf.get_dtype(),
+                list(range(len(squeezed_size_ints))),
+                full_layout.device_layout.element_arrangement,
+            )
+        copy_layout = FixedTiledLayout(
+            sizing_op.get_device(),
+            full_buf.get_dtype(),
+            tile_ranges,
+            tile_strides,
+            device_layout,
         )
-
-        V.graph.name_to_buffer[copy_name] = copy_buf
-        operations.insert(tiled_idx, copy_buf)
-        tiled_idx += 1
-
-        # tiled_op's own load index for this buffer is affine against
-        # full_buf's full-sized strides (dep.index, structurally, though the
-        # free variables at any given trace of tiled_op's inner_fn may not be
-        # dep.var_names themselves -- see _NameSwapHandler). The copy is a
-        # smaller, freshly allocated buffer with its own contiguous
-        # tile_strides, so _NameSwapHandler rescales the index's coefficients
-        # from full_strides to tile_strides at call time (_rescale_index).
-        name_map[dep.name] = (copy_name, full_strides, tile_strides)
-        logger.debug(
-            "coarse_tile: read copy-in %s -> %s (full_strides=%s tile_strides=%s)",
-            dep.name,
-            copy_name,
-            full_strides,
+    else:
+        copy_layout = FixedLayout(
+            sizing_op.get_device(),
+            full_buf.get_dtype(),
+            tile_ranges,
             tile_strides,
         )
+    copy_buf = ComputedBuffer(name=copy_name, layout=copy_layout, data=copy_data)
+    copy_buf.origins = sizing_op.origins
+    copy_buf.operation_name = copy_name
+    copy_op_metadata(sizing_op, copy_buf)
 
-    # Patch tiled_op's inner_fn once with the full name_map (wrap, not
+    # Fresh per-level tiled-dim decisions for copy_buf's own read/write —
+    # mirroring _insert_copy_op's read/write split (see its comment), but
+    # with the roles swapped: there, the copy's READ (of sizing_op's
+    # per-tile scratch) must not advance and its WRITE (to full_buf)
+    # advances a whole tile; here, the copy's READ (of full_buf) advances
+    # a whole tile per iteration and its WRITE (to this copy's own
+    # freshly allocated, tile-sized buffer) must not advance -- the copy
+    # buffer is scratch reused in place, it does not move.
+    # See _fixed_level_extents for why "must not advance" means omitting
+    # the dim, not giving it extent 1.
+    #
+    # Reusing sizing_op.loop_info verbatim here (as an earlier version of
+    # this function did) is wrong for a different reason than
+    # _insert_copy_op's original bug: it is not just the wrong extent, it
+    # is tiled_dims_per_read/output_tiled_dims computed for sizing_op's own
+    # reads/write (by then patched to read the copy buffers, not
+    # full_buf) applied positionally to copy_buf's own reads/write (of
+    # full_buf and of copy_buf's own output) via
+    # SpyreKernel._general_tile_advance's positional dep-index lookup —
+    # a semantic mismatch, not merely a magnitude one.
+    sizing_op_info = sizing_op.loop_info  # type: ignore[attr-defined]
+    copy_ranges = list(copy_data.ranges)
+    # sizing_op_info.loop_tiled_dims's dim keys are raw positional indices
+    # into sizing_op.data.ranges (see CoarseTileInfo's docstring), which
+    # may include unit-size (==1) dims (e.g. a unit B in BHLD). But
+    # copy_ranges (== list(dep.size), dep being sizing_op's own *squeezed*
+    # MemoryDep -- see extract_read_writes -> index_vars_squeeze) has
+    # already dropped those unit dims, so copy_ranges is one shorter per
+    # squeezed-out dim and its positions no longer line up with
+    # loop_tiled_dims's raw numbering. Map each raw dim to its squeezed
+    # position (mirroring SpyreKernel._host_dim_to_index_symbol's own
+    # squeeze arithmetic) before indexing copy_ranges.
+    squeeze_pos: dict[int, int] = {}
+    it_idx = 0
+    for host_idx, r in enumerate(sizing_op.data.ranges):
+        if int(r) != 1:
+            squeeze_pos[host_idx] = it_idx
+            it_idx += 1
+    write_level_extents = _fixed_level_extents(sizing_op_info.loop_tiled_dims)
+    read_level_extents: list[dict[int, Expr]] = [
+        {} for _ in sizing_op_info.loop_tiled_dims
+    ]
+    for d in {d for level in sizing_op_info.loop_tiled_dims for d in level}:
+        levels_tiling_d = [
+            i for i, dims in enumerate(sizing_op_info.loop_tiled_dims) if d in dims
+        ]
+        # The dict key must be a raw positional index into copy_buf's own
+        # data.ranges (what SpyreKernel._host_dim_to_index_symbol will
+        # later squeeze again when it runs against copy_buf) -- i.e. the
+        # squeezed position computed above, not sizing_op's raw d.
+        copy_dim = squeeze_pos[d]
+        running = sympy.sympify(copy_ranges[copy_dim])
+        for level_idx in reversed(levels_tiling_d):
+            read_level_extents[level_idx][copy_dim] = running
+            running = running * sizing_op_info.loop_count[level_idx]
+    reduction_squeeze_pos: dict[int, int] = {}
+    red_it_idx = 0
+    reduction_ranges = getattr(sizing_op.data, "reduction_ranges", None) or []
+    for host_idx, r in enumerate(reduction_ranges):
+        if int(r) != 1:
+            reduction_squeeze_pos[host_idx] = red_it_idx
+            red_it_idx += 1
+    for d in {d for level in sizing_op_info.loop_tiled_reduction_dims for d in level}:
+        levels_tiling_d = [
+            i
+            for i, dims in enumerate(sizing_op_info.loop_tiled_reduction_dims)
+            if d in dims
+        ]
+        copy_dim_key = it_idx + reduction_squeeze_pos[d]
+        running = sympy.sympify(copy_ranges[copy_dim_key])
+        for level_idx in reversed(levels_tiling_d):
+            read_level_extents[level_idx][copy_dim_key] = running
+            running = running * sizing_op_info.loop_count[level_idx]
+    copy_reads = [
+        r for r in copy_buf.get_read_writes().reads if isinstance(r, MemoryDep)
+    ]
+    copy_writes = [
+        w for w in copy_buf.get_read_writes().writes if isinstance(w, MemoryDep)
+    ]
+    tiled_dims_per_read = [
+        _tiled_dims_for_dep(r, read_level_extents) for r in copy_reads
+    ]
+    output_tiled_dims = (
+        _tiled_dims_for_dep(copy_writes[0], write_level_extents) if copy_writes else []
+    )
+    # copy_buf is its own op, not sizing_op under another name -- it must
+    # not inherit sizing_op_info.propagation. That plan was computed for
+    # sizing_op's own boundary-crossing decision (kind may be "reduction"
+    # or "copy_out"); copy_buf is purely scratch, reused in place and
+    # never read outside this loop group, so its own kind is always
+    # "loop_internal". Leaving propagation unreplaced here previously let
+    # a "reduction"-kind plan leak onto this Pointwise passthrough buffer,
+    # causing Pass 2 (_insert_all_reduction_ops) to misdispatch it into
+    # _propagate_tiled_reduction_op.
+    copy_buf.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
+        sizing_op_info,
+        tiled_dims_per_read=tiled_dims_per_read,
+        output_tiled_dims=output_tiled_dims,
+        propagation=PropagationPlan(kind="loop_internal"),
+    )
+
+    V.graph.name_to_buffer[copy_name] = copy_buf
+    operations.insert(sizing_idx, copy_buf)
+
+    logger.debug(
+        "coarse_tile: read copy-in %s -> %s",
+        dep.name,
+        copy_name,
+    )
+    return copy_buf.get_name()
+
+
+def _patch_consumer_to_read_copy(
+    consumer: ComputedBuffer,
+    dep: MemoryDep,
+    copy_name: str,
+    operations: list[Operation],
+) -> None:
+    """Patch consumer's inner_fn to read copy_name instead of dep.name.
+
+    consumer's own read index for dep.name is affine against full_buf's
+    full-sized strides (dep.index, structurally, though the free variables
+    at any given trace of consumer's inner_fn may not be dep.var_names
+    themselves -- see _NameSwapHandler). The copy (copy_name) is a smaller,
+    freshly allocated buffer with its own contiguous tile-local strides, so
+    _NameSwapHandler rescales the index's coefficients from full_strides
+    (dep.index's own per-dimension coefficients) to tile_strides
+    (recomputed here from copy_name's own current layout) at call time --
+    see _NameSwapHandler and _rescale_index. Rebuilds consumer in place
+    (splicing the fresh ComputedBuffer into operations, replacing the stale
+    one) via replace_computed_buffer_body, exactly as today.
+    """
+    full_strides = [dep.index.coeff(v) for v in dep.var_names]
+    copy_buf = next(
+        op
+        for op in operations
+        if isinstance(op, ComputedBuffer) and op.get_name() == copy_name
+    )
+    tile_strides = list(copy_buf.layout.stride)
+    name_map: dict[str, tuple[str, list[Expr], list[Expr]]] = {
+        dep.name: (copy_name, full_strides, tile_strides)
+    }
+
+    # Patch consumer's inner_fn once with the one-entry name_map (wrap, not
     # reconstruct — see _NameSwapHandler docstring).  Rebuild via
     # replace_computed_buffer_body, matching every other inner_fn-rewrite
     # site in this file (_patch_consumers, _patch_retiled_load_indexes):
@@ -2603,41 +2587,38 @@ def _insert_read_copy_ops(
     # caches, sidestepping the need to enumerate every cache key by hand.
     from ..pass_utils import replace_computed_buffer_body
 
-    orig_inner = tiled_op.data.inner_fn
+    orig_inner = consumer.data.inner_fn
 
     def new_inner_fn(*args, _map=name_map, _orig_inner=orig_inner):
         with V.set_ops_handler(_NameSwapHandler(V.ops, _map)):
             return _orig_inner(*args)
 
-    object.__setattr__(tiled_op.data, "inner_fn", new_inner_fn)
+    object.__setattr__(consumer.data, "inner_fn", new_inner_fn)
     new_op = replace_computed_buffer_body(
-        tiled_op,
-        tiled_op.data,
+        consumer,
+        consumer.data,
         operations,
         pass_name="coarse_tile",
-        reason="redirect tiled op to copied inputs",
+        reason="redirect consumer to copied inputs",
     )
     V.graph.name_to_buffer[new_op.get_name()] = new_op
 
-    # new_op.loop_info (copied from tiled_op by copy_op_metadata inside
+    # new_op.loop_info (copied from consumer by copy_op_metadata inside
     # replace_computed_buffer_body) still carries tiled_dims_per_read as
-    # planned when this op's own reads were full_buf directly -- whole-tile
-    # advance, correct at plan time. But new_op's actual reads (per
-    # get_read_writes(), re-derived from the now-patched inner_fn) are the
-    # copy buffers for every swapped name: scratch reused in place every
-    # iteration, which must not advance, exactly like
-    # _insert_copy_op's own read side. SpyreKernel._general_tile_advance
-    # matches tiled_dims_per_read to get_read_writes().reads purely
-    # positionally (see loop_info.py's docstring), so every entry
-    # corresponding to a swapped-in copy-buffer read must be zeroed (dim
-    # omitted, see _fixed_level_extents) for the dims that dependency
-    # actually reads.
+    # planned when this op's own read of dep.name was full_buf directly --
+    # whole-tile advance, correct at plan time. But new_op's actual read
+    # (per get_read_writes(), re-derived from the now-patched inner_fn) is
+    # the copy buffer: scratch reused in place every iteration, which must
+    # not advance, exactly like _insert_copy_op's own read side.
+    # SpyreKernel._general_tile_advance matches tiled_dims_per_read to
+    # get_read_writes().reads purely positionally (see loop_info.py's
+    # docstring), so the entry corresponding to the swapped-in copy-buffer
+    # read must be zeroed (dim omitted, see _fixed_level_extents).
     new_loop_info = new_op.loop_info  # type: ignore[attr-defined]
     new_reads = [r for r in new_op.get_read_writes().reads if isinstance(r, MemoryDep)]
-    swapped_in_names = {copy_name for copy_name, _, _ in name_map.values()}
     if new_loop_info.tiled_dims_per_read:
         assert len(new_reads) == len(new_loop_info.tiled_dims_per_read), (
-            f"_insert_read_copy_ops: positional mismatch between "
+            f"_patch_consumer_to_read_copy: positional mismatch between "
             f"new_op.get_read_writes().reads ({len(new_reads)} entries) and "
             f"new_loop_info.tiled_dims_per_read ({len(new_loop_info.tiled_dims_per_read)} "
             "entries) -- SpyreKernel._general_tile_advance matches these purely "
@@ -2647,16 +2628,15 @@ def _insert_read_copy_ops(
         fixed_level_extents = _fixed_level_extents(new_loop_info.loop_tiled_dims)
         new_tiled_dims_per_read = [
             (
-                _tiled_dims_for_dep(dep, fixed_level_extents)
-                if dep.name in swapped_in_names
+                _tiled_dims_for_dep(read_dep, fixed_level_extents)
+                if read_dep.name == copy_name
                 else per_level
             )
-            for dep, per_level in zip(new_reads, new_loop_info.tiled_dims_per_read)
+            for read_dep, per_level in zip(new_reads, new_loop_info.tiled_dims_per_read)
         ]
         new_op.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
             new_loop_info, tiled_dims_per_read=new_tiled_dims_per_read
         )
-    return new_op
 
 
 def _plan_read_copies(
@@ -2739,37 +2719,72 @@ def _plan_read_copies(
     return plans
 
 
-def _insert_all_read_copy_ops(operations: list[Operation]) -> None:
-    """Pass 1: insert read-copy-ins for every tiled op reading a full buffer.
+def _insert_all_read_copy_ops(
+    operations: list[Operation],
+    read_copy_plans: dict[tuple[int, ...], ReadCopyPlan],
+) -> None:
+    """Pass 1: execute a precomputed ReadCopyPlan per group.
 
-    Transformation's Pass 1 (see the plan/execute split design). Every op
-    was already stamped by _apply_plan with a loop_info, so
-    _full_buffer_read_deps(op) is available -- and it must be computed here,
-    not at planning time: op.get_read_writes() before _apply_plan's
-    _divide_ranges/_divide_reduction_ranges divided op's own ranges would
-    key each MemoryDep's index/size expressions to the pre-division
-    (full-sized) iteration space. _insert_read_copy_ops sizes and indexes
-    the inserted copy directly from dep.index/dep.size (see its docstring),
-    so a pre-division dep would size/index the copy against the wrong
-    (full, not tile) extent -- silent wrong-code, exactly the hazard
-    CLAUDE.md's "wrap, never reconstruct" convention warns about for stale
-    symbolic index expressions. _full_buffer_read_deps(op), called here on
-    the current post-division op, avoids that hazard entirely.
-
-    Must run after every group's _apply_plan (so op.loop_info is stamped)
-    and before Pass 2/3's Reduction/copy-out dispatch, which reads an op's
-    *current* reads/loader -- copy-ins must be applied before that
-    machinery is built, not interleaved with it.
+    Transformation's Pass 1 (see the plan/execute split design and
+    _plan_read_copies). All sharing/dedup decisions were already made by
+    _plan_read_copies -- this function only builds and inserts the copy
+    ops it named and patches the consumers it named. Must run after every
+    group's _apply_plan (so op.loop_info is stamped -- see
+    _plan_read_copies) and before Pass 2/3's Reduction/copy-out dispatch,
+    which reads an op's *current* reads/loader.
     """
-    for op in list(operations):
-        if not isinstance(op, ComputedBuffer):
+    for plan in read_copy_plans.values():
+        for entry in plan.entries:
+            name_to_op = {
+                op.get_operation_name(): op
+                for op in operations
+                if isinstance(op, ComputedBuffer)
+            }
+            sizing_op = name_to_op[entry.sizing_op_name]
+            new_copy_name = _insert_one_read_copy(
+                sizing_op, entry.dep, entry.copy_name, operations
+            )
+            for consumer_name in entry.consumer_op_names:
+                consumer = name_to_op[consumer_name]
+                _patch_consumer_to_read_copy(
+                    consumer, entry.dep, new_copy_name, operations
+                )
+
+
+def _insert_read_copy_ops(
+    tiled_op: ComputedBuffer,
+    full_deps: list[MemoryDep],
+    operations: list[Operation],
+) -> ComputedBuffer:
+    """Single-op convenience wrapper: one copy per unique dep name, one
+    consumer (tiled_op itself). Equivalent to a one-entry, one-consumer
+    ReadCopyPlan for tiled_op's own dedup case -- see _plan_read_copies for
+    the cross-op generalization used by production code."""
+    deduped_deps: dict[str, MemoryDep] = {}
+    for dep in full_deps:
+        if dep.name in deduped_deps:
+            prior = deduped_deps[dep.name]
+            assert prior.var_names == dep.var_names and prior.index == dep.index, (
+                f"_insert_read_copy_ops: {dep.name!r} is read via two "
+                "MemoryDeps with different index expressions "
+                f"({prior.index} vs {dep.index}); a single copy op keyed by "
+                "buffer name cannot serve both."
+            )
             continue
-        if not isinstance(op.data, (Pointwise, Reduction)):
-            continue
-        full_deps = _full_buffer_read_deps(op)
-        if not full_deps:
-            continue
-        _insert_read_copy_ops(op, full_deps, operations)
+        deduped_deps[dep.name] = dep
+
+    for dep in deduped_deps.values():
+        copy_name = V.graph.qualify_name(
+            f"coarse_tile_read_copy_{tiled_op.get_name()}_{dep.name}"
+        )
+        new_copy_name = _insert_one_read_copy(tiled_op, dep, copy_name, operations)
+        _patch_consumer_to_read_copy(tiled_op, dep, new_copy_name, operations)
+        tiled_op = next(
+            o
+            for o in operations
+            if isinstance(o, ComputedBuffer) and o.get_name() == tiled_op.get_name()
+        )
+    return tiled_op
 
 
 # ---------------------------------------------------------------------------

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -94,7 +94,14 @@ from .. import config
 from ..constants import BATCH_MATMUL_OP
 from ..errors import Unsupported
 from ..logging_utils import get_inductor_logger
-from ..loop_info import CoarseTileInfo, PropagationPlan, ReductionPlan, copy_op_metadata
+from ..loop_info import (
+    CoarseTileInfo,
+    PropagationPlan,
+    ReadCopyEntry,
+    ReadCopyPlan,
+    ReductionPlan,
+    copy_op_metadata,
+)
 from ..pass_utils import op_out_coords, host_coordinates, indirect_sizes_from_op
 from ..ir import FixedTiledLayout, SpyreConstantFallback, _resize_device_layout
 
@@ -2650,6 +2657,86 @@ def _insert_read_copy_ops(
             new_loop_info, tiled_dims_per_read=new_tiled_dims_per_read
         )
     return new_op
+
+
+def _plan_read_copies(
+    operations: list[Operation],
+    retiled_infos_by_group: list[
+        tuple[tuple[int, ...], list[Operation], dict[str, "_RetiledBufferInfo"]]
+    ],
+) -> dict[tuple[int, ...], ReadCopyPlan]:
+    """Plan Pass 1's read-copy sharing, with zero mutation.
+
+    For each group, collects every ComputedBuffer op's
+    _full_buffer_read_deps and groups equivalent reads (same buffer name,
+    same per-var index coefficients, same size -- see the canonical key
+    below) into one ReadCopyEntry each, regardless of whether the
+    equivalent reads came from the same op or from different ops in the
+    group. The first op (operations order) with an equivalent read supplies
+    both insert_before_op_name and sizing_op_name; every op in the group
+    with an equivalent read is recorded in consumer_op_names.
+
+    Must run after every group's _apply_plan (see coarse_tile()'s body):
+    _full_buffer_read_deps requires op.loop_info to be stamped and
+    op.get_read_writes() to reflect post-division ranges, neither of which
+    holds before _apply_plan runs for that op's group.
+    """
+    op_position = {op.get_operation_name(): i for i, op in enumerate(operations)}
+    plans: dict[tuple[int, ...], ReadCopyPlan] = {}
+
+    for stamped_group_id, group_ops, _retiled_infos in retiled_infos_by_group:
+        # canonical key -> list of (op, dep) in operations order.
+        keyed: dict[tuple, list[tuple[Operation, MemoryDep]]] = {}
+        for op in group_ops:
+            if not isinstance(op, ComputedBuffer):
+                continue
+            for dep in _full_buffer_read_deps(op):
+                key = (
+                    dep.name,
+                    tuple(dep.index.coeff(v) for v in dep.var_names),
+                    tuple(dep.size),
+                )
+                keyed.setdefault(key, []).append((op, dep))
+
+        entries: list[ReadCopyEntry] = []
+        for n, (key, op_deps) in enumerate(keyed.items()):
+            # Order this key's (op, dep) pairs by their position in
+            # `operations`, not by group_ops's own order, so
+            # insert_before_op_name/sizing_op_name pick the op that is
+            # actually first in the real operations list.
+            op_deps.sort(key=lambda pair: op_position[pair[0].get_operation_name()])
+            sizing_op, sizing_dep = op_deps[0]
+            sizing_info = sizing_op.loop_info  # type: ignore[attr-defined]
+            for other_op, _dep in op_deps[1:]:
+                other_info = other_op.loop_info  # type: ignore[attr-defined]
+                assert (
+                    other_info.loop_count == sizing_info.loop_count
+                    and other_info.loop_tiled_dims == sizing_info.loop_tiled_dims
+                ), (
+                    "_plan_read_copies: ops in the same coarse-tile group "
+                    f"disagree on loop_count/loop_tiled_dims ({other_op.get_name()!r} "
+                    f"vs {sizing_op.get_name()!r} sizing this shared copy of "
+                    f"{key[0]!r}) -- ops in one group must share tiling shape "
+                    "by construction."
+                )
+            copy_name = V.graph.qualify_name(
+                f"coarse_tile_read_copy_{stamped_group_id}_{key[0]}_{n}"
+            )
+            entries.append(
+                ReadCopyEntry(
+                    copy_name=copy_name,
+                    dep=sizing_dep,
+                    insert_before_op_name=sizing_op.get_operation_name(),
+                    sizing_op_name=sizing_op.get_operation_name(),
+                    consumer_op_names=tuple(
+                        op.get_operation_name() for op, _dep in op_deps
+                    ),
+                )
+            )
+        if entries:
+            plans[stamped_group_id] = ReadCopyPlan(entries=tuple(entries))
+
+    return plans
 
 
 def _insert_all_read_copy_ops(operations: list[Operation]) -> None:

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -39,11 +39,13 @@ tiled dimension from its ``loop_var`` in ``dim_hints``.
 
 Each ``ops`` list must be a contiguous sub-sequence of ``operations``.
 
-After stamping, ``coarse_tile`` runs a fixed sequence of passes --
-``_insert_all_read_copy_ops``, ``_insert_all_reduction_ops``,
-``_insert_all_write_copy_ops`` -- that allocate full-sized output buffers and
-insert copy/mutation/reduction ops for tiled operations whose results are
-consumed outside the loop, all driven by the ``PropagationPlan`` each op's
+After stamping, each entry point runs its own sequence of passes.
+``coarse_tile_pre_stickify`` runs ``_insert_all_read_copy_ops``,
+``_insert_all_reduction_ops``, then ``_insert_all_write_copy_ops``;
+``coarse_tile_post_stickify`` skips ``_insert_all_read_copy_ops`` and runs
+only the latter two. All three passes allocate full-sized output buffers
+and insert copy/mutation/reduction ops for tiled operations whose results
+are consumed outside the loop, driven by the ``PropagationPlan`` each op's
 ``loop_info`` already carries from planning.
 
 Before touching any ``inner_fn``/``layout``/``MutationLayoutSHOULDREMOVE``
@@ -453,9 +455,10 @@ def _plan_tiling_propagation(
     # _graph_output_names' own name-based buffer lookup.
     # Prefer this call's own plan (the freshest data, for ops this call is
     # about to stamp); fall back to a real, already-stamped loop_info
-    # attribute for ops outside this plan (e.g. from an earlier coarse_tile()
-    # call on the same graph, or already-processed groups within a chained
-    # call) -- exactly the candidates _find_outside_consumers/
+    # attribute for ops outside this plan (e.g. from an earlier
+    # coarse_tile_pre_stickify()/coarse_tile_post_stickify() call on the
+    # same graph, or already-processed groups within a chained call) --
+    # exactly the candidates _find_outside_consumers/
     # _full_buffer_read_deps consult via getattr(op, "loop_info", None) at
     # transformation time.
     name_to_group_outer_key: dict[str, int] = {}
@@ -2707,7 +2710,7 @@ def _plan_read_copies(
     both insert_before_op_name and sizing_op_name; every op in the group
     with an equivalent read is recorded in consumer_op_names.
 
-    Must run after every group's _apply_plan (see coarse_tile()'s body):
+    Must run after every group's _apply_plan (see _coarse_tile_common's body):
     _full_buffer_read_deps requires op.loop_info to be stamped and
     op.get_read_writes() to reflect post-division ranges, neither of which
     holds before _apply_plan runs for that op's group.
@@ -3144,7 +3147,8 @@ def _propagate_tiled_reduction_op(
         # stamped op's real, offset-adjusted loop_group_id -- its own
         # loop_group_id is still the pre-offset internal numbering
         # plan_coarse_tile_groups used only for its own bookkeeping (see
-        # coarse_tile()'s comment on group_idx_offset). Re-slice from
+        # coarse_tile_pre_stickify's/coarse_tile_post_stickify's comment on
+        # group_idx_offset). Re-slice from
         # op.loop_info's now-real loop_group_id so the fill/copy ops this
         # function stamps with fill_loop_info end up in the same outer group
         # as every other op here, not a stale, potentially colliding one.

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -2712,10 +2712,8 @@ def _plan_read_copies(
                 # Reduction (e.g. softmax's max) and a sibling Pointwise
                 # (e.g. softmax's x - max) can legitimately tile the very
                 # same logical tensor dim through these two different
-                # fields and still correctly share one copy -- see
-                # docs/superpowers/specs/2026-08-07-read-copy-sharing-and-
-                # disable-design.md for why the plan doesn't need
-                # loop_tiled_dims to build the copy either way.
+                # fields and still correctly share one copy -- the plan
+                # doesn't need loop_tiled_dims to build the copy either way.
                 assert other_info.loop_count == sizing_info.loop_count, (
                     "_plan_read_copies: ops in the same coarse-tile group "
                     f"disagree on loop_count ({other_op.get_name()!r} vs "

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -2265,6 +2265,7 @@ def _insert_one_read_copy(
     dep: MemoryDep,
     copy_name: str,
     operations: list[Operation],
+    insert_before_op: Operation,
 ) -> str:
     """Build and insert one tile-sized copy op for a single full-buffer read.
 
@@ -2294,10 +2295,17 @@ def _insert_one_read_copy(
     Otherwise (pre-stickify call site) the copy gets a plain FixedLayout, and
     stickification (which runs later) fills device_layout in normally.
 
+    insert_before_op is the plan's own insertion-point decision (see
+    ReadCopyEntry.insert_before_op_name) -- it names the first
+    (operations order) consuming op in the group and is authoritative
+    for where the copy is spliced into `operations`, independent of
+    sizing_op (which only supplies loop_info/ranges/origins here and may
+    coincide with insert_before_op but is not guaranteed to by contract).
+
     Returns the inserted copy buffer's name (copy_buf.get_name()) -- callers
     patch consumers separately via _patch_consumer_to_read_copy.
     """
-    sizing_idx = operations.index(sizing_op)
+    insert_idx = operations.index(insert_before_op)
     full_buf = V.graph.get_buffer(dep.name)
     # Graph inputs come back TensorBox(StorageBox(InputBuffer))-wrapped
     # (see graph_inputs); get_dtype() resolves to self.dtype via IRNode
@@ -2538,7 +2546,7 @@ def _insert_one_read_copy(
     )
 
     V.graph.name_to_buffer[copy_name] = copy_buf
-    operations.insert(sizing_idx, copy_buf)
+    operations.insert(insert_idx, copy_buf)
 
     logger.debug(
         "coarse_tile: read copy-in %s -> %s",
@@ -2670,6 +2678,8 @@ def _plan_read_copies(
         for op in group_ops:
             if not isinstance(op, ComputedBuffer):
                 continue
+            if not isinstance(op.data, (Pointwise, Reduction)):
+                continue
             for dep in _full_buffer_read_deps(op):
                 key = (
                     dep.name,
@@ -2689,19 +2699,35 @@ def _plan_read_copies(
             sizing_info = sizing_op.loop_info  # type: ignore[attr-defined]
             for other_op, _dep in op_deps[1:]:
                 other_info = other_op.loop_info  # type: ignore[attr-defined]
-                assert (
-                    other_info.loop_count == sizing_info.loop_count
-                    and other_info.loop_tiled_dims == sizing_info.loop_tiled_dims
-                ), (
+                # Only loop_count (the per-level trip counts) is a genuine
+                # per-*group* invariant that every op in the group shares by
+                # construction -- and it is the only one of the two fields
+                # _insert_one_read_copy actually consumes from sizing_op_info
+                # to size the shared copy's read_level_extents (see its
+                # body). loop_tiled_dims is *not* comparable across op kinds:
+                # its dim keys are positions into each op's own data.ranges
+                # (output-shaped), while a Reduction's own tiling of a
+                # reduction dim shows up in loop_tiled_reduction_dims
+                # instead, in a completely different numbering space. A
+                # Reduction (e.g. softmax's max) and a sibling Pointwise
+                # (e.g. softmax's x - max) can legitimately tile the very
+                # same logical tensor dim through these two different
+                # fields and still correctly share one copy -- see
+                # docs/superpowers/specs/2026-08-07-read-copy-sharing-and-
+                # disable-design.md for why the plan doesn't need
+                # loop_tiled_dims to build the copy either way.
+                assert other_info.loop_count == sizing_info.loop_count, (
                     "_plan_read_copies: ops in the same coarse-tile group "
-                    f"disagree on loop_count/loop_tiled_dims ({other_op.get_name()!r} "
-                    f"vs {sizing_op.get_name()!r} sizing this shared copy of "
-                    f"{key[0]!r}) -- ops in one group must share tiling shape "
+                    f"disagree on loop_count ({other_op.get_name()!r} vs "
+                    f"{sizing_op.get_name()!r} sizing this shared copy of "
+                    f"{key[0]!r}) -- ops in one group must share trip counts "
                     "by construction."
                 )
+            group_tag = "_".join(str(i) for i in stamped_group_id)
             copy_name = V.graph.qualify_name(
-                f"coarse_tile_read_copy_{stamped_group_id}_{key[0]}_{n}"
+                f"coarse_tile_read_copy_{group_tag}_{key[0]}_{n}"
             )
+            assert copy_name.isidentifier(), f"invalid copy buffer name: {copy_name!r}"
             entries.append(
                 ReadCopyEntry(
                     copy_name=copy_name,
@@ -2741,8 +2767,13 @@ def _insert_all_read_copy_ops(
                 if isinstance(op, ComputedBuffer)
             }
             sizing_op = name_to_op[entry.sizing_op_name]
+            insert_before_op = name_to_op[entry.insert_before_op_name]
             new_copy_name = _insert_one_read_copy(
-                sizing_op, entry.dep, entry.copy_name, operations
+                sizing_op,
+                entry.dep,
+                entry.copy_name,
+                operations,
+                insert_before_op=insert_before_op,
             )
             for consumer_name in entry.consumer_op_names:
                 consumer = name_to_op[consumer_name]
@@ -2777,7 +2808,9 @@ def _insert_read_copy_ops(
         copy_name = V.graph.qualify_name(
             f"coarse_tile_read_copy_{tiled_op.get_name()}_{dep.name}"
         )
-        new_copy_name = _insert_one_read_copy(tiled_op, dep, copy_name, operations)
+        new_copy_name = _insert_one_read_copy(
+            tiled_op, dep, copy_name, operations, insert_before_op=tiled_op
+        )
         _patch_consumer_to_read_copy(tiled_op, dep, new_copy_name, operations)
         tiled_op = next(
             o

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -31,7 +31,7 @@ to innermost.  For a single-level group this is a 1-element list ``[K]``.
 Entry point::
 
     groups = hints_to_coarse_tile_groups(graph)
-    coarse_tile(graph, groups)
+    coarse_tile_pre_stickify(graph, groups)
 
 ``groups`` is a list of ``(ops, levels)`` tuples where ``levels`` is a list of
 ``(hint_id, count)`` pairs, outermost first.  Each op resolves its own

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -2727,9 +2727,20 @@ def _plan_read_copies(
             if not isinstance(op.data, (Pointwise, Reduction)):
                 continue
             for dep in _full_buffer_read_deps(op):
+                # dep.index.coeff(v) is a *linear* coefficient: it is blind
+                # to any constant offset in the index (e.g. 64*d0 + d1 and
+                # 64*d0 + d1 + 5 have identical coeffs). Two reads that
+                # differ only in a constant offset (e.g. a shifted/windowed
+                # read) must not collapse to the same key -- _insert_one_
+                # read_copy sizes the shared copy from only the sizing
+                # op's own dep.index, so a merged-in consumer at a
+                # different real offset would silently read wrong or
+                # out-of-bounds data. Include the offset explicitly.
+                offset = dep.index - sum(dep.index.coeff(v) * v for v in dep.var_names)
                 key = (
                     dep.name,
                     tuple(dep.index.coeff(v) for v in dep.var_names),
+                    offset,
                     tuple(dep.size),
                 )
                 keyed.setdefault(key, []).append((op, dep))

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -1396,19 +1396,18 @@ def _is_constant_fill(op: ComputedBuffer) -> bool:
     )
 
 
-def coarse_tile(
+def coarse_tile_pre_stickify(
     graph: GraphLowering,
     groups: list[tuple],
     group_idx_offset: int = 0,
-    insert_read_copies: bool = True,
 ) -> None:
-    """Plan then transform: stamp loop_group_id / loop_count and scale ranges.
+    """Hint-driven coarse tiling.  Runs PRE-stickification.
 
     Parameters
     ----------
-    operations:
-        The full ordered list of IR operations (as seen by
-        CustomPreSchedulingPasses).  Modified in-place when the
+    graph:
+        Provides ``operations``, the full ordered list of IR operations (as
+        seen by CustomPreSchedulingPasses).  Modified in-place when the
         transformation phase inserts new buffer/copy ops.
     groups:
         Sequence of ``(ops, levels)`` tuples produced by
@@ -1416,16 +1415,60 @@ def coarse_tile(
         ``(hint_id, count)`` pairs, outermost first.
     group_idx_offset:
         Starting index for group IDs assigned to the first group.  Use this
-        when making a second ``coarse_tile`` call on the same graph so that
-        the new group IDs do not collide with IDs already stamped by an
-        earlier call (e.g. hint-driven groups stamped pre-stickification).
-    insert_read_copies:
-        When False, skip both planning and insertion of Pass 1's read
-        copy-ins entirely. Set False by _maybe_coarse_tile_span_overflow
-        (passes.py): at that post-stickify call site, every op's device
-        layout is already committed by layout propagation, so a read-copy
-        buys no layout reconciliation and would only produce an HBM-to-HBM
-        copy with no benefit.
+        when making a second call on the same graph so that the new group
+        IDs do not collide with IDs already stamped by an earlier call.
+
+    Plans and inserts read copy-ins (Pass 1), reduction machinery (Pass 2),
+    and write copy-outs (Pass 3). See coarse_tile_post_stickify for the
+    post-stickification counterpart, which never needs Pass 1.
+    """
+    _coarse_tile_common(graph, groups, group_idx_offset, run_read_copies=True)
+
+
+def coarse_tile_post_stickify(
+    graph: GraphLowering,
+    groups: list[tuple],
+    group_idx_offset: int = 0,
+) -> None:
+    """Span-overflow coarse tiling.  Runs POST-stickification.
+
+    Parameters
+    ----------
+    graph:
+        Provides ``operations``, the full ordered list of IR operations (as
+        seen by CustomPreSchedulingPasses).  Modified in-place when the
+        transformation phase inserts new buffer/copy ops.
+    groups:
+        Sequence of ``(ops, levels)`` tuples produced by
+        ``span_overflow_groups``.  ``levels`` is a list of
+        ``(hint_id, count)`` pairs, outermost first.
+    group_idx_offset:
+        Starting index for group IDs assigned to the first group.  Use this
+        so span-overflow group IDs do not collide with any hint-driven
+        groups already stamped by an earlier coarse_tile_pre_stickify call.
+
+    Every op's device layout is already committed by layout propagation by
+    the time this runs, so Pass 1 (read copy-ins) is skipped
+    unconditionally: a read-copy here would only produce an HBM-to-HBM copy
+    with no layout-reconciliation benefit. See coarse_tile_pre_stickify for
+    the pre-stickification counterpart.
+    """
+    _coarse_tile_common(graph, groups, group_idx_offset, run_read_copies=False)
+
+
+def _coarse_tile_common(
+    graph: GraphLowering,
+    groups: list[tuple],
+    group_idx_offset: int,
+    run_read_copies: bool,
+) -> None:
+    """Plan then transform: stamp loop_group_id / loop_count and scale ranges.
+
+    Shared plan-then-transform body for both stickify entry points --
+    run_read_copies is an internal-only switch (never exposed publicly) so
+    the two ~10-step orchestration bodies aren't duplicated. See
+    coarse_tile_pre_stickify/coarse_tile_post_stickify for the two public
+    entry points that call this.
     """
     operations = graph.operations
 
@@ -1464,9 +1507,9 @@ def coarse_tile(
     # group's _apply_plan above, not alongside _plan_tiling_propagation)
     # because it needs op.loop_info stamped and ranges already divided --
     # see _plan_read_copies's own docstring. Skipped entirely when
-    # insert_read_copies is False (e.g. the post-stickify call site, where
-    # layout propagation already ran and a read-copy buys nothing).
-    if insert_read_copies:
+    # run_read_copies is False (the post-stickify call site, where layout
+    # propagation already ran and a read-copy buys nothing).
+    if run_read_copies:
         read_copy_plans = _plan_read_copies(operations, retiled_infos_by_group)
         _insert_all_read_copy_ops(operations, read_copy_plans)
 

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -2450,7 +2450,7 @@ def _insert_one_read_copy(
             # back to a default row-major allocation, preserving
             # element_arrangement -- same fallback _allocate_full_buffer
             # uses for its own grow-direction resize failures.
-            logger.debug(
+            logger.warning(
                 "_insert_one_read_copy: _resize_device_layout could not "
                 "classify %r (full_size=%s tile_size=%s); using "
                 "row-major fallback",

--- a/torch_spyre/_inductor/wsr/coarse_tile_hints.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile_hints.py
@@ -15,8 +15,8 @@
 """Hint-driven coarse-tile group construction.
 
 Builds coarse-tile groups from explicit ``dim_hints`` set by
-``propagate_hints.py``, for consumption by ``coarse_tile()`` in
-``coarse_tile.py``. Runs PRE-stickification (see ``passes.py``'s
+``propagate_hints.py``, for consumption by ``coarse_tile_pre_stickify()``
+in ``coarse_tile.py``. Runs PRE-stickification (see ``passes.py``'s
 ``_maybe_coarse_tile_hints``).
 """
 
@@ -267,10 +267,12 @@ def reorder_unhinted_interlopers(graph: GraphLowering) -> None:
 
 
 def hints_to_coarse_tile_groups(graph: GraphLowering) -> list[tuple]:
-    """Build coarse_tile() groups from op.dim_hints (set by assign_dim_hints).
+    """Build coarse_tile_pre_stickify() groups from op.dim_hints (set by
+    assign_dim_hints).
 
-    coarse_tile() requires ops to be grouped: all ops in a group share the same
-    tiling spec and are tiled together inside the same loop nest.  We walk
+    coarse_tile_pre_stickify() requires ops to be grouped: all ops in a
+    group share the same tiling spec and are tiled together inside the
+    same loop nest.  We walk
     operations in topological order and collect consecutive ops that carry
     identical hints into one group, breaking whenever the hint changes or an
     op has no hint at all.

--- a/torch_spyre/_inductor/wsr/coarse_tile_span_overflow.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile_span_overflow.py
@@ -15,8 +15,9 @@
 """Span-overflow-driven coarse-tile group construction.
 
 Builds coarse-tile groups automatically when an op's per-core working set
-would overflow available span, for consumption by ``coarse_tile()`` in
-``coarse_tile.py``. Runs POST-stickification (see ``passes.py``'s
+would overflow available span, for consumption by
+``coarse_tile_post_stickify()`` in ``coarse_tile.py``. Runs
+POST-stickification (see ``passes.py``'s
 ``_maybe_coarse_tile_span_overflow``) — requires ``FixedTiledLayout``
 (``device_layout``) on all ops.
 """
@@ -209,7 +210,8 @@ def _dims_to_hints(
 def span_overflow_groups(
     graph: GraphLowering,
 ) -> tuple[list[tuple], list[tuple[Operation, list[DimHint]]]]:
-    """Build coarse_tile() groups from automatic span-overflow plans.
+    """Build coarse_tile_post_stickify() groups from automatic span-overflow
+    plans.
 
     This adapter converts SpanOverflowTilePlans into the same group shape as
     user spyre_hint annotations: ``[(ops, [(hint_id, count)])]``.  Ops that
@@ -221,7 +223,7 @@ def span_overflow_groups(
     Returns a ``(groups, dim_hint_assignments)`` pair.  ``dim_hint_assignments``
     is a list of ``(op, dim_hints)`` pairs this function decided on but did
     NOT apply — applying them (setting ``op.dim_hints``) is the caller's
-    responsibility, and must happen before ``coarse_tile()``/
+    responsibility, and must happen before ``coarse_tile_post_stickify()``/
     ``validate_coarse_tile_groups`` run, since ``dim_hints`` is an input those
     consume, not something they produce.  Keeping the assignment out of this
     function's own decision logic keeps ``span_overflow_groups`` a pure


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/
torch-spyre/blob/main/CONTRIBUTING.
md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Two enhancements to Pass 1 of `coarse_tile()`'s transformation phase
(`_insert_all_read_copy_ops` in `torch_spyre/_inductor/wsr/coarse_tile.py`),
following the existing plan/execute split the rest of `coarse_tile()` uses,
plus a follow-on refactor that splits `coarse_tile()` itself into two
entry points:

1. **Cross-op read-copy sharing.** When multiple ops in the same
   coarse-tile group read the same buffer through structurally-equivalent
   index expressions, they now share one inserted copy instead of getting
   one copy per op/read. This is implemented via a new pure planning
   function, `_plan_read_copies`, which groups equivalent reads by a
   canonical key (buffer name, per-loop-var index coefficients, size) and
   produces an inspectable `dict[tuple[int, ...], ReadCopyPlan]` — new
   frozen dataclasses `ReadCopyEntry`/`ReadCopyPlan` in `loop_info.py`,
   mirroring the existing `PropagationPlan`. `_insert_all_read_copy_ops` is
   slimmed to a pure executor that only applies these decisions (build the
   copy once, patch every consumer via the existing `_NameSwapHandler`
   pattern — no index-expression reconstruction).

2. **Disable read copy-ins for the post-stickify call site.** A read-copy
   at `_maybe_coarse_tile_span_overflow` (the post-stickification call
   site in `passes.py`) is a useless HBM-to-HBM operation: layout
   propagation has already run for that call site, so there is no
   tile-sized-vs-full-sized layout reconciliation left for a copy to buy.
   This started as a boolean flag on `coarse_tile()`
   (`insert_read_copies`), and was then cleaned up into two dedicated
   entry points once the flag's `if` branch was the only thing
   distinguishing the two call sites:
   - `coarse_tile_pre_stickify(graph, groups, group_idx_offset=0)` — used
     by `_maybe_coarse_tile_hints`; runs Pass 1 (read copy-ins), Pass 2
     (reductions), and Pass 3 (write copy-outs).
   - `coarse_tile_post_stickify(graph, groups, group_idx_offset=0)` — used
     by `_maybe_coarse_tile_span_overflow`; skips Pass 1 unconditionally.
   - Both delegate to a shared private `_coarse_tile_common(graph, groups,
     group_idx_offset, run_read_copies)`, so the ~100-line orchestration
     body isn't duplicated, but no `insert_read_copies`-style flag is
     exposed publicly. `coarse_tile()` itself is deleted — no
     backward-compatible wrapper, per this repo's no-back-compat-shim
     convention.
   - A parallel investigation into avoiding the analogous *write*-copy at
     the post-stickify call site (mirroring this read-side disable) found
     no cheap, provably-safe way to do it; that investigation is deferred
     and its write-up now lives on `ct-docs` (#3603) rather than this
     branch, to keep this PR's `docs/` diff at zero against `main` for
     CODEOWNERS scoping.

A backward-compatible single-op wrapper (`_insert_read_copy_ops`) is
preserved for existing direct-unit-test coverage, though it now has no
production callers.

**Fix discovered during final review:** the initial implementation built
the shared copy's buffer name by interpolating the group id tuple directly
into an f-string, producing names containing `(`, `)`, `,` — invalid
Python identifiers that broke downstream `sympy.Symbol()` construction and
regressed `tests/inductor/test_coarse_tile_e2e.py` from 166 passed/0
failed to 6 passed/160 failed. Fixed by sanitizing the tuple into an
identifier-safe string, plus an `isidentifier()` assertion so any future
naming change fails loudly at the point of construction rather than as an
unparseable symbol far downstream. The same fix round also restored an
`isinstance(op.data, (Pointwise, Reduction))` guard that had been dropped
from the new planning function (silently widening scope to `Scan`/`Sort`
ops, not currently used anywhere in `torch_spyre`), and made
`ReadCopyEntry.insert_before_op_name` authoritative for the copy's
insertion point rather than an unused field. A fourth, related bug was
found and fixed in the same pass: the plan's cross-op sizing-invariant
assertion compared `loop_tiled_dims`, which is expressed in different
numbering spaces for `Reduction` vs `Pointwise` ops (e.g. a softmax's
max-reduce and its subsequent subtract/exp legitimately tile the same
logical dimension through different fields); narrowed the assertion to the
actual shared invariant, `loop_count`.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->
Part of #206.

#### Update after review:

Addressed a code-review pass on this PR (one BLOCKER, three SUGGESTIONs,
two QUESTIONs). Four new commits:

1. **Fixed the BLOCKER**: `_plan_read_copies`'s canonical dedup key used
   `dep.index.coeff(v)`, which is a *linear* coefficient and is blind to
   any constant offset in the index (e.g. `64*d0 + d1` and
   `64*d0 + d1 + 5` produced identical keys). Two reads of the same
   buffer at the same stride pattern but a different constant offset
   (e.g. a shifted/windowed read) would have wrongly merged into one
   shared copy, since `_insert_one_read_copy` sizes the copy from only
   the sizing op's own `dep.index` — a merged-in consumer at a different
   real offset would then silently read wrong or out-of-bounds data.
   Fixed by folding the index's constant offset into the key explicitly.
   Added `test_offset_read_gets_its_own_copy` (modeled on the existing
   `test_transposed_read_gets_its_own_copy`), confirmed to fail without
   the fix (`len(entries) == 1` instead of `2`) and pass with it.
2. Changed `_plan_read_copies`'s cross-op `loop_count` invariant check
   from a bare `assert` to `raise Unsupported(...)` (from
   `torch_spyre/_inductor/errors.py`), since this is a compiler-pass
   invariant that could in principle be violated by a future op
   combination, not only a programming bug.
3. Bumped `_insert_one_read_copy`'s `_resize_device_layout` fallback log
   from `logger.debug` to `logger.warning`, so the row-major fallback
   path is visible without enabling debug logging.
4. Fixed stale `coarse_tile()` docstring/comment references in
   `scheduler.py`, `coarse_tile_hints.py`, and
   `coarse_tile_span_overflow.py` to name the actual current entry
   points (`coarse_tile_pre_stickify`/`coarse_tile_post_stickify`).
   `docs/tools/capture_coarse_tile_ir.py` has the same stale reference
   but is intentionally left untouched here — `docs/` stays at zero diff
   against `main` on this branch; that fix belongs on `ct-docs`/#3603.

On the two QUESTIONs: the pre-existing `squeeze_pos` `KeyError` tracked
in #3613 is confirmed unrelated to this PR's sharing logic — it's keyed
off the *sizing op's own* degenerate (size-1) dims, independent of which
op became the sizing op or how reads got grouped. Whether a future
offset-differing use case (windowed attention, conv-like patterns) is on
the roadmap is an open question for maintainers; either way, the fix and
new regression test above now document the current behavior at that
boundary.

All local regression suites re-verified after these changes: 358 passed
(357 + 1 new), 3 pre-existing xfailed; `test_coarse_tile_e2e.py` 166
passed, 49 skipped, 0 failed (exact parity with `main`). `pre-commit` is
clean. `docs/` still has zero diff against `main`.

#### Special notes for your reviewer:

- All local regression suites pass: `tests/inductor/test_coarse_tiling.py`
  + `tests/inductor/test_span_overflow_hint_analysis.py` +
  `tests/inductor/test_building_blocks.py` (358 passed, 3 pre-existing
  xfailed — see "Update after review" above), `tests/inductor/test_coarse_tile_e2e.py` (166 passed, 49
  skipped, 0 failed — exact parity with `main`). `pre-commit run
  --all-files` is clean. `docs/` has zero diff against `main`.
- New test coverage: `TestInsertAllReadCopyOps` (single-op behavior
  preserved), `TestPlanReadCopies` (same-op repeated-read dedup,
  partial sharing within a group with mixed shared/unshared reads),
  `test_post_stickify_skips_pass_1`, and
  `test_end_to_end_shares_one_copy_across_group` (full
  `coarse_tile_pre_stickify` entry point, confirms sharing survives the
  whole pipeline through the final resync loop).
- Two design open questions were investigated and resolved during
  implementation with no further code changes needed: copy-naming
  stability (no downstream code pattern-matches on the old
  single-op-derived name shape) and independence from
  `_zero_reads_of_fixed_buffers_planned` (that function runs during
  `_plan_tiling_propagation`, before `_plan_read_copies` exists in the
  pipeline, and does not consume `ReadCopyPlan`/copy-buffer names).
- Known pre-existing, unrelated gap (not introduced or fixed by this PR):
  `_insert_one_read_copy` can raise a `KeyError` in `squeeze_pos` when a
  group's tiled dimension divides an op's own range to exactly size 1.
  Reproduced at `main` before this branch; tracked in #3613.
- The pre/post-stickify split (item 2 above) was implemented and reviewed
  as its own sub-branch (subagent-driven development: 5 tasks, each with
  an implementer + task reviewer pass, then a whole-branch review) before
  being merged locally into this branch, since it was small and tightly
  coupled to the same function this PR already touches.

#### Does this PR introduce a user-facing change?

No. This is an internal Inductor compiler-pass change with no PyTorch-facing
API changes.

#### Additional note:

Implemented and reviewed via subagent-driven development: one implementer
+ reviewer pass per task (9 tasks for the read-copy-sharing work, 5 more
for the pre/post-stickify split), followed by whole-branch reviews after
each phase, fix rounds where needed, and clean scoped re-reviews.