### PR TITLE
ci(perf): land inline ClickHouse ingest plumbing on main

### DIFF
--- a/.github/actions/ingest-xml-to-clickhouse/action.yml
+++ b/.github/actions/ingest-xml-to-clickhouse/action.yml
@@ -1,0 +1,197 @@
+name: Ingest JUnit XML into ClickHouse
+description: >
+  Parse JUnit/benchmark XML files in a directory and insert their rows into
+  ClickHouse via .github/scripts/ingest_xml.py. This is the SINGLE ingest
+  implementation shared by two callers: the push-to-clickhouse.yaml
+  workflow_run job (which downloads uploaded artifacts first) and the perf job
+  in _test_matrix.yaml (which pushes its report.xml INLINE on the card runner,
+  because on a public repo benchmark numbers must not be uploaded as
+  world-readable artifacts). Secrets cannot reach a composite action, so the
+  caller passes the ClickHouse connection as plain inputs.
+
+inputs:
+  xml-dir:
+    description: Directory to glob for *.xml (non-recursive). Empty = skip.
+    required: false
+    default: ''
+  workflow:
+    description: Workflow name recorded against the rows.
+    required: false
+    default: ''
+  branch:
+    description: Branch recorded against the rows.
+    required: false
+    default: ''
+  sha:
+    description: Commit sha recorded against the rows.
+    required: false
+    default: ''
+  run-id:
+    description: Triggering run id recorded against the rows.
+    required: false
+    default: ''
+  triggered-at:
+    description: Trigger timestamp recorded against the rows (may be empty).
+    required: false
+    default: ''
+  pr-number:
+    description: PR number associated with the rows (empty on non-PR runs).
+    required: false
+    default: ''
+  trigger-type:
+    description: Suite tier (e.g. perf | regression | integration | smoke).
+    required: false
+    default: ''
+  platform:
+    description: >
+      Platform arch recorded on benchmark_runs rows (e.g. x86_64). Empty =
+      the ingest script falls back to its own host-arch default.
+    required: false
+    default: ''
+  torch-spyre-dir:
+    description: >
+      Directory that already holds a checkout containing
+      .github/scripts/ingest_xml.py (e.g. the prebaked dev image source dir or
+      a per-job checkout). When set and the script is found there, the action
+      reuses it instead of a redundant sparse-checkout. Empty = always
+      sparse-checkout the script into the workspace.
+    required: false
+    default: ''
+  clickhouse-host:
+    description: ClickHouse host. Empty = skip the whole ingest (clean no-op).
+    required: false
+    default: ''
+  clickhouse-port:
+    description: ClickHouse port (default 443 inside the script).
+    required: false
+    default: ''
+  clickhouse-user:
+    description: ClickHouse user (default "default" inside the script).
+    required: false
+    default: ''
+  clickhouse-pass:
+    description: ClickHouse password.
+    required: false
+    default: ''
+  clickhouse-db:
+    description: ClickHouse database (default "spyre" inside the script).
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    # ingest_xml.py get_client() reads CLICKHOUSE_HOST/PASS as REQUIRED env
+    # (a KeyError, not a clean skip, when absent), and an empty --xml-dir hits
+    # sys.exit(1). So the no-op gate MUST live here: when the connection or the
+    # dir is not configured, set configured=false and every later step is a
+    # no-op. This is what lets a caller without ClickHouse secrets (or a run
+    # with no XML) pass cleanly.
+    - name: Gate on ClickHouse config and XML dir
+      id: gate
+      shell: bash
+      env:
+        CH_HOST: ${{ inputs.clickhouse-host }}
+        XML_DIR: ${{ inputs.xml-dir }}
+      run: |
+        if [ -z "${CH_HOST}" ]; then
+          echo "::notice::ClickHouse host not configured — skipping ingest."
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        elif [ -z "${XML_DIR}" ]; then
+          echo "::notice::No xml-dir provided — skipping ingest."
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    # The ingest script lives under .github/scripts (a different path than the
+    # .github/actions the perf job already checks out). Reuse an on-disk copy
+    # when the caller has one (perf card runner: prebaked image or a per-job
+    # checkout); otherwise fall back to a sparse-checkout, which reproduces the
+    # push-to-clickhouse.yaml caller's original behavior (it has no product
+    # checkout).
+    - name: Locate ingest script (on disk)
+      id: locate
+      if: steps.gate.outputs.configured == 'true'
+      shell: bash
+      env:
+        TS_DIR: ${{ inputs.torch-spyre-dir }}
+      run: |
+        REL=.github/scripts/ingest_xml.py
+        FOUND=""
+        for base in "${TS_DIR}" "${GITHUB_WORKSPACE}"; do
+          [ -n "${base}" ] || continue
+          if [ -f "${base}/${REL}" ]; then
+            FOUND="${base}/${REL}"
+            break
+          fi
+        done
+        if [ -n "${FOUND}" ]; then
+          echo "Found ingest script at ${FOUND}"
+          echo "INGEST_SCRIPT=${FOUND}" >> "$GITHUB_ENV"
+          echo "need-checkout=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "Ingest script not on disk — will sparse-checkout."
+          echo "need-checkout=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Checkout ingest script (fallback)
+      if: steps.gate.outputs.configured == 'true' && steps.locate.outputs.need-checkout == 'true'
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        sparse-checkout: |
+          .github/scripts/ingest_xml.py
+        sparse-checkout-cone-mode: false
+
+    - name: Set ingest script path (fallback)
+      if: steps.gate.outputs.configured == 'true' && steps.locate.outputs.need-checkout == 'true'
+      shell: bash
+      run: echo "INGEST_SCRIPT=${GITHUB_WORKSPACE}/.github/scripts/ingest_xml.py" >> "$GITHUB_ENV"
+
+    - name: Install uv
+      if: steps.gate.outputs.configured == 'true'
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+    - name: Setup venv and dependencies
+      if: steps.gate.outputs.configured == 'true'
+      shell: bash
+      run: |
+        # Create the ingest venv in the workspace, NOT the baked shared venv, so
+        # the ingest deps never perturb the dev image's torch-spyre environment.
+        uv venv
+        source .venv/bin/activate
+        uv pip install requests clickhouse-driver clickhouse-connect lxml regex
+
+    - name: Ingest XML files into ClickHouse
+      if: steps.gate.outputs.configured == 'true'
+      shell: bash
+      env:
+        CLICKHOUSE_HOST: ${{ inputs.clickhouse-host }}
+        CLICKHOUSE_PASS: ${{ inputs.clickhouse-pass }}
+        # Port/user/db are optional. Only export them when non-empty: the script
+        # reads PORT via int(os.environ.get("CLICKHOUSE_PORT", 443)), so an
+        # empty-string value would break int(""), and empty user/db would
+        # override the script's sensible defaults ("default" / "spyre").
+        CH_PORT_IN: ${{ inputs.clickhouse-port }}
+        CH_USER_IN: ${{ inputs.clickhouse-user }}
+        CH_DB_IN: ${{ inputs.clickhouse-db }}
+        PLATFORM_IN: ${{ inputs.platform }}
+      run: |
+        source .venv/bin/activate
+        [ -n "${CH_PORT_IN}" ] && export CLICKHOUSE_PORT="${CH_PORT_IN}"
+        [ -n "${CH_USER_IN}" ] && export CLICKHOUSE_USER="${CH_USER_IN}"
+        [ -n "${CH_DB_IN}" ] && export CLICKHOUSE_DB="${CH_DB_IN}"
+        # Only pass --platform when non-empty; an empty value would override the
+        # ingest script's own host-arch default with a blank string.
+        PLATFORM_ARGS=()
+        [ -n "${PLATFORM_IN}" ] && PLATFORM_ARGS=(--platform "${PLATFORM_IN}")
+        python3 "${INGEST_SCRIPT}" \
+          --xml-dir "${{ inputs.xml-dir }}" \
+          --workflow "${{ inputs.workflow }}" \
+          --branch "${{ inputs.branch }}" \
+          --sha "${{ inputs.sha }}" \
+          --run-id "${{ inputs.run-id }}" \
+          --triggered-at "${{ inputs.triggered-at }}" \
+          --pr-number "${{ inputs.pr-number }}" \
+          --trigger-type "${{ inputs.trigger-type }}" \
+          "${PLATFORM_ARGS[@]}"

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -444,16 +444,29 @@ jobs:
       # ingest step is skipped and the perf run still succeeds.
       CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
     steps:
+      # ALWAYS sparse-checkout .github from the workflow ref, in BOTH prebaked
+      # and normal mode. `uses: ./.github/actions/*` resolves the action
+      # DEFINITION against $GITHUB_WORKSPACE/.github before any step of that
+      # action runs, so a composite action added on this branch must be present
+      # in the workspace even when the benchmark runs from a prebaked image. The
+      # matrix jobs symlink the baked .github instead, which is fine there because
+      # they only use actions old enough to be in every image; the perf job is the
+      # one that references a NEWER action (ingest-xml-to-clickhouse), so a symlink
+      # to an older baked .github fails to resolve it ("Can't find action.yml ...
+      # Did you forget to run actions/checkout"). A fresh sparse-checkout of just
+      # .github is tiny, is owned by the disposable runner workspace (a separate
+      # dir from PREBAKED_TORCH_SPYRE_DIR, so the baked tree is never mutated), and
+      # always carries the current actions + the .github/scripts the ingest action
+      # reads. The benchmark itself still runs from the baked source dir
+      # (PREBAKED_TORCH_SPYRE_DIR) below, so prebaked provenance for the RUN is
+      # unchanged.
       - name: Checkout composite actions
-        if: ${{ !inputs.prebaked_image }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          sparse-checkout: .github/actions
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
+          repository: ${{ inputs.repository || github.event.pull_request.head.repo.full_name || github.repository }}
+          sparse-checkout: .github
           sparse-checkout-cone-mode: false
-
-      - name: Expose baked composite actions in the workspace
-        if: ${{ inputs.prebaked_image }}
-        run: ln -sfn "${PREBAKED_TORCH_SPYRE_DIR}/.github" "${GITHUB_WORKSPACE}/.github"
 
       - if: ${{ !inputs.prebaked_image }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -109,6 +109,25 @@ on:
         type: boolean
         default: false
 
+    secrets:
+      # ClickHouse connection for the perf job's inline benchmark ingest. The
+      # perf report.xml is written on the card runner and is NOT uploaded as an
+      # artifact (benchmark numbers must not become world-readable on a public
+      # repo), so it cannot ride the push-to-clickhouse.yaml artifact-download
+      # path the way the matrix suites do. Instead the perf job pushes it inline.
+      # All optional: a caller that omits them (or a non-perf run) simply skips
+      # the inline push, leaving every existing caller byte-for-byte unchanged.
+      CLICKHOUSE_HOST:
+        required: false
+      CLICKHOUSE_PORT:
+        required: false
+      CLICKHOUSE_USER:
+        required: false
+      CLICKHOUSE_PASS:
+        required: false
+      CLICKHOUSE_DB:
+        required: false
+
 defaults:
   run:
     shell: bash
@@ -170,6 +189,20 @@ jobs:
           else
             pip install pyyaml --quiet
           fi
+
+          # perf is NOT an OOT pytest-config suite: it is a benchmark mode of
+          # `make tests` (TEST_TYPE=perf shells out to spyre-perf-suite; see the
+          # Makefile `ifeq ($(TEST_TYPE),perf)` branch). It carries no
+          # test_suite_config.labels, so the config filter below would always
+          # return an empty matrix. Route it to the dedicated `perf` job instead:
+          # emit an empty matrix (the `test` matrix job is then skipped) and pin
+          # resolved_test_type=perf so the downstream perf gate fires.
+          if [ "${RAW_TEST_TYPE}" = "perf" ]; then
+            echo "matrix={\"suite\":[]}" >> "$GITHUB_OUTPUT"
+            echo "resolved_test_type=perf" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           matrix=$(python3 tests/oot_framework/utils/filter_configs.py \
             --config-dir tests/configs/torch_spyre_tests \
             --test-type "${RAW_TEST_TYPE}" \
@@ -368,6 +401,140 @@ jobs:
           path: ${{ env.REPORT_PATH }}
           if-no-files-found: warn
           retention-days: 10
+
+  # ---------------------------------------------------------------------------
+  # Job 1b: perf benchmark  (test_type=perf only, never per-PR)
+  #
+  # perf is a benchmark MODE of `make tests`, not an OOT pytest-config suite, so
+  # it never appears in the config-driven `test` matrix above (generate_matrix
+  # emits an empty matrix for perf). `make tests TEST_TYPE=perf` shells out to
+  # the spyre-perf-suite console script baked into the dev image and writes
+  # report.xml into RESULTS_DIR. This job runs that single benchmark step on a
+  # card runner. The reports are not uploaded as artifacts; the results are
+  # consumed only by the ClickHouse ingest path.
+  #
+  # POLICY: perf is a weekly-only suite -- it must NEVER run on a per-PR trigger
+  # (it is expensive and holds a scarce card runner). The `github.event_name !=
+  # pull_request` guard below is the hard stop: even if a pull_request path
+  # forwarded test_type=perf, this job stays skipped. The weekly/scheduled and
+  # orchestrator paths reach here via workflow_dispatch/schedule, not
+  # pull_request, so they are unaffected.
+  # ---------------------------------------------------------------------------
+  perf:
+    name: Perf benchmark
+    needs: [generate_matrix, build_torch_spyre]
+    if: >-
+      !cancelled() &&
+      github.event_name != 'pull_request' &&
+      needs.generate_matrix.outputs.resolved_test_type == 'perf' &&
+      (needs.build_torch_spyre.result == 'success' ||
+       needs.build_torch_spyre.result == 'skipped')
+    runs-on:
+      - x86_64
+      - spyre_pf_x1
+      - ${{ inputs.runner_label }}
+      - ${{ inputs.image_label }}
+    timeout-minutes: 120
+    env:
+      # Flat results dir, matching the Makefile default and PR #3452. The suite
+      # writes both report.txt and report.xml here.
+      RESULTS_DIR: ${{ github.workspace }}/perf-results
+      # Mapped to env so the inline-ingest step can gate on it: secrets cannot be
+      # used in a step `if:`. Empty (caller passed no ClickHouse secrets) => the
+      # ingest step is skipped and the perf run still succeeds.
+      CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
+    steps:
+      - name: Checkout composite actions
+        if: ${{ !inputs.prebaked_image }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+
+      - name: Expose baked composite actions in the workspace
+        if: ${{ inputs.prebaked_image }}
+        run: ln -sfn "${PREBAKED_TORCH_SPYRE_DIR}/.github" "${GITHUB_WORKSPACE}/.github"
+
+      - if: ${{ !inputs.prebaked_image }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: torch-spyre
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
+          repository: ${{ inputs.repository || github.event.pull_request.head.repo.full_name || github.repository }}
+
+      - uses: ./.github/actions/gather-runner-info
+        with:
+          verbose: 'true'
+          torch_spyre_dir: ${{ inputs.prebaked_image && env.PREBAKED_TORCH_SPYRE_DIR || 'torch-spyre' }}
+
+      - name: Install prebuilt torch-spyre
+        if: ${{ !inputs.prebaked_image && needs.build_torch_spyre.result == 'success' }}
+        uses: ./.github/actions/install-prebuilt-torch-spyre
+
+      - name: Run perf benchmark (make tests TEST_TYPE=perf)
+        run: |
+          # Prebaked: run FROM the baked source dir + its SHARED venv at
+          # $HOME/.venv; normal: the checkout ('torch-spyre') + local '.venv'.
+          if [ "${{ inputs.prebaked_image }}" = "true" ]; then
+            SRC_DIR="${PREBAKED_TORCH_SPYRE_DIR}"
+            VENV="${PREBAKED_VENV_PATH}"
+          else
+            SRC_DIR="torch-spyre"
+            VENV="torch-spyre/.venv"
+          fi
+          mkdir -p "${RESULTS_DIR}"
+          # Refresh AIU setup so the benchmark sees the card topology, mirroring
+          # the matrix suites' pre_run. set +u because the script reads unset
+          # vars; a failed refresh must abort before the benchmark runs.
+          set +u
+          unset _IBM_AIU_SETUP
+          rm -rf /tmp/etc/ibm/spyre/topo.json
+          source /etc/profile.d/ibm-aiu-setup.sh || exit 1
+          set -u
+          # shellcheck disable=SC1091
+          source "${VENV}/bin/activate"
+          make -C "${SRC_DIR}" tests TEST_TYPE=perf RESULTS_DIR="${RESULTS_DIR}"
+
+      # The benchmark reports are not uploaded as workflow artifacts; the
+      # results are consumed only by the ClickHouse ingest path.
+      - name: Confirm perf report was produced
+        run: |
+          # Fail if the benchmark did not write its report. Do not echo the
+          # report contents to the build log.
+          test -f "${RESULTS_DIR}/report.xml" \
+            || { echo "::error::perf run did not produce report.xml"; exit 1; }
+          echo "perf report written to \${RESULTS_DIR} (not uploaded)"
+
+      # Push the perf report to ClickHouse INLINE on this card runner. The
+      # report is never uploaded as a workflow artifact (public repo: artifacts
+      # are world-readable and benchmark numbers must stay private), so it
+      # cannot ride the push-to-clickhouse.yaml artifact-download path the
+      # matrix suites use. The composite action is the SAME ingest
+      # implementation that workflow reuses, so there is one code path, not two.
+      # Gated on CLICKHOUSE_HOST: a caller that passes no ClickHouse secrets
+      # skips the push and the perf run still succeeds.
+      - name: Ingest perf report into ClickHouse (inline, no artifact)
+        if: ${{ env.CLICKHOUSE_HOST != '' }}
+        uses: ./.github/actions/ingest-xml-to-clickhouse
+        with:
+          xml-dir: ${{ env.RESULTS_DIR }}
+          workflow: ${{ github.workflow }}
+          branch: ${{ inputs.ref || github.event.pull_request.head.sha || github.ref_name }}
+          sha: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
+          run-id: ${{ github.run_id }}
+          triggered-at: ''
+          # perf never runs on pull_request (see the job `if:` above), so there
+          # is no PR to associate; leave empty.
+          pr-number: ''
+          trigger-type: perf
+          # perf runs on x86 GitHub-hosted runners, so the rows are x86_64.
+          platform: x86_64
+          torch-spyre-dir: ${{ inputs.prebaked_image && env.PREBAKED_TORCH_SPYRE_DIR || 'torch-spyre' }}
+          clickhouse-host: ${{ secrets.CLICKHOUSE_HOST }}
+          clickhouse-port: ${{ secrets.CLICKHOUSE_PORT }}
+          clickhouse-user: ${{ secrets.CLICKHOUSE_USER }}
+          clickhouse-pass: ${{ secrets.CLICKHOUSE_PASS }}
+          clickhouse-db: ${{ secrets.CLICKHOUSE_DB }}
 
   # ---------------------------------------------------------------------------
   # Job 2: Multi-Spyre test matrix

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -99,6 +99,17 @@ on:
         required: false
         type: boolean
         default: true
+      clickhouse_env:
+        description: >-
+          Which ClickHouse instance the perf job's inline ingest writes to:
+          "dev" (the CLICKHOUSE_*_DEV secret set) or "prod" (the CLICKHOUSE_*
+          set). Defaults to dev so a manual/test dispatch never writes to the
+          production perf tables by accident. The scheduled/orchestrator
+          production perf run passes prod explicitly. A no-op when the selected
+          secret set is unset (the perf ingest step self-skips on empty host).
+        required: false
+        type: string
+        default: dev
 
 concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.pull_request.html_url) || (github.event_name == 'workflow_dispatch'
@@ -151,6 +162,22 @@ jobs:
       repository: ${{ inputs.repository || '' }}
       test_type: ${{ inputs.test_type || 'integration' }}
       prebaked_image: ${{ inputs.prebaked_image }}
+    # ClickHouse connection for the perf job's inline benchmark ingest. Passed
+    # explicitly (not `secrets: inherit`) so only what _test_matrix declares is
+    # forwarded. Absent on a repo without these secrets => perf ingest no-ops.
+    #
+    # clickhouse_env selects the instance HERE (the only place both secret sets
+    # are readable): dev -> the *_DEV set, prod -> the plain set. _test_matrix
+    # stays instance-agnostic; it just receives "the ClickHouse to use". A secret
+    # context key must be a literal name, so this is a per-name ternary rather
+    # than a computed `secrets[...]` lookup. An unset selected secret forwards as
+    # empty and the perf ingest step self-skips.
+    secrets:
+      CLICKHOUSE_HOST: ${{ inputs.clickhouse_env == 'prod' && secrets.CLICKHOUSE_HOST || secrets.CLICKHOUSE_HOST_DEV }}
+      CLICKHOUSE_PORT: ${{ inputs.clickhouse_env == 'prod' && secrets.CLICKHOUSE_PORT || secrets.CLICKHOUSE_PORT_DEV }}
+      CLICKHOUSE_USER: ${{ inputs.clickhouse_env == 'prod' && secrets.CLICKHOUSE_USER || secrets.CLICKHOUSE_USER_DEV }}
+      CLICKHOUSE_PASS: ${{ inputs.clickhouse_env == 'prod' && secrets.CLICKHOUSE_PASS || secrets.CLICKHOUSE_PASS_DEV }}
+      CLICKHOUSE_DB: ${{ inputs.clickhouse_env == 'prod' && secrets.CLICKHOUSE_DB || secrets.CLICKHOUSE_DB_DEV }}
 
   # ----------------------------------------------------------------------------------
   # Fan-in gate job which is similar to run-spyre-unit-tests in torch_spyre_tests.yaml

--- a/.github/workflows/push-to-clickhouse.yaml
+++ b/.github/workflows/push-to-clickhouse.yaml
@@ -22,6 +22,16 @@ on:
         description: Workflow name (model-module-tests | upstream-tests | model-ops-tests | integration-tests)
         required: false
         default: upstream-pytorch-tests
+      clickhouse_env:
+        description: >-
+          ClickHouse instance for a MANUAL re-ingest: "prod" (the CLICKHOUSE_*
+          secret set) or "dev" (the CLICKHOUSE_*_DEV set). Default prod. Lets a
+          manual re-ingest target dev WITHOUT editing this file and pushing to
+          main (see the env block below). The automatic workflow_run path always
+          uses prod: for a workflow_run event this input is empty, so the env
+          ternary falls through to the prod secret set.
+        required: false
+        default: prod
 
 concurrency:
   # Allow at most one ingest per triggering run (re-runs queue behind)
@@ -56,19 +66,18 @@ jobs:
       #   CLICKHOUSE_DB     e.g. spyre
       # ---------------------------------------------------------------------------
 
-      # DEV INSTANCE
-      # CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST_DEV }}
-      # CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT_DEV }}
-      # CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER_DEV }}
-      # CLICKHOUSE_PASS: ${{ secrets.CLICKHOUSE_PASS_DEV }}
-      # CLICKHOUSE_DB: ${{ secrets.CLICKHOUSE_DB_DEV }}
-
-      # PROD INSTANCE
-      CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
-      CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT }}
-      CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
-      CLICKHOUSE_PASS: ${{ secrets.CLICKHOUSE_PASS }}
-      CLICKHOUSE_DB: ${{ secrets.CLICKHOUSE_DB }}
+      # Instance selected by the clickhouse_env input: "dev" -> the *_DEV secret
+      # set, anything else (incl. "prod" and the empty value a workflow_run event
+      # sends) -> the plain PROD set. The `!= 'dev'` test (not `== 'prod'`) is
+      # deliberate: it keeps the AUTOMATIC workflow_run path on prod, since that
+      # event carries no input. A secret context key must be a literal name, so
+      # this is a per-name ternary, not a computed `secrets[...]` lookup. This is
+      # what lets a manual DEV re-ingest happen with no edit+push to main.
+      CLICKHOUSE_HOST: ${{ inputs.clickhouse_env != 'dev' && secrets.CLICKHOUSE_HOST || secrets.CLICKHOUSE_HOST_DEV }}
+      CLICKHOUSE_PORT: ${{ inputs.clickhouse_env != 'dev' && secrets.CLICKHOUSE_PORT || secrets.CLICKHOUSE_PORT_DEV }}
+      CLICKHOUSE_USER: ${{ inputs.clickhouse_env != 'dev' && secrets.CLICKHOUSE_USER || secrets.CLICKHOUSE_USER_DEV }}
+      CLICKHOUSE_PASS: ${{ inputs.clickhouse_env != 'dev' && secrets.CLICKHOUSE_PASS || secrets.CLICKHOUSE_PASS_DEV }}
+      CLICKHOUSE_DB: ${{ inputs.clickhouse_env != 'dev' && secrets.CLICKHOUSE_DB || secrets.CLICKHOUSE_DB_DEV }}
 
       # Metadata about the triggering run
       TRIGGERING_RUN_ID: ${{ github.event.workflow_run.id || inputs.gha_run_id }}

--- a/.github/workflows/push-to-clickhouse.yaml
+++ b/.github/workflows/push-to-clickhouse.yaml
@@ -90,27 +90,18 @@ jobs:
           which python3
           python3 --version
 
-      - name: Checkout (for the ingest script)
+      # Check out the local composite action (and the ingest script it runs).
+      # The uv/venv/deps/ingest steps that used to live here inline now live in
+      # .github/actions/ingest-xml-to-clickhouse, shared with the perf job's
+      # inline push so there is one ingest implementation. `uses: ./...`
+      # resolves against the workspace, so the action tree must be present.
+      - name: Checkout (for the composite action and ingest script)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           sparse-checkout: |
+            .github/actions
             .github/scripts/ingest_xml.py
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-
-      - name: setup venv
-        run: |
-          pwd
-          ls -la
-          uv venv
-          source .venv/bin/activate
-          echo "VIRTUAL_ENV $VIRTUAL_ENV"
-
-      - name: Install Python dependencies
-        run: |
-          source .venv/bin/activate
-          uv pip install requests clickhouse-driver clickhouse-connect lxml regex
+          sparse-checkout-cone-mode: false
 
       - name: Install gh CLI
         run: |
@@ -132,10 +123,12 @@ jobs:
           echo "pr_number=${PR}" >> "${GITHUB_OUTPUT}"
 
       # ---------------------------------------------------------------------------
-      # Download all XML artifacts produced by the triggering run.
-      # Each matrix job uploads one artifact named after its config file, e.g.
-      #   granite_3_3_8b_instruct_spyre.xml
-      #   test_view_ops_config.xml
+      # Download every artifact from the triggering run and unzip it. Artifact
+      # *names* carry no file extension (only the file inside the zip does), so
+      # filtering must happen post-unzip by actual filename, not by artifact
+      # name — a `select(.name | endswith(".xml"))` here dropped every artifact.
+      # The ingest step globs *.xml in the unzip dir, so non-XML files that come
+      # along are simply ignored.
       # ---------------------------------------------------------------------------
       - name: List artifacts from triggering run
         id: list-artifacts
@@ -144,7 +137,7 @@ jobs:
         run: |
           ARTIFACTS=$(gh api \
             "/repos/${{ github.repository }}/actions/runs/${TRIGGERING_RUN_ID}/artifacts" \
-            --jq '[.artifacts[] | select(.name | endswith(".xml")) | {id: .id, name: .name}]')
+            --jq '[.artifacts[] | {id: .id, name: .name}]')
           echo "artifacts=$ARTIFACTS" >> "$GITHUB_OUTPUT"
           echo "Found artifacts:"
           echo "$ARTIFACTS" | python3 -c "import json,sys; [print(' •', a['name']) for a in json.load(sys.stdin)]"
@@ -189,26 +182,28 @@ jobs:
           echo "Resolved tier: ${TIER:-<none>}"
           echo "tier=${TIER}" >> "${GITHUB_OUTPUT}"
 
+      # Delegate the venv+deps+ingest to the shared composite action (the same
+      # one the perf job uses for its inline push). The ClickHouse connection
+      # comes from this job's env block above (DEV vs PROD toggle lives there);
+      # no product checkout exists here, so the action sparse-checks-out the
+      # script itself when torch-spyre-dir is not passed.
       - name: Ingest XML files into ClickHouse
-        run: |
-          source .venv/bin/activate
-          python3 .github/scripts/ingest_xml.py \
-            --xml-dir xml_artifacts \
-            --workflow "${TRIGGERING_WORKFLOW}" \
-            --branch   "${TRIGGERING_BRANCH}" \
-            --sha      "${TRIGGERING_SHA}" \
-            --run-id   "${TRIGGERING_RUN_ID}" \
-            --triggered-at "${TRIGGERING_AT}" \
-            --pr-number    "${{ steps.resolve-pr.outputs.pr_number }}" \
-            --trigger-type "${{ steps.extract-tier.outputs.tier }}" \
-            --platform     x86_64
-        env:
-          # PROD INSTANCE
-          CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
-          CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT }}
-          CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
-          CLICKHOUSE_PASS: ${{ secrets.CLICKHOUSE_PASS }}
-          CLICKHOUSE_DB: ${{ secrets.CLICKHOUSE_DB }}
+        uses: ./.github/actions/ingest-xml-to-clickhouse
+        with:
+          xml-dir: xml_artifacts
+          workflow: ${{ env.TRIGGERING_WORKFLOW }}
+          branch: ${{ env.TRIGGERING_BRANCH }}
+          sha: ${{ env.TRIGGERING_SHA }}
+          run-id: ${{ env.TRIGGERING_RUN_ID }}
+          triggered-at: ${{ env.TRIGGERING_AT }}
+          pr-number: ${{ steps.resolve-pr.outputs.pr_number }}
+          trigger-type: ${{ steps.extract-tier.outputs.tier }}
+          platform: x86_64
+          clickhouse-host: ${{ env.CLICKHOUSE_HOST }}
+          clickhouse-port: ${{ env.CLICKHOUSE_PORT }}
+          clickhouse-user: ${{ env.CLICKHOUSE_USER }}
+          clickhouse-pass: ${{ env.CLICKHOUSE_PASS }}
+          clickhouse-db: ${{ env.CLICKHOUSE_DB }}
 
       - name: Summary
         if: always()

--- a/.github/workflows/runtests_nightly.yaml
+++ b/.github/workflows/runtests_nightly.yaml
@@ -50,6 +50,15 @@ jobs:
       rpm_location: ${{ inputs.rpm_location || '' }}
       rpm_names: ${{ inputs.rpm_names || '' }}
       build_torch_spyre: ${{ inputs.build_torch_spyre == true }}
+    # ClickHouse connection for the perf job's inline ingest. Nightly is
+    # schedule-triggered (never pull_request), so a nightly test_type=perf run
+    # can ingest here. Forwarded explicitly, matching the other callers.
+    secrets:
+      CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
+      CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT }}
+      CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
+      CLICKHOUSE_PASS: ${{ secrets.CLICKHOUSE_PASS }}
+      CLICKHOUSE_DB: ${{ secrets.CLICKHOUSE_DB }}
 
   # ---------------------------------------------------------------------------
   # Job 2: run-spyre-unit-tests (fan-in gate)

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -137,6 +137,15 @@ jobs:
       rpm_names: ${{ inputs.rpm_names || '' }}
       build_torch_spyre: ${{ inputs.build_torch_spyre == true }}
       test_type: ${{ inputs.test_type || (github.event_name == 'push' && 'trunk' || 'regression') }}
+    # ClickHouse connection for the perf job's inline ingest (a no-op here in
+    # practice: perf is non-PR-gated and this workflow's test_type is never
+    # perf). Forwarded for consistency with the other _test_matrix callers.
+    secrets:
+      CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
+      CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT }}
+      CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
+      CLICKHOUSE_PASS: ${{ secrets.CLICKHOUSE_PASS }}
+      CLICKHOUSE_DB: ${{ secrets.CLICKHOUSE_DB }}
 
   # ---------------------------------------------------------------------------
   # Job 3: run-spyre-unit-tests (required check gate)


### PR DESCRIPTION
## What

Bring the perf ClickHouse inline-ingest CI plumbing onto `main`. These three
commits already live on `perf-test`; this PR cherry-picks them so the ingest
path resolves on a normal dispatch against `main`.

Cherry-picked from `perf-test` (SHAs recorded via `-x`):
- `#3536` perf ClickHouse inline ingest
- `#3537` dev/prod selector for manual push-to-clickhouse re-ingest
- `#3589` resolve inline ingest action in prebaked mode

## Why

The composite action `.github/actions/ingest-xml-to-clickhouse` currently exists
only on `perf-test`, so `uses: ./.github/actions/ingest-xml-to-clickhouse` fails
to resolve when a workflow runs at ref `main` (404 on the action). A perf run
dispatched at `main` then cannot ingest its `report.xml`. Landing the plumbing on
`main` lets the standard dispatch find the action.

## Scope

Additive, `.github/` only. Six files, all identical to their `perf-test` version:
- `.github/actions/ingest-xml-to-clickhouse/action.yml` (new)
- `.github/workflows/_test_matrix.yaml`
- `.github/workflows/integration-tests.yaml`
- `.github/workflows/push-to-clickhouse.yaml`
- `.github/workflows/runtests_nightly.yaml`
- `.github/workflows/torch_spyre_tests.yaml`

No source, test, or build files change. `main`'s other CI edits since the
`perf-test` base touched different files, so the cherry-pick applied with no
conflicts.
