### PR TITLE
feat(provenance): add offline event-driven provenance viewer

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -414,6 +414,13 @@ jobs:
           echo "REPORT_NAME=${REPORT_NAME}" >> "$GITHUB_ENV"
           echo "REPORT_PATH=${GITHUB_WORKSPACE}/${REPORT_NAME}" >> "$GITHUB_ENV"
 
+      - name: Install mandatory provenance viewer DOM gate
+        if: ${{ matrix.suite.config == 'inductor/test_provenance_viewer_config.yaml' }}
+        run: |
+          npm install --prefix "${RUNNER_TEMP}/torch-spyre-jsdom" --no-save jsdom@30.0.1
+          echo "NODE_PATH=${RUNNER_TEMP}/torch-spyre-jsdom/node_modules" >> "$GITHUB_ENV"
+          echo "SPYRE_REQUIRE_DOM_GATE=1" >> "$GITHUB_ENV"
+
       - name: Run ${{ matrix.suite.name }} tests
         id: run_tests
         uses: ./.github/actions/run-test-suite

--- a/.gitignore
+++ b/.gitignore
@@ -398,9 +398,10 @@ test/*.json
 .*env*
 stubs
 
-# provenance audit outputs
+# provenance outputs
 provenance_capture_raw.json
 
+spyre_provenance.json
 # Cost-model measurement database: fetched, not committed (tools/cost_model/records.py)
 tools/cost_model/sweep_records.json
 tools/cost_model/sweep_records.json.part

--- a/.gitignore
+++ b/.gitignore
@@ -402,6 +402,7 @@ stubs
 provenance_capture_raw.json
 
 spyre_provenance.json
+.spyre_provenance.json.*.tmp
 # Cost-model measurement database: fetched, not committed (tools/cost_model/records.py)
 tools/cost_model/sweep_records.json
 tools/cost_model/sweep_records.json.part

--- a/docs/source/user_guide/debugging/inductor_artifacts.md
+++ b/docs/source/user_guide/debugging/inductor_artifacts.md
@@ -131,6 +131,11 @@ that case. See the
 [PyTorch provenance docs][pytorch-provenance] for the upstream
 reference.
 
+For runtime-event-first inspection of Spyre source, FX, lower-IR, and direct
+OpSpec evidence, see the [offline provenance viewer](../provenance/viewer.md).
+It consumes `spyre_provenance.json` and an optional Kineto trace; raw
+`tlparse` artifacts are not required.
+
 ## Quick reference
 
 ```bash

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -12,6 +12,7 @@ debugging, and worked examples.
    running_hf_models
    supported_operations
    tensors_and_layouts
+   provenance/index
    profiling/index
    debugging/index
    examples/index

--- a/docs/source/user_guide/profiling/pytorch_profiler.md
+++ b/docs/source/user_guide/profiling/pytorch_profiler.md
@@ -129,8 +129,11 @@ metadata:
 The key-bearing event name remains the compatibility join for raw traces and
 name-only consumers. The trace does not embed source locations or full
 transformation lineage. Durable source attribution requires pairing it with
-`spyre_provenance.json`, which Phase 3b writes. Resolve a saved event and
-sidecar with the offline reader:
+`spyre_provenance.json`, which Phase 3b writes. By default, the sidecar is
+written under the run-scoped Inductor debug directory. Set
+`TORCH_SPYRE_PROVENANCE_PATH` to redirect it, or set the variable to an empty
+string to disable publication. Resolve a saved event and sidecar with the
+offline reader:
 
 ```shell
 TORCH_DEVICE_BACKEND_AUTOLOAD=0 python -m torch_spyre.provenance \
@@ -143,10 +146,11 @@ uses only the saved event and sidecar and does not import compiler internals.
 
 When several processes publish to the same configured sidecar path, cooperating
 writers hold an advisory file lock across the complete read-merge-write
-transaction. Publication flushes and synchronizes the same-directory temporary
-file before atomically replacing the sidecar. The parent directory itself is
-not synchronized, so persistence of the rename across abrupt power loss remains
-filesystem-dependent.
+transaction. Non-cooperating writers are not protected by this lock and can
+still race with publication. Publication flushes and synchronizes the
+same-directory temporary file before atomically replacing the sidecar. The
+parent directory itself is not synchronized, so persistence of the rename
+across abrupt power loss remains filesystem-dependent.
 
 The v1 key is a trace-to-sidecar join key only. It is not a compilation cache
 key or a cross-machine artifact identifier; source-path, schema, or toolchain

--- a/docs/source/user_guide/profiling/pytorch_profiler.md
+++ b/docs/source/user_guide/profiling/pytorch_profiler.md
@@ -141,6 +141,13 @@ Disabling backend autoload is required for this module command because Python
 initializes the `torch_spyre` package before executing the reader. The reader
 uses only the saved event and sidecar and does not import compiler internals.
 
+When several processes publish to the same configured sidecar path, cooperating
+writers hold an advisory file lock across the complete read-merge-write
+transaction. Publication flushes and synchronizes the same-directory temporary
+file before atomically replacing the sidecar. The parent directory itself is
+not synchronized, so persistence of the rename across abrupt power loss remains
+filesystem-dependent.
+
 The v1 key is a trace-to-sidecar join key only. It is not a compilation cache
 key or a cross-machine artifact identifier; source-path, schema, or toolchain
 changes can produce a different key. A content hash is used instead of a

--- a/docs/source/user_guide/profiling/pytorch_profiler.md
+++ b/docs/source/user_guide/profiling/pytorch_profiler.md
@@ -143,6 +143,8 @@ TORCH_DEVICE_BACKEND_AUTOLOAD=0 python -m torch_spyre.provenance \
 Disabling backend autoload is required for this module command because Python
 initializes the `torch_spyre` package before executing the reader. The reader
 uses only the saved event and sidecar and does not import compiler internals.
+For linked visual inspection of all events, generate the self-contained
+[offline provenance viewer](../provenance/viewer.md).
 
 When several processes publish to the same configured sidecar path, cooperating
 writers hold an advisory file lock across the complete read-merge-write

--- a/docs/source/user_guide/profiling/pytorch_profiler.md
+++ b/docs/source/user_guide/profiling/pytorch_profiler.md
@@ -129,7 +129,17 @@ metadata:
 The key-bearing event name remains the compatibility join for raw traces and
 name-only consumers. The trace does not embed source locations or full
 transformation lineage. Durable source attribution requires pairing it with
-`spyre_provenance.json`, which a separate artifact-publication change writes.
+`spyre_provenance.json`, which Phase 3b writes. Resolve a saved event and
+sidecar with the offline reader:
+
+```shell
+TORCH_DEVICE_BACKEND_AUTOLOAD=0 python -m torch_spyre.provenance \
+    '<event-name>' /path/to/spyre_provenance.json
+```
+
+Disabling backend autoload is required for this module command because Python
+initializes the `torch_spyre` package before executing the reader. The reader
+uses only the saved event and sidecar and does not import compiler internals.
 
 The v1 key is a trace-to-sidecar join key only. It is not a compilation cache
 key or a cross-machine artifact identifier; source-path, schema, or toolchain

--- a/docs/source/user_guide/provenance/index.md
+++ b/docs/source/user_guide/provenance/index.md
@@ -1,0 +1,21 @@
+# Provenance
+
+```{toctree}
+:hidden:
+:maxdepth: 2
+
+viewer
+```
+
+Torch-Spyre provenance connects a compiled Spyre profiler activity to the
+recorded Python source locations, ATen identities, FX nodes, lower-IR lineage,
+and direct OpSpec bindings that contributed to its finalized bundle.
+
+The rich evidence lives in `spyre_provenance.json`. A profiler event carries
+only a compact key that joins the trace to that sidecar. Use the
+[offline provenance viewer](viewer.md) to inspect the relationship as a
+self-contained six-panel HTML file.
+
+The viewer is designed for saved-artifact analysis. It does not need a Spyre
+device, compiler process, backend service, or `tlparse` installation after the
+HTML has been generated.

--- a/docs/source/user_guide/provenance/viewer.md
+++ b/docs/source/user_guide/provenance/viewer.md
@@ -1,0 +1,282 @@
+# Spyre provenance viewer
+
+The provenance viewer answers one focused question:
+
+> Which recorded source and compiler operations contributed to this saved
+> Spyre profiler event?
+
+The generator validates one `spyre_provenance.json` sidecar, optionally pairs
+individual activities from one Kineto Chrome trace, and writes a deterministic
+self-contained HTML file. The page has two selectors, compact event facts, and
+six linked evidence panels.
+
+## Quick start
+
+### 1. Capture the sidecar and trace
+
+Choose an explicit sidecar path so the trace and its matching artifact are easy
+to archive together:
+
+```bash
+TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 \
+INDUCTOR_PROVENANCE=1 \
+TORCH_SPYRE_PROVENANCE_PATH=/path/to/capture/spyre_provenance.json \
+python my_profiled_model.py
+```
+
+`TORCHINDUCTOR_FORCE_DISABLE_CACHES=1` ensures this run compiles instead of
+silently reusing an older cache entry. `INDUCTOR_PROVENANCE=1` asks Inductor
+to retain its version 2.0 node mappings. Torch-Spyre attaches those mappings to
+the sidecar's compile records. `TORCH_SPYRE_PROVENANCE_PATH` controls where
+the sidecar is published; without it, publication uses the run-scoped Inductor
+debug directory.
+
+Export a Chrome trace from the same profiled run:
+
+```python
+import torch
+from torch.profiler import ProfilerActivity, profile
+
+with profile(
+    activities=[ProfilerActivity.CPU, ProfilerActivity.PrivateUse1],
+) as prof:
+    compiled_model(example_input)
+
+prof.export_chrome_trace("/path/to/capture/spyre_trace.json")
+```
+
+The trace is optional for the viewer, but it supplies individual runtime
+occurrences, timestamps, durations, and JobPlan command suffixes.
+
+### 2. Generate the HTML
+
+```bash
+TORCH_DEVICE_BACKEND_AUTOLOAD=0 \
+python -m torch_spyre.provenance_viewer \
+  /path/to/capture/spyre_provenance.json \
+  --kineto-trace /path/to/capture/spyre_trace.json \
+  --output /path/to/capture/spyre_provenance_viewer.html
+```
+
+Backend autoload is disabled because this command reads saved JSON only. It
+does not need to initialize the Spyre backend.
+
+For sidecar-only inspection, omit `--kineto-trace`:
+
+```bash
+TORCH_DEVICE_BACKEND_AUTOLOAD=0 \
+python -m torch_spyre.provenance_viewer \
+  /path/to/capture/spyre_provenance.json \
+  --output /path/to/capture/spyre_provenance_viewer.html
+```
+
+Open the output directly in a browser. No local web server is required.
+
+The viewer does not accept a `tlparse` directory or raw compiler artifacts.
+The sidecar already carries the structured source, ATen, handle, compile,
+alias, and upstream mapping evidence required by the six panels. The existing
+`tlparse --inductor-provenance` workflow remains useful when full generated
+FX or wrapper text is needed, but it is a separate view.
+
+## Why export standalone HTML?
+
+The HTML freezes the validated evidence used for the analysis, including the
+presentation logic. This makes the result reproducible, easy to archive, and
+viewable without a device or backend environment. It is also convenient to
+share after reviewing it for sensitive source paths and model structure.
+
+Regenerate the HTML when either input changes. The embedded input paths,
+sizes, and SHA-256 digests make accidental artifact mixing diagnosable.
+
+## Selectors and event facts
+
+The **Profiler event** selector chooses one persisted finalized-bundle
+identity. Its event-name base has this form:
+
+```text
+spyre_kernel_v1_<summary>_<provenance-key>
+```
+
+The 16-character provenance key is the join into
+`kernelIdentities`. The readable summary is descriptive and is not used to
+resolve evidence. It contains only sorted, deduplicated ATen packet names, so
+many structurally different bundles can share the same readable
+`fused_<operations>` summary. Their keys differ because the key fingerprints
+the complete finalized `OpSpec | LoopSpec` tree, including the directly
+attached handle at every OpSpec position.
+
+In this viewer, a profiler event is that unique persisted event-name base and
+bundle identity. It is not one execution of the bundle.
+
+The **Runtime occurrence** selector chooses one concrete trace activity.
+Repeated activities stay separate even when they have the same event name and
+bundle identity.
+
+Runtime occurrence remains a selector rather than a static header field
+because each execution can have a different timestamp, duration, correlation
+record, or `#<step>` suffix. Choosing one occurrence updates those facts while
+leaving the bundle evidence unchanged. A static field would have to discard or
+arbitrarily choose among repeated executions.
+
+The event facts distinguish these scopes:
+
+- **Exact observed event name** is the trace name, or the persisted base name
+  in sidecar-only mode.
+- **Timestamp** and **duration** belong to the selected trace activity.
+- **JobPlan step** is the `#<step>` suffix: a static command index in the
+  finalized backend plan. It is not a token, generation iteration, stage, or
+  OpSpec index.
+- **Compile candidates** counts retained `kernelOccurrences` with the
+  selected identity key. A compile candidate is not a runtime occurrence or a
+  JobPlan step, and the viewer does not choose one when several are valid.
+
+A device event represents one `ComputeOnDevice` activity. One complete
+JobPlan execution can produce several device events with different suffixes,
+and repeated executions can produce the same suffix repeatedly. Correlation
+IDs can pair runtime activities and can support a later stage analysis, but
+they do not map an OpSpec to a proprietary backend command.
+
+## How rows are constructed
+
+The resolution path is:
+
+```text
+trace activity
+  -> native args.provenance_key and/or key in the event name
+  -> kernelIdentities[key]
+  -> direct handle IDs and recursive fused_from handles
+  -> source, ATen, lower-IR, and SpecPath evidence
+  -> matching kernelOccurrences
+  -> compile-scoped aliases and upstream v2 FX mappings
+```
+
+When both native and name-derived keys exist, they must agree. Native
+`debug_handles` are compared with the sidecar's direct handle list but never
+replace it. Carrier conflicts are errors; malformed optional trace input and
+missing optional evidence are reported without invalidating the sidecar view.
+
+Each panel has exactly one clickable row unit. Runtime and compile facts stay in
+the selected-event facts; panel headers define their row unit and show compact
+counts or coverage:
+
+| Panel | One row represents |
+| --- | --- |
+| Python source locations | One unique structured `SourceLoc` |
+| Recorded ATen identities | One unique `DebugHandle.aten_op` value |
+| FX pre-grad nodes | One `(compile ID, pre-grad node name)` |
+| FX post-grad nodes | One `(compile ID, post-grad node name)` |
+| Recorded lower-IR lineage by handle | One handle and all its recorded lineage |
+| Direct OpSpec bindings | One ordered `(position, SpecPath, handle ID)` binding |
+
+## Panel meanings
+
+### Python source locations
+
+This panel deduplicates equal structured source ranges while retaining all
+contributing handle references and their count. A `SourceLoc` contains a file,
+start line and column, and optional end line and column.
+
+It is a location, not a source snapshot. The viewer does not read local source
+files or embed literal Python text because a saved path may be missing, changed,
+private, or from another machine. Stack traces locate frames, and generated FX
+text describes compiler graphs; neither is an authoritative copy of the
+original source. Adding portable source text would require a separately
+reviewed bounded snapshot input, not a change to sidecar v1.
+
+### Recorded ATen identities
+
+This panel shows unique operation identities recorded on recursive debug
+handles. Equal display values share a row, but contributing handle
+multiplicity remains visible. No operation is promoted as representative of a
+fused bundle.
+
+ATen and post-grad FX are not redundant. For example, one recorded
+`aten.linear.default` operation can correspond to pre-grad `linear` and then
+decompose into post-grad `permute`, `mm`, and `add` nodes.
+
+### FX pre-grad and post-grad nodes
+
+FX rows are compile-scoped because graph names can be reused or change between
+compilations. The sidecar stores PyTorch Inductor mapping version 2.0, where:
+
+- `cppCodeToPost` maps a registered compiler alias to post-grad node names;
+- `postToPre` maps a post-grad node to pre-grad nodes;
+- `preToPost` is the reverse pre-grad relationship; and
+- `postToCppCode` is the reverse alias relationship.
+
+For example, an alias can map through `cppCodeToPost` to post-grad `add`,
+then through `postToPre` to pre-grad `linear`. The alias-to-post
+relationship can be exact even when the sidecar only supports bundle-level,
+derived handle attribution for that node.
+
+The Spyre provenance viewer intentionally does not embed generated FX definitions or
+raw compiler text. Use the saved `tlparse` output for full graph text.
+
+### Recorded lower-IR lineage by handle
+
+Each row contains one debug handle's complete ordered `ir_chain` and
+`transform_history`. Transformation details are subordinate to the handle;
+they are not separate peer rows.
+
+The current producer does not record stable typed entities for every lower-IR
+stage or exact old-to-new rewrite edges. This panel is therefore recorded
+lineage, not a LoopLevelIR graph and not proof of a fabricated edge sequence.
+
+### Direct OpSpec bindings
+
+Each row is one ordered `specHandleBinding`, including its binding position,
+SpecPath, and directly attached handle. A SpecPath is a nonempty zero-based
+path through the finalized `OpSpec | LoopSpec` tree:
+
+- `[0]` means the first top-level OpSpec;
+- `[1, 0]` means the first OpSpec inside the second top-level LoopSpec.
+
+A SpecPath is not an OpSpec ID, kind, runtime command, or proprietary backend
+program location. Two paths can bind the same handle and remain distinct rows.
+
+The `#<step>` runtime command remains attributed to the complete finalized
+bundle. The current backend interface does not export a command-to-OpSpec
+subset, so the viewer must not imply one.
+
+## Evidence states and interaction
+
+**Exact** means a validated field or mapping directly supports the
+relationship. **Derived** means the row follows a declared mapping or a
+documented bundle-level fallback. For example, pre-grad `linear` reached by
+`alias -> post-grad add -> postToPre -> linear` is derived.
+
+**Multiple candidates** is separate from evidence strength. It means two or
+more valid compile occurrences remain and the retained evidence cannot select
+one. A row can therefore be both derived and associated with multiple
+candidates. A relation is not ambiguous merely because it contains an
+explicitly recorded set of several members.
+
+Clicking one evidence row highlights every related row and dims unrelated rows.
+The clicked row, keyboard focus, clicked panel scroll, and page position stay
+fixed. Other panels center their first related row while retaining every
+related highlight. Click the focused row again to restore the full union.
+Changing the profiler event also clears row focus.
+
+Headers, summaries, and empty states are not interactive.
+
+## Sidecar-only mode and limits
+
+Without a trace, the viewer can still show every persisted identity and all
+sidecar evidence. Runtime timestamps, durations, command suffixes, and
+trace-to-sidecar pairing coverage are unavailable. FX panels can still be
+populated when the sidecar contains the accepted upstream mappings; they do
+not require raw graph files.
+
+An empty panel means the producer did not retain that evidence. The viewer does
+not infer missing source, FX nodes, typed lower-IR edges, scheduler decisions,
+or command-to-OpSpec relationships. Provenance can identify a recorded
+divergence boundary, but it cannot explain a fusion or split decision that no
+producer recorded.
+
+The sidecar and optional trace are each bounded to 256 MiB. Optional trace
+failures leave the validated sidecar view available with diagnostics. Invalid
+or unsupported sidecars fail generation because showing unvalidated
+attribution would be misleading.
+
+The export can reveal file paths, line numbers, operation names, and compiler
+structure. Review it before sharing.

--- a/docs/source/user_guide/provenance/viewer.md
+++ b/docs/source/user_guide/provenance/viewer.md
@@ -273,10 +273,17 @@ or command-to-OpSpec relationships. Provenance can identify a recorded
 divergence boundary, but it cannot explain a fusion or split decision that no
 producer recorded.
 
-The sidecar and optional trace are each bounded to 256 MiB. Optional trace
-failures leave the validated sidecar view available with diagnostics. Invalid
-or unsupported sidecars fail generation because showing unvalidated
-attribution would be misleading.
+The sidecar and optional trace are each bounded to 256 MiB. Each panel displays
+at most 10,000 deterministically ordered evidence rows, and the export retains
+at most the earliest 10,000 resolved runtime occurrences by trace-event index.
+Panel headers and the run summary show displayed and total counts when either
+limit is reached. The presentation becomes ``partial`` and records explicit
+truncation diagnostics; the validated sidecar and trace remain the complete
+evidence sources.
+
+Optional trace failures leave the validated sidecar view available with
+diagnostics. Invalid or unsupported sidecars fail generation because showing
+unvalidated attribution would be misleading.
 
 The export can reveal file paths, line numbers, operation names, and compiler
 structure. Review it before sharing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ build = [ # no-isolation build
 ]
 test = [
     "pytest~=9.0",
+    "jsonschema~=4.26.0",    # validates the shipped provenance artifact schema
     "pydantic",             # needed by test framework to support pydantic models for config
     "pytest-xdist",         # -n1 worker isolation for segfault resilience
 #    "torch_sendnn",        # must be installed manually
@@ -81,7 +82,7 @@ torch_spyre = "torch_spyre:_autoload"
 
 [tool.setuptools]
 package-dir = { torch_spyre = "torch_spyre" }
-package-data = { torch_spyre = ["*.dll", "*.dylib", "*.so"] }
+package-data = { torch_spyre = ["*.dll", "*.dylib", "*.so", "_inductor/schemas/*.json"] }
 
 [tool.setuptools.packages.find]
 exclude = ["tests"]  # exclude packages matching these glob patterns (empty by default)

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,6 +6,10 @@ annotated-types==0.8.0
     # via pydantic
 ast-serialize==0.6.0
     # via mypy
+attrs==26.1.0
+    # via
+    #   jsonschema
+    #   referencing
 build==1.5.0
     # via torch-spyre
 cfgv==3.5.0
@@ -39,6 +43,10 @@ jinja2==3.1.6
     # via
     #   torch
     #   torch-spyre
+jsonschema==4.26.0
+    # via torch-spyre
+jsonschema-specifications==2025.9.1
+    # via jsonschema
 librt==0.13.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 markupsafe==3.0.3
@@ -110,8 +118,16 @@ pyyaml==6.0.3
     # via
     #   pre-commit
     #   torch-spyre
+referencing==0.37.0
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
 regex==2026.7.19
     # via torch-spyre
+rpds-py==2026.6.3
+    # via
+    #   jsonschema
+    #   referencing
 setuptools==81.0.0
     # via
     #   torch
@@ -132,6 +148,7 @@ typing-extensions==4.16.0
     #   ortools
     #   pydantic
     #   pydantic-core
+    #   referencing
     #   torch
     #   typing-inspection
 typing-inspection==0.4.2

--- a/tests/configs/torch_spyre_tests/inductor/test_provenance_viewer_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_provenance_viewer_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [unit, regression, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_provenance_viewer.py
+      unlisted_test_mode: mandatory_success

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,17 @@ def _extract_failure_message(rep):
     return message
 
 
+@pytest.fixture(autouse=True)
+def _disable_provenance_publication():
+    """Keep ordinary tests from publishing a sidecar into the repository."""
+    import torch  # noqa: F401
+
+    from torch_spyre._inductor import config as spyre_config
+
+    with spyre_config.patch({"provenance_artifact_path": None}):
+        yield
+
+
 # Attaches per-test tags to the pytest report object after each test call.
 # Tags come from _RUNTIME_TAGS (set by print_test_tags_oot during test execution,
 # includes per-occurrence op tags) with fallback to _spyre_method_tags

--- a/tests/inductor/fixtures/provenance/README.md
+++ b/tests/inductor/fixtures/provenance/README.md
@@ -1,0 +1,9 @@
+# Phase 3b provenance schema fixtures
+
+`valid_v1.json` is a merged multi-graph sidecar. Handle `200` is normalized and references fused constituents `101` and `102`; identity `vsancadvtjfcq6cv` proves an empty direct-handle list is valid; identity `atqydvnuutl766na` occurs in two compile scopes; the first compiler kernel retains two exact registrations; and the second compile records the honest provenance-level-0 gap.
+
+`valid_cache_replay_v1.json` models cache replay of the first compile from `valid_v1.json`. It intentionally has the same compile ID and occurrence IDs, complete Spyre handle data, empty registrations, and `unavailable-cache-replay`. A merge keeps the richer `ok` projection and registrations from `valid_v1.json`; availability does not create a second occurrence.
+
+Every compile and occurrence key is the real digest of the documented canonical payload. The tests recompute those keys, event names, handle relationships, ATen closure, registration aliases, upstream reverse mappings, and document status.
+
+`fixture_manifest.json` defines invalid fixtures as deterministic mutations of a valid document. Reader diagnostics are separate from the writer-side `diagnostics` map stored in an artifact. Readers check `schemaVersion` first, then apply JSON Schema validation, then semantic validation, so a forward version deterministically reports `unsupported-schema-version`.

--- a/tests/inductor/fixtures/provenance/fixture_manifest.json
+++ b/tests/inductor/fixtures/provenance/fixture_manifest.json
@@ -1,0 +1,106 @@
+{
+  "valid": [
+    {
+      "path": "valid_v1.json",
+      "covers": [
+        "fused-handles",
+        "empty-handles",
+        "repeated-bundle-identity",
+        "repeated-registration",
+        "multi-graph",
+        "provenance-level-0"
+      ]
+    },
+    {
+      "path": "valid_cache_replay_v1.json",
+      "covers": [
+        "cache-replay",
+        "stable-compile-id",
+        "stable-occurrence-id",
+        "empty-registrations"
+      ]
+    }
+  ],
+  "invalid": [
+    {
+      "name": "forward-version",
+      "base": "valid_v1.json",
+      "mutation": {
+        "operation": "replace",
+        "path": "/schemaVersion",
+        "value": 2
+      },
+      "expectedReaderDiagnostic": "unsupported-schema-version"
+    },
+    {
+      "name": "unknown-field",
+      "base": "valid_v1.json",
+      "mutation": {
+        "operation": "add",
+        "path": "/futureField",
+        "value": true
+      },
+      "expectedReaderDiagnostic": "schema-validation-failure"
+    },
+    {
+      "name": "numeric-handle-id",
+      "base": "valid_v1.json",
+      "mutation": {
+        "operation": "replace",
+        "path": "/handles/101/id",
+        "value": 101
+      },
+      "expectedReaderDiagnostic": "schema-validation-failure"
+    },
+    {
+      "name": "empty-spec-path",
+      "base": "valid_v1.json",
+      "mutation": {
+        "operation": "replace",
+        "path": "/kernelIdentities/atqydvnuutl766na/specHandleBindings/0/specPath",
+        "value": []
+      },
+      "expectedReaderDiagnostic": "schema-validation-failure"
+    },
+    {
+      "name": "dangling-handle-reference",
+      "base": "valid_v1.json",
+      "mutation": {
+        "operation": "replace",
+        "path": "/kernelIdentities/atqydvnuutl766na/directHandleIds/0",
+        "value": "999"
+      },
+      "expectedReaderDiagnostic": "semantic-validation-failure"
+    },
+    {
+      "name": "wrong-compile-id",
+      "base": "valid_cache_replay_v1.json",
+      "mutation": {
+        "operation": "replace",
+        "path": "/upstreamProjections/3acd1120e2323fa1fec28f1ff89a59da68cda82541b0a19815ec47a2c922ac0e/kernels/0/compilerKernelName",
+        "value": "sdsc_wrong_name"
+      },
+      "expectedReaderDiagnostic": "semantic-validation-failure"
+    },
+    {
+      "name": "wrong-occurrence-id",
+      "base": "valid_cache_replay_v1.json",
+      "mutation": {
+        "operation": "replace",
+        "path": "/kernelOccurrences/9defcebc8e4505ae8ce0699292e7841f7e0c9d8dbfae401b797e415ff7176ef0/compilerKernelName",
+        "value": "sdsc_wrong_name"
+      },
+      "expectedReaderDiagnostic": "semantic-validation-failure"
+    },
+    {
+      "name": "wrong-document-status",
+      "base": "valid_v1.json",
+      "mutation": {
+        "operation": "replace",
+        "path": "/status",
+        "value": "complete"
+      },
+      "expectedReaderDiagnostic": "semantic-validation-failure"
+    }
+  ]
+}

--- a/tests/inductor/fixtures/provenance/valid_cache_replay_v1.json
+++ b/tests/inductor/fixtures/provenance/valid_cache_replay_v1.json
@@ -112,6 +112,8 @@
           "identityKey": "vsancadvtjfcq6cv"
         }
       ],
+      "uncollectedKernels": [],
+      "upstreamProjectionFailed": false,
       "upstreamJoin": "unavailable-cache-replay",
       "preToPost": {},
       "postToPre": {},

--- a/tests/inductor/fixtures/provenance/valid_cache_replay_v1.json
+++ b/tests/inductor/fixtures/provenance/valid_cache_replay_v1.json
@@ -1,0 +1,123 @@
+{
+  "schemaVersion": 1,
+  "eventKey": {
+    "version": 1,
+    "algorithm": "sha256-prefix-80-base32-lower",
+    "width": 16,
+    "stepAttribution": "bundle"
+  },
+  "mergeGeneration": 1,
+  "status": "partial",
+  "diagnostics": {},
+  "handles": {
+    "101": {
+      "id": "101",
+      "source": {
+        "file": "/workspace/model.py",
+        "start_line": 17,
+        "start_col": 0,
+        "end_line": null,
+        "end_col": null
+      },
+      "aten_op": "aten.linear.default",
+      "ir_chain": ["linear"],
+      "fused_from": [],
+      "transform_history": []
+    },
+    "102": {
+      "id": "102",
+      "source": {
+        "file": "/workspace/model.py",
+        "start_line": 18,
+        "start_col": 0,
+        "end_line": null,
+        "end_col": null
+      },
+      "aten_op": "aten.relu.default",
+      "ir_chain": ["relu"],
+      "fused_from": [],
+      "transform_history": []
+    },
+    "200": {
+      "id": "200",
+      "source": null,
+      "aten_op": null,
+      "ir_chain": ["linear", "relu", "buf0"],
+      "fused_from": ["101", "102"],
+      "transform_history": [
+        {
+          "kind": "fusion",
+          "pass_name": "fuse_linear_relu",
+          "reason": "same iteration space"
+        }
+      ]
+    }
+  },
+  "kernelIdentities": {
+    "atqydvnuutl766na": {
+      "directHandleIds": ["200"],
+      "specHandleBindings": [
+        {
+          "specPath": [0],
+          "handleId": "200"
+        },
+        {
+          "specPath": [1, 0],
+          "handleId": "200"
+        }
+      ],
+      "atenOps": ["aten.linear.default", "aten.relu.default"],
+      "eventNameBase": "spyre_kernel_v1_fused_linear_relu_atqydvnuutl766na"
+    },
+    "vsancadvtjfcq6cv": {
+      "directHandleIds": [],
+      "specHandleBindings": [],
+      "atenOps": [],
+      "eventNameBase": "spyre_kernel_v1_fused_unknown_vsancadvtjfcq6cv"
+    }
+  },
+  "kernelOccurrences": {
+    "628cf6fb3dc79712e3556d549e9b9895088b978deb90882cc61e7ba62d3b0cb2": {
+      "identityKey": "vsancadvtjfcq6cv",
+      "compileId": "3acd1120e2323fa1fec28f1ff89a59da68cda82541b0a19815ec47a2c922ac0e",
+      "compilerKernelName": "sdsc_fused_unknown_1",
+      "registrations": []
+    },
+    "9defcebc8e4505ae8ce0699292e7841f7e0c9d8dbfae401b797e415ff7176ef0": {
+      "identityKey": "atqydvnuutl766na",
+      "compileId": "3acd1120e2323fa1fec28f1ff89a59da68cda82541b0a19815ec47a2c922ac0e",
+      "compilerKernelName": "sdsc_fused_linear_relu_0",
+      "registrations": []
+    }
+  },
+  "upstreamProjections": {
+    "3acd1120e2323fa1fec28f1ff89a59da68cda82541b0a19815ec47a2c922ac0e": {
+      "source": "inductor_provenance_tracking_node_mappings",
+      "version": 2.0,
+      "producer": {
+        "torchSpyreVersion": "0.1.0",
+        "torchVersion": "2.13.0+cpu"
+      },
+      "settings": {
+        "provenanceTrackingLevel": 1,
+        "structuredTracing": false
+      },
+      "kernels": [
+        {
+          "compilerKernelName": "sdsc_fused_linear_relu_0",
+          "identityKey": "atqydvnuutl766na"
+        },
+        {
+          "compilerKernelName": "sdsc_fused_unknown_1",
+          "identityKey": "vsancadvtjfcq6cv"
+        }
+      ],
+      "upstreamJoin": "unavailable-cache-replay",
+      "preToPost": {},
+      "postToPre": {},
+      "cppCodeToPost": {},
+      "postToCppCode": {},
+      "kernelStackTraces": {}
+    }
+  }
+}

--- a/tests/inductor/fixtures/provenance/valid_v1.json
+++ b/tests/inductor/fixtures/provenance/valid_v1.json
@@ -132,6 +132,8 @@
           "identityKey": "vsancadvtjfcq6cv"
         }
       ],
+      "uncollectedKernels": [],
+      "upstreamProjectionFailed": false,
       "upstreamJoin": "ok",
       "preToPost": {
         "linear": ["permute", "mm", "add"],
@@ -196,6 +198,8 @@
           "identityKey": "atqydvnuutl766na"
         }
       ],
+      "uncollectedKernels": [],
+      "upstreamProjectionFailed": false,
       "upstreamJoin": "unavailable-provenance-level-0",
       "preToPost": {},
       "postToPre": {},

--- a/tests/inductor/fixtures/provenance/valid_v1.json
+++ b/tests/inductor/fixtures/provenance/valid_v1.json
@@ -1,0 +1,207 @@
+{
+  "schemaVersion": 1,
+  "eventKey": {
+    "version": 1,
+    "algorithm": "sha256-prefix-80-base32-lower",
+    "width": 16,
+    "stepAttribution": "bundle"
+  },
+  "mergeGeneration": 2,
+  "status": "partial",
+  "diagnostics": {},
+  "handles": {
+    "101": {
+      "id": "101",
+      "source": {
+        "file": "/workspace/model.py",
+        "start_line": 17,
+        "start_col": 0,
+        "end_line": null,
+        "end_col": null
+      },
+      "aten_op": "aten.linear.default",
+      "ir_chain": ["linear"],
+      "fused_from": [],
+      "transform_history": []
+    },
+    "102": {
+      "id": "102",
+      "source": {
+        "file": "/workspace/model.py",
+        "start_line": 18,
+        "start_col": 0,
+        "end_line": null,
+        "end_col": null
+      },
+      "aten_op": "aten.relu.default",
+      "ir_chain": ["relu"],
+      "fused_from": [],
+      "transform_history": []
+    },
+    "200": {
+      "id": "200",
+      "source": null,
+      "aten_op": null,
+      "ir_chain": ["linear", "relu", "buf0"],
+      "fused_from": ["101", "102"],
+      "transform_history": [
+        {
+          "kind": "fusion",
+          "pass_name": "fuse_linear_relu",
+          "reason": "same iteration space"
+        }
+      ]
+    }
+  },
+  "kernelIdentities": {
+    "atqydvnuutl766na": {
+      "directHandleIds": ["200"],
+      "specHandleBindings": [
+        {
+          "specPath": [0],
+          "handleId": "200"
+        },
+        {
+          "specPath": [1, 0],
+          "handleId": "200"
+        }
+      ],
+      "atenOps": ["aten.linear.default", "aten.relu.default"],
+      "eventNameBase": "spyre_kernel_v1_fused_linear_relu_atqydvnuutl766na"
+    },
+    "vsancadvtjfcq6cv": {
+      "directHandleIds": [],
+      "specHandleBindings": [],
+      "atenOps": [],
+      "eventNameBase": "spyre_kernel_v1_fused_unknown_vsancadvtjfcq6cv"
+    }
+  },
+  "kernelOccurrences": {
+    "5f421f9ca3acbd83a5cce6cd7e5988f119d904623fb5e307941a01bf08f76d32": {
+      "identityKey": "atqydvnuutl766na",
+      "compileId": "5254e3a133789eb4c69299ed3772ff7a5faf46ed1a2be57871fe8a0f068f52cd",
+      "compilerKernelName": "sdsc_fused_linear_relu_1",
+      "registrations": []
+    },
+    "628cf6fb3dc79712e3556d549e9b9895088b978deb90882cc61e7ba62d3b0cb2": {
+      "identityKey": "vsancadvtjfcq6cv",
+      "compileId": "3acd1120e2323fa1fec28f1ff89a59da68cda82541b0a19815ec47a2c922ac0e",
+      "compilerKernelName": "sdsc_fused_unknown_1",
+      "registrations": [
+        {
+          "ordinal": 3,
+          "alias": "sdsc_fused_unknown_1:3"
+        }
+      ]
+    },
+    "9defcebc8e4505ae8ce0699292e7841f7e0c9d8dbfae401b797e415ff7176ef0": {
+      "identityKey": "atqydvnuutl766na",
+      "compileId": "3acd1120e2323fa1fec28f1ff89a59da68cda82541b0a19815ec47a2c922ac0e",
+      "compilerKernelName": "sdsc_fused_linear_relu_0",
+      "registrations": [
+        {
+          "ordinal": 1,
+          "alias": "sdsc_fused_linear_relu_0:1"
+        },
+        {
+          "ordinal": 2,
+          "alias": "sdsc_fused_linear_relu_0:2"
+        }
+      ]
+    }
+  },
+  "upstreamProjections": {
+    "3acd1120e2323fa1fec28f1ff89a59da68cda82541b0a19815ec47a2c922ac0e": {
+      "source": "inductor_provenance_tracking_node_mappings",
+      "version": 2.0,
+      "producer": {
+        "torchSpyreVersion": "0.1.0",
+        "torchVersion": "2.13.0+cpu"
+      },
+      "settings": {
+        "provenanceTrackingLevel": 1,
+        "structuredTracing": true
+      },
+      "kernels": [
+        {
+          "compilerKernelName": "sdsc_fused_linear_relu_0",
+          "identityKey": "atqydvnuutl766na"
+        },
+        {
+          "compilerKernelName": "sdsc_fused_unknown_1",
+          "identityKey": "vsancadvtjfcq6cv"
+        }
+      ],
+      "upstreamJoin": "ok",
+      "preToPost": {
+        "linear": ["permute", "mm", "add"],
+        "relu": ["relu"]
+      },
+      "postToPre": {
+        "add": ["linear"],
+        "mm": ["linear"],
+        "permute": ["linear"],
+        "relu": ["relu"]
+      },
+      "cppCodeToPost": {
+        "sdsc_fused_linear_relu_0:1": ["mm", "permute", "add", "relu"],
+        "sdsc_fused_linear_relu_0:2": ["relu"],
+        "sdsc_fused_unknown_1:3": []
+      },
+      "postToCppCode": {
+        "add": ["sdsc_fused_linear_relu_0:1"],
+        "mm": ["sdsc_fused_linear_relu_0:1"],
+        "permute": ["sdsc_fused_linear_relu_0:1"],
+        "relu": [
+          "sdsc_fused_linear_relu_0:1",
+          "sdsc_fused_linear_relu_0:2"
+        ]
+      },
+      "kernelStackTraces": {
+        "sdsc_fused_linear_relu_0:1": {
+          "stackTraces": [
+            "File \"/workspace/model.py\", line 18, in forward"
+          ],
+          "postGradNodes": ["mm", "permute", "add", "relu"],
+          "preGradNodes": ["linear", "relu"]
+        },
+        "sdsc_fused_linear_relu_0:2": {
+          "stackTraces": [
+            "File \"/workspace/model.py\", line 18, in forward"
+          ],
+          "postGradNodes": ["relu"],
+          "preGradNodes": ["relu"]
+        },
+        "sdsc_fused_unknown_1:3": {
+          "stackTraces": [],
+          "postGradNodes": [],
+          "preGradNodes": []
+        }
+      }
+    },
+    "5254e3a133789eb4c69299ed3772ff7a5faf46ed1a2be57871fe8a0f068f52cd": {
+      "source": "inductor_provenance_tracking_node_mappings",
+      "version": 2.0,
+      "producer": {
+        "torchSpyreVersion": "0.1.0",
+        "torchVersion": "2.13.0+cpu"
+      },
+      "settings": {
+        "provenanceTrackingLevel": 0,
+        "structuredTracing": false
+      },
+      "kernels": [
+        {
+          "compilerKernelName": "sdsc_fused_linear_relu_1",
+          "identityKey": "atqydvnuutl766na"
+        }
+      ],
+      "upstreamJoin": "unavailable-provenance-level-0",
+      "preToPost": {},
+      "postToPre": {},
+      "cppCodeToPost": {},
+      "postToCppCode": {},
+      "kernelStackTraces": {}
+    }
+  }
+}

--- a/tests/inductor/fixtures/provenance/viewer_dom_check.js
+++ b/tests/inductor/fixtures/provenance/viewer_dom_check.js
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 The Torch-Spyre Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const { JSDOM } = require("jsdom");
+
+const html = fs.readFileSync(process.argv[2], "utf8");
+let pageX = 17;
+let pageY = 311;
+const dom = new JSDOM(html, {
+  pretendToBeVisual: true,
+  runScripts: "dangerously",
+  beforeParse(window) {
+    Object.defineProperty(window, "scrollX", { get: () => pageX });
+    Object.defineProperty(window, "scrollY", { get: () => pageY });
+    window.scrollTo = (x, y) => {
+      pageX = x;
+      pageY = y;
+    };
+    Object.defineProperty(window.HTMLElement.prototype, "clientHeight", {
+      get() {
+        return this.classList.contains("rows") ? 120 : 20;
+      },
+    });
+    window.HTMLElement.prototype.getBoundingClientRect = function () {
+      if (this.classList.contains("rows")) {
+        return { top: 0, height: 120 };
+      }
+      if (this.classList.contains("evidence-row")) {
+        const rows = Array.from(
+          this.closest(".rows").querySelectorAll(".evidence-row")
+        );
+        return { top: 180 + rows.indexOf(this) * 60, height: 20 };
+      }
+      return { top: 0, height: 20 };
+    };
+  },
+});
+const { document, Event } = dom.window;
+
+assert.equal(document.querySelectorAll("select").length, 2);
+assert.equal(document.querySelectorAll(".panel").length, 6);
+assert.equal(document.querySelectorAll(".panel-description").length, 6);
+assert.equal(document.querySelectorAll(".row-explanation").length, 0);
+assert.ok(
+  Array.from(document.querySelectorAll(".evidence-row .badge")).every(
+    (badge) => badge.textContent.trim().length > 0
+  )
+);
+assert.equal(document.querySelectorAll(".panel-header button").length, 0);
+assert.equal(document.querySelectorAll(".empty-state[tabindex]").length, 0);
+assert.equal(document.body.textContent.includes("Show complete attribution"), false);
+assert.equal(document.body.textContent.includes("typed rewrite edges"), false);
+assert.equal(document.getElementById("run-summary").textContent.includes("0 unresolved"), false);
+
+const opspec = document.querySelector('[data-panel-id="opspec"]');
+const opspecRows = Array.from(opspec.querySelectorAll(".evidence-row"));
+assert.equal(opspecRows.length, 2);
+assert.ok(
+  opspecRows.every((row) => row.textContent.includes("SpecPath"))
+);
+assert.equal(opspec.textContent.includes("Finalized bundle"), false);
+assert.equal(opspec.textContent.includes("compile candidates"), false);
+assert.equal(opspec.textContent.includes("Compiler kernels"), false);
+assert.equal(opspec.textContent.includes("Aliases:"), false);
+assert.equal(document.getElementById("fact-candidates").textContent, "2");
+
+const sourcePanel = document.querySelector('[data-panel-id="source"]');
+const sourceBody = sourcePanel.querySelector(".rows");
+const sourceRow = sourcePanel.querySelector(".evidence-row");
+sourceBody.scrollTop = 47;
+sourceBody.scrollLeft = 9;
+sourceRow.focus();
+sourceRow.click();
+
+assert.equal(document.activeElement, sourceRow);
+assert.equal(sourceBody.scrollTop, 47);
+assert.equal(sourceBody.scrollLeft, 9);
+assert.equal(pageX, 17);
+assert.equal(pageY, 311);
+assert.equal(sourceRow.classList.contains("is-focused"), true);
+assert.equal(sourceRow.getAttribute("aria-pressed"), "true");
+assert.equal(
+  sourcePanel.querySelectorAll(".evidence-row.is-related").length,
+  0
+);
+assert.ok(document.querySelectorAll(".evidence-row.is-related").length > 0);
+assert.ok(document.querySelectorAll(".evidence-row.is-dimmed").length > 0);
+assert.ok(
+  Array.from(document.querySelectorAll(".panel"))
+    .filter((panel) => panel !== sourcePanel)
+    .some((panel) => panel.querySelector(".rows").scrollTop > 0)
+);
+
+sourceRow.click();
+assert.equal(sourceRow.classList.contains("is-focused"), false);
+assert.equal(sourceRow.getAttribute("aria-pressed"), "false");
+assert.equal(document.querySelectorAll(".evidence-row.is-related").length, 0);
+assert.equal(document.querySelectorAll(".evidence-row.is-dimmed").length, 0);
+
+const eventSelect = document.getElementById("event-select");
+eventSelect.value = "1";
+eventSelect.dispatchEvent(new Event("change"));
+assert.equal(document.querySelectorAll(".panel").length, 6);
+assert.equal(document.querySelectorAll(".evidence-row.is-focused").length, 0);
+assert.equal(
+  dom.window.__spyreProvenanceViewer.state.focusedRowId,
+  null
+);
+assert.equal(
+  dom.window.__spyreProvenanceViewer.state.focusedPanelId,
+  null
+);
+
+process.stdout.write("Spyre provenance viewer DOM check passed\n");

--- a/tests/inductor/test_kernel_provenance.py
+++ b/tests/inductor/test_kernel_provenance.py
@@ -31,7 +31,9 @@ import regex as re
 
 import torch  # noqa: F401
 from sympy import Integer, Symbol, sympify
+from torch._inductor.graph import GraphLowering
 from torch._inductor.utils import IndentedBuffer
+from torch._inductor.virtualized import V
 
 from torch_spyre._C import (
     DataFormats,
@@ -43,9 +45,11 @@ from torch_spyre._inductor.op_spec import (
     IndirectAccess,
     LoopSpec,
     OpSpec,
+    ProvenanceTransform,
     SourceLoc,
     TensorArg,
     TensorWorkDivision,
+    UnimplementedOp,
 )
 from torch_spyre._inductor.kernel_provenance import (
     build_kernel_provenance_descriptor,
@@ -57,6 +61,14 @@ from torch_spyre._inductor.profiler_event import (
     extract_kernel_provenance_key,
     format_kernel_provenance_event_name,
 )
+from torch_spyre._inductor.provenance_artifact import (
+    collect_kernel_provenance,
+    consume_kernel_registration_state,
+    KernelRegistrationState,
+    ProvenanceCollectionBuilder,
+    record_kernel_registration,
+)
+from torch_spyre._inductor.scheduler import SuperDSCScheduling
 from torch_spyre._inductor.spyre_kernel import _codegen_op_spec_list
 from torch_spyre.execution.async_compile import SpyreAsyncCompile
 from torch_spyre.execution.kernel_runner import SpyreSDSCKernelRunner
@@ -112,6 +124,23 @@ def _event_name(
     descriptor: KernelProvenanceDescriptor,
 ) -> str:
     return format_kernel_provenance_event_name(descriptor)
+
+
+def _graph_lowering(**attributes):
+    graph = object.__new__(GraphLowering)
+    graph.__dict__.update(attributes)
+    return graph
+
+
+def _registration_state(
+    *,
+    has_graph_lowering: bool = True,
+) -> KernelRegistrationState:
+    return KernelRegistrationState(
+        has_graph_lowering=has_graph_lowering,
+        registrations={},
+        capture_failed=False,
+    )
 
 
 def _generated_wrapper_roundtrip(specs):
@@ -551,6 +580,248 @@ class TestKernelProvenanceEventName:
         assert extract_kernel_provenance_key_cpp(event_name) == expected
 
 
+class TestProvenanceArtifactCollection:
+    def test_collects_valid_bundle_without_handles(self):
+        specs = [
+            _op(None),
+            LoopSpec(count=Integer(2), body=[_op(None)]),
+        ]
+        descriptor = build_kernel_provenance_descriptor(specs)
+        kernel = collect_kernel_provenance(
+            "sdsc_fused_unknown_0",
+            specs,
+            descriptor,
+        )
+        builder = ProvenanceCollectionBuilder()
+        builder.add_kernel(kernel)
+
+        collection = builder.finish(_registration_state())
+
+        assert collection is not None
+        assert collection.handles == {}
+        assert kernel.identity.direct_handle_ids == ()
+        assert kernel.identity.spec_handle_bindings == ()
+        assert kernel.identity.aten_ops == ()
+        assert kernel.identity.event_name_base == (
+            f"spyre_kernel_v1_fused_unknown_{descriptor.key}"
+        )
+        occurrence = next(iter(collection.kernel_occurrences.values()))
+        assert occurrence.identity_key == descriptor.key
+        assert occurrence.registrations == ()
+
+    def test_normalizes_nested_handles_and_preserves_compiler_order(self):
+        linear = _handle(101, aten_op="aten.linear.default")
+        relu = _handle(102, aten_op="aten.relu.default")
+        fused = DebugHandle(
+            id=200,
+            source=None,
+            aten_op=None,
+            ir_chain=("linear", "relu", "buf0"),
+            fused_from=(linear, relu),
+            transform_history=(
+                ProvenanceTransform(
+                    kind="fusion",
+                    pass_name="fuse_linear_relu",
+                    reason="same iteration space",
+                ),
+            ),
+        )
+        specs = [
+            _op(fused),
+            LoopSpec(
+                count=Integer(2),
+                body=[
+                    _op(fused),
+                    LoopSpec(count=Integer(3), body=[_op(None)]),
+                ],
+            ),
+        ]
+        descriptor = build_kernel_provenance_descriptor(specs)
+
+        kernel = collect_kernel_provenance(
+            "sdsc_fused_linear_relu_0",
+            specs,
+            descriptor,
+        )
+
+        assert kernel.identity.direct_handle_ids == ("200",)
+        assert [
+            binding.spec_path for binding in kernel.identity.spec_handle_bindings
+        ] == [(0,), (1, 0)]
+        assert list(kernel.handles) == ["101", "102", "200"]
+        assert kernel.handles["200"].to_dict() == {
+            "id": "200",
+            "source": None,
+            "aten_op": None,
+            "ir_chain": ["linear", "relu", "buf0"],
+            "fused_from": ["101", "102"],
+            "transform_history": [
+                {
+                    "kind": "fusion",
+                    "pass_name": "fuse_linear_relu",
+                    "reason": "same iteration space",
+                }
+            ],
+        }
+        assert kernel.identity.to_dict()["eventNameBase"] == (
+            f"spyre_kernel_v1_fused_linear_relu_{descriptor.key}"
+        )
+
+    def test_assigns_real_compile_and_occurrence_ids_and_deduplicates_identity(self):
+        specs = [_op(_handle(9))]
+        descriptor = build_kernel_provenance_descriptor(specs)
+        first = collect_kernel_provenance("sdsc_fused_mm_0", specs, descriptor)
+        second = collect_kernel_provenance("sdsc_fused_mm_1", specs, descriptor)
+        builder = ProvenanceCollectionBuilder()
+        builder.add_kernel(first)
+        builder.add_kernel(second)
+        graph = _graph_lowering()
+        record_kernel_registration(graph, "sdsc_fused_mm_0", 3)
+        record_kernel_registration(graph, "sdsc_fused_mm_0", 7)
+
+        collection = builder.finish(consume_kernel_registration_state(graph))
+
+        assert collection is not None
+        expected_kernels = [
+            ["sdsc_fused_mm_0", descriptor.key],
+            ["sdsc_fused_mm_1", descriptor.key],
+        ]
+        expected_compile_id = _canonical_digest(
+            {
+                "domain": "torch-spyre-compile-v1",
+                "kernels": expected_kernels,
+            }
+        )
+        assert collection.compile_id == expected_compile_id
+        assert collection.kernels == tuple(tuple(pair) for pair in expected_kernels)
+        assert list(collection.kernel_identities) == [descriptor.key]
+        assert len(collection.kernel_occurrences) == 2
+        first_occurrence_id = _canonical_digest(
+            {
+                "domain": "torch-spyre-occurrence-v1",
+                "compileId": expected_compile_id,
+                "compilerKernelName": "sdsc_fused_mm_0",
+                "identityKey": descriptor.key,
+            }
+        )
+        first_occurrence = collection.kernel_occurrences[first_occurrence_id]
+        assert [
+            registration.to_dict() for registration in first_occurrence.registrations
+        ] == [
+            {"ordinal": 3, "alias": "sdsc_fused_mm_0:3"},
+            {"ordinal": 7, "alias": "sdsc_fused_mm_0:7"},
+        ]
+
+    def test_cache_replay_keeps_identity_with_empty_registrations(self):
+        specs = [_op(_handle(9))]
+        descriptor = build_kernel_provenance_descriptor(specs)
+        kernel = collect_kernel_provenance("sdsc_fused_mm_0", specs, descriptor)
+        fresh_builder = ProvenanceCollectionBuilder()
+        fresh_builder.add_kernel(kernel)
+        replay_builder = ProvenanceCollectionBuilder()
+        replay_builder.add_kernel(kernel)
+        graph = _graph_lowering()
+        record_kernel_registration(graph, "sdsc_fused_mm_0", 1)
+
+        fresh = fresh_builder.finish(consume_kernel_registration_state(graph))
+        replay = replay_builder.finish(_registration_state(has_graph_lowering=False))
+
+        assert fresh is not None
+        assert replay is not None
+        assert fresh.has_graph_lowering
+        assert not replay.has_graph_lowering
+        assert replay.compile_id == fresh.compile_id
+        assert replay.handles == fresh.handles
+        assert replay.kernel_identities == fresh.kernel_identities
+        assert replay.kernel_occurrences.keys() == fresh.kernel_occurrences.keys()
+        replay_occurrence = next(iter(replay.kernel_occurrences.values()))
+        assert replay_occurrence.registrations == ()
+
+    def test_no_graph_state_is_explicit_and_rejects_registration(self):
+        registration_state = consume_kernel_registration_state(V.graph)
+
+        assert not registration_state.has_graph_lowering
+        assert registration_state.registrations == {}
+        with pytest.raises(
+            TypeError,
+            match="requires a real GraphLowering",
+        ):
+            record_kernel_registration(V.graph, "sdsc_fused_mm_0", 1)
+
+    def test_rejects_conflicting_content_for_one_handle_id(self):
+        first = _handle(101, source=SourceLoc("first.py", 10))
+        conflicting = _handle(101, source=SourceLoc("second.py", 20))
+        fused = _handle(200, fused_from=(first, conflicting))
+        specs = [_op(fused)]
+        descriptor = build_kernel_provenance_descriptor(specs)
+
+        with pytest.raises(
+            ValueError,
+            match="conflicting content for debug handle ID 101",
+        ):
+            collect_kernel_provenance("sdsc_fused_mm_0", specs, descriptor)
+
+    def test_rejects_unsupported_finalized_spec(self):
+        descriptor = build_kernel_provenance_descriptor([])
+
+        with pytest.raises(TypeError, match="Unsupported finalized kernel spec"):
+            collect_kernel_provenance(
+                "sdsc_unknown_0",
+                [object()],  # type: ignore[list-item]
+                descriptor,
+            )
+
+    def test_scheduler_registers_once_and_retains_repeated_exact_aliases(self):
+        comments = []
+        definitions = []
+        wrapper = types.SimpleNamespace(
+            src_to_kernel={},
+            next_kernel_suffix=lambda: "0",
+            define_kernel=lambda *args: definitions.append(args),
+            write_provenance_debug_handle=lambda name, handle: comments.append(
+                (name, handle)
+            ),
+        )
+        graph = _graph_lowering(wrapper_code=wrapper)
+        scheduling = object.__new__(SuperDSCScheduling)
+        node_schedule = [object()]
+
+        with (
+            V.set_graph_handler(graph),
+            patch(
+                "torch_spyre._inductor.scheduler.get_fused_kernel_name",
+                return_value="fused_mm",
+            ),
+            patch(
+                "torch_spyre._inductor.scheduler.get_kernel_metadata",
+                return_value=("origins", "detailed origins"),
+            ),
+            patch(
+                "torch._inductor.debug.set_kernel_post_grad_provenance_tracing",
+                side_effect=(4, 9),
+            ) as register,
+        ):
+            first_name = scheduling.define_kernel("[]", node_schedule, object())
+            scheduling.codegen_comment(node_schedule, first_name)
+            second_name = scheduling.define_kernel("[]", node_schedule, object())
+            scheduling.codegen_comment(node_schedule, second_name)
+
+        registrations = consume_kernel_registration_state(graph).registrations
+        assert first_name == second_name == "sdsc_fused_mm_0"
+        assert len(definitions) == 1
+        assert register.call_count == 2
+        assert comments == [
+            ("sdsc_fused_mm_0", 4),
+            ("sdsc_fused_mm_0", 9),
+        ]
+        assert [
+            registration.to_dict() for registration in registrations["sdsc_fused_mm_0"]
+        ] == [
+            {"ordinal": 4, "alias": "sdsc_fused_mm_0:4"},
+            {"ordinal": 9, "alias": "sdsc_fused_mm_0:9"},
+        ]
+
+
 class TestKernelProvenancePropagation:
     def test_async_compile_builds_descriptor_from_finalized_specs(self):
         specs = [
@@ -577,6 +848,184 @@ class TestKernelProvenancePropagation:
         descriptor = runner_type.call_args.kwargs["kernel_provenance"]
         assert descriptor.debug_handle_ids == ("9", "12")
         assert extract_kernel_provenance_key(_event_name(descriptor)) == descriptor.key
+
+    def test_async_compile_finalizes_graph_scoped_collection_at_wait(self):
+        specs = [
+            _op(_handle(9)),
+            LoopSpec(count=Integer(2), body=[_op(_handle(12))]),
+        ]
+        runner = object()
+        compiler = SpyreAsyncCompile()
+        graph = _graph_lowering()
+
+        with (
+            V.set_graph_handler(graph),
+            patch(
+                "torch_spyre.execution.async_compile.get_output_dir",
+                return_value="/tmp/kernel",
+            ),
+            patch("torch_spyre.execution.async_compile.generate_bundle"),
+            patch("torch_spyre.execution.async_compile.subprocess.run"),
+            patch(
+                "torch_spyre.execution.async_compile.SpyreSDSCKernelRunner",
+                return_value=runner,
+            ),
+            patch("torch_spyre.execution.async_compile.AsyncCompile.wait") as base_wait,
+        ):
+            result = compiler.sdsc("sdsc_fused_mm_0", specs)
+            record_kernel_registration(graph, "sdsc_fused_mm_0", 6)
+            compiler.wait({})
+
+        assert result is runner
+        base_wait.assert_called_once_with({})
+        collection = compiler._last_provenance_collection
+        assert collection is not None
+        assert list(collection.handles) == ["12", "9"]
+        assert len(collection.kernel_identities) == 1
+        occurrence = next(iter(collection.kernel_occurrences.values()))
+        assert occurrence.compiler_kernel_name == "sdsc_fused_mm_0"
+        assert [
+            registration.to_dict() for registration in occurrence.registrations
+        ] == [{"ordinal": 6, "alias": "sdsc_fused_mm_0:6"}]
+        assert compiler._artifact_collection_failure_count == 0
+
+    def test_artifact_collection_failure_preserves_phase3a_descriptor(self):
+        specs = [_op(_handle(9))]
+        runner = object()
+        compiler = SpyreAsyncCompile()
+        graph = _graph_lowering()
+
+        with (
+            V.set_graph_handler(graph),
+            patch(
+                "torch_spyre.execution.async_compile.get_output_dir",
+                return_value="/tmp/kernel",
+            ),
+            patch("torch_spyre.execution.async_compile.generate_bundle"),
+            patch("torch_spyre.execution.async_compile.subprocess.run"),
+            patch(
+                "torch_spyre.execution.async_compile.collect_kernel_provenance",
+                side_effect=RuntimeError("artifact-only failure"),
+            ),
+            patch(
+                "torch_spyre.execution.async_compile.SpyreSDSCKernelRunner",
+                return_value=runner,
+            ) as runner_type,
+            patch("torch_spyre.execution.async_compile.AsyncCompile.wait"),
+            patch("torch_spyre.execution.async_compile.logger.warning") as warning,
+        ):
+            result = compiler.sdsc("sdsc_fused_mm_0", specs)
+            compiler.wait({})
+
+        descriptor = runner_type.call_args.kwargs["kernel_provenance"]
+        assert result is runner
+        assert descriptor is not None
+        assert descriptor.debug_handle_ids == ("9",)
+        assert extract_kernel_provenance_key(_event_name(descriptor)) == descriptor.key
+        collection = compiler._last_provenance_collection
+        assert collection is not None
+        assert collection.kernel_identities == {}
+        assert collection.collection_failure_count == 1
+        assert collection.uncollected_kernels[0].compiler_kernel_name == (
+            "sdsc_fused_mm_0"
+        )
+        assert warning.call_count == 2
+        assert warning.call_args_list[0].kwargs["exc_info"] is True
+        assert warning.call_args_list[1].args == (
+            "provenance artifact collection incomplete after %d failure(s) "
+            "across %d compiled Spyre kernels",
+            1,
+            1,
+        )
+
+    def test_unimplemented_kernel_does_not_discard_successful_collection(self):
+        valid_specs = [_op(_handle(9))]
+        unimplemented_specs = [UnimplementedOp("future_op")]
+        valid_runner = object()
+        unimplemented_runner = object()
+        compiler = SpyreAsyncCompile()
+        graph = _graph_lowering()
+
+        with (
+            V.set_graph_handler(graph),
+            patch(
+                "torch_spyre.execution.async_compile.get_output_dir",
+                return_value="/tmp/kernel",
+            ),
+            patch("torch_spyre.execution.async_compile.generate_bundle"),
+            patch("torch_spyre.execution.async_compile.subprocess.run"),
+            patch(
+                "torch_spyre.execution.async_compile.SpyreSDSCKernelRunner",
+                return_value=valid_runner,
+            ),
+            patch(
+                "torch_spyre.execution.async_compile.SpyreUnimplementedRunner",
+                return_value=unimplemented_runner,
+            ),
+            patch("torch_spyre.execution.async_compile.AsyncCompile.wait"),
+        ):
+            assert compiler.sdsc("sdsc_fused_mm_0", valid_specs) is valid_runner
+            assert (
+                compiler.sdsc("sdsc_future_op_1", unimplemented_specs)
+                is unimplemented_runner
+            )
+            record_kernel_registration(graph, "sdsc_fused_mm_0", 1)
+            record_kernel_registration(graph, "sdsc_future_op_1", 2)
+            compiler.wait({})
+
+        collection = compiler._last_provenance_collection
+        assert collection is not None
+        assert len(collection.kernel_identities) == 1
+        assert collection.collection_failure_count == 1
+        assert [
+            registration.alias
+            for registration in collection.uncollected_kernels[0].registrations
+        ] == ["sdsc_future_op_1:2"]
+        occurrence = next(iter(collection.kernel_occurrences.values()))
+        assert [registration.alias for registration in occurrence.registrations] == [
+            "sdsc_fused_mm_0:1"
+        ]
+
+    def test_descriptor_failure_does_not_discard_successful_collection(self):
+        valid_specs = [_op(_handle(9))]
+        invalid_specs = [_op(_handle(12), op_info={"future_value": object()})]
+        runner = object()
+        compiler = SpyreAsyncCompile()
+        graph = _graph_lowering()
+
+        with (
+            V.set_graph_handler(graph),
+            patch(
+                "torch_spyre.execution.async_compile.get_output_dir",
+                return_value="/tmp/kernel",
+            ),
+            patch("torch_spyre.execution.async_compile.generate_bundle"),
+            patch("torch_spyre.execution.async_compile.subprocess.run"),
+            patch(
+                "torch_spyre.execution.async_compile.SpyreSDSCKernelRunner",
+                return_value=runner,
+            ),
+            patch("torch_spyre.execution.async_compile.AsyncCompile.wait"),
+        ):
+            assert compiler.sdsc("sdsc_fused_mm_0", valid_specs) is runner
+            assert compiler.sdsc("sdsc_invalid_1", invalid_specs) is runner
+            record_kernel_registration(graph, "sdsc_fused_mm_0", 1)
+            record_kernel_registration(graph, "sdsc_invalid_1", 2)
+            compiler.wait({})
+
+        collection = compiler._last_provenance_collection
+        assert collection is not None
+        assert len(collection.kernel_identities) == 1
+        assert collection.collection_failure_count == 1
+        assert collection.uncollected_kernels[0].compiler_kernel_name == (
+            "sdsc_invalid_1"
+        )
+        assert [
+            registration.alias
+            for registration in collection.uncollected_kernels[0].registrations
+        ] == ["sdsc_invalid_1:2"]
+        occurrence = next(iter(collection.kernel_occurrences.values()))
+        assert occurrence.compiler_kernel_name == "sdsc_fused_mm_0"
 
     def test_async_compile_keeps_execution_on_unknown_bundle_value(self):
         specs = [_op(_handle(9), op_info={"future_value": object()})]

--- a/tests/inductor/test_kernel_provenance.py
+++ b/tests/inductor/test_kernel_provenance.py
@@ -34,6 +34,7 @@ from sympy import Integer, Symbol, sympify
 from torch._inductor.graph import GraphLowering
 from torch._inductor.utils import IndentedBuffer
 from torch._inductor.virtualized import V
+from torch._logging._internal import LazyTraceHandler
 
 from torch_spyre._C import (
     DataFormats,
@@ -70,6 +71,7 @@ from torch_spyre._inductor.provenance_artifact import (
     record_kernel_registration,
 )
 from torch_spyre._inductor.provenance_writer import (
+    capture_upstream_projection,
     ProvenanceArtifactError,
     publish_provenance_collection,
     resolve_provenance_artifact_path,
@@ -1529,6 +1531,152 @@ class TestProvenanceArtifactPublication:
         assert publish_provenance_collection(collection, str(path)) == "written"
         assert path.exists()
 
+    def test_live_upstream_projection_is_exactly_filtered_and_published(self, tmp_path):
+        from torch_spyre._inductor import provenance_writer
+
+        collection = _publication_collection(registration_ordinal=1)
+        alias = "sdsc_fused_mm_0:1"
+        node_mapping = {
+            "version": 2.0,
+            "preToPost": {
+                "pre_a": ["post_a"],
+                "pre_b": ["post_a"],
+                "pre_unrelated": ["post_unrelated"],
+            },
+            "postToPre": {
+                "post_a": ["pre_a", "pre_b"],
+                "post_unrelated": ["pre_unrelated"],
+            },
+            "cppCodeToPost": {
+                alias: ["post_a"],
+                "sdsc_unrelated_1:2": ["post_unrelated"],
+            },
+            "postToCppCode": {
+                "post_a": [alias],
+                "post_unrelated": ["sdsc_unrelated_1:2"],
+            },
+        }
+        kernel_information = {
+            alias: {
+                "stack_traces": ["model.py:10"],
+                "post_grad_nodes": ["post_a"],
+                "pre_grad_nodes": ["pre_a", "pre_b"],
+            },
+            "sdsc_unrelated_1:2": {
+                "stack_traces": ["other.py:20"],
+                "post_grad_nodes": ["post_unrelated"],
+                "pre_grad_nodes": ["pre_unrelated"],
+            },
+        }
+        path = tmp_path / "filtered.json"
+        inactive_handler = LazyTraceHandler(root_dir=None)
+        active_handler = LazyTraceHandler(root_dir=str(tmp_path))
+
+        with patch.object(
+            provenance_writer.trace_log,
+            "handlers",
+            [inactive_handler],
+        ):
+            assert not provenance_writer._structured_tracing_enabled()
+
+        with (
+            torch._inductor.config.patch("trace.provenance_tracking_level", 1),
+            patch(
+                "torch_spyre._inductor.provenance_writer.inductor_debug."
+                "dump_inductor_provenance_info",
+                return_value=node_mapping,
+            ),
+            patch(
+                "torch_spyre._inductor.provenance_writer.inductor_debug."
+                "create_kernel_information_json",
+                return_value=kernel_information,
+            ),
+            patch(
+                "torch_spyre._inductor.provenance_writer.trace_structured_artifact"
+            ) as structured_artifact,
+            patch.object(
+                provenance_writer.trace_log,
+                "handlers",
+                [active_handler],
+            ),
+        ):
+            assert provenance_writer._structured_tracing_enabled()
+            projection = capture_upstream_projection(collection)
+            assert projection is not None
+            assert not projection.failed
+            assert projection.upstream_join == "ok"
+            assert (
+                publish_provenance_collection(
+                    collection,
+                    str(path),
+                    upstream_projection=projection,
+                )
+                == "written"
+            )
+
+        document = json.loads(path.read_text(encoding="utf-8"))
+        validate_provenance_document(document)
+        _SCHEMA_VALIDATOR.validate(document)
+        assert document["status"] == "complete"
+        assert document["diagnostics"] == {}
+        persisted = document["upstreamProjections"][collection.compile_id]
+        assert persisted["cppCodeToPost"] == {alias: ["post_a"]}
+        assert persisted["settings"]["structuredTracing"] is True
+        assert persisted["postToCppCode"] == {"post_a": [alias]}
+        assert persisted["postToPre"] == {"post_a": ["pre_a", "pre_b"]}
+        assert persisted["preToPost"] == {
+            "pre_a": ["post_a"],
+            "pre_b": ["post_a"],
+        }
+        assert persisted["kernelStackTraces"] == {
+            alias: {
+                "postGradNodes": ["post_a"],
+                "preGradNodes": ["pre_a", "pre_b"],
+                "stackTraces": ["model.py:10"],
+            }
+        }
+        structured_artifact.assert_called_once()
+        assert structured_artifact.call_args.args == ("spyre_provenance", "json")
+        assert structured_artifact.call_args.kwargs["payload_fn"]() == (
+            path.read_text(encoding="utf-8")
+        )
+
+    def test_incomplete_upstream_projection_is_partial_and_diagnostic(self, tmp_path):
+        collection = _publication_collection(registration_ordinal=1)
+        with (
+            torch._inductor.config.patch("trace.provenance_tracking_level", 1),
+            patch(
+                "torch_spyre._inductor.provenance_writer.inductor_debug."
+                "dump_inductor_provenance_info",
+                return_value={
+                    "version": 2.0,
+                    "cppCodeToPost": {},
+                    "postToPre": {},
+                },
+            ),
+            patch(
+                "torch_spyre._inductor.provenance_writer.inductor_debug."
+                "create_kernel_information_json",
+                return_value={},
+            ),
+        ):
+            projection = capture_upstream_projection(collection)
+            assert projection is not None
+            assert projection.failed
+            path = tmp_path / "partial.json"
+            publish_provenance_collection(
+                collection,
+                str(path),
+                upstream_projection=projection,
+            )
+
+        document = json.loads(path.read_text(encoding="utf-8"))
+        persisted = document["upstreamProjections"][collection.compile_id]
+        assert persisted["upstreamJoin"] == "partial"
+        assert persisted["upstreamProjectionFailed"] is True
+        assert document["diagnostics"] == {"upstream-projection-failure": 1}
+        assert document["status"] == "partial"
+
     def test_first_write_is_deterministic_and_schema_valid(self, tmp_path):
         collection = _publication_collection(registration_ordinal=1)
         first_path = tmp_path / "first.json"
@@ -1723,8 +1871,12 @@ class TestProvenanceArtifactPublication:
         with pytest.raises(ProvenanceArtifactError, match="without a collected"):
             publish_provenance_collection(collection, str(path))
         assert not path.exists()
-        assert publish_provenance_collection(collection, None) == "disabled"
-        assert publish_provenance_collection(collection, "") == "disabled"
+        with patch(
+            "torch_spyre._inductor.provenance_writer.trace_structured_artifact"
+        ) as structured_artifact:
+            assert publish_provenance_collection(collection, None) == "disabled"
+            assert publish_provenance_collection(collection, "") == "disabled"
+        structured_artifact.assert_not_called()
         assert not path.exists()
 
     def test_wait_publication_failure_preserves_runtime_descriptor(self, tmp_path):
@@ -1774,6 +1926,55 @@ class TestProvenanceArtifactPublication:
             1,
         )
         assert str(tmp_path) not in repr(warning.call_args_list)
+
+    def test_wait_upstream_capture_failure_publishes_partial_sidecar(self, tmp_path):
+        specs = [_op(_handle(9))]
+        runner = object()
+        compiler = SpyreAsyncCompile()
+        graph = _graph_lowering()
+        path = tmp_path / "capture-failure.json"
+
+        with (
+            V.set_graph_handler(graph),
+            spyre_config.patch({"provenance_artifact_path": str(path)}),
+            torch._inductor.config.patch("trace.provenance_tracking_level", 1),
+            patch(
+                "torch_spyre.execution.async_compile.get_output_dir",
+                return_value="/tmp/kernel",
+            ),
+            patch("torch_spyre.execution.async_compile.generate_bundle"),
+            patch("torch_spyre.execution.async_compile.subprocess.run"),
+            patch(
+                "torch_spyre.execution.async_compile.SpyreSDSCKernelRunner",
+                return_value=runner,
+            ),
+            patch("torch_spyre.execution.async_compile.AsyncCompile.wait"),
+            patch(
+                "torch_spyre.execution.async_compile.capture_upstream_projection",
+                side_effect=ProvenanceArtifactError("upstream capture failed"),
+            ),
+            patch("torch_spyre.execution.async_compile.logger.warning") as warning,
+        ):
+            assert compiler.sdsc("sdsc_fused_mm_0", specs) is runner
+            record_kernel_registration(graph, "sdsc_fused_mm_0", 1)
+            compiler.wait({})
+
+        document = json.loads(path.read_text(encoding="utf-8"))
+        collection = compiler._last_provenance_collection
+        assert collection is not None
+        projection = document["upstreamProjections"][collection.compile_id]
+        assert projection["upstreamJoin"] == "partial"
+        assert projection["upstreamProjectionFailed"] is True
+        assert document["diagnostics"] == {"upstream-projection-failure": 1}
+        assert warning.call_count == 2
+        assert warning.call_args_list[0].args == (
+            "upstream provenance projection capture failed; continuing "
+            "with a partial sidecar",
+        )
+        assert warning.call_args_list[0].kwargs["exc_info"] is True
+        assert warning.call_args_list[1].args == (
+            "provenance upstream projection incomplete for this generated wrapper",
+        )
 
     def test_failed_temp_write_removes_temporary_file(self, tmp_path):
         from torch_spyre._inductor import provenance_writer

--- a/tests/inductor/test_kernel_provenance.py
+++ b/tests/inductor/test_kernel_provenance.py
@@ -1867,6 +1867,98 @@ class TestProvenanceArtifactPublication:
             path.read_text(encoding="utf-8")
         )
 
+    def test_projection_canonicalizes_numeric_suffix_inverse_order(self, tmp_path):
+        collection = _publication_collection(registration_ordinal=1)
+        alias = "sdsc_fused_mm_0:1"
+        node_mapping = {
+            "version": 2.0,
+            "preToPost": {
+                "attn_9": ["permute_53"],
+                "attn_10": ["permute_53"],
+                "attn_99": ["permute_503"],
+                "attn_100": ["permute_503"],
+            },
+            "postToPre": {
+                "permute_53": ["attn_9", "attn_10"],
+                "permute_503": ["attn_99", "attn_100"],
+            },
+            "cppCodeToPost": {alias: ["permute_53", "permute_503"]},
+            "postToCppCode": {
+                "permute_53": [alias],
+                "permute_503": [alias],
+            },
+        }
+        kernel_information = {
+            alias: {
+                "stack_traces": ["model.py:10"],
+                "post_grad_nodes": ["permute_53", "permute_503"],
+                "pre_grad_nodes": [
+                    "attn_9",
+                    "attn_10",
+                    "attn_99",
+                    "attn_100",
+                ],
+            }
+        }
+
+        with (
+            torch._inductor.config.patch("trace.provenance_tracking_level", 1),
+            patch(
+                "torch_spyre._inductor.provenance_writer.inductor_debug."
+                "dump_inductor_provenance_info",
+                return_value=node_mapping,
+            ),
+            patch(
+                "torch_spyre._inductor.provenance_writer.inductor_debug."
+                "create_kernel_information_json",
+                return_value=kernel_information,
+            ),
+        ):
+            projection = capture_upstream_projection(collection)
+
+        assert projection is not None
+        assert not projection.failed
+        assert projection.upstream_join == "ok"
+        assert projection.post_to_pre == {
+            "permute_503": ("attn_100", "attn_99"),
+            "permute_53": ("attn_10", "attn_9"),
+        }
+
+        path = tmp_path / "numeric-suffix-order.json"
+        assert (
+            publish_provenance_collection(
+                collection,
+                str(path),
+                upstream_projection=projection,
+            )
+            == "written"
+        )
+        document = json.loads(path.read_text(encoding="utf-8"))
+        validate_provenance_document(document)
+        _SCHEMA_VALIDATOR.validate(document)
+
+        persisted = document["upstreamProjections"][collection.compile_id]
+        assert persisted["postToPre"] == {
+            "permute_503": ["attn_100", "attn_99"],
+            "permute_53": ["attn_10", "attn_9"],
+        }
+        expected_pairs = {
+            ("attn_9", "permute_53"),
+            ("attn_10", "permute_53"),
+            ("attn_99", "permute_503"),
+            ("attn_100", "permute_503"),
+        }
+        assert {
+            (pre_node, post_node)
+            for pre_node, post_nodes in persisted["preToPost"].items()
+            for post_node in post_nodes
+        } == expected_pairs
+        assert {
+            (pre_node, post_node)
+            for post_node, pre_nodes in persisted["postToPre"].items()
+            for pre_node in pre_nodes
+        } == expected_pairs
+
     def test_incomplete_upstream_projection_is_partial_and_diagnostic(self, tmp_path):
         collection = _publication_collection(registration_ordinal=1)
         with (

--- a/tests/inductor/test_kernel_provenance.py
+++ b/tests/inductor/test_kernel_provenance.py
@@ -1517,6 +1517,24 @@ class TestProvenanceArtifactSchema:
         _SCHEMA_VALIDATOR.validate(document)
         _validate_fixture_semantics(document)
 
+    def test_shipped_package_avoids_internal_project_labels(self):
+        package_root = Path(__file__).parents[2] / "torch_spyre"
+        internal_label = re.compile(
+            r"\b(?:phase\s+(?:[0-9]+[a-z]|x)|milestone\s+[0-9]+|internship)\b",
+            re.IGNORECASE,
+        )
+        source_suffixes = {".cpp", ".h", ".json", ".py", ".pyi"}
+        offenders = {}
+
+        for path in package_root.rglob("*"):
+            if path.suffix not in source_suffixes:
+                continue
+            matches = internal_label.findall(path.read_text(encoding="utf-8"))
+            if matches:
+                offenders[str(path.relative_to(package_root))] = matches
+
+        assert offenders == {}
+
 
 class TestProvenanceArtifactResolver:
     _EVENT_BASE = "spyre_kernel_v1_fused_linear_relu_atqydvnuutl766na"

--- a/tests/inductor/test_kernel_provenance.py
+++ b/tests/inductor/test_kernel_provenance.py
@@ -1209,6 +1209,75 @@ class TestKernelProvenancePropagation:
             profiler_name=_event_name(descriptor),
         )
 
+    def test_runner_keeps_event_name_when_native_registration_fails(self):
+        descriptor = build_kernel_provenance_descriptor([_op(_handle(9))])
+        assert descriptor is not None
+
+        with (
+            patch(
+                "torch_spyre.execution.kernel_runner.register_kernel_provenance",
+                side_effect=RuntimeError("registry failed"),
+            ) as register_kernel_provenance,
+            patch(
+                "torch_spyre.execution.kernel_runner.prepare_kernel",
+                return_value="jobplan",
+            ) as prepare_kernel,
+            patch("torch_spyre.execution.kernel_runner.logger.warning") as warning,
+        ):
+            runner = SpyreSDSCKernelRunner(
+                "sdsc_fused_mm_0",
+                "/tmp/kernel",
+                kernel_provenance=descriptor,
+            )
+
+        assert runner.kernel_provenance is descriptor
+        assert runner.profiler_event_name == _event_name(descriptor)
+        assert runner.jobplan == "jobplan"
+        register_kernel_provenance.assert_called_once_with(
+            _event_name(descriptor), list(descriptor.debug_handle_ids)
+        )
+        prepare_kernel.assert_called_once_with(
+            "/tmp/kernel/spyreCodeDir",
+            profiler_name=_event_name(descriptor),
+        )
+        warning.assert_called_once()
+        assert warning.call_args.args[1] == "sdsc_fused_mm_0"
+        assert warning.call_args.kwargs["exc_info"] is True
+
+    def test_runner_uses_legacy_prepare_when_event_formatting_fails(self):
+        descriptor = build_kernel_provenance_descriptor([_op(_handle(9))])
+        assert descriptor is not None
+
+        with (
+            patch(
+                "torch_spyre.execution.kernel_runner."
+                "format_kernel_provenance_event_name",
+                side_effect=RuntimeError("formatting failed"),
+            ),
+            patch(
+                "torch_spyre.execution.kernel_runner.register_kernel_provenance"
+            ) as register_kernel_provenance,
+            patch(
+                "torch_spyre.execution.kernel_runner.prepare_kernel",
+                return_value="jobplan",
+            ) as prepare_kernel,
+            patch("torch_spyre.execution.kernel_runner.logger.warning") as warning,
+        ):
+            runner = SpyreSDSCKernelRunner(
+                "sdsc_fused_mm_0",
+                "/tmp/kernel",
+                kernel_provenance=descriptor,
+            )
+
+        assert runner.kernel_provenance is descriptor
+        assert runner.profiler_event_name is None
+        assert runner.jobplan == "jobplan"
+        register_kernel_provenance.assert_not_called()
+        prepare_kernel.assert_called_once_with("/tmp/kernel/spyreCodeDir")
+        warning.assert_called_once()
+        assert warning.call_args.args[1] == "sdsc_fused_mm_0"
+        assert warning.call_args.kwargs["exc_info"] is True
+
     def test_runner_preserves_legacy_prepare_call_without_descriptor(self):
         with (
             patch(

--- a/tests/inductor/test_kernel_provenance.py
+++ b/tests/inductor/test_kernel_provenance.py
@@ -14,6 +14,7 @@
 
 """Device-free tests for kernel provenance identity and event transport."""
 
+from concurrent.futures import ThreadPoolExecutor
 import copy
 import ctypes
 import dataclasses
@@ -75,6 +76,7 @@ from torch_spyre._inductor.provenance_artifact import (
     record_kernel_registration,
 )
 from torch_spyre._inductor.provenance_writer import (
+    CapturedUpstreamProjection,
     capture_upstream_projection,
     ProvenanceArtifactError,
     publish_provenance_collection,
@@ -2000,6 +2002,172 @@ class TestProvenanceArtifactPublication:
         first_projection = document["upstreamProjections"][first.compile_id]
         assert first_projection["uncollectedKernels"] == ["sdsc_fused_mm_0_uncollected"]
         assert first_projection["upstreamProjectionFailed"] is True
+        assert document["mergeGeneration"] == 2
+
+    def test_concurrent_publications_merge_without_lost_updates(self, tmp_path):
+        collections = [
+            _publication_collection(
+                kernel_name=f"sdsc_fused_mm_{index}",
+                handle_id=100 + index,
+                registration_ordinal=index + 1,
+            )
+            for index in range(8)
+        ]
+
+        def publish_all(path):
+            with ThreadPoolExecutor(max_workers=len(collections)) as executor:
+                return list(
+                    executor.map(
+                        lambda collection: publish_provenance_collection(
+                            collection, str(path)
+                        ),
+                        collections,
+                    )
+                )
+
+        first_path = tmp_path / "concurrent-first.json"
+        second_path = tmp_path / "concurrent-second.json"
+        with (
+            torch._inductor.config.patch("trace.provenance_tracking_level", 1),
+            patch("torch_spyre._inductor.provenance_writer.trace_structured_artifact"),
+        ):
+            assert publish_all(first_path) == ["written"] * len(collections)
+            assert publish_all(second_path) == ["written"] * len(collections)
+
+        assert first_path.read_bytes() == second_path.read_bytes()
+        document = json.loads(first_path.read_text(encoding="utf-8"))
+        validate_provenance_document(document)
+        _SCHEMA_VALIDATOR.validate(document)
+        assert document["mergeGeneration"] == len(collections)
+        assert set(document["upstreamProjections"]) == {
+            collection.compile_id for collection in collections
+        }
+        assert len(document["kernelOccurrences"]) == len(collections)
+
+    def test_complete_projection_survives_later_partial_contribution(self, tmp_path):
+        path = tmp_path / "rich-then-partial.json"
+        collection = _publication_collection(registration_ordinal=1)
+        alias = "sdsc_fused_mm_0:1"
+        complete = CapturedUpstreamProjection(
+            upstream_join="ok",
+            pre_to_post={"pre": ("post",)},
+            post_to_pre={"post": ("pre",)},
+            cpp_code_to_post={alias: ("post",)},
+            post_to_cpp_code={"post": (alias,)},
+            kernel_stack_traces={
+                alias: {
+                    "stackTraces": ("model.py:10",),
+                    "postGradNodes": ("post",),
+                    "preGradNodes": ("pre",),
+                }
+            },
+            failed=False,
+        )
+
+        with torch._inductor.config.patch("trace.provenance_tracking_level", 1):
+            assert (
+                publish_provenance_collection(
+                    collection,
+                    str(path),
+                    upstream_projection=complete,
+                )
+                == "written"
+            )
+            rich_document = json.loads(path.read_text(encoding="utf-8"))
+            rich_projection = copy.deepcopy(
+                rich_document["upstreamProjections"][collection.compile_id]
+            )
+            assert (
+                publish_provenance_collection(
+                    collection,
+                    str(path),
+                    upstream_projection_failed=True,
+                )
+                == "written"
+            )
+            partial_bytes = path.read_bytes()
+            assert (
+                publish_provenance_collection(
+                    collection,
+                    str(path),
+                    upstream_projection_failed=True,
+                )
+                == "unchanged"
+            )
+
+        assert path.read_bytes() == partial_bytes
+        document = json.loads(partial_bytes)
+        projection = document["upstreamProjections"][collection.compile_id]
+        for field in (
+            "preToPost",
+            "postToPre",
+            "cppCodeToPost",
+            "postToCppCode",
+            "kernelStackTraces",
+        ):
+            assert projection[field] == rich_projection[field]
+        assert projection["upstreamJoin"] == "ok"
+        assert projection["upstreamProjectionFailed"] is True
+        assert document["diagnostics"] == {"upstream-projection-failure": 1}
+        assert document["status"] == "partial"
+        assert document["mergeGeneration"] == 2
+
+    def test_complete_projections_union_additive_stack_context(self, tmp_path):
+        path = tmp_path / "complete-context-union.json"
+        collection = _publication_collection(registration_ordinal=1)
+        alias = "sdsc_fused_mm_0:1"
+        first = CapturedUpstreamProjection(
+            upstream_join="ok",
+            pre_to_post={"pre": ("post",)},
+            post_to_pre={"post": ("pre",)},
+            cpp_code_to_post={alias: ("post",)},
+            post_to_cpp_code={"post": (alias,)},
+            kernel_stack_traces={
+                alias: {
+                    "stackTraces": ("model.py:10",),
+                    "postGradNodes": ("post",),
+                    "preGradNodes": ("pre",),
+                }
+            },
+            failed=False,
+        )
+        second = dataclasses.replace(
+            first,
+            kernel_stack_traces={
+                alias: {
+                    "stackTraces": ("model.py:20",),
+                    "postGradNodes": ("post",),
+                    "preGradNodes": ("pre",),
+                }
+            },
+        )
+
+        with torch._inductor.config.patch("trace.provenance_tracking_level", 1):
+            assert (
+                publish_provenance_collection(
+                    collection, str(path), upstream_projection=first
+                )
+                == "written"
+            )
+            assert (
+                publish_provenance_collection(
+                    collection, str(path), upstream_projection=second
+                )
+                == "written"
+            )
+
+        document = json.loads(path.read_text(encoding="utf-8"))
+        validate_provenance_document(document)
+        _SCHEMA_VALIDATOR.validate(document)
+        projection = document["upstreamProjections"][collection.compile_id]
+        assert projection["kernelStackTraces"][alias]["stackTraces"] == [
+            "model.py:10",
+            "model.py:20",
+        ]
+        assert projection["upstreamJoin"] == "ok"
+        assert projection["upstreamProjectionFailed"] is False
+        assert document["diagnostics"] == {}
+        assert document["status"] == "complete"
         assert document["mergeGeneration"] == 2
 
     @pytest.mark.parametrize(

--- a/tests/inductor/test_kernel_provenance.py
+++ b/tests/inductor/test_kernel_provenance.py
@@ -21,10 +21,12 @@ import dataclasses
 import hashlib
 from importlib.resources import files
 import json
+import multiprocessing
 import os
 from pathlib import Path
 import subprocess
 import sys
+import time
 import types
 from unittest.mock import patch
 
@@ -89,6 +91,7 @@ from torch_spyre.execution.async_compile import SpyreAsyncCompile
 from torch_spyre.execution.kernel_runner import SpyreSDSCKernelRunner
 from torch_spyre.provenance import (
     resolve_provenance_document,
+    resolve_provenance_event,
 )
 
 
@@ -196,6 +199,41 @@ def _publication_collection(
     collection = builder.finish(registration_state)
     assert collection is not None
     return collection
+
+
+def _publish_collection_in_process(
+    path: str,
+    kernel_name: str,
+    handle_id: int,
+    registration_ordinal: int,
+    start_event,
+) -> None:
+    """Publish after a delayed read to expose cross-process lost updates."""
+    from torch_spyre._inductor import provenance_writer
+
+    collection = _publication_collection(
+        kernel_name=kernel_name,
+        handle_id=handle_id,
+        registration_ordinal=registration_ordinal,
+    )
+    read_existing_document = provenance_writer._read_existing_document
+
+    def delayed_read(candidate_path):
+        document = read_existing_document(candidate_path)
+        time.sleep(0.25)
+        return document
+
+    start_event.wait()
+    with (
+        torch._inductor.config.patch("trace.provenance_tracking_level", 1),
+        patch.object(
+            provenance_writer,
+            "_read_existing_document",
+            side_effect=delayed_read,
+        ),
+        patch.object(provenance_writer, "trace_structured_artifact"),
+    ):
+        publish_provenance_collection(collection, path)
 
 
 def _generated_wrapper_roundtrip(specs):
@@ -1656,6 +1694,27 @@ class TestProvenanceArtifactResolver:
                 == (fixture["expectedReaderDiagnostic"])
             ), fixture["name"]
 
+    def test_deeply_nested_json_reports_schema_failure(self, tmp_path):
+        path = tmp_path / "deep.json"
+        path.write_text("[" * 2000 + "0" + "]" * 2000, encoding="utf-8")
+
+        result = resolve_provenance_event(self._EVENT_BASE, path)
+
+        assert result["status"] == "error"
+        assert result["diagnostics"][0]["code"] == "schema-validation-failure"
+
+    def test_recursive_runtime_schema_validation_reports_schema_failure(self):
+        document = _load_provenance_fixture("valid_v1.json")
+
+        with patch(
+            "torch_spyre.provenance._validate_schema",
+            side_effect=RecursionError,
+        ):
+            result = resolve_provenance_document(self._EVENT_BASE, document)
+
+        assert result["status"] == "error"
+        assert result["diagnostics"][0]["code"] == "schema-validation-failure"
+
     def test_missing_key_and_collision_are_distinct(self):
         document = _load_provenance_fixture("valid_v1.json")
         missing = resolve_provenance_document(
@@ -2252,6 +2311,37 @@ class TestProvenanceArtifactPublication:
             collection.compile_id for collection in collections
         }
         assert len(document["kernelOccurrences"]) == len(collections)
+
+    def test_cross_process_publications_merge_without_lost_updates(self, tmp_path):
+        path = tmp_path / "multiprocess.json"
+        context = multiprocessing.get_context("spawn")
+        start_event = context.Event()
+        processes = [
+            context.Process(
+                target=_publish_collection_in_process,
+                args=(
+                    str(path),
+                    f"sdsc_fused_mm_{index}",
+                    200 + index,
+                    index + 1,
+                    start_event,
+                ),
+            )
+            for index in range(2)
+        ]
+
+        for process in processes:
+            process.start()
+        start_event.set()
+        for process in processes:
+            process.join(timeout=10)
+
+        assert [process.exitcode for process in processes] == [0, 0]
+        document = json.loads(path.read_text(encoding="utf-8"))
+        validate_provenance_document(document)
+        assert document["mergeGeneration"] == len(processes)
+        assert len(document["kernelIdentities"]) == len(processes)
+        assert len(document["kernelOccurrences"]) == len(processes)
 
     def test_complete_projection_survives_later_partial_contribution(self, tmp_path):
         path = tmp_path / "rich-then-partial.json"

--- a/tests/inductor/test_kernel_provenance.py
+++ b/tests/inductor/test_kernel_provenance.py
@@ -20,7 +20,10 @@ import dataclasses
 import hashlib
 from importlib.resources import files
 import json
+import os
 from pathlib import Path
+import subprocess
+import sys
 import types
 from unittest.mock import patch
 
@@ -62,6 +65,7 @@ from torch_spyre._inductor.kernel_provenance import (
 from torch_spyre._inductor.profiler_event import (
     extract_kernel_provenance_key,
     format_kernel_provenance_event_name,
+    parse_kernel_provenance_event_name,
 )
 from torch_spyre._inductor.provenance_artifact import (
     collect_kernel_provenance,
@@ -81,6 +85,9 @@ from torch_spyre._inductor.scheduler import SuperDSCScheduling
 from torch_spyre._inductor.spyre_kernel import _codegen_op_spec_list
 from torch_spyre.execution.async_compile import SpyreAsyncCompile
 from torch_spyre.execution.kernel_runner import SpyreSDSCKernelRunner
+from torch_spyre.provenance import (
+    resolve_provenance_document,
+)
 
 
 _DEFAULT_PROVENANCE_ARTIFACT_PATH = spyre_config.provenance_artifact_path
@@ -1507,6 +1514,205 @@ class TestProvenanceArtifactSchema:
         occurrence["selector"] = "future-event-occurrence-token"
         _SCHEMA_VALIDATOR.validate(document)
         _validate_fixture_semantics(document)
+
+
+class TestProvenanceArtifactResolver:
+    _EVENT_BASE = "spyre_kernel_v1_fused_linear_relu_atqydvnuutl766na"
+
+    def test_production_codec_preserves_command_step_suffix(self):
+        parsed = parse_kernel_provenance_event_name(f"{self._EVENT_BASE}#007")
+
+        assert parsed is not None
+        assert parsed.base_name == self._EVENT_BASE
+        assert parsed.key == "atqydvnuutl766na"
+        assert parsed.step == 7
+        assert parsed.step_suffix == "#007"
+        assert extract_kernel_provenance_key(parsed.name) == parsed.key
+
+    def test_resolves_lineage_and_reports_occurrence_ambiguity(self):
+        document = _load_provenance_fixture("valid_v1.json")
+
+        result = resolve_provenance_document(f"{self._EVENT_BASE}#3", document)
+
+        assert result["status"] == "partial"
+        assert result["event"]["commandStep"] == 3
+        assert result["event"]["commandStepSuffix"] == "#3"
+        assert result["directHandleIds"] == ["200"]
+        assert result["fusedConstituentIds"] == ["101", "102"]
+        assert set(result["handles"]) == {"101", "102", "200"}
+        assert result["handles"]["101"]["source"]["start_line"] == 17
+        assert result["handles"]["102"]["aten_op"] == "aten.relu.default"
+        assert result["handles"]["200"]["transform_history"][0]["kind"] == ("fusion")
+        assert len(result["occurrences"]) == 2
+        assert result["occurrenceSummary"]["ambiguous"] is True
+        fields = result["occurrenceSummary"]["fields"]
+        assert fields["identityKey"] == {
+            "ambiguous": False,
+            "value": "atqydvnuutl766na",
+        }
+        assert fields["compileId"]["ambiguous"] is True
+        assert {diagnostic["code"] for diagnostic in result["diagnostics"]} == {
+            "ambiguity",
+            "incomplete-artifact",
+            "upstream-join-status",
+        }
+
+    def test_occurrence_selector_is_an_exact_filter(self):
+        document = _load_provenance_fixture("valid_v1.json")
+        for occurrence in document["kernelOccurrences"].values():
+            if occurrence["identityKey"] != "atqydvnuutl766na":
+                continue
+            occurrence["selector"] = (
+                "fresh"
+                if occurrence["compilerKernelName"].endswith("_0")
+                else "level-zero"
+            )
+
+        result = resolve_provenance_document(
+            self._EVENT_BASE,
+            document,
+            occurrence_selector="fresh",
+        )
+
+        assert result["event"]["occurrenceSelector"] == "fresh"
+        assert len(result["occurrences"]) == 1
+        assert result["occurrences"][0]["selector"] == "fresh"
+        assert result["occurrenceSummary"]["ambiguous"] is False
+
+    def test_empty_handle_identity_resolves_without_fallback(self):
+        document = _load_provenance_fixture("valid_v1.json")
+        event_name = "spyre_kernel_v1_fused_unknown_vsancadvtjfcq6cv#0"
+
+        result = resolve_provenance_document(event_name, document)
+
+        assert result["identityKey"] == "vsancadvtjfcq6cv"
+        assert result["directHandleIds"] == []
+        assert result["fusedConstituentIds"] == []
+        assert result["handles"] == {}
+        assert len(result["occurrences"]) == 1
+
+    def test_empty_occurrence_selector_has_distinct_diagnostic(self):
+        result = resolve_provenance_document(
+            self._EVENT_BASE,
+            _load_provenance_fixture("valid_v1.json"),
+            occurrence_selector="",
+        )
+
+        assert result["status"] == "error"
+        assert result["diagnostics"][0]["code"] == "invalid-selector"
+
+    def test_deep_fused_lineage_resolves_without_python_recursion(self):
+        document = _load_provenance_fixture("valid_v1.json")
+        document["handles"]["200"]["fused_from"] = ["201"]
+        for handle_id in range(201, 2201):
+            constituents = [str(handle_id + 1)] if handle_id < 2200 else ["101", "102"]
+            identifier = str(handle_id)
+            document["handles"][identifier] = {
+                "id": identifier,
+                "source": None,
+                "aten_op": None,
+                "ir_chain": [],
+                "fused_from": constituents,
+                "transform_history": [],
+            }
+        document["handles"] = dict(sorted(document["handles"].items()))
+
+        result = resolve_provenance_document(self._EVENT_BASE, document)
+
+        assert result["status"] == "partial"
+        assert len(result["handles"]) == 2003
+        assert result["fusedConstituentIds"][-2:] == ["101", "102"]
+
+    def test_reader_diagnostics_follow_frozen_fixture_manifest(self):
+        manifest = _load_provenance_fixture("fixture_manifest.json")
+
+        for fixture in manifest["invalid"]:
+            document = _load_provenance_fixture(fixture["base"])
+            mutated = _apply_fixture_mutation(document, fixture["mutation"])
+            result = resolve_provenance_document(self._EVENT_BASE, mutated)
+            assert result["status"] == "error", fixture["name"]
+            assert (
+                result["diagnostics"][0]["code"]
+                == (fixture["expectedReaderDiagnostic"])
+            ), fixture["name"]
+
+    def test_missing_key_and_collision_are_distinct(self):
+        document = _load_provenance_fixture("valid_v1.json")
+        missing = resolve_provenance_document(
+            "spyre_kernel_v1_fused_mm_aaaaaaaaaaaaaaaa", document
+        )
+        collision = resolve_provenance_document(
+            "spyre_kernel_v1_fused_relu_atqydvnuutl766na", document
+        )
+
+        assert missing["diagnostics"][0]["code"] == "missing-key"
+        assert collision["diagnostics"][0]["code"] == "collision"
+
+    def test_fresh_process_cli_uses_only_saved_files(self):
+        fixture_path = _PROVENANCE_FIXTURE_DIR / "valid_v1.json"
+        script = (
+            "import sys; import torch; "
+            "before = set(sys.modules); "
+            "from torch_spyre.provenance import main; "
+            "loaded = set(sys.modules) - before; "
+            "assert 'torch_spyre._inductor.provenance_writer' not in loaded; "
+            "assert 'torch_spyre._inductor.kernel_provenance' not in loaded; "
+            "raise SystemExit(main())"
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", script, f"{self._EVENT_BASE}#9", str(fixture_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert completed.returncode == 0, completed.stderr
+        result = json.loads(completed.stdout)
+        assert result["event"]["commandStep"] == 9
+        assert result["identityKey"] == "atqydvnuutl766na"
+        assert len(result["occurrences"]) == 2
+
+    def test_documented_module_cli_runs_with_backend_autoload_disabled(self):
+        fixture_path = _PROVENANCE_FIXTURE_DIR / "valid_v1.json"
+        env = dict(os.environ)
+        env["TORCH_DEVICE_BACKEND_AUTOLOAD"] = "0"
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "torch_spyre.provenance",
+                f"{self._EVENT_BASE}#9",
+                str(fixture_path),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert completed.returncode == 0, completed.stderr
+        result = json.loads(completed.stdout)
+        assert result["event"]["commandStep"] == 9
+        assert result["identityKey"] == "atqydvnuutl766na"
+
+        help_result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "torch_spyre.provenance",
+                "--help",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert help_result.returncode == 0, help_result.stderr
+        assert (
+            "TORCH_DEVICE_BACKEND_AUTOLOAD=0 python -m torch_spyre.provenance"
+            in help_result.stdout
+        )
 
 
 class TestProvenanceArtifactPublication:

--- a/tests/inductor/test_kernel_provenance.py
+++ b/tests/inductor/test_kernel_provenance.py
@@ -1965,6 +1965,105 @@ class TestProvenanceArtifactPublication:
 
         assert path.read_bytes() == fresh_bytes
 
+    def test_projection_settings_enrich_monotonically_across_levels(self, tmp_path):
+        from torch_spyre._inductor import provenance_writer
+
+        path = tmp_path / "settings-levels.json"
+        collection = _publication_collection(registration_ordinal=1)
+        inactive_handler = LazyTraceHandler(root_dir=None)
+        active_handler = LazyTraceHandler(root_dir=str(tmp_path))
+
+        with (
+            torch._inductor.config.patch("trace.provenance_tracking_level", 0),
+            patch.object(provenance_writer.trace_log, "handlers", [inactive_handler]),
+        ):
+            assert publish_provenance_collection(collection, str(path)) == "written"
+
+        with (
+            torch._inductor.config.patch("trace.provenance_tracking_level", 1),
+            patch.object(provenance_writer.trace_log, "handlers", [active_handler]),
+        ):
+            assert publish_provenance_collection(collection, str(path)) == "written"
+
+        document = json.loads(path.read_text(encoding="utf-8"))
+        projection = document["upstreamProjections"][collection.compile_id]
+        assert projection["settings"] == {
+            "provenanceTrackingLevel": 1,
+            "structuredTracing": True,
+        }
+        assert document["mergeGeneration"] == 2
+        richer_bytes = path.read_bytes()
+
+        with (
+            torch._inductor.config.patch("trace.provenance_tracking_level", 0),
+            patch.object(provenance_writer.trace_log, "handlers", [inactive_handler]),
+        ):
+            assert publish_provenance_collection(collection, str(path)) == "unchanged"
+        assert path.read_bytes() == richer_bytes
+
+    def test_equal_rank_projection_retains_structured_tracing_evidence(self, tmp_path):
+        from torch_spyre._inductor import provenance_writer
+
+        path = tmp_path / "settings-tracing.json"
+        collection = _publication_collection(registration_ordinal=1)
+        inactive_handler = LazyTraceHandler(root_dir=None)
+        active_handler = LazyTraceHandler(root_dir=str(tmp_path))
+
+        with (
+            torch._inductor.config.patch("trace.provenance_tracking_level", 1),
+            patch.object(provenance_writer.trace_log, "handlers", [inactive_handler]),
+        ):
+            assert publish_provenance_collection(collection, str(path)) == "written"
+        with (
+            torch._inductor.config.patch("trace.provenance_tracking_level", 1),
+            patch.object(provenance_writer.trace_log, "handlers", [active_handler]),
+        ):
+            assert publish_provenance_collection(collection, str(path)) == "written"
+
+        document = json.loads(path.read_text(encoding="utf-8"))
+        projection = document["upstreamProjections"][collection.compile_id]
+        assert projection["settings"] == {
+            "provenanceTrackingLevel": 1,
+            "structuredTracing": True,
+        }
+        assert document["mergeGeneration"] == 2
+
+    def test_unavailable_join_reasons_prefer_enabled_cache_replay(self, tmp_path):
+        fresh_level_zero = _publication_collection()
+        cache_level_one = _publication_collection(has_graph_lowering=False)
+        level_zero_first = tmp_path / "level-zero-first.json"
+        cache_first = tmp_path / "cache-first.json"
+
+        with torch._inductor.config.patch("trace.provenance_tracking_level", 0):
+            assert (
+                publish_provenance_collection(fresh_level_zero, str(level_zero_first))
+                == "written"
+            )
+        with torch._inductor.config.patch("trace.provenance_tracking_level", 1):
+            assert (
+                publish_provenance_collection(cache_level_one, str(level_zero_first))
+                == "written"
+            )
+            assert (
+                publish_provenance_collection(cache_level_one, str(cache_first))
+                == "written"
+            )
+        with torch._inductor.config.patch("trace.provenance_tracking_level", 0):
+            assert (
+                publish_provenance_collection(fresh_level_zero, str(cache_first))
+                == "unchanged"
+            )
+
+        first_document = json.loads(level_zero_first.read_text(encoding="utf-8"))
+        second_document = json.loads(cache_first.read_text(encoding="utf-8"))
+        for document in (first_document, second_document):
+            projection = document["upstreamProjections"][cache_level_one.compile_id]
+            assert projection["upstreamJoin"] == "unavailable-cache-replay"
+            assert projection["settings"]["provenanceTrackingLevel"] == 1
+        first_document.pop("mergeGeneration")
+        second_document.pop("mergeGeneration")
+        assert first_document == second_document
+
     def test_multiple_wrappers_coexist_and_diagnostics_are_idempotent(self, tmp_path):
         path = tmp_path / "multi-wrapper.json"
         first = _publication_collection(

--- a/tests/inductor/test_kernel_provenance.py
+++ b/tests/inductor/test_kernel_provenance.py
@@ -879,6 +879,10 @@ class TestProvenanceArtifactCollection:
         graph = _graph_lowering(wrapper_code=wrapper)
         scheduling = object.__new__(SuperDSCScheduling)
         node_schedule = [object()]
+        kernel = types.SimpleNamespace(
+            _kernel_uses_hbm_pool=lambda: False,
+            pool_size=0,
+        )
 
         with (
             V.set_graph_handler(graph),
@@ -895,9 +899,9 @@ class TestProvenanceArtifactCollection:
                 side_effect=(4, 9),
             ) as register,
         ):
-            first_name = scheduling.define_kernel("[]", node_schedule, object())
+            first_name = scheduling.define_kernel("[]", node_schedule, kernel)
             scheduling.codegen_comment(node_schedule, first_name)
-            second_name = scheduling.define_kernel("[]", node_schedule, object())
+            second_name = scheduling.define_kernel("[]", node_schedule, kernel)
             scheduling.codegen_comment(node_schedule, second_name)
 
         registrations = consume_kernel_registration_state(graph).registrations

--- a/tests/inductor/test_kernel_provenance.py
+++ b/tests/inductor/test_kernel_provenance.py
@@ -14,12 +14,20 @@
 
 """Device-free tests for kernel provenance identity and event transport."""
 
+import copy
 import ctypes
 import dataclasses
+import hashlib
+from importlib.resources import files
+import json
+from pathlib import Path
 import types
 from unittest.mock import patch
 
+from jsonschema import ValidationError
+from jsonschema.validators import validator_for
 import pytest
+import regex as re
 
 import torch  # noqa: F401
 from sympy import Integer, Symbol, sympify
@@ -675,3 +683,313 @@ class TestKernelProvenancePropagation:
         assert runner.profiler_event_name is None
         prepare_kernel.assert_called_once_with("/tmp/kernel/spyreCodeDir")
         register_kernel_provenance.assert_not_called()
+
+
+_SCHEMA = json.loads(
+    files("torch_spyre._inductor.schemas")
+    .joinpath("spyre_provenance_v1.schema.json")
+    .read_text(encoding="utf-8")
+)
+_SCHEMA_VALIDATOR_TYPE = validator_for(_SCHEMA)
+_SCHEMA_VALIDATOR_TYPE.check_schema(_SCHEMA)
+_SCHEMA_VALIDATOR = _SCHEMA_VALIDATOR_TYPE(_SCHEMA)
+_PROVENANCE_FIXTURE_DIR = Path(__file__).parent / "fixtures" / "provenance"
+
+
+def _load_provenance_fixture(name: str) -> dict:
+    return json.loads((_PROVENANCE_FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def _canonical_digest(value: object) -> str:
+    payload = json.dumps(
+        value,
+        ensure_ascii=True,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("ascii")).hexdigest()
+
+
+def _fixture_compile_id(projection: dict) -> str:
+    kernels = [
+        [kernel["compilerKernelName"], kernel["identityKey"]]
+        for kernel in projection["kernels"]
+    ]
+    return _canonical_digest(
+        {
+            "domain": "torch-spyre-compile-v1",
+            "kernels": kernels,
+        }
+    )
+
+
+def _fixture_occurrence_id(occurrence: dict) -> str:
+    return _canonical_digest(
+        {
+            "domain": "torch-spyre-occurrence-v1",
+            "compileId": occurrence["compileId"],
+            "compilerKernelName": occurrence["compilerKernelName"],
+            "identityKey": occurrence["identityKey"],
+        }
+    )
+
+
+def _recursive_fixture_atens(handle_ids: list[str], handles: dict) -> list[str]:
+    names: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(handle_id: str) -> None:
+        assert handle_id in handles
+        if handle_id in visited:
+            return
+        visited.add(handle_id)
+        handle = handles[handle_id]
+        if handle["aten_op"] is not None:
+            names.add(handle["aten_op"])
+        for constituent_id in handle["fused_from"]:
+            visit(constituent_id)
+
+    for handle_id in handle_ids:
+        visit(handle_id)
+    return sorted(names)
+
+
+def _deduplicate_in_order(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))
+
+
+def _assert_sorted_keys(mapping: dict) -> None:
+    assert list(mapping) == sorted(mapping)
+
+
+def _validate_fixture_semantics(document: dict) -> None:
+    handles = document["handles"]
+    identities = document["kernelIdentities"]
+    occurrences = document["kernelOccurrences"]
+    projections = document["upstreamProjections"]
+
+    for mapping in (
+        document["diagnostics"],
+        handles,
+        identities,
+        occurrences,
+        projections,
+    ):
+        _assert_sorted_keys(mapping)
+
+    for handle_id, handle in handles.items():
+        assert handle["id"] == handle_id
+        assert all(child_id in handles for child_id in handle["fused_from"])
+
+    for identity_key, identity in identities.items():
+        binding_ids = [
+            binding["handleId"] for binding in identity["specHandleBindings"]
+        ]
+        assert all(handle_id in handles for handle_id in binding_ids)
+        assert identity["directHandleIds"] == _deduplicate_in_order(binding_ids)
+        assert identity["atenOps"] == _recursive_fixture_atens(
+            identity["directHandleIds"], handles
+        )
+        descriptor = KernelProvenanceDescriptor(
+            key=identity_key,
+            debug_handle_ids=tuple(identity["directHandleIds"]),
+            aten_ops=tuple(identity["atenOps"]),
+        )
+        assert (
+            format_kernel_provenance_event_name(descriptor) == identity["eventNameBase"]
+        )
+
+    occurrences_by_compile: dict[str, list[tuple[str, dict]]] = {}
+    for occurrence_id, occurrence in occurrences.items():
+        assert occurrence_id == _fixture_occurrence_id(occurrence)
+        assert occurrence["identityKey"] in identities
+        assert occurrence["compileId"] in projections
+        ordinals = [
+            registration["ordinal"] for registration in occurrence["registrations"]
+        ]
+        assert ordinals == sorted(ordinals)
+        assert len(ordinals) == len(set(ordinals))
+        for registration in occurrence["registrations"]:
+            assert registration["alias"] == (
+                f"{occurrence['compilerKernelName']}:{registration['ordinal']}"
+            )
+        occurrences_by_compile.setdefault(occurrence["compileId"], []).append(
+            (occurrence_id, occurrence)
+        )
+
+    for compile_id, projection in projections.items():
+        assert compile_id == _fixture_compile_id(projection)
+        kernels = [
+            (kernel["compilerKernelName"], kernel["identityKey"])
+            for kernel in projection["kernels"]
+        ]
+        assert len(kernels) == len(set(kernels))
+        assert all(identity_key in identities for _, identity_key in kernels)
+
+        compile_occurrences = occurrences_by_compile.get(compile_id, [])
+        occurrence_kernels = {
+            (
+                occurrence["compilerKernelName"],
+                occurrence["identityKey"],
+            )
+            for _, occurrence in compile_occurrences
+        }
+        assert occurrence_kernels == set(kernels)
+
+        registrations = [
+            registration
+            for _, occurrence in compile_occurrences
+            for registration in occurrence["registrations"]
+        ]
+        ordinals = [registration["ordinal"] for registration in registrations]
+        assert len(ordinals) == len(set(ordinals))
+        registration_aliases = {registration["alias"] for registration in registrations}
+
+        for relation_name in (
+            "preToPost",
+            "postToPre",
+            "cppCodeToPost",
+            "postToCppCode",
+            "kernelStackTraces",
+        ):
+            _assert_sorted_keys(projection[relation_name])
+
+        cpp_to_post = projection["cppCodeToPost"]
+        assert set(cpp_to_post) <= registration_aliases
+        if projection["upstreamJoin"] == "ok":
+            assert set(cpp_to_post) == registration_aliases
+            assert set(projection["kernelStackTraces"]) == registration_aliases
+
+        expected_post_to_cpp: dict[str, list[str]] = {}
+        for alias in sorted(cpp_to_post):
+            for post_node in cpp_to_post[alias]:
+                expected_post_to_cpp.setdefault(post_node, []).append(alias)
+        assert projection["postToCppCode"] == expected_post_to_cpp
+
+        expected_post_to_pre: dict[str, list[str]] = {}
+        for pre_node, post_nodes in projection["preToPost"].items():
+            for post_node in post_nodes:
+                expected_post_to_pre.setdefault(post_node, []).append(pre_node)
+        assert projection["postToPre"] == expected_post_to_pre
+
+    assert set(occurrences_by_compile) == set(projections)
+    expected_status = (
+        "complete"
+        if not document["diagnostics"]
+        and all(
+            projection["upstreamJoin"] == "ok" for projection in projections.values()
+        )
+        else "partial"
+    )
+    assert document["status"] == expected_status
+
+
+def _apply_fixture_mutation(document: dict, mutation: dict) -> dict:
+    mutated = copy.deepcopy(document)
+    tokens = [
+        token.replace("~1", "/").replace("~0", "~")
+        for token in mutation["path"].lstrip("/").split("/")
+    ]
+    parent: object = mutated
+    for token in tokens[:-1]:
+        parent = parent[int(token)] if isinstance(parent, list) else parent[token]
+    final = tokens[-1]
+    if isinstance(parent, list):
+        parent[int(final)] = mutation["value"]
+    else:
+        assert isinstance(parent, dict)
+        parent[final] = mutation["value"]
+    return mutated
+
+
+def _fixture_reader_diagnostic(document: dict) -> str | None:
+    if document.get("schemaVersion") != _SCHEMA["properties"]["schemaVersion"]["const"]:
+        return "unsupported-schema-version"
+    try:
+        _SCHEMA_VALIDATOR.validate(document)
+    except ValidationError:
+        return "schema-validation-failure"
+    try:
+        _validate_fixture_semantics(document)
+    except AssertionError:
+        return "semantic-validation-failure"
+    return None
+
+
+class TestProvenanceArtifactSchema:
+    def test_valid_fixtures_pass_schema_and_semantic_validation(self):
+        manifest = _load_provenance_fixture("fixture_manifest.json")
+
+        for fixture in manifest["valid"]:
+            document = _load_provenance_fixture(fixture["path"])
+            _SCHEMA_VALIDATOR.validate(document)
+            _validate_fixture_semantics(document)
+            assert _fixture_reader_diagnostic(document) is None
+
+    def test_invalid_fixture_mutations_report_declared_reader_diagnostic(self):
+        manifest = _load_provenance_fixture("fixture_manifest.json")
+
+        for fixture in manifest["invalid"]:
+            document = _load_provenance_fixture(fixture["base"])
+            mutated = _apply_fixture_mutation(document, fixture["mutation"])
+            assert (
+                _fixture_reader_diagnostic(mutated)
+                == fixture["expectedReaderDiagnostic"]
+            ), fixture["name"]
+
+    def test_schema_event_contract_matches_production_codec(self):
+        event_key_schema = _SCHEMA["properties"]["eventKey"]["$ref"]
+        assert event_key_schema == "#/$defs/eventKey"
+        assert (
+            _SCHEMA["$defs"]["eventKey"]["properties"]["version"]["const"]
+            == KERNEL_PROVENANCE_KEY_VERSION
+        )
+        assert (
+            _SCHEMA["$defs"]["eventKey"]["properties"]["width"]["const"]
+            == KERNEL_PROVENANCE_KEY_BASE32_WIDTH
+        )
+        assert _SCHEMA["$defs"]["eventKeyValue"]["pattern"] == (
+            rf"^[a-z2-7]{{{KERNEL_PROVENANCE_KEY_BASE32_WIDTH}}}$"
+        )
+
+        document = _load_provenance_fixture("valid_v1.json")
+        event_pattern = _SCHEMA["$defs"]["kernelIdentity"]["properties"][
+            "eventNameBase"
+        ]["pattern"]
+        assert all(
+            re.fullmatch(event_pattern, identity["eventNameBase"])
+            for identity in document["kernelIdentities"].values()
+        )
+
+    def test_cache_replay_reuses_compile_and_occurrence_ids(self):
+        fresh = _load_provenance_fixture("valid_v1.json")
+        cached = _load_provenance_fixture("valid_cache_replay_v1.json")
+        compile_id = "3acd1120e2323fa1fec28f1ff89a59da68cda82541b0a19815ec47a2c922ac0e"
+
+        assert compile_id in fresh["upstreamProjections"]
+        assert compile_id in cached["upstreamProjections"]
+        cached_occurrence_ids = set(cached["kernelOccurrences"])
+        assert cached_occurrence_ids <= set(fresh["kernelOccurrences"])
+        for occurrence_id in cached_occurrence_ids:
+            cached_occurrence = cached["kernelOccurrences"][occurrence_id]
+            fresh_occurrence = fresh["kernelOccurrences"][occurrence_id]
+            assert cached_occurrence["compileId"] == fresh_occurrence["compileId"]
+            assert cached_occurrence["identityKey"] == fresh_occurrence["identityKey"]
+            assert (
+                cached_occurrence["compilerKernelName"]
+                == (fresh_occurrence["compilerKernelName"])
+            )
+            assert cached_occurrence["registrations"] == []
+
+        assert fresh["upstreamProjections"][compile_id]["upstreamJoin"] == "ok"
+        assert cached["upstreamProjections"][compile_id]["upstreamJoin"] == (
+            "unavailable-cache-replay"
+        )
+
+    def test_reserved_occurrence_selector_is_an_opaque_exact_match_token(self):
+        document = _load_provenance_fixture("valid_cache_replay_v1.json")
+        occurrence = next(iter(document["kernelOccurrences"].values()))
+        occurrence["selector"] = "future-event-occurrence-token"
+        _SCHEMA_VALIDATOR.validate(document)
+        _validate_fixture_semantics(document)

--- a/tests/inductor/test_kernel_provenance.py
+++ b/tests/inductor/test_kernel_provenance.py
@@ -40,6 +40,7 @@ from torch_spyre._C import (
     ElementArrangement,
     extract_kernel_provenance_key as extract_kernel_provenance_key_cpp,
 )
+from torch_spyre._inductor import config as spyre_config
 from torch_spyre._inductor.op_spec import (
     DebugHandle,
     IndirectAccess,
@@ -68,10 +69,19 @@ from torch_spyre._inductor.provenance_artifact import (
     ProvenanceCollectionBuilder,
     record_kernel_registration,
 )
+from torch_spyre._inductor.provenance_writer import (
+    ProvenanceArtifactError,
+    publish_provenance_collection,
+    resolve_provenance_artifact_path,
+    validate_provenance_document,
+)
 from torch_spyre._inductor.scheduler import SuperDSCScheduling
 from torch_spyre._inductor.spyre_kernel import _codegen_op_spec_list
 from torch_spyre.execution.async_compile import SpyreAsyncCompile
 from torch_spyre.execution.kernel_runner import SpyreSDSCKernelRunner
+
+
+_DEFAULT_PROVENANCE_ARTIFACT_PATH = spyre_config.provenance_artifact_path
 
 
 def _handle(
@@ -141,6 +151,40 @@ def _registration_state(
         registrations={},
         capture_failed=False,
     )
+
+
+def _publication_collection(
+    *,
+    kernel_name: str = "sdsc_fused_mm_0",
+    handle_id: int = 9,
+    has_graph_lowering: bool = True,
+    registration_ordinal: int | None = None,
+    include_uncollected: bool = False,
+    upstream_projection_failed: bool = False,
+):
+    specs = [_op(_handle(handle_id))]
+    descriptor = build_kernel_provenance_descriptor(specs)
+    kernel = collect_kernel_provenance(kernel_name, specs, descriptor)
+    builder = ProvenanceCollectionBuilder()
+    builder.add_kernel(kernel)
+    if include_uncollected:
+        builder.add_uncollected_kernel(f"{kernel_name}_uncollected")
+
+    if has_graph_lowering:
+        graph = _graph_lowering()
+        if registration_ordinal is not None:
+            record_kernel_registration(graph, kernel_name, registration_ordinal)
+        registration_state = consume_kernel_registration_state(graph)
+    else:
+        assert registration_ordinal is None
+        registration_state = _registration_state(has_graph_lowering=False)
+    if upstream_projection_failed:
+        registration_state = dataclasses.replace(
+            registration_state, capture_failed=True
+        )
+    collection = builder.finish(registration_state)
+    assert collection is not None
+    return collection
 
 
 def _generated_wrapper_roundtrip(specs):
@@ -1275,6 +1319,11 @@ def _validate_fixture_semantics(document: dict) -> None:
         ]
         assert len(kernels) == len(set(kernels))
         assert all(identity_key in identities for _, identity_key in kernels)
+        uncollected_kernels = projection["uncollectedKernels"]
+        assert uncollected_kernels == sorted(set(uncollected_kernels))
+        assert all(uncollected_kernels)
+        assert not set(uncollected_kernels) & {name for name, _ in kernels}
+        assert isinstance(projection["upstreamProjectionFailed"], bool)
 
         compile_occurrences = occurrences_by_compile.get(compile_id, [])
         occurrence_kernels = {
@@ -1323,6 +1372,20 @@ def _validate_fixture_semantics(document: dict) -> None:
         assert projection["postToPre"] == expected_post_to_pre
 
     assert set(occurrences_by_compile) == set(projections)
+    expected_diagnostics = {}
+    collection_failure_count = sum(
+        len(projection["uncollectedKernels"]) for projection in projections.values()
+    )
+    upstream_projection_failure_count = sum(
+        projection["upstreamProjectionFailed"] for projection in projections.values()
+    )
+    if collection_failure_count:
+        expected_diagnostics["collection-failure"] = collection_failure_count
+    if upstream_projection_failure_count:
+        expected_diagnostics["upstream-projection-failure"] = (
+            upstream_projection_failure_count
+        )
+    assert document["diagnostics"] == expected_diagnostics
     expected_status = (
         "complete"
         if not document["diagnostics"]
@@ -1442,3 +1505,388 @@ class TestProvenanceArtifactSchema:
         occurrence["selector"] = "future-event-occurrence-token"
         _SCHEMA_VALIDATOR.validate(document)
         _validate_fixture_semantics(document)
+
+
+class TestProvenanceArtifactPublication:
+    def test_config_default_and_destination_resolution(self, monkeypatch, tmp_path):
+        assert _DEFAULT_PROVENANCE_ARTIFACT_PATH is not None
+        default_path = Path(_DEFAULT_PROVENANCE_ARTIFACT_PATH)
+        assert default_path.is_absolute()
+        assert default_path.name == "spyre_provenance.json"
+        assert default_path.parent.name == "torchinductor"
+        assert "torch_compile_debug" in default_path.parts
+
+        monkeypatch.chdir(tmp_path)
+        assert resolve_provenance_artifact_path("nested.json") == (
+            tmp_path / "nested.json"
+        )
+        assert resolve_provenance_artifact_path(None) is None
+        assert resolve_provenance_artifact_path("") is None
+
+    def test_publication_creates_missing_parent_directory(self, tmp_path):
+        collection = _publication_collection(registration_ordinal=1)
+        path = tmp_path / "run_0" / "torchinductor" / "spyre_provenance.json"
+        assert publish_provenance_collection(collection, str(path)) == "written"
+        assert path.exists()
+
+    def test_first_write_is_deterministic_and_schema_valid(self, tmp_path):
+        collection = _publication_collection(registration_ordinal=1)
+        first_path = tmp_path / "first.json"
+        second_path = tmp_path / "second.json"
+
+        with torch._inductor.config.patch(
+            {
+                "trace.provenance_tracking_level": 1,
+                "trace.enabled": False,
+            }
+        ):
+            assert publish_provenance_collection(collection, str(first_path)) == (
+                "written"
+            )
+            assert publish_provenance_collection(collection, str(second_path)) == (
+                "written"
+            )
+
+        assert first_path.read_bytes() == second_path.read_bytes()
+        document = json.loads(first_path.read_text(encoding="utf-8"))
+        validate_provenance_document(document)
+        _SCHEMA_VALIDATOR.validate(document)
+        assert document["mergeGeneration"] == 1
+        assert document["status"] == "partial"
+        projection = document["upstreamProjections"][collection.compile_id]
+        assert projection["upstreamJoin"] == "partial"
+        assert not projection["settings"]["structuredTracing"]
+
+        original = first_path.read_bytes()
+        with torch._inductor.config.patch(
+            {
+                "trace.provenance_tracking_level": 1,
+                "trace.enabled": False,
+            }
+        ):
+            assert publish_provenance_collection(collection, str(first_path)) == (
+                "unchanged"
+            )
+        assert first_path.read_bytes() == original
+
+    def test_cache_then_fresh_enriches_and_replay_cannot_erase(self, tmp_path):
+        path = tmp_path / "cache-order.json"
+        replay = _publication_collection(has_graph_lowering=False)
+        fresh = _publication_collection(registration_ordinal=1)
+
+        with torch._inductor.config.patch("trace.provenance_tracking_level", 1):
+            assert publish_provenance_collection(replay, str(path)) == "written"
+            cache_document = json.loads(path.read_text(encoding="utf-8"))
+            cache_projection = cache_document["upstreamProjections"][replay.compile_id]
+            assert cache_projection["upstreamJoin"] == "unavailable-cache-replay"
+
+            assert publish_provenance_collection(fresh, str(path)) == "written"
+            fresh_bytes = path.read_bytes()
+            document = json.loads(fresh_bytes)
+            occurrence = next(iter(document["kernelOccurrences"].values()))
+            assert occurrence["registrations"] == [
+                {"alias": "sdsc_fused_mm_0:1", "ordinal": 1}
+            ]
+            assert (
+                document["upstreamProjections"][fresh.compile_id]["upstreamJoin"]
+                == "partial"
+            )
+            assert document["mergeGeneration"] == 2
+
+            assert publish_provenance_collection(replay, str(path)) == "unchanged"
+
+        assert path.read_bytes() == fresh_bytes
+
+    def test_fresh_then_cache_is_a_deterministic_no_op(self, tmp_path):
+        path = tmp_path / "fresh-first.json"
+        fresh = _publication_collection(registration_ordinal=1)
+        replay = _publication_collection(has_graph_lowering=False)
+
+        with torch._inductor.config.patch("trace.provenance_tracking_level", 1):
+            assert publish_provenance_collection(fresh, str(path)) == "written"
+            fresh_bytes = path.read_bytes()
+            assert publish_provenance_collection(replay, str(path)) == "unchanged"
+
+        assert path.read_bytes() == fresh_bytes
+
+    def test_multiple_wrappers_coexist_and_diagnostics_are_idempotent(self, tmp_path):
+        path = tmp_path / "multi-wrapper.json"
+        first = _publication_collection(
+            kernel_name="sdsc_fused_mm_0",
+            handle_id=9,
+            registration_ordinal=1,
+            include_uncollected=True,
+            upstream_projection_failed=True,
+        )
+        second = _publication_collection(
+            kernel_name="sdsc_fused_relu_1",
+            handle_id=10,
+            registration_ordinal=2,
+        )
+
+        with torch._inductor.config.patch("trace.provenance_tracking_level", 1):
+            assert publish_provenance_collection(first, str(path)) == "written"
+            assert publish_provenance_collection(second, str(path)) == "written"
+            before_replay = path.read_bytes()
+            assert publish_provenance_collection(first, str(path)) == "unchanged"
+
+        assert path.read_bytes() == before_replay
+
+        document = json.loads(path.read_text(encoding="utf-8"))
+        validate_provenance_document(document)
+        _SCHEMA_VALIDATOR.validate(document)
+        assert set(document["upstreamProjections"]) == {
+            first.compile_id,
+            second.compile_id,
+        }
+        assert document["diagnostics"] == {
+            "collection-failure": 1,
+            "upstream-projection-failure": 1,
+        }
+        first_projection = document["upstreamProjections"][first.compile_id]
+        assert first_projection["uncollectedKernels"] == ["sdsc_fused_mm_0_uncollected"]
+        assert first_projection["upstreamProjectionFailed"] is True
+        assert document["mergeGeneration"] == 2
+
+    @pytest.mark.parametrize(
+        "case",
+        [
+            "invalid-json",
+            "invalid-utf8",
+            "unsupported-version",
+            "content-conflict",
+        ],
+    )
+    def test_invalid_or_conflicting_existing_file_is_untouched(self, case, tmp_path):
+        path = tmp_path / "existing.json"
+        collection = _publication_collection(registration_ordinal=1)
+        with torch._inductor.config.patch("trace.provenance_tracking_level", 1):
+            publish_provenance_collection(collection, str(path))
+
+        if case == "invalid-json":
+            path.write_bytes(b"{not-json")
+        elif case == "invalid-utf8":
+            path.write_bytes(b"\xff")
+        else:
+            document = json.loads(path.read_text(encoding="utf-8"))
+            if case == "unsupported-version":
+                document["schemaVersion"] = 2
+            else:
+                handle = next(iter(document["handles"].values()))
+                handle["source"]["file"] = "/conflicting/model.py"
+            path.write_text(
+                json.dumps(document, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+        before = path.read_bytes()
+
+        with (
+            torch._inductor.config.patch("trace.provenance_tracking_level", 1),
+            pytest.raises(ProvenanceArtifactError),
+        ):
+            publish_provenance_collection(collection, str(path))
+
+        assert path.read_bytes() == before
+
+    def test_failed_replace_preserves_existing_and_removes_temporary_file(
+        self, tmp_path
+    ):
+        path = tmp_path / "atomic.json"
+        first = _publication_collection(registration_ordinal=1)
+        second = _publication_collection(
+            kernel_name="sdsc_fused_relu_1",
+            handle_id=10,
+            registration_ordinal=2,
+        )
+        with torch._inductor.config.patch("trace.provenance_tracking_level", 1):
+            publish_provenance_collection(first, str(path))
+            before = path.read_bytes()
+            with (
+                patch(
+                    "torch_spyre._inductor.provenance_writer.os.replace",
+                    side_effect=OSError("interrupted"),
+                ),
+                pytest.raises(ProvenanceArtifactError, match="atomic.json"),
+            ):
+                publish_provenance_collection(second, str(path))
+
+        assert path.read_bytes() == before
+        assert list(tmp_path.glob(".atomic.json.*.tmp")) == []
+
+    def test_failed_only_and_disabled_contributions_write_nothing(self, tmp_path):
+        builder = ProvenanceCollectionBuilder()
+        builder.add_uncollected_kernel("sdsc_uncollected_0")
+        collection = builder.finish(_registration_state())
+        assert collection is not None
+        path = tmp_path / "absent.json"
+
+        with pytest.raises(ProvenanceArtifactError, match="without a collected"):
+            publish_provenance_collection(collection, str(path))
+        assert not path.exists()
+        assert publish_provenance_collection(collection, None) == "disabled"
+        assert publish_provenance_collection(collection, "") == "disabled"
+        assert not path.exists()
+
+    def test_wait_publication_failure_preserves_runtime_descriptor(self, tmp_path):
+        specs = [_op(_handle(9))]
+        runner = object()
+        compiler = SpyreAsyncCompile()
+        graph = _graph_lowering()
+        configured_path = tmp_path / "private" / "sidecar.json"
+
+        with (
+            V.set_graph_handler(graph),
+            spyre_config.patch({"provenance_artifact_path": str(configured_path)}),
+            patch(
+                "torch_spyre.execution.async_compile.get_output_dir",
+                return_value="/tmp/kernel",
+            ),
+            patch("torch_spyre.execution.async_compile.generate_bundle"),
+            patch("torch_spyre.execution.async_compile.subprocess.run"),
+            patch(
+                "torch_spyre.execution.async_compile.SpyreSDSCKernelRunner",
+                return_value=runner,
+            ) as runner_type,
+            patch("torch_spyre.execution.async_compile.AsyncCompile.wait"),
+            patch(
+                "torch_spyre.execution.async_compile.publish_provenance_collection",
+                side_effect=ProvenanceArtifactError("failed to write sidecar.json"),
+            ),
+            patch("torch_spyre.execution.async_compile.logger.warning") as warning,
+        ):
+            result = compiler.sdsc("sdsc_fused_mm_0", specs)
+            compiler.wait({})
+
+        descriptor = runner_type.call_args.kwargs["kernel_provenance"]
+        assert result is runner
+        assert descriptor is not None
+        assert compiler._last_provenance_collection is not None
+        assert warning.call_count == 2
+        assert warning.call_args_list[0].args == (
+            "provenance sidecar publication failed for %s; continuing compilation",
+            "sidecar.json",
+        )
+        assert warning.call_args_list[0].kwargs["exc_info"] is True
+        assert warning.call_args_list[1].args == (
+            "provenance sidecar publication incomplete after %d failure(s) "
+            "across %d compiled Spyre kernels",
+            1,
+            1,
+        )
+        assert str(tmp_path) not in repr(warning.call_args_list)
+
+    def test_failed_temp_write_removes_temporary_file(self, tmp_path):
+        from torch_spyre._inductor import provenance_writer
+
+        path = tmp_path / "write-failure.json"
+        collection = _publication_collection(registration_ordinal=1)
+        real_named_temporary_file = provenance_writer.tempfile.NamedTemporaryFile
+
+        def failing_named_temporary_file(*args, **kwargs):
+            temporary = real_named_temporary_file(*args, **kwargs)
+
+            class FailingTemporaryFile:
+                name = temporary.name
+
+                def __enter__(self):
+                    temporary.__enter__()
+                    return self
+
+                def write(self, payload):
+                    raise OSError("interrupted write")
+
+                def __exit__(self, *exc_info):
+                    return temporary.__exit__(*exc_info)
+
+            return FailingTemporaryFile()
+
+        with (
+            torch._inductor.config.patch("trace.provenance_tracking_level", 1),
+            patch(
+                "torch_spyre._inductor.provenance_writer.tempfile.NamedTemporaryFile",
+                side_effect=failing_named_temporary_file,
+            ),
+            pytest.raises(ProvenanceArtifactError, match="write-failure.json"),
+        ):
+            publish_provenance_collection(collection, str(path))
+
+        assert not path.exists()
+        assert list(tmp_path.glob(".write-failure.json.*.tmp")) == []
+
+    def test_disabled_publication_logs_once(self):
+        from torch_spyre.execution import async_compile as async_compile_module
+
+        with (
+            patch.object(
+                async_compile_module,
+                "_publication_disabled_logged",
+                False,
+            ),
+            patch.object(async_compile_module.logger, "debug") as debug,
+        ):
+            async_compile_module._log_publication_disabled_once()
+            async_compile_module._log_publication_disabled_once()
+
+        debug.assert_called_once_with(
+            "Spyre provenance sidecar publication is disabled"
+        )
+
+    def test_level_zero_publication_warns_once_with_enabling_setting(self, tmp_path):
+        from torch_spyre.execution import async_compile as async_compile_module
+
+        path = tmp_path / "level-zero.json"
+        collection = _publication_collection(registration_ordinal=1)
+        compiler = SpyreAsyncCompile()
+        expected_warning = (
+            "Spyre provenance upstream projection is unavailable; set "
+            "torch._inductor.config.trace.provenance_tracking_level=1 "
+            "to enable it"
+        )
+
+        with (
+            spyre_config.patch({"provenance_artifact_path": str(path)}),
+            torch._inductor.config.patch("trace.provenance_tracking_level", 0),
+            patch.object(
+                async_compile_module,
+                "_provenance_level_zero_logged",
+                False,
+            ),
+            patch.object(
+                compiler._artifact_collection_builder,
+                "finish",
+                return_value=collection,
+            ),
+            patch("torch_spyre.execution.async_compile.AsyncCompile.wait"),
+            patch.object(async_compile_module.logger, "warning") as warning,
+        ):
+            compiler.wait({})
+            warning.assert_called_once_with(expected_warning)
+            async_compile_module._log_provenance_level_zero_once()
+            warning.assert_called_once_with(expected_warning)
+
+        document = json.loads(path.read_text(encoding="utf-8"))
+        projection = document["upstreamProjections"][collection.compile_id]
+        assert projection["upstreamJoin"] == "unavailable-provenance-level-0"
+
+    def test_production_validator_rejects_boolean_integer_constants(self, tmp_path):
+        path = tmp_path / "strict-integers.json"
+        collection = _publication_collection(registration_ordinal=1)
+        with torch._inductor.config.patch("trace.provenance_tracking_level", 1):
+            publish_provenance_collection(collection, str(path))
+        document = json.loads(path.read_text(encoding="utf-8"))
+
+        for field_path in (
+            ("schemaVersion",),
+            ("eventKey", "version"),
+            ("eventKey", "width"),
+        ):
+            mutated = copy.deepcopy(document)
+            target = mutated
+            for token in field_path[:-1]:
+                target = target[token]
+            target[field_path[-1]] = True
+
+            with pytest.raises(ProvenanceArtifactError):
+                validate_provenance_document(mutated)
+            with pytest.raises(ValidationError):
+                _SCHEMA_VALIDATOR.validate(mutated)

--- a/tests/inductor/test_kernel_provenance.py
+++ b/tests/inductor/test_kernel_provenance.py
@@ -15,6 +15,7 @@
 """Device-free tests for kernel provenance identity and event transport."""
 
 from concurrent.futures import ThreadPoolExecutor
+import contextlib
 import copy
 import ctypes
 import dataclasses
@@ -1784,6 +1785,33 @@ class TestProvenanceArtifactResolver:
         assert result["status"] == "error"
         assert result["diagnostics"][0]["code"] == "schema-validation-failure"
 
+    def test_malformed_packaged_schema_reference_reports_schema_failure(self):
+        document = _load_provenance_fixture("valid_v1.json")
+        malformed_schema = {"$ref": "#/target", "target": []}
+
+        with patch("torch_spyre.provenance._schema", return_value=malformed_schema):
+            result = resolve_provenance_document(self._EVENT_BASE, document)
+
+        assert result["status"] == "error"
+        assert result["diagnostics"][0]["code"] == "schema-validation-failure"
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            OSError("missing"),
+            UnicodeError("invalid encoding"),
+            ValueError("invalid JSON"),
+        ],
+    )
+    def test_packaged_schema_load_failure_is_structured(self, error):
+        document = _load_provenance_fixture("valid_v1.json")
+
+        with patch("torch_spyre.provenance._schema", side_effect=error):
+            result = resolve_provenance_document(self._EVENT_BASE, document)
+
+        assert result["status"] == "error"
+        assert result["diagnostics"][0]["code"] == "schema-validation-failure"
+
     def test_missing_key_and_collision_are_distinct(self):
         document = _load_provenance_fixture("valid_v1.json")
         missing = resolve_provenance_document(
@@ -2621,17 +2649,26 @@ class TestProvenanceArtifactPublication:
         structured_artifact.assert_not_called()
         assert not path.exists()
 
-    def test_wait_corrupt_sidecar_preserves_runtime_descriptor(self, tmp_path):
+    @pytest.mark.parametrize("failure_mode", ["corrupt-sidecar", "missing-lock"])
+    def test_wait_publication_failure_preserves_runtime_descriptor(
+        self, tmp_path, failure_mode
+    ):
         specs = [_op(_handle(9))]
         runner = object()
         compiler = SpyreAsyncCompile()
         graph = _graph_lowering()
         configured_path = tmp_path / "private" / "sidecar.json"
-        configured_path.parent.mkdir()
-        configured_path.write_text("{not-json", encoding="utf-8")
-        corrupt_bytes = configured_path.read_bytes()
+        if failure_mode == "corrupt-sidecar":
+            configured_path.parent.mkdir()
+            configured_path.write_text("{not-json", encoding="utf-8")
+            original_bytes = configured_path.read_bytes()
+            lock_context = contextlib.nullcontext()
+        else:
+            original_bytes = None
+            lock_context = patch("torch_spyre._inductor.provenance_writer._fcntl", None)
 
         with (
+            lock_context,
             V.set_graph_handler(graph),
             spyre_config.patch({"provenance_artifact_path": str(configured_path)}),
             patch(
@@ -2654,7 +2691,10 @@ class TestProvenanceArtifactPublication:
         assert result is runner
         assert descriptor is not None
         assert compiler._last_provenance_collection is not None
-        assert configured_path.read_bytes() == corrupt_bytes
+        if original_bytes is None:
+            assert not configured_path.exists()
+        else:
+            assert configured_path.read_bytes() == original_bytes
         assert warning.call_count == 2
         assert warning.call_args_list[0].args == (
             "provenance sidecar publication failed for %s; continuing compilation",

--- a/tests/inductor/test_kernel_provenance.py
+++ b/tests/inductor/test_kernel_provenance.py
@@ -2621,12 +2621,15 @@ class TestProvenanceArtifactPublication:
         structured_artifact.assert_not_called()
         assert not path.exists()
 
-    def test_wait_publication_failure_preserves_runtime_descriptor(self, tmp_path):
+    def test_wait_corrupt_sidecar_preserves_runtime_descriptor(self, tmp_path):
         specs = [_op(_handle(9))]
         runner = object()
         compiler = SpyreAsyncCompile()
         graph = _graph_lowering()
         configured_path = tmp_path / "private" / "sidecar.json"
+        configured_path.parent.mkdir()
+        configured_path.write_text("{not-json", encoding="utf-8")
+        corrupt_bytes = configured_path.read_bytes()
 
         with (
             V.set_graph_handler(graph),
@@ -2642,10 +2645,6 @@ class TestProvenanceArtifactPublication:
                 return_value=runner,
             ) as runner_type,
             patch("torch_spyre.execution.async_compile.AsyncCompile.wait"),
-            patch(
-                "torch_spyre.execution.async_compile.publish_provenance_collection",
-                side_effect=ProvenanceArtifactError("failed to write sidecar.json"),
-            ),
             patch("torch_spyre.execution.async_compile.logger.warning") as warning,
         ):
             result = compiler.sdsc("sdsc_fused_mm_0", specs)
@@ -2655,6 +2654,7 @@ class TestProvenanceArtifactPublication:
         assert result is runner
         assert descriptor is not None
         assert compiler._last_provenance_collection is not None
+        assert configured_path.read_bytes() == corrupt_bytes
         assert warning.call_count == 2
         assert warning.call_args_list[0].args == (
             "provenance sidecar publication failed for %s; continuing compilation",

--- a/tests/inductor/test_provenance_integration.py
+++ b/tests/inductor/test_provenance_integration.py
@@ -20,6 +20,7 @@ import os
 
 import pytest
 import torch
+from torch._inductor.utils import fresh_cache
 
 
 def _spyre_available() -> bool:
@@ -63,6 +64,11 @@ class _RichMLP(torch.nn.Module):
 
     def forward(self, x):
         return self.fc2(torch.nn.functional.gelu(self.ln(self.fc1(x))))
+
+
+class _ArtifactModel(torch.nn.Module):
+    def forward(self, x):
+        return torch.relu(x + 1.0)
 
 
 def _assert_handles_survive_real_compile(monkeypatch, model, expect_rewrite):
@@ -196,6 +202,90 @@ def test_handles_survive_real_compile(monkeypatch, model_cls, expect_rewrite):
         assert prov_logger.level == logging.ERROR
     finally:
         prov_logger.setLevel(previous_level)
+
+
+def test_artifact_collection_joins_fresh_aliases_and_survives_cache_replay(
+    monkeypatch,
+):
+    import torch_spyre  # noqa: F401
+
+    from torch._inductor import debug as inductor_debug
+    from torch_spyre.constants import DEVICE_NAME
+    from torch_spyre.execution.async_compile import SpyreAsyncCompile
+
+    collections = []
+    mappings = []
+    registration_calls = []
+    original_wait = SpyreAsyncCompile.wait
+    original_register = inductor_debug.set_kernel_post_grad_provenance_tracing
+
+    def capture_wait(compiler, scope):
+        original_wait(compiler, scope)
+        collections.append(compiler._last_provenance_collection)
+        mappings.append(inductor_debug.dump_inductor_provenance_info())
+
+    def capture_registration(node_schedule, kernel_name, is_extern=False):
+        ordinal = original_register(node_schedule, kernel_name, is_extern)
+        registration_calls.append((kernel_name, ordinal))
+        return ordinal
+
+    monkeypatch.setattr(SpyreAsyncCompile, "wait", capture_wait)
+    monkeypatch.setattr(
+        inductor_debug,
+        "set_kernel_post_grad_provenance_tracing",
+        capture_registration,
+    )
+
+    model = _ArtifactModel().half().to(DEVICE_NAME).eval()
+    x = torch.randn(64, 64, dtype=torch.float16, device=DEVICE_NAME)
+    compiled = torch.compile(model, dynamic=False)
+
+    with torch._inductor.config.patch("trace.provenance_tracking_level", 1):
+        with fresh_cache():
+            with torch.no_grad():
+                compiled(x)
+
+        artifacts = torch.compiler.save_cache_artifacts()
+        assert artifacts is not None
+        artifact_bytes, _ = artifacts
+
+        torch._dynamo.reset()
+        with fresh_cache():
+            torch.compiler.load_cache_artifacts(artifact_bytes)
+            with torch.no_grad():
+                torch.compile(model, dynamic=False)(x)
+
+    assert len(collections) == 2
+    fresh, replay = collections
+    assert fresh is not None
+    assert replay is not None
+    assert fresh.has_graph_lowering
+    assert not replay.has_graph_lowering
+
+    fresh_registrations = [
+        registration
+        for occurrence in fresh.kernel_occurrences.values()
+        for registration in occurrence.registrations
+    ]
+    assert fresh_registrations
+    assert len(registration_calls) == len(fresh_registrations)
+    assert {(kernel_name, ordinal) for kernel_name, ordinal in registration_calls} == {
+        (occurrence.compiler_kernel_name, registration.ordinal)
+        for occurrence in fresh.kernel_occurrences.values()
+        for registration in occurrence.registrations
+    }
+    assert {registration.alias for registration in fresh_registrations} == set(
+        mappings[0]["cppCodeToPost"]
+    )
+
+    assert all(
+        not occurrence.registrations
+        for occurrence in replay.kernel_occurrences.values()
+    )
+    assert replay.compile_id == fresh.compile_id
+    assert replay.handles == fresh.handles
+    assert replay.kernel_identities == fresh.kernel_identities
+    assert replay.kernel_occurrences.keys() == fresh.kernel_occurrences.keys()
 
 
 def test_split_multi_ops_records_history_during_real_compile(monkeypatch):

--- a/tests/inductor/test_provenance_integration.py
+++ b/tests/inductor/test_provenance_integration.py
@@ -206,10 +206,12 @@ def test_handles_survive_real_compile(monkeypatch, model_cls, expect_rewrite):
 
 def test_artifact_collection_joins_fresh_aliases_and_survives_cache_replay(
     monkeypatch,
+    tmp_path,
 ):
     import torch_spyre  # noqa: F401
 
     from torch._inductor import debug as inductor_debug
+    from torch_spyre._inductor import config as spyre_config
     from torch_spyre.constants import DEVICE_NAME
     from torch_spyre.execution.async_compile import SpyreAsyncCompile
 
@@ -239,12 +241,17 @@ def test_artifact_collection_joins_fresh_aliases_and_survives_cache_replay(
     model = _ArtifactModel().half().to(DEVICE_NAME).eval()
     x = torch.randn(64, 64, dtype=torch.float16, device=DEVICE_NAME)
     compiled = torch.compile(model, dynamic=False)
+    sidecar_path = tmp_path / "spyre_provenance.json"
 
-    with torch._inductor.config.patch("trace.provenance_tracking_level", 1):
+    with (
+        spyre_config.patch({"provenance_artifact_path": str(sidecar_path)}),
+        torch._inductor.config.patch("trace.provenance_tracking_level", 1),
+    ):
         with fresh_cache():
             with torch.no_grad():
                 compiled(x)
 
+        fresh_sidecar_bytes = sidecar_path.read_bytes()
         artifacts = torch.compiler.save_cache_artifacts()
         assert artifacts is not None
         artifact_bytes, _ = artifacts
@@ -254,6 +261,8 @@ def test_artifact_collection_joins_fresh_aliases_and_survives_cache_replay(
             torch.compiler.load_cache_artifacts(artifact_bytes)
             with torch.no_grad():
                 torch.compile(model, dynamic=False)(x)
+
+    assert sidecar_path.read_bytes() == fresh_sidecar_bytes
 
     assert len(collections) == 2
     fresh, replay = collections

--- a/tests/inductor/test_provenance_integration.py
+++ b/tests/inductor/test_provenance_integration.py
@@ -72,6 +72,67 @@ class _ArtifactModel(torch.nn.Module):
         return torch.relu(x + 1.0)
 
 
+class _GraphBreakArtifactModel(torch.nn.Module):
+    def forward(self, x):
+        y = torch.relu(x + 1.0)
+        torch._dynamo.graph_break()
+        return torch.relu(y + 1.0)
+
+
+class _EquivalentGraphBreakArtifactModel(torch.nn.Module):
+    def _segment(self, x):
+        return torch.relu(x + 1.0)
+
+    def forward(self, x):
+        y = self._segment(x)
+        torch._dynamo.graph_break()
+        return self._segment(y)
+
+
+def _compile_lifecycle_shapes(monkeypatch, tmp_path, model, shapes):
+    import torch_spyre  # noqa: F401
+
+    from torch_spyre._inductor import config as spyre_config
+    from torch_spyre.constants import DEVICE_NAME
+    from torch_spyre.execution.async_compile import SpyreAsyncCompile
+
+    collections = []
+    original_wait = SpyreAsyncCompile.wait
+
+    def capture_wait(compiler, scope):
+        original_wait(compiler, scope)
+        collections.append(compiler._last_provenance_collection)
+
+    monkeypatch.setattr(SpyreAsyncCompile, "wait", capture_wait)
+    monkeypatch.setattr(torch._inductor.config, "force_disable_caches", True)
+    torch._dynamo.reset()
+
+    path = tmp_path / "spyre_provenance.json"
+    compiled = torch.compile(model.half().to(DEVICE_NAME).eval(), dynamic=False)
+    outputs = []
+    try:
+        with (
+            spyre_config.patch({"provenance_artifact_path": str(path)}),
+            torch._inductor.config.patch("trace.provenance_tracking_level", 1),
+            fresh_cache(),
+            torch.no_grad(),
+        ):
+            for shape in shapes:
+                outputs.append(
+                    compiled(
+                        torch.randn(
+                            *shape,
+                            dtype=torch.float16,
+                            device=DEVICE_NAME,
+                        )
+                    )
+                )
+    finally:
+        torch._dynamo.reset()
+
+    return collections, json.loads(path.read_text(encoding="utf-8")), path, outputs
+
+
 def _assert_handles_survive_real_compile(monkeypatch, model, expect_rewrite):
     """Compile ``model`` on-device and assert the provenance invariants.
 
@@ -205,10 +266,116 @@ def test_handles_survive_real_compile(monkeypatch, model_cls, expect_rewrite):
         prov_logger.setLevel(previous_level)
 
 
+def test_graph_break_merges_distinct_source_segments(monkeypatch, tmp_path):
+    from torch_spyre.provenance import resolve_provenance_event
+
+    collections, document, path, outputs = _compile_lifecycle_shapes(
+        monkeypatch,
+        tmp_path,
+        _GraphBreakArtifactModel(),
+        [(64, 64)],
+    )
+
+    assert [tuple(output.shape) for output in outputs] == [(64, 64)]
+    assert len(collections) == 2
+    assert all(collection is not None for collection in collections)
+    compile_ids = {
+        collection.compile_id for collection in collections if collection is not None
+    }
+    assert len(compile_ids) == 2
+    assert set(document["upstreamProjections"]) == compile_ids
+    assert len(document["kernelIdentities"]) == 2
+    assert len(document["kernelOccurrences"]) == 2
+    assert document["mergeGeneration"] == 2
+    assert document["status"] == "complete"
+
+    for identity in document["kernelIdentities"].values():
+        resolved = resolve_provenance_event(identity["eventNameBase"], path)
+        assert resolved["status"] == "complete"
+        assert len(resolved["occurrences"]) == 1
+
+
+def test_graph_break_equivalent_source_segments_merge_context(
+    monkeypatch, tmp_path, caplog
+):
+    from torch_spyre.provenance import resolve_provenance_event
+
+    caplog.set_level(logging.WARNING)
+    collections, document, path, outputs = _compile_lifecycle_shapes(
+        monkeypatch,
+        tmp_path,
+        _EquivalentGraphBreakArtifactModel(),
+        [(64, 64)],
+    )
+
+    assert [tuple(output.shape) for output in outputs] == [(64, 64)]
+    assert not any(
+        "provenance sidecar publication" in record.getMessage()
+        for record in caplog.records
+    )
+
+    assert len(collections) == 2
+    assert all(collection is not None for collection in collections)
+    compile_ids = {
+        collection.compile_id for collection in collections if collection is not None
+    }
+    assert len(compile_ids) == 1
+    assert set(document["upstreamProjections"]) == compile_ids
+    assert len(document["kernelIdentities"]) == 1
+    assert len(document["kernelOccurrences"]) == 1
+    assert document["mergeGeneration"] == 2
+    assert document["status"] == "complete"
+    projection = next(iter(document["upstreamProjections"].values()))
+    stack_context = next(iter(projection["kernelStackTraces"].values()))
+    stack_traces = stack_context["stackTraces"]
+    assert any("y = self._segment(x)" in trace for trace in stack_traces)
+    assert any("return self._segment(y)" in trace for trace in stack_traces)
+    assert projection["upstreamProjectionFailed"] is False
+    assert document["diagnostics"] == {}
+
+    identity = next(iter(document["kernelIdentities"].values()))
+    resolved = resolve_provenance_event(identity["eventNameBase"], path)
+    assert resolved["status"] == "complete"
+    assert len(resolved["occurrences"]) == 1
+
+
+def test_shape_recompile_merges_distinct_compiles(monkeypatch, tmp_path):
+    from torch_spyre.provenance import resolve_provenance_event
+
+    collections, document, path, outputs = _compile_lifecycle_shapes(
+        monkeypatch,
+        tmp_path,
+        _ArtifactModel(),
+        [(64, 64), (128, 64)],
+    )
+
+    assert [tuple(output.shape) for output in outputs] == [
+        (64, 64),
+        (128, 64),
+    ]
+    assert len(collections) == 2
+    assert all(collection is not None for collection in collections)
+    compile_ids = {
+        collection.compile_id for collection in collections if collection is not None
+    }
+    assert len(compile_ids) == 2
+    assert set(document["upstreamProjections"]) == compile_ids
+    assert len(document["kernelIdentities"]) == 2
+    assert len(document["kernelOccurrences"]) == 2
+    assert document["mergeGeneration"] == 2
+    assert document["status"] == "complete"
+
+    for identity in document["kernelIdentities"].values():
+        resolved = resolve_provenance_event(identity["eventNameBase"], path)
+        assert resolved["status"] == "complete"
+        assert len(resolved["occurrences"]) == 1
+
+
 def test_artifact_collection_joins_fresh_aliases_and_survives_cache_replay(
     monkeypatch,
     tmp_path,
 ):
+    torch._dynamo.reset()
     monkeypatch.delenv("TORCH_TRACE", raising=False)
     import torch_spyre  # noqa: F401
 

--- a/tests/inductor/test_provenance_integration.py
+++ b/tests/inductor/test_provenance_integration.py
@@ -14,6 +14,7 @@
 
 """Device integration test: provenance survives a real Spyre compile end-to-end."""
 
+import json
 import logging
 import logging.handlers
 import os
@@ -208,6 +209,7 @@ def test_artifact_collection_joins_fresh_aliases_and_survives_cache_replay(
     monkeypatch,
     tmp_path,
 ):
+    monkeypatch.delenv("TORCH_TRACE", raising=False)
     import torch_spyre  # noqa: F401
 
     from torch._inductor import debug as inductor_debug
@@ -285,6 +287,40 @@ def test_artifact_collection_joins_fresh_aliases_and_survives_cache_replay(
     }
     assert {registration.alias for registration in fresh_registrations} == set(
         mappings[0]["cppCodeToPost"]
+    )
+    registration_aliases = {registration.alias for registration in fresh_registrations}
+    sidecar = json.loads(fresh_sidecar_bytes)
+    assert sidecar["status"] == "complete"
+    assert sidecar["diagnostics"] == {}
+    projection = sidecar["upstreamProjections"][fresh.compile_id]
+    assert projection["upstreamJoin"] == "ok"
+    assert set(projection["cppCodeToPost"]) == registration_aliases
+    assert projection["cppCodeToPost"] == {
+        alias: mappings[0]["cppCodeToPost"][alias]
+        for alias in sorted(registration_aliases)
+    }
+    reachable_post_nodes = {
+        post_node
+        for post_nodes in projection["cppCodeToPost"].values()
+        for post_node in post_nodes
+    }
+    assert projection["postToPre"] == {
+        post_node: mappings[0]["postToPre"][post_node]
+        for post_node in sorted(reachable_post_nodes)
+    }
+    assert set(projection["kernelStackTraces"]) == registration_aliases
+    assert all(
+        context["postGradNodes"] == projection["cppCodeToPost"][alias]
+        for alias, context in projection["kernelStackTraces"].items()
+    )
+
+    from torch_spyre._inductor.profiler_event import (
+        extract_kernel_provenance_key,
+    )
+
+    assert all(
+        extract_kernel_provenance_key(identity["eventNameBase"]) == identity_key
+        for identity_key, identity in sidecar["kernelIdentities"].items()
     )
 
     assert all(

--- a/tests/inductor/test_provenance_viewer.py
+++ b/tests/inductor/test_provenance_viewer.py
@@ -292,6 +292,8 @@ class TestPresentationModel:
         assert first["inputs"]["kinetoTrace"]["status"] == "omitted"
         assert first["runSummary"] == {
             "resolvedObservations": 0,
+            "displayedObservations": 0,
+            "omittedResolvedObservations": 0,
             "unresolvedObservations": 0,
         }
 
@@ -302,6 +304,32 @@ class TestPresentationModel:
             build_provenance_presentation(_SIDECAR)
 
         assert error.value.code == "input-size-limit"
+
+    def test_panel_rows_are_deterministically_capped(self, monkeypatch):
+        monkeypatch.setattr(viewer, "_MAX_PANEL_ROWS", 1)
+
+        presentation = build_provenance_presentation(_SIDECAR)
+        panels = _panels(presentation)
+
+        assert presentation["status"] == "partial"
+        assert panels["source"]["totalRowCount"] == 2
+        assert panels["source"]["displayedRowCount"] == 1
+        assert panels["source"]["omittedRowCount"] == 1
+        assert panels["source"]["rows"][0]["label"] == ("/workspace/model.py:17:0")
+        assert "showing 1 of 2 rows" in panels["source"]["summary"]
+        diagnostics = [
+            item
+            for item in presentation["diagnostics"]
+            if item["code"] == "panel-rows-truncated"
+        ]
+        assert {item["details"]["panelId"] for item in diagnostics} == {
+            "source",
+            "aten",
+            "pre-grad",
+            "post-grad",
+            "lower-ir",
+            "opspec",
+        }
 
 
 class TestKinetoPairing:
@@ -386,6 +414,44 @@ class TestKinetoPairing:
         }
         assert _identity(presentation)["directHandleIds"] == ["200"]
 
+    def test_runtime_occurrences_are_deterministically_capped(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        monkeypatch.setattr(viewer, "_MAX_RUNTIME_OCCURRENCES", 1)
+        trace = tmp_path / "trace.json"
+        _write_trace(trace)
+
+        presentation = build_provenance_presentation(
+            _SIDECAR,
+            kineto_trace=trace,
+        )
+
+        event = next(
+            item
+            for item in presentation["events"]
+            if item["identityKey"] == _IDENTITY_KEY
+        )
+        assert [item["traceEventIndex"] for item in event["observations"]] == [0]
+        assert event["observationCount"] == 2
+        assert event["displayedObservationCount"] == 1
+        assert event["omittedObservationCount"] == 1
+        assert presentation["runSummary"] == {
+            "resolvedObservations": 2,
+            "displayedObservations": 1,
+            "omittedResolvedObservations": 1,
+            "unresolvedObservations": 0,
+        }
+        assert (
+            presentation["inputs"]["kinetoTrace"]["pairing"]["resolvedObservations"]
+            == 2
+        )
+        assert "runtime-occurrences-truncated" in {
+            item["code"] for item in presentation["diagnostics"]
+        }
+        assert presentation["status"] == "partial"
+
 
 class TestHtmlAndCli:
     def test_html_contains_only_viewer_interface(self):
@@ -410,13 +476,23 @@ class TestHtmlAndCli:
     def test_json_payload_is_script_safe(self):
         presentation = build_provenance_presentation(_SIDECAR)
         presentation["diagnostics"].append(
-            {"code": "test", "severity": "warning", "message": "</script>&"}
+            {
+                "code": "test",
+                "severity": "warning",
+                "message": "</script>&<!--\u2028",
+            }
         )
 
         html = render_provenance_html(presentation)
 
-        assert "</script>&" not in html
-        assert "\\u003c/script\\u003e\\u0026" in html
+        assert "</script>&<!--\u2028" not in html
+        assert "\\u003c/script\\u003e\\u0026\\u003c!--\\u2028" in html
+        assert "innerHTML" not in html
+        assert "document.write" not in html
+        assert "eval(" not in html
+        assert "<script src=" not in html
+        assert "<link " not in html
+        assert "url(" not in html
 
     def test_atomic_writer_replaces_output(self, tmp_path):
         output = tmp_path / "viewer.html"

--- a/tests/inductor/test_provenance_viewer.py
+++ b/tests/inductor/test_provenance_viewer.py
@@ -1,0 +1,511 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Device-free tests for the Spyre provenance viewer."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+import torch_spyre.provenance as provenance
+import torch_spyre.provenance_viewer as viewer
+from torch_spyre.provenance import (
+    load_provenance_document,
+    ProvenanceReaderError,
+)
+from torch_spyre.provenance_viewer import (
+    build_provenance_presentation,
+    render_provenance_html,
+    write_provenance_html,
+)
+
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures" / "provenance"
+_SIDECAR = _FIXTURE_DIR / "valid_v1.json"
+_DOM_CHECK = _FIXTURE_DIR / "viewer_dom_check.js"
+_IDENTITY_KEY = "atqydvnuutl766na"
+_EVENT_BASE = "spyre_kernel_v1_fused_linear_relu_atqydvnuutl766na"
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_trace(path: Path) -> None:
+    _write_json(
+        path,
+        {
+            "traceEvents": [
+                {
+                    "name": _EVENT_BASE + "#2",
+                    "ph": "X",
+                    "ts": 100.0,
+                    "dur": 10.5,
+                    "pid": 3,
+                    "tid": 4,
+                    "args": {
+                        "provenance_key": _IDENTITY_KEY,
+                        "debug_handles": ["200"],
+                        "correlation": 101,
+                        "stream": 1,
+                    },
+                },
+                {
+                    "name": _EVENT_BASE + "#3",
+                    "ph": "X",
+                    "ts": 120.0,
+                    "dur": 11.5,
+                    "pid": 3,
+                    "tid": 4,
+                    "args": {"correlation": 102},
+                },
+                {"name": "unrelated_cpu_activity", "ph": "X"},
+            ]
+        },
+    )
+
+
+def _identity(presentation: dict) -> dict:
+    return presentation["identities"][_IDENTITY_KEY]
+
+
+def _panels(presentation: dict) -> dict[str, dict]:
+    return {panel["id"]: panel for panel in _identity(presentation)["panels"]}
+
+
+class TestValidatedSidecarLoader:
+    def test_loads_and_validates_once(self, monkeypatch):
+        calls = 0
+        original = provenance._validate_document
+
+        def counted(document):
+            nonlocal calls
+            calls += 1
+            return original(document)
+
+        monkeypatch.setattr(provenance, "_validate_document", counted)
+
+        document = load_provenance_document(_SIDECAR)
+
+        assert calls == 1
+        assert document["schemaVersion"] == 1
+        assert _IDENTITY_KEY in document["kernelIdentities"]
+
+    @pytest.mark.parametrize(
+        ("contents", "code"),
+        [
+            ("{", "schema-validation-failure"),
+            ("[]", "schema-validation-failure"),
+            ('{"schemaVersion":99}', "unsupported-schema-version"),
+        ],
+    )
+    def test_rejects_invalid_documents(self, tmp_path, contents, code):
+        path = tmp_path / "invalid.json"
+        path.write_text(contents, encoding="utf-8")
+
+        with pytest.raises(ProvenanceReaderError) as error:
+            load_provenance_document(path)
+
+        assert error.value.code == code
+
+
+class TestPresentationModel:
+    def test_deduplicates_source_and_aten_without_losing_multiplicity(self):
+        source = {
+            "file": "/workspace/model.py",
+            "start_line": 17,
+            "start_col": 0,
+            "end_line": None,
+            "end_col": None,
+        }
+        handles = {
+            "1": {"source": source, "aten_op": "aten.add.Tensor"},
+            "2": {"source": source, "aten_op": "aten.add.Tensor"},
+        }
+
+        source_rows = viewer._source_rows(handles)
+        aten_rows = viewer._aten_rows(handles)
+
+        assert len(source_rows) == len(aten_rows) == 1
+        assert source_rows[0]["summary"] == "2 contributing handles"
+        assert aten_rows[0]["summary"] == "2 contributing handles"
+        assert source_rows[0]["refs"]["handleIds"] == ["1", "2"]
+        assert aten_rows[0]["refs"]["handleIds"] == ["1", "2"]
+
+    def test_builds_six_uniform_panel_collections(self):
+        presentation = build_provenance_presentation(_SIDECAR)
+        panels = _panels(presentation)
+
+        assert presentation["presentationVersion"] == 1
+        assert list(panels) == [
+            "source",
+            "aten",
+            "pre-grad",
+            "post-grad",
+            "lower-ir",
+            "opspec",
+        ]
+        assert [len(panel["rows"]) for panel in panels.values()] == [
+            2,
+            2,
+            2,
+            4,
+            3,
+            2,
+        ]
+        assert {row["label"] for row in panels["source"]["rows"]} == {
+            "/workspace/model.py:17:0",
+            "/workspace/model.py:18:0",
+        }
+        assert {row["label"] for row in panels["aten"]["rows"]} == {
+            "aten.linear.default",
+            "aten.relu.default",
+        }
+        assert {row["label"] for row in panels["pre-grad"]["rows"]} == {
+            "linear",
+            "relu",
+        }
+        assert {row["label"] for row in panels["post-grad"]["rows"]} == {
+            "add",
+            "mm",
+            "permute",
+            "relu",
+        }
+
+    def test_equal_fx_names_in_different_compiles_stay_scoped(self):
+        occurrences = [
+            {
+                "compileId": compile_id,
+                "occurrenceId": f"occurrence-{compile_id}",
+                "registrations": [{"alias": "same_alias"}],
+            }
+            for compile_id in ("compile-a", "compile-b")
+        ]
+        projections = {
+            compile_id: {
+                "cppCodeToPost": {"same_alias": ["same_post"]},
+                "postToPre": {"same_post": ["same_pre"]},
+            }
+            for compile_id in ("compile-a", "compile-b")
+        }
+
+        post_rows, pre_rows = viewer._fx_rows(
+            occurrences,
+            projections,
+            {"1": {"ir_chain": []}},
+            {"1": ["1"]},
+            "ambiguous",
+        )
+
+        assert [row["label"] for row in post_rows] == ["same_post", "same_post"]
+        assert [row["label"] for row in pre_rows] == ["same_pre", "same_pre"]
+        assert len({row["id"] for row in post_rows}) == 2
+        assert len({tuple(row["refs"]["postNodes"]) for row in post_rows}) == 2
+        assert len({tuple(row["refs"]["preNodes"]) for row in pre_rows}) == 2
+
+    def test_opspec_panel_contains_only_binding_granularity(self):
+        panel = _panels(build_provenance_presentation(_SIDECAR))["opspec"]
+
+        assert [row["label"] for row in panel["rows"]] == [
+            "SpecPath [0]",
+            "SpecPath [1, 0]",
+        ]
+        assert all(row["id"].startswith("opspec:") for row in panel["rows"])
+        assert panel["scopeDetails"] == []
+        serialized_rows = json.dumps(panel["rows"])
+        assert "Finalized bundle" not in serialized_rows
+        assert "Compile candidate" not in serialized_rows
+        assert "sdsc_fused_linear_relu" not in serialized_rows
+        assert "kernel" not in panel["description"].lower()
+        assert "alias" not in panel["description"].lower()
+        assert [row["summary"] for row in panel["rows"]] == [
+            "Binding 0 | Handle 200",
+            "Binding 1 | Handle 200",
+        ]
+
+    def test_lower_ir_keeps_complete_lineage_in_one_handle_row(self):
+        panel = _panels(build_provenance_presentation(_SIDECAR))["lower-ir"]
+        fused = next(row for row in panel["rows"] if row["label"] == "Handle 200")
+
+        assert "IR: linear -> relu -> buf0" in fused["summary"]
+        assert "Transforms: fusion by fuse_linear_relu" in fused["summary"]
+
+    def test_evidence_strength_and_candidate_state_are_orthogonal(self):
+        panels = _panels(build_provenance_presentation(_SIDECAR))
+
+        assert {
+            (row["evidenceStrength"], row["candidateState"])
+            for row in panels["source"]["rows"]
+        } == {("exact", "unique")}
+        assert {row["candidateState"] for row in panels["post-grad"]["rows"]} == {
+            "ambiguous"
+        }
+        assert any(
+            row["evidenceStrength"] == "derived" for row in panels["post-grad"]["rows"]
+        )
+        assert all(
+            row["evidenceStrength"] == "derived" for row in panels["pre-grad"]["rows"]
+        )
+
+    def test_rows_use_only_declared_typed_relationships(self):
+        panels = _panels(build_provenance_presentation(_SIDECAR))
+        expected = {"compileAliases", "handleIds", "postNodes", "preNodes"}
+
+        for panel in panels.values():
+            assert panel["description"]
+            for row in panel["rows"]:
+                assert "explanation" not in row
+                assert set(row["refs"]) == expected
+                assert all(
+                    values == sorted(set(values)) for values in row["refs"].values()
+                )
+        first_binding = panels["opspec"]["rows"][0]
+        assert first_binding["refs"]["handleIds"] == ["101", "102", "200"]
+
+    def test_sidecar_only_mode_is_deterministic(self):
+        first = build_provenance_presentation(_SIDECAR)
+        second = build_provenance_presentation(_SIDECAR)
+
+        assert first == second
+        assert render_provenance_html(first) == render_provenance_html(second)
+        assert first["inputs"]["kinetoTrace"]["status"] == "omitted"
+        assert first["runSummary"] == {
+            "resolvedObservations": 0,
+            "unresolvedObservations": 0,
+        }
+
+    def test_sidecar_size_limit_fails_before_loading(self, monkeypatch):
+        monkeypatch.setattr(viewer, "_MAX_SIDECAR_BYTES", _SIDECAR.stat().st_size - 1)
+
+        with pytest.raises(ValueError) as error:
+            build_provenance_presentation(_SIDECAR)
+
+        assert error.value.code == "input-size-limit"
+
+
+class TestKinetoPairing:
+    def test_retains_individual_runtime_observations(self, tmp_path):
+        trace = tmp_path / "trace.json"
+        _write_trace(trace)
+
+        presentation = build_provenance_presentation(
+            _SIDECAR,
+            kineto_trace=trace,
+        )
+
+        event = next(
+            item
+            for item in presentation["events"]
+            if item["identityKey"] == _IDENTITY_KEY
+        )
+        observations = event["observations"]
+        assert [item["traceEventIndex"] for item in observations] == [0, 1]
+        assert [item["commandStep"] for item in observations] == [2, 3]
+        assert [item["durationUs"] for item in observations] == [10.5, 11.5]
+        assert [item["keySource"] for item in observations] == [
+            "both",
+            "event-name",
+        ]
+        assert observations[0]["nativeDirectHandleIds"] == ["200"]
+        assert presentation["inputs"]["kinetoTrace"]["pairing"] == {
+            "candidateObservations": 2,
+            "resolutionRate": 1.0,
+            "resolvedObservations": 2,
+            "status": "complete",
+            "unresolvedObservations": 0,
+        }
+
+    def test_carrier_conflict_is_unresolved_and_loud(self, tmp_path):
+        trace = tmp_path / "trace.json"
+        _write_trace(trace)
+        value = json.loads(trace.read_text(encoding="utf-8"))
+        value["traceEvents"][0]["args"]["provenance_key"] = "aaaaaaaaaaaaaaaa"
+        _write_json(trace, value)
+
+        presentation = build_provenance_presentation(
+            _SIDECAR,
+            kineto_trace=trace,
+        )
+
+        assert presentation["status"] == "error"
+        assert presentation["runSummary"]["unresolvedObservations"] == 1
+        assert presentation["inputs"]["kinetoTrace"]["pairing"]["status"] == "error"
+        assert "carrier-conflict" in {
+            diagnostic["code"] for diagnostic in presentation["diagnostics"]
+        }
+
+    def test_malformed_optional_trace_fails_open(self, tmp_path):
+        trace = tmp_path / "trace.json"
+        trace.write_text("{", encoding="utf-8")
+
+        presentation = build_provenance_presentation(
+            _SIDECAR,
+            kineto_trace=trace,
+        )
+
+        assert presentation["status"] == "partial"
+        assert presentation["inputs"]["kinetoTrace"]["status"] == "unavailable"
+        assert presentation["events"]
+
+    def test_native_handle_disagreement_does_not_replace_sidecar(self, tmp_path):
+        trace = tmp_path / "trace.json"
+        _write_trace(trace)
+        value = json.loads(trace.read_text(encoding="utf-8"))
+        value["traceEvents"][0]["args"]["debug_handles"] = ["101"]
+        _write_json(trace, value)
+
+        presentation = build_provenance_presentation(
+            _SIDECAR,
+            kineto_trace=trace,
+        )
+
+        assert presentation["runSummary"]["resolvedObservations"] == 2
+        assert "native-handle-disagreement" in {
+            diagnostic["code"] for diagnostic in presentation["diagnostics"]
+        }
+        assert _identity(presentation)["directHandleIds"] == ["200"]
+
+
+class TestHtmlAndCli:
+    def test_html_contains_only_viewer_interface(self):
+        html = render_provenance_html(build_provenance_presentation(_SIDECAR))
+
+        assert 'id="event-select"' in html
+        assert 'id="observation-select"' in html
+        assert "Python source locations" in html
+        assert "Direct OpSpec bindings" in html
+        assert "Advanced event lookup" not in html
+        assert "Raw compiler text" not in html
+        assert "Show complete attribution" not in html
+        assert "compile-select" not in html
+        assert "search-input" not in html
+        assert "Selected runtime activity" not in html
+        assert "--selection: #defbe6" in html
+        assert "background: var(--selection)" in html
+        assert "#0f62fe" not in html
+        assert "#fff1b8" not in html
+        assert "typed rewrite edges are unavailable" not in html.lower()
+
+    def test_json_payload_is_script_safe(self):
+        presentation = build_provenance_presentation(_SIDECAR)
+        presentation["diagnostics"].append(
+            {"code": "test", "severity": "warning", "message": "</script>&"}
+        )
+
+        html = render_provenance_html(presentation)
+
+        assert "</script>&" not in html
+        assert "\\u003c/script\\u003e\\u0026" in html
+
+    def test_atomic_writer_replaces_output(self, tmp_path):
+        output = tmp_path / "viewer.html"
+        output.write_text("old", encoding="utf-8")
+        presentation = build_provenance_presentation(_SIDECAR)
+
+        write_provenance_html(presentation, output)
+
+        assert output.read_text(encoding="utf-8").startswith("<!doctype html>")
+        assert not list(tmp_path.glob(".viewer.html.*.tmp"))
+
+    def test_documented_module_cli(self, tmp_path):
+        output = tmp_path / "viewer.html"
+        env = dict(os.environ)
+        env["TORCH_DEVICE_BACKEND_AUTOLOAD"] = "0"
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "torch_spyre.provenance_viewer",
+                str(_SIDECAR),
+                "--output",
+                str(output),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert completed.returncode == 0, completed.stderr
+        assert output.is_file()
+        help_result = subprocess.run(
+            [sys.executable, "-m", "torch_spyre.provenance_viewer", "--help"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert help_result.returncode == 0
+        assert "--kineto-trace" in help_result.stdout
+        assert "--compiler-artifacts" not in help_result.stdout
+
+    def test_dom_interaction_gate(self, tmp_path):
+        require_dom_gate = os.environ.get("SPYRE_REQUIRE_DOM_GATE") == "1"
+        node = shutil.which("node")
+        if node is None:
+            if require_dom_gate:
+                pytest.fail("SPYRE_REQUIRE_DOM_GATE=1 but Node.js is unavailable")
+            pytest.skip("Node.js is unavailable")
+        probe = subprocess.run(
+            [
+                node,
+                "-e",
+                (
+                    'const version = require("jsdom/package.json").version;'
+                    'process.exit(version.startsWith("30.") ? 0 : 2);'
+                ),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if probe.returncode != 0:
+            message = (
+                "jsdom 30 is unavailable; run "
+                "'npm install --prefix /tmp/phase4a-jsdom --no-save "
+                "jsdom@30.0.1' and set "
+                "NODE_PATH=/tmp/phase4a-jsdom/node_modules"
+            )
+            if require_dom_gate:
+                pytest.fail(f"SPYRE_REQUIRE_DOM_GATE=1 but {message}")
+            pytest.skip(message)
+
+        trace = tmp_path / "trace.json"
+        output = tmp_path / "viewer.html"
+        _write_trace(trace)
+        write_provenance_html(
+            build_provenance_presentation(_SIDECAR, kineto_trace=trace),
+            output,
+        )
+
+        completed = subprocess.run(
+            [node, str(_DOM_CHECK), str(output)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert completed.returncode == 0, completed.stderr
+        assert "Spyre provenance viewer DOM check passed" in completed.stdout

--- a/tests/profiler/test_ffdc.py
+++ b/tests/profiler/test_ffdc.py
@@ -921,6 +921,25 @@ class TestFfdcAsyncCompile:
             "torch_spyre._inductor.kernel_provenance",
             build_kernel_provenance_descriptor=lambda specs: None,
         )
+
+        class _ProvenanceCollectionBuilder:
+            def add_uncollected_kernel(self, _kernel_name):
+                pass
+
+        _stub_module(
+            monkeypatch,
+            "torch_spyre._inductor.provenance_artifact",
+            CollectedProvenance=object,
+            ProvenanceCollectionBuilder=_ProvenanceCollectionBuilder,
+            collect_kernel_provenance=lambda *args, **kwargs: None,
+            consume_kernel_registration_state=lambda graph: None,
+        )
+        _stub_module(
+            monkeypatch,
+            "torch_spyre._inductor.provenance_writer",
+            capture_upstream_projection=lambda collection: None,
+            publish_provenance_collection=lambda *args, **kwargs: "disabled",
+        )
         codegen = _stub_module(monkeypatch, "torch_spyre._inductor.codegen")
         codegen.__path__ = []
         _stub_module(

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -16,6 +16,7 @@ import os
 import sys
 from typing import Literal
 
+from torch._dynamo.utils import get_debug_dir
 from torch.utils._config_module import install_config_module
 from .logging_utils import _get_env_bool
 
@@ -171,5 +172,15 @@ validate_op_specs: bool = os.environ.get("SPYRE_VALIDATE_OP_SPECS", "1") == "1"
 # to force the pure-Python packer. A missing native class is a stale or
 # incomplete build, not a supported mode, and raises rather than falling back.
 native_layout_packer: bool = _get_env_bool("TORCH_SPYRE_NATIVE_PACKER", True)
+_provenance_artifact_env = os.environ.get("TORCH_SPYRE_PROVENANCE_PATH")
+if _provenance_artifact_env is None:
+    # Match upstream Inductor: the run-scoped debug directory, not the bare cwd.
+    provenance_artifact_path: str | None = os.path.join(
+        get_debug_dir(), "torchinductor", "spyre_provenance.json"
+    )
+elif _provenance_artifact_env:
+    provenance_artifact_path = _provenance_artifact_env
+else:
+    provenance_artifact_path = None
 
 install_config_module(sys.modules[__name__])

--- a/torch_spyre/_inductor/kernel_provenance.py
+++ b/torch_spyre/_inductor/kernel_provenance.py
@@ -43,14 +43,16 @@ from torch_spyre._inductor.op_spec import (
     TensorArg,
     TensorWorkDivision,
 )
+from torch_spyre.provenance_codec import (
+    KERNEL_PROVENANCE_KEY_BASE32_WIDTH,
+    KERNEL_PROVENANCE_KEY_VERSION,
+)
 
 
 # Bump this only when existing v1 identities would be reinterpreted, or when the
 # key width changes. New optional fields may extend identity without a bump when
 # they are omitted for all previously representable bundles.
 _KERNEL_BUNDLE_KEY_DOMAIN = "spyre-kernel-bundle"
-KERNEL_PROVENANCE_KEY_VERSION = 1
-KERNEL_PROVENANCE_KEY_BASE32_WIDTH = 16
 _KERNEL_PROVENANCE_KEY_ALPHABET = frozenset("abcdefghijklmnopqrstuvwxyz234567")
 
 _EXPECTED_OP_SPEC_SCHEMA = {

--- a/torch_spyre/_inductor/profiler_event.py
+++ b/torch_spyre/_inductor/profiler_event.py
@@ -30,9 +30,12 @@ import regex
 
 from torch_spyre._C import AIUPTI_ACTIVITY_NAME_MAX_BYTES
 from torch_spyre._inductor.kernel_provenance import (
+    KernelProvenanceDescriptor,
+)
+from torch_spyre.provenance_codec import (
     KERNEL_PROVENANCE_KEY_BASE32_WIDTH,
     KERNEL_PROVENANCE_KEY_VERSION,
-    KernelProvenanceDescriptor,
+    parse_kernel_provenance_event_name,
 )
 
 
@@ -45,20 +48,8 @@ _MAX_EVENT_NAME_BASE_BYTES = (
     AIUPTI_ACTIVITY_NAME_MAX_BYTES - _MAX_COMPUTE_STEP_SUFFIX_BYTES
 )
 
-_SUPPORTED_KEY_WIDTHS = {
-    KERNEL_PROVENANCE_KEY_VERSION: KERNEL_PROVENANCE_KEY_BASE32_WIDTH
-}
-_EVENT_NAME_PREFIX = f"spyre_kernel_v{KERNEL_PROVENANCE_KEY_VERSION}_"
-# The separator before the key is unambiguous because ``_`` is not in the
-# lowercase base32 alphabet. Revisit this parser if a future version changes
-# the alphabet.
-_EVENT_KEY_RE = regex.compile(
-    r"\Aspyre_kernel_v(?P<version>[0-9]+)_"
-    r"[A-Za-z0-9_]+?_"
-    r"(?P<key>[a-z2-7]+)"
-    r"(?:#[0-9]+)?\Z"
-)
 _DISPLAY_COMPONENT_RE = regex.compile(r"[^A-Za-z0-9]+")
+_EVENT_NAME_PREFIX = f"spyre_kernel_v{KERNEL_PROVENANCE_KEY_VERSION}_"
 _MIN_EVENT_NAME_BASE_BYTES = len(
     f"{_EVENT_NAME_PREFIX}u_{'a' * KERNEL_PROVENANCE_KEY_BASE32_WIDTH}".encode("ascii")
 )
@@ -85,13 +76,8 @@ def format_kernel_provenance_event_name(
 
 def extract_kernel_provenance_key(event_name: str) -> str | None:
     """Extract a kernel-provenance key from a Spyre device event name."""
-    match = _EVENT_KEY_RE.match(event_name)
-    if match is None:
-        return None
-    version = int(match.group("version"))
-    expected_width = _SUPPORTED_KEY_WIDTHS.get(version)
-    key = match.group("key")
-    return key if expected_width is not None and len(key) == expected_width else None
+    parsed = parse_kernel_provenance_event_name(event_name)
+    return parsed.key if parsed is not None else None
 
 
 def _aten_summary(aten_ops: tuple[str, ...]) -> str:

--- a/torch_spyre/_inductor/provenance_artifact.py
+++ b/torch_spyre/_inductor/provenance_artifact.py
@@ -16,7 +16,8 @@
 
 This module stops at an immutable in-memory contribution. Physical publication,
 upstream projection, and merge policy are separate lifecycle steps so finalized
-OpSpec collection remains reusable by a future KTIR serializer.
+OpSpec collection remains reusable by a future KTIR serializer while wire
+serialization stays independently testable.
 """
 
 from __future__ import annotations

--- a/torch_spyre/_inductor/provenance_artifact.py
+++ b/torch_spyre/_inductor/provenance_artifact.py
@@ -1,0 +1,514 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compile-scoped collection for the durable Spyre provenance artifact.
+
+This module stops at an immutable in-memory contribution. Physical publication,
+upstream projection, and merge policy are separate lifecycle steps so finalized
+OpSpec collection remains reusable by a future KTIR serializer.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from types import MappingProxyType
+from typing import Any
+
+from torch._inductor.graph import GraphLowering
+from torch_spyre._inductor.kernel_provenance import KernelProvenanceDescriptor
+from torch_spyre._inductor.op_spec import (
+    DebugHandle,
+    LoopSpec,
+    OpSpec,
+    ProvenanceTransform,
+    SourceLoc,
+)
+from torch_spyre._inductor.profiler_event import (
+    format_kernel_provenance_event_name,
+)
+
+
+_GRAPH_REGISTRATIONS_ATTRIBUTE = "_spyre_provenance_registrations"
+_GRAPH_REGISTRATION_FAILURE_ATTRIBUTE = "_spyre_provenance_registration_failed"
+_COMPILE_ID_DOMAIN = "torch-spyre-compile-v1"
+_OCCURRENCE_ID_DOMAIN = "torch-spyre-occurrence-v1"
+
+
+@dataclasses.dataclass(frozen=True)
+class KernelRegistration:
+    """One exact upstream alias returned during scheduler code generation."""
+
+    ordinal: int
+    alias: str
+
+    def __post_init__(self) -> None:
+        if isinstance(self.ordinal, bool) or self.ordinal < 1:
+            raise ValueError("kernel registration ordinal must be a positive integer")
+
+    def to_dict(self) -> dict[str, object]:
+        return {"ordinal": self.ordinal, "alias": self.alias}
+
+
+@dataclasses.dataclass(frozen=True)
+class KernelRegistrationState:
+    """Consumed graph-scoped registrations and their availability state."""
+
+    has_graph_lowering: bool
+    registrations: Mapping[str, tuple[KernelRegistration, ...]]
+    capture_failed: bool
+
+
+@dataclasses.dataclass(frozen=True)
+class NormalizedDebugHandle:
+    """Wire-ready DebugHandle with constituent handles normalized by ID."""
+
+    id: str
+    source: SourceLoc | None
+    aten_op: str | None
+    ir_chain: tuple[str, ...]
+    fused_from: tuple[str, ...]
+    transform_history: tuple[ProvenanceTransform, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "source": self.source.to_dict() if self.source is not None else None,
+            "aten_op": self.aten_op,
+            "ir_chain": list(self.ir_chain),
+            "fused_from": list(self.fused_from),
+            "transform_history": [
+                transform.to_dict() for transform in self.transform_history
+            ],
+        }
+
+
+@dataclasses.dataclass(frozen=True)
+class SpecHandleBinding:
+    """Direct handle attachment at one finalized OpSpec tree position."""
+
+    spec_path: tuple[int, ...]
+    handle_id: str
+
+    def __post_init__(self) -> None:
+        if not self.spec_path:
+            raise ValueError("spec handle binding path must not be empty")
+
+    def to_dict(self) -> dict[str, object]:
+        return {"specPath": list(self.spec_path), "handleId": self.handle_id}
+
+
+@dataclasses.dataclass(frozen=True)
+class CollectedKernelIdentity:
+    """Cache-stable identity and full direct-handle layout for one bundle."""
+
+    key: str
+    direct_handle_ids: tuple[str, ...]
+    spec_handle_bindings: tuple[SpecHandleBinding, ...]
+    aten_ops: tuple[str, ...]
+    event_name_base: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "directHandleIds": list(self.direct_handle_ids),
+            "specHandleBindings": [
+                binding.to_dict() for binding in self.spec_handle_bindings
+            ],
+            "atenOps": list(self.aten_ops),
+            "eventNameBase": self.event_name_base,
+        }
+
+
+@dataclasses.dataclass(frozen=True)
+class CollectedKernel:
+    """One finalized generated-wrapper kernel before compile ID assignment."""
+
+    compiler_kernel_name: str
+    identity: CollectedKernelIdentity
+    handles: Mapping[str, NormalizedDebugHandle]
+
+
+@dataclasses.dataclass(frozen=True)
+class UncollectedKernel:
+    """Kernel lacking a safe identity, retained with any exact registrations."""
+
+    compiler_kernel_name: str
+    registrations: tuple[KernelRegistration, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class CollectedKernelOccurrence:
+    """Compile-scoped occurrence of one cache-stable kernel identity."""
+
+    occurrence_id: str
+    identity_key: str
+    compile_id: str
+    compiler_kernel_name: str
+    registrations: tuple[KernelRegistration, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "identityKey": self.identity_key,
+            "compileId": self.compile_id,
+            "compilerKernelName": self.compiler_kernel_name,
+            "registrations": [
+                registration.to_dict() for registration in self.registrations
+            ],
+        }
+
+
+@dataclasses.dataclass(frozen=True)
+class CollectedProvenance:
+    """In-memory Spyre collection outcome for one generated wrapper."""
+
+    compile_id: str
+    kernels: tuple[tuple[str, str], ...]
+    handles: Mapping[str, NormalizedDebugHandle]
+    kernel_identities: Mapping[str, CollectedKernelIdentity]
+    kernel_occurrences: Mapping[str, CollectedKernelOccurrence]
+    uncollected_kernels: tuple[UncollectedKernel, ...]
+    has_graph_lowering: bool
+    registration_capture_failed: bool
+
+    @property
+    def collection_failure_count(self) -> int:
+        return len(self.uncollected_kernels)
+
+
+def record_kernel_registration(
+    graph: object,
+    kernel_name: str,
+    ordinal: int | None,
+) -> None:
+    """Append an exact registration to the current GraphLowering side table."""
+    if ordinal is None:
+        return
+    registration = KernelRegistration(
+        ordinal=ordinal,
+        alias=f"{kernel_name}:{ordinal}",
+    )
+    namespace = _graph_namespace(graph)
+    registrations = namespace.setdefault(_GRAPH_REGISTRATIONS_ATTRIBUTE, {})
+    if not isinstance(registrations, dict):
+        raise TypeError("Spyre provenance registration side table is not a dict")
+    kernel_registrations = registrations.setdefault(kernel_name, [])
+    if not isinstance(kernel_registrations, list):
+        raise TypeError("Spyre kernel registration entry is not a list")
+    if kernel_registrations and kernel_registrations[-1].ordinal >= ordinal:
+        raise ValueError(
+            "kernel registration ordinals must increase within one compilation"
+        )
+    kernel_registrations.append(registration)
+
+
+def consume_kernel_registration_state(
+    graph: object,
+) -> KernelRegistrationState:
+    """Consume graph state or explicitly report generated-wrapper replay."""
+    if not isinstance(graph, GraphLowering):
+        return KernelRegistrationState(
+            has_graph_lowering=False,
+            registrations=MappingProxyType({}),
+            capture_failed=False,
+        )
+
+    namespace = _graph_namespace(graph)
+    registrations = namespace.pop(_GRAPH_REGISTRATIONS_ATTRIBUTE, {})
+    if not isinstance(registrations, dict):
+        raise TypeError("Spyre provenance registration side table is not a dict")
+    result: dict[str, tuple[KernelRegistration, ...]] = {}
+    for kernel_name, values in registrations.items():
+        if not isinstance(kernel_name, str) or not isinstance(values, list):
+            raise TypeError("invalid Spyre provenance registration entry")
+        if not all(isinstance(value, KernelRegistration) for value in values):
+            raise TypeError("invalid Spyre kernel registration value")
+        result[kernel_name] = tuple(values)
+    capture_failed = namespace.pop(
+        _GRAPH_REGISTRATION_FAILURE_ATTRIBUTE,
+        False,
+    )
+    if not isinstance(capture_failed, bool):
+        raise TypeError("Spyre provenance registration failure marker is not bool")
+    return KernelRegistrationState(
+        has_graph_lowering=True,
+        registrations=MappingProxyType(dict(result)),
+        capture_failed=capture_failed,
+    )
+
+
+def mark_kernel_registration_failure(graph: object) -> None:
+    """Mark alias capture incomplete without failing compiler code generation."""
+    _graph_namespace(graph)[_GRAPH_REGISTRATION_FAILURE_ATTRIBUTE] = True
+
+
+def collect_kernel_provenance(
+    kernel_name: str,
+    specs: Sequence[OpSpec | LoopSpec],
+    descriptor: KernelProvenanceDescriptor,
+) -> CollectedKernel:
+    """Normalize every handle reachable from one finalized OpSpec tree."""
+    handles: dict[str, NormalizedDebugHandle] = {}
+    bindings: list[SpecHandleBinding] = []
+    normalized_objects: set[int] = set()
+
+    def walk(entries: Sequence[object], prefix: tuple[int, ...] = ()) -> None:
+        for index, spec in enumerate(entries):
+            spec_path = (*prefix, index)
+            if isinstance(spec, OpSpec):
+                if spec.debug_handle is not None:
+                    handle_id = str(spec.debug_handle.id)
+                    bindings.append(SpecHandleBinding(spec_path, handle_id))
+                    _normalize_handle(
+                        spec.debug_handle,
+                        handles,
+                        set(),
+                        normalized_objects,
+                    )
+            elif isinstance(spec, LoopSpec):
+                walk(spec.body, spec_path)
+            else:
+                raise TypeError(
+                    f"Unsupported finalized kernel spec: {type(spec).__qualname__}"
+                )
+
+    walk(specs)
+    direct_handle_ids = tuple(dict.fromkeys(binding.handle_id for binding in bindings))
+    if direct_handle_ids != descriptor.debug_handle_ids:
+        raise ValueError("descriptor handle order disagrees with finalized OpSpecs")
+
+    identity = CollectedKernelIdentity(
+        key=descriptor.key,
+        direct_handle_ids=descriptor.debug_handle_ids,
+        spec_handle_bindings=tuple(bindings),
+        aten_ops=descriptor.aten_ops,
+        event_name_base=format_kernel_provenance_event_name(descriptor),
+    )
+    return CollectedKernel(
+        compiler_kernel_name=kernel_name,
+        identity=identity,
+        handles=MappingProxyType(dict(sorted(handles.items()))),
+    )
+
+
+class ProvenanceCollectionBuilder:
+    """Ordered per-wrapper accumulator for finalized Spyre kernels."""
+
+    def __init__(self) -> None:
+        self._kernels: list[CollectedKernel] = []
+        self._uncollected_kernel_names: list[str] = []
+        self._all_kernel_names: set[str] = set()
+
+    def add_kernel(self, kernel: CollectedKernel) -> None:
+        self._reserve_kernel_name(kernel.compiler_kernel_name)
+        self._kernels.append(kernel)
+
+    def add_uncollected_kernel(self, kernel_name: str) -> None:
+        """Retain a kernel that could not safely produce a bundle identity."""
+        self._reserve_kernel_name(kernel_name)
+        self._uncollected_kernel_names.append(kernel_name)
+
+    def _reserve_kernel_name(self, kernel_name: str) -> None:
+        if kernel_name in self._all_kernel_names:
+            raise ValueError(
+                "duplicate compiler kernel name in one generated wrapper: "
+                f"{kernel_name}"
+            )
+        self._all_kernel_names.add(kernel_name)
+
+    def finish(
+        self,
+        registration_state: KernelRegistrationState,
+    ) -> CollectedProvenance | None:
+        """Assign compile/occurrence IDs and preserve partial collection state."""
+        registrations = registration_state.registrations
+        if not self._all_kernel_names:
+            if registrations:
+                raise ValueError("registrations exist without collected Spyre kernels")
+            return None
+
+        unknown_names = set(registrations) - self._all_kernel_names
+        if unknown_names:
+            raise ValueError(
+                "registrations reference unknown Spyre kernels: "
+                f"{sorted(unknown_names)}"
+            )
+        _validate_registrations(registrations)
+
+        kernels = tuple(
+            (kernel.compiler_kernel_name, kernel.identity.key)
+            for kernel in self._kernels
+        )
+        compile_id = _canonical_digest(
+            {
+                "domain": _COMPILE_ID_DOMAIN,
+                "kernels": [list(kernel) for kernel in kernels],
+            }
+        )
+
+        handles: dict[str, NormalizedDebugHandle] = {}
+        identities: dict[str, CollectedKernelIdentity] = {}
+        occurrences: dict[str, CollectedKernelOccurrence] = {}
+        for kernel in self._kernels:
+            _merge_equal_records(handles, kernel.handles, "debug handle")
+            _merge_equal_records(
+                identities,
+                {kernel.identity.key: kernel.identity},
+                "kernel identity",
+            )
+            occurrence_payload = {
+                "domain": _OCCURRENCE_ID_DOMAIN,
+                "compileId": compile_id,
+                "compilerKernelName": kernel.compiler_kernel_name,
+                "identityKey": kernel.identity.key,
+            }
+            occurrence_id = _canonical_digest(occurrence_payload)
+            occurrence = CollectedKernelOccurrence(
+                occurrence_id=occurrence_id,
+                identity_key=kernel.identity.key,
+                compile_id=compile_id,
+                compiler_kernel_name=kernel.compiler_kernel_name,
+                registrations=tuple(registrations.get(kernel.compiler_kernel_name, ())),
+            )
+            _merge_equal_records(
+                occurrences,
+                {occurrence_id: occurrence},
+                "kernel occurrence",
+            )
+
+        uncollected_kernels = tuple(
+            UncollectedKernel(
+                compiler_kernel_name=kernel_name,
+                registrations=tuple(registrations.get(kernel_name, ())),
+            )
+            for kernel_name in self._uncollected_kernel_names
+        )
+        return CollectedProvenance(
+            compile_id=compile_id,
+            kernels=kernels,
+            handles=MappingProxyType(dict(sorted(handles.items()))),
+            kernel_identities=MappingProxyType(dict(sorted(identities.items()))),
+            kernel_occurrences=MappingProxyType(dict(sorted(occurrences.items()))),
+            uncollected_kernels=uncollected_kernels,
+            has_graph_lowering=registration_state.has_graph_lowering,
+            registration_capture_failed=registration_state.capture_failed,
+        )
+
+
+def _normalize_handle(
+    handle: DebugHandle,
+    handles: dict[str, NormalizedDebugHandle],
+    visiting: set[str],
+    normalized_objects: set[int],
+) -> None:
+    handle_id = str(handle.id)
+    if handle_id in visiting:
+        raise ValueError(f"cyclic fused_from lineage at debug handle {handle_id}")
+    object_id = id(handle)
+    if object_id in normalized_objects:
+        normalized = _normalized_handle_record(handle)
+        existing = handles.get(handle_id)
+        if existing != normalized:
+            raise ValueError(f"conflicting content for debug handle ID {handle_id}")
+        return
+
+    visiting.add(handle_id)
+    for constituent in handle.fused_from:
+        _normalize_handle(
+            constituent,
+            handles,
+            visiting,
+            normalized_objects,
+        )
+    visiting.remove(handle_id)
+    constituent_ids = tuple(str(child.id) for child in handle.fused_from)
+    if len(constituent_ids) != len(set(constituent_ids)):
+        raise ValueError(
+            f"duplicate fused_from constituent on debug handle {handle_id}"
+        )
+
+    normalized = _normalized_handle_record(handle)
+    existing = handles.get(handle_id)
+    if existing is not None and existing != normalized:
+        raise ValueError(f"conflicting content for debug handle ID {handle_id}")
+    handles[handle_id] = normalized
+    normalized_objects.add(object_id)
+
+
+def _normalized_handle_record(handle: DebugHandle) -> NormalizedDebugHandle:
+    return NormalizedDebugHandle(
+        id=str(handle.id),
+        source=handle.source,
+        aten_op=handle.aten_op,
+        ir_chain=handle.ir_chain,
+        fused_from=tuple(str(child.id) for child in handle.fused_from),
+        transform_history=handle.transform_history,
+    )
+
+
+def _validate_registrations(
+    registrations: Mapping[str, Sequence[KernelRegistration]],
+) -> None:
+    seen_ordinals: set[int] = set()
+    for kernel_name, kernel_registrations in registrations.items():
+        ordinals = [registration.ordinal for registration in kernel_registrations]
+        if ordinals != sorted(set(ordinals)):
+            raise ValueError(
+                "kernel registrations must have unique increasing ordinals"
+            )
+        if seen_ordinals.intersection(ordinals):
+            raise ValueError(
+                "kernel registration ordinals must be unique within a compilation"
+            )
+        if any(
+            registration.alias != f"{kernel_name}:{registration.ordinal}"
+            for registration in kernel_registrations
+        ):
+            raise ValueError(
+                "kernel registration alias disagrees with its name and ordinal"
+            )
+        seen_ordinals.update(ordinals)
+
+
+def _merge_equal_records(
+    destination: dict[str, Any],
+    incoming: Mapping[str, Any],
+    record_name: str,
+) -> None:
+    for key, value in incoming.items():
+        existing = destination.get(key)
+        if existing is not None and existing != value:
+            raise ValueError(f"conflicting {record_name} content for key {key}")
+        destination[key] = value
+
+
+def _canonical_digest(value: object) -> str:
+    payload = json.dumps(
+        value,
+        ensure_ascii=True,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("ascii")).hexdigest()
+
+
+def _graph_namespace(graph: object) -> dict[str, Any]:
+    if not isinstance(graph, GraphLowering):
+        raise TypeError("Spyre provenance state requires a real GraphLowering")
+    namespace = getattr(graph, "__dict__", None)
+    if not isinstance(namespace, dict):
+        raise TypeError("GraphLowering does not expose a mutable namespace")
+    return namespace

--- a/torch_spyre/_inductor/provenance_writer.py
+++ b/torch_spyre/_inductor/provenance_writer.py
@@ -186,12 +186,13 @@ def capture_upstream_projection(
     reachable_post_nodes = {
         post_node for values in cpp_to_post.values() for post_node in values
     }
-    post_to_pre = {
+    filtered_post_to_pre = {
         post_node: upstream_post_to_pre[post_node]
         for post_node in sorted(reachable_post_nodes)
         if post_node in upstream_post_to_pre
     }
-    pre_to_post = _tuple_name_map(_invert_name_map(post_to_pre))
+    pre_to_post = _tuple_name_map(_invert_name_map(filtered_post_to_pre))
+    post_to_pre = _tuple_name_map(_invert_name_map(pre_to_post))
     post_to_cpp = _tuple_name_map(_invert_name_map(cpp_to_post))
 
     upstream_stacks = _require_mapping(
@@ -218,7 +219,7 @@ def capture_upstream_projection(
             dict.fromkeys(
                 pre_node
                 for post_node in expected_post_nodes
-                for pre_node in post_to_pre.get(post_node, ())
+                for pre_node in filtered_post_to_pre.get(post_node, ())
             )
         )
         stack_contexts_match &= (

--- a/torch_spyre/_inductor/provenance_writer.py
+++ b/torch_spyre/_inductor/provenance_writer.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import copy
+import dataclasses
 import hashlib
 import json
 import os
@@ -28,6 +29,8 @@ from typing import Any, Literal
 
 import regex as re
 import torch
+from torch._inductor import debug as inductor_debug
+from torch._logging._internal import trace_log, trace_structured_artifact
 
 from torch_spyre._inductor.kernel_provenance import (
     KERNEL_PROVENANCE_KEY_BASE32_WIDTH,
@@ -42,6 +45,7 @@ from torch_spyre.version import __version__ as torch_spyre_version
 
 
 PublicationResult = Literal["disabled", "unchanged", "written"]
+UpstreamJoin = Literal["ok", "partial"]
 
 _SCHEMA_VERSION = 1
 _UPSTREAM_SOURCE = "inductor_provenance_tracking_node_mappings"
@@ -101,6 +105,31 @@ class UnsupportedProvenanceVersion(ProvenanceArtifactError):
     """Existing sidecar uses a schema version this writer cannot merge."""
 
 
+@dataclasses.dataclass(frozen=True)
+class CapturedUpstreamProjection:
+    """Filtered live Inductor relationships for one wrapper contribution."""
+
+    upstream_join: UpstreamJoin
+    pre_to_post: Mapping[str, tuple[str, ...]]
+    post_to_pre: Mapping[str, tuple[str, ...]]
+    cpp_code_to_post: Mapping[str, tuple[str, ...]]
+    post_to_cpp_code: Mapping[str, tuple[str, ...]]
+    kernel_stack_traces: Mapping[str, Mapping[str, tuple[str, ...]]]
+    failed: bool
+
+    def to_projection_fields(self) -> dict[str, object]:
+        return {
+            "preToPost": _lists_from_tuples(self.pre_to_post),
+            "postToPre": _lists_from_tuples(self.post_to_pre),
+            "cppCodeToPost": _lists_from_tuples(self.cpp_code_to_post),
+            "postToCppCode": _lists_from_tuples(self.post_to_cpp_code),
+            "kernelStackTraces": {
+                alias: _lists_from_tuples(context)
+                for alias, context in self.kernel_stack_traces.items()
+            },
+        }
+
+
 def resolve_provenance_artifact_path(
     configured_path: str | None,
 ) -> Path | None:
@@ -113,16 +142,121 @@ def resolve_provenance_artifact_path(
     return path.absolute()
 
 
+def capture_upstream_projection(
+    collection: CollectedProvenance,
+) -> CapturedUpstreamProjection | None:
+    """Capture and filter live upstream v2 state for one fresh contribution."""
+    level = int(torch._inductor.config.trace.provenance_tracking_level)
+    if level < 1 or not collection.has_graph_lowering:
+        return None
+
+    node_mapping = inductor_debug.dump_inductor_provenance_info()
+    kernel_information = inductor_debug.create_kernel_information_json()
+    mapping = _require_mapping(node_mapping, "upstream node mapping")
+    if mapping.get("version") != _UPSTREAM_VERSION:
+        raise ProvenanceArtifactError("unsupported upstream provenance version")
+
+    aliases = sorted(
+        {
+            registration.alias
+            for occurrence in collection.kernel_occurrences.values()
+            for registration in occurrence.registrations
+        }
+    )
+    upstream_cpp_to_post = _capture_name_map(
+        mapping.get("cppCodeToPost"), "upstream cppCodeToPost"
+    )
+    upstream_post_to_pre = _capture_name_map(
+        mapping.get("postToPre"), "upstream postToPre"
+    )
+    cpp_to_post = {
+        alias: upstream_cpp_to_post[alias]
+        for alias in aliases
+        if alias in upstream_cpp_to_post
+    }
+    reachable_post_nodes = {
+        post_node for values in cpp_to_post.values() for post_node in values
+    }
+    post_to_pre = {
+        post_node: upstream_post_to_pre[post_node]
+        for post_node in sorted(reachable_post_nodes)
+        if post_node in upstream_post_to_pre
+    }
+    pre_to_post = _tuple_name_map(_invert_name_map(post_to_pre))
+    post_to_cpp = _tuple_name_map(_invert_name_map(cpp_to_post))
+
+    upstream_stacks = _require_mapping(
+        kernel_information, "upstream kernel information"
+    )
+    stack_contexts: dict[str, Mapping[str, tuple[str, ...]]] = {}
+    stack_contexts_match = True
+    for alias in aliases:
+        value = upstream_stacks.get(alias)
+        if value is None:
+            continue
+        context = _require_mapping(value, "upstream kernel stack context")
+        stack_traces = _capture_string_tuple(
+            context.get("stack_traces"), "upstream stack traces"
+        )
+        post_grad_nodes = _capture_string_tuple(
+            context.get("post_grad_nodes"), "upstream stack post-grad nodes"
+        )
+        pre_grad_nodes = _capture_string_tuple(
+            context.get("pre_grad_nodes"), "upstream stack pre-grad nodes"
+        )
+        expected_post_nodes = cpp_to_post.get(alias, ())
+        expected_pre_nodes = tuple(
+            dict.fromkeys(
+                pre_node
+                for post_node in expected_post_nodes
+                for pre_node in post_to_pre.get(post_node, ())
+            )
+        )
+        stack_contexts_match &= (
+            post_grad_nodes == expected_post_nodes
+            and pre_grad_nodes == expected_pre_nodes
+        )
+        stack_contexts[alias] = {
+            "stackTraces": stack_traces,
+            "postGradNodes": post_grad_nodes,
+            "preGradNodes": pre_grad_nodes,
+        }
+
+    complete = (
+        bool(aliases)
+        and set(cpp_to_post) == set(aliases)
+        and all(cpp_to_post.values())
+        and set(post_to_pre) == reachable_post_nodes
+        and set(stack_contexts) == set(aliases)
+        and stack_contexts_match
+    )
+    return CapturedUpstreamProjection(
+        upstream_join="ok" if complete else "partial",
+        pre_to_post=pre_to_post,
+        post_to_pre=post_to_pre,
+        cpp_code_to_post=cpp_to_post,
+        post_to_cpp_code=post_to_cpp,
+        kernel_stack_traces=stack_contexts,
+        failed=not complete,
+    )
+
+
 def publish_provenance_collection(
     collection: CollectedProvenance,
     configured_path: str | None,
+    *,
+    upstream_projection: CapturedUpstreamProjection | None = None,
+    upstream_projection_failed: bool = False,
 ) -> PublicationResult:
     """Merge and atomically publish one wrapper's collection outcome."""
     path = resolve_provenance_artifact_path(configured_path)
     if path is None:
         return "disabled"
 
-    contribution = _build_contribution(collection)
+    contribution = _build_contribution(
+        collection, upstream_projection_failed, upstream_projection
+    )
+    result: PublicationResult = "written"
     with _PUBLICATION_LOCK:
         existing = _read_existing_document(path)
         if existing is None:
@@ -135,12 +269,22 @@ def publish_provenance_collection(
             validate_provenance_document(existing)
             document = _merge_document(existing, contribution)
             if _without_generation(document) == _without_generation(existing):
-                return "unchanged"
+                result = "unchanged"
 
         document = _canonicalize_document(document)
         validate_provenance_document(document)
-        _atomic_write(path, _serialize_document(document))
-    return "written"
+        payload = _serialize_document(document)
+        if result == "written":
+            _atomic_write(path, payload)
+
+    # Always submit enabled publications to PyTorch logging. Its handlers own
+    # durable trace emission; structuredTracing only records destination state.
+    trace_structured_artifact(
+        "spyre_provenance",
+        "json",
+        payload_fn=lambda: payload,
+    )
+    return result
 
 
 def validate_provenance_document(document: object) -> None:
@@ -238,7 +382,11 @@ def validate_provenance_document(document: object) -> None:
         raise ProvenanceArtifactError("document status disagrees with its content")
 
 
-def _build_contribution(collection: CollectedProvenance) -> dict[str, Any]:
+def _build_contribution(
+    collection: CollectedProvenance,
+    upstream_projection_failed: bool,
+    upstream_projection: CapturedUpstreamProjection | None,
+) -> dict[str, Any]:
     handles = {
         handle_id: handle.to_dict() for handle_id, handle in collection.handles.items()
     }
@@ -257,8 +405,14 @@ def _build_contribution(collection: CollectedProvenance) -> dict[str, Any]:
             upstream_join = "unavailable-provenance-level-0"
         elif not collection.has_graph_lowering:
             upstream_join = "unavailable-cache-replay"
-        else:
+        elif collection.registration_capture_failed or upstream_projection_failed:
             upstream_join = "partial"
+        else:
+            upstream_join = (
+                upstream_projection.upstream_join
+                if upstream_projection is not None
+                else "partial"
+            )
         projections[collection.compile_id] = {
             "source": _UPSTREAM_SOURCE,
             "version": _UPSTREAM_VERSION,
@@ -268,7 +422,7 @@ def _build_contribution(collection: CollectedProvenance) -> dict[str, Any]:
             },
             "settings": {
                 "provenanceTrackingLevel": level,
-                "structuredTracing": bool(torch._inductor.config.trace.enabled),
+                "structuredTracing": _structured_tracing_enabled(),
             },
             "kernels": [
                 {
@@ -278,10 +432,13 @@ def _build_contribution(collection: CollectedProvenance) -> dict[str, Any]:
                 for kernel_name, identity_key in collection.kernels
             ],
             "uncollectedKernels": sorted(
-                kernel.compiler_kernel_name
-                for kernel in collection.uncollected_kernels
+                kernel.compiler_kernel_name for kernel in collection.uncollected_kernels
             ),
-            "upstreamProjectionFailed": collection.registration_capture_failed,
+            "upstreamProjectionFailed": (
+                collection.registration_capture_failed
+                or upstream_projection_failed
+                or (upstream_projection.failed if upstream_projection else False)
+            ),
             "upstreamJoin": upstream_join,
             "preToPost": {},
             "postToPre": {},
@@ -289,6 +446,10 @@ def _build_contribution(collection: CollectedProvenance) -> dict[str, Any]:
             "postToCppCode": {},
             "kernelStackTraces": {},
         }
+        if upstream_projection is not None:
+            projections[collection.compile_id].update(
+                upstream_projection.to_projection_fields()
+            )
     return {
         "diagnostics": _diagnostics_from_projections(projections),
         "handles": handles,
@@ -407,8 +568,7 @@ def _merge_projections(destination_value: object, incoming_value: object) -> Non
                     f"conflicting upstream projection metadata for key {compile_id}"
                 )
         uncollected_kernels = sorted(
-            set(existing["uncollectedKernels"])
-            | set(projection["uncollectedKernels"])
+            set(existing["uncollectedKernels"]) | set(projection["uncollectedKernels"])
         )
         upstream_projection_failed = bool(
             existing["upstreamProjectionFailed"]
@@ -516,9 +676,7 @@ def _name_map_is_subset(weaker_value: object, richer_value: object) -> bool:
     )
 
 
-def _merge_name_maps(
-    first_value: object, second_value: object
-) -> dict[str, list[str]]:
+def _merge_name_maps(first_value: object, second_value: object) -> dict[str, list[str]]:
     first = _require_mapping(first_value, "name map")
     second = _require_mapping(second_value, "name map")
     keys = sorted(set(first) | set(second))
@@ -534,6 +692,39 @@ def _invert_name_map(mapping_value: object) -> dict[str, list[str]]:
         for destination in mapping[source]:
             inverse.setdefault(destination, []).append(source)
     return inverse
+
+
+def _capture_name_map(value: object, name: str) -> dict[str, tuple[str, ...]]:
+    mapping = _require_mapping(value, name)
+    return {key: _capture_string_tuple(values, name) for key, values in mapping.items()}
+
+
+def _capture_string_tuple(value: object, name: str) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise ProvenanceArtifactError(f"{name} must be an array")
+    if not all(isinstance(item, str) for item in value):
+        raise ProvenanceArtifactError(f"{name} entries must be strings")
+    if len(value) != len(set(value)):
+        raise ProvenanceArtifactError(f"{name} entries must be unique")
+    return tuple(value)
+
+
+def _tuple_name_map(
+    mapping: Mapping[str, Sequence[str]],
+) -> dict[str, tuple[str, ...]]:
+    return {key: tuple(values) for key, values in mapping.items()}
+
+
+def _lists_from_tuples(
+    mapping: Mapping[str, Sequence[str]],
+) -> dict[str, list[str]]:
+    return {key: list(values) for key, values in mapping.items()}
+
+
+def _structured_tracing_enabled() -> bool:
+    return any(
+        getattr(handler, "root_dir", None) is not None for handler in trace_log.handlers
+    )
 
 
 def _derive_status(document: dict[str, Any]) -> None:
@@ -555,17 +746,13 @@ def _diagnostics_from_projections(
     for projection_value in projections.values():
         projection = _require_mapping(projection_value, "upstream projection")
         collection_failure_count += len(projection["uncollectedKernels"])
-        upstream_projection_failure_count += int(
-            projection["upstreamProjectionFailed"]
-        )
+        upstream_projection_failure_count += int(projection["upstreamProjectionFailed"])
 
     diagnostics: dict[str, int] = {}
     if collection_failure_count:
         diagnostics["collection-failure"] = collection_failure_count
     if upstream_projection_failure_count:
-        diagnostics["upstream-projection-failure"] = (
-            upstream_projection_failure_count
-        )
+        diagnostics["upstream-projection-failure"] = upstream_projection_failure_count
     return diagnostics
 
 

--- a/torch_spyre/_inductor/provenance_writer.py
+++ b/torch_spyre/_inductor/provenance_writer.py
@@ -16,15 +16,17 @@
 
 from __future__ import annotations
 
+import contextlib
 import copy
 import dataclasses
+import fcntl
 import hashlib
 import json
 import os
 from pathlib import Path
 import tempfile
 import threading
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from typing import Any, Literal
 
 import regex as re
@@ -268,24 +270,25 @@ def publish_provenance_collection(
     )
     result: PublicationResult = "written"
     with _PUBLICATION_LOCK:
-        existing = _read_existing_document(path)
-        if existing is None:
-            if not contribution["kernelIdentities"]:
-                raise ProvenanceArtifactError(
-                    f"cannot create {path.name} without a collected kernel identity"
-                )
-            document = _new_document(contribution)
-        else:
-            validate_provenance_document(existing)
-            document = _merge_document(existing, contribution)
-            if _without_generation(document) == _without_generation(existing):
-                result = "unchanged"
+        with _interprocess_publication_lock(path):
+            existing = _read_existing_document(path)
+            if existing is None:
+                if not contribution["kernelIdentities"]:
+                    raise ProvenanceArtifactError(
+                        f"cannot create {path.name} without a collected kernel identity"
+                    )
+                document = _new_document(contribution)
+            else:
+                validate_provenance_document(existing)
+                document = _merge_document(existing, contribution)
+                if _without_generation(document) == _without_generation(existing):
+                    result = "unchanged"
 
-        document = _canonicalize_document(document)
-        validate_provenance_document(document)
-        payload = _serialize_document(document)
-        if result == "written":
-            _atomic_write(path, payload)
+            document = _canonicalize_document(document)
+            validate_provenance_document(document)
+            payload = _serialize_document(document)
+            if result == "written":
+                _atomic_write(path, payload)
 
     # Always submit enabled publications to PyTorch logging. Its handlers own
     # durable trace emission; structuredTracing only records destination state.
@@ -1222,6 +1225,29 @@ def _read_existing_document(path: Path) -> dict[str, Any] | None:
     return value
 
 
+@contextlib.contextmanager
+def _interprocess_publication_lock(path: Path) -> Iterator[None]:
+    """Serialize cooperating publishers without creating a stale lock file."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            fcntl.flock(directory_fd, fcntl.LOCK_EX)
+        except OSError:
+            os.close(directory_fd)
+            raise
+    except OSError:
+        raise ProvenanceArtifactError(f"failed to lock {path.name}") from None
+
+    try:
+        yield
+    finally:
+        try:
+            os.close(directory_fd)
+        except OSError:
+            pass
+
+
 def _atomic_write(path: Path, payload: str) -> None:
     temporary_path: Path | None = None
     try:
@@ -1236,6 +1262,8 @@ def _atomic_write(path: Path, payload: str) -> None:
         ) as temporary:
             temporary_path = Path(temporary.name)
             temporary.write(payload)
+            temporary.flush()
+            os.fsync(temporary.fileno())
         os.replace(temporary_path, path)
         temporary_path = None
     except OSError:

--- a/torch_spyre/_inductor/provenance_writer.py
+++ b/torch_spyre/_inductor/provenance_writer.py
@@ -597,29 +597,16 @@ def _merge_projections(destination_value: object, incoming_value: object) -> Non
             raise ProvenanceArtifactError(
                 f"conflicting upstream join status for key {compile_id}"
             )
-        if existing["upstreamJoin"] == "ok":
-            if any(
-                existing[field] != projection[field]
-                for field in (
-                    "preToPost",
-                    "postToPre",
-                    "cppCodeToPost",
-                    "postToCppCode",
-                    "kernelStackTraces",
-                )
-            ):
-                raise ProvenanceArtifactError(
-                    f"conflicting complete upstream projection for key {compile_id}"
-                )
-            existing["uncollectedKernels"] = uncollected_kernels
-            existing["upstreamProjectionFailed"] = upstream_projection_failed
-            continue
-        _merge_partial_projection(existing, projection)
+        # Equivalent wrappers can be compiled from different source call sites.
+        # Their graph relations and stack contexts are additive even when both
+        # captures are complete, so merge them instead of treating inequality as
+        # a content conflict.
+        _merge_projection_content(existing, projection)
         existing["uncollectedKernels"] = uncollected_kernels
         existing["upstreamProjectionFailed"] = upstream_projection_failed
 
 
-def _merge_partial_projection(
+def _merge_projection_content(
     destination: dict[str, Any], incoming: Mapping[str, object]
 ) -> None:
     for field in ("preToPost", "cppCodeToPost"):

--- a/torch_spyre/_inductor/provenance_writer.py
+++ b/torch_spyre/_inductor/provenance_writer.py
@@ -45,7 +45,12 @@ from torch_spyre.version import __version__ as torch_spyre_version
 
 
 PublicationResult = Literal["disabled", "unchanged", "written"]
-UpstreamJoin = Literal["ok", "partial"]
+UpstreamJoin = Literal[
+    "ok",
+    "partial",
+    "unavailable-cache-replay",
+    "unavailable-provenance-level-0",
+]
 
 _SCHEMA_VERSION = 1
 _UPSTREAM_SOURCE = "inductor_provenance_tracking_node_mappings"

--- a/torch_spyre/_inductor/provenance_writer.py
+++ b/torch_spyre/_inductor/provenance_writer.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import contextlib
 import copy
 import dataclasses
-import fcntl
 import hashlib
 import json
 import os
@@ -44,6 +43,13 @@ from torch_spyre._inductor.profiler_event import (
 )
 from torch_spyre._inductor.provenance_artifact import CollectedProvenance
 from torch_spyre.version import __version__ as torch_spyre_version
+
+
+_fcntl: Any
+try:
+    import fcntl as _fcntl
+except ImportError:
+    _fcntl = None
 
 
 PublicationResult = Literal["disabled", "unchanged", "written"]
@@ -1231,11 +1237,16 @@ def _interprocess_publication_lock(path: Path) -> Iterator[None]:
 
     This advisory lock does not protect against non-cooperating writers.
     """
+    if _fcntl is None:
+        raise ProvenanceArtifactError(
+            f"interprocess locking unavailable for {path.name}"
+        )
+
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         directory_fd = os.open(path.parent, os.O_RDONLY)
         try:
-            fcntl.flock(directory_fd, fcntl.LOCK_EX)
+            _fcntl.flock(directory_fd, _fcntl.LOCK_EX)
         except OSError:
             os.close(directory_fd)
             raise

--- a/torch_spyre/_inductor/provenance_writer.py
+++ b/torch_spyre/_inductor/provenance_writer.py
@@ -1227,7 +1227,10 @@ def _read_existing_document(path: Path) -> dict[str, Any] | None:
 
 @contextlib.contextmanager
 def _interprocess_publication_lock(path: Path) -> Iterator[None]:
-    """Serialize cooperating publishers without creating a stale lock file."""
+    """Serialize cooperating publishers without creating a stale lock file.
+
+    This advisory lock does not protect against non-cooperating writers.
+    """
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         directory_fd = os.open(path.parent, os.O_RDONLY)

--- a/torch_spyre/_inductor/provenance_writer.py
+++ b/torch_spyre/_inductor/provenance_writer.py
@@ -91,11 +91,15 @@ _PROJECTION_KEYS = {
     "postToCppCode",
     "kernelStackTraces",
 }
+# Prefer the most actionable evidence when v1's scalar join status must summarize
+# several equivalent contributions. A level-one cache replay outranks a level-zero
+# fresh compile because obtaining the missing mapping then requires a fresh
+# level-one compile; v2 should preserve every observed reason instead.
 _JOIN_RANK = {
     "unavailable-provenance-level-0": 0,
-    "unavailable-cache-replay": 0,
-    "partial": 1,
-    "ok": 2,
+    "unavailable-cache-replay": 1,
+    "partial": 2,
+    "ok": 3,
 }
 _TRANSFORM_KINDS = {"rewrite", "fusion", "decomposition", "clone", "remap"}
 _DIAGNOSTIC_CODES = {"collection-failure", "upstream-projection-failure"}
@@ -567,11 +571,14 @@ def _merge_projections(destination_value: object, incoming_value: object) -> Non
             destination[compile_id] = copy.deepcopy(projection)
             continue
         existing = _require_mapping(existing_value, "existing upstream projection")
-        for field in ("source", "version", "producer", "settings", "kernels"):
+        for field in ("source", "version", "producer", "kernels"):
             if existing[field] != projection[field]:
                 raise ProvenanceArtifactError(
                     f"conflicting upstream projection metadata for key {compile_id}"
                 )
+        settings = _merge_projection_settings(
+            existing["settings"], projection["settings"]
+        )
         uncollected_kernels = sorted(
             set(existing["uncollectedKernels"]) | set(projection["uncollectedKernels"])
         )
@@ -583,16 +590,21 @@ def _merge_projections(destination_value: object, incoming_value: object) -> Non
         incoming_rank = _JOIN_RANK[projection["upstreamJoin"]]
         if existing_rank > incoming_rank:
             _require_projection_subset(projection, existing, compile_id)
+            existing["settings"] = settings
             existing["uncollectedKernels"] = uncollected_kernels
             existing["upstreamProjectionFailed"] = upstream_projection_failed
             continue
         if incoming_rank > existing_rank:
             _require_projection_subset(existing, projection, compile_id)
             replacement = copy.deepcopy(projection)
+            replacement["settings"] = settings
             replacement["uncollectedKernels"] = uncollected_kernels
             replacement["upstreamProjectionFailed"] = upstream_projection_failed
             destination[compile_id] = replacement
             continue
+        # Defensive drift guard: unreachable while _JOIN_RANK values are unique,
+        # but intentionally loud if a future status shares an existing rank
+        # without defining an equivalence contract.
         if existing["upstreamJoin"] != projection["upstreamJoin"]:
             raise ProvenanceArtifactError(
                 f"conflicting upstream join status for key {compile_id}"
@@ -602,8 +614,38 @@ def _merge_projections(destination_value: object, incoming_value: object) -> Non
         # captures are complete, so merge them instead of treating inequality as
         # a content conflict.
         _merge_projection_content(existing, projection)
+        existing["settings"] = settings
         existing["uncollectedKernels"] = uncollected_kernels
         existing["upstreamProjectionFailed"] = upstream_projection_failed
+
+
+def _merge_projection_settings(
+    first_value: object, second_value: object
+) -> dict[str, object]:
+    """Retain the strongest settings observed for one merged compile ID."""
+    first = _require_mapping(first_value, "projection settings")
+    second = _require_mapping(second_value, "incoming projection settings")
+    expected_keys = {"provenanceTrackingLevel", "structuredTracing"}
+    _require_exact_keys(first, expected_keys, "projection settings")
+    _require_exact_keys(second, expected_keys, "incoming projection settings")
+    first_level = _require_int(
+        first["provenanceTrackingLevel"],
+        "provenance tracking level",
+        minimum=0,
+    )
+    second_level = _require_int(
+        second["provenanceTrackingLevel"],
+        "incoming provenance tracking level",
+        minimum=0,
+    )
+    first_tracing = first["structuredTracing"]
+    second_tracing = second["structuredTracing"]
+    if not isinstance(first_tracing, bool) or not isinstance(second_tracing, bool):
+        raise ProvenanceArtifactError("structured tracing setting must be boolean")
+    return {
+        "provenanceTrackingLevel": max(first_level, second_level),
+        "structuredTracing": first_tracing or second_tracing,
+    }
 
 
 def _merge_projection_content(

--- a/torch_spyre/_inductor/provenance_writer.py
+++ b/torch_spyre/_inductor/provenance_writer.py
@@ -1,0 +1,1080 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deterministic validation, merge, and atomic Spyre sidecar publication."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+from pathlib import Path
+import tempfile
+import threading
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal
+
+import regex as re
+import torch
+
+from torch_spyre._inductor.kernel_provenance import (
+    KERNEL_PROVENANCE_KEY_BASE32_WIDTH,
+    KERNEL_PROVENANCE_KEY_VERSION,
+    KernelProvenanceDescriptor,
+)
+from torch_spyre._inductor.profiler_event import (
+    format_kernel_provenance_event_name,
+)
+from torch_spyre._inductor.provenance_artifact import CollectedProvenance
+from torch_spyre.version import __version__ as torch_spyre_version
+
+
+PublicationResult = Literal["disabled", "unchanged", "written"]
+
+_SCHEMA_VERSION = 1
+_UPSTREAM_SOURCE = "inductor_provenance_tracking_node_mappings"
+_UPSTREAM_VERSION = 2.0
+_COMPILE_ID_DOMAIN = "torch-spyre-compile-v1"
+_OCCURRENCE_ID_DOMAIN = "torch-spyre-occurrence-v1"
+_EVENT_KEY_PATTERN = re.compile(rf"^[a-z2-7]{{{KERNEL_PROVENANCE_KEY_BASE32_WIDTH}}}$")
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_DECIMAL_ID_PATTERN = re.compile(r"^(0|[1-9][0-9]*)$")
+_ALIAS_PATTERN = re.compile(r"^.+:[1-9][0-9]*$")
+_EVENT_NAME_PATTERN = re.compile(
+    rf"^spyre_kernel_v{KERNEL_PROVENANCE_KEY_VERSION}_"
+    rf"[A-Za-z0-9_]+_[a-z2-7]{{{KERNEL_PROVENANCE_KEY_BASE32_WIDTH}}}$"
+)
+_TOP_LEVEL_KEYS = {
+    "schemaVersion",
+    "eventKey",
+    "mergeGeneration",
+    "status",
+    "diagnostics",
+    "handles",
+    "kernelIdentities",
+    "kernelOccurrences",
+    "upstreamProjections",
+}
+_PROJECTION_KEYS = {
+    "source",
+    "version",
+    "producer",
+    "settings",
+    "kernels",
+    "uncollectedKernels",
+    "upstreamProjectionFailed",
+    "upstreamJoin",
+    "preToPost",
+    "postToPre",
+    "cppCodeToPost",
+    "postToCppCode",
+    "kernelStackTraces",
+}
+_JOIN_RANK = {
+    "unavailable-provenance-level-0": 0,
+    "unavailable-cache-replay": 0,
+    "partial": 1,
+    "ok": 2,
+}
+_TRANSFORM_KINDS = {"rewrite", "fusion", "decomposition", "clone", "remap"}
+_DIAGNOSTIC_CODES = {"collection-failure", "upstream-projection-failure"}
+_PUBLICATION_LOCK = threading.Lock()
+
+
+class ProvenanceArtifactError(RuntimeError):
+    """Safe publication or validation failure with no configured path leak."""
+
+
+class UnsupportedProvenanceVersion(ProvenanceArtifactError):
+    """Existing sidecar uses a schema version this writer cannot merge."""
+
+
+def resolve_provenance_artifact_path(
+    configured_path: str | None,
+) -> Path | None:
+    """Resolve one exact configured filename at publication time."""
+    if not configured_path:
+        return None
+    path = Path(configured_path)
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    return path.absolute()
+
+
+def publish_provenance_collection(
+    collection: CollectedProvenance,
+    configured_path: str | None,
+) -> PublicationResult:
+    """Merge and atomically publish one wrapper's collection outcome."""
+    path = resolve_provenance_artifact_path(configured_path)
+    if path is None:
+        return "disabled"
+
+    contribution = _build_contribution(collection)
+    with _PUBLICATION_LOCK:
+        existing = _read_existing_document(path)
+        if existing is None:
+            if not contribution["kernelIdentities"]:
+                raise ProvenanceArtifactError(
+                    f"cannot create {path.name} without a collected kernel identity"
+                )
+            document = _new_document(contribution)
+        else:
+            validate_provenance_document(existing)
+            document = _merge_document(existing, contribution)
+            if _without_generation(document) == _without_generation(existing):
+                return "unchanged"
+
+        document = _canonicalize_document(document)
+        validate_provenance_document(document)
+        _atomic_write(path, _serialize_document(document))
+    return "written"
+
+
+def validate_provenance_document(document: object) -> None:
+    """Validate the closed v1 schema plus referential and derivation rules."""
+    if not isinstance(document, dict):
+        raise ProvenanceArtifactError("sidecar root must be an object")
+    schema_version = document.get("schemaVersion")
+    if (
+        isinstance(schema_version, bool)
+        or not isinstance(schema_version, int)
+        or schema_version != _SCHEMA_VERSION
+    ):
+        raise UnsupportedProvenanceVersion("unsupported provenance schema version")
+    _require_exact_keys(document, _TOP_LEVEL_KEYS, "sidecar")
+
+    _validate_event_key(document["eventKey"])
+    _require_int(document["mergeGeneration"], "mergeGeneration", minimum=1)
+    if document["status"] not in {"complete", "partial"}:
+        raise ProvenanceArtifactError("invalid document status")
+    _validate_diagnostics(document["diagnostics"])
+
+    handles = _require_mapping(document["handles"], "handles")
+    identities = _require_mapping(document["kernelIdentities"], "kernelIdentities")
+    occurrences = _require_mapping(document["kernelOccurrences"], "kernelOccurrences")
+    projections = _require_mapping(
+        document["upstreamProjections"], "upstreamProjections"
+    )
+    if not identities or not occurrences or not projections:
+        raise ProvenanceArtifactError(
+            "identities, occurrences, and projections must be non-empty"
+        )
+    for name, value in (
+        ("handles", handles),
+        ("kernelIdentities", identities),
+        ("kernelOccurrences", occurrences),
+        ("upstreamProjections", projections),
+    ):
+        _require_sorted_keys(value, name)
+
+    for handle_id, handle in handles.items():
+        if not isinstance(handle_id, str) or not _DECIMAL_ID_PATTERN.fullmatch(
+            handle_id
+        ):
+            raise ProvenanceArtifactError("invalid debug handle key")
+        _validate_handle(handle_id, handle, handles)
+
+    for identity_key, identity in identities.items():
+        if not isinstance(identity_key, str) or not _EVENT_KEY_PATTERN.fullmatch(
+            identity_key
+        ):
+            raise ProvenanceArtifactError("invalid kernel identity key")
+        _validate_identity(identity_key, identity, handles)
+
+    occurrences_by_compile: dict[str, list[Mapping[str, object]]] = {}
+    for occurrence_id, occurrence in occurrences.items():
+        if not isinstance(occurrence_id, str) or not _SHA256_PATTERN.fullmatch(
+            occurrence_id
+        ):
+            raise ProvenanceArtifactError("invalid kernel occurrence key")
+        validated = _validate_occurrence(
+            occurrence_id,
+            occurrence,
+            identities,
+            projections,
+        )
+        compile_id = validated["compileId"]
+        assert isinstance(compile_id, str)
+        occurrences_by_compile.setdefault(compile_id, []).append(validated)
+
+    for compile_id, projection in projections.items():
+        if not isinstance(compile_id, str) or not _SHA256_PATTERN.fullmatch(compile_id):
+            raise ProvenanceArtifactError("invalid upstream projection key")
+        _validate_projection(
+            compile_id,
+            projection,
+            identities,
+            occurrences_by_compile.get(compile_id, []),
+        )
+    if set(occurrences_by_compile) != set(projections):
+        raise ProvenanceArtifactError("occurrence and projection compile IDs disagree")
+    if document["diagnostics"] != _diagnostics_from_projections(projections):
+        raise ProvenanceArtifactError(
+            "writer diagnostics disagree with compile projections"
+        )
+
+    expected_status = (
+        "complete"
+        if not document["diagnostics"]
+        and all(
+            projection["upstreamJoin"] == "ok" for projection in projections.values()
+        )
+        else "partial"
+    )
+    if document["status"] != expected_status:
+        raise ProvenanceArtifactError("document status disagrees with its content")
+
+
+def _build_contribution(collection: CollectedProvenance) -> dict[str, Any]:
+    handles = {
+        handle_id: handle.to_dict() for handle_id, handle in collection.handles.items()
+    }
+    identities = {
+        identity_key: identity.to_dict()
+        for identity_key, identity in collection.kernel_identities.items()
+    }
+    occurrences = {
+        occurrence_id: occurrence.to_dict()
+        for occurrence_id, occurrence in collection.kernel_occurrences.items()
+    }
+    projections: dict[str, object] = {}
+    if collection.kernels:
+        level = int(torch._inductor.config.trace.provenance_tracking_level)
+        if level < 1:
+            upstream_join = "unavailable-provenance-level-0"
+        elif not collection.has_graph_lowering:
+            upstream_join = "unavailable-cache-replay"
+        else:
+            upstream_join = "partial"
+        projections[collection.compile_id] = {
+            "source": _UPSTREAM_SOURCE,
+            "version": _UPSTREAM_VERSION,
+            "producer": {
+                "torchSpyreVersion": torch_spyre_version,
+                "torchVersion": torch.__version__,
+            },
+            "settings": {
+                "provenanceTrackingLevel": level,
+                "structuredTracing": bool(torch._inductor.config.trace.enabled),
+            },
+            "kernels": [
+                {
+                    "compilerKernelName": kernel_name,
+                    "identityKey": identity_key,
+                }
+                for kernel_name, identity_key in collection.kernels
+            ],
+            "uncollectedKernels": sorted(
+                kernel.compiler_kernel_name
+                for kernel in collection.uncollected_kernels
+            ),
+            "upstreamProjectionFailed": collection.registration_capture_failed,
+            "upstreamJoin": upstream_join,
+            "preToPost": {},
+            "postToPre": {},
+            "cppCodeToPost": {},
+            "postToCppCode": {},
+            "kernelStackTraces": {},
+        }
+    return {
+        "diagnostics": _diagnostics_from_projections(projections),
+        "handles": handles,
+        "kernelIdentities": identities,
+        "kernelOccurrences": occurrences,
+        "upstreamProjections": projections,
+    }
+
+
+def _new_document(contribution: Mapping[str, object]) -> dict[str, Any]:
+    document = {
+        "schemaVersion": _SCHEMA_VERSION,
+        "eventKey": {
+            "version": KERNEL_PROVENANCE_KEY_VERSION,
+            "algorithm": "sha256-prefix-80-base32-lower",
+            "width": KERNEL_PROVENANCE_KEY_BASE32_WIDTH,
+            "stepAttribution": "bundle",
+        },
+        "mergeGeneration": 1,
+        "status": "partial",
+        **copy.deepcopy(contribution),
+    }
+    _derive_status(document)
+    return document
+
+
+def _merge_document(
+    existing: Mapping[str, object],
+    contribution: Mapping[str, object],
+) -> dict[str, Any]:
+    merged = copy.deepcopy(dict(existing))
+    _merge_equal_records(merged["handles"], contribution["handles"], "debug handle")
+    _merge_equal_records(
+        merged["kernelIdentities"],
+        contribution["kernelIdentities"],
+        "kernel identity",
+    )
+    _merge_occurrences(merged["kernelOccurrences"], contribution["kernelOccurrences"])
+    _merge_projections(
+        merged["upstreamProjections"], contribution["upstreamProjections"]
+    )
+
+    merged["diagnostics"] = _diagnostics_from_projections(
+        _require_mapping(merged["upstreamProjections"], "upstream projections")
+    )
+    _derive_status(merged)
+    if _without_generation(merged) != _without_generation(existing):
+        generation = existing["mergeGeneration"]
+        assert isinstance(generation, int)
+        merged["mergeGeneration"] = generation + 1
+    return merged
+
+
+def _merge_equal_records(
+    destination_value: object,
+    incoming_value: object,
+    record_name: str,
+) -> None:
+    destination = _require_mapping(destination_value, record_name)
+    incoming = _require_mapping(incoming_value, f"incoming {record_name}")
+    for key, value in incoming.items():
+        existing = destination.get(key)
+        if existing is not None and existing != value:
+            raise ProvenanceArtifactError(
+                f"conflicting {record_name} content for key {key}"
+            )
+        destination[key] = copy.deepcopy(value)
+
+
+def _merge_occurrences(destination_value: object, incoming_value: object) -> None:
+    destination = _require_mapping(destination_value, "kernel occurrences")
+    incoming = _require_mapping(incoming_value, "incoming kernel occurrences")
+    for occurrence_id, occurrence_value in incoming.items():
+        occurrence = _require_mapping(occurrence_value, "kernel occurrence")
+        existing_value = destination.get(occurrence_id)
+        if existing_value is None:
+            destination[occurrence_id] = copy.deepcopy(occurrence)
+            continue
+        existing = _require_mapping(existing_value, "existing kernel occurrence")
+        for field in ("identityKey", "compileId", "compilerKernelName", "selector"):
+            if existing.get(field) != occurrence.get(field):
+                raise ProvenanceArtifactError(
+                    f"conflicting kernel occurrence content for key {occurrence_id}"
+                )
+        registrations = {
+            (item["ordinal"], item["alias"]): copy.deepcopy(item)
+            for item in existing["registrations"]
+        }
+        for item in occurrence["registrations"]:
+            ordinal = item["ordinal"]
+            if any(
+                key[0] == ordinal and key[1] != item["alias"] for key in registrations
+            ):
+                raise ProvenanceArtifactError(
+                    f"conflicting registration ordinal {ordinal}"
+                )
+            registrations[(ordinal, item["alias"])] = copy.deepcopy(item)
+        existing["registrations"] = [
+            registrations[key] for key in sorted(registrations)
+        ]
+
+
+def _merge_projections(destination_value: object, incoming_value: object) -> None:
+    destination = _require_mapping(destination_value, "upstream projections")
+    incoming = _require_mapping(incoming_value, "incoming upstream projections")
+    for compile_id, projection_value in incoming.items():
+        projection = _require_mapping(projection_value, "upstream projection")
+        existing_value = destination.get(compile_id)
+        if existing_value is None:
+            destination[compile_id] = copy.deepcopy(projection)
+            continue
+        existing = _require_mapping(existing_value, "existing upstream projection")
+        for field in ("source", "version", "producer", "settings", "kernels"):
+            if existing[field] != projection[field]:
+                raise ProvenanceArtifactError(
+                    f"conflicting upstream projection metadata for key {compile_id}"
+                )
+        uncollected_kernels = sorted(
+            set(existing["uncollectedKernels"])
+            | set(projection["uncollectedKernels"])
+        )
+        upstream_projection_failed = bool(
+            existing["upstreamProjectionFailed"]
+            or projection["upstreamProjectionFailed"]
+        )
+        existing_rank = _JOIN_RANK[existing["upstreamJoin"]]
+        incoming_rank = _JOIN_RANK[projection["upstreamJoin"]]
+        if existing_rank > incoming_rank:
+            _require_projection_subset(projection, existing, compile_id)
+            existing["uncollectedKernels"] = uncollected_kernels
+            existing["upstreamProjectionFailed"] = upstream_projection_failed
+            continue
+        if incoming_rank > existing_rank:
+            _require_projection_subset(existing, projection, compile_id)
+            replacement = copy.deepcopy(projection)
+            replacement["uncollectedKernels"] = uncollected_kernels
+            replacement["upstreamProjectionFailed"] = upstream_projection_failed
+            destination[compile_id] = replacement
+            continue
+        if existing["upstreamJoin"] != projection["upstreamJoin"]:
+            raise ProvenanceArtifactError(
+                f"conflicting upstream join status for key {compile_id}"
+            )
+        if existing["upstreamJoin"] == "ok":
+            if any(
+                existing[field] != projection[field]
+                for field in (
+                    "preToPost",
+                    "postToPre",
+                    "cppCodeToPost",
+                    "postToCppCode",
+                    "kernelStackTraces",
+                )
+            ):
+                raise ProvenanceArtifactError(
+                    f"conflicting complete upstream projection for key {compile_id}"
+                )
+            existing["uncollectedKernels"] = uncollected_kernels
+            existing["upstreamProjectionFailed"] = upstream_projection_failed
+            continue
+        _merge_partial_projection(existing, projection)
+        existing["uncollectedKernels"] = uncollected_kernels
+        existing["upstreamProjectionFailed"] = upstream_projection_failed
+
+
+def _merge_partial_projection(
+    destination: dict[str, Any], incoming: Mapping[str, object]
+) -> None:
+    for field in ("preToPost", "cppCodeToPost"):
+        destination[field] = _merge_name_maps(destination[field], incoming[field])
+    destination["postToPre"] = _invert_name_map(destination["preToPost"])
+    destination["postToCppCode"] = _invert_name_map(destination["cppCodeToPost"])
+
+    stacks = _require_mapping(destination["kernelStackTraces"], "stack context")
+    incoming_stacks = _require_mapping(
+        incoming["kernelStackTraces"], "incoming stack context"
+    )
+    for alias, context_value in incoming_stacks.items():
+        context = _require_mapping(context_value, "kernel stack context")
+        if alias not in stacks:
+            stacks[alias] = copy.deepcopy(context)
+            continue
+        existing_context = _require_mapping(stacks[alias], "kernel stack context")
+        for field in ("stackTraces", "postGradNodes", "preGradNodes"):
+            existing_context[field] = sorted(
+                set(existing_context[field]) | set(context[field])
+            )
+
+
+def _require_projection_subset(
+    weaker: Mapping[str, object],
+    richer: Mapping[str, object],
+    compile_id: str,
+) -> None:
+    for field in ("preToPost", "postToPre", "cppCodeToPost", "postToCppCode"):
+        if not _name_map_is_subset(weaker[field], richer[field]):
+            raise ProvenanceArtifactError(
+                f"weaker projection conflicts with richer content for key {compile_id}"
+            )
+    weaker_stacks = _require_mapping(weaker["kernelStackTraces"], "stack context")
+    richer_stacks = _require_mapping(richer["kernelStackTraces"], "stack context")
+    for alias, context_value in weaker_stacks.items():
+        if alias not in richer_stacks:
+            raise ProvenanceArtifactError(
+                f"weaker projection conflicts with richer content for key {compile_id}"
+            )
+        context = _require_mapping(context_value, "kernel stack context")
+        richer_context = _require_mapping(
+            richer_stacks[alias], "richer kernel stack context"
+        )
+        for field in ("stackTraces", "postGradNodes", "preGradNodes"):
+            if not set(context[field]) <= set(richer_context[field]):
+                raise ProvenanceArtifactError(
+                    "weaker projection conflicts with richer content for key "
+                    f"{compile_id}"
+                )
+
+
+def _name_map_is_subset(weaker_value: object, richer_value: object) -> bool:
+    weaker = _require_mapping(weaker_value, "name map")
+    richer = _require_mapping(richer_value, "name map")
+    return all(
+        key in richer and set(values) <= set(richer[key])
+        for key, values in weaker.items()
+    )
+
+
+def _merge_name_maps(
+    first_value: object, second_value: object
+) -> dict[str, list[str]]:
+    first = _require_mapping(first_value, "name map")
+    second = _require_mapping(second_value, "name map")
+    keys = sorted(set(first) | set(second))
+    return {
+        key: sorted(set(first.get(key, [])) | set(second.get(key, []))) for key in keys
+    }
+
+
+def _invert_name_map(mapping_value: object) -> dict[str, list[str]]:
+    mapping = _require_mapping(mapping_value, "name map")
+    inverse: dict[str, list[str]] = {}
+    for source in sorted(mapping):
+        for destination in mapping[source]:
+            inverse.setdefault(destination, []).append(source)
+    return inverse
+
+
+def _derive_status(document: dict[str, Any]) -> None:
+    projections = _require_mapping(document["upstreamProjections"], "projections")
+    document["status"] = (
+        "complete"
+        if not document["diagnostics"]
+        and projections
+        and all(item["upstreamJoin"] == "ok" for item in projections.values())
+        else "partial"
+    )
+
+
+def _diagnostics_from_projections(
+    projections: Mapping[str, object],
+) -> dict[str, int]:
+    collection_failure_count = 0
+    upstream_projection_failure_count = 0
+    for projection_value in projections.values():
+        projection = _require_mapping(projection_value, "upstream projection")
+        collection_failure_count += len(projection["uncollectedKernels"])
+        upstream_projection_failure_count += int(
+            projection["upstreamProjectionFailed"]
+        )
+
+    diagnostics: dict[str, int] = {}
+    if collection_failure_count:
+        diagnostics["collection-failure"] = collection_failure_count
+    if upstream_projection_failure_count:
+        diagnostics["upstream-projection-failure"] = (
+            upstream_projection_failure_count
+        )
+    return diagnostics
+
+
+def _validate_event_key(value: object) -> None:
+    event_key = _require_mapping(value, "eventKey")
+    _require_exact_keys(
+        event_key,
+        {"version", "algorithm", "width", "stepAttribution"},
+        "eventKey",
+    )
+    _require_int(event_key["version"], "event key version", minimum=1)
+    _require_int(event_key["width"], "event key width", minimum=1)
+    expected = {
+        "version": KERNEL_PROVENANCE_KEY_VERSION,
+        "algorithm": "sha256-prefix-80-base32-lower",
+        "width": KERNEL_PROVENANCE_KEY_BASE32_WIDTH,
+        "stepAttribution": "bundle",
+    }
+    if event_key != expected:
+        raise ProvenanceArtifactError("event key contract mismatch")
+
+
+def _validate_diagnostics(value: object) -> None:
+    diagnostics = _require_mapping(value, "diagnostics")
+    _require_sorted_keys(diagnostics, "diagnostics")
+    if not set(diagnostics) <= _DIAGNOSTIC_CODES:
+        raise ProvenanceArtifactError("invalid writer diagnostic code")
+    for code, count in diagnostics.items():
+        _require_int(count, f"diagnostic {code}", minimum=1)
+
+
+def _validate_handle(
+    handle_id: str,
+    value: object,
+    handles: Mapping[str, object],
+) -> None:
+    handle = _require_mapping(value, "debug handle")
+    _require_exact_keys(
+        handle,
+        {"id", "source", "aten_op", "ir_chain", "fused_from", "transform_history"},
+        "debug handle",
+    )
+    if handle["id"] != handle_id:
+        raise ProvenanceArtifactError("debug handle key and ID disagree")
+    source = handle["source"]
+    if source is not None:
+        source_map = _require_mapping(source, "source location")
+        _require_exact_keys(
+            source_map,
+            {"file", "start_line", "start_col", "end_line", "end_col"},
+            "source location",
+        )
+        _require_nonempty_string(source_map["file"], "source file")
+        _require_int(source_map["start_line"], "source start line", minimum=1)
+        _require_int(source_map["start_col"], "source start column", minimum=0)
+        for field, minimum in (("end_line", 1), ("end_col", 0)):
+            if source_map[field] is not None:
+                _require_int(source_map[field], field, minimum=minimum)
+    if handle["aten_op"] is not None:
+        _require_nonempty_string(handle["aten_op"], "aten_op")
+    _validate_string_list(handle["ir_chain"], "ir_chain", nonempty_items=True)
+    fused_from = _validate_string_list(handle["fused_from"], "fused_from", unique=True)
+    if any(not _DECIMAL_ID_PATTERN.fullmatch(item) for item in fused_from):
+        raise ProvenanceArtifactError("invalid fused handle ID")
+    if any(item not in handles for item in fused_from):
+        raise ProvenanceArtifactError("dangling fused handle reference")
+    transforms = _require_list(handle["transform_history"], "transform history")
+    for transform_value in transforms:
+        transform = _require_mapping(transform_value, "provenance transform")
+        _require_exact_keys(transform, {"kind", "pass_name", "reason"}, "transform")
+        if transform["kind"] not in _TRANSFORM_KINDS:
+            raise ProvenanceArtifactError("invalid transform kind")
+        _require_nonempty_string(transform["pass_name"], "transform pass name")
+        if transform["reason"] is not None and not isinstance(transform["reason"], str):
+            raise ProvenanceArtifactError("invalid transform reason")
+
+
+def _validate_identity(
+    identity_key: str,
+    value: object,
+    handles: Mapping[str, object],
+) -> None:
+    identity = _require_mapping(value, "kernel identity")
+    _require_exact_keys(
+        identity,
+        {"directHandleIds", "specHandleBindings", "atenOps", "eventNameBase"},
+        "kernel identity",
+    )
+    direct_handle_ids = _validate_string_list(
+        identity["directHandleIds"],
+        "direct handle IDs",
+        unique=True,
+    )
+    if any(not _DECIMAL_ID_PATTERN.fullmatch(item) for item in direct_handle_ids):
+        raise ProvenanceArtifactError("invalid direct handle ID")
+    if any(item not in handles for item in direct_handle_ids):
+        raise ProvenanceArtifactError("dangling direct handle reference")
+
+    binding_ids: list[str] = []
+    bindings = _require_list(identity["specHandleBindings"], "spec bindings")
+    for binding_value in bindings:
+        binding = _require_mapping(binding_value, "spec handle binding")
+        _require_exact_keys(binding, {"specPath", "handleId"}, "spec binding")
+        spec_path = _require_list(binding["specPath"], "spec path")
+        if not spec_path:
+            raise ProvenanceArtifactError("spec path must not be empty")
+        for index in spec_path:
+            _require_int(index, "spec path index", minimum=0)
+        handle_id = binding["handleId"]
+        if (
+            not isinstance(handle_id, str)
+            or not _DECIMAL_ID_PATTERN.fullmatch(handle_id)
+            or handle_id not in handles
+        ):
+            raise ProvenanceArtifactError("invalid spec binding handle reference")
+        binding_ids.append(handle_id)
+    if direct_handle_ids != list(dict.fromkeys(binding_ids)):
+        raise ProvenanceArtifactError("direct handle order disagrees with bindings")
+
+    aten_ops = _validate_string_list(
+        identity["atenOps"],
+        "ATen operations",
+        unique=True,
+        nonempty_items=True,
+    )
+    if aten_ops != sorted(aten_ops):
+        raise ProvenanceArtifactError("ATen operations must be sorted")
+    if aten_ops != _recursive_aten_ops(direct_handle_ids, handles):
+        raise ProvenanceArtifactError("ATen operations disagree with handles")
+
+    event_name_base = identity["eventNameBase"]
+    if not isinstance(event_name_base, str) or not _EVENT_NAME_PATTERN.fullmatch(
+        event_name_base
+    ):
+        raise ProvenanceArtifactError("invalid profiler event name base")
+    descriptor = KernelProvenanceDescriptor(
+        key=identity_key,
+        debug_handle_ids=tuple(direct_handle_ids),
+        aten_ops=tuple(aten_ops),
+    )
+    if event_name_base != format_kernel_provenance_event_name(descriptor):
+        raise ProvenanceArtifactError("profiler event name disagrees with identity")
+
+
+def _validate_occurrence(
+    occurrence_id: str,
+    value: object,
+    identities: Mapping[str, object],
+    projections: Mapping[str, object],
+) -> dict[str, Any]:
+    occurrence = _require_mapping(value, "kernel occurrence")
+    required = {"identityKey", "compileId", "compilerKernelName", "registrations"}
+    if set(occurrence) not in (required, required | {"selector"}):
+        raise ProvenanceArtifactError("kernel occurrence has invalid fields")
+
+    identity_key = occurrence["identityKey"]
+    if (
+        not isinstance(identity_key, str)
+        or not _EVENT_KEY_PATTERN.fullmatch(identity_key)
+        or identity_key not in identities
+    ):
+        raise ProvenanceArtifactError("invalid occurrence identity reference")
+    compile_id = occurrence["compileId"]
+    if (
+        not isinstance(compile_id, str)
+        or not _SHA256_PATTERN.fullmatch(compile_id)
+        or compile_id not in projections
+    ):
+        raise ProvenanceArtifactError("invalid occurrence compile reference")
+    kernel_name = _require_nonempty_string(
+        occurrence["compilerKernelName"], "compiler kernel name"
+    )
+    if "selector" in occurrence:
+        _require_nonempty_string(occurrence["selector"], "occurrence selector")
+
+    registrations = _require_list(occurrence["registrations"], "registrations")
+    ordinals: list[int] = []
+    aliases: set[str] = set()
+    for registration_value in registrations:
+        registration = _require_mapping(registration_value, "registration")
+        _require_exact_keys(registration, {"ordinal", "alias"}, "registration")
+        ordinal = _require_int(
+            registration["ordinal"], "registration ordinal", minimum=1
+        )
+        alias = registration["alias"]
+        if (
+            not isinstance(alias, str)
+            or not _ALIAS_PATTERN.fullmatch(alias)
+            or alias != f"{kernel_name}:{ordinal}"
+        ):
+            raise ProvenanceArtifactError("registration alias disagrees with ordinal")
+        if alias in aliases:
+            raise ProvenanceArtifactError("duplicate registration alias")
+        ordinals.append(ordinal)
+        aliases.add(alias)
+    if ordinals != sorted(ordinals) or len(ordinals) != len(set(ordinals)):
+        raise ProvenanceArtifactError("registration ordinals must be sorted and unique")
+
+    expected_id = _canonical_digest(
+        {
+            "domain": _OCCURRENCE_ID_DOMAIN,
+            "compileId": compile_id,
+            "compilerKernelName": kernel_name,
+            "identityKey": identity_key,
+        }
+    )
+    if occurrence_id != expected_id:
+        raise ProvenanceArtifactError("kernel occurrence ID derivation mismatch")
+    return occurrence
+
+
+def _validate_projection(
+    compile_id: str,
+    value: object,
+    identities: Mapping[str, object],
+    occurrences: Sequence[Mapping[str, object]],
+) -> None:
+    projection = _require_mapping(value, "upstream projection")
+    _require_exact_keys(projection, _PROJECTION_KEYS, "upstream projection")
+    if projection["source"] != _UPSTREAM_SOURCE:
+        raise ProvenanceArtifactError("invalid upstream projection source")
+    if projection["version"] != _UPSTREAM_VERSION:
+        raise ProvenanceArtifactError("invalid upstream projection version")
+
+    producer = _require_mapping(projection["producer"], "producer")
+    _require_exact_keys(producer, {"torchSpyreVersion", "torchVersion"}, "producer")
+    _require_nonempty_string(producer["torchSpyreVersion"], "torch-spyre version")
+    _require_nonempty_string(producer["torchVersion"], "PyTorch version")
+
+    settings = _require_mapping(projection["settings"], "settings")
+    _require_exact_keys(
+        settings,
+        {"provenanceTrackingLevel", "structuredTracing"},
+        "settings",
+    )
+    _require_int(
+        settings["provenanceTrackingLevel"],
+        "provenance tracking level",
+        minimum=0,
+    )
+    if not isinstance(settings["structuredTracing"], bool):
+        raise ProvenanceArtifactError("structured tracing setting must be boolean")
+
+    kernels_value = _require_list(projection["kernels"], "compile kernels")
+    if not kernels_value:
+        raise ProvenanceArtifactError("compile kernels must not be empty")
+    kernels: list[tuple[str, str]] = []
+    for kernel_value in kernels_value:
+        kernel = _require_mapping(kernel_value, "compile kernel")
+        _require_exact_keys(
+            kernel, {"compilerKernelName", "identityKey"}, "compile kernel"
+        )
+        kernel_name = _require_nonempty_string(
+            kernel["compilerKernelName"], "compiler kernel name"
+        )
+        identity_key = kernel["identityKey"]
+        if (
+            not isinstance(identity_key, str)
+            or not _EVENT_KEY_PATTERN.fullmatch(identity_key)
+            or identity_key not in identities
+        ):
+            raise ProvenanceArtifactError("invalid compile kernel identity")
+        kernels.append((kernel_name, identity_key))
+    if len(kernels) != len(set(kernels)):
+        raise ProvenanceArtifactError("duplicate compile kernel")
+
+    uncollected_kernels = _validate_string_list(
+        projection["uncollectedKernels"],
+        "uncollected kernel names",
+        unique=True,
+        nonempty_items=True,
+    )
+    if uncollected_kernels != sorted(uncollected_kernels):
+        raise ProvenanceArtifactError("uncollected kernel names must be sorted")
+    if set(uncollected_kernels) & {kernel_name for kernel_name, _ in kernels}:
+        raise ProvenanceArtifactError("collected and uncollected kernels overlap")
+    if not isinstance(projection["upstreamProjectionFailed"], bool):
+        raise ProvenanceArtifactError(
+            "upstream projection failure marker must be boolean"
+        )
+
+    expected_compile_id = _canonical_digest(
+        {
+            "domain": _COMPILE_ID_DOMAIN,
+            "kernels": [list(kernel) for kernel in kernels],
+        }
+    )
+    if compile_id != expected_compile_id:
+        raise ProvenanceArtifactError("compile ID derivation mismatch")
+
+    occurrence_kernels = {
+        (item["compilerKernelName"], item["identityKey"]) for item in occurrences
+    }
+    if occurrence_kernels != set(kernels):
+        raise ProvenanceArtifactError("projection kernels disagree with occurrences")
+
+    registration_aliases: set[str] = set()
+    registration_ordinals: set[int] = set()
+    for occurrence in occurrences:
+        for registration in occurrence["registrations"]:
+            ordinal = registration["ordinal"]
+            if ordinal in registration_ordinals:
+                raise ProvenanceArtifactError(
+                    "registration ordinal repeated across one compile"
+                )
+            registration_ordinals.add(ordinal)
+            registration_aliases.add(registration["alias"])
+
+    join = projection["upstreamJoin"]
+    if join not in _JOIN_RANK:
+        raise ProvenanceArtifactError("invalid upstream join status")
+    pre_to_post = _validate_name_map(projection["preToPost"], "preToPost")
+    post_to_pre = _validate_name_map(projection["postToPre"], "postToPre")
+    cpp_to_post = _validate_name_map(projection["cppCodeToPost"], "cppCodeToPost")
+    post_to_cpp = _validate_name_map(projection["postToCppCode"], "postToCppCode")
+    if not set(cpp_to_post) <= registration_aliases:
+        raise ProvenanceArtifactError("upstream aliases lack exact registrations")
+    if join == "ok" and set(cpp_to_post) != registration_aliases:
+        raise ProvenanceArtifactError("complete projection lacks registered aliases")
+    if post_to_pre != _invert_name_map(pre_to_post):
+        raise ProvenanceArtifactError("postToPre is not the exact inverse")
+    if post_to_cpp != _invert_name_map(cpp_to_post):
+        raise ProvenanceArtifactError("postToCppCode is not the exact inverse")
+
+    stacks = _require_mapping(projection["kernelStackTraces"], "stack contexts")
+    _require_sorted_keys(stacks, "kernelStackTraces")
+    for alias, context_value in stacks.items():
+        if not isinstance(alias, str):
+            raise ProvenanceArtifactError("stack context alias must be a string")
+        context = _require_mapping(context_value, "kernel stack context")
+        _require_exact_keys(
+            context,
+            {"stackTraces", "postGradNodes", "preGradNodes"},
+            "kernel stack context",
+        )
+        for field in ("stackTraces", "postGradNodes", "preGradNodes"):
+            _validate_string_list(context[field], field, unique=True)
+    if join == "ok" and set(stacks) != registration_aliases:
+        raise ProvenanceArtifactError("complete projection lacks stack contexts")
+
+
+def _validate_name_map(value: object, name: str) -> dict[str, list[str]]:
+    mapping = _require_mapping(value, name)
+    _require_sorted_keys(mapping, name)
+    result: dict[str, list[str]] = {}
+    for key, values in mapping.items():
+        if not isinstance(key, str):
+            raise ProvenanceArtifactError(f"{name} key must be a string")
+        result[key] = _validate_string_list(values, name, unique=True)
+    return result
+
+
+def _recursive_aten_ops(
+    direct_handle_ids: Sequence[str], handles: Mapping[str, object]
+) -> list[str]:
+    names: set[str] = set()
+    visited: set[str] = set()
+    visiting: set[str] = set()
+
+    def visit(handle_id: str) -> None:
+        if handle_id in visiting:
+            raise ProvenanceArtifactError("cyclic fused handle references")
+        if handle_id in visited:
+            return
+        visiting.add(handle_id)
+        handle = _require_mapping(handles[handle_id], "debug handle")
+        aten_op = handle["aten_op"]
+        if aten_op is not None:
+            assert isinstance(aten_op, str)
+            names.add(aten_op)
+        for constituent_id in handle["fused_from"]:
+            visit(constituent_id)
+        visiting.remove(handle_id)
+        visited.add(handle_id)
+
+    for direct_handle_id in direct_handle_ids:
+        visit(direct_handle_id)
+    return sorted(names)
+
+
+def _canonical_digest(value: object) -> str:
+    payload = json.dumps(
+        value,
+        ensure_ascii=True,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("ascii")).hexdigest()
+
+
+def _canonicalize_document(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _canonicalize_document(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return [_canonicalize_document(item) for item in value]
+    return value
+
+
+def _without_generation(document: Mapping[str, object]) -> dict[str, object]:
+    result = copy.deepcopy(dict(document))
+    result.pop("mergeGeneration", None)
+    return result
+
+
+def _serialize_document(document: Mapping[str, object]) -> str:
+    return (
+        json.dumps(
+            document,
+            ensure_ascii=True,
+            allow_nan=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+
+def _read_existing_document(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except (OSError, UnicodeError):
+        raise ProvenanceArtifactError(f"failed to read {path.name}") from None
+    try:
+        value = json.loads(payload)
+    except json.JSONDecodeError:
+        raise ProvenanceArtifactError(f"invalid JSON in {path.name}") from None
+    if not isinstance(value, dict):
+        raise ProvenanceArtifactError(f"invalid document in {path.name}")
+    return value
+
+
+def _atomic_write(path: Path, payload: str) -> None:
+    temporary_path: Path | None = None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary_path = Path(temporary.name)
+            temporary.write(payload)
+        os.replace(temporary_path, path)
+        temporary_path = None
+    except OSError:
+        raise ProvenanceArtifactError(f"failed to write {path.name}") from None
+    finally:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink()
+            except OSError:
+                pass
+
+
+def _require_mapping(value: object, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ProvenanceArtifactError(f"{name} must be an object")
+    return value
+
+
+def _require_list(value: object, name: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ProvenanceArtifactError(f"{name} must be an array")
+    return value
+
+
+def _require_exact_keys(
+    value: Mapping[str, object], expected: set[str], name: str
+) -> None:
+    if set(value) != expected:
+        raise ProvenanceArtifactError(f"{name} has invalid fields")
+
+
+def _require_sorted_keys(value: Mapping[str, object], name: str) -> None:
+    if list(value) != sorted(value):
+        raise ProvenanceArtifactError(f"{name} keys must be sorted")
+
+
+def _require_int(value: object, name: str, *, minimum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise ProvenanceArtifactError(f"{name} must be an integer >= {minimum}")
+    return value
+
+
+def _require_nonempty_string(value: object, name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ProvenanceArtifactError(f"{name} must be a non-empty string")
+    return value
+
+
+def _validate_string_list(
+    value: object,
+    name: str,
+    *,
+    unique: bool = False,
+    nonempty_items: bool = False,
+) -> list[str]:
+    items = _require_list(value, name)
+    if not all(
+        isinstance(item, str) and (not nonempty_items or bool(item)) for item in items
+    ):
+        raise ProvenanceArtifactError(f"{name} must contain valid strings")
+    result = list(items)
+    if unique and len(result) != len(set(result)):
+        raise ProvenanceArtifactError(f"{name} must not contain duplicates")
+    return result

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -48,6 +48,10 @@ from .scratchpad.lx_relayout import (
     work_division_from_view,
 )
 from .op_spec import LoopSpec
+from .provenance_artifact import (
+    mark_kernel_registration_failure,
+    record_kernel_registration,
+)
 from . import config as _spyre_config
 
 logger = get_inductor_logger("scheduler")
@@ -606,6 +610,39 @@ class SuperDSCScheduling(BaseScheduling):
         """
         # Overrides superclass method that raises NotImplementedError.
         pass
+
+    def codegen_comment(
+        self,
+        node_schedule: Sequence[BaseSchedulerNode],
+        kernel_name: str | None = None,
+    ) -> None:
+        """Register and retain the exact upstream provenance alias once."""
+        if not kernel_name:
+            return
+
+        from torch._inductor.debug import set_kernel_post_grad_provenance_tracing
+
+        debug_handle = set_kernel_post_grad_provenance_tracing(
+            node_schedule,
+            kernel_name,
+        )
+        V.graph.wrapper_code.write_provenance_debug_handle(
+            kernel_name,
+            debug_handle,
+        )
+        try:
+            record_kernel_registration(V.graph, kernel_name, debug_handle)
+        except Exception:  # noqa: BLE001 - provenance must never fail codegen
+            try:
+                mark_kernel_registration_failure(V.graph)
+            except Exception:  # noqa: BLE001 - preserve the original traceback
+                pass
+            logger.warning(
+                "failed to retain the upstream provenance alias for kernel %s; "
+                "continuing without artifact registration data",
+                kernel_name,
+                exc_info=True,
+            )
 
     def can_buffer_be_removed_through_fusion(
         self, name: str, fused_node_names: OrderedSet[str]

--- a/torch_spyre/_inductor/schemas/__init__.py
+++ b/torch_spyre/_inductor/schemas/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Versioned wire schemas for Torch-Spyre compiler artifacts."""

--- a/torch_spyre/_inductor/schemas/spyre_provenance_v1.schema.json
+++ b/torch_spyre/_inductor/schemas/spyre_provenance_v1.schema.json
@@ -35,17 +35,17 @@
       "enum": ["complete", "partial"]
     },
     "diagnostics": {
-      "description": "Writer-side failure counts merged by code. Reader rejection diagnostics use a separate vocabulary defined by the resolver contract.",
+      "description": "Writer-side failure counts derived from compile projections. Reader rejection diagnostics use a separate vocabulary defined by the resolver contract.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "collection-failure": {
-          "description": "Number of kernels whose Spyre provenance could not be collected.",
+          "description": "Sum of the per-projection distinct uncollected kernel-name counts.",
           "type": "integer",
           "minimum": 1
         },
         "upstream-projection-failure": {
-          "description": "Number of failures while reading or filtering live upstream provenance.",
+          "description": "Number of compile projections that observed a failure while capturing or filtering upstream provenance.",
           "type": "integer",
           "minimum": 1
         }
@@ -413,6 +413,8 @@
         "producer",
         "settings",
         "kernels",
+        "uncollectedKernels",
+        "upstreamProjectionFailed",
         "upstreamJoin",
         "preToPost",
         "postToPre",
@@ -436,6 +438,19 @@
           "type": "array",
           "minItems": 1,
           "items": { "$ref": "#/$defs/compileKernel" }
+        },
+        "uncollectedKernels": {
+          "description": "Sorted set of compiler kernel names that belonged to this wrapper but could not safely produce a bundle identity.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "upstreamProjectionFailed": {
+          "description": "Whether this compile observed a failure while capturing or filtering upstream provenance.",
+          "type": "boolean"
         },
         "upstreamJoin": {
           "description": "Best available alias/projection status after merge. Richer data is never replaced by a weaker status.",

--- a/torch_spyre/_inductor/schemas/spyre_provenance_v1.schema.json
+++ b/torch_spyre/_inductor/schemas/spyre_provenance_v1.schema.json
@@ -22,7 +22,7 @@
       "const": 1
     },
     "eventKey": {
-      "description": "Phase 3a profiler event-key contract shared by every identity in this artifact.",
+      "description": "Versioned profiler event-key contract shared by every kernel identity in this artifact.",
       "$ref": "#/$defs/eventKey"
     },
     "mergeGeneration": {
@@ -58,7 +58,7 @@
       "additionalProperties": { "$ref": "#/$defs/handle" }
     },
     "kernelIdentities": {
-      "description": "Content identities keyed by the Phase 3a finalized-bundle key.",
+      "description": "Content identities keyed by the finalized-bundle provenance key.",
       "type": "object",
       "minProperties": 1,
       "propertyNames": { "$ref": "#/$defs/eventKeyValue" },
@@ -86,7 +86,7 @@
       "pattern": "^(0|[1-9][0-9]*)$"
     },
     "eventKeyValue": {
-      "description": "Lowercase base32 encoding of the first 80 bits of the Phase 3a SHA-256 bundle fingerprint.",
+      "description": "Lowercase base32 encoding of the first 80 bits of the SHA-256 finalized-bundle fingerprint.",
       "type": "string",
       "pattern": "^[a-z2-7]{16}$"
     },
@@ -311,7 +311,7 @@
           "$ref": "#/$defs/stringSet"
         },
         "eventNameBase": {
-          "description": "Exact Phase 3a profiler event name before the runtime appends #<step>.",
+          "description": "Exact profiler event name before the runtime appends #<step>.",
           "type": "string",
           "pattern": "^spyre_kernel_v1_[A-Za-z0-9_]+_[a-z2-7]{16}$"
         }
@@ -366,7 +366,7 @@
           "uniqueItems": true
         },
         "selector": {
-          "description": "Reserved opaque exact-match occurrence token supplied by future event metadata. V1 writers omit it.",
+          "description": "Reserved optional opaque exact-match occurrence token supplied by runtime event metadata. V1 writers omit this field.",
           "type": "string",
           "minLength": 1
         }

--- a/torch_spyre/_inductor/schemas/spyre_provenance_v1.schema.json
+++ b/torch_spyre/_inductor/schemas/spyre_provenance_v1.schema.json
@@ -1,0 +1,461 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/torch-spyre/torch-spyre/schemas/spyre_provenance_v1.schema.json",
+  "title": "Torch-Spyre provenance sidecar v1",
+  "description": "Authoritative durable mapping from Spyre profiler bundle keys to normalized source provenance and filtered upstream Inductor relationships.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "eventKey",
+    "mergeGeneration",
+    "status",
+    "diagnostics",
+    "handles",
+    "kernelIdentities",
+    "kernelOccurrences",
+    "upstreamProjections"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "description": "Wire-format version. Readers check this field before JSON Schema validation and reject unsupported versions explicitly.",
+      "const": 1
+    },
+    "eventKey": {
+      "description": "Phase 3a profiler event-key contract shared by every identity in this artifact.",
+      "$ref": "#/$defs/eventKey"
+    },
+    "mergeGeneration": {
+      "description": "One-based count of semantic publications. A no-op merge does not increment it.",
+      "type": "integer",
+      "minimum": 1
+    },
+    "status": {
+      "description": "Derived artifact completeness: complete only when diagnostics is empty and every upstream projection is ok; partial otherwise.",
+      "enum": ["complete", "partial"]
+    },
+    "diagnostics": {
+      "description": "Writer-side failure counts merged by code. Reader rejection diagnostics use a separate vocabulary defined by the resolver contract.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collection-failure": {
+          "description": "Number of kernels whose Spyre provenance could not be collected.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "upstream-projection-failure": {
+          "description": "Number of failures while reading or filtering live upstream provenance.",
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "handles": {
+      "description": "Normalized DebugHandle records keyed by decimal-string handle ID. An empty map is valid.",
+      "type": "object",
+      "propertyNames": { "$ref": "#/$defs/decimalId" },
+      "additionalProperties": { "$ref": "#/$defs/handle" }
+    },
+    "kernelIdentities": {
+      "description": "Content identities keyed by the Phase 3a finalized-bundle key.",
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": { "$ref": "#/$defs/eventKeyValue" },
+      "additionalProperties": { "$ref": "#/$defs/kernelIdentity" }
+    },
+    "kernelOccurrences": {
+      "description": "Compile-scoped reconstructed bundles keyed by their derived occurrence ID.",
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": { "$ref": "#/$defs/sha256Hex" },
+      "additionalProperties": { "$ref": "#/$defs/kernelOccurrence" }
+    },
+    "upstreamProjections": {
+      "description": "Compile metadata and filtered upstream relationships keyed by the derived compile ID.",
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": { "$ref": "#/$defs/sha256Hex" },
+      "additionalProperties": { "$ref": "#/$defs/upstreamProjection" }
+    }
+  },
+  "$defs": {
+    "decimalId": {
+      "description": "Canonical non-negative decimal integer spelling without leading zeros.",
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)$"
+    },
+    "eventKeyValue": {
+      "description": "Lowercase base32 encoding of the first 80 bits of the Phase 3a SHA-256 bundle fingerprint.",
+      "type": "string",
+      "pattern": "^[a-z2-7]{16}$"
+    },
+    "sha256Hex": {
+      "description": "Full lowercase hexadecimal SHA-256 digest.",
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "stringSet": {
+      "description": "Order-preserving array with no duplicate strings.",
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true
+    },
+    "producer": {
+      "description": "Toolchain versions that produced one compile-scoped contribution.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["torchSpyreVersion", "torchVersion"],
+      "properties": {
+        "torchSpyreVersion": {
+          "description": "torch-spyre package version.",
+          "type": "string",
+          "minLength": 1
+        },
+        "torchVersion": {
+          "description": "PyTorch package version.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "eventKey": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "algorithm", "width", "stepAttribution"],
+      "properties": {
+        "version": {
+          "description": "Profiler event-key format version.",
+          "const": 1
+        },
+        "algorithm": {
+          "description": "Bundle-key digest and encoding algorithm.",
+          "const": "sha256-prefix-80-base32-lower"
+        },
+        "width": {
+          "description": "Encoded bundle-key width in ASCII characters.",
+          "const": 16
+        },
+        "stepAttribution": {
+          "description": "Current JobExecPlan step suffixes resolve to the whole finalized open-source bundle.",
+          "const": "bundle"
+        }
+      }
+    },
+    "settings": {
+      "description": "Upstream provenance and structured-tracing settings for one compile contribution.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provenanceTrackingLevel", "structuredTracing"],
+      "properties": {
+        "provenanceTrackingLevel": {
+          "description": "Observed torch._inductor.config.trace.provenance_tracking_level. Phase 3b never changes it.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "structuredTracing": {
+          "description": "Whether upstream structured tracing was active for this contribution.",
+          "type": "boolean"
+        }
+      }
+    },
+    "sourceLoc": {
+      "description": "Structured source range matching MLIR FileLineColRange fields.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["file", "start_line", "start_col", "end_line", "end_col"],
+      "properties": {
+        "file": {
+          "description": "Source filename as recorded by the compiler.",
+          "type": "string",
+          "minLength": 1
+        },
+        "start_line": {
+          "description": "One-based starting line.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "start_col": {
+          "description": "Zero-based starting column.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "end_line": {
+          "description": "Optional one-based ending line.",
+          "oneOf": [
+            { "type": "integer", "minimum": 1 },
+            { "type": "null" }
+          ]
+        },
+        "end_col": {
+          "description": "Optional zero-based ending column.",
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "null" }
+          ]
+        }
+      }
+    },
+    "transform": {
+      "description": "One immutable lower-IR provenance transformation.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "pass_name", "reason"],
+      "properties": {
+        "kind": {
+          "description": "Typed rewrite relationship.",
+          "enum": ["rewrite", "fusion", "decomposition", "clone", "remap"]
+        },
+        "pass_name": {
+          "description": "Compiler pass that performed the transformation.",
+          "type": "string",
+          "minLength": 1
+        },
+        "reason": {
+          "description": "Optional structured explanation supplied by the pass.",
+          "oneOf": [{ "type": "string" }, { "type": "null" }]
+        }
+      }
+    },
+    "handle": {
+      "description": "Normalized DebugHandle. fused_from contains ID references rather than DebugHandle.to_dict()'s recursively nested objects.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "source",
+        "aten_op",
+        "ir_chain",
+        "fused_from",
+        "transform_history"
+      ],
+      "properties": {
+        "id": {
+          "description": "Must equal this record's key in the top-level handles map.",
+          "$ref": "#/$defs/decimalId"
+        },
+        "source": {
+          "description": "Unambiguous headline source, or null when constituents disagree or source metadata is absent.",
+          "oneOf": [
+            { "$ref": "#/$defs/sourceLoc" },
+            { "type": "null" }
+          ]
+        },
+        "aten_op": {
+          "description": "Unambiguous source-level ATen identity, or null when constituents disagree or metadata is absent.",
+          "oneOf": [
+            { "type": "string", "minLength": 1 },
+            { "type": "null" }
+          ]
+        },
+        "ir_chain": {
+          "description": "Ordered opaque compiler names. V1 does not infer stage types that production data does not encode.",
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "fused_from": {
+          "description": "Ordered authoritative constituent handle IDs. Every ID must resolve in the top-level handles map.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/decimalId" },
+          "uniqueItems": true
+        },
+        "transform_history": {
+          "description": "Ordered typed lower-IR transformation history.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/transform" }
+        }
+      }
+    },
+    "specHandleBinding": {
+      "description": "One direct handle attachment at a finalized OpSpec position.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["specPath", "handleId"],
+      "properties": {
+        "specPath": {
+          "description": "Non-empty zero-based index path through the finalized OpSpec/LoopSpec tree.",
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "integer", "minimum": 0 }
+        },
+        "handleId": {
+          "description": "Directly attached handle ID at this OpSpec position.",
+          "$ref": "#/$defs/decimalId"
+        }
+      }
+    },
+    "kernelIdentity": {
+      "description": "Cache-stable finalized-bundle identity independent of compiler occurrence context.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "directHandleIds",
+        "specHandleBindings",
+        "atenOps",
+        "eventNameBase"
+      ],
+      "properties": {
+        "directHandleIds": {
+          "description": "Ordered first-appearance deduplication of specHandleBindings handle IDs.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/decimalId" },
+          "uniqueItems": true
+        },
+        "specHandleBindings": {
+          "description": "Depth-first finalized OpSpec attachments, retaining position, multiplicity, and order.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/specHandleBinding" }
+        },
+        "atenOps": {
+          "description": "Sorted unique recursive ATen identities reachable from direct handles.",
+          "$ref": "#/$defs/stringSet"
+        },
+        "eventNameBase": {
+          "description": "Exact Phase 3a profiler event name before the runtime appends #<step>.",
+          "type": "string",
+          "pattern": "^spyre_kernel_v1_[A-Za-z0-9_]+_[a-z2-7]{16}$"
+        }
+      }
+    },
+    "registration": {
+      "description": "One exact upstream registration retained from a scheduler codegen call.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ordinal", "alias"],
+      "properties": {
+        "ordinal": {
+          "description": "One-based compile-scoped ordinal returned by upstream registration.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "alias": {
+          "description": "Exact <compiler-kernel-name>:<ordinal> upstream mapping key.",
+          "type": "string",
+          "pattern": "^.+:[1-9][0-9]*$"
+        }
+      }
+    },
+    "kernelOccurrence": {
+      "description": "One finalized sdsc() bundle reconstructed for one compiler kernel in one compile identity.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "identityKey",
+        "compileId",
+        "compilerKernelName",
+        "registrations"
+      ],
+      "properties": {
+        "identityKey": {
+          "description": "Key into kernelIdentities.",
+          "$ref": "#/$defs/eventKeyValue"
+        },
+        "compileId": {
+          "description": "Key into upstreamProjections. Availability belongs to that compile-scoped projection, not this deduplicated occurrence.",
+          "$ref": "#/$defs/sha256Hex"
+        },
+        "compilerKernelName": {
+          "description": "Exact sdsc_* name used by the generated wrapper.",
+          "type": "string",
+          "minLength": 1
+        },
+        "registrations": {
+          "description": "Ordered exact aliases observed during fresh codegen; empty on cache replay or provenance level 0.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/registration" },
+          "uniqueItems": true
+        },
+        "selector": {
+          "description": "Reserved opaque exact-match occurrence token supplied by future event metadata. V1 writers omit it.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "compileKernel": {
+      "description": "One wrapper kernel used to derive compileId in finalized wrapper order.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["compilerKernelName", "identityKey"],
+      "properties": {
+        "compilerKernelName": {
+          "type": "string",
+          "minLength": 1
+        },
+        "identityKey": {
+          "$ref": "#/$defs/eventKeyValue"
+        }
+      }
+    },
+    "nameMap": {
+      "description": "Upstream graph-name relation preserving upstream value order.",
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/stringSet" }
+    },
+    "kernelStackContext": {
+      "description": "Kernel-level display context copied from upstream, not handle-level structured provenance.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stackTraces", "postGradNodes", "preGradNodes"],
+      "properties": {
+        "stackTraces": { "$ref": "#/$defs/stringSet" },
+        "postGradNodes": { "$ref": "#/$defs/stringSet" },
+        "preGradNodes": { "$ref": "#/$defs/stringSet" }
+      }
+    },
+    "upstreamProjection": {
+      "description": "Compile-scoped producer/settings metadata plus a filtered cache of upstream-owned v2 relationships.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "version",
+        "producer",
+        "settings",
+        "kernels",
+        "upstreamJoin",
+        "preToPost",
+        "postToPre",
+        "cppCodeToPost",
+        "postToCppCode",
+        "kernelStackTraces"
+      ],
+      "properties": {
+        "source": {
+          "description": "Upstream artifact whose live state was filtered.",
+          "const": "inductor_provenance_tracking_node_mappings"
+        },
+        "version": {
+          "description": "Numeric upstream node-mapping schema version.",
+          "const": 2.0
+        },
+        "producer": { "$ref": "#/$defs/producer" },
+        "settings": { "$ref": "#/$defs/settings" },
+        "kernels": {
+          "description": "Ordered wrapper kernel list used to derive this map key as the compile ID.",
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/compileKernel" }
+        },
+        "upstreamJoin": {
+          "description": "Best available alias/projection status after merge. Richer data is never replaced by a weaker status.",
+          "enum": [
+            "ok",
+            "unavailable-provenance-level-0",
+            "unavailable-cache-replay",
+            "partial"
+          ]
+        },
+        "preToPost": { "$ref": "#/$defs/nameMap" },
+        "postToPre": { "$ref": "#/$defs/nameMap" },
+        "cppCodeToPost": { "$ref": "#/$defs/nameMap" },
+        "postToCppCode": { "$ref": "#/$defs/nameMap" },
+        "kernelStackTraces": {
+          "description": "Reachable stack context keyed by exact registration alias.",
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/kernelStackContext" }
+        }
+      }
+    }
+  }
+}

--- a/torch_spyre/_inductor/schemas/spyre_provenance_v1.schema.json
+++ b/torch_spyre/_inductor/schemas/spyre_provenance_v1.schema.json
@@ -143,18 +143,18 @@
       }
     },
     "settings": {
-      "description": "Upstream provenance and structured-tracing settings for one compile contribution.",
+      "description": "Strongest upstream provenance and structured-tracing settings observed across contributions merged into one compile identity.",
       "type": "object",
       "additionalProperties": false,
       "required": ["provenanceTrackingLevel", "structuredTracing"],
       "properties": {
         "provenanceTrackingLevel": {
-          "description": "Observed torch._inductor.config.trace.provenance_tracking_level. Phase 3b never changes it.",
+          "description": "Maximum observed torch._inductor.config.trace.provenance_tracking_level across merged contributions.",
           "type": "integer",
           "minimum": 0
         },
         "structuredTracing": {
-          "description": "Whether upstream structured tracing was active for this contribution.",
+          "description": "Whether upstream structured tracing was active for any merged contribution.",
           "type": "boolean"
         }
       }

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -83,6 +83,7 @@ def _check_ktir_device_prerequisites() -> None:
             + "\n".join(f"  - {m}" for m in missing)
         )
 
+
 _publication_disabled_lock = threading.Lock()
 _publication_disabled_logged = False
 _provenance_level_zero_lock = threading.Lock()
@@ -373,6 +374,7 @@ class SpyreAsyncCompile(AsyncCompile):
 
     def wait(self, scope: dict[str, Any]) -> None:
         super().wait(scope)
+        # Later waits must not consume stale V.graph state or publish/count twice.
         if self._provenance_wait_completed:
             return
         self._provenance_wait_completed = True

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -42,7 +42,10 @@ from torch_spyre._inductor.provenance_artifact import (
     consume_kernel_registration_state,
     ProvenanceCollectionBuilder,
 )
-from torch_spyre._inductor.provenance_writer import publish_provenance_collection
+from torch_spyre._inductor.provenance_writer import (
+    capture_upstream_projection,
+    publish_provenance_collection,
+)
 from torch_spyre._inductor.codegen.bundle import generate_bundle
 from torch_spyre.profiler._ffdc import CATEGORY_COMPILE_BACKEND, try_collect
 from .kernel_runner import SpyreSDSCKernelRunner, SpyreUnimplementedRunner
@@ -132,6 +135,7 @@ class SpyreAsyncCompile(AsyncCompile):
         self._provenance_failure_count = 0
         self._artifact_collection_builder = ProvenanceCollectionBuilder()
         self._artifact_collection_failure_count = 0
+        self._artifact_upstream_projection_failed = False
         self._artifact_publication_failure_count = 0
         # Retained after wait() for publication diagnostics and integration tests.
         self._last_provenance_collection: CollectedProvenance | None = None
@@ -373,13 +377,15 @@ class SpyreAsyncCompile(AsyncCompile):
             return
         self._provenance_wait_completed = True
         self._last_provenance_collection = None
+        upstream_projection = None
+        upstream_projection_failed = False
         try:
             registration_state = consume_kernel_registration_state(V.graph)
             self._last_provenance_collection = self._artifact_collection_builder.finish(
                 registration_state
             )
             if registration_state.capture_failed:
-                self._artifact_collection_failure_count += 1
+                upstream_projection_failed = True
         except Exception:  # noqa: BLE001 - provenance must never fail the build
             self._artifact_collection_failure_count += 1
             if self._artifact_collection_failure_count == 1:
@@ -389,11 +395,36 @@ class SpyreAsyncCompile(AsyncCompile):
                     exc_info=True,
                 )
 
+        configured_path = spyre_config.provenance_artifact_path
+        if (
+            configured_path
+            and self._last_provenance_collection is not None
+            and self._last_provenance_collection.kernels
+        ):
+            try:
+                upstream_projection = capture_upstream_projection(
+                    self._last_provenance_collection
+                )
+                if upstream_projection is not None and upstream_projection.failed:
+                    upstream_projection_failed = True
+            except Exception:  # noqa: BLE001 - projection must never fail the build
+                upstream_projection_failed = True
+                logger.warning(
+                    "upstream provenance projection capture failed; continuing "
+                    "with a partial sidecar",
+                    exc_info=True,
+                )
+
+        if upstream_projection_failed:
+            self._artifact_upstream_projection_failed = True
+
         if self._last_provenance_collection is not None:
             try:
                 publication_result = publish_provenance_collection(
                     self._last_provenance_collection,
-                    spyre_config.provenance_artifact_path,
+                    configured_path,
+                    upstream_projection=upstream_projection,
+                    upstream_projection_failed=upstream_projection_failed,
                 )
                 if publication_result == "disabled":
                     _log_publication_disabled_once()
@@ -431,6 +462,10 @@ class SpyreAsyncCompile(AsyncCompile):
                 self._artifact_collection_failure_count,
                 self._provenance_attempt_count,
             )
+        if self._artifact_upstream_projection_failed:
+            logger.warning(
+                "provenance upstream projection incomplete for this generated wrapper"
+            )
         if self._artifact_publication_failure_count:
             logger.warning(
                 "provenance sidecar publication incomplete after %d failure(s) "
@@ -442,4 +477,5 @@ class SpyreAsyncCompile(AsyncCompile):
         self._provenance_failure_count = 0
         self._artifact_collection_builder = ProvenanceCollectionBuilder()
         self._artifact_collection_failure_count = 0
+        self._artifact_upstream_projection_failed = False
         self._artifact_publication_failure_count = 0

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -18,13 +18,14 @@ from collections.abc import Sequence
 import os
 import shutil
 import subprocess
+import threading
 import torch
 import uuid
 
 from torch._inductor.async_compile import AsyncCompile
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch._inductor.virtualized import V
-from torch_spyre._inductor import config as _spyre_config
+from torch_spyre._inductor import config as spyre_config
 from torch_spyre._inductor.logging_utils import get_inductor_logger
 from torch_spyre._inductor.op_spec import (
     LoopSpec,
@@ -41,6 +42,7 @@ from torch_spyre._inductor.provenance_artifact import (
     consume_kernel_registration_state,
     ProvenanceCollectionBuilder,
 )
+from torch_spyre._inductor.provenance_writer import publish_provenance_collection
 from torch_spyre._inductor.codegen.bundle import generate_bundle
 from torch_spyre.profiler._ffdc import CATEGORY_COMPILE_BACKEND, try_collect
 from .kernel_runner import SpyreSDSCKernelRunner, SpyreUnimplementedRunner
@@ -62,11 +64,11 @@ def _check_ktir_device_prerequisites() -> None:
     """
     missing = []
 
-    if _spyre_config.bundle_symbolic_args:
+    if spyre_config.bundle_symbolic_args:
         # The env var, not just config: prepare_kernel.cpp reads it directly.
         missing.append("set BUNDLE_SYMBOLIC_ARGS=0 (baked addresses are required)")
 
-    if not _spyre_config.ktir_device_mlir:
+    if not spyre_config.ktir_device_mlir:
         missing.append("set KTIR_DEVICE_MLIR to a .mlir declaring the target device")
 
     if shutil.which("dbo-opt") is None:
@@ -77,6 +79,31 @@ def _check_ktir_device_prerequisites() -> None:
             "OpSpec->KTIR: cannot compile for the device:\n"
             + "\n".join(f"  - {m}" for m in missing)
         )
+
+_publication_disabled_lock = threading.Lock()
+_publication_disabled_logged = False
+_provenance_level_zero_lock = threading.Lock()
+_provenance_level_zero_logged = False
+
+
+def _log_publication_disabled_once() -> None:
+    global _publication_disabled_logged
+    with _publication_disabled_lock:
+        if not _publication_disabled_logged:
+            logger.debug("Spyre provenance sidecar publication is disabled")
+            _publication_disabled_logged = True
+
+
+def _log_provenance_level_zero_once() -> None:
+    global _provenance_level_zero_logged
+    with _provenance_level_zero_lock:
+        if not _provenance_level_zero_logged:
+            logger.warning(
+                "Spyre provenance upstream projection is unavailable; set "
+                "torch._inductor.config.trace.provenance_tracking_level=1 "
+                "to enable it"
+            )
+            _provenance_level_zero_logged = True
 
 
 def get_output_dir(kernel_name: str):
@@ -105,7 +132,8 @@ class SpyreAsyncCompile(AsyncCompile):
         self._provenance_failure_count = 0
         self._artifact_collection_builder = ProvenanceCollectionBuilder()
         self._artifact_collection_failure_count = 0
-        # Checkpoint seam consumed by Milestone 2 publication and integration tests.
+        self._artifact_publication_failure_count = 0
+        # Retained after wait() for publication diagnostics and integration tests.
         self._last_provenance_collection: CollectedProvenance | None = None
         self._provenance_wait_completed = False
 
@@ -268,7 +296,7 @@ class SpyreAsyncCompile(AsyncCompile):
         cmd = [
             "dbo-opt",
             "--from-ktir",
-            f"--device={_spyre_config.ktir_device_mlir}",
+            f"--device={spyre_config.ktir_device_mlir}",
             f"--export-dir={output_dir}",
             "--kEmitSpyreCode",
             ktir_path,
@@ -361,6 +389,35 @@ class SpyreAsyncCompile(AsyncCompile):
                     exc_info=True,
                 )
 
+        if self._last_provenance_collection is not None:
+            try:
+                publication_result = publish_provenance_collection(
+                    self._last_provenance_collection,
+                    spyre_config.provenance_artifact_path,
+                )
+                if publication_result == "disabled":
+                    _log_publication_disabled_once()
+                elif (
+                    self._last_provenance_collection.kernels
+                    and torch._inductor.config.trace.provenance_tracking_level < 1
+                ):
+                    _log_provenance_level_zero_once()
+            except Exception:  # noqa: BLE001 - publication must never fail the build
+                self._artifact_publication_failure_count += 1
+                if self._artifact_publication_failure_count == 1:
+                    configured_path = spyre_config.provenance_artifact_path
+                    basename = (
+                        os.path.basename(configured_path)
+                        if configured_path
+                        else "spyre_provenance.json"
+                    )
+                    logger.warning(
+                        "provenance sidecar publication failed for %s; "
+                        "continuing compilation",
+                        basename,
+                        exc_info=True,
+                    )
+
         if self._provenance_failure_count:
             logger.warning(
                 "kernel provenance disabled for %d/%d compiled Spyre kernels",
@@ -374,7 +431,15 @@ class SpyreAsyncCompile(AsyncCompile):
                 self._artifact_collection_failure_count,
                 self._provenance_attempt_count,
             )
+        if self._artifact_publication_failure_count:
+            logger.warning(
+                "provenance sidecar publication incomplete after %d failure(s) "
+                "across %d compiled Spyre kernels",
+                self._artifact_publication_failure_count,
+                self._provenance_attempt_count,
+            )
         self._provenance_attempt_count = 0
         self._provenance_failure_count = 0
         self._artifact_collection_builder = ProvenanceCollectionBuilder()
         self._artifact_collection_failure_count = 0
+        self._artifact_publication_failure_count = 0

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -23,6 +23,7 @@ import uuid
 
 from torch._inductor.async_compile import AsyncCompile
 from torch._inductor.runtime.runtime_utils import cache_dir
+from torch._inductor.virtualized import V
 from torch_spyre._inductor import config as _spyre_config
 from torch_spyre._inductor.logging_utils import get_inductor_logger
 from torch_spyre._inductor.op_spec import (
@@ -33,6 +34,12 @@ from torch_spyre._inductor.op_spec import (
 )
 from torch_spyre._inductor.kernel_provenance import (
     build_kernel_provenance_descriptor,
+)
+from torch_spyre._inductor.provenance_artifact import (
+    collect_kernel_provenance,
+    CollectedProvenance,
+    consume_kernel_registration_state,
+    ProvenanceCollectionBuilder,
 )
 from torch_spyre._inductor.codegen.bundle import generate_bundle
 from torch_spyre.profiler._ffdc import CATEGORY_COMPILE_BACKEND, try_collect
@@ -96,6 +103,11 @@ class SpyreAsyncCompile(AsyncCompile):
         super().__init__()
         self._provenance_attempt_count = 0
         self._provenance_failure_count = 0
+        self._artifact_collection_builder = ProvenanceCollectionBuilder()
+        self._artifact_collection_failure_count = 0
+        # Checkpoint seam consumed by Milestone 2 publication and integration tests.
+        self._last_provenance_collection: CollectedProvenance | None = None
+        self._provenance_wait_completed = False
 
     def triton(self, *args, **kwargs):
         raise NotImplementedError(
@@ -116,7 +128,9 @@ class SpyreAsyncCompile(AsyncCompile):
         pool_size: int = 0,
     ):
         unimp = find_unimplemented(list(specs))
+        self._provenance_attempt_count += 1
         if unimp is not None:
+            self._artifact_collection_builder.add_uncollected_kernel(kernel_name)
             logger.warning(
                 f"WARNING: Compiling unimplemented {unimp.op} to runtime exception"
             )
@@ -126,7 +140,6 @@ class SpyreAsyncCompile(AsyncCompile):
         output_dir = get_output_dir(kernel_name)
         generate_bundle(kernel_name, output_dir, specs, pool_size=pool_size)
 
-        self._provenance_attempt_count += 1
         try:
             # This is the common fresh-compile/cache-reload boundary: generated
             # wrappers have reconstructed the finalized OpSpecs before calling
@@ -149,6 +162,27 @@ class SpyreAsyncCompile(AsyncCompile):
                 )
             kernel_provenance = None
 
+            self._artifact_collection_builder.add_uncollected_kernel(kernel_name)
+        if kernel_provenance is not None:
+            try:
+                collected_kernel = collect_kernel_provenance(
+                    kernel_name,
+                    finalized_specs,
+                    kernel_provenance,
+                )
+                self._artifact_collection_builder.add_kernel(collected_kernel)
+            except Exception:  # noqa: BLE001 - provenance must never fail the build
+                self._artifact_collection_failure_count += 1
+                if self._artifact_collection_failure_count == 1:
+                    logger.warning(
+                        "provenance artifact collection failed for kernel %s; "
+                        "continuing without a sidecar contribution; additional "
+                        "failures in this compilation will be summarized",
+                        kernel_name,
+                        exc_info=True,
+                    )
+
+                self._artifact_collection_builder.add_uncollected_kernel(kernel_name)
         # Invoke backend compiler of SDSC Bundle
         with torch.profiler.record_function(f"dxp_standalone:{kernel_name}"):
             try:
@@ -307,11 +341,40 @@ class SpyreAsyncCompile(AsyncCompile):
 
     def wait(self, scope: dict[str, Any]) -> None:
         super().wait(scope)
+        if self._provenance_wait_completed:
+            return
+        self._provenance_wait_completed = True
+        self._last_provenance_collection = None
+        try:
+            registration_state = consume_kernel_registration_state(V.graph)
+            self._last_provenance_collection = self._artifact_collection_builder.finish(
+                registration_state
+            )
+            if registration_state.capture_failed:
+                self._artifact_collection_failure_count += 1
+        except Exception:  # noqa: BLE001 - provenance must never fail the build
+            self._artifact_collection_failure_count += 1
+            if self._artifact_collection_failure_count == 1:
+                logger.warning(
+                    "provenance artifact finalization failed; continuing without "
+                    "a sidecar contribution",
+                    exc_info=True,
+                )
+
         if self._provenance_failure_count:
             logger.warning(
                 "kernel provenance disabled for %d/%d compiled Spyre kernels",
                 self._provenance_failure_count,
                 self._provenance_attempt_count,
             )
+        if self._artifact_collection_failure_count:
+            logger.warning(
+                "provenance artifact collection incomplete after %d failure(s) "
+                "across %d compiled Spyre kernels",
+                self._artifact_collection_failure_count,
+                self._provenance_attempt_count,
+            )
         self._provenance_attempt_count = 0
         self._provenance_failure_count = 0
+        self._artifact_collection_builder = ProvenanceCollectionBuilder()
+        self._artifact_collection_failure_count = 0

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -273,7 +273,7 @@ class SpyreAsyncCompile(AsyncCompile):
         ktir_text = generate_ktir(
             kernel_name,
             specs,
-            bake_addresses=not _spyre_config.bundle_symbolic_args,
+            bake_addresses=not spyre_config.bundle_symbolic_args,
         )
 
         # Persist the emitted KTIR as a text file in the same per-kernel output

--- a/torch_spyre/execution/kernel_runner.py
+++ b/torch_spyre/execution/kernel_runner.py
@@ -56,22 +56,31 @@ class SpyreSDSCKernelRunner:
         self.kernel_name = name
         self.code_dir = code_dir
         self.kernel_provenance = kernel_provenance
-        self.profiler_event_name: str | None
+        self.profiler_event_name: str | None = None
         spyrecode_dir = code_dir + "/spyreCodeDir"
-        if kernel_provenance is None:
-            self.profiler_event_name = None
+        if kernel_provenance is not None:
+            try:
+                self.profiler_event_name = format_kernel_provenance_event_name(
+                    kernel_provenance
+                )
+                # Rejection is intentionally fail-open: C++ warns and counts
+                # conflicts while the key-bearing name remains the compatibility
+                # join.
+                register_kernel_provenance(
+                    self.profiler_event_name,
+                    list(kernel_provenance.debug_handle_ids),
+                )
+            except Exception:  # noqa: BLE001 - provenance must not fail preparation
+                logger.warning(
+                    "kernel provenance runtime attachment failed for kernel %s; "
+                    "continuing with any available event-name provenance",
+                    name,
+                    exc_info=True,
+                )
+
+        if self.profiler_event_name is None:
             self.jobplan = prepare_kernel(spyrecode_dir)
         else:
-            self.profiler_event_name = format_kernel_provenance_event_name(
-                kernel_provenance
-            )
-            # Rejection is intentionally fail-open: C++ warns and counts
-            # conflicts while the key-bearing name remains the compatibility
-            # join.
-            register_kernel_provenance(
-                self.profiler_event_name,
-                list(kernel_provenance.debug_handle_ids),
-            )
             with torch.profiler.record_function(f"prepare_kernel:{self.kernel_name}"):
                 self.jobplan = prepare_kernel(
                     spyrecode_dir,

--- a/torch_spyre/provenance.py
+++ b/torch_spyre/provenance.py
@@ -59,7 +59,7 @@ _OCCURRENCE_SUMMARY_FIELDS = (
 )
 
 
-class _ReaderError(Exception):
+class ProvenanceReaderError(ValueError):
     """Expected reader rejection with a stable machine-readable code."""
 
     def __init__(self, code: str, message: str):
@@ -67,8 +67,36 @@ class _ReaderError(Exception):
         self.code = code
 
 
+_ReaderError = ProvenanceReaderError
+
+
 class _SemanticError(ValueError):
     """Artifact content violates a cross-record or derivation invariant."""
+
+
+def load_provenance_document(artifact_path: str | Path) -> dict[str, Any]:
+    """Read and validate one sidecar for repeated offline queries.
+
+    The returned object has passed both the packaged v1 schema and semantic
+    validation. Consumers that resolve many events can load once instead of
+    invoking the validating document resolver for every event.
+    """
+    path = Path(artifact_path)
+    try:
+        payload = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError, ValueError) as error:
+        raise ProvenanceReaderError(
+            "artifact-read-failure",
+            f"failed to read {path.name}",
+        ) from error
+    try:
+        document = json.loads(payload)
+    except (RecursionError, ValueError) as error:
+        raise ProvenanceReaderError(
+            "schema-validation-failure",
+            f"invalid JSON in {path.name}",
+        ) from error
+    return _validate_document(document)
 
 
 def resolve_provenance_event(

--- a/torch_spyre/provenance.py
+++ b/torch_spyre/provenance.py
@@ -80,14 +80,16 @@ def resolve_provenance_event(
     """Resolve one saved event name against one saved provenance sidecar."""
     path = Path(artifact_path)
     try:
-        document = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError):
+        payload = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError, ValueError):
         return _failure_result(
             event_name,
             "artifact-read-failure",
             f"failed to read {path.name}",
         )
-    except json.JSONDecodeError:
+    try:
+        document = json.loads(payload)
+    except (RecursionError, ValueError):
         return _failure_result(
             event_name,
             "schema-validation-failure",
@@ -396,7 +398,7 @@ def _validate_document(document: object) -> dict[str, Any]:
         )
     try:
         _validate_schema(document, _schema(), _schema(), "$")
-    except ValueError as error:
+    except (RecursionError, ValueError) as error:
         raise _ReaderError("schema-validation-failure", str(error)) from None
     try:
         _validate_semantics(document)

--- a/torch_spyre/provenance.py
+++ b/torch_spyre/provenance.py
@@ -418,6 +418,9 @@ def _schema() -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+# Keep this dependency-free JSON Schema subset in parity with the packaged v1
+# schema. The fixture suite also runs the real jsonschema validator as an
+# independent oracle; schema changes must update both implementations and tests.
 def _validate_schema(
     value: object,
     schema: Mapping[str, object],

--- a/torch_spyre/provenance.py
+++ b/torch_spyre/provenance.py
@@ -397,8 +397,9 @@ def _validate_document(document: object) -> dict[str, Any]:
             "artifact schema version is not supported",
         )
     try:
-        _validate_schema(document, _schema(), _schema(), "$")
-    except (RecursionError, ValueError) as error:
+        schema = _schema()
+        _validate_schema(document, schema, schema, "$")
+    except (OSError, UnicodeError, RecursionError, ValueError) as error:
         raise _ReaderError("schema-validation-failure", str(error)) from None
     try:
         _validate_semantics(document)
@@ -415,7 +416,10 @@ def _schema() -> dict[str, Any]:
         / "schemas"
         / "spyre_provenance_v1.schema.json"
     )
-    return json.loads(path.read_text(encoding="utf-8"))
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("packaged provenance schema must be an object")
+    return value
 
 
 # Keep this dependency-free JSON Schema subset in parity with the packaged v1
@@ -435,8 +439,12 @@ def _validate_schema(
         for token in reference[2:].split("/"):
             if not isinstance(target, Mapping):
                 raise ValueError(f"{path}: invalid schema reference")
-            target = target[token.replace("~1", "/").replace("~0", "~")]
-        assert isinstance(target, Mapping)
+            decoded_token = token.replace("~1", "/").replace("~0", "~")
+            if decoded_token not in target:
+                raise ValueError(f"{path}: invalid schema reference")
+            target = target[decoded_token]
+        if not isinstance(target, Mapping):
+            raise ValueError(f"{path}: invalid schema reference")
         _validate_schema(value, target, root, path)
         return
     if "oneOf" in schema:

--- a/torch_spyre/provenance.py
+++ b/torch_spyre/provenance.py
@@ -1,0 +1,791 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline resolution of Spyre profiler events against a saved sidecar.
+
+The supported module invocation disables package backend autoload::
+
+    TORCH_DEVICE_BACKEND_AUTOLOAD=0 python -m torch_spyre.provenance \
+        '<event-name>' <artifact-path>
+
+Without that setting, Python executes ``torch_spyre.__init__`` before this
+module and can re-enter the partially initialized package while PyTorch loads
+PrivateUse1 backends.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import functools
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, cast
+
+import regex
+
+from torch_spyre.provenance_codec import (
+    KERNEL_PROVENANCE_KEY_BASE32_WIDTH,
+    KERNEL_PROVENANCE_KEY_VERSION,
+    ParsedKernelProvenanceEvent,
+    parse_kernel_provenance_event_name,
+)
+
+
+_RESOLUTION_VERSION = 1
+_SCHEMA_VERSION = 1
+_COMPILE_ID_DOMAIN = "torch-spyre-compile-v1"
+_OCCURRENCE_ID_DOMAIN = "torch-spyre-occurrence-v1"
+_OCCURRENCE_SUMMARY_FIELDS = (
+    "identityKey",
+    "compileId",
+    "compilerKernelName",
+    "registrations",
+    "selector",
+    "upstreamJoin",
+)
+
+
+class _ReaderError(Exception):
+    """Expected reader rejection with a stable machine-readable code."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+
+
+class _SemanticError(ValueError):
+    """Artifact content violates a cross-record or derivation invariant."""
+
+
+def resolve_provenance_event(
+    event_name: str,
+    artifact_path: str | Path,
+    *,
+    occurrence_selector: str | None = None,
+) -> dict[str, Any]:
+    """Resolve one saved event name against one saved provenance sidecar."""
+    path = Path(artifact_path)
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError):
+        return _failure_result(
+            event_name,
+            "artifact-read-failure",
+            f"failed to read {path.name}",
+        )
+    except json.JSONDecodeError:
+        return _failure_result(
+            event_name,
+            "schema-validation-failure",
+            f"invalid JSON in {path.name}",
+        )
+    return resolve_provenance_document(
+        event_name,
+        document,
+        occurrence_selector=occurrence_selector,
+    )
+
+
+def resolve_provenance_document(
+    event_name: str,
+    document: object,
+    *,
+    occurrence_selector: str | None = None,
+) -> dict[str, Any]:
+    """Resolve one event against an already decoded sidecar document."""
+    parsed = parse_kernel_provenance_event_name(event_name)
+    if parsed is None:
+        return _failure_result(
+            event_name,
+            "invalid-event-name",
+            "event name does not contain a supported Spyre provenance key",
+        )
+    if occurrence_selector is not None and not occurrence_selector:
+        return _failure_result(
+            event_name,
+            "invalid-selector",
+            "occurrence selector must not be empty",
+            parsed=parsed,
+        )
+
+    try:
+        validated = _validate_document(document)
+    except _ReaderError as error:
+        return _failure_result(
+            event_name,
+            error.code,
+            str(error),
+            parsed=parsed,
+        )
+
+    identities = validated["kernelIdentities"]
+    identity = identities.get(parsed.key)
+    if identity is None:
+        return _failure_result(
+            event_name,
+            "missing-key",
+            "event key is absent from the provenance artifact",
+            parsed=parsed,
+        )
+    if parsed.base_name != identity["eventNameBase"]:
+        return _failure_result(
+            event_name,
+            "collision",
+            "event key resolves to a different persisted event-name base",
+            parsed=parsed,
+            details={
+                "eventNameBase": parsed.base_name,
+                "persistedEventNameBase": identity["eventNameBase"],
+            },
+        )
+
+    candidates = [
+        (occurrence_id, occurrence)
+        for occurrence_id, occurrence in validated["kernelOccurrences"].items()
+        if occurrence["identityKey"] == parsed.key
+    ]
+    if occurrence_selector is not None:
+        candidates = [
+            item
+            for item in candidates
+            if item[1].get("selector") == occurrence_selector
+        ]
+    if not candidates:
+        details = {"identityKey": parsed.key}
+        if occurrence_selector is not None:
+            details["occurrenceSelector"] = occurrence_selector
+        return _failure_result(
+            event_name,
+            "missing-key",
+            "no matching kernel occurrence exists",
+            parsed=parsed,
+            details=details,
+        )
+
+    handles = validated["handles"]
+    direct_handle_ids = identity["directHandleIds"]
+    reachable_ids = _reachable_handle_ids(direct_handle_ids, handles)
+    direct_set = set(direct_handle_ids)
+    fused_constituent_ids = [
+        handle_id for handle_id in reachable_ids if handle_id not in direct_set
+    ]
+
+    projections = validated["upstreamProjections"]
+    resolved_occurrences = []
+    compile_ids: set[str] = set()
+    for occurrence_id, occurrence in candidates:
+        compile_id = occurrence["compileId"]
+        compile_ids.add(compile_id)
+        resolved_occurrences.append(
+            {
+                "occurrenceId": occurrence_id,
+                **copy.deepcopy(occurrence),
+                "upstreamJoin": projections[compile_id]["upstreamJoin"],
+            }
+        )
+    summary = _summarize_occurrences(resolved_occurrences)
+
+    diagnostics: list[dict[str, Any]] = []
+    if validated["status"] != "complete" or validated["diagnostics"]:
+        diagnostics.append(
+            _diagnostic(
+                "incomplete-artifact",
+                "warning",
+                "artifact records an incomplete collection or upstream join",
+                {
+                    "artifactStatus": validated["status"],
+                    "writerDiagnostics": copy.deepcopy(validated["diagnostics"]),
+                },
+            )
+        )
+    joins: dict[str, list[str]] = {}
+    for compile_id in sorted(compile_ids):
+        join = projections[compile_id]["upstreamJoin"]
+        joins.setdefault(join, []).append(compile_id)
+    for join, join_compile_ids in sorted(joins.items()):
+        diagnostics.append(
+            _diagnostic(
+                "upstream-join-status",
+                "info" if join == "ok" else "warning",
+                f"resolved occurrence upstream join is {join}",
+                {"compileIds": join_compile_ids, "upstreamJoin": join},
+            )
+        )
+    if summary["ambiguous"]:
+        diagnostics.append(
+            _diagnostic(
+                "ambiguity",
+                "warning",
+                "candidate occurrences disagree on one or more context fields",
+                {
+                    "fields": sorted(
+                        field
+                        for field, value in summary["fields"].items()
+                        if value["ambiguous"]
+                    )
+                },
+            )
+        )
+
+    return {
+        "resolutionVersion": _RESOLUTION_VERSION,
+        "status": _status_from_diagnostics(diagnostics),
+        "event": _event_dict(parsed, occurrence_selector),
+        "identityKey": parsed.key,
+        "identity": copy.deepcopy(identity),
+        "directHandleIds": list(direct_handle_ids),
+        "fusedConstituentIds": fused_constituent_ids,
+        "handles": {
+            handle_id: copy.deepcopy(handles[handle_id])
+            for handle_id in sorted(reachable_ids)
+        },
+        "occurrences": resolved_occurrences,
+        "occurrenceSummary": summary,
+        "upstreamProjections": {
+            compile_id: copy.deepcopy(projections[compile_id])
+            for compile_id in sorted(compile_ids)
+        },
+        "diagnostics": diagnostics,
+    }
+
+
+def _failure_result(
+    event_name: str,
+    code: str,
+    message: str,
+    *,
+    parsed: ParsedKernelProvenanceEvent | None = None,
+    details: Mapping[str, object] | None = None,
+) -> dict[str, Any]:
+    event: dict[str, object] = {"name": event_name}
+    if parsed is not None:
+        event = _event_dict(parsed, None)
+    return {
+        "resolutionVersion": _RESOLUTION_VERSION,
+        "status": "error",
+        "event": event,
+        "identityKey": parsed.key if parsed is not None else None,
+        "identity": None,
+        "directHandleIds": [],
+        "fusedConstituentIds": [],
+        "handles": {},
+        "occurrences": [],
+        "occurrenceSummary": {"ambiguous": False, "fields": {}},
+        "upstreamProjections": {},
+        "diagnostics": [_diagnostic(code, "error", message, details)],
+    }
+
+
+def _event_dict(
+    parsed: ParsedKernelProvenanceEvent,
+    occurrence_selector: str | None,
+) -> dict[str, object]:
+    return {
+        "name": parsed.name,
+        "baseName": parsed.base_name,
+        "identityKey": parsed.key,
+        "commandStep": parsed.step,
+        "commandStepSuffix": parsed.step_suffix,
+        "stepAttribution": "bundle",
+        "occurrenceSelector": occurrence_selector,
+    }
+
+
+def _diagnostic(
+    code: str,
+    severity: str,
+    message: str,
+    details: Mapping[str, object] | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "code": code,
+        "severity": severity,
+        "message": message,
+    }
+    if details:
+        result["details"] = copy.deepcopy(dict(details))
+    return result
+
+
+def _status_from_diagnostics(diagnostics: Sequence[Mapping[str, object]]) -> str:
+    severities = {diagnostic["severity"] for diagnostic in diagnostics}
+    if "error" in severities:
+        return "error"
+    if "warning" in severities:
+        return "partial"
+    return "complete"
+
+
+def _reachable_handle_ids(
+    direct_handle_ids: Sequence[str], handles: Mapping[str, object]
+) -> list[str]:
+    ordered: list[str] = []
+    visited: set[str] = set()
+    pending = list(reversed(direct_handle_ids))
+    while pending:
+        handle_id = pending.pop()
+        if handle_id in visited:
+            continue
+        visited.add(handle_id)
+        ordered.append(handle_id)
+        handle = handles[handle_id]
+        assert isinstance(handle, Mapping)
+        constituents = cast(Sequence[str], handle["fused_from"])
+        pending.extend(reversed(constituents))
+    return ordered
+
+
+def _summarize_occurrences(
+    occurrences: Sequence[Mapping[str, object]],
+) -> dict[str, Any]:
+    fields: dict[str, dict[str, Any]] = {}
+    for field in _OCCURRENCE_SUMMARY_FIELDS:
+        values = [occurrence.get(field) for occurrence in occurrences]
+        distinct = _distinct_values(values)
+        if len(distinct) == 1:
+            fields[field] = {
+                "ambiguous": False,
+                "value": copy.deepcopy(distinct[0]),
+            }
+        else:
+            fields[field] = {
+                "ambiguous": True,
+                "values": copy.deepcopy(distinct),
+            }
+    return {
+        "ambiguous": any(value["ambiguous"] for value in fields.values()),
+        "fields": fields,
+    }
+
+
+def _distinct_values(values: Sequence[object]) -> list[object]:
+    keyed = {
+        json.dumps(
+            value,
+            ensure_ascii=True,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ): value
+        for value in values
+    }
+    return [keyed[key] for key in sorted(keyed)]
+
+
+def _validate_document(document: object) -> dict[str, Any]:
+    if not isinstance(document, dict):
+        raise _ReaderError("schema-validation-failure", "artifact must be an object")
+    if document.get("schemaVersion") != _SCHEMA_VERSION:
+        raise _ReaderError(
+            "unsupported-schema-version",
+            "artifact schema version is not supported",
+        )
+    try:
+        _validate_schema(document, _schema(), _schema(), "$")
+    except ValueError as error:
+        raise _ReaderError("schema-validation-failure", str(error)) from None
+    try:
+        _validate_semantics(document)
+    except _SemanticError as error:
+        raise _ReaderError("semantic-validation-failure", str(error)) from None
+    return document
+
+
+@functools.cache
+def _schema() -> dict[str, Any]:
+    path = (
+        Path(__file__).parent
+        / "_inductor"
+        / "schemas"
+        / "spyre_provenance_v1.schema.json"
+    )
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validate_schema(
+    value: object,
+    schema: Mapping[str, object],
+    root: Mapping[str, object],
+    path: str,
+) -> None:
+    if "$ref" in schema:
+        reference = schema["$ref"]
+        if not isinstance(reference, str) or not reference.startswith("#/"):
+            raise ValueError(f"{path}: unsupported schema reference")
+        target: object = root
+        for token in reference[2:].split("/"):
+            if not isinstance(target, Mapping):
+                raise ValueError(f"{path}: invalid schema reference")
+            target = target[token.replace("~1", "/").replace("~0", "~")]
+        assert isinstance(target, Mapping)
+        _validate_schema(value, target, root, path)
+        return
+    if "oneOf" in schema:
+        matches = 0
+        choices = cast(Sequence[Mapping[str, object]], schema["oneOf"])
+        for choice in choices:
+            try:
+                _validate_schema(value, choice, root, path)
+            except ValueError:
+                continue
+            matches += 1
+        if matches != 1:
+            raise ValueError(f"{path}: value must match exactly one schema")
+        return
+    if "const" in schema and value != schema["const"]:
+        raise ValueError(f"{path}: value disagrees with schema constant")
+    allowed = cast(Sequence[object] | None, schema.get("enum"))
+    if allowed is not None and value not in allowed:
+        raise ValueError(f"{path}: value is outside the allowed enum")
+    expected_type = schema.get("type")
+    if expected_type is not None and not _matches_type(value, expected_type):
+        raise ValueError(f"{path}: value has the wrong type")
+
+    if isinstance(value, dict):
+        properties = cast(
+            Mapping[str, Mapping[str, object]], schema.get("properties", {})
+        )
+        required = cast(Sequence[str], schema.get("required", []))
+        if not all(key in value for key in required):
+            raise ValueError(f"{path}: required field is missing")
+        minimum_properties = cast(int | None, schema.get("minProperties"))
+        if minimum_properties is not None and len(value) < minimum_properties:
+            raise ValueError(f"{path}: object has too few fields")
+        property_names = cast(Mapping[str, object] | None, schema.get("propertyNames"))
+        if property_names is not None:
+            for key in value:
+                _validate_schema(key, property_names, root, f"{path}.<key>")
+        additional = schema.get("additionalProperties", True)
+        for key, item in value.items():
+            if key in properties:
+                item_schema = properties[key]
+            elif additional is False:
+                raise ValueError(f"{path}: unknown field {key}")
+            elif isinstance(additional, Mapping):
+                item_schema = additional
+            else:
+                continue
+            _validate_schema(item, item_schema, root, f"{path}.{key}")
+    elif isinstance(value, list):
+        minimum_items = cast(int | None, schema.get("minItems"))
+        if minimum_items is not None and len(value) < minimum_items:
+            raise ValueError(f"{path}: array has too few items")
+        if schema.get("uniqueItems"):
+            canonical = [_canonical_json(item) for item in value]
+            if len(canonical) != len(set(canonical)):
+                raise ValueError(f"{path}: array items must be unique")
+        list_item_schema = cast(Mapping[str, object] | None, schema.get("items"))
+        if list_item_schema is not None:
+            for index, item in enumerate(value):
+                _validate_schema(item, list_item_schema, root, f"{path}[{index}]")
+    elif isinstance(value, str):
+        minimum_length = cast(int | None, schema.get("minLength"))
+        if minimum_length is not None and len(value) < minimum_length:
+            raise ValueError(f"{path}: string is too short")
+        pattern = cast(str | None, schema.get("pattern"))
+        if pattern is not None and regex.fullmatch(pattern, value) is None:
+            raise ValueError(f"{path}: string does not match its pattern")
+    elif isinstance(value, (int, float)) and not isinstance(value, bool):
+        minimum = cast(int | float | None, schema.get("minimum"))
+        if minimum is not None and value < minimum:
+            raise ValueError(f"{path}: number is below its minimum")
+
+
+def _matches_type(value: object, expected: object) -> bool:
+    if expected == "object":
+        return isinstance(value, dict)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected == "boolean":
+        return isinstance(value, bool)
+    if expected == "null":
+        return value is None
+    raise ValueError(f"unsupported JSON Schema type {expected}")
+
+
+def _validate_semantics(document: Mapping[str, Any]) -> None:
+    expected_event_key = {
+        "version": KERNEL_PROVENANCE_KEY_VERSION,
+        "algorithm": "sha256-prefix-80-base32-lower",
+        "width": KERNEL_PROVENANCE_KEY_BASE32_WIDTH,
+        "stepAttribution": "bundle",
+    }
+    if document["eventKey"] != expected_event_key:
+        raise _SemanticError("event key contract mismatch")
+
+    handles = document["handles"]
+    identities = document["kernelIdentities"]
+    occurrences = document["kernelOccurrences"]
+    projections = document["upstreamProjections"]
+    _require_sorted(handles, "handles")
+    _require_sorted(identities, "kernelIdentities")
+    _require_sorted(occurrences, "kernelOccurrences")
+    _require_sorted(projections, "upstreamProjections")
+    _require_sorted(document["diagnostics"], "diagnostics")
+
+    for handle_id, handle in handles.items():
+        if handle["id"] != handle_id:
+            raise _SemanticError("debug handle key and ID disagree")
+        if any(item not in handles for item in handle["fused_from"]):
+            raise _SemanticError("dangling fused handle reference")
+    _validate_handle_cycles(handles)
+
+    for identity_key, identity in identities.items():
+        direct_ids = identity["directHandleIds"]
+        if any(handle_id not in handles for handle_id in direct_ids):
+            raise _SemanticError("dangling direct handle reference")
+        binding_ids = [
+            binding["handleId"] for binding in identity["specHandleBindings"]
+        ]
+        if any(handle_id not in handles for handle_id in binding_ids):
+            raise _SemanticError("dangling spec binding handle reference")
+        if direct_ids != list(dict.fromkeys(binding_ids)):
+            raise _SemanticError("direct handle order disagrees with bindings")
+        if identity["atenOps"] != _recursive_aten_ops(direct_ids, handles):
+            raise _SemanticError("ATen operations disagree with handles")
+        parsed = parse_kernel_provenance_event_name(identity["eventNameBase"])
+        if parsed is None or parsed.step is not None or parsed.key != identity_key:
+            raise _SemanticError("profiler event name disagrees with identity")
+
+    occurrences_by_compile: dict[str, list[Mapping[str, Any]]] = {}
+    for occurrence_id, occurrence in occurrences.items():
+        identity_key = occurrence["identityKey"]
+        compile_id = occurrence["compileId"]
+        if identity_key not in identities:
+            raise _SemanticError("invalid occurrence identity reference")
+        if compile_id not in projections:
+            raise _SemanticError("invalid occurrence compile reference")
+        kernel_name = occurrence["compilerKernelName"]
+        ordinals = []
+        for registration in occurrence["registrations"]:
+            ordinal = registration["ordinal"]
+            if registration["alias"] != f"{kernel_name}:{ordinal}":
+                raise _SemanticError("registration alias disagrees with ordinal")
+            ordinals.append(ordinal)
+        if ordinals != sorted(ordinals) or len(ordinals) != len(set(ordinals)):
+            raise _SemanticError("registration ordinals must be sorted and unique")
+        expected_occurrence_id = _canonical_digest(
+            {
+                "domain": _OCCURRENCE_ID_DOMAIN,
+                "compileId": compile_id,
+                "compilerKernelName": kernel_name,
+                "identityKey": identity_key,
+            }
+        )
+        if occurrence_id != expected_occurrence_id:
+            raise _SemanticError("kernel occurrence ID derivation mismatch")
+        occurrences_by_compile.setdefault(compile_id, []).append(occurrence)
+
+    for compile_id, projection in projections.items():
+        kernels = [
+            (kernel["compilerKernelName"], kernel["identityKey"])
+            for kernel in projection["kernels"]
+        ]
+        if len(kernels) != len(set(kernels)):
+            raise _SemanticError("duplicate compile kernel")
+        uncollected_kernels = projection["uncollectedKernels"]
+        if uncollected_kernels != sorted(uncollected_kernels):
+            raise _SemanticError("uncollected kernel names must be sorted")
+        collected_kernel_names = {kernel_name for kernel_name, _ in kernels}
+        if collected_kernel_names & set(uncollected_kernels):
+            raise _SemanticError("collected and uncollected kernels overlap")
+
+        if any(identity_key not in identities for _, identity_key in kernels):
+            raise _SemanticError("invalid compile kernel identity")
+        expected_compile_id = _canonical_digest(
+            {
+                "domain": _COMPILE_ID_DOMAIN,
+                "kernels": [list(kernel) for kernel in kernels],
+            }
+        )
+        if compile_id != expected_compile_id:
+            raise _SemanticError("compile ID derivation mismatch")
+        occurrence_kernels = {
+            (item["compilerKernelName"], item["identityKey"])
+            for item in occurrences_by_compile.get(compile_id, [])
+        }
+        if occurrence_kernels != set(kernels):
+            raise _SemanticError("projection kernels disagree with occurrences")
+        _validate_projection_relations(projection, occurrences_by_compile[compile_id])
+    if set(occurrences_by_compile) != set(projections):
+        raise _SemanticError("occurrence and projection compile IDs disagree")
+
+    expected_diagnostics: dict[str, int] = {}
+    collection_failures = sum(
+        len(projection["uncollectedKernels"]) for projection in projections.values()
+    )
+    upstream_failures = sum(
+        int(projection["upstreamProjectionFailed"])
+        for projection in projections.values()
+    )
+    if collection_failures:
+        expected_diagnostics["collection-failure"] = collection_failures
+    if upstream_failures:
+        expected_diagnostics["upstream-projection-failure"] = upstream_failures
+    if document["diagnostics"] != expected_diagnostics:
+        raise _SemanticError("writer diagnostics disagree with projections")
+    expected_status = (
+        "complete"
+        if not expected_diagnostics
+        and all(
+            projection["upstreamJoin"] == "ok" for projection in projections.values()
+        )
+        else "partial"
+    )
+    if document["status"] != expected_status:
+        raise _SemanticError("document status disagrees with its content")
+
+
+def _validate_handle_cycles(handles: Mapping[str, Mapping[str, Any]]) -> None:
+    visited: set[str] = set()
+    visiting: set[str] = set()
+
+    for handle_id in handles:
+        pending = [(handle_id, False)]
+        while pending:
+            current_id, exiting = pending.pop()
+            if exiting:
+                visiting.remove(current_id)
+                visited.add(current_id)
+                continue
+            if current_id in visiting:
+                raise _SemanticError("cyclic fused handle references")
+            if current_id in visited:
+                continue
+            visiting.add(current_id)
+            pending.append((current_id, True))
+            pending.extend(
+                (constituent_id, False)
+                for constituent_id in reversed(handles[current_id]["fused_from"])
+            )
+
+
+def _recursive_aten_ops(
+    direct_ids: Sequence[str], handles: Mapping[str, Mapping[str, Any]]
+) -> list[str]:
+    names: set[str] = set()
+    visited: set[str] = set()
+    pending = list(reversed(direct_ids))
+    while pending:
+        handle_id = pending.pop()
+        if handle_id in visited:
+            continue
+        visited.add(handle_id)
+        handle = handles[handle_id]
+        if handle["aten_op"] is not None:
+            names.add(handle["aten_op"])
+        pending.extend(reversed(handle["fused_from"]))
+    return sorted(names)
+
+
+def _validate_projection_relations(
+    projection: Mapping[str, Any],
+    occurrences: Sequence[Mapping[str, Any]],
+) -> None:
+    for name in (
+        "preToPost",
+        "postToPre",
+        "cppCodeToPost",
+        "postToCppCode",
+        "kernelStackTraces",
+    ):
+        _require_sorted(projection[name], name)
+    registration_aliases: set[str] = set()
+    registration_ordinals: set[int] = set()
+    for occurrence in occurrences:
+        for registration in occurrence["registrations"]:
+            ordinal = registration["ordinal"]
+            if ordinal in registration_ordinals:
+                raise _SemanticError("registration ordinal repeated across one compile")
+            registration_ordinals.add(ordinal)
+            registration_aliases.add(registration["alias"])
+    cpp_to_post = projection["cppCodeToPost"]
+    if not set(cpp_to_post) <= registration_aliases:
+        raise _SemanticError("upstream aliases lack exact registrations")
+    if projection["upstreamJoin"] == "ok" and set(cpp_to_post) != registration_aliases:
+        raise _SemanticError("complete projection lacks registered aliases")
+    if projection["postToPre"] != _invert_name_map(projection["preToPost"]):
+        raise _SemanticError("postToPre is not the exact inverse")
+    if projection["postToCppCode"] != _invert_name_map(cpp_to_post):
+        raise _SemanticError("postToCppCode is not the exact inverse")
+    if (
+        projection["upstreamJoin"] == "ok"
+        and set(projection["kernelStackTraces"]) != registration_aliases
+    ):
+        raise _SemanticError("complete projection lacks stack contexts")
+
+
+def _invert_name_map(mapping: Mapping[str, Sequence[str]]) -> dict[str, list[str]]:
+    inverse: dict[str, list[str]] = {}
+    for source in sorted(mapping):
+        for destination in mapping[source]:
+            inverse.setdefault(destination, []).append(source)
+    return inverse
+
+
+def _require_sorted(mapping: Mapping[str, object], name: str) -> None:
+    if list(mapping) != sorted(mapping):
+        raise _SemanticError(f"{name} keys must be sorted")
+
+
+def _canonical_digest(value: object) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("ascii")).hexdigest()
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Resolve one event from the command line and print canonical JSON."""
+    parser = argparse.ArgumentParser(
+        description="Resolve a Spyre profiler event against spyre_provenance.json",
+        epilog=(
+            "Run this offline reader with backend autoload disabled:\n"
+            "  TORCH_DEVICE_BACKEND_AUTOLOAD=0 python -m "
+            "torch_spyre.provenance '<event-name>' <artifact-path> "
+            "[--occurrence-selector TOKEN]"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("event_name")
+    parser.add_argument("artifact_path")
+    parser.add_argument("--occurrence-selector")
+    args = parser.parse_args(argv)
+    result = resolve_provenance_event(
+        args.event_name,
+        args.artifact_path,
+        occurrence_selector=args.occurrence_selector,
+    )
+    print(json.dumps(result, ensure_ascii=True, indent=2, sort_keys=True))
+    return 1 if result["status"] == "error" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/torch_spyre/provenance_codec.py
+++ b/torch_spyre/provenance_codec.py
@@ -28,8 +28,8 @@ _SUPPORTED_KEY_WIDTHS = {
     KERNEL_PROVENANCE_KEY_VERSION: KERNEL_PROVENANCE_KEY_BASE32_WIDTH
 }
 # The separator before the key is unambiguous because ``_`` is not in the
-# lowercase base32 alphabet. Revisit this parser if a future version changes
-# the alphabet.
+# lowercase base32 alphabet. Every supported version must keep the separator
+# outside its declared key alphabet.
 _EVENT_KEY_RE = regex.compile(
     r"\Aspyre_kernel_v(?P<version>[0-9]+)_"
     r"[A-Za-z0-9_]+?_"

--- a/torch_spyre/provenance_codec.py
+++ b/torch_spyre/provenance_codec.py
@@ -1,0 +1,71 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Versioned Spyre profiler event-name parsing without compiler imports."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import regex
+
+
+KERNEL_PROVENANCE_KEY_VERSION = 1
+KERNEL_PROVENANCE_KEY_BASE32_WIDTH = 16
+
+_SUPPORTED_KEY_WIDTHS = {
+    KERNEL_PROVENANCE_KEY_VERSION: KERNEL_PROVENANCE_KEY_BASE32_WIDTH
+}
+# The separator before the key is unambiguous because ``_`` is not in the
+# lowercase base32 alphabet. Revisit this parser if a future version changes
+# the alphabet.
+_EVENT_KEY_RE = regex.compile(
+    r"\Aspyre_kernel_v(?P<version>[0-9]+)_"
+    r"[A-Za-z0-9_]+?_"
+    r"(?P<key>[a-z2-7]+)"
+    r"(?P<suffix>#(?P<step>[0-9]+))?\Z"
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class ParsedKernelProvenanceEvent:
+    """Validated event transport fields used by compiler and offline readers."""
+
+    name: str
+    base_name: str
+    key: str
+    step: int | None
+    step_suffix: str | None
+
+
+def parse_kernel_provenance_event_name(
+    event_name: str,
+) -> ParsedKernelProvenanceEvent | None:
+    """Parse one supported Spyre provenance event name and command step."""
+    match = _EVENT_KEY_RE.match(event_name)
+    if match is None:
+        return None
+    version = int(match.group("version"))
+    expected_width = _SUPPORTED_KEY_WIDTHS.get(version)
+    key = match.group("key")
+    if expected_width is None or len(key) != expected_width:
+        return None
+    suffix = match.group("suffix")
+    return ParsedKernelProvenanceEvent(
+        name=event_name,
+        base_name=event_name[: -len(suffix)] if suffix else event_name,
+        key=key,
+        step=int(match.group("step")) if suffix else None,
+        step_suffix=suffix,
+    )

--- a/torch_spyre/provenance_viewer.py
+++ b/torch_spyre/provenance_viewer.py
@@ -43,6 +43,8 @@ from torch_spyre.provenance_codec import (
 _PRESENTATION_VERSION = 1
 _MAX_SIDECAR_BYTES = 256 * 1024 * 1024
 _MAX_KINETO_TRACE_BYTES = 256 * 1024 * 1024
+_MAX_PANEL_ROWS = 10_000
+_MAX_RUNTIME_OCCURRENCES = 10_000
 _HASH_CHUNK_BYTES = 1024 * 1024
 _NATIVE_KEY_RE = regex.compile(rf"\A[a-z2-7]{{{KERNEL_PROVENANCE_KEY_BASE32_WIDTH}}}\Z")
 _RELATION_FIELDS = ("compileAliases", "handleIds", "postNodes", "preNodes")
@@ -106,6 +108,7 @@ def build_provenance_presentation(
             occurrences,
             document["handles"],
             document["upstreamProjections"],
+            diagnostics,
         )
         identities[identity_key] = normalized
         event = {
@@ -123,15 +126,16 @@ def build_provenance_presentation(
         events_by_key,
         diagnostics,
     )
-    for event in events:
-        event["observations"].sort(key=lambda item: item["traceEventIndex"])
+    observation_summary = _bound_runtime_occurrences(events, diagnostics)
 
     diagnostics = _sorted_diagnostics(diagnostics)
     presentation = {
         "presentationVersion": _PRESENTATION_VERSION,
         "status": _status_from_diagnostics(diagnostics),
         "runSummary": {
-            "resolvedObservations": sum(len(event["observations"]) for event in events),
+            "resolvedObservations": observation_summary["total"],
+            "displayedObservations": observation_summary["displayed"],
+            "omittedResolvedObservations": observation_summary["omitted"],
             "unresolvedObservations": len(unresolved),
         },
         "events": events,
@@ -152,6 +156,7 @@ def _identity_presentation(
     occurrences: Sequence[Mapping[str, Any]],
     all_handles: Mapping[str, Mapping[str, Any]],
     projections: Mapping[str, Mapping[str, Any]],
+    diagnostics: list[dict[str, Any]],
 ) -> dict[str, Any]:
     direct_ids = list(identity["directHandleIds"])
     handle_ids = _reachable_handle_ids(direct_ids, all_handles)
@@ -265,6 +270,23 @@ def _identity_presentation(
             "No direct OpSpec bindings were recorded.",
         ),
     ]
+    for panel in panels:
+        if panel["omittedRowCount"]:
+            diagnostics.append(
+                _diagnostic(
+                    "panel-rows-truncated",
+                    "warning",
+                    "panel rows exceed the offline viewer limit",
+                    {
+                        "identityKey": identity_key,
+                        "panelId": panel["id"],
+                        "rowLimit": _MAX_PANEL_ROWS,
+                        "totalRows": panel["totalRowCount"],
+                        "displayedRows": panel["displayedRowCount"],
+                        "omittedRows": panel["omittedRowCount"],
+                    },
+                )
+            )
     return {
         "identityKey": identity_key,
         "eventNameBase": identity["eventNameBase"],
@@ -515,6 +537,13 @@ def _panel(
     empty_message: str,
     scope_details: Sequence[str] = (),
 ) -> dict[str, Any]:
+    all_rows = list(rows)
+    total_row_count = len(all_rows)
+    displayed_rows = all_rows[:_MAX_PANEL_ROWS]
+    displayed_row_count = len(displayed_rows)
+    omitted_row_count = total_row_count - displayed_row_count
+    if omitted_row_count:
+        summary += f" | showing {displayed_row_count} of {total_row_count} rows"
     return {
         "id": panel_id,
         "title": title,
@@ -522,7 +551,10 @@ def _panel(
         "summary": summary,
         "scopeDetails": list(scope_details),
         "emptyMessage": empty_message,
-        "rows": copy.deepcopy(list(rows)),
+        "totalRowCount": total_row_count,
+        "displayedRowCount": displayed_row_count,
+        "omittedRowCount": omitted_row_count,
+        "rows": copy.deepcopy(displayed_rows),
     }
 
 
@@ -565,6 +597,60 @@ def _reachable_handle_ids(
     return ordered
 
 
+def _bound_runtime_occurrences(
+    events: Sequence[dict[str, Any]],
+    diagnostics: list[dict[str, Any]],
+) -> dict[str, int]:
+    ordered: list[tuple[int, dict[str, Any]]] = []
+    for event in events:
+        event["observations"].sort(key=lambda item: item["traceEventIndex"])
+        event["observationCount"] = len(event["observations"])
+        ordered.extend(
+            (observation["traceEventIndex"], observation)
+            for observation in event["observations"]
+        )
+    ordered.sort(key=lambda item: item[0])
+    retained_indices = {
+        trace_index for trace_index, _ in ordered[:_MAX_RUNTIME_OCCURRENCES]
+    }
+
+    displayed_count = 0
+    for event in events:
+        event["observations"] = [
+            observation
+            for observation in event["observations"]
+            if observation["traceEventIndex"] in retained_indices
+        ]
+        event["displayedObservationCount"] = len(event["observations"])
+        event["omittedObservationCount"] = (
+            event["observationCount"] - event["displayedObservationCount"]
+        )
+        displayed_count += event["displayedObservationCount"]
+
+    total_count = len(ordered)
+    omitted_count = total_count - displayed_count
+    if omitted_count:
+        diagnostics.append(
+            _diagnostic(
+                "runtime-occurrences-truncated",
+                "warning",
+                "runtime occurrences exceed the offline viewer limit",
+                {
+                    "occurrenceLimit": _MAX_RUNTIME_OCCURRENCES,
+                    "totalOccurrences": total_count,
+                    "displayedOccurrences": displayed_count,
+                    "omittedOccurrences": omitted_count,
+                    "retentionPolicy": "earliest-trace-event-index",
+                },
+            )
+        )
+    return {
+        "total": total_count,
+        "displayed": displayed_count,
+        "omitted": omitted_count,
+    }
+
+
 def _load_kineto_trace(
     trace_path: str | Path | None,
     identities: Mapping[str, Mapping[str, Any]],
@@ -575,7 +661,7 @@ def _load_kineto_trace(
         return _omitted_input(), []
     path = Path(trace_path)
     try:
-        value = _read_json_bounded(path, _MAX_KINETO_TRACE_BYTES, "Kineto trace")
+        value = _read_json_with_limit(path, _MAX_KINETO_TRACE_BYTES, "Kineto trace")
     except _InputError as error:
         diagnostics.append(_diagnostic(error.code, "warning", str(error)))
         return {
@@ -824,7 +910,7 @@ def _nonnegative_number(value: object) -> int | float | None:
     return number if number is not None and number >= 0 else None
 
 
-def _read_json_bounded(path: Path, limit: int, label: str) -> object:
+def _read_json_with_limit(path: Path, limit: int, label: str) -> object:
     _check_size(path, limit, label)
     try:
         return json.loads(path.read_text(encoding="utf-8"))
@@ -1276,9 +1362,13 @@ function currentObservation() {
 }
 
 function eventLabel(event) {
-  const count = event.observations.length;
+  const total = event.observationCount;
+  const displayed = event.displayedObservationCount;
+  const count = total === displayed
+    ? String(total)
+    : "showing " + displayed + " of " + total;
   return event.baseName + " | " + count + " runtime occurrence" +
-    (count === 1 ? "" : "s");
+    (total === 1 ? "" : "s");
 }
 
 function observationLabel(observation) {
@@ -1495,8 +1585,13 @@ elements.observationSelect.addEventListener("change", () => {
 });
 
 const pairing = data.inputs.kinetoTrace.pairing;
+const resolved = data.runSummary.resolvedObservations;
+const displayed = data.runSummary.displayedObservations;
 const summaryParts = [
-  data.runSummary.resolvedObservations + " resolved runtime occurrences",
+  (resolved === displayed
+    ? resolved
+    : displayed + " of " + resolved + " shown") +
+    " resolved runtime occurrences",
 ];
 if (data.runSummary.unresolvedObservations) {
   summaryParts.push(data.runSummary.unresolvedObservations + " unresolved");

--- a/torch_spyre/provenance_viewer.py
+++ b/torch_spyre/provenance_viewer.py
@@ -1,0 +1,1569 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate a self-contained Spyre provenance viewer from saved artifacts."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+import copy
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import sys
+import tempfile
+from typing import Any, cast
+
+import regex
+
+from torch_spyre.provenance import (
+    load_provenance_document,
+    ProvenanceReaderError,
+)
+from torch_spyre.provenance_codec import (
+    KERNEL_PROVENANCE_KEY_BASE32_WIDTH,
+    parse_kernel_provenance_event_name,
+)
+
+
+_PRESENTATION_VERSION = 1
+_MAX_SIDECAR_BYTES = 256 * 1024 * 1024
+_MAX_KINETO_TRACE_BYTES = 256 * 1024 * 1024
+_HASH_CHUNK_BYTES = 1024 * 1024
+_NATIVE_KEY_RE = regex.compile(rf"\A[a-z2-7]{{{KERNEL_PROVENANCE_KEY_BASE32_WIDTH}}}\Z")
+_RELATION_FIELDS = ("compileAliases", "handleIds", "postNodes", "preNodes")
+
+
+class _InputError(ValueError):
+    """An optional or bounded viewer input could not be accepted."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+
+
+def build_provenance_presentation(
+    sidecar_path: str | Path,
+    *,
+    kineto_trace: str | Path | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic presentation consumed by the offline page."""
+    sidecar = Path(sidecar_path)
+    _check_size(sidecar, _MAX_SIDECAR_BYTES, "sidecar")
+    document = load_provenance_document(sidecar)
+    diagnostics: list[dict[str, Any]] = []
+
+    if document["status"] != "complete" or document["diagnostics"]:
+        diagnostics.append(
+            _diagnostic(
+                "incomplete-artifact",
+                "warning",
+                "sidecar records incomplete collection or upstream evidence",
+                {
+                    "artifactStatus": document["status"],
+                    "writerDiagnostics": copy.deepcopy(document["diagnostics"]),
+                },
+            )
+        )
+
+    occurrences_by_identity: dict[str, list[dict[str, Any]]] = {
+        identity_key: [] for identity_key in document["kernelIdentities"]
+    }
+    for occurrence_id, occurrence in document["kernelOccurrences"].items():
+        normalized = {
+            "occurrenceId": occurrence_id,
+            **copy.deepcopy(occurrence),
+            "upstreamJoin": document["upstreamProjections"][occurrence["compileId"]][
+                "upstreamJoin"
+            ],
+        }
+        occurrences_by_identity[occurrence["identityKey"]].append(normalized)
+    for occurrences in occurrences_by_identity.values():
+        occurrences.sort(key=lambda item: item["occurrenceId"])
+
+    identities: dict[str, dict[str, Any]] = {}
+    events: list[dict[str, Any]] = []
+    events_by_key: dict[str, dict[str, Any]] = {}
+    for identity_key, identity in document["kernelIdentities"].items():
+        occurrences = occurrences_by_identity[identity_key]
+        normalized = _identity_presentation(
+            identity_key,
+            identity,
+            occurrences,
+            document["handles"],
+            document["upstreamProjections"],
+        )
+        identities[identity_key] = normalized
+        event = {
+            "baseName": identity["eventNameBase"],
+            "identityKey": identity_key,
+            "observations": [],
+        }
+        events.append(event)
+        events_by_key[identity_key] = event
+    events.sort(key=lambda item: item["baseName"])
+
+    trace_input, unresolved = _load_kineto_trace(
+        kineto_trace,
+        document["kernelIdentities"],
+        events_by_key,
+        diagnostics,
+    )
+    for event in events:
+        event["observations"].sort(key=lambda item: item["traceEventIndex"])
+
+    diagnostics = _sorted_diagnostics(diagnostics)
+    presentation = {
+        "presentationVersion": _PRESENTATION_VERSION,
+        "status": _status_from_diagnostics(diagnostics),
+        "runSummary": {
+            "resolvedObservations": sum(len(event["observations"]) for event in events),
+            "unresolvedObservations": len(unresolved),
+        },
+        "events": events,
+        "identities": identities,
+        "unresolvedObservations": unresolved,
+        "inputs": {
+            "sidecar": {"status": "available", **_file_facts(sidecar)},
+            "kinetoTrace": trace_input,
+        },
+        "diagnostics": diagnostics,
+    }
+    return cast(dict[str, Any], _sorted_json_value(presentation))
+
+
+def _identity_presentation(
+    identity_key: str,
+    identity: Mapping[str, Any],
+    occurrences: Sequence[Mapping[str, Any]],
+    all_handles: Mapping[str, Mapping[str, Any]],
+    projections: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    direct_ids = list(identity["directHandleIds"])
+    handle_ids = _reachable_handle_ids(direct_ids, all_handles)
+    handles = {handle_id: all_handles[handle_id] for handle_id in handle_ids}
+    closure = {
+        handle_id: _reachable_handle_ids([handle_id], all_handles)
+        for handle_id in handle_ids
+    }
+    candidate_state = "ambiguous" if len(occurrences) > 1 else "unique"
+
+    source_rows = _source_rows(handles)
+    aten_rows = _aten_rows(handles)
+    lower_rows = _lower_ir_rows(handles, closure)
+    source_handle_count = sum(
+        handle["source"] is not None for handle in handles.values()
+    )
+    aten_handle_count = sum(
+        handle["aten_op"] is not None for handle in handles.values()
+    )
+    post_rows, pre_rows = _fx_rows(
+        occurrences,
+        projections,
+        handles,
+        closure,
+        candidate_state,
+    )
+    binding_rows = _binding_rows(identity["specHandleBindings"], closure)
+
+    aliases = sorted(
+        {
+            registration["alias"]
+            for occurrence in occurrences
+            for registration in occurrence["registrations"]
+        }
+    )
+    compile_ids = sorted({occurrence["compileId"] for occurrence in occurrences})
+
+    panels = [
+        _panel(
+            "source",
+            "Python source locations",
+            (
+                "One row per unique Python source range recorded for this "
+                "bundle. The count shows how many handles contribute to it."
+            ),
+            f"{len(source_rows)} structured locations",
+            source_rows,
+            "No structured source locations were recorded.",
+            [f"Source coverage: {source_handle_count} of {len(handles)} handles"],
+        ),
+        _panel(
+            "aten",
+            "Recorded ATen identities",
+            (
+                "One row per unique ATen operation identity in this bundle. "
+                "Equal names are grouped without losing their handle count."
+            ),
+            f"{len(aten_rows)} unique identities",
+            aten_rows,
+            "No ATen identities were recorded.",
+            [f"ATen coverage: {aten_handle_count} of {len(handles)} handles"],
+        ),
+        _panel(
+            "pre-grad",
+            "FX pre-grad nodes",
+            (
+                "One row per pre-grad FX node and compile context, reached "
+                "through the recorded post-grad-to-pre-grad mapping."
+            ),
+            _fx_panel_summary(pre_rows, compile_ids),
+            pre_rows,
+            "No pre-grad FX relationship was recorded.",
+            ["PyTorch Inductor mapping version 2.0"],
+        ),
+        _panel(
+            "post-grad",
+            "FX post-grad nodes",
+            (
+                "One row per post-grad FX node and compile context, reached "
+                "from a compiler alias. Badges show exact or derived attribution."
+            ),
+            _fx_panel_summary(post_rows, compile_ids),
+            post_rows,
+            "No post-grad FX relationship was recorded.",
+            [f"{len(aliases)} registered aliases"],
+        ),
+        _panel(
+            "lower-ir",
+            "Recorded lower-IR lineage by handle",
+            (
+                "One row per debug handle, grouping its ordered IR names and "
+                "recorded transformation steps."
+            ),
+            f"{len(lower_rows)} handles with recorded lineage",
+            lower_rows,
+            "No lower-IR lineage was recorded.",
+            [f"Lineage coverage: {len(lower_rows)} of {len(handles)} handles"],
+        ),
+        _panel(
+            "opspec",
+            "Direct OpSpec bindings",
+            (
+                "One row per ordered direct-handle attachment in the finalized "
+                "OpSpec tree. SpecPath is the attachment's structural position."
+            ),
+            (
+                f"{len(binding_rows)} bindings | {len(direct_ids)} direct / "
+                f"{len(handle_ids)} recursive handles"
+            ),
+            binding_rows,
+            "No direct OpSpec bindings were recorded.",
+        ),
+    ]
+    return {
+        "identityKey": identity_key,
+        "eventNameBase": identity["eventNameBase"],
+        "compileCandidateCount": len(occurrences),
+        "compileIds": compile_ids,
+        "directHandleIds": direct_ids,
+        "recursiveHandleIds": handle_ids,
+        "panels": panels,
+    }
+
+
+def _source_rows(
+    handles: Mapping[str, Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    grouped: dict[str, dict[str, Any]] = {}
+    for handle_id, handle in handles.items():
+        source = handle["source"]
+        if source is None:
+            continue
+        key = _canonical_json(source)
+        group = grouped.setdefault(
+            key,
+            {"source": copy.deepcopy(source), "handleIds": []},
+        )
+        group["handleIds"].append(handle_id)
+
+    rows = []
+    for key, group in sorted(grouped.items()):
+        source = group["source"]
+        handle_ids = sorted(group["handleIds"])
+        rows.append(
+            _evidence_row(
+                "source",
+                key,
+                _source_label(source),
+                _count_summary(len(handle_ids), "contributing handle"),
+                "exact",
+                refs={"handleIds": handle_ids},
+            )
+        )
+    return rows
+
+
+def _aten_rows(
+    handles: Mapping[str, Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    grouped: dict[str, list[str]] = {}
+    for handle_id, handle in handles.items():
+        aten_op = handle["aten_op"]
+        if aten_op is not None:
+            grouped.setdefault(aten_op, []).append(handle_id)
+    return [
+        _evidence_row(
+            "aten",
+            aten_op,
+            aten_op,
+            _count_summary(len(handle_ids), "contributing handle"),
+            "exact",
+            refs={"handleIds": sorted(handle_ids)},
+        )
+        for aten_op, handle_ids in sorted(grouped.items())
+    ]
+
+
+def _lower_ir_rows(
+    handles: Mapping[str, Mapping[str, Any]],
+    closure: Mapping[str, Sequence[str]],
+) -> list[dict[str, Any]]:
+    rows = []
+    for handle_id, handle in handles.items():
+        chain = list(handle["ir_chain"])
+        transforms = list(handle["transform_history"])
+        if not chain and not transforms:
+            continue
+        summary = []
+        if chain:
+            summary.append("IR: " + " -> ".join(chain))
+        if transforms:
+            summary.append(
+                "Transforms: "
+                + ", ".join(
+                    item["kind"] + " by " + item["pass_name"] for item in transforms
+                )
+            )
+        rows.append(
+            _evidence_row(
+                "lower-ir",
+                handle_id,
+                "Handle " + handle_id,
+                " | ".join(summary),
+                "exact",
+                refs={"handleIds": list(closure[handle_id])},
+            )
+        )
+    return rows
+
+
+def _fx_rows(
+    occurrences: Sequence[Mapping[str, Any]],
+    projections: Mapping[str, Mapping[str, Any]],
+    handles: Mapping[str, Mapping[str, Any]],
+    closure: Mapping[str, Sequence[str]],
+    candidate_state: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    post_groups: dict[tuple[str, str], dict[str, Any]] = {}
+    for occurrence in occurrences:
+        compile_id = occurrence["compileId"]
+        projection = projections[compile_id]
+        for registration in occurrence["registrations"]:
+            alias = registration["alias"]
+            for post_name in projection["cppCodeToPost"].get(alias, []):
+                group = post_groups.setdefault(
+                    (compile_id, post_name),
+                    {"aliases": set(), "occurrenceIds": set()},
+                )
+                group["aliases"].add(alias)
+                group["occurrenceIds"].add(occurrence["occurrenceId"])
+
+    post_rows = []
+    post_row_data: dict[tuple[str, str], dict[str, Any]] = {}
+    all_handle_ids = sorted(handles)
+    for (compile_id, post_name), group in sorted(post_groups.items()):
+        exact_handles = sorted(
+            handle_id
+            for handle_id, handle in handles.items()
+            if post_name in handle["ir_chain"]
+        )
+        if exact_handles:
+            related_handles = sorted(
+                {
+                    related
+                    for handle_id in exact_handles
+                    for related in closure[handle_id]
+                }
+            )
+            strength = "exact"
+        else:
+            related_handles = all_handle_ids
+            strength = "derived"
+        aliases = sorted(group["aliases"])
+        scoped_post = _compile_scoped_ref(compile_id, post_name)
+        row = _evidence_row(
+            "post-grad",
+            {"compileId": compile_id, "name": post_name},
+            post_name,
+            (
+                f"Compile {compile_id[:12]} | "
+                f"{_count_summary(len(aliases), 'alias', 'aliases')}"
+            ),
+            strength,
+            candidate_state=candidate_state,
+            refs={
+                "compileAliases": [
+                    _compile_scoped_ref(compile_id, alias) for alias in aliases
+                ],
+                "handleIds": related_handles,
+                "postNodes": [scoped_post],
+            },
+        )
+        post_rows.append(row)
+        post_row_data[(compile_id, post_name)] = row
+
+    pre_groups: dict[tuple[str, str], dict[str, set[str]]] = {}
+    for (compile_id, post_name), post_row in post_row_data.items():
+        projection = projections[compile_id]
+        for pre_name in projection["postToPre"].get(post_name, []):
+            group = pre_groups.setdefault(
+                (compile_id, pre_name),
+                {"handleIds": set(), "postNodes": set()},
+            )
+            group["handleIds"].update(post_row["refs"]["handleIds"])
+            group["postNodes"].add(_compile_scoped_ref(compile_id, post_name))
+
+    pre_rows = []
+    for (compile_id, pre_name), group in sorted(pre_groups.items()):
+        pre_rows.append(
+            _evidence_row(
+                "pre-grad",
+                {"compileId": compile_id, "name": pre_name},
+                pre_name,
+                (
+                    f"Compile {compile_id[:12]} | "
+                    f"{_count_summary(len(group['postNodes']), 'post-grad node')}"
+                ),
+                "derived",
+                candidate_state=candidate_state,
+                refs={
+                    "handleIds": sorted(group["handleIds"]),
+                    "postNodes": sorted(group["postNodes"]),
+                    "preNodes": [_compile_scoped_ref(compile_id, pre_name)],
+                },
+            )
+        )
+    return post_rows, pre_rows
+
+
+def _binding_rows(
+    bindings: Sequence[Mapping[str, Any]],
+    closure: Mapping[str, Sequence[str]],
+) -> list[dict[str, Any]]:
+    rows = []
+    for position, binding in enumerate(bindings):
+        handle_id = binding["handleId"]
+        spec_path = list(binding["specPath"])
+        rows.append(
+            _evidence_row(
+                "opspec",
+                {"position": position, **copy.deepcopy(binding)},
+                "SpecPath [" + ", ".join(map(str, spec_path)) + "]",
+                f"Binding {position} | Handle {handle_id}",
+                "exact",
+                refs={"handleIds": list(closure[handle_id])},
+            )
+        )
+    return rows
+
+
+def _evidence_row(
+    prefix: str,
+    identity: object,
+    label: str,
+    summary: str,
+    strength: str,
+    *,
+    candidate_state: str = "unique",
+    refs: Mapping[str, Sequence[str]] | None = None,
+) -> dict[str, Any]:
+    relation = {
+        field: sorted(set((refs or {}).get(field, []))) for field in _RELATION_FIELDS
+    }
+    digest = hashlib.sha256(_canonical_json(identity).encode("utf-8")).hexdigest()
+    return {
+        "id": prefix + ":" + digest[:16],
+        "label": label,
+        "summary": summary,
+        "evidenceStrength": strength,
+        "candidateState": candidate_state,
+        "refs": relation,
+    }
+
+
+def _panel(
+    panel_id: str,
+    title: str,
+    description: str,
+    summary: str,
+    rows: Sequence[Mapping[str, Any]],
+    empty_message: str,
+    scope_details: Sequence[str] = (),
+) -> dict[str, Any]:
+    return {
+        "id": panel_id,
+        "title": title,
+        "description": description,
+        "summary": summary,
+        "scopeDetails": list(scope_details),
+        "emptyMessage": empty_message,
+        "rows": copy.deepcopy(list(rows)),
+    }
+
+
+def _fx_panel_summary(
+    rows: Sequence[Mapping[str, Any]],
+    compile_ids: Sequence[str],
+) -> str:
+    return f"{len(rows)} nodes across {len(compile_ids)} compile candidates"
+
+
+def _source_label(source: Mapping[str, Any]) -> str:
+    label = f"{source['file']}:{source['start_line']}:{source['start_col']}"
+    if source["end_line"] is not None:
+        label += f"-{source['end_line']}:{source['end_col']}"
+    return label
+
+
+def _count_summary(count: int, unit: str, plural: str | None = None) -> str:
+    return f"{count} {unit if count == 1 else plural or unit + 's'}"
+
+
+def _compile_scoped_ref(compile_id: str, name: str) -> str:
+    return _canonical_json({"compileId": compile_id, "name": name})
+
+
+def _reachable_handle_ids(
+    direct_ids: Sequence[str],
+    handles: Mapping[str, Mapping[str, Any]],
+) -> list[str]:
+    ordered: list[str] = []
+    visited: set[str] = set()
+    pending = list(reversed(direct_ids))
+    while pending:
+        handle_id = pending.pop()
+        if handle_id in visited:
+            continue
+        visited.add(handle_id)
+        ordered.append(handle_id)
+        pending.extend(reversed(handles[handle_id]["fused_from"]))
+    return ordered
+
+
+def _load_kineto_trace(
+    trace_path: str | Path | None,
+    identities: Mapping[str, Mapping[str, Any]],
+    events_by_key: Mapping[str, dict[str, Any]],
+    diagnostics: list[dict[str, Any]],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    if trace_path is None:
+        return _omitted_input(), []
+    path = Path(trace_path)
+    try:
+        value = _read_json_bounded(path, _MAX_KINETO_TRACE_BYTES, "Kineto trace")
+    except _InputError as error:
+        diagnostics.append(_diagnostic(error.code, "warning", str(error)))
+        return {
+            "status": "unavailable",
+            "path": str(path.resolve()),
+            "sizeBytes": _safe_size(path),
+            "sha256": None,
+            "pairing": None,
+        }, []
+
+    trace_events = value.get("traceEvents") if isinstance(value, dict) else None
+    if not isinstance(trace_events, list):
+        diagnostics.append(
+            _diagnostic(
+                "kineto-trace-schema-failure",
+                "warning",
+                "Kineto trace must contain a traceEvents array",
+            )
+        )
+        return {
+            "status": "unavailable",
+            **_file_facts(path),
+            "pairing": None,
+        }, []
+
+    candidate_count = 0
+    resolved_count = 0
+    unresolved: list[dict[str, Any]] = []
+    for trace_index, raw_event in enumerate(trace_events):
+        if not isinstance(raw_event, dict):
+            continue
+        name = raw_event.get("name")
+        name = name if isinstance(name, str) else None
+        args = raw_event.get("args")
+        args = args if isinstance(args, dict) else {}
+        parsed = parse_kernel_provenance_event_name(name) if name else None
+        native_value = args.get("provenance_key")
+        native_key = (
+            native_value
+            if isinstance(native_value, str)
+            and _NATIVE_KEY_RE.fullmatch(native_value) is not None
+            else None
+        )
+        if native_value is not None and native_key is None:
+            diagnostics.append(
+                _trace_diagnostic(
+                    "malformed-native-provenance-key",
+                    "warning",
+                    "trace activity has a malformed native provenance key",
+                    trace_index,
+                    name,
+                )
+            )
+        if parsed is None and native_key is None:
+            continue
+
+        candidate_count += 1
+        name_key = parsed.key if parsed is not None else None
+        if native_key is not None and name_key is not None and native_key != name_key:
+            unresolved.append(
+                _unresolved_observation(
+                    trace_index,
+                    name,
+                    "carrier-conflict",
+                    "native and event-name provenance keys disagree",
+                )
+            )
+            diagnostics.append(
+                _trace_diagnostic(
+                    "carrier-conflict",
+                    "error",
+                    "native and event-name provenance keys disagree",
+                    trace_index,
+                    name,
+                )
+            )
+            continue
+
+        key = native_key or name_key
+        assert key is not None
+        identity = identities.get(key)
+        if identity is None:
+            unresolved.append(
+                _unresolved_observation(
+                    trace_index,
+                    name,
+                    "missing-key",
+                    "trace provenance key is absent from the sidecar",
+                )
+            )
+            diagnostics.append(
+                _trace_diagnostic(
+                    "kineto-sidecar-pairing-mismatch",
+                    "error",
+                    "trace provenance key is absent from the sidecar",
+                    trace_index,
+                    name,
+                )
+            )
+            continue
+        if parsed is not None and parsed.base_name != identity["eventNameBase"]:
+            unresolved.append(
+                _unresolved_observation(
+                    trace_index,
+                    name,
+                    "collision",
+                    "event key resolves to a different persisted event base",
+                )
+            )
+            diagnostics.append(
+                _trace_diagnostic(
+                    "collision",
+                    "error",
+                    "event key resolves to a different persisted event base",
+                    trace_index,
+                    name,
+                )
+            )
+            continue
+
+        native_handles = _native_handle_ids(
+            args.get("debug_handles"),
+            trace_index,
+            name,
+            diagnostics,
+        )
+        if native_handles is not None and native_handles != identity["directHandleIds"]:
+            diagnostics.append(
+                _trace_diagnostic(
+                    "native-handle-disagreement",
+                    "warning",
+                    "native direct handles disagree with the sidecar",
+                    trace_index,
+                    name,
+                )
+            )
+
+        observation = {
+            "traceEventIndex": trace_index,
+            "name": name,
+            "timestampUs": _finite_number(raw_event.get("ts")),
+            "durationUs": _nonnegative_number(raw_event.get("dur")),
+            "commandStep": parsed.step if parsed is not None else None,
+            "keySource": (
+                "both"
+                if native_key is not None and name_key is not None
+                else "native"
+                if native_key is not None
+                else "event-name"
+            ),
+            "nativeDirectHandleIds": native_handles,
+            "correlation": args.get("correlation"),
+            "processId": raw_event.get("pid"),
+            "threadId": raw_event.get("tid"),
+            "stream": args.get("stream"),
+        }
+        events_by_key[key]["observations"].append(observation)
+        resolved_count += 1
+
+    if candidate_count == 0:
+        diagnostics.append(
+            _diagnostic(
+                "no-supported-kineto-events",
+                "warning",
+                "Kineto trace contains no supported Spyre provenance activities",
+            )
+        )
+    pairing_status = "complete" if not unresolved else "error"
+    return {
+        "status": "available",
+        **_file_facts(path),
+        "pairing": {
+            "status": pairing_status,
+            "candidateObservations": candidate_count,
+            "resolvedObservations": resolved_count,
+            "unresolvedObservations": len(unresolved),
+            "resolutionRate": (
+                resolved_count / candidate_count if candidate_count else None
+            ),
+        },
+    }, unresolved
+
+
+def _native_handle_ids(
+    value: object,
+    trace_index: int,
+    name: str | None,
+    diagnostics: list[dict[str, Any]],
+) -> list[str] | None:
+    if value is None:
+        return None
+    if (
+        not isinstance(value, list)
+        or not all(isinstance(item, str) for item in value)
+        or len(value) != len(set(value))
+    ):
+        diagnostics.append(
+            _trace_diagnostic(
+                "malformed-native-debug-handles",
+                "warning",
+                "native debug_handles must be a unique string array",
+                trace_index,
+                name,
+            )
+        )
+        return None
+    return list(value)
+
+
+def _trace_diagnostic(
+    code: str,
+    severity: str,
+    message: str,
+    trace_index: int,
+    name: str | None,
+) -> dict[str, Any]:
+    return _diagnostic(
+        code,
+        severity,
+        message,
+        {"traceEventIndex": trace_index, "eventName": name},
+    )
+
+
+def _unresolved_observation(
+    trace_index: int,
+    name: str | None,
+    code: str,
+    message: str,
+) -> dict[str, Any]:
+    return {
+        "traceEventIndex": trace_index,
+        "name": name,
+        "diagnostic": {"code": code, "message": message},
+    }
+
+
+def _finite_number(value: object) -> int | float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return value if math.isfinite(value) else None
+
+
+def _nonnegative_number(value: object) -> int | float | None:
+    number = _finite_number(value)
+    return number if number is not None and number >= 0 else None
+
+
+def _read_json_bounded(path: Path, limit: int, label: str) -> object:
+    _check_size(path, limit, label)
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise _InputError("input-read-failure", f"{label} could not be read") from error
+    except (RecursionError, UnicodeError, ValueError) as error:
+        raise _InputError(
+            "input-json-failure",
+            f"{label} is not valid UTF-8 JSON",
+        ) from error
+
+
+def _check_size(path: Path, limit: int, label: str) -> None:
+    try:
+        size = path.stat().st_size
+    except OSError as error:
+        raise _InputError("input-read-failure", f"{label} could not be read") from error
+    if size > limit:
+        raise _InputError(
+            "input-size-limit",
+            f"{label} exceeds the {limit}-byte input limit",
+        )
+
+
+def _safe_size(path: Path) -> int | None:
+    try:
+        return path.stat().st_size
+    except OSError:
+        return None
+
+
+def _file_facts(path: Path) -> dict[str, Any]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as file:
+        while chunk := file.read(_HASH_CHUNK_BYTES):
+            size += len(chunk)
+            digest.update(chunk)
+    return {
+        "path": str(path.resolve()),
+        "sizeBytes": size,
+        "sha256": digest.hexdigest(),
+    }
+
+
+def _omitted_input() -> dict[str, Any]:
+    return {
+        "status": "omitted",
+        "path": None,
+        "sizeBytes": None,
+        "sha256": None,
+        "pairing": None,
+    }
+
+
+def _diagnostic(
+    code: str,
+    severity: str,
+    message: str,
+    details: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "code": code,
+        "severity": severity,
+        "message": message,
+    }
+    if details is not None:
+        result["details"] = copy.deepcopy(dict(details))
+    return result
+
+
+def _status_from_diagnostics(
+    diagnostics: Sequence[Mapping[str, Any]],
+) -> str:
+    severities = {item["severity"] for item in diagnostics}
+    if "error" in severities:
+        return "error"
+    if "warning" in severities:
+        return "partial"
+    return "complete"
+
+
+def _sorted_diagnostics(
+    diagnostics: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    return sorted(
+        (copy.deepcopy(dict(item)) for item in diagnostics),
+        key=lambda item: (
+            item["code"],
+            _canonical_json(item.get("details", {})),
+            item["message"],
+        ),
+    )
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _sorted_json_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _sorted_json_value(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return [_sorted_json_value(item) for item in value]
+    return value
+
+
+def render_provenance_html(presentation: Mapping[str, Any]) -> str:
+    """Render one deterministic self-contained HTML document."""
+    encoded = _canonical_json(presentation)
+    encoded = (
+        encoded.replace("&", "\\u0026").replace("<", "\\u003c").replace(">", "\\u003e")
+    )
+    return (
+        "<!doctype html>\n"
+        '<html lang="en">\n'
+        "<head>\n"
+        '<meta charset="utf-8">\n'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        "<title>Spyre provenance viewer</title>\n"
+        "<style>\n" + _CSS + "\n</style>\n"
+        "</head>\n"
+        "<body>\n"
+        "<header>\n"
+        "<h1>Spyre provenance viewer</h1>\n"
+        '<p id="run-summary"></p>\n'
+        "</header>\n"
+        "<main>\n"
+        '<section class="controls" aria-label="Provenance selection">\n'
+        '<label>Profiler event<select id="event-select"></select></label>\n'
+        '<label>Runtime occurrence<select id="observation-select"></select></label>\n'
+        "</section>\n"
+        '<section class="facts" aria-label="Selected profiler event facts">\n'
+        '<div><span>Exact observed event name</span><strong id="fact-name"></strong></div>\n'
+        '<div><span>Timestamp (us)</span><strong id="fact-ts"></strong></div>\n'
+        '<div><span>Duration (us)</span><strong id="fact-duration"></strong></div>\n'
+        "<div><span>JobPlan step (static command index)</span>"
+        '<strong id="fact-step"></strong></div>\n'
+        "<div><span>Compile candidates</span>"
+        '<strong id="fact-candidates"></strong></div>\n'
+        "</section>\n"
+        '<section id="panels" class="panels" aria-label="Provenance evidence"></section>\n'
+        "</main>\n"
+        '<script id="spyre-provenance-data" type="application/json">'
+        + encoded
+        + "</script>\n"
+        "<script>\n" + _SCRIPT + "\n</script>\n"
+        "</body>\n"
+        "</html>\n"
+    )
+
+
+def write_provenance_html(
+    presentation: Mapping[str, Any],
+    output_path: str | Path,
+) -> None:
+    """Atomically write one offline viewer."""
+    output = Path(output_path)
+    if not output.parent.is_dir():
+        raise OSError("output parent does not exist")
+    payload = render_provenance_html(presentation)
+    temporary: Path | None = None
+    try:
+        descriptor, name = tempfile.mkstemp(
+            dir=output.parent,
+            prefix="." + output.name + ".",
+            suffix=".tmp",
+        )
+        temporary = Path(name)
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as file:
+            file.write(payload)
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temporary, output)
+        temporary = None
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+_CSS = r"""
+:root {
+  color-scheme: light dark;
+  font-family: "IBM Plex Sans", system-ui, sans-serif;
+  --background: #f4f4f4;
+  --layer: #ffffff;
+  --layer-alt: #e8e8e8;
+  --text: #161616;
+  --muted: #525252;
+  --border: #c6c6c6;
+  --focus: #198038;
+  --selection: #defbe6;
+  --selection-border: #198038;
+  --exact: #198038;
+  --derived: #8e6a00;
+  --danger: #da1e28;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #161616;
+    --layer: #262626;
+    --layer-alt: #393939;
+    --text: #f4f4f4;
+    --muted: #c6c6c6;
+    --border: #525252;
+    --focus: #42be65;
+    --selection: #103b20;
+    --selection-border: #42be65;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  background: var(--background);
+  color: var(--text);
+  margin: 0;
+}
+header {
+  background: var(--layer);
+  border-bottom: 1px solid var(--border);
+  padding: 1rem 1.5rem;
+}
+h1 { font-size: 1.75rem; margin: 0 0 .3rem; }
+header p { color: var(--muted); margin: 0; }
+main { padding: 1rem 1.5rem 2rem; }
+.controls {
+  background: var(--layer);
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  padding: 1rem;
+}
+.controls label {
+  color: var(--muted);
+  display: grid;
+  font-size: .95rem;
+  font-weight: 600;
+  gap: .35rem;
+}
+select {
+  background: var(--layer);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font: inherit;
+  min-height: 2.5rem;
+  min-width: 0;
+  padding: .5rem;
+  width: 100%;
+}
+select:focus-visible, .evidence-row:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+.facts {
+  background: var(--layer);
+  display: grid;
+  gap: 1px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  margin-top: 1px;
+}
+.facts div {
+  background: var(--layer);
+  min-width: 0;
+  padding: .75rem 1rem;
+}
+.facts span {
+  color: var(--muted);
+  display: block;
+  font-size: .82rem;
+  font-weight: 600;
+}
+.facts strong {
+  display: block;
+  font-size: 1rem;
+  margin-top: .25rem;
+  overflow-wrap: anywhere;
+}
+.panels {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 1rem;
+}
+.panel {
+  background: var(--layer);
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  height: 33rem;
+  min-width: 0;
+}
+.panel-header {
+  border-bottom: 1px solid var(--border);
+  min-height: 8.75rem;
+  padding: .85rem;
+}
+.panel-header h2 { font-size: 1.15rem; margin: 0 0 .35rem; }
+.panel-description {
+  font-size: .9rem;
+  line-height: 1.4;
+  margin: .3rem 0 .55rem;
+}
+.panel-summary, .scope-detail {
+  color: var(--muted);
+  font-size: .86rem;
+  line-height: 1.35;
+  margin: .25rem 0;
+  overflow-wrap: anywhere;
+}
+.rows {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: .5rem;
+  min-height: 0;
+  overflow: auto;
+  padding: .75rem;
+}
+.evidence-row {
+  background: var(--layer-alt);
+  border: 1px solid transparent;
+  border-left: .25rem solid var(--border);
+  color: var(--text);
+  cursor: pointer;
+  display: block;
+  font: inherit;
+  padding: .65rem;
+  text-align: left;
+  width: 100%;
+}
+.evidence-row:hover { border-color: var(--focus); }
+.evidence-row.is-focused {
+  background: var(--selection);
+  border-color: var(--selection-border);
+  border-left-color: var(--selection-border);
+  box-shadow: inset 0 0 0 1px var(--selection-border);
+}
+.evidence-row.is-related {
+  background: var(--selection);
+  border-left-color: var(--selection-border);
+}
+.evidence-row.is-dimmed { opacity: .38; }
+.row-badges { display: flex; flex-wrap: wrap; gap: .3rem; }
+.badge {
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  font-size: .75rem;
+  padding: .1rem .45rem;
+  text-transform: capitalize;
+}
+.badge-exact { border-color: var(--exact); }
+.badge-derived { border-color: var(--derived); }
+.badge-ambiguous { border-color: var(--danger); }
+.row-label {
+  display: block;
+  font-size: 1rem;
+  font-weight: 600;
+  margin-top: .4rem;
+  overflow-wrap: anywhere;
+}
+.row-summary {
+  display: block;
+  font-size: .86rem;
+  margin-top: .3rem;
+  overflow-wrap: anywhere;
+}
+.row-summary { color: var(--muted); }
+.empty-state {
+  color: var(--muted);
+  font-size: .9rem;
+  font-style: italic;
+  padding: .75rem;
+}
+@media (max-width: 78rem) {
+  .panels { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .facts { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+@media (max-width: 62rem) {
+  main { padding: .75rem; }
+  .controls, .panels, .facts { grid-template-columns: 1fr; }
+  .panel { height: 24rem; }
+  .panel-header { min-height: auto; }
+}
+""".strip()
+
+
+_SCRIPT = r"""
+"use strict";
+const data = JSON.parse(
+  document.getElementById("spyre-provenance-data").textContent
+);
+const elements = {
+  eventSelect: document.getElementById("event-select"),
+  observationSelect: document.getElementById("observation-select"),
+  panels: document.getElementById("panels"),
+  runSummary: document.getElementById("run-summary"),
+  factName: document.getElementById("fact-name"),
+  factTimestamp: document.getElementById("fact-ts"),
+  factDuration: document.getElementById("fact-duration"),
+  factStep: document.getElementById("fact-step"),
+  factCandidates: document.getElementById("fact-candidates"),
+};
+const relationFields = [
+  "compileAliases",
+  "handleIds",
+  "postNodes",
+  "preNodes",
+];
+const state = {
+  eventIndex: 0,
+  observationIndex: 0,
+  focusedPanelId: null,
+  focusedRowId: null,
+  rowById: new Map(),
+};
+
+function node(tag, className, text) {
+  const result = document.createElement(tag);
+  if (className) {
+    result.className = className;
+  }
+  if (text !== undefined) {
+    result.textContent = String(text);
+  }
+  return result;
+}
+
+function display(value) {
+  return value === null || value === undefined ? "Unavailable" : String(value);
+}
+
+function currentEvent() {
+  return data.events[state.eventIndex] || null;
+}
+
+function currentIdentity() {
+  const event = currentEvent();
+  return event ? data.identities[event.identityKey] : null;
+}
+
+function currentObservation() {
+  const event = currentEvent();
+  return event ? event.observations[state.observationIndex] || null : null;
+}
+
+function eventLabel(event) {
+  const count = event.observations.length;
+  return event.baseName + " | " + count + " runtime occurrence" +
+    (count === 1 ? "" : "s");
+}
+
+function observationLabel(observation) {
+  return "trace[" + observation.traceEventIndex + "] | " +
+    display(observation.name) + " | " +
+    (observation.durationUs === null
+      ? "duration unavailable"
+      : observation.durationUs + " us");
+}
+
+function populateEvents() {
+  elements.eventSelect.replaceChildren();
+  data.events.forEach((event, index) => {
+    const option = node("option", "", eventLabel(event));
+    option.value = String(index);
+    elements.eventSelect.append(option);
+  });
+  elements.eventSelect.disabled = data.events.length === 0;
+}
+
+function populateObservations() {
+  const event = currentEvent();
+  elements.observationSelect.replaceChildren();
+  if (!event || !event.observations.length) {
+    const option = node("option", "", "No runtime occurrence");
+    option.value = "0";
+    elements.observationSelect.append(option);
+    elements.observationSelect.disabled = true;
+    state.observationIndex = 0;
+    return;
+  }
+  event.observations.forEach((observation, index) => {
+    const option = node("option", "", observationLabel(observation));
+    option.value = String(index);
+    elements.observationSelect.append(option);
+  });
+  elements.observationSelect.disabled = false;
+  elements.observationSelect.value = String(state.observationIndex);
+}
+
+function renderFacts() {
+  const event = currentEvent();
+  const identity = currentIdentity();
+  const observation = currentObservation();
+  elements.factName.textContent = display(
+    observation ? observation.name : event ? event.baseName : null
+  );
+  elements.factTimestamp.textContent = display(
+    observation ? observation.timestampUs : null
+  );
+  elements.factDuration.textContent = display(
+    observation ? observation.durationUs : null
+  );
+  elements.factStep.textContent = display(
+    observation ? observation.commandStep : null
+  );
+  elements.factCandidates.textContent = display(
+    identity ? identity.compileCandidateCount : null
+  );
+}
+
+function badge(value, className) {
+  return node("span", "badge " + className, value);
+}
+
+function renderRow(row, panelId) {
+  const button = node("button", "evidence-row");
+  button.type = "button";
+  button.dataset.rowId = row.id;
+  button.dataset.panelId = panelId;
+  const badges = node("span", "row-badges");
+  badges.append(
+    badge(row.evidenceStrength, "badge-" + row.evidenceStrength)
+  );
+  if (row.candidateState === "ambiguous") {
+    badges.append(badge("multiple candidates", "badge-ambiguous"));
+  }
+  button.append(
+    badges,
+    node("span", "row-label", row.label),
+    node("span", "row-summary", row.summary)
+  );
+  button.addEventListener("click", () => focusRow(button, row));
+  state.rowById.set(row.id, row);
+  return button;
+}
+
+function renderPanels() {
+  const identity = currentIdentity();
+  state.rowById = new Map();
+  elements.panels.replaceChildren();
+  if (!identity) {
+    elements.panels.append(node("p", "empty-state", "No persisted events."));
+    return;
+  }
+  identity.panels.forEach((panel) => {
+    const section = node("section", "panel");
+    section.dataset.panelId = panel.id;
+    const header = node("div", "panel-header");
+    header.append(
+      node("h2", "", panel.title),
+      node("p", "panel-description", panel.description),
+      node("p", "panel-summary", panel.summary)
+    );
+    panel.scopeDetails.forEach((detail) => {
+      header.append(node("p", "scope-detail", detail));
+    });
+    const rows = node("div", "rows");
+    if (!panel.rows.length) {
+      rows.append(node("p", "empty-state", panel.emptyMessage));
+    } else {
+      panel.rows.forEach((row) => rows.append(renderRow(row, panel.id)));
+    }
+    section.append(header, rows);
+    elements.panels.append(section);
+  });
+}
+
+function intersects(left, right) {
+  const values = new Set(left);
+  return right.some((value) => values.has(value));
+}
+
+function rowsRelated(left, right) {
+  if (left.id === right.id) {
+    return true;
+  }
+  return relationFields.some(
+    (field) => intersects(left.refs[field], right.refs[field])
+  );
+}
+
+function updateFocusClasses() {
+  const focused = state.focusedRowId
+    ? state.rowById.get(state.focusedRowId)
+    : null;
+  document.querySelectorAll(".evidence-row").forEach((button) => {
+    const row = state.rowById.get(button.dataset.rowId);
+    const samePanel = button.dataset.panelId === state.focusedPanelId;
+    const related = focused &&
+      (!samePanel || row.id === focused.id) &&
+      rowsRelated(focused, row);
+    button.classList.toggle("is-focused", Boolean(focused && row.id === focused.id));
+    button.classList.toggle(
+      "is-related",
+      Boolean(focused && related && row.id !== focused.id)
+    );
+    button.classList.toggle("is-dimmed", Boolean(focused && !related));
+    button.setAttribute(
+      "aria-pressed",
+      focused && row.id === focused.id ? "true" : "false"
+    );
+  });
+}
+
+function centerRelatedRows(clickedPanelId) {
+  document.querySelectorAll(".panel").forEach((panel) => {
+    if (panel.dataset.panelId === clickedPanelId) {
+      return;
+    }
+    const body = panel.querySelector(".rows");
+    const target = body.querySelector(".evidence-row.is-related");
+    if (!target) {
+      return;
+    }
+    const bodyBox = body.getBoundingClientRect();
+    const targetBox = target.getBoundingClientRect();
+    const targetTop = targetBox.top - bodyBox.top + body.scrollTop;
+    body.scrollTop = Math.max(
+      0,
+      targetTop - body.clientHeight / 2 + targetBox.height / 2
+    );
+  });
+}
+
+function focusRow(button, row) {
+  const pageX = window.scrollX || 0;
+  const pageY = window.scrollY || 0;
+  const clickedPanel = button.closest(".panel");
+  const clickedBody = clickedPanel.querySelector(".rows");
+  const clickedTop = clickedBody.scrollTop;
+  const clickedLeft = clickedBody.scrollLeft;
+  const clearing = state.focusedRowId === row.id;
+  state.focusedRowId = clearing ? null : row.id;
+  state.focusedPanelId = clearing ? null : clickedPanel.dataset.panelId;
+  updateFocusClasses();
+  if (!clearing) {
+    centerRelatedRows(clickedPanel.dataset.panelId);
+  }
+  clickedBody.scrollTop = clickedTop;
+  clickedBody.scrollLeft = clickedLeft;
+  if (typeof window.scrollTo === "function") {
+    window.scrollTo(pageX, pageY);
+  }
+}
+
+function selectEvent(index) {
+  state.eventIndex = index;
+  state.observationIndex = 0;
+  state.focusedPanelId = null;
+  state.focusedRowId = null;
+  populateObservations();
+  renderFacts();
+  renderPanels();
+  updateFocusClasses();
+}
+
+elements.eventSelect.addEventListener("change", () => {
+  selectEvent(Number(elements.eventSelect.value));
+});
+elements.observationSelect.addEventListener("change", () => {
+  state.observationIndex = Number(elements.observationSelect.value);
+  renderFacts();
+});
+
+const pairing = data.inputs.kinetoTrace.pairing;
+const summaryParts = [
+  data.runSummary.resolvedObservations + " resolved runtime occurrences",
+];
+if (data.runSummary.unresolvedObservations) {
+  summaryParts.push(data.runSummary.unresolvedObservations + " unresolved");
+}
+summaryParts.push("status " + data.status);
+if (pairing && pairing.resolutionRate !== null) {
+  summaryParts.push("pairing " + Math.round(pairing.resolutionRate * 100) + "%");
+}
+elements.runSummary.textContent = summaryParts.join(" | ");
+populateEvents();
+selectEvent(0);
+window.__spyreProvenanceViewer = {
+  data,
+  state,
+  rowsRelated,
+  selectEvent,
+};
+""".strip()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Build one offline viewer from a saved sidecar and optional trace."""
+    parser = argparse.ArgumentParser(
+        description="Build a self-contained Spyre provenance viewer",
+        epilog=(
+            "Run with backend autoload disabled:\n"
+            "  TORCH_DEVICE_BACKEND_AUTOLOAD=0 python -m "
+            "torch_spyre.provenance_viewer SIDECAR --output VIEWER.html"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("sidecar", help="validated spyre_provenance.json")
+    parser.add_argument(
+        "--kineto-trace",
+        help="optional Kineto Chrome trace containing runtime occurrences",
+    )
+    parser.add_argument("--output", required=True, help="output HTML path")
+    args = parser.parse_args(argv)
+
+    try:
+        presentation = build_provenance_presentation(
+            args.sidecar,
+            kineto_trace=args.kineto_trace,
+        )
+    except (ProvenanceReaderError, _InputError) as error:
+        code = getattr(error, "code", "viewer-input-failure")
+        print(
+            _canonical_json(_diagnostic(code, "error", str(error))),
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        write_provenance_html(presentation, args.output)
+    except OSError:
+        print(
+            _canonical_json(
+                _diagnostic(
+                    "output-write-failure",
+                    "error",
+                    "viewer output could not be written",
+                )
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    return 1 if presentation["status"] == "error" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -83,6 +83,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "build"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -225,11 +234,38 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
 name = "ktir-mlir-frontend"
 version = "0.1.0"
 source = { git = "https://github.com/torch-spyre/ktir-mlir-frontend.git?rev=05e7a0ff814ebefb6e78450b1ec0e871c488c8bc#05e7a0ff814ebefb6e78450b1ec0e871c488c8bc" }
 dependencies = [
-    { name = "nanobind", marker = "python_full_version >= '3.12'" },
+    { name = "nanobind" },
 ]
 
 [[package]]
@@ -1087,6 +1123,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "regex"
 version = "2026.7.19"
 source = { registry = "https://pypi.org/simple" }
@@ -1191,6 +1241,129 @@ wheels = [
 ]
 
 [[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/1f/a2dca5ffdbf1d475ffc4e80e4d5d720ff3a00f691795910116960ee12511/rpds_py-2026.6.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7b689145a1485c335569bd056464f3243a29af7ed3871c7be31ad624ba239bc7", size = 342174, upload-time = "2026-06-30T07:14:54.821Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/dc/323d08583c0832911768663d1944f0107fcd4088704858d84b5e06d105a0/rpds_py-2026.6.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:db08f45aecde626498fb3df07bcf6d2ec040af42e859a4f5040d79c200342911", size = 345513, upload-time = "2026-06-30T07:14:56.515Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2a/e31989834d18d2f26ec1d2774c5b1eb3331df4ea8ada525175294c94b48a/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:acc992ab27b15f852c76755eb2ab7dce86585ddadba6fa5946e58556088845b4", size = 373783, upload-time = "2026-06-30T07:14:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/87/fe/e80107ee3639585c9941c17d6a42cd65325022f656c023191fce78c324c8/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f88d653e7b3b779d71ae7454e20dcc9b6bae903f33c269db9f2be41bda3f261", size = 378316, upload-time = "2026-06-30T07:14:59.077Z" },
+    { url = "https://files.pythonhosted.org/packages/22/6f/81e3adf81acfb6fa694de2a6e4e7d8863121e3e0799e0a7725e6cf5679c4/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e52655eaf81e32593abedaa4bfe33170c8cfedf3365ed9be6e11e07f148f0278", size = 499423, upload-time = "2026-06-30T07:15:00.488Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9a/41263969df0ce3d9af2a96d5005a288200af1989aed3354bfceb5fc0b21f/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dfcc8b909769d19db55c7cc9541eb64b9b774b1057ffffb4f1048070475bb9f9", size = 386077, upload-time = "2026-06-30T07:15:01.911Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/19/7e98f468bd50346faff5b10e5297374b443bfdddacc8e9fbc65984539597/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c1255b302953c86a486b81d330d5ee1d5bd937691ce271b6be0ef0e299eaab7", size = 371315, upload-time = "2026-06-30T07:15:03.317Z" },
+    { url = "https://files.pythonhosted.org/packages/99/3c/2b973b4d371906a134b03decfea7f5d9835a2c6d263454392e15b64b5b18/rpds_py-2026.6.3-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:8d2294a31386bfa251d8c8a39472beee17db67d4f1a6eabea665d35c9a4461c3", size = 383502, upload-time = "2026-06-30T07:15:04.627Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2a/12e2799500af0a307bca76b63361c51f9fe479223561489c29eea1f2ee41/rpds_py-2026.6.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f8f23ead891a3b762f35ab3b04623da7056545b48aa60d59957e6789914545da", size = 402673, upload-time = "2026-06-30T07:15:05.856Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e3/21e5872d165fe08be4f229e3d5ee9d90019c0bf0e5538de60dbd54009450/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:421aba32367055614287a4292b6a17f1939c9452299f7a0209c117e990b646d4", size = 549964, upload-time = "2026-06-30T07:15:07.159Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d0/5ee0fe36844297de8123bee27bc12078c1a7416ad9f1b8a8ca18d6b0c0ac/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1e5822dfc2f0d4ab7e745eaa6d85945069329beeccef965af3f3bb26058fcab6", size = 615446, upload-time = "2026-06-30T07:15:08.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/80/1ea5873cb683f2fbe5f21b23ea1f6d179ead19f3c5b249b7eb5dca568ef2/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:83e35b57523816c8613fd0776b40cd8bb9f596b37ddd2692eb4a6bb5ab2f8c93", size = 576975, upload-time = "2026-06-30T07:15:09.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e1/90ef639217a5ddb15b7f4f61b1c33911fd044ad03c311bafdd2bcab85582/rpds_py-2026.6.3-cp311-cp311-win32.whl", hash = "sha256:de3eceba0b683bcbb1ab93da016d0270df1f9ae7be716b40214c5dafac6ea45a", size = 204453, upload-time = "2026-06-30T07:15:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b7/b7a1695d7af36f521fb11e80d6d3adbd744f73b921859bd3c2a2c0dc706f/rpds_py-2026.6.3-cp311-cp311-win_amd64.whl", hash = "sha256:2c54a076ca4d370980ab57bc0e31df57bbe8d41340436a90ef8b1219a3cbb127", size = 223219, upload-time = "2026-06-30T07:15:12.476Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a2/145afacf796e4506062825941176ad9445c2dcf2b3b6a1f13d3030a15e19/rpds_py-2026.6.3-cp311-cp311-win_arm64.whl", hash = "sha256:168c733a7112e071bb7a66460e667edfcff06c017a3c523f7a8a8e08d0140804", size = 219137, upload-time = "2026-06-30T07:15:13.631Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9c/f0d19ac587fd0e4ab6b72cda355e9c5a6166b01ef7e064e437aef8eb9fef/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:4cf2d36a2357e4d07bb5a4f98801265327b48256867816cfd2ceb001e9754a8f", size = 349791, upload-time = "2026-06-30T07:17:33.315Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c7/1d49d204c9fd2ee6c537601dc4c1ba921e03363ca576bfab94a00254ac9a/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:30c6dc199b24a5e3e81d50da0f00858c5bbdb2617a750395687f4339c5818171", size = 352842, upload-time = "2026-06-30T07:17:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e5/c0b5dc93cd0d4c06ce1f438907649514e2ea077bcd911e3154a51e96c38e/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9891e594296ab9dada6551c8e7b387b2721f27a67eecd528412e8906247a7b90", size = 382094, upload-time = "2026-06-30T07:17:36.514Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/54/ec0e907b4ca8d541112db352409bd15f871c9b243e0c92c9b5a46ae96f01/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b5c2dc92304aa48a4a60443b548bb12f12e119d4b72f314015e67b9e1be97fca", size = 388662, upload-time = "2026-06-30T07:17:38.235Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f4/921c22a4fd0f1c1ac13a3996ffbf0aa67951e2c8ad0d1d9574938a2932e8/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:127e08c0642d880cf32ca47ec2a4a77b901f7e2dd1ad9762adb13955d72ffcc9", size = 504896, upload-time = "2026-06-30T07:17:39.689Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1b/a114b972cefa1ab1cdb3c7bb177cd3844a12826c507c722d3a73516dbbaf/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8bb68f03f395eb793220b45c097bd4d8c32944393da0fad8b999efac0868fc8c", size = 391545, upload-time = "2026-06-30T07:17:41.336Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/98/af9b3db77d47fcbe6c8c1f36e2c2147ec70292819e99c325f871584a1c11/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3450b693fde92133e9f51060568a4c31fcca76d5e53bbd611e689ca446517e9", size = 380059, upload-time = "2026-06-30T07:17:42.857Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ba/0efd8668b97c1d26a61566386c636a7a7a09829e474fdf807caa15a2c844/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:5e8d07bddee435a2ff6f1920e18feff28d0bc4533e42f4bf6927fbd073312c41", size = 393235, upload-time = "2026-06-30T07:17:44.637Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/8c139ee9690f73b0829f32647de6f40d826f8f443af6fa72644f96351aac/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3a83ae6c67b7676b9878378547ca8e93ed77a580037bcbcd1d32f739e1e6089c", size = 413008, upload-time = "2026-06-30T07:17:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/0043896fdd7828ce09a1d9a8b06433714d0960fc4ff3fc4aa72b666b764e/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2bfd04c19ddbd6640de0b51894d764bd2758854d5b75bd102d2ef10cb9c293a9", size = 558118, upload-time = "2026-06-30T07:17:47.759Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/02355f0e134f783a8f9814c4680a1bd311d37671577a5964ea838573ff37/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ca6546b66be9dc4738b1b043d5ebd5488c66c578c5ff0fd0e8065313fe3afb76", size = 623138, upload-time = "2026-06-30T07:17:49.355Z" },
+    { url = "https://files.pythonhosted.org/packages/10/85/48f0abdcef5cce4e034c7a5b0ceeceba0b01bf0d942824f4bb720afe2dec/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8e65860d238379ed982fd9ba690579b5e95af2f4840f99c772816dbe573cb826", size = 586486, upload-time = "2026-06-30T07:17:51.141Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "81.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1230,13 +1403,13 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "networkx", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "sympy", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:e76f9bcecc52b8ff711239a2f7547d5353df95878ab232f0773c1d95928b92f8", upload-time = "2026-07-08T12:26:13Z" },
@@ -1266,13 +1439,13 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
-    { name = "networkx", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
-    { name = "setuptools", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
-    { name = "sympy", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:6e9817dbdf5ea76789babd46e457eac5bf14ff566cf85f8addbfdff2d56601ce", upload-time = "2026-07-08T19:27:52Z" },
@@ -1342,6 +1515,7 @@ lint = [
     { name = "uv" },
 ]
 test = [
+    { name = "jsonschema" },
     { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-xdist" },
@@ -1358,6 +1532,7 @@ requires-dist = [
     { name = "cmake", marker = "extra == 'build'", specifier = ">=3.27,<4.0.0" },
     { name = "expecttest", marker = "extra == 'build'", specifier = ">=0.3.0" },
     { name = "jinja2", marker = "extra == 'build'" },
+    { name = "jsonschema", marker = "extra == 'test'", specifier = "~=4.26.0" },
     { name = "mypy", marker = "extra == 'lint'", specifier = "~=2.1.0" },
     { name = "ninja", marker = "extra == 'build'" },
     { name = "numpy" },


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [x] documentation
- [ ] cleanup

#### What this PR does:

Adds a deterministic, offline Spyre provenance viewer that starts from a persisted profiler-event identity and resolves its structured source-to-OpSpec evidence.

- Validates `spyre_provenance.json` schema version 1 once and uses it as the authoritative attribution source.
- Optionally reads a bounded Kineto Chrome trace, preserves individual runtime occurrences, compares native and name-derived provenance keys, and independently validates native handle metadata.
- Presents two selectors, compact event and compile facts, and six uniform evidence panels: Python source locations, recorded ATen identities, pre-grad FX nodes, post-grad FX nodes, recorded lower-IR lineage by handle, and ordered direct SpecPath bindings.
- Uses compile-scoped typed relationships for click-to-focus highlighting and automatically centers related rows in the other panels.
- Produces one deterministic, self-contained HTML file that opens directly in a browser without a server, network connection, device, or initialized Spyre backend.
- Bounds optional inputs and emitted data, diagnoses malformed or conflicting evidence, and fails open to a sidecar-only report when optional trace evidence is unavailable.
- Documents capture, export, interpretation, evidence states, row granularity, interaction behavior, and the limits of current command-to-OpSpec attribution.

Phase 3b already records the structured source, ATen, handle, upstream FX mapping, compile, alias, lower-IR, and SpecPath evidence used here. Existing `tlparse --inductor-provenance` output remains a separate view for full generated FX and wrapper text.

#### Which issue(s) this PR is related to:

Closes #2579.

#### Special notes for your reviewer:

The six panels intentionally contain one row granularity each. Bundle, compile-candidate, runtime-occurrence, and JobPlan-command facts remain at the appropriate noninteractive level rather than appearing as peer evidence rows. Evidence strength is also kept separate from whether several compile candidates remain valid.

Validation completed:

- 22 focused viewer tests pass, including the required jsdom interaction gate.
- 22 existing Phase 3b schema and resolver tests pass.
- The retained Granite capture pairs all 83 trace observations across 83 identities.
- All changed-file pre-commit hooks and `git diff --check` pass.

#### Does this PR introduce a user-facing change?

Yes. Users can run:

```bash
TORCH_DEVICE_BACKEND_AUTOLOAD=0 \
python -m torch_spyre.provenance_viewer \
  /path/to/spyre_provenance.json \
  --kineto-trace /path/to/spyre_trace.json \
  --output /path/to/spyre_provenance_viewer.html
```

The Kineto trace is optional. Capture and usage instructions are included under the new provenance user guide and linked from the existing profiler and Inductor-artifact documentation.

#### Additional note:

The viewer is read-only. It never modifies the sidecar or trace. Missing optional trace evidence degrades to a partial report with bounded diagnostics rather than guessed attribution. The generated HTML may contain source paths and model structure and should be reviewed before sharing.
