### PR TITLE
Add logic to preserve dimension order and padding when tiling tensors

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -7563,37 +7563,51 @@ class TestTileHelpers(unittest.TestCase):
     def test_compute_tile_index_2d(self):
         p0, p1 = sympy.symbols("p0 p1", integer=True)
         self.assertEqual(
-            compute_tile_index(4096 * p0 + p1, [1024, 4096], [4096, 1], [1024, 1]),
+            compute_tile_index(
+                4096 * p0 + p1, {p0: 1024, p1: 4096}, [1024, 4096], [4096, 1], [1024, 1]
+            ),
             1024 * p0 + p1,
         )
         self.assertEqual(
-            compute_tile_index(p0 + 1024 * p1, [4096, 1024], [1024, 1], [512, 1]),
+            compute_tile_index(
+                p0 + 1024 * p1, {p0: 4096, p1: 1024}, [4096, 1024], [1024, 1], [512, 1]
+            ),
             p0 + 512 * p1,
         )
 
     def test_compute_tile_index_2d_diagonal(self):
         p0 = sympy.Symbol("p0", integer=True)
         self.assertEqual(
-            compute_tile_index(4097 * p0, [1024, 4096], [4096, 1], [1024, 1]), 1025 * p0
+            compute_tile_index(
+                1025 * p0, {p0: 1024}, [1024, 1024], [1024, 1], [512, 1]
+            ),
+            513 * p0,
         )
 
     def test_compute_tile_index_2d_col_major(self):
         p0, p1 = sympy.symbols("p0 p1", integer=True)
         self.assertEqual(
-            compute_tile_index(p0 + 1024 * p1, [1024, 4096], [1, 1024], [1, 512]),
+            compute_tile_index(
+                p0 + 1024 * p1, {p0: 4096, p1: 1024}, [1024, 4096], [1, 1024], [1, 512]
+            ),
             p0 + 512 * p1,
         )
 
     def test_compute_tile_index_2d_constant_offset(self):
         p0 = sympy.Symbol("p0", integer=True)
         self.assertEqual(
-            compute_tile_index(4096 + p0, [1024, 4096], [4096, 1], [1024, 1]), 1024 + p0
+            compute_tile_index(
+                4096 + p0, {p0: 1024}, [1024, 4096], [4096, 1], [1024, 1]
+            ),
+            1024 + p0,
         )
 
     def test_compute_tile_index_2d_no_tiling(self):
         p0 = sympy.Symbol("p0", integer=True)
         self.assertEqual(
-            compute_tile_index(4096 * p0 + 2048, [1024, 4096], [4096, 1], [4096, 1]),
+            compute_tile_index(
+                4096 * p0 + 2048, {p0: 1024}, [1024, 4096], [4096, 1], [4096, 1]
+            ),
             4096 * p0 + 2048,
         )
 

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1162,7 +1162,7 @@ class TestDivideRanges(unittest.TestCase):
             ReductionHint,
         )
 
-        N = sympy.Symbol("N", positive=True)
+        N = sympy.Symbol("N", positive=True, integer=True)
         red = Reduction(
             device=torch.device("cpu"),
             dtype=torch.float16,
@@ -7453,7 +7453,7 @@ class TestCoeffThroughFloor(unittest.TestCase):
         self.assertEqual(coeff_through_floor(expr, s), 64)
 
 
-class TestRetile(unittest.TestCase):
+class TestTileHelpers(unittest.TestCase):
     """Tests for tile.py."""
 
     def test_compute_tile_stride_1d(self):

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1137,20 +1137,20 @@ class TestDivideRanges(unittest.TestCase):
     def test_cache_invalidated_after_divide_pointwise(self):
         from torch._inductor.ir import ComputedBuffer, FixedLayout, Pointwise
 
-        N = sympy.Symbol("N", positive=True)
+        N = sympy.Symbol("N", positive=True, integer=True)
         pw = Pointwise(
             device=torch.device("cpu"),
             dtype=torch.float16,
             inner_fn=lambda index: sympy.Integer(1),
-            ranges=[N, Integer(32)],
+            ranges=[4 * N, Integer(32)],
         )
-        layout = FixedLayout(torch.device("cpu"), torch.float16, [N, Integer(32)])
+        layout = FixedLayout(torch.device("cpu"), torch.float16, [4 * N, Integer(32)])
         op = ComputedBuffer(name="buf0", layout=layout, data=pw)
 
         pw.get_free_symbol_uses()  # prime the cache
         self.assertTrue(hasattr(pw, _LOOPS_FREE_SYMS_KEY))
 
-        _divide_ranges(op, Integer(4), tiled_dims=[0])
+        _divide_ranges(op, N, tiled_dims=[0])
 
         self.assertFalse(hasattr(pw, _LOOPS_FREE_SYMS_KEY))
 
@@ -1167,20 +1167,20 @@ class TestDivideRanges(unittest.TestCase):
             device=torch.device("cpu"),
             dtype=torch.float16,
             inner_fn=lambda index, rindex: sympy.Integer(1),
-            ranges=[N],
+            ranges=[4 * N],
             reduction_ranges=[Integer(128)],
             reduction_type="sum",
             src_dtype=torch.float16,
             reduction_hint=ReductionHint.DEFAULT,
         )
-        layout = FixedLayout(torch.device("cpu"), torch.float16, [N])
+        layout = FixedLayout(torch.device("cpu"), torch.float16, [4 * N])
         op = ComputedBuffer(name="buf0", layout=layout, data=red)
 
         red.get_free_symbol_uses()  # prime both Loops and Reduction cache entries
         self.assertTrue(hasattr(red, _LOOPS_FREE_SYMS_KEY))
         self.assertTrue(hasattr(red, _REDUCTION_FREE_SYMS_KEY))
 
-        _divide_ranges(op, Integer(4), tiled_dims=[0])
+        _divide_ranges(op, N, tiled_dims=[0])
 
         self.assertFalse(hasattr(red, _LOOPS_FREE_SYMS_KEY))
         self.assertFalse(hasattr(red, _REDUCTION_FREE_SYMS_KEY))

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -105,6 +105,11 @@ from torch_spyre._inductor.temp_passes import (
     _mark_static_unit_batch_bmm,
     mark_direct_unit_bmm_pass,
 )
+from torch_spyre._inductor.wsr.tile import (
+    compute_tile_offset,
+    compute_tile_index,
+    compute_tile_stride,
+)
 
 _FP16 = DataFormats.SEN169_FP16
 
@@ -7446,6 +7451,151 @@ class TestCoeffThroughFloor(unittest.TestCase):
         s = Symbol("s")
         expr = floor(128 * s / 2)
         self.assertEqual(coeff_through_floor(expr, s), 64)
+
+
+class TestRetile(unittest.TestCase):
+    """Tests for tile.py."""
+
+    def test_compute_tile_stride_1d(self):
+        self.assertEqual(compute_tile_stride([1024], [1], [256]), [1])
+
+    def test_compute_tile_stride_2d(self):
+        self.assertEqual(
+            compute_tile_stride([1024, 4096], [4096, 1], [512, 1024]), [1024, 1]
+        )
+
+    def test_compute_tile_stride_2d_padding(self):
+        self.assertEqual(
+            compute_tile_stride([1024, 4096], [4104, 1], [512, 1024]), [1026, 1]
+        )
+
+    def test_compute_tile_stride_3d_row_major(self):
+        self.assertEqual(
+            compute_tile_stride([8, 16, 32], [512, 32, 1], [2, 4, 8]), [32, 8, 1]
+        )
+
+    def test_compute_tile_stride_3d_col_major(self):
+        self.assertEqual(
+            compute_tile_stride([8, 16, 32], [1, 8, 128], [2, 4, 8]), [1, 2, 8]
+        )
+
+    def test_compute_tile_stride_3d_min_stride_64(self):
+        self.assertEqual(
+            compute_tile_stride([4, 8, 16], [8192, 1024, 64], [2, 4, 8]),
+            [2048, 512, 64],
+        )
+
+    def test_compute_tile_stride_3d_unit_tile_middle_dim(self):
+        self.assertEqual(
+            compute_tile_stride([8, 16, 32], [512, 32, 1], [2, 1, 8]), [8, 0, 1]
+        )
+
+    def test_compute_tile_stride_3d_size1_outermost(self):
+        self.assertEqual(
+            compute_tile_stride([1, 16, 32], [512, 32, 1], [1, 4, 8]), [0, 8, 1]
+        )
+
+    def test_compute_tile_stride_3d_size1_middle(self):
+        self.assertEqual(
+            compute_tile_stride([8, 1, 32], [32, 32, 1], [2, 1, 8]), [8, 0, 1]
+        )
+
+    def test_compute_tile_stride_3d_size1_innermost(self):
+        self.assertEqual(
+            compute_tile_stride([8, 16, 1], [16, 1, 1], [2, 4, 1]), [4, 1, 0]
+        )
+
+    def test_compute_tile_stride_3d_expanded_outermost(self):
+        self.assertEqual(
+            compute_tile_stride([8, 16, 32], [0, 32, 1], [2, 4, 8]), [0, 8, 1]
+        )
+
+    def test_compute_tile_stride_3d_expanded_middle(self):
+        self.assertEqual(
+            compute_tile_stride([8, 16, 32], [32, 0, 1], [2, 4, 8]), [8, 0, 1]
+        )
+
+    def test_compute_tile_stride_3d_expanded_innermost(self):
+        self.assertEqual(
+            compute_tile_stride([8, 16, 32], [16, 1, 0], [2, 4, 8]), [4, 1, 0]
+        )
+
+    def test_compute_tile_stride_3d_padding(self):
+        self.assertEqual(
+            compute_tile_stride([8, 16, 32], [544, 32, 1], [2, 4, 8]), [34, 8, 1]
+        )
+
+    def test_compute_tile_offset_1d(self):
+        self.assertEqual(compute_tile_offset(0, [(1, 1)]), 0)
+        self.assertEqual(compute_tile_offset(1, [(1, 1)]), 1)
+        self.assertEqual(compute_tile_offset(256, [(1, 1)]), 256)
+
+    def test_compute_tile_offset_2d(self):
+        self.assertEqual(compute_tile_offset(0, [(4096, 1024), (1, 1)]), 0)
+        self.assertEqual(compute_tile_offset(1, [(4096, 1024), (1, 1)]), 1)
+        self.assertEqual(compute_tile_offset(4096, [(4096, 1024), (1, 1)]), 1024)
+        self.assertEqual(compute_tile_offset(4097, [(4096, 1024), (1, 1)]), 1025)
+        self.assertEqual(compute_tile_offset(8192, [(4096, 1024), (1, 1)]), 2048)
+        self.assertEqual(compute_tile_offset(4104, [(4104, 1026), (1, 1)]), 1026)
+
+    def test_compute_tile_offset_3d(self):
+        self.assertEqual(compute_tile_offset(512, [(512, 32), (32, 8), (1, 1)]), 32)
+        self.assertEqual(compute_tile_offset(32, [(512, 32), (32, 8), (1, 1)]), 8)
+        self.assertEqual(compute_tile_offset(545, [(512, 32), (32, 8), (1, 1)]), 41)
+
+    def test_compute_tile_offset_3d_min_stride_64(self):
+        self.assertEqual(
+            compute_tile_offset(0, [(8192, 2048), (1024, 512), (64, 64)]), 0
+        )
+        self.assertEqual(
+            compute_tile_offset(64, [(8192, 2048), (1024, 512), (64, 64)]), 64
+        )
+        self.assertEqual(
+            compute_tile_offset(1024, [(8192, 2048), (1024, 512), (64, 64)]), 512
+        )
+        self.assertEqual(
+            compute_tile_offset(8192, [(8192, 2048), (1024, 512), (64, 64)]), 2048
+        )
+        self.assertEqual(
+            compute_tile_offset(9280, [(8192, 2048), (1024, 512), (64, 64)]), 2624
+        )
+
+    def test_compute_tile_index_2d(self):
+        p0, p1 = sympy.symbols("p0 p1", integer=True)
+        self.assertEqual(
+            compute_tile_index(4096 * p0 + p1, [1024, 4096], [4096, 1], [1024, 1]),
+            1024 * p0 + p1,
+        )
+        self.assertEqual(
+            compute_tile_index(p0 + 1024 * p1, [4096, 1024], [1024, 1], [512, 1]),
+            p0 + 512 * p1,
+        )
+
+    def test_compute_tile_index_2d_diagonal(self):
+        p0 = sympy.Symbol("p0", integer=True)
+        self.assertEqual(
+            compute_tile_index(4097 * p0, [1024, 4096], [4096, 1], [1024, 1]), 1025 * p0
+        )
+
+    def test_compute_tile_index_2d_col_major(self):
+        p0, p1 = sympy.symbols("p0 p1", integer=True)
+        self.assertEqual(
+            compute_tile_index(p0 + 1024 * p1, [1024, 4096], [1, 1024], [1, 512]),
+            p0 + 512 * p1,
+        )
+
+    def test_compute_tile_index_2d_constant_offset(self):
+        p0 = sympy.Symbol("p0", integer=True)
+        self.assertEqual(
+            compute_tile_index(4096 + p0, [1024, 4096], [4096, 1], [1024, 1]), 1024 + p0
+        )
+
+    def test_compute_tile_index_2d_no_tiling(self):
+        p0 = sympy.Symbol("p0", integer=True)
+        self.assertEqual(
+            compute_tile_index(4096 * p0 + 2048, [1024, 4096], [4096, 1], [4096, 1]),
+            4096 * p0 + 2048,
+        )
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -75,7 +75,6 @@ from torch._inductor.utils import sympy_subs
 from torch._inductor.ir import (
     ComputedBuffer,
     FixedLayout,
-    FlexibleLayout,
     InputBuffer,
     IRNode,
     Layout,
@@ -106,6 +105,7 @@ from ..loop_info import (
 )
 from ..pass_utils import op_out_coords, host_coordinates, indirect_sizes_from_op
 from ..ir import FixedTiledLayout, SpyreConstantFallback, _resize_device_layout
+from .tile import compute_tile_stride
 
 logger = get_inductor_logger("coarse_tile")
 
@@ -1216,8 +1216,8 @@ def _divide_ranges(
         new_size[i] = ranges[i]
     layout.size = new_size
 
-    # Recompute contiguous strides for the smaller buffer.
-    layout.stride = list(FlexibleLayout.contiguous_strides(new_size))
+    # Recompute strides for the smaller buffer preserving the order of dimensions
+    layout.stride = compute_tile_stride(layout.size, old_stride, new_size)
 
     # Invalidate Layout- and ComputedBuffer-level caches that read size/stride.
     _clear_cache(layout, _LAYOUT_FREE_SYMS_KEY)

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -1214,10 +1214,11 @@ def _divide_ranges(
     new_size = list(layout.size)
     for i in tiled_dims:
         new_size[i] = ranges[i]
-    layout.size = new_size
 
     # Recompute strides for the smaller buffer preserving the order of dimensions
     layout.stride = compute_tile_stride(layout.size, old_stride, new_size)
+
+    layout.size = new_size
 
     # Invalidate Layout- and ComputedBuffer-level caches that read size/stride.
     _clear_cache(layout, _LAYOUT_FREE_SYMS_KEY)

--- a/torch_spyre/_inductor/wsr/tile.py
+++ b/torch_spyre/_inductor/wsr/tile.py
@@ -71,9 +71,10 @@ def decompose_index_for_tiling(index, var_ranges):
     """
     Decompose index into atoms + offset and validate assumptions.
 
-    An atom is a tuple (positive integer coefficient, iteration variable).
-    An offset is a non-negative integer.
-    Coefficients and offset may include symbols.
+    An atom is a tuple (positive integer coefficient, iteration variable). An
+    offset is a non-negative integer. Coefficients and offset may include
+    symbols. Tiling of indexes with ModularIndexing is not supported. Tiling of
+    indexes with negative coefficients is not supported.
     """
     vars = set(var_ranges.keys())
     vars_found = set()

--- a/torch_spyre/_inductor/wsr/tile.py
+++ b/torch_spyre/_inductor/wsr/tile.py
@@ -14,7 +14,7 @@
 
 import sympy
 
-from ..views import convert_modular_indexing
+from torch.utils._sympy.functions import ModularIndexing
 
 # An irregular dimension is a dimension with size one or stride zero.
 
@@ -57,7 +57,49 @@ def compute_tile_offset(offset, paired_strides):
     return tile_offset
 
 
-def compute_tile_index(index, size, stride, tile_stride):
+def decompose_index_for_tiling(index, var_ranges):
+    """
+    Decompose index into atoms + offset and validate assumptions.
+
+    An atom is a tuple (positive integer coefficient, iteration variable).
+    An offset is a non-negative integer.
+    Coefficients and offset may include symbols.
+    """
+    vars = set(var_ranges.keys())
+    vars_found = set()
+    offset = sympy.S.Zero
+    atoms = []
+    for term in index.as_ordered_terms():
+        term_vars = list(set(term.free_symbols) & vars)
+        if len(term_vars) == 0:
+            offset += term
+            continue
+        assert len(term_vars) == 1
+        var = term_vars[0]
+        assert var not in vars_found
+        vars_found.add(var)
+        assert not isinstance(term, ModularIndexing)
+        if term == var:
+            atoms.append((sympy.S.One, var))
+            continue
+        assert term.func == sympy.Mul
+        prod = sympy.S.One
+        mi = []
+        var_found = False
+        for arg in term.args:
+            assert not isinstance(arg, ModularIndexing)
+            if arg == var:
+                assert not var_found
+                var_found = True
+                continue
+            prod *= arg
+        assert prod > 0
+        atoms.append((prod, var, *mi))
+    assert offset >= 0
+    return atoms, offset
+
+
+def compute_tile_index(index, var_ranges, size, stride, tile_stride):
     """
     Convert a tensor index to a tile index.
 
@@ -65,23 +107,14 @@ def compute_tile_index(index, size, stride, tile_stride):
     same order. Irregular tensor and tile dimensions are supported. Index
     derived from views are supported.
     """
+    atoms, offset = decompose_index_for_tiling(index, var_ranges)
     # exclude irregular tensor dimensions (size==1 or stride==0)
     dims = [d for d, (s, t) in enumerate(zip(size, stride)) if s != 1 and t != 0]
     stride = [stride[d] for d in dims]
     tile_stride = [tile_stride[d] for d in dims]
     paired_strides = list(reversed(sorted(zip(stride, tile_stride))))
-    # sanitize index
-    index = convert_modular_indexing(index).replace(sympy.floor, lambda x: x).expand()
-    # handle constant offset
-    offset = index.xreplace({var: sympy.S.Zero for var in index.free_symbols})
     tile_index = compute_tile_offset(offset, paired_strides)
     # handle iteration variables
-    for term in (index - offset).as_ordered_terms():
-        assert len(term.free_symbols) == 1
-        if term.is_Symbol or term.func == sympy.Mod:
-            offset = sympy.S.One
-        else:
-            assert term.func == sympy.Mul and term.args[0].is_Rational
-            offset = term.args[0].numerator
-        tile_index += compute_tile_offset(offset, paired_strides) * term // offset
+    for atom in atoms:
+        tile_index += compute_tile_offset(atom[0], paired_strides) * atom[1]
     return tile_index

--- a/torch_spyre/_inductor/wsr/tile.py
+++ b/torch_spyre/_inductor/wsr/tile.py
@@ -105,7 +105,6 @@ def decompose_index_for_tiling(index, var_ranges):
         if term.func != sympy.Mul:
             raise Unsupported(f"index term {term} is not a linear monomial")
         prod = sympy.S.One
-        mi = []
         var_found = False
         for arg in term.args:
             if isinstance(arg, ModularIndexing):
@@ -124,7 +123,7 @@ def decompose_index_for_tiling(index, var_ranges):
             prod *= arg
         if prod <= 0:
             raise Unsupported(f"index term {term} has non-positive coefficient {prod}")
-        atoms.append((prod, var, *mi))
+        atoms.append((prod, var))
     if offset < 0:
         raise Unsupported(f"index has negative offset {offset}")
     return atoms, offset

--- a/torch_spyre/_inductor/wsr/tile.py
+++ b/torch_spyre/_inductor/wsr/tile.py
@@ -27,7 +27,6 @@ def compute_tile_stride(size, stride, tile_size):
     Cumulative tile counts must divide strides. Padding is reduced in proportion
     of tile counts. Tile strides of irregular tile dimensions are set to zero.
     """
-    print(size, tile_size)
     assert all(x % y == 0 for x, y in zip(size, tile_size))
     # exclude irregular tensor dimensions (size==1 or stride==0)
     dims = [d for d, (s, t) in enumerate(zip(size, stride)) if s != 1 and t != 0]

--- a/torch_spyre/_inductor/wsr/tile.py
+++ b/torch_spyre/_inductor/wsr/tile.py
@@ -121,11 +121,11 @@ def decompose_index_for_tiling(index, var_ranges):
                 var_found = True
                 continue
             prod *= arg
-        if prod <= 0:
-            raise Unsupported(f"index term {term} has non-positive coefficient {prod}")
+        if not (prod > 0 and prod.is_integer):
+            raise Unsupported(f"index coefficient {prod} is not a positive integer")
         atoms.append((prod, var))
-    if offset < 0:
-        raise Unsupported(f"index has negative offset {offset}")
+    if not (offset >= 0 and offset.is_integer):
+        raise Unsupported(f"index offset {offset} is not a non-negative integer")
     return atoms, offset
 
 

--- a/torch_spyre/_inductor/wsr/tile.py
+++ b/torch_spyre/_inductor/wsr/tile.py
@@ -1,0 +1,85 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import sympy
+
+# An irregular dimension is a dimension with size one or stride zero.
+
+
+def compute_tile_stride(size, stride, tile_size):
+    """
+    Convert a tensor stride to a tile stride.
+
+    Irregular dimensions are supported. Tile sizes must divide tensor sizes.
+    Cumulative tile counts must divide strides. Padding is reduced in proportion
+    of tile counts. Tile strides of irregular tile dimensions are set to zero.
+    """
+    assert all(x % y == 0 for x, y in zip(size, tile_size))
+    # exclude irregular tensor dimensions (size==1 or stride==0)
+    dims = [d for d, (s, t) in enumerate(zip(size, stride)) if s != 1 and t != 0]
+    # order regular dimensions in increasing stride order
+    dims.sort(key=lambda i: stride[i])
+    tile_stride = [sympy.S.Zero] * len(tile_size)
+    running_tile_count = sympy.S.One
+    for d in dims:
+        assert stride[d] % running_tile_count == 0
+        if tile_size[d] > 1:
+            tile_stride[d] = stride[d] // running_tile_count
+        running_tile_count *= size[d] // tile_size[d]
+    return tile_stride
+
+
+def compute_tile_offset(offset, paired_strides):
+    """
+    Convert tensor offset to tile offset.
+
+    Tensor and tile stride must be paired in decreasing tensor stride order.
+    Irregular tensor dimensions must be excluded. Min stride must divide offset.
+    """
+    tile_offset = sympy.S.Zero
+    for s, t in paired_strides:
+        q, offset = divmod(offset, s)
+        tile_offset += q * t
+    assert offset == 0
+    return tile_offset
+
+
+def compute_tile_index(index, size, stride, tile_stride):
+    """
+    Convert a tensor index to a tile index.
+
+    Tensor and tile are required to have the same dimensions laid out in the
+    same order. Irregular tensor and tile dimensions are supported. Index
+    derived from views are supported.
+    """
+    # exclude irregular tensor dimensions (size==1 or stride==0)
+    dims = [d for d, (s, t) in enumerate(zip(size, stride)) if s != 1 and t != 0]
+    stride = [stride[d] for d in dims]
+    tile_stride = [tile_stride[d] for d in dims]
+    paired_strides = list(reversed(sorted(zip(stride, tile_stride))))
+    # sanitize index
+    index = index.replace(sympy.floor, lambda x: x).expand()
+    # handle constant offset
+    offset = index.xreplace({var: sympy.S.Zero for var in index.free_symbols})
+    tile_index = compute_tile_offset(offset, paired_strides)
+    # handle iteration variables
+    for term in (index - offset).as_ordered_terms():
+        assert len(term.free_symbols) == 1
+        if term.is_Symbol or term.func == sympy.Mod:
+            offset = sympy.S.One
+        else:
+            assert term.func == sympy.Mul and term.args[0].is_Rational
+            offset = term.args[0].numerator
+        tile_index += compute_tile_offset(offset, paired_strides) * term // offset
+    return tile_index

--- a/torch_spyre/_inductor/wsr/tile.py
+++ b/torch_spyre/_inductor/wsr/tile.py
@@ -16,6 +16,8 @@ import sympy
 
 from torch.utils._sympy.functions import ModularIndexing
 
+from ..errors import Unsupported
+
 # An irregular dimension is a dimension with size one or stride zero.
 
 
@@ -27,7 +29,8 @@ def compute_tile_stride(size, stride, tile_size):
     Cumulative tile counts must divide strides. Padding is reduced in proportion
     of tile counts. Tile strides of irregular tile dimensions are set to zero.
     """
-    assert all(x % y == 0 for x, y in zip(size, tile_size))
+    if not all(x % y == 0 for x, y in zip(size, tile_size)):
+        raise Unsupported(f"tile sizes {tile_size} do not divide tensor sizes {size}")
     # exclude irregular tensor dimensions (size==1 or stride==0)
     dims = [d for d, (s, t) in enumerate(zip(size, stride)) if s != 1 and t != 0]
     # order regular dimensions in increasing stride order
@@ -35,7 +38,11 @@ def compute_tile_stride(size, stride, tile_size):
     tile_stride = [sympy.S.Zero] * len(tile_size)
     running_tile_count = sympy.S.One
     for d in dims:
-        assert stride[d] % running_tile_count == 0
+        if stride[d] % running_tile_count != 0:
+            raise Unsupported(
+                f"stride {stride[d]} at dim {d} is not divisible by cumulative"
+                f" tile count {running_tile_count}"
+            )
         if tile_size[d] > 1:
             tile_stride[d] = stride[d] // running_tile_count
         running_tile_count *= size[d] // tile_size[d]
@@ -53,7 +60,10 @@ def compute_tile_offset(offset, paired_strides):
     for s, t in paired_strides:
         q, offset = divmod(offset, s)
         tile_offset += q * t
-    assert offset == 0
+    if offset != 0:
+        raise Unsupported(
+            f"offset {offset} is not expressible in terms of the given strides"
+        )
     return tile_offset
 
 
@@ -74,28 +84,48 @@ def decompose_index_for_tiling(index, var_ranges):
         if len(term_vars) == 0:
             offset += term
             continue
-        assert len(term_vars) == 1
+        if len(term_vars) != 1:
+            raise Unsupported(
+                f"index term {term} depends on multiple iteration variables {term_vars}"
+            )
         var = term_vars[0]
-        assert var not in vars_found
+        if var in vars_found:
+            raise Unsupported(
+                f"iteration variable {var} appears in multiple index terms"
+            )
         vars_found.add(var)
-        assert not isinstance(term, ModularIndexing)
+        if isinstance(term, ModularIndexing):
+            raise Unsupported(
+                f"ModularIndexing in index term {term} is not supported for tiling"
+            )
         if term == var:
             atoms.append((sympy.S.One, var))
             continue
-        assert term.func == sympy.Mul
+        if term.func != sympy.Mul:
+            raise Unsupported(f"index term {term} is not a linear monomial")
         prod = sympy.S.One
         mi = []
         var_found = False
         for arg in term.args:
-            assert not isinstance(arg, ModularIndexing)
+            if isinstance(arg, ModularIndexing):
+                raise Unsupported(
+                    f"ModularIndexing in index term argument {arg} is not"
+                    " supported for tiling"
+                )
             if arg == var:
-                assert not var_found
+                if var_found:
+                    raise Unsupported(
+                        f"iteration variable {var} appears more than once in"
+                        f" term {term}"
+                    )
                 var_found = True
                 continue
             prod *= arg
-        assert prod > 0
+        if prod <= 0:
+            raise Unsupported(f"index term {term} has non-positive coefficient {prod}")
         atoms.append((prod, var, *mi))
-    assert offset >= 0
+    if offset < 0:
+        raise Unsupported(f"index has negative offset {offset}")
     return atoms, offset
 
 

--- a/torch_spyre/_inductor/wsr/tile.py
+++ b/torch_spyre/_inductor/wsr/tile.py
@@ -14,6 +14,8 @@
 
 import sympy
 
+from ..views import convert_modular_indexing
+
 # An irregular dimension is a dimension with size one or stride zero.
 
 
@@ -25,6 +27,7 @@ def compute_tile_stride(size, stride, tile_size):
     Cumulative tile counts must divide strides. Padding is reduced in proportion
     of tile counts. Tile strides of irregular tile dimensions are set to zero.
     """
+    print(size, tile_size)
     assert all(x % y == 0 for x, y in zip(size, tile_size))
     # exclude irregular tensor dimensions (size==1 or stride==0)
     dims = [d for d, (s, t) in enumerate(zip(size, stride)) if s != 1 and t != 0]
@@ -69,7 +72,7 @@ def compute_tile_index(index, size, stride, tile_stride):
     tile_stride = [tile_stride[d] for d in dims]
     paired_strides = list(reversed(sorted(zip(stride, tile_stride))))
     # sanitize index
-    index = index.replace(sympy.floor, lambda x: x).expand()
+    index = convert_modular_indexing(index).replace(sympy.floor, lambda x: x).expand()
     # handle constant offset
     offset = index.xreplace({var: sympy.S.Zero for var in index.free_symbols})
     tile_index = compute_tile_offset(offset, paired_strides)


### PR DESCRIPTION
#### What type of PR is this?

- [X] feature

#### What this PR does:

The current working set reduction code assigns a dense, row-major layout (ie contiguous layout) to every tile it synthesizes irrespective of the order of dimensions or padding of the tensor being tiled. This is arguably not preserving the developer's intent and will typically result in the tiled code having lower performance. Moreover, subsequent compiler passes are not equipped today to mitigate all layout incompatibilities that may result from these layout substitutions (such as discontiguous flattened dimensions).

This PR adds logic to the preserving the order of dimensions when synthesizing a tile layout from a tensor layout. It includes three helper functions for:
- deriving tile strides from tensor strides (preserving the stride order and padding),
- computing a tile offset from a tensor offset,
- deriving an index expression on a tile from an index expression on a tensor.

These functions account for irregular dimensions (size == 1 or stride == 0) as well as composite offsets and coefficients ranging over multiple dimensions.

Padding of inner dimensions is preserved and reduced proportionally to tile counts.

Unit tests have been added.

Two existing coarse tiling tests using symbolic tile sizes have been updated with static tile sizes (using symbolic tile counts instead).

#### Which issue(s) this PR is related to:

Part of #206 

#### Does this PR introduce a user-facing change?

Yes. Once fully integrated with the coarse tiling code (see below), this new logic will ensure that tile layouts match tensor layouts hence that tiling does not impact operation validity (assuming non sub-stick tiling). It will also ensure that hand-optimized tensor layouts carry over to tiles, making sure there is no performance impact due to implicit layout substitutions.

However, given the inability of subsequent compiler passes to handle every possible layout incompatibility scenarios today, it may results in new test failures, when forcing contiguous tile layouts did help work around these limitations. In such a case, the fix should be to make the tensors contiguous in the first place.

#### Additional note:

This PR does not attempt to fully integrate the new logic with the coarse tiling code. For validation purposes it is called once when deriving the stride of a tile from the stride of a tensor in `_divide_ranges`. However this conversion from tensor stride to tile stride happens in multiple places via different code snippets. Similarly indexes into tiles are required and assembled in multiple places in different ways in the coarse tiling code.

The full integration of the new logic with the coarse tiling code and the necessary refactoring will be completed in subsequent PRs.

This PR does not include code to derive the tile size from the tensor size. The new logic assumes three parameters: tensor size, tensor stride, and tile size. As before, the tile size should be derived from the combination of named dimensions and Spyre hints. 
