### PR TITLE
inductor: add lowering for aten.slice_scatter (copy_, out= on slice views)

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_shape_a_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_shape_a_config.yaml
@@ -29,6 +29,7 @@ test_suite_config:
             - TestOps::test_copy_roundtrip.*
             # slice / split
             - TestOps::test_slice.*
+            - TestOps::test_slice_scatter.*
             - TestOps::test_split.*
           mode: mandatory_success
           tags:

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -3432,6 +3432,167 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 "5d": (cached_randn((2, 3, 4, 5, 192), dtype=torch.float16),),
             },
         },
+        ("test_slice_scatter", "test_slice_scatter_cpu"): {
+            "ops_dict": {
+                # Functional slice_scatter into an INTERNAL base (x + 1.0).
+                "internal": lambda dim, start, end, x, src: torch.slice_scatter(
+                    x + 1.0, src, dim, start, end
+                ),
+                # Functional slice_scatter with the GRAPH INPUT as the base
+                # (the mutation is copied back into the placeholder).
+                "graph_input": lambda dim, start, end, x, src: torch.slice_scatter(
+                    x, src, dim, start, end
+                ),
+                # ``copy_`` into a slice view.
+                "view_copy": lambda dim, start, end, x, src: (
+                    base := x + 1.0,
+                    base.narrow(dim, start, end - start).copy_(src),
+                    base,
+                )[-1],
+            },
+            "param_sets": {
+                # Non-stick (non-last) dim: full sticks, no stick offset.
+                "nonstick_3d": (
+                    1,
+                    1,
+                    3,
+                    cached_randn((8, 4, 64)),
+                    cached_randn((8, 2, 64)),
+                ),
+                "nonstick_4d": (
+                    2,
+                    1,
+                    3,
+                    cached_randn((2, 8, 4, 64)),
+                    cached_randn((2, 8, 2, 64)),
+                ),
+                # Stick (last) dim aligned to a full stick (64).
+                "stick_1d": (
+                    0,
+                    0,
+                    64,
+                    cached_randn((128,)),
+                    cached_randn((64,)),
+                ),
+                "stick_2d": (
+                    1,
+                    0,
+                    64,
+                    cached_randn((8, 128)),
+                    cached_randn((8, 64)),
+                ),
+                "stick_3d": (
+                    2,
+                    0,
+                    64,
+                    cached_randn((2, 8, 128)),
+                    cached_randn((2, 8, 64)),
+                ),
+                "stick_4d": (
+                    3,
+                    0,
+                    64,
+                    cached_randn((2, 8, 4, 128)),
+                    cached_randn((2, 8, 4, 64)),
+                ),
+                # Stick (last) dim, offset by a full stick (cols 64:128).
+                "stick_off_1d": (
+                    0,
+                    64,
+                    128,
+                    cached_randn((128,)),
+                    cached_randn((64,)),
+                ),
+                "stick_off_2d": (
+                    1,
+                    64,
+                    128,
+                    cached_randn((8, 128)),
+                    cached_randn((8, 64)),
+                ),
+                "stick_off_4d": (
+                    3,
+                    64,
+                    128,
+                    cached_randn((2, 8, 4, 128)),
+                    cached_randn((2, 8, 4, 64)),
+                ),
+            },
+        },
+        # ``out=`` writes. Torch Inductor only supports a CONTIGUOUS ``out=``
+        # tensor, which for a slice means slicing the outermost dim (dim 0).
+        ("test_slice_scatter_out", "test_slice_scatter_cpu"): {
+            "ops_dict": {
+                # ``out=`` write into a slice view, e.g.
+                # torch.add(a, b, out=base[...]).
+                "out_arg": lambda dim, start, end, x, src: (
+                    base := x + 1.0,
+                    torch.add(src, src, out=base.narrow(dim, start, end - start)),
+                    base,
+                )[-1],
+            },
+            "param_sets": {
+                # dim 0 aligned (start 0), across 1d/2d/3d/4d.
+                "dim0_1d": (
+                    0,
+                    0,
+                    64,
+                    cached_randn((128,)),
+                    cached_randn((64,)),
+                ),
+                "dim0_2d": (
+                    0,
+                    0,
+                    4,
+                    cached_randn((8, 128)),
+                    cached_randn((4, 128)),
+                ),
+                "dim0_3d": (
+                    0,
+                    0,
+                    2,
+                    cached_randn((4, 8, 64)),
+                    cached_randn((2, 8, 64)),
+                ),
+                "dim0_4d": (
+                    0,
+                    0,
+                    2,
+                    cached_randn((4, 8, 2, 64)),
+                    cached_randn((2, 8, 2, 64)),
+                ),
+                # dim 0 offset (start != 0) -- contiguous, nonzero storage
+                # offset, across 1d/2d/3d/4d.
+                "dim0_off_1d": (
+                    0,
+                    64,
+                    128,
+                    cached_randn((128,)),
+                    cached_randn((64,)),
+                ),
+                "dim0_off_2d": (
+                    0,
+                    4,
+                    8,
+                    cached_randn((8, 128)),
+                    cached_randn((4, 128)),
+                ),
+                "dim0_off_3d": (
+                    0,
+                    2,
+                    4,
+                    cached_randn((4, 8, 64)),
+                    cached_randn((2, 8, 64)),
+                ),
+                "dim0_off_4d": (
+                    0,
+                    2,
+                    4,
+                    cached_randn((4, 8, 2, 64)),
+                    cached_randn((2, 8, 2, 64)),
+                ),
+            },
+        },
         ("test_rope_fms", "test_rope_cpu"): {
             "param_sets": {
                 "prefill_bs1": (
@@ -6384,6 +6545,34 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             return x[:, 1:2, :, :, :] + x[:, :, 2:3, :, :]
 
         self.compare_with_cpu(fn, x, clone_inputs=True, run_eager=False)
+
+    def test_slice_scatter_cpu(self, op, dim, start, end, x, src):
+        """Slice writes lowered by ``lower_slice_scatter``."""
+
+        self.compare_with_cpu(
+            lambda x, src: op(dim, start, end, x, src),
+            x,
+            src,
+            clone_inputs=True,
+            run_eager=False,
+            atol=0.005,
+            rtol=0.005,
+        )
+
+    def test_slice_scatter_step_raises(self):
+        """A strided (non-unit-step) slice_scatter raises Unsupported."""
+
+        def fn(x, src):
+            base = x + 1.0
+            return torch.slice_scatter(base, src, dim=0, start=0, end=128, step=2)
+
+        x = torch.randn(128, 128, dtype=torch.float16, device="spyre")
+        src = torch.randn(64, 128, dtype=torch.float16, device="spyre")
+
+        compiled = torch.compile(fn, backend="inductor", fullgraph=True, dynamic=False)
+        with pytest.raises(Exception) as exc_info:
+            compiled(x, src)
+        assert "step" in str(exc_info.value)
 
     def test_rope_cpu(self, q, freqs):
         def fn(q, freqs):

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -1067,6 +1067,28 @@ output[indices] = input or output[indices].copy_(input). Please report any incom
     return output
 
 
+@register_spyre_lowering(torch.ops.aten.slice_scatter.default, type_promotion_kind=None)
+def lower_slice_scatter(self, src, dim=0, start=None, end=None, step=1):
+    size = self.get_size()
+    dim = dim % len(size)
+
+    if step != 1:
+        # Only a unit step maps to a single SliceView.
+        raise Unsupported(
+            f"slice_scatter with step={step} is not supported on Spyre "
+            f"(only unit step maps to a SliceView mutation)"
+        )
+
+    start = 0 if start is None else start
+    end = size[dim] if end is None else end
+
+    output = lowering.clone(self)
+    output.realize()
+    sliced_output = ir.SliceView.create(output, dim, start, end)
+    lowering.mutate_to(sliced_output, src)
+    return output
+
+
 @register_spyre_lowering(torch.ops.spyre.restickify)
 def lower_restickify(x):
     # Restickify must operate on base tensors, so we need


### PR DESCRIPTION
#### What type of PR is this?

- [x] feature

#### What this PR does:

Registers a Spyre Inductor lowering for `aten.slice_scatter.default`, so slice writes now compile on Spyre. This covers the source-level forms that functionalize to `aten.slice_scatter`, for example a functional `slice_scatter`:

```python
torch.slice_scatter(base, src, dim, start, end)
```

a `copy_` into a slice view:

```python
base.narrow(dim, start, end - start).copy_(src)
```

and an `out=` write into a slice view:

```python
torch.add(src, src, out=base.narrow(0, start, end - start))
```

For `out=`, only contiguous slices are supported: Torch Inductor graph-breaks on a non-contiguous `out=` tensor (`unimplemented("Attempted to call op with non-contiguous out= tensor")`), and a slice view is contiguous only when it targets the outermost dim (dim 0).

PyTorch's in-tree functional decomposition of `slice_scatter` cannot codegen on Spyre — it hits the `index_expr` wall (`Cannot resolve target for 'index_expr'`). This lowering handles it directly:

1. `clone` + `realize` the base so the slice folds into a realized-storage `ReinterpretView`.
2. Build a `SliceView` over the sliced region — its layout carries the start offset.
3. `mutate_to` that view from the source.

Only unit step is supported; a non-unit step raises `Unsupported` (it does not map to a single `SliceView`).

Scope: stick-aligned writes on the stick (last) dim and full-stick writes on a non-last dim. Offset / sub-stick writes into internal buffers are **not** yet handled — they need mutation-target relocation and/or output padding and are addressed in a follow-up PR (stacked on the restickify-padding work, #3110). On this branch those shapes are not raised (baseline `main` already errored on every `slice_scatter`); the follow-up makes them correct.

#### Which issue(s) this PR is related to:

Fixes #2147

#### Special notes for your reviewer:

This is the first of a stacked split:

- **This PR** — lowering only, aligned coverage.
- Follow-up — internal-buffer mutation-target relocation + sub-stick / offset writes + multi-write / cat, stacked on #3110.

New tests in `tests/inductor/test_inductor_ops.py`, all comparing the compiled Spyre result against CPU. They cover the four source-level write styles that functionalize to `aten.slice_scatter` — `internal` (`slice_scatter(x + 1.0, ...)`), `graph_input` (`slice_scatter(x, ...)`, placeholder copy-back), `view_copy` (`narrow().copy_()`), and `out_arg` (`torch.add(..., out=base.narrow(...))`) — across 1d/2d/3d/4d shapes:

- Functional / `copy_` styles: stick-aligned writes on the stick (last) dim (`stick_*`, `stick_off_*`) and full-stick writes on a non-last dim (`nonstick_*`).
- `out=` style: contiguous dim-0 writes only (see the limitation noted above); `dim0_*` / `dim0_off_*` exercise aligned and offset dim-0 slices.

`test_slice_scatter_step_raises` asserts a non-unit-step slice raises. The CI op-shard config (`test_inductor_ops_misc_shape_a_config.yaml`) gains an explicit `test_slice_scatter.*` entry.

#### Does this PR introduce a user-facing change?

Yes — `torch.slice_scatter` / `Tensor.slice_scatter` now compile on Spyre for stick-aligned writes instead of failing to codegen.

#### Additional note:

This PR is a prerequisite for an upcoming PR that implements sub-stick torch.cat.
- #1464
