### PR TITLE
perf(embedding): use a gather-optimal device layout for nn.Embedding tables

### DIFF
--- a/tests/tensor/test_model_utils.py
+++ b/tests/tensor/test_model_utils.py
@@ -25,6 +25,7 @@ from torch.testing._internal.common_utils import (
 
 from torch_spyre.model_utils import (
     _dma_to_spyre_dim_order_swapped,
+    _dma_to_spyre_indirect_access,
     load_model_to_spyre,
     patch_module_to_for_spyre,
 )
@@ -54,6 +55,62 @@ class TestLoadModelToSpyre(TestCase):
         """The dim_order helper only accepts 2D weights."""
         with self.assertRaises(AssertionError):
             _dma_to_spyre_dim_order_swapped(torch.randn(4, dtype=torch.float16))
+
+    # ── embedding gather-optimal (indirect-access) layout ──────────
+
+    def test_embedding_has_indirect_access_layout(self):
+        """A 2D Embedding table gets device dims [rows, D // eps, eps] with the
+        vocab dim outermost. For a (1000, 256) fp16 table, eps=64, so the
+        device layout is [1000, 4, 64]."""
+        from torch_spyre._C import get_spyre_tensor_layout
+
+        w = torch.randn(1000, 256, dtype=torch.float16)
+        dev = _dma_to_spyre_indirect_access(w)
+        layout = get_spyre_tensor_layout(dev)
+        self.assertEqual(list(layout.device_size), [1000, 4, 64])
+
+    def test_embedding_stick_size_is_dtype_aware(self):
+        """elems_per_stick is 32 at fp32, so a (1000, 256) fp32 table splits
+        into 256/32 = 8 sticks, not 4."""
+        from torch_spyre._C import get_spyre_tensor_layout
+
+        w = torch.randn(1000, 256, dtype=torch.float32)
+        dev = _dma_to_spyre_indirect_access(w)
+        layout = get_spyre_tensor_layout(dev)
+        self.assertEqual(list(layout.device_size), [1000, 8, 32])
+
+    def test_embedding_non_tiling_hidden_dim_warns_and_falls_back(self):
+        """A hidden dim that isn't a multiple of the stick size warns and
+        returns None so the caller uses the default layout."""
+        w = torch.randn(1000, 100, dtype=torch.float16)  # 100 % 64 != 0
+        with self.assertWarns(UserWarning):
+            dev = _dma_to_spyre_indirect_access(w)
+        self.assertIsNone(dev)
+
+    def test_indirect_access_rejects_non_2d(self):
+        """The indirect-access helper only accepts 2D tables."""
+        with self.assertRaises(AssertionError):
+            _dma_to_spyre_indirect_access(torch.randn(4, dtype=torch.float16))
+
+    def test_load_model_routes_embedding_through_indirect_access(self):
+        """An nn.Embedding table lands on Spyre with the indirect-access layout
+        (vocab dim outermost), not the default layout."""
+        from torch_spyre._C import get_spyre_tensor_layout
+
+        model = nn.Embedding(1000, 256, dtype=torch.float16)
+        load_model_to_spyre(model)
+
+        self.assertEqual(model.weight.device.type, "spyre")
+        layout = get_spyre_tensor_layout(model.weight)
+        self.assertEqual(list(layout.device_size), [1000, 4, 64])
+
+    def test_load_model_embedding_non_tiling_falls_back(self):
+        """An embedding whose hidden dim doesn't tile still loads (default
+        layout) and warns."""
+        model = nn.Embedding(1000, 100, dtype=torch.float16)
+        with self.assertWarns(UserWarning):
+            load_model_to_spyre(model)
+        self.assertEqual(model.weight.device.type, "spyre")
 
     # ── routing ────────────────────────────────────────────────────
 

--- a/torch_spyre/model_utils.py
+++ b/torch_spyre/model_utils.py
@@ -23,6 +23,11 @@ which tells the DMA engine to stickify along host dim-0 (out_features)
 instead of the default last dim (in_features). No CPU transpose or
 intermediate copy is required.
 
+``nn.Embedding`` tables are instead read as a gather (indexed by token id
+along the vocab/leading dim), so they get a gather-optimal "indirect
+access" layout -- vocab dim outermost, hidden dim split into sticks --
+rather than the matmul or default layout.
+
 Critically, the tensor's PyTorch shape stays ``(out, in)`` -- only the
 *device* layout changes. This means:
 
@@ -48,6 +53,8 @@ Usage::
     patch_module_to_for_spyre()
     model.to("spyre")
 """
+
+import warnings
 
 from torch_spyre._inductor.logging_utils import get_inductor_logger
 
@@ -139,6 +146,59 @@ def _dma_to_spyre_dim_order_swapped(
     return dst
 
 
+def _dma_to_spyre_indirect_access(
+    weight: torch.Tensor,
+    target_dtype: torch.dtype | None = None,
+) -> torch.Tensor | None:
+    """Transfer a 2D ``nn.Embedding`` table to Spyre with a gather-optimal layout.
+
+    An embedding table is read as a gather (indexed by token id along the
+    vocab/leading dim), not a matmul, so it wants a different device layout
+    than the row-major matmul weights: the vocab dim outermost and the hidden
+    dim split into stick-sized blocks, i.e. device dims
+    ``[rows, D // eps, eps]`` where ``eps`` is the elements-per-stick for the
+    device dtype. This is the "indirect access" layout the gather source
+    needs (indexed dim outermost); see the tensors-and-layouts docs.
+
+    Uses the 3-arg device-dims ``SpyreTensorLayout`` overload with the *device*
+    dtype (``get_device_dtype``), not the host ``torch.dtype``.
+
+    Requires ``D % eps == 0``; otherwise the sticks can't tile the hidden dim,
+    so we warn and return ``None`` to signal the caller to fall back to the
+    default layout, which still loads and runs, just without the gather
+    optimization.
+
+    Caller must ensure ``weight.ndim == 2``.
+    """
+    assert weight.ndim == 2, "indirect-access path is for 2D embedding tables only"
+
+    if not weight.is_contiguous():
+        weight = weight.contiguous()
+    dev_dtype = target_dtype if target_dtype is not None else weight.dtype
+
+    rows, d = weight.shape
+    # elems_per_stick is dtype-aware (64 at fp16/bf16, 32 at fp32), so query it
+    # rather than hardcoding a stick size.
+    eps = SpyreTensorLayout(list(weight.shape), dev_dtype).elems_per_stick()
+    if d % eps != 0:
+        warnings.warn(
+            f"Embedding hidden dim {d} is not a multiple of the Spyre stick "
+            f"size {eps} for dtype {dev_dtype}; falling back to the default "
+            "layout (no gather optimization) for this embedding table.",
+            stacklevel=2,
+        )
+        return None
+
+    layout = SpyreTensorLayout(
+        [rows, d // eps, eps],  # device_size: vocab dim outermost
+        [d, eps, 1],  # stride_map
+        get_device_dtype(dev_dtype),
+    )
+    dst = spyre_empty_with_layout(weight.size(), weight.stride(), dev_dtype, layout)
+    copy_tensor(weight, dst, non_blocking=False)
+    return dst
+
+
 # --- Model loading ---------------------------------------------------
 
 
@@ -158,8 +218,9 @@ def _transfer_module(
 
     Mirrors ``nn.Module._apply``'s virtual recursion: a submodule that overrides
     ``_apply`` is delegated to and pruned from the walk. Normal modules get the
-    optimal ``dim_order=[1, 0]`` layout for 2D ``nn.Linear`` weights and the
-    default layout for everything else. Tensors already on Spyre are skipped
+    optimal ``dim_order=[1, 0]`` layout for 2D ``nn.Linear`` weights, the
+    gather-optimal indirect-access layout for 2D ``nn.Embedding`` tables, and
+    the default layout for everything else. Tensors already on Spyre are skipped
     (idempotent). ``counts`` accumulates transferred-tensor tallies for logging;
     ``prefix`` is the module's dotted path (as in ``named_modules``) for logs.
     """
@@ -176,12 +237,15 @@ def _transfer_module(
         _transfer_module(child, dtype, counts, child_prefix)
 
     is_linear = isinstance(module, nn.Linear)
+    is_embedding = isinstance(module, nn.Embedding)
     for name, param in list(module._parameters.items()):
         if param is None or param.device.type == DEVICE_NAME:
             continue
         p = param.data
-        # 2D Linear weight -> optimal stickified layout; everything else
-        # (bias, embeddings, norms, ...) -> default layout.
+        # 2D Linear weight -> optimal stickified matmul layout; 2D Embedding
+        # table -> gather-optimal indirect-access layout; everything else
+        # (bias, norms, ...) -> default layout.
+        dev = None
         if is_linear and name == "weight" and p.ndim == 2:
             logger.debug(
                 "  %s.%s: shape=%s -> Spyre dim_order=[1, 0]",
@@ -191,7 +255,19 @@ def _transfer_module(
             )
             dev = _dma_to_spyre_dim_order_swapped(p, target_dtype=dtype)
             counts["linear"] += 1
-        else:
+        elif is_embedding and name == "weight" and p.ndim == 2:
+            dev = _dma_to_spyre_indirect_access(p, target_dtype=dtype)
+            # dev is None if the hidden dim doesn't tile into sticks; the helper
+            # has already warned, so fall through to the default layout below.
+            if dev is not None:
+                logger.debug(
+                    "  %s.%s: shape=%s -> Spyre indirect-access (gather) layout",
+                    prefix,
+                    name,
+                    list(p.shape),
+                )
+                counts["embedding"] += 1
+        if dev is None:
             logger.debug(
                 "  %s.%s: shape=%s -> Spyre default layout",
                 prefix,
@@ -220,6 +296,12 @@ def load_model_to_spyre(
     (optimal for Spyre matmul). Tensor shapes are preserved, so the
     model works unmodified with the existing inference path.
 
+    For each ``nn.Embedding``, the table is transferred with a
+    gather-optimal indirect-access layout (vocab dim outermost, hidden
+    dim split into sticks) so the token-id gather runs efficiently. If
+    the hidden dim doesn't tile into sticks, it falls back to the
+    default layout with a warning.
+
     All other parameters and buffers use the default Spyre layout.
 
     Submodules that override ``_apply`` are honored, matching ``nn.Module.to`` semantics.
@@ -230,13 +312,14 @@ def load_model_to_spyre(
     # Ensure Spyre runtime is initialized before using _C functions
     _ensure_spyre_runtime()
 
-    counts = {"linear": 0, "other": 0, "buffer": 0}
+    counts = {"linear": 0, "embedding": 0, "other": 0, "buffer": 0}
     _transfer_module(model, dtype, counts)
     logger.info(
-        "load_model_to_spyre: %d Linear weights optimized "
-        "(dim_order=[1,0]), %d other params and %d buffers "
-        "transferred with default layout",
+        "load_model_to_spyre: %d Linear weights optimized (dim_order=[1,0]), "
+        "%d Embedding tables optimized (indirect-access layout), %d other "
+        "params and %d buffers transferred with default layout",
         counts["linear"],
+        counts["embedding"],
         counts["other"],
         counts["buffer"],
     )


### PR DESCRIPTION
## Summary

`nn.Embedding` weights on Spyre are read as a **gather** (indexed by token id along the vocab/leading dim), not a matmul. Today `load_model_to_spyre` sends them via the default-layout DMA path (`_dma_to_spyre_default`) alongside biases and norms — correct, but it leaves the gather unoptimized.

This PR gives each embedding table a **gather-optimal "indirect access" device layout** instead:

- vocab dim outermost, and
- the hidden dim split into stick-sized blocks,

i.e. device dims `[rows, D // eps, eps]`, built via the 3-arg device-dims `SpyreTensorLayout` overload with the **device** dtype from `get_device_dtype()` (not the host `torch.dtype`).

## What changed

`torch_spyre/model_utils.py`:

- New DMA helper **`_dma_to_spyre_indirect_access()`** — a sibling to the existing `_dma_to_spyre_default` / `_dma_to_spyre_dim_order_swapped` helpers — builds the gather-optimal layout.
- **`_transfer_module()`** detects `nn.Embedding` via `isinstance` (the same clean module-type check it already uses for `nn.Linear`) and routes its 2-D weight through the new helper. `counts["embedding"]` added to the load summary log.
- Module / function docstrings updated to describe the per-weight layout choice (matmul / gather / default).

`tests/tensor/test_model_utils.py`:

- Tests for the direct helper, the dtype-aware stick size, the non-tiling fallback warning, and end-to-end routing through `load_model_to_spyre`.

## Stick size is queried, not hardcoded

The stick size is queried per dtype via `SpyreTensorLayout(...).elems_per_stick()` (64 at fp16/bf16, **32 at fp32**) rather than hardcoded, matching the `canonical_device_layout` idiom in the existing layout tests. A hardcoded 64 would build wrong fp32 layouts.

## Fallback behavior

When the hidden dim `D` is **not** a multiple of the stick size, the sticks can't tile the hidden dim. In that case the helper `warnings.warn`s and returns `None`; `_transfer_module` falls back to the default layout — the table still loads and runs correctly, just without the gather optimization.

## Scope

Single self-contained change to the layout-selection logic in the model-loading path. No API changes; models that previously loaded still load.

## Background

Ports [torch-spyre/hf-adapters#291](https://github.com/torch-spyre/hf-adapters/pull/291) (same optimization in the hf-adapters `_move_to_spyre_with_layout` loading path) to the equivalent tensor-to-Spyre loading path here in torch-spyre.

## Testing

- `python3 -m pytest tests/tensor/test_model_utils.py` — 21 passed (6 new embedding tests).
- `pre-commit run` — ruff / ruff-format / mypy clean.
- [ ] e2e token-compare on the Spyre pod — verify a real model's embedding gather still matches reference with the new layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)