### PR TITLE
docs: HBM pool planning page, LX and op-coverage refresh

### DIFF
--- a/docs/source/_static/images/how-torch-spyre-works/fig5-op-layers.svg
+++ b/docs/source/_static/images/how-torch-spyre-works/fig5-op-layers.svg
@@ -23,15 +23,15 @@
 
   <!-- LAYER 2: Custom ops -->
   <rect x="180" y="182" width="800" height="62" rx="4" fill="#fef0e6" stroke="#e0915a" stroke-width="1.2"/>
-  <text x="200" y="206" font-size="13" font-weight="600" fill="#7a3a00">spyre::rms_norm · spyre::layer_norm · spyre::gelu · spyre::softplus · spyre::clamp · spyre::topkvalue · spyre::topkindex</text>
-  <text x="200" y="222" font-size="13" font-weight="600" fill="#7a3a00">spyre::full · spyre::ones_scalar · spyre::logical_not · spyre::constant  (plus infra: restickify, overwrite, copy_from_d2d)</text>
+  <text x="200" y="206" font-size="13" font-weight="600" fill="#7a3a00">spyre::rms_norm · spyre::layer_norm · spyre::gelu · spyre::silu · spyre::softplus · spyre::clamp · spyre::topkvalue · spyre::topkindex</text>
+  <text x="200" y="222" font-size="13" font-weight="600" fill="#7a3a00">spyre::logical_not · spyre::constant · spyre::qfp8ch · spyre::qfp8wt  (plus infra: restickify, overwrite, copy_from_d2d)</text>
   <text x="200" y="238" font-size="12" fill="#7a3a00" font-style="italic">torch.library.custom_op with @register_fake + lowering rule</text>
 
   <!-- LAYER 3: Decompositions -->
   <rect x="180" y="252" width="800" height="82" rx="4" fill="#f5f0de" stroke="#c8b464" stroke-width="1.2"/>
   <text x="200" y="275" font-size="13" font-weight="600" fill="#5a4800">logical_not · addmm → matmul+scale+add  ·  linear → matmul+add  ·  rms_norm · layer_norm · gelu · softplus</text>
   <text x="200" y="293" font-size="13" font-weight="600" fill="#5a4800">topk · max.dim · sdpa → Q·K^T·V  ·  cat · constant_pad_nd · bitwise_not · bitwise_and</text>
-  <text x="200" y="311" font-size="13" font-weight="600" fill="#5a4800">ones → ones_scalar+expand  ·  new_ones · full → spyre::full</text>
+  <text x="200" y="311" font-size="13" font-weight="600" fill="#5a4800">ones · new_ones → full  ·  _scaled_mm → qfp8ch/qfp8wt + scaled matmul</text>
   <text x="200" y="328" font-size="12" fill="#5a4800" font-style="italic">Rewritten to Layer 1 native primitives at compile time</text>
 
   <!-- SEPARATOR -->
@@ -41,6 +41,6 @@
   <rect x="220" y="356" width="760" height="70" rx="4"
         fill="#F8FAFF" stroke="#B0BDD8" stroke-width="1" stroke-dasharray="5 3"/>
   <text x="600" y="374" text-anchor="middle" font-size="14" font-weight="600" fill="#1f2937">CPU Fallback (infrequent ops, off the critical path)</text>
-  <text x="600" y="393" text-anchor="middle" font-size="12" fill="#1f2937">embedding · arange · sin · cos · tril · triu · isin · normal_ · argmax · bitwise_or · bitwise_xor · int64 max</text>
+  <text x="600" y="393" text-anchor="middle" font-size="12" fill="#1f2937">arange · cumsum · repeat · sin · cos · tril · triu · isin · where · index_copy · any · normal_ · random_ · argmax · argmin · bitwise_or · bitwise_xor · int64 max/min</text>
   <text x="600" y="411" text-anchor="middle" font-size="12" fill="#1f2937" font-style="italic">auto-transfer to CPU, transparent to the user</text>
 </svg>

--- a/docs/source/_static/images/lx/core-div-mismatch-spill.svg
+++ b/docs/source/_static/images/lx/core-div-mismatch-spill.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 360" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="14">
+  <defs>
+    <marker id="ah2" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#444"/>
+    </marker>
+    <style>
+      .title   { fill: #222; font-size: 16px; font-weight: 700; }
+      .caption { fill: #555; font-size: 12px; font-style: italic; }
+      .panel   { fill: #222; font-size: 14px; font-weight: 700; }
+      .lx      { fill: #d6efd6; stroke: #2d7a2d; stroke-width: 1.4; }
+      .hbm     { fill: #ffe0e0; stroke: #a32020; stroke-width: 1.4; }
+      .op      { fill: #e6f0ff; stroke: #2c5aa0; stroke-width: 1.4; }
+      .lbl     { fill: #222; font-size: 13px; font-weight: 600; }
+      .arrow   { stroke: #444; stroke-width: 1.6; fill: none; }
+      .good    { fill: #2d7a2d; font-size: 13px; font-weight: 700; }
+      .bad     { fill: #a32020; font-size: 13px; font-weight: 700; }
+    </style>
+  </defs>
+
+  <text x="360" y="26" text-anchor="middle" class="title">Cost of a core-division mismatch</text>
+  <text x="360" y="46" text-anchor="middle" class="caption">A shared buffer of size S. Whether it stays on LX depends on the writer and reader agreeing on the per-core split.</text>
+
+  <!-- ===== LEFT: splits agree, buffer stays on LX ===== -->
+  <text x="40" y="86" class="panel">Splits agree: buffer stays on LX</text>
+
+  <rect class="op" x="40"  y="104" width="120" height="44" rx="8"/>
+  <text class="lbl" x="100" y="131" text-anchor="middle">writer op</text>
+
+  <rect class="lx" x="220" y="104" width="140" height="44" rx="8"/>
+  <text class="lbl" x="290" y="126" text-anchor="middle">buffer on LX</text>
+  <text class="lbl" x="290" y="142" text-anchor="middle" font-size="11">per-core slice</text>
+
+  <rect class="op" x="420" y="104" width="120" height="44" rx="8"/>
+  <text class="lbl" x="480" y="131" text-anchor="middle">reader op</text>
+
+  <path class="arrow" marker-end="url(#ah2)" d="M160,126 L216,126"/>
+  <path class="arrow" marker-end="url(#ah2)" d="M360,126 L416,126"/>
+  <text class="good" x="290" y="180" text-anchor="middle">0 extra off-chip bytes</text>
+
+  <!-- ===== RIGHT: splits disagree, buffer spills to HBM ===== -->
+  <text x="40" y="228" class="panel">Splits disagree (core_div_mismatch): buffer spills to HBM</text>
+
+  <rect class="op" x="40"  y="246" width="110" height="44" rx="8"/>
+  <text class="lbl" x="95" y="273" text-anchor="middle">writer op</text>
+
+  <rect class="hbm" x="270" y="246" width="150" height="44" rx="8"/>
+  <text class="lbl" x="345" y="273" text-anchor="middle">buffer in HBM</text>
+
+  <rect class="op" x="540" y="246" width="110" height="44" rx="8"/>
+  <text class="lbl" x="595" y="273" text-anchor="middle">reader op</text>
+
+  <path class="arrow" marker-end="url(#ah2)" d="M150,268 L266,268"/>
+  <text class="bad" x="208" y="260" text-anchor="middle" font-size="11">write S</text>
+  <path class="arrow" marker-end="url(#ah2)" d="M420,268 L536,268"/>
+  <text class="bad" x="478" y="260" text-anchor="middle" font-size="11">read S</text>
+
+  <text class="bad" x="345" y="320" text-anchor="middle">2 x S off-chip bytes: one write, one later read</text>
+</svg>

--- a/docs/source/_static/images/work-division/core-id-k-mapping.svg
+++ b/docs/source/_static/images/work-division/core-id-k-mapping.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 470" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="14">
+  <defs>
+    <marker id="ah" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#444"/>
+    </marker>
+    <style>
+      .title   { fill: #222; font-size: 16px; font-weight: 700; }
+      .caption { fill: #555; font-size: 12px; font-style: italic; }
+      .panel   { fill: #222; font-size: 14px; font-weight: 700; }
+      .sub     { fill: #555; font-size: 12px; }
+      .k0      { fill: #e6f0ff; stroke: #2c5aa0; stroke-width: 1.4; }
+      .k1      { fill: #ffe9d6; stroke: #b35a1a; stroke-width: 1.4; }
+      .core    { fill: #222; font-size: 12px; font-weight: 600; }
+      .slice0  { fill: #2c5aa0; font-size: 11px; font-weight: 700; }
+      .slice1  { fill: #b35a1a; font-size: 11px; font-weight: 700; }
+      .pair    { stroke: #2d7a2d; stroke-width: 2; fill: none; }
+      .pairtxt { fill: #2d7a2d; font-size: 12px; font-weight: 700; }
+      .cost    { fill: #a32020; font-size: 12px; font-weight: 700; }
+      .costok  { fill: #2d7a2d; font-size: 12px; font-weight: 700; }
+    </style>
+  </defs>
+
+  <text x="380" y="26" text-anchor="middle" class="title">Physical core mapping for a K-split</text>
+  <text x="380" y="46" text-anchor="middle" class="caption">Example: dims [M, K], splits [4, 2], 8 cores. Green brackets join the two cores that reduce output tile M0.</text>
+
+  <!-- ============ TOP PANEL: default ============ -->
+  <text x="40" y="88" class="panel">Default order</text>
+  <text x="40" y="106" class="sub">K varies slowest. The two K slices of tile M0 sit on core 0 and core 4.</text>
+
+  <!-- 8 cores: M=core%4, K=(core//4)%2  -> c0-3 K0, c4-7 K1 -->
+  <!-- c0 -->
+  <rect class="k0" x="40"  y="120" width="82" height="46" rx="6"/>
+  <text class="core"   x="81"  y="140" text-anchor="middle">core 0</text>
+  <text class="slice0" x="81"  y="158" text-anchor="middle">M0 K0</text>
+  <!-- c1 -->
+  <rect class="k0" x="130" y="120" width="82" height="46" rx="6"/>
+  <text class="core"   x="171" y="140" text-anchor="middle">core 1</text>
+  <text class="slice0" x="171" y="158" text-anchor="middle">M1 K0</text>
+  <!-- c2 -->
+  <rect class="k0" x="220" y="120" width="82" height="46" rx="6"/>
+  <text class="core"   x="261" y="140" text-anchor="middle">core 2</text>
+  <text class="slice0" x="261" y="158" text-anchor="middle">M2 K0</text>
+  <!-- c3 -->
+  <rect class="k0" x="310" y="120" width="82" height="46" rx="6"/>
+  <text class="core"   x="351" y="140" text-anchor="middle">core 3</text>
+  <text class="slice0" x="351" y="158" text-anchor="middle">M3 K0</text>
+  <!-- c4 -->
+  <rect class="k1" x="400" y="120" width="82" height="46" rx="6"/>
+  <text class="core"   x="441" y="140" text-anchor="middle">core 4</text>
+  <text class="slice1" x="441" y="158" text-anchor="middle">M0 K1</text>
+  <!-- c5 -->
+  <rect class="k1" x="490" y="120" width="82" height="46" rx="6"/>
+  <text class="core"   x="531" y="140" text-anchor="middle">core 5</text>
+  <text class="slice1" x="531" y="158" text-anchor="middle">M1 K1</text>
+  <!-- c6 -->
+  <rect class="k1" x="580" y="120" width="82" height="46" rx="6"/>
+  <text class="core"   x="621" y="140" text-anchor="middle">core 6</text>
+  <text class="slice1" x="621" y="158" text-anchor="middle">M2 K1</text>
+  <!-- c7 -->
+  <rect class="k1" x="670" y="120" width="82" height="46" rx="6"/>
+  <text class="core"   x="711" y="140" text-anchor="middle">core 7</text>
+  <text class="slice1" x="711" y="158" text-anchor="middle">M3 K1</text>
+
+  <!-- bracket joining core0 and core4 -->
+  <path class="pair" d="M81,176 L81,190 L441,190 L441,176"/>
+  <text class="pairtxt" x="261" y="206" text-anchor="middle">M0 collaborators are 4 cores apart</text>
+  <text class="cost" x="261" y="223" text-anchor="middle">PSUM accumulation crosses several ring hops</text>
+
+  <!-- ============ BOTTOM PANEL: contiguous_dim = K ============ -->
+  <text x="40" y="278" class="panel">contiguous_dim = K</text>
+  <text x="40" y="296" class="sub">K varies fastest. The two K slices of tile M0 sit on core 0 and core 1.</text>
+
+  <!-- 8 cores: K=core%2, M=(core//2)%4 -> alternate K0/K1 -->
+  <!-- c0 -->
+  <rect class="k0" x="40"  y="310" width="82" height="46" rx="6"/>
+  <text class="core"   x="81"  y="330" text-anchor="middle">core 0</text>
+  <text class="slice0" x="81"  y="348" text-anchor="middle">M0 K0</text>
+  <!-- c1 -->
+  <rect class="k1" x="130" y="310" width="82" height="46" rx="6"/>
+  <text class="core"   x="171" y="330" text-anchor="middle">core 1</text>
+  <text class="slice1" x="171" y="348" text-anchor="middle">M0 K1</text>
+  <!-- c2 -->
+  <rect class="k0" x="220" y="310" width="82" height="46" rx="6"/>
+  <text class="core"   x="261" y="330" text-anchor="middle">core 2</text>
+  <text class="slice0" x="261" y="348" text-anchor="middle">M1 K0</text>
+  <!-- c3 -->
+  <rect class="k1" x="310" y="310" width="82" height="46" rx="6"/>
+  <text class="core"   x="351" y="330" text-anchor="middle">core 3</text>
+  <text class="slice1" x="351" y="348" text-anchor="middle">M1 K1</text>
+  <!-- c4 -->
+  <rect class="k0" x="400" y="310" width="82" height="46" rx="6"/>
+  <text class="core"   x="441" y="330" text-anchor="middle">core 4</text>
+  <text class="slice0" x="441" y="348" text-anchor="middle">M2 K0</text>
+  <!-- c5 -->
+  <rect class="k1" x="490" y="310" width="82" height="46" rx="6"/>
+  <text class="core"   x="531" y="330" text-anchor="middle">core 5</text>
+  <text class="slice1" x="531" y="348" text-anchor="middle">M2 K1</text>
+  <!-- c6 -->
+  <rect class="k0" x="580" y="310" width="82" height="46" rx="6"/>
+  <text class="core"   x="621" y="330" text-anchor="middle">core 6</text>
+  <text class="slice0" x="621" y="348" text-anchor="middle">M3 K0</text>
+  <!-- c7 -->
+  <rect class="k1" x="670" y="310" width="82" height="46" rx="6"/>
+  <text class="core"   x="711" y="330" text-anchor="middle">core 7</text>
+  <text class="slice1" x="711" y="348" text-anchor="middle">M3 K1</text>
+
+  <!-- bracket joining core0 and core1 -->
+  <path class="pair" d="M81,366 L81,380 L171,380 L171,366"/>
+  <text class="pairtxt" x="126" y="396" text-anchor="middle">adjacent</text>
+  <text class="costok" x="380" y="396" text-anchor="middle">PSUM accumulation is a single ring hop</text>
+
+  <text x="380" y="440" text-anchor="middle" class="caption">core_to_slice_mapping in core_mapping.py, gated by SPYRE_CORE_ID_K_FAST_EMISSION (default on).</text>
+</svg>

--- a/docs/source/compiler/hbm_pool_planning.md
+++ b/docs/source/compiler/hbm_pool_planning.md
@@ -1,0 +1,153 @@
+# HBM intermediates-pool planning
+
+How torch-spyre packs intermediate tensors into a shared region of device
+memory, and how that pass relates to LX scratchpad planning.
+
+:::{admonition} Status
+:class: note
+
+HBM pool planning runs by default. The pass is gated by
+`config.hbm_pool_planning`, which defaults to `True` and reads from the
+`HBM_POOL_PLANNING` environment variable. It is implemented in
+`torch_spyre/_inductor/hbm_pool_planning.py` and runs in
+`CustomPostFusionPasses`.
+:::
+
+**Quick navigation:**
+
+- [What the pass does](#what-the-pass-does)
+- [Relationship to LX scratchpad planning](#relationship-to-lx-scratchpad-planning)
+- [Pipeline position](#pipeline-position)
+- [Pool candidates](#pool-candidates)
+- [Allocation](#allocation)
+- [Codegen integration](#codegen-integration)
+- [Related documents](#related-documents)
+
+## What the pass does
+
+An inference graph produces many intermediate tensors that are written by
+one operation and read by a later one. If every intermediate received its
+own device-memory allocation, peak memory would scale with the number of
+intermediates in the graph rather than with the number that are live at
+the same time.
+
+HBM pool planning assigns intermediates to offsets inside a single shared
+region of device memory, the *intermediates segment*
+(`constants.INTERMEDIATES_SEGMENT`, size `constants.SEGMENT_SIZE` = 16 GB).
+Two intermediates whose live ranges do not overlap reuse the same offset,
+so the segment only has to be as large as the peak concurrent footprint,
+not the sum of all intermediates. The pass raises a `RuntimeError` if that
+peak exceeds the segment size.
+
+Only device memory is planned here. The 2 MB per-core LX scratchpad is
+planned by a separate pass; see below.
+
+## Relationship to LX scratchpad planning
+
+Both passes decide where an intermediate tensor's data lives, but they
+operate on different memory and at different points in the pipeline. A
+buffer is a pool candidate only if LX planning did *not* already claim it
+(`"lx" not in layout.allocation`), so the two passes are mutually
+exclusive per buffer and are applied in that order.
+
+| | LX scratchpad planning | HBM intermediates-pool planning |
+|---|---|---|
+| Memory | 2 MB on-core SRAM scratchpad, per core | Regular device memory (LPDDR5), the 16 GB intermediates segment |
+| Pipeline stage | `CustomPreSchedulingPasses`, before the `Scheduler` is constructed | `CustomPostFusionPasses`, after Inductor's fusion pass has run |
+| Gating | `config.lx_planning` (`LX_PLANNING`) | `config.hbm_pool_planning` (`HBM_POOL_PLANNING`) |
+| Goal | Keep reused tensors on fast core-local memory to cut device-memory traffic | Share one device-memory region across non-overlapping intermediates to bound peak footprint |
+| Allocation | Fixed per-core SRAM address | Bump/free-list offset in the intermediates segment |
+| Entry point | `scratchpad_planning()` in `scratchpad/allocator.py` | `hbm_pool_planning()` in `hbm_pool_planning.py` |
+
+The two passes are complementary. LX planning claims the buffers that fit
+on the scratchpad and benefit from staying there; HBM pool planning then
+packs every remaining intermediate into the shared segment.
+
+## Pipeline position
+
+`hbm_pool_planning` runs inside `CustomPostFusionPasses`, which executes
+over the graph of LoopLevelIR nodes immediately after Inductor's fusion
+pass. The pass order is:
+
+```
+demote_incoherent_lx_buffers    # re-check LX core->slice coherence with final loop orders
+hbm_pool_planning               # ← THIS PASS, gated by config.hbm_pool_planning
+spyre_fuse_nodes
+```
+
+`demote_incoherent_lx_buffers` runs first for a reason: it re-checks LX
+core-to-slice coherence now that loop orders are final, and any buffer it
+demotes off LX must still be visible to `hbm_pool_planning` as an
+unclaimed intermediate.
+
+## Pool candidates
+
+The pass collects candidates from two sources:
+
+- **Kernel intermediates.** Buffers both written and read within the
+  graph, detected from the written and read dependency sets on
+  `ComputedBuffer` nodes.
+- **`SpyreEmptyFallback` full buffers** created by coarse tiling for
+  non-outputs. These are `ExternKernel` nodes that emit no dependency-
+  tracked write, so they are collected explicitly by the underlying
+  buffer name.
+
+A candidate must carry a `FixedTiledLayout`, must not have been claimed by
+LX planning, and must not alias a graph input or output. Graph inputs and
+outputs are excluded because they are addressed by the caller, not by the
+pool. Buffers read by fallback, extern, or nop kernels are also excluded,
+because those consumers require Python-side tensors rather than a pooled
+offset.
+
+Because mutation buffers share the same `layout.allocation` dictionary
+object as their target, input/output exclusion is checked by the identity
+of the allocation object (`id(layout.allocation)`), not by name.
+
+## Allocation
+
+Each candidate's live range is `(start_step, end_step)`, where the start
+is the timestep of the node that writes the buffer and the end is the last
+timestep at which any node reads it. Candidates are sorted by start step,
+tie-broken by `(end_step, name)` for determinism, and processed in that
+order.
+
+The `Allocator` tracks free blocks within the segment as `(offset, size)`
+pairs in bytes. For each buffer it first frees any block whose live range
+has ended, then allocates:
+
+1. Reuse the first free block large enough, returning any leftover
+   fragment to the free list.
+2. Otherwise extend the pool by appending at the current pool end.
+
+Sizes are the buffer's stick-aligned device footprint: the product of the
+device-side dimensions above the stick dimension, times 128 bytes per
+stick, rounded up to a 128-byte (one-stick) boundary. The allocator tracks
+peak concurrent usage and raises if it exceeds `SEGMENT_SIZE`.
+
+The chosen offset is written to `layout.allocation["hbm_pool"]`. With
+`config.bundle_symbolic_args` the raw offset is stored (the segment base is
+added later during bundling); otherwise the absolute
+`INTERMEDIATES_SEGMENT + offset` is stored. The final pool extent is
+recorded on `V.graph.hbm_pool_size`.
+
+A `SpyreEmptyFallback` buffer that is pool-allocated is added to
+`V.graph.removed_buffers`. Its `should_allocate()` returns `False` once
+pooled, so the wrapper never emits an allocate line for it; adding the name
+to `removed_buffers` also keeps base Inductor's free machinery from
+emitting a `del` for a buffer it never allocated.
+
+## Codegen integration
+
+A pooled buffer is not allocated as an independent tensor. Its
+`layout.allocation["hbm_pool"]` offset places it within the shared segment,
+and the generated wrapper addresses it against that segment rather than
+emitting a standalone allocation and free.
+
+## Related documents
+
+- [`scratchpad_planning.md`](scratchpad_planning.md) describes LX
+  scratchpad planning, the complementary pass that claims buffers for the
+  on-core SRAM before HBM pool planning packs the remainder.
+- [`coarse_tiling_loops.md`](coarse_tiling_loops.md) describes coarse
+  tiling, which creates the `SpyreEmptyFallback` full buffers that this
+  pass collects as a second candidate source.

--- a/docs/source/compiler/index.rst
+++ b/docs/source/compiler/index.rst
@@ -58,4 +58,5 @@ test coverage, bug classification), see :doc:`/contributing/op_enablement`.
    span_overflow_hint_analysis
    work_division_planning
    scratchpad_planning
+   hbm_pool_planning
    simulated_annealing_layout

--- a/docs/source/compiler/scratchpad_planning.md
+++ b/docs/source/compiler/scratchpad_planning.md
@@ -56,8 +56,9 @@ The compiler picks which buffers live where.
 | Parameter | Value | Config |
 |---|---|---|
 | Total LX per core | 2 MB | fixed |
+| Program/debug reservation | 64 KB | fixed |
 | Backend-reserved fraction | 20% | `DXP_LX_FRAC_AVAIL` |
-| Usable LX per core | ~1.6 MB | `int((2<<20) * (1 - frac_avail))` |
+| Usable LX per core | ~1.55 MB | `round_up_128(int(((2<<20) - (64<<10)) * (1 - frac_avail)))` |
 | Alignment | 128-byte (stick) | implicit |
 | Cores | 1 to 32 | `SENCORES` |
 | Per-core HBM span limit | (255.996 MiB) | hardware, separate from LX |
@@ -265,6 +266,12 @@ The relevant code lives under `torch_spyre/_inductor/scratchpad/`:
 | `plan_solver.py` | `MemoryPlanSolver` ABC (declarative exclusion via `partition`/`excluded`), `LifetimeBoundBuffer` |
 | `greedy_solver.py` | `GreedyLayoutSolver` |
 | `firstfit_bestfit_solver.py` | `FirstFitLayoutSolver`, `BestFitLayoutSolver` |
+| `ilp_solver_ortools.py` | `CpSatLayoutSolver` (OR-Tools CP-SAT) |
+| `simulated_annealing.py` | `SimulatedAnnealingLayoutSolver` |
+| `cooling_schedules.py` | cooling schedules for the annealing search |
+| `permutation_layout.py` | `PermutationBasedLayoutSolver` |
+| `contact_profile.py` | `Profile`, buffer-contact profiling |
+| `graph_editor.py` | `GraphEditor`, the clone/rewrite helper used by input- and output-boundary cloning |
 | `allocator.py` | `ScratchpadAllocator`, `StrategyBCoOptimizingAllocator`, and the single LX-eligibility predicate (`_residency_reasons`, one reason per buffer) |
 | `utils.py` | liveness, mem usage, op-name/eligibility helpers |
 
@@ -291,8 +298,12 @@ scratchpad_planning(graph, allocator=ScratchpadAllocator())
    rest it can fit; whatever is left gets `address=None` and stays on HBM.
 4. **Push allocation.** Successful placements are written to
    `layout.allocation["lx"] = addr` on each buffer's `FixedTiledLayout`.
-5. **Post-passes.** Currently empty. Reserved for solver-driven graph
-   mutations (output cloning, op re-ordering).
+5. **Post-passes.** Reserved for solver-driven graph mutations such as op
+   re-ordering. Output-boundary cloning already runs as part of push
+   allocation: `_push_allocation` calls
+   `graph_editor.push_allocation_with_clone(..., input=False)` and
+   `change_graph_output` to promote a producer to LX and clone the value
+   back to a graph output.
 
 ### Declarative exclusion
 
@@ -320,12 +331,13 @@ The checks, in evaluation order (the first failure is the reason reported):
 
 | Reason | Why |
 |---|---|
-| `op not allowed` | not a `ComputedBuffer`, a mutation layout, or an op name outside `OP_OUTPUT_GOOD_FOR_LX_REUSE` |
+| `op not allowed` | not a `ComputedBuffer`, a mutation layout, or an op name outside `OP_OUTPUT_GOOD_FOR_LX_REUSE` (the debug flag `config.allow_all_ops_in_lx_planning` bypasses the op-name gate) |
 | `unsized (no device layout)` | no computable footprint (e.g. a `MultiOutputLayout` tuple op) |
 | `mutation target` | filled by offset writes, so one LX base mis-addresses it |
-| `tiled (advancing), not per_tile_fixed` | LX addresses cannot be `affine.apply` symbols |
+| `tiled (advancing)` | LX addresses cannot be `affine.apply` symbols; the advancing-tile check reads `loop_info` (the sole source of truth for per-tile geometry) |
 | `read by restickify (cross-frame barrier)` | the read and write frames are transposes, so a per-core LX slice is not self-sufficient (the buffer a restickify reads; its own output is safe and is not barred) |
 | `extern kernel user` | extern ops read from HBM |
+| `index tensor or indirectly accessed` | index tensors and the value tensors they index into are read via data-dependent addressing, so they must stay in HBM |
 | `graph output (no clone)` / `graph input (no clone)` | without boundary cloning there is nothing to redirect |
 | `graph output is a ReinterpretView` | output cloning cannot rewrap the view |
 | `partial/offset read` | a sliced or multi-offset read mis-addresses a single LX base |
@@ -361,6 +373,16 @@ each buffer and is the gate for whether a buffer is even eligible.
   accident. A writer/reader core-count disagreement, a partial-sum
   (K-split-reduction) writer, or any unrepresentable geometry yields
   `core_div_mismatch` (`-1`) and disqualifies the buffer from LX.
+
+:::{figure} ../_static/images/lx/core-div-mismatch-spill.svg
+:alt: When writer and reader agree on the per-core split the buffer stays on LX at no off-chip cost; when they disagree it is written to HBM and read back, costing twice its size in off-chip traffic.
+:width: 100%
+
+A buffer disqualified by `core_div_mismatch` is written to HBM by its
+producer and read back by its consumer. That boundary costs `2 x S`
+off-chip bytes for a buffer of size `S`, where an on-LX buffer would have
+cost none.
+:::
 
 ### Codegen integration
 
@@ -651,9 +673,6 @@ Candidates under evaluation:
   and is only worthwhile when liveness shows it pays off.
 - **Operation re-ordering.** Re-order independent ops to extend or
   shorten lifetimes for better packing.
-- **Output node cloning.** Promote a producer to LX and clone to HBM
-  only when an HBM-resident copy is required (draft PR
-  [#2028](https://github.com/torch-spyre/torch-spyre/pull/2028)).
 - **Driving cloning from the solver.** Input-boundary cloning currently
   runs inline in `ScratchpadAllocator` with a heuristic. The longer-term
   plan is for the solver to decide which clones pay off based on the
@@ -707,3 +726,6 @@ bugs that the hand-written cases miss.
 - [`coarse_tiling_loops.md`](coarse_tiling_loops.md) describes coarse
   tiling, which reduces working sets so adjacent ops can fit on LX in
   the first place.
+- [`hbm_pool_planning.md`](hbm_pool_planning.md) describes the
+  complementary device-memory pass, which packs every intermediate that
+  LX planning did not claim into a shared HBM segment.

--- a/docs/source/compiler/work_division_planning.md
+++ b/docs/source/compiler/work_division_planning.md
@@ -490,6 +490,16 @@ controls this codegen-side permutation. The name is legacy from when
 k-fast was also a planner. The permutation runs whenever any planner
 picks a K-split.
 
+:::{figure} ../_static/images/work-division/core-id-k-mapping.svg
+:alt: Default core order places the two K slices of one output tile four cores apart; contiguous_dim on K places them on adjacent cores.
+:width: 100%
+
+`contiguous_dim` selects which dimension varies fastest across `core_id`.
+Setting it to the K dimension puts the cores that reduce the same output
+tile next to each other, so their partial sums accumulate over one ring
+hop instead of several.
+:::
+
 ### Scratchpad planning
 
 Each pass plans one op at a time. When two adjacent ops share a tensor

--- a/docs/source/getting_started/how_torch_spyre_works.md
+++ b/docs/source/getting_started/how_torch_spyre_works.md
@@ -613,9 +613,10 @@ as `add`, `relu`, and `sigmoid`, and matrix ops such as `mm` and `bmm`. Each nat
 single SuperDSC that references an existing Deeptools OpFunc.
 
 **Custom ops** are Spyre-specific ops that we register through `torch.library.custom_op`. The
-user-facing ops are `spyre::rms_norm`, `spyre::layer_norm`, `spyre::gelu`, `spyre::softplus`,
-`spyre::clamp`, `spyre::topkvalue`, `spyre::topkindex`, `spyre::full`, `spyre::ones_scalar`,
-`spyre::logical_not`, and `spyre::constant`. There are also a few infrastructure ops
+user-facing ops are `spyre::rms_norm`, `spyre::layer_norm`, `spyre::gelu`, `spyre::silu`,
+`spyre::softplus`, `spyre::clamp`, `spyre::topkvalue`, `spyre::topkindex`, `spyre::logical_not`,
+and `spyre::constant`. FP8 quantization adds `spyre::qfp8ch` and `spyre::qfp8wt`, which convert a
+tensor to the FP8 E4M3 format for a scaled matmul. There are also a few infrastructure ops
 (`restickify`, `overwrite`, and `copy_from_d2d`). Each custom op has a `@register_fake` for
 shape and dtype inference during tracing, along with a lowering rule that emits SuperDSCs. We
 need custom ops because the default PyTorch behavior is to decompose ops such as `rms_norm` into
@@ -632,10 +633,11 @@ scalar to a size-1 constant tensor. This runs at the LoopLevelIR level in
 `dedup_and_promote_constants`, which also deduplicates identical constants so they share one
 device buffer.
 
-**CPU fallbacks** cover the long tail. The current set is `embedding`, `arange`, `sin`, `cos`,
-`tril`, `triu`, `isin`, `normal_`, `argmax`, `bitwise_or`, `bitwise_xor`, and the int64 variants
-of `max`. The runtime automatically transfers data to the CPU, executes the op, and returns the
-result to Spyre. This is transparent to the model, but these ops are off the hot path.
+**CPU fallbacks** cover the long tail. The current set is `arange`, `cumsum`, `repeat`, `sin`,
+`cos`, `tril`, `triu`, `isin`, `where`, `index_copy`, `any`, `normal_`, `random_`, `argmax`,
+`argmin`, `bitwise_or`, `bitwise_xor`, and the int64 variants of `max` and `min`. The runtime
+automatically transfers data to the CPU, executes the op, and returns the result to Spyre. This
+is transparent to the model, but these ops are off the hot path.
 
 An ATen op flows through this pipeline in the following way. Decomposition rewrites it into
 either a native op or a custom op. Custom ops then lower to SuperDSCs built from native OpFuncs.
@@ -803,9 +805,9 @@ would require invasive core changes. Deferring to codegen is too late.
 | Mechanism | PyTorch Hook | Purpose | Key Detail |
 |---|---|---|---|
 | Native ops (Deeptools-supported) | Direct mapping to OpFuncs | Pointwise and matrix ops supported natively by the hardware | Pointwise: `add`, `sub`, `mul`, `truediv`, `relu`, `sigmoid`, `abs`, `neg`, `exp`, `log`, `sqrt`, `rsqrt`, `reciprocal`, `tanh`, `floor`, `eq`, `ne`, `ge`, `le`, `lt`, `gt`, `square`, `where`, `logical_and`, `to_dtype`, plus lowered forms of `clamp`/`gelu`/`softplus`/`layernormscale`/`layernormnorm`. Matrix: `mm`, `bmm` (`matmul` is decomposed to these by Inductor upstream). Matrix ops need custom layout propagation for the contracted dimension, but both kinds map to single SDSCs. |
-| `torch.library.custom_op` | Custom op registration | Layer 3 normalization, activation, and ops that need a single named lowering target | Each op requires `@register_fake` for shape/dtype inference during tracing, plus a lowering rule mapping to Spyre primitives. User-facing ops: `spyre::rms_norm`, `spyre::layer_norm`, `spyre::gelu`, `spyre::softplus`, `spyre::clamp`, `spyre::topkvalue`, `spyre::topkindex`, `spyre::full`, `spyre::ones_scalar`, `spyre::logical_not`, `spyre::constant`. Infrastructure ops: `spyre::restickify`, `spyre::overwrite` / `spyre::overwrite_f`, `spyre::copy_from_d2d`. |
-| Decompositions | Registered in `enable_spyre_context()` | Layer 4 ops not natively available | `logical_not` → `eq(input, ne(input, input))` (bool), `addmm` → `matmul+scale+add`, `linear` → `matmul+add` (with weight transpose), `rms_norm` → `spyre::rms_norm`, `layer_norm` → `spyre::layer_norm`, `gelu` → `spyre::gelu`, `softplus` → `spyre::softplus`, `topk` → `spyre::topkvalue`/`spyre::topkindex`, `max.dim` → split value/index decomp, `scaled_dot_product_attention` → explicit Q·K^T·V, `cat`, `constant_pad_nd`, `ones` → `spyre::ones_scalar+expand+clone`, `new_ones`, `full` → `spyre::full`, `bitwise_not`, `bitwise_and` |
-| CPU fallback (auto-transfer) | PyTorch fallback dispatch | Infrequent ops that are off the critical path | `embedding`, `arange`, `sin`, `cos`, `tril`, `triu`, `isin`, `normal_`, `argmax`, `bitwise_or`, `bitwise_xor`, int64 variants of `max`. Data auto-transfers to the CPU, executes, and returns to Spyre. Transparent to the model. |
+| `torch.library.custom_op` | Custom op registration | Layer 3 normalization, activation, quantization, and ops that need a single named lowering target | Each op requires `@register_fake` for shape/dtype inference during tracing, plus a lowering rule mapping to Spyre primitives. User-facing ops: `spyre::rms_norm`, `spyre::layer_norm`, `spyre::gelu`, `spyre::silu`, `spyre::softplus`, `spyre::clamp`, `spyre::topkvalue`, `spyre::topkindex`, `spyre::logical_not`, `spyre::constant`. FP8 quantization: `spyre::qfp8ch`, `spyre::qfp8wt` (E4M3 format conversion), and `spyre::scaled_mm` (the raw FP8 matmul that `torch._scaled_mm` decomposes onto). Infrastructure ops: `spyre::restickify`, `spyre::overwrite` / `spyre::overwrite_f`, `spyre::copy_from_d2d`. |
+| Decompositions | Registered in `enable_spyre_context()` | Layer 4 ops not natively available | `logical_not` → `eq(input, ne(input, input))` (bool), `addmm` → `matmul+scale+add`, `linear` → `matmul+add` (with weight transpose), `rms_norm` → `spyre::rms_norm`, `layer_norm` → `spyre::layer_norm`, `gelu` → `spyre::gelu`, `softplus` → `spyre::softplus`, `topk` → `spyre::topkvalue`/`spyre::topkindex`, `max.dim` → split value/index decomp, `scaled_dot_product_attention` → explicit Q·K^T·V, `cat`, `constant_pad_nd`, `ones`/`new_ones` → `full`, `bitwise_not`, `bitwise_and`, `flip` → `index_select` with a descending index (reversing the last stick dimension raises), `masked_scatter` → whole-row gather (the mask must broadcast along the last dimension). `torch._scaled_mm` decomposes to `spyre::scaled_mm` (the raw FP8 matmul) followed by the `scale_a` and `scale_b` multiplies and the `bias` add. |
+| CPU fallback (auto-transfer) | PyTorch fallback dispatch | Infrequent ops that are off the critical path | `arange`, `cumsum`, `repeat`, `sin`, `cos`, `tril`, `triu`, `isin`, `where`, `index_copy`, `any`, `normal_`, `random_`, `argmax`, `argmin`, `bitwise_or`, `bitwise_xor`, int64 variants of `max` and `min`. Data auto-transfers to the CPU, executes, and returns to Spyre. Transparent to the model. |
 
 ### Profiling
 


### PR DESCRIPTION
## New
- **`compiler/hbm_pool_planning.md`** — reference page for the HBM intermediates-pool pass. Two code sites (`hbm_pool_planning.py`, `op_spec.py`) linked to this doc, but it did not exist. Covers the pass, its relation to LX planning, pipeline position, pool candidates, the free-list allocator, and codegen.
- Two figures for merged work-division mechanisms: `contiguous_dim` core mapping, and the `core_div_mismatch` HBM spill.

## Updated
- **`scratchpad_planning.md`** — usable-LX budget formula, implementation-file table, residency-reasons table, and the post-passes step (output-boundary cloning already runs). Cross-links the new HBM page.
- **`how_torch_spyre_works.md`** (Challenge 4) — `embedding` reclassified as native; added the FP8 `scaled_mm` path, `flip`, and `masked_scatter`; corrected the CPU-fallback list. `fig5` updated to match.
- **`work_division_planning.md`**, **`compiler/index.rst`** — embed the new figure and add the HBM page to the toctree.

## Scope
The LX-to-LX relayout feature is not merged (#3439, #3440, #2939 open), so nothing here documents it. The figures cover only merged mechanisms.