### PR TITLE
Centralized constraint logic for work division

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_work_division_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_work_division_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [core, full, device_critical]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_work_division.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_work_division.py
+++ b/tests/inductor/test_work_division.py
@@ -1,0 +1,307 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import sympy
+import torch
+from sympy import Symbol
+
+from torch._inductor.dependencies import MemoryDep
+from torch._inductor.ir import ComputedBuffer, FlexibleLayout, Pointwise, Reduction
+
+from torch_spyre._C import ElementArrangement, SpyreTensorLayout
+from torch_spyre._inductor.ir import FixedTiledLayout
+from torch_spyre._inductor.work_division import (
+    TensorDep,
+    multi_dim_iteration_space_split,
+)
+from torch_spyre._inductor.work_division_constraints import (
+    WorkDivConstraintContext,
+    coordinate_mask_blocked_vars,
+    indirect_access_pinned_vars,
+    qfp8wt_matmul_k_pinned,
+    qfp8wt_pinned_vars,
+)
+
+
+def _isym(name):
+    """Symbol with the (integer, positive) assumptions real Inductor loop
+    vars carry -- required for sympy's floor-division to simplify a stick
+    coordinate down to a bare symbol instead of leaving it as floor(var)."""
+    return Symbol(name, integer=True, positive=True)
+
+
+def _fixed_tiled_layout(shape, dtype=torch.float16, element_arrangement=None):
+    """Build the same kind of physical layout used by real Spyre lowering."""
+    size = list(shape)
+    stride = [int(s) for s in FlexibleLayout.contiguous_strides(size)]
+    within_stick_dim = len(size) - 1
+    dim_order = [i for i in range(len(size)) if i != within_stick_dim]
+    dim_order.append(within_stick_dim)
+    device_layout = SpyreTensorLayout(size, stride, dtype, dim_order)
+    if element_arrangement is not None:
+        device_layout = device_layout.with_element_arrangement(element_arrangement)
+    return FixedTiledLayout("spyre:0", dtype, size, stride, device_layout)
+
+
+def _tensor_dep(name, shape, symbols, element_arrangement=None):
+    """Build a real TensorDep for a contiguous access over ``symbols``."""
+    layout = _fixed_tiled_layout(shape, element_arrangement=element_arrangement)
+    index = sympy.Integer(0)
+    for sym, stride in zip(symbols, layout.stride):
+        index += sym * int(stride)
+    dep = MemoryDep(name, index, tuple(symbols), tuple(shape))
+    return TensorDep(dep=dep, layout=layout)
+
+
+def _computed_buffer(shape, name="buf0", reduction_type=None, reduction_ranges=()):
+    if reduction_type is not None:
+        data = MagicMock(spec=Reduction)
+        data.reduction_type = reduction_type
+        data.reduction_ranges = list(reduction_ranges)
+    else:
+        data = MagicMock(spec=Pointwise)
+    data.ranges = list(shape)
+    layout = _fixed_tiled_layout(shape)
+    op = ComputedBuffer(name=name, layout=layout, data=data)
+    op.operation_name = name
+    return op
+
+
+def _make_context(
+    op,
+    output_td,
+    input_tds=(),
+    it_space=None,
+    it_space_adjusted=None,
+    stick_vars=None,
+    reduction_vars=(),
+    committed_splits=None,
+):
+    it_space = it_space or {}
+    return WorkDivConstraintContext(
+        op=op,
+        it_space=it_space,
+        it_space_adjusted=it_space_adjusted
+        if it_space_adjusted is not None
+        else it_space,
+        output_td=output_td,
+        input_tds=list(input_tds),
+        stick_vars=stick_vars or {},
+        reduction_vars=list(reduction_vars),
+        committed_splits=committed_splits or {},
+    )
+
+
+class TestMultiDimIterationSpaceSplit(unittest.TestCase):
+    def _reduction_split_vars(self, splits, output_dims):
+        return {k for k, v in splits.items() if v > 1 and k not in output_dims}
+
+    def test_output_dims_absorb_all_cores(self):
+        o0, o1, r0 = Symbol("o0"), Symbol("o1"), Symbol("r0")
+        splits = multi_dim_iteration_space_split(
+            {o0: 16, o1: 16, r0: 8}, 32, [o0, o1], [r0]
+        )
+        self.assertLessEqual(len(self._reduction_split_vars(splits, [o0, o1])), 1)
+        self.assertEqual(splits[o0] * splits[o1] * splits[r0], 32)
+
+    def test_at_most_one_reduction_dim_split_when_output_dims_small(self):
+        # output dims can absorb only 4 cores; 32 total with committed r0=2
+        # leaves 4 cores for remaining reduction dims.
+        # work_distribution_pass suppresses reduction_dims when a committed split
+        # already covers a reduction var, so reduction_dims=[] is passed here.
+        o0, r0, r1 = Symbol("o0"), Symbol("r0"), Symbol("r1")
+        splits = multi_dim_iteration_space_split(
+            {o0: 4, r0: 8, r1: 8},
+            32,
+            [o0],
+            [],  # suppressed: r0 already committed, r1 must not also be split
+            min_splits={r0: 2},
+        )
+        reduction_split = self._reduction_split_vars(splits, [o0])
+        self.assertLessEqual(
+            len(reduction_split),
+            1,
+            f"Expected at most 1 reduction dim split, got {reduction_split}",
+        )
+
+    def test_no_reduction_dims_uses_greedy_on_all_dims(self):
+        o0, o1 = Symbol("o0"), Symbol("o1")
+        splits = multi_dim_iteration_space_split({o0: 8, o1: 8}, 32, [o0, o1], [])
+        self.assertEqual(splits[o0] * splits[o1], 32)
+
+    def test_single_reduction_dim_split_when_output_exhausted(self):
+        o0, r0 = Symbol("o0"), Symbol("r0")
+        splits = multi_dim_iteration_space_split({o0: 4, r0: 8}, 32, [o0], [r0])
+        self.assertEqual(splits[o0], 4)
+        self.assertEqual(splits[r0], 8)
+
+
+class TestCoordinateMaskBlockedVars(unittest.TestCase):
+    """coordinate_mask_blocked_vars only reads reduction_vars/stick_vars/it_space,
+    so output_td/op are irrelevant here and stand in with a placeholder."""
+
+    _PLACEHOLDER_OP = _computed_buffer((128,), name="placeholder_buf")
+    _PLACEHOLDER_TD = _tensor_dep("placeholder_buf", (128,), (_isym("_placeholder"),))
+
+    def test_padded_stick_aligned_reduction_dim_is_blocked(self):
+        r0 = _isym("r0")
+        ctx = _make_context(
+            self._PLACEHOLDER_OP,
+            self._PLACEHOLDER_TD,
+            it_space={r0: 10},
+            stick_vars={r0: 64},
+            reduction_vars=[r0],
+        )
+        result = coordinate_mask_blocked_vars(ctx)
+        self.assertEqual(result.blocked, {r0})
+
+    def test_stick_aligned_reduction_dim_is_not_blocked(self):
+        r0 = _isym("r0")
+        ctx = _make_context(
+            self._PLACEHOLDER_OP,
+            self._PLACEHOLDER_TD,
+            it_space={r0: 128},
+            stick_vars={r0: 64},
+            reduction_vars=[r0],
+        )
+        result = coordinate_mask_blocked_vars(ctx)
+        self.assertEqual(result.blocked, set())
+
+    def test_non_stick_var_is_not_blocked(self):
+        r0 = _isym("r0")
+        ctx = _make_context(
+            self._PLACEHOLDER_OP,
+            self._PLACEHOLDER_TD,
+            it_space={r0: 10},
+            stick_vars={},
+            reduction_vars=[r0],
+        )
+        result = coordinate_mask_blocked_vars(ctx)
+        self.assertEqual(result.blocked, set())
+
+
+class TestQfp8wtConstraints(unittest.TestCase):
+    def test_output_second_stick_coord_pinned_for_qfp8wt_output(self):
+        b, m, n = _isym("b"), _isym("m"), _isym("n")
+        op = _computed_buffer((4, 8, 128), name="qfp8_out")
+        output_td = _tensor_dep(
+            "qfp8_out",
+            (4, 8, 128),
+            (b, m, n),
+            element_arrangement=ElementArrangement.QFP8WT,
+        )
+        ctx = _make_context(op, output_td, it_space={b: 4, m: 8, n: 128})
+        result = qfp8wt_pinned_vars(ctx)
+        pinned_vars = set(output_td.device_coords[-2].free_symbols)
+        self.assertTrue(pinned_vars)
+        for v in pinned_vars:
+            self.assertEqual(result.pinned[v], 1)
+
+    def test_standard_output_yields_no_pins(self):
+        b, m, n = _isym("b"), _isym("m"), _isym("n")
+        op = _computed_buffer((4, 8, 128), name="std_out")
+        output_td = _tensor_dep("std_out", (4, 8, 128), (b, m, n))
+        ctx = _make_context(op, output_td, it_space={b: 4, m: 8, n: 128})
+        result = qfp8wt_pinned_vars(ctx)
+        self.assertEqual(result.pinned, {})
+
+    def test_matmul_k_pinned_for_batchmatmulfp8_with_qfp8wt_kernel(self):
+        from torch_spyre._inductor.constants import BATCH_MATMUL_FP8_OP
+
+        b, m, n, k = _isym("b"), _isym("m"), _isym("n"), _isym("k")
+        op = _computed_buffer(
+            (4, 8, 128),
+            name="mm_out",
+            reduction_type=BATCH_MATMUL_FP8_OP,
+            reduction_ranges=(64,),
+        )
+        output_td = _tensor_dep("mm_out", (4, 8, 128), (b, m, n))
+        kernel_td = _tensor_dep(
+            "kernel",
+            (4, 128, 64),
+            (b, n, k),
+            element_arrangement=ElementArrangement.QFP8WT,
+        )
+        ctx = _make_context(
+            op,
+            output_td,
+            input_tds=[
+                _tensor_dep("act", (4, 8, 64), (b, m, k)),
+                kernel_td,
+            ],
+            it_space={b: 4, m: 8, n: 128, k: 64},
+            reduction_vars=[k],
+        )
+        result = qfp8wt_matmul_k_pinned(ctx)
+        self.assertEqual(result.pinned, {k: 1})
+
+    def test_matmul_k_not_pinned_for_plain_batchmatmul(self):
+        from torch_spyre._inductor.constants import BATCH_MATMUL_OP
+
+        b, m, n, k = _isym("b"), _isym("m"), _isym("n"), _isym("k")
+        op = _computed_buffer(
+            (4, 8, 128),
+            name="mm_out2",
+            reduction_type=BATCH_MATMUL_OP,
+            reduction_ranges=(64,),
+        )
+        output_td = _tensor_dep("mm_out2", (4, 8, 128), (b, m, n))
+        ctx = _make_context(
+            op,
+            output_td,
+            input_tds=[
+                _tensor_dep("act2", (4, 8, 64), (b, m, k)),
+                _tensor_dep("kernel2", (4, 128, 64), (b, n, k)),
+            ],
+            it_space={b: 4, m: 8, n: 128, k: 64},
+            reduction_vars=[k],
+        )
+        result = qfp8wt_matmul_k_pinned(ctx)
+        self.assertEqual(result.pinned, {})
+
+
+class TestIndirectAccessPinnedVars(unittest.TestCase):
+    _PATCH_TARGET = (
+        "torch_spyre._inductor.work_division_constraints.indirect_info_from_op"
+    )
+
+    _PLACEHOLDER_OP = _computed_buffer((128,), name="indirect_placeholder_buf")
+    _PLACEHOLDER_TD = _tensor_dep(
+        "indirect_placeholder_buf", (128,), (_isym("_placeholder"),)
+    )
+
+    def test_indirect_op_pins_every_dim_to_one(self):
+        i0, i1 = _isym("i0"), _isym("i1")
+        ctx = _make_context(
+            self._PLACEHOLDER_OP,
+            self._PLACEHOLDER_TD,
+            it_space_adjusted={i0: 4, i1: 8},
+        )
+        with patch(self._PATCH_TARGET, return_value=(["value"], None, None)):
+            result = indirect_access_pinned_vars(ctx)
+        self.assertEqual(result.pinned, {i0: 1, i1: 1})
+
+    def test_non_indirect_op_yields_no_pins(self):
+        i0, i1 = _isym("i0"), _isym("i1")
+        ctx = _make_context(
+            self._PLACEHOLDER_OP,
+            self._PLACEHOLDER_TD,
+            it_space_adjusted={i0: 4, i1: 8},
+        )
+        with patch(self._PATCH_TARGET, return_value=([], None, None)):
+            result = indirect_access_pinned_vars(ctx)
+        self.assertEqual(result.pinned, {})

--- a/tests/inductor/test_work_division.py
+++ b/tests/inductor/test_work_division.py
@@ -13,23 +13,26 @@
 # limitations under the License.
 
 import unittest
+from contextlib import ExitStack
 from unittest.mock import MagicMock, patch
 
 import sympy
 import torch
 from sympy import Symbol
-
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.ir import ComputedBuffer, FlexibleLayout, Pointwise, Reduction
 
 from torch_spyre._C import ElementArrangement, SpyreTensorLayout
+from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.ir import FixedTiledLayout
 from torch_spyre._inductor.work_division import (
     TensorDep,
     multi_dim_iteration_space_split,
 )
 from torch_spyre._inductor.work_division_constraints import (
+    ConstraintResult,
     WorkDivConstraintContext,
+    collect_work_division_constraints,
     coordinate_mask_blocked_vars,
     indirect_access_pinned_vars,
     qfp8wt_matmul_k_pinned,
@@ -272,6 +275,73 @@ class TestQfp8wtConstraints(unittest.TestCase):
         )
         result = qfp8wt_matmul_k_pinned(ctx)
         self.assertEqual(result.pinned, {})
+
+
+class TestCollectWorkDivisionConstraints(unittest.TestCase):
+    _PATCH_TARGET = "torch_spyre._inductor.work_division_constraints"
+    _PLACEHOLDER_OP = _computed_buffer((128,), name="constraint_placeholder_buf")
+    _PLACEHOLDER_TD = _tensor_dep(
+        "constraint_placeholder_buf", (128,), (_isym("_placeholder"),)
+    )
+
+    def _collect(self, results, **context_kwargs):
+        rules = (
+            "coordinate_mask_blocked_vars",
+            "qfp8wt_pinned_vars",
+            "qfp8wt_matmul_k_pinned",
+            "indirect_access_pinned_vars",
+        )
+        with ExitStack() as stack:
+            for rule, result in zip(rules, results):
+                stack.enter_context(
+                    patch(
+                        f"{self._PATCH_TARGET}.{rule}",
+                        lambda _ctx, result=result: result,
+                    )
+                )
+            return collect_work_division_constraints(
+                _make_context(
+                    self._PLACEHOLDER_OP, self._PLACEHOLDER_TD, **context_kwargs
+                )
+            )
+
+    def test_drops_blocked_var_with_committed_split(self):
+        r0 = _isym("r0")
+        result = self._collect(
+            (
+                ConstraintResult(blocked={r0}),
+                ConstraintResult(),
+                ConstraintResult(),
+                ConstraintResult(),
+            ),
+            committed_splits={r0: 2},
+        )
+        self.assertEqual(result.blocked, set())
+
+    def test_conflicting_pins_raise_unsupported(self):
+        r0 = _isym("r0")
+        with self.assertRaisesRegex(Unsupported, "conflicting pinned split"):
+            self._collect(
+                (
+                    ConstraintResult(pinned={r0: 2}),
+                    ConstraintResult(pinned={r0: 1}),
+                    ConstraintResult(),
+                    ConstraintResult(),
+                )
+            )
+
+    def test_combines_non_conflicting_rules(self):
+        r0, r1, r2, r3 = (_isym(f"r{i}") for i in range(4))
+        result = self._collect(
+            (
+                ConstraintResult(blocked={r0}, pinned={r2: 1}),
+                ConstraintResult(blocked={r1}, pinned={r3: 2}),
+                ConstraintResult(pinned={r2: 1}),
+                ConstraintResult(),
+            )
+        )
+        self.assertEqual(result.blocked, {r0, r1})
+        self.assertEqual(result.pinned, {r2: 1, r3: 2})
 
 
 class TestIndirectAccessPinnedVars(unittest.TestCase):

--- a/tests/inductor/test_work_division.py
+++ b/tests/inductor/test_work_division.py
@@ -33,6 +33,7 @@ from torch_spyre._inductor.work_division_constraints import (
     ConstraintResult,
     WorkDivConstraintContext,
     collect_work_division_constraints,
+    conv_spatial_blocked_vars,
     coordinate_mask_blocked_vars,
     indirect_access_pinned_vars,
     qfp8wt_matmul_k_pinned,
@@ -197,6 +198,46 @@ class TestCoordinateMaskBlockedVars(unittest.TestCase):
         self.assertEqual(result.blocked, set())
 
 
+class TestConvSpatialBlockedVars(unittest.TestCase):
+    _PATCH_TARGET = "torch_spyre._inductor.work_division_constraints.op_read_writes"
+    _PLACEHOLDER_TD = _tensor_dep("conv_placeholder", (128,), (_isym("_conv"),))
+
+    def _context(self, stride):
+        mb, out, i, j = (_isym(name) for name in ("mb", "out", "i", "j"))
+        op = _computed_buffer((2, 3, 8, 16), name="strided_conv")
+        op.data.op_info = {
+            "conv_params": {"stride_i": stride[0], "stride_j": stride[1]}
+        }
+        return (
+            _make_context(
+                op,
+                self._PLACEHOLDER_TD,
+                it_space={mb: 2, out: 3, i: 8, j: 16},
+            ),
+            i,
+            j,
+        )
+
+    def test_blocks_spatial_dims_for_strided_conv(self):
+        ctx, i, j = self._context((2, 1))
+        rw = MagicMock()
+        rw.writes = [MagicMock(ranges=(_isym("mb"), _isym("out"), i, j))]
+        with patch(self._PATCH_TARGET, return_value=rw):
+            self.assertEqual(conv_spatial_blocked_vars(ctx).blocked, {i, j})
+
+    def test_allows_spatial_dims_for_unstrided_conv(self):
+        ctx, _, _ = self._context((1, 1))
+        self.assertEqual(conv_spatial_blocked_vars(ctx).blocked, set())
+
+    def test_span_commit_overrides_spatial_block(self):
+        ctx, i, j = self._context((2, 1))
+        ctx.committed_splits = {i: 2}
+        rw = MagicMock()
+        rw.writes = [MagicMock(ranges=(_isym("mb"), _isym("out"), i, j))]
+        with patch(self._PATCH_TARGET, return_value=rw):
+            self.assertEqual(collect_work_division_constraints(ctx).blocked, {j})
+
+
 class TestQfp8wtConstraints(unittest.TestCase):
     def test_output_second_stick_coord_pinned_for_qfp8wt_output(self):
         b, m, n = _isym("b"), _isym("m"), _isym("n")
@@ -287,6 +328,7 @@ class TestCollectWorkDivisionConstraints(unittest.TestCase):
     def _collect(self, results, **context_kwargs):
         rules = (
             "coordinate_mask_blocked_vars",
+            "conv_spatial_blocked_vars",
             "qfp8wt_pinned_vars",
             "qfp8wt_matmul_k_pinned",
             "indirect_access_pinned_vars",
@@ -313,6 +355,7 @@ class TestCollectWorkDivisionConstraints(unittest.TestCase):
                 ConstraintResult(),
                 ConstraintResult(),
                 ConstraintResult(),
+                ConstraintResult(),
             ),
             committed_splits={r0: 2},
         )
@@ -327,6 +370,7 @@ class TestCollectWorkDivisionConstraints(unittest.TestCase):
                     ConstraintResult(pinned={r0: 1}),
                     ConstraintResult(),
                     ConstraintResult(),
+                    ConstraintResult(),
                 )
             )
 
@@ -335,6 +379,7 @@ class TestCollectWorkDivisionConstraints(unittest.TestCase):
         with self.assertRaisesRegex(Unsupported, "hardware memory-span limit"):
             self._collect(
                 (
+                    ConstraintResult(),
                     ConstraintResult(),
                     ConstraintResult(),
                     ConstraintResult(pinned={k: 1}),
@@ -351,6 +396,7 @@ class TestCollectWorkDivisionConstraints(unittest.TestCase):
                     ConstraintResult(),
                     ConstraintResult(),
                     ConstraintResult(),
+                    ConstraintResult(),
                     ConstraintResult(pinned={i0: 1}),
                 ),
                 committed_splits={i0: 2},
@@ -362,6 +408,7 @@ class TestCollectWorkDivisionConstraints(unittest.TestCase):
             (
                 ConstraintResult(blocked={r0}, pinned={r2: 1}),
                 ConstraintResult(blocked={r1}, pinned={r3: 2}),
+                ConstraintResult(blocked={r1}),
                 ConstraintResult(pinned={r2: 1}),
                 ConstraintResult(),
             )

--- a/tests/inductor/test_work_division.py
+++ b/tests/inductor/test_work_division.py
@@ -29,6 +29,7 @@ from torch_spyre._inductor.work_division import (
     TensorDep,
     _default_split,
     multi_dim_iteration_space_split,
+    span_reduction_pass,
 )
 from torch_spyre._inductor.work_division_constraints import (
     ConstraintResult,
@@ -432,6 +433,37 @@ class TestCollectWorkDivisionConstraints(unittest.TestCase):
         )
         self.assertEqual(result.blocked, {r0, r1})
         self.assertEqual(result.pinned, {r2: 1, r3: 2})
+
+
+class TestSpanReductionConstraints(unittest.TestCase):
+    _PATCH_TARGET = "torch_spyre._inductor.work_division"
+
+    def test_multidim_indirect_reduction_stays_single_core(self):
+        o, r0, r1 = (_isym(name) for name in ("o", "r0", "r1"))
+        op = _computed_buffer((8,), name="indirect_reduction")
+        output_td = _tensor_dep("indirect_reduction", (8,), (o,))
+        with (
+            patch(
+                f"{self._PATCH_TARGET}.iteration_space_from_op",
+                return_value={o: 8, r0: 8, r1: 8},
+            ),
+            patch(
+                f"{self._PATCH_TARGET}.collect_tensor_deps",
+                return_value=([], output_td),
+            ),
+            patch(
+                f"{self._PATCH_TARGET}.adjust_it_space_for_sticks",
+                return_value=({o: 8, r0: 8, r1: 8}, {}),
+            ),
+            patch(f"{self._PATCH_TARGET}.must_split_vars", return_value={}),
+            patch(
+                f"{self._PATCH_TARGET}.collect_work_division_constraints",
+                return_value=ConstraintResult(pinned={r0: 1, r1: 1}),
+            ),
+            patch(f"{self._PATCH_TARGET}.apply_splits") as apply_splits,
+        ):
+            span_reduction_pass(op, [], 32)
+        self.assertEqual(apply_splits.call_args.args[1], {r0: 1, r1: 1})
 
 
 class TestIndirectAccessPinnedVars(unittest.TestCase):

--- a/tests/inductor/test_work_division.py
+++ b/tests/inductor/test_work_division.py
@@ -27,6 +27,7 @@ from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.ir import FixedTiledLayout
 from torch_spyre._inductor.work_division import (
     TensorDep,
+    _default_split,
     multi_dim_iteration_space_split,
 )
 from torch_spyre._inductor.work_division_constraints import (
@@ -236,6 +237,22 @@ class TestConvSpatialBlockedVars(unittest.TestCase):
         rw.writes = [MagicMock(ranges=(_isym("mb"), _isym("out"), i, j))]
         with patch(self._PATCH_TARGET, return_value=rw):
             self.assertEqual(collect_work_division_constraints(ctx).blocked, {j})
+
+    def test_blocked_spatial_dims_are_not_distributed(self):
+        mb, out, i, j = (_isym(name) for name in ("mb", "out", "i", "j"))
+        output_td = _tensor_dep("conv_out", (2, 32, 32, 32), (mb, out, i, j))
+        splits, output_dims, _ = _default_split(
+            {mb: 2, out: 32, i: 32, j: 32},
+            output_td,
+            {},
+            32,
+            {},
+            {i, j},
+        )
+        self.assertNotIn(i, output_dims)
+        self.assertNotIn(j, output_dims)
+        self.assertEqual(splits[i], 1)
+        self.assertEqual(splits[j], 1)
 
 
 class TestQfp8wtConstraints(unittest.TestCase):

--- a/tests/inductor/test_work_division.py
+++ b/tests/inductor/test_work_division.py
@@ -330,6 +330,32 @@ class TestCollectWorkDivisionConstraints(unittest.TestCase):
                 )
             )
 
+    def test_qfp8wt_k_pin_conflicting_with_span_split_raises_unsupported(self):
+        k = _isym("k")
+        with self.assertRaisesRegex(Unsupported, "hardware memory-span limit"):
+            self._collect(
+                (
+                    ConstraintResult(),
+                    ConstraintResult(),
+                    ConstraintResult(pinned={k: 1}),
+                    ConstraintResult(),
+                ),
+                committed_splits={k: 2},
+            )
+
+    def test_indirect_pin_conflicting_with_span_split_raises_unsupported(self):
+        i0 = _isym("i0")
+        with self.assertRaisesRegex(Unsupported, "hardware memory-span limit"):
+            self._collect(
+                (
+                    ConstraintResult(),
+                    ConstraintResult(),
+                    ConstraintResult(),
+                    ConstraintResult(pinned={i0: 1}),
+                ),
+                committed_splits={i0: 2},
+            )
+
     def test_combines_non_conflicting_rules(self):
         r0, r1, r2, r3 = (_isym(f"r{i}") for i in range(4))
         result = self._collect(

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -224,6 +224,20 @@ class TestNamedWorkDivisionHint(InductorTestCase):
                 max_cores=32,
             )
 
+    def test_apply_work_div_hint_rejects_pinned_split(self):
+        m = Symbol("M")
+        op = self._fake_op({m: ["M"]})
+
+        with self.assertRaisesRegex(Exception, "pinned to split=1"):
+            _wd._apply_user_hint(
+                op,
+                {m: 2},
+                {m: 64},
+                self._fake_output_td([m]),
+                max_cores=32,
+                pinned={m: 1},
+            )
+
     @config.patch({"sencores": 8})
     def test_pointwise_work_div_hint_applied(self):
         M, N = 128, 64

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -97,11 +97,8 @@ core_id_k_fast_emission: bool = (
     os.environ.get("SPYRE_CORE_ID_K_FAST_EMISSION", "1") == "1"
 )
 
-# Disable splitting on spatial image dimensions (i, j) for conv2d operations when stride > 1.
-# When enabled (default True), splits are disabled only for strided convolutions to prevent
-# DSM/strided memory access complexity that degrades correctness. For stride=1 convolutions,
-# splitting may still occur unless the backend heuristics choose not to split.
-# Set SPYRE_INDUCTOR_DISABLE_CONV2D_SPATIAL_SPLIT=0 to allow splitting on i/j dims regardless of stride.
+# Strided conv spatial splits produce incorrect per-core DSM addressing.
+# Set SPYRE_INDUCTOR_DISABLE_CONV2D_SPATIAL_SPLIT=0 to permit them.
 disable_conv2d_spatial_split: bool = (
     os.environ.get("SPYRE_INDUCTOR_DISABLE_CONV2D_SPATIAL_SPLIT", "1") == "1"
 )

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -56,7 +56,11 @@ from .pass_utils import (
     op_read_writes,
 )
 from .propagate_hints import get_op_hints
-from collections.abc import Iterable
+from .work_division_constraints import (
+    WorkDivConstraintContext,
+    collect_work_division_constraints,
+    has_qfp8wt_tensor,
+)
 from typing import Callable
 
 from .logging_utils import get_inductor_logger
@@ -193,101 +197,6 @@ def _most_splittable_dim(
     return (best_dim, best_split) if best_split > 1 else None
 
 
-def coordinate_mask_blocked_vars(
-    reduction_vars: Iterable[Symbol],
-    stick_vars: dict[Symbol, int],
-    it_space: dict[Symbol, Expr],
-) -> set[Symbol]:
-    """Return reduction stick vars that cannot be split across cores.
-
-    The backend compiler cannot apply coordinate masking to a dimension spread
-    over cores, and masking is applied to a dim that is padded, reduced, and the
-    stick dim (mirrors ``_get_coordinate_mask`` in codegen/superdsc.py). A stick
-    var is guaranteed non-symbolic, so its element count concretizes; it is
-    padded iff not stick-aligned.
-
-    ``it_space`` must be the element-valued iteration space (not the
-    stick-adjusted copy), since padding is defined on element counts.
-    ``stick_vars`` maps each stick var to its elems_per_stick (as returned by
-    ``adjust_it_space_for_sticks``).
-
-    Both work-division paths consult this: the greedy path drops these from its
-    reduction candidates, and ``enumerate_work_division_candidates`` rejects any
-    split that divides one of them.
-    """
-    return {
-        v
-        for v in reduction_vars
-        if v in stick_vars and concretize_expr(it_space[v]) % stick_vars[v] != 0
-    }
-
-
-# A conv2d's output index is (mb, out, i, j) -- see the ``index`` unpacking in
-# ``lower_convolution``'s ``inner_fn`` -- so the output-spatial (image H/W) dims
-# are the trailing pair of the write dependency's ranges. Indexing from the end
-# tolerates Inductor collapsing leading unit dims (a batch-1 input yields a
-# rank-3 write dep, not rank 4).
-_CONV2D_NUM_SPATIAL_DIMS = 2
-
-
-def conv_spatial_blocked_vars(
-    op: ComputedBuffer,
-    it_space: dict[Symbol, Expr],
-    committed_splits: dict[Symbol, int] | None = None,
-) -> set[Symbol]:
-    """Return the output-spatial iteration vars of a strided conv2d.
-
-    Splitting the output image dims (i, j) of a strided convolution across
-    cores produces incorrect per-core DSM/strided addressing. Blocking them
-    here -- rather than resetting the splits during codegen -- lets the
-    distributor spend those cores on dims that can absorb them (mb, out)
-    instead of dropping them.
-
-    ``committed_splits`` are the splits ``span_reduction_pass`` already
-    committed to satisfy ``MAX_SPAN_BYTES``. Those are mandatory: a spatial dim
-    among them is excluded from the returned set (and warned about) rather than
-    blocked, since un-splitting it would violate the hardware span limit.
-
-    Returns an empty set for non-conv ops, unstrided convs, spatial dims of
-    size 1 (unsplittable anyway), and when
-    ``config.disable_conv2d_spatial_split`` is off.
-    """
-    if not config.disable_conv2d_spatial_split:
-        return set()
-
-    op_info = getattr(op.data, "op_info", None)
-    if not isinstance(op_info, dict):
-        return set()
-    conv_params = op_info.get("conv_params")
-    if not isinstance(conv_params, dict):
-        return set()
-
-    if conv_params.get("stride_i", 1) <= 1 and conv_params.get("stride_j", 1) <= 1:
-        return set()
-
-    # Trailing pair of the output ranges. When the spatial dims themselves
-    # collapse to size 1 the write dep is shorter than that; the size filter
-    # below drops whatever remains.
-    write_ranges = list(next(iter(op_read_writes(op).writes)).ranges)
-    spatial = write_ranges[-_CONV2D_NUM_SPATIAL_DIMS:]
-
-    blocked = {
-        sym for sym in spatial if sym in it_space and concretize_expr(it_space[sym]) > 1
-    }
-
-    # Span reduction outranks the spatial-split preference: honour its commits.
-    forced = {s for s in blocked if (committed_splits or {}).get(s, 1) > 1}
-    if forced:
-        logger.warning(
-            f"{op.get_name()}: SPYRE_INDUCTOR_DISABLE_CONV2D_SPATIAL_SPLIT is set, "
-            f"but the hardware memory-span limit requires splitting spatial "
-            f"dim(s) {sorted(str(s) for s in forced)} "
-            f"({ {str(s): (committed_splits or {})[s] for s in forced} }); "
-            f"the flag is not honoured for those dims."
-        )
-    return blocked - forced
-
-
 def multi_dim_iteration_space_split(
     iteration_space: dict[Symbol, Expr],
     max_cores: int,
@@ -368,49 +277,6 @@ def multi_dim_iteration_space_split(
             splits[best_dim] = best_split
 
     return splits
-
-
-def _has_qfp8wt_tensor(tds: list[TensorDep]) -> bool:
-    """Check if any tensor has QFP8WT element arrangement."""
-    return any(
-        hasattr(td.layout.device_layout, "element_arrangement")
-        and td.layout.device_layout.element_arrangement == ElementArrangement.QFP8WT
-        for td in tds
-    )
-
-
-def _is_qfp8wt_tensor(td: TensorDep) -> bool:
-    """Check if a specific tensor has QFP8WT element arrangement."""
-    return (
-        hasattr(td.layout.device_layout, "element_arrangement")
-        and td.layout.device_layout.element_arrangement == ElementArrangement.QFP8WT
-    )
-
-
-def _get_qfp8wt_split_constraints(
-    input_tds: list[TensorDep],
-    output_td: TensorDep,
-) -> dict[Symbol, int]:
-    """Return split constraints (=1) for QFP8WT second stick dimension."""
-    constraints: dict[Symbol, int] = {}
-    if not _has_qfp8wt_tensor(input_tds + [output_td]):
-        return constraints
-
-    # Kernel tensor (second input for batchmatmul)
-    if len(input_tds) > 1:
-        kernel_td = input_tds[1]
-        if len(kernel_td.device_coords) > 1 and _is_qfp8wt_tensor(kernel_td):
-            second_stick_vars = kernel_td.device_coords[-2].free_symbols
-            for var in second_stick_vars:
-                constraints[var] = 1
-
-    # Output tensor
-    if len(output_td.device_coords) > 1 and _is_qfp8wt_tensor(output_td):
-        second_stick_vars = output_td.device_coords[-2].free_symbols
-        for var in second_stick_vars:
-            constraints[var] = 1
-
-    return constraints
 
 
 def adjust_it_space_for_sticks(
@@ -856,8 +722,20 @@ def enumerate_work_division_candidates(
     # device coordinates (mirrors prioritize_dimensions / splits_by_index_coeff).
     coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
     reduction_vars = [v for v in it_space_adjusted if v not in coord_vars]
-    mask_blocked = coordinate_mask_blocked_vars(reduction_vars, stick_vars, it_space)
-    mask_blocked |= conv_spatial_blocked_vars(op, it_space_adjusted)
+    constraint_result = collect_work_division_constraints(
+        WorkDivConstraintContext(
+            op=op,
+            it_space=it_space,
+            it_space_adjusted=it_space_adjusted,
+            output_td=output_td,
+            input_tds=input_tds,
+            stick_vars=stick_vars,
+            reduction_vars=reduction_vars,
+            committed_splits={},
+        )
+    )
+    blocked = constraint_result.blocked
+    pinned = constraint_result.pinned
 
     # Per-dim candidate factors, mirroring must_split_vars.valid_splits but with
     # no ``>= current_min`` floor (we want the full set, including 1).
@@ -884,7 +762,11 @@ def enumerate_work_division_candidates(
         ):
             return False
         if any(  # a coordinate-masked dim cannot be split across cores
-            splits[v] > 1 for v in mask_blocked
+            splits[v] > 1 for v in blocked
+        ):
+            return False
+        if any(  # a pinned dim's split must equal exactly its pinned value
+            splits[v] != pin for v, pin in pinned.items()
         ):
             return False
         return True
@@ -1037,15 +919,22 @@ def span_reduction_pass(
         all_tds, it_space, it_space_adjusted, stick_vars, max_cores, symbol_meta
     )
 
-    # For matmul ops with QFP8WT kernels, enforce split constraints
-    if isinstance(op.data, Reduction) and op.data.reduction_type in (
-        BATCH_MATMUL_OP,
-        BATCH_MATMUL_FP8_OP,
-    ):
-        qfp8_constraints = _get_qfp8wt_split_constraints(input_tds, output_td)
-        min_splits.update(qfp8_constraints)
-
     coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
+    reduction_vars = [v for v in it_space_adjusted if v not in coord_vars]
+    constraint_result = collect_work_division_constraints(
+        WorkDivConstraintContext(
+            op=op,
+            it_space=it_space,
+            it_space_adjusted=it_space_adjusted,
+            output_td=output_td,
+            input_tds=input_tds,
+            stick_vars=stick_vars,
+            reduction_vars=reduction_vars,
+            committed_splits=min_splits,
+        )
+    )
+    min_splits.update(constraint_result.pinned)
+
     reduction_vars_to_split = set(min_splits) - coord_vars
     # Each entry in Reduction.reduction_ranges maps to at most one Symbol via
     # index_vars_squeeze (size-1 entries are squeezed away). So len > 1 means
@@ -1098,11 +987,6 @@ def _default_split(
     it_space_remaining = {
         s: e for s, e in it_space_adjusted.items() if s not in committed_splits
     }
-    if len(output_td.device_coords) >= 2 and _is_qfp8wt_tensor(output_td):
-        stick_coord_vars = set(output_td.device_coords[-2].free_symbols)
-        it_space_remaining = {
-            s: e for s, e in it_space_remaining.items() if s not in stick_coord_vars
-        }
     output_dims, reduction_dims = prioritize_dimensions(
         output_td, it_space_remaining, symbol_meta
     )
@@ -1113,12 +997,9 @@ def _default_split(
     if any(v not in coord_vars for v in committed_splits):
         reduction_dims = []
 
-    # Drop dims the backend compiler can't split across cores before the greedy
-    # distributor commits them. Output dims are filtered too: coordinate masking
-    # only blocks reduction dims, but conv2d spatial blocking applies to output
-    # dims, and the distributor must not hand cores to either.
+    # Drop reduction dims the backend compiler can't split across cores before
+    # the greedy distributor commits them.
     reduction_dims = [v for v in reduction_dims if v not in blocked]
-    output_dims = [v for v in output_dims if v not in blocked]
 
     # Pass max_cores, not remaining_cores: multi_dim_iteration_space_split
     # accounts for committed_splits in its first pass, consuming those cores
@@ -1170,12 +1051,22 @@ def work_distribution_pass(
     # dims with actual committed splits so they don't overlap with priorities.
     committed_splits = {s: v for s, v in min_splits.items() if v > 1}
 
-    # For matmul ops with QFP8WT kernels, enforce split constraints
-    qfp8_constraints = _get_qfp8wt_split_constraints(input_tds, output_td)
-    for var, split_val in qfp8_constraints.items():
-        if var in committed_splits:
-            del committed_splits[var]
-        min_splits[var] = split_val
+    coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
+    reduction_vars = [v for v in it_space_adjusted if v not in coord_vars]
+    constraint_result = collect_work_division_constraints(
+        WorkDivConstraintContext(
+            op=op,
+            it_space=it_space,
+            it_space_adjusted=it_space_adjusted,
+            output_td=output_td,
+            input_tds=input_tds,
+            stick_vars=stick_vars,
+            reduction_vars=reduction_vars,
+            committed_splits=committed_splits,
+        )
+    )
+    blocked = constraint_result.blocked
+    committed_splits.update(constraint_result.pinned)
 
     if not config.ignore_work_division_hints:
         user_splits = _resolve_work_div_hint(op, it_space_adjusted)
@@ -1211,17 +1102,9 @@ def work_distribution_pass(
             )
             return
 
-    coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
-    reduction_vars = [v for v in it_space_adjusted if v not in coord_vars]
-    blocked = coordinate_mask_blocked_vars(reduction_vars, stick_vars, it_space)
-    blocked |= conv_spatial_blocked_vars(op, it_space_adjusted, committed_splits)
     splits, output_dims, reduction_dims = _default_split(
         it_space_adjusted, output_td, committed_splits, max_cores, symbol_meta, blocked
     )
-
-    # Enforce QFP8WT split constraints on the final split
-    qfp8_constraints = _get_qfp8wt_split_constraints(input_tds, output_td)
-    splits.update(qfp8_constraints)
 
     apply_splits(op, splits, output_td)
 
@@ -1525,7 +1408,7 @@ def _cost_model_matmul_planner(
     k_divs = [int(d) for d in divisors(k_sticks)]
 
     # For batchmatmulfp8 with QFP8WT kernels, do not split K
-    if _has_qfp8wt_tensor(input_tds + [output_td]):
+    if has_qfp8wt_tensor(input_tds + [output_td]):
         k_divs = [1]
 
     best = None
@@ -1562,7 +1445,7 @@ def _cost_model_matmul_planner(
 
     # Never trade down to fewer cores than the default distributor already found.
     if math.prod(new_splits.values()) < math.prod(splits.values()):
-        if not _has_qfp8wt_tensor(input_tds + [output_td]):
+        if not has_qfp8wt_tensor(input_tds + [output_td]):
             return splits
         # For QFP8WT, force k_dim = 1 regardless of core count
         new_splits[k_dim] = 1
@@ -1753,7 +1636,20 @@ def _cost_model_divide_op(op: ComputedBuffer, max_cores: int) -> bool:
 
     coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
     reduction_vars = [v for v in it_space_adjusted if v not in coord_vars]
-    blocked = coordinate_mask_blocked_vars(reduction_vars, stick_vars, it_space)
+    constraint_result = collect_work_division_constraints(
+        WorkDivConstraintContext(
+            op=op,
+            it_space=it_space,
+            it_space_adjusted=it_space_adjusted,
+            output_td=output_td,
+            input_tds=input_tds,
+            stick_vars=stick_vars,
+            reduction_vars=reduction_vars,
+            committed_splits=committed_splits,
+        )
+    )
+    blocked = constraint_result.blocked
+    committed_splits.update(constraint_result.pinned)
     default_splits, _, _ = _default_split(
         it_space_adjusted, output_td, committed_splits, max_cores, symbol_meta, blocked
     )

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -818,9 +818,13 @@ def _apply_user_hint(
     it_space_adjusted: dict[Symbol, Expr],
     output_td: TensorDep,
     max_cores: int,
+    blocked: set[Symbol] | None = None,
+    pinned: dict[Symbol, int] | None = None,
 ) -> dict[Symbol, int]:
     """Apply splits in insertion order, pruning lower-priority overflows."""
     op_name = op.get_name()
+    blocked = blocked or set()
+    pinned = pinned or {}
 
     splits: dict[Symbol, int] = {}
     cores_used = 1
@@ -842,6 +846,15 @@ def _apply_user_hint(
             raise Unsupported(
                 f"work_division_hint: {op_name} dim {sym} is not in the "
                 f"work-division iteration space."
+            )
+        if split > 1 and sym in blocked:
+            raise Unsupported(
+                f"work_division_hint: {op_name} cannot split constrained dim {sym}."
+            )
+        if sym in pinned and split != pinned[sym]:
+            raise Unsupported(
+                f"work_division_hint: {op_name} dim {sym} is pinned to split="
+                f"{pinned[sym]}."
             )
 
         next_cores = cores_used * split
@@ -876,6 +889,15 @@ def _apply_user_hint(
             f"work_division_hint: {op_name} splits "
             f"{len(reduction_vars_to_split)} reduction dimensions "
             f"({reduction_vars_to_split}), but the backend supports at most 1."
+        )
+
+    conflicting_pins = {
+        sym: split for sym, split in pinned.items() if splits.get(sym, 1) != split
+    }
+    if conflicting_pins:
+        raise Unsupported(
+            f"work_division_hint: {op_name} conflicts with pinned splits "
+            f"{conflicting_pins}."
         )
 
     return splits
@@ -935,7 +957,9 @@ def span_reduction_pass(
     )
     min_splits.update(constraint_result.pinned)
 
-    reduction_vars_to_split = set(min_splits) - coord_vars
+    reduction_vars_to_split = {
+        v for v, split in min_splits.items() if split > 1 and v not in coord_vars
+    }
     # Each entry in Reduction.reduction_ranges maps to at most one Symbol via
     # index_vars_squeeze (size-1 entries are squeezed away). So len > 1 means
     # genuinely distinct reduction dimensions, not multiple symbols from one dim.
@@ -1073,7 +1097,13 @@ def work_distribution_pass(
         user_splits = _resolve_work_div_hint(op, it_space_adjusted)
         if user_splits is not None:
             user_splits = _apply_user_hint(
-                op, user_splits, it_space_adjusted, output_td, max_cores
+                op,
+                user_splits,
+                it_space_adjusted,
+                output_td,
+                max_cores,
+                blocked,
+                constraint_result.pinned,
             )
             dropped = {
                 s: v for s, v in committed_splits.items() if user_splits.get(s, 1) < v

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -997,8 +997,9 @@ def _default_split(
     if any(v not in coord_vars for v in committed_splits):
         reduction_dims = []
 
-    # Drop reduction dims the backend compiler can't split across cores before
-    # the greedy distributor commits them.
+    # Drop blocked dims before the greedy distributor commits them. Coordinate
+    # masking only blocks reduction dims; strided conv also blocks output dims.
+    output_dims = [v for v in output_dims if v not in blocked]
     reduction_dims = [v for v in reduction_dims if v not in blocked]
 
     # Pass max_cores, not remaining_cores: multi_dim_iteration_space_split

--- a/torch_spyre/_inductor/work_division_constraints.py
+++ b/torch_spyre/_inductor/work_division_constraints.py
@@ -35,8 +35,9 @@ from torch_spyre._C import ElementArrangement
 
 from .constants import BATCH_MATMUL_OP, BATCH_MATMUL_FP8_OP
 from .errors import Unsupported
-from .pass_utils import concretize_expr, indirect_info_from_op
+from .pass_utils import concretize_expr, indirect_info_from_op, op_read_writes
 from .logging_utils import get_inductor_logger
+from . import config
 
 if typing.TYPE_CHECKING:
     # Deferred to avoid a circular import: work_division.py imports from this
@@ -92,6 +93,7 @@ def collect_work_division_constraints(
     pinned: dict[Symbol, int] = {}
     for constraint in (
         coordinate_mask_blocked_vars,
+        conv_spatial_blocked_vars,
         qfp8wt_pinned_vars,
         qfp8wt_matmul_k_pinned,
         indirect_access_pinned_vars,
@@ -141,6 +143,33 @@ def coordinate_mask_blocked_vars(ctx: WorkDivConstraintContext) -> ConstraintRes
         for v in ctx.reduction_vars
         if v in ctx.stick_vars
         and concretize_expr(ctx.it_space[v]) % ctx.stick_vars[v] != 0
+    }
+    return ConstraintResult(blocked=blocked)
+
+
+def conv_spatial_blocked_vars(ctx: WorkDivConstraintContext) -> ConstraintResult:
+    """Block output image dims for strided convolutions.
+
+    Splitting spatial dims produces incorrect per-core DSM addressing. Span-limit
+    commitments win, handled uniformly by ``collect_work_division_constraints``.
+    """
+    if not config.disable_conv2d_spatial_split:
+        return ConstraintResult()
+
+    op_info = getattr(ctx.op.data, "op_info", None)
+    if not isinstance(op_info, dict):
+        return ConstraintResult()
+    conv_params = op_info.get("conv_params")
+    if not isinstance(conv_params, dict):
+        return ConstraintResult()
+    if conv_params.get("stride_i", 1) <= 1 and conv_params.get("stride_j", 1) <= 1:
+        return ConstraintResult()
+
+    write_ranges = list(next(iter(op_read_writes(ctx.op).writes)).ranges)
+    blocked = {
+        sym
+        for sym in write_ranges[-2:]
+        if sym in ctx.it_space and concretize_expr(ctx.it_space[sym]) > 1
     }
     return ConstraintResult(blocked=blocked)
 

--- a/torch_spyre/_inductor/work_division_constraints.py
+++ b/torch_spyre/_inductor/work_division_constraints.py
@@ -1,0 +1,206 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Op-specific work-division constraints, collected in one place.
+
+work_division.py's core algorithm (span reduction, priority-based
+distribution, the matmul cost model) is generic over the iteration space. A
+few ops/layouts additionally forbid splitting specific dims, or force a dim's
+split to an exact value, for reasons the generic algorithm has no way to know
+about — e.g. the backend cannot coordinate-mask a dim spread over cores, or a
+QFP8WT tensor's second stick dimension must stay whole.
+``collect_work_division_constraints`` calls each rule and merges the results,
+so work_division.py's call sites only need one call instead of hand-invoking
+every rule.
+
+See GitHub issue #3631.
+"""
+
+import dataclasses
+import typing
+from sympy import Expr, Symbol
+
+from torch._inductor.ir import ComputedBuffer, Reduction
+from torch_spyre._C import ElementArrangement
+
+from .constants import BATCH_MATMUL_OP, BATCH_MATMUL_FP8_OP
+from .errors import Unsupported
+from .pass_utils import concretize_expr, indirect_info_from_op
+from .logging_utils import get_inductor_logger
+
+if typing.TYPE_CHECKING:
+    # Deferred to avoid a circular import: work_division.py imports from this
+    # module, so TensorDep can only be used here as a string annotation.
+    from .work_division import TensorDep
+
+logger = get_inductor_logger("work_division_constraints")
+
+
+@dataclasses.dataclass
+class WorkDivConstraintContext:
+    """Everything a constraint needs to decide which dims it restricts."""
+
+    op: ComputedBuffer
+    it_space: dict[Symbol, Expr]
+    it_space_adjusted: dict[Symbol, Expr]
+    output_td: "TensorDep"
+    input_tds: "list[TensorDep]"
+    stick_vars: dict[Symbol, int]
+    reduction_vars: list[Symbol]
+    committed_splits: dict[Symbol, int]
+
+
+@dataclasses.dataclass
+class ConstraintResult:
+    """A constraint's verdict on the iteration space in a WorkDivConstraintContext.
+
+    ``blocked`` dims must not be split beyond whatever split they already
+    carry (composes by union across constraints). ``pinned`` dims must equal
+    exactly the given split (composes by equality; two constraints pinning the
+    same dim to different values is a modeling conflict, not something to
+    silently resolve — see collect_work_division_constraints).
+    """
+
+    blocked: set[Symbol] = dataclasses.field(default_factory=set)
+    pinned: dict[Symbol, int] = dataclasses.field(default_factory=dict)
+
+
+def collect_work_division_constraints(
+    ctx: WorkDivConstraintContext,
+) -> ConstraintResult:
+    """Run every constraint below against ``ctx`` and merge the results.
+
+    A blocked dim that ``ctx.committed_splits`` has already split beyond 1 is
+    dropped from the result (with a warning): a mandatory prior commitment —
+    e.g. span_reduction satisfying the hardware span limit — outranks a
+    constraint's preference not to split that dim further.
+
+    Raises Unsupported if two constraints pin the same dim to different
+    values; that is a genuine conflict between the two rules' preconditions,
+    not something to silently arbitrate.
+    """
+    blocked: set[Symbol] = set()
+    pinned: dict[Symbol, int] = {}
+    for constraint in (
+        coordinate_mask_blocked_vars,
+        qfp8wt_pinned_vars,
+        qfp8wt_matmul_k_pinned,
+        indirect_access_pinned_vars,
+    ):
+        result = constraint(ctx)
+
+        forced = {s for s in result.blocked if ctx.committed_splits.get(s, 1) > 1}
+        if forced:
+            logger.warning(
+                f"{ctx.op.get_name()}: constraint {constraint.__name__} would "
+                f"block dim(s) {sorted(str(s) for s in forced)} from being "
+                f"split, but the hardware memory-span limit already committed "
+                f"split(s) {[(str(s), ctx.committed_splits[s]) for s in forced]}; "
+                f"the constraint is not honoured for those dims."
+            )
+        blocked |= result.blocked - forced
+
+        for sym, split in result.pinned.items():
+            if sym in pinned and pinned[sym] != split:
+                raise Unsupported(
+                    f"{ctx.op.get_name()}: conflicting pinned split for {sym}: "
+                    f"{pinned[sym]} (from an earlier constraint) vs {split} "
+                    f"(from {constraint.__name__})."
+                )
+            pinned[sym] = split
+
+    return ConstraintResult(blocked=blocked, pinned=pinned)
+
+
+def coordinate_mask_blocked_vars(ctx: WorkDivConstraintContext) -> ConstraintResult:
+    """Block reduction stick vars that cannot be split across cores.
+
+    The backend cannot coordinate-mask a dim spread over cores (mirrors
+    ``_get_coordinate_mask`` in codegen/superdsc.py). ``ctx.it_space`` must be
+    the element-valued iteration space, since padding is defined on element
+    counts.
+    """
+    blocked = {
+        v
+        for v in ctx.reduction_vars
+        if v in ctx.stick_vars
+        and concretize_expr(ctx.it_space[v]) % ctx.stick_vars[v] != 0
+    }
+    return ConstraintResult(blocked=blocked)
+
+
+def has_qfp8wt_tensor(tds: "list[TensorDep]") -> bool:
+    return any(
+        hasattr(td.layout.device_layout, "element_arrangement")
+        and td.layout.device_layout.element_arrangement == ElementArrangement.QFP8WT
+        for td in tds
+    )
+
+
+def qfp8wt_pinned_vars(ctx: WorkDivConstraintContext) -> ConstraintResult:
+    """Pin QFP8WT tensors' second stick dimension to split=1.
+
+    QFP8WT uses a 2D stick layout (2x64 elements, 128 bytes); both stick dims
+    must stay atomic 128-byte units, so any iteration var indexing the second
+    stick coordinate of the matmul kernel tensor (second input) or the output
+    is pinned to exactly 1.
+    """
+    all_tds = ctx.input_tds + [ctx.output_td]
+    if not has_qfp8wt_tensor(all_tds):
+        return ConstraintResult()
+
+    pinned: dict[Symbol, int] = {}
+
+    if len(ctx.input_tds) > 1:
+        kernel_td = ctx.input_tds[1]
+        if len(kernel_td.device_coords) > 1 and has_qfp8wt_tensor([kernel_td]):
+            for var in kernel_td.device_coords[-2].free_symbols:
+                pinned[var] = 1
+
+    if len(ctx.output_td.device_coords) > 1 and has_qfp8wt_tensor([ctx.output_td]):
+        for var in ctx.output_td.device_coords[-2].free_symbols:
+            pinned[var] = 1
+
+    return ConstraintResult(pinned=pinned)
+
+
+def qfp8wt_matmul_k_pinned(ctx: WorkDivConstraintContext) -> ConstraintResult:
+    """Pin the reduction (K) dim to split=1 for batchmatmulfp8 with a QFP8WT kernel.
+
+    Splitting K would require partial-sum accumulation across cores, which the
+    QFP8WT matmul kernel does not support.
+    """
+    if not isinstance(ctx.op.data, Reduction):
+        return ConstraintResult()
+    if ctx.op.data.reduction_type not in (BATCH_MATMUL_OP, BATCH_MATMUL_FP8_OP):
+        return ConstraintResult()
+
+    all_tds = ctx.input_tds + [ctx.output_td]
+    if not has_qfp8wt_tensor(all_tds):
+        return ConstraintResult()
+
+    return ConstraintResult(pinned={v: 1 for v in ctx.reduction_vars})
+
+
+def indirect_access_pinned_vars(ctx: WorkDivConstraintContext) -> ConstraintResult:
+    """Pin every dim to split=1 for ops with indirect (gather/scatter-style) access.
+
+    The backend's indirect-addressing path runs single-core: an indexed
+    dimension's coordinate depends on runtime data, not a static per-core
+    offset, so the generic per-core span/coordinate arithmetic does not apply.
+    """
+    dep_names, _, _ = indirect_info_from_op(ctx.op)
+    if not dep_names:
+        return ConstraintResult()
+    return ConstraintResult(pinned={v: 1 for v in ctx.it_space_adjusted})

--- a/torch_spyre/_inductor/work_division_constraints.py
+++ b/torch_spyre/_inductor/work_division_constraints.py
@@ -24,7 +24,6 @@ QFP8WT tensor's second stick dimension must stay whole.
 so work_division.py's call sites only need one call instead of hand-invoking
 every rule.
 
-See GitHub issue #3631.
 """
 
 import dataclasses
@@ -86,9 +85,8 @@ def collect_work_division_constraints(
     e.g. span_reduction satisfying the hardware span limit — outranks a
     constraint's preference not to split that dim further.
 
-    Raises Unsupported if two constraints pin the same dim to different
-    values; that is a genuine conflict between the two rules' preconditions,
-    not something to silently arbitrate.
+    Raises Unsupported if a pin conflicts with a prior span-limit commitment,
+    or if two constraints pin the same dim to different values.
     """
     blocked: set[Symbol] = set()
     pinned: dict[Symbol, int] = {}
@@ -112,6 +110,13 @@ def collect_work_division_constraints(
         blocked |= result.blocked - forced
 
         for sym, split in result.pinned.items():
+            committed_split = ctx.committed_splits.get(sym)
+            if committed_split is not None and committed_split != split:
+                raise Unsupported(
+                    f"{ctx.op.get_name()}: pinned split for {sym} is {split} "
+                    f"({constraint.__name__}), but hardware memory-span limit "
+                    f"committed {committed_split}."
+                )
             if sym in pinned and pinned[sym] != split:
                 raise Unsupported(
                     f"{ctx.op.get_name()}: conflicting pinned split for {sym}: "


### PR DESCRIPTION


Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

`work_division.py`'s core algorithm (span reduction, priority-based
distribution, the matmul cost model) is generic over the iteration space.
A few ops/layouts additionally forbid splitting specific dims, or force a
dim's split to an exact value, for reasons the generic algorithm has no way
to know about — e.g. the backend cannot coordinate-mask a dim spread over
cores, or a QFP8WT tensor's second stick dimension must stay whole.
Previously each such rule was hand-threaded through every call site that
needed it.

This PR adds `work_division_constraints.py`, which collects these rules
behind one calling convention (`WorkDivConstraintContext` in,
`ConstraintResult` out) and one entry point
(`collect_work_division_constraints`), so `work_division.py`'s call sites
make a single call instead of hand-invoking each rule.

- **`coordinate_mask_blocked_vars`** — blocks a reduction dim from being
  split when it's stick-aligned-but-padded, since the backend can't
  coordinate-mask a dim spread over cores.
- **`conv_spatial_blocked_vars`** — Block output image dims for strided convolutions.
- **`qfp8wt_pinned_vars`** — pins the second stick dimension of QFP8WT
  tensors (matmul kernel input, and output) to split=1, since QFP8WT's 2D
  stick layout requires both stick dims to stay atomic 128-byte units.
- **`qfp8wt_matmul_k_pinned`** — pins the reduction (K) dim to split=1 for
  `batchmatmulfp8` with a QFP8WT kernel, since that kernel doesn't support
  partial-sum accumulation across cores.
- **`indirect_access_pinned_vars`** — pins every dim to split=1 for ops with
  indirect (gather/scatter-style) access, since the backend's
  indirect-addressing path runs single-core.

`collect_work_division_constraints` merges each rule's `blocked`/`pinned`
verdict: `blocked` dims union across rules but are excluded (with a warning)
if a higher-priority commitment — e.g. a hardware span-limit split from
`span_reduction_pass` — has already split that dim; `pinned` values must
agree across rules, and a genuine conflict between two rules raises
`Unsupported` rather than being silently resolved.

Out of scope for this PR:

- ~~**conv2d spatial-split blocking** — depends on PR #3510, which hasn't
  landed yet.~~
- **The matmul cost model** — it replaces the split decision outright
  rather than constraining it, so it doesn't fit this callback's
  `blocked`/`pinned` shape.


##### Follow-up items (not in this PR)

1. **Indirect-access value-tensor span check.** `indirect_access_pinned_vars`
   correctly pins every dim to split=1 for indirect ops, but the value
   tensor's span is still never checked against the hardware span limit:
   `get_mem_deps_from_rw` excludes indirect reads, so `TensorDep.__post_init__`
   always passes `indirect_sizes=None` for it. Closing this gap means
   threading real `indirect_sizes` through `TensorDep` construction and the
   `it_space` computation for indirect ops — a behavior-adding change (it can
   newly raise `Unsupported` on previously-silently-passing cases), not a
   pure refactor, so it needs its own scoped PR.
2. **`codegen/superdsc.py:998-1005` comment.** This code forces indirect-op
   splits back to 1 as a safety net; now that `work_division.py` is the
   source of truth (via `indirect_access_pinned_vars`), it's effectively
   dead-code-as-defense-in-depth. Worth a comment noting that, or removing
   it once confidence is high enough — optional, low priority.
3. ~~**conv2d spatial-split blocking.** Once PR #3510 lands, migrate its
   constraint into `work_division_constraints.py` alongside the other rules.~~ included in this PR
4. **Matmul cost model.** Revisit unifying it with this callback shape only
   if a second "replace the answer" rule shows up — forcing it in now would
   be a premature abstraction.



#### Which issue(s) this PR is related to:

Fixes #3631 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
