### PR TITLE
Makes HBM pool allocation bundle-scoped instead of graph-global

### DIFF
--- a/docs/source/compiler/hbm_pool_planning.md
+++ b/docs/source/compiler/hbm_pool_planning.md
@@ -1,153 +1,182 @@
-# HBM intermediates-pool planning
+# HBM Pool Planning
 
-How torch-spyre packs intermediate tensors into a shared region of device
-memory, and how that pass relates to LX scratchpad planning.
+HBM pool planning is the compiler stage that allocates intermediate tensors
+into a pool of bulk HBM memory, allowing non-overlapping tensors to reuse the
+same storage region and reducing peak HBM pressure. This page describes what
+the pool is, how it is scoped, how it interacts with LX scratchpad planning,
+and the cross-bundle exclusion rule that prevents intermediates from being
+pool-allocated across kernel invocation boundaries.
 
-:::{admonition} Status
-:class: note
+## What the HBM pool is
 
-HBM pool planning runs by default. The pass is gated by
-`config.hbm_pool_planning`, which defaults to `True` and reads from the
-`HBM_POOL_PLANNING` environment variable. It is implemented in
-`torch_spyre/_inductor/hbm_pool_planning.py` and runs in
-`CustomPostFusionPasses`.
+The HBM pool (also called the *intermediates segment*) is a contiguous region
+of bulk HBM memory (not on-core SRAM) that houses intermediate tensors whose
+data does not need to persist beyond the kernel invocation in which they are
+produced. This is distinct from the LX scratchpad, which is a small, on-core
+SRAM dedicated to holding reused operands within a single Spyre core.
+
+:::{admonition} Terminology clarification
+:class: warning
+
+- **LX scratchpad:** 2 MB of on-core SRAM per core; managed by
+  [scratchpad planning](scratchpad_planning.md); tiny but fast; core-local.
+- **HBM pool:** bulk off-chip HBM memory; managed by this pass; plentiful but
+  slower; globally accessible. The pool exists to allow safe temporary
+  storage for intermediate computation results that will be consumed by the
+  next operation and then discarded.
+
+The two passes are independent tiers of the memory hierarchy. A single buffer
+is placed in *either* LX *or* the HBM pool, never both.
+
 :::
 
-**Quick navigation:**
+## Per-bundle scoping
 
-- [What the pass does](#what-the-pass-does)
-- [Relationship to LX scratchpad planning](#relationship-to-lx-scratchpad-planning)
-- [Pipeline position](#pipeline-position)
-- [Pool candidates](#pool-candidates)
-- [Allocation](#allocation)
-- [Codegen integration](#codegen-integration)
-- [Related documents](#related-documents)
+HBM pool planning runs in `CustomPostFusionPasses`, after `spyre_fuse_nodes`
+has already determined the final set of SDSC bundles (kernel invocations).
+Each bundle is a separate `SpyreKernel` that compiles to a single `.run()`
+call in the generated wrapper code.
 
-## What the pass does
+The fundamental constraint is:
 
-An inference graph produces many intermediate tensors that are written by
-one operation and read by a later one. If every intermediate received its
-own device-memory allocation, peak memory would scale with the number of
-intermediates in the graph rather than with the number that are live at
-the same time.
+> A buffer's pool allocation is scoped to a single bundle. The pool tensor
+> is allocated immediately before that bundle's `.run()` call and freed
+> immediately after. Separate bundles do not share a pool.
 
-HBM pool planning assigns intermediates to offsets inside a single shared
-region of device memory, the *intermediates segment*
-(`constants.INTERMEDIATES_SEGMENT`, size `constants.SEGMENT_SIZE` = 16 GB).
-Two intermediates whose live ranges do not overlap reuse the same offset,
-so the segment only has to be as large as the peak concurrent footprint,
-not the sum of all intermediates. The pass raises a `RuntimeError` if that
-peak exceeds the segment size.
+This means:
 
-Only device memory is planned here. The 2 MB per-core LX scratchpad is
-planned by a separate pass; see below.
+- A buffer written and read entirely within one bundle (its producer and all
+  its consumers in the same bundle) is eligible for pool allocation within
+  that bundle's dedicated pool.
+- A buffer written in bundle A and read by bundle B (a *cross-bundle buffer*)
+  cannot be pool-allocated, because the two bundles execute as separate,
+  sequential kernel invocations and no pool-scoped storage can persist
+  between them. Such buffers fall back to standalone HBM allocation, the same
+  as any other non-pool-eligible intermediate today.
 
-## Relationship to LX scratchpad planning
+This design enables bundle-local pool lifetimes, which reduces peak HBM
+pressure: instead of allocating pools for all bundles up front and keeping
+them resident for the entire graph execution, each bundle's pool is freed as
+soon as that bundle's computation is complete.
 
-Both passes decide where an intermediate tensor's data lives, but they
-operate on different memory and at different points in the pipeline. A
-buffer is a pool candidate only if LX planning did *not* already claim it
-(`"lx" not in layout.allocation`), so the two passes are mutually
-exclusive per buffer and are applied in that order.
+## Comparison with LX scratchpad planning
 
-| | LX scratchpad planning | HBM intermediates-pool planning |
-|---|---|---|
-| Memory | 2 MB on-core SRAM scratchpad, per core | Regular device memory (LPDDR5), the 16 GB intermediates segment |
-| Pipeline stage | `CustomPreSchedulingPasses`, before the `Scheduler` is constructed | `CustomPostFusionPasses`, after Inductor's fusion pass has run |
-| Gating | `config.lx_planning` (`LX_PLANNING`) | `config.hbm_pool_planning` (`HBM_POOL_PLANNING`) |
-| Goal | Keep reused tensors on fast core-local memory to cut device-memory traffic | Share one device-memory region across non-overlapping intermediates to bound peak footprint |
-| Allocation | Fixed per-core SRAM address | Bump/free-list offset in the intermediates segment |
-| Entry point | `scratchpad_planning()` in `scratchpad/allocator.py` | `hbm_pool_planning()` in `hbm_pool_planning.py` |
+Both HBM pool planning and LX scratchpad planning are allocation passes that
+decide where intermediate tensors live in the memory hierarchy. Here are the
+key differences:
 
-The two passes are complementary. LX planning claims the buffers that fit
-on the scratchpad and benefit from staying there; HBM pool planning then
-packs every remaining intermediate into the shared segment.
+| Aspect | HBM Pool Planning | LX Scratchpad Planning |
+|--------|-------------------|----------------------|
+| **Memory tier** | Bulk HBM | 2 MB on-core SRAM (fast) |
+| **Pipeline stage** | `CustomPostFusionPasses` (after fusion, after bundles exist) | `CustomPreSchedulingPasses` (before scheduler, before bundles exist) |
+| **Allocation strategy** | Bump-allocator with free-list reuse; same offset reused by non-overlapping buffers | Core-local address assignment; each buffer gets a fixed on-core address |
+| **Scope of sharing** | Per-bundle (a pool is local to one kernel invocation) | Per-core (an LX address persists across multiple ops executed on the same core) |
+| **Exclusion rules** | Buffers with cross-bundle live ranges are excluded | Buffers read by CPU-fallback nodes are excluded |
+| **Gating** | Enabled by `config.hbm_pool_planning` (default: on) | Enabled by `LX_PLANNING=1` (default: on) |
+
+LX planning runs first (at `CustomPreSchedulingPasses`), so it sees a flat
+operations list before bundle boundaries are known. Pool planning runs later
+(at `CustomPostFusionPasses`) and sees the final, fused, bundle-organized
+list. A buffer claimed by LX planning is excluded from pool allocation; the
+two passes are mutually exclusive per buffer, applied in that order.
 
 ## Pipeline position
 
-`hbm_pool_planning` runs inside `CustomPostFusionPasses`, which executes
-over the graph of LoopLevelIR nodes immediately after Inductor's fusion
-pass. The pass order is:
+HBM pool planning runs in `CustomPostFusionPasses`, after both work-division
+and fusion have already run:
 
 ```
-demote_incoherent_lx_buffers    # re-check LX core->slice coherence with final loop orders
-hbm_pool_planning               # ← THIS PASS, gated by config.hbm_pool_planning
-spyre_fuse_nodes
+CustomPreSchedulingPasses:
+  work_division
+  scratchpad_planning                  # LX allocation (phase 1)
+
+... Inductor scheduler construction ...
+
+CustomPostFusionPasses:
+  demote_incoherent_lx_buffers         # LX fixups (phase 2)
+  spyre_fuse_nodes                     # Determine bundle boundaries
+  hbm_pool_planning                    # Per-bundle HBM pool allocation (this pass)
 ```
 
-`demote_incoherent_lx_buffers` runs first for a reason: it re-checks LX
-core-to-slice coherence now that loop orders are final, and any buffer it
-demotes off LX must still be visible to `hbm_pool_planning` as an
-unclaimed intermediate.
+By the time this pass runs, `nodes` is the final, post-fusion top-level list.
+Each entry in `nodes` is exactly one bundle:
 
-## Pool candidates
+- A `FusedSchedulerNode` wrapping multiple fused operations.
+- A `CountedLoopSchedulerNode` (which is a `FusedSchedulerNode` subclass)
+  wrapping a loop and its body operations.
+- A standalone `SchedulerNode` or other node type that fusion left untouched
+  because it had no fusible neighbors.
 
-The pass collects candidates from two sources:
+## Algorithm: per-bundle live-range analysis and allocation
 
-- **Kernel intermediates.** Buffers both written and read within the
-  graph, detected from the written and read dependency sets on
-  `ComputedBuffer` nodes.
-- **`SpyreEmptyFallback` full buffers** created by coarse tiling for
-  non-outputs. These are `ExternKernel` nodes that emit no dependency-
-  tracked write, so they are collected explicitly by the underlying
-  buffer name.
+For each top-level entry (bundle) in the post-fusion node list:
 
-A candidate must carry a `FixedTiledLayout`, must not have been claimed by
-LX planning, and must not alias a graph input or output. Graph inputs and
-outputs are excluded because they are addressed by the caller, not by the
-pool. Buffers read by fallback, extern, or nop kernels are also excluded,
-because those consumers require Python-side tensors rather than a pooled
-offset.
+1. Flatten the bundle's tree to a list of leaf operations (to handle
+   nested `FusedSchedulerNode` and `CountedLoopSchedulerNode` hierarchies).
+2. Identify candidates: buffers that are:
+   - Written and read (not only written or only read).
+   - Not graph inputs or outputs.
+   - Not already claimed by LX planning.
+   - Not read by CPU-fallback nodes.
+   - Fully contained within the bundle (same bundle writes and reads them).
+3. For each bundle's local candidate set, compute live ranges: a buffer's
+   live range is the interval from its producer op to its last consumer op
+   within that bundle.
+4. Sort by producer order (start step), then by end step and name for
+   determinism.
+5. Allocate sequentially with a bump-allocator and free-list reuse:
+   - Process buffers in order.
+   - Before allocating a new buffer, free any previously-allocated blocks
+     whose live range ended before this buffer's start step.
+   - Assign each buffer an offset within the bundle's dedicated pool.
+6. Record the pool's final extent (total bytes needed) in
+   `V.graph.hbm_pool_sizes[bundle_name]`.
 
-Because mutation buffers share the same `layout.allocation` dictionary
-object as their target, input/output exclusion is checked by the identity
-of the allocation object (`id(layout.allocation)`), not by name.
+Only bundles with at least one pool-eligible buffer get an entry in
+`V.graph.hbm_pool_sizes`; bundles with no pool candidates get no pool tensor
+and no allocation overhead.
 
-## Allocation
+## Integration with code generation
 
-Each candidate's live range is `(start_step, end_step)`, where the start
-is the timestep of the node that writes the buffer and the end is the last
-timestep at which any node reads it. Candidates are sorted by start step,
-tie-broken by `(end_step, name)` for determinism, and processed in that
-order.
+During code generation, the scheduler looks up each bundle's pool size from
+`V.graph.hbm_pool_sizes` and passes it to `SpyreKernel`'s constructor. The
+kernel then emits pool allocation and deallocation code around its own
+`.run()` call:
 
-The `Allocator` tracks free blocks within the segment as `(offset, size)`
-pairs in bytes. For each buffer it first frees any block whose live range
-has ended, then allocates:
+```python
+_pool_{bundle_name} = spyre_empty_with_layout((pool_size_bytes,), (1,), torch.uint8, ...)
+sdsc_fused__{bundle_name}.run(_pool_{bundle_name}, ...)
+del _pool_{bundle_name}
+```
 
-1. Reuse the first free block large enough, returning any leftover
-   fragment to the free list.
-2. Otherwise extend the pool by appending at the current pool end.
+This per-bundle scoping ensures that the pool tensor's lifetime is limited to
+the bundle's own kernel invocation, minimizing peak HBM usage across the
+entire graph execution.
 
-Sizes are the buffer's stick-aligned device footprint: the product of the
-device-side dimensions above the stick dimension, times 128 bytes per
-stick, rounded up to a 128-byte (one-stick) boundary. The allocator tracks
-peak concurrent usage and raises if it exceeds `SEGMENT_SIZE`.
+## Configuration and limitations
 
-The chosen offset is written to `layout.allocation["hbm_pool"]`. With
-`config.bundle_symbolic_args` the raw offset is stored (the segment base is
-added later during bundling); otherwise the absolute
-`INTERMEDIATES_SEGMENT + offset` is stored. The final pool extent is
-recorded on `V.graph.hbm_pool_size`.
+HBM pool planning is controlled by `config.hbm_pool_planning`, which defaults
+to on. Set `HBM_POOL_PLANNING=0` to disable it globally; in that mode all
+intermediates fall back to standalone HBM.
 
-A `SpyreEmptyFallback` buffer that is pool-allocated is added to
-`V.graph.removed_buffers`. Its `should_allocate()` returns `False` once
-pooled, so the wrapper never emits an allocate line for it; adding the name
-to `removed_buffers` also keeps base Inductor's free machinery from
-emitting a `del` for a buffer it never allocated.
+**Interaction with symbolic arguments:**
 
-## Codegen integration
+In `bundle_symbolic_args=False` mode (not the default -- the default is
+`True`), `spyre_fuse_nodes` is
+disabled and every scheduler node becomes its own single-op bundle. In this
+degenerate case, any buffer read by a later node is cross-bundle by
+construction and falls back to standalone HBM. Pool allocation is effectively
+disabled, which is correct: the benefit of pooling (sharing HBM across
+non-overlapping bundle-local temporaries) does not apply when there are no
+multi-op bundles to localize to. No special handling is needed in the
+planner; the cross-bundle exclusion logic automatically handles this edge
+case.
 
-A pooled buffer is not allocated as an independent tensor. Its
-`layout.allocation["hbm_pool"]` offset places it within the shared segment,
-and the generated wrapper addresses it against that segment rather than
-emitting a standalone allocation and free.
+## See Also
 
-## Related documents
-
-- [`scratchpad_planning.md`](scratchpad_planning.md) describes LX
-  scratchpad planning, the complementary pass that claims buffers for the
-  on-core SRAM before HBM pool planning packs the remainder.
-- [`coarse_tiling_loops.md`](coarse_tiling_loops.md) describes coarse
-  tiling, which creates the `SpyreEmptyFallback` full buffers that this
-  pass collects as a second candidate source.
+- [Scratchpad Planning](scratchpad_planning.md) covers LX allocation and the
+  interaction between the two memory tiers.
+- [Tensor Layouts](../user_guide/tensors_and_layouts.md) covers device
+  layouts and memory hierarchy concepts.
+- [Spyre Accelerator](../architecture/spyre_accelerator.md) gives the full
+  hardware overview.

--- a/docs/source/compiler/hbm_pool_planning.md
+++ b/docs/source/compiler/hbm_pool_planning.md
@@ -53,6 +53,12 @@ This means:
   sequential kernel invocations and no pool-scoped storage can persist
   between them. Such buffers fall back to standalone HBM allocation, the same
   as any other non-pool-eligible intermediate today.
+- A buffer written by more than one bundle -- for example, a loop-carried
+  accumulator whose in-place update in a later bundle is renamed by
+  Inductor's scheduler (`mutation_renames`) to the same buffer name as its
+  initializer in an earlier bundle -- is never pool-eligible in any bundle,
+  regardless of where it is read. This exclusion is unconditional and
+  independent of the read-based cross-bundle check above.
 
 This design enables bundle-local pool lifetimes, which reduces peak HBM
 pressure: instead of allocating pools for all bundles up front and keeping
@@ -119,6 +125,11 @@ For each top-level entry (bundle) in the post-fusion node list:
    - Not already claimed by LX planning.
    - Not read by CPU-fallback nodes.
    - Fully contained within the bundle (same bundle writes and reads them).
+   - Written by exactly one bundle. A buffer written by two or more bundles
+     (e.g. an in-place accumulator update that Inductor's `mutation_renames`
+     maps to the same buffer name as an earlier initializing write) is
+     excluded unconditionally, even if all its reads happen to lie within
+     the last-writing bundle.
 3. For each bundle's local candidate set, compute live ranges: a buffer's
    live range is the interval from its producer op to its last consumer op
    within that bundle.

--- a/docs/source/compiler/index.rst
+++ b/docs/source/compiler/index.rst
@@ -19,11 +19,12 @@ The documentation is organized in four parts:
 * **Compilers** — deep dives on the Inductor front-end and the DeepTools
   back-end.
 * **Operations** — how to add new operations to the Spyre backend.
-* **Optimization passes** — the pre-scheduling transformations applied
-  by the front-end. These are presented in pipeline order: working set
+* **Optimization passes** — the transformations applied by the
+  front-end. These are presented in pipeline order: working set
   reduction first (the design concept), then coarse-tiling (the IR
   rewrite that implements it), then work-division across cores, then
-  scratchpad placement.
+  scratchpad placement (all pre-scheduling), then HBM pool planning
+  (post-fusion, after bundle boundaries are final).
 
 For the project workflow around enabling and triaging new ops (issues,
 test coverage, bug classification), see :doc:`/contributing/op_enablement`.
@@ -58,5 +59,5 @@ test coverage, bug classification), see :doc:`/contributing/op_enablement`.
    span_overflow_hint_analysis
    work_division_planning
    scratchpad_planning
-   hbm_pool_planning
    simulated_annealing_layout
+   hbm_pool_planning

--- a/tests/configs/torch_spyre_tests/inductor/test_hbm_pool_planning_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_hbm_pool_planning_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [core, full]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_hbm_pool_planning.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -5782,20 +5782,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         scratchpad before hbm_pool_planning ever sees them, leaving every
         bundle's pool_size at 0 and proving nothing about the plumbing this
         test exists to check.
-
-        The generated wrapper's `.run(_pool, ...)` call site is only made
-        valid by Task 4's per-bundle pool codegen (not yet landed): today
-        `wrapper.py.allocate_hbm_pool()`/`generate()` still key off the old
-        graph-global `V.graph.hbm_pool_size` scalar that Task 2 replaced
-        with the `V.graph.hbm_pool_sizes` dict, so `_pool` is never emitted
-        and calling the compiled function raises `NameError: name '_pool'
-        is not defined` at runtime -- reproducible on this branch even
-        without this test's changes. That failure happens inside the
-        generated `call()` function, strictly after `codegen_node` (and
-        therefore every `SpyreKernel()` construction this test observes)
-        has already run, so it does not affect what this test checks.
-        Catch it explicitly rather than letting it fail the test or
-        loosening the assertion below.
         """
         from unittest.mock import patch
 
@@ -5822,11 +5808,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             mock_patch(_PREPARE_KERNEL),
             mock_patch("subprocess.run"),
         ):
-            try:
-                torch.compile(fn)(x, y)
-            except NameError as e:
-                if "_pool" not in str(e):
-                    raise
+            torch.compile(fn)(x, y)
 
         self.assertTrue(seen_pool_sizes)
         self.assertTrue(

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -5766,6 +5766,75 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                 fn, x, y, run_compile=True, run_eager=False, atol=0.01, rtol=0.01
             )
 
+    # ------------------------------------------------------------------
+    # Per-bundle hbm_pool_sizes threading into SpyreKernel
+    # ------------------------------------------------------------------
+
+    @config.patch({"lx_planning": False})
+    def test_bundle_pool_size_threaded_from_hbm_pool_sizes(self):
+        """codegen_node must look up this bundle's own pool_size from
+        V.graph.hbm_pool_sizes, not a stale graph-global scalar.
+
+        lx_planning is disabled here so the `a = x + y` intermediate isn't
+        claimed by LX scratchpad planning first -- with LX planning on,
+        `add`/`mul`/`sub` outputs are all LX-eligible by default (see
+        OP_OUTPUT_GOOD_FOR_LX_REUSE in scratchpad/utils.py) and may win the
+        scratchpad before hbm_pool_planning ever sees them, leaving every
+        bundle's pool_size at 0 and proving nothing about the plumbing this
+        test exists to check.
+
+        The generated wrapper's `.run(_pool, ...)` call site is only made
+        valid by Task 4's per-bundle pool codegen (not yet landed): today
+        `wrapper.py.allocate_hbm_pool()`/`generate()` still key off the old
+        graph-global `V.graph.hbm_pool_size` scalar that Task 2 replaced
+        with the `V.graph.hbm_pool_sizes` dict, so `_pool` is never emitted
+        and calling the compiled function raises `NameError: name '_pool'
+        is not defined` at runtime -- reproducible on this branch even
+        without this test's changes. That failure happens inside the
+        generated `call()` function, strictly after `codegen_node` (and
+        therefore every `SpyreKernel()` construction this test observes)
+        has already run, so it does not affect what this test checks.
+        Catch it explicitly rather than letting it fail the test or
+        loosening the assertion below.
+        """
+        from unittest.mock import patch
+
+        from torch_spyre._inductor.spyre_kernel import SpyreKernel
+
+        seen_pool_sizes = []
+        orig_init = SpyreKernel.__init__
+
+        def _recording_init(self, pool_size=0, **kwargs):
+            seen_pool_sizes.append(pool_size)
+            orig_init(self, pool_size=pool_size, **kwargs)
+
+        def fn(x, y):
+            a = x + y
+            b = a * 2
+            return b - x
+
+        x = torch.randn(64, 64, dtype=torch.float16, device="spyre")
+        y = torch.randn(64, 64, dtype=torch.float16, device="spyre")
+
+        with (
+            patch.object(SpyreKernel, "__init__", _recording_init),
+            mock_patch(_LAUNCH_JOBPLAN),
+            mock_patch(_PREPARE_KERNEL),
+            mock_patch("subprocess.run"),
+        ):
+            try:
+                torch.compile(fn)(x, y)
+            except NameError as e:
+                if "_pool" not in str(e):
+                    raise
+
+        self.assertTrue(seen_pool_sizes)
+        self.assertTrue(
+            any(seen_pool_sizes),
+            f"expected at least one bundle with a nonzero pool_size, got "
+            f"{seen_pool_sizes}",
+        )
+
 
 class TestNamedDimsHint(InductorTestCase):
     """Tests for propagate_named_dims handling of ops with a named_dims hint.

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -5835,6 +5835,52 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             f"{seen_pool_sizes}",
         )
 
+    @config.patch({"lx_planning": False})
+    @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
+    def test_pool_alloc_scoped_per_bundle_across_fallback_boundary(self):
+        """A CPU-fallback op (torch.sin) splits the graph into multiple
+        bundles. Each bundle's pool tensor (if any) is allocated right
+        before its own .run() call and freed right after -- there is no
+        single graph-global "_pool" shared across bundles, and the
+        intermediate crossing the fallback boundary is not pool-allocated."""
+
+        def fn(t):
+            a = torch.exp(t) * 2  # compiled bundle 1; `a` crosses the
+            b = torch.sin(a)  # fallback op -- forces a bundle boundary
+            c = torch.exp(b) * 2  # compiled bundle 2
+            return c
+
+        x = torch.randn(64, 64, dtype=torch.float16, device="spyre")
+
+        with (
+            mock_patch(_LAUNCH_JOBPLAN),
+            mock_patch(_PREPARE_KERNEL),
+            mock_patch("subprocess.run"),
+            pytest.warns(UserWarning),
+        ):
+            _, source_codes = run_and_get_code(torch.compile(fn), x)
+        src = source_codes[0]
+
+        # No single graph-global "_pool = " assignment (the old scheme).
+        self.assertNotIn("_pool = spyre_empty_with_layout", src)
+        # Any pool tensor that does appear is kernel-scoped
+        # ("_pool_<kernel_name> = ..."), never the bare literal "_pool".
+        pool_alloc_lines = [
+            line
+            for line in src.splitlines()
+            if "spyre_empty_with_layout" in line and "uint8" in line
+        ]
+        for line in pool_alloc_lines:
+            self.assertRegex(line.strip(), r"^_pool_\S+\s*=")
+        # Each pool alloc line's variable is del'd, and each .run( call that
+        # uses a pool passes that same per-kernel variable, not a shared name.
+        pool_var_names = [
+            line.strip().split("=", 1)[0].strip() for line in pool_alloc_lines
+        ]
+        self.assertEqual(len(pool_var_names), len(set(pool_var_names)))
+        for var_name in pool_var_names:
+            self.assertIn(f"del {var_name}", src)
+
 
 class TestNamedDimsHint(InductorTestCase):
     """Tests for propagate_named_dims handling of ops with a named_dims hint.

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -7153,5 +7153,21 @@ class TestTileHelpers(unittest.TestCase):
         )
 
 
+class TestCustomPostFusionPassesOrder(unittest.TestCase):
+    def test_hbm_pool_planning_runs_after_fusion(self):
+        """hbm_pool_planning must see post-fusion bundles, not pre-fusion nodes."""
+        from torch_spyre._inductor.passes import CustomPostFusionPasses
+        from torch_spyre._inductor.fusion import spyre_fuse_nodes
+        from torch_spyre._inductor.hbm_pool_planning import hbm_pool_planning
+
+        pipeline = CustomPostFusionPasses()
+        names = [p.__name__ for p in pipeline.passes]
+        self.assertLess(
+            names.index(spyre_fuse_nodes.__name__),
+            names.index(hbm_pool_planning.__name__),
+            "spyre_fuse_nodes must run before hbm_pool_planning",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -7169,5 +7169,17 @@ class TestCustomPostFusionPassesOrder(unittest.TestCase):
         )
 
 
+class TestSpyreKernelPoolSize(unittest.TestCase):
+    def test_spyre_kernel_accepts_pool_size(self):
+        """SpyreKernel must accept a per-bundle pool_size, defaulting to 0."""
+        from torch_spyre._inductor.spyre_kernel import SpyreKernel
+
+        kernel = SpyreKernel(pool_size=2048)
+        self.assertEqual(kernel.pool_size, 2048)
+
+        default_kernel = SpyreKernel()
+        self.assertEqual(default_kernel.pool_size, 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_hbm_pool_planning.py
+++ b/tests/inductor/test_hbm_pool_planning.py
@@ -247,9 +247,12 @@ class TestHbmPoolPlanningPerBundle(unittest.TestCase):
         accumulator and the loop's own scratch tile are simultaneously
         live at runtime throughout the loop's execution. With the fix
         (bundle.get_nodes() -- one entry for the whole loop, not one per
-        body-op -- passed to _compute_live_ranges), "acc"'s live range
-        spans the loop's own single index, overlapping "other", and the
-        two buffers get distinct offsets.
+        body-op -- passed to _compute_live_ranges), the loop node's merged
+        read/write set (ReadWrites.merge_list) drops "acc" entirely, since
+        it is both written and read within the same node; with no visible
+        read, _compute_live_ranges conservatively keeps "acc" live through
+        the rest of the bundle, which safely overlaps "other" and gives the
+        two buffers distinct offsets.
         """
         _make_ftl_buffer("acc")
         _make_ftl_buffer("other")

--- a/tests/inductor/test_hbm_pool_planning.py
+++ b/tests/inductor/test_hbm_pool_planning.py
@@ -1,0 +1,219 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+from sympy import Integer
+from torch import fx
+from torch._inductor.dependencies import MemoryDep
+from torch._inductor.graph import GraphLowering
+from torch._inductor.ir import ComputedBuffer, FlexibleLayout, Pointwise
+from torch._inductor.scheduler import FusedSchedulerNode, SchedulerNode
+from torch._inductor.virtualized import V
+from torch.utils._ordered_set import OrderedSet
+
+from torch_spyre._C import ElementArrangement, SpyreTensorLayout
+from torch_spyre._inductor.hbm_pool_planning import hbm_pool_planning
+from torch_spyre._inductor.ir import FixedTiledLayout
+
+
+def _make_ftl_buffer(name, host_size=(64,), dim_order=(0,)):
+    """Real ComputedBuffer with a FixedTiledLayout, for pool-eligibility tests.
+
+    Mirrors _make_ftl_op in test_coarse_tiling.py:1187, trimmed to what
+    hbm_pool_planning needs (device_layout.device_size must be set for
+    _compute_size_bytes to work).
+    """
+    strides = [int(s) for s in FlexibleLayout.contiguous_strides(list(host_size))]
+    device_layout = SpyreTensorLayout(
+        list(host_size),
+        strides,
+        torch.float16,
+        list(dim_order),
+        ElementArrangement.STANDARD,
+    )
+    layout = FixedTiledLayout(
+        torch.device("cpu"),
+        torch.float16,
+        [Integer(s) for s in host_size],
+        [Integer(s) for s in strides],
+        device_layout,
+    )
+    pw = Pointwise(
+        device=torch.device("cpu"),
+        dtype=torch.float16,
+        inner_fn=lambda index: Integer(1),
+        ranges=[Integer(s) for s in host_size],
+    )
+    buf = ComputedBuffer(name=name, layout=layout, data=pw)
+    V.graph.name_to_buffer[name] = buf
+    return buf
+
+
+def _make_snode_with_rw(name, writes, reads):
+    """MagicMock SchedulerNode with real MemoryDep read_writes for the
+    given buffer names, and get_nodes()/get_name() wired for
+    _iter_all_nodes / bundle-name lookup.
+
+    FusedSchedulerNode.__init__ -> init_group_node/refresh_group_node_
+    dependencies walks several BaseSchedulerNode bookkeeping attributes
+    (ancestors, unmet_dependencies, min/max_order, min/max_input_distance,
+    outputs) that a bare ``MagicMock(spec=SchedulerNode)`` leaves
+    unconfigured and which then raise AttributeError. These are normally
+    populated by the real Scheduler during node construction; since these
+    tests build bundles directly (bypassing the Scheduler), fill them in
+    with the same empty/zero defaults BaseSchedulerNode.__init__ uses.
+    """
+    snode = MagicMock(spec=SchedulerNode)
+    snode.get_name.return_value = name
+    snode.get_nodes.return_value = [snode]
+    snode.ancestors = OrderedSet()
+    snode.unmet_dependencies = OrderedSet()
+    snode.min_order = 0
+    snode.max_order = 0
+    snode.min_input_distance = 0
+    snode.max_input_distance = 0
+    snode.outputs = []
+    snode.is_reduction.return_value = False
+    snode.group = (torch.device("cpu"), ())
+    snode.read_writes = MagicMock()
+    snode.read_writes.writes = {MemoryDep(w, Integer(0), (), ()) for w in writes}
+    snode.read_writes.reads = {MemoryDep(r, Integer(0), (), ()) for r in reads}
+    return snode
+
+
+class TestHbmPoolPlanningPerBundle(unittest.TestCase):
+    def setUp(self):
+        gm = fx.symbolic_trace(lambda: None)
+        self._graph_ctx = V.set_graph_handler(GraphLowering(gm))
+        self._graph_ctx.__enter__()
+        # A bare GraphLowering() never runs lowering, so graph_outputs is
+        # never set by __init__ (only assigned later, mid-lowering). Set it
+        # explicitly so get_output_names()/get_output_names-based filters
+        # below don't raise AttributeError.
+        V.graph.graph_outputs = []
+
+    def tearDown(self):
+        self._graph_ctx.__exit__(None, None, None)
+
+    def test_buffer_local_to_one_bundle_is_pool_eligible(self):
+        """A buffer written and read within the same bundle gets an
+        hbm_pool allocation."""
+        _make_ftl_buffer("buf0")
+        writer = _make_snode_with_rw("writer", writes=["buf0"], reads=[])
+        reader = _make_snode_with_rw("reader", writes=[], reads=["buf0"])
+        bundle = FusedSchedulerNode(MagicMock(), [writer, reader])
+
+        hbm_pool_planning([bundle])
+
+        buf = V.graph.get_buffer("buf0")
+        self.assertIn("hbm_pool", buf.get_layout().allocation)
+        self.assertIn(bundle.get_name(), V.graph.hbm_pool_sizes)
+
+    def test_buffer_crossing_bundles_is_not_pool_eligible(self):
+        """A buffer written in bundle A and read in bundle B falls back
+        to standalone HBM (no hbm_pool allocation)."""
+        _make_ftl_buffer("buf0")
+        writer = _make_snode_with_rw("writer", writes=["buf0"], reads=[])
+        reader = _make_snode_with_rw("reader", writes=[], reads=["buf0"])
+        bundle_a = FusedSchedulerNode(MagicMock(), [writer])
+        bundle_b = FusedSchedulerNode(MagicMock(), [reader])
+
+        hbm_pool_planning([bundle_a, bundle_b])
+
+        buf = V.graph.get_buffer("buf0")
+        self.assertNotIn("hbm_pool", buf.get_layout().allocation)
+
+    def test_multi_bundle_graph_produces_multiple_pool_size_entries(self):
+        """Two independent bundles, each with their own local-only
+        intermediate, each get their own hbm_pool_sizes entry."""
+        _make_ftl_buffer("buf0")
+        _make_ftl_buffer("buf1")
+        w0 = _make_snode_with_rw("w0", writes=["buf0"], reads=[])
+        r0 = _make_snode_with_rw("r0", writes=[], reads=["buf0"])
+        w1 = _make_snode_with_rw("w1", writes=["buf1"], reads=[])
+        r1 = _make_snode_with_rw("r1", writes=[], reads=["buf1"])
+        bundle_a = FusedSchedulerNode(MagicMock(), [w0, r0])
+        bundle_b = FusedSchedulerNode(MagicMock(), [w1, r1])
+
+        hbm_pool_planning([bundle_a, bundle_b])
+
+        self.assertEqual(len(V.graph.hbm_pool_sizes), 2)
+        self.assertIn(bundle_a.get_name(), V.graph.hbm_pool_sizes)
+        self.assertIn(bundle_b.get_name(), V.graph.hbm_pool_sizes)
+
+    def test_disabled_config_sets_empty_dict(self):
+        from torch_spyre._inductor import config as cfg
+
+        old = cfg.hbm_pool_planning
+        cfg.hbm_pool_planning = False
+        try:
+            result = hbm_pool_planning([])
+        finally:
+            cfg.hbm_pool_planning = old
+        self.assertEqual(V.graph.hbm_pool_sizes, {})
+        self.assertEqual(result, [])
+
+    def test_single_bundle_graph_offsets_match_pre_reorder_behavior(self):
+        """A graph that fuses into exactly one bundle must get the same
+        per-buffer hbm_pool offsets and total size that the old
+        graph-global scheme would have produced for the same buffers --
+        the per-bundle rewrite must not change single-bundle behavior.
+
+        This pins down parity by computing the expected offsets directly
+        from the same Allocator/_compute_size_bytes primitives the
+        implementation itself uses, rather than hardcoding byte constants
+        that would silently drift if _compute_size_bytes's stick-alignment
+        changes for unrelated reasons.
+        """
+        from torch_spyre._inductor.constants import SEGMENT_SIZE
+        from torch_spyre._inductor.hbm_pool_planning import (
+            Allocator,
+            _compute_size_bytes,
+        )
+
+        _make_ftl_buffer("buf0", host_size=(64,))
+        _make_ftl_buffer("buf1", host_size=(128,))
+        w0 = _make_snode_with_rw("w0", writes=["buf0"], reads=[])
+        mid = _make_snode_with_rw("mid", writes=["buf1"], reads=["buf0"])
+        r1 = _make_snode_with_rw("r1", writes=[], reads=["buf1"])
+        bundle = FusedSchedulerNode(MagicMock(), [w0, mid, r1])
+
+        hbm_pool_planning([bundle])
+
+        expected_alloc = Allocator(SEGMENT_SIZE)
+        # buf0's live range ends at "mid" (step 1), buf1's starts there --
+        # sorted by (start, end, name) as in the real implementation,
+        # buf0 allocates first.
+        buf0_size = _compute_size_bytes("buf0")
+        expected_offsets = {"buf0": expected_alloc.allocate(buf0_size)}
+        expected_alloc.free(expected_offsets["buf0"], buf0_size)
+        expected_offsets["buf1"] = expected_alloc.allocate(_compute_size_bytes("buf1"))
+        expected_pool_size = expected_alloc.get_pool_end()
+
+        buf0 = V.graph.get_buffer("buf0")
+        buf1 = V.graph.get_buffer("buf1")
+        self.assertEqual(
+            buf0.get_layout().allocation["hbm_pool"], expected_offsets["buf0"]
+        )
+        self.assertEqual(
+            buf1.get_layout().allocation["hbm_pool"], expected_offsets["buf1"]
+        )
+        self.assertEqual(V.graph.hbm_pool_sizes[bundle.get_name()], expected_pool_size)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/inductor/test_hbm_pool_planning.py
+++ b/tests/inductor/test_hbm_pool_planning.py
@@ -278,6 +278,51 @@ class TestHbmPoolPlanningPerBundle(unittest.TestCase):
             other_buf.get_layout().allocation["hbm_pool"],
         )
 
+    def test_counted_loop_accumulator_stays_live_as_bare_top_level_bundle(self):
+        """The opacity fix above relies on the loop appearing as one entry
+        inside an outer FusedSchedulerNode's own get_nodes() list. When a
+        CountedLoopSchedulerNode has no fusible neighbors, spyre_fuse_nodes's
+        _make_fused returns it directly as the top-level bundle (see
+        _make_fused in fusion.py: `len(nodes) == 1` returns `nodes[0]`
+        unwrapped, not a FusedSchedulerNode of one). In that case `bundle`
+        passed to hbm_pool_planning's per-bundle loop *is* the loop itself,
+        so `bundle.get_nodes()` would return the loop's own internal snodes
+        (acc_step, other_step, other_reader) instead of treating the loop as
+        one opaque step.
+
+        Both "acc" and "other" are written and read entirely within the
+        loop body (a loop-carried accumulator and a same-iteration temp
+        respectively), so both are pool candidates. With the bug, "acc"'s
+        merged read/write set still hides its internal read (start=end=0
+        collapsed away by the opacity check design), but "other" is read by
+        a *distinct* body op (other_reader) at a later flattened index than
+        its writer -- exposing a real, non-degenerate live range that ends
+        before the loop's remaining iterations complete, so the allocator
+        frees and reuses its offset. This reproduces the same class of
+        offset collision as the nested-loop test above, via the
+        independently-reachable bare-top-level-bundle path.
+        """
+        _make_ftl_buffer("acc")
+        _make_ftl_buffer("other")
+
+        acc_step = _make_snode_with_rw("acc_step", writes=["acc"], reads=["acc"])
+        other_step = _make_snode_with_rw("other_step", writes=["other"], reads=[])
+        other_reader = _make_snode_with_rw("other_reader", writes=[], reads=["other"])
+        loop = CountedLoopSchedulerNode(
+            MagicMock(), [acc_step, other_step, other_reader], Integer(4)
+        )
+
+        hbm_pool_planning([loop])
+
+        acc_buf = V.graph.get_buffer("acc")
+        other_buf = V.graph.get_buffer("other")
+        self.assertIn("hbm_pool", acc_buf.get_layout().allocation)
+        self.assertIn("hbm_pool", other_buf.get_layout().allocation)
+        self.assertNotEqual(
+            acc_buf.get_layout().allocation["hbm_pool"],
+            other_buf.get_layout().allocation["hbm_pool"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_hbm_pool_planning.py
+++ b/tests/inductor/test_hbm_pool_planning.py
@@ -28,6 +28,7 @@ from torch.utils._ordered_set import OrderedSet
 from torch_spyre._C import ElementArrangement, SpyreTensorLayout
 from torch_spyre._inductor.hbm_pool_planning import hbm_pool_planning
 from torch_spyre._inductor.ir import FixedTiledLayout
+from torch_spyre._inductor.scheduler import CountedLoopSchedulerNode
 
 
 def _make_ftl_buffer(name, host_size=(64,), dim_order=(0,)):
@@ -213,6 +214,66 @@ class TestHbmPoolPlanningPerBundle(unittest.TestCase):
             buf1.get_layout().allocation["hbm_pool"], expected_offsets["buf1"]
         )
         self.assertEqual(V.graph.hbm_pool_sizes[bundle.get_name()], expected_pool_size)
+
+    def test_counted_loop_accumulator_stays_live_across_the_loop(self):
+        """A buffer that is only ever read *inside* a CountedLoopScheduler
+        Node's own body (a loop-carried accumulator, e.g. a running-max/sum
+        pattern where each iteration reads the value the previous iteration
+        wrote) must be treated as live for the whole loop -- not as ending
+        right where that internal read/write happens to sit in a fully
+        flattened node list.
+
+        CountedLoopSchedulerNode represents a loop that runs loop_count
+        times at runtime as a *single* node in its containing bundle's own
+        node list (see CountedLoopSchedulerNode.unpack(), which refuses to
+        unpack itself). The IR only contains one copy of the loop body, so
+        there is no second, later textual read for a "did this survive
+        another iteration" check to find -- liveness across iterations has
+        to be inferred from the fact that this is a loop, i.e. by treating
+        it as one opaque step whose live buffers are live for that entire
+        step, not by fully flattening its body into separate timesteps.
+
+        Setup: "init" writes "acc" outside the loop. The loop's body reads
+        and writes "acc" (the accumulate step) and separately writes
+        "other" (e.g. a per-iteration scratch tile, freshly written on
+        every pass). After the loop, "final" reads only "other" -- "acc"
+        is never read again outside the loop.
+
+        With the buggy fully-flattened live-range computation, "acc"'s
+        only visible read is inside the loop body itself, so its computed
+        live range collapses to a single point (start == end) that ends
+        before "other"'s start -- the allocator frees "acc"'s block and
+        hands the identical byte offset to "other", even though the loop's
+        accumulator and the loop's own scratch tile are simultaneously
+        live at runtime throughout the loop's execution. With the fix
+        (bundle.get_nodes() -- one entry for the whole loop, not one per
+        body-op -- passed to _compute_live_ranges), "acc"'s live range
+        spans the loop's own single index, overlapping "other", and the
+        two buffers get distinct offsets.
+        """
+        _make_ftl_buffer("acc")
+        _make_ftl_buffer("other")
+
+        init = _make_snode_with_rw("init", writes=["acc"], reads=[])
+        acc_step = _make_snode_with_rw("acc_step", writes=["acc"], reads=["acc"])
+        other_step = _make_snode_with_rw("other_step", writes=["other"], reads=[])
+        loop = CountedLoopSchedulerNode(MagicMock(), [acc_step, other_step], Integer(4))
+        final = _make_snode_with_rw("final", writes=[], reads=["other"])
+        bundle = FusedSchedulerNode(MagicMock(), [init, loop, final])
+
+        hbm_pool_planning([bundle])
+
+        acc_buf = V.graph.get_buffer("acc")
+        other_buf = V.graph.get_buffer("other")
+        self.assertIn("hbm_pool", acc_buf.get_layout().allocation)
+        self.assertIn("hbm_pool", other_buf.get_layout().allocation)
+        # "acc" (live throughout the loop) and "other" (written fresh on
+        # every pass through the same loop) are simultaneously live, so
+        # they must not share the same pool offset.
+        self.assertNotEqual(
+            acc_buf.get_layout().allocation["hbm_pool"],
+            other_buf.get_layout().allocation["hbm_pool"],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_hbm_pool_planning.py
+++ b/tests/inductor/test_hbm_pool_planning.py
@@ -323,6 +323,56 @@ class TestHbmPoolPlanningPerBundle(unittest.TestCase):
             other_buf.get_layout().allocation["hbm_pool"],
         )
 
+    def test_buffer_written_in_two_bundles_with_inplace_rewrite_is_not_pool_eligible(
+        self,
+    ):
+        """A buffer written once in bundle A (an initializer) and then
+        read-and-rewritten in place in bundle B (an accumulate step, where
+        mutation_renames makes the write dep name identical to the read dep
+        name) must NOT be pool-eligible in either bundle.
+
+        Regression test for buffer_writer_bundle[name] = bundle_name being a
+        plain dict overwrite: bundle B's own read of "accum" is only visible
+        within bundle B, so the old _is_cross_bundle reader check
+        (readers - {writer}) sees writer == bundle_b, readers == {bundle_b},
+        and wrongly treats "accum" as bundle-B-local -- even though bundle A
+        also wrote it and needs a stable address for its own write.
+        """
+        _make_ftl_buffer("accum")
+        init = _make_snode_with_rw("init", writes=["accum"], reads=[])
+        accumulate = _make_snode_with_rw(
+            "accumulate", writes=["accum"], reads=["accum"]
+        )
+        bundle_a = FusedSchedulerNode(MagicMock(), [init])
+        bundle_b = FusedSchedulerNode(MagicMock(), [accumulate])
+
+        hbm_pool_planning([bundle_a, bundle_b])
+
+        buf = V.graph.get_buffer("accum")
+        self.assertNotIn("hbm_pool", buf.get_layout().allocation)
+
+    def test_buffer_written_in_two_bundles_with_only_same_bundle_reader_is_not_pool_eligible(
+        self,
+    ):
+        """A buffer written in bundle A and written again in bundle B, where
+        the only read anywhere is inside bundle B -- so buffer_reader_bundles
+        alone would say "reader set == {writer}", i.e. not cross-bundle by
+        the reader-only check -- must still be excluded because it has two
+        distinct writer bundles. This isolates the multi-writer signal from
+        the reader-based signal entirely: no read in bundle A at all.
+        """
+        _make_ftl_buffer("accum")
+        write_a = _make_snode_with_rw("write_a", writes=["accum"], reads=[])
+        write_b = _make_snode_with_rw("write_b", writes=["accum"], reads=[])
+        read_b = _make_snode_with_rw("read_b", writes=[], reads=["accum"])
+        bundle_a = FusedSchedulerNode(MagicMock(), [write_a])
+        bundle_b = FusedSchedulerNode(MagicMock(), [write_b, read_b])
+
+        hbm_pool_planning([bundle_a, bundle_b])
+
+        buf = V.graph.get_buffer("accum")
+        self.assertNotIn("hbm_pool", buf.get_layout().allocation)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_log_op_specs.py
+++ b/tests/inductor/test_log_op_specs.py
@@ -215,6 +215,7 @@ class TestSpyreKernelLogging:
                     kernel.args = MagicMock()
                     kernel.args.python_argdefs.return_value = (None, [])
                     kernel.spyre_kernel_args = []
+                    kernel.pool_size = 0
 
                     with patch("torch_spyre._inductor.spyre_kernel.simplify_op_spec"):
                         kernel.codegen_kernel()
@@ -240,6 +241,7 @@ class TestSpyreKernelLogging:
                 kernel.args = MagicMock()
                 kernel.args.python_argdefs.return_value = (None, [])
                 kernel.spyre_kernel_args = []
+                kernel.pool_size = 0
 
                 with patch("torch_spyre._inductor.spyre_kernel.simplify_op_spec"):
                     kernel.codegen_kernel()

--- a/torch_spyre/_inductor/hbm_pool_planning.py
+++ b/torch_spyre/_inductor/hbm_pool_planning.py
@@ -25,6 +25,7 @@ from torch._inductor.virtualized import V
 from .constants import SEGMENT_SIZE, INTERMEDIATES_SEGMENT
 from .ir import FixedTiledLayout, SpyreEmptyFallback
 from .logging_utils import get_inductor_logger
+from .scheduler import CountedLoopSchedulerNode
 from . import config
 
 logger = get_inductor_logger("HBM_POOL_PLANNING")
@@ -323,7 +324,20 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
         # timestep, ending its live range there and letting the allocator
         # free and reuse its offset for a different, still-live buffer
         # (e.g. the loop's own per-iteration scratch tile).
-        live_ranges = _compute_live_ranges(bundle.get_nodes(), bundle_candidates)
+        #
+        # This opacity relies on `bundle` being a FusedSchedulerNode whose
+        # `get_nodes()` returns *other* nodes (the loop appearing as one
+        # timestep among siblings). When spyre_fuse_nodes has no fusible
+        # neighbors to group a loop with, `_make_fused` returns the bare
+        # CountedLoopSchedulerNode itself as the top-level bundle -- in that
+        # case `bundle.get_nodes()` returns the loop's own internal snodes,
+        # bypassing the opacity entirely. Guard against that by treating a
+        # bare loop bundle as a single opaque timestep.
+        if isinstance(bundle, CountedLoopSchedulerNode):
+            live_range_nodes = [bundle]
+        else:
+            live_range_nodes = bundle.get_nodes()
+        live_ranges = _compute_live_ranges(live_range_nodes, bundle_candidates)
         sorted_bufs = sorted(live_ranges.items(), key=_alloc_sort_key)
 
         allocator = Allocator(SEGMENT_SIZE)

--- a/torch_spyre/_inductor/hbm_pool_planning.py
+++ b/torch_spyre/_inductor/hbm_pool_planning.py
@@ -242,10 +242,17 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
     }
 
     # Build per-buffer writer-bundle / reader-bundles maps by walking each
-    # top-level bundle's own flattened node list once.  A buffer has exactly
-    # one writer (bundle); it may have readers in zero, one, or several
-    # bundles.
+    # top-level bundle's own flattened node list once.  A buffer normally has
+    # exactly one writer (bundle), tracked in buffer_writer_bundle; it may
+    # have readers in zero, one, or several bundles.  buffer_writer_bundles
+    # additionally accumulates *every* bundle that ever wrote a given name,
+    # so a buffer written by more than one bundle (e.g. a loop-carried
+    # accumulator whose in-place update is mutation-renamed by Inductor's
+    # scheduler to the same name as its initializer in an earlier bundle) can
+    # be detected even though buffer_writer_bundle itself only ever retains
+    # the last writer.
     buffer_writer_bundle: dict[str, str] = {}
+    buffer_writer_bundles: dict[str, set[str]] = {}
     buffer_reader_bundles: dict[str, set[str]] = {}
 
     for bundle in nodes:
@@ -258,6 +265,7 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
             for dep in node.read_writes.writes:
                 if dep.name not in graph_outputs:
                     buffer_writer_bundle[dep.name] = bundle_name
+                    buffer_writer_bundles.setdefault(dep.name, set()).add(bundle_name)
             for dep in node.read_writes.reads:
                 if dep.name not in graph_inputs:
                     buffer_reader_bundles.setdefault(dep.name, set()).add(bundle_name)
@@ -274,11 +282,22 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
                 and node.node.get_name() not in graph_outputs
             ):
                 buffer_writer_bundle[node.node.get_name()] = bundle_name
+                buffer_writer_bundles.setdefault(node.node.get_name(), set()).add(
+                    bundle_name
+                )
 
     written = set(buffer_writer_bundle)
     read = set(buffer_reader_bundles)
 
     def _is_cross_bundle(name: str) -> bool:
+        if len(buffer_writer_bundles.get(name, set())) > 1:
+            logger.debug(
+                "hbm_pool_planning: %s written by multiple bundles %s -- "
+                "excluding from pool eligibility",
+                name,
+                sorted(buffer_writer_bundles[name]),
+            )
+            return True
         readers = buffer_reader_bundles.get(name, set())
         writer = buffer_writer_bundle.get(name)
         return bool(readers - {writer})

--- a/torch_spyre/_inductor/hbm_pool_planning.py
+++ b/torch_spyre/_inductor/hbm_pool_planning.py
@@ -316,7 +316,17 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
         if not bundle_candidates:
             continue
 
-        live_ranges = _compute_live_ranges(bundle_flat, bundle_candidates)
+        # Use the bundle's own direct, unflattened children here (not the
+        # recursively-flattened bundle_flat used above for candidate
+        # identification): a CountedLoopSchedulerNode's body executes many
+        # times at runtime but is represented as a single node in this list,
+        # so a loop-carried buffer that is read/written on every iteration
+        # correctly stays live for the loop's entire single timestep. Fully
+        # flattening into the loop body would instead record its live range
+        # as ending at the first (and only, in the IR) occurrence of its
+        # read, causing the allocator to free and reuse its offset for a
+        # different, still-live buffer.
+        live_ranges = _compute_live_ranges(bundle.get_nodes(), bundle_candidates)
         sorted_bufs = sorted(live_ranges.items(), key=_alloc_sort_key)
 
         allocator = Allocator(SEGMENT_SIZE)

--- a/torch_spyre/_inductor/hbm_pool_planning.py
+++ b/torch_spyre/_inductor/hbm_pool_planning.py
@@ -17,13 +17,13 @@ from sympy import Symbol
 from torch._inductor.scheduler import (
     BaseSchedulerNode,
     ExternKernelSchedulerNode,
+    FusedSchedulerNode,
     NopKernelSchedulerNode,
 )
 from torch._inductor.ir import FallbackKernel
 from torch._inductor.virtualized import V
 from .constants import SEGMENT_SIZE, INTERMEDIATES_SEGMENT
 from .ir import FixedTiledLayout, SpyreEmptyFallback
-from .scheduler import CountedLoopSchedulerNode
 from .logging_utils import get_inductor_logger
 from . import config
 
@@ -161,12 +161,23 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
     For each candidate, assigns layout.allocation["hbm_pool"] = INTERMEDIATES_SEGMENT + offset.
     Graph inputs/outputs and LX-allocated buffers are excluded.
 
+    Bundle scoping: this pass runs after ``spyre_fuse_nodes`` (see
+    ``CustomPostFusionPasses`` in passes.py), so ``nodes`` is the final,
+    post-fusion top-level list -- each entry is exactly one SDSC bundle
+    (one SpyreKernel / .run() call).  A buffer is pool-eligible only if
+    the bundle that writes it is the same bundle that contains every read
+    of it; a buffer written in one bundle and read from a different one
+    falls back to standalone HBM, since bundle-scoped pools do not
+    coexist across separate kernel invocations.  Pool offsets, sizes, and
+    live-range analysis are all computed independently per bundle -- see
+    docs/superpowers/specs/2026-08-10-pool-per-bundle-design.md.
+
     See docs/source/compiler/hbm_pool_planning.md for the full design and a
     side-by-side comparison table with LX scratchpad planning.
     """
 
     if not config.hbm_pool_planning:
-        V.graph.hbm_pool_size = 0
+        V.graph.hbm_pool_sizes = {}
         return nodes
 
     graph_inputs: set[str] = set(V.graph.graph_inputs.keys())
@@ -179,48 +190,23 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
         NopKernelSchedulerNode,
     )
 
-    # build_loop_scheduler_nodes may have already run in pre-fusion, wrapping
-    # tiled ops into CountedLoopSchedulerNodes.  Flatten them so individual ops
-    # are visible at distinct timesteps for written/read detection and live-range
-    # analysis.
+    # Now that this pass runs after spyre_fuse_nodes (post-fusion), each
+    # top-level entry in `nodes` is a bundle that may itself be a
+    # FusedSchedulerNode wrapping several SchedulerNodes/CountedLoopScheduler
+    # Nodes (or a CountedLoopSchedulerNode -- a FusedSchedulerNode subclass --
+    # wrapping a counted-loop body).  Flatten both so individual ops are
+    # visible at distinct timesteps for written/read detection and live-range
+    # analysis.  FusedSchedulerNode.get_nodes() returns self.snodes verbatim
+    # (not recursively flattened), so the recursion below handles nesting of
+    # arbitrary depth.
     def _iter_all_nodes(
         node_list: list[BaseSchedulerNode],
     ):
         for n in node_list:
-            if isinstance(n, CountedLoopSchedulerNode):
+            if isinstance(n, FusedSchedulerNode):
                 yield from _iter_all_nodes(n.get_nodes())
             else:
                 yield n
-
-    flat_nodes: list[BaseSchedulerNode] = list(_iter_all_nodes(nodes))
-    non_kernel_nodes = [n for n in flat_nodes if not isinstance(n, _kernel_arg_types)]
-
-    written = {
-        dep.name
-        for node in non_kernel_nodes
-        for dep in node.read_writes.writes
-        if dep.name not in graph_outputs
-    }
-
-    # SpyreEmptyFallback nodes allocate a buffer but emit no dep-tracked write
-    # so they never appear in `written` via the dep walk above.  Collect them here
-    # explicitly, using the underlying buffer's name (node.node.get_name()) rather
-    # than the scheduler node's own operation name (node.get_name()) — for an
-    # ExternKernelSchedulerNode these differ (e.g. "op30" vs "buf27").
-    written |= {
-        node.node.get_name()
-        for node in flat_nodes
-        if isinstance(node, ExternKernelSchedulerNode)
-        and isinstance(node.node, SpyreEmptyFallback)
-        and node.node.get_name() not in graph_outputs
-    }
-
-    read = {
-        dep.name
-        for node in non_kernel_nodes
-        for dep in node.read_writes.reads
-        if dep.name not in graph_inputs
-    }
 
     # Mutation buffers share the same allocation dict object as their target, so a
     # name-based check is insufficient.
@@ -245,94 +231,169 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
             and id(layout.allocation) not in io_alloc_ids
         )
 
-    # Buffers read by Fallback/Extern/Nop nodes must stay Python-side tensors.
+    # Buffers read by Fallback/Extern/Nop nodes must stay Python-side tensors,
+    # regardless of which bundle they belong to.
+    all_flat_nodes: list[BaseSchedulerNode] = list(_iter_all_nodes(nodes))
     fallback_read = {
         dep.name
-        for node in flat_nodes
+        for node in all_flat_nodes
         if isinstance(node, _kernel_arg_types)
         for dep in node.read_writes.reads
     }
 
-    intermediates = {
+    # Build per-buffer writer-bundle / reader-bundles maps by walking each
+    # top-level bundle's own flattened node list once.  A buffer has exactly
+    # one writer (bundle); it may have readers in zero, one, or several
+    # bundles.
+    buffer_writer_bundle: dict[str, str] = {}
+    buffer_reader_bundles: dict[str, set[str]] = {}
+    # bundle_name -> that bundle's own flattened node list, cached so the
+    # per-bundle allocation loop below doesn't redo _iter_all_nodes.
+    bundle_flat_nodes: dict[str, list[BaseSchedulerNode]] = {}
+
+    for bundle in nodes:
+        bundle_name = bundle.get_name()
+        bundle_flat = list(_iter_all_nodes([bundle]))
+        bundle_flat_nodes[bundle_name] = bundle_flat
+        bundle_non_kernel = [
+            n for n in bundle_flat if not isinstance(n, _kernel_arg_types)
+        ]
+        for node in bundle_non_kernel:
+            for dep in node.read_writes.writes:
+                if dep.name not in graph_outputs:
+                    buffer_writer_bundle[dep.name] = bundle_name
+            for dep in node.read_writes.reads:
+                if dep.name not in graph_inputs:
+                    buffer_reader_bundles.setdefault(dep.name, set()).add(bundle_name)
+        # SpyreEmptyFallback nodes allocate a buffer but emit no dep-tracked
+        # write, so they never appear via the dep walk above.  Collect them
+        # explicitly, using the underlying buffer's name (node.node.get_name())
+        # rather than the scheduler node's own operation name
+        # (node.get_name()) -- for an ExternKernelSchedulerNode these differ
+        # (e.g. "op30" vs "buf27").
+        for node in bundle_flat:
+            if (
+                isinstance(node, ExternKernelSchedulerNode)
+                and isinstance(node.node, SpyreEmptyFallback)
+                and node.node.get_name() not in graph_outputs
+            ):
+                buffer_writer_bundle[node.node.get_name()] = bundle_name
+
+    written = set(buffer_writer_bundle)
+    read = set(buffer_reader_bundles)
+
+    def _is_cross_bundle(name: str) -> bool:
+        readers = buffer_reader_bundles.get(name, set())
+        writer = buffer_writer_bundle.get(name)
+        return bool(readers - {writer})
+
+    all_candidates = {
         name
         for name in (written & read) - io_names - fallback_read
-        if _is_intermediate(name)
+        if _is_intermediate(name) and not _is_cross_bundle(name)
     }
-    if not intermediates:
-        V.graph.hbm_pool_size = 0
-        return nodes
 
-    live_ranges = _compute_live_ranges(nodes, intermediates)
+    V.graph.hbm_pool_sizes = {}
 
-    # Sort by start step so the allocator processes tensors in execution order.
-    # Tie-break on (end_step, name) for determinism:
+    # Sort by start step so the allocator processes tensors in execution
+    # order.  Tie-break on (end_step, name) for determinism:
     def _alloc_sort_key(item: tuple[str, tuple[int, int]]) -> tuple[int, int, str]:
         name, (start, end) = item
         return (start, end, name)
 
-    sorted_bufs = sorted(live_ranges.items(), key=_alloc_sort_key)
+    for bundle in nodes:
+        bundle_name = bundle.get_name()
+        bundle_flat = bundle_flat_nodes[bundle_name]
+        # Restrict to buffers this bundle actually writes -- buffer_writer_
+        # bundle[name] == bundle_name is implied by membership in
+        # all_candidates plus this bundle's own written set, but recomputing
+        # a local written set keeps this loop self-contained.
+        bundle_candidates = {
+            name
+            for name in all_candidates
+            if buffer_writer_bundle.get(name) == bundle_name
+        }
+        if not bundle_candidates:
+            continue
 
-    allocator = Allocator(SEGMENT_SIZE)
+        live_ranges = _compute_live_ranges(bundle_flat, bundle_candidates)
+        sorted_bufs = sorted(live_ranges.items(), key=_alloc_sort_key)
 
-    # Track (end_step, offset, size) so we can free blocks promptly.
-    pending_frees: list[tuple[int, int, int]] = []
+        allocator = Allocator(SEGMENT_SIZE)
 
-    for name, (start, end) in sorted_bufs:
-        # Free any blocks whose live range ended before this start step.
-        still_live = []
-        for entry in pending_frees:
-            e, off, sz = entry
-            if e < start:
-                allocator.free(off, sz)
+        # Track (end_step, offset, size) so we can free blocks promptly.
+        pending_frees: list[tuple[int, int, int]] = []
+
+        for name, (start, end) in sorted_bufs:
+            # Free any blocks whose live range ended before this start step.
+            still_live = []
+            for entry in pending_frees:
+                e, off, sz = entry
+                if e < start:
+                    allocator.free(off, sz)
+                else:
+                    still_live.append(entry)
+            pending_frees = still_live
+
+            size = _compute_size_bytes(name)
+            offset = allocator.allocate(size)
+
+            # Assign pool offset directly to layout.allocation.
+            buf = V.graph.get_buffer(name)
+            layout = buf.maybe_get_layout()
+            assert isinstance(layout, FixedTiledLayout)
+            if config.bundle_symbolic_args:
+                layout.allocation["hbm_pool"] = offset
             else:
-                still_live.append(entry)
-        pending_frees = still_live
+                layout.allocation["hbm_pool"] = INTERMEDIATES_SEGMENT + offset
 
-        size = _compute_size_bytes(name)
-        offset = allocator.allocate(size)
+            if isinstance(buf, SpyreEmptyFallback):
+                # SpyreEmptyFallback.should_allocate() returns False once
+                # pool-allocated, so the wrapper never emits an AllocateLine
+                # for it. Base Inductor's free machinery
+                # (Scheduler.free_buffers -> codegen_free -> can_reuse) does
+                # not consult should_allocate(); it frees any buffer whose
+                # last use has passed regardless of whether it was ever
+                # allocated. Without this, the generated wrapper emits
+                # `del buf27` with no prior `buf27 = ...`, raising
+                # UnboundLocalError. free_buffers() itself subtracts
+                # V.graph.removed_buffers before iterating, so adding the
+                # name here keeps it out of codegen entirely.
+                V.graph.removed_buffers.add(name)
 
-        # Assign pool offset directly to layout.allocation.
-        buf = V.graph.get_buffer(name)
-        layout = buf.maybe_get_layout()
-        assert isinstance(layout, FixedTiledLayout)
-        if config.bundle_symbolic_args:
-            layout.allocation["hbm_pool"] = offset
-        else:
-            layout.allocation["hbm_pool"] = INTERMEDIATES_SEGMENT + offset
+            pending_frees.append((end, offset, size))
 
-        if isinstance(buf, SpyreEmptyFallback):
-            # SpyreEmptyFallback.should_allocate() returns False once pool-
-            # allocated, so the wrapper never emits an AllocateLine for it.
-            # Base Inductor's free machinery (Scheduler.free_buffers ->
-            # codegen_free -> can_reuse) does not consult should_allocate();
-            # it frees any buffer whose last use has passed regardless of
-            # whether it was ever allocated. Without this, the generated
-            # wrapper emits `del buf27` with no prior `buf27 = ...`, raising
-            # UnboundLocalError. free_buffers() itself subtracts
-            # V.graph.removed_buffers before iterating, so adding the name
-            # here keeps it out of codegen entirely.
-            V.graph.removed_buffers.add(name)
+            logger.debug(
+                "hbm_pool_planning: bundle=%s  %s  live=[%d,%d]  size=%d  offset=%d",
+                bundle_name,
+                name,
+                start,
+                end,
+                size,
+                offset,
+            )
 
-        pending_frees.append((end, offset, size))
-
-        logger.debug(
-            "hbm_pool_planning: %s  live=[%d,%d]  size=%d  offset=%d",
-            name,
-            start,
-            end,
-            size,
-            offset,
+        peak = allocator.get_peak_usage()
+        pool_extent = allocator.get_pool_end()
+        logger.info(
+            "hbm_pool_planning: bundle=%s assigned %d intermediates, peak concurrent "
+            "usage %.2f GB, pool extent %.2f GB / %.2f GB",
+            bundle_name,
+            len(sorted_bufs),
+            peak / (1024**3),
+            pool_extent / (1024**3),
+            SEGMENT_SIZE / (1024**3),
         )
+        V.graph.hbm_pool_sizes[bundle_name] = pool_extent
 
-    peak = allocator.get_peak_usage()
-    pool_extent = allocator.get_pool_end()
-    logger.info(
-        "hbm_pool_planning: assigned %d intermediates, peak concurrent usage %.2f GB, pool extent %.2f GB / %.2f GB",
-        len(sorted_bufs),
-        peak / (1024**3),
-        pool_extent / (1024**3),
-        SEGMENT_SIZE / (1024**3),
-    )
-    V.graph.hbm_pool_size = pool_extent
+    if not V.graph.hbm_pool_sizes:
+        logger.info("hbm_pool_planning: no bundle had any pool-eligible intermediate")
+    else:
+        logger.info(
+            "hbm_pool_planning: %d bundle(s) with pool allocations, "
+            "total pool bytes across bundles %.2f GB",
+            len(V.graph.hbm_pool_sizes),
+            sum(V.graph.hbm_pool_sizes.values()) / (1024**3),
+        )
 
     return nodes

--- a/torch_spyre/_inductor/hbm_pool_planning.py
+++ b/torch_spyre/_inductor/hbm_pool_planning.py
@@ -169,8 +169,7 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
     of it; a buffer written in one bundle and read from a different one
     falls back to standalone HBM, since bundle-scoped pools do not
     coexist across separate kernel invocations.  Pool offsets, sizes, and
-    live-range analysis are all computed independently per bundle -- see
-    docs/superpowers/specs/2026-08-10-pool-per-bundle-design.md.
+    live-range analysis are all computed independently per bundle.
 
     See docs/source/compiler/hbm_pool_planning.md for the full design and a
     side-by-side comparison table with LX scratchpad planning.
@@ -247,14 +246,10 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
     # bundles.
     buffer_writer_bundle: dict[str, str] = {}
     buffer_reader_bundles: dict[str, set[str]] = {}
-    # bundle_name -> that bundle's own flattened node list, cached so the
-    # per-bundle allocation loop below doesn't redo _iter_all_nodes.
-    bundle_flat_nodes: dict[str, list[BaseSchedulerNode]] = {}
 
     for bundle in nodes:
         bundle_name = bundle.get_name()
         bundle_flat = list(_iter_all_nodes([bundle]))
-        bundle_flat_nodes[bundle_name] = bundle_flat
         bundle_non_kernel = [
             n for n in bundle_flat if not isinstance(n, _kernel_arg_types)
         ]
@@ -303,7 +298,6 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
 
     for bundle in nodes:
         bundle_name = bundle.get_name()
-        bundle_flat = bundle_flat_nodes[bundle_name]
         # Restrict to buffers this bundle actually writes -- buffer_writer_
         # bundle[name] == bundle_name is implied by membership in
         # all_candidates plus this bundle's own written set, but recomputing
@@ -317,7 +311,7 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
             continue
 
         # Use the bundle's own direct, unflattened children here (not the
-        # recursively-flattened bundle_flat used above for candidate
+        # recursively-flattened list used above for candidate
         # identification). A CountedLoopSchedulerNode's merged read/write
         # set (see ReadWrites.merge_list) drops any buffer the loop both
         # writes and reads internally -- a loop-carried accumulator has no

--- a/torch_spyre/_inductor/hbm_pool_planning.py
+++ b/torch_spyre/_inductor/hbm_pool_planning.py
@@ -318,14 +318,17 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
 
         # Use the bundle's own direct, unflattened children here (not the
         # recursively-flattened bundle_flat used above for candidate
-        # identification): a CountedLoopSchedulerNode's body executes many
-        # times at runtime but is represented as a single node in this list,
-        # so a loop-carried buffer that is read/written on every iteration
-        # correctly stays live for the loop's entire single timestep. Fully
-        # flattening into the loop body would instead record its live range
-        # as ending at the first (and only, in the IR) occurrence of its
-        # read, causing the allocator to free and reuse its offset for a
-        # different, still-live buffer.
+        # identification). A CountedLoopSchedulerNode's merged read/write
+        # set (see ReadWrites.merge_list) drops any buffer the loop both
+        # writes and reads internally -- a loop-carried accumulator has no
+        # visible read at all from this node's perspective. _compute_live_
+        # ranges then falls back to `len(nodes) + 1` for such a buffer's
+        # end_step, conservatively keeping it live through the rest of the
+        # bundle, rather than the buggy alternative: fully flattening into
+        # the loop body would expose its one internal read as an ordinary
+        # timestep, ending its live range there and letting the allocator
+        # free and reuse its offset for a different, still-live buffer
+        # (e.g. the loop's own per-iteration scratch tile).
         live_ranges = _compute_live_ranges(bundle.get_nodes(), bundle_candidates)
         sorted_bufs = sorted(live_ranges.items(), key=_alloc_sort_key)
 

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -285,8 +285,10 @@ class CustomPostFusionPasses(_SpyreNodePassPipeline):
         # demote_incoherent_lx_buffers runs first: it re-checks LX core->slice
         # coherence now that loop orders are final, and anything it demotes must
         # still be visible to hbm_pool_planning as an unclaimed intermediate.
+        # hbm_pool_planning runs after spyre_fuse_nodes so it can compute
+        # bundle-scoped live ranges.
         super().__init__(
-            [demote_incoherent_lx_buffers, hbm_pool_planning, spyre_fuse_nodes]
+            [demote_incoherent_lx_buffers, spyre_fuse_nodes, hbm_pool_planning]
         )
 
 

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -576,7 +576,8 @@ class SuperDSCScheduling(BaseScheduling):
         if len(nodes) == 0:
             return
 
-        kernel = SpyreKernel()
+        pool_sizes = getattr(V.graph, "hbm_pool_sizes", {})
+        kernel = SpyreKernel(pool_size=pool_sizes.get(node.get_name(), 0))
         all_schedule_nodes: list[SchedulerNode] = []
         with kernel:
             self._codegen_into_kernel(nodes, kernel, all_schedule_nodes)
@@ -611,7 +612,8 @@ class SuperDSCScheduling(BaseScheduling):
         if len(inner_nodes) == 0:
             return
 
-        kernel = SpyreKernel()
+        pool_sizes = getattr(V.graph, "hbm_pool_sizes", {})
+        kernel = SpyreKernel(pool_size=pool_sizes.get(node.get_name(), 0))
         all_schedule_nodes: list[SchedulerNode] = []
         with kernel:
             self._codegen_into_kernel(inner_nodes, kernel, all_schedule_nodes)

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -536,7 +536,7 @@ def _tile_advance_expr_from_dep(
 class SpyreKernel(Kernel[CSEVariable]):
     overrides = SpyreOpFuncs  # type: ignore[assignment]
 
-    def __init__(self) -> None:
+    def __init__(self, pool_size: int = 0) -> None:
         super().__init__()
         self.op_specs: list[OpSpec | UnimplementedOp | LoopSpec] = []
         self.spyre_kernel_args: list[Tuple[str, TensorArg]] = []
@@ -545,6 +545,7 @@ class SpyreKernel(Kernel[CSEVariable]):
         self._indirect_var_count: int = 0
         self._general_tile_advance_seen: dict[str, int] = {}
         self._tile_advance_symbols: dict[int, sympy.Symbol] = {}
+        self.pool_size: int = pool_size
 
     def indirect_var_names(self) -> "frozenset[str] | None":
         if not self.indirect_vars:

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -1239,8 +1239,7 @@ class SpyreKernel(Kernel[CSEVariable]):
 
         # Now that all loads/stores have been processed we know the final kernel_args and can map names to indices
         actuals = self.args.python_argdefs()[1]
-        hbm_pool_size = getattr(V.graph, "hbm_pool_size", 0)
-        has_pool_allocations = hbm_pool_size > 0
+        has_pool_allocations = self.pool_size > 0
 
         for name, tensor_arg in self.spyre_kernel_args:
             tensor_arg.arg_index = actuals.index(name)
@@ -1277,12 +1276,21 @@ class SpyreKernel(Kernel[CSEVariable]):
         )
 
     def call_kernel(self, name: str, node=None):
-        """Codegen a call to this kernel"""
+        """Codegen a call to this kernel, allocating/freeing this kernel's
+        own pool tensor (if any) scoped tightly around the .run() call."""
         wrapper = V.graph.wrapper_code
         call_args = []
 
-        if self._kernel_uses_hbm_pool():
-            call_args.append("_pool")
+        uses_pool = self._kernel_uses_hbm_pool()
+        pool_var_name = f"_pool_{name}"
+        if uses_pool:
+            wrapper.writeline(
+                f"{pool_var_name} = spyre_empty_with_layout("
+                f"({self.pool_size},), (1,), torch.uint8, "
+                f"SpyreTensorLayout(device_size=[{self.pool_size}], "
+                f"stride_map=[1], device_dtype=DataFormats.SENINT8))"
+            )
+            call_args.append(pool_var_name)
 
         # Add remaining kernel arguments, deduplicating tensors that appear as
         # both input and output (e.g. in-place ops like x *= 2).  With symbolic
@@ -1297,6 +1305,8 @@ class SpyreKernel(Kernel[CSEVariable]):
 
         call_args_str = ", ".join(call_args)
         wrapper.writeline(f"{name}.run({call_args_str})")
+        if uses_pool:
+            wrapper.writeline(f"del {pool_var_name}")
 
     def emit_layout_restores(self, restores) -> None:
         """Emit set_spyre_tensor_layout wrapper calls after this kernel's run.

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -1282,6 +1282,12 @@ class SpyreKernel(Kernel[CSEVariable]):
         call_args = []
 
         uses_pool = self._kernel_uses_hbm_pool()
+        # `name` is this kernel's own wrapper-module variable name (e.g.
+        # "sdsc_fused__buf12"), already guaranteed unique across kernels by
+        # Inductor's wrapper codegen -- two kernels sharing a Python
+        # identifier in the same generated module would already break
+        # `{name}.run(...)` codegen independent of pool allocation. Deriving
+        # the pool variable's name from it is therefore also collision-free.
         pool_var_name = f"_pool_{name}"
         if uses_pool:
             wrapper.writeline(

--- a/torch_spyre/_inductor/wrapper.py
+++ b/torch_spyre/_inductor/wrapper.py
@@ -21,13 +21,11 @@ from torch._inductor.codegen.wrapper import (
     SubgraphPythonWrapperCodegen,
 )
 from torch._inductor.ir import GraphPartitionSignature
-from torch._inductor.utils import ValueWithLineMap
 from torch._inductor.virtualized import V
 from torch._inductor.sizevars import SizeVarAllocator
 
 from .errors import Unsupported
 from .ir import FixedTiledLayout
-from .constants import SEGMENT_SIZE
 
 
 class SpyrePythonWrapperCodegen(PythonWrapperCodegen):
@@ -72,41 +70,6 @@ class SpyrePythonWrapperCodegen(PythonWrapperCodegen):
         )
         self.header.writeline("del async_compile")
         self.header.writeline("async_compile = SpyreAsyncCompile()")
-
-    def generate(self, is_inference):
-        """Override to add pool allocation/deallocation around kernel calls."""
-        result_tuple = super().generate(is_inference)
-        wrapper_value_with_linemap, kernel_decls = result_tuple
-
-        hbm_pool_size = getattr(V.graph, "hbm_pool_size", 0)
-        if hbm_pool_size > 0:
-            wrapper_str = str(wrapper_value_with_linemap.value)
-
-            # Inject pool allocation before kernel calls and cleanup before return.
-            lines = wrapper_str.split("\n")
-
-            # Add `del _pool` before `return (` statement.
-            for i in range(len(lines) - 1, -1, -1):
-                line = lines[i].strip()
-                if line.startswith("return ("):
-                    indent = len(lines[i]) - len(lines[i].lstrip())
-                    lines.insert(i, " " * indent + "del _pool")
-                    break
-
-            # Add pool allocation before first kernel call (`.run(`).
-            pool_alloc_code = self.allocate_hbm_pool()
-            for i, line in enumerate(lines):
-                if ".run(" in line:
-                    indent = len(line) - len(line.lstrip())
-                    lines.insert(i, " " * indent + pool_alloc_code)
-                    break
-
-            wrapper_str = "\n".join(lines)
-            wrapper_value_with_linemap = ValueWithLineMap(
-                value=wrapper_str, line_map=wrapper_value_with_linemap.line_map
-            )
-
-        return (wrapper_value_with_linemap, kernel_decls)
 
     def make_buffer_allocation(self, buffer: BufferLike):
         layout = buffer.get_layout()
@@ -176,24 +139,6 @@ class SpyrePythonWrapperCodegen(PythonWrapperCodegen):
             )
         reinterpret_view = f"reinterpret_tensor_with_layout({old_name}, {new.get_size()}, {new.get_stride()}, {offset_increment}, {new_stl!r})"
         return f"{self.declare}{new_name} = {reinterpret_view}{del_line}  {self.comment} reuse"
-
-    def allocate_hbm_pool(self):
-        """Allocate the intermediate pool."""
-        # _pool is an opaque, flat byte-addressed region: individual buffers
-        # are placed into it at byte offsets (see hbm_pool_planning.py's
-        # layout.allocation["hbm_pool"] = offset) and it is passed to kernels
-        # as-is, never sliced/reshaped in Python.  A 1D uint8 tensor of
-        # pool_size_bytes elements is the natural, unambiguous
-        # representation -- no need to route it through a multi-dim device
-        # layout, and no need to divide by 128 (each uint8 element is
-        # already one byte, not one stick).
-        pool_size_bytes = getattr(V.graph, "hbm_pool_size", SEGMENT_SIZE)
-        return (
-            f"_pool = spyre_empty_with_layout("
-            f"({pool_size_bytes},), (1,), "
-            f"torch.uint8, SpyreTensorLayout(device_size=[{pool_size_bytes}], "
-            f"stride_map=[1], device_dtype=DataFormats.SENINT8))"
-        )
 
 
 def noop_simplify_loops_impl(


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Makes HBM pool allocation bundle-scoped instead of graph-global.

Previously, `hbm_pool_planning` ran in `CustomPreSchedulingPasses`, before
`spyre_fuse_nodes` had determined SDSC bundle boundaries, and allocated a
single graph-wide pool that stayed resident (allocated once in the wrapper
preamble, freed once at the end) for the entire duration of graph execution.

This PR moves the pass to run in `CustomPostFusionPasses`, after bundle
boundaries are final, and reworks it to:

- Compute pool eligibility, live ranges, and byte offsets **independently
  per bundle** rather than once for the whole graph. A buffer is
  pool-eligible only if the bundle that writes it is the same bundle that
  contains every read of it; a buffer written in one bundle and read in a
  different one falls back to standalone HBM, since bundle-scoped pools
  cannot persist across separate kernel invocations.
- Thread each bundle's own pool size (`V.graph.hbm_pool_sizes[bundle_name]`)
  into that bundle's `SpyreKernel` construction.
- Move pool allocation/deallocation codegen so each bundle's pool tensor is
  allocated immediately before, and freed immediately after, that bundle's
  own `.run()` call — replacing the old graph-global alloc-once/free-once
  mechanism in `wrapper.py`, which is deleted.

Net effect: instead of one pool sized for the whole graph's peak usage and
held live for the entire execution, each bundle gets its own right-sized
pool that is freed as soon as that bundle finishes, reducing peak HBM
pressure for graphs with multiple bundles.

Also fixes an emergent bug uncovered during this work: a loop-carried
accumulator inside a `CountedLoopSchedulerNode` was not correctly kept live
across the whole loop by the live-range analysis, because the loop node's
merged read/write set (`ReadWrites.merge_list`) drops a buffer that is both
written and read within the same node — a loop-carried accumulator has no
*visible* read from the loop node's own perspective. Fixed by keeping
`CountedLoopSchedulerNode` opaque (using `bundle.get_nodes()`, not a fully
flattened node list) when computing live ranges, so such a buffer
conservatively stays live through the rest of the bundle instead of having
its offset reused by another buffer live at the same time (e.g. the loop's
own per-iteration scratch tile). Covered by
`test_counted_loop_accumulator_stays_live_across_the_loop` in
`tests/inductor/test_hbm_pool_planning.py`.

Adds `docs/source/compiler/hbm_pool_planning.md`, documenting the pass's
scoping rules, algorithm, codegen integration, and its relationship to LX
scratchpad planning.

#### Which issue(s) this PR is related to:

Prep work for torch-spyre/torch-spyre#2503 ("Allocate temporary tensors in
compiler-managed segment").

#### Special notes for your reviewer:

- `torch_spyre/_inductor/wrapper.py`: the old graph-global pool
  alloc/dealloc mechanism is deleted outright (55 lines removed) now that
  `spyre_kernel.py` emits per-bundle alloc/free directly.
- `torch_spyre/_inductor/hbm_pool_planning.py` is substantially rewritten
  (284 lines changed) to compute everything per-bundle; see the module
  docstring and `docs/source/compiler/hbm_pool_planning.md` for the new
  algorithm.
- New test file `tests/inductor/test_hbm_pool_planning.py` covers: a buffer
  local to one bundle is pool-eligible; a buffer crossing bundles is not;
  multiple bundles each get their own `hbm_pool_sizes` entry; disabled
  config yields an empty dict; single-bundle offsets match pre-rewrite
  behavior (parity check); and the `CountedLoopSchedulerNode` live-range
  fix described above.
- `tests/inductor/test_coarse_tiling.py` and
  `tests/inductor/test_coarse_tile_e2e.py` gained additional coverage for
  multi-bundle graphs under the new per-bundle scoping.
- Full local regression scope (`test_coarse_tiling.py`,
  `test_building_blocks.py`, `test_hbm_pool_planning.py`,
  `test_coarse_tile_e2e.py`) plus `pre-commit run --all-files`: all green,
  460 passed / 49 skipped / 0 failed, no regressions.

#### Does this PR introduce a user-facing change?

No. This is an internal compiler-pass change; no public API, config
default, or generated-kernel numerical behavior changes for existing
single-bundle graphs (parity is pinned down by
`test_single_bundle_graph_offsets_match_pre_reorder_behavior`). Multi-bundle
graphs now see reduced peak HBM pool usage as pools are freed per-bundle
rather than held for the whole graph.

#### Additional note:

