### PR TITLE
(fix) : Masked scatter for Mistral model

### DIFF
--- a/tests/inductor/test_indirect_access_internals.py
+++ b/tests/inductor/test_indirect_access_internals.py
@@ -27,6 +27,7 @@ import os
 import sys
 
 import sympy
+import torch
 
 sys.path.insert(0, os.path.dirname(__file__))
 from indirect_access_common import (  # noqa: E402
@@ -679,6 +680,73 @@ class TestIndirectSdscValidator(IndirectAccessTestCase):
         # Merge a direct op file with the gather op file (distinct filenames).
         merged = {**direct, **_gather_bundle()}
         self.assert_indirect_sdsc_fields(merged, "gather")
+
+
+# ===========================================================================
+# Layer 5: masked_scatter row-mask acceptance (pure shape/stride logic, no device)
+# ===========================================================================
+class TestMaskedScatterRejectReason(IndirectAccessTestCase):
+    """Directly exercise `_masked_scatter_reject_reason`: which masks the row-gather
+    decomposition accepts (returns None) vs rejects (returns a reason string).
+
+    Device-free -- the function only reads .dim()/.shape/.stride(), so CPU meta
+    tensors suffice. This pins the row-broadcast acceptance matrix, including the
+    un-expanded [B, S, 1] mask that regressed as Unsupported before the fix.
+    """
+
+    def _reason(self, self_shape, mask, source_shape):
+        from torch_spyre._inductor.decompositions import (
+            _masked_scatter_reject_reason,
+        )
+
+        s = torch.empty(self_shape, dtype=torch.float16)
+        src = torch.empty(source_shape, dtype=torch.float16)
+        return _masked_scatter_reject_reason(s, mask, src)
+
+    def test_unexpanded_size1_last_dim_accepted(self):
+        """The regression case: a literal [B, S, 1] mask (stride(-1) == 1) into
+        [B, S, C] is a per-row mask and must be accepted."""
+        mask = torch.empty(1, 855, 1, dtype=torch.bool)
+        self.assertEqual(mask.stride(-1), 1)  # NOT broadcast; size-1 last dim
+        self.assertIsNone(self._reason((1, 855, 5120), mask, (266, 5120)))
+
+    def test_expanded_broadcast_last_dim_accepted(self):
+        """The already-supported spelling: [B, S, 1] expanded to [B, S, C] with
+        stride(-1) == 0 stays accepted (no regression)."""
+        mask = torch.empty(1, 855, 1, dtype=torch.bool).expand(1, 855, 5120)
+        self.assertEqual(mask.stride(-1), 0)
+        self.assertIsNone(self._reason((1, 855, 5120), mask, (266, 5120)))
+
+    def test_per_element_mask_rejected(self):
+        """A genuine per-element mask (last dim == cols, stride(-1) != 0) is not
+        a per-row mask and must still be rejected."""
+        mask = torch.empty(1, 855, 5120, dtype=torch.bool)
+        self.assertNotEqual(mask.stride(-1), 0)
+        reason = self._reason((1, 855, 5120), mask, (266, 5120))
+        self.assertIsNotNone(reason)
+        self.assertIn("per-row", reason)
+
+    def test_leading_dim_mismatch_rejected(self):
+        """Leading (row) dims must match self exactly so mask[..., 0] yields one
+        bool per row; a leading-dim broadcast is rejected."""
+        mask = torch.empty(1, 1, 1, dtype=torch.bool)
+        reason = self._reason((1, 855, 5120), mask, (266, 5120))
+        self.assertIsNotNone(reason)
+        self.assertIn("leading", reason)
+
+    def test_degenerate_single_column_rejected(self):
+        """cols == 1 is a degenerate row (no block-per-row equivalence)."""
+        mask = torch.empty(8, 1, dtype=torch.bool)
+        reason = self._reason((8, 1), mask, (4, 1))
+        self.assertIsNotNone(reason)
+        self.assertIn("degenerate", reason)
+
+    def test_rank_mismatch_rejected(self):
+        """mask rank must equal self rank."""
+        mask = torch.empty(1, 855, dtype=torch.bool)
+        reason = self._reason((1, 855, 5120), mask, (266, 5120))
+        self.assertIsNotNone(reason)
+        self.assertIn("rank", reason)
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_indirect_access_scatter.py
+++ b/tests/inductor/test_indirect_access_scatter.py
@@ -276,6 +276,35 @@ class TestScatter(IndirectAccessTestCase):
             kernel, inp, mask, src, expect=GATHER_OP_SPEC, expect_close=True
         )
 
+    def test_masked_scatter_unexpanded_row_broadcast(self):
+        """torch.masked_scatter with a row mask left in its UN-EXPANDED form:
+        a literal size-1 last dim [B, S, 1] (stride(-1) == 1), not broadcast up
+        to [B, S, C]. This is what real models hand us (e.g. Mistral-Small-3.2's
+        `inputs_embeds.masked_scatter(special_image_mask, image_features)` with
+        mask [1, 855, 1] into self [1, 855, 5120]).
+
+        It is the same whole-row selection as the expanded form -- mask[..., 0]
+        collapses either spelling to one bool per row -- so it must also lower to
+        a gather.
+        """
+        ROWS, COLS, SRC_ROWS, N_TRUE = 855, 5120, 266, 266
+        inp = torch.rand(1, ROWS, COLS, dtype=torch.float16).to("spyre")
+        src = torch.rand(SRC_ROWS, COLS, dtype=torch.float16).to("spyre")
+        # Un-expanded: [1, ROWS, 1], NOT .expand()-ed to [1, ROWS, COLS].
+        mask_1d = torch.zeros(1, ROWS, dtype=torch.bool)
+        mask_1d[0, torch.randperm(ROWS)[:N_TRUE]] = True
+        mask = mask_1d.unsqueeze(-1).to("spyre")  # shape [1, ROWS, 1]
+        self.assertEqual(tuple(mask.shape), (1, ROWS, 1))
+        self.name_dims(inp, {"B": 1, "ROWS": ROWS, "COLS": COLS})
+        self.name_dims(src, {"SRC_ROWS": SRC_ROWS, "COLS": COLS})
+
+        def kernel(inp, mask, src):
+            return torch.masked_scatter(inp, mask, src)
+
+        self._stage_and_e2e(
+            kernel, inp, mask, src, expect=GATHER_OP_SPEC, expect_close=True
+        )
+
     def _row_broadcast_operands(self, shape, src_rows, n_true):
         """Supported masked_scatter operands: `self` of `shape`, a mask broadcast
         along the last dim (stride(-1) == 0) with `n_true` selected rows, and a

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -958,28 +958,44 @@ def _masked_scatter_reject_reason(
 ) -> Optional[str]:
     """Why ``masked_scatter`` cannot use the row-level path here, or ``None`` if it can.
 
-    Checks are ordered from cheapest/most general to most specific:
+    The mask must select whole rows: constant across the last (column) dim, with
+    every other dim matching ``self`` so there is exactly one mask bool per row.
+    That covers both spellings PyTorch may hand us for a row-broadcast mask, which
+    the body collapses identically via ``mask[..., 0]``:
+      * un-expanded -- the last dim is literally ``1`` (e.g. ``[B, S, 1]``); or
+      * expanded    -- the last dim is ``cols`` but broadcast (``stride(-1) == 0``).
+
+    Checks are ordered cheapest/most-general to most-specific:
       1. Rank guards (no device_layout access needed).
-      2. Exact shape equality (subsumes individual last-dim checks).
+      2. Leading-dim equality (one mask entry per row).
       3. Degenerate column guard (cols <= 1 is not a meaningful row).
       4. Source column alignment.
-      5. Broadcast-stride check (the structural row-level requirement).
+      5. Per-row last-dim check (the structural row-level requirement).
     """
     if self.dim() < 2 or source.dim() < 2 or mask.dim() != self.dim():
         return f"rank: self={self.dim()} mask={mask.dim()} source={source.dim()}"
-    # Shape equality subsumes last-dim equality; check it first so the error
-    # message names the full shape rather than just one dimension.
-    if tuple(mask.shape) != tuple(self.shape):
-        return f"mask shape {tuple(mask.shape)} != self {tuple(self.shape)}"
+    # One mask entry per row: every dim but the last must match self exactly, so
+    # mask[..., 0] has exactly `rows` elements. (The last dim may differ: it is
+    # either a literal 1 or a broadcast of cols -- checked below.)
+    if tuple(mask.shape[:-1]) != tuple(self.shape[:-1]):
+        return (
+            f"mask leading dims {tuple(mask.shape[:-1])} != self "
+            f"{tuple(self.shape[:-1])}"
+        )
     cols = self.shape[-1]
     # cols <= 1 is a degenerate row that offers no block-per-row equivalence.
     if cols <= 1:
         return f"degenerate last dim: cols={cols}"
     if source.shape[-1] != cols:
         return f"source last dim {source.shape[-1]} != self last dim {cols}"
-    # stride(-1) == 0 is what makes the mask per-row rather than per-element.
-    if mask.stride(-1) != 0:
-        return f"mask is not broadcast in its last dim (stride {mask.stride()})"
+    # Per-row means the mask is constant across the last dim. Accept a literal
+    # size-1 last dim (un-expanded) or a broadcast last dim (stride 0); reject a
+    # genuinely per-element mask (last dim cols with a non-zero stride).
+    if mask.shape[-1] != 1 and mask.stride(-1) != 0:
+        return (
+            f"mask is not per-row in its last dim (shape {tuple(mask.shape)}, "
+            f"stride {tuple(mask.stride())})"
+        )
     return None
 
 


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes `spyre_masked_scatter` rejecting a **legitimate row-broadcast mask** when it is passed in its *un-expanded* form.

The decomposition supports a mask that selects whole rows (one bool per row, broadcast across the column dim). But `_masked_scatter_reject_reason` only recognized the **expanded** spelling of such a mask -- full shape `[B, S, C]` with `stride(-1) == 0` -- and rejected the equivalent **un-expanded** spelling with a literal size-1 last dim (`[B, S, 1]`), which is what real models hand us.

Mistral-Small-3.2-24B does exactly this:

```
inputs_embeds.masked_scatter(special_image_mask, image_features)
# self=[1,855,5120], mask=[1,855,1] (bool), source=[266,5120]
```

which failed to compile with:

```
Unsupported: masked_scatter needs a mask broadcast along the last dim so it
selects whole rows (mask shape (1, 855, 1) != self (1, 855, 5120)). ...
```

Two checks were too strict and are relaxed to accept both spellings of a per-row mask:

| Old check | Why it wrongly rejected `[1,855,1]` | New check |
|---|---|---|
| `tuple(mask.shape) != tuple(self.shape)` | requires the mask to already be expanded to `self`'s full shape | `tuple(mask.shape[:-1]) != tuple(self.shape[:-1])` -- only the leading (row) dims must match, so `mask[..., 0]` still yields exactly one bool per row |
| `mask.stride(-1) != 0` | a size-1 last dim has `stride(-1) == 1`, not `0` | `mask.shape[-1] != 1 and mask.stride(-1) != 0` -- accept a literal size-1 last dim **or** a broadcast (`stride 0`) one; still reject a genuine per-element mask (last dim `cols` with non-zero stride) |

The decomposition body is unchanged: `mask[..., 0]` already collapses either spelling to one bool per row.

#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/issues/2637

#### Does this PR introduce a user-facing change?

`torch.masked_scatter` with a row-broadcast mask supplied in un-expanded form (size-1 last dim, e.g. `[B, S, 1]` into `[B, S, C]`) previously failed to compile on Spyre; it now compiles via the row-gather decomposition. No API change.

#### Additional note:

Part of the broader indirect-access / masked_scatter enablement. Unblocks the `masked_scatter` op in the Mistral-Small-3.2-24B-Instruct-2506 model-ops suite.