### PR TITLE
fix: surface underlying error when backend autoload fails

### DIFF
--- a/torch_spyre/__init__.py
+++ b/torch_spyre/__init__.py
@@ -260,6 +260,29 @@ def _autoload():
         return
     _autoload._ran = True
 
+    try:
+        _autoload_impl()
+    except BaseException:
+        # PyTorch's _import_device_backends() catches whatever this entrypoint
+        # raises and re-raises a generic "Failed to load the backend extension:
+        # torch_spyre" RuntimeError. In CI logs the chained cause is often not
+        # printed, so the real reason (e.g. an ImportError for an undefined
+        # symbol in a native runtime library such as libspyre_comms /
+        # libflex) is hidden and the failure looks like a mystery. Log the full
+        # traceback here, before control returns to PyTorch, then re-raise so
+        # behaviour is otherwise unchanged.
+        import sys
+        import traceback
+
+        print(
+            "torch_spyre backend autoload failed; underlying error follows:",
+            file=sys.stderr,
+        )
+        traceback.print_exc()
+        raise
+
+
+def _autoload_impl():
     import torch  # noqa: E402
 
     # Set all the appropriate state on PyTorch


### PR DESCRIPTION
PyTorch's `_import_device_backends()` wraps any exception raised by the `torch_spyre` autoload entrypoint in a generic:

```
RuntimeError: Failed to load the backend extension: torch_spyre.
You can disable extension auto-loading with TORCH_DEVICE_BACKEND_AUTOLOAD=0.
```

In CI logs the chained cause is frequently not shown, so the real reason is hidden and the failure looks like a mystery. A recent fleet-wide CI red was exactly this: every test crashed at `import torch` with only the generic message. The true cause only became visible by running on a pod:

```
ImportError: /opt/ibm/spyre/spyre-comms/lib/libspyre_comms.so.1: undefined symbol:
  _ZN4flex15createDmaParamsEPvmbPKNS_16CompositeAddressESt10shared_ptrI20data_conversion_infoE
```

(an undefined symbol in a native runtime library, a build/packaging skew unrelated to torch-spyre source).

## Change

Wrap the autoload body (`_autoload_impl`) so that if any import or registration fails, the full traceback of the underlying error is printed to stderr **before** control returns to PyTorch, then re-raise. Behaviour is otherwise unchanged: the same exception still propagates, PyTorch still raises its generic wrapper, but now the real cause is in the log.

## Why

So the next time a native runtime library is mismatched (or any autoload step fails), the actual error is visible directly in CI output without needing pod access to reproduce.

No functional change to the happy path.