### PR TITLE
Remove RECORD_FUNCTION from SpyreStream::synchronize

### DIFF
--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -147,7 +147,6 @@ bool SpyreStream::query() const {
 }
 
 void SpyreStream::synchronize() const {
-  RECORD_FUNCTION("host::synchronize", {});
   c10::DeviceGuard device_guard(stream_.device());
 
   DEBUGINFO("SpyreStream::synchronize() - stream ", id(), " on device ",


### PR DESCRIPTION
Remove RECORD_FUNCTION call from synchronize method.

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] cleanup

#### What this PR does:

<!--
Removes host::syncronize record function as it is being captured in flex
-->

#### Which issue(s) this PR is related to:

<!--[
(https://github.com/torch-spyre/torch-spyre/issues/3171)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
