### PR TITLE
DO NOT MERGE: shadow-validation for /next :dev runner image switch

### DIFF
--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -115,7 +115,11 @@ jobs:
     with:
       runner_label: linux
       # Per-PR ephemeral image label when provided, else the standing set.
-      image_label: ${{ inputs.runner_label || 'image_spyre_backend' }}
+      # SHADOW-VALIDATION (do not merge): redirected to the isolated shadow
+      # runner set so this suite exercises the /next :dev backend image on the
+      # `image_spyre_backend_shadow` sets. Restore to 'image_spyre_backend'
+      # before this branch is ever merged.
+      image_label: ${{ inputs.runner_label || 'image_spyre_backend_shadow' }}
       extra_test_flags: -v -m "not xfail"
       extra_test_flags_multi_spyre: -v
       checkout_pytorch: false

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -127,7 +127,7 @@ jobs:
     with:
       runner_label: linux
       # Per-PR ephemeral image label when provided, else the standing set.
-      image_label: ${{ inputs.runner_label || 'image_spyre_backend' }}
+      image_label: ${{ inputs.runner_label || 'image_spyre_backend_shadow' }}
       extra_test_flags: -v -m "not xfail"
       extra_test_flags_multi_spyre: -v
       checkout_pytorch: false


### PR DESCRIPTION
**Do not merge.** Throwaway PR that drives the Spyre unit-test suite onto the isolated *shadow* runner sets to validate the ARC runner-set image switch to `icr.io/ai_sw_accel/2.0/next/*:dev`.

Change: `torch_spyre_tests.yaml` redirects the standing image label `image_spyre_backend` -> `image_spyre_backend_shadow`. The shadow `spyrebackend` sets boot `icr.io/ai_sw_accel/2.0/next/spyre-backend:dev` (the /next dev image with the baked GHA runner). Prod sets are untouched (bidirectional label isolation).

Purpose: prove the suite runs green on the `/next :dev` image before promoting the runner-set generator change (spyre-frameworks `shadow-gha-runnerset` -> `main`). This branch is reset from `main` each validation cycle and is never merged.