### PR TITLE
WSR: replace seed-buffer carry heuristic with partial-reduction detection        

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -58,7 +58,6 @@ from torch._inductor.utils import run_and_get_code
 from torch_spyre._inductor import config
 from torch_spyre._inductor import spyre_hint
 import torch_spyre._inductor.wsr.propagate_named_dims as _pnd
-from torch._inductor.exc import InductorError
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
 from utils_inductor import compare_with_cpu, _compile_and_run  # noqa: E402

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -825,7 +825,12 @@ def test_min_3d_512x256x256_reduce_dim2_A4_B2_C4():
 
 
 def test_add_min_2d_512x256_reduce_dim0_A4():
-    """min(a + abs(amin(b, dim=0))) on [512,256] tiled A÷4."""
+    """a + abs(amin(b, dim=0)) on [512,256] tiled A÷4 must be rejected.
+
+    abs and add are loop-invariant at the reduction level but share the loop
+    group with the A-tiled reduction — they would see a partial (per-tile)
+    min, not the global min.
+    """
     inputs = [
         tensor("a", shape=(512, 256), dims=["A", "B"]),
         tensor("b", shape=(512, 256), dims=["A", "B"]),
@@ -840,7 +845,11 @@ def test_add_min_2d_512x256_reduce_dim0_A4():
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return a + temp
 
-    run_coarse_tile_test(fn, inputs, correctness=False)  # Incorrect results
+    with pytest.raises(
+        Exception,
+        match="partial reduction result consumed before accumulation is complete",
+    ):
+        run_coarse_tile_test(fn, inputs)
 
 
 def test_add_min_2d_512x256_reduce_dim0_B4():
@@ -863,7 +872,7 @@ def test_add_min_2d_512x256_reduce_dim0_B4():
 
 
 def test_add_min_2d_512x256_reduce_dim0_A4_B4():
-    """min(a + abs(amin(b, dim=0))) on [512,256] tiled A÷4 B÷4."""
+    """a + abs(amin(b, dim=0)) on [512,256] tiled A÷4 B÷4 must be rejected."""
     inputs = [
         tensor("a", shape=(512, 256), dims=["A", "B"]),
         tensor("b", shape=(512, 256), dims=["A", "B"]),
@@ -881,7 +890,11 @@ def test_add_min_2d_512x256_reduce_dim0_A4_B4():
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     return a + temp
 
-    run_coarse_tile_test(fn, inputs, correctness=False)  # Incorrect results
+    with pytest.raises(
+        Exception,
+        match="partial reduction result consumed before accumulation is complete",
+    ):
+        run_coarse_tile_test(fn, inputs)
 
 
 def test_add_min_2d_512x256_reduce_dim1_A4():
@@ -904,7 +917,7 @@ def test_add_min_2d_512x256_reduce_dim1_A4():
 
 
 def test_add_min_2d_512x256_reduce_dim1_B4():
-    """min(a + abs(amin(b, dim=1))) on [512,256] tiled B÷4."""
+    """a + abs(amin(b, dim=1)) on [512,256] tiled B÷4 must be rejected."""
     inputs = [
         tensor("a", shape=(512, 256), dims=["A", "B"]),
         tensor("b", shape=(512, 256), dims=["A", "B"]),
@@ -919,11 +932,15 @@ def test_add_min_2d_512x256_reduce_dim1_B4():
             with spyre_hint(expected_named_dims=["A", "B"]):
                 return a + temp
 
-    run_coarse_tile_test(fn, inputs, correctness=False)  # Incorrect results
+    with pytest.raises(
+        Exception,
+        match="partial reduction result consumed before accumulation is complete",
+    ):
+        run_coarse_tile_test(fn, inputs)
 
 
 def test_add_min_2d_512x256_reduce_dim1_A4_B4():
-    """min(a + abs(amin(b, dim=1))) on [512,256] tiled A÷4 B÷4."""
+    """a + abs(amin(b, dim=1)) on [512,256] tiled A÷4 B÷4 must be rejected."""
     inputs = [
         tensor("a", shape=(512, 256), dims=["A", "B"]),
         tensor("b", shape=(512, 256), dims=["A", "B"]),
@@ -941,7 +958,11 @@ def test_add_min_2d_512x256_reduce_dim1_A4_B4():
                 with spyre_hint(expected_named_dims=["A", "B"]):
                     return a + temp
 
-    run_coarse_tile_test(fn, inputs, correctness=False)  # Incorrect results
+    with pytest.raises(
+        Exception,
+        match="partial reduction result consumed before accumulation is complete",
+    ):
+        run_coarse_tile_test(fn, inputs)
 
 
 @pytest.mark.skip(reason="inconsistent loop_count across reduction fill/combine nodes")
@@ -1021,7 +1042,7 @@ def test_add_min_3d_512x256x256_reduce_dim2_A4_B2_C4():
 
 
 def test_reduce_both_dense_add_2d_512x256_A4():
-    """amin(a,dim=0) + amin(b,dim=0) on [512,256] tiled A÷4 — dense+dense."""
+    """amin(a,dim=0) + amin(b,dim=0) on [512,256] tiled A÷4 must be rejected."""
     inputs = [
         tensor("a", shape=(512, 256), dims=["A", "B"]),
         tensor("b", shape=(512, 256), dims=["A", "B"]),
@@ -1032,7 +1053,11 @@ def test_reduce_both_dense_add_2d_512x256_A4():
             with spyre_hint(expected_named_dims=["B"]):
                 return a.amin(dim=0) + b.amin(dim=0)
 
-    run_coarse_tile_test(fn, inputs, correctness=False)  # Incorrect results
+    with pytest.raises(
+        Exception,
+        match="partial reduction result consumed before accumulation is complete",
+    ):
+        run_coarse_tile_test(fn, inputs)
 
 
 def test_reduce_both_dense_add_2d_512x256_B4():
@@ -1051,7 +1076,7 @@ def test_reduce_both_dense_add_2d_512x256_B4():
 
 
 def test_reduce_both_dense_add_2d_512x256_A4_B4():
-    """amin(a,dim=0) + amin(b,dim=0) on [512,256] tiled A÷4 B÷4 — dense+dense."""
+    """amin(a,dim=0) + amin(b,dim=0) on [512,256] tiled A÷4 B÷4 must be rejected."""
     inputs = [
         tensor("a", shape=(512, 256), dims=["A", "B"]),
         tensor("b", shape=(512, 256), dims=["A", "B"]),
@@ -1063,7 +1088,11 @@ def test_reduce_both_dense_add_2d_512x256_A4_B4():
                 with spyre_hint(expected_named_dims=["B"]):
                     return a.amin(dim=0) + b.amin(dim=0)
 
-    run_coarse_tile_test(fn, inputs, correctness=False)  # Incorrect results
+    with pytest.raises(
+        Exception,
+        match="partial reduction result consumed before accumulation is complete",
+    ):
+        run_coarse_tile_test(fn, inputs)
 
 
 def test_reduce_both_sparse_add_2d_512x256_A4():
@@ -1082,7 +1111,7 @@ def test_reduce_both_sparse_add_2d_512x256_A4():
 
 
 def test_reduce_both_sparse_add_2d_512x256_B4():
-    """amin(a,dim=1) + amin(b,dim=1) on [512,256] tiled B÷4 — sparse+sparse."""
+    """amin(a,dim=1) + amin(b,dim=1) on [512,256] tiled B÷4 must be rejected."""
     inputs = [
         tensor("a", shape=(512, 256), dims=["A", "B"]),
         tensor("b", shape=(512, 256), dims=["A", "B"]),
@@ -1093,11 +1122,15 @@ def test_reduce_both_sparse_add_2d_512x256_B4():
             with spyre_hint(expected_named_dims=["A"]):
                 return a.amin(dim=1) + b.amin(dim=1)
 
-    run_coarse_tile_test(fn, inputs, correctness=False)  # Incorrect results
+    with pytest.raises(
+        Exception,
+        match="partial reduction result consumed before accumulation is complete",
+    ):
+        run_coarse_tile_test(fn, inputs)
 
 
 def test_reduce_both_sparse_add_2d_512x256_A4_B4():
-    """amin(a,dim=1) + amin(b,dim=1) on [512,256] tiled A÷4 B÷4 — sparse+sparse."""
+    """amin(a,dim=1) + amin(b,dim=1) on [512,256] tiled A÷4 B÷4 must be rejected."""
     inputs = [
         tensor("a", shape=(512, 256), dims=["A", "B"]),
         tensor("b", shape=(512, 256), dims=["A", "B"]),
@@ -1109,7 +1142,41 @@ def test_reduce_both_sparse_add_2d_512x256_A4_B4():
                 with spyre_hint(expected_named_dims=["A"]):
                     return a.amin(dim=1) + b.amin(dim=1)
 
-    run_coarse_tile_test(fn, inputs, correctness=False)  # Incorrect results
+    with pytest.raises(
+        Exception,
+        match="partial reduction result consumed before accumulation is complete",
+    ):
+        run_coarse_tile_test(fn, inputs)
+
+
+def test_partial_reduction_two_hop_A4():
+    """a + amin(b)*c on [512,256] tiled A÷4 must be rejected at compile time.
+
+    amin reduces A away; the multiply by c is a second hop from the partial
+    scratch before feeding the A-tiled add.  The compiler must raise
+    Unsupported at the multiply (first direct reader of the partial scratch),
+    not silently produce wrong results.
+    """
+    inputs = [
+        tensor("a", shape=(512, 256), dims=["A", "B"]),
+        tensor("b", shape=(512, 256), dims=["A", "B"]),
+        tensor("c", shape=(256,), dims=["B"]),
+    ]
+
+    def fn(a, b, c):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
+                r = b.amin(dim=0)
+            with spyre_hint(expected_named_dims=["B"]):
+                t = r * c
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                return a + t
+
+    with pytest.raises(
+        Exception,
+        match="partial reduction result consumed before accumulation is complete",
+    ):
+        run_coarse_tile_test(fn, inputs)
 
 
 # softmax decomposes into amax + pointwise + sum + pointwise — exercises
@@ -1726,30 +1793,8 @@ def test_copy_rmw_correction_512x256_A4_B4():
 # copies sparse reduction result into a dense buffer
 
 
-def test_copy_not_deleted():
-    """Regression: copy_ must not be eliminated by noop_registry removal.
-
-    If copy_ is deleted before lowering, the expected_reduction_dims hint on
-    the copy op is never checked (no op to check), and the test passes
-    vacuously.  If copy_ is present, validate_named_dims fires and raises
-    because copy_ has no reduction dim -- that AssertionError is the expected
-    outcome, proving the copy survived.
-    """
-    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
-
-    def fn(x):
-        out = torch.zeros(256, device=x.device, dtype=x.dtype)
-        with spyre_hint(num_tiles_per_dim={"A": 4}):
-            with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
-                out.copy_(x.amin(dim=0))
-        return out
-
-    with pytest.raises(InductorError, match="expected_reduction_dims"):
-        run_coarse_tile_test(fn, inputs)
-
-
 def test_copy_after_reduction_512x256_A4():
-    """out.copy_(x.amin(dim=0)) on [512,256] tiled A÷4."""
+    """out.copy_(x.amin(dim=0)) on [512,256] tiled A÷4 must be rejected."""
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
 
     def fn(x):
@@ -1761,7 +1806,11 @@ def test_copy_after_reduction_512x256_A4():
                 out.copy_(temp)
         return out
 
-    run_coarse_tile_test(fn, inputs, correctness=False)
+    with pytest.raises(
+        Exception,
+        match="partial reduction result consumed before accumulation is complete",
+    ):
+        run_coarse_tile_test(fn, inputs)
 
 
 def test_copy_after_reduction_512x256_B4():
@@ -1781,7 +1830,7 @@ def test_copy_after_reduction_512x256_B4():
 
 
 def test_copy_after_reduction_512x256_A4_B4():
-    """out.copy_(x.amin(dim=0)) on [512,256] tiled A÷4 B÷4."""
+    """out.copy_(x.amin(dim=0)) on [512,256] tiled A÷4 B÷4 must be rejected."""
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
 
     def fn(x):
@@ -1796,7 +1845,11 @@ def test_copy_after_reduction_512x256_A4_B4():
                     out.copy_(temp)
         return out
 
-    run_coarse_tile_test(fn, inputs, correctness=False)  # Incorrect results
+    with pytest.raises(
+        Exception,
+        match="partial reduction result consumed before accumulation is complete",
+    ):
+        run_coarse_tile_test(fn, inputs)
 
 
 def test_copy_running_max_4d_H4_Lq4():
@@ -2168,7 +2221,7 @@ def test_outside_consumer_two_accum_512x256_A4():
 
 
 def test_outside_consumer_two_accum_512x256_B4():
-    """Flash-style: out=zeros, denom=zeros; tiled copy_; return out/denom — B÷4."""
+    """Flash-style: out=zeros, denom=zeros; tiled copy_; return out/denom — B÷4 must be rejected."""
     inputs = [
         tensor("x", shape=(512, 256), dims=["A", "B"]),
         tensor("scale", shape=(512, 256), dims=["A", "B"]),
@@ -2184,7 +2237,11 @@ def test_outside_consumer_two_accum_512x256_B4():
                 denom.copy_(denom + x.sum(dim=1))
         return out / denom.unsqueeze(1)
 
-    run_coarse_tile_test(fn, inputs, loopspec=None, correctness=False)
+    with pytest.raises(
+        Exception,
+        match="partial reduction result consumed before accumulation is complete",
+    ):
+        run_coarse_tile_test(fn, inputs)
 
 
 @pytest.mark.skip(
@@ -2665,18 +2722,19 @@ def test_flash_tile_Lq():
     )
 
 
-@pytest.mark.skip(
-    reason="Unsupported: Lk reduction-dim tiling requires carry propagation"
-)
 def test_flash_tile_Lk():
-    """Flash v1: tile Lk÷2 only."""
-    run_coarse_tile_test(
-        lambda q, k, v: _flash_v1_fn(
-            q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, lk_tiles=2
-        ),
-        _flash_v1_inputs(1, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[2]),
-    )
+    """Flash v1: tile Lk÷2 only — rejected at compile time (carry propagation)."""
+    with pytest.raises(
+        Exception,
+        match="partial reduction result consumed before accumulation is complete",
+    ):
+        run_coarse_tile_test(
+            lambda q, k, v: _flash_v1_fn(
+                q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, lk_tiles=2
+            ),
+            _flash_v1_inputs(1, 8, 256, 256, 64),
+            loopspec=LoopSpecCheck(counts=[2]),
+        )
 
 
 @pytest.mark.skip(reason="KeyError: 0 — B tiling not yet supported")
@@ -2712,41 +2770,56 @@ def test_flash_tile_H_Lq():
     )
 
 
-@pytest.mark.skip(
-    reason="Unsupported: Lk reduction-dim tiling requires carry propagation"
-)
 def test_flash_tile_H_Lq_Lk():
-    """Flash v1: tile H÷4 Lq÷2 Lk÷2."""
-    run_coarse_tile_test(
-        lambda q, k, v: _flash_v1_fn(
-            q, k, v, B=1, H=8, Lq=256, Lk=256, D=64, h_tiles=4, lq_tiles=2, lk_tiles=2
-        ),
-        _flash_v1_inputs(1, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[4, 2, 2]),
-    )
+    """Flash v1: tile H÷4 Lq÷2 Lk÷2 — rejected at compile time (carry propagation)."""
+    with pytest.raises(
+        Exception,
+        match="partial reduction result consumed before accumulation is complete",
+    ):
+        run_coarse_tile_test(
+            lambda q, k, v: _flash_v1_fn(
+                q,
+                k,
+                v,
+                B=1,
+                H=8,
+                Lq=256,
+                Lk=256,
+                D=64,
+                h_tiles=4,
+                lq_tiles=2,
+                lk_tiles=2,
+            ),
+            _flash_v1_inputs(1, 8, 256, 256, 64),
+            loopspec=LoopSpecCheck(counts=[4, 2, 2]),
+        )
 
 
 @pytest.mark.skip(reason="KeyError: 0 — B tiling not yet supported")
 def test_flash_tile_all():
-    """Flash v1: tile all dims. B=2, H÷4, Lq÷2, Lk÷2."""
-    run_coarse_tile_test(
-        lambda q, k, v: _flash_v1_fn(
-            q,
-            k,
-            v,
-            B=2,
-            H=8,
-            Lq=256,
-            Lk=256,
-            D=64,
-            b_tiles=2,
-            h_tiles=4,
-            lq_tiles=2,
-            lk_tiles=2,
-        ),
-        _flash_v1_inputs(2, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[2, 4, 2, 2]),
-    )
+    """Flash v1: tile all dims. B=2, H÷4, Lq÷2, Lk÷2 — rejected at compile time (carry propagation)."""
+    with pytest.raises(
+        Exception,
+        match="partial reduction result consumed before accumulation is complete",
+    ):
+        run_coarse_tile_test(
+            lambda q, k, v: _flash_v1_fn(
+                q,
+                k,
+                v,
+                B=2,
+                H=8,
+                Lq=256,
+                Lk=256,
+                D=64,
+                b_tiles=2,
+                h_tiles=4,
+                lq_tiles=2,
+                lk_tiles=2,
+            ),
+            _flash_v1_inputs(2, 8, 256, 256, 64),
+            loopspec=LoopSpecCheck(counts=[2, 4, 2, 2]),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -2897,18 +2970,19 @@ def test_flash_v2_tile_Lq():
     )
 
 
-@pytest.mark.skip(
-    reason="Unsupported: Lk reduction-dim tiling requires carry propagation"
-)
 def test_flash_v2_tile_Lk():
-    """Flash v2: tile Lk÷2 only."""
-    run_coarse_tile_test(
-        lambda q, k, v, m: _flash_v2_fn(
-            q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, lk_tiles=2
-        ),
-        _flash_v2_inputs(1, 8, 256, 256, 64),
-        loopspec=LoopSpecCheck(counts=[2]),
-    )
+    """Flash v2: tile Lk÷2 only — rejected at compile time (carry propagation)."""
+    with pytest.raises(
+        Exception,
+        match="partial reduction result consumed before accumulation is complete",
+    ):
+        run_coarse_tile_test(
+            lambda q, k, v, m: _flash_v2_fn(
+                q, k, v, m, B=1, H=8, Lq=256, Lk=256, D=64, lk_tiles=2
+            ),
+            _flash_v2_inputs(1, 8, 256, 256, 64),
+            loopspec=LoopSpecCheck(counts=[2]),
+        )
 
 
 @pytest.mark.skip(reason="KeyError: 0 — B tiling not yet supported")

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -52,6 +52,7 @@ import torch
 import unittest
 from unittest.mock import patch as mock_patch
 
+from torch._inductor.exc import InductorError
 from torch._inductor.test_case import TestCase as InductorTestCase, fresh_cache
 from torch._inductor.utils import run_and_get_code
 
@@ -1790,6 +1791,28 @@ def test_copy_rmw_correction_512x256_A4_B4():
 
 # --- copy after reduction: out.copy_(x.amin(dim=0)) ---
 # copies sparse reduction result into a dense buffer
+
+
+def test_copy_not_deleted():
+    """Regression: copy_ must not be eliminated by noop_registry removal.
+
+    If copy_ is deleted before lowering, the expected_reduction_dims hint on
+    the copy op is never checked (no op to check), and the test passes
+    vacuously.  If copy_ is present, validate_named_dims fires and raises
+    because copy_ has no reduction dim -- that AssertionError is the expected
+    outcome, proving the copy survived.
+    """
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        out = torch.zeros(256, device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
+                out.copy_(x.amin(dim=0))
+        return out
+
+    with pytest.raises(InductorError, match="expected_reduction_dims"):
+        run_coarse_tile_test(fn, inputs)
 
 
 def test_copy_after_reduction_512x256_A4():

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -2030,104 +2030,6 @@ class TestCoarseTileTiledDimsPerRead(unittest.TestCase):
             ):
                 plan_coarse_tile_groups(group_ops, [(group_ops, levels)])
 
-    def test_plan_raises_unsupported_for_carry(self):
-        """Planning raises Unsupported for an op requiring carry propagation.
-
-        Models the flash-attention online-softmax shape
-        (tests/inductor/test_coarse_tile_e2e.py::test_hint_flash_attention's
-        running_max/QK^T pattern): a Reduction op ("red0", e.g. the QK^T
-        matmul) tiles its reduction dim at the group's only level, and a
-        sibling Pointwise op ("carry0", e.g. the running-max update) is
-        loop-invariant at that level (no output-dim tiling there) and reads
-        a pre-loop constant-fill seed buffer directly -- the exact shape
-        _seed_buffer_for_carry's docstring describes.
-
-        The seed itself must be a ComputedBuffer(Pointwise) wrapping a
-        SpyreConstantFallback scalar (matching lowering.py's real
-        full.default lowering and coarse_tile.py's own fill-insertion code
-        at ~line 2023) -- _seed_buffer_for_carry only accepts ComputedBuffer
-        reads as seed candidates (see coarse_tile.py's
-        `isinstance(buf, ComputedBuffer)` check), so carry0 must read this
-        wrapper buffer ("seed0"), not the raw SpyreConstantFallback scalar
-        directly.
-
-        _seed_buffer_for_carry uses _seed_closure_pre_stamp, which scans
-        group_ops directly rather than requiring a stamped loop_info --
-        planning is zero-mutation and runs before _apply_plan, so no op
-        has loop_info yet. No fixture pre-stamping is needed or performed
-        here; this exercises the real, never-stamped-during-planning path.
-        """
-        from torch._inductor.ir import (
-            ComputedBuffer,
-            FixedLayout,
-            Pointwise,
-            StorageBox,
-            TensorBox,
-        )
-        from torch_spyre._inductor.ir import SpyreConstantFallback
-
-        red_op = _make_real_reduction_op(
-            ranges=[Integer(8)],
-            reduction_ranges=[Integer(16)],
-            input_shape_stride=([8, 16], [16, 1]),
-            name="red0",
-            hints=((1, 1),),
-        )
-
-        # Seed buffer: a constant-fill wrapper -- ComputedBuffer(Pointwise)
-        # whose only read resolves to a SpyreConstantFallback scalar (see
-        # _is_constant_fill). Mirrors torch.full's real lowering shape.
-        scalar_op = SpyreConstantFallback(
-            torch.ops.spyre.constant.default, 0.0, torch.float32, torch.device("cpu")
-        )
-        scalar_loader = TensorBox(StorageBox(scalar_op)).make_loader()
-
-        def seed_inner_fn(index, _loader=scalar_loader):
-            return _loader([])
-
-        seed_pw = Pointwise(
-            device=torch.device("cpu"),
-            dtype=torch.float32,
-            inner_fn=seed_inner_fn,
-            ranges=[Integer(8)],
-        )
-        seed_buf = ComputedBuffer(
-            name="seed0",
-            layout=FixedLayout(torch.device("cpu"), torch.float32, [Integer(8)], None),
-            data=seed_pw,
-        )
-        seed_buf.operation_name = "seed0"
-        V.graph.name_to_buffer["seed0"] = seed_buf
-
-        # carry0 reads the seed buffer directly -- the running-max-style
-        # carry step, loop-invariant at the reduction-tiled level.
-        seed_loader = TensorBox(StorageBox(seed_buf)).make_loader()
-
-        def carry_inner_fn(index, _loader=seed_loader):
-            return _loader(index)
-
-        carry_pw = Pointwise(
-            device=torch.device("cpu"),
-            dtype=torch.float32,
-            inner_fn=carry_inner_fn,
-            ranges=[Integer(8)],
-        )
-        carry_op = ComputedBuffer(
-            name="carry0",
-            layout=FixedLayout(torch.device("cpu"), torch.float32, [Integer(8)], None),
-            data=carry_pw,
-        )
-        carry_op.operation_name = "carry0"
-        V.graph.name_to_buffer["carry0"] = carry_op
-        carry_op._test_out_coords = [sympy.Symbol("c0")]
-        carry_op.dim_hints = []  # loop-invariant: no dim_hints tile any level
-
-        group_ops = [red_op, carry_op]
-        levels = [(1, Integer(4))]
-
-        with self.assertRaisesRegex(Unsupported, "requiring carry propagation"):
-            plan_coarse_tile_groups(group_ops, [(group_ops, levels)])
-
 
 # ===========================================================================
 # 3. CountedLoopSchedulerNode and build_loop_scheduler_nodes
@@ -4381,30 +4283,22 @@ class TestCoarseTileBufferPropagation(unittest.TestCase):
         self.assertEqual(consumers, [other_group])
 
     def test_carry_propagation_functions_removed(self):
-        """_carry_terminal_op/_propagate_carry_op are deleted.
-
-        _seed_buffer_for_carry is deliberately NOT checked here: it remains
-        live, called from plan_coarse_tile_groups (Task 3) as the
-        carry-detection predicate behind its Unsupported raise — only the
-        transformation-time carry mechanism (_carry_terminal_op,
-        _propagate_carry_op, and _propagate_tiled_op's carry-trigger branch
-        that called all three) is dead code and removed by this task.
-        """
+        """_carry_terminal_op/_propagate_carry_op and the seed-detection helpers
+        are deleted."""
         import torch_spyre._inductor.wsr.coarse_tile as coarse_tile_module
 
         for name in (
             "_carry_terminal_op",
             "_propagate_carry_op",
+            "_seed_buffer_for_carry",
+            "_seed_closure_pre_stamp",
+            "_is_constant_fill",
+            "_closure_member_has_external_operands_only",
         ):
             self.assertFalse(
                 hasattr(coarse_tile_module, name),
                 f"{name} should have been deleted",
             )
-        self.assertTrue(
-            hasattr(coarse_tile_module, "_seed_buffer_for_carry"),
-            "_seed_buffer_for_carry must stay defined -- plan_coarse_tile_groups "
-            "still calls it as its carry-detection predicate",
-        )
 
     def test_has_loop_internal_real_input_removed(self):
         """_has_loop_internal_real_input is deleted along with the direct-

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -231,6 +231,11 @@ def plan_coarse_tile_groups(
         group_reduction_tiled_levels = _group_reduction_tiled_levels_in_group(
             group_ops, levels
         )
+        # Names of all ComputedBuffers in this group — used by the
+        # per-op partial-scratch check below.
+        group_op_names: set[str] = {
+            o.get_name() for o in group_ops if isinstance(o, ComputedBuffer)
+        }
 
         for op in group_ops:
             if not isinstance(op, ComputedBuffer):
@@ -279,12 +284,14 @@ def plan_coarse_tile_groups(
 
             if _plan_is_loop_invariant_at_reduction_levels(
                 op, op_tiled_dims, group_reduction_tiled_levels
+            ) and _reads_incomplete_reduction(
+                op, group_op_names, plan, group_reduction_tiled_levels
             ):
-                if _seed_buffer_for_carry(op, group_ops) is not None:
-                    raise Unsupported(
-                        f"reduction-dim tiling requiring carry propagation for "
-                        f"op {op.get_name()}"
-                    )
+                raise Unsupported(
+                    f"partial reduction result consumed before accumulation "
+                    f"is complete (op {op.get_name()} reads a per-tile "
+                    f"partial result from the same loop group)"
+                )
 
             per_level_extents = _planned_tile_extents_per_level(
                 op, op_tiled_dims, op_tiled_reduction_dims, levels
@@ -959,6 +966,30 @@ def _op_hint_dim_positions(op: ComputedBuffer, hint_id: int) -> tuple[bool, bool
     return pos is not None, False
 
 
+def _reads_incomplete_reduction(
+    op: ComputedBuffer,
+    group_op_names: set[str],
+    plan: dict,
+    group_reduction_tiled_levels: set[int],
+) -> bool:
+    """True if op reads a group-sibling whose result is still partial at any
+    reduction-tiled level — i.e. the reduction hasn't accumulated yet when op runs."""
+    for n in _op_reads(op):
+        if n not in group_op_names:
+            continue
+        buf = V.graph.get_buffer(n)
+        if not isinstance(buf, ComputedBuffer):
+            continue
+        entry = plan.get(id(buf))
+        if entry is None:
+            continue
+        if any(
+            entry.loop_tiled_reduction_dims[i] for i in group_reduction_tiled_levels
+        ):
+            return True
+    return False
+
+
 def _plan_is_loop_invariant_at_reduction_levels(
     op: ComputedBuffer,
     op_tiled_dims: list[list[int]],
@@ -973,95 +1004,6 @@ def _plan_is_loop_invariant_at_reduction_levels(
     if not group_reduction_tiled_levels:
         return False
     return all(not op_tiled_dims[i] for i in group_reduction_tiled_levels)
-
-
-def _seed_buffer_for_carry(
-    op: ComputedBuffer,
-    group_ops: list[Operation],
-) -> ComputedBuffer | None:
-    """Return the pre-loop seed buffer op carries state through, or None.
-
-    A Pointwise op that is loop-invariant at the group's reduction-tiled
-    level(s) may be the carry-producing step of an online-softmax-style
-    recurrence (running max, rescale-accumulate) rather than an ordinary
-    broadcast/hoisted computation. Detection is closure-based rather than
-    classifying op in isolation, because the seed's closure (the set of ops
-    that read it, directly or transitively, without leaving the loop group)
-    may have more than one member — see _seed_closure — and no single op's
-    own consumer count or escape-the-loop status reliably identifies "the"
-    carry (that correspondence to the traced Python's recurrence-variable
-    rebinding is not recoverable from any one op in isolation):
-
-      1. op must read exactly one pre-loop seed buffer directly (a constant
-         fill — see _is_constant_fill — whose own reads all resolve to a
-         SpyreConstantFallback scalar; torch.full/torch.zeros/
-         torch.zeros_like lower to such a Pointwise wrapper. The seed may
-         or may not have a stamped in-group loop_group_id, depending on
-         whether its Python-source declaration sits inside or outside the
-         tiled scope — that placement does not affect its seed status).
-      2. op must be a member of that seed's closure (trivially true, since
-         op reads the seed directly).
-      3. op must be the *unique* closure member whose non-seed operands are
-         all external to the closure (_closure_member_has_external_operands_only).
-         If zero or more than one closure member satisfies this, return None
-         rather than guessing — this is a known, accepted limitation for
-         closures with more than one externally-fed member (not hit by any
-         current test).
-
-    Caller (plan_coarse_tile_groups) is responsible for the shape gate
-    (_plan_is_loop_invariant_at_reduction_levels); this function only
-    checks the seed-buffer data-flow shape.
-
-    Uses the pre-stamp closure helper (_seed_closure_pre_stamp) because
-    planning is zero-mutation and runs before _apply_plan stamps
-    loop_info -- the post-stamp _seed_closure would find no matches here.
-    """
-    if not isinstance(op.data, Pointwise):
-        return None
-
-    seed_candidates = []
-    for name in _op_reads(op):
-        buf = V.graph.get_buffer(name)
-        if not isinstance(buf, ComputedBuffer) or not _is_constant_fill(buf):
-            continue
-        # _is_constant_fill already requires every read of buf to come from
-        # a SpyreConstantFallback scalar — an op with real in-group operands
-        # can never satisfy it, so no additional loop_group_id check is
-        # needed to exclude "produced inside the loop" buffers. A seed can
-        # legitimately carry a stamped in-group loop_group_id (e.g. when its
-        # Python-source declaration sits inside the tiled scope).
-        seed_candidates.append(buf)
-
-    if len(seed_candidates) != 1:
-        return None
-    seed_buf = seed_candidates[0]
-    seed_name = seed_buf.get_name()
-
-    closure = _seed_closure_pre_stamp(seed_name, group_ops)
-    if op.get_name() not in closure:
-        return None
-
-    external_candidates = [
-        name
-        for name in closure
-        if _closure_member_has_external_operands_only(
-            name, seed_name, closure, group_ops
-        )
-    ]
-    if len(external_candidates) != 1:
-        logger.warning(
-            "_seed_buffer_for_carry: ambiguous carry detection for seed %s "
-            "(closure=%s) — found %d externally-fed closure members, "
-            "expected exactly 1; treating %s as not a carry step. See "
-            "_seed_buffer_for_carry's docstring, point 3.",
-            seed_name,
-            sorted(closure),
-            len(external_candidates),
-            op.get_name(),
-        )
-        return None
-
-    return seed_buf if external_candidates[0] == op.get_name() else None
 
 
 def _seed_closure(
@@ -1094,29 +1036,6 @@ def _seed_closure(
         if seed_name in _op_reads(o):
             closure.add(o.get_name())
     return closure
-
-
-def _closure_member_has_external_operands_only(
-    op_name: str,
-    seed_name: str,
-    closure: set[str],
-    operations: list[Operation],
-) -> bool:
-    """True if op_name's non-seed read operands are all outside closure.
-
-    This is the carry-producing member test: a true recurrence-update step
-    combines the previous carry value (the seed) with fresh, externally
-    derived per-iteration data. A step that combines the seed with an
-    already-computed sibling closure member is downstream of the actual
-    update, not the update itself (e.g. `correction = exp(M - max_running)`
-    reads `max_running`, a closure member, so it is excluded even though it
-    also reads the seed `M` directly).
-    """
-    op = V.graph.name_to_buffer.get(op_name)
-    if op is None:
-        return False
-    non_seed_reads = _op_reads(op) - {seed_name}
-    return not (non_seed_reads & closure)
 
 
 def _op_reads(op: ComputedBuffer) -> set[str]:
@@ -1432,45 +1351,6 @@ def _apply_plan(
         )
 
     return retiled_infos
-
-
-def _seed_closure_pre_stamp(seed_name: str, group_ops: list[Operation]) -> set[str]:
-    """Pre-stamp equivalent of _seed_closure, over a plain group_ops list.
-
-    Not transitive — see _seed_closure's docstring for why. Used during
-    planning, before _apply_plan stamps loop_info (so the outer-loop-group
-    filtering _seed_closure does via stamped loop_info is unnecessary —
-    group_ops is already scoped to the group).
-    """
-    return {
-        o.get_name()
-        for o in group_ops
-        if isinstance(o, ComputedBuffer) and seed_name in _op_reads(o)
-    }
-
-
-def _is_constant_fill(op: ComputedBuffer) -> bool:
-    """True if op is a Pointwise whose only reads come from SpyreConstantFallback.
-
-    full.default / zeros_like / zeros lower to a SpyreConstantFallback scalar
-    broadcast through a thin Pointwise wrapper.  These ops are position-
-    independent, so shrinking their per-tile range to match the tiled group
-    is semantically equivalent to slicing a full-sized fill.
-    """
-    if not isinstance(op.data, Pointwise):
-        return False
-    try:
-        rw = op.get_read_writes()
-    except Exception:
-        return False
-    from torch._inductor.dependencies import MemoryDep
-
-    reads = [d for d in rw.reads if isinstance(d, MemoryDep)]
-    if not reads:
-        return False
-    return all(
-        isinstance(V.graph.get_buffer(d.name), SpyreConstantFallback) for d in reads
-    )
 
 
 def coarse_tile_pre_stickify(
@@ -3437,7 +3317,6 @@ def _propagate_tiled_reduction_op(
     # redundant but harmless.
     dtype = op.get_dtype()
     device = op.get_device()
-    from ..ir import SpyreConstantFallback  # deferred: avoids circular import
 
     scalar_op = SpyreConstantFallback(
         torch.ops.spyre.constant.default, float(identity), dtype, device

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -980,6 +980,9 @@ def _reads_incomplete_reduction(
         buf = V.graph.get_buffer(n)
         if not isinstance(buf, ComputedBuffer):
             continue
+        # group_ops is topologically ordered, so any in-group sibling is
+        # already in plan by the time we reach op. A missing entry means
+        # buf is outside this group (cross-group read) — not a partial result.
         entry = plan.get(id(buf))
         if entry is None:
             continue


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Replaces the `_seed_buffer_for_carry` heuristic with a single principled detector: `_reads_incomplete_reduction`. Deletes ~130 lines of fragile seed/closure detection code.

**The problem with the old approach:** `_seed_buffer_for_carry` identified carry ops by looking for a loop-invariant op reading a constant-fill seed buffer (`torch.full` / `torch.zeros` initializer). This failed for flash v2, where the accumulator is initialized via `amax(torch.full(...))` — a Reduction wrapping a constant fill, not a plain fill. The heuristic also missed the simpler illegal case (e.g. `add_min`) where a loop-invariant op reads a partial reduction with no accumulation at all.

**The new approach:** A loop-invariant Pointwise op that reads an ingroup reduction-tiled op is always wrong — it sees a per-tile partial result on every iteration, not the fully accumulated output. This covers flash v1/v2/v3 carry patterns and the add_min/reduce_both illegal patterns uniformly. One function, one error message:

> `partial reduction result consumed before accumulation is complete`

**Deleted:** `_seed_buffer_for_carry`, `_seed_closure_pre_stamp`, `_closure_member_has_external_operands_only`, `_is_constant_fill`.

**Added:** `_reads_incomplete_reduction` — a plain early-continue loop, ~15 lines.

## Tests

- `test_flash_tile_Lk`, `test_flash_tile_H_Lq_Lk`: unskipped, now assert the error is raised
- `test_flash_v2_tile_Lk`: unskipped (was skipped since flash v2 carry wasn't detected), now asserts the error is raised
- 8 `add_min` / `reduce_both` tests: converted from `correctness=False` (silently wrong) to `pytest.raises`
- 3 `test_copy_after_reduction` tests: converted from `correctness=False` to `pytest.raises`
- `test_outside_consumer_two_accum_512x256_B4`: converted from `correctness=False` to `pytest.raises`
- `test_partial_reduction_two_hop_A4`: new test for the two-hop partial-read case (`amin` result multiplied before being consumed)
- `test_plan_raises_unsupported_for_carry` (unit test): deleted — covered by the e2e flash tests above
- `test_carry_propagation_functions_removed`: updated to assert the four deleted helpers are gone

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

Note that `test_plan_raises_unsupported_for_carry` is deleted entirely for 2 reasons:

1.   The unit test was wrong — it constructs carry0 to only read seed0, not red0. In the real flash v1 IR, the carry op reads both the seed AND the reduction result.   Our new detector would catch it correctly via the block_max read.
2.  The new structured tests are already catching this error being raised for `test_flash_tile_Lk` and `test_flash_tile_H_Lq_Lk` so the coverage is not lost

We can fix `test_plan_raises_unsupported_for_carry` if desired, but I decided it is not worth reproducing the logic given the coverage from the actual flash in `test_flash_tile_Lk` and `test_flash_tile_H_Lq_Lk` 

