### PR TITLE
feat(ci): refactor test labels based on external facing tier name

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -79,19 +79,21 @@ on:
         default: true
       test_type:
         description: >-
-          Suite subset to run: smoke | core | full | device_critical |
-          suite_<group> | <label>. Selects configs whose
-          test_suite_config.labels array contains this value, or (for
-          suite_<group>) whose path sits under that directory.
-          device_critical covers the device-layer surfaces flex and
+          Suite subset to run: smoke | unit | integration | regression |
+          trunk | suite_<group> | <label>. Selects configs whose
+          test_suite_config.labels array contains this value literally, or
+          (for suite_<group>) whose path sits under that directory -- there
+          is no catch-all value that ignores a config's labels.
+          integration covers the device-layer surfaces flex and
           deeptools/dxp_standalone exercise most (streams, job launch
           plans, codegen, LX/scratchpad planning, tensor layout,
-          allocator/GC, D2D copies). Default: full (every config) -- callers
-          that want the narrower CI default (e.g. integration-tests.yaml)
-          pass test_type explicitly.
+          allocator/GC, D2D copies). Default: regression (every config
+          labeled for full functional coverage) -- callers that want the
+          narrower CI default (e.g. integration-tests.yaml) pass test_type
+          explicitly.
         required: false
         type: string
-        default: full
+        default: regression
 
       # Spyre-Next integration path: test the PRE-BAKED dev image directly instead
       # of checking out + rebuilding torch-spyre on the runner. The ephemeral ARC
@@ -131,7 +133,7 @@ jobs:
   # output via fromJSON so that only the requested subset of runners starts.
   # ---------------------------------------------------------------------------
   generate_matrix:
-    name: Generate test matrix (${{ inputs.test_type || 'full' }})
+    name: Generate test matrix (${{ inputs.test_type || 'regression' }})
     # Normal path: ubuntu-latest with a fresh sparse checkout of the configs.
     # Prebaked path: run ON the runner image so the matrix is computed from the
     # SAME PR-pinned configs baked into the dev image (not a re-fetch of main),
@@ -157,7 +159,7 @@ jobs:
       - name: Filter configs by TEST_TYPE
         id: filter
         env:
-          RAW_TEST_TYPE: ${{ inputs.test_type || 'full' }}
+          RAW_TEST_TYPE: ${{ inputs.test_type || 'regression' }}
         run: |
           # Prebaked: read the configs baked in the dev image; else the checkout cwd.
           # cd into the source root so every path below stays repo-relative and
@@ -175,18 +177,12 @@ jobs:
             --format matrix-json)
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
-          # Everything downstream of this job (TORCH_SPYRE_TEST_TYPE env var, the
-          # test_multi_spyre distributed-suite gate) compares test_type by literal
-          # string, bypassing filter_configs.py's own alias resolution -- resolve
-          # once here via the same source of truth so unit/integration/regression
-          # behave identically everywhere, not just in the label-matching path.
-          resolved=$(python3 -c "
-          import sys
-          sys.path.insert(0, 'tests/oot_framework/utils')
-          from filter_configs import resolve_test_type
-          import os
-          print(resolve_test_type(os.environ['RAW_TEST_TYPE'].strip()))
-          ")
+          # test_type is now the literal label vocabulary (smoke/unit/
+          # integration/regression/trunk) with no alias-resolution layer, so
+          # everything downstream (TORCH_SPYRE_TEST_TYPE env var, the
+          # test_multi_spyre distributed-suite gate) can compare against the
+          # trimmed raw input directly.
+          resolved=$(echo "${RAW_TEST_TYPE}" | xargs)
           echo "resolved_test_type=$resolved" >> "$GITHUB_OUTPUT"
 
   # ---------------------------------------------------------------------------
@@ -377,14 +373,20 @@ jobs:
   # Job 2: Multi-Spyre test matrix
   #
   # Only runs for test_type values that include the distributed suite:
-  #   full              — includes everything
-  #   device_critical    — used as the reduced default by integration-tests.yaml;
+  #   regression         — includes everything (distributed_tests configs
+  #                        carry the regression label)
+  #   trunk              — push-to-main coverage (distributed_tests configs
+  #                        carry the trunk label too)
+  #   integration        — used as the reduced default by integration-tests.yaml;
   #                        distributed comms (streams/barrier/broadcast/gather/
   #                        allgather) are exactly the device-layer surface this
-  #                        label exists to protect, so it always runs alongside it
+  #                        tier exists to protect, so it always runs alongside it
+  #                        (distributed_tests configs carry the "integration"
+  #                        label too, so this also matches filter_configs.py's
+  #                        own label matching)
   #   suite_distributed — targets the distributed_tests/ directory directly
-  #   (empty)           — same as full
-  # For smoke / core / suite_<other> the distributed job is skipped entirely
+  #   (empty)           — same as regression
+  # For smoke / unit / suite_<other> the distributed job is skipped entirely
   # so no x2 runners are allocated.
   # ---------------------------------------------------------------------------
   test_multi_spyre:
@@ -398,8 +400,9 @@ jobs:
     if: >-
       !cancelled() &&
       (needs.generate_matrix.outputs.resolved_test_type == '' ||
-       needs.generate_matrix.outputs.resolved_test_type == 'full' ||
-       needs.generate_matrix.outputs.resolved_test_type == 'device_critical' ||
+       needs.generate_matrix.outputs.resolved_test_type == 'regression' ||
+       needs.generate_matrix.outputs.resolved_test_type == 'trunk' ||
+       needs.generate_matrix.outputs.resolved_test_type == 'integration' ||
        needs.generate_matrix.outputs.resolved_test_type == 'suite_distributed') &&
       (needs.build_torch_spyre.result == 'success' ||
        needs.build_torch_spyre.result == 'skipped')

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,17 +1,18 @@
 name: integration-tests
-run-name: integration-tests (${{ inputs.test_type || 'device_critical' }})
-# NOTE: run-name intentionally shows the RAW, user-facing input (before
-# filter_configs.py resolves unit/integration/regression to core/device_critical/
-# full) -- this is also what push-to-clickhouse.yaml's trigger_type ends up
-# recording, so ClickHouse sees the tier name callers actually asked for.
+run-name: integration-tests (${{ inputs.test_type || 'integration' }})
+# NOTE: run-name intentionally shows the RAW, user-facing input -- test_type
+# tier names (smoke/unit/integration/regression/trunk) ARE the
+# test_suite_config.labels vocabulary directly, with no alias-resolution
+# layer, so this is also what push-to-clickhouse.yaml's trigger_type ends up
+# recording, matching the tier name callers actually asked for.
 
 # ---------------------------------------------------------------------------
 # Triggered by commits in upstream dependant repos (deeptools, flex, etc.) via
-# workflow_dispatch.  Runs the device_critical test subset (streams, job
+# workflow_dispatch.  Runs the integration test subset (streams, job
 # launch plans, codegen, LX/scratchpad planning, tensor layout, allocator/GC,
 # D2D copies -- the device-layer surfaces these upstream tools exercise
 # most) against a specified torch-spyre ref so regressions from upstream
-# changes are caught early. Pass test_type=full for full coverage.
+# changes are caught early. Pass test_type=regression for full coverage.
 #
 # Example caller pattern from an upstream repo's workflow:
 #
@@ -78,19 +79,17 @@ on:
         default: ''
       test_type:
         description: >-
-          Suite subset to run: smoke | core | full | device_critical |
-          suite_<group> | <label> -- or the user-facing tier aliases unit
-          (= core) | integration (= device_critical) | regression (= full),
-          for callers (e.g. spyre-frameworks config.yaml) that speak in tier
-          names rather than label names. Default: device_critical (configs
-          whose test_suite_config.labels cover the device-layer surfaces
-          flex and deeptools/dxp_standalone exercise most -- streams, job
-          launch plans, codegen, LX/scratchpad planning, tensor layout,
-          allocator/GC, D2D copies). Pass "full" (or "regression") to run
-          every config.
+          Suite subset to run: smoke | unit | integration | regression |
+          trunk | suite_<group> | <label>. These tier names ARE the
+          test_suite_config.labels vocabulary directly (no alias layer).
+          Default: integration (configs whose test_suite_config.labels cover
+          the device-layer surfaces flex and deeptools/dxp_standalone
+          exercise most -- streams, job launch plans, codegen,
+          LX/scratchpad planning, tensor layout, allocator/GC, D2D copies).
+          Pass "regression" to run every config.
         required: false
         type: string
-        default: device_critical
+        default: integration
       prebaked_image:
         description: >-
           Test the pre-baked torch-spyre-dev image directly (no checkout/build) —
@@ -133,13 +132,12 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
-  # Run the test matrix, defaulting to the device_critical subset -- same
+  # Run the test matrix, defaulting to the integration subset -- same
   # default as the "run-tests" job in torch_spyre_tests.yaml. Callers can
-  # still request test_type=full (or its alias, regression) for complete
-  # coverage. Tier aliases (unit/integration/regression) are resolved inside
-  # _test_matrix.yaml's generate_matrix job -- the single choke point every
-  # test_type caller (Makefile, Jenkins, GHA) passes through -- so the raw
-  # input is forwarded unchanged here.
+  # still request test_type=regression for complete coverage. Tier names
+  # (smoke/unit/integration/regression/trunk) are the literal
+  # test_suite_config.labels vocabulary -- no alias-resolution layer -- so
+  # the raw input is forwarded unchanged here.
   # ---------------------------------------------------------------------------
   run-tests:
     needs: provenance
@@ -151,7 +149,7 @@ jobs:
       checkout_pytorch: false
       ref: ${{ inputs.ref || '' }}
       repository: ${{ inputs.repository || '' }}
-      test_type: ${{ inputs.test_type || 'device_critical' }}
+      test_type: ${{ inputs.test_type || 'integration' }}
       prebaked_image: ${{ inputs.prebaked_image }}
 
   # ----------------------------------------------------------------------------------

--- a/.github/workflows/push-to-clickhouse.yaml
+++ b/.github/workflows/push-to-clickhouse.yaml
@@ -182,7 +182,7 @@ jobs:
       - name: Extract suite tier from display title
         id: extract-tier
         run: |
-          # display_title is "integration-tests (full)" / "integration-tests (device_critical)" / etc.
+          # display_title is "integration-tests (regression)" / "integration-tests (integration)" / etc.
           # Fall back to empty (ingest_xml.py defaults it to 'unknown') for manual workflow_dispatch
           # re-ingests or older runs whose display_title predates this convention.
           TIER=$(echo "${TRIGGERING_DISPLAY_TITLE}" | sed -n 's/.*(\(.*\))\s*$/\1/p')

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -3,7 +3,7 @@ name: tests
 # One of torch-spyre's four "trunk" (push-to-main) workflows -- see
 # model_ops_tests.yaml, upstream_tests.yaml, upstream_tests_beta.yaml for the
 # others. A push run passes test_type: trunk (below) so it's distinguishable
-# from a manually-dispatched full run once tier-tagging reaches ClickHouse.
+# from a manually-dispatched regression run once tier-tagging reaches ClickHouse.
 on:
   push:
     branches: [main]
@@ -56,11 +56,13 @@ on:
         default: ''
       test_type:
         description: >-
-          Suite subset to run: smoke | core | full | suite_<group> | <label>.
-          Default: full (every config).
+          Suite subset to run: smoke | unit | integration | regression |
+          trunk | suite_<group> | <label>.
+          Default: regression (every config labeled for full functional
+          coverage).
         required: false
         type: string
-        default: full
+        default: regression
 
 concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.pull_request.html_url) || (github.event_name == 'workflow_dispatch'
@@ -124,7 +126,7 @@ jobs:
       rpm_location: ${{ inputs.rpm_location || '' }}
       rpm_names: ${{ inputs.rpm_names || '' }}
       build_torch_spyre: ${{ inputs.build_torch_spyre == true }}
-      test_type: ${{ inputs.test_type || (github.event_name == 'push' && 'trunk' || 'full') }}
+      test_type: ${{ inputs.test_type || (github.event_name == 'push' && 'trunk' || 'regression') }}
 
   # ---------------------------------------------------------------------------
   # Job 3: run-spyre-unit-tests (required check gate)

--- a/Makefile
+++ b/Makefile
@@ -9,39 +9,36 @@ help: ## Show this help message
 PYTEST_ARGS ?= -v
 TEST_CONFIGS ?= tests/configs/torch_spyre_tests
 
-# TEST_TYPE selects which suite subset to run:
+# TEST_TYPE selects which suite subset to run. These tier names ARE the
+# test_suite_config.labels vocabulary directly -- there is no alias layer,
+# and a config only runs under a tier if it explicitly carries that label
+# (configs with no labels field run under nothing):
 #   smoke            — fast sanity checks (~4 suites)
-#   core             — all functional tests, excludes special-purpose hardware
-#   device_critical  — device-layer surfaces flex and deeptools/dxp_standalone
+#   unit             — all functional tests, excludes special-purpose hardware
+#   integration      — device-layer surfaces flex and deeptools/dxp_standalone
 #                       exercise most: streams, job launch plans, codegen,
 #                       LX/scratchpad planning, tensor layout, allocator/GC,
 #                       D2D copies (used as the default in integration-tests.yaml,
 #                       triggered by those upstream repos)
-#   full             — everything (core + LX-planning) under TEST_CONFIGS;
+#   regression       — everything (unit + LX-planning) under TEST_CONFIGS;
 #                      default for `make tests`
-#   trunk            — full, run across every suite directory CI's four
-#                      push-to-main workflows cover (see TRUNK_CONFIG_DIRS),
-#                      not just TEST_CONFIGS -- so `make tests TEST_TYPE=trunk`
-#                      matches what actually runs on a push to main
+#   trunk            — everything torch-spyre's four push-to-main workflows
+#                      cover across tests/configs/ (torch_spyre_tests,
+#                      distributed_tests, model_ops_tests, upstream_tests,
+#                      upstream_tests_beta), not just TEST_CONFIGS -- so
+#                      `make tests TEST_TYPE=trunk` matches what actually
+#                      runs on a push to main. Filtered by the trunk label,
+#                      same as every other tier -- no directory list to
+#                      maintain here.
 #   perf             — spyre-perf-suite benchmark (shells out, not a pytest
 #                      config suite); writes report.xml into RESULTS_DIR
 #   suite_<group>    — all configs inside the <group>/ sub-directory
 #                      (e.g. suite_inductor, suite_tensors)
 #   <label>          — any arbitrary label defined in test_suite_config.labels
 #
-# User-facing tier aliases (resolved by filter_configs.py, so every caller of
-# this Makefile target sees them too): unit=core, integration=device_critical,
-# regression=full.
-# Empty / unset defaults to "regression" (= full: all configs under TEST_CONFIGS).
+# Empty / unset defaults to "regression" (all configs under TEST_CONFIGS
+# labeled for full functional coverage).
 TEST_TYPE ?= regression
-
-# Suite directories covered by torch-spyre's four trunk (push-to-main)
-# workflows -- torch_spyre_tests.yaml, model_ops_tests.yaml,
-# upstream_tests.yaml, upstream_tests_beta.yaml, in that order. TEST_TYPE=trunk
-# scans all of them (each filtered to "full") instead of just TEST_CONFIGS, so
-# a local trunk run exercises the same configs the push workflows do
-# collectively. Update this list if a trunk workflow's config directory moves.
-TRUNK_CONFIG_DIRS := tests/configs/torch_spyre_tests tests/configs/model_ops_tests tests/configs/upstream_tests tests/configs/upstream_tests_beta
 
 # Where TEST_TYPE=perf writes its benchmark report. Flat /tmp/results so the CI
 # ClickHouse push step (ingest_xml.py globs *.xml non-recursively) finds it
@@ -80,7 +77,7 @@ precommit: ## Run all pre-commit hooks against every file
 # ---------------------------------------------------------------------------
 
 .PHONY: tests
-tests: ## Run torch spyre tests. Narrow scope with TEST_TYPE=smoke|core|full|trunk|perf|suite_<group>. TEST_CONFIGS may point at a config directory (filtered by TEST_TYPE) or a single config yaml file (run directly); ignored when TEST_TYPE=trunk (see TRUNK_CONFIG_DIRS).
+tests: ## Run torch spyre tests. Narrow scope with TEST_TYPE=smoke|unit|integration|regression|trunk|perf|suite_<group>. TEST_CONFIGS may point at a config directory (filtered by TEST_TYPE) or a single config yaml file (run directly); ignored when TEST_TYPE=trunk (scans tests/configs/ directly, filtered by the trunk label).
 # TEST_TYPE=perf is a benchmark mode, not a pytest-config suite: it does not
 # run the OOT config machinery below. It shells out to the installed
 # spyre-perf-suite console script (a wheel dependency of the dev image) and
@@ -95,11 +92,9 @@ ifeq ($(TEST_TYPE),perf)
 		{ echo "ERROR: spyre-perf-suite did not emit $(RESULTS_DIR)/report.xml" >&2; \
 		  exit 1; }
 else ifeq ($(TEST_TYPE),trunk)
-	$(eval _PATHS := $(shell for d in $(TRUNK_CONFIG_DIRS); do \
-		python3 $(FILTER_SCRIPT) --config-dir "$$d" --test-type full --format paths; \
-	done))
+	$(eval _PATHS := $(shell python3 $(FILTER_SCRIPT) --config-dir tests/configs --test-type trunk --format paths))
 	@if [ -z "$(_PATHS)" ]; then \
-		echo "ERROR: no configs matched TEST_TYPE=trunk under TRUNK_CONFIG_DIRS ($(TRUNK_CONFIG_DIRS))" >&2; \
+		echo "ERROR: no configs matched TEST_TYPE=trunk under tests/configs" >&2; \
 		exit 1; \
 	fi
 	@TORCH_SPYRE_TEST_TYPE="$(TEST_TYPE)" bash tests/run_test.sh $(_PATHS) $(PYTEST_ARGS)

--- a/tests/configs/distributed_tests/test_allgather.yaml
+++ b/tests/configs/distributed_tests/test_allgather.yaml
@@ -9,6 +9,7 @@
 # directory and launches them with: torchrun --nproc-per-node $AIU_WORLD_SIZE
 
 test_suite_config:
+  labels: [regression, trunk, integration]
   files:
     # AllGather Tests
     - path: ${TORCH_DEVICE_ROOT}/tests/distributed/test_allgather.py

--- a/tests/configs/distributed_tests/test_barrier.yaml
+++ b/tests/configs/distributed_tests/test_barrier.yaml
@@ -9,7 +9,7 @@
 # directory and launches them with: torchrun --nproc-per-node $AIU_WORLD_SIZE
 
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk, integration]
   files:
     # Barrier Tests
     - path: ${TORCH_DEVICE_ROOT}/tests/distributed/test_barrier.py

--- a/tests/configs/distributed_tests/test_broadcast.yaml
+++ b/tests/configs/distributed_tests/test_broadcast.yaml
@@ -9,7 +9,7 @@
 # directory and launches them with: torchrun --nproc-per-node $AIU_WORLD_SIZE
 
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk, integration]
   files:
     # Broadcast Tests
     - path: ${TORCH_DEVICE_ROOT}/tests/distributed/test_broadcast.py

--- a/tests/configs/distributed_tests/test_broadcast_compiled.yaml
+++ b/tests/configs/distributed_tests/test_broadcast_compiled.yaml
@@ -9,6 +9,7 @@
 # directory and launches them with: torchrun --nproc-per-node $AIU_WORLD_SIZE
 
 test_suite_config:
+  labels: [regression, trunk, integration]
   files:
     # Broadcast Compiled Tests - verify collectives lower correctly
     - path: ${TORCH_DEVICE_ROOT}/tests/distributed/test_broadcast_compiled.py

--- a/tests/configs/distributed_tests/test_gather.yaml
+++ b/tests/configs/distributed_tests/test_gather.yaml
@@ -9,6 +9,7 @@
 # directory and launches them with: torchrun --nproc-per-node $AIU_WORLD_SIZE
 
 test_suite_config:
+  labels: [regression, trunk, integration]
   files:
     # Gather Tests
     - path: ${TORCH_DEVICE_ROOT}/tests/distributed/test_gather.py

--- a/tests/configs/distributed_tests/test_general.yaml
+++ b/tests/configs/distributed_tests/test_general.yaml
@@ -9,7 +9,7 @@
 # directory and launches them with: torchrun --nproc-per-node $AIU_WORLD_SIZE
 
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk, integration]
   files:
     # SpyreCCL Backend Availability Test
     - path: ${TORCH_DEVICE_ROOT}/tests/distributed/spyreccl_backend.py

--- a/tests/configs/example_test_config.yaml
+++ b/tests/configs/example_test_config.yaml
@@ -1,5 +1,6 @@
 ### This is just an example config ###
 test_suite_config:
+  labels: [regression]
   files:
     - path: ${TORCH_ROOT}/test/test_binary_ufuncs.py
       unlisted_test_mode: skip

--- a/tests/configs/model_ops_tests/Meta-Llama-3.1-8B-Instruct.yaml
+++ b/tests/configs/model_ops_tests/Meta-Llama-3.1-8B-Instruct.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   global:
     supported_dtypes:
       - name: float16

--- a/tests/configs/model_ops_tests/Meta-Llama-3.1-8B-Instruct_spyre.yaml
+++ b/tests/configs/model_ops_tests/Meta-Llama-3.1-8B-Instruct_spyre.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   global:
     supported_dtypes:
       - name: float16

--- a/tests/configs/model_ops_tests/Ministral-3-14B-Instruct-2512.yaml
+++ b/tests/configs/model_ops_tests/Ministral-3-14B-Instruct-2512.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   global:
     supported_dtypes:
       - name: float16

--- a/tests/configs/model_ops_tests/Ministral-3-14B-Instruct-2512_spyre.yaml
+++ b/tests/configs/model_ops_tests/Ministral-3-14B-Instruct-2512_spyre.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   global:
     supported_dtypes:
       - name: float16

--- a/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506.yaml
+++ b/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   global:
     supported_dtypes:
       - name: float16

--- a/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506_spyre.yaml
+++ b/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506_spyre.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   global:
     supported_dtypes:
       - name: float16

--- a/tests/configs/model_ops_tests/Qwen2.5-7B-Instruct.yaml
+++ b/tests/configs/model_ops_tests/Qwen2.5-7B-Instruct.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   global:
     supported_dtypes:
       - name: float16

--- a/tests/configs/model_ops_tests/Qwen2.5-7B-Instruct_spyre.yaml
+++ b/tests/configs/model_ops_tests/Qwen2.5-7B-Instruct_spyre.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   global:
     supported_dtypes:
       - name: float16

--- a/tests/configs/model_ops_tests/gpt-oss-20b.yaml
+++ b/tests/configs/model_ops_tests/gpt-oss-20b.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   global:
     supported_dtypes:
       - name: float16

--- a/tests/configs/model_ops_tests/gpt-oss-20b_spyre.yaml
+++ b/tests/configs/model_ops_tests/gpt-oss-20b_spyre.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   global:
     supported_dtypes:
       - name: float16

--- a/tests/configs/model_ops_tests/granite-3.3-8b-instruct-fms.yaml
+++ b/tests/configs/model_ops_tests/granite-3.3-8b-instruct-fms.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   global:
     supported_dtypes:
       - name: float16

--- a/tests/configs/model_ops_tests/granite-3.3-8b-instruct-fms_spyre.yaml
+++ b/tests/configs/model_ops_tests/granite-3.3-8b-instruct-fms_spyre.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   global:
     supported_dtypes:
       - name: float16

--- a/tests/configs/model_ops_tests/granite-3.3-8b-instruct-with-device-layout.yaml
+++ b/tests/configs/model_ops_tests/granite-3.3-8b-instruct-with-device-layout.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   global:
     supported_dtypes:
       - name: float16

--- a/tests/configs/model_ops_tests/granite-3.3-8b-instruct.yaml
+++ b/tests/configs/model_ops_tests/granite-3.3-8b-instruct.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   global:
     supported_dtypes:
       - name: float16

--- a/tests/configs/model_ops_tests/granite-3.3-8b-instruct_spyre.yaml
+++ b/tests/configs/model_ops_tests/granite-3.3-8b-instruct_spyre.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   global:
     supported_dtypes:
       - name: float16

--- a/tests/configs/model_ops_tests/granite-4.1-8b.yaml
+++ b/tests/configs/model_ops_tests/granite-4.1-8b.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   global:
     supported_dtypes:
       - name: float16

--- a/tests/configs/model_ops_tests/granite-4.1-8b_spyre.yaml
+++ b/tests/configs/model_ops_tests/granite-4.1-8b_spyre.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   global:
     supported_dtypes:
       - name: float16

--- a/tests/configs/torch_spyre_tests/inductor/test_building_blocks_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_building_blocks_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_building_blocks.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_cache_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_cache_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_cache.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_coarse_tile_e2e_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_coarse_tile_e2e_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_coarse_tile_e2e.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_coarse_tiling_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_coarse_tiling_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_coarse_tiling.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_codegen_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_codegen_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_codegen.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_constant_tensor_cache_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_constant_tensor_cache_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_constant_tensor_cache.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_copy_back_elision_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_copy_back_elision_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_copy_back_elision.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_copy_from_d2d_offsets.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_copy_from_d2d_offsets.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_copy_from_d2d_offsets.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_core_mapping_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_core_mapping_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_core_mapping.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_decomp_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_decomp_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_decomp.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_dedup_constants_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_dedup_constants_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_dedup_constants.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_dtype_scalars_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_dtype_scalars_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_dtype_scalars.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_ea_bidirectional_conversion_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_ea_bidirectional_conversion_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_ea_bidirectional_conversion.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_fallback_kernel_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_fallback_kernel_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_fallback_kernel.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_indirect_access_gather_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_indirect_access_gather_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_indirect_access_gather.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_indirect_access_internals_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_indirect_access_internals_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_indirect_access_internals.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_indirect_access_scatter_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_indirect_access_scatter_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_indirect_access_scatter.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_fx_passes_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_fx_passes_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_fx_passes.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_fp8_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_fp8_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_fp8_operations.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_matmul_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_matmul_config.yaml
@@ -9,7 +9,7 @@
 # the source of truth for known LX-planning failures (the in-file .py
 # skip-lists were removed as duplicates).
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops_lx_planning.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_misc_compute_a_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_misc_compute_a_config.yaml
@@ -9,7 +9,7 @@
 # the source of truth for known LX-planning failures (the in-file .py
 # skip-lists were removed as duplicates).
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops_lx_planning.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_misc_compute_b_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_misc_compute_b_config.yaml
@@ -9,7 +9,7 @@
 # the source of truth for known LX-planning failures (the in-file .py
 # skip-lists were removed as duplicates).
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops_lx_planning.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_misc_compute_c_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_misc_compute_c_config.yaml
@@ -9,7 +9,7 @@
 # the source of truth for known LX-planning failures (the in-file .py
 # skip-lists were removed as duplicates).
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops_lx_planning.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_misc_shape_a_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_misc_shape_a_config.yaml
@@ -9,7 +9,7 @@
 # the source of truth for known LX-planning failures (the in-file .py
 # skip-lists were removed as duplicates).
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops_lx_planning.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_misc_shape_b_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_misc_shape_b_config.yaml
@@ -9,7 +9,7 @@
 # the source of truth for known LX-planning failures (the in-file .py
 # skip-lists were removed as duplicates).
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops_lx_planning.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_misc_shape_c_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_misc_shape_c_config.yaml
@@ -9,7 +9,7 @@
 # the source of truth for known LX-planning failures (the in-file .py
 # skip-lists were removed as duplicates).
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops_lx_planning.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_misc_shape_d_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_misc_shape_d_config.yaml
@@ -9,7 +9,7 @@
 # the source of truth for known LX-planning failures (the in-file .py
 # skip-lists were removed as duplicates).
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops_lx_planning.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_misc_shape_slice_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_misc_shape_slice_config.yaml
@@ -9,7 +9,7 @@
 # the source of truth for known LX-planning failures (the in-file .py
 # skip-lists were removed as duplicates).
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops_lx_planning.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_pointwise_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_pointwise_config.yaml
@@ -9,7 +9,7 @@
 # the source of truth for known LX-planning failures (the in-file .py
 # skip-lists were removed as duplicates).
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops_lx_planning.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_index_a_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_index_a_config.yaml
@@ -9,7 +9,7 @@
 # the source of truth for known LX-planning failures (the in-file .py
 # skip-lists were removed as duplicates).
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops_lx_planning.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_index_b_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_index_b_config.yaml
@@ -9,7 +9,7 @@
 # the source of truth for known LX-planning failures (the in-file .py
 # skip-lists were removed as duplicates).
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops_lx_planning.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_multidim0_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_multidim0_config.yaml
@@ -9,7 +9,7 @@
 # the source of truth for known LX-planning failures (the in-file .py
 # skip-lists were removed as duplicates).
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops_lx_planning.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_multidim1_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_multidim1_config.yaml
@@ -9,7 +9,7 @@
 # the source of truth for known LX-planning failures (the in-file .py
 # skip-lists were removed as duplicates).
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops_lx_planning.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_scalar_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_scalar_config.yaml
@@ -9,7 +9,7 @@
 # the source of truth for known LX-planning failures (the in-file .py
 # skip-lists were removed as duplicates).
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops_lx_planning.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_singledim0_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_singledim0_config.yaml
@@ -9,7 +9,7 @@
 # the source of truth for known LX-planning failures (the in-file .py
 # skip-lists were removed as duplicates).
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops_lx_planning.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_singledim1_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_singledim1_config.yaml
@@ -9,7 +9,7 @@
 # the source of truth for known LX-planning failures (the in-file .py
 # skip-lists were removed as duplicates).
 test_suite_config:
-  labels: [full]
+  labels: [regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops_lx_planning.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_matmul_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_matmul_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_compute_a_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_compute_a_config.yaml
@@ -8,7 +8,7 @@
 # compute group, assign it to whichever shard keeps the jobs balanced.
 
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_compute_b_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_compute_b_config.yaml
@@ -10,7 +10,7 @@
 # compute group, assign it to whichever shard keeps the two jobs balanced.
 
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_compute_c_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_compute_c_config.yaml
@@ -8,7 +8,7 @@
 # compute group, assign it to whichever shard keeps the jobs balanced.
 
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_shape_a_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_shape_a_config.yaml
@@ -8,7 +8,7 @@
 # shape group, assign it to whichever shard keeps the jobs balanced.
 
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_shape_b_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_shape_b_config.yaml
@@ -9,7 +9,7 @@
 # shape group, assign it to whichever shard keeps the two jobs balanced.
 
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_shape_c_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_shape_c_config.yaml
@@ -8,7 +8,7 @@
 # shape group, assign it to whichever shard keeps the jobs balanced.
 
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_pointwise_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_pointwise_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_index_norm_eager_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_index_norm_eager_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_multidim0_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_multidim0_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_multidim1_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_multidim1_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_singledim0_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_singledim0_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_singledim1_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_singledim1_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_scalar_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_scalar_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
       unlisted_test_mode: skip

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_scalar_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_scalar_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_scalar.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_transpose_edge_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_transpose_edge_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_transpose_edge.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_log_op_specs_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_log_op_specs_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_log_op_specs.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_log_passes_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_log_passes_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_log_passes.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_logging_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_logging_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_logging.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_lx_inplace_layout_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_lx_inplace_layout_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_lx_inplace_layout.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_matmul_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_matmul_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_matmul.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_normalization_scalars_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_normalization_scalars_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_normalization_scalars.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_offset_view_eager_ops.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_offset_view_eager_ops.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_offset_view_eager_ops.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_overwrite.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_overwrite.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_overwrite.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_padding_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_padding_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_padding.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_perm_layout_solver_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_perm_layout_solver_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_perm_layout_solver.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_propagate_named_dims_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_propagate_named_dims_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_propagate_named_dims.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_provenance_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_provenance_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_provenance.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_provenance_integration_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_provenance_integration_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_provenance_integration.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_provenance_observer_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_provenance_observer_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_provenance_observer.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_restickify_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_restickify_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_restickify.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_scratchpad_patterns_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_scratchpad_patterns_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_scratchpad_patterns.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_scratchpad_solver_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_scratchpad_solver_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_scratchpad_solver.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_scratchpad_use_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_scratchpad_use_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_scratchpad_use.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_simulated_annealing_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_simulated_annealing_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_simulated_annealing.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_span_overflow_hint_analysis_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_span_overflow_hint_analysis_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_span_overflow_hint_analysis.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_symbolic_dim_bundle_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_symbolic_dim_bundle_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_symbolic_dim_bundle.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_work_division_hint_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_work_division_hint_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_work_division_hint.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/tensors/test_coordinates_config.yaml
+++ b/tests/configs/torch_spyre_tests/tensors/test_coordinates_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/tensor/test_coordinates.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/tensors/test_it_space_splits_config.yaml
+++ b/tests/configs/torch_spyre_tests/tensors/test_it_space_splits_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/tensor/test_it_space_splits.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/tensors/test_memory_format_config.yaml
+++ b/tests/configs/torch_spyre_tests/tensors/test_memory_format_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/tensor/test_memory_format.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/tensors/test_model_utils_config.yaml
+++ b/tests/configs/torch_spyre_tests/tensors/test_model_utils_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/tensor/test_model_utils.py
       # Uses @instantiate_parametrized_tests — pytest collects the test

--- a/tests/configs/torch_spyre_tests/tensors/test_resize_config.yaml
+++ b/tests/configs/torch_spyre_tests/tensors/test_resize_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/tensor/test_resize.py
       # Uses ParameterizedTestMeta — pytest collects the test class

--- a/tests/configs/torch_spyre_tests/tensors/test_tensor_layout_config.yaml
+++ b/tests/configs/torch_spyre_tests/tensors/test_tensor_layout_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/tensor/test_tensor_layout.py
       # This file uses @instantiate_parametrized_tests which is a pure parametrize

--- a/tests/configs/torch_spyre_tests/test_allocator_e2e_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_allocator_e2e_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_allocator_e2e.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_device_enum_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_device_enum_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [smoke, core, full, device_critical]
+  labels: [smoke, unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_device_enum.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_device_error_skip_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_device_error_skip_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [smoke, core, full]
+  labels: [smoke, unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_device_error_skip.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_execution_trace_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_execution_trace_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/profiler/test_execution_trace.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_fallbacks_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_fallbacks_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [smoke, core, full]
+  labels: [smoke, unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_fallbacks.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_ffdc_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_ffdc_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/profiler/test_ffdc.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_launch_jobplan_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_launch_jobplan_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_launch_jobplan.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_logging_patterns_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_logging_patterns_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_cpp_extension_available.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_memory_pressure_gc_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_memory_pressure_gc_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_memory_pressure_gc.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_modules_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_modules_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_modules.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_prepare_kernel_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_prepare_kernel_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_prepare_kernel.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_regex_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_regex_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_regex.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_spyre_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_spyre_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [smoke, core, full, device_critical]
+  labels: [smoke, unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_spyre.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_spyre_generator_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_spyre_generator_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_spyre_generator.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_spyre_lazy_init_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_spyre_lazy_init_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_spyre_lazy_init.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_spyre_lazy_silent_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_spyre_lazy_silent_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_spyre_lazy_silent.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_spyre_profiler_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_spyre_profiler_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core]
+  labels: [trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/profiler/test_spyre_profiler.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/test_stream_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_stream_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [smoke, core, full, device_critical]
+  labels: [smoke, unit, regression, integration, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_stream.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/upstream_tests/test_profiler_config.yaml
+++ b/tests/configs/upstream_tests/test_profiler_config.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   files:
     # Classes exercised here:
     #   TestProfiler, TestExperimentalUtils, TestProfilerEventsParity

--- a/tests/configs/upstream_tests/test_view_ops_config.yaml
+++ b/tests/configs/upstream_tests/test_view_ops_config.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   files:
     - path: ${TORCH_ROOT}/test/test_view_ops.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/upstream_tests_beta/inductor-test_auto_functionalize.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_auto_functionalize.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_auto_functionalize.py

--- a/tests/configs/upstream_tests_beta/inductor-test_benchmark_fusion.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_benchmark_fusion.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_benchmark_fusion.py

--- a/tests/configs/upstream_tests_beta/inductor-test_codecache.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_codecache.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_codecache.py

--- a/tests/configs/upstream_tests_beta/inductor-test_compile.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_compile.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_compile.py

--- a/tests/configs/upstream_tests_beta/inductor-test_compile_subprocess.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_compile_subprocess.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_compile_subprocess.py

--- a/tests/configs/upstream_tests_beta/inductor-test_compiled_optimizers.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_compiled_optimizers.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_compiled_optimizers.py

--- a/tests/configs/upstream_tests_beta/inductor-test_config.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_config.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_config.py

--- a/tests/configs/upstream_tests_beta/inductor-test_control_flow.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_control_flow.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_control_flow.py

--- a/tests/configs/upstream_tests_beta/inductor-test_cpu_select_algorithm_part1.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_cpu_select_algorithm_part1.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_cpu_select_algorithm.py

--- a/tests/configs/upstream_tests_beta/inductor-test_cpu_select_algorithm_part2.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_cpu_select_algorithm_part2.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_cpu_select_algorithm.py

--- a/tests/configs/upstream_tests_beta/inductor-test_cpu_select_algorithm_part3.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_cpu_select_algorithm_part3.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_cpu_select_algorithm.py

--- a/tests/configs/upstream_tests_beta/inductor-test_custom_op_autotune.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_custom_op_autotune.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_custom_op_autotune.py

--- a/tests/configs/upstream_tests_beta/inductor-test_custom_post_grad_passes.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_custom_post_grad_passes.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_custom_post_grad_passes.py

--- a/tests/configs/upstream_tests_beta/inductor-test_debug_trace.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_debug_trace.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_debug_trace.py

--- a/tests/configs/upstream_tests_beta/inductor-test_exc_lowering_stack_trace.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_exc_lowering_stack_trace.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_exc_lowering_stack_trace.py

--- a/tests/configs/upstream_tests_beta/inductor-test_fuzzer.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_fuzzer.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_fuzzer.py

--- a/tests/configs/upstream_tests_beta/inductor-test_inductor_scheduler.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_inductor_scheduler.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_inductor_scheduler.py

--- a/tests/configs/upstream_tests_beta/inductor-test_mkldnn_pattern_matcher.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_mkldnn_pattern_matcher.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_mkldnn_pattern_matcher.py

--- a/tests/configs/upstream_tests_beta/inductor-test_move_constructors_to_gpu.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_move_constructors_to_gpu.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_move_constructors_to_gpu.py

--- a/tests/configs/upstream_tests_beta/inductor-test_op_dtype_prop.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_op_dtype_prop.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_op_dtype_prop.py

--- a/tests/configs/upstream_tests_beta/inductor-test_pattern_matcher.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_pattern_matcher.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_pattern_matcher.py

--- a/tests/configs/upstream_tests_beta/inductor-test_scatter_optimization.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_scatter_optimization.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_scatter_optimization.py

--- a/tests/configs/upstream_tests_beta/inductor-test_torchbind.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_torchbind.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/inductor/test_torchbind.py

--- a/tests/configs/upstream_tests_beta/nn-test_convolution.yaml
+++ b/tests/configs/upstream_tests_beta/nn-test_convolution.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/nn/test_convolution.py

--- a/tests/configs/upstream_tests_beta/nn-test_embedding.yaml
+++ b/tests/configs/upstream_tests_beta/nn-test_embedding.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/nn/test_embedding.py

--- a/tests/configs/upstream_tests_beta/nn-test_init.yaml
+++ b/tests/configs/upstream_tests_beta/nn-test_init.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/nn/test_init.py

--- a/tests/configs/upstream_tests_beta/nn-test_lazy_modules.yaml
+++ b/tests/configs/upstream_tests_beta/nn-test_lazy_modules.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/nn/test_lazy_modules.py

--- a/tests/configs/upstream_tests_beta/nn-test_load_state_dict.yaml
+++ b/tests/configs/upstream_tests_beta/nn-test_load_state_dict.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/nn/test_load_state_dict.py

--- a/tests/configs/upstream_tests_beta/nn-test_module_hooks.yaml
+++ b/tests/configs/upstream_tests_beta/nn-test_module_hooks.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/nn/test_module_hooks.py

--- a/tests/configs/upstream_tests_beta/nn-test_pooling.yaml
+++ b/tests/configs/upstream_tests_beta/nn-test_pooling.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/nn/test_pooling.py

--- a/tests/configs/upstream_tests_beta/optim-test_lrscheduler.yaml
+++ b/tests/configs/upstream_tests_beta/optim-test_lrscheduler.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/optim/test_lrscheduler.py

--- a/tests/configs/upstream_tests_beta/profiler-test_execution_trace.yaml
+++ b/tests/configs/upstream_tests_beta/profiler-test_execution_trace.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/profiler/test_execution_trace.py

--- a/tests/configs/upstream_tests_beta/profiler-test_memory_profiler.yaml
+++ b/tests/configs/upstream_tests_beta/profiler-test_memory_profiler.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/profiler/test_memory_profiler.py

--- a/tests/configs/upstream_tests_beta/profiler-test_profiler.yaml
+++ b/tests/configs/upstream_tests_beta/profiler-test_profiler.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/profiler/test_profiler.py

--- a/tests/configs/upstream_tests_beta/profiler-test_profiler_tree.yaml
+++ b/tests/configs/upstream_tests_beta/profiler-test_profiler_tree.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/profiler/test_profiler_tree.py

--- a/tests/configs/upstream_tests_beta/profiler-test_torch_tidy.yaml
+++ b/tests/configs/upstream_tests_beta/profiler-test_torch_tidy.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/profiler/test_torch_tidy.py

--- a/tests/configs/upstream_tests_beta/test_binary_ufuncs.yaml
+++ b/tests/configs/upstream_tests_beta/test_binary_ufuncs.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/test_binary_ufuncs.py

--- a/tests/configs/upstream_tests_beta/test_indexing.yaml
+++ b/tests/configs/upstream_tests_beta/test_indexing.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
   files:
     - path: ${TORCH_ROOT}/test/test_indexing.py
       unlisted_test_mode: skip

--- a/tests/configs/upstream_tests_beta/test_linalg.yaml
+++ b/tests/configs/upstream_tests_beta/test_linalg.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/test_linalg.py

--- a/tests/configs/upstream_tests_beta/test_masked.yaml
+++ b/tests/configs/upstream_tests_beta/test_masked.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/test_masked.py

--- a/tests/configs/upstream_tests_beta/test_ops.yaml
+++ b/tests/configs/upstream_tests_beta/test_ops.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/test_ops.py

--- a/tests/configs/upstream_tests_beta/test_prims.yaml
+++ b/tests/configs/upstream_tests_beta/test_prims.yaml
@@ -1,5 +1,6 @@
 ### Sample YAML config for testing CpuMixin integration ###
 test_suite_config:
+  labels: [trunk]
   files:
     - path: ${TORCH_ROOT}/test/test_prims.py
       unlisted_test_mode: skip

--- a/tests/configs/upstream_tests_beta/test_reductions.yaml
+++ b/tests/configs/upstream_tests_beta/test_reductions.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/test_reductions.py

--- a/tests/configs/upstream_tests_beta/test_shape_ops.yaml
+++ b/tests/configs/upstream_tests_beta/test_shape_ops.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/test_shape_ops.py

--- a/tests/configs/upstream_tests_beta/test_sort_and_select.yaml
+++ b/tests/configs/upstream_tests_beta/test_sort_and_select.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/test_sort_and_select.py

--- a/tests/configs/upstream_tests_beta/test_spectral_ops.yaml
+++ b/tests/configs/upstream_tests_beta/test_spectral_ops.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/test_spectral_ops.py

--- a/tests/configs/upstream_tests_beta/test_tensor_creation_ops.yaml
+++ b/tests/configs/upstream_tests_beta/test_tensor_creation_ops.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/test_tensor_creation_ops.py

--- a/tests/configs/upstream_tests_beta/test_torch.yaml
+++ b/tests/configs/upstream_tests_beta/test_torch.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/test_torch.py

--- a/tests/configs/upstream_tests_beta/test_unary_ufuncs.yaml
+++ b/tests/configs/upstream_tests_beta/test_unary_ufuncs.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/test_unary_ufuncs.py

--- a/tests/configs/upstream_tests_beta/test_view_ops.yaml
+++ b/tests/configs/upstream_tests_beta/test_view_ops.yaml
@@ -1,4 +1,5 @@
 test_suite_config:
+  labels: [trunk]
 
   files:
     - path: ${TORCH_ROOT}/test/test_view_ops.py

--- a/tests/oot_framework/oot_test_base_common.py
+++ b/tests/oot_framework/oot_test_base_common.py
@@ -418,14 +418,17 @@ class OOTTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa: F
 
         # per-test label filter — skip if this entry's labels don't include the
         # active TEST_TYPE.  Empty labels means "no restriction; run whenever the
-        # suite runs" so the check is a no-op for unlabelled entries.
+        # suite runs" so the check is a no-op for unlabelled entries. There is no
+        # catch-all TEST_TYPE value that bypasses an entry's explicit labels
+        # (matching filter_configs.py's file-level matching) -- only an unset
+        # TEST_TYPE (e.g. running pytest directly, outside make/CI) skips
+        # filtering entirely.
         # suite_<group> values are structural (handled by filter_configs.py at the
         # config-file level) and are ignored here.
         if entry is not None and entry.labels:
-            test_type = os.environ.get(ENV_TEST_TYPE, "full")
+            test_type = os.environ.get(ENV_TEST_TYPE, "")
             if (
                 test_type
-                and test_type != "full"
                 and not test_type.startswith("suite_")
                 and test_type not in entry.labels
             ):

--- a/tests/oot_framework/oot_test_config_models.py
+++ b/tests/oot_framework/oot_test_config_models.py
@@ -1568,7 +1568,7 @@ class TestsBlock(BaseModel):
 
     files: List[FileEntry]
     global_config: GlobalConfig = GlobalConfig()
-    labels: List[str] = ["full"]
+    labels: List[str] = []
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/oot_framework/utils/filter_configs.py
+++ b/tests/oot_framework/utils/filter_configs.py
@@ -17,15 +17,19 @@ Filter OOT test suite configs by TEST_TYPE label or suite-prefix group.
 
 Selection rules
 ---------------
-  (empty) / "full"   All configs (backward compatible by default).
   "smoke"            Configs whose test_suite_config.labels contains "smoke".
-  "core"             Configs whose test_suite_config.labels contains "core".
-  "device_critical"  Configs whose test_suite_config.labels contains
-                     "device_critical" -- the device-layer surfaces flex and
+  "unit"             Configs whose test_suite_config.labels contains "unit".
+  "integration"      Configs whose test_suite_config.labels contains
+                     "integration" -- the device-layer surfaces flex and
                      deeptools/dxp_standalone exercise most (streams, job
                      launch plans, codegen, LX/scratchpad planning, tensor
                      layout, allocator/GC, D2D copies). Used as the default
-                     test_type for the tests.yml CI workflow.
+                     test_type for integration-tests.yaml.
+  "regression"       Configs whose test_suite_config.labels contains
+                     "regression" -- the full functional-coverage tier.
+  "trunk"            Configs whose test_suite_config.labels contains
+                     "trunk" -- everything torch-spyre's push-to-main
+                     workflows cover.
   "suite_<group>"    Configs residing inside a directory named "<group>", or
                      whose filename starts with "<group>_".  This lets the
                      existing <group>/<name>_config.yaml layout act as a
@@ -33,25 +37,18 @@ Selection rules
   <other>            Treated as an arbitrary label name; matches configs
                      whose labels array contains the value.
 
-User-facing tier aliases
--------------------------
-Every caller (Makefile, GHA _test_matrix.yaml, Jenkins, config.yaml) resolves
---test-type through this one script, so the alias mapping lives here once and
-every caller sees it consistently:
-  "unit"          -> "core"
-  "integration"   -> "device_critical"
-  "regression"    -> "full"
-  "trunk"         -> "full" (push-to-main CI; same coverage as full)
-  "smoke"         -> "smoke" (already the canonical spelling, no change)
-These are the names meant for humans/CI configs to type; device_critical/full/
-core keep their existing, more specific meaning as the actual label vocabulary
-tests/configs/**/*.yaml declares.
+These tier names (smoke/unit/integration/regression/trunk) ARE the label
+vocabulary tests/configs/**/*.yaml declares -- there is no separate alias
+layer translating human-facing names to internal label names.
 
-Configs with no labels field default to ["full"] (backward compatible) --
-they run under "full" but are excluded from every narrower test_type
-(smoke, core, device_critical, suite_<group>, custom labels). Every config
-should carry an explicit labels list; an unlabeled config is a gap to close
-by adding one, not a signal to widen matching.
+Only explicitly declared labels are respected: a config's
+test_suite_config.labels array is matched literally against --test-type, with
+no catch-all value that matches regardless of labels. Configs with no labels
+field match nothing -- they are excluded from every test_type, including
+regression and trunk. Every config must carry an explicit labels list; an
+unlabeled config is a gap to close by adding one (see
+tests/scripts/check_oot_configs.py, which fails CI on missing labels), not a
+signal to widen matching.
 
 Output formats
 --------------
@@ -79,7 +76,7 @@ Usage
   # GitHub Actions generate_matrix job
   python3 tests/oot_framework/utils/filter_configs.py \\
       --config-dir tests/configs/torch_spyre_tests \\
-      --test-type core \\
+      --test-type unit \\
       --runner-map .github/runner_overrides.yaml \\
       --format matrix-json
 """
@@ -124,11 +121,11 @@ def _display_name(config_path: Path, config_dir: Path) -> str:
 
 
 def _load_labels(path: Path) -> list:
-    """Read test_suite_config.labels from a YAML config; default to ["full"]."""
+    """Read test_suite_config.labels from a YAML config; no labels means no match."""
     with path.open() as fh:
         raw = yaml.safe_load(fh) or {}
     tsc = raw.get("test_suite_config") or {}
-    return list(tsc.get("labels", ["full"]))
+    return list(tsc.get("labels") or [])
 
 
 def _load_runner_map(runner_map_path: str) -> dict:
@@ -141,26 +138,14 @@ def _load_runner_map(runner_map_path: str) -> dict:
     return {k: str(v) for k, v in data.items()}
 
 
-# User-facing tier name -> actual test_suite_config.labels vocabulary. Single
-# source of truth: every caller (Makefile, _test_matrix.yaml, Jenkins,
-# config.yaml) shells out to this script, so resolving here is sufficient --
-# no caller needs its own copy of this mapping.
-TEST_TYPE_ALIASES = {
-    "unit": "core",
-    "integration": "device_critical",
-    "regression": "full",
-    "trunk": "full",
-}
-
-
-def resolve_test_type(test_type: str) -> str:
-    """Resolve a user-facing tier alias to its underlying label/value."""
-    return TEST_TYPE_ALIASES.get(test_type, test_type)
-
-
 def _matches(labels: list, config_path: Path, test_type: str) -> bool:
-    """Return True if *config_path* should be included for *test_type*."""
-    if not test_type or test_type == "full":
+    """Return True if *config_path* should be included for *test_type*.
+
+    No catch-all: every test_type (including regression/trunk) must appear
+    literally in the config's labels array. An empty test_type matches
+    everything (used only when a caller deliberately omits filtering).
+    """
+    if not test_type:
         return True
 
     if test_type.startswith("suite_"):
@@ -190,12 +175,13 @@ def main() -> None:
     )
     ap.add_argument(
         "--test-type",
-        default="full",
+        default="regression",
         metavar="TYPE",
         help=(
-            "Selection type: smoke | core | full | device_critical | "
-            "suite_<group> | <label> -- or the user-facing tier aliases "
-            "unit | integration | regression. Default: full (all configs)."
+            "Selection type: smoke | unit | integration | regression | "
+            "trunk | suite_<group> | <label>. Matches configs whose "
+            "test_suite_config.labels array contains this value literally "
+            "-- no catch-all. Default: regression."
         ),
     )
     ap.add_argument(
@@ -223,7 +209,7 @@ def main() -> None:
     if not config_dir.is_dir():
         sys.exit(f"ERROR: --config-dir does not exist: {config_dir}")
 
-    test_type = resolve_test_type(args.test_type.strip())
+    test_type = args.test_type.strip()
 
     runner_map: dict = {}
     if args.runner_map:

--- a/tests/scripts/oot_checker/checks.py
+++ b/tests/scripts/oot_checker/checks.py
@@ -1,16 +1,73 @@
 """
-The three independent checks run against the loaded config patterns and
-the parsed test file:
+The checks run against the loaded config patterns and the parsed test file:
 
-  check_duplicates    -- same base name covered by multiple configs
-  check_missing       -- collectable base name not covered by any config
-  check_dead_patterns -- config pattern that matches nothing in the test file
+  check_missing_labels -- config file with no explicit test_suite_config.labels
+  check_duplicates      -- same base name covered by multiple configs
+  check_missing         -- collectable base name not covered by any config
+  check_dead_patterns   -- config pattern that matches nothing in the test file
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from .models import PatternEntry
 from .display import red, yellow, green, cyan, bold
+
+
+# -----------------------
+# CHECK 0: Missing labels
+# -----------------------
+
+
+def check_missing_labels(labels_by_file: dict[Path, list | None]) -> int:
+    """
+    Verify every config file declares an explicit test_suite_config.labels list.
+
+    filter_configs.py no longer defaults an absent labels field to a
+    catch-all tier -- a config with no labels field simply never runs under
+    any TEST_TYPE. That's a silent gap, not a safe default, so it's a hard
+    error here rather than a warning.
+
+    Parameters
+    ----------
+    labels_by_file : dict[Path, list | None]
+        Output of loader.load_labels(). None means the labels key was
+        absent or null in that config file.
+
+    Returns
+    -------
+    int
+        Number of config files missing an explicit labels field.
+    """
+    missing = sorted(
+        (path for path, labels in labels_by_file.items() if labels is None),
+        key=str,
+    )
+
+    if not missing:
+        print(
+            green(
+                f"  [labels] All {len(labels_by_file)} config(s) declare "
+                f"explicit labels.\n"
+            )
+        )
+        return 0
+
+    print(
+        red(
+            f"  [labels] {len(missing)} config file(s) missing an explicit "
+            f"'labels' field:\n"
+        )
+    )
+    for path in missing:
+        print(f"    {red('MISSING')}  {path}")
+        print(
+            "          add test_suite_config.labels: [regression]  "
+            "(if unsure which tier this belongs to)"
+        )
+    print()
+    return len(missing)
 
 
 # -----------------------

--- a/tests/scripts/oot_checker/cli.py
+++ b/tests/scripts/oot_checker/cli.py
@@ -13,7 +13,9 @@ from pathlib import Path
 from .runner import run
 
 
-_DESCRIPTION = "Check OOT configs for duplicate and missing test coverage."
+_DESCRIPTION = (
+    "Check OOT configs for missing labels, duplicate and missing test coverage."
+)
 
 _EPILOG = """
 examples

--- a/tests/scripts/oot_checker/loader.py
+++ b/tests/scripts/oot_checker/loader.py
@@ -49,6 +49,34 @@ def load_all_patterns(config_files: list[Path]) -> dict[str, list[PatternEntry]]
     return result
 
 
+def load_labels(config_files: list[Path]) -> dict[Path, list | None]:
+    """
+    Read test_suite_config.labels from each config file.
+
+    Parameters
+    ----------
+    config_files : list[Path]
+        Paths to OOT YAML config files.
+
+    Returns
+    -------
+    dict[Path, list | None]
+        Maps each config file to its declared labels list, or None when the
+        labels key is absent/null -- distinguishing "never set" from an
+        explicit empty list.
+    """
+    result: dict[Path, list | None] = {}
+    for cf in config_files:
+        try:
+            cfg = yaml.safe_load(cf.read_text()) or {}
+        except Exception as e:
+            _warn(f"Cannot load {cf}: {e}")
+            continue
+        tsc = cfg.get("test_suite_config") or {}
+        result[cf] = tsc.get("labels")
+    return result
+
+
 def _warn(msg: str) -> None:
     import sys
 

--- a/tests/scripts/oot_checker/runner.py
+++ b/tests/scripts/oot_checker/runner.py
@@ -1,7 +1,7 @@
 """
 runner.py
 ---------
-Orchestrates the three checks across all loaded config files.
+Orchestrates the checks across all loaded config files.
 Orchestrates together loader, parser, checks, display, and discovery modules.
 """
 
@@ -9,10 +9,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from .checks import check_duplicates, check_missing, check_dead_patterns
+from .checks import (
+    check_duplicates,
+    check_missing,
+    check_dead_patterns,
+    check_missing_labels,
+)
 from .discovery import find_test_files
 from .display import bold, green, red, yellow, heuristic_base_names, warn
-from .loader import load_all_patterns
+from .loader import load_all_patterns, load_labels
 from .parser import parse_test_file
 
 
@@ -45,10 +50,15 @@ def run(
     int
         0 if clean (or only warnings), 1 if problems and fail_on_problems.
     """
+    print(bold("CHECK 0: Labels"))
+    total_hard_problems = check_missing_labels(load_labels(config_files))
+
     all_patterns = load_all_patterns(config_files)
 
     if not any(all_patterns.values()):
         print("[WARN] No test patterns found in any config file.")
+        if fail_on_problems and total_hard_problems > 0:
+            return 1
         return 0
 
     # Build the reference map: basename → (collectable_names, helper_only)
@@ -82,7 +92,6 @@ def run(
                         f"CHECK 2 + 3 skipped for this file."
                     )
 
-    total_hard_problems = 0
     total_warnings = 0
 
     # Determine which basenames to process:
@@ -178,9 +187,9 @@ def _print_summary(hard: int, warnings: int) -> None:
     print(bold("━" * 68))
     parts = []
     parts.append(
-        green("0 duplicates/missing")
+        green("0 duplicates/missing/unlabeled")
         if hard == 0
-        else red(f"{hard} duplicate(s)/missing test(s)")
+        else red(f"{hard} duplicate(s)/missing test(s)/unlabeled config(s)")
     )
     parts.append(
         green("0 dead patterns")


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

- Renamed the test label vocabulary repo-wide: `core`→`unit`, `device_critical`→`integration`, `full`→`regression`, and added `trunk` to every config covered by the four push-to-main CI workflows.

- Removed implicit label defaulting — `filter_configs.py` and the OOT framework no longer treat a missing `labels` field as `full`; every tier (including `regression`/`trunk`) now requires the config to explicitly carry that label.

- Simplified `Makefile`'s `TEST_TYPE=trunk` to filter `tests/configs/` by the `trunk` label instead of maintaining a hardcoded `TRUNK_CONFIG_DIRS` list, and updated CI workflow defaults (`integration-tests.yaml` now defaults to `integration`) to match the new vocabulary.

- Added a hard-failing `CHECK 0: Labels` step to `check-all-configs` that errors on any config missing an explicit `labels` field, prompting the author to add `regression` if unsure.


```bash
make tests TEST_TYPE=integration
make tests TEST_TYPE=unit
make tests TEST_TYPE=regression
make tests TEST_TYPE=trunk
```
