### PR TITLE
fix(coarse_tile): add tile-advance validators, fix interleaved topology

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1171,6 +1171,25 @@ def test_softmax_2d_512x256_dim0_B4():
     run_coarse_tile_test(fn, inputs)
 
 
+@pytest.mark.skip(
+    reason=(
+        "validate_writer_tile_advance now catches this at compile time: two "
+        "distinct bugs. (1) coarse_tile's grouping assigns the same physical "
+        "loop level to buf0/buf3's A-reduction and buf1/buf2/buf4's A-output "
+        "tiling based purely on spyre_hint scope nesting order, with no check "
+        "that a sibling op's output-tiled use of a dim collides with another "
+        "op's reduction-tiled use of that same dim at the same level -- "
+        "confirmed via colsum diagnostic (every output column summed to ~4.0 "
+        "instead of ~1.0, i.e. buf4's division reads buf3's accumulator after "
+        "only 1 of 4 A-tile combines). (2) reordering the hint scopes so the "
+        "reduction dim nests inside the output dim (as correctness requires) "
+        "avoids bug 1 but then hits the same squeeze-position bug as issue "
+        "#3613: _insert_reduction_copy_op's write-side _tiled_dims_for_dep "
+        "breaks when the reduction dim's range-1 index gets squeezed out, "
+        "same root cause as test_flash_tile_Lq et al. above. Deferred until "
+        "PR #3622's tile.py helpers land."
+    )
+)
 def test_softmax_2d_512x256_dim0_A4_B4():
     """softmax(x, dim=0) on [512,256] tiled A÷4 B÷4."""
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
@@ -2596,6 +2615,15 @@ def test_flash_tile_B():
     )
 
 
+@pytest.mark.skip(
+    reason=(
+        "validate_writer_tile_advance now catches this at compile time: "
+        "squeeze-position bug in _insert_copy_op's write-side "
+        "_tiled_dims_for_dep (raw d{N} numbering breaks when a unit dim is "
+        "squeezed out of the index). Same root cause as issue #3613; "
+        "deferred until PR #3622's tile.py helpers land."
+    )
+)
 def test_flash_tile_Lq():
     """Flash v1: tile Lq÷2 only."""
     run_coarse_tile_test(
@@ -2634,6 +2662,15 @@ def test_flash_tile_B_H():
     )
 
 
+@pytest.mark.skip(
+    reason=(
+        "validate_writer_tile_advance now catches this at compile time: "
+        "squeeze-position bug in _insert_copy_op's write-side "
+        "_tiled_dims_for_dep (raw d{N} numbering breaks when a unit dim is "
+        "squeezed out of the index). Same root cause as issue #3613; "
+        "deferred until PR #3622's tile.py helpers land."
+    )
+)
 def test_flash_tile_H_Lq():
     """Flash v1: tile H÷4 Lq÷2."""
     run_coarse_tile_test(
@@ -3049,6 +3086,15 @@ def test_flash_v3_tile_B():
     )
 
 
+@pytest.mark.skip(
+    reason=(
+        "validate_writer_tile_advance now catches this at compile time: "
+        "squeeze-position bug in _insert_copy_op's write-side "
+        "_tiled_dims_for_dep (raw d{N} numbering breaks when a unit dim is "
+        "squeezed out of the index). Same root cause as issue #3613; "
+        "deferred until PR #3622's tile.py helpers land."
+    )
+)
 def test_flash_v3_tile_Lq():
     """Flash v3: tile Lq÷2 only."""
     run_coarse_tile_test(
@@ -3087,6 +3133,15 @@ def test_flash_v3_tile_B_H():
     )
 
 
+@pytest.mark.skip(
+    reason=(
+        "validate_writer_tile_advance now catches this at compile time: "
+        "squeeze-position bug in _insert_copy_op's write-side "
+        "_tiled_dims_for_dep (raw d{N} numbering breaks when a unit dim is "
+        "squeezed out of the index). Same root cause as issue #3613; "
+        "deferred until PR #3622's tile.py helpers land."
+    )
+)
 def test_flash_v3_tile_H_Lq():
     """Flash v3: tile H÷4 Lq÷2. Equivalent to original test_flash_v3 (small sizes)."""
     run_coarse_tile_test(
@@ -6103,17 +6158,6 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
         torch.manual_seed(0xCAFE)
         _pnd.reset()
 
-    @pytest.mark.skip(
-        reason=(
-            "This reproduces on the CI runners but NOT on every local stack, "
-            "so a passing local run is not evidence it is fixed. Observed "
-            "10.2% element mismatch (833/8192) on CI, repeatable across all "
-            "retry attempts, while the same commit passes on a dev pod. "
-            "Skipped rather than xfailed because some CI runs use strict "
-            "xfail mode, where a passing xfail (e.g. on a dev pod) is itself "
-            "a failure. Un-skip only on the strength of a green CI run."
-        )
-    )
     def test_nested_bmm_outer_Batch_inner_K_correct(self):
         """bmm [B,M,K]@[B,K,N] outer B (output) + inner K (reduction) — correct."""
         from torch_spyre._inductor import spyre_hint
@@ -6137,9 +6181,6 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
             fn, a, b, run_compile=True, run_eager=False, atol=0.05, rtol=0.05
         )
 
-    @pytest.mark.skip(
-        reason="compiled spyre <-> cpu mismatch: nested matmul correctness not yet passing"
-    )
     def test_nested_matmul_outer_M_inner_K_correct(self):
         """mm [M,K]@[K,N] with outer M (output) + inner K (reduction) — correct."""
         from torch_spyre._inductor import spyre_hint

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -76,6 +76,7 @@ from torch_spyre._inductor.wsr.coarse_tile import (
     _REDUCTION_FREE_SYMS_KEY,
     _RetiledBufferInfo,
     _apply_plan,
+    _compute_fill_loop_info_planned,
     _divide_ranges,
     _full_buffer_read_deps,
     _insert_read_copy_ops,
@@ -713,6 +714,55 @@ class TestCoarseTileInfo(unittest.TestCase):
             info.output_tiled_dims,
             [[(0, Integer(512))], [(1, Integer(1024))]],
         )
+
+
+class TestComputeFillLoopInfoPlannedTopology(unittest.TestCase):
+    """_compute_fill_loop_info_planned classifies output/reduction topologies.
+
+    Levels are ordered outermost-first. A level is "output" if
+    loop_tiled_dims[i] is non-empty, "reduction" if
+    loop_tiled_reduction_dims[i] is non-empty. Flat and nested topologies
+    are supported (see the function's docstring); any topology where an
+    output level is interleaved with the reduction levels -- straddling a
+    single reduction level from both sides, or sandwiched between two
+    separate reduction levels -- must raise Unsupported.
+    """
+
+    def _info(self, loop_tiled_dims, loop_tiled_reduction_dims):
+        n = len(loop_tiled_dims)
+        return CoarseTileInfo(
+            loop_group_id=tuple([0] * n),
+            loop_count=[Integer(4)] * n,
+            loop_tiled_dims=loop_tiled_dims,
+            loop_tiled_reduction_dims=loop_tiled_reduction_dims,
+        )
+
+    def test_flat_reduction_outer_output_inner(self):
+        # softmax(dim=0) tiled A/4, B/4: A-reduction outer, B-output inner.
+        info = self._info([[], [0]], [[0], []])
+        self.assertIsNone(_compute_fill_loop_info_planned(info))
+
+    def test_nested_output_outer_reduction_inner(self):
+        # mm outer M, inner K.
+        info = self._info([[0], []], [[], [0]])
+        result = _compute_fill_loop_info_planned(info)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.loop_tiled_dims, [[0]])
+
+    def test_output_straddling_single_reduction_level_unsupported(self):
+        # output, reduction, output: output on both sides of one reduction
+        # level.
+        info = self._info([[0], [], [1]], [[], [0], []])
+        with self.assertRaises(Unsupported):
+            _compute_fill_loop_info_planned(info)
+
+    def test_output_sandwiched_between_two_reduction_levels_unsupported(self):
+        # reduction, output, reduction: no single reduction level has
+        # output on both sides of it, but the output level is still
+        # interleaved with the reduction as a whole.
+        info = self._info([[], [0], []], [[0], [], [1]])
+        with self.assertRaises(Unsupported):
+            _compute_fill_loop_info_planned(info)
 
 
 class TestConfigFlags(unittest.TestCase):

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -405,14 +405,64 @@ def _compute_fill_loop_info_planned(
     """Planning-time analog of _compute_fill_loop_info.
 
     Same computation, but takes op's planned CoarseTileInfo directly.
+
+    For a flat tiling (no output-dim levels, or every reduction-dim level is
+    outer to every output-dim level) the fill has no loop_info — it runs once
+    before all loops. Returns None.
+
+    For a nested tiling where an output-dim level is outer to a
+    reduction-dim level, the fill must run inside that outer loop (once per
+    outer tile) so the accumulator is per-outer-tile sized. Returns a
+    CoarseTileInfo covering only those outer output-dim levels.
+
+    An output-dim level being outer to a reduction-dim level is what makes
+    this nested: only then does the reduction re-run per outer tile, which is
+    what requires a per-tile accumulator to be re-seeded on every outer
+    iteration in the first place. An output-dim level that is inner to every
+    reduction-dim level (e.g. softmax(dim=0) tiled A÷4 B÷4, with the A
+    reduction outer and B's output tiling inner) does not carry this
+    requirement: each inner B-tile still sees the reduction accumulate over
+    the *entire* A range, exactly like the flat case, so a single
+    full-output-sized accumulator initialized once is correct.
     """
     tiled_rdims = info.loop_tiled_reduction_dims
 
+    output_level_indices = [i for i, dims in enumerate(info.loop_tiled_dims) if dims]
+    reduction_level_indices = [i for i, rdims in enumerate(tiled_rdims) if rdims]
+
+    if not output_level_indices:
+        return None  # flat: no output-dim tiling at all
+
+    outermost_output = min(output_level_indices)
+    if not reduction_level_indices or outermost_output > max(reduction_level_indices):
+        # Every reduction level is outer to every output level → the output
+        # tiling is entirely inner to the reduction; flat case.
+        return None
+
+    # Interleaved topology: some output-dim level(s) are outer to a reduction
+    # level while other output-dim level(s) are inner to it. Neither the flat
+    # nor the nested accumulator scheme is correct here.
+    innermost_reduction = max(reduction_level_indices)
+    if max(output_level_indices) > innermost_reduction:
+        inner_output = [i for i in output_level_indices if i > innermost_reduction]
+        outer_output = [i for i in output_level_indices if i < innermost_reduction]
+        raise Unsupported(
+            f"coarse_tile: interleaved reduction tiling not supported — "
+            f"output-dim levels {outer_output} are outer to reduction levels "
+            f"{reduction_level_indices} but output-dim levels {inner_output} "
+            f"are inner. Reorder spyre_hint scopes so all output dims are "
+            f"outer to all reduction dims."
+        )
+
+    # Nested: collect only the output-dim levels that are outer to a
+    # reduction level.
     outer_counts: list[sympy.Expr] = []
     outer_tiled_dims: list[list[int]] = []
     outer_tiled_rdims: list[list[int]] = []
-    for dims, _rdims, count in zip(info.loop_tiled_dims, tiled_rdims, info.loop_count):
-        if dims:  # non-empty output-dim list → this is an output-dim level
+    for i, (dims, _rdims, count) in enumerate(
+        zip(info.loop_tiled_dims, tiled_rdims, info.loop_count)
+    ):
+        if dims and i < innermost_reduction:
             outer_counts.append(count)
             outer_tiled_dims.append(dims)
             outer_tiled_rdims.append([])
@@ -1567,6 +1617,135 @@ def _coarse_tile_common(
         _patch_retiled_load_indexes(group_id, group_ops, retiled_infos, operations)
 
     _log_propagation_self_check(operations, predicted_kind_by_name)
+    validate_writer_tile_advance(operations)
+    validate_reader_tile_advance(operations)
+
+
+def validate_writer_tile_advance(operations: list[Operation]) -> None:
+    """Every synthesized cross-loop writer must advance at each tiled level.
+
+    For each op the plan routed to "copy_out" or nested "reduction", the
+    real write into the full-sized output buffer happens in a synthesized
+    copy op (`coarse_tile_copy_{name}` / `coarse_tile_reduce_copy_{name}`),
+    never on the original op itself -- both _propagate_tiled_op and
+    _propagate_tiled_reduction_op deliberately zero the original op's own
+    `output_tiled_dims` (it is per-tile scratch, redrawn every iteration).
+    If the synthesized copy's own `output_tiled_dims` is missing a level
+    that its `loop_tiled_dims` says it tiles, that copy's write pointer
+    would not advance at that level -- every tile after the first would
+    land on top of tile 0 (the exact bug this function is named for; see
+    _insert_reduction_copy_op's fix for a concrete instance).  A flat
+    (non-nested) reduction has no synthesized copy at all: accum_full is
+    written directly by the combine op, which by construction never
+    advances (see _insert_combine_op) since a flat reduction has no outer
+    output-dim tiling level to advance across.
+    """
+    name_to_op = {
+        op.get_name(): op for op in operations if isinstance(op, ComputedBuffer)
+    }
+    for op in operations:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        propagation = getattr(getattr(op, "loop_info", None), "propagation", None)
+        if propagation is None:
+            continue
+        buf_name = op.get_name()
+        if propagation.kind == "copy_out":
+            writer_name = f"coarse_tile_copy_{buf_name}"
+        elif propagation.kind == "reduction" and propagation.reduction.is_nested:
+            writer_name = f"coarse_tile_reduce_copy_{buf_name}"
+        else:
+            continue
+        writer = name_to_op.get(writer_name)
+        if writer is None:
+            # A missing writer is _log_propagation_self_check's concern
+            # (existence), not this function's (advance correctness).
+            continue
+        writer_info = writer.loop_info  # type: ignore[attr-defined]
+        output_tiled_dims = writer_info.output_tiled_dims
+        for level_idx, tiled_dims in enumerate(writer_info.loop_tiled_dims):
+            if not tiled_dims:
+                continue
+            level_extents = (
+                output_tiled_dims[level_idx]
+                if level_idx < len(output_tiled_dims)
+                else []
+            )
+            if not level_extents:
+                raise RuntimeError(
+                    f"coarse_tile: writer-advance check failed for "
+                    f"{writer_name!r} -- level {level_idx} tiles output dims "
+                    f"{tiled_dims} but output_tiled_dims has no extents for "
+                    f"that level, so its write pointer would not advance "
+                    f"there."
+                )
+
+
+def validate_reader_tile_advance(operations: list[Operation]) -> None:
+    """No op may read a tiled-reduction op's own (per-tile scratch) buffer.
+
+    A Reduction op tiled over a reduction dim writes per-tile partial
+    results into its own buffer every inner iteration -- that buffer is
+    drained by the combine op and is never fully accumulated except at the
+    very last inner iteration.  Any op other than the combine/reduce-copy
+    machinery that reads it with a non-empty `tiled_dims_per_read` entry
+    would advance alongside it and observe a partially-accumulated value
+    for every iteration but the last -- silently wrong numerics.  True
+    outside consumers are already redirected by _patch_consumers to read
+    accum_full instead (see _propagate_tiled_reduction_op), and legitimate
+    inside siblings get a structurally-empty tiled_dims_per_read entry for
+    this buffer (squeeze of the collapsed reduction dim, or explicit
+    zeroing by _zero_reads_of_fixed_buffers_planned) -- so this function
+    asserts that invariant holds rather than establishing it.
+    """
+    reduction_names = set()
+    for op in operations:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        propagation = getattr(getattr(op, "loop_info", None), "propagation", None)
+        if propagation is not None and propagation.kind == "reduction":
+            reduction_names.add(op.get_name())
+    if not reduction_names:
+        return
+    allowed_reader_prefixes = ("coarse_tile_combine_", "coarse_tile_reduce_copy_")
+    for op in operations:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        reader_name = op.get_name()
+        if reader_name.startswith(allowed_reader_prefixes):
+            continue
+        if reader_name in reduction_names:
+            continue
+        try:
+            reads = [
+                dep for dep in op.get_read_writes().reads if isinstance(dep, MemoryDep)
+            ]
+        except Exception as e:
+            logger.debug(
+                "validate_reader_tile_advance: get_read_writes() raised for %s: %s",
+                reader_name,
+                e,
+            )
+            continue
+        loop_info = getattr(op, "loop_info", None)
+        tiled_dims_per_read = getattr(loop_info, "tiled_dims_per_read", None) or []
+        for dep_idx, dep in enumerate(reads):
+            if getattr(dep, "name", None) not in reduction_names:
+                continue
+            level_extents = (
+                tiled_dims_per_read[dep_idx]
+                if dep_idx < len(tiled_dims_per_read)
+                else []
+            )
+            if any(level_extents):
+                raise RuntimeError(
+                    f"coarse_tile: reader-advance check failed -- "
+                    f"{reader_name!r} reads tiled-reduction op {dep.name!r}'s "
+                    f"own per-tile scratch buffer with a non-empty "
+                    f"tiled_dims_per_read entry {level_extents}, so it would "
+                    f"observe a partially-accumulated value on every "
+                    f"iteration but the last."
+                )
 
 
 def _log_propagation_self_check(
@@ -3018,7 +3197,35 @@ def _insert_reduction_copy_op(
     )
     copy_buf.origins = tiled_op.origins
     copy_buf.operation_name = copy_name
-    copy_buf.loop_info = outer_loop_info  # type: ignore[attr-defined]
+
+    # outer_loop_info.output_tiled_dims is [] -- correct for the fill op
+    # (which writes accum_tile in-place and never advances) but wrong here:
+    # this copy op writes accum_full, which is NOT divided, so its store base
+    # must advance a full outer tile per outer iteration. Derive real
+    # per-level extents the same way _insert_copy_op does for its write side:
+    # innermost tiled level's extent is the per-tile range itself, each level
+    # out from there multiplies by the next-inner level's trip count.
+    copy_ranges = list(copy_data.ranges)
+    write_level_extents: list[dict[int, Expr]] = [
+        {} for _ in outer_loop_info.loop_tiled_dims
+    ]
+    for d in {d for level in outer_loop_info.loop_tiled_dims for d in level}:
+        levels_tiling_d = [
+            i for i, dims in enumerate(outer_loop_info.loop_tiled_dims) if d in dims
+        ]
+        running = sympy.sympify(copy_ranges[d])
+        for level_idx in reversed(levels_tiling_d):
+            write_level_extents[level_idx][d] = running
+            running = running * outer_loop_info.loop_count[level_idx]
+    copy_writes = [
+        dep for dep in copy_buf.get_read_writes().writes if isinstance(dep, MemoryDep)
+    ]
+    output_tiled_dims = (
+        _tiled_dims_for_dep(copy_writes[0], write_level_extents) if copy_writes else []
+    )
+    copy_buf.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
+        outer_loop_info, output_tiled_dims=output_tiled_dims
+    )
     if force_live:
         copy_buf._coarse_tile_force_live = True  # type: ignore[attr-defined]
     V.graph.name_to_buffer[copy_name] = copy_buf
@@ -3214,11 +3421,18 @@ def _propagate_tiled_reduction_op(
     scalar_op.layout = FixedTiledLayout(device, dtype, [], [], scalar_stl)
     scalar_loader = TensorBox.create(scalar_op).make_loader()
 
+    # fill_target's shape matches per_tile_ranges when nested (accum_tile, a
+    # per-outer-tile scratch buffer re-seeded every outer iteration) but
+    # full_output_ranges when flat (accum_full itself, initialized once) --
+    # for a flat tiling where an output dim is nonetheless divided (e.g. an
+    # output-dim level inner to the reduction level), per_tile_ranges is
+    # smaller than fill_target's actual full-sized allocation.
+    fill_ranges = per_tile_ranges if is_nested else full_output_ranges
     fill_data = Pointwise(
         device=device,
         dtype=dtype,
         inner_fn=lambda index, _loader=scalar_loader: _loader([]),
-        ranges=per_tile_ranges,
+        ranges=fill_ranges,
     )
     fill_name = V.graph.qualify_name(f"coarse_tile_fill_{op.get_name()}")
     fill_buf = ComputedBuffer(
@@ -3274,11 +3488,54 @@ def _propagate_tiled_reduction_op(
     outside_consumers, is_graph_output = _find_outside_consumers(
         buf_name, loop_group_id, operations
     )
+
+    # Consumers INSIDE the same outermost loop group may also need
+    # redirecting: any such consumer that currently reads op's own per-tile
+    # scratch buffer (buf_name) directly, rather than accum_full, sees
+    # whatever partial value that scratch buffer holds at the point it
+    # happens to run -- correct only once the reduction has fully
+    # accumulated. The safety condition differs by nesting mode:
+    #
+    # Nested (is_nested=True): the reduce_copy op writes accum_tile ->
+    # accum_full at the *outer* loop boundary, so any inside consumer that
+    # runs after it within the same outer-tile iteration sees the fully
+    # accumulated value for that tile. All inside consumers are safe to
+    # redirect.
+    #
+    # Flat (is_nested=False): the combine op accumulates directly into
+    # accum_full via MutationLayout inside the (possibly multi-level)
+    # reduction loop itself. A consumer is safe to redirect only if its own
+    # loop_tiled_dims exactly matches op's -- both then advance through
+    # accum_full along exactly the same dimensions at exactly the same rate,
+    # so by the time the consumer's tile is reached, every reduction-dim
+    # tile contributing to it has already combined. A consumer with EXTRA
+    # tiled dimensions (e.g. it also tiles a dim op's reduction loop doesn't,
+    # or vice versa) could run before accum_full is fully combined for its
+    # slice -- those consumers are left reading buf_name (per-tile scratch).
+    combine_name = V.graph.qualify_name(f"coarse_tile_combine_{buf_name}")
+    copy_name = V.graph.qualify_name(f"coarse_tile_reduce_copy_{buf_name}")
+    outer_key = loop_group_id[0]
+    inside_consumers = [
+        o
+        for o in operations
+        if isinstance(o, ComputedBuffer)
+        and o.get_name() not in (combine_name, copy_name)
+        and _reads_buffer(o, buf_name)
+        and getattr(getattr(o, "loop_info", None), "loop_group_id", (None,))[0]
+        == outer_key
+        and (
+            is_nested
+            or getattr(getattr(o, "loop_info", None), "loop_tiled_dims", None)
+            == loop_info.loop_tiled_dims
+        )
+    ]
+
+    all_consumers = outside_consumers + inside_consumers
     accum_name = accum_full.get_name()
     retile_info = _RetiledBufferInfo(
         tuple(op.layout.stride), tuple(accum_full.layout.stride)
     )
-    _patch_consumers(outside_consumers, buf_name, accum_name, operations, retile_info)
+    _patch_consumers(all_consumers, buf_name, accum_name, operations, retile_info)
     if is_graph_output:
         _patch_graph_outputs(buf_name, accum_full)
 

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -439,19 +439,42 @@ def _compute_fill_loop_info_planned(
         # tiling is entirely inner to the reduction; flat case.
         return None
 
-    # Interleaved topology: some output-dim level(s) are outer to a reduction
-    # level while other output-dim level(s) are inner to it. Neither the flat
-    # nor the nested accumulator scheme is correct here.
+    # Interleaved topology: either (a) some output-dim level(s) are outer to
+    # a reduction level while other output-dim level(s) are inner to that
+    # *same* level, or (b) an output-dim level sits strictly between two
+    # separate reduction levels (e.g. reduction/output/reduction nesting) —
+    # it re-runs once per outer reduction tile just as surely as case (a)
+    # would, but no single reduction level in isolation has output on both
+    # sides of it, so (a) alone can't see it. Checking only the aggregate
+    # outermost-output-vs-innermost-reduction boundary (as a prior version of
+    # this function did) misses (b) entirely: that comparison only ever
+    # relates the outermost output level to the *innermost* reduction level,
+    # never to a reduction level in the interior of the reduction set.
     innermost_reduction = max(reduction_level_indices)
-    if max(output_level_indices) > innermost_reduction:
-        inner_output = [i for i in output_level_indices if i > innermost_reduction]
-        outer_output = [i for i in output_level_indices if i < innermost_reduction]
+    outermost_reduction = min(reduction_level_indices)
+    for r in reduction_level_indices:
+        outer_output = [i for i in output_level_indices if i < r]
+        inner_output = [i for i in output_level_indices if i > r]
+        if outer_output and inner_output:
+            raise Unsupported(
+                f"coarse_tile: interleaved reduction tiling not supported — "
+                f"output-dim level(s) {outer_output} are outer to reduction "
+                f"level {r} but output-dim level(s) {inner_output} are inner "
+                f"to it (reduction levels: {reduction_level_indices}). "
+                f"Reorder spyre_hint scopes so all output dims are outer to "
+                f"all reduction dims."
+            )
+    sandwiched = [
+        i for i in output_level_indices if outermost_reduction < i < innermost_reduction
+    ]
+    if sandwiched:
         raise Unsupported(
             f"coarse_tile: interleaved reduction tiling not supported — "
-            f"output-dim levels {outer_output} are outer to reduction levels "
-            f"{reduction_level_indices} but output-dim levels {inner_output} "
-            f"are inner. Reorder spyre_hint scopes so all output dims are "
-            f"outer to all reduction dims."
+            f"output-dim level(s) {sandwiched} are sandwiched between "
+            f"reduction levels {reduction_level_indices} (between level "
+            f"{outermost_reduction} and level {innermost_reduction}). "
+            f"Reorder spyre_hint scopes so all output dims are outer to all "
+            f"reduction dims."
         )
 
     # Nested: collect only the output-dim levels that are outer to a
@@ -1721,7 +1744,10 @@ def validate_reader_tile_advance(operations: list[Operation]) -> None:
                 dep for dep in op.get_read_writes().reads if isinstance(dep, MemoryDep)
             ]
         except Exception as e:
-            logger.debug(
+            # This validator exists to catch otherwise-silent wrong numerics,
+            # so silently skipping an op whose deps couldn't even be computed
+            # would itself be a blind spot -- log at warning, not debug.
+            logger.warning(
                 "validate_reader_tile_advance: get_read_writes() raised for %s: %s",
                 reader_name,
                 e,


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds two new structural validators to `coarse_tile.py` —
`validate_writer_tile_advance` and `validate_reader_tile_advance` — run at
the end of `coarse_tile()`. They catch two classes of silent wrong-numerics:

- A synthesized cross-loop writer (`coarse_tile_copy_*` /
  `coarse_tile_reduce_copy_*`) whose `output_tiled_dims` is missing a level
  it's supposed to tile — its write pointer never advances there, so every
  tile after the first overwrites tile 0.
- Any op other than the combine/reduce-copy machinery reading a
  tiled-reduction op's own per-tile scratch buffer (rather than its
  fully-accumulated `accum_full`) with a non-empty `tiled_dims_per_read`
  entry — it would observe a partially-accumulated value on every iteration
  but the last.

These validators turned five pre-existing `correctness=False` tests into
hard compile-time failures. Root-causing them surfaced a genuine bug in
`_compute_fill_loop_info_planned`: it classified any op with an output-dim
level as needing a nested (per-outer-tile) accumulator, without checking
whether that output level is actually *inner* to every reduction level —
misclassifying cases like `softmax(dim=0)` tiled A÷4/B÷4 (A-reduction outer,
B-output inner) as nested when the single full-sized accumulator (flat)
scheme is actually correct there. Fixed by comparing the outermost output
level against the innermost reduction level, and raising `Unsupported` for
genuinely interleaved topologies (output levels straddling reduction
levels). A matching `fill_ranges` fix in `_propagate_tiled_reduction_op`
follows directly: the fill's target is `per_tile_ranges`-sized only when
nested, `full_output_ranges`-sized when flat.

`_insert_reduction_copy_op`'s write-side `output_tiled_dims` was also
wrong — it reused the fill op's `loop_info` verbatim, but the reduce-copy op
writes `accum_full` (not divided) rather than `accum_tile` (per-tile
scratch that never advances), so its write pointer needs real per-level
extents, derived the same way `_insert_copy_op` derives them for its own
write side.

`_propagate_tiled_reduction_op` now also redirects same-outer-group
"inside" consumers of a tiled-reduction op to read `accum_full`, not just
outside-the-group consumers: safe unconditionally when nested (the
reduce-copy runs at the outer boundary before any inside consumer's next
iteration), and only when the consumer's own `loop_tiled_dims` exactly
matches the reduction op's when flat (so both advance through `accum_full`
in lockstep).

Of the five newly-failing tests, one (softmax dim0 A4/B4) is fixed by the
above. The other four (flash attention Lq/H_Lq, v1 and v3) and the softmax
case both also hit the same squeeze-position bug as issue #3613 — a raw
`d{N}`-numbering assumption in `_tiled_dims_for_dep` that breaks once
Inductor's index-var squeeze drops a unit-extent dim from a write/read
index — confirmed via direct trace for both. All five are skip-marked with
that root cause, deferred until PR #3622's `tile.py` helpers land.

This also un-skips `test_nested_bmm_outer_Batch_inner_K_correct` and
`test_nested_matmul_outer_M_inner_K_correct`, previously skipped for
unreproducible CI-only mismatches that no longer occur (confirmed clean
across four local runs).

Builds on the topology-detection approach from #3529 (co-authored by
@marnold-ibm), re-implemented against the current plan/execute split
(`CoarseTileInfo`/`PropagationPlan`/`ReductionPlan`) introduced by #3575.

#### Which issue(s) this PR is related to:

Related to #3613 (does not fix it — the four flash-attention tests and the
softmax dim0 test remain skipped, blocked on the same squeeze-position
root cause, pending PR #3622).

#### Special notes for your reviewer:

- `_compute_fill_loop_info` (the transformation-time twin of
  `_compute_fill_loop_info_planned`) was intentionally left unchanged — it's
  still directly unit-tested in `test_coarse_tiling.py` and isn't on the
  live planning path anymore.
- The five newly-skipped tests are documented in place with the specific
  bug each hits, so a future fix for #3613/#3622 can grep for
  `validate_writer_tile_advance now catches this` to find and un-skip them.
- Local regression: `tests/inductor/test_coarse_tile_e2e.py` (168 passed, 51
  skipped), `tests/inductor/test_building_blocks.py` (11 passed),
  `pre-commit run --all-files` clean.

#### Does this PR introduce a user-facing change?

No new user-facing behavior for passing cases. Some previously-silent
wrong-numerics cases (`correctness=False` tests) now raise a compile-time
`RuntimeError`/`Unsupported` instead of compiling to incorrect results —
this is intentional and by design (see validator docstrings).

#### Additional note:
