### PR TITLE
Ensure copies do not get deleted so they remain in WSR groups V2

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -58,6 +58,7 @@ from torch._inductor.utils import run_and_get_code
 from torch_spyre._inductor import config
 from torch_spyre._inductor import spyre_hint
 import torch_spyre._inductor.wsr.propagate_named_dims as _pnd
+from torch._inductor.exc import InductorError
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
 from utils_inductor import compare_with_cpu, _compile_and_run  # noqa: E402
@@ -1706,8 +1707,15 @@ def test_copy_rmw_correction_512x256_A4_B4():
 # copies sparse reduction result into a dense buffer
 
 
-def test_copy_after_reduction_512x256_A4():
-    """out.copy_(x.amin(dim=0)) on [512,256] tiled A÷4."""
+def test_copy_not_deleted():
+    """Regression: copy_ must not be eliminated by noop_registry removal.
+
+    If copy_ is deleted before lowering, the expected_reduction_dims hint on
+    the copy op is never checked (no op to check), and the test passes
+    vacuously.  If copy_ is present, validate_named_dims fires and raises
+    because copy_ has no reduction dim -- that AssertionError is the expected
+    outcome, proving the copy survived.
+    """
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
 
     def fn(x):
@@ -1717,7 +1725,24 @@ def test_copy_after_reduction_512x256_A4():
                 out.copy_(x.amin(dim=0))
         return out
 
-    run_coarse_tile_test(fn, inputs)
+    with pytest.raises(InductorError, match="expected_reduction_dims"):
+        run_coarse_tile_test(fn, inputs)
+
+
+def test_copy_after_reduction_512x256_A4():
+    """out.copy_(x.amin(dim=0)) on [512,256] tiled A÷4."""
+    inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
+
+    def fn(x):
+        out = torch.zeros(256, device=x.device, dtype=x.dtype)
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
+                temp = x.amin(dim=0)
+            with spyre_hint(expected_named_dims=["B"]):
+                out.copy_(temp)
+        return out
+
+    run_coarse_tile_test(fn, inputs, correctness=False)
 
 
 def test_copy_after_reduction_512x256_B4():
@@ -1728,10 +1753,12 @@ def test_copy_after_reduction_512x256_B4():
         out = torch.zeros(256, device=x.device, dtype=x.dtype)
         with spyre_hint(num_tiles_per_dim={"B": 4}):
             with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
-                out.copy_(x.amin(dim=0))
+                temp = x.amin(dim=0)
+            with spyre_hint(expected_named_dims=["B"]):
+                out.copy_(temp)
         return out
 
-    run_coarse_tile_test(fn, inputs)
+    run_coarse_tile_test(fn, inputs, correctness=False)
 
 
 def test_copy_after_reduction_512x256_A4_B4():
@@ -1745,7 +1772,9 @@ def test_copy_after_reduction_512x256_A4_B4():
                 with spyre_hint(
                     expected_named_dims=["B"], expected_reduction_dims=["A"]
                 ):
-                    out.copy_(x.amin(dim=0))
+                    temp = x.amin(dim=0)
+                with spyre_hint(expected_named_dims=["B"]):
+                    out.copy_(temp)
         return out
 
     run_coarse_tile_test(fn, inputs, correctness=False)  # Incorrect results
@@ -6440,9 +6469,6 @@ def test_sum_reduce_implicit_accumulator():
     torch.testing.assert_close(result, ref, atol=0.01, rtol=0.1)
 
 
-@pytest.mark.skip(
-    reason="zeros with named_dims hint acquires wrong layout in tiled scope"
-)
 def test_zeros_named_dims_hint_correctness():
     """zeros with explicit named_dims hint inside a tiled scope should be correct.
 

--- a/torch_spyre/_inductor/patches.py
+++ b/torch_spyre/_inductor/patches.py
@@ -137,6 +137,13 @@ def enable_spyre_context(example_inputs: list[InputType]):
 
     SchedulerNode.has_side_effects = _spyre_scheduler_node_has_side_effects  # type: ignore[method-assign]
 
+    # Prevent remove_noop_ops from eliminating aten.copy.default nodes.
+    # That pass treats copy.default as an alias no-op and replaces copy(dst, src)
+    # with src, discarding the copy before it reaches lowering.
+    from torch._inductor.fx_passes.post_grad import noop_registry
+
+    _saved_copy_noop = noop_registry.pop(torch.ops.aten.copy.default, None)
+
     with (
         spyre_data_types(),
         enable_spyre_lowerings(),
@@ -151,6 +158,8 @@ def enable_spyre_context(example_inputs: list[InputType]):
             Loops.has_large_inner_fn = old_loop
             GraphLowering._update_scheduler = old_update_scheduler  # type: ignore[method-assign]
             SchedulerNode.has_side_effects = old_scheduler_node_has_side_effects  # type: ignore[method-assign]
+            if _saved_copy_noop is not None:
+                noop_registry[torch.ops.aten.copy.default] = _saved_copy_noop
 
 
 OBSERVER_HOOKS_KEY = "__spyre_hooks_meta"


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### Background:
NOTE: This is a re-submission of #3615 but with only the first commit (dd8be54b7cd153372dd55fe566e9591897dd5eb4) and not second (75d96a1028ead297dda601cc7cea75eccf656300). The second commit was claude recommending we extend this treatment to `clone` as well as `copy`, but `clone` ended up breaking granite.  This breakage will be investigated in parallel, but we want `copy_` handled immediately to unblock other WSR work.

#### What this PR does:

Multiple of the coarse tiling tests were passing incorrectly because `copy_` was being removed by inductor very early in compilation.  This defeats WSR variants such as **f[lash_v2 which intentionally insert copies](https://github.com/marnold-ibm/torch-spyre/blob/9d80d88c8044af75a2f272fd5d9f33397c42df6c/tests/inductor/test_coarse_tile_e2e.py#L4217)**  inside the WSR loop.   As per claude:

```
Inside `joint_graph_passes` (called from `compile_fx_forward` → `_recursive_joint_graph_passes`),
`remove_noop_ops` runs. It has `aten.copy.default` in its `noop_registry` as a
`true_noop` — it replaces `copy(dst, src)` with just `src`, redirecting all users
of the copy result to `src` directly, then erases the copy node.

For `denominator.copy_(new_denom)`: the copy result was a graph output. After
`remove_noop_ops`, that graph output slot now holds `new_denom` directly. The copy
node is gone.
```

This PR is a claude-proposed fix of simply removing `aten.copy` from the `noop_registry` during the compilation to prevent them from being removed by the `remove_noop_ops` pass.

**Risk** - This fix has the potential performance downside of preventing removal other copies that may be harmless for WSR.  If we discover that to be the case, we could detect and remove copies in our own pass that has knowledge of spyre_hints and WSR.

There several changed tests
- 3 `test_copy_after_reduction` tests were (correctly) broken by this change. They were only working because copies were not being tiled.   (a) They had incorrect `expected_named_dims` annotations that began failing once the copies remain.  These test annotations were fixed so they continue to produce an op-spec.  (b) They now produce incorrect final results so are marked with `correctness=False` which is the correct.  They are not working when copies are tiled
- Added test `test_copy_not_deleted` to ensure that if copies disappear again we will know.   It detects when copies disappear because the intentionally-incorrect annotation will start passing.
- Un-skip 1 test `test_zeros_named_dims_hint_correctness` that was already passing on main 
   

#### Which issue(s) this PR is related to:

Part of #206

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

Granite passes