### PR TITLE
[Bug] Do not keep a buffer LX-resident across an extern kernel call

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_lx_extern_kernel_clobber.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_lx_extern_kernel_clobber.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [core, full, device_critical]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_lx_extern_kernel_clobber.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_lx_extern_kernel_clobber.py
+++ b/tests/inductor/test_lx_extern_kernel_clobber.py
@@ -1,0 +1,135 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests: a buffer must not stay resident in the LX scratchpad
+across an opaque extern kernel call.
+
+Background. The LX scratchpad is a fixed per-core resource shared by *every*
+compiled Spyre program, and a resident buffer is handed from one kernel launch
+to the next by its LX offset alone -- it is not threaded through the generated
+wrapper as a tensor. An extern kernel (``FallbackKernel``, e.g. a
+``torch.library.custom_op``) is opaque: its body may launch other compiled
+programs, and those programs allocate the same LX offsets. So a buffer left
+resident across such a call is silently overwritten and its consumer reads the
+other program's data.
+
+The graph shape that triggers it is an ordinary transformer residual:
+
+    r = f(x)                 # written before the op, read after it,
+    t = x @ w                # and never passed *to* the op
+    o = opaque_custom_op(t)
+    out = r + o
+
+``r`` is fused into the producing kernel and left in LX; the consumer reads it
+back after the opaque call. This is the shape behind the ``spyre-inference``
+whole-model-compile corruption (``SPYRE_FORCE_COMPILE_ATTN=1`` with
+``-cc.mode STOCK_TORCH_COMPILE``): attention is an opaque custom op, and
+compiling the paged-attention kernel makes its body launch a nested program.
+
+``_extern_kernel_in_live_range`` is the guard; :func:`test_extern_kernel_in_live_range`
+is the deterministic signal that it still rejects the spanning case, and
+:func:`test_nested_launch_does_not_clobber_residual` asserts the behaviour on
+device.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+import torch_spyre  # noqa: F401
+from torch._inductor.ir import ExternKernel
+from torch_spyre._inductor.scratchpad.allocator import _extern_kernel_in_live_range
+
+
+DEVICE = "spyre"
+DTYPE = torch.float16
+N = 128
+INNER_N = 64
+
+
+class _FakeGraph:
+    """Minimal stand-in exposing only what the guard reads."""
+
+    def __init__(self, operations):
+        self.operations = operations
+
+
+def test_extern_kernel_in_live_range():
+    """The guard must fire for a buffer merely *live across* an extern kernel.
+
+    Being read/written by the extern kernel (index in ``uses``) was already
+    rejected; spanning one without touching it is the case that silently
+    corrupted results.
+    """
+    extern = Mock(spec=ExternKernel)
+    plain = Mock()
+
+    spanning = _FakeGraph([plain, extern, plain])
+    assert _extern_kernel_in_live_range(spanning, [0, 2]), (
+        "a buffer live across an extern kernel must be rejected"
+    )
+    assert _extern_kernel_in_live_range(spanning, [1]), "extern kernel user"
+
+    # Live range entirely before the extern kernel: LX residency is fine.
+    assert not _extern_kernel_in_live_range(spanning, [0])
+    assert not _extern_kernel_in_live_range(_FakeGraph([plain, plain, plain]), [0, 2])
+    assert not _extern_kernel_in_live_range(spanning, [])
+
+
+@pytest.mark.parametrize("layers", [1, 4])
+def test_nested_launch_does_not_clobber_residual(layers):
+    """Launching an unrelated compiled program inside an opaque custom op must
+    not change the outer compiled program's result.
+
+    The nested program's result is discarded, so the two runs must agree
+    bit-for-bit. Before the fix they did not: the nested program's data landed
+    in the LX scratchpad slot holding the outer graph's residual.
+    """
+    launch = False
+
+    inner = torch.compile(lambda t: t * 2.0 + 1.0, dynamic=False)
+    inner_arg = torch.ones(INNER_N, INNER_N, dtype=DTYPE, device=DEVICE)
+    inner(inner_arg)  # compile + warm before the outer program ever runs
+
+    @torch.library.custom_op("test_lx_clobber::opaque", mutates_args=())
+    def opaque(x: torch.Tensor) -> torch.Tensor:
+        if launch:
+            inner(inner_arg)  # discarded; only the nested launch is under test
+        return x.clone()
+
+    @opaque.register_fake
+    def _(x):
+        return torch.empty_like(x)
+
+    def model(x, ws):
+        h = x
+        for w in ws:
+            r = h * 1.5 + 0.25  # live across the opaque op, not an argument
+            t = h @ w
+            o = torch.ops.test_lx_clobber.opaque(t)
+            h = r + o
+        return h
+
+    torch.manual_seed(0)
+    x = torch.randn(N, N, dtype=DTYPE).to(DEVICE)
+    ws = [(torch.randn(N, N, dtype=DTYPE) / (N**0.5)).to(DEVICE) for _ in range(layers)]
+
+    compiled = torch.compile(model, dynamic=False)
+    without = compiled(x, ws).to("cpu").float()
+    launch = True
+    with_launch = compiled(x, ws).to("cpu").float()
+    launch = False
+
+    torch.testing.assert_close(with_launch, without, atol=0, rtol=0)

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -107,6 +107,32 @@ _LX_TRACKER_CAPACITY_BYTES = (
 )
 _LX_ALLOCATION_GRANULARITY_BYTES = 128
 
+
+def _extern_kernel_in_live_range(graph: GraphLowering, uses: list[int]) -> bool:
+    """True if an opaque extern kernel runs at any point while the buffer is live.
+
+    The LX scratchpad is a fixed per-core resource shared by *every* compiled
+    Spyre program, and it is not threaded through the generated wrapper as a
+    tensor -- a resident buffer is handed from one kernel launch to the next by
+    its LX offset alone. An extern kernel is opaque: its body can launch other
+    compiled programs (a nested ``torch.compile``, or any eager op, which
+    torch-spyre compiles standalone via ``compile_once``), and those programs
+    allocate the same LX offsets. A buffer left resident across such a call is
+    therefore silently overwritten, and its consumer reads the other program's
+    data.
+
+    Being *accessed by* the extern kernel is the narrow case (already fatal,
+    since the value must be a real HBM tensor to be passed to it); merely being
+    live *across* one is equally fatal and is not visible from ``uses``
+    membership alone.
+    """
+    if not uses:
+        return False
+    return any(
+        isinstance(graph.operations[i], ExternKernel)
+        for i in range(min(uses), max(uses) + 1)
+    )
+
 # A ``MemoryPlanSolver`` is single-use (buffers are required at construction),
 # so the allocators hold a factory -- how to build a solver for a given buffer
 # set -- rather than a live instance, and build a fresh one per solve.
@@ -345,8 +371,8 @@ class ScratchpadAllocator:
         restickify = self._restickify_barrier(graph, name, uses)
         if restickify is not None:
             return restickify
-        if any(isinstance(graph.operations[u], ExternKernel) for u in uses):
-            return "extern kernel user"
+        if _extern_kernel_in_live_range(graph, uses):
+            return "extern kernel user or live across extern kernel"
         if self._is_index_or_indirectly_accessed(graph, name, uses, op):
             # Index tensors and the value tensors they index into are read via
             # data-dependent (indirect) addressing, must stay in hbm.
@@ -404,6 +430,8 @@ class ScratchpadAllocator:
             return "no consumer reads it from LX"
         if self._is_index_or_indirectly_accessed(graph, name, uses, None):
             return "index tensor or indirectly accessed"
+        if _extern_kernel_in_live_range(graph, uses):
+            return "extern kernel user or live across extern kernel"
         if not GraphEditor.all_uses_are_rewritable(graph, uses):
             return "use is not rewritable to the clone"
         if buffer_not_read_in_full(graph, name):


### PR DESCRIPTION
#### What type of PR is this?

- [X] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

A buffer left resident in the LX scratchpad **across an opaque extern kernel call** is silently
overwritten, and its consumer reads another program's data.

**Root cause**

- The LX scratchpad is a fixed per-core resource shared by *every* compiled Spyre program, and a
  resident buffer is handed from one kernel launch to the next **by its LX offset alone** — it is
  never threaded through the generated wrapper as a tensor.
- An extern kernel (`FallbackKernel`, e.g. a `torch.library.custom_op`) is opaque: its body may
  launch other compiled programs — a nested `torch.compile`, or any eager op, which torch-spyre
  compiles standalone via `compile_once`. Those programs allocate the same LX offsets.
- `_buffer_residency_reason` already rejected a buffer that an extern kernel **reads or writes**
  (`"extern kernel user"`), but never considered a buffer merely **live across** one — which is not
  visible from `uses` membership, since the extern kernel's op index simply falls between the
  producer's and the consumer's.

The graph shape that triggers it is an ordinary transformer residual:

```python
r = h * 1.5 + 0.25     # written before the op, read after it, never passed *to* it
t = h @ w
o = opaque_custom_op(t)
h = r + o
```

`r` is fused into the producing kernel and left in LX; the consumer reads it back after the opaque
call. The generated wrapper shows the problem plainly — the last kernel computes `r + o` but is
handed only `o` and its output buffer:

```python
buf2 = spyre_empty_with_layout((128,128), ...)
sdsc_fused_add_mm_mul_0.run(arg0_1, buf6, buf7, arg1_1, buf2)   # computes BOTH r and t
buf3 = torch.ops.dbg.op_ret.default(buf2)                       # opaque op -> nested launch
buf5 = spyre_empty_with_layout((128,128), ...)
sdsc_fused_add_1.run(buf3, buf5)                                # computes r + o
```

`sdsc_fused_add_1`'s third `TensorArg` carries `allocation={'lx': 0}` — that is `r`. The nested
program's kernel carries `allocation={'lx': 0}` as well.

**Fix**

Extend the guard from "an extern kernel accesses this buffer" to "an extern kernel executes while
this buffer is live", via `_extern_kernel_in_live_range()`. Applied in both
`_buffer_residency_reason` and `_input_residency_reason` (a graph input pinned into LX by boundary
cloning has the same exposure).

**Evidence that it is the LX offset and not something else**

Measured on device with a standalone repro (no vLLM), toggling *only* whether an unrelated compiled
program is launched inside the opaque op — its result discarded, so the two runs must be
bit-identical:

| what runs inside the opaque op | before | after |
|---|---|---|
| nothing | 0.0000 | 0.0000 |
| `torch.empty_like(arg)` | 0.0000 | 0.0000 |
| `arg * 2.0`, `arg @ arg` (eager) | 0.0000 | 0.0000 |
| `arg.mul_(1.0)` / `arg.add_(0.0)` | 6.4854 | **0.0000** |
| nested `torch.compile`d program | 7.4863 | **0.0000** |

(`max|out_with_launch - out_without_launch|` on a tensor of magnitude 8.05, 1 layer, N=128, fp16.
A 4-layer/N=256 variant behaves the same: 34.2656 / 35.4062 → 0.0000.)

Further characterization, all consistent with an LX overwrite and inconsistent with a baked
output address:

- The corrupted output depends on the nested program's **input** value (0/1/3/9 → diffs
  5.4854 / 7.4863 / 11.4844 / 23.4766) but **not** on its output value (a constant-output program
  with S = 0/1/100/1000 gives byte-identical corruption).
- Damage scales with the nested program's footprint (16²→31.1, 128²→36.2, 256²→51.5 at 4 layers).
- Deterministic and non-persistent: a later run without the nested launch is clean again.

**End-to-end**

In `spyre-inference`, `-cc.mode STOCK_TORCH_COMPILE` together with `SPYRE_FORCE_COMPILE_ATTN=1`
(attention is an opaque custom op, and compiling the paged-attention kernel makes its body launch a
nested program) produced pure garbage — `[19011] × 20`, `"algalgalg..."`. With this patch the same
command produces output token-identical to the eager-attention baseline:
`[203, 203, 3057, 11071, 2575, 6866, ...]`. The `STOCK_TORCH_COMPILE`-only path is unchanged, and
decode time for 20 tokens moved 1.70 s → 1.71 s.

Both A/B directions were run with a fresh `TORCHINDUCTOR_CACHE_DIR` and `TORCH_SENDNN_CACHE_ENABLE=0`,
since the change affects codegen and stale cached kernels would mask it.

#### Which issue(s) this PR is related to:

Sibling of #3669 (in-place-arith clobber) / spyre-inference#456 — same family (a compiled kernel
writing where the caller still owns the memory), different trigger. I verified #3669 does **not**
fix this case (`compiled` row above stays at 7.4863 with it applied), and this patch does not
replace it. Both should land.

Worth a look for the reviewer: with this patch alone, the in-place rows also come out clean in my
repro, because the victim buffer is no longer LX-resident across the opaque call. That does not make
#3669 redundant, but it does suggest the gemma-3-1b corruption may have the same LX ingredient
underneath, and is worth re-testing against spyre-inference#456.

#### Special notes for your reviewer:

Denying residency is the conservative, correctness-first choice. The alternative is to **spill**:
write LX → HBM before the extern call and reload after, keeping residency for the rest of the live
range. That is strictly better for a large model with many residuals spanning attention; it was
measured free on `micro-g3.3-8b-instruct-1b`, so I did not attempt it here. Happy to follow up if
you prefer the spill.

I am not an expert in this region of torch-spyre and would welcome advice on whether the guard sits
at the right level. This PR was written and prepared with the help of an AI agent.

#### Does this PR introduce a user-facing change?

Graphs containing an opaque custom op may see fewer LX-resident intermediates, and correspondingly
more HBM traffic, in exchange for correct results.
