### PR TITLE
support TORCH_LOGS for SDSC generation

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_sdsc_logging_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_sdsc_logging_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [unit, regression, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_sdsc_logging.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_sdsc_logging.py
+++ b/tests/inductor/test_sdsc_logging.py
@@ -1,0 +1,197 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Tests for SDSC IR artifact logging via spyre.inductor.sdsc logger.
+
+Verifies that the spyre.inductor.sdsc logger is correctly registered and
+that SDSC JSON and bundle.mlir content is emitted when logging is enabled
+via TORCH_LOGS="+spyre.inductor.sdsc".
+"""
+
+import logging
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import torch  # noqa: F401
+
+from torch_spyre._inductor.logging_utils import get_inductor_logger
+
+
+class TestSdscLoggerConfiguration:
+    """Tests for the spyre.inductor.sdsc logger registration."""
+
+    def test_logger_exists_with_correct_name(self):
+        sdsc_log = get_inductor_logger("sdsc")
+        assert sdsc_log.name == "spyre.inductor.sdsc"
+
+    def test_registered_in_default_log_levels(self):
+        from torch_spyre.logging_config import DEFAULT_LOG_LEVELS, LogLevel
+
+        assert "spyre.inductor.sdsc" in DEFAULT_LOG_LEVELS
+        assert DEFAULT_LOG_LEVELS["spyre.inductor.sdsc"] == LogLevel.WARNING
+
+    def test_logger_created_dynamically(self):
+        from torch_spyre._inductor.codegen import bundle
+
+        assert bundle.sdsc_log.name == "spyre.inductor.sdsc"
+
+
+class TestSdscJsonLogging:
+    """Tests for SDSC JSON content logging in _compile_specs."""
+
+    def test_sdsc_json_logged_when_enabled(self):
+        """SDSC JSON content is logged at INFO when logger is enabled."""
+        from torch_spyre._inductor.codegen import bundle
+
+        sdsc_log = logging.getLogger("spyre.inductor.sdsc")
+        with patch.object(sdsc_log, "isEnabledFor", return_value=True):
+            with patch.object(sdsc_log, "info") as mock_info:
+                fake_json = {"0_add": {"dscs_": []}}
+                with patch(
+                    "torch_spyre._inductor.codegen.bundle.compile_op_spec",
+                    return_value=(fake_json, [], [], []),
+                ):
+                    specs = [MagicMock()]
+                    specs[0].__class__ = bundle.OpSpec
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        bundle._compile_specs(
+                            specs,
+                            symbols=[],
+                            compiled=[],
+                            sdsc_counter=[0],
+                            symbol_id_offset_counter=[0],
+                            output_dir=tmpdir,
+                            use_symbols=False,
+                        )
+
+                info_calls = mock_info.call_args_list
+                sdsc_json_calls = [
+                    c
+                    for c in info_calls
+                    if len(c.args) >= 1 and "SDSC JSON" in c.args[0]
+                ]
+                assert len(sdsc_json_calls) == 1
+                assert "sdsc_0.json" in sdsc_json_calls[0].args[1]
+
+    def test_no_json_formatting_when_disabled(self):
+        """json.dumps is not called when the sdsc logger is disabled."""
+        from torch_spyre._inductor.codegen import bundle
+
+        sdsc_log = logging.getLogger("spyre.inductor.sdsc")
+        with patch.object(sdsc_log, "isEnabledFor", return_value=False):
+            with patch.object(sdsc_log, "info") as mock_info:
+                fake_json = {"0_add": {"dscs_": []}}
+                with patch(
+                    "torch_spyre._inductor.codegen.bundle.compile_op_spec",
+                    return_value=(fake_json, [], [], []),
+                ):
+                    specs = [MagicMock()]
+                    specs[0].__class__ = bundle.OpSpec
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        bundle._compile_specs(
+                            specs,
+                            symbols=[],
+                            compiled=[],
+                            sdsc_counter=[0],
+                            symbol_id_offset_counter=[0],
+                            output_dir=tmpdir,
+                            use_symbols=False,
+                        )
+
+                sdsc_json_calls = [
+                    c
+                    for c in mock_info.call_args_list
+                    if len(c.args) >= 1 and "SDSC JSON" in c.args[0]
+                ]
+                assert len(sdsc_json_calls) == 0
+
+
+class TestBundleMlirLogging:
+    """Tests for bundle.mlir content logging in generate_bundle."""
+
+    def test_bundle_mlir_logged_when_enabled(self):
+        """bundle.mlir content is logged at INFO when logger is enabled."""
+        from torch_spyre._inductor.codegen import bundle
+
+        sdsc_log = logging.getLogger("spyre.inductor.sdsc")
+        with patch.object(sdsc_log, "isEnabledFor", return_value=True):
+            with patch.object(sdsc_log, "info") as mock_info:
+                with (
+                    patch.object(bundle.logger, "isEnabledFor", return_value=False),
+                    patch(
+                        "torch_spyre._inductor.codegen.bundle._compile_specs",
+                    ),
+                    patch(
+                        "torch_spyre._inductor.codegen.bundle._collect_loop_bounds",
+                    ),
+                    patch(
+                        "torch_spyre._inductor.codegen.bundle._collect_affine_maps",
+                    ),
+                    patch(
+                        "torch_spyre._inductor.codegen.bundle._emit_specs",
+                    ),
+                ):
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        bundle.generate_bundle(
+                            kernel_name="test_kernel",
+                            output_dir=tmpdir,
+                            specs=[],
+                            use_symbols=False,
+                        )
+
+                mlir_calls = [
+                    c
+                    for c in mock_info.call_args_list
+                    if len(c.args) >= 1 and "BUNDLE MLIR" in c.args[0]
+                ]
+                assert len(mlir_calls) == 1
+                assert "func.func @sdsc_bundle()" in mlir_calls[0].args[1]
+
+    def test_bundle_mlir_not_logged_when_disabled(self):
+        """bundle.mlir is not read back when the sdsc logger is disabled."""
+        from torch_spyre._inductor.codegen import bundle
+
+        sdsc_log = logging.getLogger("spyre.inductor.sdsc")
+        with patch.object(sdsc_log, "isEnabledFor", return_value=False):
+            with patch.object(sdsc_log, "info") as mock_info:
+                with (
+                    patch.object(bundle.logger, "isEnabledFor", return_value=False),
+                    patch(
+                        "torch_spyre._inductor.codegen.bundle._compile_specs",
+                    ),
+                    patch(
+                        "torch_spyre._inductor.codegen.bundle._collect_loop_bounds",
+                    ),
+                    patch(
+                        "torch_spyre._inductor.codegen.bundle._collect_affine_maps",
+                    ),
+                    patch(
+                        "torch_spyre._inductor.codegen.bundle._emit_specs",
+                    ),
+                ):
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        bundle.generate_bundle(
+                            kernel_name="test_kernel",
+                            output_dir=tmpdir,
+                            specs=[],
+                            use_symbols=False,
+                        )
+
+                mlir_calls = [
+                    c
+                    for c in mock_info.call_args_list
+                    if len(c.args) >= 1 and "BUNDLE MLIR" in c.args[0]
+                ]
+                assert len(mlir_calls) == 0

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -28,6 +28,7 @@ from torch_spyre._inductor.logging_utils import get_inductor_logger
 
 
 logger = get_inductor_logger("sdsc_compile")
+sdsc_log = get_inductor_logger("sdsc")
 
 # ---------------------------------------------------------------------------
 # Types
@@ -406,6 +407,11 @@ def generate_bundle(
         f.write("\t}\n")
         f.write("}\n")
 
+    if sdsc_log.isEnabledFor(logging.INFO):
+        bundle_path = os.path.join(output_dir, "bundle.mlir")
+        with open(bundle_path, "r") as bf:
+            sdsc_log.info("BUNDLE MLIR [bundle.mlir]\n%s", bf.read())
+
 
 # ---------------------------------------------------------------------------
 # Pass 1 helpers
@@ -453,6 +459,12 @@ def _compile_specs(
             with open(os.path.join(output_dir, file_name), "w") as f:
                 logger.info(f"Generating {f.name}")
                 json.dump(sdsc_json, f, indent=2)
+            if sdsc_log.isEnabledFor(logging.INFO):
+                sdsc_log.info(
+                    "SDSC JSON [%s]\n%s",
+                    file_name,
+                    json.dumps(sdsc_json, indent=2),
+                )
         # UnimplementedOp and other types are silently skipped.
 
 

--- a/torch_spyre/logging_config.py
+++ b/torch_spyre/logging_config.py
@@ -48,6 +48,7 @@ DEFAULT_LOG_LEVELS = {
     "spyre.inductor.stickify": LogLevel.WARNING,
     "spyre.inductor.codegen": LogLevel.WARNING,
     "spyre.inductor.passes": LogLevel.WARNING,
+    "spyre.inductor.sdsc": LogLevel.WARNING,
     "spyre.runtime": LogLevel.WARNING,
     "spyre.execution": LogLevel.WARNING,
     "spyre.device": LogLevel.WARNING,


### PR DESCRIPTION
Add spyre.inductor.sdsc logger that emits SDSC JSON and bundle.mlir content via TORCH_LOGS="+spyre.inductor.sdsc" for easier debugging.

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds a dedicated `spyre.inductor.sdsc` logger that emits SDSC JSON and
bundle.mlir content via `TORCH_LOGS="+spyre.inductor.sdsc"` for easier
debugging of compiler IR artifacts.

Changes:
- Registers `spyre.inductor.sdsc` in `DEFAULT_LOG_LEVELS` (`logging_config.py`)
- Creates `sdsc_log` in `bundle.py` using `get_inductor_logger("sdsc")`
- Logs SDSC JSON content after each `sdsc_N.json` file is written
- Logs bundle.mlir content after the file is written
- Uses `isEnabledFor(logging.INFO)` guards to ensure zero cost when disabled
- Adds unit tests covering logger registration, enabled/disabled paths

Usage:
```bash
# Enable SDSC IR logging only
TORCH_LOGS="+spyre.inductor.sdsc" python my_script.py

# Enable all inductor logging (includes sdsc)
TORCH_LOGS="+spyre.inductor" python my_script.py

# Enable at DEBUG level
TORCH_LOGS="spyre.inductor.sdsc:DEBUG" python my_script.py
```

#### Which issue(s) this PR is related to:

Fixes #574

#### Special notes for your reviewer:

- The logger uses INFO level (not DEBUG) because `+spyre.inductor.sdsc`
  (the natural activation syntax) sets INFO. Using DEBUG would require the
  less discoverable `:DEBUG` suffix.
- The bundle.mlir logging re-reads the file after writing rather than using
  a StringIO tee approach. This keeps the implementation simple and follows
  the existing pattern. The cost is negligible since this only runs when
  logging is explicitly enabled.
- Parent-level propagation works correctly: `TORCH_LOGS="+spyre.inductor"`
  will also activate `spyre.inductor.sdsc`.

#### Does this PR introduce a user-facing change?

Yes. Users can now inspect SDSC JSON and bundle.mlir content in log output
by setting `TORCH_LOGS="+spyre.inductor.sdsc"`. Previously, developers had
to manually navigate output directories to inspect these artifacts.

#### Additional note:

New files:
- `tests/inductor/test_sdsc_logging.py`
- `tests/configs/torch_spyre_tests/inductor/test_sdsc_logging_config.yaml`
