### PR TITLE
[test] fix KeyError: 'getattr' in op-level test after #3535

### DIFF
--- a/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506.yaml
+++ b/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506.yaml
@@ -210,23 +210,6 @@ test_suite_config:
                     - bf16operation
                     - constant
                     - torch.flatten.1
-                - name: getattr
-                  sample_inputs_func:
-                    args:
-                      - tensor:
-                          shape: [1024, 1064]
-                          stride: [1064, 1]
-                          storage_offset: 0
-                          dtype: torch.bfloat16
-                          device: cuda:0
-                          init: rand
-                      - value: T
-                  description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/pixtral/modeling_pixtral.py#L458 in torch_dynamo_resume_in_forward_at_452,
-                    code: patch_embeds = torch.cat([p.flatten(1).T for p in patch_embeds_list], dim=0).unsqueeze(0)'
-                  tags:
-                    - bf16operation
-                    - constant
-                    - getattr.1
                 - name: torch.cat
                   sample_inputs_func:
                     args:

--- a/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506_spyre.yaml
+++ b/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506_spyre.yaml
@@ -205,22 +205,6 @@ test_suite_config:
                   tags:
                     - constant
                     - torch.flatten.1_spyre
-                - name: getattr
-                  sample_inputs_func:
-                    args:
-                      - tensor:
-                          shape: [1024, 1064]
-                          stride: [1064, 1]
-                          storage_offset: 0
-                          dtype: torch.float16
-                          device: cuda:0
-                          init: rand
-                      - value: T
-                  description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/pixtral/modeling_pixtral.py#L458 in torch_dynamo_resume_in_forward_at_452,
-                    code: patch_embeds = torch.cat([p.flatten(1).T for p in patch_embeds_list], dim=0).unsqueeze(0)'
-                  tags:
-                    - constant
-                    - getattr.1_spyre
                 - name: torch.cat
                   sample_inputs_func:
                     args:

--- a/tests/models/test_model_ops.py
+++ b/tests/models/test_model_ops.py
@@ -73,7 +73,11 @@ def add_model_ops_db(loadedCases: List[LoadedCase]):
     for loadedCase in loadedCases:
         test_name = loadedCase.case["name"]
         op_name = loadedCase.case["op"]
-        adapter = OP_REGISTRY[op_name]
+        try:
+            adapter = OP_REGISTRY[op_name]
+        except KeyError as e:
+            print("Missing op:", op_name)
+            raise e
         basename = os.path.basename(loadedCase.source_path)
         test_name = f"{test_name}__{basename}_"
         assert test_name not in seen_test_names

--- a/tests/resource/models/Mistral-Small-3.2-24B-Instruct-2506.yaml
+++ b/tests/resource/models/Mistral-Small-3.2-24B-Instruct-2506.yaml
@@ -124,22 +124,6 @@ cases:
     marks:
       - bf16operation
       - constant
-  - name: getattr.1
-    op: getattr
-    inputs:
-      - tensor:
-          shape: [1024, 1064]
-          stride: [1064, 1]
-          storage_offset: 0
-          dtype: torch.bfloat16
-          device: cuda:0
-          init: rand
-      - value: T
-    description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/pixtral/modeling_pixtral.py#L458 in torch_dynamo_resume_in_forward_at_452,
-      code: patch_embeds = torch.cat([p.flatten(1).T for p in patch_embeds_list], dim=0).unsqueeze(0)'
-    marks:
-      - bf16operation
-      - constant
   - name: torch.cat.1
     op: torch.cat
     inputs:

--- a/tests/resource/models/Mistral-Small-3.2-24B-Instruct-2506_spyre.yaml
+++ b/tests/resource/models/Mistral-Small-3.2-24B-Instruct-2506_spyre.yaml
@@ -115,20 +115,6 @@ cases:
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/pixtral/modeling_pixtral.py#L458 in torch_dynamo_resume_in_forward_at_452,
       code: patch_embeds = torch.cat([p.flatten(1).T for p in patch_embeds_list], dim=0).unsqueeze(0)'
     marks: constant
-  - name: getattr.1_spyre
-    op: getattr
-    inputs:
-      - tensor:
-          shape: [1024, 1064]
-          stride: [1064, 1]
-          storage_offset: 0
-          dtype: torch.float16
-          device: cuda:0
-          init: rand
-      - value: T
-    description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/pixtral/modeling_pixtral.py#L458 in torch_dynamo_resume_in_forward_at_452,
-      code: patch_embeds = torch.cat([p.flatten(1).T for p in patch_embeds_list], dim=0).unsqueeze(0)'
-    marks: constant
   - name: torch.cat.1_spyre
     op: torch.cat
     inputs:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

This PR is a follow-up of #3535 and fixes a regression of #3535.

#3535 unexpectedly introduced non-PyTorch op `getattr` into YAML files. This PR removes `getattr` from YAML files.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
Exception w/o this PR

```
% $ pytest -rsapd tests/models/test_model_ops.py -v -s --model granite-3.3-8b-instruct -k embedding
================================================================================================================================================================================================ test session starts ================================================================================================================================================================================================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0 -- /home/ishizaki/aiu-src/dt-inductor/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/ishizaki/aiu-src/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: anyio-4.13.0, xdist-3.8.0
collecting ... /home/ishizaki/aiu-src/dt-inductor/torch-spyre/tests/resource/models/Meta-Llama-3.1-8B-Instruct.yaml
/home/ishizaki/aiu-src/dt-inductor/torch-spyre/tests/resource/models/Meta-Llama-3.1-8B-Instruct_spyre.yaml
/home/ishizaki/aiu-src/dt-inductor/torch-spyre/tests/resource/models/Ministral-3-14B-Instruct-2512.yaml
/home/ishizaki/aiu-src/dt-inductor/torch-spyre/tests/resource/models/Ministral-3-14B-Instruct-2512_spyre.yaml
/home/ishizaki/aiu-src/dt-inductor/torch-spyre/tests/resource/models/Mistral-Small-3.2-24B-Instruct-2506.yaml
/home/ishizaki/aiu-src/dt-inductor/torch-spyre/tests/resource/models/Mistral-Small-3.2-24B-Instruct-2506_spyre.yaml
/home/ishizaki/aiu-src/dt-inductor/torch-spyre/tests/resource/models/Qwen2.5-7B-Instruct.yaml
/home/ishizaki/aiu-src/dt-inductor/torch-spyre/tests/resource/models/Qwen2.5-7B-Instruct_spyre.yaml
/home/ishizaki/aiu-src/dt-inductor/torch-spyre/tests/resource/models/gpt-oss-20b.yaml
/home/ishizaki/aiu-src/dt-inductor/torch-spyre/tests/resource/models/gpt-oss-20b_spyre.yaml
/home/ishizaki/aiu-src/dt-inductor/torch-spyre/tests/resource/models/granite-3.3-8b-instruct-fms.yaml
/home/ishizaki/aiu-src/dt-inductor/torch-spyre/tests/resource/models/granite-3.3-8b-instruct-fms_spyre.yaml
/home/ishizaki/aiu-src/dt-inductor/torch-spyre/tests/resource/models/granite-3.3-8b-instruct.yaml
/home/ishizaki/aiu-src/dt-inductor/torch-spyre/tests/resource/models/granite-3.3-8b-instruct_spyre.yaml
/home/ishizaki/aiu-src/dt-inductor/torch-spyre/tests/resource/models/granite-4.1-8b.yaml
/home/ishizaki/aiu-src/dt-inductor/torch-spyre/tests/resource/models/granite-4.1-8b_spyre.yaml
/home/ishizaki/aiu-src/dt-inductor/torch-spyre/tests/resource/models/template.yaml
Missing op: getattr
collected 0 items / 1 error                                                                                                                                                                                                                                                                                                                                                                                         

====================================================================================================================================================================================================== ERRORS =======================================================================================================================================================================================================
__________________________________________________________________________________________________________________________________________________________________________________ ERROR collecting tests/models/test_model_ops.py __________________________________________________________________________________________________________________________________________________________________________________
tests/models/test_model_ops.py:113: in <module>
    _init_model_ops_db()
tests/models/test_model_ops.py:110: in _init_model_ops_db
    add_model_ops_db(loadedCases)
tests/models/test_model_ops.py:80: in add_model_ops_db
    raise e
tests/models/test_model_ops.py:77: in add_model_ops_db
    adapter = OP_REGISTRY[op_name]
              ^^^^^^^^^^^^^^^^^^^^
E   KeyError: 'getattr'
============================================================================================================================================================================================== short test summary info ==============================================================================================================================================================================================
ERROR tests/models/test_model_ops.py - KeyError: 'getattr'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
================================================================================================================================================================================================= 1 error in 6.30s ==================================================================================================================================================================================================
```