### PR TITLE
Remove dead code left behind by coarse_tile refactor series

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1984,7 +1984,10 @@ def test_copy_accum_with_reduction_512x256_A4():
 
 
 @pytest.mark.skip(
-    reason="IndexError: _insert_read_copy_ops fails when tiling B with unit-size B dim in scale"
+    reason=(
+        "IndexError: _insert_all_read_copy_ops fails when tiling B with "
+        "unit-size B dim in scale"
+    )
 )
 def test_copy_accum_with_reduction_512x256_B4():
     """acc.copy_(acc * scale + x.amin(dim=1,keepdim=True)) tiled B÷4."""
@@ -2006,7 +2009,10 @@ def test_copy_accum_with_reduction_512x256_B4():
 
 
 @pytest.mark.skip(
-    reason="IndexError: _insert_read_copy_ops fails when tiling B with unit-size B dim in scale"
+    reason=(
+        "IndexError: _insert_all_read_copy_ops fails when tiling B with "
+        "unit-size B dim in scale"
+    )
 )
 def test_copy_accum_with_reduction_512x256_A4_B4():
     """acc.copy_(acc * scale + x.amin(dim=1,keepdim=True)) tiled A÷4 B÷4."""
@@ -5363,7 +5369,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         rather than the 1st (H), producing wrong per-tile stride advances.
 
         Previously also broken for the copy ops inserted by
-        _insert_read_copy_ops: their tiled_dims_per_read/output_tiled_dims
+        _insert_all_read_copy_ops: their tiled_dims_per_read/output_tiled_dims
         dicts were keyed by tiled_op's raw (unsqueezed) host-range indices
         but read against copy_ranges (== dep.size, already squeezed) --
         fixed by mapping tiled_op's raw dim index to its squeezed position

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -79,7 +79,6 @@ from torch_spyre._inductor.wsr.coarse_tile import (
     _compute_fill_loop_info_planned,
     _divide_ranges,
     _full_buffer_read_deps,
-    _insert_read_copy_ops,
     _replace_group_op,
     _rescale_index,
     _retile_load_index_from_strides,
@@ -4242,31 +4241,6 @@ class TestCoarseTileBufferPropagation(unittest.TestCase):
             "_has_inside_consumers should have been deleted",
         )
 
-    def test_compute_full_ranges_flat(self):
-        from torch_spyre._inductor.wsr.coarse_tile import _compute_full_ranges
-
-        op = _make_tiled_op("op0", [Integer(16), Integer(8)], (0,), [Integer(4)], [[0]])
-        full = _compute_full_ranges(op)
-        # dim 0: 16 * 4 = 64; dim 1 untiled: 8
-        self.assertEqual(full[0], Integer(64))
-        self.assertEqual(full[1], Integer(8))
-
-    def test_compute_full_ranges_nested(self):
-        from torch_spyre._inductor.wsr.coarse_tile import _compute_full_ranges
-
-        # Nested: outer K=4 tiles dim 0, inner K=2 tiles dim 1
-        op = _make_tiled_op(
-            "op0",
-            [Integer(16), Integer(32)],
-            (0, 0),
-            [Integer(4), Integer(2)],
-            [[0], [1]],
-        )
-        full = _compute_full_ranges(op)
-        # dim 0: 16 * 4 = 64; dim 1: 32 * 2 = 64
-        self.assertEqual(full[0], Integer(64))
-        self.assertEqual(full[1], Integer(64))
-
     def test_different_loop_group_id_is_outside(self):
         """Op in loop group 1 should be seen as outside consumer of group 0."""
         from torch_spyre._inductor.wsr.coarse_tile import _find_outside_consumers
@@ -4294,6 +4268,25 @@ class TestCoarseTileBufferPropagation(unittest.TestCase):
             "_seed_closure_pre_stamp",
             "_is_constant_fill",
             "_closure_member_has_external_operands_only",
+        ):
+            self.assertFalse(
+                hasattr(coarse_tile_module, name),
+                f"{name} should have been deleted",
+            )
+
+    def test_planned_twin_leftovers_removed(self):
+        """Transformation-time functions superseded by their planning-time
+        twins, and helpers orphaned by earlier partial cleanups, are deleted.
+        """
+        import torch_spyre._inductor.wsr.coarse_tile as coarse_tile_module
+
+        for name in (
+            "_compute_full_ranges",
+            "_insert_read_copy_ops",
+            "_compute_fill_loop_info",
+            "_group_reduction_tiled_hint_ids",
+            "_op_hint_dim_positions",
+            "_seed_closure",
         ):
             self.assertFalse(
                 hasattr(coarse_tile_module, name),
@@ -4434,8 +4427,8 @@ class TestCoarseTileBufferPropagation(unittest.TestCase):
             # _propagate_tiled_op (Pass 3) now consumes a precomputed
             # PropagationPlan instead of deriving it itself -- full_ranges
             # is the pre-division full shape (8 * loop_count 8 == 64),
-            # matching what the old in-function _compute_full_ranges call
-            # used to compute from the tile-sized op.data.ranges.
+            # matching what _compute_full_ranges_planned computes from
+            # the tile-sized op.data.ranges.
             propagation = PropagationPlan(
                 kind="copy_out",
                 full_ranges=[Integer(64)],
@@ -4601,7 +4594,7 @@ class TestPlanTilingPropagation(unittest.TestCase):
     def test_nested_tiled_reduction_matches_is_nested(self):
         """Nested output+reduction tiling -> reduction plan with
         is_nested=True and a trimmed outer_fill_loop_info, matching
-        _compute_fill_loop_info's non-None nested case."""
+        _compute_fill_loop_info_planned's non-None nested case."""
         op = _make_tiled_reduction_op(
             "red0",
             ranges=[Integer(64)],
@@ -4834,13 +4827,13 @@ def _make_full_buffer_read_fixture():
     FX-node lowering) rather than a plain ``InputBuffer`` -- this is what
     ``_full_buffer_read_deps`` specifically filters for.  The op's own
     ranges are smaller than the full buffer's shape (8 rows out of 64),
-    modeling the tile-vs-full-buffer mismatch ``_insert_read_copy_ops``
+    modeling the tile-vs-full-buffer mismatch ``_insert_all_read_copy_ops``
     exists to resolve.
 
     Caller must have an active graph handler (``V.set_graph_handler(...)``)
     around this call, matching every other real-IR helper in this file.
     Returns ``(tiled_op, full_deps, operations)`` ready to pass straight into
-    ``_insert_read_copy_ops``.
+    ``_insert_all_read_copy_ops``.
     """
     from torch._inductor.ir import (
         ComputedBuffer,
@@ -5468,262 +5461,6 @@ class TestInsertAllReadCopyOps(unittest.TestCase):
         self.assertNotIn("buf_y", loaded)
 
 
-class TestInsertReadCopyOps(unittest.TestCase):
-    """_insert_read_copy_ops always materializes a real copy, never a view.
-
-    Regression coverage added alongside the rename from
-    _insert_read_view_ops -- there was no direct unit test of this function
-    before (confirmed by grep across tests/inductor/ at the time this test
-    was written), even though the function's actual behavior has always
-    been to build a genuine Pointwise computation into a fresh,
-    independently-laid-out ComputedBuffer (never an IR-level view/alias
-    node such as ReinterpretView) -- the "view" in the old name was a
-    misnomer, not a description of a second, non-materializing code path.
-    """
-
-    def setUp(self):
-        gm = fx.symbolic_trace(lambda: None)
-        self._graph_ctx = V.set_graph_handler(GraphLowering(gm))
-        self._graph_ctx.__enter__()
-
-    def tearDown(self):
-        self._graph_ctx.__exit__(None, None, None)
-
-    def test_boundary_read_always_copies_not_views(self):
-        """A full-buffer boundary read must always get a real copy, never a
-        view-only op."""
-        from torch._inductor.ir import ComputedBuffer, FixedLayout, Pointwise
-
-        from torch_spyre._inductor.ir import SpyreEmptyFallback
-
-        tiled_op, full_deps, operations = _make_full_buffer_read_fixture()
-        self.assertEqual(len(full_deps), 1)
-        full_buf = V.graph.get_buffer(full_deps[0].name)
-
-        new_op = _insert_read_copy_ops(tiled_op, full_deps, operations)
-
-        # Exactly one new op was inserted (the copy), immediately before
-        # tiled_op; the original full_buf is untouched.
-        self.assertEqual(len(operations), 3)
-        copy_buf = operations[1]
-        self.assertIs(operations[0], full_buf)
-        self.assertIs(operations[2], new_op)
-
-        # The inserted op is a real materializing copy, not a pass-through
-        # view/alias:
-        #  - it is a genuine Pointwise computation (not a ReinterpretView or
-        #    other aliasing IR node), so it has its own independent storage;
-        self.assertIsInstance(copy_buf, ComputedBuffer)
-        self.assertIsInstance(copy_buf.data, Pointwise)
-        #  - its layout is an independent FixedLayout sized to the *tile*
-        #    range, distinct from (not shared with, not a view over)
-        #    full_buf's own full-size layout;
-        self.assertIsInstance(copy_buf.layout, FixedLayout)
-        self.assertIsNot(copy_buf.layout, full_buf.layout)
-        self.assertEqual(list(copy_buf.layout.size), [8, 128])
-        self.assertEqual(list(full_buf.layout.size), [64, 128])
-        #  - its own inner_fn actually loads from the full buffer (i.e. it
-        #    reads through the dependency rather than aliasing it) --
-        #    observed by installing a recording ops handler, matching this
-        #    codebase's WrapperHandler-based inner_fn inspection convention
-        #    rather than re-deriving index expressions by hand;
-        loaded_names = []
-
-        class _RecordingHandler:
-            def load(self, name, index):
-                loaded_names.append(name)
-                return 0.0
-
-        with V.set_ops_handler(_RecordingHandler()):
-            copy_buf.data.inner_fn([sympy.Integer(0) for _ in copy_buf.data.ranges])
-        self.assertEqual(loaded_names, [full_buf.get_name()])
-
-        #  - tiled_op's own (reconstructed) inner_fn is patched to read the
-        #    copy instead of the full buffer -- confirming the name-swap
-        #    landed and no consumer still reads full_buf directly.
-        redirected_names = []
-
-        class _RecordingHandler2:
-            def load(self, name, index):
-                redirected_names.append(name)
-                return 0.0
-
-        with V.set_ops_handler(_RecordingHandler2()):
-            new_op.data.inner_fn([sympy.Integer(0) for _ in new_op.data.ranges])
-        self.assertEqual(redirected_names, [copy_buf.get_name()])
-        self.assertNotIn(full_buf.get_name(), redirected_names)
-
-        # SpyreEmptyFallback (the only buffer type _full_buffer_read_deps
-        # matches) is unmodified -- confirms the fixture is exercising the
-        # intended full-vs-tile mismatch, not some other buffer kind.
-        self.assertIsInstance(full_buf, SpyreEmptyFallback)
-
-    def test_cross_group_plain_producer_copy_derivation(self):
-        """_insert_read_copy_ops must work for a cross-group read whose
-        producer is a plain ComputedBuffer, not just SpyreEmptyFallback
-        (Open Question 5).
-
-        Runs _make_cross_group_producer_read_fixture's tiled_op/full_deps
-        through _insert_read_copy_ops directly and asserts the same shape of
-        outcome test_boundary_read_always_copies_not_views already asserts
-        for the SpyreEmptyFallback case: a real materializing Pointwise copy,
-        correctly retargeted via _NameSwapHandler.
-        """
-        from torch._inductor.ir import ComputedBuffer, FixedLayout, Pointwise
-
-        tiled_op, full_deps, operations = _make_cross_group_producer_read_fixture()
-        self.assertEqual(len(full_deps), 1)
-        producer = V.graph.get_buffer(full_deps[0].name)
-
-        new_op = _insert_read_copy_ops(tiled_op, full_deps, operations)
-
-        # Exactly one new op was inserted (the copy), immediately before
-        # tiled_op; the original producer is untouched.
-        self.assertEqual(len(operations), 3)
-        copy_buf = operations[1]
-        self.assertIs(operations[0], producer)
-        self.assertIs(operations[2], new_op)
-
-        # The inserted op is a real materializing copy, not a pass-through
-        # view/alias, exactly as in the SpyreEmptyFallback case:
-        self.assertIsInstance(copy_buf, ComputedBuffer)
-        self.assertIsInstance(copy_buf.data, Pointwise)
-        self.assertIsInstance(copy_buf.layout, FixedLayout)
-        self.assertIsNot(copy_buf.layout, producer.layout)
-        self.assertEqual(list(copy_buf.layout.size), [8, 128])
-        self.assertEqual(list(producer.layout.size), [64, 128])
-
-        loaded_names = []
-
-        class _RecordingHandler:
-            def load(self, name, index):
-                loaded_names.append(name)
-                return 0.0
-
-        with V.set_ops_handler(_RecordingHandler()):
-            copy_buf.data.inner_fn([sympy.Integer(0) for _ in copy_buf.data.ranges])
-        self.assertEqual(loaded_names, [producer.get_name()])
-
-        redirected_names = []
-
-        class _RecordingHandler2:
-            def load(self, name, index):
-                redirected_names.append(name)
-                return 0.0
-
-        with V.set_ops_handler(_RecordingHandler2()):
-            new_op.data.inner_fn([sympy.Integer(0) for _ in new_op.data.ranges])
-        self.assertEqual(redirected_names, [copy_buf.get_name()])
-        self.assertNotIn(producer.get_name(), redirected_names)
-
-    def test_post_stickify_copy_drops_device_layout(self):
-        """Regression for Task 3's Open Question 6 finding: on the
-        post-stickify (span-overflow) call site, _insert_read_copy_ops's
-        copy buffer must preserve device_layout, not drop it.
-
-        _allocate_full_buffer (coarse_tile.py) explicitly branches on
-        isinstance(orig_layout, FixedTiledLayout) so a post-stickify full
-        buffer gets a FixedTiledLayout copy (preserving
-        device_layout/SpyreTensorLayout stick-addressing metadata), while a
-        pre-stickify one gets a plain FixedLayout (stickification runs
-        later and fills device_layout in). _insert_read_copy_ops mirrors
-        that same branch: when the read target already carries a
-        FixedTiledLayout, the copy op must too, with a device_layout
-        resized down to the tile via _resize_device_layout.
-
-        On the post-stickify call site (_maybe_coarse_tile_span_overflow,
-        passes.py), this pass runs *after* finalize_layouts/insert_restickify
-        have already completed, and every downstream pass in the pipeline
-        (span_reduction, work_distribution, LX scratchpad planning) expects
-        FixedTiledLayout.device_layout for physical span arithmetic (see
-        CustomPreSchedulingPasses's pipeline docstring). Before the fix, a
-        copy op stamped with a plain FixedLayout at this point had no
-        device_layout at all, even though every sibling op's layout at this
-        pipeline stage is a FixedTiledLayout.
-        """
-        from torch._inductor.ir import ComputedBuffer, FlexibleLayout, Pointwise
-
-        from torch_spyre._C import ElementArrangement, SpyreTensorLayout
-        from torch_spyre._inductor.ir import FixedTiledLayout
-
-        device = torch.device("cpu")
-        dtype = torch.float16
-
-        def _make_ftl_op(name, host_size, loop_group_id, loop_count, loop_tiled_dims):
-            strides = [int(s) for s in FlexibleLayout.contiguous_strides(host_size)]
-            device_layout = SpyreTensorLayout(
-                host_size,
-                strides,
-                dtype,
-                list(range(len(host_size))),
-                ElementArrangement.STANDARD,
-            )
-            layout = FixedTiledLayout(
-                device,
-                dtype,
-                [Integer(s) for s in host_size],
-                [Integer(s) for s in strides],
-                device_layout,
-            )
-            pw = Pointwise(
-                device=device,
-                dtype=dtype,
-                inner_fn=lambda index: sympy.Integer(0),
-                ranges=[Integer(s) for s in host_size],
-            )
-            op = ComputedBuffer(name=name, layout=layout, data=pw)
-            op.operation_name = name
-            op.origins = OrderedSet()
-            op.loop_info = CoarseTileInfo(
-                loop_group_id=loop_group_id,
-                loop_count=loop_count,
-                loop_tiled_dims=loop_tiled_dims,
-            )
-            V.graph.name_to_buffer[name] = op
-            return op
-
-        # Producer: a post-stickify FixedTiledLayout buffer in a different
-        # outer loop group, modeling an already-stickified cross-group read
-        # target on the span-overflow call site.
-        producer = _make_ftl_op("producer0", [64, 128], (1,), [Integer(1)], [[]])
-
-        from torch._inductor.ir import StorageBox, TensorBox
-
-        producer_box = TensorBox(StorageBox(producer))
-
-        def inner_fn(index):
-            with ComputedBuffer.force_realize():
-                return producer_box.make_loader()(index)
-
-        tiled_op = _make_ftl_op("tiled_op0", [8, 128], (0,), [Integer(8)], [[0]])
-        object.__setattr__(tiled_op.data, "inner_fn", inner_fn)
-
-        operations = [producer, tiled_op]
-        full_deps = _full_buffer_read_deps(tiled_op)
-        self.assertEqual(len(full_deps), 1)
-
-        _insert_read_copy_ops(tiled_op, full_deps, operations)
-        copy_buf = operations[1]
-
-        # tiled_op and producer both carry FixedTiledLayout (post-stickify),
-        # and the inserted copy must too -- with a device_layout correctly
-        # resized down to the tile size.
-        self.assertIsInstance(producer.layout, FixedTiledLayout)
-        self.assertIsInstance(tiled_op.layout, FixedTiledLayout)
-        self.assertIsInstance(copy_buf.layout, FixedTiledLayout)
-        self.assertTrue(hasattr(copy_buf.layout, "device_layout"))
-
-        expected_strides = [int(s) for s in FlexibleLayout.contiguous_strides([8, 128])]
-        expected_device_layout = SpyreTensorLayout(
-            [8, 128],
-            expected_strides,
-            dtype,
-            [0, 1],
-            ElementArrangement.STANDARD,
-        )
-        self.assertEqual(copy_buf.layout.device_layout, expected_device_layout)
-
-
 class TestIsReadAdvancingAnywhere(unittest.TestCase):
     """A buffer with a fixed write can still be barred from LX by a reader.
 
@@ -5733,7 +5470,7 @@ class TestIsReadAdvancingAnywhere(unittest.TestCase):
     coarse-tile loop (e.g. a full HBM buffer with a fixed write, copied
     into a nested tile every outer iteration -- exactly the shape
     ``_make_full_buffer_read_fixture`` already builds for
-    ``_insert_read_copy_ops``'s own tests). ``compute_ops.py``'s
+    ``_insert_all_read_copy_ops``'s own tests). ``compute_ops.py``'s
     ``is_tiled_lx`` check applies to every ``TensorArg`` -- reads and the
     write -- so missing this at allocation time only defers the same
     ``NotImplementedError`` to codegen. This class exercises
@@ -5830,7 +5567,7 @@ class TestIsReadAdvancingAnywhere(unittest.TestCase):
 class TestRescaleIndex(unittest.TestCase):
     """Direct unit coverage for _rescale_index's coefficient matching.
 
-    _insert_read_copy_ops's own tests exercise _rescale_index only
+    _insert_all_read_copy_ops's own tests exercise _rescale_index only
     indirectly, through whatever index shapes its fixtures happen to
     produce. These tests call it directly with hand-built indexes so the
     matching rules documented on _rescale_index itself -- largest-stride-
@@ -5842,7 +5579,7 @@ class TestRescaleIndex(unittest.TestCase):
         # full_strides/tile_strides are always sympy Expr in the real
         # calling convention (dep.index.coeff(...) and a
         # sympy.Integer(1)-seeded running product in
-        # _insert_read_copy_ops) -- never raw Python ints. Use
+        # _insert_all_read_copy_ops) -- never raw Python ints. Use
         # sympy.Integer throughout so these tests match that convention.
         c0, c1 = sympy.symbols("c0 c1")
         index = c0 * 128 + c1 * 4
@@ -5988,85 +5725,6 @@ class TestCoarseTileReductionPropagation(unittest.TestCase):
         _validate_planned_reduction_tiling(
             op, op.loop_info.loop_tiled_dims, op.loop_info.loop_tiled_reduction_dims
         )
-
-    def test_nested_fill_gets_outer_loop_info(self):
-        """Fill op gets outer-level loop_info for nested output+reduction tiling."""
-        from torch_spyre._inductor.wsr.coarse_tile import _compute_fill_loop_info
-
-        op = _make_tiled_reduction_op(
-            "red0",
-            ranges=[Integer(64)],
-            reduction_ranges=[Integer(256)],
-            reduction_type="sum",
-            loop_group_id=(0, 0),
-            loop_count=[Integer(2), Integer(4)],
-            loop_tiled_dims=[[0], []],
-        )
-        op.loop_info.loop_tiled_reduction_dims = [[], [0]]
-        fill_info = _compute_fill_loop_info(op)
-        self.assertIsNotNone(fill_info)
-        self.assertEqual(fill_info.loop_group_id, (0,))
-        self.assertEqual(fill_info.loop_count, [Integer(2)])
-        self.assertEqual(fill_info.loop_tiled_dims, [[0]])
-
-    def test_flat_fill_has_no_loop_info(self):
-        """Fill op gets no loop_info for flat (pure) reduction tiling."""
-        from torch_spyre._inductor.wsr.coarse_tile import _compute_fill_loop_info
-
-        op = _make_tiled_reduction_op(
-            "red0",
-            ranges=[Integer(128)],
-            reduction_ranges=[Integer(256)],
-            reduction_type="sum",
-            loop_group_id=(0,),
-            loop_count=[Integer(4)],
-            loop_tiled_dims=[[]],
-        )
-        op.loop_info.loop_tiled_reduction_dims = [[0]]
-        fill_info = _compute_fill_loop_info(op)
-        self.assertIsNone(fill_info)
-
-
-class TestComputeFillLoopInfo(unittest.TestCase):
-    """_compute_fill_loop_info returns trimmed CoarseTileInfo for the fill op."""
-
-    def test_flat_reduction_returns_none(self):
-        """Pure reduction tiling (no output-dim level) → None (fill before all loops)."""
-        from torch_spyre._inductor.wsr.coarse_tile import _compute_fill_loop_info
-
-        op = _make_tiled_reduction_op(
-            "red0",
-            ranges=[Integer(128)],
-            reduction_ranges=[Integer(256)],
-            reduction_type="sum",
-            loop_group_id=(0,),
-            loop_count=[Integer(4)],
-            loop_tiled_dims=[[]],
-        )
-        op.loop_info.loop_tiled_reduction_dims = [[0]]
-        result = _compute_fill_loop_info(op)
-        self.assertIsNone(result)
-
-    def test_nested_outer_output_inner_reduction(self):
-        """Outer tiles dim 0 (output), inner tiles reduction dim 0 → fill gets outer loop_info."""
-        from torch_spyre._inductor.wsr.coarse_tile import _compute_fill_loop_info
-
-        op = _make_tiled_reduction_op(
-            "red0",
-            ranges=[Integer(64)],
-            reduction_ranges=[Integer(256)],
-            reduction_type="sum",
-            loop_group_id=(0, 0),
-            loop_count=[Integer(2), Integer(4)],
-            loop_tiled_dims=[[0], []],
-        )
-        op.loop_info.loop_tiled_reduction_dims = [[], [0]]
-        result = _compute_fill_loop_info(op)
-        self.assertIsNotNone(result)
-        self.assertEqual(result.loop_group_id, (0,))
-        self.assertEqual(result.loop_count, [Integer(2)])
-        self.assertEqual(result.loop_tiled_dims, [[0]])
-        self.assertEqual(result.loop_tiled_reduction_dims, [[]])
 
 
 class TestValidatePlannedReductionTiling(unittest.TestCase):

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -4227,20 +4227,6 @@ class TestCoarseTileBufferPropagation(unittest.TestCase):
         self.assertEqual(consumers, [])
         self.assertFalse(is_out)
 
-    def test_has_inside_consumers_removed(self):
-        """_has_inside_consumers is deleted along with the direct-mutation
-        Case 2/"Case 3" branch it used to help gate -- every cross-loop-
-        group write now takes the unconditional _insert_copy_op path
-        regardless of whether the tiled op also has inside consumers, so
-        this predicate no longer has a caller.
-        """
-        import torch_spyre._inductor.wsr.coarse_tile as coarse_tile_module
-
-        self.assertFalse(
-            hasattr(coarse_tile_module, "_has_inside_consumers"),
-            "_has_inside_consumers should have been deleted",
-        )
-
     def test_different_loop_group_id_is_outside(self):
         """Op in loop group 1 should be seen as outside consumer of group 0."""
         from torch_spyre._inductor.wsr.coarse_tile import _find_outside_consumers
@@ -4255,56 +4241,6 @@ class TestCoarseTileBufferPropagation(unittest.TestCase):
         ):
             consumers, _ = _find_outside_consumers("op0", (0,), [tiled, other_group])
         self.assertEqual(consumers, [other_group])
-
-    def test_carry_propagation_functions_removed(self):
-        """_carry_terminal_op/_propagate_carry_op and the seed-detection helpers
-        are deleted."""
-        import torch_spyre._inductor.wsr.coarse_tile as coarse_tile_module
-
-        for name in (
-            "_carry_terminal_op",
-            "_propagate_carry_op",
-            "_seed_buffer_for_carry",
-            "_seed_closure_pre_stamp",
-            "_is_constant_fill",
-            "_closure_member_has_external_operands_only",
-        ):
-            self.assertFalse(
-                hasattr(coarse_tile_module, name),
-                f"{name} should have been deleted",
-            )
-
-    def test_planned_twin_leftovers_removed(self):
-        """Transformation-time functions superseded by their planning-time
-        twins, and helpers orphaned by earlier partial cleanups, are deleted.
-        """
-        import torch_spyre._inductor.wsr.coarse_tile as coarse_tile_module
-
-        for name in (
-            "_compute_full_ranges",
-            "_insert_read_copy_ops",
-            "_compute_fill_loop_info",
-            "_group_reduction_tiled_hint_ids",
-            "_op_hint_dim_positions",
-            "_seed_closure",
-        ):
-            self.assertFalse(
-                hasattr(coarse_tile_module, name),
-                f"{name} should have been deleted",
-            )
-
-    def test_has_loop_internal_real_input_removed(self):
-        """_has_loop_internal_real_input is deleted along with the direct-
-        mutation Case 2/"Case 3" branch it used to gate -- every cross-loop-
-        group write now takes the unconditional _insert_copy_op path, so the
-        loop-internal-input special case no longer needs its own predicate.
-        """
-        import torch_spyre._inductor.wsr.coarse_tile as coarse_tile_module
-
-        self.assertFalse(
-            hasattr(coarse_tile_module, "_has_loop_internal_real_input"),
-            "_has_loop_internal_real_input should have been deleted",
-        )
 
     def test_case2_condition_now_produces_copy_op(self):
         """An op that used to hit the direct-mutation branch (outside

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -50,7 +50,7 @@ class ReductionPlan:
     is_nested:
         True when an outer level tiles an output dim and an inner level
         tiles a reduction dim, requiring separate tile-sized and full-sized
-        accumulators (see ``_compute_fill_loop_info``). False for a flat
+        accumulators (see ``_compute_fill_loop_info_planned``). False for a flat
         (reduction-dim-only) tiling.
     full_output_ranges:
         Full (pre-division) output shape for the accumulation buffer --
@@ -62,7 +62,8 @@ class ReductionPlan:
         ``_divide_ranges`` performs later, in place, during transformation).
     outer_fill_loop_info:
         ``CoarseTileInfo`` covering only the outer output-dim levels, to
-        stamp on the fill op for a nested tiling (``_compute_fill_loop_info``).
+        stamp on the fill op for a nested tiling
+        (``_compute_fill_loop_info_planned``).
         ``None`` for a flat tiling, where the fill runs once before all loops.
         Its ``loop_group_id`` is planning-time, pre-offset numbering --
         transformation must re-slice it from the op's own real, stamped
@@ -127,7 +128,7 @@ class ReadCopyEntry:
         The canonical MemoryDep (buffer name + index + var_names + size)
         every equivalent read in the group shares -- the same object one of
         the consuming ops' own full_deps produced, used to size/index the
-        copy exactly as _insert_read_copy_ops does today.
+        copy exactly as _insert_all_read_copy_ops does today.
     insert_before_op_name:
         get_operation_name() of the first (operations order) consuming op
         in the group -- where the copy is inserted.

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -365,14 +365,12 @@ def _find_outside_consumers_planned(
 def _compute_full_ranges_planned(
     op: ComputedBuffer, info: CoarseTileInfo
 ) -> list[Expr]:
-    """Planning-time analog of _compute_full_ranges.
+    """Compute op's full (pre-division) output ranges without mutating.
 
-    _compute_full_ranges reconstructs the pre-division ranges from op.data
-    .ranges, which by the time transformation calls it has already been
-    divided by _divide_ranges. Planning runs *before* _apply_plan/
-    _divide_ranges, so op.data.ranges is already the undivided, full shape
-    here -- return it unchanged rather than multiplying by loop_count again
-    (which would double the extent of every tiled dim).
+    Planning runs *before* _apply_plan/_divide_ranges, so op.data.ranges is
+    already the undivided, full shape here -- return it unchanged rather
+    than multiplying by loop_count again (which would double the extent of
+    every tiled dim).
     """
     return list(op.data.ranges)
 
@@ -409,9 +407,7 @@ def _compute_per_tile_ranges_planned(
 def _compute_fill_loop_info_planned(
     info: CoarseTileInfo,
 ) -> CoarseTileInfo | None:
-    """Planning-time analog of _compute_fill_loop_info.
-
-    Same computation, but takes op's planned CoarseTileInfo directly.
+    """Compute the fill op's trimmed loop_info from op's planned CoarseTileInfo.
 
     For a flat tiling (no output-dim levels, or every reduction-dim level is
     outer to every output-dim level) the fill has no loop_info — it runs once
@@ -926,46 +922,6 @@ def _group_reduction_tiled_levels_in_group(
     return reduction_levels
 
 
-def _group_reduction_tiled_hint_ids(
-    group_ops: list[Operation], levels: list[tuple]
-) -> set[int]:
-    """Return hint_ids among ``levels`` that tile a reduction dim for some
-    Reduction op in group_ops."""
-    reduction_hint_ids: set[int] = set()
-    for hint_id, _count in levels:
-        for op in group_ops:
-            if not isinstance(op, ComputedBuffer) or not isinstance(op.data, Reduction):
-                continue
-            _, has_reduction_pos = _op_hint_dim_positions(op, hint_id)
-            if has_reduction_pos:
-                reduction_hint_ids.add(hint_id)
-                break
-    return reduction_hint_ids
-
-
-def _op_hint_dim_positions(op: ComputedBuffer, hint_id: int) -> tuple[bool, bool]:
-    """Return (has_output_pos, has_reduction_pos) for op at the given hint_id.
-
-    has_output_pos: op's own output ranges contain a dim driven by this hint.
-    has_reduction_pos: op is a Reduction whose reduction_ranges contain a dim
-    driven by this hint.  This is the hint-to-position lookup used to decide
-    which of op's own dims a given hint_id tiles.
-    """
-    dim_hint = next(
-        (h for h in getattr(op, "dim_hints", []) if h.hint_id == hint_id), None
-    )
-    if dim_hint is None or dim_hint.loop_var is None:
-        return False, False
-    if dim_hint.is_reduction:
-        if not isinstance(op.data, Reduction):
-            return False, False
-        pos = _loop_var_to_reduction_ranges_pos(op, dim_hint.loop_var)
-        return False, pos is not None
-    op_out = op_out_coords(op)
-    pos = _loop_var_to_ranges_pos(op_out, dim_hint.loop_var)
-    return pos is not None, False
-
-
 def _reads_incomplete_reduction(
     op: ComputedBuffer,
     group_op_names: set[str],
@@ -1007,38 +963,6 @@ def _plan_is_loop_invariant_at_reduction_levels(
     if not group_reduction_tiled_levels:
         return False
     return all(not op_tiled_dims[i] for i in group_reduction_tiled_levels)
-
-
-def _seed_closure(
-    seed_name: str, loop_group_id: tuple, operations: list[Operation]
-) -> set[str]:
-    """Return the closure of seed_name within its outer loop group.
-
-    The closure is every op in the same outer loop group that reads
-    seed_name *directly* — e.g. both `max_running = maximum(M, block_max)`
-    and `correction = exp(M - max_running)` read `M` directly, so both are
-    in `M`'s closure. This is intentionally NOT transitive: an op that reads
-    a closure member but not the seed itself (e.g.
-    `denominator = denominator * correction + ...`, which reads `correction`
-    but not `M`) is an ordinary downstream consumer, not part of the seed's
-    closure — including it would pull in the whole downstream dependency
-    cone, which is a different (much larger, wrong) set.
-
-    Restricted to ops stamped with loop_info in the same outer group (i.e.
-    after _apply_plan has stamped loop_info; see _seed_closure_pre_stamp for
-    the pre-stamp equivalent used during planning).
-    """
-    outer_key = loop_group_id[0]
-    closure: set[str] = set()
-    for o in operations:
-        if not isinstance(o, ComputedBuffer):
-            continue
-        li = getattr(o, "loop_info", None)
-        if li is None or li.loop_group_id[0] != outer_key:
-            continue
-        if seed_name in _op_reads(o):
-            closure.add(o.get_name())
-    return closure
 
 
 def _op_reads(op: ComputedBuffer) -> set[str]:
@@ -1947,7 +1871,7 @@ def _full_buffer_read_deps(op: ComputedBuffer) -> list[MemoryDep]:
     against a full-size buffer -- the same indexing bug _insert_copy_op's
     write side had before that fix, just on the read side and against an
     external buffer instead of a freshly allocated one. See
-    _insert_read_copy_ops and _find_outside_consumers (same outer-key
+    _insert_all_read_copy_ops and _find_outside_consumers (same outer-key
     comparison, mirrored here on the read side).
     """
     from ..ir import SpyreEmptyFallback  # deferred: avoids circular import
@@ -1989,22 +1913,6 @@ def _graph_output_names() -> set[str]:
 # ---------------------------------------------------------------------------
 # Full-buffer allocation
 # ---------------------------------------------------------------------------
-
-
-def _compute_full_ranges(op: ComputedBuffer) -> list[Expr]:
-    """Compute the original (pre-division) iteration ranges of op.
-
-    op.data.ranges holds the already-divided ranges.  Reconstruct the full
-    ranges by multiplying each tiled dimension back by its loop_count.
-    """
-    full_ranges = list(op.data.ranges)
-    loop_count: list[Expr] = op.loop_info.loop_count
-    loop_tiled_dims: list[list[int]] = op.loop_info.loop_tiled_dims
-    for count, dims in zip(loop_count, loop_tiled_dims):
-        for d in dims:
-            if 0 <= d < len(full_ranges):
-                full_ranges[d] = sympy.simplify(full_ranges[d] * count)
-    return full_ranges
 
 
 def _allocate_full_buffer(
@@ -2113,7 +2021,7 @@ def _allocate_full_buffer(
         # never read by stickification -- generic_layout builds
         # SpyreTensorLayout from .size alone), but it cannot be written that
         # way: full_buf gets read (via name-swapped consumer inner_fns,
-        # e.g. _insert_read_copy_ops) before stickification runs, and
+        # e.g. _insert_all_read_copy_ops) before stickification runs, and
         # split_multi_ops traces those inner_fns by calling make_loader()/
         # make_indexer() on full_buf. Inductor's Layout.make_indexer()
         # (torch/_inductor/ir.py) asserts FlexibleLayout.allow_indexing --
@@ -2252,7 +2160,7 @@ class _NameSwapHandler(WrapperHandler):
 
     Unlike insert_restickify's version, entries here also carry the
     full-buffer and tile-local strides for the swapped name (see
-    _insert_read_copy_ops): the copy buffer being swapped in is physically
+    _insert_all_read_copy_ops): the copy buffer being swapped in is physically
     smaller than the full buffer it replaces, so tiled_op's original index
     (affine in its own loop vars, using full_buf's stride coefficients) no
     longer resolves to a valid offset into it.
@@ -2263,7 +2171,7 @@ class _NameSwapHandler(WrapperHandler):
     times (e.g. by scheduler fusion checks) with a *different* dummy
     variable each time (d0, i0, q0, ... have all been observed for the same
     load site), so a single precomputed replacement expression captured at
-    _insert_read_copy_ops time would be wrong on every trace that doesn't
+    _insert_all_read_copy_ops time would be wrong on every trace that doesn't
     happen to reuse those exact symbols. Instead, `index` is rescaled at
     call time: each additive term's coefficient is matched (by value) against
     full_strides to find its dimension, then replaced by that dimension's
@@ -2927,44 +2835,6 @@ def _insert_all_read_copy_ops(
                 )
 
 
-def _insert_read_copy_ops(
-    tiled_op: ComputedBuffer,
-    full_deps: list[MemoryDep],
-    operations: list[Operation],
-) -> ComputedBuffer:
-    """Single-op convenience wrapper: one copy per unique dep name, one
-    consumer (tiled_op itself). Equivalent to a one-entry, one-consumer
-    ReadCopyPlan for tiled_op's own dedup case -- see _plan_read_copies for
-    the cross-op generalization used by production code."""
-    deduped_deps: dict[str, MemoryDep] = {}
-    for dep in full_deps:
-        if dep.name in deduped_deps:
-            prior = deduped_deps[dep.name]
-            assert prior.var_names == dep.var_names and prior.index == dep.index, (
-                f"_insert_read_copy_ops: {dep.name!r} is read via two "
-                "MemoryDeps with different index expressions "
-                f"({prior.index} vs {dep.index}); a single copy op keyed by "
-                "buffer name cannot serve both."
-            )
-            continue
-        deduped_deps[dep.name] = dep
-
-    for dep in deduped_deps.values():
-        copy_name = V.graph.qualify_name(
-            f"coarse_tile_read_copy_{tiled_op.get_name()}_{dep.name}"
-        )
-        new_copy_name = _insert_one_read_copy(
-            tiled_op, dep, copy_name, operations, insert_before_op=tiled_op
-        )
-        _patch_consumer_to_read_copy(tiled_op, dep, new_copy_name, operations)
-        tiled_op = next(
-            o
-            for o in operations
-            if isinstance(o, ComputedBuffer) and o.get_name() == tiled_op.get_name()
-        )
-    return tiled_op
-
-
 # ---------------------------------------------------------------------------
 # Case: reduction-dim tiling — combine op insertion
 # ---------------------------------------------------------------------------
@@ -3152,45 +3022,6 @@ def _insert_reduction_copy_op(
         else:
             insert_idx = operations.index(tiled_op) + 1
     operations.insert(insert_idx, copy_buf)
-
-
-def _compute_fill_loop_info(op: ComputedBuffer) -> "CoarseTileInfo | None":
-    """Return the loop_info to stamp on the fill op for a nested tiled reduction.
-
-    For a flat (pure reduction) tiling the fill has no loop_info — it runs
-    once before all loops.  Returns None.
-
-    For a nested tiling where outer level(s) tile output dims and the inner
-    level tiles a reduction dim, the fill must run inside the outer loop (once
-    per outer tile) so the accumulator is per-outer-tile sized.  Returns a
-    CoarseTileInfo covering only the outer output-dim levels.
-    """
-    loop_info = op.loop_info
-    tiled_rdims = getattr(loop_info, "loop_tiled_reduction_dims", [])
-
-    outer_counts: list[sympy.Expr] = []
-    outer_tiled_dims: list[list[int]] = []
-    outer_tiled_rdims: list[list[int]] = []
-    for dims, rdims, count in zip(
-        loop_info.loop_tiled_dims, tiled_rdims, loop_info.loop_count
-    ):
-        if dims:  # non-empty output-dim list → this is an output-dim level
-            outer_counts.append(count)
-            outer_tiled_dims.append(dims)
-            outer_tiled_rdims.append([])
-
-    if not outer_counts:
-        return None  # flat: fill runs before all loops
-
-    outer_gid = loop_info.loop_group_id[: len(outer_counts)]
-    return CoarseTileInfo(
-        loop_group_id=outer_gid,
-        loop_count=outer_counts,
-        loop_tiled_dims=outer_tiled_dims,
-        loop_tiled_reduction_dims=outer_tiled_rdims,
-        tiled_dims_per_read=[],
-        output_tiled_dims=[],
-    )
 
 
 def _insert_all_reduction_ops(operations: list[Operation]) -> None:

--- a/torch_spyre/_inductor/wsr/coarse_tile_span_overflow.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile_span_overflow.py
@@ -218,7 +218,7 @@ def span_overflow_groups(
     already carry user dim hints are left for the user-hint grouping path.
     ``is_reduction`` is not carried in the group-level ``levels`` list; it
     lives on each op's own ``DimHint`` and is consulted directly by
-    ``plan_coarse_tile_groups`` (via ``_op_hint_dim_positions``).
+    ``plan_coarse_tile_groups``.
 
     Returns a ``(groups, dim_hint_assignments)`` pair.  ``dim_hint_assignments``
     is a list of ``(op, dim_hints)`` pairs this function decided on but did

--- a/torch_spyre/_inductor/wsr/propagate_named_dims.py
+++ b/torch_spyre/_inductor/wsr/propagate_named_dims.py
@@ -232,16 +232,6 @@ def named_dims_for_sym(op: ComputedBuffer, sym: sympy.Symbol) -> list[tuple[str,
     return [(n, _named_dims[n]) for n in names if n in _named_dims]
 
 
-def named_dims_for_coord(
-    op: ComputedBuffer, coord: sympy.Expr
-) -> list[tuple[str, int]] | None:
-    """Return [(name, size), ...] for the named dims covered by a host coord expression."""
-    sym = _lone_sym(coord)
-    if sym is None:
-        return None
-    return named_dims_for_sym(op, sym)
-
-
 def get_input_named_dims(inputs: list, op=None) -> dict:
     """
     Merge named dim mappings from all inputs into a single loop-var → names dict.


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Audits and removes dead code left behind by the series of coarse-tiling
refactors. Two patterns of dead code were identified and removed:

- **Old twins left behind after a plan/execute split** — a `_planned`
  replacement now runs in production, but the original transformation-time
  function survived only because unit tests still called it directly:
  `_compute_full_ranges`, `_compute_fill_loop_info`, `_insert_read_copy_ops`
  (all in `coarse_tile.py`).
- **Orphaned by a prior partial cleanup** — helpers with zero callers
  anywhere, including tests, left behind when a sibling function was
  deleted without also removing them: `_group_reduction_tiled_hint_ids`
  and its exclusive helper `_op_hint_dim_positions`, and `_seed_closure`
  (all in `coarse_tile.py`); `named_dims_for_coord`
  (`propagate_named_dims.py`), never called by anything.

Also removes the now-orphaned unit tests exercising these functions
directly, adds a regression test (`test_planned_twin_leftovers_removed`)
asserting the removed names stay deleted, and rewords docstrings/comments
in `coarse_tile.py`, `coarse_tile_span_overflow.py`, and
`test_coarse_tiling.py` that dangled references to the removed names.

A third candidate pattern — `compute_tile_index`, `compute_tile_offset`,
and `decompose_index_for_tiling` in `tile.py`, added by #3622 but never
wired into production — was intentionally **excluded** from this PR.
Separate parallel work is landing to integrate them, so they and every
test that touches them were left untouched.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

Part of #206

#### Special notes for your reviewer:

- No behavioral change: all removed functions were unreachable from
  production code paths, confirmed via AST call-graph analysis, grep
  cross-referencing, and git history archaeology (`git log -S`,
  `git show --stat`) for each candidate.
- `tile.py`'s `compute_tile_index`, `compute_tile_offset`, and
  `decompose_index_for_tiling` are deliberately out of scope — do not
  flag these as missed dead code; they're pending a separate integration
  PR.
- Local regression: `tests/inductor/test_coarse_tiling.py`,
  `tests/inductor/test_coarse_tile_e2e.py`, and
  `tests/inductor/test_building_blocks.py` — 471 passed, 48 skipped.
  `pre-commit run --all-files` clean.

#### Does this PR introduce a user-facing change?

No.

#### Additional note:

Net: -521 lines (560 removed, 39 added) across 4 files.