### PR TITLE
test(lx-planning): tag large-matmul xfails slow so --skip-slow skips them

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_matmul_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_matmul_config.yaml
@@ -27,10 +27,23 @@ test_suite_config:
             - LxPlanning.*::test_mm_mm_55x2_2x99_lx_planning_pointwise
             - LxPlanning.*::test_addmm_1152_10x1152_1152x1152_lx_planning_reduction
             - LxPlanning.*::test_addmm_out_basic_lx_planning_reduction
-            - LxPlanning.*::test_large_matmul_matmul_2d_M2048_K2048_N65536_lx_planning_reduction
-            - LxPlanning.*::test_large_matmul_matmul_4d_B2_H2_M2048_K2048_N65536_lx_planning_pointwise
             - LxPlanning.*::test_fp8_scaled_mm_128x128x128_1.0_1.0_0.0_lx_planning_(pointwise|reduction)
           mode: xfail
+        # Known LX-planning failures for the large-matmul variants. Kept in a
+        # separate xfail entry so they carry the slow__plat_* tags: a variant
+        # resolves to exactly one entry, so the slow tags MUST live on the
+        # entry the variant selects (the first matching entry, which for these
+        # tagless names is this xfail entry) or --skip-slow cannot deselect
+        # them. Without the tags here, --skip-slow left these ~1 hour tests
+        # running on ppc64le and s390x.
+        - names:
+            - LxPlanning.*::test_large_matmul_matmul_2d_M2048_K2048_N65536_lx_planning_reduction
+            - LxPlanning.*::test_large_matmul_matmul_4d_B2_H2_M2048_K2048_N65536_lx_planning_pointwise
+          mode: xfail
+          tags:
+            - ops__inductor-matmul
+            - slow__plat_ppc64
+            - slow__plat_s390x
         - names:
             - LxPlanning.*::test_(addmm|mm|bmm|einsum|matmul|linear).*_lx_planning_(pointwise|reduction)
           mode: mandatory_success


### PR DESCRIPTION
## Problem

On s390x (and ppc64le), `run_test.sh --skip-slow` does **not** skip the
`test_large_matmul` variant, so the matmul-config run takes ~1h17m instead of
<10min. Reported by Gnanesh while testing the s390x torch-spyre image.

`--skip-slow` maps the arch to a slow tag and appends the pytest filter
`-m "not slow__plat_<arch>"` (see `tests/oot_framework/run_test.sh`). So a test
is only skipped if it actually carries that pytest **mark**.

## Root cause

In `oot_test_base_common.py` the per-variant marks come from a **single**
resolved config entry: `variant_tags = list(resolved_entry.tags)`.
`_select_entry_for_variant` (`oot_test_utilities.py`) picks that entry by
**dtype only** and is blind to tags and to `xfail`/`mandatory_success` mode.

In this config the large_matmul variants are named without a dtype token
(`..._2d_M2048_K2048_N65536`), so the dtype pass finds nothing and selection
falls back to the **first matching entry**. That first entry was the `xfail`
entry, which carried **no tags**. The `slow__plat_ppc64` / `slow__plat_s390x`
tags declared on the later `mandatory_success` entry were therefore never
applied as marks, and `-m "not slow__plat_s390x"` could not deselect the test.

Log evidence: the test runs as `XPASS [TAGS = platform__s390x]` under
`--skip-slow`: only the auto-added platform tag, no slow tag.

## Fix (config-only)

Split the two `test_large_matmul` names into their own `xfail` entry that
carries the `slow__plat_ppc64` / `slow__plat_s390x` tags (plus
`ops__inductor-matmul`). The variant now resolves to an entry that has the slow
mark, so `--skip-slow` deselects it. `xfail` semantics are preserved (still
non-strict xfail; XPASS does not fail CI). The other tests that shared the old
xfail entry are unchanged: they were never meant to be slow.

This is the minimal, config-only fix. A companion framework fix (apply the
**union** of tags across all matching entries, so a tag declared on any
matching entry is honored) is proposed separately.

## Verification

- `--skip-slow` = `-m "not slow__plat_<arch>"` confirmed in `run_test.sh`.
- Per-variant marks come from the single `resolved_entry.tags`
  (`oot_test_base_common.py`), selected dtype-blind by
  `_select_entry_for_variant` (`oot_test_utilities.py`).
- YAML parses; `pre-commit run --files <config>` passes (yamlfmt Passed).
- pytest `-m` deselection happens at collection time, before xfail is
  evaluated, so a slow-tagged xfail test is correctly deselected by
  `--skip-slow`.
