### PR TITLE
test(oot framework): apply union of tags across all matching entries

### DIFF
--- a/tests/oot_framework/oot_test_base_common.py
+++ b/tests/oot_framework/oot_test_base_common.py
@@ -68,6 +68,7 @@ from oot_framework.oot_test_utilities import (
     _build_test_entry_map,
     _select_entry_by_op_index,
     _select_entry_for_variant,
+    _union_tags_for_variant,
     _extract_op_name_from_method,
 )
 
@@ -735,10 +736,24 @@ class OOTTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa: F
                         cls.GLOBAL_SUPPORTED_DTYPES,
                     )
 
-            # Tags for this specific variant = tags from the resolved entry only
-            variant_tags: List[str] = (
-                list(resolved_entry.tags) if resolved_entry else []
-            )
+            # Tags for this specific variant = union of the tags from EVERY
+            # entry that applies to this variant, not just the single entry
+            # resolved above for mode/dtype behaviour.  A variant resolves to
+            # one entry (dtype-driven, mode-blind), but declarative tags such
+            # as slow__plat_<arch> may be declared on a different matching
+            # entry.  Taking tags from resolved_entry alone dropped those
+            # tags, so run_test.sh --skip-slow (a "-m not slow__plat_<arch>"
+            # filter) could not deselect a test whose slow tag lived on a
+            # sibling entry.  Union across matching entries so any declared
+            # tag becomes a mark.  resolved_entry still drives mode/dtype.
+            if all_entries_for_name:
+                variant_tags: List[str] = _union_tags_for_variant(
+                    all_entries_for_name,
+                    method_name,
+                    cls.GLOBAL_SUPPORTED_DTYPES,
+                )
+            else:
+                variant_tags = list(resolved_entry.tags) if resolved_entry else []
 
             enabled, reason, is_xfail, is_strict = cls._should_run(
                 method_name=method_name,

--- a/tests/oot_framework/oot_test_utilities.py
+++ b/tests/oot_framework/oot_test_utilities.py
@@ -393,6 +393,60 @@ def _select_entry_for_variant(
     return entries[0]
 
 
+def _union_tags_for_variant(
+    entries: List[Any],
+    method_name: str,
+    global_supported_dtypes: Optional[Set[torch.dtype]],
+) -> List[str]:
+    """Union YAML tags from every entry that applies to *method_name*.
+
+    A concrete variant resolves to a single TestEntry for its mode/dtype
+    behaviour (see ``_select_entry_for_variant``), but declarative tags are
+    not mode-specific: a ``slow__plat_*`` tag declared on ANY entry that
+    covers this variant must be applied as a pytest mark, otherwise a
+    marker filter such as ``-m "not slow__plat_s390x"`` (run_test.sh
+    ``--skip-slow``) cannot deselect the test.
+
+    ``entries`` are already the entries whose name pattern matched this
+    test's base name (built by ``instantiate_test``), so the only remaining
+    per-variant discriminator is dtype.  We therefore union the tags of
+    every entry that is dtype-compatible with this variant:
+
+      - an entry with no dtype restriction always applies;
+      - an entry with a dtype restriction applies only when the variant's
+        dtype (if any) is in its set.
+
+    Order is preserved (first appearance wins) so the result is stable.
+    """
+    # Deferred import to avoid a circular dependency at module load time.
+    from .oot_test_matching import extract_dtype_from_name, parse_dtype
+
+    dtype_str = extract_dtype_from_name(method_name)
+    variant_dtype: Optional[torch.dtype] = None
+    if dtype_str:
+        try:
+            variant_dtype = parse_dtype(dtype_str)
+        except ValueError:
+            pass
+
+    union: List[str] = []
+    seen: Set[str] = set()
+    for entry in entries:
+        eset = _entry_dtype_set(entry, global_supported_dtypes)
+        # An entry with a dtype restriction only contributes its tags when
+        # the variant's dtype is covered by that set.  When we cannot read a
+        # dtype off the method name we cannot exclude the entry on dtype
+        # grounds, so it still contributes (matching the selector's wildcard
+        # behaviour).
+        if eset is not None and variant_dtype is not None and variant_dtype not in eset:
+            continue
+        for tag in entry.tags or []:
+            if tag not in seen:
+                seen.add(tag)
+                union.append(tag)
+    return union
+
+
 def _extract_op_name_from_method(
     method_name: str, base_test_name: str, oot_device_type: str
 ) -> Optional[str]:


### PR DESCRIPTION
## Problem

`run_test.sh --skip-slow` did not skip `test_large_matmul` on s390x/ppc64le
(the matmul-config run took ~1h17m instead of <10min). Reported by Gnanesh on
the s390x torch-spyre image.

`--skip-slow` appends the pytest filter `-m "not slow__plat_<arch>"`
(`tests/oot_framework/run_test.sh`), so a test is skipped only if it carries
that pytest **mark**.

## Root cause

A concrete test variant resolves to a **single** `TestEntry` for its
mode/dtype behaviour via `_select_entry_for_variant` (dtype-driven,
mode-blind). Per-variant marks were then taken from that one entry only:

```python
variant_tags = list(resolved_entry.tags) if resolved_entry else []
```

But declarative tags such as `slow__plat_<arch>` are not mode-specific and may
be declared on a **different** entry that also matches the same test.
`test_large_matmul` declared its slow tags on a `mandatory_success` entry, yet
the variant (its name has no dtype token) resolved to a **tagless `xfail`**
entry. So the slow mark was never applied and `--skip-slow` could not deselect
it.

Note the framework already computes an `all_tags_union` across all matching
entries, but only for the **collection-time summary print**, not for the marks
pytest actually filters on. This PR closes that gap.

## Fix

Add `_union_tags_for_variant` and use it in `instantiate_test`: the applied
marks are now the **union** of tags from every entry that applies to the
variant. All entries in `all_entries_for_name` already matched the test's base
name, so the only remaining per-variant discriminator is dtype: an entry with a
dtype restriction contributes its tags only when the variant's dtype is in its
set (dtype-incompatible entries are excluded). `resolved_entry` still drives
mode/dtype/enabled: no behaviour change there.

This is the framework-level companion to the config-only fix in
torch-spyre/torch-spyre#3688. It fixes the whole class of "a tag declared on a
sibling entry is silently dropped" bugs, not just the large_matmul case, and
aligns the applied marks with the `all_tags_union` summary.

## Verification

- `pre-commit run --files <both files>`: ruff, ruff format, mypy, and the
  import-regex hook all Passed.
- `py_compile` of both files: OK.
- Algorithm validated on four scenarios (standalone, since the device stack is
  not importable off-hardware):
  1. reported bug (no dtype token; tagless xfail first, slow entry later) ->
     `slow__plat_ppc64` / `slow__plat_s390x` / `ops__inductor-matmul` all
     present after union.
  2. dtype-discriminated variant (`float16`): a `bfloat16`-only sibling entry
     does **not** contribute its tags.
  3. single-entry case: tags unchanged.
  4. no dtype in name but dtype-restricted entries: both contribute (cannot
     exclude on dtype grounds), matching the selector's wildcard behaviour.
- pytest `-m` deselection runs at collection time, before xfail is evaluated,
  so a slow-tagged xfail test is correctly deselected by `--skip-slow`.

I do not have Spyre hardware locally, so the on-device pytest run was not
executed here; the CI matrix on this PR exercises the real path.
