### PR TITLE
Guard copy optimization elimination with DISABLE_COPY_OPT

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1793,6 +1793,7 @@ def test_copy_rmw_correction_512x256_A4_B4():
 # copies sparse reduction result into a dense buffer
 
 
+@config.patch({"disable_copy_opt": True})
 def test_copy_not_deleted():
     """Regression: copy_ must not be eliminated by noop_registry removal.
 
@@ -1815,6 +1816,7 @@ def test_copy_not_deleted():
         run_coarse_tile_test(fn, inputs)
 
 
+@config.patch({"disable_copy_opt": True})
 def test_copy_after_reduction_512x256_A4():
     """out.copy_(x.amin(dim=0)) on [512,256] tiled A÷4 must be rejected."""
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
@@ -1851,6 +1853,7 @@ def test_copy_after_reduction_512x256_B4():
     run_coarse_tile_test(fn, inputs, correctness=False)
 
 
+@config.patch({"disable_copy_opt": True})
 def test_copy_after_reduction_512x256_A4_B4():
     """out.copy_(x.amin(dim=0)) on [512,256] tiled A÷4 B÷4 must be rejected."""
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
@@ -2248,6 +2251,7 @@ def test_outside_consumer_two_accum_512x256_A4():
     run_coarse_tile_test(fn, inputs)
 
 
+@config.patch({"disable_copy_opt": True})
 def test_outside_consumer_two_accum_512x256_B4():
     """Flash-style: out=zeros, denom=zeros; tiled copy_; return out/denom — B÷4 must be rejected."""
     inputs = [

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -103,6 +103,12 @@ disable_conv2d_spatial_split: bool = (
     os.environ.get("SPYRE_INDUCTOR_DISABLE_CONV2D_SPATIAL_SPLIT", "1") == "1"
 )
 
+# When True, disable PyTorch's remove_noop_ops elimination of aten.copy.default.
+# Required for WSR variants that intentionally insert copies (e.g. flash_v2)
+# inside WSR loops. Off by default — enabling this for models that don't need
+# it may prevent harmless copy removal and hurt performance.
+disable_copy_opt: bool = os.environ.get("DISABLE_COPY_OPT", "0") == "1"
+
 # When True (default), HBM tensor addresses are emitted as runtime symbols
 # with !sdscbundle.input_arg<index> parameters and input_arg_extract ops
 # in the bundle.mlir.

--- a/torch_spyre/_inductor/patches.py
+++ b/torch_spyre/_inductor/patches.py
@@ -21,6 +21,8 @@ from torch._inductor.scheduler import SchedulerNode
 from torch._inductor.utils import InputType
 from torch._inductor.virtualized import V
 
+import torch_spyre._inductor.config as spyre_config
+
 
 @contextmanager
 def spyre_data_types():
@@ -140,9 +142,15 @@ def enable_spyre_context(example_inputs: list[InputType]):
     # Prevent remove_noop_ops from eliminating aten.copy.default nodes.
     # That pass treats copy.default as an alias no-op and replaces copy(dst, src)
     # with src, discarding the copy before it reaches lowering.
+    # Guarded by DISABLE_COPY_OPT so models that don't need preserved copies
+    # (e.g. granite) are not affected.
     from torch._inductor.fx_passes.post_grad import noop_registry
 
-    _saved_copy_noop = noop_registry.pop(torch.ops.aten.copy.default, None)
+    _saved_copy_noop = (
+        noop_registry.pop(torch.ops.aten.copy.default, None)
+        if spyre_config.disable_copy_opt
+        else None
+    )
 
     with (
         spyre_data_types(),


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR guards the disabling of copy optimzation in #3681 with an environment variable that is off by default to unblock downstream teams that may be affected

#### Which issue(s) this PR is related to:
https://github.com/torch-spyre/torch-spyre/issues/3693

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
