### PR TITLE
feat(oot-framework): add testtype__<label> pytest marker driven by test_suite_config.labels

### DIFF
--- a/tests/oot_framework/oot_test_base_common.py
+++ b/tests/oot_framework/oot_test_base_common.py
@@ -224,9 +224,20 @@ class OOTTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa: F
         cls.GLOBAL_DTYPE_FORCE_XFAIL = (
             config.global_config.resolved_supported_dtypes_force_xfail()
         )
-        cls.TEST_SUITE_LABELS = list(config.test_suite_config.labels)
 
         file_entry: FileEntry = resolve_current_file(config, path)
+
+        # Prefer file_entry.labels: for a multi-config directory run,
+        # merge_yaml_configs() threads each source config's own
+        # test_suite_config.labels onto its file entries (the merged
+        # document has no single top-level labels field that could
+        # represent per-file provenance once files from different configs
+        # are combined). Empty there means a single-config run (the source
+        # YAML never sets per-file labels), so fall back to the top-level
+        # field, which correctly applies to every file in that one config.
+        cls.TEST_SUITE_LABELS = list(
+            file_entry.labels or config.test_suite_config.labels
+        )
 
         # Build the exact-name lookup map and the regex-pattern list.
         # Regex patterns (names containing regex metacharacters) go into

--- a/tests/oot_framework/oot_test_base_common.py
+++ b/tests/oot_framework/oot_test_base_common.py
@@ -48,6 +48,7 @@ from oot_framework.oot_upstream_patcher import (
     _OOTCpuMovePatcher,
     _OOTNoGradPatcher,
     _OOTPlatformMarkerPatcher,
+    _OOTTestTypeMarkerPatcher,
 )
 from oot_framework.oot_test_config_models import (
     OOTTestConfig,
@@ -143,6 +144,10 @@ class OOTTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa: F
     GLOBAL_DTYPE_PRECISION: Dict[torch.dtype, "Precision"] = {}
     GLOBAL_DTYPE_FORCE_XFAIL: Set[torch.dtype] = set()
 
+    # test_suite_config.labels from the YAML, e.g. ["unit", "regression", "trunk"].
+    # Drives the testtype__<label> pytest markers (see _OOTTestTypeMarkerPatcher).
+    TEST_SUITE_LABELS: List[str] = []
+
     # File-level module filtering (populated during config load)
     # Use None as sentinel to indicate not yet initialized, avoiding shared mutable default
     _FILE_LEVEL_INCLUDED_MODULES: Optional[Set[str]] = None
@@ -219,6 +224,7 @@ class OOTTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa: F
         cls.GLOBAL_DTYPE_FORCE_XFAIL = (
             config.global_config.resolved_supported_dtypes_force_xfail()
         )
+        cls.TEST_SUITE_LABELS = list(config.test_suite_config.labels)
 
         file_entry: FileEntry = resolve_current_file(config, path)
 
@@ -697,6 +703,10 @@ class OOTTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa: F
 
         # Attaches platform__<arch> marker
         _OOTPlatformMarkerPatcher(test).patch()
+
+        # Attaches testtype__<label> marker(s) from this config's
+        # test_suite_config.labels
+        _OOTTestTypeMarkerPatcher(test, cls.TEST_SUITE_LABELS).patch()
 
         existing_methods = set(cls.__dict__.keys())
         super().instantiate_test(name, test, generic_cls=generic_cls)

--- a/tests/oot_framework/oot_test_config_models.py
+++ b/tests/oot_framework/oot_test_config_models.py
@@ -1357,6 +1357,14 @@ class FileEntry(BaseModel):
 
     path: str
     unlisted_test_mode: str = MODE_XFAIL
+    # Not a real YAML field -- never set by a hand-written config. Populated
+    # by merge_yaml_configs() with the origin config's test_suite_config.labels
+    # so per-file labels survive a multi-config merge (which drops the
+    # top-level labels field, since it can't represent per-file provenance
+    # once files from different configs are combined). See
+    # OOTTestBase._load_test_suite_config(), which prefers this over
+    # test_suite_config.labels when non-empty.
+    labels: List[str] = []
     tests: List[TestEntry] = []
 
     @field_validator("unlisted_test_mode")

--- a/tests/oot_framework/oot_test_constants.py
+++ b/tests/oot_framework/oot_test_constants.py
@@ -12,7 +12,7 @@ import torch
 
 DEFAULT_FLOATING_PRECISION: float = 1e-3
 
-_DYNAMIC_TAG_PREFIXES = ("op__", "dtype__", "module__", "platform__")
+_DYNAMIC_TAG_PREFIXES = ("op__", "dtype__", "module__", "platform__", "testtype__")
 
 MODE_MANDATORY_SUCCESS = "mandatory_success"
 MODE_XFAIL = "xfail"

--- a/tests/oot_framework/oot_test_utilities.py
+++ b/tests/oot_framework/oot_test_utilities.py
@@ -626,6 +626,7 @@ def _merge_file_entries(entries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 "path": path,
                 "unlisted_test_mode": entry.get("unlisted_test_mode", "xfail"),
                 "tests": list(entry.get("tests") or []),
+                "labels": list(entry.get("labels") or []),
             }
         else:
             existing = merged[path]
@@ -639,6 +640,13 @@ def _merge_file_entries(entries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                     f"ignoring '{incoming_mode}'.",
                     file=sys.stderr,
                 )
+
+            # Same path claimed by multiple source configs: union their
+            # labels (order-preserving) so the merged file entry is
+            # discoverable under every tier any contributing config declared.
+            for lbl in entry.get("labels") or []:
+                if lbl not in existing["labels"]:
+                    existing["labels"].append(lbl)
 
             for test_block in entry.get("tests") or []:
                 block_names = frozenset(
@@ -744,9 +752,18 @@ def merge_yaml_configs(
         suites.append(suite)
 
     # ---- Merge `files` entries ----------------------------------------
+    # Thread each source config's own test_suite_config.labels onto its file
+    # entries BEFORE merging. The merged document has no single top-level
+    # labels field that could represent per-file provenance once files from
+    # different configs are combined, so this is how a file's origin labels
+    # (e.g. "integration") survive the merge -- see FileEntry.labels.
     all_file_entries: List[Dict[str, Any]] = []
     for suite in suites:
-        all_file_entries.extend(suite.get("files") or [])
+        suite_labels = suite.get("labels") or []
+        for f in suite.get("files") or []:
+            f = dict(f)
+            f["labels"] = list(suite_labels)
+            all_file_entries.append(f)
 
     merged_files = _merge_file_entries(all_file_entries)
 

--- a/tests/oot_framework/oot_upstream_patcher.py
+++ b/tests/oot_framework/oot_upstream_patcher.py
@@ -710,6 +710,40 @@ class _OOTPlatformMarkerPatcher:
         )
 
 
+class _OOTTestTypeMarkerPatcher:
+    """Attaches a pytest marker ``testtype__<label>`` for every label the
+    config's ``test_suite_config.labels`` declares, applied like the
+    platform tag (uniform per file, patched onto the underlying function
+    before ``instantiate_test`` propagates it to every variant). Labels are
+    normalised to valid identifiers, enabling e.g.
+    ``bash run_test.sh tests/configs/torch_spyre_tests/ -m testtype__integration``.
+    """
+
+    def __init__(self, test: object, labels: Optional[List[str]]) -> None:
+        self._underlying_fn = (
+            test.__func__ if hasattr(test, "__func__") else test  # type: ignore[union-attr]
+        )
+        self._labels = labels or []
+
+    def patch(self) -> None:
+        if not self._labels:
+            return
+
+        marks = []
+        for label in self._labels:
+            label_safe = re.sub(r"[^a-zA-Z0-9_]", "_", label).strip("_")
+            if label_safe:
+                marks.append(pytest.mark.__getattr__(f"testtype__{label_safe}"))
+        if not marks:
+            return
+
+        if not hasattr(self._underlying_fn, "pytestmark"):
+            self._underlying_fn.pytestmark = []  # type: ignore[union-attr]
+        self._underlying_fn.pytestmark = (  # type: ignore[union-attr]
+            list(self._underlying_fn.pytestmark) + marks  # type: ignore[union-attr]
+        )
+
+
 class _OOTOpMarkerPatcher:
     """Patches @ops._parametrize_test to attach pytest markers directly on
     each test_wrapper as it is yielded, before super().instantiate_test()

--- a/tests/oot_framework/run_test.sh
+++ b/tests/oot_framework/run_test.sh
@@ -2508,9 +2508,19 @@ for i in "${!RUN_FILES[@]}"; do
     # so conftest.py files are discovered correctly.
     #
     # If the probe finds 0 matching tests (exit code 5) the -m flag is stripped
-    # from _FILE_PYTEST_ARGS so the file's tests all run normally. 
+    # from _FILE_PYTEST_ARGS so the file's tests all run normally --
     # the marker filter applies to files that USE that marker
-    # family; files that don't use it are unaffected.
+    # family; files that don't use it are unaffected. This fallback is for
+    # op__/dtype__/module__/platform__-style tags, where a per-file 0-match
+    # just means "this marker family isn't used here". It does NOT apply to
+    # testtype__<label> (see _OOTTestTypeMarkerPatcher): that tag is a
+    # whole-file inclusion marker driven by the config's
+    # test_suite_config.labels, so a 0-match genuinely means this file's
+    # config doesn't carry the requested label and the file must stay
+    # excluded, not fall back to running unfiltered. -m is left in place for
+    # that case; the real run below will also report 0 collected (exit 5),
+    # which the exit-code handling further down already treats as
+    # NOTEST/warning-only, not a failure.
     #
     # ---------------------------------------------------------------------------
     _HAS_M=0
@@ -2541,7 +2551,9 @@ for i in "${!RUN_FILES[@]}"; do
         (cd "$run_dir" && python3 -m pytest "$run_basename" \
             "${_PROBE_ARGS[@]}" --collect-only -q 2>/dev/null) || _probe_exit=$?
 
-        if [[ $_probe_exit -eq 5 ]]; then
+        if [[ $_probe_exit -eq 5 && "${_PROBE_ARGS[*]}" == *"testtype__"* ]]; then
+            echo "[torch_oot_device_tests_run] -m filter matched 0 tests in $(basename "$original_file") (testtype__ label not present) -- file excluded" >&2
+        elif [[ $_probe_exit -eq 5 ]]; then
             # 0 tests match this marker in this file — strip -m from args.
             echo "[torch_oot_device_tests_run] -m filter matched 0 tests in $(basename "$original_file"), running without -m" >&2
             _ARGS_NO_M=()


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

1. Adds testtype__<label> pytest marker driven by config's test_suite_config.labels field.
2. Fixes run_test.sh to correctly exclude files missing requested label instead running unfiltered.

#### Usage:

```bash
bash tests/run_test.sh tests/configs/torch_spyre_tests/ -m testtype__integration
```

While execution, the config suites missing  `integration` from the `labels:` will be skipped. 

### Verification of correctness 

<img width="2388" height="1118" alt="image" src="https://github.com/user-attachments/assets/ce368145-f763-4fb2-a30f-efc84b2996f5" /> <br>

<img width="2242" height="2050" alt="image" src="https://github.com/user-attachments/assets/80e92256-d59f-4662-808b-e9718ef53d4c" />
