### PR TITLE
inductor: fix conv2d backGap suppression leaking to non-conv ops

### DIFF
--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -273,8 +273,6 @@ _CONV2D_PAD_DIM_J = CONV2D_DIM_LABELS[3]
 _CONV2D_WINDOW_DIM_I = CONV2D_DIM_LABELS[-2]
 _CONV2D_WINDOW_DIM_J = CONV2D_DIM_LABELS[-1]
 
-_CONV2D_SPATIAL_DIM_NAMES = (_CONV2D_PAD_DIM_I, _CONV2D_PAD_DIM_J)
-
 
 def _is_conv2d_kernel_tensor(arg: TensorArg, tensor_position: int | None) -> bool:
     """Check if a tensor is a kernel tensor for conv2d ops.
@@ -1146,16 +1144,12 @@ def _create_sdsc_tensors(
                 dim_offset = int(dim_coord.as_coeff_Add()[0])
                 offsets[dim] = dim_offset * dim_device_stride
                 # conv2d addresses the difference between device and iteration space sizes
-                # in its spatial dims (i, j) through the
-                # window/padding machinery in _conv2d_sdsc_fields, which already
+                # through the window/padding machinery in _conv2d_sdsc_fields, which already
                 # accounts for the gap between the device extent and the
-                # iteration extent. Emitting a backGap for them double-counts
+                # iteration extent. Emitting a backGap for a conv op double-counts
                 # that gap and corrupts the generated addressing.
                 #
-                if (
-                    not _is_conv(op_spec.op)
-                    and str(dim) not in _CONV2D_SPATIAL_DIM_NAMES
-                ):
+                if not _is_conv(op_spec.op):
                     backGap[dim] = dev_dim_size - it_dim_size
                 strides[dim] = strides[dim] // dev_dim_size * it_dim_size
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

The depthwise-conv2d change (#3510) added a guard in `_create_sdsc_tensors` (`codegen/superdsc.py`) meant to skip the padding `backGap` for conv2d, whose device/iteration size difference is already handled by the window/padding machinery in `_conv2d_sdsc_fields`. The guard was written as:

```python
not _is_conv(op_spec.op) and str(dim) not in _CONV2D_SPATIAL_DIM_NAMES
```

Because `_is_conv` already gates the whole conv case, the extra `dim not in {i, j}` term never affected a conv op — but it did suppress the `backGap` for any **non-conv** op whose dim happens to be labeled `"i"`/`"j"`. Those are shared SDSC dim names, so a generic op — e.g. an unaligned restickify/`identity` produced by a `transpose(-2,-1).clone()` whose padded dim maps to `"i"` (dev=128 vs iteration extent 65) — silently loses its padding gap and miscompiles.

Suppress the `backGap` for conv ops only, restoring it for every non-conv op:

```python
not _is_conv(op_spec.op)
```

This keeps conv2d behavior byte-identical (all its dims were, and remain, suppressed) and drops the now-unused `_CONV2D_SPATIAL_DIM_NAMES` tuple.

**Why drop the `i`/`j` check rather than keep it.** The adjacent comment names only the *spatial* dims `i`/`j`, so one might expect the fix to restrict the check to those dims. What the `#3510` code actually did is broader, and matching it keeps conv2d unchanged:

- `_is_conv(op)` is `op in [DEPTHWISE_CONV2D_OP]`, so for any conv op `not _is_conv(op)` is already `False` and short-circuits the whole condition — the `dim not in {i, j}` term is never evaluated for a conv op. So in the original tree the guard suppressed the `backGap` for **every** dim of a conv op, not just `i`/`j`.
- Instrumenting the guard while running the depthwise-conv2d suite shows conv ops reaching this branch (`dev > it`) on dims **`i`, `j`, `ki`, `kj`** — including the kernel dims `ki`/`kj`, which are *not* in `_CONV2D_SPATIAL_DIM_NAMES`:

  ```
  CONVGAP op=depthwiseconv2dnative dim=j  dev=64  it=62  suppressed=True
  CONVGAP op=depthwiseconv2dnative dim=i  dev=64  it=62  suppressed=True
  CONVGAP op=depthwiseconv2dnative dim=kj dev=3   it=1   suppressed=True
  CONVGAP op=depthwiseconv2dnative dim=ki dev=3   it=1   suppressed=True
  ```

  Suppressing `i`/`j` only would hand `ki`/`kj` a `backGap`, and the depthwise-conv2d tests only pass when `ki`/`kj` are *also* suppressed — consistent with conv2d handling its entire device/iteration gap in `_conv2d_sdsc_fields`. So `not _is_conv(op)` preserves the existing conv2d behavior exactly while restoring the `backGap` for non-conv ops; the comment is updated to describe that.

#### Which issue(s) this PR is related to:

<!-- none -->

#### Special notes for your reviewer:

Small guard correction (3 insertions, 9 deletions incl. the now-dead `_CONV2D_SPATIAL_DIM_NAMES` tuple). Verified against the existing `test_dwise_conv2d_*` suite (`tests/inductor/test_inductor_ops.py`, `-k dwise_conv2d`), which stays green — the new form leaves conv2d addressing byte-identical. No regression test is added for the fixed non-conv case: the incorrect suppression is only *observable* when an unaligned dim emits a `backGap` on an `i`/`j`-labeled dim, and no op on `main` currently drives that path (it requires the restickify output-padding work, still in flight as #3110). The downstream padding branch's `test_strict_nd_transpose_clone[2x2x3x65x4]` fails without this fix and passes with it; the culprit was confirmed via a rebase-based bisect landing on #3510.

#### Does this PR introduce a user-facing change?

No.

#### Additional note:
