### PR TITLE
ci: honor the integration-test label in the merge queue too

### DIFF
--- a/.github/actions/detect-integration-test-label/action.yml
+++ b/.github/actions/detect-integration-test-label/action.yml
@@ -1,0 +1,60 @@
+name: Detect integration-test label
+description: |
+  Reports whether the PR behind the triggering event carries the
+  `integration-test` label, for both pull_request and merge_group events.
+
+  A merge_group payload has no pull_request object, so the label cannot be read
+  with `contains(github.event.pull_request.labels.*.name, ...)` the way it can on
+  a pull_request event. The queue's ref carries the originating PR number
+  (gh-readonly-queue/<base>/pr-<n>-<sha>), so that number is parsed out and the
+  PR queried -- labels remain readable after merge, so this stays correct for an
+  entry that merges while the queue is still running.
+
+outputs:
+  labeled:
+    description: >-
+      'true' if the originating PR has the `integration-test` label, meaning the
+      Jenkins integration run owns this commit's testing; 'false' otherwise
+      (including when no PR can be resolved, so tests run rather than silently
+      being skipped).
+    value: ${{ steps.detect.outputs.labeled }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve integration-test label
+      id: detect
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        EVENT_NAME: ${{ github.event_name }}
+        PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        MERGE_GROUP_REF: ${{ github.event.merge_group.head_ref }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -uo pipefail
+        labeled=false
+
+        if [ "$EVENT_NAME" = "pull_request" ]; then
+          # Labels are already in the payload -- no API call needed.
+          if printf '%s' "$PR_LABELS" | grep -q '"integration-test"'; then
+            labeled=true
+          fi
+        elif [ "$EVENT_NAME" = "merge_group" ]; then
+          # gh-readonly-queue/main/pr-3695-<sha> -> 3695
+          pr="$(printf '%s' "$MERGE_GROUP_REF" | sed -n 's|.*/pr-\([0-9]\+\)-[0-9a-f]\+$|\1|p')"
+          if [ -n "$pr" ]; then
+            # Fail OPEN: on any API error the label is treated as absent, so the
+            # tests run. A spurious run is recoverable; silently skipping the only
+            # gate on a commit entering main is not.
+            if gh api "repos/${REPO}/pulls/${pr}" --jq '.labels[].name' 2>/dev/null \
+                 | grep -qx 'integration-test'; then
+              labeled=true
+            fi
+          else
+            echo "could not parse a PR number from '${MERGE_GROUP_REF}' -- assuming unlabeled"
+          fi
+        fi
+
+        echo "event=${EVENT_NAME} integration-test labeled=${labeled}"
+        echo "labeled=${labeled}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/detect-integration-test-label/action.yml
+++ b/.github/actions/detect-integration-test-label/action.yml
@@ -41,8 +41,21 @@ runs:
             labeled=true
           fi
         elif [ "$EVENT_NAME" = "merge_group" ]; then
-          # gh-readonly-queue/main/pr-3695-<sha> -> 3695
-          pr="$(printf '%s' "$MERGE_GROUP_REF" | sed -n 's|.*/pr-\([0-9]\+\)-[0-9a-f]\+$|\1|p')"
+          # gh-readonly-queue/main/pr-3695-<sha> -> 3695. Bash parameter expansion
+          # rather than sed: `\+` is a GNU extension that yields an EMPTY match on BSD
+          # sed instead of erroring, so a regex that works on the runner can silently
+          # extract nothing elsewhere -- and "no PR number" reads as "unlabeled", which
+          # would quietly run the full suite on every queued entry.
+          pr=""
+          case "$MERGE_GROUP_REF" in
+            */pr-*-*)
+              pr="${MERGE_GROUP_REF##*/pr-}"   # 3695-<sha>
+              pr="${pr%%-*}"                    # 3695
+              case "$pr" in
+                ''|*[!0-9]*) pr="" ;;           # not all digits -> treat as unparseable
+              esac
+              ;;
+          esac
           if [ -n "$pr" ]; then
             # Fail OPEN: on any API error the label is treated as absent, so the
             # tests run. A spurious run is recoverable; silently skipping the only

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -150,23 +150,29 @@ jobs:
   #   run-tests result = skipped -> docs-only PR, no tests -> green (instant)
   #   run-tests result = failure -> one or more suites bad -> red   (blocks merge)
   #
-  # For an `integration-test`-labeled PR this job doesn't run at all
+  # This job must ALWAYS run, including for an `integration-test`-labeled commit:
+  # it is a REQUIRED check, and a required check that is skipped is reported as
+  # MISSING rather than green, which blocks the merge queue outright. So when the
+  # label hands testing to Jenkins, run-tests is skipped but this gate still runs
+  # and reports green -- Jenkins publishes its own verdict separately.
   # ---------------------------------------------------------------------------
   run-spyre-unit-tests:
     name: Run Spyre unit tests
     runs-on: ubuntu-latest
     needs: [changes, run-tests]
-    # Same label gate as run-tests: this job publishes the aggregate check, so
-    # leaving it enabled while run-tests is skipped would report a verdict for a
-    # suite that never ran.
-    if: |
-      always() &&
-      needs.changes.outputs.integration_labeled != 'true'
+    if: always()
     steps:
       - name: Evaluate test results
         run: |-
           RESULT="${{ needs.run-tests.result }}"
           echo "run-tests result: ${RESULT}"
+
+          if [[ "${{ needs.changes.outputs.integration_labeled }}" == "true" ]]; then
+            echo "integration-test label set -- the Jenkins integration run owns this"
+            echo "commit's testing and reports its own check. Passing this required"
+            echo "gate so the merge queue is not blocked by a missing check."
+            exit 0
+          fi
 
           if [[ "${RESULT}" == "success" ]]; then
             echo "All test suites passed."

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -90,6 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code_changed: ${{ steps.filter.outputs.code_changed }}
+      integration_labeled: ${{ steps.label.outputs.labeled }}
     steps:
       - name: Checkout composite actions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -101,18 +102,27 @@ jobs:
         id: filter
         uses: ./.github/actions/detect-doc-only-change
 
+      - name: Check for the integration-test label
+        id: label
+        uses: ./.github/actions/detect-integration-test-label
+
   # ---------------------------------------------------------------------------
   # Job 2: delegate to the shared test matrix
   #
   # Only runs when `changes.code_changed == 'true'`. For docs-only PRs the
   # reusable workflow is never invoked — no hardware runners are consumed.
-  # Also skipped when `integration-test` is labeled -- spyre-framework handles it
+  # Also skipped when `integration-test` is labeled -- spyre-frameworks' Jenkins
+  # integration run owns this commit's testing instead. Read via the composite
+  # action, NOT `github.event.pull_request.labels`: a merge_group payload has no
+  # pull_request object, so the inline expression is always false in the queue and
+  # the whole suite re-ran there -- on one measured merge-queue commit that was
+  # 815 GHA check-runs / ~21 h of runner time re-testing what the PR just passed.
   # ---------------------------------------------------------------------------
   run-tests:
     needs: changes
     if: |
       needs.changes.outputs.code_changed == 'true' &&
-      !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'integration-test'))
+      needs.changes.outputs.integration_labeled != 'true'
     uses: ./.github/workflows/_test_matrix.yaml
     with:
       runner_label: linux
@@ -146,9 +156,12 @@ jobs:
     name: Run Spyre unit tests
     runs-on: ubuntu-latest
     needs: [changes, run-tests]
+    # Same label gate as run-tests: this job publishes the aggregate check, so
+    # leaving it enabled while run-tests is skipped would report a verdict for a
+    # suite that never ran.
     if: |
       always() &&
-      !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'integration-test'))
+      needs.changes.outputs.integration_labeled != 'true'
     steps:
       - name: Evaluate test results
         run: |-

--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -56,6 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code_changed: ${{ steps.filter.outputs.code_changed }}
+      integration_labeled: ${{ steps.label.outputs.labeled }}
     steps:
       - name: Checkout composite actions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -67,15 +68,22 @@ jobs:
         id: filter
         uses: ./.github/actions/detect-doc-only-change
 
+      - name: Check for the integration-test label
+        id: label
+        uses: ./.github/actions/detect-integration-test-label
+
   # Build the torch_spyre._C extension ONCE and publish it as a wheel; the
   # matrix job below installs that single wheel instead of recompiling per entry.
   build:
     name: Build torch-spyre wheel (once)
     needs: changes
-    # Also skipped when `integration-test` is labeled -- Jenkins handles it instead
+    # Also skipped when `integration-test` is labeled -- Jenkins handles it instead.
+    # Read via the composite action: a merge_group payload carries no
+    # pull_request object, so the inline labels expression never matched in the
+    # queue and this rebuilt/retested every queued entry.
     if: |
       needs.changes.outputs.code_changed == 'true' &&
-      !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'integration-test'))
+      needs.changes.outputs.integration_labeled != 'true'
     # Compile-only: needs the backend image + SDK toolchain but NO physical Spyre
     # card, so it targets the cardless spyre_pf_x0 pool and leaves card runners
     # for the test jobs.


### PR DESCRIPTION
## Problem

The `integration-test` label hands a commit's testing to the Jenkins integration
run, but the existing gate only matches `pull_request` events:

```yaml
!(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'integration-test'))
```

A `merge_group` payload has **no `pull_request` object**, so that conjunct is always
false in the queue and every heavy suite re-runs there — re-testing what the PR just
passed, on the very runners the label exists to avoid. Stale runners then fail the
queued build.

Measured on merge-queue commit `2160f817` (PR-3695): **817 check-runs — 815 from
GitHub Actions**, 2 from Jenkins, ~**21 h** of runner time on that one commit.

## Fix

A `detect-integration-test-label` composite action, in the same shape as the existing
`detect-doc-only-change` (which already handles this pull_request-vs-merge_group
asymmetry). For `merge_group` it recovers the PR number from the queue ref
(`gh-readonly-queue/<base>/pr-<n>-<sha>`) and reads that PR's labels — verified labels
remain readable after merge, so this stays correct for an entry that merges while the
queue is still running.

**Fails open**: an unparseable ref or API error reports unlabeled, so tests run. A
spurious run is recoverable; silently skipping the only gate on a commit entering
`main` is not.

## Required checks are deliberately left running

`run-spyre-unit-tests` is a **required** check (`tests / Run Spyre unit tests`, per its
own job comment). It is *not* gated on the label — a skipped required check is reported
as **MISSING**, not green, which would block the queue entry outright. It now always
runs and exits 0 when the label is set, stating why in the log. Only `run-tests` (the
matrix) is skipped.

Jenkins already mirrors the same verdict onto that check name via `check_names` in
spyre-frameworks' `pipelines/components/torch-spyre/config.yaml`:

    check_names: ["Run Spyre unit tests", "Spyre test (merge-queue)"]

**DCO** (external app) and **linters** (no label gate) keep reporting from GHA, unchanged.

## One thing to confirm before merging

The job comment says the required context is `tests / Run Spyre unit tests`
(workflow-prefixed), while `config.yaml` mirrors the bare `Run Spyre unit tests`. Both
names appear on PR-3175. If branch protection requires the **prefixed** form, the
Jenkins mirror won't satisfy it and the GHA job can't stand aside. I couldn't read
branch protection to check (`HTTP 404` for my token).

## Testing

YAML validated; no stale `pull_request`-only label expressions remain. Not yet
exercised in a live queue.
