### PR TITLE
Rebase LX relayout materialization

### DIFF
--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -34,7 +34,7 @@ def _coordinates(splits, num_cores, **kwargs):
     mapping = core_to_slice_mapping(dims, splits, num_cores, **kwargs)
     core_id = sympy.Symbol("core_id")
     return [
-        tuple(int(mapping[str(dim)].subs(core_id, core)) for dim in dims)
+        tuple(int(mapping[dim].subs(core_id, core)) for dim in dims)
         for core in range(num_cores)
     ]
 
@@ -162,7 +162,7 @@ def test_planner_and_sdsc_use_the_same_mapping(monkeypatch, op, reduction_contig
 
     sdsc_spec, renamed = parse_op_spec(op_spec)
     sdsc_output_mapping = {
-        device_dim: sdsc_spec.core_id_to_work_slice[str(renamed[dim])]
+        device_dim: sdsc_spec.core_id_to_work_slice[renamed[dim]]
         for device_dim, dim in enumerate(dims[:2])
     }
     assert representable

--- a/tests/inductor/test_kernel_provenance.py
+++ b/tests/inductor/test_kernel_provenance.py
@@ -37,6 +37,7 @@ from torch_spyre._inductor.op_spec import (
     OpSpec,
     SourceLoc,
     TensorArg,
+    TensorWorkDivision,
 )
 from torch_spyre._inductor.kernel_provenance import (
     build_kernel_provenance_descriptor,
@@ -237,6 +238,11 @@ class TestKernelProvenanceDescriptor:
                 dataclasses.replace(arg, element_arrangement=ElementArrangement.EXX2)
             ],
         )
+        owned_arg = dataclasses.replace(
+            arg,
+            work_division=TensorWorkDivision({c0: 2}, {c0: Symbol("core_id")}),
+        )
+        changed_owner = dataclasses.replace(first, args=[owned_arg])
 
         first_descriptor = build_kernel_provenance_descriptor([first])
         reordered_descriptor = build_kernel_provenance_descriptor([reordered_metadata])
@@ -244,14 +250,17 @@ class TestKernelProvenanceDescriptor:
         changed_arrangement_descriptor = build_kernel_provenance_descriptor(
             [changed_arrangement]
         )
+        changed_owner_descriptor = build_kernel_provenance_descriptor([changed_owner])
 
         assert first_descriptor is not None
         assert reordered_descriptor is not None
         assert changed_descriptor is not None
         assert changed_arrangement_descriptor is not None
+        assert changed_owner_descriptor is not None
         assert reordered_descriptor.key == first_descriptor.key
         assert changed_descriptor.key != first_descriptor.key
         assert changed_arrangement_descriptor.key != first_descriptor.key
+        assert changed_owner_descriptor.key != first_descriptor.key
 
     def test_pins_rich_canonical_bundle_key(self):
         c0 = Symbol("c0")
@@ -337,7 +346,9 @@ class TestKernelProvenanceDescriptor:
         assert original is not None
         assert reconstructed == original
 
-    @pytest.mark.parametrize("changed_schema", [OpSpec, TensorArg, LoopSpec])
+    @pytest.mark.parametrize(
+        "changed_schema", [OpSpec, TensorArg, TensorWorkDivision, LoopSpec]
+    )
     def test_rejects_finalized_schema_drift(self, changed_schema):
         real_fields = dataclasses.fields
 
@@ -367,6 +378,7 @@ class TestKernelProvenanceDescriptor:
         [
             (OpSpec, "iteration_space"),
             (TensorArg, "device_coordinates"),
+            (TensorWorkDivision, "work_slices"),
             (LoopSpec, "body"),
         ],
     )

--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -1667,10 +1667,8 @@ class TestBoundaryCloneInPlace(BaseTestScratchpadUsage):
         consumer ``p`` (whose result is itself read, so it is a realized candidate)
         reuses ``y``'s slot -- i.e. the output-feeding buffer is an in-place parent.
         This is a regression guard: if output in-place ever breaks, it fails here."""
-        from torch_spyre._inductor.scratchpad.allocator import (
-            ScratchpadAllocator,
-            _op_short_name,
-        )
+        from torch_spyre._inductor.pass_utils import op_short_name
+        from torch_spyre._inductor.scratchpad.allocator import ScratchpadAllocator
 
         x = self.rand_device((64, 1024))
 
@@ -1695,7 +1693,7 @@ class TestBoundaryCloneInPlace(BaseTestScratchpadUsage):
                 output_feeders.add(name)
                 op = by_name.get(name)
                 # A graph output that is a clone pins the buffer it copies.
-                if op is not None and _op_short_name(op) == "clone":
+                if op is not None and op_short_name(op) == "clone":
                     output_feeders.update(d.name for d in op.get_read_writes().reads)
 
         with self.pre_scheduling_iterating_pass(collect_feeders):
@@ -1741,10 +1739,8 @@ class TestBoundaryCloneInPlace(BaseTestScratchpadUsage):
         returned ``y`` is captured before its slot is overwritten. We assert the
         reuse edge is actually offered (the hazard is exercised, not vacuous) and
         that both returned values are correct."""
-        from torch_spyre._inductor.scratchpad.allocator import (
-            ScratchpadAllocator,
-            _op_short_name,
-        )
+        from torch_spyre._inductor.pass_utils import op_short_name
+        from torch_spyre._inductor.scratchpad.allocator import ScratchpadAllocator
 
         x = self.rand_device((64, 1024))
 
@@ -1770,7 +1766,7 @@ class TestBoundaryCloneInPlace(BaseTestScratchpadUsage):
             for name in graph.get_output_names():
                 output_feeders.add(name)
                 op = by_name.get(name)
-                if op is not None and _op_short_name(op) == "clone":
+                if op is not None and op_short_name(op) == "clone":
                     output_feeders.update(d.name for d in op.get_read_writes().reads)
 
         with self.pre_scheduling_iterating_pass(collect_feeders):
@@ -1804,10 +1800,8 @@ class TestBoundaryCloneInPlace(BaseTestScratchpadUsage):
         """Same aliasing hazard as the sibling test, exercised on the co-optimizing
         (joint CP-SAT) path: a returned buffer whose LX slot is reused in place must
         still be handed back to the caller intact (#3212)."""
-        from torch_spyre._inductor.scratchpad.allocator import (
-            CoOptimizingAllocator,
-            _op_short_name,
-        )
+        from torch_spyre._inductor.pass_utils import op_short_name
+        from torch_spyre._inductor.scratchpad.allocator import CoOptimizingAllocator
 
         x = self.rand_device((64, 1024))
 
@@ -1833,7 +1827,7 @@ class TestBoundaryCloneInPlace(BaseTestScratchpadUsage):
             for name in graph.get_output_names():
                 output_feeders.add(name)
                 op = by_name.get(name)
-                if op is not None and _op_short_name(op) == "clone":
+                if op is not None and op_short_name(op) == "clone":
                     output_feeders.update(d.name for d in op.get_read_writes().reads)
 
         with self.pre_scheduling_iterating_pass(collect_feeders):
@@ -1872,7 +1866,7 @@ class TestBoundaryCloneInPlace(BaseTestScratchpadUsage):
         it in place, so it does not occupy a dedicated slot. We read the final LX
         allocations after the allocator runs and assert the input clone's address is
         shared by another LX buffer (and values are correct)."""
-        from torch_spyre._inductor.scratchpad.allocator import _op_short_name
+        from torch_spyre._inductor.pass_utils import op_short_name
 
         x = self.rand_device((64, 1024))
 
@@ -1889,7 +1883,7 @@ class TestBoundaryCloneInPlace(BaseTestScratchpadUsage):
                     graph.get_buffer(op.name).get_layout(), "allocation", {}
                 )
                 per_op[op.name] = {
-                    "short": _op_short_name(op),
+                    "short": op_short_name(op),
                     "lx": alloc.get("lx"),
                     "reads": [d.name for d in op.get_read_writes().reads],
                 }

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -729,7 +729,7 @@ def test_lx_relayout_two_private_consumers_are_numerically_correct(second_consum
     }
 
 
-def test_lx_relayout_allocation_is_atomic_and_retries_stock_once():
+def test_lx_relayout_allocation_is_atomic_and_retries_stock_once(caplog):
     complete = [_relayout_plan("complete", name) for name in ("a", "b")]
     incomplete = [_relayout_plan("incomplete", name) for name in ("c", "d")]
 
@@ -780,7 +780,8 @@ def test_lx_relayout_allocation_is_atomic_and_retries_stock_once():
         0,
         2,
     ]
-    allocation = solve(allocator, buffers, graph)
+    with caplog.at_level(logging.DEBUG, logger="spyre.inductor.scratchpad.allocator"):
+        allocation = solve(allocator, buffers, graph)
     by_name = {buffer.name: buffer for buffer in allocation}
     assert by_name["complete"].address == 0
     assert [by_name[plan.destination_name].uses for plan in complete] == [
@@ -791,8 +792,15 @@ def test_lx_relayout_allocation_is_atomic_and_retries_stock_once():
     assert by_name["incomplete"].address is None
     assert all(by_name[plan.destination_name].address is None for plan in incomplete)
     assert allocator._lx_relayout_plans == {plan.edge: plan for plan in complete}
+    assert any(
+        "rejected LX relayout group source=incomplete" in record.message
+        and incomplete[1].destination_name in record.message
+        and "None" in record.message
+        for record in caplog.records
+    )
 
     Solver.calls = 0
+    caplog.clear()
     allocator = ScratchpadAllocator(Solver, 1024)
     allocator._lx_relayout_plans = {plan.edge: plan for plan in incomplete}
     graph = SimpleNamespace(
@@ -805,9 +813,15 @@ def test_lx_relayout_allocation_is_atomic_and_retries_stock_once():
     allocator._generate_buffers = lambda _graph: [
         LifetimeBoundBuffer("incomplete", 128, [2, 3])
     ]
-    fallback = solve(allocator, buffers, graph)
+    with caplog.at_level(logging.DEBUG, logger="spyre.inductor.scratchpad.allocator"):
+        fallback = solve(allocator, buffers, graph)
     assert [(buffer.name, buffer.address) for buffer in fallback] == [("incomplete", 0)]
     assert Solver.calls == 2
+    assert any(
+        "no LX relayout groups survived allocation; retrying stock LX placement"
+        in record.message
+        for record in caplog.records
+    )
 
 
 class _RelayoutNode:

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -736,6 +736,103 @@ def test_lx_relayout_normalizes_ownership_and_lowers_only_in_superdsc():
     assert core_three == {inner: 1, outer: 1}
 
 
+def _folds(node):
+    """Per-dim core and element-array fold factors from one allocate node."""
+    return {
+        dim: {
+            "core_fold": next(
+                attr["factor_"]
+                for attr in meta["folds"]["dim_prop_attr"]
+                if attr["label_"] == "core_fold"
+            ),
+            "elem_arr": [
+                attr["factor_"]
+                for attr in meta["folds"]["dim_prop_attr"]
+                if attr["label_"].startswith("elem_arr")
+            ],
+        }
+        for dim, meta in node["coordinates_"]["coordInfo"].items()
+    }
+
+
+def test_lx_relayout_folds_share_element_arrays_across_ownership():
+    """Pin the fold factors for a relayout whose two sides split differently.
+
+    The permutation case above keeps both sides on the same 8-way split. Here a
+    4x8 producer feeds a 32-way destination, so the ownership genuinely differs
+    -- and the invariant worth pinning is that the two sides still present the
+    *same* element arrays, expressing the difference only through core_fold and
+    coreIdToWkSlice_.
+
+    That is what makes one loop nest serve both tensors. An earlier revision
+    emitted per-side element arrays instead (mb 128 against 16 here), and
+    DeepTools rejected the descriptor with "[distributeElemArrToTemporalLoops]
+    Not enough elements to distribute" because the cardinalities disagreed along
+    a looped dim. No per-core-slice assertion can see that; these can.
+    """
+
+    m, n = Symbol("m"), Symbol("n")
+    source_view = PerCoreView(
+        ((0, 4), (1, 8)), ((0, floor(_CORE_ID / 8)), (1, Mod(_CORE_ID, 8)))
+    )
+    destination_view = PerCoreView(((0, 32),), ((0, _CORE_ID),))
+    coordinates = [m, floor(n / 64), Mod(n, 64)]
+    base = TensorArg(
+        True, -1, DataFormats.SEN169_FP16, [512, 200, 64], coordinates, {"lx": 0}
+    )
+    spec = OpSpec(
+        IDENTITY_OP,
+        False,
+        {m: (512, 32), n: (12800, 1)},
+        [
+            replace(
+                base,
+                work_division=work_division_from_view(source_view, coordinates, (m, n)),
+            ),
+            replace(
+                base,
+                is_input=False,
+                allocation={"lx": 0x44000},
+                work_division=work_division_from_view(
+                    destination_view, coordinates, (m, n)
+                ),
+            ),
+        ],
+        {},
+    )
+    root, allocations = _compile_spec(spec)
+
+    assert set(root["dscs_"][0]) == {"shuffle"}
+    assert root["numCoresUsed_"] == 32
+
+    # Derived from the declared views rather than transcribed: the source owns
+    # (core // 8, core % 8) of a 4x8 split, the destination (core, 0) of 32.
+    source_map, destination_map = (
+        node["coordinates_"]["coreIdToWkSlice_"] for node in allocations
+    )
+    assert source_map == {
+        str(core): {"mb": core // 8, "out": core % 8} for core in range(32)
+    }
+    assert destination_map == {str(core): {"mb": core, "out": 0} for core in range(32)}
+
+    source_folds, destination_folds = (_folds(node) for node in allocations)
+    assert source_folds == {
+        "mb": {"core_fold": 4, "elem_arr": [16]},
+        "out": {"core_fold": 8, "elem_arr": [200, 64]},
+    }
+    assert destination_folds == {
+        "mb": {"core_fold": 32, "elem_arr": [16]},
+        "out": {"core_fold": 1, "elem_arr": [200, 64]},
+    }
+    # The load-bearing part: element arrays agree, only core_fold differs.
+    assert {dim: f["elem_arr"] for dim, f in source_folds.items()} == {
+        dim: f["elem_arr"] for dim, f in destination_folds.items()
+    }
+    assert {dim: f["core_fold"] for dim, f in source_folds.items()} != {
+        dim: f["core_fold"] for dim, f in destination_folds.items()
+    }
+
+
 @config.patch(
     {
         "sencores": 8,

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -32,6 +32,7 @@ from torch._dynamo.test_case import (
 )
 from torch._functorch.aot_autograd import aot_module_simplified
 from torch._functorch._aot_autograd.utils import make_boxed_func
+from torch._inductor.dependencies import MemoryDep
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code, InputType
 
@@ -581,6 +582,89 @@ def test_lx_relayout_activation_policy_is_source_wide():
     ):
         assert not lx_relayout_module._is_activation_source({}, producer)
         assert lx_relayout_module._is_activation_source({"input": dep}, producer)
+
+
+def test_lx_relayout_rejection_names_the_consumer_and_the_gate(caplog):
+    """One uncoverable read drops the whole source, and says which and why."""
+
+    class _Pointwise:
+        pass
+
+    class _Consumer:
+        def __init__(self, name):
+            self.name = name
+            self.data = _Pointwise()
+            self.layout = SimpleNamespace(device_layout=object())
+
+        def get_name(self):
+            return self.name
+
+    x, y = Symbol("x"), Symbol("y")
+    producer, good, bad = _Consumer("shared"), _Consumer("good"), _Consumer("bad")
+    write = MemoryDep("shared", 64 * x + y, (x, y), (2, 64))
+    read_good = MemoryDep("shared", 64 * x + y, (x, y), (2, 64))
+    read_bad = MemoryDep("shared", 64 * x + y, (x, y), (2, 64))
+    read_writes = {
+        "shared": SimpleNamespace(reads=[], writes=[write]),
+        "good": SimpleNamespace(reads=[read_good], writes=[]),
+        "bad": SimpleNamespace(reads=[read_bad], writes=[]),
+    }
+    views = {
+        producer: PerCoreView(((1, 2),), ((1, _CORE_ID),)),
+        good: PerCoreView(((1, 2),), ((1, 1 - _CORE_ID),)),
+        bad: PerCoreView(((0, 2),), ((0, _CORE_ID),)),
+    }
+    coordinates = [x, Mod(y, 64)]
+
+    with (
+        config.patch({"lx_planner_relayout": True, "ktir_emitter": False}),
+        mock_patch.object(lx_relayout_module, "ComputedBuffer", _Consumer),
+        mock_patch.object(lx_relayout_module, "Pointwise", _Pointwise),
+        mock_patch.object(lx_relayout_module, "FixedTiledLayout", SimpleNamespace),
+        mock_patch.object(
+            lx_relayout_module, "MutationLayoutSHOULDREMOVE", type("NoMut", (), {})
+        ),
+        mock_patch.object(
+            lx_relayout_module, "op_read_writes", lambda op: read_writes[op.get_name()]
+        ),
+        mock_patch.object(lx_relayout_module, "_single_write", lambda *_: write),
+        mock_patch.object(lx_relayout_module, "_is_matmul_op", lambda _: False),
+        mock_patch.object(lx_relayout_module, "_op_num_cores", lambda _: 2),
+        mock_patch.object(lx_relayout_module, "_is_activation_source", lambda *_: True),
+        mock_patch.object(
+            lx_relayout_module,
+            "_per_core_view_on_buf",
+            lambda op, *_: (views[op], False, True),
+        ),
+        mock_patch.object(
+            lx_relayout_module,
+            "iteration_space_from_op",
+            lambda _: {x: Integer(2), y: Integer(64)},
+        ),
+        mock_patch.object(
+            lx_relayout_module, "work_division_from_view", lambda *_: None
+        ),
+        mock_patch.object(
+            lx_relayout_module, "materialized_lx_relayouts", lambda _: {}
+        ),
+        # "bad" has no resolvable device coordinates, so the plan already made
+        # for "good" has to be abandoned with it.
+        mock_patch.object(
+            lx_relayout_module,
+            "try_device_coordinates",
+            lambda _layout, dep, _sizes: None if dep is read_bad else coordinates,
+        ),
+        caplog.at_level(logging.DEBUG, logger=lx_relayout_module.logger.name),
+    ):
+        plans = lx_relayout_module.collect_lx_relayout_plans(
+            SimpleNamespace(operations=[producer, good, bad])
+        )
+
+    assert plans == []
+    dropped = [r.getMessage() for r in caplog.records if "dropped" in r.getMessage()]
+    assert len(dropped) == 1, caplog.records
+    assert "shared" in dropped[0]
+    assert "bad read has no device coordinates" in dropped[0]
 
 
 def _compile_spec(spec, normalize=True):

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -16,7 +16,7 @@ from collections.abc import Sequence
 from dataclasses import replace
 import logging
 import logging.handlers
-import re
+import regex as re
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch as mock_patch

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -13,14 +13,16 @@
 # limitations under the License.
 
 from collections.abc import Sequence
+from dataclasses import replace
 import logging
 import logging.handlers
+import re
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch as mock_patch
 
 import pytest
-from sympy import Integer, Symbol
+from sympy import floor, Integer, Mod, Symbol
 import torch
 import torch.fx.traceback
 from torch.fx.graph_module import GraphModule
@@ -35,8 +37,22 @@ from torch._inductor.utils import run_and_get_code, InputType
 
 
 from torch_spyre._inductor import config, spyre_hint
+import torch_spyre._inductor.lx_relayout as lx_relayout_module
+import torch_spyre._inductor.scheduler as scheduler_module
 import torch_spyre._inductor.work_division as _wd
 import torch_spyre._inductor.wsr.propagate_named_dims as _pnd
+from torch_spyre._C import DataFormats
+from torch_spyre._inductor.codegen.superdsc import compile_op_spec, parse_op_spec
+from torch_spyre._inductor.constants import IDENTITY_OP
+from torch_spyre._inductor.lx_relayout import (
+    LXRelayoutPlan,
+    work_division_from_view,
+)
+from torch_spyre._inductor.op_spec import OpSpec, TensorArg, TensorWorkDivision
+from torch_spyre._inductor.pass_utils import PerCoreView
+from torch_spyre._inductor.scratchpad.allocator import ScratchpadAllocator
+from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
+from torch_spyre._inductor.spyre_kernel import _remap_work_division, simplify_op_spec
 
 _LAUNCH_JOBPLAN = "torch_spyre.execution.kernel_runner.launch_jobplan"
 _PREPARE_KERNEL = "torch_spyre.execution.kernel_runner.prepare_kernel"
@@ -535,6 +551,400 @@ class TestNamedWorkDivisionHint(InductorTestCase):
             Exception, "reduction dimensions|expected exactly 1 reduction variable"
         ):
             torch.compile(fn, dynamic=False)(x)
+
+
+_CORE_ID = Symbol("core_id")
+_SOURCE_VIEW = PerCoreView(
+    ((0, 4), (1, 2)), ((0, floor(_CORE_ID / 2)), (1, Mod(_CORE_ID, 2)))
+)
+_DESTINATION_VIEW = PerCoreView(((0, 8),), ((0, _CORE_ID),))
+
+
+def _relayout_plan(source="source", consumer="consumer"):
+    return LXRelayoutPlan(source, consumer, _SOURCE_VIEW, _DESTINATION_VIEW, 8)
+
+
+def test_lx_relayout_activation_policy_is_source_wide():
+    dep = SimpleNamespace(name="input")
+    producer = SimpleNamespace()
+    with (
+        mock_patch.object(
+            lx_relayout_module, "op_short_name", return_value="restickify"
+        ),
+        mock_patch.object(
+            lx_relayout_module,
+            "op_read_writes",
+            return_value=SimpleNamespace(reads=[dep]),
+        ),
+        mock_patch.object(lx_relayout_module, "MemoryDep", SimpleNamespace),
+        mock_patch.object(lx_relayout_module, "ComputedBuffer", SimpleNamespace),
+    ):
+        assert not lx_relayout_module._is_activation_source({}, producer)
+        assert lx_relayout_module._is_activation_source({"input": dep}, producer)
+
+
+def _compile_spec(spec, normalize=True):
+    if normalize:
+        simplify_op_spec(spec)
+    payload, *_ = compile_op_spec(0, spec, [])
+    root = next(iter(payload.values()))
+    dsc = next(iter(root["dscs_"][0].values()))
+    return root, [
+        node for node in dsc["scheduleTree_"] if node["nodeType_"] == "allocate"
+    ]
+
+
+def test_lx_relayout_normalizes_ownership_and_lowers_only_in_superdsc():
+    m, n = Symbol("m"), Symbol("n")
+    source_view = PerCoreView(((1, 8),), ((1, _CORE_ID),))
+    destination_view = PerCoreView(((1, 8),), ((1, 7 - _CORE_ID),))
+    coordinates = [Mod(n, 32), floor(n / 32), Mod(m, 64)]
+    base = TensorArg(
+        True, -1, DataFormats.SEN169_FP16, [32, 8, 64], coordinates, {"lx": 0}
+    )
+    args = [
+        replace(
+            base,
+            work_division=work_division_from_view(source_view, coordinates, (m, n)),
+        ),
+        replace(
+            base,
+            is_input=False,
+            allocation={"lx": 256},
+            work_division=work_division_from_view(
+                destination_view, coordinates, (m, n)
+            ),
+        ),
+    ]
+    spec = OpSpec(IDENTITY_OP, False, {n: (256, 8), m: (64, 1)}, args, {})
+    root, allocations = _compile_spec(spec)
+    assert spec.op == IDENTITY_OP
+    assert set(root["dscs_"][0]) == {"shuffle"}
+    assert root["dscs_"][0]["shuffle"]["labeledDs_"][0]["dsType_"] == "OUTPUT"
+    assert all(arg.work_division.work_slices == {Symbol("z0"): 8} for arg in spec.args)
+    maps = [node["coordinates_"]["coreIdToWkSlice_"] for node in allocations]
+    assert [maps[0][str(i)]["x"] for i in range(8)] == list(range(8))
+    assert [maps[1][str(i)]["x"] for i in range(8)] == list(reversed(range(8)))
+    with pytest.raises(ValueError, match="cannot map device dimension"):
+        work_division_from_view(source_view, [Integer(0), m + n, Integer(0)], (m, n))
+
+    for arg in spec.args:
+        arg.work_division = None
+    ordinary_root, ordinary_allocations = _compile_spec(spec, normalize=False)
+    ordinary_sdsc, _ = parse_op_spec(spec)
+    assert set(ordinary_root["dscs_"][0]) == {IDENTITY_OP}
+    assert all(arg.work_division is not None for arg in ordinary_sdsc.args)
+    assert all(
+        not node["coordinates_"]["coreIdToWkSlice_"] for node in ordinary_allocations
+    )
+
+    old, inner, outer = Symbol("old"), Symbol("inner"), Symbol("outer")
+    remapped = replace(
+        base,
+        work_division=TensorWorkDivision({old: 16}, {old: Mod(_CORE_ID, 16)}),
+    )
+    _remap_work_division(remapped, {old: ((inner, 2), (outer, 8))})
+    assert remapped.work_division is not None
+    core_three = {
+        dim: int(slot.subs(_CORE_ID, 3))
+        for dim, slot in remapped.work_division.core_id_to_work_slice.items()
+    }
+    assert core_three == {inner: 1, outer: 1}
+
+
+@config.patch(
+    {
+        "sencores": 8,
+        "lx_planning": True,
+        "allow_all_ops_in_lx_planning": True,
+        "lx_planner_relayout": True,
+    }
+)
+@pytest.mark.parametrize("second_consumer", ["pointwise", "matmul_lhs", "matmul_rhs"])
+def test_lx_relayout_two_private_consumers_are_numerically_correct(second_consumer):
+    torch.manual_seed(0)
+    m_size = 64 if second_consumer == "matmul_rhs" else 32
+    x = torch.randn(8, m_size, 64, dtype=torch.float16)
+    weight = torch.randn(8, 64, m_size, dtype=torch.float16)
+    for name, size in (
+        ("B", 8),
+        ("M", m_size),
+        ("K", 64),
+        ("N", m_size),
+        ("L", 64),
+    ):
+        _declare_tensor_dim(name, size)
+
+    def fn(x, weight):
+        with spyre_hint(work_div={"B": 4, "M": 2}):
+            hidden = torch.neg(x)
+        with spyre_hint(work_div={"B": 2, "M": 4}):
+            pointwise = torch.relu(hidden)
+        with spyre_hint(work_div={"B": 8}):
+            if second_consumer == "matmul_lhs":
+                second = torch.bmm(hidden, weight)
+            elif second_consumer == "matmul_rhs":
+                second = torch.bmm(weight, hidden)
+            else:
+                second = torch.abs(hidden)
+        return pointwise, second
+
+    device_x = _name_tensor_dims(x.to("spyre"), ["B", "M", "K"])
+    weight_dims = (
+        ["B", "L", "M"] if second_consumer == "matmul_rhs" else ["B", "K", "N"]
+    )
+    device_weight = _name_tensor_dims(weight.to("spyre"), weight_dims)
+    torch._inductor.codecache.FxGraphCache.clear()
+    actual, code = run_and_get_code(
+        torch.compile(fn, dynamic=False, options={"epilogue_fusion": False}),
+        device_x,
+        device_weight,
+    )
+    for index, (got, expected) in enumerate(zip(actual, fn(x, weight))):
+        tolerance = (
+            {"rtol": 2e-2, "atol": 1e-1}
+            if index == 1 and second_consumer.startswith("matmul")
+            else {}
+        )
+        torch.testing.assert_close(got.cpu(), expected, **tolerance)
+    generated = "\n".join(code)
+    identities = [
+        block for block in generated.split("OpSpec(") if "op='identity'" in block[:100]
+    ]
+    ordinary = [
+        block
+        for block in generated.split("OpSpec(")
+        if "op='" in block[:100] and "op='identity'" not in block[:100]
+    ]
+    assert all("work_division=" not in block for block in ordinary)
+    divisions = [
+        re.findall(r"TensorWorkDivision\(work_slices=\{([^}]*)", block)
+        for block in identities
+    ]
+    assert len(divisions) == 2 and all(len(pair) == 2 for pair in divisions)
+    assert {divisions[0][0], divisions[1][0]} == {"sympify('c1'): 2, sympify('c0'): 4"}
+    assert {divisions[0][1], divisions[1][1]} == {
+        "sympify('c1'): 4, sympify('c0'): 2",
+        "sympify('c0'): 8",
+    }
+
+
+def test_lx_relayout_allocation_is_atomic_and_retries_stock_once():
+    complete = [_relayout_plan("complete", name) for name in ("a", "b")]
+    incomplete = [_relayout_plan("incomplete", name) for name in ("c", "d")]
+
+    class Solver:
+        calls = 0
+
+        def __init__(self, buffers, _size):
+            self.buffers = buffers
+
+        def plan_layout(self, log_lx_usage=False):
+            Solver.calls += 1
+            addresses = (
+                {
+                    "complete": 0,
+                    complete[0].destination_name: 256,
+                    complete[1].destination_name: 512,
+                    "incomplete": 768,
+                    incomplete[0].destination_name: 1024,
+                }
+                if Solver.calls == 1
+                else {"incomplete": 0}
+            )
+            for buffer in self.buffers:
+                buffer.address = addresses.get(buffer.name)
+            return list(self.buffers)
+
+    def solve(allocator, buffers, graph):
+        solver = allocator._build_solver(buffers)
+        return allocator._finalize_lx_relayout_allocation(
+            graph, solver, allocator._solve(solver)
+        )[1]
+
+    allocator = ScratchpadAllocator(Solver, 2048)
+    plans = [*complete, *incomplete]
+    allocator._lx_relayout_plans = {plan.edge: plan for plan in plans}
+    graph = SimpleNamespace(
+        operations=[
+            SimpleNamespace(get_name=lambda name=name: name)
+            for name in ("a", "b", "c", "d")
+        ]
+    )
+    buffers = [
+        LifetimeBoundBuffer("complete", 128, [0, 1]),
+        LifetimeBoundBuffer("incomplete", 128, [2, 3]),
+    ]
+    allocator._append_lx_relayout_destinations(graph, buffers)
+    assert next(buffer for buffer in buffers if buffer.name == "complete").uses == [
+        0,
+        2,
+    ]
+    allocation = solve(allocator, buffers, graph)
+    by_name = {buffer.name: buffer for buffer in allocation}
+    assert by_name["complete"].address == 0
+    assert [by_name[plan.destination_name].uses for plan in complete] == [
+        [0, 1],
+        [2, 3],
+    ]
+    assert [by_name[plan.destination_name].address for plan in complete] == [256, 512]
+    assert by_name["incomplete"].address is None
+    assert all(by_name[plan.destination_name].address is None for plan in incomplete)
+    assert allocator._lx_relayout_plans == {plan.edge: plan for plan in complete}
+
+    Solver.calls = 0
+    allocator = ScratchpadAllocator(Solver, 1024)
+    allocator._lx_relayout_plans = {plan.edge: plan for plan in incomplete}
+    graph = SimpleNamespace(
+        operations=[
+            SimpleNamespace(get_name=lambda name=name: name) for name in ("c", "d")
+        ]
+    )
+    buffers = [LifetimeBoundBuffer("incomplete", 128, [0, 1])]
+    allocator._append_lx_relayout_destinations(graph, buffers)
+    allocator._generate_buffers = lambda _graph: [
+        LifetimeBoundBuffer("incomplete", 128, [2, 3])
+    ]
+    fallback = solve(allocator, buffers, graph)
+    assert [(buffer.name, buffer.address) for buffer in fallback] == [("incomplete", 0)]
+    assert Solver.calls == 2
+
+
+class _RelayoutNode:
+    def __init__(self, name, reads=(), writes=(), layout=None):
+        self.name = name
+        self.node = SimpleNamespace(layout=layout or SimpleNamespace(allocation={}))
+        self.read_writes = SimpleNamespace(reads=list(reads), writes=list(writes))
+
+    def get_nodes(self):
+        return [self]
+
+    def get_name(self):
+        return self.name
+
+
+def _relayout_layout(address, view):
+    return SimpleNamespace(allocation={"lx": address}, lx_view=view)
+
+
+def test_lx_relayout_scheduler_checks_final_ownership_projection():
+    m, n = Symbol("m"), Symbol("n")
+    layout = SimpleNamespace(device_layout=object())
+    graph = SimpleNamespace(
+        try_get_buffer=lambda name: (
+            SimpleNamespace(get_layout=lambda: layout) if name == "source" else None
+        )
+    )
+    node, dep = SimpleNamespace(), SimpleNamespace()
+
+    def projectable(coordinates):
+        with (
+            mock_patch.object(scheduler_module, "V", SimpleNamespace(graph=graph)),
+            mock_patch.object(scheduler_module, "FixedTiledLayout", SimpleNamespace),
+            mock_patch.object(
+                scheduler_module,
+                "try_device_coordinates",
+                return_value=coordinates,
+            ),
+            mock_patch.object(
+                scheduler_module, "iteration_space", return_value={m: 32, n: 64}
+            ),
+        ):
+            return scheduler_module._ownership_projectable(
+                node, dep, "source", _SOURCE_VIEW
+            )
+
+    assert projectable([m, n])
+    assert not projectable([m + n, n])
+
+
+def test_lx_relayout_scheduler_demotes_groups_but_not_ordinary_unary():
+    def run_registered(drift):
+        plan = _relayout_plan()
+        src, dst = SimpleNamespace(name="source"), SimpleNamespace(name="destination")
+        unary_src = SimpleNamespace(name="ordinary_source")
+        unary_dst = SimpleNamespace(name="ordinary_unary")
+        layouts = {
+            "source": _relayout_layout(0, _SOURCE_VIEW),
+            "destination": _relayout_layout(256, _DESTINATION_VIEW),
+            "ordinary_source": _relayout_layout(512, _SOURCE_VIEW),
+            "ordinary_unary": _relayout_layout(768, _DESTINATION_VIEW),
+        }
+        node = _RelayoutNode
+        nodes = [
+            node("source", writes=(src,), layout=layouts["source"]),
+            node("destination", (src,), (dst,), layouts["destination"]),
+            node("consumer", reads=(dst,)),
+            node(
+                "ordinary_source",
+                writes=(unary_src,),
+                layout=layouts["ordinary_source"],
+            ),
+            node(
+                "ordinary_unary", (unary_src,), (unary_dst,), layouts["ordinary_unary"]
+            ),
+            node("ordinary_consumer", reads=(unary_dst,)),
+        ]
+        if drift == "missing":
+            nodes = [node for node in nodes if node.name != "destination"]
+        buffers = {
+            name: SimpleNamespace(
+                layout=SimpleNamespace(),
+                get_layout=lambda layout=layout: layout,
+            )
+            for name, layout in layouts.items()
+        }
+        if drift == "missing_buffer":
+            del buffers["destination"]
+        graph = SimpleNamespace(
+            _spyre_lx_relayout_copies={plan.edge: ("destination", plan)},
+            try_get_buffer=buffers.get,
+            get_buffer=buffers.__getitem__,
+        )
+
+        def view(node, _dep, name):
+            if name == "ordinary_source":
+                expected = (
+                    _DESTINATION_VIEW if node.name == "ordinary_unary" else _SOURCE_VIEW
+                )
+            else:
+                expected = _SOURCE_VIEW if name == "source" else _DESTINATION_VIEW
+            return (
+                PerCoreView((), ()) if node.name == drift else expected,
+                False,
+                True,
+            )
+
+        with (
+            mock_patch.object(scheduler_module, "SchedulerNode", _RelayoutNode),
+            mock_patch.object(scheduler_module, "MemoryDep", SimpleNamespace),
+            mock_patch.object(scheduler_module, "FixedTiledLayout", SimpleNamespace),
+            mock_patch.object(lx_relayout_module, "FixedTiledLayout", SimpleNamespace),
+            mock_patch.object(scheduler_module, "V", SimpleNamespace(graph=graph)),
+            mock_patch.object(scheduler_module, "per_core_view_scheduled", view),
+            mock_patch.object(
+                scheduler_module,
+                "_ownership_projectable",
+                side_effect=lambda node, _dep, _name, _view: (
+                    not (drift == "projection" and node.name == "consumer")
+                ),
+            ),
+            config.patch({"lx_planning": True}),
+        ):
+            scheduler_module.demote_incoherent_lx_buffers(nodes)
+        assert graph._spyre_lx_relayout_copies == {}
+        assert "lx" not in layouts["source"].allocation
+        if drift != "missing_buffer":
+            assert "lx" not in layouts["destination"].allocation
+            assert layouts["destination"].lx_view is None
+        assert "lx" not in layouts["ordinary_source"].allocation
+        assert "lx" in layouts["ordinary_unary"].allocation
+
+    run_registered("source")
+    run_registered("consumer")
+    run_registered("projection")
+    run_registered("missing")
+    run_registered("missing_buffer")
 
 
 def aot_backend(gm: GraphModule, example_inputs: Sequence[InputType]):

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -20,6 +20,7 @@ from sympy import Symbol
 from torch_spyre._C import DataFormats, encode_constant
 from torch_spyre._inductor.constants import CONV2D_DIM_LABELS, DEPTHWISE_CONV2D_OP
 from torch_spyre._inductor.errors import Unsupported
+from torch_spyre._inductor.op_spec import TensorWorkDivision
 from torch_spyre._inductor.pass_utils import coeff_through_floor
 
 
@@ -690,6 +691,13 @@ def generate_sdsc(
         }
         for c in range(sdsc_spec.num_cores)
     }
+    operation_work_division = TensorWorkDivision(
+        {dim: int(split) for dim, split in sdsc_spec.work_slices.items()},
+        {dim: sdsc_spec.core_id_to_work_slice[dim] for dim in sdsc_spec.work_slices},
+    )
+    for tensor in sdsc_spec.args:
+        if tensor.work_division is None:
+            tensor.work_division = operation_work_division
     symbolic_dims = sdsc_spec.symbolic_dims or {}
 
     # Register dimension symbols BEFORE address symbols so their IDs never collide.
@@ -1179,7 +1187,7 @@ def generate_sdsc(
             dim_str = str(dim)
             scale = tensor.scales[dim]
             is_tiled = scale == 1
-            nsplits = sdsc_spec.work_slices[dim] if is_tiled else 1
+            nsplits = tensor.work_division.work_slices[dim] if is_tiled else 1
             # dim_size feeds get_conv_params (#3510). size uses #3284's
             # _coord_per_core_size, a safe superset: it returns the windowed
             # span only for forward conv2d (opfunc=="conv2d") and otherwise
@@ -1568,7 +1576,14 @@ def generate_sdsc(
                                         "coordInfo": _build_coord_info(
                                             sdsc_spec.opfunc, tensor, i
                                         ),
-                                        "coreIdToWkSlice_": {},
+                                        "coreIdToWkSlice_": (
+                                            tensor.work_division.to_core_slices(
+                                                sdsc_spec.num_cores
+                                            )
+                                            if sdsc_spec.opfunc == "shuffle"
+                                            and tensor.work_division is not None
+                                            else {}
+                                        ),
                                     },
                                 }
                                 for i, tensor in enumerate(sdsc_spec.args)

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -59,6 +59,8 @@ from torch_spyre._inductor.op_spec import (
     IndirectAccess,
     OpSpec,
     TensorArg,
+    TensorWorkDivision,
+    is_lx_relayout_identity,
 )
 from torch_spyre._inductor.pass_utils import coeff_through_floor
 
@@ -79,6 +81,7 @@ class SDSCArgs:
     allocation: dict[str, Any]
     start_address: int | Symbol
     backGap: dict[Symbol, int]
+    work_division: TensorWorkDivision | None = None
     arg_index: int = -1
     is_index_tensor: bool = False
     related_value_tensor_idx: int = -1
@@ -104,6 +107,7 @@ class SDSCArgs:
             f"  backGap={self.backGap}\n"
             f"  is_index_tensor={self.is_index_tensor}\n"
             f"  related_value_tensor_idx={self.related_value_tensor_idx}\n"
+            f"  work_division={self.work_division}\n"
             f")"
         )
 
@@ -1103,7 +1107,6 @@ def _create_sdsc_tensors(
     # own natural (per-tensor) dim order and the weight gets the KERNEL layout
     # label. Reduced-dim appending (below) is a single-input-reduction concern.
     use_op_dims = not (_is_matmul(op_spec.op) or _is_conv(op_spec.op))
-
     # Detect indirect access from device_coordinates: index tensors are those
     # whose name is referenced by an IndirectAccess in another tensor's coordinates,
     # and value tensors are those that contain IndirectAccess in their coordinates.
@@ -1383,24 +1386,25 @@ def _create_sdsc_tensors(
             get_value_tensor_idx_for_index(op_spec, i) if is_idx_tensor else -1
         )
 
-        sdsc_args.append(
-            SDSCArgs(
-                layout=label,
-                dim_order=dim_order,
-                data_format=arg_data_format,
-                scales=scales,
-                strides=strides,
-                offsets=offsets,
-                max_dim_sizes=max_dim_sizes,
-                allocation=arg.allocation,
-                start_address=start_addr,
-                backGap=backGap,
-                arg_index=arg.arg_index,
-                is_index_tensor=is_idx_tensor,
-                related_value_tensor_idx=related_val_idx,
-                device_tile_advance_expr=arg.device_tile_advance_expr,
-            )
+        sdsc_arg = SDSCArgs(
+            layout=label,
+            dim_order=dim_order,
+            data_format=arg_data_format,
+            scales=scales,
+            strides=strides,
+            offsets=offsets,
+            max_dim_sizes=max_dim_sizes,
+            allocation=arg.allocation,
+            start_address=start_addr,
+            backGap=backGap,
+            arg_index=arg.arg_index,
+            is_index_tensor=is_idx_tensor,
+            related_value_tensor_idx=related_val_idx,
+            device_tile_advance_expr=arg.device_tile_advance_expr,
         )
+        if arg.work_division is not None:
+            sdsc_arg.work_division = arg.work_division.remap_symbols(symbol_mapping)
+        sdsc_args.append(sdsc_arg)
 
     return sdsc_args, layouts, missing_dim
 
@@ -1578,9 +1582,49 @@ def _inject_implicit_conv_kernel_dims(
         work_slices[kj_sym] = 1
 
 
+def _finalize_tensor_work_divisions(
+    args: list[SDSCArgs],
+    mapping_dims: tuple[Symbol, ...],
+    work_slices: dict[Symbol, Any],
+    core_map: dict[Symbol, Expr],
+    num_cores: int,
+    is_lx_relayout: bool,
+) -> None:
+    """Give every tensor one effective ownership after SDSC normalization."""
+
+    operation_work_division = TensorWorkDivision(
+        {dim: work_slices[dim] for dim in mapping_dims},
+        {dim: core_map[dim] for dim in mapping_dims},
+    )
+    assert is_lx_relayout or all(arg.work_division is None for arg in args), (
+        "per-tensor ownership is supported only for LX relayout identities"
+    )
+    for arg in args:
+        override = arg.work_division
+        # A relayout tensor can override the operation-wide split on selected
+        # dimensions; unsplit dimensions inherit one slice owned by core zero.
+        effective = (
+            operation_work_division
+            if override is None
+            else TensorWorkDivision(
+                {dim: int(override.work_slices.get(dim, 1)) for dim in mapping_dims},
+                {
+                    dim: override.core_id_to_work_slice.get(dim, Integer(0))
+                    for dim in mapping_dims
+                },
+            )
+        )
+        if math.prod(effective.work_slices.values()) != num_cores:
+            raise ValueError(
+                f"tensor ownership uses {effective.work_slices}, expected {num_cores} cores"
+            )
+        arg.work_division = effective
+
+
 def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
     is_matmul = _is_matmul(op_spec.op)
     is_conv2d = _is_conv(op_spec.op)
+    is_relayout = is_lx_relayout_identity(op_spec.op, op_spec.args)
     is_pool = _is_pool(op_spec.op)
     is_conv = _is_conv(op_spec.op)
     ndim = len(op_spec.iteration_space)
@@ -1978,7 +2022,14 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
         num_cores,
         contiguous_dim=contiguous_dim,
     )
-
+    _finalize_tensor_work_divisions(
+        args,
+        mapping_dims,
+        work_slices,
+        core_id_to_work_slice,
+        num_cores,
+        is_relayout,
+    )
     # Collect index tensor indices for indirect access
     indirect_access_indices = [
         i for i, arg in enumerate(op_spec.args) if is_index_tensor(arg, op_spec)
@@ -1995,7 +2046,11 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
 
     return (
         SDSCSpec(
-            opfunc=_get_op_func(op_spec.op, op_spec.is_reduction, args[-1].scales),
+            opfunc=(
+                "shuffle"
+                if is_relayout
+                else _get_op_func(op_spec.op, op_spec.is_reduction, args[-1].scales)
+            ),
             # Forward conv2d (#3284) is a native "pt" (processing-tile) op like
             # matmul; depthwise conv2d (#3510) runs on the "sfp" unit. `is_conv`
             # matches both, so dispatch forward explicitly and leave depthwise

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -57,6 +57,10 @@ ktir_emitter: bool = os.environ.get("TORCH_SPYRE_KTIR", "0") == "1"
 # A .mlir declaring the target device, passed to the backend compiler.
 ktir_device_mlir: str = os.environ.get("KTIR_DEVICE_MLIR", "")
 
+# Materialize compatible producer/consumer LX ownership changes as identity copies.
+# Set SPYRE_LX_PLANNER_RELAYOUT=0 to disable this optimization.
+lx_planner_relayout: bool = _get_env_bool("SPYRE_LX_PLANNER_RELAYOUT", True)
+
 allow_all_ops_in_lx_planning: bool = False
 
 dxp_lx_frac_avail: float = float(os.environ.get("DXP_LX_FRAC_AVAIL", "0.2"))

--- a/torch_spyre/_inductor/core_mapping.py
+++ b/torch_spyre/_inductor/core_mapping.py
@@ -28,7 +28,7 @@ def core_to_slice_mapping(
     num_cores: int,
     *,
     contiguous_dim: int | None = None,
-) -> dict[str, Expr]:
+) -> dict[Symbol, Expr]:
     """Return the logical work slice assigned to each physical core.
 
     By default dimensions vary in iteration-space order. ``contiguous_dim``
@@ -54,7 +54,7 @@ def core_to_slice_mapping(
 
     core_id: Expr = Symbol("core_id")
     stride = Integer(1)
-    result: dict[str, Expr] = {}
+    result: dict[Symbol, Expr] = {}
     for dim in dim_order:
         split = Integer(splits[dim])
         if split == 1:
@@ -63,6 +63,6 @@ def core_to_slice_mapping(
             coordinate = Mod(core_id, split)
         else:
             coordinate = Mod(floor(core_id / stride), split)
-        result[str(dims[dim])] = coordinate
+        result[dims[dim]] = coordinate
         stride *= split
     return result

--- a/torch_spyre/_inductor/ir.py
+++ b/torch_spyre/_inductor/ir.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Optional, Sequence
+from typing import Any, Callable, Optional, Sequence, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .pass_utils import PerCoreView
 
 from sympy import Expr
 import torch
@@ -99,6 +102,7 @@ class FixedTiledLayout(FixedLayout):
         super().__init__(device, dtype, size, stride, offset)
         self.device_layout: SpyreTensorLayout = device_layout
         self.allocation: dict[str, Any] = {}
+        self.lx_view: Optional["PerCoreView"] = None
 
     def __str__(self) -> str:
         device_index_str = "" if self.device.index is None else f":{self.device.index}"

--- a/torch_spyre/_inductor/kernel_provenance.py
+++ b/torch_spyre/_inductor/kernel_provenance.py
@@ -36,12 +36,18 @@ from collections.abc import Iterator, Mapping, Sequence
 
 import sympy
 
-from torch_spyre._inductor.op_spec import DebugHandle, LoopSpec, OpSpec, TensorArg
+from torch_spyre._inductor.op_spec import (
+    DebugHandle,
+    LoopSpec,
+    OpSpec,
+    TensorArg,
+    TensorWorkDivision,
+)
 
 
-# Version 1 defines the first public finalized-bundle fingerprint as an
-# 80-bit digest prefix. Once published, any canonicalization or width change
-# must bump this version so persisted sidecars are never reinterpreted.
+# Bump this only when existing v1 identities would be reinterpreted, or when the
+# key width changes. New optional fields may extend identity without a bump when
+# they are omitted for all previously representable bundles.
 _KERNEL_BUNDLE_KEY_DOMAIN = "spyre-kernel-bundle"
 KERNEL_PROVENANCE_KEY_VERSION = 1
 KERNEL_PROVENANCE_KEY_BASE32_WIDTH = 16
@@ -65,10 +71,15 @@ _EXPECTED_TENSOR_ARG_SCHEMA = {
     "device_dtype": "DataFormats",
     "device_size": "list[int]",
     "device_coordinates": "list[Expr]",
-    "allocation": "Any",
+    "allocation": "dict[str, Any]",
     "name": "str | None",
     "device_tile_advance_expr": "Expr | None",
     "element_arrangement": "ElementArrangement",
+    "work_division": "TensorWorkDivision | None",
+}
+_EXPECTED_TENSOR_WORK_DIVISION_SCHEMA = {
+    "work_slices": "dict[Symbol, int]",
+    "core_id_to_work_slice": "dict[Symbol, Expr]",
 }
 _EXPECTED_LOOP_SPEC_SCHEMA = {
     "count": "Expr",
@@ -175,8 +186,8 @@ def _kernel_bundle_key(specs: Sequence[OpSpec | LoopSpec]) -> str:
     The canonical payload contains execution-relevant OpSpec/LoopSpec structure
     and the directly attached handle ID at every OpSpec position. It excludes
     Python identities, temporary output paths, generated kernel counters, and
-    runtime launch state. Any canonicalization change requires a visible format
-    version bump.
+    runtime launch state. Changes that reinterpret existing canonical payloads
+    require a visible format version bump.
     """
     payload = {
         "domain": _KERNEL_BUNDLE_KEY_DOMAIN,
@@ -196,6 +207,7 @@ def _validate_finalized_schema() -> None:
     schemas = (
         (OpSpec, _EXPECTED_OP_SPEC_SCHEMA),
         (TensorArg, _EXPECTED_TENSOR_ARG_SCHEMA),
+        (TensorWorkDivision, _EXPECTED_TENSOR_WORK_DIVISION_SCHEMA),
         (LoopSpec, _EXPECTED_LOOP_SPEC_SCHEMA),
     )
     for schema, expected_schema in schemas:
@@ -258,7 +270,7 @@ def _canonical_spec(spec: object) -> object:
 
 
 def _canonical_tensor_arg(arg: TensorArg) -> object:
-    return {
+    result = {
         "is_input": arg.is_input,
         "arg_index": arg.arg_index,
         "device_dtype": str(arg.device_dtype),
@@ -269,6 +281,16 @@ def _canonical_tensor_arg(arg: TensorArg) -> object:
         "device_tile_advance_expr": _canonical_value(arg.device_tile_advance_expr),
         "element_arrangement": arg.element_arrangement.name,
     }
+    # Preserve existing v1 identities for ordinary tensors. Ownership changes
+    # execution only when a relayout tensor carries an explicit override.
+    if arg.work_division is not None:
+        result["work_division"] = {
+            "work_slices": _canonical_value(arg.work_division.work_slices),
+            "core_id_to_work_slice": _canonical_value(
+                arg.work_division.core_id_to_work_slice
+            ),
+        }
+    return result
 
 
 def _canonical_value(value: object) -> object:

--- a/torch_spyre/_inductor/lx_relayout.py
+++ b/torch_spyre/_inductor/lx_relayout.py
@@ -156,9 +156,52 @@ def _overlap(a: int, an: int, b: int, bn: int) -> bool:
     return a * bn < (b + 1) * an and b * an < (a + 1) * bn
 
 
-def _compatible_partitions(
+@dataclasses.dataclass(frozen=True)
+class RelayoutGeometry:
+    """Peer-to-peer shape of one ownership change.
+
+    Keeps the fan-in and fan-out rather than collapsing them into a verdict, so
+    a caller can report which condition refused a pairing, and so a destination
+    that receives more than one source slice per core can be sized from the
+    fan-in.
+    """
+
+    num_cores: int
+    source_map: dict[int, dict[int, int]]
+    destination_map: dict[int, dict[int, int]]
+    source_splits: dict[int, int]
+    destination_splits: dict[int, int]
+    edges: set[tuple[int, int]]
+    fanout: list[int]
+    fanin: list[int]
+
+    def rejection(self) -> str | None:
+        """Which condition refuses this pairing, or ``None`` if none does."""
+        if not self.edges:
+            return "no source slice overlaps any destination slice"
+        if len(set(self.fanout)) != 1:
+            return f"non-uniform fan-out {sorted(set(self.fanout))}"
+        if len(set(self.fanin)) != 1:
+            return f"non-uniform fan-in {sorted(set(self.fanin))}"
+        for side, core_map, splits in (
+            ("source", self.source_map, self.source_splits),
+            ("destination", self.destination_map, self.destination_splits),
+        ):
+            owned = len({tuple(sorted(row.items())) for row in core_map.values()})
+            if owned != self.num_cores:
+                return (
+                    f"{side} view owns {owned} distinct slices across "
+                    f"{self.num_cores} cores"
+                )
+            product = math.prod(splits.values())
+            if product != self.num_cores:
+                return f"{side} splits multiply to {product}, not {self.num_cores}"
+        return None
+
+
+def _relayout_geometry(
     source: PerCoreView, destination: PerCoreView, num_cores: int
-) -> bool:
+) -> RelayoutGeometry:
     source_map = _core_slices(source, num_cores)
     destination_map = _core_slices(destination, num_cores)
     source_splits = dict(source.work_slice_dims)
@@ -178,19 +221,15 @@ def _compatible_partitions(
             for dim in dims
         )
     }
-    fanout = [sum(src == core for src, _ in edges) for core in range(num_cores)]
-    fanin = [sum(dst == core for _, dst in edges) for core in range(num_cores)]
-    return bool(edges) and all(
-        (
-            len(set(fanout)) == 1,
-            len(set(fanin)) == 1,
-            len({tuple(sorted(row.items())) for row in source_map.values()})
-            == num_cores,
-            len({tuple(sorted(row.items())) for row in destination_map.values()})
-            == num_cores,
-            math.prod(source_splits.values()) == num_cores,
-            math.prod(destination_splits.values()) == num_cores,
-        )
+    return RelayoutGeometry(
+        num_cores=num_cores,
+        source_map=source_map,
+        destination_map=destination_map,
+        source_splits=source_splits,
+        destination_splits=destination_splits,
+        edges=edges,
+        fanout=[sum(src == core for src, _ in edges) for core in range(num_cores)],
+        fanin=[sum(dst == core for _, dst in edges) for core in range(num_cores)],
     )
 
 
@@ -309,7 +348,7 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                 break
             if not is_matmul and not isinstance(consumer.data, Pointwise):
                 break
-            if not _compatible_partitions(source_view, view, num_cores):
+            if _relayout_geometry(source_view, view, num_cores).rejection():
                 break
             try:
                 work_division_from_view(view, consumer_coordinates, consumer_symbols)

--- a/torch_spyre/_inductor/lx_relayout.py
+++ b/torch_spyre/_inductor/lx_relayout.py
@@ -1,0 +1,364 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from collections.abc import Sequence
+from typing import cast
+
+import sympy
+from torch._inductor.dependencies import MemoryDep
+from torch._inductor.graph import GraphLowering
+from torch._inductor.ir import (
+    ComputedBuffer,
+    MutationLayoutSHOULDREMOVE,
+    Operation,
+    Pointwise,
+)
+
+from . import config
+from .ir import FixedTiledLayout
+from .logging_utils import get_inductor_logger
+from .op_spec import TensorWorkDivision
+from .pass_utils import (
+    PerCoreView,
+    _is_matmul_op,
+    _per_core_view_on_buf,
+    iteration_space_from_op,
+    op_short_name,
+    op_read_writes,
+    try_device_coordinates,
+)
+from .scratchpad.utils import _op_num_cores
+
+logger = get_inductor_logger("lx_relayout")
+_DESTINATION_PREFIX = "__spyre_lx_relayout__"
+_REGISTRY = "_spyre_lx_relayout_copies"
+
+
+@dataclasses.dataclass(frozen=True)
+class LXRelayoutPlan:
+    source_name: str
+    consumer_name: str
+    source_view: PerCoreView
+    destination_view: PerCoreView
+    num_cores: int
+    source_address: int | None = None
+    destination_address: int | None = None
+
+    @property
+    def destination_name(self) -> str:
+        return f"{_DESTINATION_PREFIX}:{self.source_name}:{self.consumer_name}"
+
+    @property
+    def edge(self) -> tuple[str, str]:
+        return self.source_name, self.consumer_name
+
+
+def work_division_from_view(
+    view: PerCoreView | None,
+    device_coordinates: Sequence[sympy.Expr],
+    iteration_symbols: Sequence[sympy.Symbol],
+) -> TensorWorkDivision | None:
+    """Project physical per-core ownership into operation-loop symbols."""
+
+    if view is None:
+        return None
+    loop_symbols = set(iteration_symbols)
+    splits: dict[sympy.Symbol, int] = {}
+    core_map: dict[sympy.Symbol, sympy.Expr] = {}
+    slots = dict(view.core_to_slot)
+    for device_dim, split in view.work_slice_dims:
+        if device_dim >= len(device_coordinates):
+            raise ValueError(f"missing device coordinate {device_dim}")
+        matches = device_coordinates[device_dim].free_symbols & loop_symbols
+        if len(matches) != 1:
+            raise ValueError(f"cannot map device dimension {device_dim} to one loop")
+        dim = next(iter(matches))
+        slot = sympy.sympify(slots[device_dim])
+        if dim in splits and (splits[dim], core_map[dim]) != (split, slot):
+            raise ValueError(f"conflicting ownership for loop {dim}")
+        splits[dim] = split
+        core_map[dim] = slot
+    return TensorWorkDivision(splits, core_map)
+
+
+def materialized_lx_relayouts(
+    graph: GraphLowering,
+) -> dict[tuple[str, str], tuple[str, LXRelayoutPlan]]:
+    return getattr(graph, _REGISTRY, {})
+
+
+def _discard_lx_relayout_group(graph: GraphLowering, source_name: str) -> set[str]:
+    copies = materialized_lx_relayouts(graph)
+    removed = set()
+    for edge, (copy_name, _) in list(copies.items()):
+        if edge[0] == source_name:
+            removed.add(copy_name)
+            del copies[edge]
+    return removed
+
+
+def _clear_lx_state(layout: FixedTiledLayout) -> None:
+    """Clear an LX buffer's placement and physical ownership."""
+
+    layout.allocation.pop("lx", None)
+    layout.lx_view = None
+
+
+def demote_lx_relayout_group(
+    graph: GraphLowering, source_name: str, reason: str
+) -> None:
+    """Remove one relayout group from LX and its materialization registry."""
+
+    names = {source_name, *_discard_lx_relayout_group(graph, source_name)}
+    for name in names:
+        buffer = graph.try_get_buffer(name)
+        if buffer is None:
+            continue
+        layout = buffer.get_layout()
+        if isinstance(layout, FixedTiledLayout):
+            _clear_lx_state(layout)
+    logger.info("demoted %s out of LX: %s", ", ".join(sorted(names)), reason)
+
+
+def _core_slices(view: PerCoreView, num_cores: int) -> dict[int, dict[int, int]]:
+    core_id = sympy.Symbol("core_id")
+    splits = dict(view.work_slice_dims)
+    slots = dict(view.core_to_slot)
+    result = {}
+    for core in range(num_cores):
+        row = {}
+        for dim, split in splits.items():
+            value = sympy.sympify(slots[dim]).subs(core_id, core)
+            assert not value.free_symbols, f"non-concrete owner slot {value}"
+            slot = int(value)
+            assert 0 <= slot < split, f"owner slot {slot} outside split {split}"
+            row[dim] = slot
+        result[core] = row
+    return result
+
+
+def _overlap(a: int, an: int, b: int, bn: int) -> bool:
+    return a * bn < (b + 1) * an and b * an < (a + 1) * bn
+
+
+def _compatible_partitions(
+    source: PerCoreView, destination: PerCoreView, num_cores: int
+) -> bool:
+    source_map = _core_slices(source, num_cores)
+    destination_map = _core_slices(destination, num_cores)
+    source_splits = dict(source.work_slice_dims)
+    destination_splits = dict(destination.work_slice_dims)
+    dims = set(source_splits) | set(destination_splits)
+    edges = {
+        (s_core, d_core)
+        for s_core, s_slice in source_map.items()
+        for d_core, d_slice in destination_map.items()
+        if all(
+            _overlap(
+                s_slice.get(dim, 0),
+                source_splits.get(dim, 1),
+                d_slice.get(dim, 0),
+                destination_splits.get(dim, 1),
+            )
+            for dim in dims
+        )
+    }
+    fanout = [sum(src == core for src, _ in edges) for core in range(num_cores)]
+    fanin = [sum(dst == core for _, dst in edges) for core in range(num_cores)]
+    return bool(edges) and all(
+        (
+            len(set(fanout)) == 1,
+            len(set(fanin)) == 1,
+            len({tuple(sorted(row.items())) for row in source_map.values()})
+            == num_cores,
+            len({tuple(sorted(row.items())) for row in destination_map.values()})
+            == num_cores,
+            math.prod(source_splits.values()) == num_cores,
+            math.prod(destination_splits.values()) == num_cores,
+        )
+    )
+
+
+def _single_write(op: ComputedBuffer, name: str) -> MemoryDep | None:
+    writes = [
+        dep
+        for dep in op_read_writes(op).writes
+        if isinstance(dep, MemoryDep) and dep.name == name
+    ]
+    if len(writes) != 1 or writes[0].is_indirect():
+        return None
+    return writes[0]
+
+
+def _is_activation_source(operations: dict[str, Operation], op: Operation) -> bool:
+    """Exclude restickified graph inputs and weights from activation relayout."""
+
+    return op_short_name(op) != "restickify" or any(
+        isinstance(operations.get(dep.name), ComputedBuffer)
+        for dep in op_read_writes(op).reads
+        if isinstance(dep, MemoryDep)
+    )
+
+
+def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
+    if not config.lx_planner_relayout or config.ktir_emitter:
+        return []
+    assert not materialized_lx_relayouts(graph), (
+        "LX relayout planning requires an unmaterialized graph"
+    )
+
+    cache: dict = {}
+    operations = {op.get_name(): op for op in graph.operations}
+    reads: dict[str, list[tuple[Operation, MemoryDep]]] = {}
+    for consumer in graph.operations:
+        deps = [d for d in op_read_writes(consumer).reads if isinstance(d, MemoryDep)]
+        for dep in deps:
+            reads.setdefault(dep.name, []).append((consumer, dep))
+
+    result = []
+    for source_name, consumer_reads in reads.items():
+        producer = operations.get(source_name)
+        if (
+            not isinstance(producer, ComputedBuffer)
+            or not isinstance(producer.layout, FixedTiledLayout)
+            or (write := _single_write(producer, source_name)) is None
+        ):
+            continue
+        source_view, partial, representable = _per_core_view_on_buf(
+            producer, write, source_name, cache
+        )
+        num_cores = _op_num_cores(producer)
+        if partial or not representable:
+            continue
+
+        # Activation eligibility belongs to the producer, not to an individual
+        # edge. Never relayout a restickified graph input or weight.
+        if not _is_activation_source(operations, producer):
+            continue
+
+        producer_coordinates = try_device_coordinates(
+            producer.layout.device_layout, write, None
+        )
+        if producer_coordinates is None:
+            continue
+        try:
+            work_division_from_view(
+                source_view,
+                producer_coordinates,
+                tuple(iteration_space_from_op(producer)),
+            )
+        except ValueError:
+            continue
+
+        source_plans = []
+        seen_consumers = set()
+        for consumer, dep in consumer_reads:
+            consumer_name = consumer.get_name()
+            if (
+                consumer_name in seen_consumers
+                or not isinstance(consumer, ComputedBuffer)
+                or isinstance(consumer.layout, MutationLayoutSHOULDREMOVE)
+            ):
+                break
+            seen_consumers.add(consumer_name)
+            deps = [
+                d for d in op_read_writes(consumer).reads if isinstance(d, MemoryDep)
+            ]
+            if any(d.is_indirect() for d in deps):
+                break
+            view, consumer_partial, representable = _per_core_view_on_buf(
+                consumer, dep, source_name, cache
+            )
+            if (
+                consumer_partial
+                or not representable
+                or _op_num_cores(consumer) != num_cores
+            ):
+                break
+            consumer_coordinates = try_device_coordinates(
+                producer.layout.device_layout, dep, None
+            )
+            if consumer_coordinates is None:
+                break
+            consumer_symbols = tuple(iteration_space_from_op(consumer))
+            try:
+                work_division_from_view(
+                    source_view, consumer_coordinates, consumer_symbols
+                )
+            except ValueError:
+                break
+            if view == source_view:
+                continue
+            is_matmul = _is_matmul_op(consumer)
+            if is_matmul and len(deps) != 2:
+                break
+            if not is_matmul and not isinstance(consumer.data, Pointwise):
+                break
+            if not _compatible_partitions(source_view, view, num_cores):
+                break
+            try:
+                work_division_from_view(view, consumer_coordinates, consumer_symbols)
+            except ValueError:
+                break
+            source_plans.append(
+                LXRelayoutPlan(
+                    source_name,
+                    consumer_name,
+                    source_view,
+                    view,
+                    num_cores,
+                )
+            )
+        else:
+            result.extend(source_plans)
+    return result
+
+
+def materialize_lx_relayouts(graph: GraphLowering, plans: list[LXRelayoutPlan]) -> None:
+    if not plans:
+        assert not materialized_lx_relayouts(graph)
+        return
+    from .scratchpad.graph_editor import GraphEditor
+
+    copies = materialized_lx_relayouts(graph)
+    assert not copies, "LX relayouts were already materialized"
+    editor = GraphEditor(graph)
+    setattr(graph, _REGISTRY, copies)
+    for plan in plans:
+        source = cast(ComputedBuffer, graph.get_buffer(plan.source_name))
+        consumer = cast(ComputedBuffer, graph.get_buffer(plan.consumer_name))
+        copy = editor.insert_clone_before_consumer(source, consumer)
+        copies[plan.edge] = (copy.get_name(), plan)
+
+        assert plan.source_address is not None and plan.destination_address is not None
+        assert plan.source_view != plan.destination_view
+        source_layout = cast(FixedTiledLayout, source.layout)
+        copy_layout = cast(FixedTiledLayout, copy.layout)
+        source_layout.allocation["lx"] = plan.source_address
+        copy_layout.allocation["lx"] = plan.destination_address
+        source_layout.lx_view = plan.source_view
+        copy_layout.lx_view = plan.destination_view
+        logger.debug(
+            "accepted LX relayout %s -> %s: source=%s@%d destination=%s@%d",
+            source.get_name(),
+            copy.get_name(),
+            plan.source_view,
+            plan.source_address,
+            plan.destination_view,
+            plan.destination_address,
+        )

--- a/torch_spyre/_inductor/lx_relayout.py
+++ b/torch_spyre/_inductor/lx_relayout.py
@@ -306,53 +306,80 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
 
         source_plans = []
         seen_consumers = set()
+        rejection = None
         for consumer, dep in consumer_reads:
             consumer_name = consumer.get_name()
-            if (
-                consumer_name in seen_consumers
-                or not isinstance(consumer, ComputedBuffer)
-                or isinstance(consumer.layout, MutationLayoutSHOULDREMOVE)
-            ):
+            if consumer_name in seen_consumers:
+                rejection = f"{consumer_name} reads {source_name} more than once"
+                break
+            if not isinstance(consumer, ComputedBuffer):
+                rejection = (
+                    f"{consumer_name} is {type(consumer).__name__}, "
+                    "not a ComputedBuffer"
+                )
+                break
+            if isinstance(consumer.layout, MutationLayoutSHOULDREMOVE):
+                rejection = f"{consumer_name} writes through a mutation alias"
                 break
             seen_consumers.add(consumer_name)
             deps = [
                 d for d in op_read_writes(consumer).reads if isinstance(d, MemoryDep)
             ]
             if any(d.is_indirect() for d in deps):
+                rejection = f"{consumer_name} uses indirect (gather/scatter) indices"
                 break
             view, consumer_partial, representable = _per_core_view_on_buf(
                 consumer, dep, source_name, cache
             )
-            if (
-                consumer_partial
-                or not representable
-                or _op_num_cores(consumer) != num_cores
-            ):
+            if consumer_partial:
+                rejection = f"{consumer_name} read leaves K-split partials"
+                break
+            if not representable:
+                rejection = f"{consumer_name} per-core view is not representable"
+                break
+            consumer_cores = _op_num_cores(consumer)
+            if consumer_cores != num_cores:
+                rejection = (
+                    f"{consumer_name} runs on {consumer_cores} cores, producer on "
+                    f"{num_cores}"
+                )
                 break
             consumer_coordinates = try_device_coordinates(
                 producer.layout.device_layout, dep, None
             )
             if consumer_coordinates is None:
+                rejection = f"{consumer_name} read has no device coordinates"
                 break
             consumer_symbols = tuple(iteration_space_from_op(consumer))
             try:
                 work_division_from_view(
                     source_view, consumer_coordinates, consumer_symbols
                 )
-            except ValueError:
+            except ValueError as error:
+                rejection = f"{consumer_name} cannot express the source view: {error}"
                 break
             if view == source_view:
                 continue
             is_matmul = _is_matmul_op(consumer)
             if is_matmul and len(deps) != 2:
+                rejection = (
+                    f"{consumer_name} is a matmul reading {len(deps)} operands, not 2"
+                )
                 break
             if not is_matmul and not isinstance(consumer.data, Pointwise):
+                rejection = (
+                    f"{consumer_name} is neither matmul nor pointwise "
+                    f"({type(consumer.data).__name__})"
+                )
                 break
-            if _relayout_geometry(source_view, view, num_cores).rejection():
+            geometry = _relayout_geometry(source_view, view, num_cores).rejection()
+            if geometry:
+                rejection = f"{consumer_name}: {geometry}"
                 break
             try:
                 work_division_from_view(view, consumer_coordinates, consumer_symbols)
-            except ValueError:
+            except ValueError as error:
+                rejection = f"{consumer_name} cannot express its own view: {error}"
                 break
             source_plans.append(
                 LXRelayoutPlan(
@@ -365,6 +392,19 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
             )
         else:
             result.extend(source_plans)
+            continue
+        # Reached only on a break, which abandons every plan for this source:
+        # partial coverage would let LX eligibility hide an uncovered division
+        # mismatch. Worth reporting only once an edge had been planned --
+        # otherwise the buffer was never a candidate and the noise would swamp
+        # the signal.
+        if source_plans:
+            logger.debug(
+                "dropped %d planned LX relayout edge(s) for %s: %s",
+                len(source_plans),
+                source_name,
+                rejection,
+            )
     return result
 
 

--- a/torch_spyre/_inductor/op_spec.py
+++ b/torch_spyre/_inductor/op_spec.py
@@ -20,10 +20,12 @@ import dataclasses
 import threading
 from typing import Any, Literal, Sequence
 
-from sympy import Symbol, Expr, Function
+from sympy import Symbol, Expr, Function, sympify
 from torch_spyre._C import DataFormats, ElementArrangement
 import torch
 from torch_spyre import _C
+
+from .constants import IDENTITY_OP
 
 
 class IndirectAccess(Function):
@@ -137,6 +139,51 @@ class DebugHandle:
         }
 
 
+@dataclasses.dataclass(frozen=True)
+class TensorWorkDivision:
+    """Tensor ownership expressed in operation-loop symbols.
+
+    Both mappings have the same symbol keys. ``work_slices`` gives each loop's
+    split count and ``core_id_to_work_slice`` maps the free symbol ``core_id``
+    to that loop's owned slice.
+    """
+
+    work_slices: dict[Symbol, int]
+    core_id_to_work_slice: dict[Symbol, Expr]
+
+    def remap_symbols(self, symbol_mapping: dict[Symbol, Symbol]) -> TensorWorkDivision:
+        """Return this ownership expressed in remapped loop symbols."""
+
+        return TensorWorkDivision(
+            {
+                symbol_mapping.get(dim, dim): split
+                for dim, split in self.work_slices.items()
+            },
+            {
+                symbol_mapping.get(dim, dim): sympify(slot).xreplace(symbol_mapping)
+                for dim, slot in self.core_id_to_work_slice.items()
+            },
+        )
+
+    def to_core_slices(self, num_cores: int) -> dict[str, dict[str, int]]:
+        """Expand symbolic ownership into DeepTools' per-core slice map."""
+
+        core_id = Symbol("core_id")
+        result = {}
+        for core in range(num_cores):
+            slots = {}
+            for dim, expression in self.core_id_to_work_slice.items():
+                slot = int(sympify(expression).subs(core_id, core))
+                split = self.work_slices[dim]
+                if not 0 <= slot < split:
+                    raise ValueError(
+                        f"core {core} owns invalid {dim} slot {slot} for split {split}"
+                    )
+                slots[str(dim)] = slot
+            result[str(core)] = slots
+        return result
+
+
 @dataclasses.dataclass
 class TensorArg:
     """
@@ -168,6 +215,8 @@ class TensorArg:
             device-element space via views.tiling_expr_to_device_expr, and summed into a
             single combined Expr. This is the sole tile-advance mechanism. ``None`` for
             ops without loop_info/coarse tiling.
+        work_division: Optional tensor-specific ownership used when it differs
+            from the operation's work division.
     """
 
     is_input: bool
@@ -175,11 +224,27 @@ class TensorArg:
     device_dtype: DataFormats
     device_size: list[int]
     device_coordinates: list[Expr]
-    allocation: Any
+    allocation: dict[str, Any]
     name: str | None = None
     device_tile_advance_expr: Expr | None = None
     element_arrangement: ElementArrangement = dataclasses.field(
         default_factory=lambda: ElementArrangement.STANDARD
+    )
+    work_division: TensorWorkDivision | None = None
+
+
+def is_lx_relayout_identity(op: str, args: Sequence[TensorArg]) -> bool:
+    """An LX identity whose input and output have different owners."""
+
+    if op != IDENTITY_OP or len(args) != 2:
+        return False
+    source, destination = args
+    return (
+        "lx" in source.allocation
+        and "lx" in destination.allocation
+        and source.work_division is not None
+        and destination.work_division is not None
+        and source.work_division != destination.work_division
     )
 
 

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -110,6 +110,17 @@ def op_read_writes(op: Operation) -> ReadWrites:
     return rw
 
 
+def op_short_name(op: Operation) -> str:
+    """Resolve an operation's short name, including fused FX origins."""
+
+    for fx_node in (getattr(op, "origin_node", None), *getattr(op, "origins", ())):
+        target = getattr(fx_node, "target", None)
+        for attr in ("_opname", "__name__", "name"):
+            if name := getattr(target, attr, None):
+                return str(name)
+    return "None"
+
+
 def invalidate_op_read_writes(op: Operation) -> None:
     """Drop any memoized :func:`op_read_writes` result for ``op``.
 
@@ -1670,7 +1681,7 @@ def _per_core_view_from_prep(
         if prep.is_matmul and config.core_id_k_fast_emission
         else None
     )
-    core_to_slot_by_name = core_to_slice_mapping(
+    core_to_slot = core_to_slice_mapping(
         iter_symbols,
         dim_splits,
         num_cores,
@@ -1681,9 +1692,7 @@ def _per_core_view_from_prep(
     # compare equal even if they name their iter axes differently.
     pruned_core_to_slot: list[tuple[int, "Expr"]] = []
     for sym, dev_dim in sym_to_device_dim.items():
-        expr = core_to_slot_by_name.get(str(sym))
-        if expr is not None:
-            pruned_core_to_slot.append((dev_dim, expr))
+        pruned_core_to_slot.append((dev_dim, core_to_slot[sym]))
     pruned_core_to_slot.sort(key=lambda x: x[0])
 
     view = PerCoreView(

--- a/torch_spyre/_inductor/patches.py
+++ b/torch_spyre/_inductor/patches.py
@@ -113,7 +113,12 @@ def enable_spyre_context(example_inputs: list[InputType]):
     _pre_scheduling_pass = CustomPreSchedulingPasses()
 
     def _spyre_update_scheduler(self: GraphLowering) -> None:
-        _pre_scheduling_pass(self)
+        # Nested compiler contexts may wrap this hook more than once. Run the
+        # pre-scheduling pipeline once; LX relayout materialization is not
+        # idempotent.
+        if not getattr(self, "_spyre_pre_scheduling_complete", False):
+            _pre_scheduling_pass(self)
+            setattr(self, "_spyre_pre_scheduling_complete", True)
         old_update_scheduler(self)
 
     GraphLowering._update_scheduler = _spyre_update_scheduler  # type: ignore[method-assign]

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -34,12 +34,47 @@ from torch._inductor.codecache import code_hash
 from torch.utils._ordered_set import OrderedSet
 
 from .spyre_kernel import SpyreKernel
-from .pass_utils import iteration_space, per_core_view_scheduled
+from .ir import FixedTiledLayout
+from .pass_utils import (
+    PerCoreView,
+    iteration_space,
+    per_core_view_scheduled,
+    try_device_coordinates,
+)
 from .logging_utils import get_inductor_logger
+from .lx_relayout import (
+    demote_lx_relayout_group,
+    materialized_lx_relayouts,
+    work_division_from_view,
+)
 from .op_spec import LoopSpec
 from . import config as _spyre_config
 
 logger = get_inductor_logger("scheduler")
+
+
+def _ownership_projectable(
+    node: SchedulerNode,
+    dep: MemoryDep,
+    name: str,
+    view: PerCoreView,
+) -> bool:
+    """Whether final scheduled coordinates can carry ``view`` into codegen."""
+
+    buffer = V.graph.try_get_buffer(name)
+    if buffer is None:
+        return False
+    layout = buffer.get_layout()
+    if not isinstance(layout, FixedTiledLayout):
+        return False
+    coordinates = try_device_coordinates(layout.device_layout, dep, None)
+    if coordinates is None:
+        return False
+    try:
+        work_division_from_view(view, coordinates, tuple(iteration_space(node)))
+    except ValueError:
+        return False
+    return True
 
 
 class CountedLoopSchedulerNode(FusedSchedulerNode):
@@ -321,6 +356,18 @@ def _lx_resident(node: SchedulerNode) -> bool:
     return allocation is not None and "lx" in allocation
 
 
+def _lx_view(name: str):
+    buffer = V.graph.try_get_buffer(name)
+    if buffer is None:
+        return None
+    layout = buffer.get_layout()
+    if not isinstance(layout, FixedTiledLayout):
+        return None
+    if "lx" not in layout.allocation:
+        return None
+    return layout.lx_view
+
+
 def align_lx_producer_loop_order(
     nodes: list[BaseSchedulerNode],
 ) -> list[BaseSchedulerNode]:
@@ -354,7 +401,7 @@ def align_lx_producer_loop_order(
     for node in nodes:
         if isinstance(node, SchedulerNode) and _lx_resident(node):
             for dep in node.read_writes.writes:
-                if isinstance(dep, MemoryDep):
+                if isinstance(dep, MemoryDep) and _lx_view(dep.name) is None:
                     producers[dep.name] = node
 
     if not producers:
@@ -433,32 +480,107 @@ def demote_incoherent_lx_buffers(
     if not _spyre_config.lx_planning:
         return nodes
 
-    # dep is needed per (node, buffer): a node reading and writing the same
-    # buffer contributes one entry per access, so an in-place op whose read and
-    # write views diverge is caught too.
+    # dep is needed per (node, buffer), including in-place read/write pairs.
     users: dict[str, list[tuple[SchedulerNode, MemoryDep]]] = {}
     lx_names: OrderedSet[str] = OrderedSet()
-    for node in nodes:
-        for inner in node.get_nodes():
-            if not isinstance(inner, SchedulerNode):
-                continue
-            if _lx_resident(inner):
-                for dep in inner.read_writes.writes:
-                    if isinstance(dep, MemoryDep):
-                        lx_names.add(dep.name)
-            rw = inner.read_writes
-            for dep in list(rw.reads) + list(rw.writes):
+    scheduled = [
+        inner
+        for node in nodes
+        for inner in node.get_nodes()
+        if isinstance(inner, SchedulerNode)
+    ]
+    plans_by_copy = {
+        copy_name: plan
+        for copy_name, plan in materialized_lx_relayouts(V.graph).values()
+    }
+    source_by_copy = {
+        copy_name: plan.source_name for copy_name, plan in plans_by_copy.items()
+    }
+    relayout_sources = set(source_by_copy.values())
+
+    copy_reads = set()
+    invalid_sources = {}
+    seen_copies = set()
+    for node in scheduled:
+        if _lx_resident(node):
+            for dep in node.read_writes.writes:
                 if isinstance(dep, MemoryDep):
-                    users.setdefault(dep.name, []).append((inner, dep))
+                    lx_names.add(dep.name)
+        rw = node.read_writes
+        reads = [dep for dep in rw.reads if isinstance(dep, MemoryDep)]
+        writes = [dep for dep in rw.writes if isinstance(dep, MemoryDep)]
+        for dep in [*reads, *writes]:
+            users.setdefault(dep.name, []).append((node, dep))
+        copies = [dep for dep in writes if dep.name in plans_by_copy]
+        if not copies:
+            continue
+        for dep in copies:
+            seen_copies.add(dep.name)
+            plan = plans_by_copy[dep.name]
+            source_view = _lx_view(plan.source_name)
+            destination_view = _lx_view(dep.name)
+            if (
+                source_view is None
+                or destination_view is None
+                or source_view == destination_view
+                or len(reads) != 1
+                or len(writes) != 1
+                or reads[0].name != plan.source_name
+                or not _ownership_projectable(
+                    node, reads[0], plan.source_name, source_view
+                )
+                or not _ownership_projectable(node, dep, dep.name, destination_view)
+            ):
+                invalid_sources[plan.source_name] = f"invalid relayout copy {dep.name}"
+            else:
+                copy_reads.add((node.get_name(), plan.source_name))
+    for copy_name, plan in plans_by_copy.items():
+        if copy_name not in seen_copies:
+            invalid_sources[plan.source_name] = f"missing relayout copy {copy_name}"
+
+    demoted = set()
+
+    def demote(source_name: str, reason: str) -> None:
+        if source_name in demoted:
+            return
+        demoted.add(source_name)
+        if source_name in relayout_sources:
+            # Scheduling supplies the final ownership verdict; the relayout
+            # layer owns atomic group fallback and registry cleanup.
+            demote_lx_relayout_group(V.graph, source_name, reason)
+            return
+        buffer = V.graph.try_get_buffer(source_name)
+        if buffer is not None:
+            layout = buffer.get_layout()
+            if isinstance(layout, FixedTiledLayout):
+                layout.allocation.pop("lx", None)
+                layout.lx_view = None
+        logger.info("demoted %s out of LX: %s", source_name, reason)
+
+    for source_name, reason in invalid_sources.items():
+        demote(source_name, reason)
 
     for name in lx_names:
         ref = None
         culprit = None
+        expected = _lx_view(name)
         for node, dep in users.get(name, []):
+            # The copy executes with its destination division; the source map is
+            # carried by its input tensor and validated at the producer.
+            if (node.get_name(), name) in copy_reads:
+                continue
             view, _, representable = per_core_view_scheduled(node, dep, name)
             if not representable:
                 culprit = f"{node.get_name()} view unrepresentable"
                 break
+            if expected is not None:
+                if view != expected:
+                    culprit = f"{node.get_name()} view {view} != {expected}"
+                    break
+                if not _ownership_projectable(node, dep, name, expected):
+                    culprit = f"{node.get_name()} ownership unprojectable"
+                    break
+                continue
             if ref is None:
                 ref = view
             elif view != ref:
@@ -466,12 +588,7 @@ def demote_incoherent_lx_buffers(
                 break
         if culprit is None:
             continue
-        buf = V.graph.try_get_buffer(name)
-        layout = getattr(buf, "layout", None)
-        allocation = getattr(layout, "allocation", None)
-        if allocation is not None:
-            allocation.pop("lx", None)
-        logger.info("demoted %s out of LX: %s", name, culprit)
+        demote(source_by_copy.get(name, name), culprit)
 
     return nodes
 

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -241,8 +241,29 @@ class ScratchpadAllocator:
             plan.source_name for plan in self._lx_relayout_plans.values()
         } - complete
         if rejected:
+            by_name = {buffer.name: buffer for buffer in allocation}
+            for source_name in sorted(rejected):
+                destinations = sorted(
+                    plan.destination_name
+                    for plan in self._lx_relayout_plans.values()
+                    if plan.source_name == source_name
+                )
+                allocations = {
+                    name: (by_name[name].address, by_name[name].size)
+                    for name in (source_name, *destinations)
+                }
+                logger.debug(
+                    "rejected LX relayout group source=%s allocations=%s; "
+                    "every member must be allocated and destinations must not "
+                    "overlap the source",
+                    source_name,
+                    allocations,
+                )
             self._clear_lx_relayout_groups(allocation, rejected)
         if not complete:
+            logger.debug(
+                "no LX relayout groups survived allocation; retrying stock LX placement"
+            )
             self._lx_relayout_plans = {}
             stock = self._generate_buffers(graph)
             solver = self._build_solver(stock)

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -16,6 +16,7 @@ import logging
 import math
 import time
 from collections.abc import Sequence
+from dataclasses import replace
 from typing import Any, Callable, Optional
 
 import sympy
@@ -42,6 +43,7 @@ from torch_spyre._inductor.pass_utils import (
     op_read_writes,
     _prepare_per_core_view,
     _per_core_view_from_prep,
+    op_short_name,
 )
 from torch_spyre._inductor.work_division import enumerate_work_division_candidates
 from torch_spyre._inductor.errors import Unsupported
@@ -86,6 +88,11 @@ from torch_spyre._inductor.ir import FixedTiledLayout
 
 from torch_spyre._inductor import config
 from torch_spyre._inductor.logging_utils import get_inductor_logger
+from torch_spyre._inductor.lx_relayout import (
+    LXRelayoutPlan,
+    collect_lx_relayout_plans,
+    materialize_lx_relayouts,
+)
 from torch_spyre._inductor.pass_utils import _is_matmul_op
 
 logger = get_inductor_logger("scratchpad.allocator")
@@ -158,6 +165,15 @@ class ScratchpadAllocator:
         self.post_optimization_passes = post_optimization_passes
         self.layout_planning: Optional[LayoutSolverFactory] = layout_planning
         self.size = size
+        self._lx_relayout_plans: dict[tuple[str, str], LXRelayoutPlan] = {}
+        self._accepted_lx_relayouts: list[LXRelayoutPlan] = []
+
+    def _planned_lx_buffers(self) -> set[str]:
+        return {
+            name
+            for plan in self._lx_relayout_plans.values()
+            for name in (plan.source_name, plan.destination_name)
+        }
 
     def _build_solver(self, buffers: Sequence[Any]) -> MemoryPlanSolver:
         """Build a fresh solver over ``buffers`` from :attr:`layout_planning`."""
@@ -182,6 +198,9 @@ class ScratchpadAllocator:
         buffers = self._prepare_buffers(graph)
         solver = self._build_solver(buffers)
         allocation = self._solve(solver)
+        solver, allocation = self._finalize_lx_relayout_allocation(
+            graph, solver, allocation
+        )
         self._post_solve(graph, allocation)
         reasons = self._get_spill_reasons(solver, allocation)
         self._push_allocation(graph, allocation)
@@ -197,11 +216,39 @@ class ScratchpadAllocator:
 
     def _prepare_buffers(self, graph: GraphLowering) -> Sequence[Any]:
         """Buffers to hand the solver. Base: fixed-division LifetimeBoundBuffers."""
-        return self._generate_buffers(graph)
+        self._lx_relayout_plans = {
+            plan.edge: plan for plan in collect_lx_relayout_plans(graph)
+        }
+        buffers = self._generate_buffers(graph)
+        self._append_lx_relayout_destinations(graph, buffers)
+        return buffers
 
     def _solve(self, solver: MemoryPlanSolver) -> Sequence[Any]:
         """Assign LX addresses. Base: placement-only ``plan_layout``."""
         return solver.plan_layout(log_lx_usage=True)
+
+    def _finalize_lx_relayout_allocation(
+        self,
+        graph: GraphLowering,
+        solver: MemoryPlanSolver,
+        allocation: Sequence[LifetimeBoundBuffer],
+    ) -> tuple[MemoryPlanSolver, Sequence[LifetimeBoundBuffer]]:
+        if not self._lx_relayout_plans:
+            self._accepted_lx_relayouts = []
+            return solver, allocation
+        complete = self._complete_lx_relayout_sources(allocation)
+        rejected = {
+            plan.source_name for plan in self._lx_relayout_plans.values()
+        } - complete
+        if rejected:
+            self._clear_lx_relayout_groups(allocation, rejected)
+        if not complete:
+            self._lx_relayout_plans = {}
+            stock = self._generate_buffers(graph)
+            solver = self._build_solver(stock)
+            allocation = self._solve(solver)
+        self._accepted_lx_relayouts = self._accepted_plans(allocation)
+        return solver, allocation
 
     def _post_solve(self, graph: GraphLowering, allocation: Sequence[Any]) -> None:
         """Hook run after the solve, before reasons/push. Base: nothing to commit."""
@@ -227,7 +274,7 @@ class ScratchpadAllocator:
         return solver_reasons
 
     def _get_op_name(self, op: Any) -> str:
-        return _op_short_name(op)
+        return op_short_name(op)
 
     def _op_output_good_for_lx_reuse(self, op: Any) -> bool:
         if not isinstance(op, ComputedBuffer):
@@ -238,8 +285,11 @@ class ScratchpadAllocator:
         # with no device_layout and can never be LX-pinned.
         if not isinstance(op.layout, FixedTiledLayout):
             return False
+        # A planned source intentionally bypasses the profitability allowlist:
+        # the relayout planner has already applied its stricter structural gates.
         return config.allow_all_ops_in_lx_planning or (
             self._get_op_name(op) in OP_OUTPUT_GOOD_FOR_LX_REUSE
+            or op.get_name() in self._planned_lx_buffers()
         )
 
     @staticmethod
@@ -767,6 +817,16 @@ class ScratchpadAllocator:
         ncores, ncores_reasons = get_ncores_for_buffers(graph)
         t1 = time.perf_counter()
         mem_usage = mem_usage_by_buf(graph, cache)
+        for plan in self._lx_relayout_plans.values():
+            for name in (plan.source_name, plan.destination_name):
+                if name not in mem_usage:
+                    continue
+                ncores[name] = plan.num_cores
+                ncores_reasons.pop(name, None)
+                mem_usage[name]["size_per_core"] = (
+                    mem_usage[name]["size"] // plan.num_cores
+                )
+                mem_usage[name]["core_div_mismatch"] = False
         t2 = time.perf_counter()
         if timings is not None:
             timings["residency"] += t1 - t0
@@ -792,6 +852,109 @@ class ScratchpadAllocator:
             ncores=ncores,
             ncores_reasons=ncores_reasons,
         )
+
+    def _append_lx_relayout_destinations(
+        self, graph: GraphLowering, buffers: list[LifetimeBoundBuffer]
+    ) -> None:
+        by_name = {buffer.name: buffer for buffer in buffers}
+        op_index = {op.get_name(): i for i, op in enumerate(graph.operations)}
+        entries = []
+        invalid = set()
+        for plan in self._lx_relayout_plans.values():
+            source = by_name[plan.source_name]
+            consumer_tick = op_index[plan.consumer_name]
+            assert consumer_tick in source.uses
+            if source.residency_reason is not None:
+                invalid.add(plan.source_name)
+            else:
+                entries.append((source, plan, consumer_tick))
+        if invalid:
+            entries = [entry for entry in entries if entry[0].name not in invalid]
+            self._clear_lx_relayout_groups(buffers, invalid)
+        planned_sources = {
+            plan.source_name for plan in self._lx_relayout_plans.values()
+        }
+        for buffer in buffers:
+            buffer.in_place_parents = [
+                parent
+                for parent in buffer.in_place_parents
+                if parent not in planned_sources
+            ]
+        if not entries:
+            return
+        for buffer in buffers:
+            buffer.uses = [2 * use + 1 for use in buffer.uses]
+
+        # Adjacent half-ticks rely on DSCs within a bundle executing serially;
+        # otherwise the allocator's lifetime reuse is unsound beyond relayout too.
+        for source, plan, original_tick in entries:
+            consumer_tick = 2 * original_tick + 1
+            transfer_tick = consumer_tick - 1
+            source.uses = sorted(
+                {use for use in source.uses if use != consumer_tick} | {transfer_tick}
+            )
+            destination = LifetimeBoundBuffer(
+                plan.destination_name,
+                round_up_to_alignment(source.size, _LX_ALLOCATION_GRANULARITY_BYTES),
+                [transfer_tick, consumer_tick],
+            )
+            buffers.insert(buffers.index(source), destination)
+
+    def _complete_lx_relayout_sources(
+        self, allocation: Sequence[LifetimeBoundBuffer]
+    ) -> set[str]:
+        by_name = {buffer.name: buffer for buffer in allocation}
+        groups: dict[str, list[LXRelayoutPlan]] = {}
+        for plan in self._lx_relayout_plans.values():
+            groups.setdefault(plan.source_name, []).append(plan)
+        complete = set()
+        for source_name, plans in groups.items():
+            source = by_name[source_name]
+            if source.address is None:
+                continue
+            if all(
+                (destination := by_name[plan.destination_name]).address is not None
+                and not (
+                    source.address < destination.address + destination.size
+                    and destination.address < source.address + source.size
+                )
+                for plan in plans
+            ):
+                complete.add(source_name)
+        return complete
+
+    def _clear_lx_relayout_groups(
+        self,
+        allocation: Sequence[LifetimeBoundBuffer],
+        sources: set[str],
+    ) -> None:
+        names = set(sources)
+        names.update(
+            plan.destination_name
+            for plan in self._lx_relayout_plans.values()
+            if plan.source_name in sources
+        )
+        for buffer in allocation:
+            if buffer.name in names:
+                buffer.address = None
+        self._lx_relayout_plans = {
+            edge: plan
+            for edge, plan in self._lx_relayout_plans.items()
+            if plan.source_name not in sources
+        }
+
+    def _accepted_plans(
+        self, allocation: Sequence[LifetimeBoundBuffer]
+    ) -> list[LXRelayoutPlan]:
+        by_name = {buffer.name: buffer for buffer in allocation}
+        return [
+            replace(
+                plan,
+                source_address=by_name[plan.source_name].address,
+                destination_address=by_name[plan.destination_name].address,
+            )
+            for plan in self._lx_relayout_plans.values()
+        ]
 
     def _log_lx_pinning(self, graph: GraphLowering, reasons: dict) -> None:
         """Log the final LX pinning decision for every op in the graph."""
@@ -830,25 +993,29 @@ class ScratchpadAllocator:
         graph_editor = GraphEditor(graph)
 
         for b in buffers:
-            if b.address is None:
+            if b.address is None or b.name.startswith("__spyre_lx_relayout__:"):
                 continue
 
             buf = graph.get_buffer(b.name)
             if b.name in inputs:
                 new_buffer = graph_editor.push_allocation_with_clone(
-                    buf, b.address, buffer_users[b.name], input=True
+                    buf, buffer_users[b.name], input=True
                 )
                 self._set_one_allocation(new_buffer, b.address)
 
             elif b.name in outputs:
                 new_buffer = graph_editor.push_allocation_with_clone(
-                    buf, b.address, buffer_users[b.name], input=False
+                    buf, buffer_users[b.name], input=False
                 )
                 self._set_one_allocation(buf, b.address)
                 graph_editor.change_graph_output(buf, new_buffer)
 
             else:
                 self._set_one_allocation(buf, b.address)
+
+        # Keep graph mutation last and in pre-scheduling: solver retries require
+        # the original graph, and post-grad no-op elimination has already run.
+        materialize_lx_relayouts(graph, self._accepted_lx_relayouts)
 
     def _set_one_allocation(self, buf: TensorBox | ComputedBuffer, address: int):
         layout = buf.get_layout()
@@ -881,30 +1048,6 @@ def _fixed_core_division(op: Operation) -> CoreDivision:
     """
     seed: tuple[dict, dict] = getattr(op, "op_it_space_splits", None) or ({}, {})
     return CoreDivision(output_splits=dict(seed[0]), reduction_splits=dict(seed[1]))
-
-
-def _op_short_name(op: Any) -> str:
-    """Resolve an op's short name from its ``origin_node`` target, falling back
-    to each fused fx node in ``op.origins``; ``"None"`` when unresolvable.
-
-    ``origin_node`` is tried first (independent of ``origins``, which may be
-    empty), so a plain op still resolves; the ``origins`` fallback recovers a
-    fused op like bmm+permute, whose ``origin_node`` target has no resolvable
-    name and would otherwise resolve to ``"None"`` and be wrongly rejected as
-    "op not allowed". Module-level so ``ScratchpadAllocator._get_op_name``
-    delegates to one implementation.
-    """
-    name = None
-    for fx_node in (getattr(op, "origin_node", None), *getattr(op, "origins", ())):
-        target = getattr(fx_node, "target", None)
-        name = (
-            getattr(target, "_opname", None)
-            or getattr(target, "__name__", None)
-            or getattr(target, "name", None)
-        )
-        if name is not None:
-            break
-    return name if name is not None else "None"
 
 
 DEFAULT_VARIANT_CAP = 6
@@ -1365,6 +1508,7 @@ class StrategyBCoOptimizingAllocator(ScratchpadAllocator):
         )
         solver = self._build_solver(buffers)
         allocation = solver.plan_layout(log_lx_usage=True)
+        assert not self._lx_relayout_plans
         reasons = self._get_spill_reasons(solver, allocation)
         self._push_allocation(graph, allocation)
         self._log_lx_pinning(graph, reasons)
@@ -2204,6 +2348,11 @@ def select_allocator() -> ScratchpadAllocator:
                 return ScratchpadAllocator(
                     layout_planning=GreedyLayoutSolver, size=size
                 )
+            if config.lx_planner_relayout:
+                logger.warning(
+                    "LX relayout is not supported by CoOptimizingAllocator; "
+                    "continuing without relayout"
+                )
             return CoOptimizingAllocator(layout_planning=solver, size=size)
         # Placement-only CP-SAT on the pre-determined core divisions.
         if solver is None:
@@ -2221,6 +2370,11 @@ def select_allocator() -> ScratchpadAllocator:
         )
 
     if config.co_optimizing_lx_planning:
+        if config.lx_planner_relayout:
+            logger.warning(
+                "LX relayout is not supported by StrategyBCoOptimizingAllocator; "
+                "continuing without relayout"
+            )
         return StrategyBCoOptimizingAllocator(layout_planning=solver_cls, size=size)
     return ScratchpadAllocator(layout_planning=solver_cls, size=size)
 

--- a/torch_spyre/_inductor/scratchpad/graph_editor.py
+++ b/torch_spyre/_inductor/scratchpad/graph_editor.py
@@ -100,36 +100,34 @@ class GraphEditor:
 
         raise KeyError(f"could not find buffer {old_name} to replace as output")
 
+    @staticmethod
+    def _clone_output_splits(name: str, consumer: ComputedBuffer) -> dict:
+        splits: tuple[dict, dict] = getattr(consumer, "op_it_space_splits", ({}, {}))
+        if not any(n > 1 for values in splits for n in values.values()):
+            return {}
+        rw = op_read_writes(consumer)
+        read = next((dep for dep in rw.reads if dep.name == name), None)
+        if read is None:
+            return {}
+        write_index = next(iter(rw.writes)).index
+        reference_index = next((dep.index for dep in rw.reads), write_index)
+        by_symbol = apply_splits_from_index_coeff(
+            splits,
+            write_index,
+            reference_index,
+            iteration_space_from_op(consumer),
+        )
+        return splits_by_index_coeff(by_symbol, read.index, read.index)[0]
+
     def push_allocation_with_clone(
         self,
         buffer: ComputedBuffer | TensorBox,
-        address: int,
         buffer_users: list[Operation],
         *,
         input: bool,
+        private: bool = False,
     ) -> ComputedBuffer:
-        """
-        Insert an operation using clone_lowering in GraphLowering.operations list after the given op
-        (buffer, a TensorBox or a ComputedBuffer). Will update GraphLowering FX graph and the
-        operations list. If update_downstream is True, then update any operations following the
-        given buffer to refer to the clone instead.
-
-        The clone will be inserted after buf. For example, the original ops list may look like this
-        (with buf0 taking the role of buf):
-            buf0 -> buf1 -> buf2
-        Insert a clone of buf0 and let buf1 read from it: this will become
-            buf0 ->(clone) buf3 -> buf1 ->buf2
-
-        Returns the new buffer so that either it or the original node can be allocated on the
-        scratchpad.
-
-        NOTE:
-        - Even though it is not a necessary condition, we assume FX graph and Operations are fully
-          consistent and we will try to maintain it that way.
-        - To update existing users of the old buffer -> hack the inner_fn then refresh LoopIR.
-
-        """
-        # Step 1: Add a new FX node for clone and update dependencies
+        """Insert a clone; private clones rewire only ``buffer_users``."""
         if isinstance(buffer, TensorBox):
             buf_name = buffer.data.data.name  # type: ignore
         else:
@@ -140,128 +138,102 @@ class GraphEditor:
         assert isinstance(buf_name, str)
         buf_fx = list(buffer.origins)[0]  # .origin_node may not exist
         old_users = list(buf_fx.users.keys())
+        if private:
+            consumer_fx = getattr(buffer_users[0], "origin_node", None) or next(
+                iter(buffer_users[0].origins)
+            )
+            old_users = [consumer_fx]
         self.fx_graph.inserting_after(buf_fx)
         new_fx_node = self.fx_graph.create_node(
             "call_function", self.clone_aten_op, (buf_fx,)
         )
         for user in old_users:
-            user.args = tuple(new_fx_node if ar is buf_fx else ar for ar in user.args)
+            user.replace_input_with(buf_fx, new_fx_node)
         self.lowering.orig_gm.recompile()
 
-        # Step 2: Create a new ComBuf of a Pointwise IR (need to support Reduction?)
-        pw_ir_tb = clone_lowering(buffer)  # a TensorBox wrapping a PointwiseIR
         layout = buffer.layout
         assert isinstance(layout, FixedTiledLayout)
+        clone_layout = FixedTiledLayout(
+            layout.device,
+            layout.dtype,
+            list(layout.size),
+            list(layout.stride),
+            layout.device_layout,
+            offset=layout.offset,
+        )
+        # Input buffers have no loop metadata, so input clones inherit it from
+        # their consumer. Output clones inherit it from their producer.
+        metadata_source = buffer_users[0] if input else buffer
+        assert isinstance(metadata_source, ComputedBuffer)
+        clone_tb = clone_lowering(buffer)
         new_com_buf = ComputedBuffer(
             name=None,
-            layout=FixedTiledLayout(
-                layout.device,
-                layout.dtype,
-                layout.size,  # pyright: ignore[reportArgumentType]
-                layout.stride,  # pyright: ignore[reportArgumentType]
-                layout.device_layout,
-                offset=layout.offset,
-            ),  # create a new copy of FixedTiledLayout from buffer's layout
-            data=pw_ir_tb.data.data,  # type: ignore
+            layout=clone_layout,
+            data=clone_tb.data.data,  # type: ignore[union-attr]
         )
+        new_com_buf.data.origins.add(new_fx_node)
         new_com_buf.origins.add(new_fx_node)
         new_com_buf.origin_node = new_fx_node
-        # Copy loop-group metadata so the clone stays in the same coarse-tile
-        # group as its neighbours and doesn't split a contiguous run.
-        # For input clones the original buffer is an InputBuffer (no metadata),
-        # so we inherit from the first consumer instead. For output clones the
-        # original ComputedBuffer already carries the right metadata.
-        copy_op_metadata(src=buffer_users[0] if input else buffer, dst=new_com_buf)
-        # TODO why arg0 ComputedBuffer doesn't have this attr?
+        copy_op_metadata(metadata_source, new_com_buf)
         new_com_buf.name = self.lowering.register_buffer(new_com_buf)
         self.lowering.register_operation(new_com_buf)
-        new_buf_name = new_com_buf.name
+        new_buf_name = new_com_buf.get_name()
 
-        # Propagate per-core splits to the clone. Users share one per_core_view
-        # (core_div_mismatch guard), so the first user is representative.
-        first_user = buffer_users[0]
-        fu_splits: tuple[dict, dict] = getattr(
-            first_user, "op_it_space_splits", ({}, {})
+        # Ordinary input clones have compatible consumers; private clones have one.
+        first_consumer = buffer_users[0]
+        consumer_splits: tuple[dict, dict] = getattr(
+            first_consumer, "op_it_space_splits", ({}, {})
         )
-        clone_out_splits: dict = fu_splits[0]
+        clone_out_splits: dict = consumer_splits[0]
         if input:
-            # An input clone is inserted *before* its consumers and they read
-            # the clone, so the clone's split must match how they read it.
-            # op_it_space_splits keys are stride coefficients in the consumer's
-            # index space -- NOT layout-invariant: a key maps to the same
-            # physical dim only when the consumer's output shape matches the
-            # clone's (== the buffer's) shape. A reduction consumer's output
-            # drops the reduced dim, so copying its keys verbatim splits the
-            # wrong axis of the full-shape clone (wrong values / SDSC abort at
-            # multi-core).
-            #
-            # Re-key: recover the consumer's {symbol: split}, then encode it
-            # against the consumer's READ index on this buffer. The clone is a
-            # Pointwise copy writing the buffer with that same (identity) index,
-            # so buffer-stride coeffs are valid clone output-split keys. Every
-            # per-core split -- output-dim or reduction/k-split -- lands on the
-            # matching buffer axis.
-            fu_rw = op_read_writes(first_user)
-            read_dep = next((d for d in fu_rw.reads if d.name == buf_name), None)
-            clone_out_splits = {}
-            if read_dep is not None and any(
-                n > 1 for d in fu_splits for n in d.values()
-            ):
-                fu_write_index = next(iter(fu_rw.writes)).index
-                fu_read_index = next((d.index for d in fu_rw.reads), fu_write_index)
-                per_sym = apply_splits_from_index_coeff(
-                    fu_splits,
-                    fu_write_index,
-                    fu_read_index,
-                    iteration_space_from_op(first_user),
-                )
-                clone_out_splits, _ = splits_by_index_coeff(
-                    per_sym, read_dep.index, read_dep.index
-                )
-        # An output clone copies the produced buffer 1:1 (same shape/layout), so
-        # the consumer's output splits transfer directly without re-keying.
+            # Re-key consumer splits against this read. Copying output keys is
+            # wrong for reductions because their output drops reduced axes.
+            assert isinstance(first_consumer, ComputedBuffer)
+            clone_out_splits = self._clone_output_splits(buf_name, first_consumer)
         new_com_buf.op_it_space_splits = (clone_out_splits, {})
 
         if input:
-            # Step 3: Update self.graph.name_to_users (a list of TensorBox), e.g., existing users of
-            # arg0, other than InpBuf and new_buf, should become users of new_buf.
-            users_of_inp = []
-            users_of_new_buf = []
+            source_users = []
+            clone_users = []
             for node in self.lowering.name_to_users[buf_name]:
                 while not isinstance(node, Buffer):
                     assert hasattr(node, "data"), (
                         f"unexpected node type {type(node)} ({node})"
                     )
                     node = node.data
-                if node.name in [buf_name, new_buf_name]:  # type: ignore
-                    users_of_inp.append(node)
+                keep_source = node.name in [buf_name, new_buf_name] or (
+                    private and node.name != buffer_users[0].get_name()
+                )
+                if keep_source:
+                    source_users.append(node)
                 else:
-                    users_of_new_buf.append(node)
-            self.lowering.name_to_users[buf_name] = users_of_inp
-            self.lowering.name_to_users[new_buf_name] = users_of_new_buf
+                    clone_users.append(node)
+            self.lowering.name_to_users[buf_name] = source_users
+            self.lowering.name_to_users[new_buf_name] = clone_users
 
-            # Step 4: Hack user nodes' inner_fn
-            for old_com_buf in buffer_users:
-                if GraphEditor.is_rewritable_consumer(old_com_buf):
-                    self._swap_loops_input(old_com_buf, buf_name, new_buf_name)
+            for consumer in buffer_users:
+                if GraphEditor.is_rewritable_consumer(consumer):
+                    self._replace_loop_input(consumer, buf_name, new_buf_name)
                 else:
                     raise NotImplementedError(
-                        f"unexpected buffer user type {type(old_com_buf)} ({old_com_buf})"
+                        f"unexpected buffer user type {type(consumer)} ({consumer})"
                     )
 
-        # NOTE: operations is a reference to graph.operations, which is already
-        # updated when we call graph.register_operation() earlier. But the new Op
-        # was appended at the end of the list, need to insert at the correct position.
-        first_user = buffer_users[0]
-        idx_to_first_user = self.lowering.operations.index(first_user)
-        assert self.lowering.operations[-1].name == new_com_buf.name, (
-            f"removing {new_com_buf.name} from "
-            f"{[op.name for op in self.lowering.operations]}"
+        self.lowering.operations.remove(new_com_buf)
+        self.lowering.operations.insert(
+            self.lowering.operations.index(buffer_users[0]), new_com_buf
         )
-        self.lowering.operations.pop()
-        self.lowering.operations.insert(idx_to_first_user, new_com_buf)
 
         return new_com_buf
+
+    def insert_clone_before_consumer(
+        self,
+        buffer: ComputedBuffer,
+        consumer: ComputedBuffer,
+    ) -> ComputedBuffer:
+        return self.push_allocation_with_clone(
+            buffer, [consumer], input=True, private=True
+        )
 
     @staticmethod
     def all_uses_are_rewritable(graph: GraphLowering, uses: list[int]) -> bool:
@@ -290,17 +262,16 @@ class GraphEditor:
         """
         return hasattr(op, "data") and isinstance(op.data, Pointwise | Reduction)
 
-    def _swap_loops_input(self, old_loop: Operation, old_name: str, new_name: str):
-        """Hack inner_fn with a nameSwapper ops handler and make a new LoopIR."""
+    def _replace_loop_input(
+        self, old_loop: Operation, old_name: str, new_name: str
+    ) -> None:
+        """Replace one buffer load in a pointwise or reduction loop."""
         assert isinstance(old_loop.data, Pointwise | Reduction)
         new_loop = self._create_loop_hack_inner_fn(
             old_loop.data, name_map={old_name: new_name}
         )
         old_loop.data = new_loop
-        # inner_fn now loads new_name in place of old_name, so this op's
-        # get_read_writes() changes; drop its memoized entry so any later
-        # op_read_writes() re-traces instead of returning the pre-swap reads.
-        # TODO: Contemplate automating there to make the cache opaque.
+        # The dependency set changed; force the next query to retrace the loop.
         invalidate_op_read_writes(old_loop)
 
     class _NameSwapHandler(WrapperHandler):

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -1520,7 +1520,7 @@ def _codegen_op_spec_list(specs, buf: IndentedBuffer, sympy_str) -> None:
             buf.writeline("),")
 
 
-def _remap_work_division(arg: TensorArg, iteration_remap) -> None:
+def _remap_work_division(arg: TensorArg, work_division_remap) -> None:
     """Carry tensor ownership through iteration-space normalization."""
 
     if arg.work_division is None:
@@ -1528,7 +1528,7 @@ def _remap_work_division(arg: TensorArg, iteration_remap) -> None:
     new_splits: dict[sympy.Symbol, int] = {}
     new_core_map: dict[sympy.Symbol, sympy.Expr] = {}
     for old_dim, split in arg.work_division.work_slices.items():
-        new_dims = iteration_remap[old_dim]
+        new_dims = work_division_remap[old_dim]
         remaining_split = int(split)
         split_factors = []
         if len(new_dims) == 1:
@@ -1565,7 +1565,7 @@ def simplify_op_spec(op_spec, indirect_sizes=None, indirect_access_subs=None):
     # decomposes symbols in align_tensors; indirect_access_subs replaces them with IndirectAccess.
     it_space = op_spec.iteration_space
 
-    new_op_space_splits, new_tensors, iteration_remap = align_tensors(
+    new_op_space_splits, new_tensors, work_division_remap = align_tensors(
         it_space,
         [
             {"size": arg.device_size, "coordinates": arg.device_coordinates}
@@ -1576,7 +1576,7 @@ def simplify_op_spec(op_spec, indirect_sizes=None, indirect_access_subs=None):
     op_spec.iteration_space = new_op_space_splits
 
     for arg, t in zip(op_spec.args, new_tensors):
-        _remap_work_division(arg, iteration_remap)
+        _remap_work_division(arg, work_division_remap)
         arg.device_size = t["size"]
         arg.device_coordinates = t["coordinates"]
 

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass, field
+import math
 from typing import Any, Callable, Self, Sequence, Tuple, Union
 from abc import ABC
 
@@ -47,6 +48,7 @@ from .constants import (
 from . import config as _spyre_config
 from .errors import Unsupported
 from .ir import FixedTiledLayout
+from .lx_relayout import work_division_from_view
 from .pass_utils import (
     concretize_expr,
     concretize_index,
@@ -64,8 +66,10 @@ from .op_spec import (
     LoopSpec,
     OpSpec,
     TensorArg,
+    TensorWorkDivision,
     UnimplementedOp as OpSpecUnimplementedOp,
     format_op_spec_list,
+    is_lx_relayout_identity,
 )
 from torch_spyre._inductor.provenance import build_debug_handle
 import logging
@@ -768,6 +772,11 @@ class SpyreKernel(Kernel[CSEVariable]):
             index,
             self.indirect_sizes,
         )
+        work_division = work_division_from_view(
+            tensor.layout.lx_view if "lx" in tensor.layout.allocation else None,
+            device_coords,
+            tuple(it_space),
+        )
         device_tile_advance_expr = self._general_tile_advance(tensor, is_input, name)
         tensor_arg = TensorArg(
             is_input,
@@ -779,6 +788,7 @@ class SpyreKernel(Kernel[CSEVariable]):
             element_arrangement=tensor.layout.device_layout.element_arrangement,
             name=opspec_name,
             device_tile_advance_expr=device_tile_advance_expr,
+            work_division=work_division,
         )
         if (
             "lx" not in tensor.layout.allocation
@@ -942,6 +952,10 @@ class SpyreKernel(Kernel[CSEVariable]):
             and hasattr(ir_node.data, "ranges")
             else None
         )
+        if not is_lx_relayout_identity(op, args):
+            for arg in args:
+                arg.work_division = None
+
         return OpSpec(
             op,
             is_reduction,
@@ -1487,9 +1501,63 @@ def _codegen_op_spec_list(specs, buf: IndentedBuffer, sympy_str) -> None:
                                 buf.writeline(
                                     f"element_arrangement={arg.element_arrangement},"
                                 )
+                            if arg.work_division is not None:
+                                splits = ", ".join(
+                                    f"{sympy_str(dim)}: {split}"
+                                    for dim, split in arg.work_division.work_slices.items()
+                                )
+                                core_map = ", ".join(
+                                    f"{sympy_str(dim)}: {sympy_str(slot)}"
+                                    for dim, slot in arg.work_division.core_id_to_work_slice.items()
+                                )
+                                buf.writeline(
+                                    "work_division=TensorWorkDivision("
+                                    f"work_slices={{{splits}}}, "
+                                    f"core_id_to_work_slice={{{core_map}}}),"
+                                )
                         buf.writeline("),")
                 buf.writeline("]")
             buf.writeline("),")
+
+
+def _remap_work_division(arg: TensorArg, iteration_remap) -> None:
+    """Carry tensor ownership through iteration-space normalization."""
+
+    if arg.work_division is None:
+        return
+    new_splits: dict[sympy.Symbol, int] = {}
+    new_core_map: dict[sympy.Symbol, sympy.Expr] = {}
+    for old_dim, split in arg.work_division.work_slices.items():
+        new_dims = iteration_remap[old_dim]
+        remaining_split = int(split)
+        split_factors = []
+        if len(new_dims) == 1:
+            split_factors = [(new_dims[0][0], remaining_split)]
+            remaining_split = 1
+        else:
+            for new_dim, basis in reversed(new_dims):
+                factor = math.gcd(remaining_split, basis)
+                split_factors.append((new_dim, factor))
+                remaining_split //= factor
+            split_factors.reverse()
+        if remaining_split != 1:
+            raise ValueError(f"cannot normalize {split}-way split on {old_dim}")
+
+        slot = arg.work_division.core_id_to_work_slice[old_dim]
+        slot_stride = 1
+        for new_dim, factor in split_factors:
+            if factor == 1:
+                continue
+            new_slot = sympy.Mod(sympy.floor(slot / slot_stride), factor)
+            if new_dim in new_splits and (
+                new_splits[new_dim],
+                new_core_map[new_dim],
+            ) != (factor, new_slot):
+                raise ValueError(f"conflicting normalized ownership on {new_dim}")
+            new_splits[new_dim] = factor
+            new_core_map[new_dim] = new_slot
+            slot_stride *= factor
+    arg.work_division = TensorWorkDivision(new_splits, new_core_map)
 
 
 def simplify_op_spec(op_spec, indirect_sizes=None, indirect_access_subs=None):
@@ -1497,7 +1565,7 @@ def simplify_op_spec(op_spec, indirect_sizes=None, indirect_access_subs=None):
     # decomposes symbols in align_tensors; indirect_access_subs replaces them with IndirectAccess.
     it_space = op_spec.iteration_space
 
-    new_op_space_splits, new_tensors = align_tensors(
+    new_op_space_splits, new_tensors, iteration_remap = align_tensors(
         it_space,
         [
             {"size": arg.device_size, "coordinates": arg.device_coordinates}
@@ -1508,6 +1576,7 @@ def simplify_op_spec(op_spec, indirect_sizes=None, indirect_access_subs=None):
     op_spec.iteration_space = new_op_space_splits
 
     for arg, t in zip(op_spec.args, new_tensors):
+        _remap_work_division(arg, iteration_remap)
         arg.device_size = t["size"]
         arg.device_coordinates = t["coordinates"]
 

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -532,7 +532,9 @@ def align_tensors(
     tensors: list[Dict[str, list[sympy.Expr]]],
     indirect_sizes: "dict[sympy.Symbol, int] | None" = None,
 ) -> tuple[
-    (dict[sympy.Symbol, tuple[sympy.Expr, int]], list[dict[str, list[sympy.Expr]]])
+    dict[sympy.Symbol, tuple[sympy.Expr, int]],
+    list[dict[str, list]],
+    dict[sympy.Symbol, tuple[tuple[sympy.Symbol, int], ...]],
 ]:
     """
     Transform op iteration space and tensor arguments to satisfy codegen requirements.
@@ -656,6 +658,7 @@ def align_tensors(
     new_var_ranges = {}
     new_op_it_space_splits = {}
     remap = {}  # map old var to new vars in splits order
+    ownership_remap = {}
     for var, split in splits.items():
         div = op_it_space_splits[var] if var in op_it_space_splits else 1
         if len(split) > 1:
@@ -666,6 +669,7 @@ def align_tensors(
                 new_var_ranges[new_var] = split[i + 1] // split[i]
                 remap[var].append(new_var)
 
+            bases = {}
             # distribute work division for old var to new vars
             for v in reversed(remap[var]):
                 # Re-intersect the committed split against the basis work
@@ -679,8 +683,10 @@ def align_tensors(
                 else:
                     # Non-stick var (or synthetic sub-dim): element range.
                     basis = new_var_ranges[v]
+                bases[v] = int(basis)
                 new_op_it_space_splits[v] = math.gcd(div, basis)
                 div //= new_op_it_space_splits[v]
+            ownership_remap[var] = tuple((v, bases[v]) for v in remap[var])
         else:
             # no splits keep existing var, range, and work division
             # may happen with a single stick since the stick size is omitted
@@ -704,6 +710,7 @@ def align_tensors(
             new_op_it_space_splits[var] = (
                 op_it_space_splits[var] if var in op_it_space_splits else 1
             )
+            ownership_remap[var] = ((var, 1),)
     # create new tensors with new sizes and coordinate expressions matching new vars
     new_tensors = []
     for j, terms in enumerate(all_terms):
@@ -822,7 +829,7 @@ def align_tensors(
         if k not in indirect_syms
     }
 
-    return new_iteration_space, new_tensors
+    return new_iteration_space, new_tensors, ownership_remap
 
 
 def tiling_expr_to_device_expr(

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -658,7 +658,7 @@ def align_tensors(
     new_var_ranges = {}
     new_op_it_space_splits = {}
     remap = {}  # map old var to new vars in splits order
-    ownership_remap = {}
+    work_division_remap = {}
     for var, split in splits.items():
         div = op_it_space_splits[var] if var in op_it_space_splits else 1
         if len(split) > 1:
@@ -686,7 +686,7 @@ def align_tensors(
                 bases[v] = int(basis)
                 new_op_it_space_splits[v] = math.gcd(div, basis)
                 div //= new_op_it_space_splits[v]
-            ownership_remap[var] = tuple((v, bases[v]) for v in remap[var])
+            work_division_remap[var] = tuple((v, bases[v]) for v in remap[var])
         else:
             # no splits keep existing var, range, and work division
             # may happen with a single stick since the stick size is omitted
@@ -710,7 +710,7 @@ def align_tensors(
             new_op_it_space_splits[var] = (
                 op_it_space_splits[var] if var in op_it_space_splits else 1
             )
-            ownership_remap[var] = ((var, 1),)
+            work_division_remap[var] = ((var, 1),)
     # create new tensors with new sizes and coordinate expressions matching new vars
     new_tensors = []
     for j, terms in enumerate(all_terms):
@@ -829,7 +829,7 @@ def align_tensors(
         if k not in indirect_syms
     }
 
-    return new_iteration_space, new_tensors, ownership_remap
+    return new_iteration_space, new_tensors, work_division_remap
 
 
 def tiling_expr_to_device_expr(

--- a/torch_spyre/_inductor/wrapper.py
+++ b/torch_spyre/_inductor/wrapper.py
@@ -55,7 +55,7 @@ class SpyrePythonWrapperCodegen(PythonWrapperCodegen):
         self.imports.splice(
             """
                 from sympy import sympify
-                from torch_spyre._inductor.op_spec import TensorArg, OpSpec, UnimplementedOp, LoopSpec, spyre_constant_tensor, IndirectAccess, DebugHandle, SourceLoc, ProvenanceTransform
+                from torch_spyre._inductor.op_spec import TensorArg, TensorWorkDivision, OpSpec, UnimplementedOp, LoopSpec, spyre_constant_tensor, IndirectAccess, DebugHandle, SourceLoc, ProvenanceTransform
                 from torch_spyre.execution.async_compile import SpyreAsyncCompile
                 from torch_spyre._C import DataFormats, ElementArrangement, SpyreTensorLayout, spyre_empty_with_layout, set_spyre_tensor_layout
                 import subprocess


### PR DESCRIPTION
## Summary

Carries @AdnanHoque's #3439 forward onto current `main` and addresses the review feedback on it. **Draft**: the LX relayout transport still needs DeepTools support that has not landed, so the pass ships opt-in and its end-to-end numeric test is `xfail`.

Opened to unblock the review discussion on #3439, which is stalled on a design question that turns out to be answerable with evidence. Not intended to take ownership away from @AdnanHoque - happy to fold any of this back into #3439 instead if that is cleaner.

## The design question #3439 is blocked on

@dgrove-oss asked whether the SHUFFLE genuinely needs a different SDSC encoding than an ordinary copy, or whether that is only an artifact of how the pass computes coordinates. It is the former. Comparing the two copies emitted in one bundle, per-dim fold factors:

| | `mb` | `out` |
|---|---|---|
| `identity` source | core_fold=4, elem_arr=[64] | core_fold=1, elem_arr=[1,64] |
| `identity` dest | core_fold=4, elem_arr=[64] | core_fold=1, elem_arr=[1,64] |
| `shuffle` source | core_fold=8, elem_arr=**[16]** | core_fold=1, elem_arr=**[4,64]** |
| `shuffle` dest | core_fold=2, elem_arr=**[64]** | core_fold=4, elem_arr=**[1,64]** |

An ordinary identity copy has identical per-core element arrays on both sides, so one loop nest serves both. The relayout differs on both dims, and that is exactly what DeepTools rejects:

```
DtException: [distributeElemArrToTemporalLoops] Not enough elements to distribute.
  Loop=loop_ds1_ds3_out_mb: requires 64 elements in total, across 64 iterations.
  ElemArr: innerCardinality=1 elemArr[0]: (alpha=1, cardinality=16)
```

The asymmetry is not incidental - per-core extents differing *is* what redistributing a buffer across cores means, and an SDSC op has one loop nest over one iteration space. So folding the relayout into the existing
`RESTICKIFY_OP`/`IDENTITY_OP` dispatch is not available: those are precisely the cases where the extents match. Making the node more ordinary makes it less expressible.

Two ways out: a transport primitive the toolchain models as a redistribution, or decomposing into per-peer transfers whose extents match on both sides. DeepTools support for the former is in flight, which is what this is waiting on.

## Why #3439's CI was green

The end-to-end numeric test (`test_lx_relayout_between_named_work_divisions_numeric`) was added with the pass in `30c275f8` and removed again in `1a9436c8` while the codegen was being restructured. It is the only check that a planner-accepted ownership change executes and matches CPU, so its absence is what let the pass look green while `test_mlp`, `test__simple_attn` and `test_flash_attention` were failing on hardware with the abort above.

It is restored here, `xfail(strict=True)` against the DeepTools abort: the
failure is recorded rather than hidden, and the marker has to come off as soon as the transport works. The pass also defaults off now, since leaving it on aborts `dxp_standalone` on the graphs it targets.

## Changes on top of #3439

**Rebase.** #3439's 13 commits are squashed into one, authored by @AdnanHoque, tree byte-identical to its head. The intermediate commits rewrote each other, so a 13-step rebase would have resolved conflicts against states that were then discarded. Main's `MemoryPlanSolver` refactor (#3620) needed real adaptation: solvers are single-use now, so `_build_solver` picks the factory and the atomic-relayout fallback builds a second instance over the reduced buffer set.

**`operation_name` is no longer hijacked.** The copy was marked by overwriting `operation_name` with the literal `"lx_relayout_copy"` after `register_operation` had assigned it `opN`. That field is the operation's identity: it keys `GraphLowering.name_to_op`, it is what `BaseSchedulerNode.get_name` returns, and it feeds `compute_ancestors` and every fusion-legality check. It is also not unique, so one source feeding two mismatched consumers produced two scheduler nodes answering to the same name. Replaced with a dedicated marker attribute.

**Rejections are diagnosable.** The planner had twelve places that abandoned a source, none of which logged anything, in one 91-line loop body - a relayout that silently did not happen was undiagnosable from outside. The per-edge decision is now `_plan_relayout_edge`, returning a plan, `None`, or the reason, and there are 18 distinct reasons where there were 12 silent exits (the geometry check's single `False` was hiding five separate causes).

**De-duplication.** `core_id`-to-slot evaluation existed three times in three key spaces, all required to agree; it is now one generic `evaluate_core_slot_map` in `core_mapping.py`, beside the function that builds the expressions it evaluates. The dimension-to-loop-symbol predicate is shared between planner and codegen - previously the planner returned a bool and fell back to HBM while codegen reimplemented the check and raised, so drift would have turned a clean fallback into a compile failure.

Also: `RelayoutGeometry` replaces a bool that discarded the fan-in (#3440 had to rewrite that function to get it back); the allocator's destination insertion is decide-then-apply rather than a rescan per relayout; and several docstrings deleted during the rework are restored.

## Still open

- `TensorArg.work_division` still coexists with the op-level `work_slices`/`core_id_to_work_slice`. This is the remaining part of @dgrove-oss's ask, and @cyang49 asked for it independently. Worth noting the explicit-ownership shape existed at `23f66b6` and @cyang49 reviewed it favourably before the identity-copy rework replaced it - given the transport is real, something close to that earlier shape is probably right.
- A relayout demoted by the scheduler leaves a dead HBM-to-HBM copy in the graph, because `materialize_lx_relayouts` runs before `demote_incoherent_lx_buffers`.
- #3440 is stacked on a pre-restructure copy of #3439 and needs to rebase onto whatever lands here. Most of it does not depend on this: the `copy_fx_custom_meta` hint-preservation change and the named gather-dim core mapping are independent and could land separately.

Tracking: #3049. Supersedes nothing yet - #3439 remains the PR of record until there is agreement on which to carry forward.
