### PR TITLE
Change frontend codegen to use pool_base_addr to intermediate tensors

### DIFF
--- a/docs/source/compiler/hbm_pool_planning.md
+++ b/docs/source/compiler/hbm_pool_planning.md
@@ -39,9 +39,9 @@ call in the generated wrapper code.
 
 The fundamental constraint is:
 
-> A buffer's pool allocation is scoped to a single bundle. The pool tensor
-> is allocated immediately before that bundle's `.run()` call and freed
-> immediately after. Separate bundles do not share a pool.
+> A buffer's pool allocation is scoped to a single bundle: the pool is
+> allocated inside that bundle's own generated MLIR and its lifetime is that
+> bundle's execution. Separate bundles do not share a pool.
 
 This means:
 
@@ -144,8 +144,8 @@ For each top-level entry (bundle) in the post-fusion node list:
    `V.graph.hbm_pool_sizes[bundle_name]`.
 
 Only bundles with at least one pool-eligible buffer get an entry in
-`V.graph.hbm_pool_sizes`; bundles with no pool candidates get no pool tensor
-and no allocation overhead.
+`V.graph.hbm_pool_sizes`; bundles with no pool candidates get no pool
+allocation and no allocation overhead.
 
 ## Integration with code generation
 

--- a/docs/source/compiler/hbm_pool_planning.md
+++ b/docs/source/compiler/hbm_pool_planning.md
@@ -173,6 +173,40 @@ HBM pool planning is controlled by `config.hbm_pool_planning`, which defaults
 to on. Set `HBM_POOL_PLANNING=0` to disable it globally; in that mode all
 intermediates fall back to standalone HBM.
 
+**Pool size budget:**
+
+Each bundle's pool is capped at `constants.MAX_POOL_SIZE_BYTES`, defined as
+`SEGMENT_SIZE - 2 GiB`. `SEGMENT_SIZE` is the full size of the HBM segment
+(`constants.INTERMEDIATES_SEGMENT`) that the pool is carved out of; the 2 GiB
+of headroom below that is reserved for other consumers of the same program
+segment (e.g. kernel-address and dimension-symbol bookkeeping), which are
+allocated from the same segment independently of pool planning. The
+reservation is scoped to the program's own HBM segment -- rather than, say, a
+separate fixed address range -- because the segment is the unit the runtime
+already partitions and tracks; carving the pool's budget out of it keeps all
+of a program's HBM consumers accounted for against the same limit instead of
+introducing a second, independently-tracked budget.
+
+`Allocator.allocate()` gates on the pool's bump-pointer high-water mark
+(`pool_end`), not on peak concurrent usage: `pool_end` is exactly the byte
+count `generate_bundle` reserves via `sdscbundle.device_mem_allocate`, and
+free-list fragmentation can push `pool_end` past the budget even while
+concurrent usage stays low, so gating on usage alone would let an
+over-budget pool slip through undetected.
+
+**Overflow behavior:**
+
+If a bundle's pool-eligible intermediates would collectively push `pool_end`
+past `MAX_POOL_SIZE_BYTES`, `Allocator.allocate()` returns `None` for the
+buffer(s) that would overflow it. Those buffers are not failures: they simply
+fall back to standalone HBM allocation (no `"hbm_pool"` key on their layout),
+the same path already used for cross-bundle and I/O buffers. The rest of the
+bundle's pool-eligible buffers are unaffected. The cost of falling back is
+that the buffer's address is computed independently (typically via
+`affine.apply`-based addressing) rather than as a cheap `arith.addi` offset
+from the bundle's single `%pool` base -- strictly a performance cost, not a
+correctness one.
+
 **Interaction with symbolic arguments:**
 
 In `bundle_symbolic_args=False` mode (not the default -- the default is

--- a/docs/source/compiler/hbm_pool_planning.md
+++ b/docs/source/compiler/hbm_pool_planning.md
@@ -150,19 +150,22 @@ and no allocation overhead.
 ## Integration with code generation
 
 During code generation, the scheduler looks up each bundle's pool size from
-`V.graph.hbm_pool_sizes` and passes it to `SpyreKernel`'s constructor. The
-kernel then emits pool allocation and deallocation code around its own
-`.run()` call:
+`V.graph.hbm_pool_sizes` and passes it to `SpyreKernel`'s constructor. Unlike
+LX scratchpad buffers, the pool is never materialized as a Python-side
+tensor: `pool_size` is threaded through `define_kernel()` into the
+generated `async_compile.sdsc(...)` call, and from there into
+`generate_bundle()`, which emits the pool allocation as a single MLIR op
+inside the bundle's own function body:
 
-```python
-_pool_{bundle_name} = spyre_empty_with_layout((pool_size_bytes,), (1,), torch.uint8, ...)
-sdsc_fused__{bundle_name}.run(_pool_{bundle_name}, ...)
-del _pool_{bundle_name}
+```mlir
+%pool = sdscbundle.device_mem_allocate {pool_size_bytes} bytes : index
 ```
 
-This per-bundle scoping ensures that the pool tensor's lifetime is limited to
-the bundle's own kernel invocation, minimizing peak HBM usage across the
-entire graph execution.
+Every pool-allocated buffer's address is then computed relative to `%pool`
+via `arith.addi`, deduplicated by offset (unchanged from before). Because
+the allocation is a single MLIR op scoped to the bundle's own function body,
+its lifetime is implicitly limited to that bundle's execution -- there is no
+explicit free op, and no Python-side tensor to allocate or delete.
 
 ## Configuration and limitations
 

--- a/docs/source/compiler/hbm_pool_planning.md
+++ b/docs/source/compiler/hbm_pool_planning.md
@@ -157,7 +157,7 @@ generated `async_compile.sdsc(...)` call, and from there into
 `generate_bundle()`, which emits the pool allocation as a single MLIR op
 inside the bundle's own function body:
 
-```mlir
+```none
 %pool = sdscbundle.device_mem_allocate {pool_size_bytes} bytes : index
 ```
 

--- a/tests/inductor/indirect_access_common.py
+++ b/tests/inductor/indirect_access_common.py
@@ -130,7 +130,7 @@ def capture_op_specs():
     """
     captured: list[list] = []
 
-    def _spy(self, kernel_name, specs):  # noqa: ARG001
+    def _spy(self, kernel_name, specs, pool_size=0):  # noqa: ARG001
         captured.append(list(specs))
         return _NoopRunner()
 
@@ -146,7 +146,7 @@ def capture_sdsc_calls():
     """
     calls: list[tuple[str, list]] = []
 
-    def _spy(self, kernel_name, specs):  # noqa: ARG001
+    def _spy(self, kernel_name, specs, pool_size=0):  # noqa: ARG001
         calls.append((kernel_name, list(specs)))
         return _NoopRunner()
 

--- a/tests/inductor/indirect_access_common.py
+++ b/tests/inductor/indirect_access_common.py
@@ -314,7 +314,10 @@ def generate_sdsc_jsons(kernel, *dev_args) -> dict:
     for ci, specs in enumerate(captured):
         sub = os.path.join(out, f"kernel{ci}")
         os.makedirs(sub, exist_ok=True)
-        generate_bundle(f"kernel{ci}", sub, specs)
+        # This exercises SDSC JSON generation, not hardware pool sizing, so a
+        # placeholder non-zero size satisfies generate_bundle's pool_size
+        # validation whenever a pool symbol happens to be present.
+        generate_bundle(f"kernel{ci}", sub, specs, pool_size=1024)
         for path in sorted(glob.glob(os.path.join(sub, "sdsc_*.json"))):
             with open(path) as f:
                 jsons[os.path.relpath(path, out)] = json.load(f)
@@ -500,7 +503,10 @@ def bundle_jsons_from_captured(captured) -> dict:
         sub = os.path.join(out, f"kernel{ci}")
         os.makedirs(sub, exist_ok=True)
         try:
-            generate_bundle(f"kernel{ci}", sub, specs)
+            # This call only inspects SDSC JSON structure, not hardware pool
+            # sizing, so a placeholder non-zero size satisfies generate_bundle's
+            # pool_size validation whenever a pool symbol happens to be present.
+            generate_bundle(f"kernel{ci}", sub, specs, pool_size=1024)
         except Exception:  # noqa: BLE001 - absence of jsons is itself an outcome
             continue
         for path in sorted(glob.glob(os.path.join(sub, "sdsc_*.json"))):

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -5848,10 +5848,11 @@ class TestCoarseTileSpyreHints(InductorTestCase):
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_pool_alloc_scoped_per_bundle_across_fallback_boundary(self):
         """A CPU-fallback op (torch.sin) splits the graph into multiple
-        bundles. Each bundle's pool tensor (if any) is allocated right
-        before its own .run() call and freed right after -- there is no
-        single graph-global "_pool" shared across bundles, and the
-        intermediate crossing the fallback boundary is not pool-allocated."""
+        bundles. Each bundle's pool (if any) is allocated inside that
+        bundle's own generated MLIR via sdscbundle.device_mem_allocate --
+        there is no Python-side pool tensor, and no bundle's MLIR references
+        another bundle's pool."""
+        from torch_spyre.execution import async_compile as async_compile_mod
 
         def fn(t):
             a = torch.exp(t) * 2  # compiled bundle 1; `a` crosses the
@@ -5861,34 +5862,64 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
         x = torch.randn(64, 64, dtype=torch.float16, device="spyre")
 
+        # get_output_dir() mints a fresh random tempdir on every call (see
+        # its uuid4()-based implementation), so it cannot be re-invoked from
+        # the test to recover the directory sdsc() actually used to write
+        # bundle.mlir. Wrap it to record kernel_name -> output_dir while
+        # still delegating to the real implementation.
+        real_get_output_dir = async_compile_mod.get_output_dir
+        output_dirs_by_kernel = {}
+
+        def _recording_get_output_dir(kernel_name):
+            output_dir = real_get_output_dir(kernel_name)
+            output_dirs_by_kernel[kernel_name] = output_dir
+            return output_dir
+
         with (
             mock_patch(_LAUNCH_JOBPLAN),
             mock_patch(_PREPARE_KERNEL),
             mock_patch("subprocess.run"),
+            mock_patch.object(
+                async_compile_mod, "get_output_dir", _recording_get_output_dir
+            ),
             pytest.warns(UserWarning),
         ):
             _, source_codes = run_and_get_code(torch.compile(fn), x)
         src = source_codes[0]
 
-        # No single graph-global "_pool = " assignment (the old scheme).
-        self.assertNotIn("_pool = spyre_empty_with_layout", src)
-        # Any pool tensor that does appear is kernel-scoped
-        # ("_pool_<kernel_name> = ..."), never the bare literal "_pool".
+        # No Python-side pool tensor of any kind remains in the wrapper.
+        # Ordinary output buffers legitimately use spyre_empty_with_layout,
+        # so distinguish pool allocs by their telltale uint8 dtype, same as
+        # test_no_python_side_pool_tensor_allocated below.
         pool_alloc_lines = [
             line
             for line in src.splitlines()
             if "spyre_empty_with_layout" in line and "uint8" in line
         ]
-        for line in pool_alloc_lines:
-            self.assertRegex(line.strip(), r"^_pool_\S+\s*=")
-        # Each pool alloc line's variable is del'd, and each .run( call that
-        # uses a pool passes that same per-kernel variable, not a shared name.
-        pool_var_names = [
-            line.strip().split("=", 1)[0].strip() for line in pool_alloc_lines
-        ]
-        self.assertEqual(len(pool_var_names), len(set(pool_var_names)))
-        for var_name in pool_var_names:
-            self.assertIn(f"del {var_name}", src)
+        self.assertEqual(pool_alloc_lines, [])
+        self.assertNotIn("_pool_", src)
+
+        # Each kernel name mentioned in an async_compile.sdsc(...) call gets
+        # its own bundle.mlir; any that uses a pool must self-allocate it via
+        # device_mem_allocate, never via a %pool_base_addr parameter.
+        kernel_names = re.findall(r"async_compile\.sdsc\('(\w+)'", src)
+        self.assertTrue(kernel_names)
+        saw_pool_allocate = False
+        for kernel_name in kernel_names:
+            self.assertIn(kernel_name, output_dirs_by_kernel)
+            bundle_path = os.path.join(
+                output_dirs_by_kernel[kernel_name], "bundle.mlir"
+            )
+            with open(bundle_path) as f:
+                bundle_text = f.read()
+            self.assertNotIn("%pool_base_addr", bundle_text)
+            if "device_mem_allocate" in bundle_text:
+                saw_pool_allocate = True
+        self.assertTrue(
+            saw_pool_allocate,
+            f"expected at least one bundle to use device_mem_allocate, "
+            f"kernels were {kernel_names}",
+        )
 
     @config.patch({"lx_planning": False})
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -5890,6 +5890,33 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         for var_name in pool_var_names:
             self.assertIn(f"del {var_name}", src)
 
+    @config.patch({"lx_planning": False})
+    def test_pool_size_kwarg_in_generated_sdsc_call(self):
+        """define_kernel() must append pool_size=<N> to the generated
+        async_compile.sdsc(...) call text for a kernel whose pool_size > 0,
+        and omit the kwarg entirely for a kernel with no pool usage."""
+
+        def fn(x, y):
+            a = x + y
+            b = a * 2
+            return b - x
+
+        x = torch.randn(64, 64, dtype=torch.float16, device="spyre")
+        y = torch.randn(64, 64, dtype=torch.float16, device="spyre")
+
+        with (
+            mock_patch(_LAUNCH_JOBPLAN),
+            mock_patch(_PREPARE_KERNEL),
+            mock_patch("subprocess.run"),
+        ):
+            _, source_codes = run_and_get_code(torch.compile(fn), x, y)
+        src = source_codes[0]
+
+        self.assertIn("pool_size=", src)
+        # Every async_compile.sdsc( call either has no pool_size kwarg, or a
+        # positive one -- pool_size=0 must never be emitted explicitly.
+        self.assertNotIn("pool_size=0", src)
+
 
 class TestNamedDimsHint(InductorTestCase):
     """Tests for propagate_named_dims handling of ops with a named_dims hint.

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -5961,7 +5961,9 @@ class TestCoarseTileSpyreHints(InductorTestCase):
     def test_pool_size_kwarg_in_generated_sdsc_call(self):
         """define_kernel() must append pool_size=<N> to the generated
         async_compile.sdsc(...) call text for a kernel whose pool_size > 0,
-        and omit the kwarg entirely for a kernel with no pool usage."""
+        and pool_size=0 must never be emitted explicitly. See
+        test_pool_size_kwarg_omitted_when_no_pool below for the omission
+        case on a kernel with no pool usage at all."""
 
         def fn(x, y):
             a = x + y
@@ -5983,6 +5985,36 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         # Every async_compile.sdsc( call either has no pool_size kwarg, or a
         # positive one -- pool_size=0 must never be emitted explicitly.
         self.assertNotIn("pool_size=0", src)
+
+    @config.patch({"lx_planning": True})
+    def test_pool_size_kwarg_omitted_when_no_pool(self):
+        """A kernel with no pool usage gets no pool_size kwarg at all.
+
+        With lx_planning enabled, the `a = x + y` intermediate is claimed by
+        LX scratchpad planning before hbm_pool_planning ever sees it (see
+        OP_OUTPUT_GOOD_FOR_LX_REUSE in scratchpad/utils.py), so this bundle
+        has no pool-eligible buffer and define_kernel() must omit the
+        pool_size kwarg entirely rather than emit pool_size=0.
+        """
+
+        def fn(x, y):
+            a = x + y
+            b = a * 2
+            return b - x
+
+        x = torch.randn(64, 64, dtype=torch.float16, device="spyre")
+        y = torch.randn(64, 64, dtype=torch.float16, device="spyre")
+
+        with (
+            mock_patch(_LAUNCH_JOBPLAN),
+            mock_patch(_PREPARE_KERNEL),
+            mock_patch("subprocess.run"),
+        ):
+            _, source_codes = run_and_get_code(torch.compile(fn), x, y)
+        src = source_codes[0]
+
+        self.assertIn("async_compile.sdsc(", src)
+        self.assertNotIn("pool_size", src)
 
 
 class TestNamedDimsHint(InductorTestCase):

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -5891,6 +5891,42 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             self.assertIn(f"del {var_name}", src)
 
     @config.patch({"lx_planning": False})
+    @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
+    def test_no_python_side_pool_tensor_allocated(self):
+        """No bundle allocates a Python-side _pool_<name> tensor any more --
+        pool allocation is now entirely inside the generated MLIR."""
+
+        def fn(t):
+            a = torch.exp(t) * 2
+            b = torch.sin(a)  # fallback op -- forces a bundle boundary
+            c = torch.exp(b) * 2
+            return c
+
+        x = torch.randn(64, 64, dtype=torch.float16, device="spyre")
+
+        with (
+            mock_patch(_LAUNCH_JOBPLAN),
+            mock_patch(_PREPARE_KERNEL),
+            mock_patch("subprocess.run"),
+            pytest.warns(UserWarning),
+        ):
+            _, source_codes = run_and_get_code(torch.compile(fn), x)
+        src = source_codes[0]
+
+        # No Python-side pool tensor allocation (uint8 SpyreTensorLayout) --
+        # ordinary output buffers still legitimately use
+        # spyre_empty_with_layout, so distinguish pool allocs by their
+        # telltale uint8 dtype, same as
+        # test_pool_alloc_scoped_per_bundle_across_fallback_boundary above.
+        pool_alloc_lines = [
+            line
+            for line in src.splitlines()
+            if "spyre_empty_with_layout" in line and "uint8" in line
+        ]
+        self.assertEqual(pool_alloc_lines, [])
+        self.assertNotIn("_pool_", src)
+
+    @config.patch({"lx_planning": False})
     def test_pool_size_kwarg_in_generated_sdsc_call(self):
         """define_kernel() must append pool_size=<N> to the generated
         async_compile.sdsc(...) call text for a kernel whose pool_size > 0,

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -6020,7 +6020,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
 
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
-    def _bundle(self, specs, fake_compile=None):
+    def _bundle(self, specs, fake_compile=None, pool_size=0):
         if fake_compile is None:
             fake_compile = _fake_compile_op_spec
         with patch(
@@ -6031,6 +6031,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 "test_kernel",
                 self.tmpdir,
                 specs,
+                pool_size=pool_size,
             )
         return _read_mlir(self.tmpdir)
 
@@ -6163,7 +6164,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
             )  # op_b has pool allocation
             return _make_tiled_json(idx, sym_id), [values[i]], [{}], [kind]
 
-        mlir = self._bundle([op_a, op_b], fake_compile=fake)
+        mlir = self._bundle([op_a, op_b], fake_compile=fake, pool_size=1024)
 
         # First sym → parameter (kernel tensor arg)
         self.assertIn("%arg_0_base_addr: !sdscbundle.input_arg<index>", mlir)
@@ -6320,7 +6321,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 [SymbolKind.pool()],
             )
 
-        mlir = self._bundle([a, b, c], fake_compile=fake)
+        mlir = self._bundle([a, b, c], fake_compile=fake, pool_size=4096)
 
         # Exactly two arith.constant / arith.addi pairs (offsets 0 and 2048)
         self.assertEqual(mlir.count("arith.constant 0 : index"), 1)

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -6169,7 +6169,8 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         self.assertIn("%arg_0_base_addr: !sdscbundle.input_arg<index>", mlir)
         self.assertNotIn("arith.constant 17179869184", mlir)
         # Second sym → pool: arith.addi %pool, <offset>
-        self.assertIn("%pool_base_addr: !sdscbundle.input_arg<index>", mlir)
+        self.assertNotIn("%pool_base_addr", mlir)
+        self.assertIn("sdscbundle.device_mem_allocate", mlir)
         self.assertIn("%pool_addr_0 = arith.addi %pool", mlir)
 
     def test_multi_sdsc_two_tensor_args_snapshot(self):

--- a/tests/inductor/test_hbm_pool_planning.py
+++ b/tests/inductor/test_hbm_pool_planning.py
@@ -495,14 +495,14 @@ class TestHbmPoolPlanningPerBundle(unittest.TestCase):
         self.assertNotIn("hbm_pool", alias_buf.get_layout().allocation)
 
     def test_buffer_that_overflows_pool_falls_back_to_standalone_hbm(self):
-        """When MAX_POOL_SIZE is too small to hold every pool-eligible
+        """When MAX_POOL_SIZE_BYTES is too small to hold every pool-eligible
         buffer, the ones that fit get an hbm_pool allocation and the
         overflow buffer(s) fall back to standalone HBM (no hbm_pool key)
         instead of raising.
 
         buf0 (128 bytes) and buf1 (256 bytes) have non-overlapping live
         ranges but the allocator restarts a fresh Allocator per bundle, so
-        with MAX_POOL_SIZE patched to 200 bytes, buf0 fits (128 <= 200) but
+        with MAX_POOL_SIZE_BYTES patched to 200 bytes, buf0 fits (128 <= 200) but
         buf1 does not (256 > 200): the very first allocation call already
         exceeds budget for buf1 regardless of live-range-driven reuse.
         """
@@ -514,7 +514,7 @@ class TestHbmPoolPlanningPerBundle(unittest.TestCase):
         r1 = _make_snode_with_rw("r1", writes=[], reads=["buf1"])
         bundle = FusedSchedulerNode(MagicMock(), [w0, r0, w1, r1])
 
-        with patch("torch_spyre._inductor.hbm_pool_planning.MAX_POOL_SIZE", 200):
+        with patch("torch_spyre._inductor.hbm_pool_planning.MAX_POOL_SIZE_BYTES", 200):
             hbm_pool_planning([bundle])
 
         buf0 = V.graph.get_buffer("buf0")
@@ -526,7 +526,7 @@ class TestHbmPoolPlanningPerBundle(unittest.TestCase):
         self.assertEqual(V.graph.hbm_pool_sizes[bundle.get_name()], 128)
 
     def test_all_buffers_overflow_pool_produces_zero_size_pool(self):
-        """If MAX_POOL_SIZE is too small for even the first buffer, every
+        """If MAX_POOL_SIZE_BYTES is too small for even the first buffer, every
         pool-eligible buffer in the bundle falls back to standalone HBM and
         the bundle's recorded pool extent is 0 -- no RuntimeError."""
         _make_ftl_buffer("buf0", host_size=(64,))
@@ -534,7 +534,7 @@ class TestHbmPoolPlanningPerBundle(unittest.TestCase):
         reader = _make_snode_with_rw("reader", writes=[], reads=["buf0"])
         bundle = FusedSchedulerNode(MagicMock(), [writer, reader])
 
-        with patch("torch_spyre._inductor.hbm_pool_planning.MAX_POOL_SIZE", 1):
+        with patch("torch_spyre._inductor.hbm_pool_planning.MAX_POOL_SIZE_BYTES", 1):
             hbm_pool_planning([bundle])
 
         buf0 = V.graph.get_buffer("buf0")
@@ -558,7 +558,7 @@ class TestHbmPoolPlanningPerBundle(unittest.TestCase):
         # one live buffer at a time, not both concurrently.
         bundle = FusedSchedulerNode(MagicMock(), [w0, r0, w1, r1])
 
-        with patch("torch_spyre._inductor.hbm_pool_planning.MAX_POOL_SIZE", 128):
+        with patch("torch_spyre._inductor.hbm_pool_planning.MAX_POOL_SIZE_BYTES", 128):
             hbm_pool_planning([bundle])
 
         buf0 = V.graph.get_buffer("buf0")

--- a/tests/inductor/test_hbm_pool_planning.py
+++ b/tests/inductor/test_hbm_pool_planning.py
@@ -63,29 +63,49 @@ class TestAllocator(unittest.TestCase):
         self.assertEqual(allocator.get_pool_end(), 90)
 
     def test_failed_allocate_does_not_consume_free_block(self):
-        """A rejected allocate() that would have reused a free block must
-        leave that block in the free list for a later, smaller request."""
+        """A rejected allocate() that would have extended pool_end past the
+        budget must leave an existing free block untouched for a later,
+        smaller request."""
         allocator = Allocator(100)
         allocator.allocate(50)
-        allocator.free(0, 50)  # currently_allocated back to 0; free: [(0, 50)]
+        allocator.free(0, 50)  # pool_end stays 50; free: [(0, 50)]
 
-        # allocate(60) finds no free block big enough (50 < 60), so it
-        # extends the pool instead, leaving (0, 50) untouched in the free
-        # list. currently_allocated is now 60.
-        grown = allocator.allocate(60)
-        self.assertEqual(grown, 50)
-
-        # Reusing (0, 50) would bring currently_allocated to 60 + 50 = 110,
-        # over budget -- rejected without consuming the free block.
-        rejected = allocator.allocate(50)
+        # allocate(60) finds no free block big enough (50 < 60), so it would
+        # need to extend pool_end to 110 -- over the 100 budget. Rejected
+        # without consuming the (0, 50) free block.
+        rejected = allocator.allocate(60)
         self.assertIsNone(rejected)
 
-        # Freeing the 60-byte block drops currently_allocated back to 0, so
-        # the same (0, 50) free block -- never consumed by the rejection --
-        # is still available and now fits.
-        allocator.free(50, 60)
+        # The free block is still available and now fits.
         fits = allocator.allocate(50)
         self.assertEqual(fits, 0)
+
+    def test_exact_boundary_allocation_succeeds(self):
+        """An allocation that brings pool_end exactly to the segment size
+        limit must succeed, not be rejected."""
+        allocator = Allocator(100)
+        offset = allocator.allocate(100)
+        self.assertEqual(offset, 0)
+        self.assertEqual(allocator.get_pool_end(), 100)
+
+    def test_fragmentation_rejected_even_under_concurrent_usage_budget(self):
+        """A free/reallocate sequence whose peak concurrent usage never
+        exceeds the budget must still be rejected once it would push
+        pool_end (the bump-pointer high-water mark) past the segment size
+        -- concurrent usage alone is not the quantity generate_bundle's
+        assert checks."""
+        allocator = Allocator(100)
+        first = allocator.allocate(40)
+        second = allocator.allocate(40)
+        allocator.free(first, 40)
+        allocator.free(second, 40)  # currently_allocated back to 0
+
+        # No free block of exactly 50 bytes exists ((0, 40) and (40, 40) are
+        # both too small), so this would extend pool_end to 130 -- over
+        # budget, even though concurrent usage would only be 50.
+        rejected = allocator.allocate(50)
+        self.assertIsNone(rejected)
+        self.assertEqual(allocator.get_pool_end(), 80)
 
 
 def _make_ftl_buffer(name, host_size=(64,), dim_order=(0,)):

--- a/tests/inductor/test_hbm_pool_planning.py
+++ b/tests/inductor/test_hbm_pool_planning.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 from sympy import Integer
@@ -26,9 +26,66 @@ from torch._inductor.virtualized import V
 from torch.utils._ordered_set import OrderedSet
 
 from torch_spyre._C import ElementArrangement, SpyreTensorLayout
-from torch_spyre._inductor.hbm_pool_planning import hbm_pool_planning
+from torch_spyre._inductor.hbm_pool_planning import Allocator, hbm_pool_planning
 from torch_spyre._inductor.ir import FixedTiledLayout
 from torch_spyre._inductor.scheduler import CountedLoopSchedulerNode
+
+
+class TestAllocator(unittest.TestCase):
+    """Unit tests for Allocator.allocate's overflow-fallback behavior."""
+
+    def test_allocate_within_budget_succeeds(self):
+        allocator = Allocator(100)
+        self.assertEqual(allocator.allocate(60), 0)
+
+    def test_allocate_past_budget_returns_none(self):
+        allocator = Allocator(100)
+        self.assertIsNone(allocator.allocate(101))
+
+    def test_failed_allocate_leaves_state_untouched(self):
+        """A rejected allocate() must not advance pool_end, bump
+        currently_allocated/peak_usage, or consume a free block -- the next
+        allocate() call sees exactly the state it would have without the
+        rejected call ever happening."""
+        allocator = Allocator(100)
+        first = allocator.allocate(50)
+        self.assertEqual(first, 0)
+
+        rejected = allocator.allocate(60)  # 50 + 60 > 100
+        self.assertIsNone(rejected)
+
+        # State is exactly as after the first allocate() alone: the next
+        # real allocation continues from pool_end=50, not from some
+        # partially-applied 110.
+        second = allocator.allocate(40)
+        self.assertEqual(second, 50)
+        self.assertEqual(allocator.get_peak_usage(), 90)
+        self.assertEqual(allocator.get_pool_end(), 90)
+
+    def test_failed_allocate_does_not_consume_free_block(self):
+        """A rejected allocate() that would have reused a free block must
+        leave that block in the free list for a later, smaller request."""
+        allocator = Allocator(100)
+        allocator.allocate(50)
+        allocator.free(0, 50)  # currently_allocated back to 0; free: [(0, 50)]
+
+        # allocate(60) finds no free block big enough (50 < 60), so it
+        # extends the pool instead, leaving (0, 50) untouched in the free
+        # list. currently_allocated is now 60.
+        grown = allocator.allocate(60)
+        self.assertEqual(grown, 50)
+
+        # Reusing (0, 50) would bring currently_allocated to 60 + 50 = 110,
+        # over budget -- rejected without consuming the free block.
+        rejected = allocator.allocate(50)
+        self.assertIsNone(rejected)
+
+        # Freeing the 60-byte block drops currently_allocated back to 0, so
+        # the same (0, 50) free block -- never consumed by the rejection --
+        # is still available and now fits.
+        allocator.free(50, 60)
+        fits = allocator.allocate(50)
+        self.assertEqual(fits, 0)
 
 
 def _make_ftl_buffer(name, host_size=(64,), dim_order=(0,)):
@@ -372,6 +429,82 @@ class TestHbmPoolPlanningPerBundle(unittest.TestCase):
 
         buf = V.graph.get_buffer("accum")
         self.assertNotIn("hbm_pool", buf.get_layout().allocation)
+
+    def test_buffer_that_overflows_pool_falls_back_to_standalone_hbm(self):
+        """When MAX_POOL_SIZE is too small to hold every pool-eligible
+        buffer, the ones that fit get an hbm_pool allocation and the
+        overflow buffer(s) fall back to standalone HBM (no hbm_pool key)
+        instead of raising.
+
+        buf0 (128 bytes) and buf1 (256 bytes) have non-overlapping live
+        ranges but the allocator restarts a fresh Allocator per bundle, so
+        with MAX_POOL_SIZE patched to 200 bytes, buf0 fits (128 <= 200) but
+        buf1 does not (256 > 200): the very first allocation call already
+        exceeds budget for buf1 regardless of live-range-driven reuse.
+        """
+        _make_ftl_buffer("buf0", host_size=(64,))
+        _make_ftl_buffer("buf1", host_size=(128,))
+        w0 = _make_snode_with_rw("w0", writes=["buf0"], reads=[])
+        r0 = _make_snode_with_rw("r0", writes=[], reads=["buf0"])
+        w1 = _make_snode_with_rw("w1", writes=["buf1"], reads=[])
+        r1 = _make_snode_with_rw("r1", writes=[], reads=["buf1"])
+        bundle = FusedSchedulerNode(MagicMock(), [w0, r0, w1, r1])
+
+        with patch("torch_spyre._inductor.hbm_pool_planning.MAX_POOL_SIZE", 200):
+            hbm_pool_planning([bundle])
+
+        buf0 = V.graph.get_buffer("buf0")
+        buf1 = V.graph.get_buffer("buf1")
+        self.assertIn("hbm_pool", buf0.get_layout().allocation)
+        self.assertNotIn("hbm_pool", buf1.get_layout().allocation)
+        # The bundle still gets a pool-size entry reflecting only what was
+        # actually placed in the pool (buf0), not the buffer that overflowed.
+        self.assertEqual(V.graph.hbm_pool_sizes[bundle.get_name()], 128)
+
+    def test_all_buffers_overflow_pool_produces_zero_size_pool(self):
+        """If MAX_POOL_SIZE is too small for even the first buffer, every
+        pool-eligible buffer in the bundle falls back to standalone HBM and
+        the bundle's recorded pool extent is 0 -- no RuntimeError."""
+        _make_ftl_buffer("buf0", host_size=(64,))
+        writer = _make_snode_with_rw("writer", writes=["buf0"], reads=[])
+        reader = _make_snode_with_rw("reader", writes=[], reads=["buf0"])
+        bundle = FusedSchedulerNode(MagicMock(), [writer, reader])
+
+        with patch("torch_spyre._inductor.hbm_pool_planning.MAX_POOL_SIZE", 1):
+            hbm_pool_planning([bundle])
+
+        buf0 = V.graph.get_buffer("buf0")
+        self.assertNotIn("hbm_pool", buf0.get_layout().allocation)
+        self.assertEqual(V.graph.hbm_pool_sizes[bundle.get_name()], 0)
+
+    def test_freed_space_is_reused_before_hitting_pool_budget(self):
+        """A buffer that fits only because an earlier buffer's live range
+        already ended (and its block was freed) must still get pool
+        allocated -- the fallback path must not trigger for buffers that
+        fit via reuse, only for genuine budget overflow."""
+        _make_ftl_buffer("buf0", host_size=(64,))  # 128 bytes
+        _make_ftl_buffer("buf1", host_size=(64,))  # 128 bytes
+        w0 = _make_snode_with_rw("w0", writes=["buf0"], reads=[])
+        r0 = _make_snode_with_rw("r0", writes=[], reads=["buf0"])
+        w1 = _make_snode_with_rw("w1", writes=["buf1"], reads=[])
+        r1 = _make_snode_with_rw("r1", writes=[], reads=["buf1"])
+        # buf0's live range [0, 1] ends before buf1's starts at [2, 3], so
+        # buf1 can reuse buf0's freed 128-byte block instead of needing a
+        # fresh 128 bytes on top -- a pool budget of 128 is only enough for
+        # one live buffer at a time, not both concurrently.
+        bundle = FusedSchedulerNode(MagicMock(), [w0, r0, w1, r1])
+
+        with patch("torch_spyre._inductor.hbm_pool_planning.MAX_POOL_SIZE", 128):
+            hbm_pool_planning([bundle])
+
+        buf0 = V.graph.get_buffer("buf0")
+        buf1 = V.graph.get_buffer("buf1")
+        self.assertIn("hbm_pool", buf0.get_layout().allocation)
+        self.assertIn("hbm_pool", buf1.get_layout().allocation)
+        self.assertEqual(
+            buf0.get_layout().allocation["hbm_pool"],
+            buf1.get_layout().allocation["hbm_pool"],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_hbm_pool_planning.py
+++ b/tests/inductor/test_hbm_pool_planning.py
@@ -121,6 +121,17 @@ def _make_ftl_buffer(name, host_size=(64,), dim_order=(0,)):
     return buf
 
 
+def _make_ftl_buffer_aliased(name, alias_of, host_size=(64,), dim_order=(0,)):
+    """Real ComputedBuffer whose FixedTiledLayout.allocation is the exact
+    same dict object as `alias_of`'s -- reproduces the aliasing
+    MutationLayoutSHOULDREMOVE (or copy-elision) produces when one op's
+    write target is another buffer's storage under a different name.
+    """
+    buf = _make_ftl_buffer(name, host_size, dim_order)
+    buf.get_layout().allocation = alias_of.get_layout().allocation
+    return buf
+
+
 def _make_snode_with_rw(name, writes, reads):
     """MagicMock SchedulerNode with real MemoryDep read_writes for the
     given buffer names, and get_nodes()/get_name() wired for
@@ -429,6 +440,39 @@ class TestHbmPoolPlanningPerBundle(unittest.TestCase):
 
         buf = V.graph.get_buffer("accum")
         self.assertNotIn("hbm_pool", buf.get_layout().allocation)
+
+    def test_aliased_buffer_across_bundles_is_not_pool_eligible(self):
+        """A buffer allocated in bundle A (e.g. a `full()` accumulator) that
+        is later mutated in bundle B under a *different* name -- because
+        MutationLayoutSHOULDREMOVE/copy-elision makes the mutating op's
+        FixedTiledLayout.allocation the same dict object as the original
+        buffer's, not merely dependency-linked to it by name -- must not be
+        pool-eligible in either bundle.
+
+        Regression test for issue #3775: bundle B's own candidacy check for
+        "alias" sees a normal, single-bundle-local write+read and pool-
+        allocates it, silently mutating the shared allocation dict. That
+        retroactively assigns "target" (bundle A, never itself a candidate)
+        a stale/foreign offset that is out of bounds against bundle A's own
+        pool size, since bundle A's allocator never accounted for it. The
+        old _is_cross_bundle check is purely name-keyed and cannot see this:
+        "target" and "alias" share no read/write dependency edge at all.
+        """
+        target = _make_ftl_buffer("target")
+        write_target = _make_snode_with_rw("write_target", writes=["target"], reads=[])
+        bundle_a = FusedSchedulerNode(MagicMock(), [write_target])
+
+        _make_ftl_buffer_aliased("alias", alias_of=target)
+        write_alias = _make_snode_with_rw("write_alias", writes=["alias"], reads=[])
+        read_alias = _make_snode_with_rw("read_alias", writes=[], reads=["alias"])
+        bundle_b = FusedSchedulerNode(MagicMock(), [write_alias, read_alias])
+
+        hbm_pool_planning([bundle_a, bundle_b])
+
+        target_buf = V.graph.get_buffer("target")
+        alias_buf = V.graph.get_buffer("alias")
+        self.assertNotIn("hbm_pool", target_buf.get_layout().allocation)
+        self.assertNotIn("hbm_pool", alias_buf.get_layout().allocation)
 
     def test_buffer_that_overflows_pool_falls_back_to_standalone_hbm(self):
         """When MAX_POOL_SIZE is too small to hold every pool-eligible

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -6978,6 +6978,58 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         self.compare_with_cpu(fn, q, k, v, attn_mask, is_causal, enable_gqa)
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
+    def test_sdpa_bf16_gqa_noncontiguous_query_pool_planning(self):
+        """Regression test for issue #3775: a bf16 GQA SDPA result with a
+        non-contiguous query (the `view(...).transpose(1, 2)` layout normal
+        transformer attention blocks produce) and an in-bundle consumer (the
+        trailing `+ 0`) previously returned finite but catastrophically wrong
+        values under HBM pool planning, because the SDPA output buffer's
+        cross-bundle allocation-dict aliasing was not detected as pool-
+        ineligible. Adapted from the standalone reproducer posted on PR #3707
+        by arielge, which traced this to 0/5 matching generation tokens on
+        Qwen2.5-1.5B in bf16."""
+        generator = torch.Generator().manual_seed(1337)
+        q_source = (
+            torch.randn((1, 64, 1536), dtype=torch.bfloat16, generator=generator) * 0.1
+        )
+        k_source = (
+            torch.randn((1, 64, 256), dtype=torch.bfloat16, generator=generator) * 0.1
+        )
+        v_source = (
+            torch.randn((1, 64, 256), dtype=torch.bfloat16, generator=generator) * 0.1
+        )
+        q = q_source.view(1, 64, 12, 128).transpose(1, 2)
+        k = k_source.view(1, 64, 2, 128).transpose(1, 2).contiguous()
+        v = v_source.view(1, 64, 2, 128).transpose(1, 2).contiguous()
+        mask = torch.zeros((1, 1, 64, 64), dtype=torch.bfloat16)
+        upper = torch.triu(torch.ones(64, 64, dtype=torch.bool), 1)
+        mask[:, :, upper] = torch.finfo(torch.bfloat16).min
+
+        def fn(q, k, v, mask):
+            attention = F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=mask,
+                dropout_p=0.0,
+                scale=1 / 128**0.5,
+                enable_gqa=True,
+            )
+            return attention + 0
+
+        expected = fn(q, k, v, mask)
+        actual = torch.compile(fn, dynamic=False)(
+            q.to("spyre"), k.to("spyre"), v.to("spyre"), mask.to("spyre")
+        ).cpu()
+
+        expected = expected.float().flatten()
+        actual = actual.float().flatten()
+        cosine = F.cosine_similarity(actual, expected, dim=0).item()
+        assert torch.isfinite(actual).all() and cosine >= 0.99, (
+            f"cosine={cosine:.8f} max_abs={(actual - expected).abs().max().item():.8f}"
+        )
+
+    @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_implicit_loading(self):
         def test(end, device=None):
             return torch.arange(end, device=device, dtype=torch.float16)

--- a/tests/inductor/test_symbolic_dim_bundle.py
+++ b/tests/inductor/test_symbolic_dim_bundle.py
@@ -153,7 +153,7 @@ class TestGenerateBundleDimensionSymbols(InductorTestCase):
         with open(os.path.join(self.output_dir, "bundle.mlir")) as f:
             return f.read()
 
-    def _run_bundle(self, compiled_entries, op_specs=None):
+    def _run_bundle(self, compiled_entries, op_specs=None, pool_size=0):
         """Run generate_bundle with mocked compile_op_spec, return bundle.mlir text."""
         if op_specs is None:
             op_specs = [_minimal_op_spec() for _ in compiled_entries]
@@ -167,6 +167,7 @@ class TestGenerateBundleDimensionSymbols(InductorTestCase):
                 "test",
                 self.output_dir,
                 op_specs,
+                pool_size=pool_size,
             )
         return self._read_bundle()
 
@@ -302,3 +303,57 @@ class TestGenerateBundleDimensionSymbols(InductorTestCase):
         # list and in the symbol_ids attribute).
         self.assertIn("sdscbundle.sdsc_execute (%sym_0_1, %arg_0)", bundle)
         self.assertIn('"symbol_ids"=[-1, -2]', bundle)
+
+    def test_pool_device_mem_allocate_emitted(self):
+        """A pool symbol triggers device_mem_allocate with the right byte
+        count, and no %pool_base_addr parameter."""
+        pool_kind = SymbolKind.pool()
+        entry = (
+            _make_sdsc_json(hbm_sym_ids_per_core={"[0, 0, 0]": -1}),
+            [0],
+            [],
+            [pool_kind],
+        )
+
+        bundle = self._run_bundle([entry], pool_size=65536)
+
+        self.assertIn(
+            "%pool = sdscbundle.device_mem_allocate 65536 bytes : index",
+            bundle,
+        )
+        self.assertNotIn("%pool_base_addr", bundle)
+        self.assertNotIn("input_arg_extract value from %pool_base_addr", bundle)
+
+    def test_pool_absent_when_no_pool_symbols(self):
+        """A bundle with no pool symbols emits no device_mem_allocate at all,
+        regardless of the pool_size argument passed in."""
+        dim_kind = SymbolKind.dimension(granularity=56, max_value=616, pytorch_sym="s0")
+        entry = (_make_sdsc_json(dim_sym_ids={"mb": [-1]}), [0], [], [dim_kind])
+
+        bundle = self._run_bundle([entry], pool_size=65536)
+
+        self.assertNotIn("device_mem_allocate", bundle)
+        self.assertNotIn("%pool", bundle)
+
+    def test_pool_and_kernel_address_combination(self):
+        """A pool symbol and a kernel-address symbol coexist: device_mem_allocate
+        appears in the body, %arg_0_base_addr is still the only signature param."""
+        pool_kind = SymbolKind.pool()
+        kernel_kind = SymbolKind.kernel(arg_index=0)
+        entry = (
+            _make_sdsc_json(hbm_sym_ids_per_core={"[0, 0, 0]": -1}),
+            [0, 0],
+            [],
+            [kernel_kind, pool_kind],
+        )
+
+        bundle = self._run_bundle([entry], pool_size=4096)
+
+        self.assertIn(
+            "func.func @sdsc_bundle(%arg_0_base_addr: !sdscbundle.input_arg<index>)",
+            bundle,
+        )
+        self.assertIn(
+            "%pool = sdscbundle.device_mem_allocate 4096 bytes : index",
+            bundle,
+        )

--- a/tests/inductor/test_symbolic_dim_bundle.py
+++ b/tests/inductor/test_symbolic_dim_bundle.py
@@ -373,8 +373,8 @@ class TestGenerateBundleDimensionSymbols(InductorTestCase):
         with self.assertRaises(AssertionError):
             self._run_bundle([entry], pool_size=0)
 
-    def test_pool_size_at_or_above_max_raises(self):
-        """A pool symbol with pool_size >= MAX_POOL_SIZE must fail loudly."""
+    def test_pool_size_above_max_raises(self):
+        """A pool symbol with pool_size > MAX_POOL_SIZE must fail loudly."""
         pool_kind = SymbolKind.pool()
         entry = (
             _make_sdsc_json(hbm_sym_ids_per_core={"[0, 0, 0]": -1}),
@@ -384,4 +384,23 @@ class TestGenerateBundleDimensionSymbols(InductorTestCase):
         )
 
         with self.assertRaises(AssertionError):
-            self._run_bundle([entry], pool_size=MAX_POOL_SIZE)
+            self._run_bundle([entry], pool_size=MAX_POOL_SIZE + 1)
+
+    def test_pool_size_at_max_succeeds(self):
+        """A pool symbol with pool_size == MAX_POOL_SIZE (the exact budget
+        boundary) must be accepted, not rejected -- MAX_POOL_SIZE is itself
+        an in-budget value, and Allocator can legitimately return an offset
+        whose pool_end lands exactly there."""
+        pool_kind = SymbolKind.pool()
+        entry = (
+            _make_sdsc_json(hbm_sym_ids_per_core={"[0, 0, 0]": -1}),
+            [0],
+            [],
+            [pool_kind],
+        )
+
+        bundle = self._run_bundle([entry], pool_size=MAX_POOL_SIZE)
+        self.assertIn(
+            f"%pool = sdscbundle.device_mem_allocate {MAX_POOL_SIZE} bytes : index",
+            bundle,
+        )

--- a/tests/inductor/test_symbolic_dim_bundle.py
+++ b/tests/inductor/test_symbolic_dim_bundle.py
@@ -28,7 +28,7 @@ from torch_spyre._inductor.codegen.bundle import (
     generate_bundle,
 )
 from torch_spyre._inductor.codegen.compute_ops import SymbolKind
-from torch_spyre._inductor.constants import MAX_POOL_SIZE
+from torch_spyre._inductor.constants import MAX_POOL_SIZE_BYTES
 from torch_spyre._inductor.op_spec import OpSpec
 
 
@@ -374,7 +374,7 @@ class TestGenerateBundleDimensionSymbols(InductorTestCase):
             self._run_bundle([entry], pool_size=0)
 
     def test_pool_size_above_max_raises(self):
-        """A pool symbol with pool_size > MAX_POOL_SIZE must fail loudly."""
+        """A pool symbol with pool_size > MAX_POOL_SIZE_BYTES must fail loudly."""
         pool_kind = SymbolKind.pool()
         entry = (
             _make_sdsc_json(hbm_sym_ids_per_core={"[0, 0, 0]": -1}),
@@ -384,11 +384,11 @@ class TestGenerateBundleDimensionSymbols(InductorTestCase):
         )
 
         with self.assertRaises(AssertionError):
-            self._run_bundle([entry], pool_size=MAX_POOL_SIZE + 1)
+            self._run_bundle([entry], pool_size=MAX_POOL_SIZE_BYTES + 1)
 
     def test_pool_size_at_max_succeeds(self):
-        """A pool symbol with pool_size == MAX_POOL_SIZE (the exact budget
-        boundary) must be accepted, not rejected -- MAX_POOL_SIZE is itself
+        """A pool symbol with pool_size == MAX_POOL_SIZE_BYTES (the exact budget
+        boundary) must be accepted, not rejected -- MAX_POOL_SIZE_BYTES is itself
         an in-budget value, and Allocator can legitimately return an offset
         whose pool_end lands exactly there."""
         pool_kind = SymbolKind.pool()
@@ -399,8 +399,8 @@ class TestGenerateBundleDimensionSymbols(InductorTestCase):
             [pool_kind],
         )
 
-        bundle = self._run_bundle([entry], pool_size=MAX_POOL_SIZE)
+        bundle = self._run_bundle([entry], pool_size=MAX_POOL_SIZE_BYTES)
         self.assertIn(
-            f"%pool = sdscbundle.device_mem_allocate {MAX_POOL_SIZE} bytes : index",
+            f"%pool = sdscbundle.device_mem_allocate {MAX_POOL_SIZE_BYTES} bytes : index",
             bundle,
         )

--- a/tests/inductor/test_symbolic_dim_bundle.py
+++ b/tests/inductor/test_symbolic_dim_bundle.py
@@ -28,6 +28,7 @@ from torch_spyre._inductor.codegen.bundle import (
     generate_bundle,
 )
 from torch_spyre._inductor.codegen.compute_ops import SymbolKind
+from torch_spyre._inductor.constants import MAX_POOL_SIZE
 from torch_spyre._inductor.op_spec import OpSpec
 
 
@@ -357,3 +358,30 @@ class TestGenerateBundleDimensionSymbols(InductorTestCase):
             "%pool = sdscbundle.device_mem_allocate 4096 bytes : index",
             bundle,
         )
+
+    def test_pool_size_zero_with_pool_symbol_raises(self):
+        """A pool symbol with pool_size=0 must fail loudly rather than emit a
+        useless zero-byte device_mem_allocate."""
+        pool_kind = SymbolKind.pool()
+        entry = (
+            _make_sdsc_json(hbm_sym_ids_per_core={"[0, 0, 0]": -1}),
+            [0],
+            [],
+            [pool_kind],
+        )
+
+        with self.assertRaises(AssertionError):
+            self._run_bundle([entry], pool_size=0)
+
+    def test_pool_size_at_or_above_max_raises(self):
+        """A pool symbol with pool_size >= MAX_POOL_SIZE must fail loudly."""
+        pool_kind = SymbolKind.pool()
+        entry = (
+            _make_sdsc_json(hbm_sym_ids_per_core={"[0, 0, 0]": -1}),
+            [0],
+            [],
+            [pool_kind],
+        )
+
+        with self.assertRaises(AssertionError):
+            self._run_bundle([entry], pool_size=MAX_POOL_SIZE)

--- a/tests/profiler/test_spyre_profiler.py
+++ b/tests/profiler/test_spyre_profiler.py
@@ -230,8 +230,8 @@ def test_compiled_kernel_event_keys_match_captured_debug_handles(monkeypatch):
     captures = []
     original_sdsc = SpyreAsyncCompile.sdsc
 
-    def capture_sdsc(self, kernel_name, specs):
-        runner = original_sdsc(self, kernel_name, specs)
+    def capture_sdsc(self, kernel_name, specs, pool_size=0):
+        runner = original_sdsc(self, kernel_name, specs, pool_size=pool_size)
         handles = []
 
         def collect(spec_list):

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -57,6 +57,7 @@ def generate_bundle(
     kernel_name: str,
     output_dir: str,
     specs: Sequence,
+    pool_size: int = 0,
 ):
     """Output the SDSC Bundle for the OpSpecs in output_dir.
 
@@ -75,6 +76,13 @@ def generate_bundle(
     the KTIR emitter path, which is gated separately). Running this
     function with the flag off would silently miscompile addresses rather
     than error, so it's rejected up front instead.
+
+    ``pool_size`` is the byte count for this bundle's HBM pool (from
+    ``hbm_pool_planning.py`` via ``SpyreKernel.pool_size``). Ignored unless
+    a pool symbol is present in ``specs``. When a pool symbol is present,
+    it is emitted as ``%pool = sdscbundle.device_mem_allocate <pool_size>
+    bytes : index`` as the first statement of the bundle body — there is
+    no ``%pool_base_addr`` function parameter.
     """
     if not _spyre_config.bundle_symbolic_args:
         raise AssertionError(
@@ -219,15 +227,14 @@ def generate_bundle(
         f.write("module {\n")
 
         # Function signature:
-        #   - optional leading %pool_base_addr param for pool-allocated tensors
         #   - one !sdscbundle.input_arg<index> param per kernel tensor arg
         #   - one !sdscbundle.input_arg<index, granularity=G, max_value=M> param
         #     per unique dynamic-shape (mark_dynamic) symbol; emitted whenever
         #     present.
-        if has_pool or kernel_arg_sym_indices or dimension_sym_indices:
+        # Pool allocation is emitted in the body as device_mem_allocate,
+        # not as a function parameter.
+        if kernel_arg_sym_indices or dimension_sym_indices:
             params = []
-            if has_pool:
-                params.append("%pool_base_addr: !sdscbundle.input_arg<index>")
             for sym_idx in kernel_arg_sym_indices:
                 ai = symbol_kinds[sym_idx].arg_index
                 params.append(f"%arg_{ai}_base_addr: !sdscbundle.input_arg<index>")
@@ -237,26 +244,28 @@ def generate_bundle(
                     f"{dim_param_names[sym_idx]}_base: {_dim_input_arg_type(dim_sk)}"
                 )
             f.write(f"\tfunc.func @sdsc_bundle({', '.join(params)}) {{\n")
-            if has_pool:
-                f.write(
-                    "\t\t%pool = sdscbundle.input_arg_extract value from"
-                    " %pool_base_addr : !sdscbundle.input_arg<index> -> index\n"
-                )
-            for sym_idx in kernel_arg_sym_indices:
-                ai = symbol_kinds[sym_idx].arg_index
-                f.write(
-                    f"\t\t%arg_{ai} = sdscbundle.input_arg_extract value from"
-                    f" %arg_{ai}_base_addr : !sdscbundle.input_arg<index> -> index\n"
-                )
-            for sym_idx in dimension_sym_indices:
-                dim_sk = symbol_kinds[sym_idx]
-                name = dim_param_names[sym_idx]
-                f.write(
-                    f"\t\t{name} = sdscbundle.input_arg_extract value from"
-                    f" {name}_base : {_dim_input_arg_type(dim_sk)} -> index\n"
-                )
         else:
             f.write("\tfunc.func @sdsc_bundle() {\n")
+
+        if has_pool:
+            f.write(
+                f"\t\t%pool = sdscbundle.device_mem_allocate {pool_size} bytes"
+                " : index\n"
+            )
+
+        for sym_idx in kernel_arg_sym_indices:
+            ai = symbol_kinds[sym_idx].arg_index
+            f.write(
+                f"\t\t%arg_{ai} = sdscbundle.input_arg_extract value from"
+                f" %arg_{ai}_base_addr : !sdscbundle.input_arg<index> -> index\n"
+            )
+        for sym_idx in dimension_sym_indices:
+            dim_sk = symbol_kinds[sym_idx]
+            name = dim_param_names[sym_idx]
+            f.write(
+                f"\t\t{name} = sdscbundle.input_arg_extract value from"
+                f" {name}_base : {_dim_input_arg_type(dim_sk)} -> index\n"
+            )
 
         # Standard loop constants (only emitted when there are loops).
         if loop_bounds:

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -248,9 +248,9 @@ def generate_bundle(
         else:
             f.write("\tfunc.func @sdsc_bundle() {\n")
 
-        assert not has_pool or 0 < pool_size < MAX_POOL_SIZE, (
+        assert not has_pool or 0 < pool_size <= MAX_POOL_SIZE, (
             f"generate_bundle: pool_size={pool_size} out of range "
-            f"(0, {MAX_POOL_SIZE}) for a bundle with a pool symbol present"
+            f"(0, {MAX_POOL_SIZE}] for a bundle with a pool symbol present"
         )
         if has_pool:
             f.write(

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -23,7 +23,7 @@ import sympy
 from torch_spyre._inductor import config as _spyre_config
 from torch_spyre._inductor.codegen.compute_ops import SymbolKind
 from torch_spyre._inductor.codegen.superdsc import compile_op_spec
-from torch_spyre._inductor.constants import MAX_POOL_SIZE
+from torch_spyre._inductor.constants import MAX_POOL_SIZE_BYTES
 from torch_spyre._inductor.op_spec import LoopSpec, OpSpec, format_op_spec_list
 from torch_spyre._inductor.logging_utils import get_inductor_logger
 
@@ -248,9 +248,9 @@ def generate_bundle(
         else:
             f.write("\tfunc.func @sdsc_bundle() {\n")
 
-        assert not has_pool or 0 < pool_size <= MAX_POOL_SIZE, (
+        assert not has_pool or 0 < pool_size <= MAX_POOL_SIZE_BYTES, (
             f"generate_bundle: pool_size={pool_size} out of range "
-            f"(0, {MAX_POOL_SIZE}] for a bundle with a pool symbol present"
+            f"(0, {MAX_POOL_SIZE_BYTES}] for a bundle with a pool symbol present"
         )
         if has_pool:
             f.write(

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -23,6 +23,7 @@ import sympy
 from torch_spyre._inductor import config as _spyre_config
 from torch_spyre._inductor.codegen.compute_ops import SymbolKind
 from torch_spyre._inductor.codegen.superdsc import compile_op_spec
+from torch_spyre._inductor.constants import MAX_POOL_SIZE
 from torch_spyre._inductor.op_spec import LoopSpec, OpSpec, format_op_spec_list
 from torch_spyre._inductor.logging_utils import get_inductor_logger
 
@@ -247,6 +248,10 @@ def generate_bundle(
         else:
             f.write("\tfunc.func @sdsc_bundle() {\n")
 
+        assert not has_pool or 0 < pool_size < MAX_POOL_SIZE, (
+            f"generate_bundle: pool_size={pool_size} out of range "
+            f"(0, {MAX_POOL_SIZE}) for a bundle with a pool symbol present"
+        )
         if has_pool:
             f.write(
                 f"\t\t%pool = sdscbundle.device_mem_allocate {pool_size} bytes"

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -130,6 +130,12 @@ SEGMENT_OFFSETS = [
 INTERMEDIATES_SEGMENT = 0x0
 SEGMENT_SIZE = 0x400000000
 
+# The intermediates pool must leave headroom below the full segment size --
+# 2 GiB is reserved for other segment-7 consumers (e.g. kernel-address/dim
+# symbol bookkeeping), so the pool itself may never grow to claim the whole
+# segment.
+MAX_POOL_SIZE = SEGMENT_SIZE - 2 * 1024**3
+
 SPYRE_FP32_OPS = [
     "add",
     "sub",

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -134,7 +134,7 @@ SEGMENT_SIZE = 0x400000000
 # 2 GiB is reserved for other segment-7 consumers (e.g. kernel-address/dim
 # symbol bookkeeping), so the pool itself may never grow to claim the whole
 # segment.
-MAX_POOL_SIZE = SEGMENT_SIZE - 2 * 1024**3
+MAX_POOL_SIZE_BYTES = SEGMENT_SIZE - 2 * 1024**3
 
 SPYRE_FP32_OPS = [
     "add",

--- a/torch_spyre/_inductor/hbm_pool_planning.py
+++ b/torch_spyre/_inductor/hbm_pool_planning.py
@@ -235,6 +235,25 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
             and id(layout.allocation) not in io_alloc_ids
         )
 
+    def _alloc_id(name: str) -> int | None:
+        """Return id(layout.allocation) for `name`, or None if unavailable.
+
+        Buffers that alias another buffer's storage (e.g. a
+        MutationLayoutSHOULDREMOVE target written by a later, differently-
+        named op) share the same allocation dict object even though the two
+        names are unrelated by any read/write dependency edge -- this is the
+        same aliasing io_alloc_ids above already has to work around for
+        graph I/O.  Resolving it here lets bundle attribution below catch
+        the intermediate-to-intermediate case too.
+        """
+        buf = V.graph.get_buffer(name)
+        if buf is None:
+            return None
+        layout = buf.maybe_get_layout()
+        if not isinstance(layout, FixedTiledLayout):
+            return None
+        return id(layout.allocation)
+
     # Buffers read by Fallback/Extern/Nop nodes must stay Python-side tensors,
     # regardless of which bundle they belong to.
     all_flat_nodes: list[BaseSchedulerNode] = list(_iter_all_nodes(nodes))
@@ -258,6 +277,11 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
     buffer_writer_bundle: dict[str, str] = {}
     buffer_writer_bundles: dict[str, set[str]] = {}
     buffer_reader_bundles: dict[str, set[str]] = {}
+    # id(layout.allocation) -> every bundle that wrote a name resolving to
+    # that allocation dict.  Populated alongside buffer_writer_bundles so
+    # aliased names (see _alloc_id) are attributed to the same underlying
+    # storage even though they share no name-based dependency edge.
+    alloc_id_bundles: dict[int, set[str]] = {}
 
     for bundle in nodes:
         bundle_name = bundle.get_name()
@@ -270,6 +294,8 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
                 if dep.name not in graph_outputs:
                     buffer_writer_bundle[dep.name] = bundle_name
                     buffer_writer_bundles.setdefault(dep.name, set()).add(bundle_name)
+                    if (alloc_id := _alloc_id(dep.name)) is not None:
+                        alloc_id_bundles.setdefault(alloc_id, set()).add(bundle_name)
             for dep in node.read_writes.reads:
                 if dep.name not in graph_inputs:
                     buffer_reader_bundles.setdefault(dep.name, set()).add(bundle_name)
@@ -289,6 +315,8 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
                 buffer_writer_bundles.setdefault(node.node.get_name(), set()).add(
                     bundle_name
                 )
+                if (alloc_id := _alloc_id(node.node.get_name())) is not None:
+                    alloc_id_bundles.setdefault(alloc_id, set()).add(bundle_name)
 
     written = set(buffer_writer_bundle)
     read = set(buffer_reader_bundles)
@@ -300,6 +328,16 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
                 "excluding from pool eligibility",
                 name,
                 sorted(buffer_writer_bundles[name]),
+            )
+            return True
+        alloc_id = _alloc_id(name)
+        if alloc_id is not None and len(alloc_id_bundles.get(alloc_id, set())) > 1:
+            logger.debug(
+                "hbm_pool_planning: %s shares its allocation with a buffer "
+                "written in another bundle %s -- excluding from pool "
+                "eligibility",
+                name,
+                sorted(alloc_id_bundles[alloc_id]),
             )
             return True
         readers = buffer_reader_bundles.get(name, set())

--- a/torch_spyre/_inductor/hbm_pool_planning.py
+++ b/torch_spyre/_inductor/hbm_pool_planning.py
@@ -22,7 +22,7 @@ from torch._inductor.scheduler import (
 )
 from torch._inductor.ir import FallbackKernel
 from torch._inductor.virtualized import V
-from .constants import SEGMENT_SIZE, INTERMEDIATES_SEGMENT
+from .constants import MAX_POOL_SIZE, INTERMEDIATES_SEGMENT
 from .ir import FixedTiledLayout, SpyreEmptyFallback
 from .logging_utils import get_inductor_logger
 from .scheduler import CountedLoopSchedulerNode
@@ -48,33 +48,37 @@ class Allocator:
         self._currently_allocated: int = 0  # bytes in-use right now
         self._peak_usage: int = 0  # peak concurrent usage
 
-    def allocate(self, size: int) -> int:
+    def allocate(self, size: int) -> int | None:
         """Return a byte offset from INTERMEDIATES_SEGMENT for a block of
-        `size` bytes. Reuses an existing free block when possible."""
+        `size` bytes. Reuses an existing free block when possible.
+
+        Returns None, leaving all internal state untouched, if `size` would
+        push peak concurrent usage past the segment size limit -- callers
+        fall back to standalone HBM allocation for that buffer instead.
+        """
         for i, (blk_offset, blk_size) in enumerate(self._free):
             if blk_size >= size:
-                self._free.pop(i)
-                # Return any leftover fragment to the free list.
-                remainder = blk_size - size
-                if remainder > 0:
-                    self._free.append((blk_offset + size, remainder))
                 offset = blk_offset
+                new_pool_end = self._pool_end
                 break
         else:
             # No suitable free block — extend the pool.
             offset = self._pool_end
-            self._pool_end += size
+            new_pool_end = self._pool_end + size
+            i = None
 
-        self._currently_allocated += size
-        if self._currently_allocated > self._peak_usage:
-            self._peak_usage = self._currently_allocated
+        new_currently_allocated = self._currently_allocated + size
+        if new_currently_allocated > self._segment_size:
+            return None
 
-        if self._peak_usage > self._segment_size:
-            raise RuntimeError(
-                f"HBM intermediate pool peak usage ({self._peak_usage} bytes, "
-                f"{self._peak_usage / (1024**3):.2f} GB) exceeds segment size "
-                f"({self._segment_size} bytes, {self._segment_size / (1024**3):.2f} GB)"
-            )
+        if i is not None:
+            self._free.pop(i)
+            remainder = blk_size - size
+            if remainder > 0:
+                self._free.append((blk_offset + size, remainder))
+        self._pool_end = new_pool_end
+        self._currently_allocated = new_currently_allocated
+        self._peak_usage = max(self._currently_allocated, self._peak_usage)
 
         return offset
 
@@ -359,10 +363,11 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
         live_ranges = _compute_live_ranges(live_range_nodes, bundle_candidates)
         sorted_bufs = sorted(live_ranges.items(), key=_alloc_sort_key)
 
-        allocator = Allocator(SEGMENT_SIZE)
+        allocator = Allocator(MAX_POOL_SIZE)
 
         # Track (end_step, offset, size) so we can free blocks promptly.
         pending_frees: list[tuple[int, int, int]] = []
+        overflowed = 0
 
         for name, (start, end) in sorted_bufs:
             # Free any blocks whose live range ended before this start step.
@@ -377,6 +382,23 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
 
             size = _compute_size_bytes(name)
             offset = allocator.allocate(size)
+
+            if offset is None:
+                # Pool is full: leave this buffer on the standalone-HBM path
+                # (no "hbm_pool" key) rather than failing the whole bundle --
+                # it gets the same allocation graph inputs/outputs and
+                # cross-bundle buffers already use.
+                overflowed += 1
+                logger.debug(
+                    "hbm_pool_planning: bundle=%s  %s  live=[%d,%d]  size=%d  "
+                    "does not fit in pool -- falling back to standalone HBM",
+                    bundle_name,
+                    name,
+                    start,
+                    end,
+                    size,
+                )
+                continue
 
             # Assign pool offset directly to layout.allocation.
             buf = V.graph.get_buffer(name)
@@ -415,14 +437,22 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
 
         peak = allocator.get_peak_usage()
         pool_extent = allocator.get_pool_end()
+        if overflowed:
+            logger.warning(
+                "hbm_pool_planning: bundle=%s  %d intermediate(s) did not fit in "
+                "the %.2f GB pool budget and fell back to standalone HBM",
+                bundle_name,
+                overflowed,
+                MAX_POOL_SIZE / (1024**3),
+            )
         logger.info(
             "hbm_pool_planning: bundle=%s assigned %d intermediates, peak concurrent "
             "usage %.2f GB, pool extent %.2f GB / %.2f GB",
             bundle_name,
-            len(sorted_bufs),
+            len(sorted_bufs) - overflowed,
             peak / (1024**3),
             pool_extent / (1024**3),
-            SEGMENT_SIZE / (1024**3),
+            MAX_POOL_SIZE / (1024**3),
         )
         V.graph.hbm_pool_sizes[bundle_name] = pool_extent
 

--- a/torch_spyre/_inductor/hbm_pool_planning.py
+++ b/torch_spyre/_inductor/hbm_pool_planning.py
@@ -22,7 +22,7 @@ from torch._inductor.scheduler import (
 )
 from torch._inductor.ir import FallbackKernel
 from torch._inductor.virtualized import V
-from .constants import MAX_POOL_SIZE, INTERMEDIATES_SEGMENT
+from .constants import MAX_POOL_SIZE_BYTES, INTERMEDIATES_SEGMENT
 from .ir import FixedTiledLayout, SpyreEmptyFallback
 from .logging_utils import get_inductor_logger
 from .scheduler import CountedLoopSchedulerNode
@@ -30,6 +30,7 @@ from . import config
 
 logger = get_inductor_logger("HBM_POOL_PLANNING")
 _STICK_BYTES = 128
+_BYTES_PER_GB = 1024**3
 
 
 class Allocator:
@@ -419,7 +420,7 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
         live_ranges = _compute_live_ranges(live_range_nodes, bundle_candidates)
         sorted_bufs = sorted(live_ranges.items(), key=_alloc_sort_key)
 
-        allocator = Allocator(MAX_POOL_SIZE)
+        allocator = Allocator(MAX_POOL_SIZE_BYTES)
 
         # Track (end_step, offset, size) so we can free blocks promptly.
         pending_frees: list[tuple[int, int, int]] = []
@@ -499,16 +500,16 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
                 "the %.2f GB pool budget and fell back to standalone HBM",
                 bundle_name,
                 overflowed,
-                MAX_POOL_SIZE / (1024**3),
+                MAX_POOL_SIZE_BYTES / _BYTES_PER_GB,
             )
         logger.info(
             "hbm_pool_planning: bundle=%s assigned %d intermediates, peak concurrent "
             "usage %.2f GB, pool extent %.2f GB / %.2f GB",
             bundle_name,
             len(sorted_bufs) - overflowed,
-            peak / (1024**3),
-            pool_extent / (1024**3),
-            MAX_POOL_SIZE / (1024**3),
+            peak / _BYTES_PER_GB,
+            pool_extent / _BYTES_PER_GB,
+            MAX_POOL_SIZE_BYTES / _BYTES_PER_GB,
         )
         V.graph.hbm_pool_sizes[bundle_name] = pool_extent
 
@@ -519,7 +520,7 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
             "hbm_pool_planning: %d bundle(s) with pool allocations, "
             "total pool bytes across bundles %.2f GB",
             len(V.graph.hbm_pool_sizes),
-            sum(V.graph.hbm_pool_sizes.values()) / (1024**3),
+            sum(V.graph.hbm_pool_sizes.values()) / _BYTES_PER_GB,
         )
 
     return nodes

--- a/torch_spyre/_inductor/hbm_pool_planning.py
+++ b/torch_spyre/_inductor/hbm_pool_planning.py
@@ -38,7 +38,10 @@ class Allocator:
     whose live ranges do not overlap share the same region. Each block is a
     (offset, size) pair measured in bytes.
 
-    Ensures peak concurrent memory usage does not exceed the segment size limit.
+    Ensures the pool's high-water mark (`pool_end`, a bump pointer that never
+    decreases even after `free()`) never exceeds the segment size limit --
+    this is the same quantity `generate_bundle` reserves via
+    `sdscbundle.device_mem_allocate`, so the two must agree.
     """
 
     def __init__(self, segment_size: int) -> None:
@@ -53,8 +56,13 @@ class Allocator:
         `size` bytes. Reuses an existing free block when possible.
 
         Returns None, leaving all internal state untouched, if `size` would
-        push peak concurrent usage past the segment size limit -- callers
-        fall back to standalone HBM allocation for that buffer instead.
+        push the pool's high-water mark (`pool_end`) past the segment size
+        limit -- callers fall back to standalone HBM allocation for that
+        buffer instead. Gating on `pool_end` rather than concurrent usage
+        matters because `pool_end` -- not peak concurrent usage -- is the
+        quantity `generate_bundle` reserves via
+        `sdscbundle.device_mem_allocate`; free-list fragmentation can push
+        `pool_end` past the limit even while concurrent usage stays low.
         """
         for i, (blk_offset, blk_size) in enumerate(self._free):
             if blk_size >= size:
@@ -67,8 +75,7 @@ class Allocator:
             new_pool_end = self._pool_end + size
             i = None
 
-        new_currently_allocated = self._currently_allocated + size
-        if new_currently_allocated > self._segment_size:
+        if new_pool_end > self._segment_size:
             return None
 
         if i is not None:
@@ -77,7 +84,7 @@ class Allocator:
             if remainder > 0:
                 self._free.append((blk_offset + size, remainder))
         self._pool_end = new_pool_end
-        self._currently_allocated = new_currently_allocated
+        self._currently_allocated += size
         self._peak_usage = max(self._currently_allocated, self._peak_usage)
 
         return offset
@@ -281,6 +288,17 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
     # that allocation dict.  Populated alongside buffer_writer_bundles so
     # aliased names (see _alloc_id) are attributed to the same underlying
     # storage even though they share no name-based dependency edge.
+    #
+    # Deliberately write-keyed only: the sole Inductor mechanism that makes
+    # two distinct buffer names share the literal id(layout.allocation)
+    # object is MutationLayoutSHOULDREMOVE, which always attaches to a
+    # write (set via `src.data.layout = MutationLayoutSHOULDREMOVE(dst)` in
+    # Inductor's realize_into/mark_buffer_mutated) -- so walking .writes
+    # alone is provably complete. Inductor's read-only aliasing mechanism
+    # (NonOwningLayout, used for views) builds a new Layout object rather
+    # than sharing one, and such buffers are excluded from pool eligibility
+    # entirely by the isinstance(layout, FixedTiledLayout) checks in
+    # _is_intermediate/_alloc_id, independent of bundle analysis.
     alloc_id_bundles: dict[int, set[str]] = {}
 
     for bundle in nodes:

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -839,7 +839,10 @@ class SuperDSCScheduling(BaseScheduling):
             buf.writeline(f"async_compile.{method}('{kernel_name}',")
             with buf.indent():
                 buf.splice(f"{src_code}")
-            buf.writeline(")")
+            if method == "sdsc" and kernel._kernel_uses_hbm_pool():
+                buf.writeline(f", pool_size={kernel.pool_size})")
+            else:
+                buf.writeline(")")
             origins, detailed_origins = get_kernel_metadata(node_schedule, wrapper)
             metadata_comment = f"{origins}\n{detailed_origins}"
             wrapper.define_kernel(kernel_name, buf.getvalue(), metadata_comment)

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -1324,30 +1324,15 @@ class SpyreKernel(Kernel[CSEVariable]):
         )
 
     def call_kernel(self, name: str, node=None):
-        """Codegen a call to this kernel, allocating/freeing this kernel's
-        own pool tensor (if any) scoped tightly around the .run() call."""
+        """Codegen a call to this kernel. This kernel's own HBM pool tensor
+        (if any) is allocated by the generated MLIR itself, via
+        sdscbundle.device_mem_allocate -- there is no Python-side pool
+        tensor to allocate or free here."""
         wrapper = V.graph.wrapper_code
         call_args = []
 
-        uses_pool = self._kernel_uses_hbm_pool()
-        # `name` is this kernel's own wrapper-module variable name (e.g.
-        # "sdsc_fused__buf12"), already guaranteed unique across kernels by
-        # Inductor's wrapper codegen -- two kernels sharing a Python
-        # identifier in the same generated module would already break
-        # `{name}.run(...)` codegen independent of pool allocation. Deriving
-        # the pool variable's name from it is therefore also collision-free.
-        pool_var_name = f"_pool_{name}"
-        if uses_pool:
-            wrapper.writeline(
-                f"{pool_var_name} = spyre_empty_with_layout("
-                f"({self.pool_size},), (1,), torch.uint8, "
-                f"SpyreTensorLayout(device_size=[{self.pool_size}], "
-                f"stride_map=[1], device_dtype=DataFormats.SENINT8))"
-            )
-            call_args.append(pool_var_name)
-
-        # Add remaining kernel arguments, deduplicating tensors that appear as
-        # both input and output (e.g. in-place ops like x *= 2).  With symbolic
+        # Add kernel arguments, deduplicating tensors that appear as both
+        # input and output (e.g. in-place ops like x *= 2).  With symbolic
         # args the MLIR bundle emits one !sdscbundle.input_arg<index> per unique
         # arg_index; passing the same tensor twice would cause a runtime
         # "Number of inputs mismatches" error in processComputeOnHostCommand.
@@ -1359,8 +1344,6 @@ class SpyreKernel(Kernel[CSEVariable]):
 
         call_args_str = ", ".join(call_args)
         wrapper.writeline(f"{name}.run({call_args_str})")
-        if uses_pool:
-            wrapper.writeline(f"del {pool_var_name}")
 
     def emit_layout_restores(self, restores) -> None:
         """Emit set_spyre_tensor_layout wrapper calls after this kernel's run.

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -110,7 +110,10 @@ class SpyreAsyncCompile(AsyncCompile):
         )
 
     def sdsc(
-        self, kernel_name: str, specs: Sequence[OpSpec | LoopSpec | UnimplementedOp]
+        self,
+        kernel_name: str,
+        specs: Sequence[OpSpec | LoopSpec | UnimplementedOp],
+        pool_size: int = 0,
     ):
         unimp = find_unimplemented(list(specs))
         if unimp is not None:
@@ -121,7 +124,7 @@ class SpyreAsyncCompile(AsyncCompile):
 
         # Generate SDSC Bundle from OpSpecs
         output_dir = get_output_dir(kernel_name)
-        generate_bundle(kernel_name, output_dir, specs)
+        generate_bundle(kernel_name, output_dir, specs, pool_size=pool_size)
 
         self._provenance_attempt_count += 1
         try:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Moves HBM-pool allocation for intermediates not placed in LX scratchpad
from a Python-side pool tensor to a per-bundle MLIR allocation emitted
via `sdscbundle.device_mem_allocate`.

Previously, `hbm_pool_planning` allocated a single `_pool_<kernel>`
tensor on the Python side before `.run()` and freed it afterward, with
its base address threaded into the compiled kernel through a
`%pool_base_addr` input parameter. This PR removes that mechanism
entirely: each pool-using bundle now self-allocates its pool via
`sdscbundle.device_mem_allocate` directly in `bundle.mlir`, scoped to
that bundle, and `pool_size` is threaded into the generated `sdsc()`
call instead of a runtime pointer.

Changes:

- `bundle.py`: emit `sdscbundle.device_mem_allocate` for pool
  allocation instead of expecting a `%pool_base_addr` parameter.
  `generate_bundle` now also asserts `0 < pool_size < MAX_POOL_SIZE`
  whenever a pool symbol is present, so a zero or out-of-range pool
  size fails loudly at bundle-generation time instead of silently
  emitting a useless or oversized `device_mem_allocate`.
- `scheduler.py` / `async_compile.py`: thread `pool_size` into the
  generated `sdsc()` call.
- `spyre_kernel.py`: stop allocating the Python-side HBM pool tensor.
- `constants.py`: add `MAX_POOL_SIZE = SEGMENT_SIZE - 2 * 1024**3`,
  reserving 2 GiB of headroom below the full hardware segment for
  other segment-7 consumers rather than letting the pool claim the whole segment.
- `hbm_pool_planning.py`: cap the per-bundle pool allocator at
  `MAX_POOL_SIZE` instead of the full `SEGMENT_SIZE`. `Allocator.
  allocate()` now returns `None` on overflow (leaving all internal
  state untouched) instead of raising `RuntimeError`; a buffer that
  doesn't fit in the pool falls back to standalone HBM allocation
  (no `"hbm_pool"` allocation key) instead of failing the whole
  bundle. A `logger.warning` reports how many intermediates
  overflowed per bundle, if any.
- Tests updated/added across `test_symbolic_dim_bundle.py`,
  `test_coarse_tiling.py`, and `test_coarse_tile_e2e.py` to reflect
  the new per-bundle `device_mem_allocate` mechanism, including a
  fallback-boundary test rewrite (the old version passed vacuously
  after the Python-side pool tensor was removed) and coverage for the
  `pool_size` kwarg being omitted entirely when a bundle has no
  pool-eligible buffer.
- `test_hbm_pool_planning.py`: new `Allocator`-level unit tests
  (budget success/rejection, state-untouched-on-rejection, freed-block
  reuse) and new end-to-end tests exercising a mix of pool-allocated
  and HBM-fallback buffers within a single bundle (partial overflow,
  full overflow, and freed-space-still-reused-before-overflow), using
  an artificially low `MAX_POOL_SIZE` to force the fallback path.
- `test_symbolic_dim_bundle.py`: new tests asserting `generate_bundle`
  raises when a pool symbol is present with `pool_size=0` or
  `pool_size >= MAX_POOL_SIZE`.
- `indirect_access_common.py`: two `generate_bundle` call sites that
  build synthetic pool-kind SDSCs purely to inspect JSON/MLIR
  structure now pass a placeholder non-zero `pool_size`, since they
  never validated hardware pool sizing to begin with.
- `docs/source/compiler/hbm_pool_planning.md`: updated codegen example
  and per-bundle-scoping description to match the new mechanism.

#### Which issue(s) this PR is related to:

Fixes #2506
Related to #3775 (backend compiler under-provisions the hardware
segment relative to the pool size requested by
`device_mem_allocate` — `MAX_POOL_SIZE` reserves headroom against
that class of issue, though the backend-side fix is tracked
separately in #3775).

#### Special notes for your reviewer:

- `test_pool_alloc_scoped_per_bundle_across_fallback_boundary` was
  rewritten from scratch: it previously asserted properties of the
  now-deleted Python-side pool tensor, and its assertion loops
  iterated over an empty list, so it was passing vacuously. It now
  inspects the actual generated `bundle.mlir` per kernel.
- No bundle's `bundle.mlir` should reference a `%pool_base_addr`
  parameter anymore; this is asserted directly in the updated tests.
- Addressed review nit: `generate_bundle` now asserts
  `not has_pool or 0 < pool_size < MAX_POOL_SIZE` before emitting
  `device_mem_allocate` ([comment](https://github.com/torch-spyre/torch-spyre/pull/3707#issuecomment-5284664848)).
  This surfaced a few test call sites that were passing `pool_size=0`
  implicitly while exercising a pool-kind symbol; those now pass an
  explicit placeholder size.
- The pool-overflow fallback (standalone HBM instead of
  `RuntimeError`) requires no new allocation-path code: omitting the
  `"hbm_pool"` allocation key routes a buffer through the pre-existing
  standalone-HBM codegen path, the same one already used for
  cross-bundle and I/O buffers.

#### Does this PR introduce a user-facing change?

No. This is an internal codegen/runtime mechanism change; pool
planning behavior (`HBM_POOL_PLANNING=1`) is unchanged from the user's
perspective, aside from a pool-eligible tensor that doesn't fit in the
(now slightly smaller) pool budget silently falling back to standalone
HBM allocation instead of raising `RuntimeError`.

#### Additional note:
None