### PR TITLE
Extend topk support from 2-D-only tensors to arbitrary rank

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1184,11 +1184,6 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                     4,
                     -1,
                 ),
-                "3d_k1_dim0": (
-                    unique_randn_along_dim((64, 71, 256), dim=0),
-                    1,
-                    0,
-                ),
                 "3d_k2_dim1": (
                     unique_randn_along_dim((64, 71, 256), dim=1),
                     2,
@@ -1202,11 +1197,6 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 "3d_k4_dim0": (
                     unique_randn_along_dim((67, 71, 256), dim=0),
                     4,
-                    0,
-                ),
-                "4d_k1_dim0": (
-                    unique_randn_along_dim((6, 17, 7, 64), dim=0),
-                    1,
                     0,
                 ),
                 "4d_k2_dim1": (

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1184,6 +1184,46 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                     4,
                     -1,
                 ),
+                "3d_k1_dim0": (
+                    unique_randn_along_dim((64, 71, 256), dim=0),
+                    1,
+                    0,
+                ),
+                "3d_k2_dim1": (
+                    unique_randn_along_dim((64, 71, 256), dim=1),
+                    2,
+                    1,
+                ),
+                "3d_k3_dim1": (
+                    unique_randn_along_dim((67, 71, 256), dim=1),
+                    3,
+                    1,
+                ),
+                "3d_k4_dim0": (
+                    unique_randn_along_dim((67, 71, 256), dim=0),
+                    4,
+                    0,
+                ),
+                "4d_k1_dim0": (
+                    unique_randn_along_dim((6, 17, 7, 64), dim=0),
+                    1,
+                    0,
+                ),
+                "4d_k2_dim1": (
+                    unique_randn_along_dim((6, 17, 7, 64), dim=1),
+                    2,
+                    1,
+                ),
+                "4d_k3_dim2": (
+                    unique_randn_along_dim((6, 17, 7, 64), dim=2),
+                    3,
+                    2,
+                ),
+                "4d_k4_dim0": (
+                    unique_randn_along_dim((6, 17, 7, 64), dim=0),
+                    4,
+                    0,
+                ),
                 # "2d_k4_dim0_lessthanstick": (unique_randn_along_dim((8, 32), dim=0), 4, 0),
                 # "2d_k4_dim_minusone_lessthanstick": (unique_randn_along_dim((1, 32), dim=-1), 4, -1),
             },

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -130,15 +130,11 @@ def _(
 
 @torch.library.custom_op("spyre::topkvalue", mutates_args=(), device_types="spyre")
 def topkvalue(x: torch.Tensor, k: int, dim: int) -> torch.Tensor:
-    if len(x.size()) != 2:
-        raise Unsupported("topk only implemented for 2-D tensors")
     pass
 
 
 @topkvalue.register_fake
 def _(x: torch.Tensor, k: int, dim: int) -> torch.Tensor:
-    if len(x.size()) != 2:
-        raise Unsupported("topk only implemented for 2-D tensors")
     norm_dim = dim % len(x.size())
     out_size = list(x.size())
     out_size[norm_dim] = k
@@ -147,15 +143,11 @@ def _(x: torch.Tensor, k: int, dim: int) -> torch.Tensor:
 
 @torch.library.custom_op("spyre::topkindex", mutates_args=(), device_types="spyre")
 def topkindex(x: torch.Tensor, k: int, dim: int) -> torch.Tensor:
-    if len(x.size()) != 2:
-        raise Unsupported("topk only implemented for 2-D tensors")
     pass
 
 
 @topkindex.register_fake
 def _(x: torch.Tensor, k: int, dim: int) -> torch.Tensor:
-    if len(x.size()) != 2:
-        raise Unsupported("topk only implemented for 2-D tensors")
     norm_dim = dim % len(x.size())
     out_size = list(x.size())
     out_size[norm_dim] = k

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -630,41 +630,28 @@ def lower_layernormscale(x, eps):
     return pw
 
 
-@register_spyre_lowering(torch.ops.spyre.topkvalue)
-def lower_topkvalue(x, k, dim):
+def _topk_reduction_kwargs(x, k, dim):
+    """Build Reduction.create kwargs for topk along an arbitrary dim/rank.
+
+    Unlike a normal reduction, topk keeps `k` elements along the reduced
+    dim rather than collapsing it to size 1, so lowering._make_reduction_inner
+    can't be reused directly.
+    """
     x_size = x.get_size()
     ndim = len(x_size)
-    # Normalize dim to a positive index.
     norm_dim = dim % ndim
     loader = x.make_loader()
 
-    if norm_dim == ndim - 1:
-        # dim=-1 (or last dim): input shape [mb, n_in], reduce along n_in.
-        # ranges=[mb, k]: index=[mb_idx, k_idx], rindex=[n_in_idx].
-        mb = x_size[0]
-        n_in = x_size[1]
+    ranges = list(x_size)
+    ranges[norm_dim] = k
+    reduction_ranges = [x_size[norm_dim]]
 
-        def inner_fn(index, rindex):
-            return loader([index[0], rindex[0]])
+    def inner_fn(index, rindex):
+        full_index = list(index)
+        full_index[norm_dim] = rindex[0]
+        return loader(full_index)
 
-        ranges = [mb, k]
-        reduction_ranges = [n_in]
-    else:
-        # dim=0: input shape [n_in, mb], reduce along n_in (dim 0).
-        # ranges=[k, mb]: index=[k_idx, mb_idx], rindex=[n_in_idx].
-        mb = x_size[1]
-
-        def inner_fn(index, rindex):
-            # index = [k_idx, mb_idx], rindex = [n_in_idx]
-            # Load from input at (n_in_idx, mb_idx); k_idx is the output row.
-            return loader([rindex[0], index[1]])
-
-        ranges = [k, mb]
-        reduction_ranges = x_size[:1]
-
-    result = Reduction.create(
-        reduction_type="topkvalue",
-        input_node=x,
+    return dict(
         device=x.get_device(),
         dst_dtype=x.get_dtype(),
         src_dtype=x.get_dtype(),
@@ -672,51 +659,25 @@ def lower_topkvalue(x, k, dim):
         ranges=ranges,
         reduction_ranges=reduction_ranges,
     )
+
+
+@register_spyre_lowering(torch.ops.spyre.topkvalue)
+def lower_topkvalue(x, k, dim):
+    result = Reduction.create(
+        reduction_type="topkvalue",
+        input_node=x,
+        **_topk_reduction_kwargs(x, k, dim),
+    )
     result.realize()
     return result
 
 
 @register_spyre_lowering(torch.ops.spyre.topkindex)
 def lower_topkindex(x, k, dim):
-    x_size = x.get_size()
-    ndim = len(x_size)
-    # Normalize dim to a positive index.
-    norm_dim = dim % ndim
-    loader = x.make_loader()
-
-    if norm_dim == ndim - 1:
-        # dim=-1 (or last dim): input shape [mb, n_in], reduce along n_in.
-        # ranges=[mb, k]: index=[mb_idx, k_idx], rindex=[n_in_idx].
-        mb = x_size[0]
-        n_in = x_size[1]
-
-        def inner_fn(index, rindex):
-            return loader([index[0], rindex[0]])
-
-        ranges = [mb, k]
-        reduction_ranges = [n_in]
-    else:
-        # dim=0: input shape [n_in, mb], reduce along n_in (dim 0).
-        # ranges=[k, mb]: index=[k_idx, mb_idx], rindex=[n_in_idx].
-        mb = x_size[1]
-
-        def inner_fn(index, rindex):
-            # index = [k_idx, mb_idx], rindex = [n_in_idx]
-            # Load from input at (n_in_idx, mb_idx); k_idx is the output row.
-            return loader([rindex[0], index[1]])
-
-        ranges = [k, mb]
-        reduction_ranges = x_size[:1]
-
     result = Reduction.create(
         reduction_type="topkindex",
         input_node=x,
-        device=x.get_device(),
-        dst_dtype=x.get_dtype(),
-        src_dtype=x.get_dtype(),
-        inner_fn=inner_fn,
-        ranges=ranges,
-        reduction_ranges=reduction_ranges,
+        **_topk_reduction_kwargs(x, k, dim),
     )
     result.realize()
     return result


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
Replace hand-written 2-D-only branching logic in `lower_topkvalue` and `lower_topkindex` with a shared `_topk_reduction_kwargs` helper that computes `ranges`/`reduction_ranges`/`inner_fn` for any rank and any dim.
Test cases are added.

#### Which issue(s) this PR is related to:
Part of #3636 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
