### PR TITLE
Support temporal-1 Conv3D by folding to a batched Conv2d

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_scalar_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_scalar_config.yaml
@@ -40,7 +40,7 @@ test_suite_config:
             - LxPlanning.*::test_conv2d_direct_.*_s2_lx_planning_(pointwise|reduction)
           mode: xfail
         - names:
-            - LxPlanning.*::test_(all_dim|any_dim|count_nonzero|cummax|cummin|cumprod|logcumsumexp|max_default|median|mode_|nanmean|nanmedian|nanquantile|nansum|quantile|std_|topk|conv2d|dwise_conv2d|var_).*_lx_planning_(pointwise|reduction)
+            - LxPlanning.*::test_(all_dim|any_dim|count_nonzero|cummax|cummin|cumprod|logcumsumexp|max_default|median|mode_|nanmean|nanmedian|nanquantile|nansum|quantile|std_|topk|conv2d|conv3d|dwise_conv2d|var_).*_lx_planning_(pointwise|reduction)
           mode: mandatory_success
           tags:
             - ops__inductor-reduction

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_scalar_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_scalar_config.yaml
@@ -19,7 +19,7 @@ test_suite_config:
             # but the base method names are test_sum_keepdim0/1 from test file
             # Note: argmin and logsumexp are excluded here because their base
             # names contain "keepdim" and are covered by the keepdim shard.
-            - TestOps::test_(all_dim|any_dim|count_nonzero|cummax|cummin|cumprod|logcumsumexp|max_default|median|mode_|nanmean|nanmedian|nanquantile|nansum|quantile|std_|topk|conv2d|dwise_conv2d|var_).*
+            - TestOps::test_(all_dim|any_dim|count_nonzero|cummax|cummin|cumprod|logcumsumexp|max_default|median|mode_|nanmean|nanmedian|nanquantile|nansum|quantile|std_|topk|conv2d|conv3d|dwise_conv2d|var_).*
 
           mode: mandatory_success
           tags:

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -5219,6 +5219,85 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 # unrelated to direct lowering).
             },
         },
+        # Conv3D with a unit temporal (depth) kernel, folded to a batched
+        # Conv2d by conv2d_via_bmm_decomp (input.dim()==5 branch): each depth
+        # slice is convolved independently with the same [C_out,C_in,kH,kW]
+        # weight, so (N,C,D,H,W) -> (N*D,C,H,W) -> conv2d -> unfold. The inner
+        # 2D conv reuses the direct-lowering path when the flag is on (these
+        # cases mirror the supported corners of test_conv2d_direct: fp16,
+        # groups==1, zero pad, dilation 1, C_in stick-aligned, kH/kW<=3). Params
+        # are standard NCDHW (x, weight[C_out,C_in,kD=1,kH,kW], bias, stride);
+        # the test builds channel-last device tensors and toggles the flag.
+        ("test_conv3d_via_conv2d", "test_conv3d_via_conv2d_base"): {
+            "param_sets": {
+                # D==1: degenerate depth -- the fold is a single-slice batch.
+                "1x64x1x8x8_k3": (
+                    cached_randn((1, 64, 1, 8, 8)),
+                    cached_randn((64, 64, 1, 3, 3)),
+                    None,
+                    (1, 1, 1),
+                ),
+                # D>1: the batched fold over multiple depth slices, 3x3 kernel.
+                "1x64x4x8x8_k3": (
+                    cached_randn((1, 64, 4, 8, 8)),
+                    cached_randn((64, 64, 1, 3, 3)),
+                    None,
+                    (1, 1, 1),
+                ),
+                # Batch N>1 with D>1: exercises the N*D batch fold across both.
+                "2x64x3x8x8_k3": (
+                    cached_randn((2, 64, 3, 8, 8)),
+                    cached_randn((64, 64, 1, 3, 3)),
+                    None,
+                    (1, 1, 1),
+                ),
+                # 2x2 kernel -- smallest direct-lowered window.
+                "1x64x4x8x8_k2": (
+                    cached_randn((1, 64, 4, 8, 8)),
+                    cached_randn((64, 64, 1, 2, 2)),
+                    None,
+                    (1, 1, 1),
+                ),
+                # Bias present: added once on C_out inside the inner 2D conv.
+                "1x64x4x8x8_k3_bias": (
+                    cached_randn((1, 64, 4, 8, 8)),
+                    cached_randn((64, 64, 1, 3, 3)),
+                    cached_randn((64,)),
+                    (1, 1, 1),
+                ),
+                # C_out != C_in (32 output channels).
+                "1x64x4x8x8_k3_cout32": (
+                    cached_randn((1, 64, 4, 8, 8)),
+                    cached_randn((32, 64, 1, 3, 3)),
+                    None,
+                    (1, 1, 1),
+                ),
+            },
+        },
+        ("test_conv3d_via_conv2d_im2col", "test_conv3d_via_conv2d_im2col_base"): {
+            "param_sets": {
+                # Small non-overlapping patchify: kernel==stride==4, C_in=6.
+                # Both kernel>3 and C_in not 64-aligned put the folded 2D conv
+                # outside the direct SDSC envelope, so it rides im2col+matmul.
+                "1x6x2x8x8_k4s4": (
+                    cached_randn((1, 6, 2, 8, 8)),
+                    cached_randn((16, 6, 1, 4, 4)),
+                    None,
+                    (1, 4, 4),
+                ),
+                # Large non-overlapping patchify (kernel==stride==16, C_in=6 ->
+                # C_out=1024) over a 224x224 x 4-depth cube -- a ViT-style 3D
+                # patch embed. Exercises im2col at scale: stick-aligned
+                # contraction (6*16*16=1536) and a large token count
+                # (H_out*W_out=14*14) that pads to stick boundaries.
+                "1x6x4x224x224_k16s16": (
+                    cached_randn((1, 6, 4, 224, 224)),
+                    cached_randn((1024, 6, 1, 16, 16)),
+                    None,
+                    (1, 16, 16),
+                ),
+            },
+        },
         ("test_avg_pool2d", "test_avg_pool2d_base"): {
             "ops_dict": {
                 "k2s2": lambda x: F.avg_pool2d(x, kernel_size=2, stride=2),
@@ -7446,6 +7525,137 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 rtol=0.1,
                 run_eager=False,
             )
+
+    def _run_conv3d_via_conv2d(self, x, weight, bias, stride, direct_flag):
+        # Shared body for the conv3d-via-conv2d cases. A Conv3D with a unit
+        # temporal (depth) kernel is folded to a batched Conv2d by
+        # conv2d_via_bmm_decomp (input.dim()==5 branch); the folded 4D conv then
+        # rides whichever 2D path fits -- the native conv2d SDSC when
+        # direct_flag is on and the case is in the SDSC envelope, else
+        # im2col+matmul. direct_flag pins config.conv2d_direct_lowering so a case
+        # can target a specific inner path.
+        #
+        # Same channel-last convention as test_conv2d_direct_base, extended to
+        # 5D: Spyre sticks C innermost, so the activation is handed to the
+        # harness as channel-last NDHWC and the weight sticks on C_out. fn
+        # permutes back to the logical NCDHW / [C_out,C_in,kD,kH,kW] layouts and
+        # calls torch.conv3d, so the standard compare_with_cpu harness holds.
+        #
+        # run_eager=False: Spyre has no eager conv3d kernel; only the compiled
+        # (fold + lowering) path is valid here.
+        x_ndhwc = x.permute(0, 2, 3, 4, 1).contiguous()  # [N, D, H, W, C_in]
+        # [C_out,C_in,kD,kH,kW] -> [C_in,kD,kH,kW,C_out]
+        w_dev = weight.permute(1, 2, 3, 4, 0).contiguous()
+
+        def fn(xc, wc, b):
+            xn = xc.permute(0, 4, 1, 2, 3)  # NDHWC -> NCDHW
+            wn = wc.permute(4, 0, 1, 2, 3)  # [C_in,kD,kH,kW,C_out] -> [C_out,...]
+            out = torch.conv3d(xn, wn, b, stride=stride, padding=0, groups=1)
+            return out.permute(0, 2, 3, 4, 1)  # NCDHW -> NDHWC
+
+        with mock.patch.object(inductor_config, "conv2d_direct_lowering", direct_flag):
+            self.compare_with_cpu(
+                fn,
+                x_ndhwc,
+                w_dev,
+                bias,
+                atol=0.5,
+                rtol=0.1,
+                run_eager=False,
+            )
+
+    def test_conv3d_via_conv2d_base(self, x, weight, bias, stride):
+        # Temporal-1 Conv3D whose folded 2D conv is in the direct SDSC envelope
+        # (C_in 64-aligned, kernel <= 3): direct-lowering flag on -> native
+        # conv2d SDSC.
+        self._run_conv3d_via_conv2d(x, weight, bias, stride, direct_flag=True)
+
+    def test_conv3d_via_conv2d_im2col_base(self, x, weight, bias, stride):
+        # Temporal-1 Conv3D whose folded 2D conv is OUTSIDE the direct SDSC
+        # envelope (kernel > 3 and/or C_in not 64-aligned, e.g. a ViT/Prithvi
+        # patch-embed) so it decomposes to im2col+matmul. The direct-lowering
+        # flag is OFF, proving the fold rides the im2col path too (the "allow
+        # im2col for Conv3D" policy) rather than requiring the direct path.
+        #
+        # Unlike the direct base test, inputs are plain row-major NCDHW /
+        # [C_out,C_in,kD,kH,kW] -- the natural layout a real model (e.g. Prithvi)
+        # hands to conv3d, and the one the im2col path wants. The direct path
+        # needs channel-last so C lands on the stick; im2col instead linearizes
+        # the channels into the matmul contraction, so it wants the ordinary
+        # contiguous layout. Handing im2col a channel-last weight (C_out on the
+        # stick as the outermost logical dim) is unrepresentable for the
+        # reshape/d2h that flattens it, so it is deliberately not tested here.
+        #
+        # run_eager=False: Spyre has no eager conv3d kernel; only the compiled
+        # (fold + im2col) path is valid here.
+        def fn(xc, wc, b):
+            return torch.conv3d(xc, wc, b, stride=stride, padding=0, groups=1)
+
+        with mock.patch.object(inductor_config, "conv2d_direct_lowering", False):
+            self.compare_with_cpu(
+                fn,
+                x,
+                weight,
+                bias,
+                atol=0.5,
+                rtol=0.1,
+                run_eager=False,
+            )
+
+    def test_conv3d_via_conv2d_temporal1_gate(self):
+        # Pure-Python guard check (no compile/hardware) of the
+        # conv2d_via_bmm_decomp 5D branch. Only the *temporal* geometry gates the
+        # fold: a unit temporal kernel (kD==1 with unit depth stride, zero depth
+        # pad, unit depth dilation) makes Conv3D a batched Conv2d and folds; a
+        # genuinely 3-D conv (kD>1 or non-trivial depth geometry) is out of scope
+        # and must raise Unsupported. This gate is independent of
+        # config.conv2d_direct_lowering -- the flag only steers the *inner* 2D op
+        # (direct SDSC vs im2col+matmul), it no longer gates Conv3D on/off. The
+        # rejection fires before any Spyre-device op, so it is checkable on CPU
+        # tensors here; the accepted path is exercised end-to-end in
+        # test_conv3d_via_conv2d_base.
+        from torch_spyre._inductor.decompositions import conv2d_via_bmm_decomp
+        from torch_spyre._inductor.errors import Unsupported
+
+        def _call(kD=1, stride_d=1, pad_d=0, dil_d=1):
+            x = torch.zeros(1, 64, 2, 8, 8, dtype=torch.float16)
+            w = torch.zeros(64, 64, kD, 3, 3, dtype=torch.float16)
+            return conv2d_via_bmm_decomp(
+                x,
+                w,
+                None,
+                [stride_d, 1, 1],
+                [pad_d, 0, 0],
+                [dil_d, 1, 1],
+                False,
+                [0, 0, 0],
+                1,
+            )
+
+        # The temporal gate holds regardless of the direct-lowering flag.
+        for flag in (False, True):
+            with mock.patch.object(inductor_config, "conv2d_direct_lowering", flag):
+                # Non-temporal-1 depth geometry is genuinely 3-D -> rejected.
+                with self.assertRaises(Unsupported):
+                    _call(kD=2)
+                with self.assertRaises(Unsupported):
+                    _call(stride_d=2)
+                with self.assertRaises(Unsupported):
+                    _call(pad_d=1)
+                with self.assertRaises(Unsupported):
+                    _call(dil_d=2)
+
+                # Temporal-1 passes the gate: it must NOT raise Unsupported. It
+                # proceeds into the fold, whose reshape_via_cpu has no CPU kernel
+                # in this pure-Python test, so a non-Unsupported error there is
+                # expected and ignored (the fold runs for real on hardware in the
+                # base test).
+                try:
+                    _call(kD=1)
+                except Unsupported as e:  # noqa: F841
+                    self.fail(f"temporal-1 conv3d should pass the gate, got: {e}")
+                except Exception:
+                    pass
 
     def test_conv2d_direct_support_predicate(self):
         # Pure-Python guard check (no compile/hardware): the direct-lowering

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -7617,9 +7617,9 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         from torch_spyre._inductor.decompositions import conv2d_via_bmm_decomp
         from torch_spyre._inductor.errors import Unsupported
 
-        def _call(kD=1, stride_d=1, pad_d=0, dil_d=1):
+        def _call(kD=1, stride_d=1, pad_d=0, dil_d=1, groups=1):
             x = torch.zeros(1, 64, 2, 8, 8, dtype=torch.float16)
-            w = torch.zeros(64, 64, kD, 3, 3, dtype=torch.float16)
+            w = torch.zeros(64, 64 // groups, kD, 3, 3, dtype=torch.float16)
             return conv2d_via_bmm_decomp(
                 x,
                 w,
@@ -7629,7 +7629,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 [dil_d, 1, 1],
                 False,
                 [0, 0, 0],
-                1,
+                groups,
             )
 
         # The temporal gate holds regardless of the direct-lowering flag.
@@ -7644,6 +7644,14 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                     _call(pad_d=1)
                 with self.assertRaises(Unsupported):
                     _call(dil_d=2)
+                # Grouped/depthwise fold is out of scope: will_direct is binary
+                # (direct vs im2col) and cannot express the 4D depthwise exit,
+                # so a temporal-1 conv3d with groups != 1 must be rejected here
+                # rather than mis-folded into the wrong layout.
+                with self.assertRaises(Unsupported):
+                    _call(groups=2)
+                with self.assertRaises(Unsupported):
+                    _call(groups=64)  # depthwise
 
                 # Temporal-1 passes the gate: it must NOT raise Unsupported. It
                 # proceeds into the fold, whose reshape_via_cpu has no CPU kernel
@@ -7683,9 +7691,12 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         )
 
         def _supported(c_in, k=3, hw=8, **overrides):
-            x = torch.zeros(1, c_in, hw, hw, dtype=torch.float16)
-            w = torch.zeros(eps, c_in, k, k, dtype=torch.float16)
-            return _is_direct_conv_supported(x, w, **{**common, **overrides})
+            return _is_direct_conv_supported(
+                (1, c_in, hw, hw),
+                torch.float16,
+                (eps, c_in, k, k),
+                **{**common, **overrides},
+            )
 
         # C_in stick alignment.
         self.assertTrue(_supported(eps), f"C_in={eps} should direct-lower")

--- a/tests/inductor/test_inductor_ops_lx_planning.py
+++ b/tests/inductor/test_inductor_ops_lx_planning.py
@@ -145,6 +145,9 @@ INHERITED_TEST_ATTRIBUTES = [
     "is_dtype_supported",
     "_get_core_reduction_invalid_dim_cases",
     "_get_single_dim_reduction_invalid_dim_cases",
+    # Shared body for the direct-path conv3d cases; the im2col conv3d and gate
+    # tests are self-contained, but test_conv3d_via_conv2d_base delegates here.
+    "_run_conv3d_via_conv2d",
 ]
 
 POINTWISE_TEST_FAILURES = []

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -517,7 +517,12 @@ def spyre_reshape_via_cpu(
     """
     warn_fallback("torch.ops.spyre.reshape_via_cpu")
     input_cpu = input.to("cpu")
-    result_cpu = input_cpu.reshape(shape)
+    # reshape() can return a non-contiguous VIEW -- e.g. squeezing a size-1 dim
+    # out of a non-contiguous/permuted input -- but the register_fake below
+    # advertises a *contiguous* new_empty(shape), so force contiguity so the real
+    # output matches the fake stride and inductor's assert_size_stride holds for
+    # every caller.
+    result_cpu = input_cpu.reshape(shape).contiguous()
     return result_cpu.to(input.device)
 
 

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -864,6 +864,126 @@ def conv2d_via_bmm_decomp(
     if any(op != 0 for op in output_padding):
         raise Unsupported("conv2d_via_bmm: output_padding not supported")
 
+    if input.dim() == 5:
+        # A Conv3D with a unit temporal (depth) kernel is a *batched* Conv2d:
+        # with kD == 1 (and unit depth stride, zero depth pad, unit depth
+        # dilation) every depth slice is convolved independently with the same
+        # [C_out, C_in, kH, kW] weight. So fold D into the batch dim, run the
+        # ordinary 2D conv, and unfold:
+        #     (N, C, D, H, W) -> (N*D, C, H, W) -> conv2d -> unfold back.
+        # The folded op is a plain aten.convolution.default that the
+        # decomposition table re-processes exactly like any 2D conv: with the
+        # direct-lowering flag on and a supported case it declines to the native
+        # conv2d SDSC (lower_convolution / _is_direct_conv_supported); otherwise
+        # -- the flag is off, or the case is outside the SDSC envelope, e.g. a
+        # ViT patch-embed kernel (kH/kW > 3) or a non-stick-aligned C_in as in
+        # Prithvi-EO-2.0's Conv3d(6->1024, kernel (1,16,16)) -- it decomposes to
+        # im2col+matmul. Conv3D thus rides whichever 2D path fits, with no new
+        # lowering, and the dim() == 5 guard means the folded 4D op never
+        # re-triggers this branch (no infinite recursion).
+        #
+        # A non-temporal-1 Conv3D (kD > 1, or a non-trivial depth
+        # stride/pad/dilation) is genuinely 3-D and out of scope here -- it
+        # stays Unsupported.
+        N, C_in, D, H_in, W_in = input.shape
+        C_out, C_in_per_group, K_d, K_h, K_w = weight.shape
+        if not (K_d == 1 and stride[0] == 1 and padding[0] == 0 and dilation[0] == 1):
+            raise Unsupported(
+                "conv2d_via_bmm: 3D convolution is only supported when the "
+                "temporal (depth) kernel is 1 with unit depth stride, zero depth "
+                f"padding and unit depth dilation (got kD={K_d}, "
+                f"stride_d={stride[0]}, pad_d={padding[0]}, dil_d={dilation[0]})"
+            )
+
+        conv2d_stride = [stride[1], stride[2]]
+        conv2d_padding = [padding[1], padding[2]]
+        conv2d_dilation = [dilation[1], dilation[2]]
+
+        # The two inner 2D paths want OPPOSITE activation layouts, so the fold
+        # must lay the data out for whichever one the recursive 4D conv will
+        # take. The direct conv2d SDSC contracts over C_in and needs C_in on the
+        # Spyre stick (channel-last fold); the im2col+matmul path needs the
+        # default row-major layout (W on the stick). Get it wrong and the conv
+        # layout pass rejects the activation with an unrepresentable stick
+        # expression -- a channel-last activation into im2col yields `2*d1 + d2`,
+        # a row-major one into the direct path yields `d3 + d6`. Decide up front
+        # with the SAME predicate the recursion will evaluate on the folded 4D
+        # op (it reads only shapes/dtype, so probe it with empty tensors of the
+        # folded shapes), keeping the two decisions in lock-step.
+        will_direct = config.conv2d_direct_lowering and _is_direct_conv_supported(
+            input.new_empty((N * D, C_in, H_in, W_in)),
+            weight.new_empty((C_out, C_in_per_group, K_h, K_w)),
+            conv2d_stride,
+            transposed,
+            [output_padding[1], output_padding[2]],
+            conv2d_padding,
+            conv2d_dilation,
+            groups,
+        )
+
+        if will_direct:
+            # Channel-last fold: reshape_via_cpu returns default row-major
+            # layout, so the *innermost logical* dim lands on the stick. Reshape
+            # in channel-last order (C innermost) and expose the logical NCHW /
+            # [C_out, C_in, kH, kW] shape with a permute VIEW -- exactly the form
+            # the 4D direct path receives its inputs (NHWC-contiguous viewed as
+            # NCHW), so C_in / C_out stay on the stick.
+            # activation (N,C,D,H,W) -> view (N,D,H,W,C) -> (N*D,H,W,C)
+            #            -> view (N*D,C,H,W).
+            x_cl = torch.permute(input, (0, 2, 3, 4, 1)).contiguous()
+            x_cl = torch.ops.spyre.reshape_via_cpu(x_cl, (N * D, H_in, W_in, C_in))
+            x4 = torch.permute(x_cl, (0, 3, 1, 2))
+            # weight (C_out,C_in,1,kH,kW) -> view (C_in,1,kH,kW,C_out)
+            #        -> (C_in,kH,kW,C_out) -> view (C_out,C_in,kH,kW). This also
+            # squeezes the unit depth tap.
+            w_cl = torch.permute(weight, (1, 2, 3, 4, 0)).contiguous()
+            w_cl = torch.ops.spyre.reshape_via_cpu(
+                w_cl, (C_in_per_group, K_h, K_w, C_out)
+            )
+            w4 = torch.permute(w_cl, (3, 0, 1, 2))
+        else:
+            # Default row-major fold (W on the stick), the layout the im2col path
+            # accepts. Permute D next to N and squeeze it into the batch; the
+            # weight's unit depth tap is a pure reshape.
+            # activation (N,C,D,H,W) -> view (N,D,C,H,W) -> (N*D,C,H,W).
+            x_dchw = torch.permute(input, (0, 2, 1, 3, 4)).contiguous()
+            x4 = torch.ops.spyre.reshape_via_cpu(x_dchw, (N * D, C_in, H_in, W_in))
+            # weight (C_out,C_in,1,kH,kW) -> (C_out,C_in,kH,kW).
+            w4 = torch.ops.spyre.reshape_via_cpu(
+                weight, (C_out, C_in_per_group, K_h, K_w)
+            )
+
+        # Recurse into the 4D conv path; bias is added once, on the C_out dim,
+        # inside the inner conv (folding D into the batch leaves C_out intact),
+        # so it must NOT be re-added here.
+        out4 = torch.ops.aten.convolution.default(
+            x4,
+            w4,
+            bias,
+            conv2d_stride,
+            conv2d_padding,
+            conv2d_dilation,
+            False,
+            [0, 0],
+            groups,
+        )
+        # out4 is (N*D, C_out, H_out, W_out); read H_out/W_out back rather than
+        # recomputing them from the conv geometry, then unfold in the matching
+        # layout so the returned logical NCDHW tensor is correct either way.
+        _, C_out_o, H_out, W_out = out4.shape
+        if will_direct:
+            # view (N*D,H_out,W_out,C_out) -> (N,D,H_out,W_out,C_out)
+            # -> view (N,C_out,D,H_out,W_out).
+            out_cl = torch.permute(out4, (0, 2, 3, 1)).contiguous()
+            out_cl = torch.ops.spyre.reshape_via_cpu(
+                out_cl, (N, D, H_out, W_out, C_out_o)
+            )
+            return torch.permute(out_cl, (0, 4, 1, 2, 3))
+        # Row-major: view (N*D,C_out,H_out,W_out) -> (N,D,C_out,H_out,W_out)
+        # -> view (N,C_out,D,H_out,W_out).
+        out5 = torch.ops.spyre.reshape_via_cpu(out4, (N, D, C_out_o, H_out, W_out))
+        return torch.permute(out5, (0, 2, 1, 3, 4))
+
     if input.dim() != 4:
         raise Unsupported(f"conv2d_via_bmm: expected 4D input, got {input.dim()}D")
 

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -706,8 +706,9 @@ _CONV_MAX_KERNEL = 3
 
 
 def _is_direct_conv_supported(
-    input: torch.Tensor,
-    weight: torch.Tensor,
+    input_shape: Sequence[int],
+    input_dtype: torch.dtype,
+    weight_shape: Sequence[int],
     stride: list[int],
     transposed: bool,
     output_padding: list[int],
@@ -791,8 +792,8 @@ def _is_direct_conv_supported(
     the im2col+matmul fallback branch is gone (see above) -- a mismatch surfaces
     downstream as a hard Unsupported, not silent wrong numerics.
     """
-    kH, kW = weight.shape[-2], weight.shape[-1]
-    C_in = input.shape[1]
+    kH, kW = weight_shape[-2], weight_shape[-1]
+    C_in = input_shape[1]
     eps = get_elem_in_stick(torch.float16)
     supported = (
         not transposed
@@ -800,8 +801,8 @@ def _is_direct_conv_supported(
         and all(p == 0 for p in padding)
         and all(d == 1 for d in dilation)
         and groups == 1
-        and input.dim() == 4
-        and input.dtype == torch.float16
+        and len(input_shape) == 4
+        and input_dtype == torch.float16
         and not (kH == 1 and kW == 1)
         # Dense conv k>3 overflows the LX contraction budget in the backend.
         and kH <= _CONV_MAX_KERNEL
@@ -821,11 +822,46 @@ def _is_direct_conv_supported(
     # and mis-accumulates the dangling column when (W_in - kW) % sW != 0. Only
     # decidable for a static width; a dynamic (SymInt) width stays on the direct
     # path rather than adding a symbolic-remainder shape guard.
-    W_in = input.shape[-1]
+    W_in = input_shape[-1]
     sW = stride[-1]
     if isinstance(W_in, int) and (W_in - kW) % sW != 0:
         return False
     return True
+
+
+def _will_lower_conv2d_direct(
+    input_shape: Sequence[int],
+    input_dtype: torch.dtype,
+    weight_shape: Sequence[int],
+    stride: list[int],
+    transposed: bool,
+    output_padding: list[int],
+    padding: list[int],
+    dilation: list[int],
+    groups: int,
+) -> bool:
+    """Single source of truth for whether conv2d_via_bmm_decomp defers a 4D conv.
+
+    True iff the decomposition will decline (return NotImplemented) and leave
+    aten.convolution for the native direct SDSC lowering, rather than expand into
+    im2col+matmul. Decides purely from shapes/dtype, so both callers pass shapes
+    directly: the 4D gate its own input/weight shapes, and the 3D->2D fold the
+    *folded* 4D shapes (it must pick a physical layout matching the path the
+    recursive 4D conv will actually take -- channel-last for direct, row-major for
+    im2col). Sharing this one decision is what keeps the fold's layout choice from
+    ever diverging from the routing the recursion makes.
+    """
+    return config.conv2d_direct_lowering and _is_direct_conv_supported(
+        input_shape,
+        input_dtype,
+        weight_shape,
+        stride,
+        transposed,
+        output_padding,
+        padding,
+        dilation,
+        groups,
+    )
 
 
 @register_spyre_decompositions([torch.ops.aten.convolution.default])
@@ -853,8 +889,16 @@ def conv2d_via_bmm_decomp(
     # non-fp16) fall through and decompose to im2col+matmul as before. This is
     # the compile-path target; the flag defaults off so eager and default
     # compile behavior are unchanged.
-    if config.conv2d_direct_lowering and _is_direct_conv_supported(
-        input, weight, stride, transposed, output_padding, padding, dilation, groups
+    if _will_lower_conv2d_direct(
+        input.shape,
+        input.dtype,
+        weight.shape,
+        stride,
+        transposed,
+        output_padding,
+        padding,
+        dilation,
+        groups,
     ):
         return NotImplemented
 
@@ -894,6 +938,19 @@ def conv2d_via_bmm_decomp(
                 f"padding and unit depth dilation (got kD={K_d}, "
                 f"stride_d={stride[0]}, pad_d={padding[0]}, dil_d={dilation[0]})"
             )
+        # A grouped/depthwise fold is out of scope: will_direct is binary
+        # (direct vs im2col), but the 4D body has a third exit -- the
+        # C_in == groups == C_out depthwise branch (spyre.conv2d_with_bias),
+        # which needs C on the stick. A depthwise conv3d predicts
+        # will_direct=False (the direct predicate requires groups==1) -> folds
+        # row-major -> lands in that channel-last branch with the wrong layout
+        # and fails obscurely downstream. Reject it here instead, so the binary
+        # layout decision below is exactly the routing the recursion will take.
+        if groups != 1:
+            raise Unsupported(
+                "conv2d_via_bmm: grouped/depthwise temporal-1 Conv3D is not "
+                f"supported (got groups={groups})"
+            )
 
         conv2d_stride = [stride[1], stride[2]]
         conv2d_padding = [padding[1], padding[2]]
@@ -906,13 +963,14 @@ def conv2d_via_bmm_decomp(
         # default row-major layout (W on the stick). Get it wrong and the conv
         # layout pass rejects the activation with an unrepresentable stick
         # expression -- a channel-last activation into im2col yields `2*d1 + d2`,
-        # a row-major one into the direct path yields `d3 + d6`. Decide up front
-        # with the SAME predicate the recursion will evaluate on the folded 4D
-        # op (it reads only shapes/dtype, so probe it with empty tensors of the
-        # folded shapes), keeping the two decisions in lock-step.
-        will_direct = config.conv2d_direct_lowering and _is_direct_conv_supported(
-            input.new_empty((N * D, C_in, H_in, W_in)),
-            weight.new_empty((C_out, C_in_per_group, K_h, K_w)),
+        # a row-major one into the direct path yields `d3 + d6`. Call the SAME
+        # decision the recursion will make (_will_lower_conv2d_direct), passing the
+        # *folded* 4D shapes it will see: not a copy of the predicate, the predicate
+        # itself, so the fold and the 4D gate can never disagree.
+        will_direct = _will_lower_conv2d_direct(
+            (N * D, C_in, H_in, W_in),
+            input.dtype,
+            (C_out, C_in_per_group, K_h, K_w),
             conv2d_stride,
             transposed,
             [output_padding[1], output_padding[2]],


### PR DESCRIPTION
A Conv3D with a unit temporal (depth) kernel is a batched Conv2d: with kD == 1 (and unit depth stride, zero depth pad, unit depth dilation) every depth slice is convolved independently with the same [C_out, C_in, kH, kW] weight. Fold D into the batch dim, run the ordinary 2D conv, and unfold:
    (N, C, D, H, W) -> (N*D, C, H, W) -> conv2d -> unfold back.

Handled in the input.dim() == 5 branch of conv2d_via_bmm_decomp. The folded op is a plain aten.convolution.default reprocessed like any 2D conv, so Conv3D rides whichever 2D path fits with no new lowering: the native conv2d SDSC (#3284) when the direct-lowering flag is on and the case is in the SDSC envelope, else im2col+matmul (e.g. a ViT/Prithvi patch-embed with kernel > 3 or a non-stick-aligned C_in). Only the temporal geometry gates the fold; a genuinely 3-D conv stays Unsupported.

The two inner 2D paths want opposite activation layouts, so will_direct is evaluated up front with the same predicate the recursion applies to the folded 4D op, keeping the fold layout in lock-step with the inner path: channel-last (C_in on the stick) for the direct SDSC, row-major (W on the stick) for im2col. A wrong guess is a hard, unrepresentable stick-expr compile error, never silent wrong numerics.

Also make spyre_reshape_via_cpu force the result contiguous: reshape() can return a non-contiguous view (e.g. squeezing the unit depth tap out of a permuted input), but register_fake advertises a contiguous new_empty(shape); .contiguous() keeps real and fake strides in agreement so inductor's assert_size_stride holds for every caller.

Tests: 6 direct-path cases (D==1, D>1, N>1, k2, bias, C_out!=C_in), 2 im2col cases (small patchify and the Prithvi 1x6x4x224x224 k16s16 shape), and a pure-Python temporal-1 gate check.

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
