### PR TITLE
feat: Add mode for run_test to classify gating CI jobs vs validation jobs

### DIFF
--- a/.github/workflows/_upstream_tests_beta_matrix.yaml
+++ b/.github/workflows/_upstream_tests_beta_matrix.yaml
@@ -39,6 +39,14 @@ on:
         required: false
         type: string
         default: ''
+      mode:
+        description: >-
+          Forwarded to run_test.sh as --mode. 'gating' (default) fails the
+          job on test failures; 'validate' still records failures in the
+          summary/JUnit XML but does not fail the job on them.
+        required: false
+        type: string
+        default: gating
 
 defaults:
   run:
@@ -230,7 +238,7 @@ jobs:
         with:
           suite_name: ${{ matrix.suite.name }}
           config: tests/configs/upstream_tests_beta/${{ matrix.suite.config }}
-          extra_test_flags: -v -m "not xfail"
+          extra_test_flags: -v -m "not xfail" --mode=${{ inputs.mode }}
           junit_xml_path: ${{ env.REPORT_PATH }}
           report_name: ${{ env.REPORT_NAME }}
 

--- a/.github/workflows/build_test_pytorch_source.yaml
+++ b/.github/workflows/build_test_pytorch_source.yaml
@@ -195,6 +195,7 @@ jobs:
       artifact_name: torch-spyre-wheel-${{ inputs.pytorch_sha }}
       pytorch_sha: ${{ inputs.pytorch_sha }}
       pytorch_wheel_artifact_name: pytorch-wheel-${{ inputs.pytorch_sha }}
+      mode: validate
 
   # ---------------------------------------------------------------------------
   # Aggregate the per-suite JUnit XMLs the `test` matrix uploaded (one per

--- a/tests/oot_framework/run_test.sh
+++ b/tests/oot_framework/run_test.sh
@@ -98,24 +98,56 @@ fi
 #                  (comma count + 1) or torch.spyre.device_count() as fallback.
 #                  Falls back to serial execution when only one card is found.
 #
+# --mode=<gating|validate>
+#                  Controls whether test *failures* (pytest exit code 1 --
+#                  "some tests failed/errored") make this script exit non-zero.
+#                    gating   (default) -- current behaviour: a test failure
+#                              propagates to a non-zero exit code (e.g. for CI
+#                              gates that must fail the job).
+#                    validate -- test failures are recorded in the printed
+#                              summary as usual but do NOT cause this script
+#                              to exit non-zero. All other non-zero exits
+#                              (no tests collected, missing python3/pytest,
+#                              Ctrl-C, segfault/xdist-fallback issues, etc.)
+#                              are unaffected by --mode and behave identically
+#                              in both modes.
+#
 # Usage:
 #   run_test.sh config.yaml                 # default: all tests run serially
 #   run_test.sh config.yaml --include-slow  # same, explicit
 #   run_test.sh config.yaml --skip-slow     # skip slow tests on this platform
 #   run_test.sh config.yaml --parallel      # parallelize tests across all Spyre cards
+#   run_test.sh config.yaml --mode=validate # test failures don't fail the script
 # ------------------------------------------------------------------------------------
 _SKIP_SLOW=0
 _PARALLEL=0
+_MODE="gating"
 _FILTERED_ARGS=()
+_take_next_mode=0
 for _arg in "$@"; do
+    if [[ $_take_next_mode -eq 1 ]]; then
+        _MODE="$_arg"
+        _take_next_mode=0
+        continue
+    fi
     case "$_arg" in
         --skip-slow)    _SKIP_SLOW=1 ;;
         --include-slow) _SKIP_SLOW=0 ;;
         --parallel)     _PARALLEL=1 ;;
+        --mode=*)       _MODE="${_arg#--mode=}" ;;
+        --mode)         _take_next_mode=1 ;;
         *)              _FILTERED_ARGS+=("$_arg") ;;
     esac
 done
 set -- "${_FILTERED_ARGS[@]+"${_FILTERED_ARGS[@]}"}"
+
+case "$_MODE" in
+    gating|validate) ;;
+    *)
+        echo "ERROR: --mode must be 'gating' or 'validate' (got: '$_MODE')" >&2
+        exit 1
+        ;;
+esac
 # ---------------------------------------------------------------------------
 # Multi-config support
 #
@@ -1827,9 +1859,13 @@ _run_xdist_fallback() {
     fi
     rm -f "$_xdist_out_tmp"
 
-    # Propagate test failures from the xdist fallback run.
+    # Propagate test failures from the xdist fallback run. As above, in
+    # --mode=validate a test-failure exit (1) is recorded in the summary but
+    # does not fail the script; other non-zero exits are unaffected by mode.
     if [[ $_xexit -eq 1 ]]; then
-        [[ $OVERALL_EXIT -eq 0 ]] && OVERALL_EXIT=1
+        if [[ "$_MODE" != "validate" ]]; then
+            [[ $OVERALL_EXIT -eq 0 ]] && OVERALL_EXIT=1
+        fi
     elif [[ $_xexit -ne 0 && $_xexit -ne 5 ]]; then
         OVERALL_EXIT=$_xexit
     fi
@@ -2284,7 +2320,13 @@ _run_parallel_across_cards() {
                 # Exit-code handling.
                 case $_exit in
                     0) ;;
-                    1)  [[ $_card_overall -eq 0 ]] && _card_overall=1 ;;
+                    1)
+                        # Test failure — masked in --mode=validate (see serial
+                        # loop above for the equivalent, non-parallel path).
+                        if [[ "$_MODE" != "validate" ]]; then
+                            [[ $_card_overall -eq 0 ]] && _card_overall=1
+                        fi
+                        ;;
                     5)  echo "[torch_oot_device_tests_run] WARNING: no tests collected for card ${_subshell_card} slice of $(basename "$original_file")" >&2 ;;
                     127)
                         echo "[torch_oot_device_tests_run_err] FATAL: python3/pytest not found for $original_file" >&2
@@ -2307,7 +2349,14 @@ _run_parallel_across_cards() {
                             ) || true
                             if [[ -f "$_exit_tmp" ]]; then
                                 local _xexit; _xexit=$(< "$_exit_tmp"); rm -f "$_exit_tmp"
-                                [[ $_xexit -ne 0 && $_xexit -ne 5 && $_card_overall -eq 0 ]] && _card_overall=$_xexit
+                                if [[ $_xexit -eq 1 ]]; then
+                                    # Test failure on retry — masked in --mode=validate.
+                                    if [[ "$_MODE" != "validate" ]]; then
+                                        [[ $_card_overall -eq 0 ]] && _card_overall=1
+                                    fi
+                                elif [[ $_xexit -ne 0 && $_xexit -ne 5 ]]; then
+                                    [[ $_card_overall -eq 0 ]] && _card_overall=$_xexit
+                                fi
                                 if [[ -n "$_shard_xml" && -f "$_shard_xml" ]]; then
                                     python3 -c "$_XML_INJECT_PY" "$_shard_xml" "$YAML_CONFIG" || true
                                 fi
@@ -2650,8 +2699,12 @@ for i in "${!RUN_FILES[@]}"; do
         1)
             # Some tests failed or errored — pytest already reported them.
             # Propagate so CI marks the job as failed when mandatory_success
-            # tests do not pass.
-            [[ $OVERALL_EXIT -eq 0 ]] && OVERALL_EXIT=1
+            # tests do not pass. In --mode=validate this is intentionally not
+            # propagated: the failure is still visible in the printed
+            # summary, but the script itself exits 0 for this case.
+            if [[ "$_MODE" != "validate" ]]; then
+                [[ $OVERALL_EXIT -eq 0 ]] && OVERALL_EXIT=1
+            fi
             ;;
         5)
             # No tests collected — warn but do not fail the overall run.

--- a/tests/oot_framework/run_test.sh
+++ b/tests/oot_framework/run_test.sh
@@ -99,18 +99,13 @@ fi
 #                  Falls back to serial execution when only one card is found.
 #
 # --mode=<gating|validate>
-#                  Controls whether test *failures* (pytest exit code 1 --
-#                  "some tests failed/errored") make this script exit non-zero.
-#                    gating   (default) -- current behaviour: a test failure
-#                              propagates to a non-zero exit code (e.g. for CI
-#                              gates that must fail the job).
+#                  Mode of running this script
+#                    gating   (default) -- current behaviour: failed tests
+#                              propagates to a non-zero exit code (e.g. for CI jobs
+#                              that needing gating on all tests passed).
 #                    validate -- test failures are recorded in the printed
-#                              summary as usual but do NOT cause this script
-#                              to exit non-zero. All other non-zero exits
-#                              (no tests collected, missing python3/pytest,
-#                              Ctrl-C, segfault/xdist-fallback issues, etc.)
-#                              are unaffected by --mode and behave identically
-#                              in both modes.
+#                              summary as usual but won't gate a CI job. 
+#                              All other non-zero exits are captured anyway.
 #
 # Usage:
 #   run_test.sh config.yaml                 # default: all tests run serially


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

PR add mode to run_test script so that it can be reused for non-gating CI jobs like the case of CRCR where we want to record failures but not gate a job on that. 

