### PR TITLE
Fix Makefile TEST_TYPE=perf workload set to use default flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ tests: ## Run torch spyre tests. Narrow scope with TEST_TYPE=smoke|unit|integrat
 # suite, so no new Makefile target or Jenkins wiring is needed.
 ifeq ($(TEST_TYPE),perf)
 	@mkdir -p "$(RESULTS_DIR)"
-	spyre-perf-suite --no-experimental --stacks torch-spyre \
+	spyre-perf-suite --default --stacks torch-spyre \
 		--report "$(RESULTS_DIR)/report.txt"
 	@test -f "$(RESULTS_DIR)/report.xml" || \
 		{ echo "ERROR: spyre-perf-suite did not emit $(RESULTS_DIR)/report.xml" >&2; \


### PR DESCRIPTION

#### What this PR does:

Use make TEST_TYPE=perf in the Makefile use --default, not --no-experimental  

The TEST_TYPE=perf branch of make tests invokes:

```
spyre-perf-suite --no-experimental --stacks torch-spyre \
    --report "$(RESULTS_DIR)/report.txt"
```
We need to use --default flag to avoid any kind of issue in the workload which has been set by this [ Issue 94 ](https://github.ibm.com/ai-sw-acceleration/spyre-perf-suite/issues/94)on spyre-perf-suite

We also need to be able to run merge results between x86 and s390x to produce uniform result

#### Which issue(s) this PR is related to:

This PR is related to[ Issue 94 ](https://github.ibm.com/ai-sw-acceleration/spyre-perf-suite/issues/94)on spyre-perf-suite

#### The solution:

```
spyre-perf-suite --default--stacks torch-spyre \
    --report "$(RESULTS_DIR)/report.txt"
```

OR

```
spyre-perf-suite --default--stacks torch-spyre \
    --generate-report "$(RESULTS_DIR)/report.txt"
```


#### Test done to verify default  vs no experimental 
x86 and s390x

spyre-perf-suite --default --stacks torch-spyre
spyre-perf-suite --generate-report


x86 and s390x
spyre-perf-suite  --no-experimental --stacks torch-spyre
spyre-perf-suite --generate-report