### PR TITLE
feat(oot): add InputArgModule and apply_device_layout for adapter-wrapped module tests

### DIFF
--- a/tests/oot_framework/oot_test_base_common.py
+++ b/tests/oot_framework/oot_test_base_common.py
@@ -346,6 +346,13 @@ class OOTTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa: F
                     decorators=None,
                     dtypes=dtypes,
                 )
+                # ModuleInfo has no field for this, and upstream never looks at
+                # it; attach it so device-specific tests can read the YAML's
+                # intent off the same object @modules hands them (they receive
+                # module_info, never the YAML item). Read with
+                # getattr(module_info, "apply_device_layout", False) so a
+                # ModuleInfo from any other source stays valid.
+                module_info.apply_device_layout = module_item.apply_device_layout
                 module_db.append(module_info)
                 existing_names.add(module_name)
             except Exception as e:

--- a/tests/oot_framework/oot_test_config_models.py
+++ b/tests/oot_framework/oot_test_config_models.py
@@ -534,6 +534,53 @@ class InputArgConfig(BaseModel):
         return self
 
 
+class InputArgModule(BaseModel):
+    """An ``nn.Module`` positional/keyword argument, built from its class + config.
+
+    For wrappers whose ``__init__`` takes a *live module* rather than a config.
+    An out-of-tree adapter may wrap an already-constructed upstream module to
+    adopt its submodules -- e.g. Spyre's ``StandardGQAAttention(attn)`` reuses an
+    HF attention's q/k/v/o projections -- and such a wrapper cannot be built from
+    a config spec alone: the inner module has to be constructed first, and a live
+    ``nn.Module`` is not expressible in YAML. ``py`` is no escape hatch either
+    (``_eval_py_literal`` permits only literals and ``slice(...)``).
+
+    The inner module is built by importing ``module_path`` and calling it with a
+    config resolved exactly like :class:`InputArgConfig` (``model_id`` preferred,
+    ``config_path`` + ``config_kwargs`` as the narrower fallback), plus
+    ``module_kwargs`` (e.g. ``layer_idx``). A module needing no config at all may
+    set neither and pass only ``module_kwargs``.
+
+    Weights are whatever the inner module's own ``__init__`` produces (fresh
+    init): this spec carries *shape*, not values. Put the dimensions the module
+    actually runs with in the config -- for a device that pads a dimension for
+    alignment, that means the padded value, not the checkpoint's.
+    """
+
+    module_path: str  # e.g. "transformers.models.granite...GraniteAttention"
+    config_path: Optional[str] = None
+    config_kwargs: Dict[str, Any] = {}
+    model_id: Optional[str] = None  # HF path/dir for AutoConfig.from_pretrained
+    config_overrides: Dict[str, Any] = {}  # applied via setattr after from_pretrained
+    module_kwargs: Dict[str, Any] = {}  # e.g. {"layer_idx": 0}
+
+    def config_arg(self) -> Optional["InputArgConfig"]:
+        """Return the config spec to build the inner module with, if any.
+
+        Reuses :class:`InputArgConfig` rather than duplicating its two
+        reconstruction strategies, so ``model_id`` / ``config_path`` behave
+        identically here and in a bare config arg.
+        """
+        if not self.model_id and not self.config_path:
+            return None
+        return InputArgConfig(
+            config_path=self.config_path,
+            config_kwargs=self.config_kwargs,
+            model_id=self.model_id,
+            config_overrides=self.config_overrides,
+        )
+
+
 class InputArgCache(BaseModel):
     """A pre-populated KV cache argument (e.g. a decode-step ``past_key_values``).
 
@@ -563,6 +610,7 @@ class InputArgCache(BaseModel):
 InputArg = Union[
     InputArgTensor,
     InputArgTensorList,
+    InputArgModule,
     InputArgConfig,
     InputArgCache,
     InputArgValue,
@@ -583,6 +631,7 @@ def _parse_input_arg(raw: Any) -> InputArg:
         (
             InputArgTensor,
             InputArgTensorList,
+            InputArgModule,
             InputArgConfig,
             InputArgCache,
             InputArgValue,
@@ -611,6 +660,18 @@ def _parse_input_arg(raw: Any) -> InputArg:
             config_path=c.get("config_path"),
             config_kwargs=c.get("config_kwargs", {}) or {},
         )
+    # Checked BEFORE the config keys: a module spec carries "module_path" AND
+    # (usually) "model_id"/"config_path", so the config branch would otherwise
+    # swallow it and build the bare config instead of the module.
+    if "module_path" in keys:
+        return InputArgModule(
+            module_path=raw["module_path"],
+            config_path=raw.get("config_path"),
+            config_kwargs=raw.get("config_kwargs", {}) or {},
+            model_id=raw.get("model_id"),
+            config_overrides=raw.get("config_overrides", {}) or {},
+            module_kwargs=raw.get("module_kwargs", {}) or {},
+        )
     # A config arg is identified by either key: "model_id" (load full config via
     # AutoConfig.from_pretrained — no config_path required) or "config_path"
     # (rebuild from config_kwargs).
@@ -627,7 +688,8 @@ def _parse_input_arg(raw: Any) -> InputArg:
         return InputArgPy(py=raw["py"])
     raise ValueError(
         f"Each args element must contain exactly one of: "
-        f"tensor, tensor_list, config_path, model_id, value, py. Got keys: {keys}"
+        f"tensor, tensor_list, module_path, config_path, model_id, value, py. "
+        f"Got keys: {keys}"
     )
 
 
@@ -664,6 +726,32 @@ def _build_hf_config(arg: "InputArgConfig") -> Any:
         )
     config_cls = getattr(importlib.import_module(module_path), cls_name)
     return config_cls(**arg.config_kwargs)
+
+
+def _build_inner_module(arg: "InputArgModule") -> Any:
+    """Construct the inner ``nn.Module`` described by an :class:`InputArgModule`.
+
+    Shared by the positional (``build_cpu_args``) and keyword
+    (``resolved_kwargs``) resolution paths, mirroring
+    :func:`_build_hf_config`.
+
+    Built on CPU like every other arg; the caller relocates the assembled wrapper
+    to the test device afterwards. The module is left in whatever mode its
+    ``__init__`` chose -- the test harness sets train/eval on the outer wrapper.
+    """
+    import importlib
+
+    mod_path, _, cls_name = arg.module_path.rpartition(".")
+    if not mod_path:
+        raise ValueError(
+            f"Invalid module_path {arg.module_path!r}: expected "
+            f"'package.module.ClassName'"
+        )
+    inner_cls = getattr(importlib.import_module(mod_path), cls_name)
+
+    config_arg = arg.config_arg()
+    ctor_args = [] if config_arg is None else [_build_hf_config(config_arg)]
+    return inner_cls(*ctor_args, **arg.module_kwargs)
 
 
 def _dtypes_from_input_arg(arg: "InputArg") -> Set[torch.dtype]:
@@ -848,6 +936,9 @@ class InputsEdits(BaseModel):
                 ]
                 cpu_args.append(_move_to_test_device(lst, test_device))
 
+            elif isinstance(arg, InputArgModule):
+                cpu_args.append(_build_inner_module(arg))
+
             elif isinstance(arg, InputArgConfig):
                 cpu_args.append(_build_hf_config(arg))
 
@@ -943,7 +1034,15 @@ class InputsEdits(BaseModel):
 
         # Tensor-spec dicts carry exactly one of these keys; anything else is a
         # plain scalar/dtype/device value handled by the string branch below.
-        _SPEC_KEYS = {"tensor", "tensor_list", "config_path", "model_id", "cache", "py"}
+        _SPEC_KEYS = {
+            "tensor",
+            "tensor_list",
+            "module_path",
+            "config_path",
+            "model_id",
+            "cache",
+            "py",
+        }
 
         out: Dict[str, Any] = {}
         for i, (k, v) in enumerate(self.kwargs.items()):
@@ -965,6 +1064,13 @@ class InputsEdits(BaseModel):
                         for j, spec in enumerate(arg.tensor_list)
                     ]
                     out[k] = _move_to_test_device(lst, test_device)
+                elif isinstance(arg, InputArgModule):
+                    # Left on CPU: _move_to_test_device only relocates tensors
+                    # (an nn.Module passes through untouched), and the wrapper
+                    # that adopts this module is itself moved to the test device
+                    # by the harness, which carries the adopted submodules with
+                    # it.
+                    out[k] = _build_inner_module(arg)
                 elif isinstance(arg, InputArgConfig):
                     out[k] = _build_hf_config(arg)
                 elif isinstance(arg, InputArgCache):
@@ -1029,6 +1135,24 @@ class ModulesNamedItem(BaseModel):
     name: str
     module_path: Optional[str] = None  # Full import path (e.g., "torch.nn.Linear")
     description: Optional[str] = None
+
+    # When true, a device-side instance of this module has its parameters and
+    # buffers REALLOCATED with the device layout the production path uses,
+    # instead of a plain ``.to(device)``.
+    #
+    # Distinct from ``InputTensorSpec.device_layout``, which lays out a single
+    # *input* tensor from an explicit device_size/stride_map: this flag concerns
+    # the module's own *parameters*, whose layout the production code derives per
+    # tensor (on Spyre: row-major [1, 0] dim_order on 2-D matmul weights,
+    # embeddings excluded) rather than spelling out in YAML. Those rules live in
+    # the device backend's own code -- on Spyre,
+    # ``hf_adapters.hf_common.apply_spyre_layout_to_module`` -- so what the test
+    # allocates cannot drift from what production allocates.
+    #
+    # Consumed by the out-of-tree custom module tests; ignored on devices with no
+    # layout concept (e.g. CPU).
+    apply_device_layout: bool = False
+
     sample_inputs_func: InputsEdits = InputsEdits()  # Legacy: forward inputs only
     constructor_inputs: Optional[InputsEdits] = None  # New: explicit constructor inputs
     forward_inputs: Optional[Union[InputsEdits, List[InputsEdits]]] = (


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This is a PR to enable module-level tests for a model with hf-adapters.

Adds two capabilities to the OOT test framework so that module tests can cover
**adapter-wrapped modules** — modules that an out-of-tree backend substitutes into
the model tree in place of an upstream one. Both are additive and default to the
current behaviour.

**1. `InputArgModule`: a live `nn.Module` as a constructor argument**

Some adapter wrappers take an *already-constructed* module rather than a config,
so they can adopt its submodules. For example, the Spyre HF adapters' 
`StandardGQAAttention(attn)` reuses an HF attention's `q_proj`/`k_proj`/`v_proj`/
`o_proj`.

Such a wrapper could not be expressed in YAML at all before this change:

- `config_path` / `model_id` build a `PretrainedConfig`, not a module.
- `py` is not an escape hatch — `_eval_py_literal` permits only literals and
  `slice(...)`, with empty `__builtins__`.

The new arg kind builds the inner module first, then hands it to the outer
wrapper's constructor:

```yaml
constructor_inputs:
  args:
    - module_path: transformers.models.granite.modeling_granite.GraniteAttention
      config_path: transformers.models.granite.configuration_granite.GraniteConfig
      config_kwargs: {hidden_size: 4096, num_attention_heads: 32, head_dim: 128}
      module_kwargs: {layer_idx: 0}
```

The config is resolved by delegating to `InputArgConfig` (via
`InputArgModule.config_arg()`), so `model_id` + `config_overrides` and
`config_path` + `config_kwargs` behave identically here and in a bare config arg —
no duplicated resolution logic. A module needing no config may set neither and
pass only `module_kwargs`. Wired into both the positional (`build_cpu_args`) and
keyword (`resolved_kwargs`) paths through one shared `_build_inner_module()`,
mirroring the existing `_build_hf_config()`.

**2. `apply_device_layout`: reproduce the production parameter layout**

New `bool` field on `ModulesNamedItem` (default `False`). When set, the consuming
test allocates the module's **parameters** with the device layout the production
path uses, instead of a plain `.to(device)`.

This is distinct from the existing `InputTensorSpec.device_layout`, which lays out
a single *input* tensor from an explicit `device_size`/`stride_map`. Parameter
layout is derived per tensor by [the compiler](https://github.com/torch-spyre/torch-spyre/blob/cf8fa81caf927dc018fe0243b46ad95a4081da78/torch_spyre/model_utils.py#L151) (on Spyre: row-major `[1, 0]`
dim_order on 2-D matmul weights, embeddings excluded), so spelling it out per
parameter in YAML would be both verbose and prone to drifting from production.
The flag therefore carries only the *intent*; the rules stay in the backend's own
code.

A device layout is fixed at allocation time, so `.to(device)` cannot express one —
a moved tensor silently keeps the default layout, and a test that only calls
`.to(device)` cannot exercise the real one.

`ModuleInfo` has no field for this and upstream never reads it, so the flag is
attached as an attribute in `_register_custom_modules_from_edits`. Consumers read
it with `getattr(module_info, "apply_device_layout", False)`, which keeps a
`ModuleInfo` from any other source valid.

#### Which issue(s) this PR is related to:

<!-- Please link the tracking issue for the HF-adapters module-test work. -->
https://github.com/torch-spyre/torch-spyre/issues/3009

#### Special notes for your reviewer:

- **Parse ordering matters.** In `_parse_input_arg`, `module_path` is checked
  *before* `config_path`/`model_id`: a module spec carries both keys, so the
  config branch would otherwise swallow it and build the bare config instead of
  the module. There is a comment at the call site.
- **`InputArgModule` builds on CPU and stays there.** `torch_spyre.model_utils.load_model_to_spyre` only
  relocates tensors (an `nn.Module` passes through untouched), so calling it here
  would be a silent no-op. The wrapper that adopts the inner module is itself
  moved to the test device by the harness, which carries the adopted submodules
  with it.
- **Weights are fresh init.** `InputArgModule` reproduces *shape*, not values —
  it is for shape/lowering coverage. Callers should put the dimensions the module
  actually runs with in the config; for a backend that pads a dimension for
  alignment, that means the padded value, not the checkpoint's.
- No existing YAML is affected: the new arg kind is opt-in by key, and
  `apply_device_layout` defaults to `False`.
- `tests/spyre_test_config_schema.json` was **not** updated. Its `TestEdits` has
  only `ops`/`dtypes` and predates `edits.modules` entirely, and no code
  references it, so today's generated module configs would already fail it.
  Bringing it up to date looks like separate work — happy to split it out if you
  disagree.

#### Does this PR introduce a user-facing change?

Yes, additive only — two new optional YAML surfaces for OOT test configs:

- a `module_path`-keyed constructor/forward arg (`InputArgModule`) for
  modules whose `__init__` takes a live `nn.Module`
- `apply_device_layout: <bool>` on a `edits.modules.include` entry

Existing configs behave exactly as before.

#### Additional note:
