### PR TITLE
Multi-Spyre/Stream: Fix default tls_idx for multi-spyre stream initialization

### DIFF
--- a/tests/distributed/spyreccl_backend.py
+++ b/tests/distributed/spyreccl_backend.py
@@ -12,16 +12,91 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import subprocess
+import sys
+import textwrap
+
 import torch.distributed as dist
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 class TestSpyreCCLBackend(TestCase):
+    def _run_local_rank_script(
+        self, local_rank: str
+    ) -> subprocess.CompletedProcess[str]:
+        script = textwrap.dedent(
+            f"""
+            import os
+
+            os.environ[\"LOCAL_RANK\"] = {local_rank!r}
+
+            import torch
+            import torch_spyre
+
+            torch.ones(1, device=\"spyre\")
+            """
+        )
+        env = os.environ.copy()
+        return subprocess.run(
+            [sys.executable, "-c", script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            timeout=130,
+            text=True,
+            check=False,
+        )
+
     def test_spyreccl_device_to_backend(self) -> None:
         # Make sure the module has been loaded
         assert dist.distributed_c10d.is_backend_available("spyreccl")
         # Make sure the module is the default for the spyre device
         assert "spyreccl" == dist.get_default_backend_for_device("spyre")
+
+    def test_parse_local_rank_invalid_text_raises(self) -> None:
+        proc = self._run_local_rank_script("invalid")
+        output = f"{proc.stdout}\n{proc.stderr}"
+        assert proc.returncode != 0, output
+        # - Torch Spyre will catch and throw with the message:
+        #   LOCAL_RANK must be a valid integer (no digits found): 'invalid'
+        assert "LOCAL_RANK must be a valid integer" in output, output
+
+    def test_parse_local_rank_negative_raises(self) -> None:
+        proc = self._run_local_rank_script("-1")
+        output = f"{proc.stdout}\n{proc.stderr}"
+        assert proc.returncode != 0, output
+        # Two layers of the library can catch this and may throw different
+        # exception messages (account for both):
+        # - Spyre Comms will catch and throw with the message:
+        #   LOCAL_RANK value overflows unsigned long long: -1
+        # - Torch Spyre will catch and throw with the message:
+        #   LOCAL_RANK value is out of range: -1
+        assert any(
+            text in output
+            for text in (
+                "LOCAL_RANK value is out of range",
+                "LOCAL_RANK value overflows",
+            )
+        ), output
+
+    def test_parse_local_rank_too_large_raises(self) -> None:
+        proc = self._run_local_rank_script("128")
+        output = f"{proc.stdout}\n{proc.stderr}"
+        assert proc.returncode != 0, output
+        # Two layers of the library can catch this and may throw different
+        # exception messages (account for both):
+        # - Spyre Comms will catch and throw with the message:
+        #   LOCAL_RANK value 128 exceeds maximum allowed value 3 (range: [0, 3])
+        # - Torch Spyre will catch and throw with the message:
+        #   LOCAL_RANK value 128 exceeds the maximum supported device index (127)
+        assert any(
+            text in output
+            for text in (
+                "exceeds maximum allowed value",
+                "exceeds the maximum supported device index",
+            )
+        ), output
 
 
 if __name__ == "__main__":

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -92,15 +92,25 @@ void _startRuntime() {
   //   1. tls_idx (non-zero) — set via explicit set_device() call
   //   2. LOCAL_RANK env var — set by torchrun per process
   //   3. 0 — single-device / non-torchrun default
+  //
+  // tls_idx is initialised to parse_local_rank() at thread-local init time
+  // in spyre_guard.cpp (covering cases 2 and 3 automatically). The if/else
+  // here only distinguishes "tls_idx is non-zero (either from TLS init or
+  // from a set_device() call)" from "tls_idx is zero". There is no way at
+  // this point to distinguish a set_device() call from a LOCAL_RANK-seeded
+  // TLS init.
   int logical_device_id = 0;
   int tls_idx = static_cast<int>(SpyreGuardImpl::tls_idx);
   if (tls_idx != 0) {
     logical_device_id = tls_idx;
-  } else if (const char* lr = std::getenv("LOCAL_RANK")) {
-    logical_device_id = std::atoi(lr);
+  } else {
+    // parse_local_rank() returns 0 when LOCAL_RANK is unset, and throws on
+    // invalid / out-of-range values.
+    const c10::DeviceIndex rank = parse_local_rank();
+    logical_device_id = static_cast<int>(rank);
     // Match the current (c10) device to the rank so unqualified stream/pool
     // lookups don't fall back to spyre:0.
-    SpyreGuardImpl::tls_idx = static_cast<c10::DeviceIndex>(logical_device_id);
+    SpyreGuardImpl::tls_idx = rank;
   }
 
   const int num_devices = getVisibleDeviceCount();

--- a/torch_spyre/csrc/spyre_guard.cpp
+++ b/torch_spyre/csrc/spyre_guard.cpp
@@ -18,6 +18,9 @@
 
 #include <ATen/core/op_registration/adaption.h>
 
+#include <cstdint>
+#include <cstdlib>
+
 #include "module.h"
 #include "spyre_device_enum.h"
 #include "spyre_stream.h"
@@ -113,7 +116,19 @@ c10::DeviceCapability SpyreGuardImpl::getDeviceCapability(
   return cap;
 }
 
-thread_local c10::DeviceIndex SpyreGuardImpl::tls_idx = 0;
+static c10::DeviceIndex default_device_index() {
+  const char* env = std::getenv("LOCAL_RANK");
+  if (env) {
+    char* end;
+    int64_t val = std::strtoll(env, &end, 10);
+    if (end != env) {
+      return static_cast<c10::DeviceIndex>(val);
+    }
+  }
+  return 0;
+}
+
+thread_local c10::DeviceIndex SpyreGuardImpl::tls_idx = default_device_index();
 
 // Registration — runs when _C.so is loaded.
 // Loading _C.so does NOT trigger device initialization; that only

--- a/torch_spyre/csrc/spyre_guard.cpp
+++ b/torch_spyre/csrc/spyre_guard.cpp
@@ -18,14 +18,50 @@
 
 #include <ATen/core/op_registration/adaption.h>
 
+#include <cerrno>
+#include <climits>
 #include <cstdint>
 #include <cstdlib>
+#include <limits>
+#include <stdexcept>
+#include <string>
 
 #include "module.h"
 #include "spyre_device_enum.h"
 #include "spyre_stream.h"
 
 namespace spyre {
+
+c10::DeviceIndex parse_local_rank() {
+  const char* env = std::getenv("LOCAL_RANK");
+  if (!env || env[0] == '\0') {
+    return 0;
+  }
+
+  errno = 0;
+  char* end = nullptr;
+  const int64_t val = std::strtoll(env, &end, 10);
+
+  if (end == env || *end != '\0') {
+    throw std::invalid_argument(
+        std::string("LOCAL_RANK is not a valid integer: '") + env + "'");
+  }
+  if (errno == ERANGE || val < 0) {
+    throw std::range_error(std::string("LOCAL_RANK value is out of range: '") +
+                           env + "'");
+  }
+  // c10::DeviceIndex is int8_t — guard against silent truncation.
+  constexpr int64_t kMaxDeviceIndex =
+      static_cast<int64_t>(std::numeric_limits<c10::DeviceIndex>::max());
+  if (val > kMaxDeviceIndex) {
+    throw std::range_error(std::string("LOCAL_RANK value ") +
+                           std::to_string(val) +
+                           " exceeds the maximum supported device index (" +
+                           std::to_string(kMaxDeviceIndex) + ")");
+  }
+
+  return static_cast<c10::DeviceIndex>(val);
+}
 
 c10::DeviceType SpyreGuardImpl::type() const {
   return c10::DeviceType::PrivateUse1;
@@ -116,19 +152,7 @@ c10::DeviceCapability SpyreGuardImpl::getDeviceCapability(
   return cap;
 }
 
-static c10::DeviceIndex default_device_index() {
-  const char* env = std::getenv("LOCAL_RANK");
-  if (env) {
-    char* end;
-    int64_t val = std::strtoll(env, &end, 10);
-    if (end != env) {
-      return static_cast<c10::DeviceIndex>(val);
-    }
-  }
-  return 0;
-}
-
-thread_local c10::DeviceIndex SpyreGuardImpl::tls_idx = default_device_index();
+thread_local c10::DeviceIndex SpyreGuardImpl::tls_idx = parse_local_rank();
 
 // Registration — runs when _C.so is loaded.
 // Loading _C.so does NOT trigger device initialization; that only

--- a/torch_spyre/csrc/spyre_guard.cpp
+++ b/torch_spyre/csrc/spyre_guard.cpp
@@ -152,7 +152,22 @@ c10::DeviceCapability SpyreGuardImpl::getDeviceCapability(
   return cap;
 }
 
-thread_local c10::DeviceIndex SpyreGuardImpl::tls_idx = parse_local_rank();
+// Safe seed for the thread_local initializer.
+// parse_local_rank() can throw (malformed / out-of-range LOCAL_RANK).  A
+// thread_local dynamic initializer has no surrounding try/catch on worker
+// threads, so an exception there calls std::terminate.  Return 0 on any
+// error; _startRuntime re-calls parse_local_rank() on the guarded path and
+// will surface the error as a catchable exception.
+static c10::DeviceIndex parse_local_rank_safe() noexcept {
+  try {
+    return parse_local_rank();
+  }
+  catch (...) {
+    return 0;
+  }
+}
+
+thread_local c10::DeviceIndex SpyreGuardImpl::tls_idx = parse_local_rank_safe();
 
 // Registration — runs when _C.so is loaded.
 // Loading _C.so does NOT trigger device initialization; that only

--- a/torch_spyre/csrc/spyre_guard.h
+++ b/torch_spyre/csrc/spyre_guard.h
@@ -16,9 +16,19 @@
 
 #pragma once
 
+#include <c10/core/DeviceType.h>
 #include <torch/library.h>
 
 namespace spyre {
+
+// Parse LOCAL_RANK from the environment.
+//
+// Uses strtoll + end-pointer check (not atoi) so that non-numeric or empty
+// strings are detected. Validates that the result is non-negative and fits in
+// c10::DeviceIndex (int8_t) without truncation. Returns 0 when LOCAL_RANK is
+// unset. Throws std::invalid_argument on malformed input and std::range_error
+// if the value is negative or exceeds c10::DeviceIndex's range.
+c10::DeviceIndex parse_local_rank();
 
 struct SpyreGuardImpl final : c10::impl::DeviceGuardImplInterface {
   static thread_local c10::DeviceIndex

--- a/torch_spyre/csrc/spyre_guard.h
+++ b/torch_spyre/csrc/spyre_guard.h
@@ -28,6 +28,12 @@ namespace spyre {
 // c10::DeviceIndex (int8_t) without truncation. Returns 0 when LOCAL_RANK is
 // unset. Throws std::invalid_argument on malformed input and std::range_error
 // if the value is negative or exceeds c10::DeviceIndex's range.
+//
+// Do NOT call this directly from a thread_local initializer — use the
+// file-local parse_local_rank_safe() wrapper in spyre_guard.cpp instead, which
+// catches and returns 0 so that std::terminate is not called on worker threads
+// that have no surrounding try/catch.  _startRuntime() calls this function on
+// the guarded path where exceptions propagate normally.
 c10::DeviceIndex parse_local_rank();
 
 struct SpyreGuardImpl final : c10::impl::DeviceGuardImplInterface {

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -71,6 +71,9 @@ struct StreamPool {
 
   // Per-device initialization flags
   std::unordered_map<c10::DeviceIndex, std::once_flag> device_init_flags;
+
+  // Tracks the device_index parameter used during initializeStreamPoolImpl
+  c10::DeviceIndex initialized_device_index = -1;
 };
 
 StreamPool& getStreamPool() {
@@ -290,6 +293,14 @@ void initializeStreamPoolImpl(c10::DeviceIndex device_index) {
   auto& pool = getStreamPool();
   std::unique_lock<std::shared_mutex> lock(pool.mutex);
 
+  // Check that this is the first and only device initialization
+  TORCH_CHECK(pool.initialized_device_index == -1,
+              "initializeStreamPoolImpl already called with device_index ",
+              static_cast<int>(pool.initialized_device_index),
+              "; cannot reinitialize with device_index ",
+              static_cast<int>(device_index));
+  pool.initialized_device_index = device_index;
+
   // Initialize mapping from StreamId → RuntimeStream*.
   // RuntimeStream instances are owned by GlobalRuntime.
   // StreamPool only stores non-owning pointers for lookup.
@@ -311,7 +322,8 @@ void initializeStreamPoolImpl(c10::DeviceIndex device_index) {
         pool.stream_handle_map.find(sid) == pool.stream_handle_map.end(),
         "Host compute stream id ", sid,
         " is already registered; only one Spyre device per process is "
-        "supported");
+        "supported. Device ID ",
+        static_cast<int>(pool.initialized_device_index));
     pool.stream_handle_map[sid] =
         runtime->createStream(flex::RuntimeStreamPriority::NORMAL);
     pool.host_compute_streams[device_index].push_back(sid);

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -72,7 +72,10 @@ struct StreamPool {
   // Per-device initialization flags
   std::unordered_map<c10::DeviceIndex, std::once_flag> device_init_flags;
 
-  // Tracks the device_index parameter used during initializeStreamPoolImpl
+  // Set to true once initializeStreamPoolImpl has been called.
+  bool initialized = false;
+  // Records the device_index passed to initializeStreamPoolImpl (valid only
+  // when initialized == true), used in error messages.
   c10::DeviceIndex initialized_device_index = -1;
 };
 
@@ -294,11 +297,12 @@ void initializeStreamPoolImpl(c10::DeviceIndex device_index) {
   std::unique_lock<std::shared_mutex> lock(pool.mutex);
 
   // Check that this is the first and only device initialization
-  TORCH_CHECK(pool.initialized_device_index == -1,
+  TORCH_CHECK(!pool.initialized,
               "initializeStreamPoolImpl already called with device_index ",
               static_cast<int>(pool.initialized_device_index),
               "; cannot reinitialize with device_index ",
               static_cast<int>(device_index));
+  pool.initialized = true;
   pool.initialized_device_index = device_index;
 
   // Initialize mapping from StreamId → RuntimeStream*.
@@ -322,8 +326,7 @@ void initializeStreamPoolImpl(c10::DeviceIndex device_index) {
         pool.stream_handle_map.find(sid) == pool.stream_handle_map.end(),
         "Host compute stream id ", sid,
         " is already registered; only one Spyre device per process is "
-        "supported. Device ID ",
-        static_cast<int>(pool.initialized_device_index));
+        "supported.");
     pool.stream_handle_map[sid] =
         runtime->createStream(flex::RuntimeStreamPriority::NORMAL);
     pool.host_compute_streams[device_index].push_back(sid);


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

* `SpyreGuardImpl::tls_idx` needs to be defaulted to non-zero on local_rank > 0. Otherwise `initializeStreamPoolImpl` will be called multiple times because some threads use the default `0` while others use the `LOCAL_RANK` value (if available).
  * This caused a crash at the non-zero ranks when checking for duplicate stream id registration.
  * By defaulting the `tls_idx` to the `LOCAL_RANK` value, we only call `initializeStreamPoolImpl` once instead of multiple times due to the default `tls_idx=0` and `tls_idx=LOCAL_RANK` which caused the exception to be thrown.

#### Which issue(s) this PR is related to:

Resolves Multi-Spyre support for LLMs. The following Issues/PRs are limited due to this bug.
* https://github.com/torch-spyre/torch-spyre/pull/3490
* https://github.com/torch-spyre/hf-adapters/issues/158

#### Special notes for your reviewer:

This worked for single Spyre runs because `tls_idx` defaulted to `0` which was correct for the "Rank 0" device. This failure only showed up with Multi-Spyre runs at the non-zero ranks. It did not show up in the unit tests that we have, but when running HF Adapters Granite. I was not able to isolate a smaller unit test reproducer, but it has something to do with the `spyre_copy_from` calling `getCurrentStream` with a device id of either `-1` or `0` on the non-zero ranks.

#### Does this PR introduce a user-facing change?

No

#### Additional note:

N/A