### PR TITLE
fix(inductor): let contiguous device dims fuse across an interposed size-1 dim

### DIFF
--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -27,7 +27,11 @@ from torch_spyre._inductor.propagate_layouts import (
     PropArg,
     _check_supported_input_sticks,
 )
-from torch_spyre._inductor.views import compute_coordinates, tiling_expr_to_device_expr
+from torch_spyre._inductor.views import (
+    compute_coordinates,
+    normalize_coordinates,
+    tiling_expr_to_device_expr,
+)
 from torch.utils._sympy.functions import ModularIndexing
 
 p0, p1, p2, p3, p4, p5 = sympy.symbols("p0 p1 p2 p3 p4 p5", integer=True)
@@ -347,6 +351,122 @@ class TestTilingExprToDeviceExpr(TestCase):
         index = p0
         result = tiling_expr_to_device_expr([64, 1024, 64], [64, 4096, 1], index)
         self.assertEqual(result, p0)
+
+
+class TestNormalizeCoordinatesFusion(TestCase):
+    """``normalize_coordinates``' contiguous-device-dim fusion.
+
+    The fusion loop is a single-pass adjacent-pair scan, so an inert placeholder
+    term -- a size-1 device dim with a constant-zero coordinate -- used to break a
+    fusion run even though the emitted layout discards it anyway. Leaving the run
+    broken splits one logical axis across two device dims, and a matmul reading
+    such a layout ends up contracting two axes, which the backend cannot schedule
+    (deeptools ``getMinParamBmm``'s ``out_reuse_dim`` DT_CHECK).
+    """
+
+    def _normalize(self, var_ranges, size, coordinates):
+        counter = [0]
+
+        def synthetic_var():
+            counter[0] += 1
+            return sympy.Symbol(f"z{counter[0] - 1}")
+
+        return normalize_coordinates(dict(var_ranges), size, coordinates, synthetic_var)
+
+    def _addr(self, terms):
+        """Flat device address encoded by a dense term list (last term = stick)."""
+        stride = sympy.Integer(1)
+        addr = sympy.S.Zero
+        for term in reversed(terms):
+            if term.var is None:
+                coord = term.offset
+            else:
+                coord = (
+                    term.num * sympy.floor(sympy.Mod(term.var, term.mod) / term.den)
+                    + term.offset
+                )
+            addr += stride * coord
+            stride *= term.dim_size
+        return addr
+
+    def test_placeholder_does_not_block_fusion(self):
+        """``[B=1, H=16, seq=1, D=128]`` SDPA output read as one flat 2048 axis.
+
+        ``get_generic_stick_layout``'s rank-4 map puts the squeezed ``seq`` dim
+        between ``H`` and the non-stick half of ``D``, and the squeezed ``B`` dim
+        just before the stick. ``H`` and ``D``'s outer half must still fuse into a
+        single 32-wide dim, so the matmul consuming this buffer contracts exactly
+        one axis.
+        """
+        k = sympy.Symbol("c1")
+        terms = self._normalize(
+            {k: 2048},
+            [16, 1, 2, 1, 64],
+            [
+                sympy.floor(k / 128),
+                sympy.S.Zero,
+                sympy.floor(sympy.Mod(k, 128) / 64),
+                sympy.S.Zero,
+                sympy.Mod(k, 64),
+            ],
+        )
+        self.assertEqual([int(t.dim_size) for t in terms], [32, 64])
+        # ... and the fused dim addresses exactly what the two dims did.
+        addr = self._addr(terms)
+        for val in range(2048):
+            self.assertEqual(int(addr.subs({k: val})), val)
+
+    def test_fusion_declined_when_outer_term_has_offset(self):
+        """An offset on the outer term counts in units of that term's ``den``.
+
+        Fusing shrinks ``den``, which would silently rescale the offset, so the
+        fusion must not happen across a placeholder in that case.
+        """
+        k = sympy.Symbol("c1")
+        terms = self._normalize(
+            {k: 1024},
+            [16, 1, 2, 1, 64],
+            [
+                4 + sympy.floor(k / 128),
+                sympy.S.Zero,
+                sympy.floor(sympy.Mod(k, 128) / 64),
+                sympy.S.Zero,
+                sympy.Mod(k, 64),
+            ],
+        )
+        self.assertEqual([int(t.dim_size) for t in terms], [16, 2, 64])
+        addr = self._addr(terms)
+        for val in (0, 1, 63, 64, 127, 128, 1023):
+            self.assertEqual(int(addr.subs({k: val})), 512 + val)
+
+    def test_fusion_declined_when_pair_is_not_dense(self):
+        """A gap between the two dims (3*64 < 256) makes the fusion inexact."""
+        k = sympy.Symbol("c1")
+        terms = self._normalize(
+            {k: 1536},
+            [8, 1, 3, 64],
+            [
+                sympy.floor(k / 256),
+                sympy.S.Zero,
+                sympy.floor(sympy.Mod(k, 256) / 64),
+                sympy.Mod(k, 64),
+            ],
+        )
+        self.assertEqual([int(t.dim_size) for t in terms], [8, 3, 64])
+
+    def test_adjacent_fusion_unchanged(self):
+        """No placeholder: the historical predicate is untouched."""
+        k = sympy.Symbol("c1")
+        terms = self._normalize(
+            {k: 2048},
+            [16, 2, 64],
+            [
+                sympy.floor(k / 128),
+                sympy.floor(sympy.Mod(k, 128) / 64),
+                sympy.Mod(k, 64),
+            ],
+        )
+        self.assertEqual([int(t.dim_size) for t in terms], [32, 64])
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -385,7 +385,9 @@ def normalize_coordinates(
 
     Split dimension into n dimensions if expression has n>1 terms.
     Split dim_size into n according to iteration range of each term.
-    Fuse contiguous dimensions if corresponding terms can be fused.
+    Fuse contiguous dimensions if corresponding terms can be fused.  Size-1
+    device dims with a constant zero coordinate are dropped, and do not stop
+    the dims on either side of them from fusing.
     """
     # terms in non-increasing stride order
     terms = []
@@ -504,11 +506,43 @@ def normalize_coordinates(
     # never fuse last dimension = stick dimension!
     fused_terms = []
     fused_term = terms[0]
+    # Whether a transparent placeholder term was skipped since ``fused_term``
+    # was last (re)set.  A placeholder is a size-1 device dim with a constant
+    # zero coordinate, e.g. the squeezed ``seq`` dim that
+    # ``get_generic_stick_layout`` puts *between* ``H`` and the non-stick half
+    # of ``D`` for a ``[B, H, 1, D]`` attention output.  It occupies no space
+    # and is discarded by the flush guards below, but because this scan only
+    # compares neighbouring list entries it would flush the pending term and
+    # break a fusion run between two dims that ``compute_coordinates`` already
+    # treats as stride-adjacent (``next_stride`` ignores ``size == 1`` dims).
+    # Splitting an otherwise contiguous axis that way makes ``align_tensors``
+    # mint an extra loop variable for it, and for a matmul that produces a
+    # second reduction dim, which the backend cannot schedule (a bmm contracts
+    # exactly one dim; deeptools aborts with ``out_reuse_dim.size() == 1``).
+    skipped_placeholder = False
     for term in terms[1:-1]:
+        if term.var is None and term.dim_size == 1 and term.offset == 0:
+            skipped_placeholder = True
+            continue
         if (
             fused_term.num == 1
             and fused_term.var == term.var
             and fused_term.den == term.mod
+            # Fusing *across* a placeholder must not change the address that
+            # any (dim, coordinate) pair encodes.  It provably does not when
+            # the pair is densely packed (``den == term.den * term.dim_size``),
+            # the inner term skips no elements (``num == 1``), and the outer
+            # term carries no offset -- the outer offset counts in units of the
+            # outer ``den`` and is not rescaled when ``den`` shrinks on fusion.
+            # Adjacent terms keep the historical predicate unchanged.
+            and (
+                not skipped_placeholder
+                or (
+                    term.num == 1
+                    and fused_term.offset == 0
+                    and fused_term.den == term.den * term.dim_size
+                )
+            )
         ):
             # fuse terms
             fused_term.num = term.num
@@ -519,6 +553,7 @@ def normalize_coordinates(
             if fused_term.dim_size > 1 or fused_term.var is not None:
                 fused_terms.append(fused_term)
             fused_term = term
+        skipped_placeholder = False
     if fused_term.dim_size > 1 or fused_term.var is not None:
         fused_terms.append(fused_term)
     # add term for stick dimension


### PR DESCRIPTION
## Summary

`normalize_coordinates`' contiguous-device-dim fusion fails to fuse two physically
adjacent, fusable dims when an **inert size-1 dim sits between them**. For a
single-token decode this splits a projection matmul's contraction axis in two, and
the backend cannot schedule a bmm that contracts two dims:

```
DtException: out_reuse_dim.size() == 1
  dcg/dcg_fe/scheduler/L3DlOpsScheduler.cpp:960  (getMinParamBmm)
  -> dxp_standalone died with SIGABRT
```

Found while making the hf-adapters decode loop write one token per step instead of
a 64-token block (torch-spyre/hf-adapters#330). Every real decoder block hits it:
`seq_len=1` SDPA followed by `o_proj`.

## Root cause

`views.py:507` scans `terms[1:-1]` comparing only neighbouring entries. A
placeholder term — size-1 device dim, constant-zero coordinate, so `var is None`
and `num is None` — matches neither fusion predicate (`fused_term.num == 1` fails
when it is the accumulator; `fused_term.var == term.var` fails when it is the
incoming term). It flushes the pending term, becomes the new accumulator, and is
then discarded by the pre-existing `dim_size > 1 or var is not None` guard. Net
effect: the two real terms end up **adjacent in the emitted layout but unfused**.

Where the placeholder comes from: for a `[B, H, 1, D]` attention output,
`get_generic_stick_layout`'s rank-4 dim map (`spyre_tensor_impl.cpp:61-64`,
`{h1,h2,h3,h0,h3}`) yields `device_size=[16(H), 1(seq), 2(D/64), 1(B), 64(stick)]`
— the squeezed `seq` dim lands at device position 1, **between `H` and `D`'s
non-stick half**.

The following `o_proj` reads that buffer as one flat 2048-wide axis, and
`compute_coordinates` correctly emits
`[floor(k/128), 0, floor(Mod(k,128)/64), 0, Mod(k,64)]`. Terms 1 and 3 satisfy the
fusion predicate exactly (`den(128) == mod(128)`, same var) and the buffer is a
dense 2048-element run — but the interposed singleton breaks the run, so
`align_tensors` mints a second loop variable and the bmm contracts two dims.

### Why `seq_len > 1` was unaffected

Only by accident. At `seq > 1`, `attn_out.transpose(1,2).reshape(B,S,H*D)` is not a
legal view (after transposing, `H`'s stride is `S*D`, not `D`), so ATen must
materialize a copy. In the resulting **token-major** buffer the real `seq` dim is
outermost and `H`/`D_outer` are adjacent, so the fusion loop fires. There are two
such relayout ops in the `seq=64` graph and **zero** in the `seq=1` graph.

Concretely, the same `o_proj`, both ranks:

```
seq=64   inp0=['in','mb']    inp1=['in','out']        out=['out','mb']   contract {'in'}          ok
seq=1    inp0=['out','in']   inp1=['out','in','mb']   out=['mb']         contract {'in','out'}    abort
```

## The fix

Skip placeholder terms so the dims on either side can fuse, **gated on the
address-preservation condition**:

- `term.num == 1` — the inner term skips no elements
- `fused_term.offset == 0` — an outer offset counts in units of the outer `den`,
  which shrinks on fusion and would silently rescale it
- `fused_term.den == term.den * term.dim_size` — the pair is densely packed

Adjacent terms keep the historical predicate untouched, so the change is
**additive**: it can only create fusions, never remove them.

### The gating is load-bearing — an ungated skip miscompiles

An earlier candidate filtered placeholders out and reused the weak predicate
(`num == 1 and var == var and den == mod`), which is not sufficient once a dim has
been removed from between the pair. For `[1, 16, 1, 80]` (head_dim=80) it fuses to
`[32, 64]` and addresses flat element 80 at device offset **80 instead of 144** —
reading head 0's stick padding instead of head 1, wrong for every head after the
first. It is invisible on head_dim=128 (stick-aligned), which is why it passes the
obvious repro. That candidate was rejected; this PR is the gated version.

## Testing

**Added** `TestNormalizeCoordinatesFusion` to `tests/tensor/test_coordinates.py`,
which already covers `views.py` — the regression case plus three negative cases
(outer offset, non-dense pair, no placeholder). Pure sympy arithmetic:
`normalize_coordinates` takes the coordinate expressions as arguments, so no graph
handler or MLIR is involved.

Verified meaningful: 4 pass with the fix, and `test_placeholder_does_not_block_fusion`
**fails** without it while the three negative cases still pass.

**On device:**
- minimal repro (`sdpa_seq1_fusion_repro.py`), 5 graph shapes at `seq=1`: was 1/5
  passing, now **5/5**
- real model, `hf-adapters` Qwen3-0.6B single-token decode smoke test: was SIGABRT,
  now **passes** (72 s)

**Not yet complete at time of opening:** the full `tests/inductor/test_inductor_ops.py`
numerics suite is still running. `normalize_coordinates` runs for every TensorArg of
every op, so although the observable change is narrow, that suite (plus
`test_restickify.py` / `test_padding.py`) is the real gate rather than the repro. I
will post results. Reviewers may reasonably want to wait for them.

Equivalence evidence gathered while developing: the old and new loops implemented as
pure functions and compared exhaustively over every term list of length 2-4 from a
10-element alphabet (inert placeholders, non-unit constant dims, opaque-offset terms,
real terms across two vars and four `(den, mod)` combinations) — 16093 cases, 16027
identical, and every one of the 66 differences was a newly-enabled fusion that
satisfies the gate. All 23 existing `tests/tensor/test_coordinates.py` cases are
byte-identical.

## Follow-ups, not in this PR

1. **A geometry guard.** Nothing on the Python side validates that an emitted bmm
   contracts exactly one dim, so this class of bug reaches the backend as a SIGABRT
   rather than a clear `Unsupported`. A guard in `superdsc.py` reading the same three
   `layoutDimOrder_` lists `getMinParamBmm` reads is written and ready; happy to open
   it separately.
2. **`propagate_layouts.py:1014`** mishandles negative `rank_diff` and drops the
   trailing `-1` sparse-stick marker — filed separately as an issue.
