### PR TITLE
fix(inductor): project dim_order onto higher-rank operands and keep the sparse-stick marker

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_index_b_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_index_b_config.yaml
@@ -34,7 +34,7 @@ test_suite_config:
             - LxPlanning.*::test_linalg_norm_keepdim.*_lx_planning_(pointwise|reduction)
             - LxPlanning.*::test_argmin_keepdim0.*_lx_planning_(pointwise|reduction)
             - LxPlanning.*::test_min_tuple_output_keepdim0.*_lx_planning_(pointwise|reduction)
-            - LxPlanning.*::test_logsumexp_keepdim0_known_xfail.*_lx_planning_(pointwise|reduction)
+            - LxPlanning.*::test_logsumexp_keepdim0.*_lx_planning_(pointwise|reduction)
             - LxPlanning.*::test_mean_3d_dim0_keepdim.*_lx_planning_(pointwise|reduction)
             - LxPlanning.*::test_index_copy_.*_lx_planning_(pointwise|reduction)
             # Regression guard for LX producer/consumer core->slice agreement

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_index_norm_eager_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_index_norm_eager_config.yaml
@@ -15,7 +15,7 @@ test_suite_config:
             - TestOps::test_linalg_norm_keepdim.*
             - TestOps::test_argmin_keepdim0
             - TestOps::test_min_tuple_output_keepdim0
-            - TestOps::test_logsumexp_keepdim0_known_xfail
+            - TestOps::test_logsumexp_keepdim0
             # test_mean has a param named "3d_dim0_keepdim" whose instantiated name
             # contains "keepdim" — the old .*keepdim.* pattern matched it here.
             # The base method test_mean belongs to misc, but this one specific param

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_index_norm_eager_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_reduction_keepdim_index_norm_eager_config.yaml
@@ -22,6 +22,10 @@ test_suite_config:
             # variant was collected in the reductions shard via substring match.
             - TestOps::test_mean_3d_dim0_keepdim
             - TestOps::test_index_copy_.*
+            # Regression guard for the multi-arg pointwise dim_order projection
+            # onto an operand that outranks the gather's output (negative
+            # rank_diff), which raised "Incompatible host_size and dim_order".
+            - TestOps::test_gather_from_.*
             # Regression guard for LX producer/consumer core->slice agreement
             # (#3374, #3387). Asserts both values and that the buffer stays in LX.
             - TestOps::test_shared_input_two_reductions.*

--- a/tests/configs/torch_spyre_tests/inductor/test_project_dim_order_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_project_dim_order_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [unit, regression, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_project_dim_order.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -6031,15 +6031,12 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             run_eager=False,
         )
 
-    @pytest.mark.xfail(
-        reason=(
-            "Spyre compiled backend hits an internal lowering bug for "
-            "torch.logsumexp (stable error signature: InductorError: "
-            "IndexError: list index out of range)"
-        ),
-        strict=True,
-    )
-    def test_logsumexp_keepdim0_known_xfail(self):
+    def test_logsumexp_keepdim0(self):
+        """Was a strict xfail: the compiled path raised "Incompatible host_size
+        and dim_order" from the multi-arg pointwise dim_order projection, which
+        did not handle an operand of higher rank than the output. This op reaches
+        that path with a rank-2 operand against a rank-1 output.
+        """
         x = cached_randn((67, 256), scale=0.1)
         self.compare_with_cpu(
             lambda x: torch.logsumexp(x, dim=0, keepdim=False),

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -7635,6 +7635,61 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             index_copy_fn, cache, index, source, run_compile=False, run_eager=True
         )
 
+    def test_gather_from_higher_rank_operand(self):
+        """Gather whose value operand outranks the gather's output.
+
+        `flatten`/`transpose` are views, so the multi-arg pointwise feeding the
+        gather keeps its rank-5 shape while the gather's output is rank 4. The
+        dim_order projection in _multi_arg_pointwise_layouts assumed an operand
+        rank <= the output's and came up short, raising "Incompatible host_size
+        and dim_order".
+        """
+
+        def fn(a, b, index):
+            out = a.mul(b).flatten(3).transpose(1, 2)
+            return out.index_select(2, index)
+
+        a = cached_randn((1, 64, 8, 2, 64), differentiation="rankdiff_a")
+        b = cached_randn((1, 64, 8, 2, 64), differentiation="rankdiff_b")
+        index = torch.tensor([17], dtype=torch.int32)
+
+        self.compare_with_cpu(fn, a, b, index)
+
+    def test_gather_from_higher_rank_rope_operand(self):
+        """The rope-shaped instance of test_gather_from_higher_rank_operand.
+
+        Mirrors hf_adapters `apply_rope_matmul` followed by a KV-cache
+        `index_select`: a rank-6 [B, L, H, 2, 1, D/2] intermediate viewed down to
+        [B, H, L, D] before the gather, giving an operand two ranks above the
+        gather's rank-4 output.
+        """
+
+        def fn(sf, x, index):
+            out = sf.mul(x.unsqueeze(-3)).sum(4, keepdim=True).flatten(3)
+            return out.transpose(1, 2).index_select(2, index)
+
+        sf = cached_randn((1, 64, 1, 2, 2, 64), differentiation="rankdiff_sf")
+        x = cached_randn((1, 64, 8, 2, 64), differentiation="rankdiff_x")
+        index = torch.tensor([17], dtype=torch.int32)
+
+        self.compare_with_cpu(fn, sf, x, index)
+
+    def test_gather_from_rank_aligned_operand(self):
+        """Control for the two tests above: operand rank == output rank.
+
+        The same gather on an operand the projection always handled, so a
+        failure here means the gather itself broke rather than the projection.
+        """
+
+        def fn(a, b, index):
+            return a.mul(b).index_select(2, index)
+
+        a = cached_randn((1, 8, 64, 128), differentiation="rankdiff_ctl_a")
+        b = cached_randn((1, 8, 64, 128), differentiation="rankdiff_ctl_b")
+        index = torch.tensor([17], dtype=torch.int32)
+
+        self.compare_with_cpu(fn, a, b, index)
+
     def test_repeat_cpu(self, x, *repeat_args):
         def fn(a):
             return a.repeat(*repeat_args)

--- a/tests/inductor/test_project_dim_order.py
+++ b/tests/inductor/test_project_dim_order.py
@@ -1,0 +1,110 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests for project_dim_order, which re-expresses a multi-arg pointwise output's
+# dim_order as a dim_order for one of its operands.
+#
+# These are pure-function tests: no compilation, no backend codegen, no device.
+# The invariant under test is the one SpyreTensorLayout::init asserts
+# (spyre_tensor_impl.cpp) — len(dim_order) == rank, or rank + 1 when the last
+# entry is -1 (sparse stick).
+
+import pytest
+
+from torch_spyre._inductor.propagate_layouts import project_dim_order
+
+
+def _assert_layout_invariant(dim_order, rank):
+    """Mirror the TORCH_CHECK in SpyreTensorLayout::init."""
+    sparse = len(dim_order) > 0 and dim_order[-1] == -1
+    assert len(dim_order) == rank or (sparse and len(dim_order) == rank + 1), (
+        f"dim_order {dim_order} (len {len(dim_order)}) is incompatible with "
+        f"rank {rank}"
+    )
+    # The non-stick entries must be a permutation of the operand's dims.
+    core = dim_order[:-1] if sparse else dim_order
+    assert sorted(core) == list(range(rank)), (
+        f"dim_order {dim_order} is not a permutation of range({rank})"
+    )
+
+
+class TestBroadcast:
+    """Operand rank <= output rank: the case the projection always handled."""
+
+    def test_equal_rank_is_identity(self):
+        assert project_dim_order([1, 3, 0, 2], 4, 4) == [1, 3, 0, 2]
+
+    def test_leading_broadcast_dims_dropped(self):
+        # Operand [C, D] against output [A, B, C, D]: output dims 0,1 don't exist
+        # on the operand and are dropped; 2,3 shift down to 0,1.
+        assert project_dim_order([1, 3, 0, 2], 4, 2) == [1, 0]
+
+    def test_scalar_operand(self):
+        assert project_dim_order([1, 3, 0, 2], 4, 0) == []
+
+    @pytest.mark.parametrize("arg_rank", [0, 1, 2, 3, 4])
+    def test_invariant_holds(self, arg_rank):
+        _assert_layout_invariant(project_dim_order([1, 3, 0, 2], 4, arg_rank), arg_rank)
+
+
+class TestSparseStickMarker:
+    """A trailing -1 means the stick maps to no host dim. It must survive."""
+
+    def test_marker_preserved_at_equal_rank(self):
+        # Regression: the old `if d >= rank_diff` filter dropped -1 whenever
+        # rank_diff >= 0, quietly turning a sparse-stick operand layout dense.
+        assert project_dim_order([1, 3, 0, 2, -1], 4, 4) == [1, 3, 0, 2, -1]
+
+    def test_marker_preserved_under_broadcast(self):
+        assert project_dim_order([1, 3, 0, 2, -1], 4, 2) == [1, 0, -1]
+
+    def test_marker_not_treated_as_a_dim(self):
+        # -1 must not be shifted into a real dim index.
+        projected = project_dim_order([1, 3, 0, 2, -1], 4, 6)
+        assert projected.count(-1) == 1
+        assert projected[-1] == -1
+
+    @pytest.mark.parametrize("arg_rank", [1, 2, 3, 4, 5, 6])
+    def test_invariant_holds(self, arg_rank):
+        _assert_layout_invariant(
+            project_dim_order([1, 3, 0, 2, -1], 4, arg_rank), arg_rank
+        )
+
+
+class TestHigherRankOperand:
+    """Operand rank > output rank: previously unhandled, and the crash."""
+
+    def test_qwen3_rope_gather(self):
+        # The real failure from hf-adapters#330. An index_select on a fused RoPE
+        # chain: the gather's value operand is still the rank-6
+        # [B, L, H, 2, 1, D/2] = [1, 64, 8, 2, 1, 64] intermediate (flatten and
+        # transpose are views), while the gather's output is rank-4
+        # [B, H, 1, D] = [1, 8, 1, 128].
+        #
+        # The old projection produced [3, 5, 2, 4, 1]: five entries against six
+        # host sizes, and the -1 marker shifted into a bogus dim index 1. That
+        # tripped "Incompatible host_size and dim_order".
+        projected = project_dim_order([1, 3, 0, 2, -1], out_rank=4, arg_rank=6)
+        assert projected != [3, 5, 2, 4, 1]
+        _assert_layout_invariant(projected, 6)
+
+    def test_extra_leading_dims_get_entries(self):
+        # Operand rank 6, output rank 4: the operand's two extra leading dims
+        # must appear, and the shared trailing dims stay right-aligned.
+        assert project_dim_order([1, 3, 0, 2], 4, 6) == [0, 1, 3, 5, 2, 4]
+
+    @pytest.mark.parametrize("arg_rank", [5, 6])
+    @pytest.mark.parametrize("dim_order", [[1, 3, 0, 2], [1, 3, 0, 2, -1]])
+    def test_invariant_holds(self, dim_order, arg_rank):
+        _assert_layout_invariant(project_dim_order(dim_order, 4, arg_rank), arg_rank)

--- a/tests/inductor/test_project_dim_order.py
+++ b/tests/inductor/test_project_dim_order.py
@@ -28,15 +28,12 @@ from torch_spyre._inductor.propagate_layouts import project_dim_order
 def _assert_layout_invariant(dim_order, rank):
     """Mirror the TORCH_CHECK in SpyreTensorLayout::init."""
     sparse = len(dim_order) > 0 and dim_order[-1] == -1
-    assert len(dim_order) == rank or (sparse and len(dim_order) == rank + 1), (
-        f"dim_order {dim_order} (len {len(dim_order)}) is incompatible with "
-        f"rank {rank}"
-    )
+    length_ok = len(dim_order) == rank or (sparse and len(dim_order) == rank + 1)
+    assert length_ok, f"{dim_order} incompatible with rank {rank}"
     # The non-stick entries must be a permutation of the operand's dims.
     core = dim_order[:-1] if sparse else dim_order
-    assert sorted(core) == list(range(rank)), (
-        f"dim_order {dim_order} is not a permutation of range({rank})"
-    )
+    expected = list(range(rank))
+    assert sorted(core) == expected, f"{dim_order} core is not {expected}"
 
 
 class TestBroadcast:

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -205,6 +205,54 @@ def _compute_dim_order(stick_dim, size, coords):
     return dim_order
 
 
+# Longest dim_order get_generic_stick_layout (spyre_tensor_impl.cpp) can tile.
+# A length-7 dim_order is accepted only for a sparse stick (trailing -1).
+_MAX_DIM_ORDER_LEN = 7
+
+
+def project_dim_order(dim_order, out_rank, arg_rank):
+    """Re-express an output dim_order as a dim_order for one of its operands.
+
+    ``dim_order`` is a permutation of host dim indices with the stick dim last
+    (see `_compute_dim_order`); a trailing ``-1`` instead means the stick maps
+    to no host dim at all (sparse stick). `SpyreTensorLayout` requires
+    ``len(dim_order) == rank``, or ``rank + 1`` when the last entry is ``-1``.
+
+    Operands are right-aligned against the output, numpy-broadcast style, so
+    operand dim ``i`` corresponds to output dim ``i + rank_diff``.
+
+    Two cases the naive ``[d - rank_diff for d in dim_order if d >= rank_diff]``
+    got wrong:
+
+    - ``rank_diff < 0`` (operand of *higher* rank than the output — an
+      `aten.index` gather whose value operand keeps its pre-view rank, say).
+      The operand's extra leading dims never received entries, so the projection
+      came up short and tripped the rank check in `spyre_tensor_impl.cpp`
+      ("Incompatible host_size and dim_order").
+    - The trailing ``-1`` was silently dropped whenever ``rank_diff >= 0``,
+      because ``-1 >= rank_diff`` is false. That does not raise: it builds a
+      *dense*-stick operand layout to stand in for a sparse-stick output, so
+      the feasibility test below silently answered for the wrong layout.
+    """
+    sparse = bool(dim_order) and dim_order[-1] == -1
+    core = dim_order[:-1] if sparse else list(dim_order)
+    rank_diff = out_rank - arg_rank
+
+    if rank_diff >= 0:
+        # Broadcast: the operand lacks the output's leading dims. Drop them.
+        projected = [d - rank_diff for d in core if d >= rank_diff]
+    else:
+        # The operand carries dims the output does not. Keep the right-aligned
+        # correspondence for the shared trailing dims and give the extra leading
+        # dims entries of their own, outermost first.
+        extra = -rank_diff
+        projected = list(range(extra)) + [d + extra for d in core]
+
+    if sparse:
+        projected.append(-1)
+    return projected
+
+
 def _pick_stick_dim(stick_expr, out_coords) -> int:
     """Map a stick expression to an output dimension index, or -1 if it doesn't survive."""
     maybe = matching_dim(out_coords, stick_expr)
@@ -1098,9 +1146,19 @@ def _multi_arg_pointwise_layouts(
 
     def _is_supported_layout(dim_order):
         for arg in args:
-            # Project output dim_order to input, dropping leading dims missing due to broadcast.
-            rank_diff = len(output.size) - len(arg.layout.size)
-            projected_dim_order = [d - rank_diff for d in dim_order if d >= rank_diff]
+            projected_dim_order = project_dim_order(
+                dim_order, len(output.size), len(arg.layout.size)
+            )
+            # get_generic_stick_layout (spyre_tensor_impl.cpp) tiles dim_orders
+            # of length 1..7, and length 7 only for a sparse stick. Projecting
+            # onto a higher-rank operand can exceed that; report the layout as
+            # unsupported rather than letting the constructor's TORCH_CHECK
+            # escape as a hard error.
+            if len(projected_dim_order) > _MAX_DIM_ORDER_LEN or (
+                len(projected_dim_order) == _MAX_DIM_ORDER_LEN
+                and projected_dim_order[-1] != -1
+            ):
+                return False
             c_in_size = [concretize_expr(s) for s in arg.layout.size]
             c_in_stride = [concretize_expr(s) for s in arg.layout.stride]
             in_stl = SpyreTensorLayout(


### PR DESCRIPTION
## Summary

`_multi_arg_pointwise_layouts._is_supported_layout` re-expressed the output's
`dim_order` for each operand with one line:

```python
rank_diff = len(output.size) - len(arg.layout.size)
projected_dim_order = [d - rank_diff for d in dim_order if d >= rank_diff]
```

It was written for broadcast, where an operand's rank is at most the output's.
Two defects followed.

**1. `rank_diff < 0` was unhandled (hard error).** When an operand outranks the
output, its extra leading dims never received entries, so `len(projected) < rank`
and `SpyreTensorLayout::init` raised `Incompatible host_size and dim_order`
(`spyre_tensor_impl.cpp:144`). An `aten.index` gather hits this whenever
`flatten`/`transpose` view its value operand down to a lower rank — the views
don't materialize, so the fused pointwise keeps the pre-view rank.

**2. The trailing `-1` sparse-stick marker was mishandled in both directions
(silent).** `-1 >= rank_diff` is false for any `rank_diff >= 0`, so the marker
was filtered out and the operand was probed as a **dense**-stick layout standing
in for a sparse-stick output. That doesn't raise — it silently answers the
feasibility question about a different layout. Under `rank_diff < 0` the marker
was instead shifted into a bogus real dim index.

Defect 2 is the wider one: it affects every sparse-stick multi-arg pointwise
today, with no crash to announce it.

## Reproducer

No model, no KV cache, no scatter, no SDPA:

```python
def f(a, b, index):
    out = a.mul(b).flatten(3).transpose(1, 2)   # rank 5 -> rank 4, both views
    return out.index_select(2, index)           # -> [1, 8, 1, 128]

a = torch.randn(1, 64, 8, 2, 64, dtype=torch.float16)
torch.compile(f, dynamic=False)(a.to("spyre"), a.to("spyre"),
                                torch.tensor([17], dtype=torch.int32).to("spyre"))
```

```
torch._inductor.exc.InductorError: RuntimeError: Incompatible host_size and dim_order
```

A rank-aligned control (`a.mul(b)` then the identical `index_select`) compiles
bit-exact, isolating the rank relationship as the trigger. All three are now
committed as compiled-path tests.

## Where it came from

Surfaced by hf-adapters#330, which replaces the int-specialized KV slice write
with `index_copy_` plus an `index_select` on a new `source_index`. The gather
runs on a fused `apply_rope_matmul` chain whose rank-6 `[B, L, H, 2, 1, D/2]` =
`[1, 64, 8, 2, 1, 64]` intermediate is viewed to `[B, H, L, D]` before the
gather, so `rank_diff = 4 - 6 = -2`. The reported failing STL was
`size=[1, 64, 8, 2, 1, 64] dim_order=[3, 5, 2, 4, 1]` — five entries against six
sizes, with the `-1` shifted to `1`.

`index_copy_` is **not** implicated: swapping it for `index_put_` or a subscript
assign gives the identical error, and the repro above has no scatter at all.

**This defect is already known in-tree.** `_inductor/decompositions.py:1234-1242`
(masked_scatter, #3308) carries a nine-line comment describing the same failure
mode and the same error string, and works around it by keeping every `where`
operand rank-aligned with the output. No issue was filed at the time.

## Fix

`project_dim_order` separates the stick marker from the permutation, keeps the
existing right-alignment for `rank_diff >= 0`, and gives a higher-rank operand's
extra leading dims entries of their own. Plus a length guard:
`get_generic_stick_layout` tiles `dim_order`s of length 1..7 and length 7 only
for a sparse stick, so an over-long projection is reported as an unsupported
layout rather than letting the constructor's `TORCH_CHECK` escape.

21 executable lines.

### Why the blast radius is small

`projected_dim_order` and the `in_stl` built from it **never leave**
`_is_supported_layout` — it is a boolean probe, and the committed layout is the
*output* STL built in `_try_stick_dim`. So a mis-projection can only cause a
wrong accept/reject decision, never directly wrong addresses. The probe is also
validated rather than trusted: `try_device_coordinates` rejects a candidate whose
stick expression isn't offset-free or depends on an index symbol.

## This also fixes `torch.logsumexp` on the compiled path

`test_logsumexp_keepdim0` was a **strict xfail** for an "internal lowering bug".
It is this same defect: logsumexp reaches `_multi_arg_pointwise_layouts` with a
rank-2 operand against a rank-1 output, so `rank_diff < 0`.

A/B on device, same checkout, only `propagate_layouts.py` differing:

| | Result |
|---|---|
| unpatched | `InductorError: RuntimeError: Incompatible host_size and dim_order` |
| patched | **XPASS (strict)** — the test passes |

The marker is removed and the `_known_xfail` suffix dropped in this PR.
`test_logsumexp_keepdim0` now PASSES on device (a real pass, not an xpass).

Two things worth reviewers' attention:

- The marker's recorded signature was **stale** — it documented `IndexError: list
  index out of range`, but the actual failure is the `host_size`/`dim_order`
  `TORCH_CHECK`. Both are consistent with a short `dim_order` list, so the
  signature likely predates that check being added.
- **The strict xfail did not surface as a CI failure once fixed.** The OOT wrapper
  reports the underlying `XPASS(strict)` as an `XFAIL`, so the suite stayed green
  at `139 xfailed / 0 failed` *with the fix applied*. Only `--runxfail` reveals
  it. This is why it had to be found by decision-diffing the projection rather
  than by reading test results — worth knowing, since it means any other strict
  xfail this fix unblocks is also invisible in a green run.

## Decision diff: what this change actually alters

To measure the blast radius directly rather than infer it from green tests, both
projections were run on every probe in one instrumented pass, logging only the
cases where the accept/reject verdict differs.

```
calls=2782  diverged=4  unique=3  new_errors=0
2317 passed, 6 skipped, 139 xfailed, 0 failed
```

| Old verdict | New verdict | Shape | Test |
|---|---|---|---|
| `False(indirect)` | `True` | `out_rank=1, args=[1,1], dim_order=[0,-1]` | `test_flip_1d_stick` |
| `False(indirect)` | `True` | `out_rank=2, args=[1,2], dim_order=[0,1,-1]` | `test_flip_2d_dim_1_stick` |
| `STL_ERROR` | `True` | `out_rank=1, args=[1,2], dim_order=[0]` | `test_logsumexp_keepdim0` |

- **`new_errors=0`** across 2,782 probes: the fixed projection never built a
  layout the constructor refused.
- The marker fix changes exactly **two** decisions in the whole suite, both
  `False → True`, both on sparse-stick `dim_order`s the old code had turned dense
  before probing.
- No divergence appeared that isn't one of the two documented defects, and no
  wrong-accept surfaced.

## Verification

| Check | Result |
|---|---|
| `tests/inductor/test_project_dim_order.py` (new, no device) | 23 passed, 0.44 s |
| `rankdiff` device repro | 2 failures → 3/3 pass, **max abs diff 0.0** |
| `tests/inductor/test_inductor_ops.py` | 2188 passed, 2 skipped, 139 xfailed, 95 subtests, **0 failed** |
| `test_building_blocks` + `propagate_named_dims` + `lx_inplace_layout` + `perm_layout_solver` | 129 passed, 4 skipped, **0 failed** |

Run on a dev pod at torch 2.13.0+cpu; that checkout sits on a
`conv2d-direct-lowering` merge rather than pure `main`. The three new
compiled-path gather tests and `test_logsumexp_keepdim0` have since been verified
both on the pod and on upstream CI hardware.

## Open question for review

For `rank_diff < 0`, "extra leading dims outermost, in order" is a **guarded
heuristic**, not a derivation. Right-alignment is arguably ill-defined there,
because operand and output are related by a *view*, not a broadcast.

The principled alternative: derive the operand's `dim_order` from its own
`host_coordinates` (already computed as `in_coords`), matching the output's stick
*expression* via `matching_dim`, then `_compute_dim_order`. That needs no rank
correspondence at all, and the layout invariant would hold by construction. It's
a broader behavioural change, so it's offered as a follow-up rather than folded
in here — happy to do it in this PR instead if reviewers prefer.

## Related

- #3705 — the scatter twin: an unpinned indirect `index_copy_` writes the wrong
  rows silently. Independent defect, different layer (enforcement pass, not
  propagation), but the same "silently wrong layout" family as defect 2 here.
- #3401 — a malformed explicit layout `SIGFPE`s in `get_device_stride_infos`
  instead of raising. That is why the length guard above lives in Python rather
  than relying on the C++ to catch it.
- #3308 — added the in-tree workaround for this same defect.

All three are symptoms of the `SpyreTensorLayout` contract being enforced in
several places at several levels of rigor, with no single validator. A unified
validator would close all three classes; worth proposing separately, not a
prerequisite here.

Draft while CI runs.
