### PR TITLE
Eliminate use_symbols parameter from SDSC bundle.py and its plumbing

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -6132,6 +6132,33 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         self.assertEqual(execute_lines[2].split("(")[1].split(")")[0], "%pool_addr_0")
 
 
+class TestGenerateBundleRequiresSymbolicArgs(unittest.TestCase):
+    """generate_bundle must fail fast when bundle_symbolic_args is False.
+
+    The SDSC path always emits symbolic HBM addresses; baked addressing is
+    only meaningful on the (separately-gated) KTIR emitter path. Without
+    this guard, disabling the flag on the default path would silently
+    miscompile addresses instead of erroring.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_raises_when_bundle_symbolic_args_false(self):
+        a = _make_minimal_op_spec("a")
+        with patch(
+            "torch_spyre._inductor.codegen.bundle._spyre_config.bundle_symbolic_args",
+            False,
+        ):
+            with self.assertRaises(AssertionError):
+                generate_bundle("test_kernel", self.tmpdir, [a])
+
+
 class TestSymbolKind(unittest.TestCase):
     """Unit tests for the SymbolKind dataclass."""
 

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -632,7 +632,6 @@ def _fake_compile_op_spec(
     op_spec: OpSpec,
     symbols: list,
     symbol_id_offset: int = 0,
-    use_symbols: bool = False,
 ):
     """Stub that returns (json, [], [], []) — no real SDSC compilation."""
     return {f"{idx}_{op_spec.op}": {"op": op_spec.op}}, [], [], []
@@ -2299,7 +2298,6 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[[s]],
-            use_symbols=True,
         )
         # affine_strides[tensor_idx] is list[dict] (per level, outermost first).
         # With one tiling level, affine_strides[0] = [{s: stride}].
@@ -2318,7 +2316,6 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[[s]],
-            use_symbols=True,
         )
         self.assertEqual(len(affine_strides), 1)
         self.assertIn(s, affine_strides[0][0])
@@ -2336,7 +2333,6 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[[s]],
-            use_symbols=True,
         )
         self.assertEqual(len(symbols), 1)
         self.assertEqual(symbols[0], 0)  # kernel sentinel = arg_index = 0
@@ -2351,7 +2347,6 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[[s]],
-            use_symbols=True,
         )
         top_val = next(iter(sdsc_json.values()))
         node = top_val["dscs_"][0]["add"]["scheduleTree_"][0]
@@ -2401,7 +2396,6 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=5,
             tiled_symbols=[[s]],
-            use_symbols=True,
         )
         top_val = next(iter(sdsc_json.values()))
         node = top_val["dscs_"][0]["add"]["scheduleTree_"][0]
@@ -2458,7 +2452,6 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[[s]],
-            use_symbols=True,
         )
         self.assertEqual(len(symbols), 2)
         self.assertEqual(symbols[0], 0)  # kernel sentinel = arg_index = 0
@@ -2522,7 +2515,6 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[[lvl0], [lvl1]],
-            use_symbols=True,
         )
         self.assertEqual(len(affine_strides), 1)
         per_level = affine_strides[0]
@@ -2584,7 +2576,6 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[[lvl0]],
-            use_symbols=True,
         )
         self.assertEqual(len(affine_strides), 1)
         per_level = affine_strides[0]
@@ -2652,7 +2643,7 @@ class TestCompileOpSpecTwoTiledSymbols(unittest.TestCase):
     def test_two_tiled_symbols_produce_two_stride_entries(self):
         op_spec = self._make_3d_op_spec()
         symbols: list[int] = []
-        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
+        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols)
         # affine_strides[tensor_idx] = list[dict] (per level, outermost first).
         # Both tensors have one tiling level with two symbols.
         # Find tensors with non-empty strides at any level.
@@ -2669,7 +2660,7 @@ class TestCompileOpSpecTwoTiledSymbols(unittest.TestCase):
     def test_two_tiled_symbols_strides_are_positive(self):
         op_spec = self._make_3d_op_spec()
         symbols: list[int] = []
-        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
+        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols)
         for per_level in affine_strides:
             for level_strides in per_level:
                 for sym, stride in level_strides.items():
@@ -2683,7 +2674,7 @@ class TestCompileOpSpecTwoTiledSymbols(unittest.TestCase):
         # tiling level.
         op_spec = self._make_3d_op_spec()
         symbols: list[int] = []
-        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
+        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols)
         mb = Symbol("mb")
         x = Symbol("x")
         self.assertEqual(len(affine_strides), 2)
@@ -2698,7 +2689,7 @@ class TestCompileOpSpecSymbolMapping(unittest.TestCase):
     def test_affine_strides_non_empty_for_tiled_op(self):
         op_spec = _make_tiled_op_spec()
         symbols: list[int] = []
-        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
+        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols)
         # affine_strides[tensor_idx] = list[dict] (per level, outermost first).
         has_strides = any(
             any(len(level_d) > 0 for level_d in per_level)
@@ -2713,7 +2704,7 @@ class TestCompileOpSpecSymbolMapping(unittest.TestCase):
         op_spec = _make_tiled_op_spec()
         loop = LoopSpec(count=Integer(4), body=[op_spec])
         tmpdir = tempfile.mkdtemp()
-        generate_bundle("test_kernel", tmpdir, [loop], use_symbols=True)
+        generate_bundle("test_kernel", tmpdir, [loop])
 
         with open(os.path.join(tmpdir, "bundle.mlir")) as f:
             mlir = f.read()
@@ -2752,7 +2743,7 @@ class TestCompileOpSpecSymbolMapping(unittest.TestCase):
         # minted symbol too (as an identity mapping -- Site 1's fix), not
         # just parse_op_spec's returned symbol_mapping dict in isolation.
         symbols: list[int] = []
-        compile_op_spec(0, op_spec, symbols, use_symbols=True)
+        compile_op_spec(0, op_spec, symbols)
         tiled_symbols_per_level = [
             [symbol_mapping[s] for s in level if s in symbol_mapping]
             for level in reversed(op_spec.tiled_symbols)
@@ -2782,7 +2773,7 @@ class TestCompileOpSpecSymbolMapping(unittest.TestCase):
                 arg.device_tile_advance_expr = sympy.floor(64 * minted)
         symbols: list[int] = []
         # Must not raise, and must not silently produce empty affine_strides.
-        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
+        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols)
         has_strides = any(
             any(len(level_d) > 0 for level_d in per_level)
             for per_level in affine_strides
@@ -2837,7 +2828,7 @@ class TestCompileOpSpecSymbolMapping(unittest.TestCase):
             if arg.device_tile_advance_expr is not None:
                 arg.device_tile_advance_expr = sympy.floor(64 * out)
         symbols: list[int] = []
-        sdsc_json, _, _, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
+        sdsc_json, _, _, _ = compile_op_spec(0, op_spec, symbols)
         found_backgap = False
         for entry in sdsc_json.values():
             for dsc in entry.get("dscs_", []):
@@ -2923,7 +2914,6 @@ class TestCompileOpSpecSymbolMapping(unittest.TestCase):
                 symbols,
                 symbol_id_offset=0,
                 tiled_symbols=[[minted]],
-                use_symbols=True,
             )
 
     def test_tiled_on_split_dim_detects_floor_wrapped_minted_symbol(self):
@@ -2992,7 +2982,6 @@ class TestCompileOpSpecSymbolMapping(unittest.TestCase):
                 symbols,
                 symbol_id_offset=0,
                 tiled_symbols=[[minted]],
-                use_symbols=True,
             )
 
     def test_minted_symbol_tiled_on_different_dim_does_not_raise_unsupported(self):
@@ -3063,7 +3052,6 @@ class TestCompileOpSpecSymbolMapping(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[[minted]],
-            use_symbols=True,
         )
 
 
@@ -3444,7 +3432,6 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
                 "test_kernel",
                 self.tmpdir,
                 specs,
-                use_symbols=True,
             )
         return _read_mlir(self.tmpdir)
 
@@ -3452,7 +3439,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
         s = self._s
         stride = 16384
 
-        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000)
             # affine_strides: list[list[dict]] — one tensor, one level, one stride.
@@ -3473,7 +3460,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
         self.assertIn('"symbol_ids"=[-1]', mlir)
 
     def test_non_tiled_tensor_in_loop_no_affine_apply(self):
-        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x2000)
             return _make_tiled_json(idx, sym_id), [0x2000], [[{}]], []
@@ -3491,7 +3478,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
         s = self._s
         stride = 8192
 
-        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x3000)
             return _make_tiled_json(idx, sym_id), [0x3000], [[{s: stride}]], []
@@ -3508,7 +3495,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
     def test_affine_apply_inside_scf_for(self):
         s = self._s
 
-        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x4000)
             return _make_tiled_json(idx, sym_id), [0x4000], [[{s: 512}]], []
@@ -3527,7 +3514,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
     def test_tiled_snapshot(self):
         s = self._s
 
-        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000)
             return _make_tiled_json(idx, sym_id), [0x1000], [[{s: 256}]], []
@@ -3591,7 +3578,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
             tiled_symbol_trip_counts={c0: 128},
         )
         loop = LoopSpec(count=Integer(4), body=[op])
-        generate_bundle("test_kernel", self.tmpdir, [loop], use_symbols=True)
+        generate_bundle("test_kernel", self.tmpdir, [loop])
         mlir = _read_mlir(self.tmpdir)
 
         expected = (
@@ -3634,14 +3621,13 @@ class TestGenerateBundleNestedTiling(unittest.TestCase):
                 "test_kernel",
                 self.tmpdir,
                 specs,
-                use_symbols=True,
             )
         return _read_mlir(self.tmpdir)
 
     def _fake_compile_two_strides(self, outer_stride, inner_stride):
         s0, s1 = self.s0, self.s1
 
-        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000)
             # per_level_strides: outermost-first. Level 0 (outer) has s0 stride,
@@ -3741,7 +3727,6 @@ class TestGenerateBundleAffineLoopPath(unittest.TestCase):
                 "test_kernel",
                 self.tmpdir,
                 specs,
-                use_symbols=True,
             )
         return _read_mlir(self.tmpdir)
 
@@ -3750,7 +3735,7 @@ class TestGenerateBundleAffineLoopPath(unittest.TestCase):
     def test_flat_loop_tiled_tensor_emits_affine_apply(self):
         s = self._s
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000)
             # One tensor, one level (the enclosing loop), one stride.
@@ -3765,7 +3750,7 @@ class TestGenerateBundleAffineLoopPath(unittest.TestCase):
         self.assertIn("256", mlir)
 
     def test_flat_loop_non_tiled_tensor_no_affine_apply(self):
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x2000)
             return _make_tiled_json(idx, sym_id), [0x2000], [[{}]], []
@@ -3781,7 +3766,7 @@ class TestGenerateBundleAffineLoopPath(unittest.TestCase):
     def test_flat_loop_snapshot(self):
         s = self._s
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000)
             return _make_tiled_json(idx, sym_id), [0x1000], [[{s: 256}]], []
@@ -3825,7 +3810,7 @@ class TestGenerateBundleAffineLoopPath(unittest.TestCase):
         c_k = self._c_k
         call_count = [0]
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             i = call_count[0]
             call_count[0] += 1
             sym_id = -(symbol_id_offset + 1)
@@ -3926,7 +3911,7 @@ class TestGenerateBundleAffineLoopPath(unittest.TestCase):
         c_k, c_b = self._c_k, self._c_b
         call_count = [0]
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             i = call_count[0]
             call_count[0] += 1
             sym_id = -(symbol_id_offset + 1)
@@ -4064,7 +4049,7 @@ class TestGenerateBundleAffineLoopPath(unittest.TestCase):
                 }
             }
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             sid0 = -(symbol_id_offset + 1)
             sid1 = -(symbol_id_offset + 2)
             symbols.append(0x1000)
@@ -5831,7 +5816,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
 
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
-    def _bundle(self, specs, use_symbols=False, fake_compile=None):
+    def _bundle(self, specs, fake_compile=None):
         if fake_compile is None:
             fake_compile = _fake_compile_op_spec
         with patch(
@@ -5842,7 +5827,6 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 "test_kernel",
                 self.tmpdir,
                 specs,
-                use_symbols=use_symbols,
             )
         return _read_mlir(self.tmpdir)
 
@@ -5868,15 +5852,10 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
             op_info={},
         )
 
-    def test_signature_accepts_symbolic_args_param(self):
-        a = _make_minimal_op_spec("a")
-        mlir = self._bundle([a], use_symbols=False)
-        self.assertIn("sdsc_execute", mlir)
-
     def test_func_signature_has_params_for_tensor_args(self):
         a = self._make_op_spec_with_hbm_args("a", [0, 1])
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             for i, arg in enumerate(op_spec.args):
                 symbols.append(arg.allocation["hbm"])
             ids = [-(symbol_id_offset + i + 1) for i in range(len(op_spec.args))]
@@ -5907,7 +5886,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 [SymbolKind.kernel(arg.arg_index) for arg in op_spec.args],
             )
 
-        mlir = self._bundle([a], use_symbols=True, fake_compile=fake)
+        mlir = self._bundle([a], fake_compile=fake)
 
         self.assertIn(
             "func.func @sdsc_bundle("
@@ -5931,7 +5910,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
     def test_sdsc_execute_uses_extracted_names(self):
         a = self._make_op_spec_with_hbm_args("a", [0])
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(op_spec.args[0].allocation["hbm"])
             return (
@@ -5941,7 +5920,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 [SymbolKind.kernel(0)],
             )
 
-        mlir = self._bundle([a], use_symbols=True, fake_compile=fake)
+        mlir = self._bundle([a], fake_compile=fake)
 
         self.assertIn("sdscbundle.sdsc_execute (%arg_0)", mlir)
         self.assertNotIn("sdsc_execute (%sym_0_1)", mlir)
@@ -5970,7 +5949,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         call_count = [0]
         values = [0x400000000, 0x0]
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             i = call_count[0]
             call_count[0] += 1
             sym_id = -(symbol_id_offset + 1)
@@ -5980,7 +5959,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
             )  # op_b has pool allocation
             return _make_tiled_json(idx, sym_id), [values[i]], [{}], [kind]
 
-        mlir = self._bundle([op_a, op_b], use_symbols=True, fake_compile=fake)
+        mlir = self._bundle([op_a, op_b], fake_compile=fake)
 
         # First sym → parameter (kernel tensor arg)
         self.assertIn("%arg_0_base_addr: !sdscbundle.input_arg<index>", mlir)
@@ -5988,16 +5967,6 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         # Second sym → pool: arith.addi %pool, <offset>
         self.assertIn("%pool_base_addr: !sdscbundle.input_arg<index>", mlir)
         self.assertIn("%pool_addr_0 = arith.addi %pool", mlir)
-
-    def test_symbolic_args_false_no_params(self):
-        a = self._make_op_spec_with_hbm_args("a", [0])
-        # When use_symbols=False: no symbols registered,
-        # sdsc_execute has no operands.
-        mlir = self._bundle([a], use_symbols=False)
-        self.assertIn("func.func @sdsc_bundle()", mlir)
-        self.assertNotIn("input_arg", mlir)
-        self.assertNotIn("%sym_", mlir)
-        self.assertIn("sdsc_execute () {sdsc_filename=", mlir)
 
     def test_multi_sdsc_two_tensor_args_snapshot(self):
         """Two tensor args shared across multiple SDSCs emit exactly two input_arg params.
@@ -6019,7 +5988,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
             (0x400040000, 0x800040000),
         ]
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             i = call_count[0]
             call_count[0] += 1
             a0, a1 = sdsc_addr_pairs[i]
@@ -6050,7 +6019,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
             kinds = [SymbolKind.kernel(0), SymbolKind.kernel(1)]
             return json_out, [a0, a1], [{}, {}], kinds
 
-        mlir = self._bundle([op0] + ops_rest, use_symbols=True, fake_compile=fake)
+        mlir = self._bundle([op0] + ops_rest, fake_compile=fake)
 
         # 10 symbols across 5 SDSCs but only 2 unique arg_indices → 2 params
         self.assertIn("%arg_0_base_addr: !sdscbundle.input_arg<index>", mlir)
@@ -6068,13 +6037,13 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         base = 0x400000000  # SEGMENT_OFFSETS[1], arg_index=0
         call_count = [0]
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             call_count[0] += 1
             sym_id = -(symbol_id_offset + 1)
             symbols.append(base)
             return _make_tiled_json(idx, sym_id), [base], [{}], [SymbolKind.kernel(0)]
 
-        mlir = self._bundle([a, b], use_symbols=True, fake_compile=fake)
+        mlir = self._bundle([a, b], fake_compile=fake)
 
         # Only one input_arg param (deduped cross-SDSC)
         self.assertIn("%arg_0_base_addr: !sdscbundle.input_arg<index>", mlir)
@@ -6098,7 +6067,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         addrs = [addr0, addr1]
         call_count = [0]
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             i = call_count[0]
             call_count[0] += 1
             sym_id = -(symbol_id_offset + 1)
@@ -6110,7 +6079,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 [SymbolKind.kernel(0)],
             )
 
-        mlir = self._bundle([a, b], use_symbols=True, fake_compile=fake)
+        mlir = self._bundle([a, b], fake_compile=fake)
 
         # Only one input_arg param — no duplicate %arg_0_base_addr
         self.assertEqual(
@@ -6134,7 +6103,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         call_count = [0]
         pool_values = [0, 2048, 0]
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             i = call_count[0]
             call_count[0] += 1
             sym_id = -(symbol_id_offset + 1)
@@ -6146,7 +6115,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 [SymbolKind.pool()],
             )
 
-        mlir = self._bundle([a, b, c], use_symbols=True, fake_compile=fake)
+        mlir = self._bundle([a, b, c], fake_compile=fake)
 
         # Exactly two arith.constant / arith.addi pairs (offsets 0 and 2048)
         self.assertEqual(mlir.count("arith.constant 0 : index"), 1)
@@ -6246,7 +6215,6 @@ class TestSymbolKind(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[[s]],
-            use_symbols=True,
         )
         self.assertEqual(len(kinds), 2)
         self.assertIsInstance(kinds[0], SymbolKind)
@@ -6264,7 +6232,7 @@ class TestSymbolKind(unittest.TestCase):
 
         call_count = [0]
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             i = call_count[0]
             call_count[0] += 1
             base = 0x400000000
@@ -6291,7 +6259,6 @@ class TestSymbolKind(unittest.TestCase):
                 "test_kernel",
                 self.tmpdir,
                 [a, b],
-                use_symbols=True,
             )
         mlir = _read_mlir(self.tmpdir)
 

--- a/tests/inductor/test_codegen.py
+++ b/tests/inductor/test_codegen.py
@@ -683,7 +683,7 @@ class TestGenerateSdscSymbolicPerCoreAddresses(InductorTestCase):
     def test_per_core_symbolic_addresses_emitted(self):
         op_spec = self._make_symbolic_op_spec()
         sdsc_json, _, _, symbol_kinds = compile_op_spec(
-            idx=0, op_spec=op_spec, symbols=[], use_symbols=True
+            idx=0, op_spec=op_spec, symbols=[]
         )
 
         top = next(iter(sdsc_json.values()))
@@ -744,9 +744,7 @@ class TestGenerateSdscSymbolicPerCoreAddresses(InductorTestCase):
         # in the SDSC's local range, before any address symbol. A future change
         # that inverts this would silently shift bundle.mlir operand positions.
         op_spec = self._make_symbolic_op_spec()
-        _, _, _, symbol_kinds = compile_op_spec(
-            idx=0, op_spec=op_spec, symbols=[], use_symbols=True
-        )
+        _, _, _, symbol_kinds = compile_op_spec(idx=0, op_spec=op_spec, symbols=[])
         first_address = next(
             i for i, sk in enumerate(symbol_kinds) if not sk.is_dimension
         )

--- a/tests/inductor/test_log_op_specs.py
+++ b/tests/inductor/test_log_op_specs.py
@@ -283,7 +283,6 @@ class TestBundleLogging:
                         kernel_name="test_kernel",
                         output_dir="/tmp/test",
                         specs=[op],
-                        use_symbols=False,
                     )
 
                 info_calls = mock_info.call_args_list

--- a/tests/inductor/test_symbolic_dim_bundle.py
+++ b/tests/inductor/test_symbolic_dim_bundle.py
@@ -153,7 +153,7 @@ class TestGenerateBundleDimensionSymbols(InductorTestCase):
         with open(os.path.join(self.output_dir, "bundle.mlir")) as f:
             return f.read()
 
-    def _run_bundle(self, compiled_entries, op_specs=None, use_symbols=False):
+    def _run_bundle(self, compiled_entries, op_specs=None):
         """Run generate_bundle with mocked compile_op_spec, return bundle.mlir text."""
         if op_specs is None:
             op_specs = [_minimal_op_spec() for _ in compiled_entries]
@@ -167,12 +167,11 @@ class TestGenerateBundleDimensionSymbols(InductorTestCase):
                 "test",
                 self.output_dir,
                 op_specs,
-                use_symbols=use_symbols,
             )
         return self._read_bundle()
 
     def test_single_dim_sym_function_signature(self):
-        """Dimension symbol produces an input_arg param even when use_symbols=False."""
+        """Dimension symbol always produces an input_arg param."""
         dim_kind = SymbolKind.dimension(granularity=56, max_value=616, pytorch_sym="s0")
         entry = (_make_sdsc_json(dim_sym_ids={"mb": [-1]}), [0], [], [dim_kind])
 
@@ -264,8 +263,7 @@ class TestGenerateBundleDimensionSymbols(InductorTestCase):
     def test_dimension_and_kernel_address_combination(self):
         """A dimension symbol and a kernel-address symbol coexist in one bundle.
 
-        Both kinds must appear side by side, in the correct param/operand order,
-        when use_symbols=True and a dimension symbol is also present.
+        Both kinds must appear side by side, in the correct param/operand order.
         """
         dim_kind = SymbolKind.dimension(granularity=56, max_value=616, pytorch_sym="s0")
         kernel_kind = SymbolKind.kernel(arg_index=0)
@@ -279,7 +277,7 @@ class TestGenerateBundleDimensionSymbols(InductorTestCase):
             [dim_kind, kernel_kind],
         )
 
-        bundle = self._run_bundle([entry], use_symbols=True)
+        bundle = self._run_bundle([entry])
 
         # Kernel-address param comes before the dimension param in the signature.
         self.assertIn(

--- a/tests/test_launch_jobplan.py
+++ b/tests/test_launch_jobplan.py
@@ -25,11 +25,10 @@ import torch
 import torch._dynamo
 import torch_spyre
 
-from torch_spyre._inductor import config as _spyre_config
 from test_prepare_kernel import TestPrepareKernel as tpk
 
 
-def _run_compiled_op(op_name: str, symbolic_args: bool) -> None:
+def _run_compiled_op(op_name: str) -> None:
     """
     Compile an op with SpyreCode and run it on Spyre, comparing to CPU.
 
@@ -56,21 +55,9 @@ def _run_compiled_op(op_name: str, symbolic_args: bool) -> None:
 
     cpu_result = op_fn(*inputs)
 
-    old_sym = os.environ.get("BUNDLE_SYMBOLIC_ARGS")
-    try:
-        # Keep the C++ prepare_kernel env var in sync with the Python config
-        # patch: prepare_kernel reads BUNDLE_SYMBOLIC_ARGS directly from the
-        # process environment, so patching only the Python config is insufficient.
-        os.environ["BUNDLE_SYMBOLIC_ARGS"] = "1" if symbolic_args else "0"
-        with _spyre_config.patch(bundle_symbolic_args=symbolic_args):  # type: ignore[attr-defined]
-            compiled_fn = torch.compile(op_fn, backend="inductor")
-            spyre_inputs = tuple(inp.to("spyre") for inp in inputs)
-            spyre_result = compiled_fn(*spyre_inputs).cpu()
-    finally:
-        if old_sym is None:
-            os.environ.pop("BUNDLE_SYMBOLIC_ARGS", None)
-        else:
-            os.environ["BUNDLE_SYMBOLIC_ARGS"] = old_sym
+    compiled_fn = torch.compile(op_fn, backend="inductor")
+    spyre_inputs = tuple(inp.to("spyre") for inp in inputs)
+    spyre_result = compiled_fn(*spyre_inputs).cpu()
 
     torch.testing.assert_close(
         spyre_result, cpu_result, atol=0.1, rtol=0.1, equal_nan=True
@@ -78,29 +65,13 @@ def _run_compiled_op(op_name: str, symbolic_args: bool) -> None:
 
 
 class TestLaunchJobPlan(TestCase):
-    """Test suite for JobPlan-backed compiled op execution.
+    """Test suite for JobPlan-backed compiled op execution."""
 
-    Each op is exercised twice: once with symbolic_args=True (the default since
-    BUNDLE_SYMBOLIC_ARGS=1 was made the process default) and once with
-    symbolic_args=False (the non-default override path, retained as a regression
-    guard for users who explicitly disable symbolic args).
-    """
+    def test_abs_matches_cpu(self):
+        _run_compiled_op("abs")
 
-    def test_abs_matches_cpu_no_symbols(self):
-        """abs with symbolic_args=False (non-default override path)."""
-        _run_compiled_op("abs", symbolic_args=False)
-
-    def test_abs_matches_cpu_with_symbols(self):
-        """abs with symbolic_args=True (default path)."""
-        _run_compiled_op("abs", symbolic_args=True)
-
-    def test_mul_matches_cpu_no_symbols(self):
-        """mul with symbolic_args=False (non-default override path)."""
-        _run_compiled_op("mul", symbolic_args=False)
-
-    def test_mul_matches_cpu_with_symbols(self):
-        """mul with symbolic_args=True (default path)."""
-        _run_compiled_op("mul", symbolic_args=True)
+    def test_mul_matches_cpu(self):
+        _run_compiled_op("mul")
 
     def test_invalid_hcm_metadata_surfaces_on_synchronize(self):
         """Host callback failures should surface as RuntimeError on stream synchronize."""
@@ -185,7 +156,7 @@ def _build_d2h_jobplan(tmpdir: str, dev_ptr: int, size_bytes: int):
     with open(os.path.join(spyrecode_dir, "init_binary.bin"), "wb") as f:
         f.write(b"\x00" * 1024)
 
-    return torch_spyre._C.prepare_kernel(spyrecode_dir)
+    return torch_spyre._C.prepare_kernel(spyrecode_dir)  # type: ignore[attr-defined]
 
 
 class TestD2HFromTensorSegment(TestCase):

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import sympy
 
+from torch_spyre._inductor import config as _spyre_config
 from torch_spyre._inductor.codegen.compute_ops import SymbolKind
 from torch_spyre._inductor.codegen.superdsc import compile_op_spec
 from torch_spyre._inductor.op_spec import LoopSpec, OpSpec, format_op_spec_list
@@ -66,7 +67,24 @@ def generate_bundle(
     constants) in ``bundle.mlir``. Dimension symbols (from ``mark_dynamic``)
     always produce
     ``!sdscbundle.input_arg<index, granularity=G, max_value=M>`` parameters.
+
+    Requires ``config.bundle_symbolic_args`` to be True: the SDSC path
+    (this function) unconditionally emits symbolic addresses, but
+    ``spyre_kernel.py``/``hbm_pool_planning.py`` still bake absolute
+    addresses into tensor allocations when the flag is False (reserved for
+    the KTIR emitter path, which is gated separately). Running this
+    function with the flag off would silently miscompile addresses rather
+    than error, so it's rejected up front instead.
     """
+    if not _spyre_config.bundle_symbolic_args:
+        raise AssertionError(
+            "generate_bundle() requires config.bundle_symbolic_args=True "
+            "(BUNDLE_SYMBOLIC_ARGS=1). The SDSC bundle path always emits "
+            "symbolic HBM addresses; baked absolute addresses "
+            "(bundle_symbolic_args=False) are only supported on the KTIR "
+            "emitter path (config.ktir_emitter=True)."
+        )
+
     specs_list: list = list(specs)
 
     if logger.isEnabledFor(logging.INFO):

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -20,7 +20,6 @@ from typing import Any
 
 import sympy
 
-from torch_spyre._inductor import config as _spyre_config
 from torch_spyre._inductor.codegen.compute_ops import SymbolKind
 from torch_spyre._inductor.codegen.superdsc import compile_op_spec
 from torch_spyre._inductor.op_spec import LoopSpec, OpSpec, format_op_spec_list
@@ -57,25 +56,17 @@ def generate_bundle(
     kernel_name: str,
     output_dir: str,
     specs: Sequence,
-    use_symbols: bool | None = None,
 ):
     """Output the SDSC Bundle for the OpSpecs in output_dir.
 
     ``specs`` is a list of ``OpSpec | LoopSpec`` entries (nested ``LoopSpec``
     entries are supported).
 
-    ``use_symbols`` controls whether HBM tensor addresses are emitted as
-    runtime symbols (``%sym_N`` constants) in ``bundle.mlir``.
-    When ``None`` (the default) the value is
-    read from ``config.bundle_symbolic_args``.
-
-     Dimension symbols (from ``mark_dynamic``) always produce
-    ``!sdscbundle.input_arg<index, granularity=G, max_value=M>`` parameters
-    independent of ``use_symbols``.
+    HBM tensor addresses are emitted as runtime symbols (``%sym_N``
+    constants) in ``bundle.mlir``. Dimension symbols (from ``mark_dynamic``)
+    always produce
+    ``!sdscbundle.input_arg<index, granularity=G, max_value=M>`` parameters.
     """
-    if use_symbols is None:
-        use_symbols = _spyre_config.bundle_symbolic_args
-
     specs_list: list = list(specs)
 
     if logger.isEnabledFor(logging.INFO):
@@ -102,7 +93,6 @@ def generate_bundle(
         sdsc_counter,
         symbol_id_offset_counter,
         output_dir,
-        use_symbols=use_symbols,
     )
 
     # -----------------------------------------------------------------------
@@ -147,15 +137,10 @@ def generate_bundle(
                     sdsc_idx,
                     local_dim_ordinal,
                 )
-            elif not use_symbols:
-                raise AssertionError(
-                    "use_symbols=False but compute_op_spec registered a "
-                    f"non-dimension SymbolKind ({lk.kind!r}); address-symbol."
-                )
             symbol_kinds.append(lk)
 
     # Determine whether a pool parameter is needed (any pool symbol present).
-    has_pool = use_symbols and any(sk.is_pool for sk in symbol_kinds)
+    has_pool = any(sk.is_pool for sk in symbol_kinds)
     # Indices of kernel-base symbols that become input_arg parameters.
     # Deduplicated by arg_index: multiple SDSCs operating on different slices of
     # the same logical tensor arg share one function parameter (the first-seen
@@ -166,22 +151,21 @@ def generate_bundle(
     # kernel_dup_canonical: maps duplicate kernel sym_idx → canonical sym_idx.
     kernel_arg_sym_indices: list[int] = []
     kernel_dup_canonical: dict[int, int] = {}  # duplicate sym_idx → canonical sym_idx
-    if use_symbols:
-        seen_kernel_arg_index: dict[int, int] = {}  # arg_index → canonical sym_idx
-        for i, kind_i in enumerate(symbol_kinds):
-            if kind_i.kind == "kernel":
-                ai = kind_i.arg_index
-                if ai not in seen_kernel_arg_index:
-                    seen_kernel_arg_index[ai] = i
-                    kernel_arg_sym_indices.append(i)
-                else:
-                    kernel_dup_canonical[i] = seen_kernel_arg_index[ai]
-        # Sort by arg_index so the function signature matches the positional order
-        # that call_kernel passes tensors to .run().
-        kernel_arg_sym_indices.sort(key=lambda idx: symbol_kinds[idx].arg_index)
+    seen_kernel_arg_index: dict[int, int] = {}  # arg_index → canonical sym_idx
+    for i, kind_i in enumerate(symbol_kinds):
+        if kind_i.kind == "kernel":
+            ai = kind_i.arg_index
+            if ai not in seen_kernel_arg_index:
+                seen_kernel_arg_index[ai] = i
+                kernel_arg_sym_indices.append(i)
+            else:
+                kernel_dup_canonical[i] = seen_kernel_arg_index[ai]
+    # Sort by arg_index so the function signature matches the positional order
+    # that call_kernel passes tensors to .run().
+    kernel_arg_sym_indices.sort(key=lambda idx: symbol_kinds[idx].arg_index)
 
     # Deduplicate dimension symbols by pytorch_sym (same shape var may appear
-    # in every SDSC with a different local ID). Runs regardless of use_symbols.
+    # in every SDSC with a different local ID).
     dimension_sym_indices: list[int] = []
     dimension_dup_canonical: dict[int, int] = {}  # dup sym_idx → canonical sym_idx
     seen_dim_sym: dict[str, int] = {}  # pytorch_sym → canonical sym_idx
@@ -218,13 +202,10 @@ def generate_bundle(
 
         # Function signature:
         #   - optional leading %pool_base_addr param for pool-allocated tensors
-        #     (only when use_symbols=True)
         #   - one !sdscbundle.input_arg<index> param per kernel tensor arg
-        #     (only when use_symbols=True)
         #   - one !sdscbundle.input_arg<index, granularity=G, max_value=M> param
         #     per unique dynamic-shape (mark_dynamic) symbol; emitted whenever
-        #     present, independent of use_symbols (which only governs the
-        #     pool/kernel-address params above).
+        #     present.
         if has_pool or kernel_arg_sym_indices or dimension_sym_indices:
             params = []
             if has_pool:
@@ -266,7 +247,7 @@ def generate_bundle(
             for lb_idx, lb in enumerate(loop_bounds):
                 f.write(f"\t\t%loop_bound_{lb_idx} = {_mlir_count_value(lb)}\n")
 
-        # Emit one declaration per symbol (use_symbols path):
+        # Emit one declaration per symbol:
         #   - "kernel"          → skipped; already a function param + extract op above
         #   - "kernel_slice"    → arith.addi %arg_{arg_index}, <slice_offset_bytes>
         #                         deduped by (arg_index, slice_offset) pair;
@@ -397,7 +378,6 @@ def generate_bundle(
             [],
             f,
             indent=2,
-            use_symbols=use_symbols,
             kernel_sym_to_arg_idx=kernel_sym_to_arg_idx,
             sym_canonical=sym_canonical,
         )
@@ -419,7 +399,6 @@ def _compile_specs(
     sdsc_counter: list,
     symbol_id_offset_counter: list,
     output_dir: str,
-    use_symbols: bool = False,
 ) -> None:
     """Recursively compile all OpSpecs in specs depth-first."""
     for entry in specs:
@@ -431,7 +410,6 @@ def _compile_specs(
                 sdsc_counter,
                 symbol_id_offset_counter,
                 output_dir,
-                use_symbols=use_symbols,
             )
         elif isinstance(entry, OpSpec):
             idx = sdsc_counter[0]
@@ -442,7 +420,6 @@ def _compile_specs(
                     entry,
                     symbols,
                     symbol_id_offset_counter[0],
-                    use_symbols=use_symbols,
                 )
             )
             symbol_id_offset_counter[0] += len(local_sym_values)
@@ -571,7 +548,6 @@ def _emit_specs(
     loop_vars: list,
     f,
     indent: int,
-    use_symbols: bool = False,
     kernel_sym_to_arg_idx: dict | None = None,
     sym_canonical: dict | None = None,
 ) -> None:
@@ -617,7 +593,6 @@ def _emit_specs(
                 loop_vars + [loop_var],
                 f,
                 indent + 1,
-                use_symbols=use_symbols,
                 kernel_sym_to_arg_idx=kernel_sym_to_arg_idx,
                 sym_canonical=sym_canonical,
             )

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -977,7 +977,7 @@ def generate_sdsc(
         # detects directly.
         per_level_strides: list[dict] = []
         any_tiled = False
-        for level_idx, level_syms in enumerate(tiled_symbols):
+        for level_syms in tiled_symbols:
             tensor_tiled_at_level = [
                 s for s in level_syms if _tensor_tiled_by_symbol(tensor, s)
             ]

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -643,32 +643,25 @@ def generate_sdsc(
     symbols: list[int],
     symbol_id_offset: int = 0,
     tiled_symbols=None,
-    use_symbols: bool = False,
 ):
     """Generate SDSC JSON for one OpSpec.
 
     Returns a 4-tuple ``(sdsc_json, base_symbol_values, affine_strides, symbol_kinds)``:
     - ``sdsc_json``: the JSON dict to write to ``sdsc_N.json``
-    - ``base_symbol_values``: list of HBM byte offsets registered in ``symbols``;
-      empty when ``use_symbols=False``
+    - ``base_symbol_values``: list of HBM byte offsets registered in ``symbols``
     - ``affine_strides``: list (parallel to ``sdsc_spec.args``) of per-level
       stride lists.  Each element is a list of dicts, one per loop-nesting level
       (outermost first), where each dict maps ``tiled_sym -> stride_bytes`` for
-      that level's tiled symbols.  Always ``[[]] * len(sdsc_spec.args)`` when
-      ``use_symbols=False``.  Used by ``bundle.py`` to emit ``affine.apply`` ops
-      inside ``scf.for`` loops, with one stride per level mapped to the correct
-      loop variable.
-    - ``symbol_kinds``: list of ``SymbolKind`` parallel to ``base_symbol_values``;
-      empty when ``use_symbols=False``.  Classifies each symbol as a kernel base
-      address, per-core derived address, or pool-allocated address.
+      that level's tiled symbols.  Used by ``bundle.py`` to emit ``affine.apply``
+      ops inside ``scf.for`` loops, with one stride per level mapped to the
+      correct loop variable.
+    - ``symbol_kinds``: list of ``SymbolKind`` parallel to ``base_symbol_values``.
+      Classifies each symbol as a kernel base address, per-core derived
+      address, or pool-allocated address.
 
-    When ``use_symbols=False``, HBM tensor addresses are baked directly as
-    concrete integers into the SDSC JSON.  No symbol IDs are registered and
-    ``symbols`` is not modified.
-
-    When ``use_symbols=True``, HBM addresses are registered as negative symbol
-    IDs in the JSON and their values appended to ``symbols``, enabling
-    ``affine.apply`` address computation in ``bundle.mlir`` for tiled loops.
+    HBM addresses are registered as negative symbol IDs in the JSON and their
+    values appended to ``symbols``, enabling ``affine.apply`` address
+    computation in ``bundle.mlir`` for tiled loops.
 
     ``tensor.device_tile_advance_expr``: each tensor's own device-element-
     offset ``sympy.Expr | None``, symbolic in the real Inductor iteration
@@ -755,355 +748,251 @@ def generate_sdsc(
             arg_index=arg_index,
         )
 
-    if use_symbols:
+    def offset_as_symbol(s, kind: SymbolKind):
+        key: tuple | int
+        if kind.is_pool:
+            key = ("pool", s)
+        elif kind.kind == "kernel":
+            key = ("kernel", kind.arg_index)
+        elif kind.kind == "kernel_slice":
+            key = ("kernel_slice", kind.arg_index, kind.offset)
+        elif kind.is_derived_symbolic:
+            # Per-core symbolic address: key by (tensor, core) so every
+            # (arg_index, core_idx) is a distinct registration and never
+            # collides with a concrete kernel_derived key (a bare int addr).
+            key = ("kernel_derived_symbolic", kind.arg_index, kind.core_idx)
+        else:
+            # kernel_derived: s is a large per-core HBM byte address,
+            # distinct from pool offsets and sentinel values.
+            key = s
+        if key not in local_symbols:
+            # Address symbols start after dim symbols in the ID counter.
+            local_symbols[key] = -(
+                symbol_id_offset + n_dim_syms + len(local_symbols) + 1
+            )
+            symbols.append(s)
+            local_symbol_kind.append(kind)
+        return local_symbols[key]
 
-        def offset_as_symbol(s, kind: SymbolKind):
-            key: tuple | int
-            if kind.is_pool:
-                key = ("pool", s)
-            elif kind.kind == "kernel":
-                key = ("kernel", kind.arg_index)
-            elif kind.kind == "kernel_slice":
-                key = ("kernel_slice", kind.arg_index, kind.offset)
-            elif kind.is_derived_symbolic:
-                # Per-core symbolic address: key by (tensor, core) so every
-                # (arg_index, core_idx) is a distinct registration and never
-                # collides with a concrete kernel_derived key (a bare int addr).
-                key = ("kernel_derived_symbolic", kind.arg_index, kind.core_idx)
-            else:
-                # kernel_derived: s is a large per-core HBM byte address,
-                # distinct from pool offsets and sentinel values.
-                key = s
-            if key not in local_symbols:
-                # Address symbols start after dim symbols in the ID counter.
-                local_symbols[key] = -(
-                    symbol_id_offset + n_dim_syms + len(local_symbols) + 1
+    def _register_per_core_derived(
+        tensor,
+        c: int,
+        addr: int,
+        core0_addr: int,
+        sliced_base_sym_idx: int,
+        symbolic_split: tuple[str, int, str] | None,
+    ) -> None:
+        """Register the c>0 derived address for a kernel tensor.
+
+        Routes to ``kernel_derived_symbolic`` when the tensor is split on a
+        symbolic dim (the byte offset depends on the runtime dim size and is
+        resolved by a later bundle arm), otherwise the concrete
+        ``kernel_derived`` path.  ``addr`` is the compile-time (max-shape)
+        address, used for the concrete path and as the symbols[] placeholder
+        value for the symbolic path.
+        """
+        if symbolic_split is not None:
+            _sdsc_dim_name, split_count, pytorch_sym = symbolic_split
+            # TODO:  only TAG the per-core address as symbolic. The
+            # runtime arith (core * ceildiv(S, split) * per_element_stride)
+            # and the per-element stride it needs are the bundle-arm
+            # follow-up, so nothing stride-related is computed here.
+            offset_as_symbol(
+                addr,
+                SymbolKind.kernel_derived_symbolic(
+                    arg_index=tensor.arg_index,
+                    core_idx=c,
+                    split_count=split_count,
+                    base_sym_idx=sliced_base_sym_idx,
+                    pytorch_sym=pytorch_sym,
+                ),
+            )
+        else:
+            offset_as_symbol(
+                addr,
+                _derived_kind(tensor.arg_index, core0_addr, addr, sliced_base_sym_idx),
+            )
+
+    # Compute per-tensor, per-level affine strides and register base addresses.
+    # affine_strides[i] is a list of dicts, one per loop-nesting level
+    # (outermost first), where each dict maps tiled_sym -> stride_bytes for
+    # the symbols at that level that advance tensor i.  Empty list of dicts
+    # (i.e. [{}] * n_levels or []) for non-tiled tensors.
+    affine_strides: list[list[dict]] = []
+    for tensor in sdsc_spec.args:
+        if "lx" in tensor.allocation:
+            # LX addresses are never registered as symbols in the SDSC JSON
+            # (isStartAddrSymbolic_ is always unset for lx, and bundle.py's
+            # _get_tensor_core_sym_id returns None for non-hbm components), so
+            # affine.apply can never target an LX address today. A tiled
+            # (advancing) lx tensor therefore has no way to express its
+            # per-iteration address change in this preserved-loop path.
+            # A non-advancing reference has no term in
+            # device_tile_advance_expr, which _tensor_tiled_by_symbol
+            # already detects directly.
+            is_tiled_lx = any(
+                _tensor_tiled_by_symbol(tensor, s)
+                for level_syms in tiled_symbols
+                for s in level_syms
+            )
+            if is_tiled_lx:
+                raise NotImplementedError(
+                    "Tiled (advancing) lx-allocated tensors are not yet supported."
                 )
-                symbols.append(s)
-                local_symbol_kind.append(kind)
-            return local_symbols[key]
-
-        def _register_per_core_derived(
-            tensor,
-            c: int,
-            addr: int,
-            core0_addr: int,
-            sliced_base_sym_idx: int,
-            symbolic_split: tuple[str, int, str] | None,
-        ) -> None:
-            """Register the c>0 derived address for a kernel tensor.
-
-            Routes to ``kernel_derived_symbolic`` when the tensor is split on a
-            symbolic dim (the byte offset depends on the runtime dim size and is
-            resolved by a later bundle arm), otherwise the concrete
-            ``kernel_derived`` path.  ``addr`` is the compile-time (max-shape)
-            address, used for the concrete path and as the symbols[] placeholder
-            value for the symbolic path.
-            """
-            if symbolic_split is not None:
-                _sdsc_dim_name, split_count, pytorch_sym = symbolic_split
-                # TODO:  only TAG the per-core address as symbolic. The
-                # runtime arith (core * ceildiv(S, split) * per_element_stride)
-                # and the per-element stride it needs are the bundle-arm
-                # follow-up, so nothing stride-related is computed here.
-                offset_as_symbol(
-                    addr,
-                    SymbolKind.kernel_derived_symbolic(
-                        arg_index=tensor.arg_index,
-                        core_idx=c,
-                        split_count=split_count,
-                        base_sym_idx=sliced_base_sym_idx,
-                        pytorch_sym=pytorch_sym,
-                    ),
-                )
-            else:
-                offset_as_symbol(
-                    addr,
-                    _derived_kind(
-                        tensor.arg_index, core0_addr, addr, sliced_base_sym_idx
-                    ),
-                )
-
-        # Compute per-tensor, per-level affine strides and register base addresses.
-        # affine_strides[i] is a list of dicts, one per loop-nesting level
-        # (outermost first), where each dict maps tiled_sym -> stride_bytes for
-        # the symbols at that level that advance tensor i.  Empty list of dicts
-        # (i.e. [{}] * n_levels or []) for non-tiled tensors.
-        affine_strides: list[list[dict]] = []
-        for tensor in sdsc_spec.args:
-            if "lx" in tensor.allocation:
-                # LX addresses are never registered as symbols in the SDSC JSON
-                # (isStartAddrSymbolic_ is always unset for lx, and bundle.py's
-                # _get_tensor_core_sym_id returns None for non-hbm components), so
-                # affine.apply can never target an LX address today. A tiled
-                # (advancing) lx tensor therefore has no way to express its
-                # per-iteration address change in this preserved-loop path.
-                # A non-advancing reference has no term in
-                # device_tile_advance_expr, which _tensor_tiled_by_symbol
-                # already detects directly.
-                is_tiled_lx = any(
-                    _tensor_tiled_by_symbol(tensor, s)
+            affine_strides.append([{} for _ in tiled_symbols])
+            continue
+        nb = num_bytes(tensor.data_format)
+        slice_offset_bytes = sum(tensor.offsets.values()) * nb
+        # core0_addr: compile-time address for core 0 including the tensor's
+        # slice offset (device_coordinate constant terms, e.g. z0+3 → 3 rows).
+        core0_addr = (
+            tensor.start_address
+            + core_idx_to_slice_offset(
+                tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
+            )
+            * nb
+        )
+        # Per-core symbolic split: cores 1..n-1 of a kernel tensor split on a
+        # symbolic dim get kernel_derived_symbolic addresses (byte offset
+        # depends on the runtime dim size).  A symbolic-split dim that is ALSO
+        # tiled for this tensor is out of scope: the per-core address would
+        # need both a symbolic term and an affine.apply term.
+        symbolic_split = _symbolic_split_info(
+            tensor, sdsc_spec.work_slices, symbolic_dims
+        )
+        if symbolic_split is not None:
+            sym_dim_name = symbolic_split[0]
+            sym_dim = Symbol(sym_dim_name)
+            # Real-symbol fast path: s IS the dim symbol (already renamed
+            # to its SDSC dim label by symbol_mapping), so name equality
+            # against sym_dim_name is a correct, direct test.
+            #
+            # Minted-symbol path (spyre_kernel._get_or_mint_level_symbol):
+            # a minted symbol names a loop-nesting *level*, not a
+            # dimension -- _general_tile_advance (spyre_kernel.py) sums
+            # every host dim tiled at a level into ONE combined
+            # coefficient on that level's minted symbol before this
+            # tensor's device_tile_advance_expr is ever built, so by the
+            # time we get here there is no way to recover, from a
+            # nonzero coeff(minted_sym) alone, *which* of this tensor's
+            # active dims that coefficient came from (see fix-loop
+            # round-1 review: a tensor with two active dims, tiled only
+            # on one of them, previously false-positived on the other
+            # merely because it was also active and the tensor advanced
+            # via *some* dim).
+            #
+            # Absent that per-dimension provenance, the only sound test
+            # (no false positives) is: flag `sym_dim_name` only when it
+            # is this tensor's *sole* active (non-reduced) dim -- then a
+            # nonzero combined coefficient cannot be attributed to any
+            # other dim, because there is no other dim. This is a
+            # deliberate narrowing versus "any tiling at all, on any
+            # dim" -- it can under-detect (miss a real conflict on a
+            # tensor with 2+ active dims where sym_dim_name genuinely is
+            # the tiled one) but never over-detects, which is the
+            # correctness-critical direction for a False positive to
+            # avoid: it would otherwise reject support for supported
+            # ops using this check.
+            active_dims = [d for d in tensor.strides if tensor.scales.get(d, 1) > 0]
+            tensor_advances_at_some_level = (
+                tensor.device_tile_advance_expr is not None
+                and any(
+                    coeff_through_floor(tensor.device_tile_advance_expr, s)
                     for level_syms in tiled_symbols
                     for s in level_syms
                 )
-                if is_tiled_lx:
-                    raise NotImplementedError(
-                        "Tiled (advancing) lx-allocated tensors are not yet supported."
-                    )
-                affine_strides.append([{} for _ in tiled_symbols])
-                continue
-            nb = num_bytes(tensor.data_format)
-            slice_offset_bytes = sum(tensor.offsets.values()) * nb
-            # core0_addr: compile-time address for core 0 including the tensor's
-            # slice offset (device_coordinate constant terms, e.g. z0+3 → 3 rows).
-            core0_addr = (
-                tensor.start_address
-                + core_idx_to_slice_offset(
-                    tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
-                )
-                * nb
             )
-            # Per-core symbolic split: cores 1..n-1 of a kernel tensor split on a
-            # symbolic dim get kernel_derived_symbolic addresses (byte offset
-            # depends on the runtime dim size).  A symbolic-split dim that is ALSO
-            # tiled for this tensor is out of scope: the per-core address would
-            # need both a symbolic term and an affine.apply term.
-            symbolic_split = _symbolic_split_info(
-                tensor, sdsc_spec.work_slices, symbolic_dims
+            tiled_on_split_dim = any(
+                str(s) == sym_dim_name
+                for level_syms in tiled_symbols
+                for s in level_syms
+                if s in tensor.strides
+            ) or (
+                sym_dim in tensor.strides
+                and tensor.scales.get(sym_dim, 1) > 0
+                and active_dims == [sym_dim]
+                and tensor_advances_at_some_level
             )
-            if symbolic_split is not None:
-                sym_dim_name = symbolic_split[0]
-                sym_dim = Symbol(sym_dim_name)
-                # Real-symbol fast path: s IS the dim symbol (already renamed
-                # to its SDSC dim label by symbol_mapping), so name equality
-                # against sym_dim_name is a correct, direct test.
-                #
-                # Minted-symbol path (spyre_kernel._get_or_mint_level_symbol):
-                # a minted symbol names a loop-nesting *level*, not a
-                # dimension -- _general_tile_advance (spyre_kernel.py) sums
-                # every host dim tiled at a level into ONE combined
-                # coefficient on that level's minted symbol before this
-                # tensor's device_tile_advance_expr is ever built, so by the
-                # time we get here there is no way to recover, from a
-                # nonzero coeff(minted_sym) alone, *which* of this tensor's
-                # active dims that coefficient came from (see fix-loop
-                # round-1 review: a tensor with two active dims, tiled only
-                # on one of them, previously false-positived on the other
-                # merely because it was also active and the tensor advanced
-                # via *some* dim).
-                #
-                # Absent that per-dimension provenance, the only sound test
-                # (no false positives) is: flag `sym_dim_name` only when it
-                # is this tensor's *sole* active (non-reduced) dim -- then a
-                # nonzero combined coefficient cannot be attributed to any
-                # other dim, because there is no other dim. This is a
-                # deliberate narrowing versus "any tiling at all, on any
-                # dim" -- it can under-detect (miss a real conflict on a
-                # tensor with 2+ active dims where sym_dim_name genuinely is
-                # the tiled one) but never over-detects, which is the
-                # correctness-critical direction for a False positive to
-                # avoid: it would otherwise reject support for supported
-                # ops using this check.
-                active_dims = [d for d in tensor.strides if tensor.scales.get(d, 1) > 0]
-                tensor_advances_at_some_level = (
-                    tensor.device_tile_advance_expr is not None
-                    and any(
-                        coeff_through_floor(tensor.device_tile_advance_expr, s)
-                        for level_syms in tiled_symbols
-                        for s in level_syms
-                    )
+            if tiled_on_split_dim:
+                raise Unsupported(
+                    f"Symbolic dim '{sym_dim_name}' is both split across "
+                    f"cores and tiled on the tensor at arg_index="
+                    f"{tensor.arg_index}; per-core symbolic addresses inside "
+                    "tiled loops are not supported."
                 )
-                tiled_on_split_dim = any(
-                    str(s) == sym_dim_name
-                    for level_syms in tiled_symbols
-                    for s in level_syms
-                    if s in tensor.strides
-                ) or (
-                    sym_dim in tensor.strides
-                    and tensor.scales.get(sym_dim, 1) > 0
-                    and active_dims == [sym_dim]
-                    and tensor_advances_at_some_level
-                )
-                if tiled_on_split_dim:
-                    raise Unsupported(
-                        f"Symbolic dim '{sym_dim_name}' is both split across "
-                        f"cores and tiled on the tensor at arg_index="
-                        f"{tensor.arg_index}; per-core symbolic addresses inside "
-                        "tiled loops are not supported."
-                    )
-            if tensor.arg_index >= 0:
-                # Kernel tensors: register the raw base address first so bundle.py
-                # can emit the input_arg function parameter.
-                #
-                # On the symbolic path, tensor.start_address = arg_index + tile_offset_bytes,
-                # where tile_offset_bytes is the per-tile byte advance computed for the
-                # affine-stride path.  We always register the raw kernel symbol keyed by
-                # arg_index so that bundle.py emits exactly one !sdscbundle.input_arg
-                # parameter per logical tensor, regardless of how many tiles reference it.
-                raw_base = tensor.arg_index  # sentinel value for this arg
+        if tensor.arg_index >= 0:
+            # Kernel tensors: register the raw base address first so bundle.py
+            # can emit the input_arg function parameter.
+            #
+            # On the symbolic path, tensor.start_address = arg_index + tile_offset_bytes,
+            # where tile_offset_bytes is the per-tile byte advance computed for the
+            # affine-stride path.  We always register the raw kernel symbol keyed by
+            # arg_index so that bundle.py emits exactly one !sdscbundle.input_arg
+            # parameter per logical tensor, regardless of how many tiles reference it.
+            raw_base = tensor.arg_index  # sentinel value for this arg
+            offset_as_symbol(raw_base, SymbolKind.kernel(arg_index=tensor.arg_index))
+            # Derive the 0-based symbols[] index of the kernel symbol from its
+            # registered ID.  Must be looked up (not inferred from current
+            # len(local_symbols)) because the same arg_index may have been
+            # registered already by an earlier tensor in this SDSC, in which case
+            # the offset_as_symbol call above was a no-op.
+            kernel_sym_idx = abs(local_symbols[("kernel", tensor.arg_index)]) - 1
+            # tile_offset_bytes: arg.allocation['hbm'] advances by i*stride for
+            # tile i, so start_address = arg_index + tile_offset. tile_offset_bytes
+            # == 0 for tile 0, positive for later tiles.
+            tile_offset_bytes = tensor.start_address - tensor.arg_index
+            # total_slice_offset: combine the per-tile byte offset with any
+            # device-coordinate compile-time slice offset (e.g. from z0+3 expressions).
+            # This is the total compile-time offset above the raw %arg_N base that the
+            # sliced-base SSA value represents in bundle.mlir.
+            total_slice_offset = tile_offset_bytes + slice_offset_bytes
+            # sliced_base_sym_idx: the symbols[] index that per-core derived symbols
+            # reference.  When total_slice_offset == 0 the kernel sym IS the sliced
+            # base; otherwise a kernel_slice sym is registered for the combined offset.
+            if total_slice_offset > 0:
                 offset_as_symbol(
-                    raw_base, SymbolKind.kernel(arg_index=tensor.arg_index)
+                    core0_addr,
+                    SymbolKind.kernel_slice(
+                        arg_index=tensor.arg_index, offset=total_slice_offset
+                    ),
                 )
-                # Derive the 0-based symbols[] index of the kernel symbol from its
-                # registered ID.  Must be looked up (not inferred from current
-                # len(local_symbols)) because the same arg_index may have been
-                # registered already by an earlier tensor in this SDSC, in which case
-                # the offset_as_symbol call above was a no-op.
-                kernel_sym_idx = abs(local_symbols[("kernel", tensor.arg_index)]) - 1
-                # tile_offset_bytes: arg.allocation['hbm'] advances by i*stride for
-                # tile i, so start_address = arg_index + tile_offset. tile_offset_bytes
-                # == 0 for tile 0, positive for later tiles.
-                tile_offset_bytes = tensor.start_address - tensor.arg_index
-                # total_slice_offset: combine the per-tile byte offset with any
-                # device-coordinate compile-time slice offset (e.g. from z0+3 expressions).
-                # This is the total compile-time offset above the raw %arg_N base that the
-                # sliced-base SSA value represents in bundle.mlir.
-                total_slice_offset = tile_offset_bytes + slice_offset_bytes
-                # sliced_base_sym_idx: the symbols[] index that per-core derived symbols
-                # reference.  When total_slice_offset == 0 the kernel sym IS the sliced
-                # base; otherwise a kernel_slice sym is registered for the combined offset.
-                if total_slice_offset > 0:
-                    offset_as_symbol(
-                        core0_addr,
-                        SymbolKind.kernel_slice(
-                            arg_index=tensor.arg_index, offset=total_slice_offset
-                        ),
-                    )
-                    slice_key = ("kernel_slice", tensor.arg_index, total_slice_offset)
-                    sliced_base_sym_idx = abs(local_symbols[slice_key]) - 1
-                else:
-                    sliced_base_sym_idx = kernel_sym_idx
+                slice_key = ("kernel_slice", tensor.arg_index, total_slice_offset)
+                sliced_base_sym_idx = abs(local_symbols[slice_key]) - 1
             else:
-                # Pool tensor: no raw-base or slice symbol needed.
-                sliced_base_sym_idx = -1
-            # Build per-level strides: for each level, collect the symbols at that
-            # level that tile this tensor (see _tensor_tiled_by_symbol -- a nonzero
-            # coeff on tensor.device_tile_advance_expr, with real dimension symbols
-            # additionally required to have a positive scale).
-            # Exclude symbols whose scale is negative: those are reduced dimensions
-            # whose stride describes element layout within one tile, not the advance
-            # between tiles.  Tiling by a reduction-dim symbol would incorrectly
-            # advance the base address of a pool output past its single allocated slot.
-            # A tile-local scratch tensor reused every iteration (see unroll.py)
-            # never advances either -- it simply has no term in
-            # device_tile_advance_expr, which _tensor_tiled_by_symbol already
-            # detects directly.
-            per_level_strides: list[dict] = []
-            any_tiled = False
-            for level_idx, level_syms in enumerate(tiled_symbols):
-                tensor_tiled_at_level = [
-                    s for s in level_syms if _tensor_tiled_by_symbol(tensor, s)
-                ]
-                strides_for_level: dict = {}
-                for s in tensor_tiled_at_level:
-                    coeff = (
-                        coeff_through_floor(tensor.device_tile_advance_expr, s)
-                        if tensor.device_tile_advance_expr is not None
-                        else 0
-                    )
-                    strides_for_level[s] = int(coeff) * nb
-                    any_tiled = True
-                per_level_strides.append(strides_for_level)
-            if not any_tiled:
-                # Non-tiled HBM: register per-core addresses.
-                for c in range(sdsc_spec.num_cores):
-                    addr = (
-                        tensor.start_address
-                        + core_idx_to_slice_offset(
-                            tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
-                        )
-                        * nb
-                    )
-                    if c == 0:
-                        if tensor.arg_index < 0:
-                            offset_as_symbol(addr, SymbolKind.pool())
-                        # kernel / kernel_slice already registered above; skip c==0
-                    else:
-                        if tensor.arg_index < 0:
-                            offset_as_symbol(addr, SymbolKind.pool())
-                        elif addr != core0_addr:
-                            # Only register a derived symbol when the core has a
-                            # distinct address from core 0.  When addr == core0_addr
-                            # (e.g. a non-split tensor where all cores share one
-                            # address) the sliced-base symbol already covers it and
-                            # we must not create a duplicate registration.
-                            _register_per_core_derived(
-                                tensor,
-                                c,
-                                addr,
-                                core0_addr,
-                                sliced_base_sym_idx,
-                                symbolic_split,
-                            )
-                affine_strides.append([{} for _ in tiled_symbols])
-            else:
-                # Tiled HBM: symbol value = per-core iter-0 base address.
-                # The affine map adds loop_var * tile_stride on top at runtime.
-                for c in range(sdsc_spec.num_cores):
-                    addr = (
-                        tensor.start_address
-                        + core_idx_to_slice_offset(
-                            tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
-                        )
-                        * nb
-                    )
-                    if c == 0:
-                        if tensor.arg_index < 0:
-                            offset_as_symbol(addr, SymbolKind.pool())
-                        # kernel / kernel_slice already registered above; skip c==0
-                    else:
-                        if tensor.arg_index < 0:
-                            offset_as_symbol(addr, SymbolKind.pool())
-                        elif addr != core0_addr:
-                            # Symbolic split on a non-tiled dim combined with
-                            # tiling on another dim still routes through the
-                            # helper; the split==tiled case is rejected above.
-                            _register_per_core_derived(
-                                tensor,
-                                c,
-                                addr,
-                                core0_addr,
-                                sliced_base_sym_idx,
-                                symbolic_split,
-                            )
-                affine_strides.append(per_level_strides)
-
-        def _start_addr_data(tensor):
-            # All per-core addresses were already registered by the per-tensor loop
-            # above. Look them up using the same key scheme as offset_as_symbol.
-            if "lx" in tensor.allocation:
-                return {
-                    f"[{c}, 0, 0]": str(tensor.start_address)
-                    for c in range(sdsc_spec.num_cores)
-                }
-            nb = num_bytes(tensor.data_format)
-            is_pool_tensor = tensor.arg_index < 0 and "hbm_pool" in tensor.allocation
-            # Recompute the symbolic-split status so c>0 cores resolve to the
-            # ("kernel_derived_symbolic", arg_index, core_idx) key the per-tensor
-            # loop registered.  Pure function of the tensor + work_slices, so this
-            # matches the registration decision exactly.
-            symbolic_split = _symbolic_split_info(
-                tensor, sdsc_spec.work_slices, symbolic_dims
-            )
-            # Hoist kernel-tensor compile-time offsets so they are not
-            # duplicated across the c==0 and c>0 branches.
-            if not is_pool_tensor:
-                slice_offset_bytes = sum(tensor.offsets.values()) * nb
-                tile_offset_bytes = tensor.start_address - tensor.arg_index
-                total_slice_offset = tile_offset_bytes + slice_offset_bytes
-                c0_slice_key: tuple | int = (
-                    ("kernel_slice", tensor.arg_index, total_slice_offset)
-                    if total_slice_offset > 0
-                    else ("kernel", tensor.arg_index)
+                sliced_base_sym_idx = kernel_sym_idx
+        else:
+            # Pool tensor: no raw-base or slice symbol needed.
+            sliced_base_sym_idx = -1
+        # Build per-level strides: for each level, collect the symbols at that
+        # level that tile this tensor (see _tensor_tiled_by_symbol -- a nonzero
+        # coeff on tensor.device_tile_advance_expr, with real dimension symbols
+        # additionally required to have a positive scale).
+        # Exclude symbols whose scale is negative: those are reduced dimensions
+        # whose stride describes element layout within one tile, not the advance
+        # between tiles.  Tiling by a reduction-dim symbol would incorrectly
+        # advance the base address of a pool output past its single allocated slot.
+        # A tile-local scratch tensor reused every iteration (see unroll.py)
+        # never advances either -- it simply has no term in
+        # device_tile_advance_expr, which _tensor_tiled_by_symbol already
+        # detects directly.
+        per_level_strides: list[dict] = []
+        any_tiled = False
+        for level_idx, level_syms in enumerate(tiled_symbols):
+            tensor_tiled_at_level = [
+                s for s in level_syms if _tensor_tiled_by_symbol(tensor, s)
+            ]
+            strides_for_level: dict = {}
+            for s in tensor_tiled_at_level:
+                coeff = (
+                    coeff_through_floor(tensor.device_tile_advance_expr, s)
+                    if tensor.device_tile_advance_expr is not None
+                    else 0
                 )
-                core0_addr_lookup = (
-                    tensor.start_address
-                    + core_idx_to_slice_offset(
-                        tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
-                    )
-                    * nb
-                )
-            result = {}
+                strides_for_level[s] = int(coeff) * nb
+                any_tiled = True
+            per_level_strides.append(strides_for_level)
+        if not any_tiled:
+            # Non-tiled HBM: register per-core addresses.
             for c in range(sdsc_spec.num_cores):
                 addr = (
                     tensor.start_address
@@ -1112,45 +1001,121 @@ def generate_sdsc(
                     )
                     * nb
                 )
-                if is_pool_tensor:
-                    key: tuple | int = ("pool", addr)
-                elif c == 0:
-                    key = c0_slice_key
-                elif addr == core0_addr_lookup:
-                    # Non-split tensor: all cores share core 0's address, so no
-                    # derived symbol was registered, reuse the sliced-base key.
-                    key = c0_slice_key
-                elif symbolic_split is not None:
-                    # Symbolic-dim split: c>0 registered a kernel_derived_symbolic
-                    # symbol keyed by (tensor, core).
-                    key = ("kernel_derived_symbolic", tensor.arg_index, c)
+                if c == 0:
+                    if tensor.arg_index < 0:
+                        offset_as_symbol(addr, SymbolKind.pool())
+                    # kernel / kernel_slice already registered above; skip c==0
                 else:
-                    # c>0 concrete per-core derived address (bare int key).
-                    key = addr
-                result[f"[{c}, 0, 0]"] = str(local_symbols[key])
-            return result
-
-    else:
-        # use_symbols=False: bake concrete HBM addresses directly into the JSON.
-        # symbols and local_symbols are not modified.
-        affine_strides = [[{} for _ in tiled_symbols] for _ in sdsc_spec.args]
-
-        def _start_addr_data(tensor):
-            if "lx" in tensor.allocation:
-                return {
-                    f"[{c}, 0, 0]": str(tensor.start_address)
-                    for c in range(sdsc_spec.num_cores)
-                }
-            return {
-                f"[{c}, 0, 0]": str(
+                    if tensor.arg_index < 0:
+                        offset_as_symbol(addr, SymbolKind.pool())
+                    elif addr != core0_addr:
+                        # Only register a derived symbol when the core has a
+                        # distinct address from core 0.  When addr == core0_addr
+                        # (e.g. a non-split tensor where all cores share one
+                        # address) the sliced-base symbol already covers it and
+                        # we must not create a duplicate registration.
+                        _register_per_core_derived(
+                            tensor,
+                            c,
+                            addr,
+                            core0_addr,
+                            sliced_base_sym_idx,
+                            symbolic_split,
+                        )
+            affine_strides.append([{} for _ in tiled_symbols])
+        else:
+            # Tiled HBM: symbol value = per-core iter-0 base address.
+            # The affine map adds loop_var * tile_stride on top at runtime.
+            for c in range(sdsc_spec.num_cores):
+                addr = (
                     tensor.start_address
                     + core_idx_to_slice_offset(
                         tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
                     )
-                    * num_bytes(tensor.data_format)
+                    * nb
                 )
+                if c == 0:
+                    if tensor.arg_index < 0:
+                        offset_as_symbol(addr, SymbolKind.pool())
+                    # kernel / kernel_slice already registered above; skip c==0
+                else:
+                    if tensor.arg_index < 0:
+                        offset_as_symbol(addr, SymbolKind.pool())
+                    elif addr != core0_addr:
+                        # Symbolic split on a non-tiled dim combined with
+                        # tiling on another dim still routes through the
+                        # helper; the split==tiled case is rejected above.
+                        _register_per_core_derived(
+                            tensor,
+                            c,
+                            addr,
+                            core0_addr,
+                            sliced_base_sym_idx,
+                            symbolic_split,
+                        )
+            affine_strides.append(per_level_strides)
+
+    def _start_addr_data(tensor):
+        # All per-core addresses were already registered by the per-tensor loop
+        # above. Look them up using the same key scheme as offset_as_symbol.
+        if "lx" in tensor.allocation:
+            return {
+                f"[{c}, 0, 0]": str(tensor.start_address)
                 for c in range(sdsc_spec.num_cores)
             }
+        nb = num_bytes(tensor.data_format)
+        is_pool_tensor = tensor.arg_index < 0 and "hbm_pool" in tensor.allocation
+        # Recompute the symbolic-split status so c>0 cores resolve to the
+        # ("kernel_derived_symbolic", arg_index, core_idx) key the per-tensor
+        # loop registered.  Pure function of the tensor + work_slices, so this
+        # matches the registration decision exactly.
+        symbolic_split = _symbolic_split_info(
+            tensor, sdsc_spec.work_slices, symbolic_dims
+        )
+        # Hoist kernel-tensor compile-time offsets so they are not
+        # duplicated across the c==0 and c>0 branches.
+        if not is_pool_tensor:
+            slice_offset_bytes = sum(tensor.offsets.values()) * nb
+            tile_offset_bytes = tensor.start_address - tensor.arg_index
+            total_slice_offset = tile_offset_bytes + slice_offset_bytes
+            c0_slice_key: tuple | int = (
+                ("kernel_slice", tensor.arg_index, total_slice_offset)
+                if total_slice_offset > 0
+                else ("kernel", tensor.arg_index)
+            )
+            core0_addr_lookup = (
+                tensor.start_address
+                + core_idx_to_slice_offset(
+                    tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
+                )
+                * nb
+            )
+        result = {}
+        for c in range(sdsc_spec.num_cores):
+            addr = (
+                tensor.start_address
+                + core_idx_to_slice_offset(
+                    tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
+                )
+                * nb
+            )
+            if is_pool_tensor:
+                key: tuple | int = ("pool", addr)
+            elif c == 0:
+                key = c0_slice_key
+            elif addr == core0_addr_lookup:
+                # Non-split tensor: all cores share core 0's address, so no
+                # derived symbol was registered, reuse the sliced-base key.
+                key = c0_slice_key
+            elif symbolic_split is not None:
+                # Symbolic-dim split: c>0 registered a kernel_derived_symbolic
+                # symbol keyed by (tensor, core).
+                key = ("kernel_derived_symbolic", tensor.arg_index, c)
+            else:
+                # c>0 concrete per-core derived address (bare int key).
+                key = addr
+            result[f"[{c}, 0, 0]"] = str(local_symbols[key])
+        return result
 
     def _build_coord_info(op, tensor, tensor_idx: int) -> dict:
         """Builds the coordinate information for all dimensions of a tensor.
@@ -1494,7 +1459,7 @@ def generate_sdsc(
                                     ),
                                     **(
                                         {"isStartAddrSymbolic_": 1}
-                                        if use_symbols and "lx" not in tensor.allocation
+                                        if "lx" not in tensor.allocation
                                         else {}
                                     ),
                                     "layoutDimOrder_": [

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -2035,7 +2035,6 @@ def compile_op_spec(
     op_spec: OpSpec,
     symbols: list[int],
     symbol_id_offset: int = 0,
-    use_symbols: bool = False,
 ) -> tuple[Any, list[int], list[list[dict]], list[SymbolKind]]:
     sdsc_spec, symbol_mapping = parse_op_spec(op_spec)
     logger.debug("%s", sdsc_spec)
@@ -2052,6 +2051,5 @@ def compile_op_spec(
         symbols,
         symbol_id_offset,
         tiled_symbols=tiled_symbols_per_level,
-        use_symbols=use_symbols,
     )
     return result

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -130,8 +130,9 @@ disable_copy_opt: bool = os.environ.get("DISABLE_COPY_OPT", "0") == "1"
 # When True (default), HBM tensor addresses are emitted as runtime symbols
 # with !sdscbundle.input_arg<index> parameters and input_arg_extract ops
 # in the bundle.mlir.
-# When False, HBM tensor addresses are baked as concrete integers
-# into the SDSC JSON and bundle.mlir emits sdsc_execute with no operands.
+# When False, HBM tensor addresses are baked as concrete integers.
+# (SDSC path always symbolic as of #3741; baked mode only via the KTIR
+# emitter, i.e. also requires ktir_emitter=True / TORCH_SPYRE_KTIR=1.)
 bundle_symbolic_args: bool = os.environ.get("BUNDLE_SYMBOLIC_ARGS", "1") == "1"
 
 # Layout solver class used by default in scratchpad.allocator.ScratchpadAllocator.


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Eliminates the `use_symbols` parameter from `generate_bundle()` in
`bundle.py` and its downstream plumbing, pinning behavior to always emit
HBM addresses as runtime symbols (the `use_symbols=True` path). The
`use_symbols=False` path — baking concrete HBM addresses directly into
`bundle.mlir` as `arith.constant`s — has been dead in production for a
while (the default has already been `True`); it was only ever exercised
by tests passing `use_symbols=False` explicitly.

Changes:

- `bundle.py`: removed the `use_symbols` parameter from
  `generate_bundle()`, `_compile_specs()`, and `_emit_specs()`, along with
  the dead `config.bundle_symbolic_args`-based default resolution and the
  now-unconditional invariant check. Dropped the unused `_spyre_config`
  import.
- `superdsc.py`: removed `use_symbols` from `compile_op_spec()`.
- `compute_ops.py`: removed `use_symbols` from `generate_sdsc()` and
  deleted the entire baked-address `else` branch (~370 lines), unindenting
  the symbolic-addressing implementation as the sole remaining path.
- Updated all test call sites and stub signatures across
  `test_coarse_tiling.py`, `test_codegen.py`, `test_log_op_specs.py`, and
  `test_symbolic_dim_bundle.py` to drop the `use_symbols` kwarg/param.
- Deleted `test_symbolic_args_false_no_params`, which asserted the
  baked-address/no-params behavior that no longer exists.
- Removed `test_signature_accepts_symbolic_args_param` (renamed in an
  earlier pass to `test_bundle_emits_sdsc_execute`), which had become a
  vacuous subset of `test_func_signature_has_params_for_tensor_args` and
  every other test in the same class.
- `tests/test_launch_jobplan.py`: removed `test_abs_matches_cpu_no_symbols`
  and `test_mul_matches_cpu_no_symbols`. These drove
  `config.bundle_symbolic_args=False` through the default (non-ktir) SDSC
  codegen path — i.e. through `bundle.py`'s now-deleted baked-address
  branch — so with that branch gone they became exact duplicates of the
  `_with_symbols` variants. Also simplified `_run_compiled_op` by dropping
  the `symbolic_args` parameter and the env-var/config-patch scaffolding
  that existed only to drive that now-dead branch.

**Out of scope**: `config.bundle_symbolic_args` (`BUNDLE_SYMBOLIC_ARGS`
env var) is a separate, similarly-named global flag consumed independently
by `ktir.py`, `spyre_kernel.py`, `hbm_pool_planning.py`, `fusion.py`, and
`async_compile.py`. It is untouched by this PR — including
`TestD2HFromTensorSegment`'s `_prepare_with_symbolic_args` fixture in
`test_launch_jobplan.py`, which patches the config flag directly to drive
the C++ `prepare_kernel` path and is unrelated to `bundle.py`'s parameter.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#3100

#### Special notes for your reviewer:

The `compute_ops.py` diff is large but mechanical: the `if use_symbols:`
body was dedented by 4 spaces and the `else:` branch was deleted, with no
logic changes to the symbolic-addressing path itself. The one non-mechanical
line change is in the `isStartAddrSymbolic_` field builder, where
`if use_symbols and "lx" not in tensor.allocation` became
`if "lx" not in tensor.allocation`.

`test_launch_jobplan.py` requires real Spyre hardware, so its changes were
verified via `pre-commit` (ruff + mypy) and manual review rather than a
local test run. Removing the import of `torch_spyre._inductor.config`
incidentally exposed a latent mypy gap on `torch_spyre._C.prepare_kernel`
in `_build_d2h_jobplan` (that import's side effect of resolving
`torch_spyre`'s package `__init__` was masking it) — fixed with an
explicit `# type: ignore[attr-defined]`, matching how other
`torch_spyre._C` accesses in the file are already annotated.

#### Does this PR introduce a user-facing change?

No. `use_symbols` was never exposed as a public/user-facing option — it
was always called with `use_symbols=True` (or omitted, defaulting to the
config flag which defaults to `True`) in production code paths.

#### Additional note:

Verified locally: `pre-commit run --all-files` clean, and
`test_coarse_tiling.py` (287 passed, 1 skipped), `test_symbolic_dim_bundle.py`
(11 passed), `test_codegen.py` (45 passed), `test_log_op_specs.py`
(13 passed), and `test_building_blocks.py` (11 passed) all pass. Final
`grep -rn "use_symbols" torch_spyre/ tests/` returns zero hits.