### PR TITLE
Add subagent test-dispatch guidance to inductor-overview skill

### DIFF
--- a/torch_spyre/_inductor/.claude/skills/inductor-overview/references/testing-conventions.md
+++ b/torch_spyre/_inductor/.claude/skills/inductor-overview/references/testing-conventions.md
@@ -10,6 +10,22 @@ Always run pytest as a single sequential process. Never use `-n`,
 `-n auto`, `pytest-xdist`, or any other parallel/distributed test runner
 for any suite in this repo — including in CI-adjacent local scripts.
 
+### Multi-agent/subagent dispatch
+
+The same constraint applies across processes, not just within one — so it
+binds subagent orchestration too. Never dispatch two subagents that both
+run pytest concurrently against Spyre; they'll contend for the device and
+one will fail or hang. When splitting `_inductor` work across subagents:
+
+- Parallelize investigation and code changes (reading passes, drafting
+  fixes) freely — that part doesn't touch the device.
+- Serialize test execution: either designate a single agent (or the
+  orchestrator) to run all tests after the others finish, or have each
+  agent return code changes only and run the combined suite yourself.
+- If a dispatched agent's tests fail with a device-acquisition error,
+  another process is holding the device — don't retry in parallel; rerun
+  sequentially.
+
 ## Local regression scope before pushing
 
 The full `tests/` suite is slow to run locally and CI already covers it in


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [x] documentation
- [ ] cleanup

#### What this PR does:

Extracts the multi-agent orchestration pattern from PR #2423 (never dispatch parallel test-running subagents against Spyre; parallelize investigation, serialize test execution) into the _inductor-scoped skill, since that PR is being abandoned but the pattern is worth keeping for the inductor squad. The base device-exclusivity fact was already documented here.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
