### PR TITLE
adopt fast compute

### DIFF
--- a/torch_spyre/csrc/job_plan.cpp
+++ b/torch_spyre/csrc/job_plan.cpp
@@ -18,6 +18,7 @@
 
 #include <iostream>
 #include <memory>
+#include <string>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -159,6 +160,7 @@ void JobPlanStepHostCompute::construct(LaunchContext& ctx,
   // Case 1: input_buffer_ is provided
   if (input_buffer_ != nullptr) {
     launch_host_callback([this](void*) {
+      // Use regular path - input_buffer_ is already properly formatted
       deeptools::processComputeOnHostCommand(*hcm_, output_buffer_,
                                              input_buffer_);
     });
@@ -170,6 +172,7 @@ void JobPlanStepHostCompute::construct(LaunchContext& ctx,
   // and it's {0}, it's for fake symbols
   if (ishape_.size() == 1 && ishape_[0] == 0) {
     launch_host_callback([this](void*) {
+      // Fake symbols don't need fast path - use regular path
       deeptools::processComputeOnHostCommand(*hcm_, output_buffer_, nullptr);
     });
     return;
@@ -187,7 +190,10 @@ void JobPlanStepHostCompute::construct(LaunchContext& ctx,
   }
 
   launch_host_callback([this, addresses](void*) {
-    deeptools::processComputeOnHostCommand(*hcm_, output_buffer_, &addresses);
+    // Use fast path with all tensor addresses
+    // Returns true if fast path was actually used, false if fell back
+    bool used_fast_path = deeptools::processComputeOnHostCommandFast(
+        fast_plan_, *hcm_, output_buffer_, addresses.data(), addresses.size());
   });
 }
 
@@ -195,6 +201,16 @@ void JobPlanStepHostCompute::write(std::ostream& os) const {
   os << "  Host Compute\n";
   os << "    Output buffer: " << output_buffer_ << "\n";
   os << "    HCM metadata: " << (hcm_ ? "present" : "null") << "\n";
+  os << "    Fast path: "
+     << (fast_plan_.valid
+             ? "enabled"
+             : (fast_plan_.output_size == UINT32_MAX ? "disabled" : "building"))
+     << "\n";
+  if (fast_plan_.valid) {
+    os << "    Fast plan: " << fast_plan_.patches.size() << " patches, "
+       << fast_plan_.num_input_symbols << " input symbols, "
+       << fast_plan_.output_size << " bytes output\n";
+  }
   os << "    Pipeline barrier: " << (pipeline_barrier_ ? "enabled" : "disabled")
      << "\n";
 }

--- a/torch_spyre/csrc/job_plan.h
+++ b/torch_spyre/csrc/job_plan.h
@@ -28,6 +28,7 @@
 #include <variant>
 #include <vector>
 
+#include "spyrecode-host-functions/fast_process_hcm.h"
 #include "spyrecode-host-functions/spyrecode.h"
 
 namespace spyre {
@@ -437,8 +438,17 @@ class JobPlanStepHostCompute final : public JobPlanStep {
       : hcm_(std::move(hcm)),
         output_buffer_(output_buffer),
         input_buffer_(input_buffer),
-        ishape_(ishape) {
+        ishape_(std::move(ishape)) {
     pipeline_barrier_ = false;  // host callbacks are overlap-eligible
+
+    // Try to build fast plan at construction time (prepare time)
+    if (hcm_) {
+      fast_plan_.valid = deeptools::buildFastHcmPatchPlan(fast_plan_, *hcm_);
+      if (!fast_plan_.valid) {
+        // Mark as permanently invalid so we don't retry
+        fast_plan_.output_size = UINT32_MAX;
+      }
+    }
   }
 
   void construct(LaunchContext& ctx, const SpyreStream& stream) const override;
@@ -450,6 +460,9 @@ class JobPlanStepHostCompute final : public JobPlanStep {
   void* output_buffer_;       // Non-owning pointer (JobPlan owns the buffer)
   const void* input_buffer_;  // Non-owning pointer (JobPlan owns the buffer)
   std::vector<int64_t> ishape_;
+
+  // Pre-compiled patch plan for fast execution
+  mutable deeptools::FastHcmPatchPlan fast_plan_;
 };
 
 /**


### PR DESCRIPTION

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Once PR 4548 in deeptools is approved, we can then adopt the fast-path for HostCompute which save greatly the time to run at each JobPlan invocation. 
