### PR TITLE
fix(test): Place input tensors onto CPU for reference output

### DIFF
--- a/tests/models/test_model_ops_v2.py
+++ b/tests/models/test_model_ops_v2.py
@@ -355,6 +355,9 @@ class TestSpyreModelOps(TestCase):
         device_replace_disabled: bool = bool(
             pytestconfig.getoption("--no-device-replace", default=False)
         )
+        assert not device_replace_disabled, (
+            "Tentatively, --no-device-replace option is disabled"
+        )
 
         method_name = self._testMethodName
         ops_item: OpsNamedItem = op.ops_item
@@ -408,7 +411,7 @@ class TestSpyreModelOps(TestCase):
         # Build CPU SampleInput — all construction delegated to spyre_test_config_models
         cpu_sample: SampleInput = ops_item.build_sample_input(
             seed=seed,
-            test_device=None if device_replace_disabled else test_device,
+            test_device="cpu",
             SampleInput=SampleInput,
         )
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

This PR resolves an inconsistency (described in #3717) in the results of op-level tests between v1 and v2. V2 currently generates reference output by using input tensors on Spyre. This PR places input tensors onto CPU for reference output.
Then, v2 can detect numerical errors on Spyre, and the results of v1 and v2 are consistent.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

Fixes #3717 

#### Special notes for your reviewer:

After applying PR,

v1
```
% pytest tests/models/test_model_ops.py --model Qwen2.5-7B-Instruct -s -v -rsapd -k "index_copy and Instruct_spyre"
...
==================================================================================================================================================================================================== short test summary info =====================================================================================================================================================================================================
SKIPPED [6] tests/models/test_model_ops.py:150: Filtered out by --model (selected=['Qwen2.5-7B-Instruct'])
FAILED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_index_copy__1_spyre__Qwen2_5-7B-Instruct_spyre_yaml__spyre_float16 - AssertionError: test_model_ops_db_torch_index_copy__1_spyre__Qwen2_5-7B-Instruct_spyre_yaml__spyre_float16 FAILED since output is not close to an expected result
FAILED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_index_copy__2_spyre__Qwen2_5-7B-Instruct_spyre_yaml__spyre_float16 - AssertionError: test_model_ops_db_torch_index_copy__2_spyre__Qwen2_5-7B-Instruct_spyre_yaml__spyre_float16 FAILED since output is not close to an expected result
FAILED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_index_copy__3_spyre__Qwen2_5-7B-Instruct_spyre_yaml__spyre_float16 - AssertionError: test_model_ops_db_torch_index_copy__3_spyre__Qwen2_5-7B-Instruct_spyre_yaml__spyre_float16 FAILED since output is not close to an expected result
=================================================================================================================================================================================== 3 failed, 6 skipped, 3557 deselected, 1 warning in 25.86s ====================================================================================================================================================================================
```

v2
```
% bash tests/run_test.sh tests/configs/model_ops_tests/Qwen2.5-7B-Instruct_spyre.yaml -s -v -rsapd -k index_copy
...
=========================== short test summary info ============================
XFAIL [TAGS = model__Qwen2.5-7B-Instruct_spyre dtype__float16 op__torch_index_copy platform__x86_64 testtype__trunk constant torch.index_copy_.2_spyre] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_index_copy___102_spyre_float16 - expected failure (OOT xfail): AssertionError: test_model_ops_db_torch_index_copy___102_spyre_float16 FAILED: output not close to reference Tensor-likes are not close! Mismatched elements: 1005 / 1048576 (0.1%) Greatest absolute difference: 0.9638671875 at index (0, 0, 479, 8) (up to 0.005 allowed) Greatest relative difference: 1...
XFAIL [TAGS = model__Qwen2.5-7B-Instruct_spyre dtype__float16 op__torch_index_copy platform__x86_64 testtype__trunk constant torch.index_copy_.3_spyre] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_index_copy___103_spyre_float16 - expected failure (OOT xfail): AssertionError: test_model_ops_db_torch_index_copy___103_spyre_float16 FAILED: output not close to reference Tensor-likes are not close! Mismatched elements: 1005 / 1048576 (0.1%) Greatest absolute difference: 0.9638671875 at index (0, 0, 479, 8) (up to 0.005 allowed) Greatest relative difference: 1...
XFAIL [TAGS = model__Qwen2.5-7B-Instruct_spyre dtype__float16 op__torch_index_copy platform__x86_64 testtype__trunk constant torch.index_copy_.1_spyre] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_index_copy___48_spyre_float16 - expected failure (OOT xfail): AssertionError: test_model_ops_db_torch_index_copy___48_spyre_float16 FAILED: output not close to reference Tensor-likes are not close! Mismatched elements: 39195 / 1048576 (3.7%) Greatest absolute difference: 0.998046875 at index (0, 0, 1647, 106) (up to 0.005 allowed) Greatest relative difference:...
================ 116 deselected, 3 xfailed, 1 warning in 19.24s ================

========================================================================
[torch_oot_device_tests_run] Per-file result summary:
========================================================================
  PASS      test_model_ops_v2.py                                  3 xfailed in 19.24s
========================================================================

[torch_oot_device_tests_run] Done. Overall exit code: 0
[torch_oot_device_tests_run] Cleaned up marker sidecar: /home/ishizaki/aiu-src/dt-inductor/torch-spyre/tests/configs/model_ops_tests/Qwen2.5-7B-Instruct_spyre.yaml.markers.json
```

#### Does this PR introduce a user-facing change?

#### Additional note:
