### PR TITLE
test(model-ops): fix v2 op-test correctness gaps and align with v1

### DIFF
--- a/tests/models/runner.py
+++ b/tests/models/runner.py
@@ -21,6 +21,9 @@ from torch.testing._internal.opinfo.core import (  # noqa: F401
     SampleInput,
 )
 
+from oot_framework.fallback_utils import assert_no_cpu_fallback, capture_cpu_fallbacks
+from oot_framework.tensor_layout_utils import apply_layout
+
 from .op_registry import OP_REGISTRY
 
 DTYPE_MAP = {
@@ -117,7 +120,10 @@ def make_tensor_from_conf(
         else:
             raise ValueError(f"Unknown init: {init}")
 
-    return t
+    # Honor the captured memory layout (stride/storage_offset) using the seeded
+    # values, so v1 exercises the same real, non-contiguous layouts as the v2
+    # framework instead of an always-contiguous tensor. See apply_layout.
+    return apply_layout(t, tconf.get("stride"), tconf.get("storage_offset", 0))
 
 
 def confirm_device(x: Any, expected_device: torch.device) -> bool:
@@ -352,19 +358,21 @@ def run_test(
         test_sample = adapter.pre(test_sample)
 
     # Run
-    with torch.no_grad():
-        ref_out = op(cpu_sample.input, *cpu_sample.args, **cpu_sample.kwargs)
-        test_out = _maybe_compile_call(
-            op,
-            test_sample,
-            device,
-            compile_backend,
-        )
+    fell_back: list = []
+    with capture_cpu_fallbacks(fell_back):
+        with torch.no_grad():
+            ref_out = op(cpu_sample.input, *cpu_sample.args, **cpu_sample.kwargs)
+            test_out = _maybe_compile_call(
+                op,
+                test_sample,
+                device,
+                compile_backend,
+            )
 
-        if adapter.is_inplace:
-            # compare mutated arg0
-            ref_out = cpu_sample.input
-            test_out = test_sample.input
+            if adapter.is_inplace:
+                # compare mutated arg0
+                ref_out = cpu_sample.input
+                test_out = test_sample.input
 
     ref_out_cpu = to_device(ref_out, torch.device("cpu"))
 
@@ -416,6 +424,11 @@ def run_test(
         )
     else:
         assert confirm_device(test_out, device), "this result must be on spyre"
+
+    # A silent CPU fallback means the op did not run on the device path this
+    # test claims to exercise; treat it as a failure before the numeric check
+    # (which would otherwise pass on the CPU result).
+    assert_no_cpu_fallback(case_name, fell_back)
 
     test_out_cpu = to_device(test_out, torch.device("cpu"))
     _assert_same(

--- a/tests/models/test_model_ops_v2.py
+++ b/tests/models/test_model_ops_v2.py
@@ -37,6 +37,7 @@ from oot_framework.oot_test_config_models import (
     OpsNamedItem,
     TestEntry,
 )
+from oot_framework.fallback_utils import assert_no_cpu_fallback, capture_cpu_fallbacks
 from oot_framework.oot_test_constants import ENV_TEST_CONFIG
 from oot_framework.oot_test_parsing import load_yaml_config, resolve_current_file
 from oot_framework.oot_test_utilities import (
@@ -405,8 +406,22 @@ class TestSpyreModelOps(TestCase):
             _dtype_prec.rtol if _dtype_prec and _dtype_prec.rtol is not None else 5e-3
         )
 
-        # Build CPU SampleInput — all construction delegated to spyre_test_config_models
+        # Reference sample, built on CPU: a true CPU baseline whose tensors are
+        # INDEPENDENT from the device tensors under test. Building the reference
+        # on-device would make test_sample alias it (``.to(device)`` on an
+        # already-on-device tensor returns the same object), so for in-place ops
+        # -- whose result IS the input -- ref_out and test_out would be the same
+        # buffer and the comparison would be a vacuous self-check. Built with the
+        # same seed as the device sample below, so their values match exactly.
         cpu_sample: SampleInput = ops_item.build_sample_input(
+            seed=seed,
+            test_device=None,
+            SampleInput=SampleInput,
+        )
+        # Device sample, built with test_device so device kwargs / device_layout
+        # resolve correctly; its tensors are placed on-device (layout-aware) by
+        # _to_target_device below to form test_sample.
+        device_sample: SampleInput = ops_item.build_sample_input(
             seed=seed,
             test_device=None if device_replace_disabled else test_device,
             SampleInput=SampleInput,
@@ -459,11 +474,11 @@ class TestSpyreModelOps(TestCase):
 
             return x
 
-        # Build test_sample with per-tensor layout awareness
+        # Build test_sample from the device sample, with per-tensor layout awareness
         test_args = []
         for i, (cpu_arg, spec_arg) in enumerate(
             zip(
-                [cpu_sample.input] + list(cpu_sample.args),
+                [device_sample.input] + list(device_sample.args),
                 ops_item.sample_inputs_func.args,
             )
         ):
@@ -478,10 +493,12 @@ class TestSpyreModelOps(TestCase):
                 # resolved_kwargs() will raise if one ever tries to. If that changes,
                 # this needs the same arg_spec-based layout lookup as _to_target_device
                 # uses for positional args above.
-                kwargs={k: _to_target_device(v) for k, v in cpu_sample.kwargs.items()},
+                kwargs={
+                    k: _to_target_device(v) for k, v in device_sample.kwargs.items()
+                },
             )
         else:
-            test_sample = cpu_sample.transform(lambda x: _to_target_device(x))
+            test_sample = device_sample.transform(lambda x: _to_target_device(x))
 
         # Adapter pre-hook (e.g. dropout sets training=False)
         if adapter.pre is not None:
@@ -490,13 +507,17 @@ class TestSpyreModelOps(TestCase):
 
         # Run
         fn = adapter.fn
+        fell_back: List[str] = []
         try:
-            with torch.no_grad():
-                ref_out = fn(cpu_sample.input, *cpu_sample.args, **cpu_sample.kwargs)
-                test_out = _run_op(fn, test_sample, test_device, compile_backend)
-                if adapter.is_inplace:
-                    ref_out = cpu_sample.input
-                    test_out = test_sample.input
+            with capture_cpu_fallbacks(fell_back):
+                with torch.no_grad():
+                    ref_out = fn(
+                        cpu_sample.input, *cpu_sample.args, **cpu_sample.kwargs
+                    )
+                    test_out = _run_op(fn, test_sample, test_device, compile_backend)
+                    if adapter.is_inplace:
+                        ref_out = cpu_sample.input
+                        test_out = test_sample.input
 
             expected_device = (
                 torch.device("cpu")
@@ -506,6 +527,11 @@ class TestSpyreModelOps(TestCase):
             assert _confirm_device(test_out, expected_device), (
                 f"Output must be on {expected_device}"
             )
+
+            # A silent CPU fallback means the op did not run on the device path
+            # this test claims to exercise; treat it as a failure before the
+            # numeric check (which would otherwise pass on the CPU result).
+            assert_no_cpu_fallback(method_name, fell_back)
 
             _assert_close(
                 self,

--- a/tests/oot_framework/fallback_utils.py
+++ b/tests/oot_framework/fallback_utils.py
@@ -1,0 +1,117 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Surface CPU fallbacks in the model-op test frameworks, and fail the ones
+that mask a device bug.
+
+When a compiled op runs on Spyre but hits a CPU fallback, the op test would
+otherwise pass on the CPU implementation -- not the device path it claims to
+exercise -- masking real backend bugs. We capture the ``FallbackWarning`` during
+the compiled run, always report it, and fail the test **only when the op that
+fell back has a Spyre device kernel** (so the fallback hid a broken kernel).
+Ops that have no device kernel at all (a known gap, e.g. ``sin``/``cos``,
+factory ops, int<->float conversions) fall back by design, so those are
+reported but not failed.
+
+Set ``SPYRE_OPTEST_ALLOW_CPU_FALLBACK=1`` to downgrade every fallback to a
+printed warning (e.g. while triaging).
+"""
+
+import contextlib
+import os
+import warnings
+from typing import Iterator, List
+
+try:  # torch_spyre may be absent during collection on a non-device host
+    from torch_spyre.ops.fallbacks import FallbackWarning
+except Exception:  # pragma: no cover - import guard
+    FallbackWarning = None  # type: ignore[assignment, misc]
+
+ALLOW_ENV = "SPYRE_OPTEST_ALLOW_CPU_FALLBACK"
+
+# aten ops that have NO Spyre device kernel: a CPU fallback here is expected and
+# is reported, not failed. Kept in sync with the CPU-fallback ops registered in
+# torch_spyre/ops/fallbacks.py, MINUS ops that do have a device kernel (e.g.
+# index_copy via index_put) -- for those a fallback masks a real bug and must
+# fail. int<->float dtype conversions (a known device limitation) are also
+# treated as a known gap.
+_KNOWN_NO_KERNEL_OPS = (
+    "aten.sin",
+    "aten.cos",
+    "aten.arange",
+    "aten.cumsum",
+    "aten.repeat",
+    "aten.tril",
+    "aten.triu",
+    "aten.isin",
+    "aten.argmax",
+    "aten.argmin",
+    "aten.where",
+    "aten.bitwise_xor",
+    "aten.bitwise_or",
+    "aten.ne",
+    "aten.any",
+    "aten.normal",
+    "aten.random",
+)
+
+
+def _is_known_gap(message: str) -> bool:
+    """True if this fallback is an expected no-device-kernel gap, not a bug."""
+    if message.startswith("conversion from"):  # int<->float dtype conversion
+        return True
+    return any(op in message for op in _KNOWN_NO_KERNEL_OPS)
+
+
+@contextlib.contextmanager
+def capture_cpu_fallbacks(sink: List[str]) -> Iterator[None]:
+    """Record ``FallbackWarning`` messages emitted in the block into ``sink``.
+
+    Non-fallback warnings raised in the block are re-emitted so nothing else is
+    swallowed.
+    """
+    if FallbackWarning is None:
+        yield
+        return
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always", FallbackWarning)
+        yield
+    for w in records:
+        if issubclass(w.category, FallbackWarning):
+            sink.append(str(w.message))
+        else:
+            warnings.warn_explicit(w.message, w.category, w.filename, w.lineno)
+
+
+def assert_no_cpu_fallback(case_name: str, messages: List[str]) -> None:
+    """Report CPU fallbacks; fail only those that mask a device-kernel bug.
+
+    Every fallback is printed. A fallback for an op that has a Spyre device
+    kernel (i.e. not a known no-kernel gap, see ``_is_known_gap``) fails the
+    test, because it silently ran on CPU instead of exercising that kernel.
+    Set ``SPYRE_OPTEST_ALLOW_CPU_FALLBACK=1`` to downgrade all to warnings.
+    """
+    if not messages:
+        return
+    unique = sorted(set(messages))
+    print(f"\n[CPU-FALLBACK] {case_name}: {'; '.join(unique)}")
+    if os.environ.get(ALLOW_ENV):
+        return
+    masking = [m for m in unique if not _is_known_gap(m)]
+    if not masking:
+        return
+    raise AssertionError(
+        f"{case_name}: op(s) with a Spyre device kernel silently fell back to "
+        f"CPU, masking a device bug: {masking}. Fix the kernel, mark the case "
+        f"xfail, or set {ALLOW_ENV}=1 to allow."
+    )

--- a/tests/oot_framework/fallback_utils.py
+++ b/tests/oot_framework/fallback_utils.py
@@ -33,37 +33,43 @@ import warnings
 from typing import Iterator, List
 
 try:  # torch_spyre may be absent during collection on a non-device host
-    from torch_spyre.ops.fallbacks import FallbackWarning
+    from torch_spyre.ops.fallbacks import FallbackWarning, fallback_ops
 except Exception:  # pragma: no cover - import guard
     FallbackWarning = None  # type: ignore[assignment, misc]
+    fallback_ops = []
 
 ALLOW_ENV = "SPYRE_OPTEST_ALLOW_CPU_FALLBACK"
 
-# aten ops that have NO Spyre device kernel: a CPU fallback here is expected and
-# is reported, not failed. Kept in sync with the CPU-fallback ops registered in
-# torch_spyre/ops/fallbacks.py, MINUS ops that do have a device kernel (e.g.
-# index_copy via index_put) -- for those a fallback masks a real bug and must
-# fail. int<->float dtype conversions (a known device limitation) are also
-# treated as a known gap.
-_KNOWN_NO_KERNEL_OPS = (
-    "aten.sin",
-    "aten.cos",
-    "aten.arange",
-    "aten.cumsum",
-    "aten.repeat",
-    "aten.tril",
-    "aten.triu",
-    "aten.isin",
-    "aten.argmax",
-    "aten.argmin",
-    "aten.where",
-    "aten.bitwise_xor",
-    "aten.bitwise_or",
-    "aten.ne",
-    "aten.any",
-    "aten.normal",
-    "aten.random",
-)
+# Ops registered with a CPU fallback that nonetheless HAVE a real Spyre device
+# kernel: a fallback for one of these masks a device bug and must fail the test,
+# so they are excluded from the known-gap set below. (index_copy runs on-device
+# via index_put.)
+_HAS_DEVICE_KERNEL = ("aten.index_copy",)
+
+
+def _known_no_kernel_ops() -> frozenset:
+    """Names of ops whose CPU fallback is an expected no-device-kernel gap.
+
+    Derived from ``fallback_ops`` (the fallback registry in
+    ``torch_spyre.ops.fallbacks``) so that module stays the single source of
+    truth rather than duplicating the list here; we only subtract the ops that
+    do have a device kernel (``_HAS_DEVICE_KERNEL``). Names are matched as a
+    substring of the fallback warning message, so packet-level names
+    (``aten.sin``) transparently cover every overload.
+    """
+    names = set()
+    for op in fallback_ops:
+        # OpOverload -> packet-level name (aten.cumsum.default -> aten.cumsum);
+        # string custom ops (e.g. "spyre::...") are kept verbatim.
+        name = str(getattr(op, "overloadpacket", op))
+        if not name.startswith(_HAS_DEVICE_KERNEL):
+            names.add(name)
+    return frozenset(names)
+
+
+# int<->float dtype conversions (a known device limitation) are treated as a
+# known gap separately, in ``_is_known_gap``.
+_KNOWN_NO_KERNEL_OPS = _known_no_kernel_ops()
 
 
 def _is_known_gap(message: str) -> bool:

--- a/tests/oot_framework/oot_test_config_models.py
+++ b/tests/oot_framework/oot_test_config_models.py
@@ -27,6 +27,7 @@ from .oot_test_constants import (
     _VALID_UNLISTED_MODES,
 )
 from .oot_test_matching import parse_dtype
+from .tensor_layout_utils import apply_layout
 from .oot_test_utilities import (
     _eval_py_literal,
     _resolve_dtype_str,
@@ -332,39 +333,12 @@ class InputTensorSpec(BaseModel):
             else:
                 raise ValueError(f"Unknown init strategy: {init!r}")
 
-        # Handle custom stride/storage_offset
-        # if self.stride is not None or self.storage_offset != 0:
-        #     stride = self.stride if self.stride is not None else list(t.stride())
-        #     offset = self.storage_offset
-        #     needed = offset + (
-        #         sum((s - 1) * st for s, st in zip(shape, stride)) + 1 if shape else 1
-        #     )
-        #     backing = torch.empty(needed, dtype=dtype)
-        #     t = torch.as_strided(backing, shape, stride, offset)
-        if self.stride is not None or self.storage_offset != 0:
-            stride = self.stride if self.stride is not None else list(t.stride())
-            offset = self.storage_offset
-            needed = offset + (
-                sum((s - 1) * st for s, st in zip(shape, stride)) + 1 if shape else 1
-            )
-            backing = torch.empty(needed, dtype=dtype)
-            with torch.no_grad():
-                if init == "rand":
-                    backing.copy_(  # fill flat backing, no aliasing
-                        make_tensor(
-                            needed, dtype=dtype, device="cpu", low=0.0, high=1.0
-                        )
-                    )
-                elif init == "randn":
-                    # See note above: make_tensor is uniform, not normal.
-                    backing.copy_(torch.randn(needed, dtype=dtype))
-                elif init == "randint":
-                    backing.copy_(
-                        make_tensor(
-                            needed, dtype=dtype, device="cpu", low=ia.low, high=ia.high
-                        )
-                    )
-            t = torch.as_strided(backing, shape, stride, offset)  # view created after
+        # Reproduce the captured memory layout (stride/storage_offset) using the
+        # seeded values built above. The layout must be applied to the *seeded*
+        # tensor -- re-drawing here would silently discard the seed, making the
+        # case non-reproducible and diverging from the v1 framework (which builds
+        # the same seeded values). See tensor_layout_utils.apply_layout.
+        t = apply_layout(t, self.stride, self.storage_offset)
 
         return t
 
@@ -402,20 +376,8 @@ class InputTensorSpec(BaseModel):
             else:
                 raise ValueError(f"Unknown init strategy: {init!r}")
 
-        if self.stride is not None or self.storage_offset != 0:
-            stride = self.stride if self.stride is not None else list(t.stride())
-            offset = self.storage_offset
-            needed = offset + (
-                sum((s - 1) * st for s, st in zip(shape, stride)) + 1 if shape else 1
-            )
-            backing = torch.empty(needed, dtype=dtype)
-            with torch.no_grad():
-                if init == "rand":
-                    backing.copy_(torch.rand(needed, dtype=dtype))
-                elif init == "randn":
-                    backing.copy_(torch.randn(needed, dtype=dtype))
-                elif init == "randint":
-                    backing.copy_(torch.randint(ia.low, ia.high, [needed], dtype=dtype))
+        # Reproduce the captured layout from the seeded values (see build()).
+        t = apply_layout(t, self.stride, self.storage_offset)
 
         return t
 

--- a/tests/oot_framework/tensor_layout_utils.py
+++ b/tests/oot_framework/tensor_layout_utils.py
@@ -1,0 +1,92 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared helpers for reconstructing a tensor's captured memory layout.
+
+The model-op test configs record each input tensor's real ``shape``,
+``stride`` and ``storage_offset`` (captured from a live HuggingFace forward
+trace). Both op-test frameworks build a contiguous, *seeded* tensor and then
+need to reproduce that captured layout without disturbing the seeded values --
+so a case is reproducible and identical across the two frameworks.
+
+``apply_layout`` takes a contiguous seeded tensor and returns a view/copy with
+the requested stride/storage_offset whose *logical* values are unchanged.
+"""
+
+from typing import List, Optional, Sequence
+
+import torch
+
+
+def _contiguous_stride(shape: Sequence[int]) -> List[int]:
+    """C-contiguous stride for ``shape`` (matches ``torch.empty(shape).stride()``)."""
+    stride = [1] * len(shape)
+    acc = 1
+    for i in range(len(shape) - 1, -1, -1):
+        stride[i] = acc
+        acc *= shape[i]
+    return stride
+
+
+def apply_layout(
+    t: torch.Tensor,
+    stride: Optional[Sequence[int]],
+    storage_offset: int = 0,
+) -> torch.Tensor:
+    """Return ``t``'s seeded values laid out with ``stride``/``storage_offset``.
+
+    ``t`` must be the contiguous, seeded tensor. The returned tensor has the
+    same shape, dtype and *logical* values as ``t`` but the requested physical
+    layout, so downstream ops see the real captured strides. A trivial layout
+    (no stride and zero offset, or a stride equal to ``t``'s own) returns ``t``
+    unchanged.
+
+    Broadcast layouts (a ``0`` in ``stride``, e.g. GQA ``repeat_kv`` expand)
+    cannot hold independent values in the broadcast dim, so they are rebuilt by
+    seeding the collapsed (size-1) shape and expanding -- matching how the real
+    tensor was produced.
+    """
+    if stride is None and not storage_offset:
+        return t
+
+    shape = list(t.shape)
+    resolved = list(stride) if stride is not None else list(t.stride())
+    if storage_offset == 0 and resolved == _contiguous_stride(shape):
+        return t
+
+    if 0 in resolved:
+        # Broadcast/expand view: seed only the physically distinct positions
+        # (collapse each broadcast dim to size 1) and expand back to `shape`.
+        collapsed = [1 if st == 0 else s for s, st in zip(shape, resolved)]
+        base = torch.as_strided(
+            t.reshape(-1)[: _numel(collapsed)].clone(),
+            collapsed,
+            _contiguous_stride(collapsed),
+        )
+        return base.expand(shape)
+
+    needed = storage_offset + (
+        sum((s - 1) * st for s, st in zip(shape, resolved)) + 1 if shape else 1
+    )
+    backing = torch.empty(needed, dtype=t.dtype)
+    view = torch.as_strided(backing, shape, resolved, storage_offset)
+    with torch.no_grad():
+        view.copy_(t)  # place the seeded values into the requested layout
+    return view
+
+
+def _numel(shape: Sequence[int]) -> int:
+    n = 1
+    for s in shape:
+        n *= s
+    return n

--- a/tests/oot_framework/test_fallback_utils.py
+++ b/tests/oot_framework/test_fallback_utils.py
@@ -1,0 +1,52 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for fallback_utils classification (device-free)."""
+
+import pytest
+
+from oot_framework.fallback_utils import (
+    _is_known_gap,
+    assert_no_cpu_fallback,
+)
+
+_COS = "aten.cos.default is falling back to cpu"
+_CONV = "conversion from torch.int64 to torch.float32 is falling back to cpu"
+_INDEX_COPY = "aten.index_copy.out is falling back to cpu"
+
+
+def test_no_messages_is_noop():
+    assert_no_cpu_fallback("case", [])  # must not raise
+
+
+def test_known_gap_ops_do_not_fail():
+    assert _is_known_gap(_COS)
+    assert _is_known_gap(_CONV)
+    # sin/arange are also known gaps
+    assert _is_known_gap("aten.sin.default is falling back to cpu")
+    assert _is_known_gap("aten.arange.default is falling back to cpu")
+    # reporting only; must not raise
+    assert_no_cpu_fallback("case", [_COS, _CONV])
+
+
+def test_kernel_backed_fallback_fails():
+    # index_copy has a device kernel -> a fallback masks a bug -> must fail.
+    assert not _is_known_gap(_INDEX_COPY)
+    with pytest.raises(AssertionError, match="masking a device bug"):
+        assert_no_cpu_fallback("case", [_INDEX_COPY])
+
+
+def test_allow_env_downgrades_to_warning(monkeypatch):
+    monkeypatch.setenv("SPYRE_OPTEST_ALLOW_CPU_FALLBACK", "1")
+    # even a bug-masking fallback is downgraded to a print, not a failure
+    assert_no_cpu_fallback("case", [_INDEX_COPY])

--- a/tests/oot_framework/test_tensor_layout_utils.py
+++ b/tests/oot_framework/test_tensor_layout_utils.py
@@ -1,0 +1,67 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for tensor_layout_utils.apply_layout (device-free, CPU only)."""
+
+import torch
+
+from oot_framework.tensor_layout_utils import apply_layout
+
+
+def _seeded(shape, seed, dtype=torch.bfloat16):
+    with torch.random.fork_rng(devices=[]):
+        torch.manual_seed(seed)
+        return torch.rand(shape, dtype=dtype)
+
+
+def test_none_stride_zero_offset_returns_same_object():
+    t = _seeded([2, 3], 0)
+    assert apply_layout(t, None, 0) is t
+
+
+def test_contiguous_stride_is_noop():
+    t = _seeded([1, 4, 39, 128], 1)
+    # Requesting t's own contiguous stride must not rebuild/redraw.
+    assert apply_layout(t, list(t.stride()), 0) is t
+
+
+def test_non_contiguous_transpose_preserves_values():
+    # index_copy source layout: transpose(1, 2) of a contiguous [1, 39, 4, 128].
+    t = _seeded([1, 4, 39, 128], 3123)
+    out = apply_layout(t, [19968, 128, 512, 1], 0)
+    assert out.stride() == (19968, 128, 512, 1)
+    assert not out.is_contiguous()
+    assert torch.equal(out, t)  # logical values unchanged
+
+
+def test_storage_offset_preserves_values():
+    t = _seeded([4], 7)
+    out = apply_layout(t, [1], 64)
+    assert out.storage_offset() == 64
+    assert torch.equal(out, t)
+
+
+def test_reproducible_from_same_seed():
+    a = apply_layout(_seeded([1, 4, 39, 128], 5), [19968, 128, 512, 1], 0)
+    b = apply_layout(_seeded([1, 4, 39, 128], 5), [19968, 128, 512, 1], 0)
+    assert torch.equal(a, b)
+
+
+def test_broadcast_stride_zero_reconstructs_expand():
+    # GQA repeat_kv: a stride-0 (broadcast) dim.
+    t = _seeded([1, 4, 7, 2048, 128], 11)
+    out = apply_layout(t, [1048576, 262144, 0, 128, 1], 0)
+    assert out.shape == (1, 4, 7, 2048, 128)
+    assert out.stride()[2] == 0
+    # Every slice along the broadcast dim aliases the same storage.
+    assert torch.equal(out[:, :, 0], out[:, :, 5])


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

The v2 op-test framework (test_model_ops_v2.py) produced false passes and diverged from v1 (test_model_ops.py) on the same ops. Root causes, all in how v2 built and compared samples:

1. Aliased reference/test tensors. build_cpu_args moves cpu_sample to the test device, and test_sample = _to_target_device(cpu_sample.input) calls .to(device) on an already-on-device tensor, which returns the SAME object. For in-place ops (index_copy_, add_, scatter_, masked_fill_, copy_, ...) ref_out and test_out were then the same buffer, so the comparison was a vacuous self-check that passed regardless of kernel correctness. For non-inplace ops the "reference" ran device-eager (not a true CPU baseline), masking bugs where eager and compiled agree.

2. Non-reproducible, layout-divergent inputs. InputTensorSpec.build (and _build_fallback) re-drew make_tensor OUTSIDE the seeded block whenever a stride/storage_offset was set, discarding the seeded tensor -- so v2 was ~100% value-divergent from v1 despite the same seed, and its contiguity differed. v1's make_tensor_from_conf ignored the captured stride/storage_offset entirely. The captured layouts are real (from a HuggingFace forward trace via hf-adapters torchop_yaml.py), so both frameworks should honor them.

3. Silent CPU fallbacks passed. A compiled op that fell back to CPU ran on the CPU implementation, not the device path under test, masking backend bugs.

Changes:
- test_model_ops_v2.py: build two independent, same-seed samples -- cpu_sample on CPU (true reference) and device_sample on device (for test_sample) -- so reference and test tensors never alias and the reference is a genuine CPU baseline (matches v1).
- tensor_layout_utils.apply_layout: place the seeded values into the captured stride/storage_offset (contiguous fast-path; broadcast/expand handling). Used by both v2 build()/_build_fallback() and v1 make_tensor_from_conf(), so both build byte-identical inputs.
- fallback_utils: capture FallbackWarning during the compiled run; fail when an op that HAS a Spyre device kernel silently falls back (masking a bug), and report-only for known no-kernel gaps (sin/cos/arange/int<->float). Downgrade all with SPYRE_OPTEST_ALLOW_CPU_FALLBACK=1.
- Unit tests for both helpers.

BEHAVIOR CHANGE (v1): make_tensor_from_conf previously ignored the captured stride/storage_offset and always built contiguous tensors; it now honors them via apply_layout. v1 therefore exercises the real (possibly non-contiguous) captured layouts instead of contiguous stand-ins, which can change which device kernel path a case runs and thus its pass/fail (this is intended -- the captured layouts are what the real model produces).

After this, v1 and v2 feed identical inputs and observe the same behavior: on the Qwen2.5-7B-Instruct config v2 stops falsely passing 15 cases and now fails the same op families as v1 (index_copy, torch.to, linear, matmul, mean). index_copy_ fails with the same numeric mismatch in both. The underlying Spyre SDSC index_copy kernel bug this exposes is tracked separately.


#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/issues/3717

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No. This affects the test framework only.

#### Additional note:
