### PR TITLE
[KTIR Emitter] Take the grid from the iteration space: multi-core work division  

### DIFF
--- a/tests/inductor/test_ktir_emitter.py
+++ b/tests/inductor/test_ktir_emitter.py
@@ -209,6 +209,79 @@ module {
     _mlir_ktdp_available(),
     "mlir_ktdp with the func/arith/linalg/scf/tensor dialect bindings is not installed",
 )
+class TestWorkDividedEmission(unittest.TestCase):
+    """The same add over 32 cores: the grid, one tile id, and a smaller tile.
+
+    Everything that changes against ``EXPECTED_ADD_KTIR`` is a consequence of the
+    iteration space's work division -- ``grid = [32]``, the per-core index, and
+    tiles of [16, 16, 64] instead of the whole [16, 512, 64].  The *views* do not
+    change: every core addresses the same buffer.
+    """
+
+    EXPECTED_DIVIDED_ADD_KTIR = """\
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#set = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 15 >= 0, d1 >= 0, -d1 + 511 >= 0, d2 >= 0, -d2 + 63 >= 0)>
+#set1 = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 15 >= 0, d1 >= 0, -d1 + 15 >= 0, d2 >= 0, -d2 + 63 >= 0)>
+module {
+  func.func @ktir_fused_add_0(%arg0: index, %arg1: index, %arg2: index) attributes {grid = [32]} {
+    %c0 = arith.constant 0 : index
+    %0 = ktdp.get_compute_tile_id : index
+    %1 = ktdp.construct_memory_view %arg0, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %2 = ktdp.construct_memory_view %arg1, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %3 = ktdp.construct_memory_view %arg2, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %c16 = arith.constant 16 : index
+    %4 = arith.muli %0, %c16 : index
+    %5 = ktdp.construct_access_tile %1[%c0, %4, %c0] {access_tile_order = #map, access_tile_set = #set1} : memref<16x512x64xf16> -> !ktdp.access_tile<16x16x64xindex>
+    %6 = ktdp.load %5 : <16x16x64xindex> -> tensor<16x16x64xf16>
+    %c16_0 = arith.constant 16 : index
+    %7 = arith.muli %0, %c16_0 : index
+    %8 = ktdp.construct_access_tile %2[%c0, %7, %c0] {access_tile_order = #map, access_tile_set = #set1} : memref<16x512x64xf16> -> !ktdp.access_tile<16x16x64xindex>
+    %9 = ktdp.load %8 : <16x16x64xindex> -> tensor<16x16x64xf16>
+    %10 = tensor.empty() : tensor<16x16x64xf16>
+    %11 = linalg.add ins(%6, %9 : tensor<16x16x64xf16>, tensor<16x16x64xf16>) outs(%10 : tensor<16x16x64xf16>) -> tensor<16x16x64xf16>
+    %c16_1 = arith.constant 16 : index
+    %12 = arith.muli %0, %c16_1 : index
+    %13 = ktdp.construct_access_tile %3[%c0, %12, %c0] {access_tile_order = #map, access_tile_set = #set1} : memref<16x512x64xf16> -> !ktdp.access_tile<16x16x64xindex>
+    ktdp.store %11, %13 : tensor<16x16x64xf16>, <16x16x64xindex>
+    return
+  }
+}
+"""
+
+    def test_divided_add_golden(self):
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        emitted = generate_ktir(
+            "ktir_fused_add_0", [make_op_spec(divisions={"d1": 32})]
+        )
+        self.assertEqual(emitted, self.EXPECTED_DIVIDED_ADD_KTIR)
+
+    def test_one_core_emits_no_tile_id(self):
+        """An undivided space costs nothing: the single-core text is unchanged."""
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        emitted = generate_ktir("ktir_fused_add_0", [make_op_spec()])
+        self.assertNotIn("get_compute_tile_id", emitted)
+        self.assertEqual(emitted, TestKtirEmitter.EXPECTED_ADD_KTIR)
+
+    def test_two_divided_symbols_read_the_id_as_mixed_radix(self):
+        """``d0`` takes ``id // 4`` and ``d1`` takes ``id % 4`` of an 8-core grid,
+        from the one tile id -- the plan's ``inner`` and ``div`` spelled out."""
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        emitted = generate_ktir(
+            "ktir_add_8", [make_op_spec(divisions={"d0": 2, "d1": 4})]
+        )
+        self.assertIn("attributes {grid = [8]}", emitted)
+        self.assertEqual(emitted.count("get_compute_tile_id"), 1)
+        self.assertIn("arith.divui", emitted)
+        self.assertIn("arith.remui", emitted)
+
+
+@unittest.skipUnless(
+    _mlir_ktdp_available(),
+    "mlir_ktdp with the func/arith/linalg/scf/tensor dialect bindings is not installed",
+)
 class TestTiledLoopEmission(unittest.TestCase):
     """A two-level nest, planned and emitted through the ordinary path.
 

--- a/tests/inductor/test_ktir_validate.py
+++ b/tests/inductor/test_ktir_validate.py
@@ -238,11 +238,15 @@ class TestValidateRejections(unittest.TestCase):
     def test_empty_spec_list_rejected(self):
         self._rejects([], "no OpSpec to emit")
 
-    def test_work_division_rejected(self):
-        """The grid comes from the contract, so the refusal reads the contract:
-        a symbol the iteration space splits has no grid to emit for yet."""
-        specs = [make_op_spec(divisions={"d1": 32})]
-        self._rejects(specs, "multi-core work division is not supported")
+    def test_mixed_work_division_rejected(self):
+        """Two ops in one kernel, two grids: there is only one grid to emit."""
+        specs = [make_op_spec(), make_op_spec(divisions={"d1": 2})]
+        self._rejects(specs, "different work divisions")
+
+    def test_ragged_work_division_rejected(self):
+        """A division that does not divide the axis evenly has no per-core tile."""
+        specs = [make_op_spec(divisions={"d1": 7})]  # 512 / 7 is not a whole tile
+        self._rejects(specs, "do not divide evenly")
 
     # -- spec-tree shape ---------------------------------------------------
 
@@ -343,10 +347,8 @@ class TestRejectionsThroughGenerateKtir(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             ktir.generate_ktir("ktir_fused_atan2_0", specs)
 
-    def test_work_division_unsupported(self):
-        specs = [make_op_spec()]
-        d1 = next(s for s in specs[0].iteration_space if str(s) == "d1")
-        specs[0].iteration_space[d1] = (512, 32)
+    def test_ragged_work_division_unsupported(self):
+        specs = [make_op_spec(divisions={"d1": 7})]
         with self.assertRaises(NotImplementedError):
             ktir.generate_ktir("ktir_fused_add_0", specs)
 
@@ -374,6 +376,57 @@ class TestPlanOptions(unittest.TestCase):
             sorted(f.name for f in dataclasses.fields(ktir.PlanOptions)),
             ["bake_addresses"],
         )
+
+
+class TestWorkDivision(unittest.TestCase):
+    """The grid, and the per-core tile, as ``iteration_space`` states them.
+
+    ``work_division.py`` has already turned ``config.sencores`` into a per-symbol
+    division by the time the emitter sees a spec, so the emitter reads the
+    contract and never the config -- the same source the SDSC path reads as its
+    work slices.
+    """
+
+    def test_an_undivided_space_is_one_core(self):
+        plan = ktir.build_kernel_plan([make_op_spec()])
+        self.assertEqual(plan.grid, (1,))
+        self.assertEqual(plan.divisions, ())
+
+    def test_the_grid_is_the_product_of_the_divisions(self):
+        plan = ktir.build_kernel_plan([make_op_spec(divisions={"d1": 32})])
+        self.assertEqual(plan.grid, (32,))
+        self.assertEqual(plan.divisions, (ktir.Division(symbol="d1", div=32, inner=1),))
+
+    def test_two_divided_symbols_are_mixed_radix(self):
+        """Outermost-first, and ``inner`` is that symbol's stride in the grid."""
+        plan = ktir.build_kernel_plan([make_op_spec(divisions={"d0": 2, "d1": 4})])
+        self.assertEqual(plan.grid, (8,))
+        self.assertEqual(
+            plan.divisions,
+            (
+                ktir.Division(symbol="d0", div=2, inner=4),
+                ktir.Division(symbol="d1", div=4, inner=1),
+            ),
+        )
+
+    def test_the_tile_shrinks_and_the_view_does_not(self):
+        """One core's tile is its share; every core addresses the whole buffer."""
+        plan = ktir.build_kernel_plan([make_op_spec(divisions={"d1": 32})])
+        for buffer in plan.parameters:
+            with self.subTest(buf_id=buffer.buf_id):
+                self.assertEqual(buffer.layout.extent, (16, 512, 64))
+        step = plan.steps[0]
+        self.assertEqual(step.out.extent, (16, 16, 64))  # 512 / 32 rows
+        # The division walks dim 1 in per-core-extent steps, and nothing else.
+        self.assertEqual(step.out.index_coeffs, ((0,), (16,), (0,)))
+
+    def test_a_division_no_output_axis_follows_is_rejected(self):
+        """A stick is the unit of transfer, so the lane axis is never divided --
+        which leaves a division of the lane symbol with no axis to walk, and every
+        core writing the same elements.  Refused rather than silently duplicated."""
+        with self.assertRaises(NotImplementedError) as ctx:
+            ktir.build_kernel_plan([make_op_spec(divisions={"d2": 2})])
+        self.assertIn("no device axis of the output", str(ctx.exception))
 
 
 class TestKernelPlan(unittest.TestCase):
@@ -408,10 +461,6 @@ class TestKernelPlan(unittest.TestCase):
             [e.base_elements for e in plan.parameters],
             [0, (1 << 34) // 2, (2 << 34) // 2],
         )
-
-    def test_the_grid_is_one_core(self):
-        """One core until the grid is read from the iteration space."""
-        self.assertEqual(ktir.build_kernel_plan([make_op_spec()]).grid, (1,))
 
     def test_repeated_buffer_is_registered_once(self):
         specs = [make_op_spec()] + [make_op_spec()]
@@ -616,19 +665,6 @@ class TestLoopDerivations(unittest.TestCase):
         c_access = ktir._access(c, c.device_size, c_q, c_layout)
         self.assertEqual(c_access.extent, (1, 64))
         self.assertEqual(c_access.index_coeffs, ((1, 0), (0, 0)))
-
-    def test_symbolic_view_extent_rejected(self):
-        """A symbolic device size would have to reach the kernel as an argument
-        and size a dynamic memref dim; neither exists yet.
-
-        Asserted at the derivation, not through the walk: a symbolic
-        ``device_size`` does not survive the pointwise alignment check's
-        ``int()`` either, so the walk reports the wrong thing about it.
-        """
-        arg = make_op_spec(size=[sympy.Symbol("s0"), 512, 64]).args[0]
-        with self.assertRaises(NotImplementedError) as ctx:
-            ktir._solve_layout(arg, [])
-        self.assertIn("is symbolic; a symbolic device size", str(ctx.exception))
 
     def test_untiled_access_sits_at_the_view_origin(self):
         """Depth zero is the general answer, not a special case."""

--- a/tests/inductor/test_opspec_utils.py
+++ b/tests/inductor/test_opspec_utils.py
@@ -35,6 +35,8 @@ from torch_spyre._inductor.codegen.opspec_utils import (
     _iteration_space_key,
     align_reshape_plan,
     buf_id,
+    core_divisions,
+    per_core_extent,
     row_major_strides,
 )
 from torch_spyre._inductor.op_spec import OpSpec, TensorArg
@@ -197,6 +199,69 @@ class TestAlignReshapePlan(unittest.TestCase):
                 [d, sympy.Mod(c, 64)],
                 [4, 64],
             )
+
+
+class TestCoreDivisions(unittest.TestCase):
+    """The grid, read off the iteration space's per-symbol work division."""
+
+    def test_undivided_is_one_core(self):
+        d0, d1 = sympy.symbols("d0 d1")
+        self.assertEqual(core_divisions({d0: (16, 1), d1: (512, 1)}), ([], 1))
+
+    def test_one_divided_symbol_owns_the_whole_grid(self):
+        d0, d1 = sympy.symbols("d0 d1")
+        divisions, cores = core_divisions({d0: (16, 1), d1: (512, 32)})
+        self.assertEqual(cores, 32)
+        self.assertEqual(divisions, [(d1, 32, 1)])
+
+    def test_two_divided_symbols_are_mixed_radix_innermost_first(self):
+        """``inner`` is the grid stride of one step of that symbol, so the flat
+        id decodes as ``(id // inner) % div``."""
+        d0, d1 = sympy.symbols("d0 d1")
+        divisions, cores = core_divisions({d0: (16, 2), d1: (512, 4)})
+        self.assertEqual(cores, 8)
+        self.assertEqual(divisions, [(d1, 4, 1), (d0, 2, 4)])
+
+
+class TestPerCoreExtent(unittest.TestCase):
+    """One core's share of each device axis, and which division it follows."""
+
+    @staticmethod
+    def _arg(size, coords):
+        return TensorArg(
+            is_input=True,
+            arg_index=0,
+            device_dtype=DataFormats.SEN169_FP16,
+            device_size=size,
+            device_coordinates=coords,
+            allocation={"hbm": None},
+            name="arg0",
+        )
+
+    def test_undivided_is_the_whole_extent(self):
+        d0, d1 = sympy.symbols("d0 d1")
+        arg = self._arg([16, 512, 64], [d0, d1, sympy.Mod(d1, 64)])
+        self.assertEqual(per_core_extent(arg, {}), ([16, 512, 64], [None, None, None]))
+
+    def test_a_divided_axis_shrinks_and_names_its_symbol(self):
+        d0, d1 = sympy.symbols("d0 d1")
+        arg = self._arg([16, 512, 64], [d0, d1, sympy.Mod(d1, 64)])
+        self.assertEqual(
+            per_core_extent(arg, {d1: 32}), ([16, 16, 64], [None, d1, None])
+        )
+
+    def test_the_within_stick_axis_is_never_divided(self):
+        """A stick is the unit of transfer, so the last axis keeps its extent even
+        when its symbol is divided."""
+        d0 = sympy.symbols("d0")
+        arg = self._arg([32, 64], [sympy.floor(d0 / 64), sympy.Mod(d0, 64)])
+        self.assertEqual(per_core_extent(arg, {d0: 32}), ([1, 64], [d0, None]))
+
+    def test_a_ragged_division_raises(self):
+        d0, d1 = sympy.symbols("d0 d1")
+        arg = self._arg([16, 512, 64], [d0, d1, sympy.Mod(d1, 64)])
+        with self.assertRaises(NotImplementedError):
+            per_core_extent(arg, {d1: 7})
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/codegen/ktir.py
+++ b/torch_spyre/_inductor/codegen/ktir.py
@@ -63,6 +63,8 @@ from torch_spyre._inductor.codegen.compute_ops import num_bytes
 from torch_spyre._inductor.codegen.opspec_utils import (
     align_reshape_plan,
     buf_id,
+    core_divisions,
+    per_core_extent,
     row_major_strides,
 )
 from torch_spyre._inductor.constants import STAGGERED_EAS
@@ -210,6 +212,26 @@ class Level:
 
 
 @dataclasses.dataclass(frozen=True)
+class Division:
+    """One work-divided iteration symbol: a level the *cores* walk in parallel.
+
+    A division is the outermost kind of level there is.  Where a ``Level``'s
+    index comes from an ``scf.for``, a division's comes from this core's place in
+    the grid -- ``(compute_tile_id // inner) % div`` -- so the two differ only in
+    where the index value is read, and the plan carries them in one ordered list
+    (divisions first, outermost) whose coefficients ``Access.index_coeffs``
+    holds.
+
+    ``symbol`` is the iteration symbol's name, kept for messages only: emission
+    needs the two numbers.
+    """
+
+    symbol: str
+    div: int  # how many cores share this symbol's range
+    inner: int  # the grid stride of one step of this symbol
+
+
+@dataclasses.dataclass(frozen=True)
 class Layout:
     """A buffer's device extent and strides, in elements.
 
@@ -236,13 +258,16 @@ class Buffer:
 class Access:
     """One (OpSpec, TensorArg) access; sole input to an access tile.
 
-    ``extent`` is the tile's own extent, which is ``device_size``: the tile
-    extent is what tiling already baked into ``device_size``, while the *buffer*
-    extent grows back out of it in ``_layout``.
+    ``extent`` is the tile's own extent: ``device_size``, divided by whatever
+    work division splits an axis across cores.  The *buffer* extent grows back
+    out of it in ``_layout``.
 
     ``index_coeffs[i][l]`` is the step level ``l`` takes along view dim ``i``, so
     the index for dim ``i`` is ``sum_l index_coeffs[i][l] * iv_l``, where ``iv_l``
-    is the induction variable of the ``l``-th enclosing loop.  The record holds
+    is the index of the ``l``-th enclosing level -- this core's portion of a
+    ``Division`` for the outermost ones, the induction variable of an enclosing
+    ``scf.for`` for the rest.  A division and a loop differ only in where that
+    index comes from, so one matrix covers both.  The record holds
     the coefficients only -- the variables exist during emission, not during
     planning -- and the builder zips them against the loops it has open.  This is
     the design's ``base_map`` as a matrix; the builder spells it the way
@@ -563,6 +588,34 @@ def _solve_layout(
     return _layout(arg, levels, q), q
 
 
+def _divide(
+    arg: TensorArg, symbols: Sequence[Any], divisors: dict
+) -> tuple[tuple[int, ...], list[tuple[int, ...]]]:
+    """``arg``'s per-core tile extent, and each division's step along each dim.
+
+    The one place work division touches an access.  A division walks the axis
+    its symbol addresses one per-core extent at a time, so its step along that
+    axis *is* that extent, and the cores between them cover ``device_size``
+    exactly (``A * D``).  The view is unaffected -- ``_solve_layout`` builds it
+    from the whole ``device_size``, because every core addresses the same buffer
+    -- so nothing else in the emitter has to know that cores exist.
+
+    ``symbols`` is outermost-first, matching the plan's division order; the rows
+    come back in that order so they prepend to the loop levels' rows.
+    """
+    if not symbols:
+        return tuple(_static(s) for s in arg.device_size), []
+    per_core, axis_symbol = per_core_extent(arg, divisors)
+    rows = [
+        tuple(
+            per_core[axis] if axis_symbol[axis] == symbol else 0
+            for axis in range(len(per_core))
+        )
+        for symbol in symbols
+    ]
+    return tuple(per_core), rows
+
+
 def _access(
     arg: TensorArg,
     extent: Sequence[Any],
@@ -572,11 +625,13 @@ def _access(
 ) -> Access:
     """The access record for one ``(OpSpec, TensorArg)``.
 
-    ``rows`` is one step vector per enclosing level, outermost-first, which the
-    builder multiplies by that level's induction variable at emit time.
+    ``extent`` is the per-core tile extent and ``rows`` is one step vector per
+    enclosing level, outermost-first (divisions, then loops) -- which the builder
+    multiplies by that level's index at emit time.
 
     With no levels every row is empty, so every index expression is the empty
-    sum -- zero -- which is why an untiled access sits at the view's origin.
+    sum -- zero -- which is why an undivided, untiled access sits at the view's
+    origin.
     """
     extent = tuple(_static(s) for s in extent)
     for value in extent:
@@ -691,6 +746,49 @@ class PlanOptions:
     bake_addresses: bool = False
 
 
+def _divisions(specs: Sequence[Any]) -> tuple[list[Any], tuple[Division, ...]]:
+    """``(symbols, divisions)``: the core grid the spec tree asks for.
+
+    Read from ``OpSpec.iteration_space``, whose per-symbol work division is what
+    ``work_division.py`` decided from ``config.sencores`` -- so the grid is a fact
+    of the contract, the same one the SDSC path reads as its work slices, rather
+    than a core count this emitter takes on the side.  Nothing else here reads
+    ``config``.
+
+    Every op in one kernel must ask for the same division: they share one grid,
+    and one core runs one instance of the whole body.  The symbols come back
+    outermost-first, so a division's coefficients prepend to the loop levels'.
+    """
+    spaces = [spec.iteration_space for spec in _op_specs(specs)]
+    if not spaces:
+        return [], ()
+    divided, total = core_divisions(spaces[0])
+    for space in spaces[1:]:
+        if core_divisions(space)[0] != divided:
+            raise NotImplementedError(
+                "OpSpec->KTIR: the ops in this kernel ask for different work "
+                "divisions, so they cannot share one grid; mixed work division "
+                "within a kernel is not supported"
+            )
+    divided = list(reversed(divided))  # outermost-first
+    symbols = [symbol for symbol, _div, _inner in divided]
+    divisions = tuple(
+        Division(symbol=str(symbol), div=div, inner=inner)
+        for symbol, div, inner in divided
+    )
+    assert total == functools.reduce(lambda a, d: a * d.div, divisions, 1)
+    return symbols, divisions
+
+
+def _op_specs(specs: Sequence[Any]) -> Iterator[OpSpec]:
+    """Every ``OpSpec`` in a spec tree, loop bodies included."""
+    for entry in specs:
+        if isinstance(entry, LoopSpec):
+            yield from _op_specs(entry.body)
+        elif isinstance(entry, OpSpec):
+            yield entry
+
+
 class KernelPlan:
     """One kernel, resolved: its grid, its buffers, and the steps for its body.
 
@@ -707,9 +805,10 @@ class KernelPlan:
 
     def __init__(self, options: PlanOptions | None = None) -> None:
         self.options = options or PlanOptions()
-        # One core: work division is refused in ``_steps`` until the grid is
-        # read from the iteration space.
         self.grid: tuple[int, ...] = (1,)
+        self.divisions: tuple[Division, ...] = ()
+        self._symbols: list[Any] = []  # the divided symbols, outermost-first
+        self._divisors: dict = {}
         self.buffers: dict[str, Buffer] = {}
         self.steps: tuple[Step, ...] = ()
 
@@ -727,7 +826,16 @@ class KernelPlan:
         )
 
     def add_specs(self, specs: Sequence[OpSpec | LoopSpec | UnimplementedOp]) -> None:
-        """Plan ``specs`` into this plan's buffers and steps."""
+        """Plan ``specs`` into this plan's grid, buffers and steps."""
+        self._symbols, self.divisions = _divisions(specs)
+        self._divisors = {
+            symbol: division.div
+            for symbol, division in zip(self._symbols, self.divisions, strict=True)
+        }
+        cores = 1
+        for division in self.divisions:
+            cores *= division.div
+        self.grid = (cores,)
         self.steps = self._steps(specs, ())
         self._check_internal_buffers(self.steps)
 
@@ -811,15 +919,6 @@ class KernelPlan:
                     f"OpSpec->KTIR: op {entry.op!r} is not supported yet "
                     f"(registered: {sorted(KtirBuilder.RECIPES)})"
                 )
-            for symbol, (_range, division) in entry.iteration_space.items():
-                if int(division) > 1:
-                    # Read from the contract, not from a core count, because that
-                    # is where the grid comes from -- so implementing this is
-                    # replacing the refusal with the same reading.
-                    raise NotImplementedError(
-                        "OpSpec->KTIR: multi-core work division is not supported "
-                        f"yet ({symbol} is split across {division} cores)"
-                    )
             if entry.is_reduction:
                 # A reduction is a second emission shape (an accumulator, and
                 # axes that do not survive), not a second binding: refused until
@@ -863,6 +962,21 @@ class KernelPlan:
                 )
         levels = _levels(spec, loops)
         accesses = {buf_id(arg): self._access_of(arg, levels) for arg in args}
+        # Every division must move this op's output: cores divide work by writing
+        # different elements, so a division no output axis follows is cores
+        # duplicating each other rather than sharing.  An *input* may legitimately
+        # not follow one (every core reads the same operand), which is why this
+        # asks the output only.
+        out_coeffs = accesses[buf_id(out)].index_coeffs
+        for level, division in enumerate(self.divisions):
+            if not any(row[level] for row in out_coeffs):
+                raise NotImplementedError(
+                    f"OpSpec->KTIR: work division splits {division.symbol} across "
+                    f"{division.div} cores, but no device axis of the output "
+                    f"{out.name!r} follows it, so every core would compute the "
+                    "same elements; dividing the within-stick axis or a reduced "
+                    "axis (which needs a cross-core combine) reads like this"
+                )
         return ComputeStep(
             op=spec.op,
             family=Family.of(spec),
@@ -890,7 +1004,9 @@ class KernelPlan:
                 buf_id(arg),
                 _buffer(arg, layout, elems, bake_addresses=self.options.bake_addresses),
             )
-        return _access(arg, arg.device_size, q, layout, buffer)
+        # The divisions are the outermost levels, so their steps come first.
+        extent, rows = _divide(arg, self._symbols, self._divisors)
+        return _access(arg, extent, [*rows, *q], layout, buffer)
 
 
 def _base_address_elements(arg: TensorArg) -> int:
@@ -1012,12 +1128,19 @@ class ScopeStack:
 
     Pushed and popped by ``KtirBuilder.emit`` via ``with``.  A base frame is
     always present so values produced at function level have somewhere to live.
+    It carries the core portions, if the kernel is work-divided: those are the
+    outermost levels, in scope for the whole body and not tied to any loop.
     """
 
     def __init__(self) -> None:
         # ([index values], {buf_id: Value}), innermost last.  A frame's list is
-        # the levels it opens: one iv for a loop, none for a plain value scope.
+        # the levels it opens: one iv for a loop, the core portions for the base
+        # frame, none for a plain value scope.
         self._frames: list[tuple[list, dict[str, Any]]] = [([], {})]
+
+    def bind_ivs(self, ivs: Sequence) -> None:
+        """Give the current frame these level indices (the base frame's cores)."""
+        self._frames[-1][0].extend(ivs)
 
     @contextlib.contextmanager
     def scope(self, iv: Any = None) -> Iterator[None]:
@@ -1041,8 +1164,9 @@ class ScopeStack:
         """The index of every open level, outermost-first.
 
         What ``Access.index_coeffs`` is zipped against: one coefficient per
-        enclosing level, in the same order the plan derived them: one induction
-        variable per enclosing loop.
+        enclosing level, in the same order the plan derived them -- the core
+        portions of the work divisions first, then one induction variable per
+        enclosing loop.
         """
         return [iv for ivs, _ in self._frames for iv in ivs]
 
@@ -1151,6 +1275,7 @@ class KtirBuilder:
                 self.block_args = list(block.arguments)
                 with ir.InsertionPoint(block):
                     self.c0 = self.icst_index(0)
+                    self.env.bind_ivs(self.core_portions())
                     for position, buffer in enumerate(buffers):
                         if not baked:
                             base = self.block_args[position]
@@ -1168,6 +1293,28 @@ class KtirBuilder:
             self._text = str(module)
         finally:
             self._stack.close()
+
+    def core_portions(self) -> list:
+        """This core's index along each division, outermost-first.
+
+        One ``ktdp.get_compute_tile_id`` -- the flat grid index -- read as the
+        mixed-radix number the plan's divisions describe: ``(id // inner) % div``.
+        A term whose factor is trivial is not emitted, so a single divided symbol
+        uses the id itself and the undivided case emits nothing at all.
+        """
+        if not self.plan.divisions:
+            return []
+        # A result *list*: the op is variadic in the bindings, single-result here.
+        tile_id = self.val(ktdp.get_compute_tile_id([self.index_t]))
+        portions = []
+        for division in self.plan.divisions:
+            index = tile_id
+            if division.inner > 1:
+                index = self.val(arith.DivUIOp(index, self.icst_index(division.inner)))
+            if division.inner * division.div != self.plan.grid[0]:
+                index = self.val(arith.RemUIOp(index, self.icst_index(division.div)))
+            portions.append(index)
+        return portions
 
     def finish(self) -> str:
         """The canonical MLIR text of the module built by ``open_kernel()``."""

--- a/torch_spyre/_inductor/codegen/opspec_utils.py
+++ b/torch_spyre/_inductor/codegen/opspec_utils.py
@@ -35,69 +35,28 @@ something to build on.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any
 
 import sympy
 from torch.utils._sympy.functions import FloorDiv, ModularIndexing
 
-from torch_spyre._inductor.op_spec import Expr, OpSpec, TensorArg
+from torch_spyre._inductor.op_spec import OpSpec, TensorArg
 
 __all__ = [
     "align_reshape_plan",
     "buf_id",
+    "core_divisions",
+    "per_core_extent",
     "row_major_strides",
-    "symbolic_dim_max",
 ]
 
 
-def row_major_strides(device_size: Sequence[Any]) -> list[Any]:
-    """Row-major (C-contiguous) strides for a device-size list.
-
-    A symbolic extent is carried through rather than rejected: a stride is the
-    product of the extents inside it, so a symbolic extent leaves every stride
-    *inside* it an integer and makes the ones outside it expressions.  An
-    all-integer size therefore still gets plain ``int`` strides.
-    """
+def row_major_strides(device_size: Sequence[int]) -> list[int]:
+    """Row-major (C-contiguous) strides for a device-size list."""
     n = len(device_size)
-    strides: list[Any] = [1] * n
+    strides = [1] * n
     for i in range(n - 2, -1, -1):
-        product = strides[i + 1] * device_size[i + 1]
-        try:
-            strides[i] = int(product)
-        except TypeError:  # a sympy expression over an unresolved dim
-            strides[i] = product
+        strides[i] = strides[i + 1] * int(device_size[i + 1])
     return strides
-
-
-def symbolic_dim_max(expr: Expr, symbolic_dim_bounds: dict) -> int:
-    """``expr`` with every symbolic dim replaced by its maximum, as an int.
-
-    ``OpSpec.symbolic_dim_bounds`` maps a PyTorch symbol *name* to
-    ``(max, granularity)``, computed from the ShapeEnv at codegen time and
-    serialized as plain ints, so this works during the reload phase when the
-    ShapeEnv is gone.  Baking the max over-allocates but needs nothing at run
-    time, which is why both emitters offer it.
-
-    Note for anyone unifying this with ``superdsc._resolve_sdsc_size``: that one
-    returns the first symbol's max *directly* (so it answers ``s0`` for ``s0 + 1``)
-    and falls back to a live-ShapeEnv hint when the symbol is unbounded.  This one
-    substitutes into the whole expression and raises instead of guessing, so the
-    two are not interchangeable without deciding which behaviour is wanted.
-    """
-    resolved = expr
-    for symbol in {str(s) for s in getattr(expr, "free_symbols", ())}:
-        if symbol not in symbolic_dim_bounds:
-            raise NotImplementedError(
-                f"extent {expr} has no bound for {symbol!r} in symbolic_dim_bounds"
-            )
-        resolved = resolved.subs({symbol: int(symbolic_dim_bounds[symbol][0])})
-    try:
-        return int(resolved)
-    except TypeError:
-        raise NotImplementedError(
-            f"extent {expr} does not become an integer under its bounds "
-            f"{symbolic_dim_bounds!r}"
-        ) from None
 
 
 def buf_id(arg: TensorArg) -> str:
@@ -278,3 +237,83 @@ def align_reshape_plan(
         )
     broadcast_to = out_block if reshape_to != out_block else None
     return (reshape_to, broadcast_to)
+
+
+# ---------------------------------------------------------------------------
+# Work division: the core grid, as the iteration space states it
+# ---------------------------------------------------------------------------
+
+
+def core_divisions(
+    iteration_space: dict[sympy.Symbol, tuple[sympy.Expr, int]],
+) -> tuple[list[tuple[sympy.Symbol, int, int]], int]:
+    """``(divisions, total_cores)`` for one iteration space.
+
+    ``OpSpec.iteration_space`` maps each symbol to ``(range, work_division)``,
+    where the division is the number of cores that symbol's range is split
+    across -- decided upstream by ``work_division.py`` from ``config.sencores``.
+    The core grid is one flat index in ``[0, total_cores)``, read as a mixed-radix
+    number over the divided symbols, so each division is returned as
+    ``(sym, div, inner)`` **innermost-first**: that symbol's portion of the grid
+    is ``(core_id // inner) % div``.
+
+    ``total_cores`` is the product of the divisions, so an undivided space gives
+    ``([], 1)`` -- a single-core kernel, stated by the contract rather than
+    assumed.
+    """
+    split = [
+        (sym, int(div)) for sym, (_range, div) in iteration_space.items() if div > 1
+    ]
+    total_cores = 1
+    for _sym, div in split:
+        total_cores *= div
+    divisions: list[tuple[sympy.Symbol, int, int]] = []
+    inner = 1
+    for sym, div in reversed(split):  # innermost first
+        divisions.append((sym, div, inner))
+        inner *= div
+    return divisions, total_cores
+
+
+def per_core_extent(
+    arg: TensorArg, divisors: dict[sympy.Symbol, int]
+) -> tuple[list[int], list[sympy.Symbol | None]]:
+    """``(extent, symbol)`` per device axis: one core's share, and what divides it.
+
+    Each device axis carries at most one iteration symbol -- a bare ``c_i`` or an
+    outer-stick ``c_i // stick`` -- so at most one divisor applies to it, and the
+    axis' per-core extent is its full extent divided by that divisor.  The
+    trailing axis is the within-stick one and is never divided: a stick is the
+    unit of transfer, so splitting it across cores would split a stick.
+
+    The returned symbol list says which division each axis follows (``None`` for
+    an axis no division touches), which is what turns a division into a step
+    along that axis.
+    """
+    extent = [int(s) for s in arg.device_size]
+    coords = list(arg.device_coordinates)
+    if divisors and len(coords) != len(extent):
+        raise NotImplementedError(
+            f"OpSpec work division: {arg.name!r} carries {len(coords)} device "
+            f"coordinate(s) for {len(extent)} device axes, so which axis a "
+            "divided symbol walks cannot be told"
+        )
+    per_core: list[int] = []
+    symbols: list[sympy.Symbol | None] = []
+    last = len(extent) - 1
+    for axis, size in enumerate(extent):
+        symbol = None
+        if divisors and axis != last:
+            kind, symbol = _dim_info(coords[axis])
+            if kind == _DIM_CONST:
+                symbol = None
+        divisor = divisors.get(symbol, 1) if symbol is not None else 1
+        if divisor > 1 and size % divisor:
+            raise NotImplementedError(
+                f"OpSpec work division: device axis {axis} of {arg.name!r} has "
+                f"extent {size}, which {divisor} cores do not divide evenly; a "
+                "ragged per-core tile is not supported"
+            )
+        per_core.append(size // divisor)
+        symbols.append(symbol if divisor > 1 else None)
+    return per_core, symbols


### PR DESCRIPTION
> **Stacked PR — 2 of 4.**  Each PR's base is the one above it, so review and
> merge top-down.  The diff here is only this PR's own commits.
>
> 1. `ktir-emitter` — Split the KTIR emitter into a plan and an emission: the plan/emit boundary, loops, threaded intermediates
> 2. `ktir-core-grid` — Take the grid from the iteration space: multi-core work division  **← you are here**
> 3. `ktir-reduction` — Emit a reduction as one linalg.reduce: `sum`
> 4. `ktir-dims` — Take a symbolic device dimension as a kernel argument: the only part with no on-device evidence, hence last
>
> Base of the stack is `main`.  PR numbers are filled in once the later ones are
> open; until then the branch names are the reference.

---
#### What type of PR is this?

- [x] feature

#### What this PR does

The grid comes from `iteration_space`'s per-symbol work division — the value
`work_division.py` already derived from the configured core count. The emitter reads
the contract rather than taking a core count of its own, and after this PR nothing in
it reads `config` at all.

A division is planned as the **outermost level**. Its step along an axis is the
per-core extent, so it lands in the same coefficient matrix as an enclosing loop's
induction variable, and emission is unchanged: one `ktdp.get_compute_tile_id`, read
as the mixed-radix number the divisions describe, with trivial terms omitted. The
views do not move — every core addresses the same buffer — only the tiles shrink.

#### Where this mirrors the SDSC path

| | SDSC | KTIR |
|---|---|---|
| Grid | work slices, from the per-symbol division in `iteration_space` | `grid = [product]` plus one tile id, from the same division |
| Per-core offset | folded into each core's compiled base address | a subscript term, derived from the tile id |
| Per-core extent | `strides // work_slices` | `device_size // division`, applied per axis |

#### Refused, because each is a silently wrong kernel otherwise

Two ops in one kernel asking for different divisions — there is one grid. A division
that does not divide its axis evenly — a ragged per-core tile. A division no output
axis follows — that is cores duplicating each other rather than sharing work, and is
what dividing the within-stick axis or a reduced axis looks like.

#### Verified

The pointwise `add` divided across 32 cores was compiled through the backend and run
on device against CPU eager, matching to one fp16 unit in the last place. Acceptance
did not vary with the core count — 1, 2, 8 and 32 behave identically — so the grid
determines how work is divided rather than whether the kernel compiles.

Goldens pin the divided form (`grid = [32]`, one tile id, per-core tiles against
unchanged views), the single-core form emitting no tile id at all, and the
mixed-radix decode when two symbols are divided.

#### Does this PR introduce a user-facing change?

No. `generate_ktir` is reached only under `TORCH_SPYRE_KTIR=1`; the SDSC path is
untouched.
