### PR TITLE
[KTIR Emitter] Emit a reduction as one linalg.reduce: `sum`-nononstick

### DIFF
--- a/tests/inductor/test_ktir_emitter.py
+++ b/tests/inductor/test_ktir_emitter.py
@@ -282,6 +282,95 @@ module {
     _mlir_ktdp_available(),
     "mlir_ktdp with the func/arith/linalg/scf/tensor dialect bindings is not installed",
 )
+class TestReductionEmission(unittest.TestCase):
+    """``sum`` over the axis that does not survive, one stick per core.
+
+    The spec is the shape the frontend really produces for
+    ``torch.sum(x[256, 2048], dim=0)``: the reduced axis is still in the output's
+    ``device_size`` as a unit extent with a constant coordinate, and the output's
+    2048 lanes are 32 sticks, which is what the 32 cores divide.
+
+    What comes out is the form a hand-written KTIR ``sum`` kernel uses -- a
+    ``linalg.reduce`` with ``dimensions = [1]`` into a bare ``tensor.empty``, and
+    no reshape, because the placeholder axis is dropped rather than reduced.  A
+    ``linalg.fill`` accumulator would be rejected by the scheduler's first pass,
+    and ``tensor.expand_shape`` is not supported anywhere in it, so both are worth
+    the golden pinning them out.
+    """
+
+    EXPECTED_SUM_KTIR = """\
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map1 = affine_map<(d0, d1) -> (d0, d1)>
+#set = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 31 >= 0, d1 >= 0, -d1 + 255 >= 0, d2 >= 0, -d2 + 63 >= 0)>
+#set1 = affine_set<(d0, d1) : (d0 >= 0, -d0 + 31 >= 0, d1 >= 0, -d1 + 63 >= 0)>
+#set2 = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 >= 0, d1 >= 0, -d1 + 255 >= 0, d2 >= 0, -d2 + 63 >= 0)>
+#set3 = affine_set<(d0, d1) : (d0 >= 0, -d0 >= 0, d1 >= 0, -d1 + 63 >= 0)>
+module {
+  func.func @ktir_sum_0(%arg0: index, %arg1: index) attributes {grid = [32]} {
+    %c0 = arith.constant 0 : index
+    %0 = ktdp.get_compute_tile_id : index
+    %1 = ktdp.construct_memory_view %arg0, sizes: [32, 256, 64], strides: [16384, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<32x256x64xf16>
+    %2 = ktdp.construct_memory_view %arg1, sizes: [32, 64], strides: [64, 1] {coordinate_set = #set1, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<32x64xf16>
+    %3 = ktdp.construct_access_tile %1[%0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set2} : memref<32x256x64xf16> -> !ktdp.access_tile<1x256x64xindex>
+    %4 = ktdp.load %3 : <1x256x64xindex> -> tensor<1x256x64xf16>
+    %5 = tensor.empty() : tensor<1x64xf16>
+    %reduced = linalg.reduce ins(%4 : tensor<1x256x64xf16>) outs(%5 : tensor<1x64xf16>) dimensions = [1] 
+      (%in: f16, %init: f16) {
+        %7 = arith.addf %in, %init : f16
+        linalg.yield %7 : f16
+      }
+    %6 = ktdp.construct_access_tile %2[%0, %c0] {access_tile_order = #map1, access_tile_set = #set3} : memref<32x64xf16> -> !ktdp.access_tile<1x64xindex>
+    ktdp.store %reduced, %6 : tensor<1x64xf16>, <1x64xindex>
+    return
+  }
+}
+"""
+
+    @staticmethod
+    def _sum_specs():
+        """``sum(x[256, 2048], dim=0)`` as the frontend projects it."""
+        import sympy
+
+        lanes, rows = sympy.symbols("c0 c1")
+        # The two device-axis coordinate forms the projection emits: the plain
+        # sympy floor for the outer-stick index, and Mod for the lanes.
+        stick, lane = sympy.floor(lanes / 64), sympy.Mod(lanes, 64)
+        return [
+            make_op_spec(
+                "sum",
+                is_reduction=True,
+                inputs=1,
+                sizes=[[32, 256, 64], [1, 32, 64]],
+                # The reduced axis is still in the output, as a unit extent at a
+                # constant coordinate: rank 3 in, rank 3 out.
+                coords_per_arg=[[stick, rows, lane], [sympy.Integer(0), stick, lane]],
+                space={lanes: (2048, 32), rows: (256, 1)},
+            )
+        ]
+
+    def test_sum_golden(self):
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        emitted = generate_ktir("ktir_sum_0", self._sum_specs())
+        self.assertEqual(emitted, self.EXPECTED_SUM_KTIR)
+
+    def test_the_placeholder_axis_is_dropped_not_reduced(self):
+        """The output is rank 2 everywhere -- view, tile and stored tensor -- so
+        no reshape stands between the reduce and the store."""
+        from torch_spyre._inductor.codegen import ktir
+
+        plan = ktir.build_kernel_plan(self._sum_specs())
+        [step] = plan.steps
+        self.assertEqual(step.reduce_dims, (1,))  # the 256 rows
+        self.assertEqual(step.out.extent, (1, 64))
+        self.assertEqual(plan.buffers["buf0"].layout.extent, (32, 64))
+        self.assertNotIn("expand_shape", ktir.generate_ktir("k", self._sum_specs()))
+
+
+@unittest.skipUnless(
+    _mlir_ktdp_available(),
+    "mlir_ktdp with the func/arith/linalg/scf/tensor dialect bindings is not installed",
+)
 class TestTiledLoopEmission(unittest.TestCase):
     """A two-level nest, planned and emitted through the ordinary path.
 

--- a/tests/inductor/test_ktir_validate.py
+++ b/tests/inductor/test_ktir_validate.py
@@ -71,6 +71,7 @@ def make_op_spec(
     size: list = ADD_SIZE,
     sizes: list | None = None,
     coords: list | None = None,
+    coords_per_arg: list | None = None,
     dtype: DataFormats = FP16,
     allocations: list | None = None,
     baked: bool = False,
@@ -92,8 +93,10 @@ def make_op_spec(
     The deviations, each a keyword:
 
     * ``op`` / ``inputs`` / ``outputs`` / ``names`` -- the op and its roles.
-    * ``size`` for every arg, or ``sizes`` per arg; ``coords=[]`` for a tiled arg,
-      which addresses through ``advances`` instead of coordinates.
+    * ``size`` for every arg, or ``sizes`` per arg; likewise ``coords`` for every
+      arg or ``coords_per_arg`` for one list each, which a reduction needs because
+      its output drops an axis.  ``coords=[]`` is a tiled arg, addressing through
+      ``advances`` instead of coordinates.
     * ``allocations`` per arg, for an ``lx`` / ``hbm_pool`` intermediate or an
       unrecognised space; ``baked=True`` for the byte HBM address the baked form
       wants, which is the same field said the other way, so not both.
@@ -123,17 +126,18 @@ def make_op_spec(
             if allocation is None:
                 allocation = {"hbm": arg_index << 34 if baked else None}
         arg_size = at(sizes, position) or size
+        arg_coords = at(coords_per_arg, position)
+        if arg_coords is None:
+            arg_coords = (
+                sympy.symbols(f"d0:{len(arg_size)}") if coords is None else coords
+            )
         args.append(
             TensorArg(
                 is_input=is_input,
                 arg_index=arg_index,
                 device_dtype=dtype,
                 device_size=list(arg_size),
-                device_coordinates=(
-                    list(sympy.symbols(f"d0:{len(arg_size)}"))
-                    if coords is None
-                    else list(coords)
-                ),
+                device_coordinates=list(arg_coords),
                 allocation=allocation,
                 name=at(names, position)
                 or (f"arg{ordinal}" if is_input else f"buf{ordinal}"),
@@ -256,10 +260,11 @@ class TestValidateRejections(unittest.TestCase):
     def test_unexpected_entry_rejected(self):
         self._rejects(["not a spec"], "unexpected spec entry str")
 
-    def test_reduction_rejected(self):
-        """A reduction is a second emission shape, not a second binding: refused
-        until a builder method exists for it."""
-        self._rejects([make_op_spec(is_reduction=True)], "reductions are not supported")
+    def test_family_mismatch_rejected(self):
+        """An ``add`` asked for as a reduction: the recipe is what has an
+        emission, so the request is refused rather than emitted elementwise."""
+        specs = [make_op_spec(is_reduction=True)]
+        self._rejects(specs, "registered as ELEMENTWISE")
 
     def test_unregistered_op_rejected(self):
         """An op with no recipe is rejected, and the message names what exists."""
@@ -335,9 +340,8 @@ class TestRejectionsThroughGenerateKtir(unittest.TestCase):
     ``mlir_ktdp``; they run here precisely because it validates first.
     """
 
-    def test_reduction_unsupported(self):
-        specs = [make_op_spec()]
-        specs[0].is_reduction = True
+    def test_family_mismatch_unsupported(self):
+        specs = [make_op_spec(is_reduction=True)]
         with self.assertRaises(NotImplementedError):
             ktir.generate_ktir("ktir_fused_add_0", specs)
 
@@ -552,12 +556,12 @@ class TestRecipes(unittest.TestCase):
             ktir.Recipe(arity=0, family=ktir.Family.ELEMENTWISE, binding=lambda: None)
 
     def test_family_comes_from_the_spec_not_the_name(self):
-        """The family is read from the spec rather than the op name, so one
-        binding can be wanted in more than one shape.  Only ELEMENTWISE has an
-        emission today, which is why a reducing spec is refused by the walk."""
-        spec = [make_op_spec()][0]
-        self.assertIs(ktir.Family.of(spec), ktir.Family.ELEMENTWISE)
-        self.assertEqual(list(ktir.Family), [ktir.Family.ELEMENTWISE])
+        """A reducing spec asks for REDUCTION even when the op is registered
+        elementwise -- which is why the plan walk rejects it rather than the walk
+        silently emitting the wrong shape."""
+        self.assertIs(ktir.Family.of(make_op_spec()), ktir.Family.ELEMENTWISE)
+        reducing = make_op_spec(is_reduction=True)
+        self.assertIs(ktir.Family.of(reducing), ktir.Family.REDUCTION)
 
     def test_emit_asserts_on_an_unplanned_step(self):
         """The emitter's only remaining ``raise`` is this plan-bug guard.

--- a/tests/inductor/test_opspec_utils.py
+++ b/tests/inductor/test_opspec_utils.py
@@ -37,6 +37,7 @@ from torch_spyre._inductor.codegen.opspec_utils import (
     buf_id,
     core_divisions,
     per_core_extent,
+    reduced_axes,
     row_major_strides,
 )
 from torch_spyre._inductor.op_spec import OpSpec, TensorArg
@@ -262,6 +263,45 @@ class TestPerCoreExtent(unittest.TestCase):
         arg = self._arg([16, 512, 64], [d0, d1, sympy.Mod(d1, 64)])
         with self.assertRaises(NotImplementedError):
             per_core_extent(arg, {d1: 7})
+
+
+class TestReducedAxes(unittest.TestCase):
+    """Which input axes a reduction consumes, read from the coordinates."""
+
+    def test_the_placeholder_axis_is_the_reduced_one(self):
+        """``sum(x[256, 2048], dim=0)`` as projected: the reduced axis survives in
+        the output as a unit extent at a constant coordinate."""
+        lanes, rows = sympy.symbols("c0 c1")
+        stick, lane = sympy.floor(lanes / 64), sympy.Mod(lanes, 64)
+        reduced, placeholder = reduced_axes(
+            [stick, rows, lane],
+            [32, 256, 64],
+            [sympy.Integer(0), stick, lane],
+            [1, 32, 64],
+        )
+        self.assertEqual(reduced, (1,))  # the 256 rows
+        self.assertEqual(placeholder, (0,))
+
+    def test_a_dropped_axis_needs_no_placeholder(self):
+        """The same reduction with the output already at rank 2."""
+        lanes, rows = sympy.symbols("c0 c1")
+        stick, lane = sympy.floor(lanes / 64), sympy.Mod(lanes, 64)
+        self.assertEqual(
+            reduced_axes([stick, rows, lane], [32, 256, 64], [stick, lane], [32, 64]),
+            ((1,), ()),
+        )
+
+    def test_nothing_reduced_raises(self):
+        lanes, rows = sympy.symbols("c0 c1")
+        with self.assertRaises(NotImplementedError):
+            reduced_axes([rows, lanes], [256, 64], [rows, lanes], [256, 64])
+
+    def test_a_resized_surviving_axis_raises(self):
+        """A kept axis whose extent changed is not a reduction of the other axes."""
+        lanes, rows = sympy.symbols("c0 c1")
+        stick, lane = sympy.floor(lanes / 64), sympy.Mod(lanes, 64)
+        with self.assertRaises(NotImplementedError):
+            reduced_axes([stick, rows, lane], [32, 256, 64], [stick, lane], [16, 64])
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/codegen/ktir.py
+++ b/torch_spyre/_inductor/codegen/ktir.py
@@ -65,6 +65,7 @@ from torch_spyre._inductor.codegen.opspec_utils import (
     buf_id,
     core_divisions,
     per_core_extent,
+    reduced_axes,
     row_major_strides,
 )
 from torch_spyre._inductor.constants import STAGGERED_EAS
@@ -309,7 +310,8 @@ class ComputeStep:
 
     ``ins`` is one ``(buf_id, Access)`` per operand, in the op's operand order.
     ``store`` is ``False`` for an internal result, which is bound in scope for a
-    later step instead of being stored through ``out``.
+    later step instead of being stored through ``out``.  ``reduce_dims`` is the
+    input tile axes a REDUCTION consumes, and empty for every other family.
     """
 
     op: str  # a KtirBuilder.RECIPES key
@@ -318,6 +320,7 @@ class ComputeStep:
     out: Access
     out_buf_id: str
     store: bool
+    reduce_dims: tuple[int, ...] = ()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -614,6 +617,22 @@ def _divide(
         for symbol in symbols
     ]
     return tuple(per_core), rows
+
+
+def _squeezed(arg: TensorArg, axes: Sequence[int]) -> TensorArg:
+    """``arg`` without ``axes``: same buffer, same bytes, fewer device axes.
+
+    Dropping a unit axis renames nothing and moves nothing -- it contributes no
+    elements and no stride -- so every later derivation sees an arg of the rank
+    the emitted tile actually has, and ``buf_id`` still identifies one buffer.
+    """
+    drop = set(axes)
+    keep = [axis for axis in range(len(arg.device_size)) if axis not in drop]
+    return dataclasses.replace(
+        arg,
+        device_size=[arg.device_size[axis] for axis in keep],
+        device_coordinates=[arg.device_coordinates[axis] for axis in keep],
+    )
 
 
 def _access(
@@ -919,12 +938,16 @@ class KernelPlan:
                     f"OpSpec->KTIR: op {entry.op!r} is not supported yet "
                     f"(registered: {sorted(KtirBuilder.RECIPES)})"
                 )
-            if entry.is_reduction:
-                # A reduction is a second emission shape (an accumulator, and
-                # axes that do not survive), not a second binding: refused until
-                # ``Family.REDUCTION`` has a builder method behind it.
+            family = Family.of(entry)
+            if family is not KtirBuilder.RECIPES[entry.op].family:
+                # The spec asks for a shape this op's recipe does not implement
+                # (an 'add' as a reduction, a 'sum' as elementwise).  The recipe
+                # is what has an emission behind it, so the request is refused
+                # rather than emitted in the shape that happens to exist.
                 raise NotImplementedError(
-                    "OpSpec->KTIR: reductions are not supported yet"
+                    f"OpSpec->KTIR: op {entry.op!r} is registered as "
+                    f"{KtirBuilder.RECIPES[entry.op].family.name} but this spec "
+                    f"asks for {family.name}"
                 )
             steps.append(self._compute_step(entry, loops))
         return tuple(steps)
@@ -939,27 +962,51 @@ class KernelPlan:
         """
         out, inputs = validated_roles(spec)
         out_extents = [int(s) for s in out.device_size]
-        args = list(spec.args)
+        family = Family.of(spec)
         for arg in inputs:
             # In-place (input buffer aliases the output) is not supported yet.
             if buf_id(arg) == buf_id(out):
                 raise NotImplementedError(
                     "OpSpec->KTIR: in-place ops (input aliases output) not supported"
                 )
-            # Reject broadcast / transpose operands: only operands whose device
-            # axes already match the output tile exactly are supported.
-            if (
-                align_reshape_plan(
-                    list(arg.device_coordinates),
-                    [int(s) for s in arg.device_size],
-                    list(out.device_coordinates),
-                    out_extents,
-                )
-                is not None
-            ):
-                raise NotImplementedError(
-                    "OpSpec->KTIR: broadcast / reshape operands not supported yet"
-                )
+        reduce_dims: tuple[int, ...] = ()
+        args = list(spec.args)
+        if family is Family.REDUCTION:
+            # Which axes a reduction consumes is a fact about its operands, so it
+            # is derived here (once) and carried on the step, not re-derived from
+            # the op name at emit time.
+            [source] = inputs
+            reduce_dims, placeholder = reduced_axes(
+                source.device_coordinates,
+                [int(s) for s in source.device_size],
+                out.device_coordinates,
+                out_extents,
+            )
+            if placeholder:
+                # The projection leaves each reduced axis in the output as a unit
+                # extent; the reduced tile does not have it at all.  Squeezing the
+                # arg here, once, is what keeps every derivation after this point
+                # unaware that a reduction is different: the output's view, tile
+                # and stored tensor are all the same (lower) rank.
+                squeezed = _squeezed(out, placeholder)
+                args = [squeezed if arg is out else arg for arg in args]
+                out = squeezed
+        else:
+            for arg in inputs:
+                # Reject broadcast / transpose operands: only operands whose
+                # device axes already match the output tile exactly are supported.
+                if (
+                    align_reshape_plan(
+                        list(arg.device_coordinates),
+                        [int(s) for s in arg.device_size],
+                        list(out.device_coordinates),
+                        out_extents,
+                    )
+                    is not None
+                ):
+                    raise NotImplementedError(
+                        "OpSpec->KTIR: broadcast / reshape operands not supported yet"
+                    )
         levels = _levels(spec, loops)
         accesses = {buf_id(arg): self._access_of(arg, levels) for arg in args}
         # Every division must move this op's output: cores divide work by writing
@@ -979,10 +1026,11 @@ class KernelPlan:
                 )
         return ComputeStep(
             op=spec.op,
-            family=Family.of(spec),
+            family=family,
             ins=tuple((buf_id(arg), accesses[buf_id(arg)]) for arg in inputs),
             out=accesses[buf_id(out)],
             out_buf_id=buf_id(out),
+            reduce_dims=reduce_dims,
             # An internal buffer never reaches memory: it is threaded as a value,
             # so it gets no store, no func parameter, no view and no address.
             store=not is_internal(out),
@@ -1099,12 +1147,13 @@ class Family(enum.Enum):
     ``Family.of`` reads the one a spec asks for."""
 
     ELEMENTWISE = enum.auto()
+    REDUCTION = enum.auto()
 
     @classmethod
     def of(cls, spec: OpSpec) -> Family:
         """The family ``spec`` asks for, read from the spec rather than the op
         name: the same binding can be wanted in more than one shape."""
-        return cls.ELEMENTWISE
+        return cls.REDUCTION if spec.is_reduction else cls.ELEMENTWISE
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1496,6 +1545,7 @@ class KtirBuilder:
     RECIPES: ClassVar[dict[str, Recipe]] = {
         "add": Recipe(arity=2, family=Family.ELEMENTWISE, binding=lambda: linalg.add),
         "mul": Recipe(arity=2, family=Family.ELEMENTWISE, binding=lambda: linalg.mul),
+        "sum": Recipe(arity=1, family=Family.REDUCTION, binding=lambda: arith.addf),
     }
 
     def elementwise(self, recipe: Recipe, ins: Sequence, step: ComputeStep):
@@ -1515,6 +1565,40 @@ class KtirBuilder:
             outs=[dest],
             result_tensors=[ir.RankedTensorType.get(extents, elt_t)],
         )
+
+    def reduction(self, recipe: Recipe, ins: Sequence, step: ComputeStep):
+        """``linalg.reduce`` over ``step.reduce_dims``, combining with ``recipe``.
+
+        The recipe contributes the *combiner* here rather than a whole-op builder
+        (``arith.addf`` for a sum), because ``linalg.reduce`` is one op for every
+        reduction and the payload is what differs between them.
+
+        The accumulator is a bare ``tensor.empty``, not a filled one: the identity
+        belongs to whoever materialises the accumulator, and on this path that is
+        the scheduler's reduction passes -- a ``linalg.fill`` here becomes a second
+        compute op they have to unpick.  Reducing in place also means no reshape:
+        keeping the surviving axes in the output tile makes the result the shape
+        the store's access tile already has.
+        """
+        [source] = ins
+        extents = list(step.out.extent)
+        elt_t = self.named_type(step.out.elems.value)
+        dest = self.val(tensor.EmptyOp(extents, elt_t))
+        combine = recipe.binding()
+
+        def body(accumulated, element):
+            return combine(accumulated, element)
+
+        # The region builder reads the block argument types off the annotations,
+        # and the element type is only known here, so they are set rather than
+        # written.
+        body.__annotations__ = {"accumulated": elt_t, "element": elt_t}
+        return linalg.reduce(
+            result=[ir.RankedTensorType.get(extents, elt_t)],
+            inputs=[source],
+            inits=[dest],
+            dimensions=list(step.reduce_dims),
+        )(body)
 
     # -- attributes --------------------------------------------------------
 

--- a/torch_spyre/_inductor/codegen/opspec_utils.py
+++ b/torch_spyre/_inductor/codegen/opspec_utils.py
@@ -46,6 +46,7 @@ __all__ = [
     "buf_id",
     "core_divisions",
     "per_core_extent",
+    "reduced_axes",
     "row_major_strides",
 ]
 
@@ -237,6 +238,70 @@ def align_reshape_plan(
         )
     broadcast_to = out_block if reshape_to != out_block else None
     return (reshape_to, broadcast_to)
+
+
+def reduced_axes(
+    in_coords: Sequence[sympy.Expr],
+    in_extent: Sequence[int],
+    out_coords: Sequence[sympy.Expr],
+    out_extent: Sequence[int],
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """``(reduced, placeholder)`` axes for one reduction.
+
+    ``reduced`` is the input device axes the reduction consumes, in increasing
+    order, and ``placeholder`` is the output axes that are only standing in for
+    them: the projection keeps a reduced axis in the output's ``device_size`` as a
+    unit extent with a constant coordinate, so the output is the same rank as the
+    input even though it carries less.  A consumer wants the reduced axis gone
+    (the accepted KTIR form stores a rank-2 tile into a rank-2 view), so a
+    consumer of this helper drops those axes.
+
+    Which axes survive is read from the coordinates -- an output axis matches an
+    input axis when their ``(kind, sym)`` classifications agree (see
+    ``_dim_info``) -- rather than from the op name or a position convention, so a
+    reduction over the middle axis of a stick-tiled tile is described as exactly
+    that.
+
+    Raises ``NotImplementedError`` when the surviving axes are permuted (which
+    needs a transpose, not a reduce) or when a surviving extent changes, either
+    of which would make the reduce silently read the wrong elements.
+    """
+    in_info = [_dim_info(c) for c in in_coords]
+    placeholder = tuple(
+        axis
+        for axis, coord in enumerate(out_coords)
+        if _dim_info(coord)[0] == _DIM_CONST and int(out_extent[axis]) == 1
+    )
+    surviving = [axis for axis in range(len(out_coords)) if axis not in placeholder]
+    out_info = [_dim_info(out_coords[axis]) for axis in surviving]
+    kept: list[int] = []
+    position = 0
+    for axis, info in enumerate(out_info):
+        while position < len(in_info) and in_info[position] != info:
+            position += 1
+        if position == len(in_info):
+            raise NotImplementedError(
+                f"OpSpec reduction: output device axis {surviving[axis]} "
+                f"({out_coords[surviving[axis]]!r}) does not match a later input "
+                "axis; the surviving axes are permuted, which needs a transpose "
+                "rather than a reduction"
+            )
+        kept.append(position)
+        position += 1
+    for axis, source in enumerate(kept):
+        if int(out_extent[surviving[axis]]) != int(in_extent[source]):
+            raise NotImplementedError(
+                f"OpSpec reduction: surviving axis {surviving[axis]} has extent "
+                f"{out_extent[surviving[axis]]} but its input axis {source} has "
+                f"extent {in_extent[source]}; a reduction does not resize a kept axis"
+            )
+    reduced = tuple(axis for axis in range(len(in_info)) if axis not in set(kept))
+    if not reduced:
+        raise NotImplementedError(
+            "OpSpec reduction: the output carries every input device axis, so "
+            "there is no axis to reduce"
+        )
+    return reduced, placeholder
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> **Stacked PR — 3 of 4.**  Each PR's base is the one above it, so review and
> merge top-down.  The diff here is only this PR's own commits.
>
> 1. `ktir-emitter` — Split the KTIR emitter into a plan and an emission: the plan/emit boundary, loops, threaded intermediates
> 2. `ktir-core-grid` — Take the grid from the iteration space: multi-core work division
> 3. `ktir-reduction` — Emit a reduction as one linalg.reduce: `sum`  **← you are here**
> 4. `ktir-dims` — Take a symbolic device dimension as a kernel argument: the only part with no on-device evidence, hence last
>
> Base of the stack is `main`.  PR numbers are filled in once the later ones are
> open; until then the branch names are the reference.

---
#### What type of PR is this?

- [x] feature

#### What this PR does

`sum` is one `RECIPES` entry in a new `Family.REDUCTION`, whose builder method is
a single `linalg.reduce` over the axes read from the operands' coordinates.

The recipe contributes the **combiner** (`arith.addf`) rather than a whole-op
builder, because `linalg.reduce` is the op for every reduction and the payload is
what differs between them — so `max` will be `arith.maximumf` and nothing else.
Which axes are reduced is read from the device coordinates, not from the op name
or a position convention, so a reduction over the middle axis of a stick-tiled
tile is described as exactly that.

Two things the emitted form deliberately does **not** have:

* **No `linalg.fill` on the accumulator.** The identity belongs to whoever
  materialises the accumulator, which on this path is the scheduler's reduction
  passes; a fill here becomes a second compute op for them to unpick.
* **No reshape.** The projection leaves each reduced axis in the output's
  `device_size` as a unit extent at a constant coordinate. Rather than reduce to a
  lower rank and expand back — nothing downstream supports `expand_shape` — the
  arg is squeezed once, in the plan. The output's view, tile and stored tensor are
  then all the same rank, and every derivation after that point is unaware that a
  reduction is different.

Because the family is read from the spec while the emission comes from the recipe,
the two can now disagree: an `add` asked for as a reduction, or a `sum` asked for
as elementwise, is refused rather than emitted in whichever shape happens to
exist.

#### Where this mirrors the SDSC path

| | SDSC | KTIR |
|---|---|---|
| Reduction | one of several op families `parse_op_spec` covers, selected by opfunc | one recipe plus one builder method, selected by `Family` |
| Accumulator | the compiled op owns it | left to the scheduler's reduction passes, which materialise and zero the real one — a bare destination is what they expect |
| Reduced axes | iteration space and work slices | read from the operands' device coordinates |

#### Refused

A reduction split across cores — the previous PR's check already refuses a
division no output axis follows, which is exactly what dividing the reduced axis
looks like. It needs a cross-core combine.

#### Verified

`torch.sum` over a stick-aligned input was compiled through the backend and run on
device against CPU eager, matching within fp16 accumulation error (the device sums
in a different order). The emitted form is the one a hand-written KTIR `sum`
kernel already uses, so the scheduler reads this shape today.

#### Does this PR introduce a user-facing change?

No. `generate_ktir` is reached only under `TORCH_SPYRE_KTIR=1`; the SDSC path is
untouched.
