### PR TITLE
:bug: Remove lazy initialzation for spyre profiler which also starts runtime

### DIFF
--- a/tests/test_spyre_lazy_init.py
+++ b/tests/test_spyre_lazy_init.py
@@ -95,6 +95,69 @@ class TestSpyre(TestCase):
         )
         assert out.endswith("OK"), f"unexpected stdout:\n{out}\nstderr:\n{err}"
 
+    def test_profiler_construction_does_not_start_runtime(self):
+        """Constructing ``torch.profiler.profile`` must not start the runtime.
+
+        Autoload patches ``torch.profiler.profile.__init__`` so the first
+        construction imports ``_C``, whose static
+        ``REGISTER_PRIVATEUSE1_PROFILER`` initializer registers the activity
+        profiler. Importing ``_C`` is sufficient; starting the device runtime is
+        not, and doing so breaks processes that construct a profiler without
+        owning a card -- the vLLM API-server front-end builds a CPU-only
+        profiler and would fail to open the VFIO device already held by the
+        worker process. Run in a fresh process so an already-started runtime
+        from another test cannot mask a regression.
+        """
+        import sys
+        import subprocess
+        import textwrap
+
+        script = textwrap.dedent("""
+            import torch
+
+            assert torch.spyre.is_initialized() is False, (
+                "runtime was initialized during import"
+            )
+
+            # CPU-only profiler: nothing here justifies touching the device.
+            torch.profiler.profile(
+                activities=[torch.profiler.ProfilerActivity.CPU],
+            )
+            assert torch.spyre.is_initialized() is False, (
+                "constructing torch.profiler.profile started the device runtime"
+            )
+
+            # The patch is one-shot and restores the original __init__; a second
+            # construction must leave the runtime alone too.
+            torch.profiler.profile(
+                activities=[torch.profiler.ProfilerActivity.CPU],
+            )
+            assert torch.spyre.is_initialized() is False, (
+                "second profile() construction started the device runtime"
+            )
+
+            print("OK")
+        """)
+
+        env = os.environ.copy()
+        env["DT_DEEPRT_VERBOSE"] = "-1"
+        env["DTLOG_LEVEL"] = "error"
+
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            timeout=130,
+            text=True,
+        )
+        out = (proc.stdout or "").strip()
+        err = (proc.stderr or "").strip()
+        assert proc.returncode == 0, (
+            f"subprocess failed (rc={proc.returncode}).\nstdout:\n{out}\nstderr:\n{err}"
+        )
+        assert out.endswith("OK"), f"unexpected stdout:\n{out}\nstderr:\n{err}"
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch_spyre/__init__.py
+++ b/torch_spyre/__init__.py
@@ -356,11 +356,19 @@ def _autoload_impl():
         _orig_init = torch.profiler.profile.__init__
 
         def _init_with_spyre_profiler(self, *args, **kwargs):
-            # For first call, need to ensure torch_spyre._C is loaded so that SpyreProfiler is registered
-            if not torch.spyre.is_initialized():
-                torch.spyre._impl._lazy_init()
+            # Loading _C is all that is needed to register the Spyre profiler:
+            # the PrivateUse1 activity profiler is installed by the static
+            # REGISTER_PRIVATEUSE1_PROFILER initializer in
+            # csrc/profiler/SpyreActivityProfiler.cpp, which runs at .so load
+            # time and does not touch the device runtime.
+            #
+            # Deliberately does NOT start the runtime. profile() is constructed
+            # in processes that have no device role -- e.g. the vLLM API-server
+            # front-end, which traces CPU activity only -- and opening the card
+            # there fails once the process that owns it has it. Real device work
+            # self-triggers startRuntime() via std::call_once, so PrivateUse1
+            # tracing is unaffected.
             try:
-                # This will automatically register the profiler
                 import torch_spyre._C  # noqa: F401
             except ImportError:
                 pass


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Stops `torch.profiler.profile(...)` construction from starting the Spyre device runtime.


#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/spyre-inference/issues/528

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
