### PR TITLE
test: regression guards for indirect-KV / decode-path compile defects (#3705, #3732)

### DIFF
--- a/tests/inductor/test_gather_rank_projection.py
+++ b/tests/inductor/test_gather_rank_projection.py
@@ -1,0 +1,145 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Owner(s): ["module: cpp"]
+
+"""Regression guard: pointwise dim_order projection when a gather's value
+operand OUTRANKS its output (rank_diff < 0), torch-spyre#3732.
+
+``aten.index`` is a 2-arg pointwise (index tensor + value tensor), so
+``compute_layouts`` routes it to ``_multi_arg_pointwise_layouts``, whose
+``_is_supported_layout`` projects the output dim_order onto each input with::
+
+    rank_diff = len(output.size) - len(arg.layout.size)   # propagate_layouts.py
+    projected_dim_order = [d - rank_diff for d in dim_order if d >= rank_diff]
+
+That was written for BROADCAST (arg rank <= output rank). When the arg
+*outranks* the output (rank_diff < 0) the filter admits every entry and shifts
+them the wrong way, and the arg's extra leading dims are never added -- so the
+projected dim_order has fewer entries than the arg's host rank and the backend
+raises "Incompatible host_size and dim_order" at compile time.
+
+The minimal trigger is a rank-6 pointwise producer (a RoPE matmul over
+``[B, L, H, 2, 2, hd/2]``) feeding an ``aten.index`` gather whose rank-4 output
+is lower-rank than the producer. This is the shape hf-adapters' former Qwen3
+"fill" step built, before it dropped the ``source_index`` gather in favour of a
+single-token decode (see hf_adapters ``hf_common.kv_cache_update``). The
+gather-*before*-RoPE ordering (rank-4 value operand, rank_diff >= 0) is a
+bit-exact-equivalent workaround and compiles cleanly -- it is the passing
+control here.
+
+``test_gather_from_high_rank_producer`` is xfail until #3732 teaches the
+projection to handle rank_diff < 0; it flips to xpass the day the bug is fixed.
+The failure today is a compile-time ``InductorError`` (a Python exception, not a
+backend abort), so it is safe to keep in the suite.
+"""
+
+import pytest
+import torch
+from torch.testing._internal.common_utils import (
+    TestCase,
+    run_tests,
+)
+
+DEVICE = "spyre"
+
+# Shapes from the Qwen3-0.6B fill step that first surfaced this (B=1, nkv=8,
+# head_dim=128, BLOCK_SIZE=64). tok is an arbitrary in-block position to gather.
+_B, _NKV, _HD, _SEQ, _TOK = 1, 8, 128, 64, 37
+_DT = torch.float16
+# fp16 device storage rounds to ~4.9e-4; 2e-3 sits above that without masking a
+# wrong-value regression (matches tests/tensor/test_tensor_layout.py).
+_ATOL = _RTOL = 2e-3
+
+
+def _apply_rope_matmul(x, selected_freqs):
+    """RoPE-as-matmul (verbatim from hf_adapters.hf_common, inlined to keep this
+    test self-contained). The ``sf.mul(...)`` intermediate is rank 6:
+    ``[B, L, H, 2, 2, hd/2]``.
+    """
+    bsz, heads, length, dim = x.shape
+    half = dim // 2
+    x_ = x.transpose(1, 2).reshape(bsz, length, heads, 2, half)
+    sf = selected_freqs[:, :, None, :, :, :]
+    out = sf.mul(x_.unsqueeze(-3)).sum(4, keepdim=True).flatten(3)
+    return out.transpose(1, 2)
+
+
+def _gather_after_rope(k_full, freqs, sidx):
+    """Minimal #3732 trigger: rank-6 RoPE producer -> rank-4 gather. The gather's
+    value operand outranks its output (rank_diff < 0)."""
+    return _apply_rope_matmul(k_full, freqs).index_select(2, sidx)
+
+
+def _gather_before_rope(k_full, freqs, sidx):
+    """Workaround: gather first (rank-4 value operand), then RoPE. RoPE is
+    per-position, so gathering before or after it is bit-exact equivalent."""
+    k1 = k_full.index_select(2, sidx)
+    f1 = freqs.index_select(1, sidx)
+    return _apply_rope_matmul(k1, f1)
+
+
+def _inputs():
+    torch.manual_seed(0xAFFE)
+    k_full = torch.rand(_B, _NKV, _SEQ, _HD, dtype=_DT)
+    freqs = torch.rand(_B, _SEQ, 2, 2, _HD // 2, dtype=_DT)
+    sidx = torch.tensor([_TOK], dtype=torch.int64)
+    return k_full, freqs, sidx
+
+
+class TestGatherRankProjection(TestCase):
+    """Pin the rank_diff < 0 pointwise projection contract (torch-spyre#3732)."""
+
+    def setUp(self):
+        # Lazy device init (mirrors test_tensor_layout.py's `x.to("spyre")`).
+        torch.zeros(1, dtype=torch.float16).to(DEVICE)
+
+    def test_gather_before_rope_workaround_compiles(self):
+        """Control: the gather-before-RoPE ordering (rank-4 value operand,
+        rank_diff >= 0) compiles and matches the CPU reference. Proves the
+        gather itself is fine and isolates the defect to rank_diff < 0."""
+        k_full, freqs, sidx = _inputs()
+        want = _gather_before_rope(k_full, freqs, sidx)
+        got = torch.compile(_gather_before_rope, dynamic=False)(
+            k_full.to(DEVICE), freqs.to(DEVICE), sidx.to(DEVICE)
+        ).cpu()
+        self.assertEqual(got.shape, want.shape)
+        self.assertEqual(got.float(), want.float(), atol=_ATOL, rtol=_RTOL)
+
+    @pytest.mark.xfail(
+        reason=(
+            "torch-spyre#3732: _multi_arg_pointwise_layouts._is_supported_layout "
+            "projects the output dim_order onto inputs assuming arg rank <= output "
+            "rank; when the gather's value operand outranks its output "
+            "(rank_diff < 0) it builds a dim_order whose rank no longer matches "
+            "host_size and raises 'Incompatible host_size and dim_order' at "
+            "compile. Remove this xfail when #3732 handles rank_diff < 0."
+        ),
+        strict=False,
+    )
+    def test_gather_from_high_rank_producer(self):
+        """The SAME gather fed by a rank-6 RoPE producer (rank_diff < 0) must
+        compile and match the CPU reference. Today it raises 'Incompatible
+        host_size and dim_order' at compile, so this is xfail."""
+        k_full, freqs, sidx = _inputs()
+        want = _gather_after_rope(k_full, freqs, sidx)
+        got = torch.compile(_gather_after_rope, dynamic=False)(
+            k_full.to(DEVICE), freqs.to(DEVICE), sidx.to(DEVICE)
+        ).cpu()
+        self.assertEqual(got.shape, want.shape)
+        self.assertEqual(got.float(), want.float(), atol=_ATOL, rtol=_RTOL)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/inductor/test_seq1_decode_projection.py
+++ b/tests/inductor/test_seq1_decode_projection.py
@@ -1,0 +1,152 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Owner(s): ["module: cpp"]
+
+"""Regression guard: single-token (seq_len=1) SDPA feeding a projection matmul
+aborts the DDL scheduler with a degenerate ``M=1`` bmm geometry.
+
+A single-token decode step runs ``scaled_dot_product_attention`` on a
+``q=[B, H, 1, D]`` query and feeds the ``[B, H, 1, D]`` result -- reshaped to
+``[B, 1, H*D]`` -- into the output projection ``@ wo``. That trailing matmul has
+``M = 1`` (one row), and Inductor fuses it with the SDPA into a single bundle.
+The backend then aborts::
+
+    DtException: out_reuse_dim.size() == 1
+      deeptools/dcg/dcg_fe/scheduler/L3DlOpsScheduler.cpp line 960  (getMinParamBmm)
+    -> dxp_standalone died with SIGABRT
+
+``out_reuse_dim`` is the set of dims present in both bmm inputs but absent from
+the output -- the contracted dims. ``getMinParamBmm`` assumes exactly one. When
+``M`` degenerates to 1 the projection bmm's role labels come out as
+``inp0=[out, in]``, ``inp1=[out, in, mb]``, ``out=[mb]`` -- it contracts *both*
+``in`` and ``out``, so the reuse set has two members and the
+single-contraction-dim precondition fails. At ``seq_len=64`` the same op is
+generated with a healthy ``out_reuse={in}`` (size 1) and compiles cleanly, so
+the defect needs *both* ``M=1`` *and* the SDPA->projection fusion.
+
+The abort is raised inside the ``dxp_standalone`` child process and surfaces to
+the caller as a catchable ``InductorError`` (``CalledProcessError`` /
+``SIGABRT``), not a crash of the test process -- so this is a safe in-process
+``xfail``. It flips to xpass the day the scheduler handles the ``M=1``
+projection bmm geometry.
+
+See also torch-spyre#2527, a sibling ``M=1`` single-row decode abort in the same
+scheduler (``L3DlOpsScheduler.cpp:1041``, "Expect valid lower and upper bound
+parameters") -- same M=1-decode family, a different scheduler precondition.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+from torch.testing._internal.common_utils import (
+    TestCase,
+    run_tests,
+)
+
+DEVICE = "spyre"
+
+# Granite/Qwen-class decode shapes (B=1, H=8 heads, head_dim=128, cache L=576).
+_B, _H, _L, _D = 1, 8, 576, 128
+_HID = _H * _D
+_DT = torch.float16
+
+
+def _sdpa(q, k, v, m):
+    """Bare single-/multi-token attention over the full cache."""
+    return F.scaled_dot_product_attention(
+        q, k, v, attn_mask=m, scale=_D**-0.5, enable_gqa=True
+    )
+
+
+def _sdpa_oproj(q, k, v, m, wo):
+    """SDPA followed by the output projection -- the minimal fusion that aborts
+    at seq_len=1 (the ``M=1`` degenerate projection bmm)."""
+    a = _sdpa(q, k, v, m)
+    b, hh, s, dd = a.shape
+    return a.transpose(1, 2).reshape(b, s, hh * dd) @ wo
+
+
+def _sdpa_inputs(seq):
+    """CPU inputs for a decode (seq=1) or block (seq=64) step; move to device in
+    the test so the CPU tensors double as the golden reference."""
+    torch.manual_seed(0xAFFE)
+    q = torch.rand(_B, _H, seq, _D, dtype=_DT)
+    k = torch.rand(_B, _H, _L, _D, dtype=_DT)
+    v = torch.rand(_B, _H, _L, _D, dtype=_DT)
+    m = torch.zeros(_B, 1, seq, _L, dtype=_DT)
+    return q, k, v, m
+
+
+class TestSeq1DecodeProjection(TestCase):
+    """Pin the single-token SDPA->projection compile contract (M=1 bmm)."""
+
+    def setUp(self):
+        # Lazy device init (mirrors test_tensor_layout.py's `x.to("spyre")`).
+        torch.zeros(1, dtype=torch.float16).to(DEVICE)
+
+    def test_seq1_sdpa_alone_compiles(self):
+        """Control: bare SDPA at seq_len=1 compiles and matches CPU. Proves the
+        M=1 attention itself is fine and isolates the defect to the fusion with
+        the projection matmul."""
+        q, k, v, m = _sdpa_inputs(seq=1)
+        want = _sdpa(q, k, v, m)
+        got = torch.compile(_sdpa, dynamic=False)(
+            q.to(DEVICE), k.to(DEVICE), v.to(DEVICE), m.to(DEVICE)
+        ).cpu()
+        self.assertEqual(got.shape, want.shape)
+        self.assertEqual(got.float(), want.float(), atol=2e-3, rtol=2e-3)
+
+    def test_seq64_sdpa_oproj_compiles(self):
+        """Control: SDPA + output projection at seq_len=64 compiles and matches
+        CPU. Proves the fused SDPA->projection is fine when M > 1 and isolates
+        the defect to M=1."""
+        q, k, v, m = _sdpa_inputs(seq=64)
+        wo = torch.rand(_HID, _HID, dtype=_DT)
+        want = _sdpa_oproj(q, k, v, m, wo)
+        got = torch.compile(_sdpa_oproj, dynamic=False)(
+            q.to(DEVICE), k.to(DEVICE), v.to(DEVICE), m.to(DEVICE), wo.to(DEVICE)
+        ).cpu()
+        self.assertEqual(got.shape, want.shape)
+        # o_proj reduces over H*D=1024 fp16 terms (magnitude ~O(256)); a loose
+        # rtol distinguishes a correct result from garbage without flaking.
+        self.assertEqual(got.float(), want.float(), atol=2e-1, rtol=2e-2)
+
+    @pytest.mark.xfail(
+        reason=(
+            "torch-spyre: single-token (seq_len=1) SDPA fused with the output "
+            "projection makes an M=1 bmm whose output drops both contraction "
+            "dims, so getMinParamBmm's out_reuse_dim.size()==1 precondition fails "
+            "and dxp_standalone aborts (DtException, L3DlOpsScheduler.cpp:960). "
+            "Remove this xfail when the DDL scheduler handles the M=1 projection "
+            "bmm geometry. See also torch-spyre#2527 (sibling M=1-decode abort)."
+        ),
+        strict=False,
+    )
+    def test_seq1_sdpa_oproj_degenerate_bmm(self):
+        """The SAME SDPA->projection fusion at seq_len=1 must compile and match
+        CPU. Today the M=1 projection bmm aborts the scheduler
+        (out_reuse_dim.size()==1), so this is xfail."""
+        q, k, v, m = _sdpa_inputs(seq=1)
+        wo = torch.rand(_HID, _HID, dtype=_DT)
+        want = _sdpa_oproj(q, k, v, m, wo)
+        got = torch.compile(_sdpa_oproj, dynamic=False)(
+            q.to(DEVICE), k.to(DEVICE), v.to(DEVICE), m.to(DEVICE), wo.to(DEVICE)
+        ).cpu()
+        self.assertEqual(got.shape, want.shape)
+        self.assertEqual(got.float(), want.float(), atol=2e-1, rtol=2e-2)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/tensor/test_kv_scatter_layout.py
+++ b/tests/tensor/test_kv_scatter_layout.py
@@ -1,0 +1,269 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Owner(s): ["module: cpp"]
+
+"""Regression guard for the KV-scatter layout requirement (torch-spyre#3705).
+
+An indirect row scatter (``cache.index_copy(0, idx, src)``) is only correct on
+Spyre when the *indexed* dimension -- the cache-position dim, dim 0 here -- is
+pinned to device position 0 (outermost). With a position-major
+``SpyreTensorLayout`` the scatter lands on exactly the rows named by ``idx``.
+
+With the *default* layout, the last logical dim becomes the stick-count and is
+placed outermost, so the indexed dim arrives at device position 1, behind the
+stick dim (cf. ``canonical_device_layout`` in
+``tests/inductor/indirect_access_common.py``). The indirect scatter then
+silently writes the *wrong* rows (or the backend aborts on the bundle -- cf.
+``tests/inductor/test_indirect_access_scatter.py``, which xfails the same
+``index_copy`` on a plain layout). That is torch-spyre#3705.
+
+This file pins the workaround the hf-adapters KV cache is built on: the
+pinned-layout scatter is correct, reuses a single compiled binary across every
+decode position, and survives a scatter->gather round trip. It also encodes the
+negative case as an ``xfail`` so it flips to xpass the day #3705 is fixed.
+"""
+
+import pytest
+import torch
+from torch.spyre import SpyreTensorLayout, get_device_dtype
+from torch.testing._internal.common_utils import (
+    TestCase,
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    subtest,
+)
+
+DEVICE = "spyre"
+
+
+def _position_major_stl(L, rows, hd, dtype):
+    """Layout for logical ``[L, rows, hd]`` with the indexed dim ``L`` pinned to
+    device position 0 (outermost).
+
+    Mirrors ``canonical_device_layout`` in
+    ``tests/inductor/indirect_access_common.py`` for a 3-D operand: lead dims
+    stay outermost, the last dim is split into (stick-count, elems-per-stick).
+    """
+    eps = SpyreTensorLayout([L, rows, hd], dtype).elems_per_stick()
+    sticks = (hd + eps - 1) // eps
+    return SpyreTensorLayout(
+        device_size=[L, rows, sticks, eps],
+        stride_map=[rows * hd, hd, eps, 1],
+        device_dtype=get_device_dtype(dtype),
+    )
+
+
+def _scatter(cache, idx, src):
+    """Row scatter under test: write ``src`` rows into ``cache`` at ``idx``."""
+    return cache.index_copy(0, idx, src)
+
+
+def _gather(cache, idx):
+    """Read the rows at ``idx`` back out (how attention consumes the cache)."""
+    return cache[idx]
+
+
+def _tol(dtype):
+    """(atol, rtol) for a device round trip.
+
+    Device fp16 storage rounds to ~4.9e-4, so 2e-3 sits above real precision
+    without masking a wrong-row regression (see test_tensor_layout.py). bf16's
+    ~8-bit mantissa is coarser (~3.9e-3 near 1.0), so it needs 1e-2.
+    """
+    return (1e-2, 1e-2) if dtype == torch.bfloat16 else (2e-3, 2e-3)
+
+
+def _write_positions(L, nwrite):
+    """A spread of valid start positions: origin, around a stick boundary (64),
+    mid-cache, and the last in-bounds start."""
+    last = L - nwrite
+    candidates = {0, 1, 63, 64, 128, 320, 512, last}
+    return sorted(p for p in candidates if 0 <= p <= last)
+
+
+# (L, rows, hd, dtype, nwrite) -- the per-layer shapes hf-adapters exercises.
+# rows folds [B * nkv]: B=1 -> rows=nkv; B=4, nkv=8 -> rows=32. nwrite=1 is the
+# decode step (the compile-explosion case), nwrite=64 a prefill/block write.
+_PINNED_CASES = [
+    subtest((576, 8, 128, torch.float16, 1), name="granite8b_decode_fp16"),
+    subtest((576, 8, 256, torch.float16, 1), name="padded_hd256_decode_fp16"),
+    subtest((576, 1, 128, torch.float16, 1), name="mqa_decode_fp16"),
+    subtest((576, 32, 128, torch.float16, 1), name="batched_b4_decode_fp16"),
+    subtest((576, 8, 128, torch.bfloat16, 1), name="granite8b_decode_bf16"),
+    subtest((576, 8, 128, torch.float16, 64), name="granite8b_block_fp16"),
+    subtest((576, 32, 128, torch.float16, 64), name="batched_b4_block_fp16"),
+    subtest((576, 8, 128, torch.bfloat16, 64), name="granite8b_block_bf16"),
+    subtest((2048, 8, 128, torch.float16, 1), name="granite8b_L2048_decode"),
+    subtest((2048, 8, 128, torch.float16, 64), name="granite8b_L2048_block"),
+]
+
+_ROUNDTRIP_CASES = [
+    subtest((576, 8, 128, torch.float16, 1, 137), name="fp16_1row_pos137"),
+    subtest((576, 8, 128, torch.float16, 64, 192), name="fp16_64row_pos192"),
+    subtest((576, 8, 128, torch.bfloat16, 64, 256), name="bf16_64row_pos256"),
+]
+
+
+@instantiate_parametrized_tests
+class TestKVScatterLayout(TestCase):
+    """Pin the position-major KV-cache scatter contract (torch-spyre#3705)."""
+
+    def setUp(self):
+        torch.manual_seed(0xAFFE)
+        # Lazy device init (mirrors test_tensor_layout.py's `x.to("spyre")`).
+        torch.zeros(1, dtype=torch.float16).to(DEVICE)
+
+    @parametrize("L,rows,hd,dtype,nwrite", _PINNED_CASES)
+    def test_pinned_layout_scatters_correct_rows(self, L, rows, hd, dtype, nwrite):
+        """A cache whose indexed dim is pinned to device position 0 scatters
+        into exactly the rows named by ``idx``.
+
+        Primary regression guard for torch-spyre#3705: the pinned-layout
+        indirect ``index_copy`` must match the CPU ``index_copy_`` reference
+        row-for-row at every write position. This is the workaround the
+        hf-adapters KV cache relies on and must stay green.
+        """
+        stl = _position_major_stl(L, rows, hd, dtype)
+        atol, rtol = _tol(dtype)
+        compiled = torch.compile(_scatter, dynamic=False)
+        for pos in _write_positions(L, nwrite):
+            cache = torch.rand(L, rows, hd, dtype=dtype)
+            src = torch.rand(nwrite, rows, hd, dtype=dtype)
+            idx = torch.arange(pos, pos + nwrite, dtype=torch.int32)
+            # CPU golden: index_copy_ needs an int64 index.
+            want = cache.clone().index_copy_(0, idx.long(), src)
+            got = compiled(
+                cache.to(DEVICE, device_layout=stl),
+                idx.to(DEVICE),
+                src.to(DEVICE),
+            ).cpu()
+            self.assertEqual(got.shape, want.shape)
+            self.assertEqual(
+                got.float(),
+                want.float(),
+                msg=f"wrong rows scattered at pos={pos} (L={L}, nwrite={nwrite})",
+                atol=atol,
+                rtol=rtol,
+            )
+
+    @parametrize("L,rows,hd,dtype,nwrite,pos", _ROUNDTRIP_CASES)
+    def test_scatter_gather_roundtrip(self, L, rows, hd, dtype, nwrite, pos):
+        """Scatter rows in, then gather the same rows back out: the values must
+        survive the scatter->gather round trip attention runs on the cache."""
+        stl = _position_major_stl(L, rows, hd, dtype)
+        atol, rtol = _tol(dtype)
+        cache = torch.zeros(L, rows, hd, dtype=dtype)
+        # Offset away from zero so a dropped write is not masked by the zeros.
+        src = torch.rand(nwrite, rows, hd, dtype=dtype) + 0.5
+        idx = torch.arange(pos, pos + nwrite, dtype=torch.int32)
+
+        written = torch.compile(_scatter, dynamic=False)(
+            cache.to(DEVICE, device_layout=stl),
+            idx.to(DEVICE),
+            src.to(DEVICE),
+        )
+        got = torch.compile(_gather, dynamic=False)(written, idx.to(DEVICE)).cpu()
+        self.assertEqual(
+            got.float(),
+            src.float(),
+            msg=f"round-trip corrupted rows at pos={pos}",
+            atol=atol,
+            rtol=rtol,
+        )
+
+    def test_pinned_layout_single_binary_across_positions(self):
+        """One compiled binary must serve every write position -- the point of
+        the pinned-layout rewrite.
+
+        Decode steps at different cache positions must hit the SAME graph, not
+        recompile per position, while still landing on the correct rows. Guards
+        both correctness and the compile explosion the workaround avoids.
+        """
+        L, rows, hd, dtype, nwrite = 576, 8, 128, torch.float16, 1
+        stl = _position_major_stl(L, rows, hd, dtype)
+        atol, rtol = _tol(dtype)
+
+        torch._dynamo.reset()
+        torch._dynamo.utils.counters["stats"].clear()
+        compiled = torch.compile(_scatter, dynamic=False)
+
+        for pos in _write_positions(L, nwrite):
+            cache = torch.rand(L, rows, hd, dtype=dtype)
+            src = torch.rand(nwrite, rows, hd, dtype=dtype)
+            idx = torch.arange(pos, pos + nwrite, dtype=torch.int32)
+            want = cache.clone().index_copy_(0, idx.long(), src)
+            got = compiled(
+                cache.to(DEVICE, device_layout=stl),
+                idx.to(DEVICE),
+                src.to(DEVICE),
+            ).cpu()
+            self.assertEqual(
+                got.float(),
+                want.float(),
+                msg=f"wrong rows scattered at pos={pos}",
+                atol=atol,
+                rtol=rtol,
+            )
+
+        graphs = torch._dynamo.utils.counters["stats"].get("unique_graphs", 0)
+        self.assertLessEqual(
+            graphs,
+            1,
+            f"expected a single compiled binary across positions, got {graphs}",
+        )
+
+    @pytest.mark.xfail(
+        reason=(
+            "torch-spyre#3705: with the cache-position dim NOT pinned to device "
+            "position 0 (the default/plain layout), the indirect scatter silently "
+            "writes the wrong rows, or the backend aborts on the bundle. Remove "
+            "this xfail (and promote to a hard assertion) when #3705 is fixed."
+        ),
+        strict=False,
+    )
+    def test_default_layout_scatters_wrong_rows(self):
+        """Negative guard: the SAME ``index_copy`` on the DEFAULT (non-pinned)
+        device layout does NOT land on the intended rows -- the bug behind
+        torch-spyre#3705.
+
+        We assert the *correct* placement; today that assertion fails (wrong
+        rows) or the backend aborts, so this is xfail. If it ever passes, #3705
+        has been fixed and this guard should be promoted/removed. Compare
+        tests/inductor/test_indirect_access_scatter.py::test_index_copy, which
+        xfails the same op on a plain layout.
+        """
+        L, rows, hd, dtype, nwrite, pos = 576, 8, 128, torch.float16, 1, 137
+        atol, rtol = _tol(dtype)
+        cache = torch.rand(L, rows, hd, dtype=dtype)
+        src = torch.rand(nwrite, rows, hd, dtype=dtype)
+        idx = torch.arange(pos, pos + nwrite, dtype=torch.int32)
+        want = cache.clone().index_copy_(0, idx.long(), src)
+        got = torch.compile(_scatter, dynamic=False)(
+            cache.to(DEVICE),  # default layout: indexed dim NOT at position 0
+            idx.to(DEVICE),
+            src.to(DEVICE),
+        ).cpu()
+        self.assertEqual(
+            got.float(),
+            want.float(),
+            msg="default (non-pinned) layout mis-scattered rows",
+            atol=atol,
+            rtol=rtol,
+        )
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
## Summary

Three device-verified regression tests that pin compile-path contracts the
indirect-access KV cache work in hf-adapters depends on. Each defect was first
hit while bringing up single-token decode against the `"spyre"` backend, then
reduced to a minimal, model-free reproduction here. Every test moves a golden
CPU reference onto the device and compares values — none of them trust a clean
compile exit.

Each file pairs **passing control(s)** (the working shape, or the bit-exact
workaround) with a **strict=False `xfail`** for the broken shape. The controls
prove the reduction is faithful; the xfails flip to xpass the day each backend
defect is fixed, so the suite tells us when that happens.

### `tests/tensor/test_kv_scatter_layout.py` — #3705, indirect scatter layout

An indirect `cache.index_copy_(0, idx, src)` writes the correct rows on Spyre
**only** when the indexed (cache-position) dim is pinned to device position 0 via
a position-major `SpyreTensorLayout`. Under the default layout the scatter writes
the right *number* of elements to the *wrong* rows, with no error — this is the
layout invariant the hf-adapters KV cache is built on. Parametrized over 10
pinned-layout cases + 3 round-trips, plus a single-binary check and an `xfail`
that documents the wrong-rows failure under the default layout.

### `tests/inductor/test_gather_rank_projection.py` — #3732, rank_diff < 0 projection

`aten.index` is a 2-arg pointwise op, so `compute_layouts` routes it through
`_multi_arg_pointwise_layouts._is_supported_layout`, which projects the output
`dim_order` onto each input assuming **broadcast** (arg rank ≤ output rank):

```python
rank_diff = len(output.size) - len(arg.layout.size)   # propagate_layouts.py
projected  = [d - rank_diff for d in dim_order if d >= rank_diff]
```

When the gather's *value* operand **outranks** its output (`rank_diff < 0`) the
projection comes up short and the backend raises `Incompatible host_size and
dim_order` at compile. The minimal trigger is a rank-6 RoPE-as-matmul producer
feeding a rank-4 `index_select` — the shape the former Qwen3 "fill" step built.
The gather-**before**-RoPE ordering (rank-4 operand, bit-exact equivalent) is the
passing control.

### `tests/inductor/test_seq1_decode_projection.py` — seq_len=1 M=1 projection bmm

A single-token decode runs SDPA on `q=[B,H,1,D]` and feeds the `[B,H,1,D]` result
— reshaped to `[B,1,H*D]` — into the output projection `@ wo`. That trailing
matmul has `M=1`, and Inductor fuses it with the SDPA. The backend then aborts in
`getMinParamBmm`:

```
DtException: out_reuse_dim.size() == 1
  L3DlOpsScheduler.cpp line 960  (getMinParamBmm)  -> dxp_standalone died with SIGABRT
```

At `M=1` the projection bmm contracts *both* the `in` and `out` dims, so the
"contracted dims" set has two members and the single-contraction-dim precondition
fails. At `seq_len=64` the same op keeps `out_reuse={in}` (size 1) and compiles —
so the defect needs *both* `M=1` **and** the SDPA→projection fusion, which the two
controls (`seq1` SDPA-alone, `seq64` SDPA+o_proj) isolate. The SIGABRT is raised
in the `dxp_standalone` **child**; it surfaces to the caller as a catchable
`InductorError`, so the xfail is safe in-process (verified: parent survives,
rc=0).

## Verification (on device, current `upstream/main` + these 3 commits)

| Test | Result |
|---|---|
| `test_kv_scatter_layout.py` (#3705) | **14 passed, 1 xfailed** (default-layout wrong-rows) |
| `test_gather_rank_projection.py` (#3732) | **1 passed** (workaround), **1 xfailed** (`Incompatible host_size and dim_order`) |
| `test_seq1_decode_projection.py` (seq1 M=1) | **2 passed** (controls), **1 xfailed** (`out_reuse_dim.size()==1`) |

`pre-commit run --files` passes on all three (Apache header, `Owner(s)` tag, ruff
88-col, no bare `import re`). Commits are DCO-signed.

## Open question — why this is a draft

#3705 and #3732 have upstream issues. The **seq_len=1 M=1 projection bmm abort
has no exact upstream issue** — the closest is **#2527**, a sibling M=1 single-row
decode abort in the same scheduler (`L3DlOpsScheduler.cpp:1041`, "Expect valid
lower and upper bound parameters"): same M=1-decode family, a *different*
scheduler precondition. The `test_seq1_decode_projection.py` xfail cites the exact
abort signature and points at #2527 as "see also," rather than asserting they are
the same bug.

**Before this lands:** should the seq1 defect get its own tracking issue (and the
xfail reason updated to reference it), or should it be folded into #2527? Holding
as draft for that call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
