### PR TITLE
ci(perf): do not record an empty benchmark_runs row for a zero-benchmark XML

### DIFF
--- a/.github/scripts/ingest_xml.py
+++ b/.github/scripts/ingest_xml.py
@@ -700,6 +700,20 @@ def main():
                 )
                 continue
 
+            # A benchmark XML that parsed to zero benchmark rows is not a run: it
+            # produced no numbers. Some result dirs also carry a non-suite stub XML
+            # (e.g. cpu_kernel_report_tsp.xml) whose testcases have "benchmark" in
+            # the classname but do not match the perf-name pattern, so every case is
+            # skipped and this list comes back empty. Inserting a benchmark_runs row
+            # for it would create an orphan run with 0 ops / 0 models that shows up on
+            # the dashboard as an empty run. Skip it instead of recording a hollow run.
+            if not benchmarks:
+                print(
+                    f"  No benchmark rows parsed from {xml_path.name}: "
+                    "skipping (not recording an empty benchmark run)."
+                )
+                continue
+
             # benchmark_runs.run_id is UInt64 — use a random 64-bit int
             run_id = uuid.uuid4().int >> 64  # positive 64-bit int
             print(f"  run_id={run_id}  benchmarks={len(benchmarks)}")


### PR DESCRIPTION
The perf ingest (`.github/scripts/ingest_xml.py`) globs `*.xml` in the results dir and treats any file whose testcases all carry `benchmark` in the classname as a benchmark report. A result dir can also carry a non-suite stub (for example `cpu_kernel_report_tsp.xml`) whose testcase names do not match the perf-name pattern `perf_<op>_<metric>_ms_<shapes>`, so every case is skipped and `parse_benchmark_xml` returns a valid `run_meta` with an empty benchmark list.

`insert_perf_benchmarks` already early-returns on an empty list, but `insert_benchmark_run` runs first and created an orphan `benchmark_runs` row with 0 ops and 0 models. On the dashboard that shows up as an empty perf run next to the real one from the same build.

### Observed on dev (ppc64le)
Build #42 produced an empty run from `cpu_kernel_report_tsp.xml` (`benchmark_count`/op/model all 0) alongside the real `report.xml` run from build #41 (23 benchmarks, 4 models, 19 ops).

### Fix
Skip the `benchmark_runs` insert when no benchmark rows were parsed, so a stub or otherwise empty benchmark XML no longer creates a hollow run. Real perf reports are unaffected.

### Test
Verified locally: the stub XML parses to `run_meta != None` but `benchmarks == []` (so the old code inserted the orphan row, the new guard skips it), while a real `perf_*_ms_*` XML still parses to `>= 1` benchmark row.