### PR TITLE
fix(integration-tests): key non-PR integration-tests concurrency group by test_type, only cancel-in-progress for PR runs

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -101,9 +101,25 @@ on:
         default: true
 
 concurrency:
+  # PR-context runs (native pull_request, or workflow_dispatch carrying a
+  # pr_url_hash) key on the PR itself, so re-triggering the same PR cancels its
+  # own stale in-flight run -- unchanged from before.
+  #
+  # A non-PR dispatch (scheduled/main-push/nightly/weekly -- pr_url_hash empty)
+  # previously fell back to bare github.ref, so EVERY such dispatch of this
+  # workflow on the same ref shared one group regardless of test_type. Two
+  # unrelated dispatches landing close together (e.g. a nightly trunk run while
+  # a push-triggered trunk run is still going) then cancelled each other via
+  # cancel-in-progress, silently killing a run mid-job with no test failure and
+  # no error -- see the run/job-level symptoms this fixes. Disambiguating by
+  # test_type stops different suites from colliding at all.
   group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.pull_request.html_url) || (github.event_name == 'workflow_dispatch'
-    && inputs.pr_url_hash != '' && inputs.pr_url_hash) || github.ref }}
-  cancel-in-progress: true
+    && inputs.pr_url_hash != '' && inputs.pr_url_hash) || format('{0}-{1}', github.ref, inputs.test_type) }}
+  # Only cancel for a PR-context run (re-running the same PR should supersede
+  # its own stale run). A non-PR dispatch is never "the same PR re-triggered" --
+  # cancelling it destroys a run that has nothing superseding it, so a same
+  # test_type/ref collision QUEUES behind the in-flight run instead of killing it.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.pr_url_hash != '') }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup


### Problem: 

- workflow_dispatch runs with no `pr_url_hash` (every scheduled/main-push/nightly/weekly trigger) all fell into the same `github.ref` concurrency group regardless of `test_type`, so a later dispatch silently cancelled an earlier one mid-job via `cancel-in-progress: true` , no test failure, no error, just a killed run with hanged output screen.

### Fix

- key the non-PR fallback group on `ref+test_type` and cancel-in-progress only for PR-context runs.
