### PR TITLE
feat(inductor): extend work_division to split topk k across cores

### DIFF
--- a/docs/source/compiler/work_division_planning.md
+++ b/docs/source/compiler/work_division_planning.md
@@ -46,7 +46,8 @@ and dispatched from `CustomPreSchedulingPasses` in
 [passes.py](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/passes.py).
 
 The planner only sees ops whose IR data is `Pointwise` or `Reduction`
-(and excluding TopK reductions, which return early). `FallbackKernel`,
+(TopK reductions use dedicated constraints; see [TopK work
+division](#topk-work-division)). `FallbackKernel`,
 `ExternKernel`, `SpyreConstantFallback`, and `SpyreEmptyFallback`
 allocation kernels are filtered out earlier and never reach the passes.
 
@@ -415,6 +416,22 @@ may include at most one reduction variable. If more than one reduction
 variable would have to be split to satisfy the 255.996 MiB span limit, the
 compiler raises an error.
 
+(topk-work-division)=
+
+## TopK work division
+
+TopK reductions use constraint-based work division:
+
+1. **k is split, capped at 4 rows per core.** The hardware can only produce
+   up to 4 top-k rows per core, so the smallest divisor `d` of `k` with
+   `k / d <= 4` is chosen. If no valid divisor exists within max_cores, the
+   compiler raises `Unsupported`.
+2. **The search-space dimension is never split.** The dimension being
+   searched (the `dim` argument to `torch.topk`) must stay whole on one core.
+
+Other output/batch dimensions are distributed across the remaining core budget
+under the constraint that total cores used is `k_cores * product(other_dims) <= max_cores`.
+
 ## Worked example: large matmul on 32 cores
 
 Take a single matmul with `A: [8192, 32768]`, `W: [32768, 4096]`,
@@ -591,8 +608,8 @@ annotations and use the automatic work-distribution planner.
   the requested component yet.
 - Only `Pointwise` and `Reduction` IR nodes are dispatched for work
   division. `ExternKernel` and `FallbackKernel` nodes are skipped.
-- TOPK reductions currently run single-core, so `work_div` hints on TOPK
-  operations are ignored with a warning.
+- TopK reductions use constraint-based work division, so `work_div` hints
+  are not supported for TopK operations.
 - Each pass plans one op at a time. Adjacent ops can pick incompatible
   per-core splits for a shared tensor, which the LX scratchpad planner
   then treats as a core-division mismatch.

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_scalar_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_scalar_config.yaml
@@ -38,6 +38,7 @@ test_suite_config:
             # pins conv output -- conv is not in OP_OUTPUT_GOOD_FOR_LX_REUSE --
             # so this is a test-only path (backend follow-up on PR #3284).
             - LxPlanning.*::test_conv2d_direct_.*_s2_lx_planning_(pointwise|reduction)
+            - LxPlanning.*::test_topk.*_lx_planning_(pointwise|reduction)
           mode: xfail
         - names:
             - LxPlanning.*::test_(all_dim|any_dim|count_nonzero|cummax|cummin|cumprod|logcumsumexp|max_default|median|mode_|nanmean|nanmedian|nanquantile|nansum|quantile|std_|topk|conv2d|dwise_conv2d|var_).*_lx_planning_(pointwise|reduction)

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1217,8 +1217,31 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                     4,
                     0,
                 ),
-                # "2d_k4_dim0_lessthanstick": (unique_randn_along_dim((8, 32), dim=0), 4, 0),
-                # "2d_k4_dim_minusone_lessthanstick": (unique_randn_along_dim((1, 32), dim=-1), 4, -1),
+                "2d_k8_dim0": (
+                    unique_randn_along_dim((256, 256), dim=0),
+                    8,
+                    0,
+                ),
+                "2d_k32_dim0": (
+                    unique_randn_along_dim((256, 32), dim=0, dtype=torch.float32),
+                    32,
+                    0,
+                ),
+                "3d_k12_dim1": (
+                    unique_randn_along_dim((2, 64, 32), dim=1, dtype=torch.float32),
+                    12,
+                    1,
+                ),
+                "3d_k20_dim1": (
+                    unique_randn_along_dim((6, 256, 32), dim=1, dtype=torch.float32),
+                    20,
+                    1,
+                ),
+                "4d_k32_dim2": (
+                    unique_randn_along_dim((2, 8, 128, 32), dim=2, dtype=torch.float32),
+                    32,
+                    2,
+                ),
             },
         },
         ("test_reduce_keepdim0", "test_reduce_keepdim0_cpu"): {
@@ -6011,6 +6034,17 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         with pytest.raises(Exception, match="Unsupported"):
             _compile_and_run(
                 lambda x: torch.topk(x, 4, dim=0, largest=False)[0],
+                [x],
+                "spyre",
+            )
+
+    def test_topk_unsplittable_k_rejected(self):
+        # k=35's divisors are 1, 5, 7, 35: none give k // d <= 4 with
+        # d <= SENCORES (32), so no valid multi-core split exists.
+        x = unique_randn_along_dim((64, 35), dim=-1)
+        with pytest.raises(Exception, match="Unsupported"):
+            _compile_and_run(
+                lambda x: torch.topk(x, 35, dim=-1)[0],
                 [x],
                 "spyre",
             )

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1242,6 +1242,26 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                     32,
                     2,
                 ),
+                "2d_k8_dim_0_fp16": (
+                    unique_randn_along_dim((32, 192), dim=0),
+                    8,
+                    0,
+                ),
+                "3d_k16_dim_1_fp16": (
+                    unique_randn_along_dim((4, 64, 192), dim=1),
+                    16,
+                    1,
+                ),
+                "4d_k10_dim2_fp16": (
+                    unique_randn_along_dim((2, 4, 64, 64), dim=2),
+                    10,
+                    2,
+                ),
+                "2d_k128_dim_0": (
+                    unique_randn_along_dim((256, 64), dim=0),
+                    128,
+                    0,
+                ),
             },
         },
         ("test_reduce_keepdim0", "test_reduce_keepdim0_cpu"): {

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -335,8 +335,6 @@ def spyre_topk(
     largest: bool = True,
     sorted: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    if k > 4:
-        raise Unsupported("Topk is not supported for this config")
     if not largest:
         raise Unsupported("topk with largest=False")
     # sorted=False only relaxes the ordering guarantee (any order of the top-k

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -335,6 +335,8 @@ def spyre_topk(
     largest: bool = True,
     sorted: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    if k > 128:
+        raise Unsupported(f"topk with k={k} is not supported (max k=128)")
     if not largest:
         raise Unsupported("topk with largest=False")
     # sorted=False only relaxes the ordering guarantee (any order of the top-k

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -696,18 +696,15 @@ def enumerate_work_division_candidates(
     of ``1`` means the dim is unsplit; the all-ones single-core split is
     included when it is itself permissible.
 
-    Only ``Pointwise`` / ``Reduction`` ops have a divisible iteration space;
-    ``TOPK`` reductions run single-core, so they yield only the unsplit split.
+    For ``TOPK`` reductions, k's factors are restricted to divisors ``d``
+    with ``k / d <= _TOPK_MAX_K_PER_CORE`` (mirrors ``_divide_topk_op``), and
+    the search-space dim is pinned to 1 -- topk splits k only.
     """
     # TODO: Enumerate compute bound ops and for seeds or compute optimized
     # work division where HBM bandwidth can saturate compute.
 
     it_space = iteration_space_from_op(op)
-
-    # TOPK reductions run single-core (see divide_reduction_op): the only
-    # permissible "division" is the unsplit one.
-    if isinstance(op.data, Reduction) and op.data.reduction_type in TOPK_OPS:
-        return [{v: 1 for v in it_space}]
+    is_topk = isinstance(op.data, Reduction) and op.data.reduction_type in TOPK_OPS
 
     input_tds, output_td = collect_tensor_deps(
         op, get_mem_deps_from_rw(op_read_writes(op))
@@ -723,6 +720,15 @@ def enumerate_work_division_candidates(
     # device coordinates (mirrors prioritize_dimensions / splits_by_index_coeff).
     coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
     reduction_vars = [v for v in it_space_adjusted if v not in coord_vars]
+
+    topk_k_sym = None
+    if is_topk:
+        output_dims, _ = prioritize_dimensions(output_td, it_space_adjusted)
+        topk_k_sym = _find_topk_k_symbol(output_dims, input_tds)
+        if topk_k_sym is None:
+            # k=1: inductor optimizes away the size-1 loop, so k has no symbol.
+            return [{v: 1 for v in it_space}]
+
     constraint_result = collect_work_division_constraints(
         WorkDivConstraintContext(
             op=op,
@@ -737,10 +743,16 @@ def enumerate_work_division_candidates(
     )
     blocked = constraint_result.blocked
     pinned = constraint_result.pinned
+    if is_topk:
+        # Topk never splits the search space itself -- only k.
+        pinned = {**pinned, **{v: 1 for v in reduction_vars}}
 
     # Per-dim candidate factors, mirroring must_split_vars.valid_splits but with
     # no ``>= current_min`` floor (we want the full set, including 1).
     def factors(v: Symbol) -> list[int]:
+        if is_topk and v == topk_k_sym:
+            k_val = concretize_expr(it_space[v])
+            return _topk_valid_k_splits(k_val, max_cores) or [1]
         if v in symbol_meta:
             basis = symbol_meta[v][1]  # granularity
         elif v in stick_vars:
@@ -1504,63 +1516,85 @@ def divide_pointwise_op(
 _TOPK_MAX_K_PER_CORE = 4
 
 
+def _find_topk_k_symbol(
+    output_dims: list[Symbol], input_tds: list[TensorDep]
+) -> Symbol | None:
+    """Return the output symbol absent from every input's device coords.
+
+    ``_topk_reduction_kwargs`` (lowering.py) substitutes the reduction loop
+    var for k in every input load, so k's symbol never appears in an input's
+    device coords -- unlike batch/other output dims, which pass through
+    unchanged. This distinguishes k independent of size.
+
+    Returns None if no such symbol exists, or more than one does (should not
+    happen for a well-formed topk op).
+    """
+    input_syms = {
+        s for td in input_tds for e in td.device_coords[:-1] for s in e.free_symbols
+    }
+    candidates = [d for d in output_dims if d not in input_syms]
+    return candidates[0] if len(candidates) == 1 else None
+
+
+def _topk_valid_k_splits(k_val: int, max_cores: int) -> list[int]:
+    """Return every divisor of k_val that is a legal per-core k-split.
+
+    A divisor ``d`` is legal iff ``d <= max_cores`` and
+    ``k_val // d <= _TOPK_MAX_K_PER_CORE``. ``d=1`` is included iff
+    ``k_val <= _TOPK_MAX_K_PER_CORE``. Results are sorted ascending.
+    """
+    return [
+        d
+        for d in sorted(divisors(k_val))
+        if d <= max_cores and k_val // d <= _TOPK_MAX_K_PER_CORE
+    ]
+
+
 def _divide_topk_op(
     op: ComputedBuffer,
     args: list[SchedNodeArg],
     max_cores: int,
 ) -> None:
-    """Apply multi-core work division for topk ops where k > _TOPK_MAX_K_PER_CORE.
+    """Apply multi-core work division for topk ops.
 
-    The topk backend processes at most _TOPK_MAX_K_PER_CORE output rows per
-    core.  When k exceeds this limit the k dimension must be split across
-    cores, with each core computing k/num_cores output rows.
-
-    The required number of cores is the smallest divisor of k for which
-    k / divisor <= _TOPK_MAX_K_PER_CORE, capped at max_cores.  If no such
-    divisor exists, Unsupported is raised to trigger the fallback path.
+    Splits only k, across the smallest number of cores d with
+    k / d <= _TOPK_MAX_K_PER_CORE. Raises Unsupported if no such d exists
+    within max_cores.
     """
     input_tds, output_td = collect_tensor_deps(op, args)
 
     it_space = iteration_space_from_op(op)
-
-    # Identify the k symbol: the only non-stick output dimension.
     it_space_adjusted, _ = adjust_it_space_for_sticks(it_space, input_tds + [output_td])
     output_dims, _ = prioritize_dimensions(output_td, it_space_adjusted)
     if not output_dims:
         return
 
-    # For topk the only non-stick output dim is k (mb is the stick dim).
-    k_sym = output_dims[0]
+    k_sym = _find_topk_k_symbol(output_dims, input_tds)
+    if k_sym is None:
+        # k=1: inductor optimizes away the size-1 loop. Single-core is correct.
+        return
     k_val = concretize_expr(it_space[k_sym])
 
-    if k_val <= _TOPK_MAX_K_PER_CORE:
-        return
-
-    # Find the smallest divisor of k such that k/divisor <= _TOPK_MAX_K_PER_CORE,
-    # capped at max_cores.
-    required_cores = None
-    for d in sorted(divisors(k_val)):
-        if d > 1 and k_val // d <= _TOPK_MAX_K_PER_CORE and d <= max_cores:
-            required_cores = d
-            break
-
-    if required_cores is None:
+    valid_k_splits = _topk_valid_k_splits(k_val, max_cores)
+    if not valid_k_splits:
         raise Unsupported(
-            f"topk: k={k_val} cannot be split across at most {max_cores} cores "
-            f"such that k_per_core <= {_TOPK_MAX_K_PER_CORE}; "
-            f"no valid divisor exists in [2, {max_cores}]"
+            f"topk(k={k_val}): no divisor of k in [1, {max_cores}] gives "
+            f"k_per_core <= {_TOPK_MAX_K_PER_CORE}, so k cannot be split "
+            f"across at most {max_cores} cores"
         )
+    required_k_cores = valid_k_splits[0]
 
+    # Commit only the k-split, leaving all other dims at split=1.
     splits = {sym: 1 for sym in it_space}
-    splits[k_sym] = required_cores
+    splits[k_sym] = required_k_cores
     apply_splits(op, splits, output_td)
 
     logger.debug(
-        "_divide_topk_op %s: k=%d, cores=%d, k_per_core=%d",
+        "_divide_topk_op %s: k=%d, k_cores=%d, k_per_core=%d",
         op.get_name(),
         k_val,
-        required_cores,
-        k_val // required_cores,
+        required_k_cores,
+        k_val // required_k_cores,
     )
 
 
@@ -1573,11 +1607,7 @@ def divide_reduction_op(
     red: Reduction = op.data
 
     if red.reduction_type in TOPK_OPS:
-        # Topk requires at most _TOPK_MAX_K_PER_CORE output rows per core.
-        # For k <= _TOPK_MAX_K_PER_CORE a single core suffices; for larger k
-        # the k dimension must be split across cores.  Work distribution passes
-        # (span_reduction, work_distribution) are not applicable to topk so we
-        # handle the split here directly.
+        # span_reduction/work_distribution don't apply to topk; split directly.
         _divide_topk_op(op, args, max_cores)
         return
 

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -697,8 +697,8 @@ def enumerate_work_division_candidates(
     included when it is itself permissible.
 
     For ``TOPK`` reductions, k's factors are restricted to divisors ``d``
-    with ``k / d <= _TOPK_MAX_K_PER_CORE`` (mirrors ``_divide_topk_op``), and
-    the search-space dim is pinned to 1 -- topk splits k only.
+    with ``k / d <= _TOPK_MAX_K_PER_CORE``, and the search-space dim is
+    pinned to 1 via the ``topk_pinned_search_space_vars`` constraint.
     """
     # TODO: Enumerate compute bound ops and for seeds or compute optimized
     # work division where HBM bandwidth can saturate compute.
@@ -725,9 +725,6 @@ def enumerate_work_division_candidates(
     if is_topk:
         output_dims, _ = prioritize_dimensions(output_td, it_space_adjusted)
         topk_k_sym = _find_topk_k_symbol(output_dims, input_tds)
-        if topk_k_sym is None:
-            # k=1: inductor optimizes away the size-1 loop, so k has no symbol.
-            return [{v: 1 for v in it_space}]
 
     constraint_result = collect_work_division_constraints(
         WorkDivConstraintContext(
@@ -743,9 +740,6 @@ def enumerate_work_division_candidates(
     )
     blocked = constraint_result.blocked
     pinned = constraint_result.pinned
-    if is_topk:
-        # Topk never splits the search space itself -- only k.
-        pinned = {**pinned, **{v: 1 for v in reduction_vars}}
 
     # Per-dim candidate factors, mirroring must_split_vars.valid_splits but with
     # no ``>= current_min`` floor (we want the full set, including 1).
@@ -1550,67 +1544,12 @@ def _topk_valid_k_splits(k_val: int, max_cores: int) -> list[int]:
     ]
 
 
-def _divide_topk_op(
-    op: ComputedBuffer,
-    args: list[SchedNodeArg],
-    max_cores: int,
-) -> None:
-    """Apply multi-core work division for topk ops.
-
-    Splits only k, across the smallest number of cores d with
-    k / d <= _TOPK_MAX_K_PER_CORE. Raises Unsupported if no such d exists
-    within max_cores.
-    """
-    input_tds, output_td = collect_tensor_deps(op, args)
-
-    it_space = iteration_space_from_op(op)
-    it_space_adjusted, _ = adjust_it_space_for_sticks(it_space, input_tds + [output_td])
-    output_dims, _ = prioritize_dimensions(output_td, it_space_adjusted)
-    if not output_dims:
-        return
-
-    k_sym = _find_topk_k_symbol(output_dims, input_tds)
-    if k_sym is None:
-        # k=1: inductor optimizes away the size-1 loop. Single-core is correct.
-        return
-    k_val = concretize_expr(it_space[k_sym])
-
-    valid_k_splits = _topk_valid_k_splits(k_val, max_cores)
-    if not valid_k_splits:
-        raise Unsupported(
-            f"topk(k={k_val}): no divisor of k in [1, {max_cores}] gives "
-            f"k_per_core <= {_TOPK_MAX_K_PER_CORE}, so k cannot be split "
-            f"across at most {max_cores} cores"
-        )
-    required_k_cores = valid_k_splits[0]
-
-    # Commit only the k-split, leaving all other dims at split=1.
-    splits = {sym: 1 for sym in it_space}
-    splits[k_sym] = required_k_cores
-    apply_splits(op, splits, output_td)
-
-    logger.debug(
-        "_divide_topk_op %s: k=%d, k_cores=%d, k_per_core=%d",
-        op.get_name(),
-        k_val,
-        required_k_cores,
-        k_val // required_k_cores,
-    )
-
-
 def divide_reduction_op(
     op: ComputedBuffer,
     args: list[SchedNodeArg],
     max_cores: int,
     pass_fn: Callable,
 ) -> None:
-    red: Reduction = op.data
-
-    if red.reduction_type in TOPK_OPS:
-        # span_reduction/work_distribution don't apply to topk; split directly.
-        _divide_topk_op(op, args, max_cores)
-        return
-
     pass_fn(op, args, max_cores)
 
 

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -1500,6 +1500,70 @@ def divide_pointwise_op(
     pass_fn(op, args, max_cores)
 
 
+# Maximum k rows that the topk hardware op can process per core.
+_TOPK_MAX_K_PER_CORE = 4
+
+
+def _divide_topk_op(
+    op: ComputedBuffer,
+    args: list[SchedNodeArg],
+    max_cores: int,
+) -> None:
+    """Apply multi-core work division for topk ops where k > _TOPK_MAX_K_PER_CORE.
+
+    The topk backend processes at most _TOPK_MAX_K_PER_CORE output rows per
+    core.  When k exceeds this limit the k dimension must be split across
+    cores, with each core computing k/num_cores output rows.
+
+    The required number of cores is the smallest divisor of k for which
+    k / divisor <= _TOPK_MAX_K_PER_CORE, capped at max_cores.  If no such
+    divisor exists, Unsupported is raised to trigger the fallback path.
+    """
+    input_tds, output_td = collect_tensor_deps(op, args)
+
+    it_space = iteration_space_from_op(op)
+
+    # Identify the k symbol: the only non-stick output dimension.
+    it_space_adjusted, _ = adjust_it_space_for_sticks(it_space, input_tds + [output_td])
+    output_dims, _ = prioritize_dimensions(output_td, it_space_adjusted)
+    if not output_dims:
+        return
+
+    # For topk the only non-stick output dim is k (mb is the stick dim).
+    k_sym = output_dims[0]
+    k_val = concretize_expr(it_space[k_sym])
+
+    if k_val <= _TOPK_MAX_K_PER_CORE:
+        return
+
+    # Find the smallest divisor of k such that k/divisor <= _TOPK_MAX_K_PER_CORE,
+    # capped at max_cores.
+    required_cores = None
+    for d in sorted(divisors(k_val)):
+        if d > 1 and k_val // d <= _TOPK_MAX_K_PER_CORE and d <= max_cores:
+            required_cores = d
+            break
+
+    if required_cores is None:
+        raise Unsupported(
+            f"topk: k={k_val} cannot be split across at most {max_cores} cores "
+            f"such that k_per_core <= {_TOPK_MAX_K_PER_CORE}; "
+            f"no valid divisor exists in [2, {max_cores}]"
+        )
+
+    splits = {sym: 1 for sym in it_space}
+    splits[k_sym] = required_cores
+    apply_splits(op, splits, output_td)
+
+    logger.debug(
+        "_divide_topk_op %s: k=%d, cores=%d, k_per_core=%d",
+        op.get_name(),
+        k_val,
+        required_cores,
+        k_val // required_cores,
+    )
+
+
 def divide_reduction_op(
     op: ComputedBuffer,
     args: list[SchedNodeArg],
@@ -1508,14 +1572,13 @@ def divide_reduction_op(
 ) -> None:
     red: Reduction = op.data
 
-    # Currently we support Topk for k<=4, which can be handled efficiently on single core
-    # TODO: Modification will be required to enable Topk for k>4
     if red.reduction_type in TOPK_OPS:
-        if not config.ignore_work_division_hints and _has_work_div_hint(op):
-            logger.warning(
-                f"work_division_hint: {op.get_name()} ignores work_div hint "
-                f"because TOPK reductions run single-core."
-            )
+        # Topk requires at most _TOPK_MAX_K_PER_CORE output rows per core.
+        # For k <= _TOPK_MAX_K_PER_CORE a single core suffices; for larger k
+        # the k dimension must be split across cores.  Work distribution passes
+        # (span_reduction, work_distribution) are not applicable to topk so we
+        # handle the split here directly.
+        _divide_topk_op(op, args, max_cores)
         return
 
     pass_fn(op, args, max_cores)

--- a/torch_spyre/_inductor/work_division_constraints.py
+++ b/torch_spyre/_inductor/work_division_constraints.py
@@ -96,6 +96,8 @@ def collect_work_division_constraints(
         conv_spatial_blocked_vars,
         qfp8wt_pinned_vars,
         qfp8wt_matmul_k_pinned,
+        topk_pinned_search_space_vars,
+        topk_k_split_constraint,
         indirect_access_pinned_vars,
     ):
         result = constraint(ctx)
@@ -230,6 +232,75 @@ def qfp8wt_matmul_k_pinned(ctx: WorkDivConstraintContext) -> ConstraintResult:
         return ConstraintResult()
 
     return ConstraintResult(pinned={v: 1 for v in ctx.reduction_vars})
+
+
+def topk_pinned_search_space_vars(ctx: WorkDivConstraintContext) -> ConstraintResult:
+    """Pin the search-space (reduction) dim to split=1 for topk ops.
+
+    The topk hardware op searches the full dimension on one core to compute
+    the top-k results. Splitting the search-space would require merging
+    partial top-k results across cores, which the hardware does not support.
+    """
+    from .constants import TOPK_OPS
+
+    if not isinstance(ctx.op.data, Reduction):
+        return ConstraintResult()
+    if ctx.op.data.reduction_type not in TOPK_OPS:
+        return ConstraintResult()
+
+    return ConstraintResult(pinned={v: 1 for v in ctx.reduction_vars})
+
+
+def topk_k_split_constraint(ctx: WorkDivConstraintContext) -> ConstraintResult:
+    """Pin k to the smallest valid split for topk ops.
+
+    Each core can produce at most 4 top-k results per pass. The smallest valid
+    k-split is ceil(k / 4), chosen to minimize core usage while satisfying the
+    hardware constraint. This is pinned as a hard constraint to ensure the
+    work_distribution planner picks the minimal k-split rather than a
+    larger one that leaves more cores for other dims.
+    """
+    from .constants import TOPK_OPS
+    from sympy import divisors
+
+    if not isinstance(ctx.op.data, Reduction):
+        return ConstraintResult()
+    if ctx.op.data.reduction_type not in TOPK_OPS:
+        return ConstraintResult()
+
+    # Find k's symbol (output dim absent from every input's device coords).
+    coord_vars = {
+        s for td in ctx.input_tds for e in td.device_coords[:-1] for s in e.free_symbols
+    }
+    output_vars = {s for e in ctx.output_td.device_coords[:-1] for s in e.free_symbols}
+    k_sym_candidates = [s for s in output_vars if s not in coord_vars]
+    if len(k_sym_candidates) != 1:
+        # k=1 or malformed; no constraint needed.
+        return ConstraintResult()
+
+    k_sym = k_sym_candidates[0]
+    k_val = concretize_expr(ctx.it_space[k_sym])
+
+    # Find the smallest divisor d of k such that k / d <= 4.
+    _TOPK_MAX_K_PER_CORE = 4
+    max_cores = config.sencores
+    min_k_split = None
+    for d in sorted(divisors(k_val)):
+        if k_val // d <= _TOPK_MAX_K_PER_CORE and d <= max_cores:
+            min_k_split = d
+            break
+
+    if min_k_split is None:
+        raise Unsupported(
+            f"topk(k={k_val}): no divisor of k in [1, {max_cores}] gives "
+            f"k_per_core <= {_TOPK_MAX_K_PER_CORE}, so k cannot be split "
+            f"across at most {max_cores} cores"
+        )
+
+    if min_k_split > 1:
+        return ConstraintResult(pinned={k_sym: min_k_split})
+
+    return ConstraintResult()
 
 
 def indirect_access_pinned_vars(ctx: WorkDivConstraintContext) -> ConstraintResult:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
Extends topk to support 4 < k < 128 by splitting k across cores (max 4/core) while keeping the search-space dimension unsplit using work division constraints.

- Added `topk_pinned_search_space_vars` constraint (search-space dim pinned to 1)
- Added `topk_k_split_constraint` (k split to smallest valid divisor where k/d ≤ 4)
- Added k > 128 rejection in decompositions
- Updated work_division_planning.md docs
- Added tests covering 2D-4D, k values 6-128, fp16 and fp32, unsplittable k rejection.

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:
https://github.com/torch-spyre/torch-spyre/issues/452
https://github.com/torch-spyre/torch-spyre/issues/3636
<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
