### PR TITLE
fix(ci): stop doubling torch_spyre_tests/ in trunk test config paths

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -234,6 +234,22 @@ jobs:
               --test-type "${RAW_TEST_TYPE}" \
               --runner-map .github/runner_overrides.yaml \
               --format matrix-json)
+            # filter_configs emits `config` relative to --config-dir, so the
+            # narrower scan yields configs like `inductor/foo.yaml` (no
+            # torch_spyre_tests/ prefix) while the trunk scan yields
+            # `torch_spyre_tests/inductor/foo.yaml`. Re-add the prefix here so
+            # every tier's `config` is uniformly relative to tests/configs and
+            # the run step can prepend a single fixed base (see the `test` and
+            # `test_multi_spyre` jobs, `config: tests/configs/...`).
+            matrix=$(echo "${matrix}" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          data['suite'] = [
+              {**s, 'config': 'torch_spyre_tests/' + s['config']}
+              for s in data['suite']
+          ]
+          print(json.dumps(data))
+          ")
           fi
 
           # distributed_tests configs carry the trunk label too but are
@@ -413,7 +429,7 @@ jobs:
         uses: ./.github/actions/run-test-suite
         with:
           suite_name: ${{ matrix.suite.name }}
-          config: tests/configs/torch_spyre_tests/${{ matrix.suite.config }}
+          config: tests/configs/${{ matrix.suite.config }}
           # Prebaked: run FROM the baked source dir + its SHARED venv at
           # $HOME/.venv (a sibling of the source, not inside it); normal: the
           # checkout (default 'torch-spyre') + its local '.venv'.


### PR DESCRIPTION
## Problem

Trunk (main-branch) integration jobs fail at test time with:

```
ERROR: No YAML config file(s) found in the arguments.
```

(seen on `main-build` #202 -> orchestrator, and directly on GHA run
`31968909408`, job "Inductor / Test Building Blocks").

### Root cause

PR #3781 widened `generate_matrix`'s **trunk** scan in
`.github/workflows/_test_matrix.yaml` from
`--config-dir tests/configs/torch_spyre_tests` to `--config-dir tests/configs`,
so trunk now also covers `model_ops_tests/`, `upstream_tests/`, etc.

`filter_configs.py` emits each matrix entry's `config` **relative to
`--config-dir`** (see its docstring and `rel = str(cfg.relative_to(config_dir))`).
So after the widening, the trunk matrix entries carry a leading
`torch_spyre_tests/`:

- non-trunk scan (`--config-dir tests/configs/torch_spyre_tests`) emits
  `inductor/test_building_blocks_config.yaml`
- trunk scan (`--config-dir tests/configs`) emits
  `torch_spyre_tests/inductor/test_building_blocks_config.yaml`

But the single-card `test` job's run step still prepended the old narrower base:

```yaml
config: tests/configs/torch_spyre_tests/${{ matrix.suite.config }}
```

Under trunk this produced a **doubled** path:

```
tests/configs/torch_spyre_tests/torch_spyre_tests/inductor/test_building_blocks_config.yaml
```

which does not exist, so the runner found no config and aborted. The
`test_multi_spyre` job was unaffected because it already prepends only
`tests/configs/`.

## Fix

Make every tier's `config` uniformly relative to `tests/configs`, then prepend
a single fixed base in the run step (matching `test_multi_spyre`):

- Re-add the `torch_spyre_tests/` prefix to the **narrower (non-trunk)** scan's
  matrix output, so its entries are also relative to `tests/configs`.
- Change the `test` job's run step from
  `config: tests/configs/torch_spyre_tests/${{ matrix.suite.config }}` to
  `config: tests/configs/${{ matrix.suite.config }}`.

The two `--config-dir` literals are left unchanged, so
`tests/scripts/check_test_coverage.sh` (which greps the workflow for a literal
`--config-dir <path>` token) still detects dynamic coverage.

## Validation (hardware-free)

Ran the real `filter_configs.py` at this branch's tip for both tiers:

- **trunk / building_blocks:** emitted `torch_spyre_tests/inductor/test_building_blocks_config.yaml`
  -> run step yields `tests/configs/torch_spyre_tests/inductor/test_building_blocks_config.yaml`
  -> file EXISTS (previously doubled -> 404).
- **non-trunk / integration** (e.g. `inductor/test_cache_config.yaml`): after the
  normalize step + new run-step base, resolves to the same path the old code
  produced (`tests/configs/torch_spyre_tests/inductor/test_cache_config.yaml`,
  EXISTS) -> no regression for the previously-working tiers.

`pre-commit run --files .github/workflows/_test_matrix.yaml`: yamlfmt + GitHub
Actions workflow lint both pass.

## Test link

This repo runs GitHub Actions, so the PR's own trunk integration matrix
exercises the fix directly (the Inductor "Test Building Blocks" leg that was
404ing should now resolve its config and run).

cc @Anubhav Jana (author of #3781) — flagging in case you prefer the mirror-image
shape (strip the `torch_spyre_tests/` prefix off the trunk output and keep the
narrower run-step base) instead of this normalize-up approach; both fix the
doubling, this one keeps the two run steps consistent.
