### PR TITLE
fix(tests): make the YAML `name` authoritative for OOT ModuleInfo test names

### DIFF
--- a/tests/oot_framework/oot_test_base_common.py
+++ b/tests/oot_framework/oot_test_base_common.py
@@ -58,6 +58,7 @@ from oot_framework.oot_test_config_models import (
     TestEntry,
 )
 from oot_framework.oot_test_common_methods_invocations import (
+    _make_named_module_info_cls,
     create_module_inputs_func_from_yaml,
     create_module_inputs_func_from_config,
 )
@@ -106,54 +107,6 @@ def remove_builtin_privateuse1_test_base():
 
 # Call the filter function to apply the side effect
 remove_builtin_privateuse1_test_base()
-
-
-# ---------------------------------------------------------------------------
-# YAML-named ModuleInfo
-# ---------------------------------------------------------------------------
-
-
-def _make_named_module_info_cls(module_info_cls: type) -> type:
-    """Build a ``ModuleInfo`` subclass whose ``name`` comes from the YAML entry.
-
-    Upstream derives ``name`` -- and therefore the generated test name, see
-    ``common_modules.py`` ``test_name = module_info.formatted_name`` -- from
-    ``module_cls.__name__``. That makes two entries for the same class collide:
-    the second registration raises ``AssertionError: Redefinition of test ...``
-    from ``common_device_type.py``.
-
-    A YAML may legitimately register the same class more than once, each entry
-    carrying its own captured shapes. Today that is one entry per decoder layer;
-    the same need arises for any other axis a generator splits on (e.g. one entry
-    per execution phase). This wrapper is deliberately agnostic about WHY there
-    are several: it only makes the YAML's ``name`` authoritative, so a generator
-    can encode any distinction in the name with no further framework change.
-
-    Built lazily by a factory because ``ModuleInfo`` is imported inside
-    ``_register_custom_modules_from_edits`` (torch's test internals are optional
-    at import time), so the subclass cannot be declared at module scope without
-    making that import mandatory.
-
-    ``name`` is a read-only property upstream, so it is overridden rather than
-    assigned. Seed derivation is deliberately NOT touched: the seed comes from
-    ``input_config.seed`` plus an invocation-index offset and never from the name,
-    so renaming an entry must not change the tensors it builds.
-    """
-
-    class _OOTNamedModuleInfo(module_info_cls):  # type: ignore[valid-type,misc]
-        def __init__(self, *args, oot_name: Optional[str] = None, **kwargs):
-            super().__init__(*args, **kwargs)
-            self._oot_name = oot_name
-
-        @property
-        def name(self) -> str:
-            return self._oot_name if self._oot_name else super().name
-
-        @property
-        def formatted_name(self) -> str:
-            return self.name.replace(".", "_")
-
-    return _OOTNamedModuleInfo
 
 
 # ---------------------------------------------------------------------------

--- a/tests/oot_framework/oot_test_base_common.py
+++ b/tests/oot_framework/oot_test_base_common.py
@@ -109,6 +109,54 @@ remove_builtin_privateuse1_test_base()
 
 
 # ---------------------------------------------------------------------------
+# YAML-named ModuleInfo
+# ---------------------------------------------------------------------------
+
+
+def _make_named_module_info_cls(module_info_cls: type) -> type:
+    """Build a ``ModuleInfo`` subclass whose ``name`` comes from the YAML entry.
+
+    Upstream derives ``name`` -- and therefore the generated test name, see
+    ``common_modules.py`` ``test_name = module_info.formatted_name`` -- from
+    ``module_cls.__name__``. That makes two entries for the same class collide:
+    the second registration raises ``AssertionError: Redefinition of test ...``
+    from ``common_device_type.py``.
+
+    A YAML may legitimately register the same class more than once, each entry
+    carrying its own captured shapes. Today that is one entry per decoder layer;
+    the same need arises for any other axis a generator splits on (e.g. one entry
+    per execution phase). This wrapper is deliberately agnostic about WHY there
+    are several: it only makes the YAML's ``name`` authoritative, so a generator
+    can encode any distinction in the name with no further framework change.
+
+    Built lazily by a factory because ``ModuleInfo`` is imported inside
+    ``_register_custom_modules_from_edits`` (torch's test internals are optional
+    at import time), so the subclass cannot be declared at module scope without
+    making that import mandatory.
+
+    ``name`` is a read-only property upstream, so it is overridden rather than
+    assigned. Seed derivation is deliberately NOT touched: the seed comes from
+    ``input_config.seed`` plus an invocation-index offset and never from the name,
+    so renaming an entry must not change the tensors it builds.
+    """
+
+    class _OOTNamedModuleInfo(module_info_cls):  # type: ignore[valid-type,misc]
+        def __init__(self, *args, oot_name: Optional[str] = None, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._oot_name = oot_name
+
+        @property
+        def name(self) -> str:
+            return self._oot_name if self._oot_name else super().name
+
+        @property
+        def formatted_name(self) -> str:
+            return self.name.replace(".", "_")
+
+    return _OOTNamedModuleInfo
+
+
+# ---------------------------------------------------------------------------
 # OOTTestBase
 # ---------------------------------------------------------------------------
 
@@ -282,6 +330,11 @@ class OOTTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa: F
             )
             return
 
+        # The YAML's `name` has to win over the class-derived one so several
+        # entries for the same class (one per layer, per phase, ...) each get a
+        # distinct test name instead of colliding.
+        named_module_info_cls = _make_named_module_info_cls(ModuleInfo)
+
         # Get existing module names to avoid duplicates
         existing_names = {m.name for m in module_db}
         for i, module_item in enumerate(modules_named_items):
@@ -339,12 +392,13 @@ class OOTTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa: F
                     if resolved_dtypes
                     else (torch.float32, torch.float16, torch.bfloat16)
                 )
-                module_info = ModuleInfo(
+                module_info = named_module_info_cls(
                     module_cls,
                     module_inputs_func=create_module_inputs_func_from_yaml(module_item),
                     skips=(),
                     decorators=None,
                     dtypes=dtypes,
+                    oot_name=module_name,
                 )
                 # ModuleInfo has no field for this, and upstream never looks at
                 # it; attach it so device-specific tests can read the YAML's

--- a/tests/oot_framework/oot_test_common_methods_invocations.py
+++ b/tests/oot_framework/oot_test_common_methods_invocations.py
@@ -5,9 +5,51 @@ This module contains helper functions for creating module input generators
 and other test utilities that are used by OOTTestBase.
 """
 
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 import torch
+
+
+def _make_named_module_info_cls(module_info_cls: type) -> type:
+    """Build a ``ModuleInfo`` subclass whose ``name`` comes from the YAML entry.
+
+    Upstream derives ``name`` -- and therefore the generated test name, see
+    ``common_modules.py`` ``test_name = module_info.formatted_name`` -- from
+    ``module_cls.__name__``. That makes two entries for the same class collide:
+    the second registration raises ``AssertionError: Redefinition of test ...``
+    from ``common_device_type.py``.
+
+    A YAML may legitimately register the same class more than once, each entry
+    carrying its own captured shapes. Today that is one entry per decoder layer;
+    the same need arises for any other axis a generator splits on (e.g. one entry
+    per execution phase). This wrapper is deliberately agnostic about WHY there
+    are several: it only makes the YAML's ``name`` authoritative, so a generator
+    can encode any distinction in the name with no further framework change.
+
+    Built lazily by a factory because ``ModuleInfo`` is imported inside the
+    caller (torch's test internals are optional at import time), so the subclass
+    cannot be declared at module scope without making that import mandatory.
+
+    ``name`` is a read-only property upstream, so it is overridden rather than
+    assigned. Seed derivation is deliberately NOT touched: the seed comes from
+    ``input_config.seed`` plus an invocation-index offset and never from the name,
+    so renaming an entry must not change the tensors it builds.
+    """
+
+    class _OOTNamedModuleInfo(module_info_cls):  # type: ignore[valid-type,misc]
+        def __init__(self, *args, oot_name: Optional[str] = None, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._oot_name = oot_name
+
+        @property
+        def name(self) -> str:
+            return self._oot_name if self._oot_name else super().name
+
+        @property
+        def formatted_name(self) -> str:
+            return self.name.replace(".", "_")
+
+    return _OOTNamedModuleInfo
 
 
 def create_module_inputs_func_from_yaml(item: Any) -> Callable:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR intends to support the same name modules in different layers and to give different test names to prefill and decoding phases.

Makes a YAML module entry's `name` authoritative for the generated test name, so
the same `module_cls` can be registered more than once in a single module-config
YAML.

Upstream `ModuleInfo` derives `name` from `module_cls.__name__`, and
`common_modules.py` builds the test name from `module_info.formatted_name`. As a
result two YAML entries pointing at the same class produce the same test name,
and the second registration fails in `common_device_type.py` with:

```
AssertionError: Redefinition of test <name>
```

This is a real configuration, not a mistake: a YAML may legitimately register one
entry per decoder layer, each carrying its own captured shapes. The same need
arises for any other axis a config generator splits on (for example, one entry
per execution phase).

Changes in `tests/oot_framework/oot_test_base_common.py`:

- Add `_make_named_module_info_cls(module_info_cls)`, a factory that returns a
  `ModuleInfo` subclass accepting an `oot_name` kwarg and overriding the
  read-only `name` property (plus `formatted_name`) to prefer it, falling back to
  upstream behaviour when `oot_name` is not given.
- Pass `oot_name=module_name` when `_register_custom_modules_from_edits` builds a
  `ModuleInfo` from a YAML entry.

The wrapper is deliberately agnostic about *why* there are several entries — it
only makes the YAML's `name` win — so a generator can encode any distinction in
the name without further framework changes.

#### Which issue(s) this PR is related to:

<!-- Fixes #<issue number> -->
https://github.com/torch-spyre/hf-adapters/issues/357

#### Special notes for your reviewer:

- **Factory instead of a module-scope class.** `ModuleInfo` is imported *inside*
  `_register_custom_modules_from_edits` because torch's test internals are
  optional at import time. Declaring the subclass at module scope would make that
  import mandatory, so it is built lazily.
- **Property override, not assignment.** `name` is a read-only property upstream,
  hence the subclass rather than a simple attribute set.
- **Seed derivation is intentionally untouched.** The seed comes from
  `input_config.seed` plus an invocation-index offset and never from the name, so
  renaming an entry does not change the tensors it builds. Please confirm you
  agree this is the right invariant to preserve.
- Duplicate-name detection via `existing_names` is unchanged: entries still need
  distinct `name` values in the YAML, and this PR is what makes those distinct
  names actually reach the test id.

#### Does this PR introduce a user-facing change?

Yes, for authors of OOT module-config YAMLs: a module entry's `name` now
determines the generated test name (`.` replaced with `_`), instead of being
derived from the module class name. Multiple entries for the same class are now
supported as long as their `name` fields differ. Existing YAMLs whose `name`
already matches the class name are unaffected.

#### Additional note:
