### PR TITLE
fix: [CRCR] git rate limits mainly submodule

### DIFF
--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -37,6 +37,18 @@ runs:
         source "$HOME/.bashrc"
         source /etc/profile.d/ibm-aiu-setup.sh
 
+        # Retry helper for failing commands
+        retry() {
+          local attempt=1 max=4 delay=5
+          until "$@"; do
+            if (( attempt >= max )); then return 1; fi
+            echo "Command failed (attempt ${attempt}/${max}); retrying in ${delay}s..." >&2
+            sleep "$delay"
+            delay=$(( delay * 2 ))
+            attempt=$(( attempt + 1 ))
+          done
+        }
+
         [[ "$TORCH_SPYRE_DIR" != /* ]] && TORCH_SPYRE_DIR="${PWD}/${TORCH_SPYRE_DIR}"
         [[ "$PYTORCH_DIR" != /* ]] && PYTORCH_DIR="${PWD}/${PYTORCH_DIR}"
         echo "TORCH_SPYRE_DIR $TORCH_SPYRE_DIR"
@@ -78,7 +90,7 @@ runs:
           git remote add origin "$PYTORCH_REPO_URL"
         fi
 
-        git fetch --depth=1 origin "$FETCH_REF"
+        retry git fetch --depth=1 origin "$FETCH_REF"
 
         # Self-hosted runners may reuse a workspace across jobs; a previous
         # run's build (generated files, permission/line-ending changes from
@@ -90,7 +102,7 @@ runs:
 
         git submodule sync --recursive
         git submodule foreach --recursive 'git reset --hard HEAD && git clean -fdx' >/dev/null 2>&1 || true
-        git submodule update --init --recursive --depth 1 --jobs 8 --force
+        retry git submodule update --init --recursive --depth 1 --jobs 8 --force
 
         git log -1 --oneline || true
 


### PR DESCRIPTION
Lot of CRCR runs are failing with HTTP 403 due to submodule fetch ratelimits. This PR attempts to fix this. 