### PR TITLE
ci: echo requested runner labels in gather-runner-info

### DIFF
--- a/.github/actions/gather-runner-info/action.yml
+++ b/.github/actions/gather-runner-info/action.yml
@@ -17,6 +17,17 @@ inputs:
     required: false
     type: string
     default: torch-spyre
+  runner_labels:
+    description: |
+      The runner-label selectors the caller requested in its `runs-on`
+      (a JSON array string, e.g. '["x86_64","spyre_pf_x1","linux",
+      "image_spyre_backend"]'). The matrix strategy parameterizes these
+      per job, so echoing them shows which labels routed this specific
+      run. Optional: when empty, only the resolved runner identity is
+      printed.
+    required: false
+    type: string
+    default: ''
 
 runs:
   using: composite
@@ -26,10 +37,27 @@ runs:
       env:
         VERBOSE: ${{ inputs.verbose }}
         TORCH_SPYRE_DIR: ${{ inputs.torch_spyre_dir }}
+        # The runner-label selectors the caller passed to `runs-on`. GHA
+        # does not expose the resolved `runs-on` array to the running job,
+        # so the caller forwards the exact expression it used.
+        REQUESTED_RUNNER_LABELS: ${{ inputs.runner_labels }}
+        # Built-in contexts describing the runner GHA actually selected.
+        RUNNER_NAME: ${{ runner.name }}
+        RUNNER_OS: ${{ runner.os }}
+        RUNNER_ARCH: ${{ runner.arch }}
       run: |
         source "$HOME/.bashrc"
         source /etc/profile.d/ibm-aiu-setup.sh
         echo "================================="
+        echo "--- runner labels ---"
+        # Requested labels: the `runs-on` selectors the matrix job asked
+        # for. Resolved identity: the runner GHA matched to them. Together
+        # these make it clear which labels a given run used.
+        echo "REQUESTED_RUNNER_LABELS ${REQUESTED_RUNNER_LABELS:-<none>}"
+        echo "RUNNER_NAME $RUNNER_NAME"
+        echo "RUNNER_OS $RUNNER_OS"
+        echo "RUNNER_ARCH $RUNNER_ARCH"
+        echo "---------------------------------"
         date
         pwd
         whoami

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -304,6 +304,8 @@ jobs:
       - uses: ./.github/actions/gather-runner-info
         with:
           verbose: 'true'
+          # Echo the exact runner-label selectors this job's runs-on used.
+          runner_labels: ${{ format('["x86_64","spyre_pf_x0","{0}","{1}"]', inputs.runner_label, inputs.image_label) }}
 
       - name: Build torch-spyre wheel
         id: build
@@ -393,6 +395,8 @@ jobs:
         with:
           verbose: 'true'
           torch_spyre_dir: ${{ inputs.prebaked_image && env.PREBAKED_TORCH_SPYRE_DIR || 'torch-spyre' }}
+          # Echo the exact runner-label selectors this job's runs-on used.
+          runner_labels: ${{ format('["x86_64","{0}","{1}","{2}"]', matrix.suite.runner || 'spyre_pf_x1', inputs.runner_label, inputs.image_label) }}
 
       # Install the wheel built once by build_torch_spyre — no recompile.
       # Skipped on the RPM path (build_torch_spyre skipped) AND on the prebaked
@@ -699,6 +703,8 @@ jobs:
         with:
           verbose: 'true'
           torch_spyre_dir: ${{ inputs.prebaked_image && env.PREBAKED_TORCH_SPYRE_DIR || 'torch-spyre' }}
+          # Echo the exact runner-label selectors this job's runs-on used.
+          runner_labels: ${{ format('["x86_64","spyre_pf_x2","{0}","{1}"]', inputs.runner_label, inputs.image_label) }}
 
       # Install the wheel built once by build_torch_spyre — no recompile.
       # Skipped on the RPM path (build skipped) AND on the prebaked path.


### PR DESCRIPTION
## What

The test matrix parameterizes runner labels per job (`runner_label`, `image_label`, plus the fixed pool labels), but the job log does not record which labels routed a given run. GitHub Actions does not expose the resolved `runs-on` array to the running job, so from a finished run you cannot tell which label combination selected the runner.

Example run: a job shows a runner named `x8664-cards1-spyrebackend-mjrr7-runner-tr85w` with matrix inputs `runner_label: linux`, `image_label: image_spyre_backend`, `test_type: regression`, but the labels are not printed anywhere in the log.

## Change

Echo the requested runner labels in the shared `gather-runner-info` composite action, which runs in every test job.

- Add an optional `runner_labels` input to `.github/actions/gather-runner-info/action.yml`. It takes the JSON-array string of selectors the caller used in its `runs-on`.
- The action prints `REQUESTED_RUNNER_LABELS` alongside the resolved runner identity (`RUNNER_NAME`, `RUNNER_OS`, `RUNNER_ARCH`) from the GHA built-in `runner.*` contexts.
- Each call site in `.github/workflows/_test_matrix.yaml` forwards the exact `runs-on` selector expression it used, built with `format(...)` so the parameterized `runner_label` / `image_label` inputs appear in the printed value.

The input is optional and defaults to empty, so when a caller does not pass it the action prints only the resolved runner identity. No test behavior changes.
