### PR TITLE
Revert 60s timeout on dxp_standalone

### DIFF
--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -40,9 +40,8 @@ from .kernel_runner import SpyreSDSCKernelRunner, SpyreUnimplementedRunner
 
 logger = get_inductor_logger("sdsc_compile")
 
-# Wall-clock ceiling on ONE backend-compiler invocation, shared by both of them
-# (dxp_standalone on the SDSC path, dbo-opt on the KTIR path) so the two behave
-# alike. It bounds a wedged compiler -- which would otherwise block
+# Wall-clock ceiling on ONE backend-compiler invocation, only used for dbo-opt
+# on the KTIR path. It bounds a wedged compiler -- which would otherwise block
 # torch.compile forever with no diagnostic -- rather than policing slowness:
 # both finish in well under a second on a small kernel.
 _COMPILE_TIMEOUT_S = 60.0
@@ -153,7 +152,6 @@ class SpyreAsyncCompile(AsyncCompile):
                 subprocess.run(
                     ["dxp_standalone", "-d", output_dir],
                     check=True,
-                    timeout=_COMPILE_TIMEOUT_S,
                 )
             except Exception as exc:
                 try_collect(


### PR DESCRIPTION
#### What type of PR is this?

- [X] bug

#### What this PR does:

This PR reverts the 60s timeout on `dxp_standalone` invocations introduced in #3651 but leaves it in place for `dbo-opt` invocations.
