### PR TITLE
Add persistent dense expert execution planning

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_expert_execution_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_expert_execution_config.yaml
@@ -1,0 +1,7 @@
+test_suite_config:
+  labels: [unit, regression, integration, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_expert_execution_planner.py
+      unlisted_test_mode: mandatory_success
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_moe_ffn_semantics.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_expert_execution_planner.py
+++ b/tests/inductor/test_expert_execution_planner.py
@@ -1,0 +1,206 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import dataclasses
+
+import pytest
+import torch
+
+from torch_spyre._inductor.expert_execution import (
+    ExpertGraphPlan,
+    ExpertPlanningError,
+    ExpertStrategy,
+    materialize_expert_execution_graph,
+    plan_expert_execution_graph,
+    prepare_expert_execution_graph,
+)
+from torch_spyre._inductor.expert_execution.custom_op import (
+    dense_expert_persistent_ffn,
+    moe_ffn,
+)
+
+
+def _graph_module():
+    graph = torch.fx.Graph()
+    specs = (
+        ("x", (64, 64), None),
+        ("gate", (2, 64, 64), (64, 128, 1)),
+        ("up", (2, 64, 64), (64, 128, 1)),
+        ("down", (2, 64, 64), (64, 128, 1)),
+        ("routing", (64, 2, 1), (1, 64, 1)),
+    )
+    args = []
+    for name, shape, stride in specs:
+        node = graph.placeholder(name)
+        value = torch.empty(shape, device="meta", dtype=torch.float16)
+        if stride is not None:
+            value = torch.as_strided(value, shape, stride)
+        node.meta["val"] = value
+        args.append(node)
+    result = graph.call_function(moe_ffn._opoverload, args=(*args, 1, "silu"))
+    result.meta["val"] = torch.empty((64, 64), device="meta", dtype=torch.float16)
+    graph.output(result)
+    return torch.fx.GraphModule(torch.nn.Module(), graph)
+
+
+def _call_target(graph_module):
+    return next(
+        node.target for node in graph_module.graph.nodes if node.op == "call_function"
+    )
+
+
+def test_planning_is_pure_and_selects_persistent_schedule():
+    graph_module = _graph_module()
+    before_code = graph_module.code
+    before_meta = {node.name: dict(node.meta) for node in graph_module.graph.nodes}
+
+    plan = plan_expert_execution_graph(
+        graph_module,
+        persistent_available=True,
+        available_lx_bytes=1_000_000,
+    )
+
+    assert graph_module.code == before_code
+    for node in graph_module.graph.nodes:
+        assert node.meta.keys() == before_meta[node.name].keys()
+        for key, value in node.meta.items():
+            assert value is before_meta[node.name][key]
+    selected = plan.nodes[0]
+    assert selected.strategy is ExpertStrategy.PERSISTENT_DENSE
+    assert selected.expert_count == 2
+    assert selected.schedule.binding_kind == "sequential_affine"
+    assert selected.schedule.weight_layout == "logical_expert_major_k_major_backing"
+    assert selected.schedule.routing_layout == "logical_token_major"
+    assert selected.schedule.preheader == ("stage_x", "fill_accumulator")
+    assert selected.schedule.drain == ("drain_output",)
+
+
+def test_conservative_feasibility_selects_ordinary_dense():
+    plan = plan_expert_execution_graph(
+        _graph_module(), persistent_available=True, available_lx_bytes=1
+    )
+
+    assert plan.nodes[0].strategy is ExpertStrategy.ORDINARY_DENSE
+    assert plan.nodes[0].schedule is None
+
+
+def test_materialization_rewrites_only_an_isolated_clone():
+    source = _graph_module()
+    plan = plan_expert_execution_graph(
+        source, persistent_available=True, available_lx_bytes=1_000_000
+    )
+
+    candidate = materialize_expert_execution_graph(source, plan)
+
+    assert candidate is not source
+    assert _call_target(source) == moe_ffn._opoverload
+    assert _call_target(candidate) == dense_expert_persistent_ffn._opoverload
+    call = next(node for node in candidate.graph.nodes if node.op == "call_function")
+    assert call.args[-1] == call.name
+
+
+def test_contiguous_expert_weights_do_not_select_persistent():
+    graph_module = _graph_module()
+    for name in ("gate", "up", "down"):
+        node = next(node for node in graph_module.graph.nodes if node.name == name)
+        node.meta["val"] = torch.empty(
+            tuple(node.meta["val"].shape), device="meta", dtype=torch.float16
+        )
+
+    plan = plan_expert_execution_graph(
+        graph_module,
+        persistent_available=True,
+        available_lx_bytes=1_000_000,
+    )
+
+    assert plan.nodes[0].strategy is ExpertStrategy.ORDINARY_DENSE
+
+
+def test_contiguous_token_major_routing_selects_persistent():
+    graph_module = _graph_module()
+    routing = next(node for node in graph_module.graph.nodes if node.name == "routing")
+    routing.meta["val"] = torch.empty(
+        tuple(routing.meta["val"].shape), device="meta", dtype=torch.float16
+    )
+
+    plan = plan_expert_execution_graph(
+        graph_module,
+        persistent_available=True,
+        available_lx_bytes=1_000_000,
+    )
+
+    assert plan.nodes[0].strategy is ExpertStrategy.PERSISTENT_DENSE
+
+
+def test_ordinary_dense_materialization_is_a_no_op():
+    source = _graph_module()
+    plan = plan_expert_execution_graph(
+        source, persistent_available=False, available_lx_bytes=1_000_000
+    )
+
+    candidate = materialize_expert_execution_graph(source, plan)
+
+    assert candidate is source
+    assert _call_target(source) == moe_ffn._opoverload
+
+
+def test_materialization_rejects_a_changed_source_graph():
+    source = _graph_module()
+    plan = plan_expert_execution_graph(
+        source, persistent_available=True, available_lx_bytes=1_000_000
+    )
+    call = next(node for node in source.graph.nodes if node.op == "call_function")
+    call.args = (*call.args[:-1], "gelu_tanh")
+    source.recompile()
+
+    with pytest.raises(ExpertPlanningError, match="changed after expert planning"):
+        materialize_expert_execution_graph(source, plan)
+
+
+def test_failed_materialization_does_not_change_the_source():
+    source = _graph_module()
+    plan = plan_expert_execution_graph(
+        source, persistent_available=True, available_lx_bytes=1_000_000
+    )
+    invalid_node = dataclasses.replace(plan.nodes[0], schedule=None)
+    invalid_plan = ExpertGraphPlan(plan.source_structure, (invalid_node,))
+
+    with pytest.raises(ExpertPlanningError, match="not a valid persistent"):
+        materialize_expert_execution_graph(source, invalid_plan)
+
+    assert _call_target(source) == moe_ffn._opoverload
+
+
+def test_prepare_uses_configured_lx_budget(monkeypatch):
+    source = _graph_module()
+    monkeypatch.setattr(
+        "torch_spyre._inductor.config.enable_dense_expert_persistent", True
+    )
+    monkeypatch.setattr("torch_spyre._inductor.config.sencores", 32)
+    monkeypatch.setattr(
+        "torch_spyre._inductor.scratchpad.allocator._lx_planning_size",
+        lambda: 1_000_000,
+    )
+
+    candidate, plan = prepare_expert_execution_graph(source)
+
+    assert len(plan.nodes) == 1
+    assert _call_target(source) == moe_ffn._opoverload
+    assert _call_target(candidate) == dense_expert_persistent_ffn._opoverload
+
+
+def test_persistent_strategy_is_not_user_enabled():
+    from torch_spyre._inductor import config
+
+    assert config.enable_dense_expert_persistent is False

--- a/tests/inductor/test_moe_ffn_semantics.py
+++ b/tests/inductor/test_moe_ffn_semantics.py
@@ -1,0 +1,111 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from torch_spyre._inductor.expert_execution.custom_op import (
+    expert_shared_lhs_mm,
+    moe_ffn,
+)
+from torch_spyre._inductor.expert_execution.semantics import moe_ffn_reference
+from torch_spyre._inductor.decompositions import (
+    decompose_dense_expert_persistent_ffn,
+    get_spyre_decomp_table,
+)
+
+
+def _inputs(dtype=torch.float32):
+    generator = torch.Generator().manual_seed(17)
+    tokens, experts, hidden, intermediate = 4, 3, 8, 6
+    x = torch.randn(tokens, hidden, dtype=dtype, generator=generator)
+    gate = torch.randn(experts, hidden, intermediate, dtype=dtype, generator=generator)
+    up = torch.randn(experts, hidden, intermediate, dtype=dtype, generator=generator)
+    down = torch.randn(experts, intermediate, hidden, dtype=dtype, generator=generator)
+    routing = torch.randn(tokens, experts, 1, dtype=dtype, generator=generator)
+    return x, gate, up, down, routing
+
+
+@pytest.mark.parametrize("activation", ["gelu_tanh", "silu"])
+def test_moe_ffn_cpu_matches_direct_reference(activation):
+    inputs = _inputs()
+
+    actual = moe_ffn(*inputs, 2, activation)
+    expected = moe_ffn_reference(*inputs, 2, activation)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_zero_routing_weight_removes_an_expert_contribution():
+    x, gate, up, down, routing = _inputs()
+    routing[:, 1, :] = 0
+
+    actual = moe_ffn(x, gate, up, down, routing, 2, "silu")
+    expected = moe_ffn(
+        x,
+        gate[[0, 2]],
+        up[[0, 2]],
+        down[[0, 2]],
+        routing[:, [0, 2], :],
+        2,
+        "silu",
+    )
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_moe_ffn_requires_explicit_singleton_routing_axis():
+    x, gate, up, down, routing = _inputs()
+
+    with pytest.raises(ValueError, match=r"\[T,E,1\]"):
+        moe_ffn(x, gate, up, down, routing.squeeze(-1), 2, "silu")
+
+
+def test_moe_ffn_rejects_mismatched_logical_weight_schema():
+    x, gate, up, down, routing = _inputs()
+
+    with pytest.raises(ValueError, match="up_weight"):
+        moe_ffn(x, gate, up[:, :-1], down, routing, 2, "silu")
+
+
+def test_moe_ffn_rejects_invalid_top_k():
+    inputs = _inputs()
+
+    with pytest.raises(ValueError, match="top_k"):
+        moe_ffn(*inputs, 4, "silu")
+
+
+def test_internal_shared_lhs_projection_matches_expert_loop():
+    x, gate, _up, _down, _routing = _inputs()
+
+    actual = expert_shared_lhs_mm(x, gate)
+    expected = torch.stack(tuple(torch.mm(x, weight) for weight in gate))
+
+    assert actual.shape == (gate.shape[0], x.shape[0], gate.shape[2])
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.parametrize("activation", ["gelu_tanh", "silu"])
+def test_persistent_decomposition_matches_semantic_reference(activation):
+    inputs = _inputs()
+
+    actual = decompose_dense_expert_persistent_ffn(
+        *inputs, 2, activation, "test_region"
+    )
+    expected = moe_ffn_reference(*inputs, 2, activation)
+
+    torch.testing.assert_close(actual, expected)
+    assert (
+        torch.ops.spyre.dense_expert_persistent_ffn.default in get_spyre_decomp_table()
+    )

--- a/torch_spyre/_inductor/__init__.py
+++ b/torch_spyre/_inductor/__init__.py
@@ -138,6 +138,27 @@ def enable_spyre_compile_fx_wrapper():
             try:
                 if uses_spyre:
                     torch.spyre._impl._lazy_init()
+                    from torch_spyre._inductor.expert_execution.custom_op import (
+                        moe_ffn,
+                    )
+
+                    if any(
+                        node.op == "call_function"
+                        and node.target == moe_ffn._opoverload
+                        for node in gm.graph.nodes
+                    ):
+                        from torch_spyre._inductor.expert_execution.planner import (
+                            prepare_expert_execution_graph,
+                        )
+
+                        gm, expert_plan = prepare_expert_execution_graph(gm)
+                        logger.debug(
+                            "planned %d semantic MoE nodes; selected %d persistent",
+                            len(expert_plan.nodes),
+                            sum(
+                                node.schedule is not None for node in expert_plan.nodes
+                            ),
+                        )
                     # AOTAutograd uses the dict passed via ``decompositions=``
                     # to decompose the joint graph; Spyre-specific
                     # decompositions must be applied at this stage so ops like

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -67,6 +67,11 @@ dxp_lx_frac_avail: float = float(os.environ.get("DXP_LX_FRAC_AVAIL", "0.2"))
 
 sencores: int = int(os.getenv("SENCORES", "32"))
 
+# Internal development gate.  This is deliberately not environment-controlled:
+# the persistent strategy is not selectable until its physical schedule lands.
+# Tests may monkeypatch it while exercising the pure planner/materializer.
+enable_dense_expert_persistent: bool = False
+
 # Symbolic-dim knobs consumed by compute_granularity in pass_utils.py.
 # The pointwise work-division PR (#2499) wires that helper into the
 # compilation pipeline; until then these knobs are read only by the

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -110,6 +110,10 @@ COPY_BACK_CANDIDATE_ATTR = "_spyre_copy_back_candidate"
 # compute mutation op from a pure-copy mutation op.
 ELIDED_COPY_BACK_ATTR = "_spyre_writes_copy_back_target"
 
+# OpSpec marker for a persistent expert projection whose expert weight remains
+# a graph HBM operand and is rebound once per counted-loop iteration.
+PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY = "persistent_expert_stream_weight"
+
 # FX ``custom`` metadata key for BMMs created from a shared 2D weight whose
 # logical batch dim is statically 1.  The downstream OpSpec key carries the same
 # fact after lowering, where FX metadata is no longer directly available.

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -20,6 +20,11 @@ from torch_spyre.ops.eager import compile_once
 from torch_spyre.ops.fallbacks import warn_fallback
 
 from .errors import Unsupported
+from .expert_execution.custom_op import (  # noqa: F401
+    dense_expert_persistent_ffn,
+    expert_shared_lhs_mm,
+    moe_ffn,
+)
 
 aten = torch.ops.aten
 

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -113,6 +113,71 @@ def register_spyre_decompositions(ops: OpOrOps):
     return decomp.register_decomposition(ops, spyre_decompositions)
 
 
+@register_spyre_decompositions(torch.ops.spyre.moe_ffn.default)
+def decompose_moe_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+) -> torch.Tensor:
+    """Lower the semantic operation through the ordinary dense device path."""
+    from .expert_execution.semantics import moe_ffn_reference
+
+    return moe_ffn_reference(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+
+
+@register_spyre_decompositions(torch.ops.spyre.dense_expert_persistent_ffn.default)
+def decompose_dense_expert_persistent_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+    region_id: str,
+) -> torch.Tensor:
+    """Materialize one logical body for a static persistent expert loop.
+
+    This decomposition does not iterate over experts in Python. The expert
+    dimension remains in the logical tensors and is tiled to one by the
+    compiler, which turns it into one counted device loop around a single
+    gate/up/down body.
+    """
+    del top_k, region_id  # Routing weights already encode top-k selection.
+    experts = gate_weight.shape[0]
+    with spyre_hint(num_tiles_per_dim={"E": experts}):
+        with spyre_hint(named_dims=["E", "T", "F"]):
+            gate = torch.ops.spyre.expert_shared_lhs_mm(x, gate_weight)
+            up = torch.ops.spyre.expert_shared_lhs_mm(x, up_weight)
+            if activation == "gelu_tanh":
+                activated_gate = torch.nn.functional.gelu(gate, approximate="tanh")
+            elif activation == "silu":
+                activated_gate = torch.nn.functional.silu(gate)
+            else:
+                raise Unsupported(f"unsupported MoE activation {activation!r}")
+            hidden = activated_gate * up
+        with spyre_hint(named_dims=["E", "T", "H"]):
+            down = torch.bmm(hidden, down_weight)
+        with spyre_hint(named_dims=["E", "T", "route"]):
+            route_by_expert = routing_weight.permute(1, 0, 2)
+        with spyre_hint(named_dims=["E", "T", "H"]):
+            weighted_down = down * route_by_expert
+        with spyre_hint(named_dims=["T", "H"], expected_reduction_dims=["E"]):
+            return torch.sum(weighted_down, dim=0)
+
+
 def get_spyre_decomp_table() -> dict[Any, Callable[..., Any]]:
     """Return the decomposition table Inductor sees when compiling for Spyre.
 

--- a/torch_spyre/_inductor/expert_execution/__init__.py
+++ b/torch_spyre/_inductor/expert_execution/__init__.py
@@ -1,0 +1,37 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dense-expert semantic operations and compiler strategy selection."""
+
+from .planner import (
+    ExpertGraphPlan,
+    ExpertPlanningError,
+    ExpertStrategy,
+    PersistentExpertSchedule,
+    PlannedExpertNode,
+    materialize_expert_execution_graph,
+    plan_expert_execution_graph,
+    prepare_expert_execution_graph,
+)
+
+__all__ = [
+    "ExpertGraphPlan",
+    "ExpertPlanningError",
+    "ExpertStrategy",
+    "PersistentExpertSchedule",
+    "PlannedExpertNode",
+    "materialize_expert_execution_graph",
+    "plan_expert_execution_graph",
+    "prepare_expert_execution_graph",
+]

--- a/torch_spyre/_inductor/expert_execution/custom_op.py
+++ b/torch_spyre/_inductor/expert_execution/custom_op.py
@@ -1,0 +1,186 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Strategy-neutral routed-expert FFN custom operation."""
+
+import torch
+
+from .semantics import moe_ffn_reference, validate_moe_ffn_inputs
+
+
+@torch.library.custom_op(
+    "spyre::expert_shared_lhs_mm", mutates_args=(), device_types=("cpu", "spyre")
+)
+def expert_shared_lhs_mm(x: torch.Tensor, expert_weights: torch.Tensor) -> torch.Tensor:
+    """Evaluate the internal shared-LHS expert projection in eager mode."""
+    _validate_shared_lhs_mm(x, expert_weights)
+    return torch.stack(
+        tuple(
+            torch.mm(x, expert_weights[expert]) for expert in range(len(expert_weights))
+        )
+    )
+
+
+@expert_shared_lhs_mm.register_fake
+def _(x: torch.Tensor, expert_weights: torch.Tensor) -> torch.Tensor:
+    _validate_shared_lhs_mm(x, expert_weights)
+    return x.new_empty((expert_weights.shape[0], x.shape[0], expert_weights.shape[2]))
+
+
+def _validate_shared_lhs_mm(x: torch.Tensor, expert_weights: torch.Tensor) -> None:
+    if x.ndim != 2:
+        raise ValueError(f"x must have shape [T,K], got {tuple(x.shape)}")
+    if expert_weights.ndim != 3:
+        raise ValueError(
+            f"expert_weights must have shape [E,K,N], got {tuple(expert_weights.shape)}"
+        )
+    if x.shape[1] != expert_weights.shape[1]:
+        raise ValueError("x and expert_weights have different reduction dimensions")
+    if x.device != expert_weights.device or x.dtype != expert_weights.dtype:
+        raise ValueError("x and expert_weights must share device and dtype")
+
+
+def _internal_moe_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+) -> torch.Tensor:
+    return moe_ffn_reference(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+
+
+def _fake_internal_moe_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+    region_id: str,
+) -> torch.Tensor:
+    del region_id
+    validate_moe_ffn_inputs(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+    return x.new_empty(x.shape)
+
+
+@torch.library.custom_op(
+    "spyre::dense_expert_persistent_ffn",
+    mutates_args=(),
+    device_types=("cpu", "spyre"),
+    schema=(
+        "(Tensor x, Tensor gate_weight, Tensor up_weight, Tensor down_weight, "
+        "Tensor routing_weight, int top_k, str activation, str region_id) -> Tensor"
+    ),
+)
+def dense_expert_persistent_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+    region_id: str,
+) -> torch.Tensor:
+    """Compiler-internal target for the persistent strategy."""
+    del region_id
+    return _internal_moe_ffn(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+
+
+dense_expert_persistent_ffn.register_fake(_fake_internal_moe_ffn)
+
+
+@torch.library.custom_op(
+    "spyre::moe_ffn",
+    mutates_args=(),
+    device_types=("cpu", "spyre"),
+    schema=(
+        "(Tensor x, Tensor gate_weight, Tensor up_weight, Tensor down_weight, "
+        "Tensor routing_weight, int top_k, str activation) -> Tensor"
+    ),
+)
+def moe_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+) -> torch.Tensor:
+    """Evaluate the routed-expert value path in eager mode.
+
+    Router-logit generation and any shared-expert FFN are intentionally outside
+    this operation. ``routing_weight`` is the already-normalized post-down
+    expert weight with logical shape ``[T, E, 1]``.
+    """
+    return moe_ffn_reference(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+
+
+@moe_ffn.register_fake
+def _(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+) -> torch.Tensor:
+    validate_moe_ffn_inputs(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+    return x.new_empty(x.shape)

--- a/torch_spyre/_inductor/expert_execution/planner.py
+++ b/torch_spyre/_inductor/expert_execution/planner.py
@@ -1,0 +1,352 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure selection and transactional FX materialization for expert execution."""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+from enum import StrEnum
+from typing import Any
+
+import torch
+
+from .custom_op import dense_expert_persistent_ffn, moe_ffn
+
+
+class ExpertStrategy(StrEnum):
+    """Compiler strategies currently available for the semantic MoE operation."""
+
+    PERSISTENT_DENSE = "persistent_dense"
+    ORDINARY_DENSE = "ordinary_dense"
+
+
+@dataclasses.dataclass(frozen=True)
+class PersistentExpertSchedule:
+    """The schedule contract materialized by the persistent strategy."""
+
+    preheader: tuple[str, ...] = ("stage_x", "fill_accumulator")
+    loop_body: tuple[str, ...] = (
+        "gate",
+        "up",
+        "activation",
+        "gated_product",
+        "down",
+        "route_weight",
+        "accumulator_combine",
+    )
+    drain: tuple[str, ...] = ("drain_output",)
+    streamed_operands: tuple[str, ...] = (
+        "gate_weight",
+        "up_weight",
+        "down_weight",
+        "routing_weight",
+    )
+    binding_kind: str = "sequential_affine"
+    weight_layout: str = "logical_expert_major_k_major_backing"
+    routing_layout: str = "logical_token_major"
+
+
+@dataclasses.dataclass(frozen=True)
+class PlannedExpertNode:
+    """The selected strategy for one semantic MoE FX node."""
+
+    node_name: str
+    strategy: ExpertStrategy
+    expert_count: int
+    minimum_lx_bytes: int
+    schedule: PersistentExpertSchedule | None
+
+
+@dataclasses.dataclass(frozen=True)
+class ExpertGraphPlan:
+    """Immutable result of planning every semantic MoE node in an FX graph."""
+
+    source_structure: tuple[tuple[Any, ...], ...]
+    nodes: tuple[PlannedExpertNode, ...]
+
+
+class ExpertPlanningError(RuntimeError):
+    """The selected strategy could not be materialized without mutation."""
+
+
+def graph_structure(graph: torch.fx.Graph) -> tuple[tuple[Any, ...], ...]:
+    """Return a stable, metadata-independent graph representation."""
+
+    def encode(value):
+        if isinstance(value, torch.fx.Node):
+            return ("node", value.name)
+        if isinstance(value, tuple):
+            return tuple(encode(item) for item in value)
+        if isinstance(value, list):
+            return ("list", *(encode(item) for item in value))
+        if isinstance(value, dict):
+            return tuple((key, encode(value[key])) for key in sorted(value))
+        return value
+
+    return tuple(
+        (node.name, node.op, str(node.target), encode(node.args), encode(node.kwargs))
+        for node in graph.nodes
+    )
+
+
+def _tensor_argument(node: torch.fx.Node, index: int, name: str) -> torch.fx.Node:
+    value = node.args[index]
+    if not isinstance(value, torch.fx.Node):
+        raise ValueError(f"{name} must be a tensor FX node")
+    return value
+
+
+def _tensor_metadata(node: torch.fx.Node, name: str):
+    """Return the tensor metadata produced by Dynamo or post-grad FX."""
+
+    value = node.meta.get("val")
+    if value is None:
+        value = node.meta.get("example_value")
+    if value is None:
+        raise ValueError(f"{name} has no tensor metadata")
+    return value
+
+
+def _shape(node: torch.fx.Node, name: str) -> tuple[int, ...]:
+    shape = getattr(_tensor_metadata(node, name), "shape", None)
+    if shape is None:
+        raise ValueError(f"{name} has no tensor shape metadata")
+    try:
+        return tuple(int(dim) for dim in shape)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} requires static dimensions") from exc
+
+
+def _element_size(node: torch.fx.Node, name: str) -> int:
+    value = _tensor_metadata(node, name)
+    if not hasattr(value, "element_size"):
+        raise ValueError(f"{name} has no tensor dtype metadata")
+    return int(value.element_size())
+
+
+def _stride(node: torch.fx.Node, name: str) -> tuple[int, ...]:
+    value = _tensor_metadata(node, name)
+    if not hasattr(value, "stride"):
+        raise ValueError(f"{name} has no tensor stride metadata")
+    try:
+        return tuple(int(dim) for dim in value.stride())
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} requires static strides") from exc
+
+
+def _has_persistent_weight_layout(
+    node: torch.fx.Node,
+    name: str,
+    *,
+    experts: int,
+    reduction: int,
+    output: int,
+) -> bool:
+    """Check the logical ``[E,K,N]`` view over packed ``[K,E,N]`` storage."""
+
+    return _shape(node, name) == (experts, reduction, output) and _stride(
+        node, name
+    ) == (output, experts * output, 1)
+
+
+def _has_persistent_routing_layout(
+    node: torch.fx.Node,
+    name: str,
+    *,
+    tokens: int,
+    experts: int,
+) -> bool:
+    """Check a logical ``[T,E,1]`` route tensor the loop can stream directly."""
+
+    if _shape(node, name) != (tokens, experts, 1):
+        return False
+    return _stride(node, name) in {
+        (experts, 1, 1),  # contiguous token-major storage
+        (1, tokens, 1),  # logical token-major view over expert-major storage
+    }
+
+
+def _plan_node(
+    node: torch.fx.Node,
+    *,
+    persistent_available: bool,
+    available_lx_bytes: int,
+) -> PlannedExpertNode:
+    if len(node.args) != 7:
+        raise ValueError("spyre::moe_ffn expects exactly seven arguments")
+    x = _tensor_argument(node, 0, "x")
+    gate = _tensor_argument(node, 1, "gate_weight")
+    up = _tensor_argument(node, 2, "up_weight")
+    down = _tensor_argument(node, 3, "down_weight")
+    routing = _tensor_argument(node, 4, "routing_weight")
+    top_k, activation = node.args[5:7]
+
+    if type(top_k) is not int or not isinstance(activation, str):
+        raise ValueError("top_k and activation must be static")
+    x_shape = _shape(x, "x")
+    gate_shape = _shape(gate, "gate_weight")
+    if len(x_shape) != 2 or len(gate_shape) != 3:
+        raise ValueError("moe_ffn requires x[T,H] and gate_weight[E,H,F]")
+    tokens, hidden = x_shape
+    experts, gate_hidden, intermediate = gate_shape
+    if gate_hidden != hidden:
+        raise ValueError("gate_weight hidden dimension differs from x")
+    if _shape(up, "up_weight") != (experts, hidden, intermediate):
+        raise ValueError("up_weight does not match gate_weight")
+    if _shape(down, "down_weight") != (experts, intermediate, hidden):
+        raise ValueError("down_weight does not match gate_weight")
+    if _shape(routing, "routing_weight") != (tokens, experts, 1):
+        raise ValueError("routing_weight must have shape [T,E,1]")
+    if not 0 < top_k <= experts:
+        raise ValueError("top_k must be in [1, E]")
+    if activation not in {"gelu_tanh", "silu"}:
+        raise ValueError(f"unsupported activation {activation!r}")
+
+    # Conservative feasibility check. Placement remains authoritative.
+    minimum_lx_bytes = _element_size(x, "x") * (
+        2 * tokens * hidden + 2 * tokens * intermediate
+    )
+    packed_weights = (
+        _has_persistent_weight_layout(
+            gate,
+            "gate_weight",
+            experts=experts,
+            reduction=hidden,
+            output=intermediate,
+        )
+        and _has_persistent_weight_layout(
+            up,
+            "up_weight",
+            experts=experts,
+            reduction=hidden,
+            output=intermediate,
+        )
+        and _has_persistent_weight_layout(
+            down,
+            "down_weight",
+            experts=experts,
+            reduction=intermediate,
+            output=hidden,
+        )
+    )
+    packed_routing = _has_persistent_routing_layout(
+        routing,
+        "routing_weight",
+        tokens=tokens,
+        experts=experts,
+    )
+    use_persistent = (
+        persistent_available
+        and packed_weights
+        and packed_routing
+        and minimum_lx_bytes <= available_lx_bytes
+    )
+    return PlannedExpertNode(
+        node_name=node.name,
+        strategy=(
+            ExpertStrategy.PERSISTENT_DENSE
+            if use_persistent
+            else ExpertStrategy.ORDINARY_DENSE
+        ),
+        expert_count=experts,
+        minimum_lx_bytes=minimum_lx_bytes,
+        schedule=PersistentExpertSchedule() if use_persistent else None,
+    )
+
+
+def plan_expert_execution_graph(
+    graph_module: torch.fx.GraphModule,
+    *,
+    persistent_available: bool,
+    available_lx_bytes: int,
+) -> ExpertGraphPlan:
+    """Select strategies without modifying graph structure or metadata."""
+    before = graph_structure(graph_module.graph)
+    plans = tuple(
+        _plan_node(
+            node,
+            persistent_available=persistent_available,
+            available_lx_bytes=available_lx_bytes,
+        )
+        for node in graph_module.graph.nodes
+        if node.op == "call_function" and node.target == moe_ffn._opoverload
+    )
+    if graph_structure(graph_module.graph) != before:
+        raise RuntimeError("expert planning mutated the source FX graph")
+    return ExpertGraphPlan(before, plans)
+
+
+def _find_node(graph: torch.fx.Graph, name: str) -> torch.fx.Node:
+    matches = [node for node in graph.nodes if node.name == name]
+    if len(matches) != 1:
+        raise ExpertPlanningError(
+            f"expected one FX node named {name}, got {len(matches)}"
+        )
+    return matches[0]
+
+
+def materialize_expert_execution_graph(
+    graph_module: torch.fx.GraphModule,
+    plan: ExpertGraphPlan,
+) -> torch.fx.GraphModule:
+    """Rewrite a clone and publish it only after all checks succeed."""
+    if graph_structure(graph_module.graph) != plan.source_structure:
+        raise ExpertPlanningError("FX graph changed after expert planning")
+    persistent_nodes = tuple(
+        node for node in plan.nodes if node.strategy == ExpertStrategy.PERSISTENT_DENSE
+    )
+    if not persistent_nodes:
+        return graph_module
+
+    candidate = copy.deepcopy(graph_module)
+    for node_plan in persistent_nodes:
+        node = _find_node(candidate.graph, node_plan.node_name)
+        if node.target != moe_ffn._opoverload or node_plan.schedule is None:
+            raise ExpertPlanningError(
+                f"{node_plan.node_name} is not a valid persistent MoE node"
+            )
+        node.target = dense_expert_persistent_ffn._opoverload
+        # The stable FX node name is the compiler-owned region identity.  It is
+        # serialized as a static internal-op argument so the selected region
+        # survives AOT decomposition without relying on user hint IDs.
+        node.args = (*node.args, node_plan.node_name)
+    candidate.graph.lint()
+    candidate.recompile()
+
+    for node_plan in persistent_nodes:
+        if (
+            _find_node(candidate.graph, node_plan.node_name).target
+            != dense_expert_persistent_ffn._opoverload
+        ):
+            raise ExpertPlanningError(f"failed to materialize {node_plan.node_name}")
+    if graph_structure(graph_module.graph) != plan.source_structure:
+        raise RuntimeError("expert materialization mutated the source FX graph")
+    return candidate
+
+
+def prepare_expert_execution_graph(
+    graph_module: torch.fx.GraphModule,
+) -> tuple[torch.fx.GraphModule, ExpertGraphPlan]:
+    """Plan once, then transactionally materialize compiler-owned strategies."""
+    from .. import config
+    from ..scratchpad.allocator import _lx_planning_size
+
+    plan = plan_expert_execution_graph(
+        graph_module,
+        persistent_available=config.enable_dense_expert_persistent,
+        available_lx_bytes=config.sencores * _lx_planning_size(),
+    )
+    return materialize_expert_execution_graph(graph_module, plan), plan

--- a/torch_spyre/_inductor/expert_execution/semantics.py
+++ b/torch_spyre/_inductor/expert_execution/semantics.py
@@ -1,0 +1,123 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Semantic definition of the routed-expert FFN operation."""
+
+from __future__ import annotations
+
+import torch
+
+
+SUPPORTED_ACTIVATIONS = ("gelu_tanh", "silu")
+
+
+def validate_moe_ffn_inputs(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+) -> tuple[int, int, int, int]:
+    """Validate the logical, strategy-neutral routed-FFN tensor contract."""
+    if activation not in SUPPORTED_ACTIVATIONS:
+        raise ValueError(
+            f"unsupported MoE activation {activation!r}; "
+            f"expected one of {SUPPORTED_ACTIVATIONS}"
+        )
+    if x.ndim != 2:
+        raise ValueError(f"x must have shape [T,H], got {tuple(x.shape)}")
+    if gate_weight.ndim != 3 or up_weight.ndim != 3 or down_weight.ndim != 3:
+        raise ValueError("expert weights must be rank-3 logical weight banks")
+    if routing_weight.ndim != 3 or routing_weight.shape[-1] != 1:
+        raise ValueError(
+            "routing_weight must have shape [T,E,1]; the explicit singleton "
+            "preserves post-down scalar broadcast semantics"
+        )
+
+    tokens, hidden = x.shape
+    experts, gate_hidden, intermediate = gate_weight.shape
+    if top_k <= 0 or top_k > experts:
+        raise ValueError(f"top_k must be in [1,{experts}], got {top_k}")
+    expected_up = (experts, hidden, intermediate)
+    expected_down = (experts, intermediate, hidden)
+    expected_routing = (tokens, experts, 1)
+    if gate_hidden != hidden:
+        raise ValueError(
+            f"gate_weight has hidden size {gate_hidden}, expected {hidden}"
+        )
+    if tuple(up_weight.shape) != expected_up:
+        raise ValueError(
+            f"up_weight must have shape {expected_up}, got {tuple(up_weight.shape)}"
+        )
+    if tuple(down_weight.shape) != expected_down:
+        raise ValueError(
+            "down_weight must have shape "
+            f"{expected_down}, got {tuple(down_weight.shape)}"
+        )
+    if tuple(routing_weight.shape) != expected_routing:
+        raise ValueError(
+            "routing_weight must have shape "
+            f"{expected_routing}, got {tuple(routing_weight.shape)}"
+        )
+    if any(
+        tensor.device != x.device
+        for tensor in (gate_weight, up_weight, down_weight, routing_weight)
+    ):
+        raise ValueError("all MoE tensors must be on the same device")
+    if any(
+        tensor.dtype != x.dtype
+        for tensor in (gate_weight, up_weight, down_weight, routing_weight)
+    ):
+        raise ValueError("all MoE tensors must have the same dtype")
+    return tokens, experts, hidden, intermediate
+
+
+def moe_ffn_reference(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+) -> torch.Tensor:
+    """Evaluate the logical all-expert routed FFN without strategy assumptions.
+
+    The reference intentionally expresses one expert at a time. It defines
+    semantics for eager execution and correctness tests; compiler strategies
+    are free to use a persistent device loop, partitioned dense execution, or
+    another implementation that preserves this result.
+    """
+    _tokens, experts, _hidden, _intermediate = validate_moe_ffn_inputs(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+    result = torch.zeros_like(x)
+    for expert in range(experts):
+        gate = torch.mm(x, gate_weight[expert])
+        up = torch.mm(x, up_weight[expert])
+        if activation == "gelu_tanh":
+            gate = torch.nn.functional.gelu(gate, approximate="tanh")
+        else:
+            gate = torch.nn.functional.silu(gate)
+        down = torch.mm(gate * up, down_weight[expert])
+        result = result + down * routing_weight[:, expert, :]
+    return result

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -31,6 +31,7 @@ from .constants import (
     COPY_BACK_CANDIDATE_ATTR,
     BATCH_MATMUL_FP8_OP,
     DEPTHWISE_CONV2D_OP,
+    PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY,
     SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY,
     SHARED_WEIGHT_UNIT_BMM_INFO_KEY,
 )
@@ -558,6 +559,62 @@ def lower_bmm(x, y):
             f"bmm: x{list(x_size)} @ y{list(y_size)} -> {list(result_buf.get_size())}"
         )
 
+    return result
+
+
+@register_spyre_lowering(torch.ops.spyre.expert_shared_lhs_mm.default)
+def lower_expert_shared_lhs_mm(x, expert_weights):
+    """Lower ``[T,K] @ [E,K,N]`` without expanding X over E.
+
+    The expert coordinate indexes only the weight and output tensors. This is
+    the logical projection needed by a later persistent expert loop: tiling E
+    to one changes the streamed weight address while leaving the X address
+    invariant.
+    """
+    x.realize()
+    expert_weights.realize()
+    x_size = x.get_size()
+    weight_size = expert_weights.get_size()
+    if len(x_size) != 2 or len(weight_size) != 3:
+        raise Unsupported(
+            "expert_shared_lhs_mm requires [T,K] and [E,K,N], "
+            f"got {x_size} and {weight_size}"
+        )
+    if x_size[1] != weight_size[1]:
+        raise Unsupported(
+            "expert_shared_lhs_mm reduction dimensions differ: "
+            f"{x_size[1]} versus {weight_size[1]}"
+        )
+    if x.get_dtype() != expert_weights.get_dtype():
+        raise Unsupported("expert_shared_lhs_mm inputs must have the same dtype")
+
+    x_loader = x.make_loader()
+    weight_loader = expert_weights.make_loader()
+    ranges = [weight_size[0], x_size[0], weight_size[2]]
+
+    def inner_fn(index, reduction_index):
+        expert, row, column = index
+        (reduction,) = reduction_index
+        return (
+            x_loader([row, reduction]),
+            weight_loader([expert, reduction, column]),
+        )
+
+    result = SpyreReduction.create(
+        reduction_type=BATCH_MATMUL_OP,
+        input_node=[x, expert_weights],
+        device=x.get_device(),
+        dst_dtype=x.get_dtype(),
+        src_dtype=x.get_dtype(),
+        inner_fn=inner_fn,
+        ranges=ranges,
+        reduction_ranges=[x_size[1]],
+        op_info={
+            "persistent_expert_shared_lhs": {"expert_dim": 0},
+            PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY: True,
+        },
+    )
+    result.realize()
     return result
 
 


### PR DESCRIPTION
# Add persistent dense expert execution planning

Tracking: #3565

Local head: `ah/dense_expert_persistent` at `1a3459b5`

Base: `upstream/main` at `9678c796`

## Dependency order

This is Unit 0 and has no dependency on the later physical-schedule units. Unit A is draft PR #3815 (`a28991d4`).

## Purpose

Add the compiler-facing operation and planning layer for persistent dense expert execution. The target schedule represents the expert FFN as one logical expert body under a counted device loop rather than one statically unrolled body per expert.

## What this PR implements

- A strategy-neutral `spyre::moe_ffn` operation with validated eager semantics.
- An ordinary dense decomposition for the currently supported device path.
- A small immutable planner that can describe ordinary or persistent dense execution using an early LX-capacity estimate.
- Pure planning followed by clone-only materialization, so a failed rewrite cannot modify the source FX graph.
- An internal persistent-expert target whose decomposition keeps the expert dimension available for compiler loop formation.
- Shared-LHS expert projections for `[T,K] @ [E,K,N]` without expanding X to `[E,T,K]`.
- The shared-LHS projection lowers directly to `SpyreReduction` with its persistent-expert operation metadata, so the operation and its lowering contract are reviewed together.
- Post-down routing-weight application and expert reduction semantics.

The local revision contains 757 production insertions and 282 test and test-registration insertions across 13 files (1,039 insertions total).

## Current boundary

This PR defines the operation and source-level plan only. Follow-up PRs form the counted loop, preserve X and the output accumulator in LX, constrain work division, and validate the resulting physical schedule. The persistent strategy remains internally disabled in this unit; this PR does not yet make the selected schedule authoritative in the physical compiler pipeline.

The prototype timing is feasibility evidence for the complete schedule; this PR does not claim that performance by itself.

## Validation

- Planning purity, clone-only materialization, semantics, and shared-LHS behavior have focused tests.
- Ruff, Python bytecode compilation, formatting, and `git diff --check` pass at the local head.
- Focused pytest must be rerun in the configured torch-spyre test environment before the local revision replaces the current remote head; the local Python environment does not contain PyTorch.

This branch contains only source, tests, and test registration.
