### PR TITLE
fix(optimize_restickify): scale KV-chunked flash attention to arbitrary chunk counts

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -5537,9 +5537,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         This is the production shape -- vLLM-style chunked prefill -- not a
         scaled-down proxy.  Both H and Lq are WSR-tiled; Lk is not hinted.
 
-        kv_block is 2048 (4 chunks) rather than 512 (16) because layout solving
-        fails past ~6 unrolled chunks; see the docstring on
-        test_hint_flash_attention_kv_chunked_chunk_ceiling.  Lq stays at the
+        kv_block is 2048 (4 chunks) rather than 512 (16) because the 16-chunk
+        graph at Lq=512 takes significantly longer to compile.  Lq stays at the
         query-block size deliberately: the same 4-chunk graph at Lq=8192
         compiled for over two hours without finishing, while at Lq=512 it takes
         well under a minute, so compile cost is driven by Lq extent rather than
@@ -5576,25 +5575,24 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         """h_tiles == H (one head per tile) crashes in read-copy insertion."""
         self._run_kv_chunked_flash(h_tiles=8, lq_tiles=2)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Layout solving fails past ~6 unrolled K/V chunks: 4 and 6 chunks "
-            "compile and are exact, 8/10/12/16 all fail _no_feasible_layout_error "
-            "with the failing buffer at a fixed ~81% of the graph, i.e. always "
-            "around the 6th-7th chunk. NOT a graph-size limit -- dropping the "
-            "running-max carry yields MORE buffers (128 vs the failing 112) and "
-            "compiles. Every single ablation (either matmul, any one of the three "
-            "carries, the reductions) restores feasibility, so it is the "
-            "conjunction of constraints that becomes infeasible. Invariant to Lq "
-            "(256/512/8192), Lq tiling, D, and kv_block. This is what forces "
-            "kv_block=2048 for 8k instead of the 512 a memory budget would pick."
-        ),
-    )
-    def test_hint_flash_attention_kv_chunked_chunk_ceiling(self):
-        """8 unrolled K/V chunks exceed what layout solving can satisfy."""
+    def test_hint_flash_attention_kv_chunked_8_chunks(self):
+        """8 unrolled K/V chunks: now succeeds with optimized layouts for constants"""
         self._run_kv_chunked_flash(
             h_tiles=4, lq_tiles=None, B=1, H=8, Lq=256, Lk=4096, D=128, kv_block=512
+        )
+
+    @pytest.mark.skip(reason="Long test - takes ~6 mins to complete")
+    def test_hint_flash_attention_kv_chunked_16_chunks(self):
+        """16 unrolled K/V chunks: now succeeds with optimized layouts for constants"""
+        self._run_kv_chunked_flash(
+            h_tiles=4, lq_tiles=None, B=1, H=8, Lq=256, Lk=4096, D=128, kv_block=256
+        )
+
+    @pytest.mark.skip(reason="Long test - takes ~40 mins to complete")
+    def test_hint_flash_attention_kv_chunked_32_chunks(self):
+        """32 unrolled K/V chunks: now succeeds with optimized layouts for constants"""
+        self._run_kv_chunked_flash(
+            h_tiles=4, lq_tiles=None, B=1, H=8, Lq=256, Lk=4096, D=128, kv_block=128
         )
 
     def test_hint_h_tiling_elementwise(self):

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -5352,7 +5352,18 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             " divide Lq ranges on each op using that op's own dim role",
         )
 
-    def _run_kv_chunked_flash(self, h_tiles, n_chunks=2):
+    def _run_kv_chunked_flash(
+        self,
+        *,
+        h_tiles=4,
+        lq_tiles=2,
+        B=1,
+        H=8,
+        Lq=256,
+        Lk=256,
+        D=64,
+        kv_block=128,
+    ):
         """Flash attention with K/V chunking in PYTHON and WSR tiling only H/Lq.
 
         Shared by the two tests below so the h_tiles == H degenerate-tile case
@@ -5401,9 +5412,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         """
         from torch_spyre._inductor import spyre_hint
 
-        B, H, Lq, Lk, D = 1, 8, 256, 256, 64
-        kv_block = Lk // n_chunks
-        lq_tiles = 2
+        n_chunks = Lk // kv_block
+        self.assertEqual(Lk % kv_block, 0, "chunks must divide Lk")
         scale = 1.0 / math.sqrt(math.sqrt(D))
 
         torch.manual_seed(42)
@@ -5425,29 +5435,44 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                 ).amax(dim=-1)
             with spyre_hint(named_dims=["B", "H", "Lq", "D"]):
                 acc = torch.zeros_like(queries)
-            out = None
+
+            def sweep(running_max, denom, acc):
+                """The unrolled K/V sweep.
+
+                Carries are parameters so they can be rebound locally without a
+                nonlocal declaration.
+                """
+                out = None
+                for kb in range(n_chunks):  # unrolled into the graph
+                    k_c, v_c = k_chunks[kb], v_chunks[kb]
+                    keys_T = (k_c * scale).transpose(-1, -2).contiguous()
+                    # A matmul output inherits no names from its inputs, so both
+                    # matmuls need an explicit named_dims hint.
+                    with spyre_hint(named_dims=["B", "H", "Lq", "Lkc"]):
+                        scores = torch.matmul(queries * scale, keys_T)
+                    block_max = torch.amax(scores, dim=-1)
+                    new_max = torch.maximum(running_max, block_max)
+                    correction = torch.exp(running_max - new_max)
+                    exp_scores = torch.exp(scores - new_max.unsqueeze(-1))
+                    new_denom = denom * correction + exp_scores.sum(dim=-1)
+                    with spyre_hint(named_dims=["B", "H", "Lq", "D"]):
+                        weighted = torch.matmul(exp_scores, v_c)
+                    new_acc = acc * correction.unsqueeze(-1) + weighted
+                    if kb == n_chunks - 1:
+                        out = new_acc / new_denom.unsqueeze(-1)
+                    else:
+                        running_max, denom, acc = new_max, new_denom, new_acc
+                return out
+
+            # Lq cannot be tiled at Lq == 1 (decode), so that hint is optional.
+            # Written as two branches rather than a stand-in context manager: a
+            # contextlib.nullcontext() inside a traced function has previously
+            # produced spurious dynamo errors in this suite.
             with spyre_hint(num_tiles_per_dim={"H": h_tiles}):
-                with spyre_hint(num_tiles_per_dim={"Lq": lq_tiles}):
-                    for kb in range(n_chunks):  # unrolled into the graph
-                        k_c, v_c = k_chunks[kb], v_chunks[kb]
-                        keys_T = (k_c * scale).transpose(-1, -2).contiguous()
-                        # A matmul output inherits no names from its inputs, so
-                        # both matmuls need an explicit named_dims hint.
-                        with spyre_hint(named_dims=["B", "H", "Lq", "Lkc"]):
-                            scores = torch.matmul(queries * scale, keys_T)
-                        block_max = torch.amax(scores, dim=-1)
-                        new_max = torch.maximum(running_max, block_max)
-                        correction = torch.exp(running_max - new_max)
-                        exp_scores = torch.exp(scores - new_max.unsqueeze(-1))
-                        new_denom = denom * correction + exp_scores.sum(dim=-1)
-                        with spyre_hint(named_dims=["B", "H", "Lq", "D"]):
-                            weighted = torch.matmul(exp_scores, v_c)
-                        new_acc = acc * correction.unsqueeze(-1) + weighted
-                        if kb == n_chunks - 1:
-                            out = new_acc / new_denom.unsqueeze(-1)
-                        else:
-                            running_max, denom, acc = new_max, new_denom, new_acc
-            return out
+                if lq_tiles:
+                    with spyre_hint(num_tiles_per_dim={"Lq": lq_tiles}):
+                        return sweep(running_max, denom, acc)
+                return sweep(running_max, denom, acc)
 
         def chunk(t):
             return [
@@ -5485,18 +5510,56 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         )
         src = source_codes[0]
         self.assertIn("LoopSpec(", src, "expected coarse tiling to survive codegen")
+        self.assertEqual(
+            src.count("LoopSpec("),
+            2 if lq_tiles else 1,
+            "expected one loop level per tiled dim (H, plus Lq when tiled)",
+        )
         self.assertIn(
             f"count=sympify('{h_tiles}')",
             src,
             f"expected the H loop count (h_tiles={h_tiles})",
         )
-        self.assertIn(
-            "count=sympify('2')", src, "expected the Lq loop count (lq_tiles=2)"
-        )
+        if lq_tiles:
+            self.assertIn(
+                f"count=sympify('{lq_tiles}')",
+                src,
+                f"expected the Lq loop count (lq_tiles={lq_tiles})",
+            )
 
     def test_hint_flash_attention_kv_chunked_python_loop(self):
         """K/V chunked in Python, WSR tiling H (4) and Lq (2). See impl docstring."""
-        self._run_kv_chunked_flash(h_tiles=4)
+        self._run_kv_chunked_flash(h_tiles=4, lq_tiles=2)
+
+    def test_hint_flash_attention_kv_chunked_prefill_8k(self):
+        """Chunked prefill: a 512-token query block against an 8k K/V cache.
+
+        This is the production shape -- vLLM-style chunked prefill -- not a
+        scaled-down proxy.  Both H and Lq are WSR-tiled; Lk is not hinted.
+
+        kv_block is 2048 (4 chunks) rather than 512 (16) because layout solving
+        fails past ~6 unrolled chunks; see the docstring on
+        test_hint_flash_attention_kv_chunked_chunk_ceiling.  Lq stays at the
+        query-block size deliberately: the same 4-chunk graph at Lq=8192
+        compiled for over two hours without finishing, while at Lq=512 it takes
+        well under a minute, so compile cost is driven by Lq extent rather than
+        by chunk count or cache length.
+        """
+        self._run_kv_chunked_flash(
+            h_tiles=4, lq_tiles=2, B=1, H=8, Lq=512, Lk=8192, D=128, kv_block=2048
+        )
+
+    def test_hint_flash_attention_kv_chunked_decode_8k(self):
+        """Decode: one query token, batch 4, against a full 8k K/V cache.
+
+        Lq == 1 cannot be tiled, so H tiling is the only level and there is a
+        single LoopSpec.  A full cache means every key is valid, so no mask is
+        needed and the fully-masked-chunk case (block_max == -inf, making
+        exp(-inf - -inf) NaN) does not arise here -- that remains untested.
+        """
+        self._run_kv_chunked_flash(
+            h_tiles=4, lq_tiles=None, B=4, H=8, Lq=1, Lk=8192, D=128, kv_block=2048
+        )
 
     @pytest.mark.xfail(
         strict=True,
@@ -5511,7 +5574,28 @@ class TestCoarseTileSpyreHints(InductorTestCase):
     )
     def test_hint_flash_attention_kv_chunked_unit_h_tile(self):
         """h_tiles == H (one head per tile) crashes in read-copy insertion."""
-        self._run_kv_chunked_flash(h_tiles=8)
+        self._run_kv_chunked_flash(h_tiles=8, lq_tiles=2)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Layout solving fails past ~6 unrolled K/V chunks: 4 and 6 chunks "
+            "compile and are exact, 8/10/12/16 all fail _no_feasible_layout_error "
+            "with the failing buffer at a fixed ~81% of the graph, i.e. always "
+            "around the 6th-7th chunk. NOT a graph-size limit -- dropping the "
+            "running-max carry yields MORE buffers (128 vs the failing 112) and "
+            "compiles. Every single ablation (either matmul, any one of the three "
+            "carries, the reductions) restores feasibility, so it is the "
+            "conjunction of constraints that becomes infeasible. Invariant to Lq "
+            "(256/512/8192), Lq tiling, D, and kv_block. This is what forces "
+            "kv_block=2048 for 8k instead of the 512 a memory budget would pick."
+        ),
+    )
+    def test_hint_flash_attention_kv_chunked_chunk_ceiling(self):
+        """8 unrolled K/V chunks exceed what layout solving can satisfy."""
+        self._run_kv_chunked_flash(
+            h_tiles=4, lq_tiles=None, B=1, H=8, Lq=256, Lk=4096, D=128, kv_block=512
+        )
 
     def test_hint_h_tiling_elementwise(self):
         """spyre_hint(num_tiles_per_dim={"H": 2}) tiles elementwise multiply over the H dimension.

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -5352,6 +5352,167 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             " divide Lq ranges on each op using that op's own dim role",
         )
 
+    def _run_kv_chunked_flash(self, h_tiles, n_chunks=2):
+        """Flash attention with K/V chunking in PYTHON and WSR tiling only H/Lq.
+
+        Shared by the two tests below so the h_tiles == H degenerate-tile case
+        can reuse the graph rather than duplicate it.  Asserts inline.
+
+        WSR's reduction-dim carry propagation is unimplemented (#3432), so every
+        flash variant that hints Lk is xfailed.  Here the K/V sweep is an ordinary
+        Python ``for`` loop that torch.compile unrolls into the graph, so the
+        online-softmax recurrence becomes explicit dataflow.  WSR is then only
+        asked to tile H and Lq -- non-reduction dims -- and never sees a carry.
+
+        Complements test_hint_flash_attention_v2_divide_in_scope (#3429), which
+        tiles H/Lq over a SINGLE K block.  This covers more than one K block,
+        which that test does not reach.
+
+        Four things are load-bearing; each one produced a wrong answer or a hard
+        error while this was being written:
+
+        1.  **The K loop must be INSIDE a single H/Lq scope.**  Wrapping each
+            chunk in its own scope instead makes the scheduler interleave the
+            chunks, so a scope's ops are no longer contiguous and
+            validate_coarse_tile_groups rejects it with "hint_id=N appears in
+            both group X and group Y".  Measured op order for 2 chunks was
+            chunk0-main, chunk1-main, chunk0-tail, chunk1-tail.
+        2.  **K/V chunks are sliced by the CALLER and passed in as named
+            tensors.**  Slicing inside the graph and naming the slice output with
+            spyre_hint(named_dims=...) does not work and fails SILENTLY: the hint
+            branch of propagate_named_dims sets _dim_prop_info and returns, so
+            the read of the unnamed full tensor never gets an H mapping, and the
+            _untracked warning that would have said so disappears.  Naming the
+            full tensor does not work either -- slicing Lk shrinks the axis, so
+            _consume_names finds no prefix matching it and drops the binding.
+            Symptom either way: H tile 0 correct, every later tile ~85% wrong.
+        3.  **Carry inits use the sparse idiom** ``full((B,H,Lq,64)).amax(-1)``.
+            A plain 3-D ``full((B,H,Lq))`` raises "no mechanism to resolve stick
+            incompatibility".
+        4.  **The final divide is inside the innermost scope** (#3429): read past
+            the loop group it becomes a full buffer plus a copy op whose target a
+            second consumer also reads, and finalize_layouts overwrites it.
+
+        h_tiles=4 and lq_tiles=2 differ deliberately so the LoopSpec assertions
+        can tell the two levels apart; equal counts would pass even if one level
+        were dropped.  No causal mask here on purpose: with K chunking a fully
+        masked chunk gives block_max == -inf and exp(-inf - -inf) is NaN, which
+        is a real trap but a separate one from what this test pins down.
+        """
+        from torch_spyre._inductor import spyre_hint
+
+        B, H, Lq, Lk, D = 1, 8, 256, 256, 64
+        kv_block = Lk // n_chunks
+        lq_tiles = 2
+        scale = 1.0 / math.sqrt(math.sqrt(D))
+
+        torch.manual_seed(42)
+        queries_t = torch.randn(B, H, Lq, D, dtype=torch.float16)
+        keys_t = torch.randn(B, H, Lk, D, dtype=torch.float16)
+        values_t = torch.randn(B, H, Lk, D, dtype=torch.float16)
+
+        def flash(queries, k_chunks, v_chunks):
+            with spyre_hint(named_dims=["B", "H", "Lq"]):
+                running_max = torch.full(
+                    (B, H, Lq, 64),
+                    float("-inf"),
+                    device=queries.device,
+                    dtype=torch.float16,
+                ).amax(dim=-1)
+            with spyre_hint(named_dims=["B", "H", "Lq"]):
+                denom = torch.full(
+                    (B, H, Lq, 64), 0.0, device=queries.device, dtype=torch.float16
+                ).amax(dim=-1)
+            with spyre_hint(named_dims=["B", "H", "Lq", "D"]):
+                acc = torch.zeros_like(queries)
+            out = None
+            with spyre_hint(num_tiles_per_dim={"H": h_tiles}):
+                with spyre_hint(num_tiles_per_dim={"Lq": lq_tiles}):
+                    for kb in range(n_chunks):  # unrolled into the graph
+                        k_c, v_c = k_chunks[kb], v_chunks[kb]
+                        keys_T = (k_c * scale).transpose(-1, -2).contiguous()
+                        # A matmul output inherits no names from its inputs, so
+                        # both matmuls need an explicit named_dims hint.
+                        with spyre_hint(named_dims=["B", "H", "Lq", "Lkc"]):
+                            scores = torch.matmul(queries * scale, keys_T)
+                        block_max = torch.amax(scores, dim=-1)
+                        new_max = torch.maximum(running_max, block_max)
+                        correction = torch.exp(running_max - new_max)
+                        exp_scores = torch.exp(scores - new_max.unsqueeze(-1))
+                        new_denom = denom * correction + exp_scores.sum(dim=-1)
+                        with spyre_hint(named_dims=["B", "H", "Lq", "D"]):
+                            weighted = torch.matmul(exp_scores, v_c)
+                        new_acc = acc * correction.unsqueeze(-1) + weighted
+                        if kb == n_chunks - 1:
+                            out = new_acc / new_denom.unsqueeze(-1)
+                        else:
+                            running_max, denom, acc = new_max, new_denom, new_acc
+            return out
+
+        def chunk(t):
+            return [
+                t[..., i * kv_block : (i + 1) * kv_block, :].contiguous()
+                for i in range(n_chunks)
+            ]
+
+        # CPU reference first, then device setup -- matching the driver pattern.
+        k_chunks_t, v_chunks_t = chunk(keys_t), chunk(values_t)
+        ref = flash(queries_t, k_chunks_t, v_chunks_t)
+
+        queries_dev = queries_t.to("spyre")
+        k_chunks = [t.to("spyre") for t in k_chunks_t]
+        v_chunks = [t.to("spyre") for t in v_chunks_t]
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("H", H)
+        _declare_tensor_dim("Lq", Lq)
+        _declare_tensor_dim("D", D)
+        # The per-chunk key extent: what the scores' last axis really is.
+        _declare_tensor_dim("Lkc", kv_block)
+        _name_tensor_dims(queries_dev, ["B", "H", "Lq", "D"])
+        for t in k_chunks + v_chunks:
+            _name_tensor_dims(t, ["B", "H", "Lkc", "D"])
+
+        result, source_codes = run_and_get_code(
+            torch.compile(flash), queries_dev, k_chunks, v_chunks
+        )
+        torch.testing.assert_close(
+            result.cpu(),
+            ref,
+            equal_nan=True,
+            atol=0.01,
+            rtol=0.1,
+            msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
+        )
+        src = source_codes[0]
+        self.assertIn("LoopSpec(", src, "expected coarse tiling to survive codegen")
+        self.assertIn(
+            f"count=sympify('{h_tiles}')",
+            src,
+            f"expected the H loop count (h_tiles={h_tiles})",
+        )
+        self.assertIn(
+            "count=sympify('2')", src, "expected the Lq loop count (lq_tiles=2)"
+        )
+
+    def test_hint_flash_attention_kv_chunked_python_loop(self):
+        """K/V chunked in Python, WSR tiling H (4) and Lq (2). See impl docstring."""
+        self._run_kv_chunked_flash(h_tiles=4)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "h_tiles == H gives a 1-element H tile, and a unit-size tiled dim is "
+            "squeezed out of _insert_one_read_copy's squeeze_pos map (built by "
+            "skipping ranges where int(r) == 1), so the subsequent "
+            "squeeze_pos[d] lookup raises KeyError. Reproduced at 2 and 4 chunks "
+            "on main; h_tiles of 2 and 4 are numerically exact. Compile-time "
+            "error only -- it does not leave the device in an error state."
+        ),
+    )
+    def test_hint_flash_attention_kv_chunked_unit_h_tile(self):
+        """h_tiles == H (one head per tile) crashes in read-copy insertion."""
+        self._run_kv_chunked_flash(h_tiles=8)
+
     def test_hint_h_tiling_elementwise(self):
         """spyre_hint(num_tiles_per_dim={"H": 2}) tiles elementwise multiply over the H dimension.
 

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -779,9 +779,9 @@ def test_wrong_optimal_cost_fails():
 
 
 def test_constant_plus_xt():
-    """ones_like(x) + x.t() — constant tensor should adopt x.t()'s stick, cost 0."""
+    """ones_like(x) + x.t() — constant tensor should adopt x.t()'s stick (cost 0 once constant layout optimization is implemented)."""
     x = torch.randn((S, S), dtype=torch.float16)
-    _compare(lambda x: torch.ones_like(x) + x.t(), x, optimal_cost=0)
+    _compare(lambda x: torch.ones_like(x) + x.t(), x)
 
 
 def test_constant_in_conflict_chain():
@@ -797,25 +797,22 @@ def test_constant_matmul_x():
 
 
 def test_two_constants_plus_xt():
-    """ones_like(x) + zeros_like(x) + x.t() — two flexible constants, cost still 0."""
+    """ones_like(x) + zeros_like(x) + x.t() — two flexible constants (cost 0 once constant layout optimization is implemented)."""
     x = torch.randn((S, S), dtype=torch.float16)
-    _compare(
-        lambda x: torch.ones_like(x) + torch.zeros_like(x) + x.t(), x, optimal_cost=0
-    )
+    _compare(lambda x: torch.ones_like(x) + torch.zeros_like(x) + x.t(), x)
 
 
 def test_full_plus_xt():
-    """torch.full + x.t() — full tensor constant should adopt x.t()'s stick, cost 0."""
+    """torch.full + x.t() — full tensor constant should adopt x.t()'s stick (cost 0 once constant layout optimization is implemented)."""
     x = torch.randn((S, S), dtype=torch.float16)
     _compare(
         lambda x: torch.full((S, S), 0.5, dtype=torch.float16, device=x.device) + x.t(),
         x,
-        optimal_cost=0,
     )
 
 
 def test_fill_plus_xt():
-    """empty_like + fill_ + x.t() — mutation-based constant should adopt x.t()'s stick, cost 0."""
+    """empty_like + fill_ + x.t() — mutation-based constant should adopt x.t()'s stick (cost 0 once constant layout optimization is implemented)."""
     x = torch.randn((S, S), dtype=torch.float16)
 
     def fn(x):
@@ -823,7 +820,51 @@ def test_fill_plus_xt():
         e.fill_(1.0)
         return e + x.t()
 
-    _compare(fn, x, optimal_cost=0)
+    _compare(fn, x)
+
+
+def test_constant_two_consumers():
+    """zeros_like fed to two consumers with conflicting layouts.
+
+    With the current algorithm, the constant gets the generic (row-major) layout.
+    out1 = z + a is free (both row-major); out2 = z + x.t() requires one restickify
+    of z, costing A.numel().
+
+    Once constant layout optimization is implemented, the constant will instead adopt
+    x.t()'s stick for free and out1 will pay the restickify — same total cost, but
+    the constant itself will never need a restickify.
+    """
+    A = torch.randn((S, S), dtype=torch.float16)
+    X = torch.randn((S, S), dtype=torch.float16)
+
+    def fn(a, x):
+        z = torch.zeros_like(
+            a
+        )  # gets generic (row-major) layout until optimization lands
+        out1 = z + a  # consumer 1: row-major — free
+        out2 = z + x.t()  # consumer 2: col-major — restickify of z
+        return out1 + out2
+
+    _compare(fn, A, X, optimal_cost=A.numel())
+
+
+def test_constant_three_consumers():
+    """zeros_like fed to three consumers; first wins the layout, others may restickify.
+
+    Correctness check only — cost depends on fusion decisions.
+    """
+    A = torch.randn((S, S), dtype=torch.float16)
+    X = torch.randn((S, S), dtype=torch.float16)
+    B = torch.randn((S, S), dtype=torch.float16)
+
+    def fn(a, x, b):
+        z = torch.zeros_like(a)  # flexible
+        out1 = z + a  # consumer 1: row-major
+        out2 = z + x.t()  # consumer 2: col-major — may restickify
+        out3 = z + b  # consumer 3: row-major — same as consumer 1, free
+        return out1 + out2 + out3
+
+    _compare(fn, A, X, B)
 
 
 def test_arange_plus_xt():

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -1384,6 +1384,13 @@ def _all_constant_layouts(op: Operation) -> list[SpyreTensorLayout]:
     is correct.  Offering all valid choices lets the optimizer pick whichever
     is compatible with the rest of the graph at zero cost, avoiding a needless
     restickify.
+
+    NOTE: constant-fill ops in the main propagation loop currently use
+    generic_layout instead (a single default-layout candidate) to avoid
+    exponential beam-state growth in loop-unrolled graphs.  This function is
+    still used for the accumulator fallback path (in-place update ops with no
+    real inputs) where the enumeration is bounded and correct.  It will also be
+    restored for the single-consumer constant case once that optimization lands.
     """
     output: FixedLayout = op.get_layout()
     c_size = [concretize_expr(s) for s in output.size]
@@ -1907,7 +1914,11 @@ def propagate_spyre_tensor_layouts(
                     for r in mem_reads
                 )
                 if is_constant_fill:
-                    op.layouts = _all_constant_layouts(op)
+                    # Constant-fill ops (zeros_like, full, ones_like, ...) have no real
+                    # memory layout — they can materialize in any stick orientation.
+                    # For now, using a single generic layout candidate to reduce beam
+                    # state space explosion.  Optimizations to follow.
+                    op.layouts = [generic_layout(op)]
                 else:
                     logger.warning(
                         f"{op.get_name()} has no propagatable args but reads non-constant "


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Closes #3687

## Problem
KV-chunked FlashAttention unrolls the key/value loop, creating a graph that `optimize_restickify` handles poorly.  The problematic scenario was constant-fill ops (`zeros_like`, `full`, `ones_like`, etc.) whose layouts are not constrained until their downstream consumers are resolved.

A constant-fill op can be created with whatever layout is needed by its consumer.  Layout optimizer implemented this flexibility by generating one STL candidate per possible layout for each constant-fill op. This full enumeration of candidate STLs is theoretically valid but creates unnecessary state space pressure, particularly in graphs where constants are created early and their layout constraint only becomes apparent at a later in the graph. This is particularly problematic with the repeating diamond pattern created by the loop-unrolled code, where the beam state grows exponentially through N such diamonds.

## Fix

This PR provides a temporary fix by assigning only the default layout to constant tensors. This eliminates the exponential problem entirely: optimize_restickify_locations now scales at roughly 2.4× per doubling of chunks in the KV-chunked FlashAttention tests.

The downside, and why this is a stop-gap, is that the compiler may now _could_ end up restickifying a constant tensor when the default layout is incompatible, which is pure waste because it could have been assigned any layout at creation.  Optimizing this is straightforward, but will be addressed in a follow-up PR due to failures interacting with SDPA lowering and coarse tiling in ways that are not yet understood - unconfirmed suspicions is that it is triggering other bugs somewhere in system.    In the mean time, the worst case is that there may be one extra restickify on constant tensors when their use is in the non-default layout.    Note, this does not happen for the KV-chunked flash tests discussed below.

## Compile-time scaling

Before this fix, compilation failed past ~6 unrolled chunks. After the fix, all chunk counts compile successfully. Measured compile times on the KV-chunked flash attention workload (frontend passes + `dxp_standalone` backend compiler):

| Phase | 8 chunks | 16 chunks | 32 chunks |
|---|---|---|---|
| `_maybe_coarse_tile_hints` | 20 s | 81 s | 321 s |
| `optimize_restickify_locations` | 4.5 s | 9.8 s | 23.7 s |
| `dedup_and_promote_constants` | 5.6 s | 21.7 s | 86.7 s |
| `propagate_spyre_tensor_layouts` | 1.5 s | 3.0 s | 5.9 s |
| `_maybe_scratchpad_planning` | 1.8 s | 3.3 s | 7.0 s |
| Other passes | ~3.1 s | ~6.5 s | ~12.4 s |
| **Total frontend** | **~37 s** | **~125 s** | **~457 s** |
| `dxp_standalone` | 68 s | 209 s | 1946 s |

The backend compiler (dxp_standalone) dominates total compile time. Within the frontend, _maybe_coarse_tile_hints is the largest pass and a separate scalability concern. optimize_restickify_locations scales at roughly 2.2–2.4× per doubling of chunks — well below the exponential blowup this fix was addressing.        
                                                                                                                                                                                                                

## Tests

- `test_hint_flash_attention_kv_chunked_chunk_ceiling` (renamed `test_hint_flash_attention_kv_chunked_8_chunks` since it is no longer a ceiling) — previously xfail, now passes;; verifies 8 unrolled chunks compile successfully.  
- `test_hint_flash_attention_kv_chunked_16_chunks` and `_32_chunks` — added as skipped scalability regression tests (compile time is 10–40 min; run manually)
- `test_constant_two_consumers` and `test_constant_three_consumers` added to `test_restickify.py` — cover the multi-consumer flexible layout case where one consumer gets the flexible layout at zero cost and additional consumers with conflicting orientations get a restickify

**Modified tests:**      
                                                                                                                                                                                                                 `test_constant_plus_xt`, `test_two_constants_plus_xt`, `test_full_plus_xt`, `test_fill_plus_xt` in `test_restickify.py`
Relaxed expected restickify cost from 0 to allow a non-zero value, because constants now receive only the default layout. These tests were originally designed to confirm there is never a restickify cost on constant-like tensors. The assertion is relaxed for now; a follow-up PR will optimize the single-consumer constant case and restore the zero-cost expectation.              

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

The first two commits (c345569f test(coarse_tile_e2e): K/V chunking in Python... and 4f014bc4 test(coarse_tile_e2e): 8k chunked-prefill and decode...) were authored by  @mudhakar and cherry-picked into this branch. They are test-only and establish the KV-chunked flash attention test infrastructure that the fix in the third commit  (cd23b518) unblocks. They are included here rather than merged separately because the xfail removal and new chunk-count tests in cd23b518 depend on them being present first.                           
