### PR TITLE
Form persistent expert loops with advancing operands

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_expert_execution_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_expert_execution_config.yaml
@@ -5,3 +5,5 @@ test_suite_config:
       unlisted_test_mode: mandatory_success
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_moe_ffn_semantics.py
       unlisted_test_mode: mandatory_success
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_persistent_expert_loop_planning.py
+      unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_expert_execution_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_expert_execution_config.yaml
@@ -1,0 +1,7 @@
+test_suite_config:
+  labels: [unit, regression, integration, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_expert_execution_planner.py
+      unlisted_test_mode: mandatory_success
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_moe_ffn_semantics.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -102,9 +102,12 @@ from torch_spyre._inductor.scheduler import (
     build_loop_scheduler_nodes,
 )
 from torch_spyre._inductor.spyre_kernel import (
+    LoopOperandBinding,
+    SpyreKernel,
     _codegen_op_spec_list,
     _iter_op_specs,
     _preserve_shared_weight_unit_bmm_dim,
+    _tensor_args_advance_by_symbol,
 )
 from torch_spyre._inductor.temp_passes import (
     _mark_static_unit_batch_bmm,
@@ -117,6 +120,99 @@ from torch_spyre._inductor.wsr.tile import (
 )
 
 _FP16 = DataFormats.SEN169_FP16
+
+
+class TestUnitDimArgumentAdvanceSymbols(unittest.TestCase):
+    """A squeezed expert tile must still advance its runtime operand."""
+
+    @staticmethod
+    def _arg(expr):
+        return TensorArg(
+            is_input=True,
+            arg_index=0,
+            device_dtype=_FP16,
+            device_size=[1, 64],
+            device_coordinates=[Integer(0), Integer(0)],
+            allocation={"hbm": 0},
+            device_tile_advance_expr=expr,
+        )
+
+    def test_detects_plain_and_floor_wrapped_symbols(self):
+        level = Symbol("_tile_adv_copy_lvl0")
+        other = Symbol("_tile_adv_copy_lvl1")
+
+        self.assertTrue(_tensor_args_advance_by_symbol([self._arg(64 * level)], level))
+        self.assertTrue(
+            _tensor_args_advance_by_symbol([self._arg(floor(64 * level))], level)
+        )
+        self.assertFalse(_tensor_args_advance_by_symbol([self._arg(64 * other)], level))
+        self.assertFalse(_tensor_args_advance_by_symbol([self._arg(None)], level))
+
+    def test_binding_rejects_unknown_addressing_kind(self):
+        with self.assertRaisesRegex(Unsupported, "unknown loop operand binding"):
+            LoopOperandBinding("indexed", Integer(0))
+
+    def test_create_op_spec_serializes_arg_only_level_symbol(self):
+        level = Symbol("_tile_adv_copy_lvl0")
+        ir_node = SimpleNamespace(
+            loop_info=CoarseTileInfo(
+                loop_group_id=(0,),
+                loop_count=[Integer(2)],
+                loop_tiled_dims=[],
+                loop_tiled_reduction_dims=[],
+            ),
+            get_operation_name=lambda: "identity",
+        )
+        kernel = SpyreKernel()
+        kernel.current_node = SimpleNamespace(node=ir_node)
+        kernel._tile_advance_symbols = {0: level}
+
+        with (
+            patch(
+                "torch_spyre._inductor.spyre_kernel.iteration_space",
+                return_value={},
+            ),
+            patch(
+                "torch_spyre._inductor.spyre_kernel.build_debug_handle",
+                return_value=None,
+            ),
+        ):
+            op = kernel.create_op_spec(
+                "identity", False, [self._arg(floor(64 * level))], {}
+            )
+
+        self.assertEqual(op.tiled_symbols, [[level]])
+        self.assertEqual(op.tiled_symbol_trip_counts, {level: 2})
+
+    def test_create_op_spec_keeps_invariant_level_empty(self):
+        level = Symbol("_tile_adv_copy_lvl0")
+        ir_node = SimpleNamespace(
+            loop_info=CoarseTileInfo(
+                loop_group_id=(0,),
+                loop_count=[Integer(2)],
+                loop_tiled_dims=[],
+                loop_tiled_reduction_dims=[],
+            ),
+            get_operation_name=lambda: "identity",
+        )
+        kernel = SpyreKernel()
+        kernel.current_node = SimpleNamespace(node=ir_node)
+        kernel._tile_advance_symbols = {0: level}
+
+        with (
+            patch(
+                "torch_spyre._inductor.spyre_kernel.iteration_space",
+                return_value={},
+            ),
+            patch(
+                "torch_spyre._inductor.spyre_kernel.build_debug_handle",
+                return_value=None,
+            ),
+        ):
+            op = kernel.create_op_spec("identity", False, [self._arg(None)], {})
+
+        self.assertEqual(op.tiled_symbols, [[]])
+        self.assertEqual(op.tiled_symbol_trip_counts, {})
 
 
 # ===========================================================================

--- a/tests/inductor/test_expert_execution_planner.py
+++ b/tests/inductor/test_expert_execution_planner.py
@@ -1,0 +1,206 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import dataclasses
+
+import pytest
+import torch
+
+from torch_spyre._inductor.expert_execution import (
+    ExpertGraphPlan,
+    ExpertPlanningError,
+    ExpertStrategy,
+    materialize_expert_execution_graph,
+    plan_expert_execution_graph,
+    prepare_expert_execution_graph,
+)
+from torch_spyre._inductor.expert_execution.custom_op import (
+    dense_expert_persistent_ffn,
+    moe_ffn,
+)
+
+
+def _graph_module():
+    graph = torch.fx.Graph()
+    specs = (
+        ("x", (64, 64), None),
+        ("gate", (2, 64, 64), (64, 128, 1)),
+        ("up", (2, 64, 64), (64, 128, 1)),
+        ("down", (2, 64, 64), (64, 128, 1)),
+        ("routing", (64, 2, 1), (1, 64, 1)),
+    )
+    args = []
+    for name, shape, stride in specs:
+        node = graph.placeholder(name)
+        value = torch.empty(shape, device="meta", dtype=torch.float16)
+        if stride is not None:
+            value = torch.as_strided(value, shape, stride)
+        node.meta["val"] = value
+        args.append(node)
+    result = graph.call_function(moe_ffn._opoverload, args=(*args, 1, "silu"))
+    result.meta["val"] = torch.empty((64, 64), device="meta", dtype=torch.float16)
+    graph.output(result)
+    return torch.fx.GraphModule(torch.nn.Module(), graph)
+
+
+def _call_target(graph_module):
+    return next(
+        node.target for node in graph_module.graph.nodes if node.op == "call_function"
+    )
+
+
+def test_planning_is_pure_and_selects_persistent_schedule():
+    graph_module = _graph_module()
+    before_code = graph_module.code
+    before_meta = {node.name: dict(node.meta) for node in graph_module.graph.nodes}
+
+    plan = plan_expert_execution_graph(
+        graph_module,
+        persistent_available=True,
+        available_lx_bytes=1_000_000,
+    )
+
+    assert graph_module.code == before_code
+    for node in graph_module.graph.nodes:
+        assert node.meta.keys() == before_meta[node.name].keys()
+        for key, value in node.meta.items():
+            assert value is before_meta[node.name][key]
+    selected = plan.nodes[0]
+    assert selected.strategy is ExpertStrategy.PERSISTENT_DENSE
+    assert selected.expert_count == 2
+    assert selected.schedule.binding_kind == "sequential_affine"
+    assert selected.schedule.weight_layout == "logical_expert_major_k_major_backing"
+    assert selected.schedule.routing_layout == "logical_token_major"
+    assert selected.schedule.preheader == ("stage_x", "fill_accumulator")
+    assert selected.schedule.drain == ("drain_output",)
+
+
+def test_conservative_feasibility_selects_ordinary_dense():
+    plan = plan_expert_execution_graph(
+        _graph_module(), persistent_available=True, available_lx_bytes=1
+    )
+
+    assert plan.nodes[0].strategy is ExpertStrategy.ORDINARY_DENSE
+    assert plan.nodes[0].schedule is None
+
+
+def test_materialization_rewrites_only_an_isolated_clone():
+    source = _graph_module()
+    plan = plan_expert_execution_graph(
+        source, persistent_available=True, available_lx_bytes=1_000_000
+    )
+
+    candidate = materialize_expert_execution_graph(source, plan)
+
+    assert candidate is not source
+    assert _call_target(source) == moe_ffn._opoverload
+    assert _call_target(candidate) == dense_expert_persistent_ffn._opoverload
+    call = next(node for node in candidate.graph.nodes if node.op == "call_function")
+    assert call.args[-1] == call.name
+
+
+def test_contiguous_expert_weights_do_not_select_persistent():
+    graph_module = _graph_module()
+    for name in ("gate", "up", "down"):
+        node = next(node for node in graph_module.graph.nodes if node.name == name)
+        node.meta["val"] = torch.empty(
+            tuple(node.meta["val"].shape), device="meta", dtype=torch.float16
+        )
+
+    plan = plan_expert_execution_graph(
+        graph_module,
+        persistent_available=True,
+        available_lx_bytes=1_000_000,
+    )
+
+    assert plan.nodes[0].strategy is ExpertStrategy.ORDINARY_DENSE
+
+
+def test_contiguous_token_major_routing_selects_persistent():
+    graph_module = _graph_module()
+    routing = next(node for node in graph_module.graph.nodes if node.name == "routing")
+    routing.meta["val"] = torch.empty(
+        tuple(routing.meta["val"].shape), device="meta", dtype=torch.float16
+    )
+
+    plan = plan_expert_execution_graph(
+        graph_module,
+        persistent_available=True,
+        available_lx_bytes=1_000_000,
+    )
+
+    assert plan.nodes[0].strategy is ExpertStrategy.PERSISTENT_DENSE
+
+
+def test_ordinary_dense_materialization_is_a_no_op():
+    source = _graph_module()
+    plan = plan_expert_execution_graph(
+        source, persistent_available=False, available_lx_bytes=1_000_000
+    )
+
+    candidate = materialize_expert_execution_graph(source, plan)
+
+    assert candidate is source
+    assert _call_target(source) == moe_ffn._opoverload
+
+
+def test_materialization_rejects_a_changed_source_graph():
+    source = _graph_module()
+    plan = plan_expert_execution_graph(
+        source, persistent_available=True, available_lx_bytes=1_000_000
+    )
+    call = next(node for node in source.graph.nodes if node.op == "call_function")
+    call.args = (*call.args[:-1], "gelu_tanh")
+    source.recompile()
+
+    with pytest.raises(ExpertPlanningError, match="changed after expert planning"):
+        materialize_expert_execution_graph(source, plan)
+
+
+def test_failed_materialization_does_not_change_the_source():
+    source = _graph_module()
+    plan = plan_expert_execution_graph(
+        source, persistent_available=True, available_lx_bytes=1_000_000
+    )
+    invalid_node = dataclasses.replace(plan.nodes[0], schedule=None)
+    invalid_plan = ExpertGraphPlan(plan.source_structure, (invalid_node,))
+
+    with pytest.raises(ExpertPlanningError, match="not a valid persistent"):
+        materialize_expert_execution_graph(source, invalid_plan)
+
+    assert _call_target(source) == moe_ffn._opoverload
+
+
+def test_prepare_uses_configured_lx_budget(monkeypatch):
+    source = _graph_module()
+    monkeypatch.setattr(
+        "torch_spyre._inductor.config.enable_dense_expert_persistent", True
+    )
+    monkeypatch.setattr("torch_spyre._inductor.config.sencores", 32)
+    monkeypatch.setattr(
+        "torch_spyre._inductor.scratchpad.allocator._lx_planning_size",
+        lambda: 1_000_000,
+    )
+
+    candidate, plan = prepare_expert_execution_graph(source)
+
+    assert len(plan.nodes) == 1
+    assert _call_target(source) == moe_ffn._opoverload
+    assert _call_target(candidate) == dense_expert_persistent_ffn._opoverload
+
+
+def test_persistent_strategy_is_not_user_enabled():
+    from torch_spyre._inductor import config
+
+    assert config.enable_dense_expert_persistent is False

--- a/tests/inductor/test_moe_ffn_semantics.py
+++ b/tests/inductor/test_moe_ffn_semantics.py
@@ -1,0 +1,111 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from torch_spyre._inductor.expert_execution.custom_op import (
+    expert_shared_lhs_mm,
+    moe_ffn,
+)
+from torch_spyre._inductor.expert_execution.semantics import moe_ffn_reference
+from torch_spyre._inductor.decompositions import (
+    decompose_dense_expert_persistent_ffn,
+    get_spyre_decomp_table,
+)
+
+
+def _inputs(dtype=torch.float32):
+    generator = torch.Generator().manual_seed(17)
+    tokens, experts, hidden, intermediate = 4, 3, 8, 6
+    x = torch.randn(tokens, hidden, dtype=dtype, generator=generator)
+    gate = torch.randn(experts, hidden, intermediate, dtype=dtype, generator=generator)
+    up = torch.randn(experts, hidden, intermediate, dtype=dtype, generator=generator)
+    down = torch.randn(experts, intermediate, hidden, dtype=dtype, generator=generator)
+    routing = torch.randn(tokens, experts, 1, dtype=dtype, generator=generator)
+    return x, gate, up, down, routing
+
+
+@pytest.mark.parametrize("activation", ["gelu_tanh", "silu"])
+def test_moe_ffn_cpu_matches_direct_reference(activation):
+    inputs = _inputs()
+
+    actual = moe_ffn(*inputs, 2, activation)
+    expected = moe_ffn_reference(*inputs, 2, activation)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_zero_routing_weight_removes_an_expert_contribution():
+    x, gate, up, down, routing = _inputs()
+    routing[:, 1, :] = 0
+
+    actual = moe_ffn(x, gate, up, down, routing, 2, "silu")
+    expected = moe_ffn(
+        x,
+        gate[[0, 2]],
+        up[[0, 2]],
+        down[[0, 2]],
+        routing[:, [0, 2], :],
+        2,
+        "silu",
+    )
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_moe_ffn_requires_explicit_singleton_routing_axis():
+    x, gate, up, down, routing = _inputs()
+
+    with pytest.raises(ValueError, match=r"\[T,E,1\]"):
+        moe_ffn(x, gate, up, down, routing.squeeze(-1), 2, "silu")
+
+
+def test_moe_ffn_rejects_mismatched_logical_weight_schema():
+    x, gate, up, down, routing = _inputs()
+
+    with pytest.raises(ValueError, match="up_weight"):
+        moe_ffn(x, gate, up[:, :-1], down, routing, 2, "silu")
+
+
+def test_moe_ffn_rejects_invalid_top_k():
+    inputs = _inputs()
+
+    with pytest.raises(ValueError, match="top_k"):
+        moe_ffn(*inputs, 4, "silu")
+
+
+def test_internal_shared_lhs_projection_matches_expert_loop():
+    x, gate, _up, _down, _routing = _inputs()
+
+    actual = expert_shared_lhs_mm(x, gate)
+    expected = torch.stack(tuple(torch.mm(x, weight) for weight in gate))
+
+    assert actual.shape == (gate.shape[0], x.shape[0], gate.shape[2])
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.parametrize("activation", ["gelu_tanh", "silu"])
+def test_persistent_decomposition_matches_semantic_reference(activation):
+    inputs = _inputs()
+
+    actual = decompose_dense_expert_persistent_ffn(
+        *inputs, 2, activation, "test_region"
+    )
+    expected = moe_ffn_reference(*inputs, 2, activation)
+
+    torch.testing.assert_close(actual, expected)
+    assert (
+        torch.ops.spyre.dense_expert_persistent_ffn.default in get_spyre_decomp_table()
+    )

--- a/tests/inductor/test_moe_ffn_semantics.py
+++ b/tests/inductor/test_moe_ffn_semantics.py
@@ -12,11 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from contextlib import contextmanager
+
 import pytest
 import torch
 
+from torch_spyre._inductor import decompositions
 from torch_spyre._inductor.expert_execution.custom_op import (
+    expert_mm_prepacked,
+    expert_route_prepacked,
     expert_shared_lhs_mm,
+    expert_shared_lhs_mm_prepacked,
     moe_ffn,
 )
 from torch_spyre._inductor.expert_execution.semantics import moe_ffn_reference
@@ -96,6 +102,28 @@ def test_internal_shared_lhs_projection_matches_expert_loop():
     torch.testing.assert_close(actual, expected)
 
 
+def test_internal_prepacked_projections_match_logical_expert_loop():
+    x, gate, _up, down, _routing = _inputs()
+    gate_packed = gate.permute(1, 0, 2)
+    down_packed = down.permute(1, 0, 2)
+
+    projected = expert_shared_lhs_mm_prepacked(x, gate_packed)
+    expected_projected = torch.stack(tuple(torch.mm(x, weight) for weight in gate))
+    restored = expert_mm_prepacked(projected, down_packed)
+    expected_restored = torch.stack(
+        tuple(torch.mm(expected_projected[e], down[e]) for e in range(gate.shape[0]))
+    )
+
+    torch.testing.assert_close(projected, expected_projected)
+    torch.testing.assert_close(restored, expected_restored)
+
+
+def test_internal_prepacked_route_is_an_identity():
+    routing = _inputs()[-1].permute(1, 0, 2).contiguous()
+
+    torch.testing.assert_close(expert_route_prepacked(routing), routing)
+
+
 @pytest.mark.parametrize("activation", ["gelu_tanh", "silu"])
 def test_persistent_decomposition_matches_semantic_reference(activation):
     inputs = _inputs()
@@ -109,3 +137,32 @@ def test_persistent_decomposition_matches_semantic_reference(activation):
     assert (
         torch.ops.spyre.dense_expert_persistent_ffn.default in get_spyre_decomp_table()
     )
+
+
+def test_persistent_decomposition_marks_the_complete_loop_body(monkeypatch):
+    regions = []
+
+    @contextmanager
+    def record_region(scope_id, **metadata):
+        regions.append((scope_id, metadata))
+        yield
+
+    monkeypatch.setattr(decompositions, "compiler_hint", record_region)
+    decompose_dense_expert_persistent_ffn(*_inputs(), 2, "gelu_tanh", "region-7")
+
+    assert len(regions) == 8
+    assert {scope_id for scope_id, _ in regions} == {"region-7"}
+    assert all(
+        metadata["expert_execution"] == "persistent_dense_expert"
+        for _, metadata in regions
+    )
+    assert [metadata.get("streamed_operand_role") for _, metadata in regions] == [
+        "gate_weight",
+        "up_weight",
+        None,
+        None,
+        "down_weight",
+        "routing_weight",
+        None,
+        None,
+    ]

--- a/tests/inductor/test_moe_ffn_semantics.py
+++ b/tests/inductor/test_moe_ffn_semantics.py
@@ -21,6 +21,7 @@ from torch_spyre._inductor import decompositions
 from torch_spyre._inductor.expert_execution.custom_op import (
     expert_mm_prepacked,
     expert_route_prepacked,
+    expert_route_weighted_down,
     expert_shared_lhs_mm,
     expert_shared_lhs_mm_prepacked,
     moe_ffn,
@@ -124,6 +125,21 @@ def test_internal_prepacked_route_is_an_identity():
     torch.testing.assert_close(expert_route_prepacked(routing), routing)
 
 
+def test_internal_route_weighting_preserves_token_expert_semantics():
+    routing = _inputs()[-1]
+    down = torch.randn(
+        routing.shape[1],
+        routing.shape[0],
+        8,
+        generator=torch.Generator().manual_seed(9),
+    )
+
+    actual = expert_route_weighted_down(down, routing)
+    expected = down * routing.permute(1, 0, 2)
+
+    torch.testing.assert_close(actual, expected)
+
+
 @pytest.mark.parametrize("activation", ["gelu_tanh", "silu"])
 def test_persistent_decomposition_matches_semantic_reference(activation):
     inputs = _inputs()
@@ -150,7 +166,7 @@ def test_persistent_decomposition_marks_the_complete_loop_body(monkeypatch):
     monkeypatch.setattr(decompositions, "compiler_hint", record_region)
     decompose_dense_expert_persistent_ffn(*_inputs(), 2, "gelu_tanh", "region-7")
 
-    assert len(regions) == 8
+    assert len(regions) == 7
     assert {scope_id for scope_id, _ in regions} == {"region-7"}
     assert all(
         metadata["expert_execution"] == "persistent_dense_expert"
@@ -163,6 +179,5 @@ def test_persistent_decomposition_marks_the_complete_loop_body(monkeypatch):
         None,
         "down_weight",
         "routing_weight",
-        None,
         None,
     ]

--- a/tests/inductor/test_persistent_expert_loop_planning.py
+++ b/tests/inductor/test_persistent_expert_loop_planning.py
@@ -1,0 +1,197 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import sympy
+import pytest
+from torch._inductor.dependencies import MemoryDep
+from torch._inductor.utils import sympy_index_symbol
+
+from torch_spyre._inductor.loop_info import (
+    CoarseTileInfo,
+    LoopOperandBindingRequirement,
+    copy_op_metadata,
+)
+from torch_spyre._inductor.errors import Unsupported
+from torch_spyre._inductor.pass_utils import coeff_through_floor
+from torch_spyre._inductor.spyre_kernel import SpyreKernel, TensorAccess
+from torch_spyre._inductor.wsr.coarse_tile import _host_tile_advances_for_dep
+
+
+def test_expert_advance_is_measured_relative_to_the_window_base():
+    expert = sympy_index_symbol("d0")
+    row = sympy_index_symbol("d1")
+    dep = MemoryDep(
+        name="weight",
+        index=17 + 4096 * expert + 64 * row,
+        var_names=(expert, row),
+        size=(2, 64),
+    )
+
+    advances = _host_tile_advances_for_dep(
+        dep,
+        [{}, {0: sympy.Integer(1)}],
+    )
+
+    assert advances == [[], [(0, sympy.Integer(4096))]]
+
+
+def test_typed_preheader_owner_survives_ir_reconstruction():
+    source = type("Source", (), {})()
+    source.loop_info = CoarseTileInfo(
+        loop_group_id=(),
+        loop_count=[],
+        loop_tiled_dims=[],
+        preheader_for_group=(3, 1),
+    )
+    destination = type("Destination", (), {})()
+
+    copy_op_metadata(source, destination)
+
+    assert destination.loop_info.preheader_for_group == (3, 1)
+
+
+def _fully_squeezed_read_advance(binding):
+    dep = MemoryDep(
+        name="weight",
+        index=sympy.Integer(0),
+        var_names=(),
+        size=(),
+    )
+    ir_node = SimpleNamespace(
+        loop_info=CoarseTileInfo(
+            loop_group_id=(0,),
+            loop_count=[sympy.Integer(128)],
+            loop_tiled_dims=[[0]],
+            tiled_dims_per_read=[[[]]],
+            squeezed_advance_per_read=[[[(sympy.Integer(64), sympy.Integer(1))]]],
+            loop_operand_bindings=[binding],
+        ),
+        get_operation_name=lambda: "expert_weight_copy",
+        get_read_writes=lambda: SimpleNamespace(reads=[dep], writes=[]),
+    )
+    kernel = SpyreKernel()
+    kernel.current_node = SimpleNamespace(node=ir_node)
+    tensor = TensorAccess(
+        "weight",
+        sympy.Integer(0),
+        SimpleNamespace(
+            device_layout=SimpleNamespace(
+                device_size=[128, 64],
+                stride_map=[64, 1],
+            )
+        ),
+    )
+
+    advance = kernel._general_tile_advance(tensor, True, "weight")
+    level = kernel._tile_advance_symbols[0]
+    return sympy.expand(advance).coeff(level)
+
+
+def test_persistent_binding_and_ordinary_squeezed_advance_coexist():
+    # The upstream squeezed-dim fallback remains the address source for an
+    # ordinary copy. A persistent expert operand instead uses its pre-division
+    # binding, which retains the weight-bank stride hidden by the unit E tile.
+    assert _fully_squeezed_read_advance(None) == 64
+    assert (
+        _fully_squeezed_read_advance(
+            LoopOperandBindingRequirement(
+                kind="sequential_affine",
+                host_advance_per_level=(sympy.Integer(4096),),
+            )
+        )
+        == 4096
+    )
+
+
+def test_binding_conflict_with_surviving_dim_fails_closed():
+    dim = sympy_index_symbol("d0")
+    dep = MemoryDep(
+        name="weight",
+        index=dim,
+        var_names=(dim,),
+        size=(64,),
+    )
+    ir_node = SimpleNamespace(
+        loop_info=CoarseTileInfo(
+            loop_group_id=(0,),
+            loop_count=[sympy.Integer(128)],
+            loop_tiled_dims=[[0]],
+            tiled_dims_per_read=[[[(0, sympy.Integer(1))]]],
+            loop_operand_bindings=[
+                LoopOperandBindingRequirement(
+                    kind="sequential_affine",
+                    host_advance_per_level=(sympy.Integer(4096),),
+                )
+            ],
+        ),
+        get_operation_name=lambda: "mixed_weight_copy",
+        get_read_writes=lambda: SimpleNamespace(reads=[dep], writes=[]),
+    )
+    kernel = SpyreKernel()
+    kernel.current_node = SimpleNamespace(node=ir_node)
+    tensor = TensorAccess(
+        "weight",
+        sympy.Integer(0),
+        SimpleNamespace(
+            device_layout=SimpleNamespace(
+                device_size=[64],
+                stride_map=[1],
+            )
+        ),
+    )
+
+    with pytest.raises(Unsupported, match="conflicts with surviving tiled dimensions"):
+        kernel._general_tile_advance(tensor, True, "weight")
+
+
+def test_binding_owns_a_squeezed_expert_dim_without_aliasing_the_row_symbol():
+    row = sympy_index_symbol("d0")
+    dep = MemoryDep(
+        name="routing_weight",
+        index=row,
+        var_names=(row,),
+        size=(64,),
+    )
+    ir_node = SimpleNamespace(
+        data=SimpleNamespace(ranges=[1, 64, 1]),
+        loop_info=CoarseTileInfo(
+            loop_group_id=(0,),
+            loop_count=[sympy.Integer(128)],
+            loop_tiled_dims=[[0]],
+            tiled_dims_per_read=[[[(0, sympy.Integer(1))]]],
+            loop_operand_bindings=[
+                LoopOperandBindingRequirement(
+                    kind="sequential_affine",
+                    host_advance_per_level=(sympy.Integer(64),),
+                )
+            ],
+        ),
+        get_operation_name=lambda: "routing_weight_copy",
+        get_read_writes=lambda: SimpleNamespace(reads=[dep], writes=[]),
+    )
+    kernel = SpyreKernel()
+    kernel.current_node = SimpleNamespace(node=ir_node)
+    tensor = TensorAccess(
+        "routing_weight",
+        sympy.Integer(0),
+        SimpleNamespace(
+            device_layout=SimpleNamespace(device_size=[64], stride_map=[1])
+        ),
+    )
+
+    advance = kernel._general_tile_advance(tensor, True, "routing_weight")
+    level = kernel._tile_advance_symbols[0]
+    assert coeff_through_floor(advance, level) == 64

--- a/torch_spyre/_inductor/__init__.py
+++ b/torch_spyre/_inductor/__init__.py
@@ -138,6 +138,27 @@ def enable_spyre_compile_fx_wrapper():
             try:
                 if uses_spyre:
                     torch.spyre._impl._lazy_init()
+                    from torch_spyre._inductor.expert_execution.custom_op import (
+                        moe_ffn,
+                    )
+
+                    if any(
+                        node.op == "call_function"
+                        and node.target == moe_ffn._opoverload
+                        for node in gm.graph.nodes
+                    ):
+                        from torch_spyre._inductor.expert_execution.planner import (
+                            prepare_expert_execution_graph,
+                        )
+
+                        gm, expert_plan = prepare_expert_execution_graph(gm)
+                        logger.debug(
+                            "planned %d semantic MoE nodes; selected %d persistent",
+                            len(expert_plan.nodes),
+                            sum(
+                                node.schedule is not None for node in expert_plan.nodes
+                            ),
+                        )
                     # AOTAutograd uses the dict passed via ``decompositions=``
                     # to decompose the joint graph; Spyre-specific
                     # decompositions must be applied at this stage so ops like

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -67,6 +67,11 @@ dxp_lx_frac_avail: float = float(os.environ.get("DXP_LX_FRAC_AVAIL", "0.2"))
 
 sencores: int = int(os.getenv("SENCORES", "32"))
 
+# Internal development gate.  This is deliberately not environment-controlled:
+# the persistent strategy is not selectable until its physical schedule lands.
+# Tests may monkeypatch it while exercising the pure planner/materializer.
+enable_dense_expert_persistent: bool = False
+
 # Symbolic-dim knobs consumed by compute_granularity in pass_utils.py.
 # The pointwise work-division PR (#2499) wires that helper into the
 # compilation pipeline; until then these knobs are read only by the

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -110,6 +110,10 @@ COPY_BACK_CANDIDATE_ATTR = "_spyre_copy_back_candidate"
 # compute mutation op from a pure-copy mutation op.
 ELIDED_COPY_BACK_ATTR = "_spyre_writes_copy_back_target"
 
+# OpSpec marker for a persistent expert projection whose expert weight remains
+# a graph HBM operand and is rebound once per counted-loop iteration.
+PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY = "persistent_expert_stream_weight"
+
 # FX ``custom`` metadata key for BMMs created from a shared 2D weight whose
 # logical batch dim is statically 1.  The downstream OpSpec key carries the same
 # fact after lowering, where FX metadata is no longer directly available.

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -24,6 +24,7 @@ from .expert_execution.custom_op import (  # noqa: F401
     dense_expert_persistent_ffn,
     expert_mm_prepacked,
     expert_route_prepacked,
+    expert_route_weighted_down,
     expert_shared_lhs_mm,
     expert_shared_lhs_mm_prepacked,
     moe_ffn,

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -20,6 +20,11 @@ from torch_spyre.ops.eager import compile_once
 from torch_spyre.ops.fallbacks import warn_fallback
 
 from .errors import Unsupported
+from .expert_execution.custom_op import (  # noqa: F401
+    dense_expert_persistent_ffn,
+    expert_shared_lhs_mm,
+    moe_ffn,
+)
 
 aten = torch.ops.aten
 

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -22,7 +22,10 @@ from torch_spyre.ops.fallbacks import warn_fallback
 from .errors import Unsupported
 from .expert_execution.custom_op import (  # noqa: F401
     dense_expert_persistent_ffn,
+    expert_mm_prepacked,
+    expert_route_prepacked,
     expert_shared_lhs_mm,
+    expert_shared_lhs_mm_prepacked,
     moe_ffn,
 )
 

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -113,6 +113,71 @@ def register_spyre_decompositions(ops: OpOrOps):
     return decomp.register_decomposition(ops, spyre_decompositions)
 
 
+@register_spyre_decompositions(torch.ops.spyre.moe_ffn.default)
+def decompose_moe_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+) -> torch.Tensor:
+    """Lower the semantic operation through the ordinary dense device path."""
+    from .expert_execution.semantics import moe_ffn_reference
+
+    return moe_ffn_reference(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+
+
+@register_spyre_decompositions(torch.ops.spyre.dense_expert_persistent_ffn.default)
+def decompose_dense_expert_persistent_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+    region_id: str,
+) -> torch.Tensor:
+    """Materialize one logical body for a static persistent expert loop.
+
+    This decomposition does not iterate over experts in Python. The expert
+    dimension remains in the logical tensors and is tiled to one by the
+    compiler, which turns it into one counted device loop around a single
+    gate/up/down body.
+    """
+    del top_k, region_id  # Routing weights already encode top-k selection.
+    experts = gate_weight.shape[0]
+    with spyre_hint(num_tiles_per_dim={"E": experts}):
+        with spyre_hint(named_dims=["E", "T", "F"]):
+            gate = torch.ops.spyre.expert_shared_lhs_mm(x, gate_weight)
+            up = torch.ops.spyre.expert_shared_lhs_mm(x, up_weight)
+            if activation == "gelu_tanh":
+                activated_gate = torch.nn.functional.gelu(gate, approximate="tanh")
+            elif activation == "silu":
+                activated_gate = torch.nn.functional.silu(gate)
+            else:
+                raise Unsupported(f"unsupported MoE activation {activation!r}")
+            hidden = activated_gate * up
+        with spyre_hint(named_dims=["E", "T", "H"]):
+            down = torch.bmm(hidden, down_weight)
+        with spyre_hint(named_dims=["E", "T", "route"]):
+            route_by_expert = routing_weight.permute(1, 0, 2)
+        with spyre_hint(named_dims=["E", "T", "H"]):
+            weighted_down = down * route_by_expert
+        with spyre_hint(named_dims=["T", "H"], expected_reduction_dims=["E"]):
+            return torch.sum(weighted_down, dim=0)
+
+
 def get_spyre_decomp_table() -> dict[Any, Callable[..., Any]]:
     """Return the decomposition table Inductor sees when compiling for Spyre.
 

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -202,14 +202,10 @@ def decompose_dense_expert_persistent_ffn(
     with compiler_hint(
         region_id,
         **loop,
-        named_dims=["E", "T", "route"],
+        named_dims=["E", "T", "H"],
         streamed_operand_role="routing_weight",
     ):
-        route_by_expert = torch.ops.spyre.expert_route_prepacked(
-            routing_weight.permute(1, 0, 2)
-        )
-    with compiler_hint(region_id, **loop, named_dims=["E", "T", "H"]):
-        weighted_down = down * route_by_expert
+        weighted_down = torch.ops.spyre.expert_route_weighted_down(down, routing_weight)
     with compiler_hint(
         region_id,
         **loop,

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -39,6 +39,7 @@ from .logging_utils import get_inductor_logger
 
 from . import customops  # noqa: F401
 from . import spyre_hint
+from .propagate_hints import compiler_hint
 from torch_spyre._C import DataFormats, get_device_dtype, get_elem_in_stick
 import torch_spyre._inductor.customops  # noqa: F401
 
@@ -155,27 +156,67 @@ def decompose_dense_expert_persistent_ffn(
     compiler, which turns it into one counted device loop around a single
     gate/up/down body.
     """
-    del top_k, region_id  # Routing weights already encode top-k selection.
+    del top_k  # Routing weights already encode top-k selection.
     experts = gate_weight.shape[0]
-    with spyre_hint(num_tiles_per_dim={"E": experts}):
-        with spyre_hint(named_dims=["E", "T", "F"]):
-            gate = torch.ops.spyre.expert_shared_lhs_mm(x, gate_weight)
-            up = torch.ops.spyre.expert_shared_lhs_mm(x, up_weight)
-            if activation == "gelu_tanh":
-                activated_gate = torch.nn.functional.gelu(gate, approximate="tanh")
-            elif activation == "silu":
-                activated_gate = torch.nn.functional.silu(gate)
-            else:
-                raise Unsupported(f"unsupported MoE activation {activation!r}")
-            hidden = activated_gate * up
-        with spyre_hint(named_dims=["E", "T", "H"]):
-            down = torch.bmm(hidden, down_weight)
-        with spyre_hint(named_dims=["E", "T", "route"]):
-            route_by_expert = routing_weight.permute(1, 0, 2)
-        with spyre_hint(named_dims=["E", "T", "H"]):
-            weighted_down = down * route_by_expert
-        with spyre_hint(named_dims=["T", "H"], expected_reduction_dims=["E"]):
-            return torch.sum(weighted_down, dim=0)
+    loop = {
+        "num_tiles_per_dim": {"E": experts},
+        "expert_execution": "persistent_dense_expert",
+    }
+    # The semantic weights are logical [E,K,N] views backed by packed
+    # [K,E,N] storage.  Expose that physical layout to the internal lowerings
+    # without changing the model-facing contract.
+    gate_packed = gate_weight.permute(1, 0, 2)
+    up_packed = up_weight.permute(1, 0, 2)
+    down_packed = down_weight.permute(1, 0, 2)
+
+    with compiler_hint(
+        region_id,
+        **loop,
+        named_dims=["E", "T", "F"],
+        streamed_operand_role="gate_weight",
+    ):
+        gate = torch.ops.spyre.expert_shared_lhs_mm_prepacked(x, gate_packed)
+    with compiler_hint(
+        region_id,
+        **loop,
+        named_dims=["E", "T", "F"],
+        streamed_operand_role="up_weight",
+    ):
+        up = torch.ops.spyre.expert_shared_lhs_mm_prepacked(x, up_packed)
+    with compiler_hint(region_id, **loop, named_dims=["E", "T", "F"]):
+        if activation == "gelu_tanh":
+            activated_gate = torch.nn.functional.gelu(gate, approximate="tanh")
+        elif activation == "silu":
+            activated_gate = torch.nn.functional.silu(gate)
+        else:
+            raise Unsupported(f"unsupported MoE activation {activation!r}")
+    with compiler_hint(region_id, **loop, named_dims=["E", "T", "F"]):
+        hidden = activated_gate * up
+    with compiler_hint(
+        region_id,
+        **loop,
+        named_dims=["E", "T", "H"],
+        streamed_operand_role="down_weight",
+    ):
+        down = torch.ops.spyre.expert_mm_prepacked(hidden, down_packed)
+    with compiler_hint(
+        region_id,
+        **loop,
+        named_dims=["E", "T", "route"],
+        streamed_operand_role="routing_weight",
+    ):
+        route_by_expert = torch.ops.spyre.expert_route_prepacked(
+            routing_weight.permute(1, 0, 2)
+        )
+    with compiler_hint(region_id, **loop, named_dims=["E", "T", "H"]):
+        weighted_down = down * route_by_expert
+    with compiler_hint(
+        region_id,
+        **loop,
+        expected_named_dims=["T", "H"],
+        expected_reduction_dims=["E"],
+    ):
+        return torch.sum(weighted_down, dim=0)
 
 
 def get_spyre_decomp_table() -> dict[Any, Callable[..., Any]]:

--- a/torch_spyre/_inductor/expert_execution/__init__.py
+++ b/torch_spyre/_inductor/expert_execution/__init__.py
@@ -1,0 +1,37 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dense-expert semantic operations and compiler strategy selection."""
+
+from .planner import (
+    ExpertGraphPlan,
+    ExpertPlanningError,
+    ExpertStrategy,
+    PersistentExpertSchedule,
+    PlannedExpertNode,
+    materialize_expert_execution_graph,
+    plan_expert_execution_graph,
+    prepare_expert_execution_graph,
+)
+
+__all__ = [
+    "ExpertGraphPlan",
+    "ExpertPlanningError",
+    "ExpertStrategy",
+    "PersistentExpertSchedule",
+    "PlannedExpertNode",
+    "materialize_expert_execution_graph",
+    "plan_expert_execution_graph",
+    "prepare_expert_execution_graph",
+]

--- a/torch_spyre/_inductor/expert_execution/custom_op.py
+++ b/torch_spyre/_inductor/expert_execution/custom_op.py
@@ -38,6 +38,95 @@ def _(x: torch.Tensor, expert_weights: torch.Tensor) -> torch.Tensor:
     return x.new_empty((expert_weights.shape[0], x.shape[0], expert_weights.shape[2]))
 
 
+@torch.library.custom_op(
+    "spyre::expert_shared_lhs_mm_prepacked",
+    mutates_args=(),
+    device_types=("cpu", "spyre"),
+)
+def expert_shared_lhs_mm_prepacked(
+    x: torch.Tensor, expert_weights: torch.Tensor
+) -> torch.Tensor:
+    """Internal shared-LHS projection with physical weights ``[K,E,N]``."""
+
+    _validate_shared_lhs_mm_prepacked(x, expert_weights)
+    return torch.stack(
+        tuple(
+            torch.mm(x, expert_weights[:, expert, :])
+            for expert in range(expert_weights.shape[1])
+        )
+    )
+
+
+@expert_shared_lhs_mm_prepacked.register_fake
+def _(x: torch.Tensor, expert_weights: torch.Tensor) -> torch.Tensor:
+    _validate_shared_lhs_mm_prepacked(x, expert_weights)
+    return x.new_empty((expert_weights.shape[1], x.shape[0], expert_weights.shape[2]))
+
+
+def _validate_shared_lhs_mm_prepacked(
+    x: torch.Tensor, expert_weights: torch.Tensor
+) -> None:
+    if x.ndim != 2 or expert_weights.ndim != 3:
+        raise ValueError("expected x[T,K] and expert_weights[K,E,N]")
+    if x.shape[1] != expert_weights.shape[0]:
+        raise ValueError("x and expert_weights have different reduction dimensions")
+    if x.device != expert_weights.device or x.dtype != expert_weights.dtype:
+        raise ValueError("x and expert_weights must share device and dtype")
+
+
+@torch.library.custom_op(
+    "spyre::expert_mm_prepacked", mutates_args=(), device_types=("cpu", "spyre")
+)
+def expert_mm_prepacked(x: torch.Tensor, expert_weights: torch.Tensor) -> torch.Tensor:
+    """Internal expert projection with physical weights ``[K,E,N]``."""
+
+    _validate_expert_mm_prepacked(x, expert_weights)
+    return torch.stack(
+        tuple(
+            torch.mm(x[expert], expert_weights[:, expert, :])
+            for expert in range(expert_weights.shape[1])
+        )
+    )
+
+
+@expert_mm_prepacked.register_fake
+def _(x: torch.Tensor, expert_weights: torch.Tensor) -> torch.Tensor:
+    _validate_expert_mm_prepacked(x, expert_weights)
+    return x.new_empty((x.shape[0], x.shape[1], expert_weights.shape[2]))
+
+
+def _validate_expert_mm_prepacked(
+    x: torch.Tensor, expert_weights: torch.Tensor
+) -> None:
+    if x.ndim != 3 or expert_weights.ndim != 3:
+        raise ValueError("expected x[E,T,K] and expert_weights[K,E,N]")
+    if x.shape[0] != expert_weights.shape[1] or x.shape[2] != expert_weights.shape[0]:
+        raise ValueError("expert or reduction dimension mismatch")
+    if x.device != expert_weights.device or x.dtype != expert_weights.dtype:
+        raise ValueError("x and expert_weights must share device and dtype")
+
+
+@torch.library.custom_op(
+    "spyre::expert_route_prepacked", mutates_args=(), device_types=("cpu", "spyre")
+)
+def expert_route_prepacked(routing_weight: torch.Tensor) -> torch.Tensor:
+    """Internal identity over an expert-major ``[E,T,1]`` routing tensor."""
+
+    _validate_expert_route_prepacked(routing_weight)
+    return routing_weight.clone()
+
+
+@expert_route_prepacked.register_fake
+def _(routing_weight: torch.Tensor) -> torch.Tensor:
+    _validate_expert_route_prepacked(routing_weight)
+    return routing_weight.new_empty(routing_weight.shape)
+
+
+def _validate_expert_route_prepacked(routing_weight: torch.Tensor) -> None:
+    if routing_weight.ndim != 3 or routing_weight.shape[2] != 1:
+        raise ValueError("expected routing_weight[E,T,1]")
+
+
 def _validate_shared_lhs_mm(x: torch.Tensor, expert_weights: torch.Tensor) -> None:
     if x.ndim != 2:
         raise ValueError(f"x must have shape [T,K], got {tuple(x.shape)}")

--- a/torch_spyre/_inductor/expert_execution/custom_op.py
+++ b/torch_spyre/_inductor/expert_execution/custom_op.py
@@ -127,6 +127,37 @@ def _validate_expert_route_prepacked(routing_weight: torch.Tensor) -> None:
         raise ValueError("expected routing_weight[E,T,1]")
 
 
+@torch.library.custom_op(
+    "spyre::expert_route_weighted_down",
+    mutates_args=(),
+    device_types=("cpu", "spyre"),
+)
+def expert_route_weighted_down(
+    down: torch.Tensor, routing_weight: torch.Tensor
+) -> torch.Tensor:
+    """Apply logical ``[T,E,1]`` route weights to ``[E,T,H]`` expert output."""
+
+    _validate_expert_route_weighted_down(down, routing_weight)
+    return down * routing_weight.permute(1, 0, 2)
+
+
+@expert_route_weighted_down.register_fake
+def _(down: torch.Tensor, routing_weight: torch.Tensor) -> torch.Tensor:
+    _validate_expert_route_weighted_down(down, routing_weight)
+    return down.new_empty(down.shape)
+
+
+def _validate_expert_route_weighted_down(
+    down: torch.Tensor, routing_weight: torch.Tensor
+) -> None:
+    if down.ndim != 3 or routing_weight.ndim != 3:
+        raise ValueError("expected down[E,T,H] and routing_weight[T,E,1]")
+    if routing_weight.shape != (down.shape[1], down.shape[0], 1):
+        raise ValueError("routing_weight must have shape [T,E,1]")
+    if down.device != routing_weight.device or down.dtype != routing_weight.dtype:
+        raise ValueError("down and routing_weight must share device and dtype")
+
+
 def _validate_shared_lhs_mm(x: torch.Tensor, expert_weights: torch.Tensor) -> None:
     if x.ndim != 2:
         raise ValueError(f"x must have shape [T,K], got {tuple(x.shape)}")

--- a/torch_spyre/_inductor/expert_execution/custom_op.py
+++ b/torch_spyre/_inductor/expert_execution/custom_op.py
@@ -1,0 +1,186 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Strategy-neutral routed-expert FFN custom operation."""
+
+import torch
+
+from .semantics import moe_ffn_reference, validate_moe_ffn_inputs
+
+
+@torch.library.custom_op(
+    "spyre::expert_shared_lhs_mm", mutates_args=(), device_types=("cpu", "spyre")
+)
+def expert_shared_lhs_mm(x: torch.Tensor, expert_weights: torch.Tensor) -> torch.Tensor:
+    """Evaluate the internal shared-LHS expert projection in eager mode."""
+    _validate_shared_lhs_mm(x, expert_weights)
+    return torch.stack(
+        tuple(
+            torch.mm(x, expert_weights[expert]) for expert in range(len(expert_weights))
+        )
+    )
+
+
+@expert_shared_lhs_mm.register_fake
+def _(x: torch.Tensor, expert_weights: torch.Tensor) -> torch.Tensor:
+    _validate_shared_lhs_mm(x, expert_weights)
+    return x.new_empty((expert_weights.shape[0], x.shape[0], expert_weights.shape[2]))
+
+
+def _validate_shared_lhs_mm(x: torch.Tensor, expert_weights: torch.Tensor) -> None:
+    if x.ndim != 2:
+        raise ValueError(f"x must have shape [T,K], got {tuple(x.shape)}")
+    if expert_weights.ndim != 3:
+        raise ValueError(
+            f"expert_weights must have shape [E,K,N], got {tuple(expert_weights.shape)}"
+        )
+    if x.shape[1] != expert_weights.shape[1]:
+        raise ValueError("x and expert_weights have different reduction dimensions")
+    if x.device != expert_weights.device or x.dtype != expert_weights.dtype:
+        raise ValueError("x and expert_weights must share device and dtype")
+
+
+def _internal_moe_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+) -> torch.Tensor:
+    return moe_ffn_reference(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+
+
+def _fake_internal_moe_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+    region_id: str,
+) -> torch.Tensor:
+    del region_id
+    validate_moe_ffn_inputs(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+    return x.new_empty(x.shape)
+
+
+@torch.library.custom_op(
+    "spyre::dense_expert_persistent_ffn",
+    mutates_args=(),
+    device_types=("cpu", "spyre"),
+    schema=(
+        "(Tensor x, Tensor gate_weight, Tensor up_weight, Tensor down_weight, "
+        "Tensor routing_weight, int top_k, str activation, str region_id) -> Tensor"
+    ),
+)
+def dense_expert_persistent_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+    region_id: str,
+) -> torch.Tensor:
+    """Compiler-internal target for the persistent strategy."""
+    del region_id
+    return _internal_moe_ffn(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+
+
+dense_expert_persistent_ffn.register_fake(_fake_internal_moe_ffn)
+
+
+@torch.library.custom_op(
+    "spyre::moe_ffn",
+    mutates_args=(),
+    device_types=("cpu", "spyre"),
+    schema=(
+        "(Tensor x, Tensor gate_weight, Tensor up_weight, Tensor down_weight, "
+        "Tensor routing_weight, int top_k, str activation) -> Tensor"
+    ),
+)
+def moe_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+) -> torch.Tensor:
+    """Evaluate the routed-expert value path in eager mode.
+
+    Router-logit generation and any shared-expert FFN are intentionally outside
+    this operation. ``routing_weight`` is the already-normalized post-down
+    expert weight with logical shape ``[T, E, 1]``.
+    """
+    return moe_ffn_reference(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+
+
+@moe_ffn.register_fake
+def _(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+) -> torch.Tensor:
+    validate_moe_ffn_inputs(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+    return x.new_empty(x.shape)

--- a/torch_spyre/_inductor/expert_execution/planner.py
+++ b/torch_spyre/_inductor/expert_execution/planner.py
@@ -1,0 +1,352 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure selection and transactional FX materialization for expert execution."""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+from enum import StrEnum
+from typing import Any
+
+import torch
+
+from .custom_op import dense_expert_persistent_ffn, moe_ffn
+
+
+class ExpertStrategy(StrEnum):
+    """Compiler strategies currently available for the semantic MoE operation."""
+
+    PERSISTENT_DENSE = "persistent_dense"
+    ORDINARY_DENSE = "ordinary_dense"
+
+
+@dataclasses.dataclass(frozen=True)
+class PersistentExpertSchedule:
+    """The schedule contract materialized by the persistent strategy."""
+
+    preheader: tuple[str, ...] = ("stage_x", "fill_accumulator")
+    loop_body: tuple[str, ...] = (
+        "gate",
+        "up",
+        "activation",
+        "gated_product",
+        "down",
+        "route_weight",
+        "accumulator_combine",
+    )
+    drain: tuple[str, ...] = ("drain_output",)
+    streamed_operands: tuple[str, ...] = (
+        "gate_weight",
+        "up_weight",
+        "down_weight",
+        "routing_weight",
+    )
+    binding_kind: str = "sequential_affine"
+    weight_layout: str = "logical_expert_major_k_major_backing"
+    routing_layout: str = "logical_token_major"
+
+
+@dataclasses.dataclass(frozen=True)
+class PlannedExpertNode:
+    """The selected strategy for one semantic MoE FX node."""
+
+    node_name: str
+    strategy: ExpertStrategy
+    expert_count: int
+    minimum_lx_bytes: int
+    schedule: PersistentExpertSchedule | None
+
+
+@dataclasses.dataclass(frozen=True)
+class ExpertGraphPlan:
+    """Immutable result of planning every semantic MoE node in an FX graph."""
+
+    source_structure: tuple[tuple[Any, ...], ...]
+    nodes: tuple[PlannedExpertNode, ...]
+
+
+class ExpertPlanningError(RuntimeError):
+    """The selected strategy could not be materialized without mutation."""
+
+
+def graph_structure(graph: torch.fx.Graph) -> tuple[tuple[Any, ...], ...]:
+    """Return a stable, metadata-independent graph representation."""
+
+    def encode(value):
+        if isinstance(value, torch.fx.Node):
+            return ("node", value.name)
+        if isinstance(value, tuple):
+            return tuple(encode(item) for item in value)
+        if isinstance(value, list):
+            return ("list", *(encode(item) for item in value))
+        if isinstance(value, dict):
+            return tuple((key, encode(value[key])) for key in sorted(value))
+        return value
+
+    return tuple(
+        (node.name, node.op, str(node.target), encode(node.args), encode(node.kwargs))
+        for node in graph.nodes
+    )
+
+
+def _tensor_argument(node: torch.fx.Node, index: int, name: str) -> torch.fx.Node:
+    value = node.args[index]
+    if not isinstance(value, torch.fx.Node):
+        raise ValueError(f"{name} must be a tensor FX node")
+    return value
+
+
+def _tensor_metadata(node: torch.fx.Node, name: str):
+    """Return the tensor metadata produced by Dynamo or post-grad FX."""
+
+    value = node.meta.get("val")
+    if value is None:
+        value = node.meta.get("example_value")
+    if value is None:
+        raise ValueError(f"{name} has no tensor metadata")
+    return value
+
+
+def _shape(node: torch.fx.Node, name: str) -> tuple[int, ...]:
+    shape = getattr(_tensor_metadata(node, name), "shape", None)
+    if shape is None:
+        raise ValueError(f"{name} has no tensor shape metadata")
+    try:
+        return tuple(int(dim) for dim in shape)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} requires static dimensions") from exc
+
+
+def _element_size(node: torch.fx.Node, name: str) -> int:
+    value = _tensor_metadata(node, name)
+    if not hasattr(value, "element_size"):
+        raise ValueError(f"{name} has no tensor dtype metadata")
+    return int(value.element_size())
+
+
+def _stride(node: torch.fx.Node, name: str) -> tuple[int, ...]:
+    value = _tensor_metadata(node, name)
+    if not hasattr(value, "stride"):
+        raise ValueError(f"{name} has no tensor stride metadata")
+    try:
+        return tuple(int(dim) for dim in value.stride())
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} requires static strides") from exc
+
+
+def _has_persistent_weight_layout(
+    node: torch.fx.Node,
+    name: str,
+    *,
+    experts: int,
+    reduction: int,
+    output: int,
+) -> bool:
+    """Check the logical ``[E,K,N]`` view over packed ``[K,E,N]`` storage."""
+
+    return _shape(node, name) == (experts, reduction, output) and _stride(
+        node, name
+    ) == (output, experts * output, 1)
+
+
+def _has_persistent_routing_layout(
+    node: torch.fx.Node,
+    name: str,
+    *,
+    tokens: int,
+    experts: int,
+) -> bool:
+    """Check a logical ``[T,E,1]`` route tensor the loop can stream directly."""
+
+    if _shape(node, name) != (tokens, experts, 1):
+        return False
+    return _stride(node, name) in {
+        (experts, 1, 1),  # contiguous token-major storage
+        (1, tokens, 1),  # logical token-major view over expert-major storage
+    }
+
+
+def _plan_node(
+    node: torch.fx.Node,
+    *,
+    persistent_available: bool,
+    available_lx_bytes: int,
+) -> PlannedExpertNode:
+    if len(node.args) != 7:
+        raise ValueError("spyre::moe_ffn expects exactly seven arguments")
+    x = _tensor_argument(node, 0, "x")
+    gate = _tensor_argument(node, 1, "gate_weight")
+    up = _tensor_argument(node, 2, "up_weight")
+    down = _tensor_argument(node, 3, "down_weight")
+    routing = _tensor_argument(node, 4, "routing_weight")
+    top_k, activation = node.args[5:7]
+
+    if type(top_k) is not int or not isinstance(activation, str):
+        raise ValueError("top_k and activation must be static")
+    x_shape = _shape(x, "x")
+    gate_shape = _shape(gate, "gate_weight")
+    if len(x_shape) != 2 or len(gate_shape) != 3:
+        raise ValueError("moe_ffn requires x[T,H] and gate_weight[E,H,F]")
+    tokens, hidden = x_shape
+    experts, gate_hidden, intermediate = gate_shape
+    if gate_hidden != hidden:
+        raise ValueError("gate_weight hidden dimension differs from x")
+    if _shape(up, "up_weight") != (experts, hidden, intermediate):
+        raise ValueError("up_weight does not match gate_weight")
+    if _shape(down, "down_weight") != (experts, intermediate, hidden):
+        raise ValueError("down_weight does not match gate_weight")
+    if _shape(routing, "routing_weight") != (tokens, experts, 1):
+        raise ValueError("routing_weight must have shape [T,E,1]")
+    if not 0 < top_k <= experts:
+        raise ValueError("top_k must be in [1, E]")
+    if activation not in {"gelu_tanh", "silu"}:
+        raise ValueError(f"unsupported activation {activation!r}")
+
+    # Conservative feasibility check. Placement remains authoritative.
+    minimum_lx_bytes = _element_size(x, "x") * (
+        2 * tokens * hidden + 2 * tokens * intermediate
+    )
+    packed_weights = (
+        _has_persistent_weight_layout(
+            gate,
+            "gate_weight",
+            experts=experts,
+            reduction=hidden,
+            output=intermediate,
+        )
+        and _has_persistent_weight_layout(
+            up,
+            "up_weight",
+            experts=experts,
+            reduction=hidden,
+            output=intermediate,
+        )
+        and _has_persistent_weight_layout(
+            down,
+            "down_weight",
+            experts=experts,
+            reduction=intermediate,
+            output=hidden,
+        )
+    )
+    packed_routing = _has_persistent_routing_layout(
+        routing,
+        "routing_weight",
+        tokens=tokens,
+        experts=experts,
+    )
+    use_persistent = (
+        persistent_available
+        and packed_weights
+        and packed_routing
+        and minimum_lx_bytes <= available_lx_bytes
+    )
+    return PlannedExpertNode(
+        node_name=node.name,
+        strategy=(
+            ExpertStrategy.PERSISTENT_DENSE
+            if use_persistent
+            else ExpertStrategy.ORDINARY_DENSE
+        ),
+        expert_count=experts,
+        minimum_lx_bytes=minimum_lx_bytes,
+        schedule=PersistentExpertSchedule() if use_persistent else None,
+    )
+
+
+def plan_expert_execution_graph(
+    graph_module: torch.fx.GraphModule,
+    *,
+    persistent_available: bool,
+    available_lx_bytes: int,
+) -> ExpertGraphPlan:
+    """Select strategies without modifying graph structure or metadata."""
+    before = graph_structure(graph_module.graph)
+    plans = tuple(
+        _plan_node(
+            node,
+            persistent_available=persistent_available,
+            available_lx_bytes=available_lx_bytes,
+        )
+        for node in graph_module.graph.nodes
+        if node.op == "call_function" and node.target == moe_ffn._opoverload
+    )
+    if graph_structure(graph_module.graph) != before:
+        raise RuntimeError("expert planning mutated the source FX graph")
+    return ExpertGraphPlan(before, plans)
+
+
+def _find_node(graph: torch.fx.Graph, name: str) -> torch.fx.Node:
+    matches = [node for node in graph.nodes if node.name == name]
+    if len(matches) != 1:
+        raise ExpertPlanningError(
+            f"expected one FX node named {name}, got {len(matches)}"
+        )
+    return matches[0]
+
+
+def materialize_expert_execution_graph(
+    graph_module: torch.fx.GraphModule,
+    plan: ExpertGraphPlan,
+) -> torch.fx.GraphModule:
+    """Rewrite a clone and publish it only after all checks succeed."""
+    if graph_structure(graph_module.graph) != plan.source_structure:
+        raise ExpertPlanningError("FX graph changed after expert planning")
+    persistent_nodes = tuple(
+        node for node in plan.nodes if node.strategy == ExpertStrategy.PERSISTENT_DENSE
+    )
+    if not persistent_nodes:
+        return graph_module
+
+    candidate = copy.deepcopy(graph_module)
+    for node_plan in persistent_nodes:
+        node = _find_node(candidate.graph, node_plan.node_name)
+        if node.target != moe_ffn._opoverload or node_plan.schedule is None:
+            raise ExpertPlanningError(
+                f"{node_plan.node_name} is not a valid persistent MoE node"
+            )
+        node.target = dense_expert_persistent_ffn._opoverload
+        # The stable FX node name is the compiler-owned region identity.  It is
+        # serialized as a static internal-op argument so the selected region
+        # survives AOT decomposition without relying on user hint IDs.
+        node.args = (*node.args, node_plan.node_name)
+    candidate.graph.lint()
+    candidate.recompile()
+
+    for node_plan in persistent_nodes:
+        if (
+            _find_node(candidate.graph, node_plan.node_name).target
+            != dense_expert_persistent_ffn._opoverload
+        ):
+            raise ExpertPlanningError(f"failed to materialize {node_plan.node_name}")
+    if graph_structure(graph_module.graph) != plan.source_structure:
+        raise RuntimeError("expert materialization mutated the source FX graph")
+    return candidate
+
+
+def prepare_expert_execution_graph(
+    graph_module: torch.fx.GraphModule,
+) -> tuple[torch.fx.GraphModule, ExpertGraphPlan]:
+    """Plan once, then transactionally materialize compiler-owned strategies."""
+    from .. import config
+    from ..scratchpad.allocator import _lx_planning_size
+
+    plan = plan_expert_execution_graph(
+        graph_module,
+        persistent_available=config.enable_dense_expert_persistent,
+        available_lx_bytes=config.sencores * _lx_planning_size(),
+    )
+    return materialize_expert_execution_graph(graph_module, plan), plan

--- a/torch_spyre/_inductor/expert_execution/semantics.py
+++ b/torch_spyre/_inductor/expert_execution/semantics.py
@@ -1,0 +1,123 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Semantic definition of the routed-expert FFN operation."""
+
+from __future__ import annotations
+
+import torch
+
+
+SUPPORTED_ACTIVATIONS = ("gelu_tanh", "silu")
+
+
+def validate_moe_ffn_inputs(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+) -> tuple[int, int, int, int]:
+    """Validate the logical, strategy-neutral routed-FFN tensor contract."""
+    if activation not in SUPPORTED_ACTIVATIONS:
+        raise ValueError(
+            f"unsupported MoE activation {activation!r}; "
+            f"expected one of {SUPPORTED_ACTIVATIONS}"
+        )
+    if x.ndim != 2:
+        raise ValueError(f"x must have shape [T,H], got {tuple(x.shape)}")
+    if gate_weight.ndim != 3 or up_weight.ndim != 3 or down_weight.ndim != 3:
+        raise ValueError("expert weights must be rank-3 logical weight banks")
+    if routing_weight.ndim != 3 or routing_weight.shape[-1] != 1:
+        raise ValueError(
+            "routing_weight must have shape [T,E,1]; the explicit singleton "
+            "preserves post-down scalar broadcast semantics"
+        )
+
+    tokens, hidden = x.shape
+    experts, gate_hidden, intermediate = gate_weight.shape
+    if top_k <= 0 or top_k > experts:
+        raise ValueError(f"top_k must be in [1,{experts}], got {top_k}")
+    expected_up = (experts, hidden, intermediate)
+    expected_down = (experts, intermediate, hidden)
+    expected_routing = (tokens, experts, 1)
+    if gate_hidden != hidden:
+        raise ValueError(
+            f"gate_weight has hidden size {gate_hidden}, expected {hidden}"
+        )
+    if tuple(up_weight.shape) != expected_up:
+        raise ValueError(
+            f"up_weight must have shape {expected_up}, got {tuple(up_weight.shape)}"
+        )
+    if tuple(down_weight.shape) != expected_down:
+        raise ValueError(
+            "down_weight must have shape "
+            f"{expected_down}, got {tuple(down_weight.shape)}"
+        )
+    if tuple(routing_weight.shape) != expected_routing:
+        raise ValueError(
+            "routing_weight must have shape "
+            f"{expected_routing}, got {tuple(routing_weight.shape)}"
+        )
+    if any(
+        tensor.device != x.device
+        for tensor in (gate_weight, up_weight, down_weight, routing_weight)
+    ):
+        raise ValueError("all MoE tensors must be on the same device")
+    if any(
+        tensor.dtype != x.dtype
+        for tensor in (gate_weight, up_weight, down_weight, routing_weight)
+    ):
+        raise ValueError("all MoE tensors must have the same dtype")
+    return tokens, experts, hidden, intermediate
+
+
+def moe_ffn_reference(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+) -> torch.Tensor:
+    """Evaluate the logical all-expert routed FFN without strategy assumptions.
+
+    The reference intentionally expresses one expert at a time. It defines
+    semantics for eager execution and correctness tests; compiler strategies
+    are free to use a persistent device loop, partitioned dense execution, or
+    another implementation that preserves this result.
+    """
+    _tokens, experts, _hidden, _intermediate = validate_moe_ffn_inputs(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+    result = torch.zeros_like(x)
+    for expert in range(experts):
+        gate = torch.mm(x, gate_weight[expert])
+        up = torch.mm(x, up_weight[expert])
+        if activation == "gelu_tanh":
+            gate = torch.nn.functional.gelu(gate, approximate="tanh")
+        else:
+            gate = torch.nn.functional.silu(gate)
+        down = torch.mm(gate * up, down_weight[expert])
+        result = result + down * routing_weight[:, expert, :]
+    return result

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -31,6 +31,34 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True)
+class CountedLoopPlan:
+    """Compiler-owned contract for one static persistent expert loop."""
+
+    kind: Literal["persistent_dense_expert"]
+    trip_count: int
+    loop_dim: str = "E"
+    row_dim: str = "T"
+    invariant_operands: tuple[str, ...] = ("x",)
+    streamed_operands: tuple[str, ...] = (
+        "gate_weight",
+        "up_weight",
+        "down_weight",
+        "routing_weight",
+    )
+    transport_free: bool = True
+
+
+@dataclass(frozen=True)
+class LoopOperandBindingRequirement:
+    """Planning-time contract for one named streamed loop operand."""
+
+    kind: Literal["sequential_affine"]
+    host_advance_per_level: tuple[sympy.Expr, ...]
+    operand_role: str | None = None
+    source_name: str | None = None
+
+
+@dataclass(frozen=True)
 class ReductionPlan:
     """Planned shape/identity/nesting data for a tiled-reduction op.
 
@@ -152,6 +180,14 @@ class ReadCopyEntry:
     consumer_op_names:
         Names of every op in the group that must have this dep's buffer
         name patched (via _NameSwapHandler) to load from copy_name instead.
+    planned_dep_levels:
+        Planning-time, pre-range-division per-level tiled-dim metadata for
+        this exact source read.  Captured on the entry because earlier
+        entries may rebuild/patch the sizing op before this one executes.
+        ``None`` preserves legacy behavior for hand-built plans that do not
+        carry per-read metadata.
+    binding_requirement:
+        Typed sequential-affine address requirement for this source read.
     """
 
     copy_name: str
@@ -159,6 +195,8 @@ class ReadCopyEntry:
     insert_before_op_name: str
     sizing_op_name: str
     consumer_op_names: tuple[str, ...]
+    planned_dep_levels: tuple[tuple[tuple[int, sympy.Expr], ...], ...] | None = None
+    binding_requirement: LoopOperandBindingRequirement | None = None
 
 
 @dataclass(frozen=True)
@@ -220,6 +258,10 @@ class CoarseTileInfo:
         (possibly later-rewritten) index expression happens in
         spyre_kernel.py at OpSpec/TensorArg construction time, when the
         index is guaranteed final.
+    loop_operand_bindings:
+        One typed address requirement per read. Populated only for a planned
+        persistent expert loop; ordinary coarse-tiled graphs pay no symbolic
+        advance-analysis cost and retain their existing behavior.
     output_tiled_dims:
         The analogous per-level ``(op_dim_index, extent)`` list for this
         op's own write dependency. Defaults to ``[]`` (no levels tiled).
@@ -270,6 +312,9 @@ class CoarseTileInfo:
     tiled_dims_per_read: list[list[list[tuple[int, sympy.Expr]]]] = field(
         default_factory=list
     )
+    loop_operand_bindings: list[LoopOperandBindingRequirement | None] = field(
+        default_factory=list
+    )
     output_tiled_dims: list[list[tuple[int, sympy.Expr]]] = field(default_factory=list)
     squeezed_advance_per_read: list[list[list[tuple[sympy.Expr, sympy.Expr]]]] = field(
         default_factory=list
@@ -277,6 +322,8 @@ class CoarseTileInfo:
     squeezed_advance_output: list[list[tuple[sympy.Expr, sympy.Expr]]] = field(
         default_factory=list
     )
+    counted_loop_plan: CountedLoopPlan | None = None
+    preheader_for_group: tuple[int, ...] | None = None
     propagation: "PropagationPlan | None" = None
 
 

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -74,6 +74,30 @@ def _current_fx_custom_meta() -> dict[str, Any]:
     return custom if isinstance(custom, dict) else {}
 
 
+def _in_persistent_expert_scope(custom_meta: dict[str, Any]) -> bool:
+    return any(
+        isinstance(value, dict)
+        and value.get("expert_execution") == "persistent_dense_expert"
+        for value in custom_meta.values()
+    )
+
+
+def _persistent_streamed_operand_role(custom_meta: dict[str, Any]) -> str | None:
+    roles = {
+        value["streamed_operand_role"]
+        for value in custom_meta.values()
+        if isinstance(value, dict) and "streamed_operand_role" in value
+    }
+    if not roles:
+        return None
+    if len(roles) != 1:
+        raise Unsupported(f"ambiguous persistent streamed operand roles: {roles}")
+    role = next(iter(roles))
+    if role not in {"gate_weight", "up_weight", "down_weight", "routing_weight"}:
+        raise Unsupported(f"unknown persistent streamed operand role {role!r}")
+    return role
+
+
 def register_spyre_lowering(
     op,
     name=None,
@@ -531,6 +555,8 @@ def lower_bmm(x, y):
         op_info[SHARED_WEIGHT_UNIT_BMM_INFO_KEY] = custom_meta[
             SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY
         ]
+    if _in_persistent_expert_scope(custom_meta):
+        op_info[PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY] = True
 
     if reduction_numel == 1:
         # Reduction degenerates to a pointwise mul
@@ -613,6 +639,131 @@ def lower_expert_shared_lhs_mm(x, expert_weights):
             "persistent_expert_shared_lhs": {"expert_dim": 0},
             PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY: True,
         },
+    )
+    result.realize()
+    return result
+
+
+@register_spyre_lowering(torch.ops.spyre.expert_shared_lhs_mm_prepacked.default)
+def lower_expert_shared_lhs_mm_prepacked(x, expert_weights):
+    """Lower ``[T,K] @ [K,E,N]`` without expanding the shared LHS."""
+
+    x.realize()
+    expert_weights.realize()
+    x_size = x.get_size()
+    weight_size = expert_weights.get_size()
+    if len(x_size) != 2 or len(weight_size) != 3 or x_size[1] != weight_size[0]:
+        raise Unsupported(
+            "expert_shared_lhs_mm_prepacked requires [T,K] and [K,E,N], "
+            f"got {x_size} and {weight_size}"
+        )
+    if x.get_dtype() != expert_weights.get_dtype():
+        raise Unsupported("x and expert_weights must have the same dtype")
+    role = _persistent_streamed_operand_role(_current_fx_custom_meta())
+    if role not in {"gate_weight", "up_weight"}:
+        raise Unsupported(
+            "prepacked shared-LHS projection requires a gate/up operand role"
+        )
+    x_loader = x.make_loader()
+    weight_loader = expert_weights.make_loader()
+
+    def inner_fn(index, reduction_index):
+        expert, row, column = index
+        (reduction,) = reduction_index
+        return (
+            x_loader([row, reduction]),
+            weight_loader([reduction, expert, column]),
+        )
+
+    result = SpyreReduction.create(
+        reduction_type=BATCH_MATMUL_OP,
+        input_node=[x, expert_weights],
+        device=x.get_device(),
+        dst_dtype=x.get_dtype(),
+        src_dtype=x.get_dtype(),
+        inner_fn=inner_fn,
+        ranges=[weight_size[1], x_size[0], weight_size[2]],
+        reduction_ranges=[x_size[1]],
+        op_info={
+            "persistent_expert_shared_lhs": {"expert_dim": 0},
+            PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY: role,
+        },
+    )
+    result.realize()
+    return result
+
+
+@register_spyre_lowering(torch.ops.spyre.expert_mm_prepacked.default)
+def lower_expert_mm_prepacked(x, expert_weights):
+    """Lower ``[E,T,K] @ [K,E,N]`` with a named streamed weight bank."""
+
+    x.realize()
+    expert_weights.realize()
+    x_size = x.get_size()
+    weight_size = expert_weights.get_size()
+    if (
+        len(x_size) != 3
+        or len(weight_size) != 3
+        or x_size[0] != weight_size[1]
+        or x_size[2] != weight_size[0]
+    ):
+        raise Unsupported(
+            "expert_mm_prepacked requires [E,T,K] and [K,E,N], "
+            f"got {x_size} and {weight_size}"
+        )
+    if x.get_dtype() != expert_weights.get_dtype():
+        raise Unsupported("x and expert_weights must have the same dtype")
+    role = _persistent_streamed_operand_role(_current_fx_custom_meta())
+    if role != "down_weight":
+        raise Unsupported("prepacked expert projection requires down_weight role")
+    x_loader = x.make_loader()
+    weight_loader = expert_weights.make_loader()
+
+    def inner_fn(index, reduction_index):
+        expert, row, column = index
+        (reduction,) = reduction_index
+        return (
+            x_loader([expert, row, reduction]),
+            weight_loader([reduction, expert, column]),
+        )
+
+    result = SpyreReduction.create(
+        reduction_type=BATCH_MATMUL_OP,
+        input_node=[x, expert_weights],
+        device=x.get_device(),
+        dst_dtype=x.get_dtype(),
+        src_dtype=x.get_dtype(),
+        inner_fn=inner_fn,
+        ranges=[x_size[0], x_size[1], weight_size[2]],
+        reduction_ranges=[x_size[2]],
+        op_info={PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY: role},
+    )
+    result.realize()
+    return result
+
+
+@register_spyre_lowering(torch.ops.spyre.expert_route_prepacked.default)
+def lower_expert_route_prepacked(routing_weight):
+    """Expose one expert-major routing plane as a named streamed operand."""
+
+    routing_weight.realize()
+    size = routing_weight.get_size()
+    if len(size) != 3 or size[2] != 1:
+        raise Unsupported(f"expert_route_prepacked requires [E,T,1], got {size}")
+    role = _persistent_streamed_operand_role(_current_fx_custom_meta())
+    if role != "routing_weight":
+        raise Unsupported("prepacked expert routing requires routing_weight role")
+    loader = routing_weight.make_loader()
+    result = Pointwise.create(
+        device=routing_weight.get_device(),
+        dtype=routing_weight.get_dtype(),
+        inner_fn=lambda index: loader(index),
+        ranges=size,
+        origin_node=routing_weight.get_origin_node(),
+        traceback=routing_weight.get_traceback(),
+    )
+    result.data.data._post_init_setattr(
+        "op_info", {PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY: role}
     )
     result.realize()
     return result

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -31,6 +31,7 @@ from .constants import (
     COPY_BACK_CANDIDATE_ATTR,
     BATCH_MATMUL_FP8_OP,
     DEPTHWISE_CONV2D_OP,
+    PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY,
     SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY,
     SHARED_WEIGHT_UNIT_BMM_INFO_KEY,
 )
@@ -558,6 +559,62 @@ def lower_bmm(x, y):
             f"bmm: x{list(x_size)} @ y{list(y_size)} -> {list(result_buf.get_size())}"
         )
 
+    return result
+
+
+@register_spyre_lowering(torch.ops.spyre.expert_shared_lhs_mm.default)
+def lower_expert_shared_lhs_mm(x, expert_weights):
+    """Lower ``[T,K] @ [E,K,N]`` without expanding X over E.
+
+    The expert coordinate indexes only the weight and output tensors. This is
+    the logical projection needed by a later persistent expert loop: tiling E
+    to one changes the streamed weight address while leaving the X address
+    invariant.
+    """
+    x.realize()
+    expert_weights.realize()
+    x_size = x.get_size()
+    weight_size = expert_weights.get_size()
+    if len(x_size) != 2 or len(weight_size) != 3:
+        raise Unsupported(
+            "expert_shared_lhs_mm requires [T,K] and [E,K,N], "
+            f"got {x_size} and {weight_size}"
+        )
+    if x_size[1] != weight_size[1]:
+        raise Unsupported(
+            "expert_shared_lhs_mm reduction dimensions differ: "
+            f"{x_size[1]} versus {weight_size[1]}"
+        )
+    if x.get_dtype() != expert_weights.get_dtype():
+        raise Unsupported("expert_shared_lhs_mm inputs must have the same dtype")
+
+    x_loader = x.make_loader()
+    weight_loader = expert_weights.make_loader()
+    ranges = [weight_size[0], x_size[0], weight_size[2]]
+
+    def inner_fn(index, reduction_index):
+        expert, row, column = index
+        (reduction,) = reduction_index
+        return (
+            x_loader([row, reduction]),
+            weight_loader([expert, reduction, column]),
+        )
+
+    result = SpyreReduction.create(
+        reduction_type=BATCH_MATMUL_OP,
+        input_node=[x, expert_weights],
+        device=x.get_device(),
+        dst_dtype=x.get_dtype(),
+        src_dtype=x.get_dtype(),
+        inner_fn=inner_fn,
+        ranges=ranges,
+        reduction_ranges=[x_size[1]],
+        op_info={
+            "persistent_expert_shared_lhs": {"expert_dim": 0},
+            PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY: True,
+        },
+    )
+    result.realize()
     return result
 
 

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -769,6 +769,48 @@ def lower_expert_route_prepacked(routing_weight):
     return result
 
 
+@register_spyre_lowering(torch.ops.spyre.expert_route_weighted_down.default)
+def lower_expert_route_weighted_down(down, routing_weight):
+    """Lower post-down route weighting while retaining route binding identity."""
+
+    down.realize()
+    routing_weight.realize()
+    down_size = down.get_size()
+    routing_size = routing_weight.get_size()
+    if (
+        len(down_size) != 3
+        or len(routing_size) != 3
+        or routing_size != [down_size[1], down_size[0], 1]
+    ):
+        raise Unsupported(
+            "expert_route_weighted_down requires down[E,T,H] and "
+            f"routing_weight[T,E,1], got {down_size} and {routing_size}"
+        )
+    if down.get_dtype() != routing_weight.get_dtype():
+        raise Unsupported("down and routing_weight must have the same dtype")
+    role = _persistent_streamed_operand_role(_current_fx_custom_meta())
+    if role != "routing_weight":
+        raise Unsupported("persistent route weighting requires routing_weight role")
+    down_loader = down.make_loader()
+    routing_loader = routing_weight.make_loader()
+
+    def inner_fn(index):
+        expert, row, feature = index
+        return down_loader(index) * routing_loader([row, expert, 0])
+
+    result = Pointwise.create(
+        device=down.get_device(),
+        dtype=down.get_dtype(),
+        inner_fn=inner_fn,
+        ranges=down_size,
+    )
+    result.data.data._post_init_setattr(
+        "op_info", {PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY: role}
+    )
+    result.realize()
+    return result
+
+
 @register_spyre_lowering(torch.ops.spyre.conv2d.default)
 def lower_depthwise_conv2d(x, w, stride, padding, dilation, groups):
     x = V.graph.get_buffer(x.realize())

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -836,9 +836,16 @@ def find_matmul_generated_var(
     generated_vars = (
         y_dep.index.free_symbols & out_dep.index.free_symbols
     ) - x_dep.index.free_symbols
+    # A counted shared-LHS expert matmul retains its statically-unit expert
+    # symbol after E is tiled to one.  It is not a physical generated axis.
+    if len(generated_vars) > 1:
+        generated_vars = {
+            var for var in generated_vars if sympy.sympify(out_dep.ranges[var]) != 1
+        }
     if len(generated_vars) != 1:
         raise Unsupported(
-            f"expected exactly 1 generated variable, got {generated_vars}"
+            f"expected exactly 1 generated variable, got {generated_vars}; "
+            f"output ranges={out_dep.ranges}"
         )
     return next(iter(generated_vars))
 

--- a/torch_spyre/_inductor/propagate_hints.py
+++ b/torch_spyre/_inductor/propagate_hints.py
@@ -14,6 +14,7 @@
 
 
 import dataclasses
+import hashlib
 from typing import Any
 
 import regex as re
@@ -91,6 +92,22 @@ def spyre_hint(**kwargs: Any):
     else:
         _id = 0
     return torch.fx.traceback.annotate({f"_hint_{_id}": kwargs})
+
+
+def compiler_hint(scope_id: str, **kwargs: Any):
+    """Attach compiler-owned metadata with a stable region identity.
+
+    Unlike :func:`spyre_hint`, this is not a user scheduling request and does
+    not consume Dynamo's per-trace hint counter.  Every operation emitted for
+    one selected compiler plan uses the same deterministic ID, while separate
+    semantic MoE nodes remain separate coarse-tile regions.
+    """
+
+    digest = hashlib.sha256(scope_id.encode("utf-8")).digest()
+    # Reserve the high bit of the positive 63-bit space so compiler IDs cannot
+    # collide with the small monotonically increasing user-hint IDs.
+    hint_id = (int.from_bytes(digest[:8], "big") & ((1 << 62) - 1)) | (1 << 62)
+    return torch.fx.traceback.annotate({f"_hint_{hint_id}": kwargs})
 
 
 def get_op_hints(op: Operation) -> dict[int, dict[str, Any]]:

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -63,6 +63,7 @@ from .constants import (
     REDUCTIONS_NON_STICK_DIM_ONLY,
     STAGGERED_EAS,
     TOPK_OPS,
+    PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY,
 )
 from .ir import (
     AllReduceAsyncFallback,
@@ -111,6 +112,15 @@ class PropArg(NamedTuple):
     dep: MemoryDep
     layout: FixedLayout
     layouts: list[SpyreTensorLayout]
+
+
+def _is_graph_input(name: str) -> bool:
+    source = V.graph.get_buffer(name)
+    if isinstance(source, TensorBox):
+        source = source.data
+    if isinstance(source, StorageBox):
+        source = source.data
+    return isinstance(source, InputBuffer)
 
 
 def _get_prop_args(reads) -> list[PropArg]:
@@ -1096,9 +1106,31 @@ def _multi_arg_pointwise_layouts(
     stick_size = get_elem_in_stick(out_dtype_for_layout)
     c_size = [concretize_expr(s) for s in output.size]
     c_stride = [concretize_expr(s) for s in output.stride]
+    op_info = getattr(op.data, "op_info", None) or {}
+    persistent_route_deps = tuple(
+        arg.dep
+        for arg in args
+        if op_info.get(PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY) == "routing_weight"
+        and _is_graph_input(arg.dep.name)
+    )
+    if op_info.get(PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY) == "routing_weight" and (
+        len(persistent_route_deps) != 1
+    ):
+        raise Unsupported(
+            f"{op.get_name()}: expected exactly one graph-input routing operand"
+        )
 
     def _is_supported_layout(dim_order):
         for arg in args:
+            if arg.dep in persistent_route_deps:
+                if not any(
+                    (coord := try_device_coordinates(stl, arg.dep, ind_sizes))
+                    is not None
+                    and is_stick_expr_offset_free(coord[-1], stick_size)
+                    for stl in arg.layouts
+                ):
+                    return False
+                continue
             # Project output dim_order to input, dropping leading dims missing due to broadcast.
             rank_diff = len(output.size) - len(arg.layout.size)
             projected_dim_order = [d - rank_diff for d in dim_order if d >= rank_diff]

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -129,7 +129,7 @@ def _loop_group_id(node: BaseSchedulerNode):
         if isinstance(snode, SchedulerNode) and snode.node is not None:
             loop_info = getattr(snode.node, "loop_info", None)
             if loop_info is not None:
-                return loop_info.loop_group_id
+                return loop_info.loop_group_id or None
     return None
 
 

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -52,6 +52,7 @@ from .scratchpad.lx_relayout import work_division_from_view
 from .pass_utils import (
     concretize_expr,
     concretize_index,
+    coeff_through_floor,
     compute_symbolic_bounds,
     finite_upper_or_none,
     apply_splits_from_index_coeff,
@@ -75,6 +76,28 @@ from torch_spyre._inductor.provenance import build_debug_handle
 import logging
 
 logger = get_inductor_logger("spyre_kernel")
+
+
+@dataclass(frozen=True)
+class LoopOperandBinding:
+    """Resolved per-iteration address change for one counted-loop operand."""
+
+    kind: str
+    device_element_offset: sympy.Expr
+
+    def __post_init__(self) -> None:
+        if self.kind != "sequential_affine":
+            raise Unsupported(f"unknown loop operand binding kind {self.kind!r}")
+
+
+def _tensor_args_advance_by_symbol(
+    args: Sequence["TensorArg"], symbol: sympy.Symbol
+) -> bool:
+    return any(
+        arg.device_tile_advance_expr is not None
+        and coeff_through_floor(arg.device_tile_advance_expr, symbol) != 0
+        for arg in args
+    )
 
 
 class RValue(ABC):
@@ -590,7 +613,7 @@ class SpyreKernel(Kernel[CSEVariable]):
         return self._tile_advance_symbols[level_idx]
 
     @staticmethod
-    def _host_dim_to_index_symbol(ir_node: Any, dim: int) -> sympy.Symbol:
+    def _host_dim_to_index_symbol(ir_node: Any, dim: int) -> sympy.Symbol | None:
         """Map a host-range positional dim index to its dep.index d{i} symbol.
 
         CoarseTileInfo.tiled_dims_per_read/output_tiled_dims store *host-range*
@@ -637,9 +660,13 @@ class SpyreKernel(Kernel[CSEVariable]):
                             break
                         red_it_idx += 1
         if mapped is None:
-            # Fallback: identity mapping (no unit dims to skip, or ir_node
-            # lacks a `data` attribute -- e.g. in unit tests using bare
-            # fixtures).
+            if hasattr(ir_node, "data") and hasattr(ir_node.data, "ranges"):
+                # A known unit output/reduction dimension has no iteration
+                # symbol. Returning d{dim} here can alias the next surviving
+                # dimension after squeeze and manufacture a false binding
+                # conflict.
+                return None
+            # Bare unit-test fixtures have no range information to squeeze.
             mapped = dim
         return sympy_index_symbol(f"d{mapped}")
 
@@ -677,6 +704,7 @@ class SpyreKernel(Kernel[CSEVariable]):
 
         op_name = ir_node.get_operation_name()
         squeezed_advance_per_level: list[list[tuple[sympy.Expr, sympy.Expr]]] = []
+        preserved_per_level: tuple[sympy.Expr, ...] = ()
 
         if is_input:
             read_deps = [
@@ -705,6 +733,16 @@ class SpyreKernel(Kernel[CSEVariable]):
             )
             if squeezed_advance_per_read and dep_idx < len(squeezed_advance_per_read):
                 squeezed_advance_per_level = squeezed_advance_per_read[dep_idx]
+            binding = (
+                loop_info.loop_operand_bindings[dep_idx]
+                if dep_idx < len(loop_info.loop_operand_bindings)
+                else None
+            )
+            preserved_per_level = (
+                binding.host_advance_per_level if binding is not None else ()
+            )
+            if binding is not None and binding.kind != "sequential_affine":
+                raise Unsupported(f"unknown loop operand binding kind {binding.kind!r}")
         else:
             write_deps = [
                 dep
@@ -719,32 +757,77 @@ class SpyreKernel(Kernel[CSEVariable]):
                 getattr(loop_info, "squeezed_advance_output", None) or []
             )
 
-        if not per_level_dims and not any(squeezed_advance_per_level):
+        if (
+            not per_level_dims
+            and not any(squeezed_advance_per_level)
+            and not any(preserved_per_level)
+        ):
             return None
 
         device_size = tensor.layout.device_layout.device_size
         stride_map = tensor.layout.device_layout.stride_map
 
         total_device_expr: "sympy.Expr | None" = None
-        n_levels = max(len(per_level_dims), len(squeezed_advance_per_level))
+        n_levels = max(
+            len(per_level_dims),
+            len(squeezed_advance_per_level),
+            len(preserved_per_level),
+        )
         for level_idx in range(n_levels):
-            dim_extent_pairs = (
+            planned_dim_extent_pairs = (
                 per_level_dims[level_idx] if level_idx < len(per_level_dims) else []
             )
+            # Planning records host dimensions before division.  Once a
+            # dimension is divided to one, Inductor may squeeze its symbol
+            # from the final dependency.  In that case the explicit binding,
+            # not the stale planned dimension, owns the address advance.
+            dim_extent_pairs = []
+            for dim, extent in planned_dim_extent_pairs:
+                index_symbol = self._host_dim_to_index_symbol(ir_node, dim)
+                if index_symbol is not None and index_symbol in dep.index.free_symbols:
+                    dim_extent_pairs.append((dim, extent))
             squeezed_pairs = (
                 squeezed_advance_per_level[level_idx]
                 if level_idx < len(squeezed_advance_per_level)
                 else []
             )
-            if not dim_extent_pairs and not squeezed_pairs:
+            # A typed binding is authoritative when division squeezed every
+            # tiled dim from this read.  Otherwise retain the ordinary
+            # per-dim and squeezed-dim machinery, which may represent a mix
+            # of surviving and squeezed dimensions at the same level.
+            requested_preserved_advance = (
+                preserved_per_level[level_idx]
+                if level_idx < len(preserved_per_level)
+                and preserved_per_level[level_idx] != 0
+                else sympy.Integer(0)
+            )
+            if dim_extent_pairs and requested_preserved_advance != 0:
+                raise Unsupported(
+                    "loop operand binding conflicts with surviving tiled dimensions "
+                    f"for {op_name} at loop level {level_idx}: "
+                    f"dims={dim_extent_pairs}, dep_index={dep.index}"
+                )
+            preserved_host_advance = (
+                requested_preserved_advance
+                if not dim_extent_pairs
+                else sympy.Integer(0)
+            )
+            if preserved_host_advance != 0:
+                squeezed_pairs = []
+            if (
+                not dim_extent_pairs
+                and not squeezed_pairs
+                and preserved_host_advance == 0
+            ):
                 continue
             level_symbol = self._get_or_mint_level_symbol(level_idx, op_name)
             host_expr = sympy.S.Zero
             if dim_extent_pairs:
-                tiled_dim_extents = {
-                    self._host_dim_to_index_symbol(ir_node, d): extent * level_symbol
-                    for d, extent in dim_extent_pairs
-                }
+                tiled_dim_extents = {}
+                for d, extent in dim_extent_pairs:
+                    index_symbol = self._host_dim_to_index_symbol(ir_node, d)
+                    assert index_symbol is not None
+                    tiled_dim_extents[index_symbol] = extent * level_symbol
                 subs = dict(tiled_dim_extents)
                 subs.update(
                     {
@@ -756,6 +839,8 @@ class SpyreKernel(Kernel[CSEVariable]):
                 host_expr += dep.index.subs(subs)
             for host_stride, extent in squeezed_pairs:
                 host_expr += level_symbol * extent * host_stride
+            if preserved_host_advance != 0:
+                host_expr += preserved_host_advance * level_symbol
             device_expr = tiling_expr_to_device_expr(device_size, stride_map, host_expr)
             total_device_expr = (
                 device_expr
@@ -764,6 +849,14 @@ class SpyreKernel(Kernel[CSEVariable]):
             )
 
         return total_device_expr
+
+    def _resolve_loop_operand_binding(
+        self, tensor: TensorAccess, is_input: bool, name: str
+    ) -> "LoopOperandBinding | None":
+        device_offset = self._general_tile_advance(tensor, is_input, name)
+        if device_offset is None:
+            return None
+        return LoopOperandBinding("sequential_affine", device_offset)
 
     def create_tensor_arg(
         self,
@@ -808,7 +901,9 @@ class SpyreKernel(Kernel[CSEVariable]):
             device_coords,
             tuple(it_space),
         )
-        device_tile_advance_expr = self._general_tile_advance(tensor, is_input, name)
+        loop_operand_binding = self._resolve_loop_operand_binding(
+            tensor, is_input, name
+        )
         tensor_arg = TensorArg(
             is_input,
             -1,
@@ -818,7 +913,11 @@ class SpyreKernel(Kernel[CSEVariable]):
             tensor.layout.allocation,
             element_arrangement=tensor.layout.device_layout.element_arrangement,
             name=opspec_name,
-            device_tile_advance_expr=device_tile_advance_expr,
+            device_tile_advance_expr=(
+                loop_operand_binding.device_element_offset
+                if loop_operand_binding is not None
+                else None
+            ),
             work_division=work_division,
         )
         if (
@@ -897,13 +996,16 @@ class SpyreKernel(Kernel[CSEVariable]):
         # nesting level), so max() is just a safety net; in practice both
         # lists have the same length and the per-level loop below never
         # silently drops an entry from the shorter one.
-        n_levels = max(len(raw_tiled_dims), len(raw_tiled_red_dims))
+        loop_count = li.loop_count if li is not None else []
+        n_levels = max(
+            len(raw_tiled_dims),
+            len(raw_tiled_red_dims),
+            len(loop_count),
+        )
 
         tiled_symbol_trip_counts: dict = {}
         tiled_syms: list[list] = []
         if n_levels > 0:
-            loop_count = li.loop_count if li is not None else []
-
             op_name = ir_node.get_operation_name()
             tiled_syms_per_level_outermost: list[list] = []
             for lvl in range(n_levels):
@@ -911,10 +1013,24 @@ class SpyreKernel(Kernel[CSEVariable]):
                 has_any_tiled_dim = (
                     lvl < len(raw_tiled_dims) and raw_tiled_dims[lvl]
                 ) or (lvl < len(raw_tiled_red_dims) and raw_tiled_red_dims[lvl])
-                if has_any_tiled_dim:
-                    level_syms.append(self._get_or_mint_level_symbol(lvl, op_name))
+                minted_level_symbol = self._tile_advance_symbols.get(lvl)
+                has_arg_advance = (
+                    minted_level_symbol is not None
+                    and _tensor_args_advance_by_symbol(args, minted_level_symbol)
+                )
+                if has_any_tiled_dim or has_arg_advance:
+                    level_syms.append(
+                        minted_level_symbol
+                        if minted_level_symbol is not None
+                        else self._get_or_mint_level_symbol(lvl, op_name)
+                    )
                 tiled_syms_per_level_outermost.append(level_syms)
-                if lvl < len(loop_count):
+                if level_syms:
+                    if lvl >= len(loop_count):
+                        raise Unsupported(
+                            "coarse-tile symbol has no enclosing loop trip count: "
+                            f"op={op_name!r}, level={lvl}, symbols={level_syms}"
+                        )
                     trip_count = int(loop_count[lvl])
                     for sym in level_syms:
                         tiled_symbol_trip_counts[sym] = trip_count

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -91,10 +91,12 @@ from torch.utils._ordered_set import OrderedSet
 from torch_spyre._C import SpyreTensorLayout
 
 from .. import config
-from ..constants import BATCH_MATMUL_OP
+from ..constants import BATCH_MATMUL_OP, PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY
 from ..errors import Unsupported
 from ..logging_utils import get_inductor_logger
 from ..loop_info import (
+    CountedLoopPlan,
+    LoopOperandBindingRequirement,
     CoarseTileInfo,
     PropagationPlan,
     ReadCopyEntry,
@@ -103,10 +105,75 @@ from ..loop_info import (
     copy_op_metadata,
 )
 from ..pass_utils import op_out_coords, host_coordinates, indirect_sizes_from_op
+from ..propagate_hints import get_op_hints
 from ..ir import FixedTiledLayout, SpyreConstantFallback, _resize_device_layout
 from .tile import compute_tile_index, compute_tile_stride
 
 logger = get_inductor_logger("coarse_tile")
+
+
+_PERSISTENT_EXPERT_HINT = "persistent_dense_expert"
+_PERSISTENT_STREAMED_ROLES = {
+    "gate_weight",
+    "up_weight",
+    "down_weight",
+    "routing_weight",
+}
+
+
+def _streamed_operand_role(op: ComputedBuffer) -> str | None:
+    op_info = getattr(op.data, "op_info", None) or {}
+    marked = op_info.get(PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY)
+    hinted = {
+        hint["streamed_operand_role"]
+        for hint in get_op_hints(op).values()
+        if "streamed_operand_role" in hint
+    }
+    roles = ({marked} if isinstance(marked, str) else set()) | hinted
+    if not roles:
+        return None
+    if len(roles) != 1 or not roles <= _PERSISTENT_STREAMED_ROLES:
+        raise Unsupported(f"invalid persistent streamed operand roles: {roles}")
+    return next(iter(roles))
+
+
+def _is_graph_input(name: str) -> bool:
+    source = V.graph.get_buffer(name)
+    if isinstance(source, TensorBox):
+        source = source.data
+    if isinstance(source, StorageBox):
+        source = source.data
+    return isinstance(source, InputBuffer)
+
+
+def _outer_loop_key(op: Operation) -> int | None:
+    group_id = getattr(getattr(op, "loop_info", None), "loop_group_id", ())
+    return group_id[0] if group_id else None
+
+
+def _counted_loop_plan_for_group(
+    group_ops: list[Operation], levels: list[tuple[int, int]]
+) -> CountedLoopPlan | None:
+    """Read the compiler-owned loop marker attached by the internal lowering."""
+
+    level_ids = {hint_id for hint_id, _count in levels}
+    markers = {
+        hint["expert_execution"]
+        for op in group_ops
+        if isinstance(op, ComputedBuffer)
+        for hint_id, hint in get_op_hints(op).items()
+        if hint_id in level_ids and "expert_execution" in hint
+    }
+    if not markers:
+        return None
+    if markers != {_PERSISTENT_EXPERT_HINT} or len(levels) != 1:
+        raise Unsupported(
+            "persistent expert execution requires one statically counted loop"
+        )
+    return CountedLoopPlan(
+        kind="persistent_dense_expert",
+        trip_count=int(levels[0][1]),
+    )
 
 
 class _RetiledBufferInfo(NamedTuple):
@@ -225,6 +292,7 @@ def plan_coarse_tile_groups(
     """
     plan: dict[int, CoarseTileInfo] = {}
     for group_idx, (group_ops, levels) in enumerate(groups):
+        counted_loop_plan = _counted_loop_plan_for_group(group_ops, levels)
         group_id: tuple[int, ...] = (group_idx,)
         nested_group_id: tuple[int, ...] = group_id + (0,) * (len(levels) - 1)
         counts = [count for _, count in levels]
@@ -300,6 +368,37 @@ def plan_coarse_tile_groups(
             tiled_dims_per_read = [
                 _tiled_dims_for_dep(dep, per_level_extents) for dep in read_deps
             ]
+            loop_operand_bindings: list[LoopOperandBindingRequirement | None]
+            if counted_loop_plan is None:
+                loop_operand_bindings = [None for _ in read_deps]
+            else:
+                loop_operand_bindings = []
+                streamed_role = _streamed_operand_role(op)
+                for dep in read_deps:
+                    per_dim = _host_tile_advances_for_dep(dep, per_level_extents)
+                    per_level = tuple(
+                        sum(
+                            (sympy.sympify(advance) for _dim, advance in level),
+                            sympy.Integer(0),
+                        )
+                        for level in per_dim
+                    )
+                    has_advance = any(per_level)
+                    is_named_stream = (
+                        streamed_role is not None
+                        and has_advance
+                        and _is_graph_input(dep.name)
+                    )
+                    loop_operand_bindings.append(
+                        LoopOperandBindingRequirement(
+                            kind="sequential_affine",
+                            host_advance_per_level=per_level,
+                            operand_role=streamed_role,
+                            source_name=dep.name,
+                        )
+                        if is_named_stream
+                        else None
+                    )
             output_tiled_dims = (
                 _tiled_dims_for_dep(write_deps[0], per_level_extents)
                 if write_deps
@@ -312,7 +411,9 @@ def plan_coarse_tile_groups(
                 loop_tiled_dims=op_tiled_dims,
                 loop_tiled_reduction_dims=op_tiled_reduction_dims,
                 tiled_dims_per_read=tiled_dims_per_read,
+                loop_operand_bindings=loop_operand_bindings,
                 output_tiled_dims=output_tiled_dims,
+                counted_loop_plan=counted_loop_plan,
             )
 
             logger.debug(
@@ -902,6 +1003,36 @@ def _tiled_dims_for_dep(
         [(d, extent) for d, extent in level.items() if d in dep_dims]
         for level in per_level_extents
     ]
+
+
+def _host_tile_advances_for_dep(
+    dep: MemoryDep,
+    per_level_extents: list[dict[int, Expr]],
+) -> list[list[tuple[int, Expr]]]:
+    """Preserve each tiled dim's flat host-element advance before division.
+
+    This is deliberately parallel to ``_tiled_dims_for_dep`` and is not the
+    normal tile-advance path.  It only supplies the information that cannot
+    be reconstructed later when division turns a tiled dim into size one and
+    Inductor squeezes its symbol from the final MemoryDep.  Evaluate one dim
+    at a time (all other symbols zero) and subtract the all-zero offset so a
+    constant/window offset is not mistaken for a per-iteration advance.
+    """
+    zero_subs = {sym: sympy.Integer(0) for sym in dep.index.free_symbols}
+    zero_offset = dep.index.subs(zero_subs)
+    result: list[list[tuple[int, Expr]]] = []
+    for level in per_level_extents:
+        level_advances: list[tuple[int, Expr]] = []
+        for dim, extent in level.items():
+            dim_symbol = sympy_index_symbol(f"d{dim}")
+            if dim_symbol not in dep.index.free_symbols:
+                continue
+            subs = dict(zero_subs)
+            subs[dim_symbol] = extent
+            advance = sympy.simplify(dep.index.subs(subs) - zero_offset)
+            level_advances.append((dim, advance))
+        result.append(level_advances)
+    return result
 
 
 def _stick_host_dim(op: ComputedBuffer, device_layout) -> int | None:
@@ -1856,9 +1987,7 @@ def _propagate_tiled_op(
     group_start_idx = next(
         i
         for i, o in enumerate(operations)
-        if isinstance(o, ComputedBuffer)
-        and getattr(getattr(o, "loop_info", None), "loop_group_id", (None,))[0]
-        == outer_key
+        if isinstance(o, ComputedBuffer) and _outer_loop_key(o) == outer_key
     )
     full_buf = _allocate_full_buffer(
         op, full_ranges, full_strides, operations, group_start_idx
@@ -2478,7 +2607,9 @@ def _insert_one_read_copy(
     copy_name: str,
     operations: list[Operation],
     insert_before_op: Operation,
-) -> str:
+    planned_dep_levels: tuple[tuple[tuple[int, Expr], ...], ...] | None = None,
+    binding_requirement: LoopOperandBindingRequirement | None = None,
+) -> tuple[str, list[Expr]]:
     """Build and insert one tile-sized copy op for a single full-buffer read.
 
     sizing_op reads (or is the first of a group of ops that all read) a
@@ -2514,8 +2645,9 @@ def _insert_one_read_copy(
     sizing_op (which only supplies loop_info/ranges/origins here and may
     coincide with insert_before_op but is not guaranteed to by contract).
 
-    Returns the inserted copy buffer's name (copy_buf.get_name()) -- callers
-    patch consumers separately via _patch_consumer_to_read_copy.
+    Returns the inserted copy buffer's name and the full dependency-position
+    stride vector used to patch consumers. The latter is returned as data,
+    rather than smuggled through a private buffer attribute.
     """
     insert_idx = operations.index(insert_before_op)
     full_buf = V.graph.get_buffer(dep.name)
@@ -2529,8 +2661,10 @@ def _insert_one_read_copy(
         full_buf = full_buf.data
     if isinstance(full_buf, StorageBox):
         full_buf = full_buf.data
+    sizing_loop_info = sizing_op.loop_info  # type: ignore[attr-defined]
+    persistent_copy = sizing_loop_info.counted_loop_plan is not None
 
-    tile_ranges = list(dep.size)
+    dep_ranges = list(dep.size)
     # Derive copy buffer strides using compute_tile_stride.
     # dep.size is the full loop iteration space (output + reduction dims) and
     # may have higher rank than the tensor (e.g. for a Reduction reading
@@ -2544,25 +2678,49 @@ def _insert_one_read_copy(
     # broadcast/absent (e.g. the N dim in a Reduction reading a[M,K]).
     active_idx = [i for i, c in enumerate(full_coeff) if c != 0]
 
+    tile_ranges: list[Expr]
     tile_strides: list[Expr]
+    dep_tile_strides: list[Expr] = [sympy.Integer(0)] * len(dep_ranges)
+    compact_dep_positions: list[int]
     if not active_idx:
+        # Preserve the existing scalar/all-broadcast representation. Persistent
+        # expert operands all have active dims; this protects legacy scalars.
+        tile_ranges = dep_ranges
         tile_strides = [sympy.Integer(0)] * len(tile_ranges)
-    else:
+        compact_dep_positions = list(range(len(dep_ranges)))
+    elif persistent_copy:
         active_full_sizes = [dep.size[i] for i in active_idx]
         active_full_strides = [full_coeff[i] for i in active_idx]
-        active_tile_ranges = [tile_ranges[i] for i in active_idx]
-        active_tile_strides = compute_tile_stride(
-            active_full_sizes, active_full_strides, active_tile_ranges
+        tile_ranges = [dep_ranges[i] for i in active_idx]
+        tile_strides = compute_tile_stride(
+            active_full_sizes, active_full_strides, tile_ranges
         )
-        # active_tile_strides[i] corresponds to active_idx[i]: both are indexed
-        # by position in the compressed active-dims space, so zip pairs each
-        # full dep.var_names position with its computed tile stride correctly.
+        compact_dep_positions = active_idx
+        for dep_pos, stride in zip(active_idx, tile_strides):
+            dep_tile_strides[dep_pos] = stride
+    else:
+        # Preserve the existing full-rank copy representation for every graph
+        # without an explicit persistent expert plan.
+        tile_ranges = dep_ranges
+        active_tile_strides = compute_tile_stride(
+            [dep.size[i] for i in active_idx],
+            [full_coeff[i] for i in active_idx],
+            [tile_ranges[i] for i in active_idx],
+        )
         tile_strides = [sympy.Integer(0)] * len(tile_ranges)
-        for pos, ts in zip(active_idx, active_tile_strides):
-            tile_strides[pos] = ts
+        for dep_pos, stride in zip(active_idx, active_tile_strides):
+            tile_strides[dep_pos] = stride
+        dep_tile_strides = list(tile_strides)
+        compact_dep_positions = list(range(len(dep_ranges)))
 
     def _copy_inner_fn(idx, _dep=dep, _full_name=full_buf.get_name()):
-        subs = dict(zip(_dep.var_names, idx))
+        # Pointwise iteration covers only dimensions the source dependency
+        # actually indexes.  Reduction output dimensions broadcast by this
+        # operand (e.g. N for X[M,K] in matmul) are not physical copy-buffer
+        # dimensions and must not inflate [Ttile,H] into [Ttile,F,H].
+        subs = {var: sympy.Integer(0) for var in _dep.var_names}
+        for compact_pos, dep_pos in enumerate(compact_dep_positions):
+            subs[_dep.var_names[dep_pos]] = idx[compact_pos]
         flat_index = sympy_subs(_dep.index, subs)
         return V.ops.load(_full_name, flat_index)
 
@@ -2756,7 +2914,6 @@ def _insert_one_read_copy(
     copy_buf.origins = sizing_op.origins
     copy_buf.operation_name = copy_name
     copy_op_metadata(sizing_op, copy_buf)
-
     # Fresh per-level tiled-dim decisions for copy_buf's own read/write —
     # mirroring _insert_copy_op's read/write split (see its comment), but
     # with the roles swapped: there, the copy's READ (of sizing_op's
@@ -2777,7 +2934,14 @@ def _insert_one_read_copy(
     # full_buf and of copy_buf's own output) via
     # SpyreKernel._general_tile_advance's positional dep-index lookup —
     # a semantic mismatch, not merely a magnitude one.
-    sizing_op_info = sizing_op.loop_info  # type: ignore[attr-defined]
+    sizing_op_info = sizing_loop_info
+    # ``tiled_dims_per_read`` was planned before range division, so it is
+    # the authoritative record of which loop levels this particular source
+    # read actually advances at.  Keep that record: post-division
+    # ``MemoryDep`` extraction squeezes unit dimensions, which is exactly
+    # what happens to the expert dimension when an E=2 expert loop is tiled
+    # down to one expert per iteration.  The shared activation is invariant
+    # at that inner level even though the consuming BMM is not.
     copy_ranges = list(copy_data.ranges)
     # sizing_op_info.loop_tiled_dims's dim keys are raw positional indices
     # into sizing_op.data.ranges (see CoarseTileInfo's docstring), which
@@ -2802,10 +2966,41 @@ def _insert_one_read_copy(
     squeezed_advance: list[list[tuple[Expr, Expr]]] = [
         [] for _ in sizing_op_info.loop_tiled_dims
     ]
+
+    def _require_unit_dim_advance(level_idx: int, dim: int) -> None:
+        if binding_requirement is None:
+            raise Unsupported(
+                f"coarse_tile: read copy of {dep.name!r} for "
+                f"{sizing_op.get_name()!r} needs the pre-division base stride "
+                f"for squeezed tiled dim {dim}, but no planning-time host "
+                "binding was planned"
+            )
+        if (
+            binding_requirement.kind != "sequential_affine"
+            or level_idx >= len(binding_requirement.host_advance_per_level)
+            or binding_requirement.host_advance_per_level[level_idx] == 0
+        ):
+            raise Unsupported(
+                f"coarse_tile: read copy of {dep.name!r} for "
+                f"{sizing_op.get_name()!r} advances along squeezed tiled dim "
+                f"{dim}, but its sequential-affine binding is missing"
+            )
+
     for d in {d for level in sizing_op_info.loop_tiled_dims for d in level}:
         levels_tiling_d = [
             i for i, dims in enumerate(sizing_op_info.loop_tiled_dims) if d in dims
         ]
+        if planned_dep_levels is not None:
+            levels_tiling_d = [
+                level_idx
+                for level_idx in levels_tiling_d
+                if any(
+                    planned_dim == d
+                    for planned_dim, _extent in planned_dep_levels[level_idx]
+                )
+            ]
+        if not levels_tiling_d:
+            continue
         if d not in squeeze_pos:
             # sizing_op.data.ranges[d] == 1 for this tiled dim (e.g. a
             # B-tiled group where the per-tile B extent is 1) -- it was
@@ -2831,17 +3026,44 @@ def _insert_one_read_copy(
             # stride_map-based dimension selection cannot be compared
             # against (see _insert_copy_op's write-side analogue for the
             # collision this caused when the two happened to diverge).
-            host_stride = sympy.prod(sizing_op.data.ranges[d + 1 :])
-            running = sympy.Integer(1)
-            for level_idx in reversed(levels_tiling_d):
-                squeezed_advance[level_idx].append((host_stride, running))
-                running = running * sizing_op_info.loop_count[level_idx]
+            if persistent_copy:
+                for level_idx in levels_tiling_d:
+                    _require_unit_dim_advance(level_idx, d)
+            else:
+                host_stride = sympy.prod(sizing_op.data.ranges[d + 1 :])
+                running = sympy.Integer(1)
+                for level_idx in reversed(levels_tiling_d):
+                    squeezed_advance[level_idx].append((host_stride, running))
+                    running = running * sizing_op_info.loop_count[level_idx]
             continue
         # The dict key must be a raw positional index into copy_buf's own
         # data.ranges (what SpyreKernel._host_dim_to_index_symbol will
         # later squeeze again when it runs against copy_buf) -- i.e. the
         # squeezed position computed above, not sizing_op's raw d.
-        copy_dim = squeeze_pos[d]
+        dep_dim = squeeze_pos.get(d)
+        copy_dim = (
+            compact_dep_positions.index(dep_dim)
+            if dep_dim in compact_dep_positions
+            else None
+        )
+        if copy_dim is None:
+            # A unit post-division dimension disappears from dep.size.  It
+            # is safe to omit only when planning already proved this source
+            # read invariant at every level tiling that dimension (the
+            # shared-LHS activation's expert dimension).  If the source read
+            # itself advances there (an expert weight bank), silently
+            # dropping it would reload expert zero on every iteration; that
+            # needs a separate preserved-base-stride mechanism.
+            if planned_dep_levels is None:
+                _require_unit_dim_advance(levels_tiling_d[-1], d)
+            else:
+                for level_idx in levels_tiling_d:
+                    if any(
+                        planned_dim == d
+                        for planned_dim, _extent in planned_dep_levels[level_idx]
+                    ):
+                        _require_unit_dim_advance(level_idx, d)
+            continue
         running = sympy.sympify(copy_ranges[copy_dim])
         for level_idx in reversed(levels_tiling_d):
             read_level_extents[level_idx][copy_dim] = running
@@ -2859,7 +3081,41 @@ def _insert_one_read_copy(
             for i, dims in enumerate(sizing_op_info.loop_tiled_reduction_dims)
             if d in dims
         ]
-        copy_dim_key = it_idx + reduction_squeeze_pos[d]
+        planned_dim_key = len(sizing_op.data.ranges) + d
+        if planned_dep_levels is not None:
+            levels_tiling_d = [
+                level_idx
+                for level_idx in levels_tiling_d
+                if any(
+                    planned_dim == planned_dim_key
+                    for planned_dim, _extent in planned_dep_levels[level_idx]
+                )
+            ]
+        if not levels_tiling_d:
+            continue
+        reduction_copy_dim = reduction_squeeze_pos.get(d)
+        if reduction_copy_dim is None:
+            if planned_dep_levels is None:
+                _require_unit_dim_advance(levels_tiling_d[-1], planned_dim_key)
+            else:
+                for level_idx in levels_tiling_d:
+                    if any(
+                        planned_dim == planned_dim_key
+                        for planned_dim, _extent in planned_dep_levels[level_idx]
+                    ):
+                        _require_unit_dim_advance(level_idx, planned_dim_key)
+            continue
+        dep_dim_key = it_idx + reduction_copy_dim
+        copy_dim_key = (
+            compact_dep_positions.index(dep_dim_key)
+            if dep_dim_key in compact_dep_positions
+            else None
+        )
+        if copy_dim_key is None:
+            raise Unsupported(
+                f"coarse_tile: tiled reduction dim {d} of read {dep.name!r} "
+                "has no active compact copy-buffer dimension"
+            )
         running = sympy.sympify(copy_ranges[copy_dim_key])
         for level_idx in reversed(levels_tiling_d):
             read_level_extents[level_idx][copy_dim_key] = running
@@ -2876,6 +3132,36 @@ def _insert_one_read_copy(
     output_tiled_dims = (
         _tiled_dims_for_dep(copy_writes[0], write_level_extents) if copy_writes else []
     )
+    # A copy-in follows the source read, not the consuming op's output.  In
+    # particular, a shared-LHS BMM has an inner expert loop while its 2-D X
+    # operand is invariant there.  Give the copy only the source-dependent
+    # loop prefix: it is emitted once immediately before the first nested
+    # level at which the source stops advancing.  Scheduler nesting then
+    # produces ``outer { copy X; inner expert { ... } }`` rather than
+    # reloading X in every expert iteration.
+    if planned_dep_levels is None:
+        # Legacy/hand-built CoarseTileInfo (including older unit fixtures)
+        # has no per-read planning record. Preserve the prior behavior and
+        # keep the copy in the full consumer nest. Unit-dim hoisting remains
+        # fail-closed above because invariance cannot be proven without the
+        # planning record.
+        loop_depth = len(sizing_op_info.loop_count)
+    else:
+        active_levels = [i for i, level in enumerate(planned_dep_levels) if level]
+        loop_depth = max(active_levels) + 1 if active_levels else 0
+    copy_loop_tiled_dims = [
+        sorted(level_extents) for level_extents in read_level_extents[:loop_depth]
+    ]
+    copy_binding_requirement = (
+        dataclasses.replace(
+            binding_requirement,
+            host_advance_per_level=binding_requirement.host_advance_per_level[
+                :loop_depth
+            ],
+        )
+        if binding_requirement is not None
+        else None
+    )
     # copy_buf is its own op, not sizing_op under another name -- it must
     # not inherit sizing_op_info.propagation. That plan was computed for
     # sizing_op's own boundary-crossing decision (kind may be "reduction"
@@ -2885,13 +3171,39 @@ def _insert_one_read_copy(
     # a "reduction"-kind plan leak onto this Pointwise passthrough buffer,
     # causing Pass 2 (_insert_all_reduction_ops) to misdispatch it into
     # _propagate_tiled_reduction_op.
-    copy_buf.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
-        sizing_op_info,
-        tiled_dims_per_read=tiled_dims_per_read,
-        output_tiled_dims=output_tiled_dims,
-        squeezed_advance_per_read=[squeezed_advance] if copy_reads else [],
-        propagation=PropagationPlan(kind="loop_internal"),
-    )
+    if loop_depth:
+        copy_buf.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
+            sizing_op_info,
+            loop_group_id=sizing_op_info.loop_group_id[:loop_depth],
+            loop_count=sizing_op_info.loop_count[:loop_depth],
+            loop_tiled_dims=copy_loop_tiled_dims,
+            loop_tiled_reduction_dims=[[] for _ in range(loop_depth)],
+            tiled_dims_per_read=[
+                per_level[:loop_depth] for per_level in tiled_dims_per_read
+            ],
+            squeezed_advance_per_read=(
+                [squeezed_advance[:loop_depth]] if copy_reads else []
+            ),
+            loop_operand_bindings=[copy_binding_requirement for _ in copy_reads],
+            output_tiled_dims=output_tiled_dims[:loop_depth],
+            propagation=PropagationPlan(kind="loop_internal"),
+        )
+    else:
+        # Keep typed ownership while using an empty scheduling path, so this
+        # operation remains a top-level preheader rather than entering the loop.
+        copy_buf.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
+            sizing_op_info,
+            loop_group_id=(),
+            loop_count=[],
+            loop_tiled_dims=[],
+            loop_tiled_reduction_dims=[],
+            tiled_dims_per_read=[[] for _ in copy_reads],
+            squeezed_advance_per_read=[[] for _ in copy_reads],
+            loop_operand_bindings=[None for _ in copy_reads],
+            output_tiled_dims=[],
+            preheader_for_group=sizing_op_info.loop_group_id,
+            propagation=PropagationPlan(kind="loop_internal"),
+        )
 
     V.graph.name_to_buffer[copy_name] = copy_buf
     operations.insert(insert_idx, copy_buf)
@@ -2901,7 +3213,7 @@ def _insert_one_read_copy(
         dep.name,
         copy_name,
     )
-    return copy_buf.get_name()
+    return copy_buf.get_name(), dep_tile_strides
 
 
 def _patch_consumer_to_read_copy(
@@ -2909,6 +3221,7 @@ def _patch_consumer_to_read_copy(
     dep: MemoryDep,
     copy_name: str,
     operations: list[Operation],
+    source_dep_tile_strides: list[Expr] | None = None,
 ) -> None:
     """Patch consumer's inner_fn to read copy_name instead of dep.name.
 
@@ -2955,7 +3268,11 @@ def _patch_consumer_to_read_copy(
         for op in operations
         if isinstance(op, ComputedBuffer) and op.get_name() == copy_name
     )
-    tile_strides = list(copy_buf.layout.stride)
+    tile_strides = list(
+        copy_buf.layout.stride
+        if source_dep_tile_strides is None
+        else source_dep_tile_strides
+    )
     tile_strides.extend(
         sympy.Integer(0) for _ in range(len(full_strides) - len(tile_strides))
     )
@@ -3018,8 +3335,17 @@ def _patch_consumer_to_read_copy(
             )
             for read_dep, per_level in zip(new_reads, new_loop_info.tiled_dims_per_read)
         ]
+        old_bindings = list(new_loop_info.loop_operand_bindings)
+        if len(old_bindings) < len(new_reads):
+            old_bindings.extend([None] * (len(new_reads) - len(old_bindings)))
+        new_bindings = [
+            None if read_dep.name == copy_name else binding
+            for read_dep, binding in zip(new_reads, old_bindings)
+        ]
         new_op.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
-            new_loop_info, tiled_dims_per_read=new_tiled_dims_per_read
+            new_loop_info,
+            tiled_dims_per_read=new_tiled_dims_per_read,
+            loop_operand_bindings=new_bindings,
         )
 
 
@@ -3084,6 +3410,82 @@ def _plan_read_copies(
             op_deps.sort(key=lambda pair: op_position[pair[0].get_operation_name()])
             sizing_op, sizing_dep = op_deps[0]
             sizing_info = sizing_op.loop_info  # type: ignore[attr-defined]
+            sizing_reads = [
+                dep
+                for dep in sizing_op.get_read_writes().reads
+                if isinstance(dep, MemoryDep)
+            ]
+            try:
+                sizing_dep_idx = sizing_reads.index(sizing_dep)
+            except ValueError as exc:
+                raise RuntimeError(
+                    f"_plan_read_copies: cannot match {sizing_dep!r} to a read "
+                    f"of sizing op {sizing_op.get_name()!r}"
+                ) from exc
+            planned_dep_levels = (
+                tuple(
+                    tuple((dim, extent) for dim, extent in level)
+                    for level in sizing_info.tiled_dims_per_read[sizing_dep_idx]
+                )
+                if sizing_info.counted_loop_plan is not None
+                and sizing_dep_idx < len(sizing_info.tiled_dims_per_read)
+                else None
+            )
+            binding_requirement = (
+                sizing_info.loop_operand_bindings[sizing_dep_idx]
+                if sizing_dep_idx < len(sizing_info.loop_operand_bindings)
+                else None
+            )
+            source = V.graph.get_buffer(sizing_dep.name)
+            if isinstance(source, TensorBox):
+                source = source.data
+            if isinstance(source, StorageBox):
+                source = source.data
+            op_info = getattr(sizing_op.data, "op_info", None) or {}
+            streamed_role = op_info.get(PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY)
+            direct_streamed_expert_weight = (
+                isinstance(source, InputBuffer)
+                and streamed_role in _PERSISTENT_STREAMED_ROLES
+                and planned_dep_levels is not None
+                and any(planned_dep_levels)
+                and binding_requirement is not None
+                and any(binding_requirement.host_advance_per_level)
+                and all(
+                    (getattr(op.data, "op_info", None) or {}).get(
+                        PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY
+                    )
+                    == streamed_role
+                    for op, _dep in op_deps
+                )
+            )
+            if direct_streamed_expert_weight:
+                # The marked operand already has the BMM kernel's selected
+                # layout. Keep the original HBM dependency on the
+                # consumer and let its preserved unit-expert host advance
+                # become the LoopSpec affine base update.  Inserting the
+                # ordinary tile copy here would add an HBM-to-HBM weight
+                # materialization on every expert iteration.
+                for consumer, consumer_dep in op_deps:
+                    consumer_reads = [
+                        dep
+                        for dep in consumer.get_read_writes().reads
+                        if isinstance(dep, MemoryDep)
+                    ]
+                    consumer_dep_idx = consumer_reads.index(consumer_dep)
+                    consumer_info = consumer.loop_info  # type: ignore[attr-defined]
+                    consumer_binding = (
+                        consumer_info.loop_operand_bindings[consumer_dep_idx]
+                        if consumer_dep_idx < len(consumer_info.loop_operand_bindings)
+                        else None
+                    )
+                    if consumer_binding is None or not any(
+                        consumer_binding.host_advance_per_level
+                    ):
+                        raise Unsupported(
+                            "coarse_tile: direct streamed expert weight has no "
+                            f"preserved loop advance for {consumer.get_name()!r}"
+                        )
+                continue
             for other_op, _dep in op_deps[1:]:
                 other_info = other_op.loop_info  # type: ignore[attr-defined]
                 # Only loop_count (the per-level trip counts) is a genuine
@@ -3123,6 +3525,8 @@ def _plan_read_copies(
                     consumer_op_names=tuple(
                         op.get_operation_name() for op, _dep in op_deps
                     ),
+                    planned_dep_levels=planned_dep_levels,
+                    binding_requirement=binding_requirement,
                 )
             )
         if entries:
@@ -3154,17 +3558,23 @@ def _insert_all_read_copy_ops(
             }
             sizing_op = name_to_op[entry.sizing_op_name]
             insert_before_op = name_to_op[entry.insert_before_op_name]
-            new_copy_name = _insert_one_read_copy(
+            new_copy_name, source_dep_tile_strides = _insert_one_read_copy(
                 sizing_op,
                 entry.dep,
                 entry.copy_name,
                 operations,
                 insert_before_op=insert_before_op,
+                planned_dep_levels=entry.planned_dep_levels,
+                binding_requirement=entry.binding_requirement,
             )
             for consumer_name in entry.consumer_op_names:
                 consumer = name_to_op[consumer_name]
                 _patch_consumer_to_read_copy(
-                    consumer, entry.dep, new_copy_name, operations
+                    consumer,
+                    entry.dep,
+                    new_copy_name,
+                    operations,
+                    source_dep_tile_strides,
                 )
 
 
@@ -3476,9 +3886,7 @@ def _propagate_tiled_reduction_op(
     group_start_idx = next(
         i
         for i, o in enumerate(operations)
-        if isinstance(o, ComputedBuffer)
-        and getattr(getattr(o, "loop_info", None), "loop_group_id", (None,))[0]
-        == outer_key
+        if isinstance(o, ComputedBuffer) and _outer_loop_key(o) == outer_key
     )
 
     fill_loop_info = reduction_plan.outer_fill_loop_info
@@ -3655,8 +4063,7 @@ def _propagate_tiled_reduction_op(
         if isinstance(o, ComputedBuffer)
         and o.get_name() not in (combine_name, copy_name)
         and _reads_buffer(o, buf_name)
-        and getattr(getattr(o, "loop_info", None), "loop_group_id", (None,))[0]
-        == outer_key
+        and _outer_loop_key(o) == outer_key
         and (
             is_nested
             or getattr(getattr(o, "loop_info", None), "loop_tiled_dims", None)


### PR DESCRIPTION
# Form persistent expert loops with advancing operands

Tracking: #3565

Local head: `ah/dense_expert_persistent_loop` at `a28991d4`

Base: Unit 0 (`ah/dense_expert_persistent`) at `1a3459b5`

Depends on draft PR #3807. Because this cross-fork draft targets `main`, its displayed diff temporarily includes Unit 0 until #3807 merges.

## Dependency order

1. Unit 0 defines the operation and source-level planning records.
2. Unit A (this draft) prototypes the counted device loop and advancing operands.
3. Unit B is draft PR #3816; later units add compatible work division and end-to-end enablement.

## Purpose

Prototype the compiler pieces needed to turn persistent dense expert execution into one counted device loop whose body is compiled once and reused for every expert.

## What this PR implements

- Typed counted-loop and streamed-operand records.
- Coarse-tiling support for a single expert loop.
- One compact X read staged before the loop.
- Gate, up, down, and routing operands that advance to the next expert on each iteration.
- Direct HBM weight streaming instead of expert-weight copy buffers.
- Codegen support for advancing operands whose expert dimension becomes size one inside the loop.
- A fail-closed check when a preserved bank advance conflicts with a surviving tiled dimension at the same loop level.

This unit changes coarse tiling, loop metadata, persistent-scope lowering, kernel codegen, and CI registration. The shared-LHS operation lowering itself is owned by Unit 0. Relative to Unit 0, this unit contains 572 production insertions, 47 production deletions, and 254 test/config insertions across 8 files.

## Boundary

This draft is limited to loop formation and operand addressing. It does not add persistent LX lifetime or accumulator support, change work division, or change LX relayout policy.

## Draft status

- Full integration coverage is missing: no test yet proves the complete path from schedule selection through X preheader staging, four advancing operands, and one emitted counted loop.
- The schedule and operand binding records are not yet authoritative end to end. The loop plan is reconstructed from an internal lowering hint, and codegen still derives the physical advance that the binding record verifies.
- Read-copy planning still has separate ordinary and persistent regimes. These must be unified before this is ready for review as production architecture.

## Validation

- Focused test code covers loop planning, invariant X staging, streamed operands, and squeezed-dimension address advances and is registered in CI, but is not yet a complete integration gate.
- Ruff, Python bytecode compilation, formatting, and `git diff --check` pass at the local head.
- Focused pytest must run in the configured torch-spyre test environment; the local Python environment does not contain PyTorch.
