### PR TITLE
Keep persistent expert state in LX

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_expert_execution_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_expert_execution_config.yaml
@@ -5,3 +5,5 @@ test_suite_config:
       unlisted_test_mode: mandatory_success
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_moe_ffn_semantics.py
       unlisted_test_mode: mandatory_success
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_persistent_expert_loop_planning.py
+      unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_expert_execution_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_expert_execution_config.yaml
@@ -1,0 +1,7 @@
+test_suite_config:
+  labels: [unit, regression, integration, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_expert_execution_planner.py
+      unlisted_test_mode: mandatory_success
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_moe_ffn_semantics.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -5944,6 +5944,327 @@ def _make_tiled_reduction_op(
     return op
 
 
+class TestUnitTiledSumContributionCollapse(unittest.TestCase):
+    """The expert loop, not a unit local DDL reduction, owns the E sum."""
+
+    def setUp(self):
+        gm = fx.symbolic_trace(lambda: None)
+        self._graph_ctx = V.set_graph_handler(GraphLowering(gm))
+        self._graph_ctx.__enter__()
+
+    def tearDown(self):
+        self._graph_ctx.__exit__(None, None, None)
+
+    def _fixture(
+        self,
+        reduction_extent,
+        *,
+        insert_combine,
+        src_dtype=torch.float32,
+        num_inputs=1,
+    ):
+        from torch._inductor.ir import (
+            ComputedBuffer,
+            FixedLayout,
+            InputBuffer,
+            Pointwise,
+            Reduction,
+            ReductionHint,
+            StorageBox,
+            TensorBox,
+        )
+
+        from torch_spyre._inductor.loop_info import (
+            CountedLoopPlan,
+            LoopStoragePlan,
+            PropagationPlan,
+            ReductionPlan,
+        )
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _divide_reduction_ranges,
+            _insert_combine_op,
+        )
+
+        full_reduction_extent = Integer(reduction_extent) * 2
+        input_boxes = []
+        for input_index in range(num_inputs):
+            inp = InputBuffer(
+                name=f"in{input_index}_buf6",
+                layout=FixedLayout(
+                    torch.device("cpu"),
+                    src_dtype,
+                    [Integer(4), full_reduction_extent],
+                    [full_reduction_extent, Integer(1)],
+                ),
+            )
+            V.graph.name_to_buffer[inp.get_name()] = inp
+            input_boxes.append(TensorBox(StorageBox(inp)))
+
+        def reduction_inner_fn(index, reduction_index):
+            values = [
+                input_box.make_loader()([index[0], reduction_index[0]])
+                for input_box in input_boxes
+            ]
+            result = values[0]
+            for value in values[1:]:
+                result = result + value
+            return result
+
+        # Construct Reduction directly.  Reduction.create() deliberately
+        # canonicalizes unit (and other sufficiently small) reductions to a
+        # Pointwise before coarse tiling, whereas the real failure starts as
+        # the full expert-axis Reduction and becomes extent one only after
+        # _divide_reduction_ranges mutates it in place.
+        reduction = Reduction(
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+            src_dtype=src_dtype,
+            inner_fn=reduction_inner_fn,
+            ranges=[Integer(4)],
+            reduction_ranges=[full_reduction_extent],
+            reduction_type="sum",
+            reduction_hint=ReductionHint.DEFAULT,
+        )
+        tiled_sum = ComputedBuffer(
+            name="buf6",
+            layout=FixedLayout(
+                torch.device("cpu"), torch.float32, [Integer(4)], [Integer(1)]
+            ),
+            data=reduction,
+        )
+        tiled_sum.operation_name = "buf6"
+        tiled_sum.origins = OrderedSet()
+        V.graph.name_to_buffer[tiled_sum.get_name()] = tiled_sum
+        # Match the real pass boundary: lowering first creates a genuine
+        # extent-E Reduction, then coarse tiling divides its reduction range
+        # to the per-expert extent.  Constructing Reduction.create directly
+        # with extent one would let upstream Inductor canonicalize it to a
+        # Pointwise before this pass ever sees it.
+        _divide_reduction_ranges(tiled_sum, Integer(2), [0])
+        tiled_sum.loop_info = CoarseTileInfo(
+            loop_group_id=(0,),
+            loop_count=[Integer(2)],
+            loop_tiled_dims=[[]],
+            loop_tiled_reduction_dims=[[0]],
+            tiled_dims_per_read=[[[(1, Integer(reduction_extent))]]],
+            output_tiled_dims=[[]],
+            counted_loop_plan=CountedLoopPlan(
+                kind="persistent_dense_expert", trip_count=2
+            ),
+            propagation=PropagationPlan(
+                kind="reduction",
+                reduction=ReductionPlan(
+                    reduction_type="sum",
+                    identity=0,
+                    is_nested=False,
+                    full_output_ranges=[Integer(4)],
+                    per_tile_ranges=[Integer(4)],
+                    outer_fill_loop_info=None,
+                    full_output_strides=(Integer(1),),
+                    per_tile_strides=(Integer(1),),
+                ),
+                is_graph_output=True,
+            ),
+        )
+
+        accum_data = Pointwise(
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+            inner_fn=lambda index: sympy.Integer(0),
+            ranges=[Integer(4)],
+        )
+        accum = ComputedBuffer(
+            name="accum",
+            layout=FixedLayout(
+                torch.device("cpu"), torch.float32, [Integer(4)], [Integer(1)]
+            ),
+            data=accum_data,
+        )
+        accum.operation_name = "accum"
+        accum.loop_storage_plan = LoopStoragePlan(
+            kind="loop_carried_accumulator", owner_group=(0,)
+        )
+        V.graph.name_to_buffer[tiled_sum.get_name()] = tiled_sum
+        V.graph.name_to_buffer[accum.get_name()] = accum
+
+        operations = [tiled_sum]
+        combine_name = f"coarse_tile_combine_{tiled_sum.get_name()}"
+        if insert_combine:
+            combine_name = _insert_combine_op(
+                tiled_sum, accum, operations, is_nested=False
+            )
+        return tiled_sum, combine_name, operations
+
+    def test_static_unit_flat_sum_becomes_pointwise_contribution(self):
+        from torch._inductor.ir import Pointwise, Reduction
+
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _collapse_unit_tiled_sum_contribution,
+        )
+
+        tiled_sum, combine_name, operations = self._fixture(
+            Integer(1), insert_combine=True
+        )
+        self.assertIsInstance(tiled_sum.data, Reduction)
+
+        contribution = _collapse_unit_tiled_sum_contribution(
+            tiled_sum, combine_name, operations, pre_stickify=True
+        )
+
+        self.assertIsNot(contribution, tiled_sum)
+        self.assertIs(operations[0], contribution)
+        self.assertIs(V.graph.name_to_buffer["buf6"], contribution)
+        self.assertIsInstance(contribution.data, Pointwise)
+        self.assertEqual(contribution.get_name(), "buf6")
+        self.assertIs(contribution.loop_info, tiled_sum.loop_info)
+        self.assertEqual(list(contribution.data.ranges), [Integer(4)])
+
+        class _Recorder(list):
+            def load(self, name, index):
+                self.append((name, sympy.expand(index)))
+                return sympy.Symbol("value")
+
+        recorder = _Recorder()
+        row = sympy.Symbol("row", integer=True)
+        with V.set_ops_handler(recorder):
+            result = contribution.data.inner_fn([row])
+        self.assertEqual(result, sympy.Symbol("value"))
+        self.assertEqual(recorder, [("in0_buf6", 2 * row)])
+
+    def test_extent_greater_than_one_stays_a_reduction(self):
+        from torch._inductor.ir import Reduction
+
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _collapse_unit_tiled_sum_contribution,
+        )
+
+        tiled_sum, combine_name, operations = self._fixture(
+            Integer(2), insert_combine=True
+        )
+        result = _collapse_unit_tiled_sum_contribution(
+            tiled_sum, combine_name, operations, pre_stickify=True
+        )
+
+        self.assertIs(result, tiled_sum)
+        self.assertIs(operations[0], tiled_sum)
+        self.assertIsInstance(tiled_sum.data, Reduction)
+
+    def test_missing_combine_stays_a_reduction(self):
+        from torch._inductor.ir import Reduction
+
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _collapse_unit_tiled_sum_contribution,
+        )
+
+        tiled_sum, combine_name, operations = self._fixture(
+            Integer(1), insert_combine=False
+        )
+        result = _collapse_unit_tiled_sum_contribution(
+            tiled_sum, combine_name, operations, pre_stickify=True
+        )
+
+        self.assertIs(result, tiled_sum)
+        self.assertIs(operations[0], tiled_sum)
+        self.assertIsInstance(tiled_sum.data, Reduction)
+
+    def test_post_stickify_stays_a_reduction(self):
+        from torch._inductor.ir import Reduction
+
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _collapse_unit_tiled_sum_contribution,
+        )
+
+        tiled_sum, combine_name, operations = self._fixture(
+            Integer(1), insert_combine=True
+        )
+        result = _collapse_unit_tiled_sum_contribution(
+            tiled_sum, combine_name, operations, pre_stickify=False
+        )
+
+        self.assertIs(result, tiled_sum)
+        self.assertIsInstance(tiled_sum.data, Reduction)
+
+    def test_promoted_sum_stays_a_reduction(self):
+        from torch._inductor.ir import Reduction
+
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _collapse_unit_tiled_sum_contribution,
+        )
+
+        tiled_sum, combine_name, operations = self._fixture(
+            Integer(1), insert_combine=True, src_dtype=torch.float16
+        )
+        result = _collapse_unit_tiled_sum_contribution(
+            tiled_sum, combine_name, operations, pre_stickify=True
+        )
+
+        self.assertIs(result, tiled_sum)
+        self.assertIsInstance(tiled_sum.data, Reduction)
+
+    def test_multiple_read_contributions_stay_a_reduction(self):
+        from torch._inductor.ir import Reduction
+
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _collapse_unit_tiled_sum_contribution,
+        )
+
+        tiled_sum, combine_name, operations = self._fixture(
+            Integer(1), insert_combine=True, num_inputs=2
+        )
+        result = _collapse_unit_tiled_sum_contribution(
+            tiled_sum, combine_name, operations, pre_stickify=True
+        )
+
+        self.assertIs(result, tiled_sum)
+        self.assertIsInstance(tiled_sum.data, Reduction)
+
+    def test_later_retile_patch_rewrites_collapsed_pointwise_load(self):
+        from torch._inductor.ir import Pointwise
+
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _collapse_unit_tiled_sum_contribution,
+            _patch_retiled_load_indexes,
+        )
+
+        tiled_sum, combine_name, operations = self._fixture(
+            Integer(1), insert_combine=True
+        )
+        contribution = _collapse_unit_tiled_sum_contribution(
+            tiled_sum, combine_name, operations, pre_stickify=True
+        )
+        group_ops = [contribution]
+
+        _patch_retiled_load_indexes(
+            (0,),
+            group_ops,
+            {
+                "in0_buf6": _RetiledBufferInfo(
+                    old_stride=(Integer(2), Integer(1)),
+                    new_stride=(Integer(1), Integer(1)),
+                    old_size=(Integer(4), Integer(2)),
+                )
+            },
+            operations,
+        )
+
+        final_contribution = operations[0]
+        self.assertIs(group_ops[0], final_contribution)
+        self.assertIs(V.graph.name_to_buffer["buf6"], final_contribution)
+        self.assertIsInstance(final_contribution.data, Pointwise)
+
+        class _Recorder(list):
+            def load(self, name, index):
+                self.append((name, sympy.expand(index)))
+                return sympy.Symbol("value")
+
+        recorder = _Recorder()
+        row = sympy.Symbol("row", integer=True)
+        with V.set_ops_handler(recorder):
+            result = final_contribution.data.inner_fn([row])
+        self.assertEqual(result, sympy.Symbol("value"))
+        self.assertEqual(recorder, [("in0_buf6", row)])
+
+
 class TestCoarseTileReductionPropagation(unittest.TestCase):
     """Tests for tiling propagation Reduction support."""
 

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -102,9 +102,12 @@ from torch_spyre._inductor.scheduler import (
     build_loop_scheduler_nodes,
 )
 from torch_spyre._inductor.spyre_kernel import (
+    LoopOperandBinding,
+    SpyreKernel,
     _codegen_op_spec_list,
     _iter_op_specs,
     _preserve_shared_weight_unit_bmm_dim,
+    _tensor_args_advance_by_symbol,
 )
 from torch_spyre._inductor.temp_passes import (
     _mark_static_unit_batch_bmm,
@@ -117,6 +120,99 @@ from torch_spyre._inductor.wsr.tile import (
 )
 
 _FP16 = DataFormats.SEN169_FP16
+
+
+class TestUnitDimArgumentAdvanceSymbols(unittest.TestCase):
+    """A squeezed expert tile must still advance its runtime operand."""
+
+    @staticmethod
+    def _arg(expr):
+        return TensorArg(
+            is_input=True,
+            arg_index=0,
+            device_dtype=_FP16,
+            device_size=[1, 64],
+            device_coordinates=[Integer(0), Integer(0)],
+            allocation={"hbm": 0},
+            device_tile_advance_expr=expr,
+        )
+
+    def test_detects_plain_and_floor_wrapped_symbols(self):
+        level = Symbol("_tile_adv_copy_lvl0")
+        other = Symbol("_tile_adv_copy_lvl1")
+
+        self.assertTrue(_tensor_args_advance_by_symbol([self._arg(64 * level)], level))
+        self.assertTrue(
+            _tensor_args_advance_by_symbol([self._arg(floor(64 * level))], level)
+        )
+        self.assertFalse(_tensor_args_advance_by_symbol([self._arg(64 * other)], level))
+        self.assertFalse(_tensor_args_advance_by_symbol([self._arg(None)], level))
+
+    def test_binding_rejects_unknown_addressing_kind(self):
+        with self.assertRaisesRegex(Unsupported, "unknown loop operand binding"):
+            LoopOperandBinding("indexed", Integer(0))
+
+    def test_create_op_spec_serializes_arg_only_level_symbol(self):
+        level = Symbol("_tile_adv_copy_lvl0")
+        ir_node = SimpleNamespace(
+            loop_info=CoarseTileInfo(
+                loop_group_id=(0,),
+                loop_count=[Integer(2)],
+                loop_tiled_dims=[],
+                loop_tiled_reduction_dims=[],
+            ),
+            get_operation_name=lambda: "identity",
+        )
+        kernel = SpyreKernel()
+        kernel.current_node = SimpleNamespace(node=ir_node)
+        kernel._tile_advance_symbols = {0: level}
+
+        with (
+            patch(
+                "torch_spyre._inductor.spyre_kernel.iteration_space",
+                return_value={},
+            ),
+            patch(
+                "torch_spyre._inductor.spyre_kernel.build_debug_handle",
+                return_value=None,
+            ),
+        ):
+            op = kernel.create_op_spec(
+                "identity", False, [self._arg(floor(64 * level))], {}
+            )
+
+        self.assertEqual(op.tiled_symbols, [[level]])
+        self.assertEqual(op.tiled_symbol_trip_counts, {level: 2})
+
+    def test_create_op_spec_keeps_invariant_level_empty(self):
+        level = Symbol("_tile_adv_copy_lvl0")
+        ir_node = SimpleNamespace(
+            loop_info=CoarseTileInfo(
+                loop_group_id=(0,),
+                loop_count=[Integer(2)],
+                loop_tiled_dims=[],
+                loop_tiled_reduction_dims=[],
+            ),
+            get_operation_name=lambda: "identity",
+        )
+        kernel = SpyreKernel()
+        kernel.current_node = SimpleNamespace(node=ir_node)
+        kernel._tile_advance_symbols = {0: level}
+
+        with (
+            patch(
+                "torch_spyre._inductor.spyre_kernel.iteration_space",
+                return_value={},
+            ),
+            patch(
+                "torch_spyre._inductor.spyre_kernel.build_debug_handle",
+                return_value=None,
+            ),
+        ):
+            op = kernel.create_op_spec("identity", False, [self._arg(None)], {})
+
+        self.assertEqual(op.tiled_symbols, [[]])
+        self.assertEqual(op.tiled_symbol_trip_counts, {})
 
 
 # ===========================================================================

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -5446,6 +5446,44 @@ class TestInsertAllReadCopyOps(unittest.TestCase):
         self.assertNotIn(full_buf.get_name(), loaded_by_a)
         self.assertNotIn(full_buf.get_name(), loaded_by_b)
 
+    def test_persistent_invariant_copy_is_typed_as_preheader_storage(self):
+        from dataclasses import replace
+
+        from torch._inductor.ir import ComputedBuffer
+
+        from torch_spyre._inductor.loop_info import CountedLoopPlan
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _insert_all_read_copy_ops,
+            _plan_read_copies,
+        )
+
+        op_a, op_b, _, operations = _make_two_op_shared_read_fixture()
+        for op in (op_a, op_b):
+            op.loop_info = replace(
+                op.loop_info,
+                loop_tiled_dims=[[]],
+                tiled_dims_per_read=[[[]]],
+                counted_loop_plan=CountedLoopPlan(
+                    kind="persistent_dense_expert",
+                    trip_count=8,
+                ),
+            )
+
+        plans = _plan_read_copies(operations, [((0,), [op_a, op_b], {})])
+        _insert_all_read_copy_ops(operations, plans)
+
+        copy_buf = next(
+            op
+            for op in operations
+            if isinstance(op, ComputedBuffer)
+            and op.get_name().startswith("coarse_tile_read_copy_")
+        )
+        self.assertEqual(copy_buf.loop_info.loop_group_id, ())
+        self.assertEqual(copy_buf.loop_info.preheader_for_group, (0,))
+        self.assertEqual(copy_buf.loop_storage_plan.kind, "loop_invariant")
+        self.assertEqual(copy_buf.loop_storage_plan.owner_group, (0,))
+        self.assertEqual(copy_buf.loop_storage_plan.execution_role, "input_activation")
+
     def test_transposed_read_gets_its_own_copy(self):
         """a+b+a.t()-style: two reads of the same buffer with different
         index expressions must NOT share a copy."""
@@ -6082,7 +6120,9 @@ class TestUnitTiledSumContributionCollapse(unittest.TestCase):
         )
         accum.operation_name = "accum"
         accum.loop_storage_plan = LoopStoragePlan(
-            kind="loop_carried_accumulator", owner_group=(0,)
+            kind="loop_carried_accumulator",
+            owner_group=(0,),
+            execution_role="output_accumulator",
         )
         V.graph.name_to_buffer[tiled_sum.get_name()] = tiled_sum
         V.graph.name_to_buffer[accum.get_name()] = accum
@@ -6201,6 +6241,30 @@ class TestUnitTiledSumContributionCollapse(unittest.TestCase):
         self.assertIs(result, tiled_sum)
         self.assertIsInstance(tiled_sum.data, Reduction)
 
+    def test_persistent_accumulator_contract_is_source_dtype(self):
+        from dataclasses import replace
+
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _preflight_persistent_reduction,
+        )
+
+        tiled_sum, _, operations = self._fixture(Integer(1), insert_combine=False)
+        counted_plan = tiled_sum.loop_info.counted_loop_plan
+        tiled_sum.loop_info.counted_loop_plan = replace(
+            counted_plan,
+            carried_reduction=replace(
+                counted_plan.carried_reduction,
+                accumulation_dtype="fp32",
+            ),
+        )
+
+        with self.assertRaisesRegex(Unsupported, "source contribution dtype"):
+            _preflight_persistent_reduction(
+                tiled_sum,
+                operations,
+                pre_stickify=True,
+            )
+
     def test_multiple_read_contributions_stay_a_reduction(self):
         from torch._inductor.ir import Reduction
 
@@ -6217,6 +6281,39 @@ class TestUnitTiledSumContributionCollapse(unittest.TestCase):
 
         self.assertIs(result, tiled_sum)
         self.assertIsInstance(tiled_sum.data, Reduction)
+
+    def test_persistent_reduction_rejects_consumer_before_mutation(self):
+        from torch._inductor.ir import ComputedBuffer, FixedLayout, Pointwise
+
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _propagate_tiled_reduction_op,
+        )
+
+        tiled_sum, _, operations = self._fixture(Integer(1), insert_combine=False)
+        consumer = ComputedBuffer(
+            name="same_loop_consumer",
+            layout=FixedLayout(
+                torch.device("cpu"), torch.float32, [Integer(4)], [Integer(1)]
+            ),
+            data=Pointwise(
+                device=torch.device("cpu"),
+                dtype=torch.float32,
+                inner_fn=tiled_sum.make_loader(),
+                ranges=[Integer(4)],
+            ),
+        )
+        consumer.operation_name = consumer.get_name()
+        consumer.loop_info = tiled_sum.loop_info
+        V.graph.name_to_buffer[consumer.get_name()] = consumer
+        operations.append(consumer)
+        before_operations = list(operations)
+        before_names = set(V.graph.name_to_buffer)
+
+        with self.assertRaisesRegex(Unsupported, "must be terminal"):
+            _propagate_tiled_reduction_op(tiled_sum, operations, pre_stickify=True)
+
+        self.assertEqual(operations, before_operations)
+        self.assertEqual(set(V.graph.name_to_buffer), before_names)
 
     def test_later_retile_patch_rewrites_collapsed_pointwise_load(self):
         from torch._inductor.ir import Pointwise

--- a/tests/inductor/test_expert_execution_planner.py
+++ b/tests/inductor/test_expert_execution_planner.py
@@ -1,0 +1,206 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import dataclasses
+
+import pytest
+import torch
+
+from torch_spyre._inductor.expert_execution import (
+    ExpertGraphPlan,
+    ExpertPlanningError,
+    ExpertStrategy,
+    materialize_expert_execution_graph,
+    plan_expert_execution_graph,
+    prepare_expert_execution_graph,
+)
+from torch_spyre._inductor.expert_execution.custom_op import (
+    dense_expert_persistent_ffn,
+    moe_ffn,
+)
+
+
+def _graph_module():
+    graph = torch.fx.Graph()
+    specs = (
+        ("x", (64, 64), None),
+        ("gate", (2, 64, 64), (64, 128, 1)),
+        ("up", (2, 64, 64), (64, 128, 1)),
+        ("down", (2, 64, 64), (64, 128, 1)),
+        ("routing", (64, 2, 1), (1, 64, 1)),
+    )
+    args = []
+    for name, shape, stride in specs:
+        node = graph.placeholder(name)
+        value = torch.empty(shape, device="meta", dtype=torch.float16)
+        if stride is not None:
+            value = torch.as_strided(value, shape, stride)
+        node.meta["val"] = value
+        args.append(node)
+    result = graph.call_function(moe_ffn._opoverload, args=(*args, 1, "silu"))
+    result.meta["val"] = torch.empty((64, 64), device="meta", dtype=torch.float16)
+    graph.output(result)
+    return torch.fx.GraphModule(torch.nn.Module(), graph)
+
+
+def _call_target(graph_module):
+    return next(
+        node.target for node in graph_module.graph.nodes if node.op == "call_function"
+    )
+
+
+def test_planning_is_pure_and_selects_persistent_schedule():
+    graph_module = _graph_module()
+    before_code = graph_module.code
+    before_meta = {node.name: dict(node.meta) for node in graph_module.graph.nodes}
+
+    plan = plan_expert_execution_graph(
+        graph_module,
+        persistent_available=True,
+        available_lx_bytes=1_000_000,
+    )
+
+    assert graph_module.code == before_code
+    for node in graph_module.graph.nodes:
+        assert node.meta.keys() == before_meta[node.name].keys()
+        for key, value in node.meta.items():
+            assert value is before_meta[node.name][key]
+    selected = plan.nodes[0]
+    assert selected.strategy is ExpertStrategy.PERSISTENT_DENSE
+    assert selected.expert_count == 2
+    assert selected.schedule.binding_kind == "sequential_affine"
+    assert selected.schedule.weight_layout == "logical_expert_major_k_major_backing"
+    assert selected.schedule.routing_layout == "logical_token_major"
+    assert selected.schedule.preheader == ("stage_x", "fill_accumulator")
+    assert selected.schedule.drain == ("drain_output",)
+
+
+def test_conservative_feasibility_selects_ordinary_dense():
+    plan = plan_expert_execution_graph(
+        _graph_module(), persistent_available=True, available_lx_bytes=1
+    )
+
+    assert plan.nodes[0].strategy is ExpertStrategy.ORDINARY_DENSE
+    assert plan.nodes[0].schedule is None
+
+
+def test_materialization_rewrites_only_an_isolated_clone():
+    source = _graph_module()
+    plan = plan_expert_execution_graph(
+        source, persistent_available=True, available_lx_bytes=1_000_000
+    )
+
+    candidate = materialize_expert_execution_graph(source, plan)
+
+    assert candidate is not source
+    assert _call_target(source) == moe_ffn._opoverload
+    assert _call_target(candidate) == dense_expert_persistent_ffn._opoverload
+    call = next(node for node in candidate.graph.nodes if node.op == "call_function")
+    assert call.args[-1] == call.name
+
+
+def test_contiguous_expert_weights_do_not_select_persistent():
+    graph_module = _graph_module()
+    for name in ("gate", "up", "down"):
+        node = next(node for node in graph_module.graph.nodes if node.name == name)
+        node.meta["val"] = torch.empty(
+            tuple(node.meta["val"].shape), device="meta", dtype=torch.float16
+        )
+
+    plan = plan_expert_execution_graph(
+        graph_module,
+        persistent_available=True,
+        available_lx_bytes=1_000_000,
+    )
+
+    assert plan.nodes[0].strategy is ExpertStrategy.ORDINARY_DENSE
+
+
+def test_contiguous_token_major_routing_selects_persistent():
+    graph_module = _graph_module()
+    routing = next(node for node in graph_module.graph.nodes if node.name == "routing")
+    routing.meta["val"] = torch.empty(
+        tuple(routing.meta["val"].shape), device="meta", dtype=torch.float16
+    )
+
+    plan = plan_expert_execution_graph(
+        graph_module,
+        persistent_available=True,
+        available_lx_bytes=1_000_000,
+    )
+
+    assert plan.nodes[0].strategy is ExpertStrategy.PERSISTENT_DENSE
+
+
+def test_ordinary_dense_materialization_is_a_no_op():
+    source = _graph_module()
+    plan = plan_expert_execution_graph(
+        source, persistent_available=False, available_lx_bytes=1_000_000
+    )
+
+    candidate = materialize_expert_execution_graph(source, plan)
+
+    assert candidate is source
+    assert _call_target(source) == moe_ffn._opoverload
+
+
+def test_materialization_rejects_a_changed_source_graph():
+    source = _graph_module()
+    plan = plan_expert_execution_graph(
+        source, persistent_available=True, available_lx_bytes=1_000_000
+    )
+    call = next(node for node in source.graph.nodes if node.op == "call_function")
+    call.args = (*call.args[:-1], "gelu_tanh")
+    source.recompile()
+
+    with pytest.raises(ExpertPlanningError, match="changed after expert planning"):
+        materialize_expert_execution_graph(source, plan)
+
+
+def test_failed_materialization_does_not_change_the_source():
+    source = _graph_module()
+    plan = plan_expert_execution_graph(
+        source, persistent_available=True, available_lx_bytes=1_000_000
+    )
+    invalid_node = dataclasses.replace(plan.nodes[0], schedule=None)
+    invalid_plan = ExpertGraphPlan(plan.source_structure, (invalid_node,))
+
+    with pytest.raises(ExpertPlanningError, match="not a valid persistent"):
+        materialize_expert_execution_graph(source, invalid_plan)
+
+    assert _call_target(source) == moe_ffn._opoverload
+
+
+def test_prepare_uses_configured_lx_budget(monkeypatch):
+    source = _graph_module()
+    monkeypatch.setattr(
+        "torch_spyre._inductor.config.enable_dense_expert_persistent", True
+    )
+    monkeypatch.setattr("torch_spyre._inductor.config.sencores", 32)
+    monkeypatch.setattr(
+        "torch_spyre._inductor.scratchpad.allocator._lx_planning_size",
+        lambda: 1_000_000,
+    )
+
+    candidate, plan = prepare_expert_execution_graph(source)
+
+    assert len(plan.nodes) == 1
+    assert _call_target(source) == moe_ffn._opoverload
+    assert _call_target(candidate) == dense_expert_persistent_ffn._opoverload
+
+
+def test_persistent_strategy_is_not_user_enabled():
+    from torch_spyre._inductor import config
+
+    assert config.enable_dense_expert_persistent is False

--- a/tests/inductor/test_moe_ffn_semantics.py
+++ b/tests/inductor/test_moe_ffn_semantics.py
@@ -1,0 +1,111 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from torch_spyre._inductor.expert_execution.custom_op import (
+    expert_shared_lhs_mm,
+    moe_ffn,
+)
+from torch_spyre._inductor.expert_execution.semantics import moe_ffn_reference
+from torch_spyre._inductor.decompositions import (
+    decompose_dense_expert_persistent_ffn,
+    get_spyre_decomp_table,
+)
+
+
+def _inputs(dtype=torch.float32):
+    generator = torch.Generator().manual_seed(17)
+    tokens, experts, hidden, intermediate = 4, 3, 8, 6
+    x = torch.randn(tokens, hidden, dtype=dtype, generator=generator)
+    gate = torch.randn(experts, hidden, intermediate, dtype=dtype, generator=generator)
+    up = torch.randn(experts, hidden, intermediate, dtype=dtype, generator=generator)
+    down = torch.randn(experts, intermediate, hidden, dtype=dtype, generator=generator)
+    routing = torch.randn(tokens, experts, 1, dtype=dtype, generator=generator)
+    return x, gate, up, down, routing
+
+
+@pytest.mark.parametrize("activation", ["gelu_tanh", "silu"])
+def test_moe_ffn_cpu_matches_direct_reference(activation):
+    inputs = _inputs()
+
+    actual = moe_ffn(*inputs, 2, activation)
+    expected = moe_ffn_reference(*inputs, 2, activation)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_zero_routing_weight_removes_an_expert_contribution():
+    x, gate, up, down, routing = _inputs()
+    routing[:, 1, :] = 0
+
+    actual = moe_ffn(x, gate, up, down, routing, 2, "silu")
+    expected = moe_ffn(
+        x,
+        gate[[0, 2]],
+        up[[0, 2]],
+        down[[0, 2]],
+        routing[:, [0, 2], :],
+        2,
+        "silu",
+    )
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_moe_ffn_requires_explicit_singleton_routing_axis():
+    x, gate, up, down, routing = _inputs()
+
+    with pytest.raises(ValueError, match=r"\[T,E,1\]"):
+        moe_ffn(x, gate, up, down, routing.squeeze(-1), 2, "silu")
+
+
+def test_moe_ffn_rejects_mismatched_logical_weight_schema():
+    x, gate, up, down, routing = _inputs()
+
+    with pytest.raises(ValueError, match="up_weight"):
+        moe_ffn(x, gate, up[:, :-1], down, routing, 2, "silu")
+
+
+def test_moe_ffn_rejects_invalid_top_k():
+    inputs = _inputs()
+
+    with pytest.raises(ValueError, match="top_k"):
+        moe_ffn(*inputs, 4, "silu")
+
+
+def test_internal_shared_lhs_projection_matches_expert_loop():
+    x, gate, _up, _down, _routing = _inputs()
+
+    actual = expert_shared_lhs_mm(x, gate)
+    expected = torch.stack(tuple(torch.mm(x, weight) for weight in gate))
+
+    assert actual.shape == (gate.shape[0], x.shape[0], gate.shape[2])
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.parametrize("activation", ["gelu_tanh", "silu"])
+def test_persistent_decomposition_matches_semantic_reference(activation):
+    inputs = _inputs()
+
+    actual = decompose_dense_expert_persistent_ffn(
+        *inputs, 2, activation, "test_region"
+    )
+    expected = moe_ffn_reference(*inputs, 2, activation)
+
+    torch.testing.assert_close(actual, expected)
+    assert (
+        torch.ops.spyre.dense_expert_persistent_ffn.default in get_spyre_decomp_table()
+    )

--- a/tests/inductor/test_moe_ffn_semantics.py
+++ b/tests/inductor/test_moe_ffn_semantics.py
@@ -12,11 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from contextlib import contextmanager
+
 import pytest
 import torch
 
+from torch_spyre._inductor import decompositions
 from torch_spyre._inductor.expert_execution.custom_op import (
+    expert_mm_prepacked,
+    expert_route_prepacked,
     expert_shared_lhs_mm,
+    expert_shared_lhs_mm_prepacked,
     moe_ffn,
 )
 from torch_spyre._inductor.expert_execution.semantics import moe_ffn_reference
@@ -96,6 +102,28 @@ def test_internal_shared_lhs_projection_matches_expert_loop():
     torch.testing.assert_close(actual, expected)
 
 
+def test_internal_prepacked_projections_match_logical_expert_loop():
+    x, gate, _up, down, _routing = _inputs()
+    gate_packed = gate.permute(1, 0, 2)
+    down_packed = down.permute(1, 0, 2)
+
+    projected = expert_shared_lhs_mm_prepacked(x, gate_packed)
+    expected_projected = torch.stack(tuple(torch.mm(x, weight) for weight in gate))
+    restored = expert_mm_prepacked(projected, down_packed)
+    expected_restored = torch.stack(
+        tuple(torch.mm(expected_projected[e], down[e]) for e in range(gate.shape[0]))
+    )
+
+    torch.testing.assert_close(projected, expected_projected)
+    torch.testing.assert_close(restored, expected_restored)
+
+
+def test_internal_prepacked_route_is_an_identity():
+    routing = _inputs()[-1].permute(1, 0, 2).contiguous()
+
+    torch.testing.assert_close(expert_route_prepacked(routing), routing)
+
+
 @pytest.mark.parametrize("activation", ["gelu_tanh", "silu"])
 def test_persistent_decomposition_matches_semantic_reference(activation):
     inputs = _inputs()
@@ -109,3 +137,32 @@ def test_persistent_decomposition_matches_semantic_reference(activation):
     assert (
         torch.ops.spyre.dense_expert_persistent_ffn.default in get_spyre_decomp_table()
     )
+
+
+def test_persistent_decomposition_marks_the_complete_loop_body(monkeypatch):
+    regions = []
+
+    @contextmanager
+    def record_region(scope_id, **metadata):
+        regions.append((scope_id, metadata))
+        yield
+
+    monkeypatch.setattr(decompositions, "compiler_hint", record_region)
+    decompose_dense_expert_persistent_ffn(*_inputs(), 2, "gelu_tanh", "region-7")
+
+    assert len(regions) == 8
+    assert {scope_id for scope_id, _ in regions} == {"region-7"}
+    assert all(
+        metadata["expert_execution"] == "persistent_dense_expert"
+        for _, metadata in regions
+    )
+    assert [metadata.get("streamed_operand_role") for _, metadata in regions] == [
+        "gate_weight",
+        "up_weight",
+        None,
+        None,
+        "down_weight",
+        "routing_weight",
+        None,
+        None,
+    ]

--- a/tests/inductor/test_moe_ffn_semantics.py
+++ b/tests/inductor/test_moe_ffn_semantics.py
@@ -21,6 +21,7 @@ from torch_spyre._inductor import decompositions
 from torch_spyre._inductor.expert_execution.custom_op import (
     expert_mm_prepacked,
     expert_route_prepacked,
+    expert_route_weighted_down,
     expert_shared_lhs_mm,
     expert_shared_lhs_mm_prepacked,
     moe_ffn,
@@ -124,6 +125,21 @@ def test_internal_prepacked_route_is_an_identity():
     torch.testing.assert_close(expert_route_prepacked(routing), routing)
 
 
+def test_internal_route_weighting_preserves_token_expert_semantics():
+    routing = _inputs()[-1]
+    down = torch.randn(
+        routing.shape[1],
+        routing.shape[0],
+        8,
+        generator=torch.Generator().manual_seed(9),
+    )
+
+    actual = expert_route_weighted_down(down, routing)
+    expected = down * routing.permute(1, 0, 2)
+
+    torch.testing.assert_close(actual, expected)
+
+
 @pytest.mark.parametrize("activation", ["gelu_tanh", "silu"])
 def test_persistent_decomposition_matches_semantic_reference(activation):
     inputs = _inputs()
@@ -150,7 +166,7 @@ def test_persistent_decomposition_marks_the_complete_loop_body(monkeypatch):
     monkeypatch.setattr(decompositions, "compiler_hint", record_region)
     decompose_dense_expert_persistent_ffn(*_inputs(), 2, "gelu_tanh", "region-7")
 
-    assert len(regions) == 8
+    assert len(regions) == 7
     assert {scope_id for scope_id, _ in regions} == {"region-7"}
     assert all(
         metadata["expert_execution"] == "persistent_dense_expert"
@@ -163,6 +179,5 @@ def test_persistent_decomposition_marks_the_complete_loop_body(monkeypatch):
         None,
         "down_weight",
         "routing_weight",
-        None,
         None,
     ]

--- a/tests/inductor/test_perm_layout_solver.py
+++ b/tests/inductor/test_perm_layout_solver.py
@@ -1399,6 +1399,17 @@ class NativeSolverDifferentialTests(TestCase):
         self.assertEqual(cpp_plan.quality(), py_plan.quality(), tag)
         self.assertEqual(cpp_plan.count_allocated(), py_plan.count_allocated(), tag)
 
+    def test_lifetime_end_override_matches_python(self):
+        held = LifetimeBoundBuffer("held", 64, [0], lifetime_end_override=4)
+        later = LifetimeBoundBuffer("later", 64, [1, 3])
+        buffers = [held, later]
+
+        py_plan = PermutationBasedLayoutSolver(buffers, [0, 1], 10_000, 1)
+        cpp_plan = NativePermutationLayoutSolver(buffers, [0, 1], 10_000, 1)
+
+        self._assert_equal(py_plan, cpp_plan, "lifetime end override")
+        self.assertEqual(list(cpp_plan.addresses), [0, 64])
+
     def test_fast_path_reads_pokethrough_top_not_dead_parent(self):
         """The aggregate fast path's boundary case, pinned deterministically.
 

--- a/tests/inductor/test_persistent_expert_loop_planning.py
+++ b/tests/inductor/test_persistent_expert_loop_planning.py
@@ -1,0 +1,197 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import sympy
+import pytest
+from torch._inductor.dependencies import MemoryDep
+from torch._inductor.utils import sympy_index_symbol
+
+from torch_spyre._inductor.loop_info import (
+    CoarseTileInfo,
+    LoopOperandBindingRequirement,
+    copy_op_metadata,
+)
+from torch_spyre._inductor.errors import Unsupported
+from torch_spyre._inductor.pass_utils import coeff_through_floor
+from torch_spyre._inductor.spyre_kernel import SpyreKernel, TensorAccess
+from torch_spyre._inductor.wsr.coarse_tile import _host_tile_advances_for_dep
+
+
+def test_expert_advance_is_measured_relative_to_the_window_base():
+    expert = sympy_index_symbol("d0")
+    row = sympy_index_symbol("d1")
+    dep = MemoryDep(
+        name="weight",
+        index=17 + 4096 * expert + 64 * row,
+        var_names=(expert, row),
+        size=(2, 64),
+    )
+
+    advances = _host_tile_advances_for_dep(
+        dep,
+        [{}, {0: sympy.Integer(1)}],
+    )
+
+    assert advances == [[], [(0, sympy.Integer(4096))]]
+
+
+def test_typed_preheader_owner_survives_ir_reconstruction():
+    source = type("Source", (), {})()
+    source.loop_info = CoarseTileInfo(
+        loop_group_id=(),
+        loop_count=[],
+        loop_tiled_dims=[],
+        preheader_for_group=(3, 1),
+    )
+    destination = type("Destination", (), {})()
+
+    copy_op_metadata(source, destination)
+
+    assert destination.loop_info.preheader_for_group == (3, 1)
+
+
+def _fully_squeezed_read_advance(binding):
+    dep = MemoryDep(
+        name="weight",
+        index=sympy.Integer(0),
+        var_names=(),
+        size=(),
+    )
+    ir_node = SimpleNamespace(
+        loop_info=CoarseTileInfo(
+            loop_group_id=(0,),
+            loop_count=[sympy.Integer(128)],
+            loop_tiled_dims=[[0]],
+            tiled_dims_per_read=[[[]]],
+            squeezed_advance_per_read=[[[(sympy.Integer(64), sympy.Integer(1))]]],
+            loop_operand_bindings=[binding],
+        ),
+        get_operation_name=lambda: "expert_weight_copy",
+        get_read_writes=lambda: SimpleNamespace(reads=[dep], writes=[]),
+    )
+    kernel = SpyreKernel()
+    kernel.current_node = SimpleNamespace(node=ir_node)
+    tensor = TensorAccess(
+        "weight",
+        sympy.Integer(0),
+        SimpleNamespace(
+            device_layout=SimpleNamespace(
+                device_size=[128, 64],
+                stride_map=[64, 1],
+            )
+        ),
+    )
+
+    advance = kernel._general_tile_advance(tensor, True, "weight")
+    level = kernel._tile_advance_symbols[0]
+    return sympy.expand(advance).coeff(level)
+
+
+def test_persistent_binding_and_ordinary_squeezed_advance_coexist():
+    # The upstream squeezed-dim fallback remains the address source for an
+    # ordinary copy. A persistent expert operand instead uses its pre-division
+    # binding, which retains the weight-bank stride hidden by the unit E tile.
+    assert _fully_squeezed_read_advance(None) == 64
+    assert (
+        _fully_squeezed_read_advance(
+            LoopOperandBindingRequirement(
+                kind="sequential_affine",
+                host_advance_per_level=(sympy.Integer(4096),),
+            )
+        )
+        == 4096
+    )
+
+
+def test_binding_conflict_with_surviving_dim_fails_closed():
+    dim = sympy_index_symbol("d0")
+    dep = MemoryDep(
+        name="weight",
+        index=dim,
+        var_names=(dim,),
+        size=(64,),
+    )
+    ir_node = SimpleNamespace(
+        loop_info=CoarseTileInfo(
+            loop_group_id=(0,),
+            loop_count=[sympy.Integer(128)],
+            loop_tiled_dims=[[0]],
+            tiled_dims_per_read=[[[(0, sympy.Integer(1))]]],
+            loop_operand_bindings=[
+                LoopOperandBindingRequirement(
+                    kind="sequential_affine",
+                    host_advance_per_level=(sympy.Integer(4096),),
+                )
+            ],
+        ),
+        get_operation_name=lambda: "mixed_weight_copy",
+        get_read_writes=lambda: SimpleNamespace(reads=[dep], writes=[]),
+    )
+    kernel = SpyreKernel()
+    kernel.current_node = SimpleNamespace(node=ir_node)
+    tensor = TensorAccess(
+        "weight",
+        sympy.Integer(0),
+        SimpleNamespace(
+            device_layout=SimpleNamespace(
+                device_size=[64],
+                stride_map=[1],
+            )
+        ),
+    )
+
+    with pytest.raises(Unsupported, match="conflicts with surviving tiled dimensions"):
+        kernel._general_tile_advance(tensor, True, "weight")
+
+
+def test_binding_owns_a_squeezed_expert_dim_without_aliasing_the_row_symbol():
+    row = sympy_index_symbol("d0")
+    dep = MemoryDep(
+        name="routing_weight",
+        index=row,
+        var_names=(row,),
+        size=(64,),
+    )
+    ir_node = SimpleNamespace(
+        data=SimpleNamespace(ranges=[1, 64, 1]),
+        loop_info=CoarseTileInfo(
+            loop_group_id=(0,),
+            loop_count=[sympy.Integer(128)],
+            loop_tiled_dims=[[0]],
+            tiled_dims_per_read=[[[(0, sympy.Integer(1))]]],
+            loop_operand_bindings=[
+                LoopOperandBindingRequirement(
+                    kind="sequential_affine",
+                    host_advance_per_level=(sympy.Integer(64),),
+                )
+            ],
+        ),
+        get_operation_name=lambda: "routing_weight_copy",
+        get_read_writes=lambda: SimpleNamespace(reads=[dep], writes=[]),
+    )
+    kernel = SpyreKernel()
+    kernel.current_node = SimpleNamespace(node=ir_node)
+    tensor = TensorAccess(
+        "routing_weight",
+        sympy.Integer(0),
+        SimpleNamespace(
+            device_layout=SimpleNamespace(device_size=[64], stride_map=[1])
+        ),
+    )
+
+    advance = kernel._general_tile_advance(tensor, True, "routing_weight")
+    level = kernel._tile_advance_symbols[0]
+    assert coeff_through_floor(advance, level) == 64

--- a/tests/inductor/test_persistent_expert_loop_planning.py
+++ b/tests/inductor/test_persistent_expert_loop_planning.py
@@ -20,14 +20,25 @@ from torch._inductor.dependencies import MemoryDep
 from torch._inductor.utils import sympy_index_symbol
 
 from torch_spyre._inductor.loop_info import (
+    CountedLoopPlan,
     CoarseTileInfo,
     LoopOperandBindingRequirement,
+    LoopStoragePlan,
     copy_op_metadata,
 )
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.pass_utils import coeff_through_floor
+from torch_spyre._inductor import ir as spyre_ir
+from torch_spyre._inductor.ir import SpyreEmptyFallback
+from torch_spyre._inductor.scratchpad.allocator import (
+    _reject_required_loop_lx_relayouts,
+    _safe_in_place_parents,
+    _validate_required_loop_lx_allocation,
+)
+from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
 from torch_spyre._inductor.scratchpad.utils import (
     hoisted_loop_lifetime_end_overrides,
+    required_loop_lx_storage_names,
 )
 from torch_spyre._inductor.spyre_kernel import SpyreKernel, TensorAccess
 from torch_spyre._inductor.wsr.coarse_tile import _host_tile_advances_for_dep
@@ -100,7 +111,7 @@ def _fully_squeezed_read_advance(binding):
 
     advance = kernel._general_tile_advance(tensor, True, "weight")
     level = kernel._tile_advance_symbols[0]
-    return sympy.expand(advance).coeff(level)
+    return coeff_through_floor(advance, level)
 
 
 def test_persistent_binding_and_ordinary_squeezed_advance_coexist():
@@ -209,6 +220,12 @@ def test_hoisted_copy_lifetime_ends_after_its_own_loop_group():
             loop_tiled_dims=[[] for _ in group],
             preheader_for_group=preheader_for_group,
         )
+        if preheader_for_group is not None:
+            value.loop_storage_plan = LoopStoragePlan(
+                kind="loop_invariant",
+                owner_group=preheader_for_group,
+                execution_role="input_activation",
+            )
         return value
 
     graph = type("Graph", (), {})()
@@ -220,3 +237,93 @@ def test_hoisted_copy_lifetime_ends_after_its_own_loop_group():
     ]
 
     assert hoisted_loop_lifetime_end_overrides(graph) == {"x_copy": 3}
+
+
+def test_typed_loop_storage_is_required_in_lx():
+    def op(name):
+        return type("Op", (), {"get_name": lambda self: name})()
+
+    x_copy = op("x_copy")
+    x_copy.loop_info = CoarseTileInfo(
+        loop_group_id=(),
+        loop_count=[],
+        loop_tiled_dims=[],
+        preheader_for_group=(2,),
+        counted_loop_plan=CountedLoopPlan(
+            kind="persistent_dense_expert", trip_count=128
+        ),
+    )
+    x_copy.loop_storage_plan = LoopStoragePlan(
+        kind="loop_invariant",
+        owner_group=(2,),
+        execution_role="input_activation",
+    )
+    accumulator = op("accumulator")
+    accumulator.loop_storage_plan = LoopStoragePlan(
+        kind="loop_carried_accumulator",
+        owner_group=(2,),
+        execution_role="output_accumulator",
+    )
+    body = op("body")
+    body.loop_info = CoarseTileInfo(
+        loop_group_id=(2,),
+        loop_count=[128],
+        loop_tiled_dims=[[]],
+        counted_loop_plan=CountedLoopPlan(
+            kind="persistent_dense_expert",
+            trip_count=128,
+            body_memory_kind="lx",
+        ),
+    )
+    graph = SimpleNamespace(operations=[x_copy, accumulator, body])
+
+    assert required_loop_lx_storage_names(graph) == frozenset({"x_copy", "accumulator"})
+
+
+def test_only_typed_loop_empty_skips_wrapper_allocation_for_lx(monkeypatch):
+    class Layout:
+        def __init__(self, allocation):
+            self.allocation = allocation
+
+    monkeypatch.setattr(spyre_ir, "FixedTiledLayout", Layout)
+
+    ordinary = SimpleNamespace(
+        get_layout=lambda: Layout({"lx": 0}),
+        loop_storage_plan=None,
+    )
+    persistent = SimpleNamespace(
+        get_layout=lambda: Layout({"lx": 0}),
+        loop_storage_plan=LoopStoragePlan(
+            kind="loop_carried_accumulator",
+            owner_group=(2,),
+            execution_role="output_accumulator",
+        ),
+    )
+
+    assert SpyreEmptyFallback.should_allocate(ordinary)
+    assert not SpyreEmptyFallback.should_allocate(persistent)
+
+
+def test_required_loop_storage_rejects_relayout_and_spill():
+    plan = SimpleNamespace(source_name="x_copy", destination_name="x_relayout")
+    try:
+        _reject_required_loop_lx_relayouts([plan], frozenset({"x_copy"}))
+    except Unsupported:
+        pass
+    else:
+        raise AssertionError("persistent loop storage relayout must fail closed")
+
+    spilled = LifetimeBoundBuffer("x_copy", 128, [0, 1])
+    try:
+        _validate_required_loop_lx_allocation(frozenset({"x_copy"}), [spilled])
+    except Unsupported:
+        pass
+    else:
+        raise AssertionError("required persistent loop storage may not spill")
+
+    spilled.address = 0
+    _validate_required_loop_lx_allocation(frozenset({"x_copy"}), [spilled])
+
+
+def test_loop_lifetime_disables_in_place_handoff():
+    assert _safe_in_place_parents(["x_copy", "ordinary"], {"x_copy": 8}) == ["ordinary"]

--- a/tests/inductor/test_persistent_expert_loop_planning.py
+++ b/tests/inductor/test_persistent_expert_loop_planning.py
@@ -26,6 +26,9 @@ from torch_spyre._inductor.loop_info import (
 )
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.pass_utils import coeff_through_floor
+from torch_spyre._inductor.scratchpad.utils import (
+    hoisted_loop_lifetime_end_overrides,
+)
 from torch_spyre._inductor.spyre_kernel import SpyreKernel, TensorAccess
 from torch_spyre._inductor.wsr.coarse_tile import _host_tile_advances_for_dep
 
@@ -48,7 +51,7 @@ def test_expert_advance_is_measured_relative_to_the_window_base():
     assert advances == [[], [(0, sympy.Integer(4096))]]
 
 
-def test_typed_preheader_owner_survives_ir_reconstruction():
+def test_hoisted_copy_owner_survives_ir_reconstruction():
     source = type("Source", (), {})()
     source.loop_info = CoarseTileInfo(
         loop_group_id=(),
@@ -195,3 +198,25 @@ def test_binding_owns_a_squeezed_expert_dim_without_aliasing_the_row_symbol():
     advance = kernel._general_tile_advance(tensor, True, "routing_weight")
     level = kernel._tile_advance_symbols[0]
     assert coeff_through_floor(advance, level) == 64
+
+
+def test_hoisted_copy_lifetime_ends_after_its_own_loop_group():
+    def op(name, group=(), preheader_for_group=None):
+        value = type("Op", (), {"get_name": lambda self: name})()
+        value.loop_info = CoarseTileInfo(
+            loop_group_id=group,
+            loop_count=[2] * len(group),
+            loop_tiled_dims=[[] for _ in group],
+            preheader_for_group=preheader_for_group,
+        )
+        return value
+
+    graph = type("Graph", (), {})()
+    graph.operations = [
+        op("x_copy", preheader_for_group=(2,)),
+        op("first", (2,)),
+        op("nested", (2, 0)),
+        op("later", (3,)),
+    ]
+
+    assert hoisted_loop_lifetime_end_overrides(graph) == {"x_copy": 3}

--- a/tests/inductor/test_scratchpad_solver.py
+++ b/tests/inductor/test_scratchpad_solver.py
@@ -665,6 +665,27 @@ class BaseLayoutSolverTests:
             LifetimeBoundBuffer("E", 20, [], first_use_is_read=True).read_count, 0
         )
 
+    def test_lifetime_end_override_changes_overlap_not_reads_or_score(self):
+        from torch_spyre._inductor.scratchpad.permutation_layout import (
+            buffer_quality,
+        )
+
+        ordinary = LifetimeBoundBuffer("ordinary", 20, [3, 5, 8], residency_reason=None)
+        loop_carried = LifetimeBoundBuffer(
+            "loop_carried",
+            20,
+            [3, 5, 8],
+            residency_reason=None,
+            lifetime_end_override=20,
+        )
+
+        self.assertEqual(loop_carried.uses, [3, 5, 8])
+        self.assertEqual(loop_carried.read_count, ordinary.read_count)
+        self.assertEqual(buffer_quality(loop_carried), buffer_quality(ordinary))
+        self.assertEqual(loop_carried.residency_reason, ordinary.residency_reason)
+        self.assertEqual(ordinary.end_time, 9)
+        self.assertEqual(loop_carried.end_time, 20)
+
     def test_repeated_index_cannot_pass_as_a_read(self):
         # The in-place rule tests for a use strictly after the first rather than
         # relying on read_count, so a buffer whose uses were mutated into a

--- a/tests/inductor/test_scratchpad_solver.py
+++ b/tests/inductor/test_scratchpad_solver.py
@@ -32,6 +32,7 @@ from torch_spyre._inductor.scratchpad.plan_solver import (
     LifetimeBoundBuffer,
 )
 from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
+from torch_spyre._inductor.scratchpad.exhaustive_search import ExhaustiveSearchSolver
 
 try:
     from ortools.sat.python import cp_model  # noqa: F401
@@ -707,6 +708,31 @@ class BaseLayoutSolverTests:
             AssertionError, "computed buffer that is never read"
         ):
             _assert_in_place_relationships([p, c])
+
+
+class TestExhaustiveLifetimeOverride(TestCase):
+    def test_leaf_solver_preserves_lifetime_end_override(self):
+        observed = []
+
+        def inner_factory(buffers, size):
+            observed.append({b.name: b.lifetime_end_override for b in buffers})
+            return GreedyLayoutSolver(buffers, size, alignment=1)
+
+        held = CoreDivisionBuffer(
+            "held",
+            64,
+            [0],
+            lifetime_end_override=4,
+            core_divisions=[CoreDivision()],
+        )
+        solver = ExhaustiveSearchSolver(
+            [held], 256, inner_factory=inner_factory, alignment=1
+        )
+
+        solver.plan_layout_and_core_divisions()
+
+        self.assertTrue(observed)
+        self.assertTrue(all(item["held"] == 4 for item in observed))
 
 
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))

--- a/torch_spyre/_inductor/__init__.py
+++ b/torch_spyre/_inductor/__init__.py
@@ -138,6 +138,27 @@ def enable_spyre_compile_fx_wrapper():
             try:
                 if uses_spyre:
                     torch.spyre._impl._lazy_init()
+                    from torch_spyre._inductor.expert_execution.custom_op import (
+                        moe_ffn,
+                    )
+
+                    if any(
+                        node.op == "call_function"
+                        and node.target == moe_ffn._opoverload
+                        for node in gm.graph.nodes
+                    ):
+                        from torch_spyre._inductor.expert_execution.planner import (
+                            prepare_expert_execution_graph,
+                        )
+
+                        gm, expert_plan = prepare_expert_execution_graph(gm)
+                        logger.debug(
+                            "planned %d semantic MoE nodes; selected %d persistent",
+                            len(expert_plan.nodes),
+                            sum(
+                                node.schedule is not None for node in expert_plan.nodes
+                            ),
+                        )
                     # AOTAutograd uses the dict passed via ``decompositions=``
                     # to decompose the joint graph; Spyre-specific
                     # decompositions must be applied at this stage so ops like

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -67,6 +67,11 @@ dxp_lx_frac_avail: float = float(os.environ.get("DXP_LX_FRAC_AVAIL", "0.2"))
 
 sencores: int = int(os.getenv("SENCORES", "32"))
 
+# Internal development gate.  This is deliberately not environment-controlled:
+# the persistent strategy is not selectable until its physical schedule lands.
+# Tests may monkeypatch it while exercising the pure planner/materializer.
+enable_dense_expert_persistent: bool = False
+
 # Symbolic-dim knobs consumed by compute_granularity in pass_utils.py.
 # The pointwise work-division PR (#2499) wires that helper into the
 # compilation pipeline; until then these knobs are read only by the

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -110,6 +110,10 @@ COPY_BACK_CANDIDATE_ATTR = "_spyre_copy_back_candidate"
 # compute mutation op from a pure-copy mutation op.
 ELIDED_COPY_BACK_ATTR = "_spyre_writes_copy_back_target"
 
+# OpSpec marker for a persistent expert projection whose expert weight remains
+# a graph HBM operand and is rebound once per counted-loop iteration.
+PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY = "persistent_expert_stream_weight"
+
 # FX ``custom`` metadata key for BMMs created from a shared 2D weight whose
 # logical batch dim is statically 1.  The downstream OpSpec key carries the same
 # fact after lowering, where FX metadata is no longer directly available.

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -24,6 +24,7 @@ from .expert_execution.custom_op import (  # noqa: F401
     dense_expert_persistent_ffn,
     expert_mm_prepacked,
     expert_route_prepacked,
+    expert_route_weighted_down,
     expert_shared_lhs_mm,
     expert_shared_lhs_mm_prepacked,
     moe_ffn,

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -20,6 +20,11 @@ from torch_spyre.ops.eager import compile_once
 from torch_spyre.ops.fallbacks import warn_fallback
 
 from .errors import Unsupported
+from .expert_execution.custom_op import (  # noqa: F401
+    dense_expert_persistent_ffn,
+    expert_shared_lhs_mm,
+    moe_ffn,
+)
 
 aten = torch.ops.aten
 

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -22,7 +22,10 @@ from torch_spyre.ops.fallbacks import warn_fallback
 from .errors import Unsupported
 from .expert_execution.custom_op import (  # noqa: F401
     dense_expert_persistent_ffn,
+    expert_mm_prepacked,
+    expert_route_prepacked,
     expert_shared_lhs_mm,
+    expert_shared_lhs_mm_prepacked,
     moe_ffn,
 )
 

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -113,6 +113,71 @@ def register_spyre_decompositions(ops: OpOrOps):
     return decomp.register_decomposition(ops, spyre_decompositions)
 
 
+@register_spyre_decompositions(torch.ops.spyre.moe_ffn.default)
+def decompose_moe_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+) -> torch.Tensor:
+    """Lower the semantic operation through the ordinary dense device path."""
+    from .expert_execution.semantics import moe_ffn_reference
+
+    return moe_ffn_reference(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+
+
+@register_spyre_decompositions(torch.ops.spyre.dense_expert_persistent_ffn.default)
+def decompose_dense_expert_persistent_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+    region_id: str,
+) -> torch.Tensor:
+    """Materialize one logical body for a static persistent expert loop.
+
+    This decomposition does not iterate over experts in Python. The expert
+    dimension remains in the logical tensors and is tiled to one by the
+    compiler, which turns it into one counted device loop around a single
+    gate/up/down body.
+    """
+    del top_k, region_id  # Routing weights already encode top-k selection.
+    experts = gate_weight.shape[0]
+    with spyre_hint(num_tiles_per_dim={"E": experts}):
+        with spyre_hint(named_dims=["E", "T", "F"]):
+            gate = torch.ops.spyre.expert_shared_lhs_mm(x, gate_weight)
+            up = torch.ops.spyre.expert_shared_lhs_mm(x, up_weight)
+            if activation == "gelu_tanh":
+                activated_gate = torch.nn.functional.gelu(gate, approximate="tanh")
+            elif activation == "silu":
+                activated_gate = torch.nn.functional.silu(gate)
+            else:
+                raise Unsupported(f"unsupported MoE activation {activation!r}")
+            hidden = activated_gate * up
+        with spyre_hint(named_dims=["E", "T", "H"]):
+            down = torch.bmm(hidden, down_weight)
+        with spyre_hint(named_dims=["E", "T", "route"]):
+            route_by_expert = routing_weight.permute(1, 0, 2)
+        with spyre_hint(named_dims=["E", "T", "H"]):
+            weighted_down = down * route_by_expert
+        with spyre_hint(named_dims=["T", "H"], expected_reduction_dims=["E"]):
+            return torch.sum(weighted_down, dim=0)
+
+
 def get_spyre_decomp_table() -> dict[Any, Callable[..., Any]]:
     """Return the decomposition table Inductor sees when compiling for Spyre.
 

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -202,14 +202,10 @@ def decompose_dense_expert_persistent_ffn(
     with compiler_hint(
         region_id,
         **loop,
-        named_dims=["E", "T", "route"],
+        named_dims=["E", "T", "H"],
         streamed_operand_role="routing_weight",
     ):
-        route_by_expert = torch.ops.spyre.expert_route_prepacked(
-            routing_weight.permute(1, 0, 2)
-        )
-    with compiler_hint(region_id, **loop, named_dims=["E", "T", "H"]):
-        weighted_down = down * route_by_expert
+        weighted_down = torch.ops.spyre.expert_route_weighted_down(down, routing_weight)
     with compiler_hint(
         region_id,
         **loop,

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -39,6 +39,7 @@ from .logging_utils import get_inductor_logger
 
 from . import customops  # noqa: F401
 from . import spyre_hint
+from .propagate_hints import compiler_hint
 from torch_spyre._C import DataFormats, get_device_dtype, get_elem_in_stick
 import torch_spyre._inductor.customops  # noqa: F401
 
@@ -155,27 +156,67 @@ def decompose_dense_expert_persistent_ffn(
     compiler, which turns it into one counted device loop around a single
     gate/up/down body.
     """
-    del top_k, region_id  # Routing weights already encode top-k selection.
+    del top_k  # Routing weights already encode top-k selection.
     experts = gate_weight.shape[0]
-    with spyre_hint(num_tiles_per_dim={"E": experts}):
-        with spyre_hint(named_dims=["E", "T", "F"]):
-            gate = torch.ops.spyre.expert_shared_lhs_mm(x, gate_weight)
-            up = torch.ops.spyre.expert_shared_lhs_mm(x, up_weight)
-            if activation == "gelu_tanh":
-                activated_gate = torch.nn.functional.gelu(gate, approximate="tanh")
-            elif activation == "silu":
-                activated_gate = torch.nn.functional.silu(gate)
-            else:
-                raise Unsupported(f"unsupported MoE activation {activation!r}")
-            hidden = activated_gate * up
-        with spyre_hint(named_dims=["E", "T", "H"]):
-            down = torch.bmm(hidden, down_weight)
-        with spyre_hint(named_dims=["E", "T", "route"]):
-            route_by_expert = routing_weight.permute(1, 0, 2)
-        with spyre_hint(named_dims=["E", "T", "H"]):
-            weighted_down = down * route_by_expert
-        with spyre_hint(named_dims=["T", "H"], expected_reduction_dims=["E"]):
-            return torch.sum(weighted_down, dim=0)
+    loop = {
+        "num_tiles_per_dim": {"E": experts},
+        "expert_execution": "persistent_dense_expert",
+    }
+    # The semantic weights are logical [E,K,N] views backed by packed
+    # [K,E,N] storage.  Expose that physical layout to the internal lowerings
+    # without changing the model-facing contract.
+    gate_packed = gate_weight.permute(1, 0, 2)
+    up_packed = up_weight.permute(1, 0, 2)
+    down_packed = down_weight.permute(1, 0, 2)
+
+    with compiler_hint(
+        region_id,
+        **loop,
+        named_dims=["E", "T", "F"],
+        streamed_operand_role="gate_weight",
+    ):
+        gate = torch.ops.spyre.expert_shared_lhs_mm_prepacked(x, gate_packed)
+    with compiler_hint(
+        region_id,
+        **loop,
+        named_dims=["E", "T", "F"],
+        streamed_operand_role="up_weight",
+    ):
+        up = torch.ops.spyre.expert_shared_lhs_mm_prepacked(x, up_packed)
+    with compiler_hint(region_id, **loop, named_dims=["E", "T", "F"]):
+        if activation == "gelu_tanh":
+            activated_gate = torch.nn.functional.gelu(gate, approximate="tanh")
+        elif activation == "silu":
+            activated_gate = torch.nn.functional.silu(gate)
+        else:
+            raise Unsupported(f"unsupported MoE activation {activation!r}")
+    with compiler_hint(region_id, **loop, named_dims=["E", "T", "F"]):
+        hidden = activated_gate * up
+    with compiler_hint(
+        region_id,
+        **loop,
+        named_dims=["E", "T", "H"],
+        streamed_operand_role="down_weight",
+    ):
+        down = torch.ops.spyre.expert_mm_prepacked(hidden, down_packed)
+    with compiler_hint(
+        region_id,
+        **loop,
+        named_dims=["E", "T", "route"],
+        streamed_operand_role="routing_weight",
+    ):
+        route_by_expert = torch.ops.spyre.expert_route_prepacked(
+            routing_weight.permute(1, 0, 2)
+        )
+    with compiler_hint(region_id, **loop, named_dims=["E", "T", "H"]):
+        weighted_down = down * route_by_expert
+    with compiler_hint(
+        region_id,
+        **loop,
+        expected_named_dims=["T", "H"],
+        expected_reduction_dims=["E"],
+    ):
+        return torch.sum(weighted_down, dim=0)
 
 
 def get_spyre_decomp_table() -> dict[Any, Callable[..., Any]]:

--- a/torch_spyre/_inductor/expert_execution/__init__.py
+++ b/torch_spyre/_inductor/expert_execution/__init__.py
@@ -1,0 +1,37 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dense-expert semantic operations and compiler strategy selection."""
+
+from .planner import (
+    ExpertGraphPlan,
+    ExpertPlanningError,
+    ExpertStrategy,
+    PersistentExpertSchedule,
+    PlannedExpertNode,
+    materialize_expert_execution_graph,
+    plan_expert_execution_graph,
+    prepare_expert_execution_graph,
+)
+
+__all__ = [
+    "ExpertGraphPlan",
+    "ExpertPlanningError",
+    "ExpertStrategy",
+    "PersistentExpertSchedule",
+    "PlannedExpertNode",
+    "materialize_expert_execution_graph",
+    "plan_expert_execution_graph",
+    "prepare_expert_execution_graph",
+]

--- a/torch_spyre/_inductor/expert_execution/custom_op.py
+++ b/torch_spyre/_inductor/expert_execution/custom_op.py
@@ -38,6 +38,95 @@ def _(x: torch.Tensor, expert_weights: torch.Tensor) -> torch.Tensor:
     return x.new_empty((expert_weights.shape[0], x.shape[0], expert_weights.shape[2]))
 
 
+@torch.library.custom_op(
+    "spyre::expert_shared_lhs_mm_prepacked",
+    mutates_args=(),
+    device_types=("cpu", "spyre"),
+)
+def expert_shared_lhs_mm_prepacked(
+    x: torch.Tensor, expert_weights: torch.Tensor
+) -> torch.Tensor:
+    """Internal shared-LHS projection with physical weights ``[K,E,N]``."""
+
+    _validate_shared_lhs_mm_prepacked(x, expert_weights)
+    return torch.stack(
+        tuple(
+            torch.mm(x, expert_weights[:, expert, :])
+            for expert in range(expert_weights.shape[1])
+        )
+    )
+
+
+@expert_shared_lhs_mm_prepacked.register_fake
+def _(x: torch.Tensor, expert_weights: torch.Tensor) -> torch.Tensor:
+    _validate_shared_lhs_mm_prepacked(x, expert_weights)
+    return x.new_empty((expert_weights.shape[1], x.shape[0], expert_weights.shape[2]))
+
+
+def _validate_shared_lhs_mm_prepacked(
+    x: torch.Tensor, expert_weights: torch.Tensor
+) -> None:
+    if x.ndim != 2 or expert_weights.ndim != 3:
+        raise ValueError("expected x[T,K] and expert_weights[K,E,N]")
+    if x.shape[1] != expert_weights.shape[0]:
+        raise ValueError("x and expert_weights have different reduction dimensions")
+    if x.device != expert_weights.device or x.dtype != expert_weights.dtype:
+        raise ValueError("x and expert_weights must share device and dtype")
+
+
+@torch.library.custom_op(
+    "spyre::expert_mm_prepacked", mutates_args=(), device_types=("cpu", "spyre")
+)
+def expert_mm_prepacked(x: torch.Tensor, expert_weights: torch.Tensor) -> torch.Tensor:
+    """Internal expert projection with physical weights ``[K,E,N]``."""
+
+    _validate_expert_mm_prepacked(x, expert_weights)
+    return torch.stack(
+        tuple(
+            torch.mm(x[expert], expert_weights[:, expert, :])
+            for expert in range(expert_weights.shape[1])
+        )
+    )
+
+
+@expert_mm_prepacked.register_fake
+def _(x: torch.Tensor, expert_weights: torch.Tensor) -> torch.Tensor:
+    _validate_expert_mm_prepacked(x, expert_weights)
+    return x.new_empty((x.shape[0], x.shape[1], expert_weights.shape[2]))
+
+
+def _validate_expert_mm_prepacked(
+    x: torch.Tensor, expert_weights: torch.Tensor
+) -> None:
+    if x.ndim != 3 or expert_weights.ndim != 3:
+        raise ValueError("expected x[E,T,K] and expert_weights[K,E,N]")
+    if x.shape[0] != expert_weights.shape[1] or x.shape[2] != expert_weights.shape[0]:
+        raise ValueError("expert or reduction dimension mismatch")
+    if x.device != expert_weights.device or x.dtype != expert_weights.dtype:
+        raise ValueError("x and expert_weights must share device and dtype")
+
+
+@torch.library.custom_op(
+    "spyre::expert_route_prepacked", mutates_args=(), device_types=("cpu", "spyre")
+)
+def expert_route_prepacked(routing_weight: torch.Tensor) -> torch.Tensor:
+    """Internal identity over an expert-major ``[E,T,1]`` routing tensor."""
+
+    _validate_expert_route_prepacked(routing_weight)
+    return routing_weight.clone()
+
+
+@expert_route_prepacked.register_fake
+def _(routing_weight: torch.Tensor) -> torch.Tensor:
+    _validate_expert_route_prepacked(routing_weight)
+    return routing_weight.new_empty(routing_weight.shape)
+
+
+def _validate_expert_route_prepacked(routing_weight: torch.Tensor) -> None:
+    if routing_weight.ndim != 3 or routing_weight.shape[2] != 1:
+        raise ValueError("expected routing_weight[E,T,1]")
+
+
 def _validate_shared_lhs_mm(x: torch.Tensor, expert_weights: torch.Tensor) -> None:
     if x.ndim != 2:
         raise ValueError(f"x must have shape [T,K], got {tuple(x.shape)}")

--- a/torch_spyre/_inductor/expert_execution/custom_op.py
+++ b/torch_spyre/_inductor/expert_execution/custom_op.py
@@ -127,6 +127,37 @@ def _validate_expert_route_prepacked(routing_weight: torch.Tensor) -> None:
         raise ValueError("expected routing_weight[E,T,1]")
 
 
+@torch.library.custom_op(
+    "spyre::expert_route_weighted_down",
+    mutates_args=(),
+    device_types=("cpu", "spyre"),
+)
+def expert_route_weighted_down(
+    down: torch.Tensor, routing_weight: torch.Tensor
+) -> torch.Tensor:
+    """Apply logical ``[T,E,1]`` route weights to ``[E,T,H]`` expert output."""
+
+    _validate_expert_route_weighted_down(down, routing_weight)
+    return down * routing_weight.permute(1, 0, 2)
+
+
+@expert_route_weighted_down.register_fake
+def _(down: torch.Tensor, routing_weight: torch.Tensor) -> torch.Tensor:
+    _validate_expert_route_weighted_down(down, routing_weight)
+    return down.new_empty(down.shape)
+
+
+def _validate_expert_route_weighted_down(
+    down: torch.Tensor, routing_weight: torch.Tensor
+) -> None:
+    if down.ndim != 3 or routing_weight.ndim != 3:
+        raise ValueError("expected down[E,T,H] and routing_weight[T,E,1]")
+    if routing_weight.shape != (down.shape[1], down.shape[0], 1):
+        raise ValueError("routing_weight must have shape [T,E,1]")
+    if down.device != routing_weight.device or down.dtype != routing_weight.dtype:
+        raise ValueError("down and routing_weight must share device and dtype")
+
+
 def _validate_shared_lhs_mm(x: torch.Tensor, expert_weights: torch.Tensor) -> None:
     if x.ndim != 2:
         raise ValueError(f"x must have shape [T,K], got {tuple(x.shape)}")

--- a/torch_spyre/_inductor/expert_execution/custom_op.py
+++ b/torch_spyre/_inductor/expert_execution/custom_op.py
@@ -1,0 +1,186 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Strategy-neutral routed-expert FFN custom operation."""
+
+import torch
+
+from .semantics import moe_ffn_reference, validate_moe_ffn_inputs
+
+
+@torch.library.custom_op(
+    "spyre::expert_shared_lhs_mm", mutates_args=(), device_types=("cpu", "spyre")
+)
+def expert_shared_lhs_mm(x: torch.Tensor, expert_weights: torch.Tensor) -> torch.Tensor:
+    """Evaluate the internal shared-LHS expert projection in eager mode."""
+    _validate_shared_lhs_mm(x, expert_weights)
+    return torch.stack(
+        tuple(
+            torch.mm(x, expert_weights[expert]) for expert in range(len(expert_weights))
+        )
+    )
+
+
+@expert_shared_lhs_mm.register_fake
+def _(x: torch.Tensor, expert_weights: torch.Tensor) -> torch.Tensor:
+    _validate_shared_lhs_mm(x, expert_weights)
+    return x.new_empty((expert_weights.shape[0], x.shape[0], expert_weights.shape[2]))
+
+
+def _validate_shared_lhs_mm(x: torch.Tensor, expert_weights: torch.Tensor) -> None:
+    if x.ndim != 2:
+        raise ValueError(f"x must have shape [T,K], got {tuple(x.shape)}")
+    if expert_weights.ndim != 3:
+        raise ValueError(
+            f"expert_weights must have shape [E,K,N], got {tuple(expert_weights.shape)}"
+        )
+    if x.shape[1] != expert_weights.shape[1]:
+        raise ValueError("x and expert_weights have different reduction dimensions")
+    if x.device != expert_weights.device or x.dtype != expert_weights.dtype:
+        raise ValueError("x and expert_weights must share device and dtype")
+
+
+def _internal_moe_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+) -> torch.Tensor:
+    return moe_ffn_reference(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+
+
+def _fake_internal_moe_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+    region_id: str,
+) -> torch.Tensor:
+    del region_id
+    validate_moe_ffn_inputs(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+    return x.new_empty(x.shape)
+
+
+@torch.library.custom_op(
+    "spyre::dense_expert_persistent_ffn",
+    mutates_args=(),
+    device_types=("cpu", "spyre"),
+    schema=(
+        "(Tensor x, Tensor gate_weight, Tensor up_weight, Tensor down_weight, "
+        "Tensor routing_weight, int top_k, str activation, str region_id) -> Tensor"
+    ),
+)
+def dense_expert_persistent_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+    region_id: str,
+) -> torch.Tensor:
+    """Compiler-internal target for the persistent strategy."""
+    del region_id
+    return _internal_moe_ffn(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+
+
+dense_expert_persistent_ffn.register_fake(_fake_internal_moe_ffn)
+
+
+@torch.library.custom_op(
+    "spyre::moe_ffn",
+    mutates_args=(),
+    device_types=("cpu", "spyre"),
+    schema=(
+        "(Tensor x, Tensor gate_weight, Tensor up_weight, Tensor down_weight, "
+        "Tensor routing_weight, int top_k, str activation) -> Tensor"
+    ),
+)
+def moe_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+) -> torch.Tensor:
+    """Evaluate the routed-expert value path in eager mode.
+
+    Router-logit generation and any shared-expert FFN are intentionally outside
+    this operation. ``routing_weight`` is the already-normalized post-down
+    expert weight with logical shape ``[T, E, 1]``.
+    """
+    return moe_ffn_reference(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+
+
+@moe_ffn.register_fake
+def _(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+) -> torch.Tensor:
+    validate_moe_ffn_inputs(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+    return x.new_empty(x.shape)

--- a/torch_spyre/_inductor/expert_execution/planner.py
+++ b/torch_spyre/_inductor/expert_execution/planner.py
@@ -1,0 +1,352 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure selection and transactional FX materialization for expert execution."""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+from enum import StrEnum
+from typing import Any
+
+import torch
+
+from .custom_op import dense_expert_persistent_ffn, moe_ffn
+
+
+class ExpertStrategy(StrEnum):
+    """Compiler strategies currently available for the semantic MoE operation."""
+
+    PERSISTENT_DENSE = "persistent_dense"
+    ORDINARY_DENSE = "ordinary_dense"
+
+
+@dataclasses.dataclass(frozen=True)
+class PersistentExpertSchedule:
+    """The schedule contract materialized by the persistent strategy."""
+
+    preheader: tuple[str, ...] = ("stage_x", "fill_accumulator")
+    loop_body: tuple[str, ...] = (
+        "gate",
+        "up",
+        "activation",
+        "gated_product",
+        "down",
+        "route_weight",
+        "accumulator_combine",
+    )
+    drain: tuple[str, ...] = ("drain_output",)
+    streamed_operands: tuple[str, ...] = (
+        "gate_weight",
+        "up_weight",
+        "down_weight",
+        "routing_weight",
+    )
+    binding_kind: str = "sequential_affine"
+    weight_layout: str = "logical_expert_major_k_major_backing"
+    routing_layout: str = "logical_token_major"
+
+
+@dataclasses.dataclass(frozen=True)
+class PlannedExpertNode:
+    """The selected strategy for one semantic MoE FX node."""
+
+    node_name: str
+    strategy: ExpertStrategy
+    expert_count: int
+    minimum_lx_bytes: int
+    schedule: PersistentExpertSchedule | None
+
+
+@dataclasses.dataclass(frozen=True)
+class ExpertGraphPlan:
+    """Immutable result of planning every semantic MoE node in an FX graph."""
+
+    source_structure: tuple[tuple[Any, ...], ...]
+    nodes: tuple[PlannedExpertNode, ...]
+
+
+class ExpertPlanningError(RuntimeError):
+    """The selected strategy could not be materialized without mutation."""
+
+
+def graph_structure(graph: torch.fx.Graph) -> tuple[tuple[Any, ...], ...]:
+    """Return a stable, metadata-independent graph representation."""
+
+    def encode(value):
+        if isinstance(value, torch.fx.Node):
+            return ("node", value.name)
+        if isinstance(value, tuple):
+            return tuple(encode(item) for item in value)
+        if isinstance(value, list):
+            return ("list", *(encode(item) for item in value))
+        if isinstance(value, dict):
+            return tuple((key, encode(value[key])) for key in sorted(value))
+        return value
+
+    return tuple(
+        (node.name, node.op, str(node.target), encode(node.args), encode(node.kwargs))
+        for node in graph.nodes
+    )
+
+
+def _tensor_argument(node: torch.fx.Node, index: int, name: str) -> torch.fx.Node:
+    value = node.args[index]
+    if not isinstance(value, torch.fx.Node):
+        raise ValueError(f"{name} must be a tensor FX node")
+    return value
+
+
+def _tensor_metadata(node: torch.fx.Node, name: str):
+    """Return the tensor metadata produced by Dynamo or post-grad FX."""
+
+    value = node.meta.get("val")
+    if value is None:
+        value = node.meta.get("example_value")
+    if value is None:
+        raise ValueError(f"{name} has no tensor metadata")
+    return value
+
+
+def _shape(node: torch.fx.Node, name: str) -> tuple[int, ...]:
+    shape = getattr(_tensor_metadata(node, name), "shape", None)
+    if shape is None:
+        raise ValueError(f"{name} has no tensor shape metadata")
+    try:
+        return tuple(int(dim) for dim in shape)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} requires static dimensions") from exc
+
+
+def _element_size(node: torch.fx.Node, name: str) -> int:
+    value = _tensor_metadata(node, name)
+    if not hasattr(value, "element_size"):
+        raise ValueError(f"{name} has no tensor dtype metadata")
+    return int(value.element_size())
+
+
+def _stride(node: torch.fx.Node, name: str) -> tuple[int, ...]:
+    value = _tensor_metadata(node, name)
+    if not hasattr(value, "stride"):
+        raise ValueError(f"{name} has no tensor stride metadata")
+    try:
+        return tuple(int(dim) for dim in value.stride())
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} requires static strides") from exc
+
+
+def _has_persistent_weight_layout(
+    node: torch.fx.Node,
+    name: str,
+    *,
+    experts: int,
+    reduction: int,
+    output: int,
+) -> bool:
+    """Check the logical ``[E,K,N]`` view over packed ``[K,E,N]`` storage."""
+
+    return _shape(node, name) == (experts, reduction, output) and _stride(
+        node, name
+    ) == (output, experts * output, 1)
+
+
+def _has_persistent_routing_layout(
+    node: torch.fx.Node,
+    name: str,
+    *,
+    tokens: int,
+    experts: int,
+) -> bool:
+    """Check a logical ``[T,E,1]`` route tensor the loop can stream directly."""
+
+    if _shape(node, name) != (tokens, experts, 1):
+        return False
+    return _stride(node, name) in {
+        (experts, 1, 1),  # contiguous token-major storage
+        (1, tokens, 1),  # logical token-major view over expert-major storage
+    }
+
+
+def _plan_node(
+    node: torch.fx.Node,
+    *,
+    persistent_available: bool,
+    available_lx_bytes: int,
+) -> PlannedExpertNode:
+    if len(node.args) != 7:
+        raise ValueError("spyre::moe_ffn expects exactly seven arguments")
+    x = _tensor_argument(node, 0, "x")
+    gate = _tensor_argument(node, 1, "gate_weight")
+    up = _tensor_argument(node, 2, "up_weight")
+    down = _tensor_argument(node, 3, "down_weight")
+    routing = _tensor_argument(node, 4, "routing_weight")
+    top_k, activation = node.args[5:7]
+
+    if type(top_k) is not int or not isinstance(activation, str):
+        raise ValueError("top_k and activation must be static")
+    x_shape = _shape(x, "x")
+    gate_shape = _shape(gate, "gate_weight")
+    if len(x_shape) != 2 or len(gate_shape) != 3:
+        raise ValueError("moe_ffn requires x[T,H] and gate_weight[E,H,F]")
+    tokens, hidden = x_shape
+    experts, gate_hidden, intermediate = gate_shape
+    if gate_hidden != hidden:
+        raise ValueError("gate_weight hidden dimension differs from x")
+    if _shape(up, "up_weight") != (experts, hidden, intermediate):
+        raise ValueError("up_weight does not match gate_weight")
+    if _shape(down, "down_weight") != (experts, intermediate, hidden):
+        raise ValueError("down_weight does not match gate_weight")
+    if _shape(routing, "routing_weight") != (tokens, experts, 1):
+        raise ValueError("routing_weight must have shape [T,E,1]")
+    if not 0 < top_k <= experts:
+        raise ValueError("top_k must be in [1, E]")
+    if activation not in {"gelu_tanh", "silu"}:
+        raise ValueError(f"unsupported activation {activation!r}")
+
+    # Conservative feasibility check. Placement remains authoritative.
+    minimum_lx_bytes = _element_size(x, "x") * (
+        2 * tokens * hidden + 2 * tokens * intermediate
+    )
+    packed_weights = (
+        _has_persistent_weight_layout(
+            gate,
+            "gate_weight",
+            experts=experts,
+            reduction=hidden,
+            output=intermediate,
+        )
+        and _has_persistent_weight_layout(
+            up,
+            "up_weight",
+            experts=experts,
+            reduction=hidden,
+            output=intermediate,
+        )
+        and _has_persistent_weight_layout(
+            down,
+            "down_weight",
+            experts=experts,
+            reduction=intermediate,
+            output=hidden,
+        )
+    )
+    packed_routing = _has_persistent_routing_layout(
+        routing,
+        "routing_weight",
+        tokens=tokens,
+        experts=experts,
+    )
+    use_persistent = (
+        persistent_available
+        and packed_weights
+        and packed_routing
+        and minimum_lx_bytes <= available_lx_bytes
+    )
+    return PlannedExpertNode(
+        node_name=node.name,
+        strategy=(
+            ExpertStrategy.PERSISTENT_DENSE
+            if use_persistent
+            else ExpertStrategy.ORDINARY_DENSE
+        ),
+        expert_count=experts,
+        minimum_lx_bytes=minimum_lx_bytes,
+        schedule=PersistentExpertSchedule() if use_persistent else None,
+    )
+
+
+def plan_expert_execution_graph(
+    graph_module: torch.fx.GraphModule,
+    *,
+    persistent_available: bool,
+    available_lx_bytes: int,
+) -> ExpertGraphPlan:
+    """Select strategies without modifying graph structure or metadata."""
+    before = graph_structure(graph_module.graph)
+    plans = tuple(
+        _plan_node(
+            node,
+            persistent_available=persistent_available,
+            available_lx_bytes=available_lx_bytes,
+        )
+        for node in graph_module.graph.nodes
+        if node.op == "call_function" and node.target == moe_ffn._opoverload
+    )
+    if graph_structure(graph_module.graph) != before:
+        raise RuntimeError("expert planning mutated the source FX graph")
+    return ExpertGraphPlan(before, plans)
+
+
+def _find_node(graph: torch.fx.Graph, name: str) -> torch.fx.Node:
+    matches = [node for node in graph.nodes if node.name == name]
+    if len(matches) != 1:
+        raise ExpertPlanningError(
+            f"expected one FX node named {name}, got {len(matches)}"
+        )
+    return matches[0]
+
+
+def materialize_expert_execution_graph(
+    graph_module: torch.fx.GraphModule,
+    plan: ExpertGraphPlan,
+) -> torch.fx.GraphModule:
+    """Rewrite a clone and publish it only after all checks succeed."""
+    if graph_structure(graph_module.graph) != plan.source_structure:
+        raise ExpertPlanningError("FX graph changed after expert planning")
+    persistent_nodes = tuple(
+        node for node in plan.nodes if node.strategy == ExpertStrategy.PERSISTENT_DENSE
+    )
+    if not persistent_nodes:
+        return graph_module
+
+    candidate = copy.deepcopy(graph_module)
+    for node_plan in persistent_nodes:
+        node = _find_node(candidate.graph, node_plan.node_name)
+        if node.target != moe_ffn._opoverload or node_plan.schedule is None:
+            raise ExpertPlanningError(
+                f"{node_plan.node_name} is not a valid persistent MoE node"
+            )
+        node.target = dense_expert_persistent_ffn._opoverload
+        # The stable FX node name is the compiler-owned region identity.  It is
+        # serialized as a static internal-op argument so the selected region
+        # survives AOT decomposition without relying on user hint IDs.
+        node.args = (*node.args, node_plan.node_name)
+    candidate.graph.lint()
+    candidate.recompile()
+
+    for node_plan in persistent_nodes:
+        if (
+            _find_node(candidate.graph, node_plan.node_name).target
+            != dense_expert_persistent_ffn._opoverload
+        ):
+            raise ExpertPlanningError(f"failed to materialize {node_plan.node_name}")
+    if graph_structure(graph_module.graph) != plan.source_structure:
+        raise RuntimeError("expert materialization mutated the source FX graph")
+    return candidate
+
+
+def prepare_expert_execution_graph(
+    graph_module: torch.fx.GraphModule,
+) -> tuple[torch.fx.GraphModule, ExpertGraphPlan]:
+    """Plan once, then transactionally materialize compiler-owned strategies."""
+    from .. import config
+    from ..scratchpad.allocator import _lx_planning_size
+
+    plan = plan_expert_execution_graph(
+        graph_module,
+        persistent_available=config.enable_dense_expert_persistent,
+        available_lx_bytes=config.sencores * _lx_planning_size(),
+    )
+    return materialize_expert_execution_graph(graph_module, plan), plan

--- a/torch_spyre/_inductor/expert_execution/semantics.py
+++ b/torch_spyre/_inductor/expert_execution/semantics.py
@@ -1,0 +1,123 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Semantic definition of the routed-expert FFN operation."""
+
+from __future__ import annotations
+
+import torch
+
+
+SUPPORTED_ACTIVATIONS = ("gelu_tanh", "silu")
+
+
+def validate_moe_ffn_inputs(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+) -> tuple[int, int, int, int]:
+    """Validate the logical, strategy-neutral routed-FFN tensor contract."""
+    if activation not in SUPPORTED_ACTIVATIONS:
+        raise ValueError(
+            f"unsupported MoE activation {activation!r}; "
+            f"expected one of {SUPPORTED_ACTIVATIONS}"
+        )
+    if x.ndim != 2:
+        raise ValueError(f"x must have shape [T,H], got {tuple(x.shape)}")
+    if gate_weight.ndim != 3 or up_weight.ndim != 3 or down_weight.ndim != 3:
+        raise ValueError("expert weights must be rank-3 logical weight banks")
+    if routing_weight.ndim != 3 or routing_weight.shape[-1] != 1:
+        raise ValueError(
+            "routing_weight must have shape [T,E,1]; the explicit singleton "
+            "preserves post-down scalar broadcast semantics"
+        )
+
+    tokens, hidden = x.shape
+    experts, gate_hidden, intermediate = gate_weight.shape
+    if top_k <= 0 or top_k > experts:
+        raise ValueError(f"top_k must be in [1,{experts}], got {top_k}")
+    expected_up = (experts, hidden, intermediate)
+    expected_down = (experts, intermediate, hidden)
+    expected_routing = (tokens, experts, 1)
+    if gate_hidden != hidden:
+        raise ValueError(
+            f"gate_weight has hidden size {gate_hidden}, expected {hidden}"
+        )
+    if tuple(up_weight.shape) != expected_up:
+        raise ValueError(
+            f"up_weight must have shape {expected_up}, got {tuple(up_weight.shape)}"
+        )
+    if tuple(down_weight.shape) != expected_down:
+        raise ValueError(
+            "down_weight must have shape "
+            f"{expected_down}, got {tuple(down_weight.shape)}"
+        )
+    if tuple(routing_weight.shape) != expected_routing:
+        raise ValueError(
+            "routing_weight must have shape "
+            f"{expected_routing}, got {tuple(routing_weight.shape)}"
+        )
+    if any(
+        tensor.device != x.device
+        for tensor in (gate_weight, up_weight, down_weight, routing_weight)
+    ):
+        raise ValueError("all MoE tensors must be on the same device")
+    if any(
+        tensor.dtype != x.dtype
+        for tensor in (gate_weight, up_weight, down_weight, routing_weight)
+    ):
+        raise ValueError("all MoE tensors must have the same dtype")
+    return tokens, experts, hidden, intermediate
+
+
+def moe_ffn_reference(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    routing_weight: torch.Tensor,
+    top_k: int,
+    activation: str,
+) -> torch.Tensor:
+    """Evaluate the logical all-expert routed FFN without strategy assumptions.
+
+    The reference intentionally expresses one expert at a time. It defines
+    semantics for eager execution and correctness tests; compiler strategies
+    are free to use a persistent device loop, partitioned dense execution, or
+    another implementation that preserves this result.
+    """
+    _tokens, experts, _hidden, _intermediate = validate_moe_ffn_inputs(
+        x,
+        gate_weight,
+        up_weight,
+        down_weight,
+        routing_weight,
+        top_k,
+        activation,
+    )
+    result = torch.zeros_like(x)
+    for expert in range(experts):
+        gate = torch.mm(x, gate_weight[expert])
+        up = torch.mm(x, up_weight[expert])
+        if activation == "gelu_tanh":
+            gate = torch.nn.functional.gelu(gate, approximate="tanh")
+        else:
+            gate = torch.nn.functional.silu(gate)
+        down = torch.mm(gate * up, down_weight[expert])
+        result = result + down * routing_weight[:, expert, :]
+    return result

--- a/torch_spyre/_inductor/ir.py
+++ b/torch_spyre/_inductor/ir.py
@@ -424,7 +424,8 @@ class SpyreEmptyFallback(ir.ExternKernel):
     def should_allocate(self) -> bool:
         layout = self.get_layout()
         if isinstance(layout, FixedTiledLayout) and (
-            "hbm_pool" in layout.allocation or "lx" in layout.allocation
+            "hbm_pool" in layout.allocation
+            or ("lx" in layout.allocation and self.loop_storage_plan is not None)
         ):
             return False
         return True

--- a/torch_spyre/_inductor/ir.py
+++ b/torch_spyre/_inductor/ir.py
@@ -37,6 +37,7 @@ import sympy
 from torch.utils._ordered_set import OrderedSet
 import torch._inductor.ir as ir
 from torch_spyre._inductor.logging_utils import get_inductor_logger
+from torch_spyre._inductor.loop_info import LoopStoragePlan
 
 logger = get_inductor_logger("ir")
 
@@ -422,7 +423,9 @@ class SpyreEmptyFallback(ir.ExternKernel):
 
     def should_allocate(self) -> bool:
         layout = self.get_layout()
-        if isinstance(layout, FixedTiledLayout) and "hbm_pool" in layout.allocation:
+        if isinstance(layout, FixedTiledLayout) and (
+            "hbm_pool" in layout.allocation or "lx" in layout.allocation
+        ):
             return False
         return True
 
@@ -448,6 +451,7 @@ class SpyreEmptyFallback(ir.ExternKernel):
             (),
             op_overload=op_overload,
         )
+        self.loop_storage_plan: LoopStoragePlan | None = None
         self.name = V.graph.register_buffer(self)
         V.graph.register_operation(self)
 

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -31,6 +31,25 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True)
+class CarriedReductionPlan:
+    """One reduction state that remains at a fixed address across a loop."""
+
+    kind: Literal["terminal_sum"] = "terminal_sum"
+    memory_kind: Literal["lx"] = "lx"
+    fill_once: bool = True
+    drain_once: bool = True
+
+
+@dataclass(frozen=True)
+class LoopStoragePlan:
+    """Typed storage intent consumed by scratchpad placement."""
+
+    kind: Literal["loop_carried_accumulator"]
+    owner_group: tuple[int, ...]
+    memory_kind: Literal["lx"] = "lx"
+
+
+@dataclass(frozen=True)
 class CountedLoopPlan:
     """Compiler-owned contract for one static persistent expert loop."""
 
@@ -46,6 +65,9 @@ class CountedLoopPlan:
         "routing_weight",
     )
     transport_free: bool = True
+    carried_reduction: CarriedReductionPlan = field(
+        default_factory=CarriedReductionPlan
+    )
 
 
 @dataclass(frozen=True)

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -35,6 +35,7 @@ class CarriedReductionPlan:
     """One reduction state that remains at a fixed address across a loop."""
 
     kind: Literal["terminal_sum"] = "terminal_sum"
+    accumulation_dtype: Literal["source"] = "source"
     memory_kind: Literal["lx"] = "lx"
     fill_once: bool = True
     drain_once: bool = True
@@ -44,8 +45,9 @@ class CarriedReductionPlan:
 class LoopStoragePlan:
     """Typed storage intent consumed by scratchpad placement."""
 
-    kind: Literal["loop_carried_accumulator"]
+    kind: Literal["loop_invariant", "loop_carried_accumulator"]
     owner_group: tuple[int, ...]
+    execution_role: Literal["input_activation", "output_accumulator"]
     memory_kind: Literal["lx"] = "lx"
 
 
@@ -65,6 +67,7 @@ class CountedLoopPlan:
         "routing_weight",
     )
     transport_free: bool = True
+    body_memory_kind: Literal["lx"] = "lx"
     carried_reduction: CarriedReductionPlan = field(
         default_factory=CarriedReductionPlan
     )

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -31,6 +31,34 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True)
+class CountedLoopPlan:
+    """Compiler-owned contract for one static persistent expert loop."""
+
+    kind: Literal["persistent_dense_expert"]
+    trip_count: int
+    loop_dim: str = "E"
+    row_dim: str = "T"
+    invariant_operands: tuple[str, ...] = ("x",)
+    streamed_operands: tuple[str, ...] = (
+        "gate_weight",
+        "up_weight",
+        "down_weight",
+        "routing_weight",
+    )
+    transport_free: bool = True
+
+
+@dataclass(frozen=True)
+class LoopOperandBindingRequirement:
+    """Planning-time contract for one named streamed loop operand."""
+
+    kind: Literal["sequential_affine"]
+    host_advance_per_level: tuple[sympy.Expr, ...]
+    operand_role: str | None = None
+    source_name: str | None = None
+
+
+@dataclass(frozen=True)
 class ReductionPlan:
     """Planned shape/identity/nesting data for a tiled-reduction op.
 
@@ -152,6 +180,14 @@ class ReadCopyEntry:
     consumer_op_names:
         Names of every op in the group that must have this dep's buffer
         name patched (via _NameSwapHandler) to load from copy_name instead.
+    planned_dep_levels:
+        Planning-time, pre-range-division per-level tiled-dim metadata for
+        this exact source read.  Captured on the entry because earlier
+        entries may rebuild/patch the sizing op before this one executes.
+        ``None`` preserves legacy behavior for hand-built plans that do not
+        carry per-read metadata.
+    binding_requirement:
+        Typed sequential-affine address requirement for this source read.
     """
 
     copy_name: str
@@ -159,6 +195,8 @@ class ReadCopyEntry:
     insert_before_op_name: str
     sizing_op_name: str
     consumer_op_names: tuple[str, ...]
+    planned_dep_levels: tuple[tuple[tuple[int, sympy.Expr], ...], ...] | None = None
+    binding_requirement: LoopOperandBindingRequirement | None = None
 
 
 @dataclass(frozen=True)
@@ -220,6 +258,10 @@ class CoarseTileInfo:
         (possibly later-rewritten) index expression happens in
         spyre_kernel.py at OpSpec/TensorArg construction time, when the
         index is guaranteed final.
+    loop_operand_bindings:
+        One typed address requirement per read. Populated only for a planned
+        persistent expert loop; ordinary coarse-tiled graphs pay no symbolic
+        advance-analysis cost and retain their existing behavior.
     output_tiled_dims:
         The analogous per-level ``(op_dim_index, extent)`` list for this
         op's own write dependency. Defaults to ``[]`` (no levels tiled).
@@ -270,6 +312,9 @@ class CoarseTileInfo:
     tiled_dims_per_read: list[list[list[tuple[int, sympy.Expr]]]] = field(
         default_factory=list
     )
+    loop_operand_bindings: list[LoopOperandBindingRequirement | None] = field(
+        default_factory=list
+    )
     output_tiled_dims: list[list[tuple[int, sympy.Expr]]] = field(default_factory=list)
     squeezed_advance_per_read: list[list[list[tuple[sympy.Expr, sympy.Expr]]]] = field(
         default_factory=list
@@ -277,6 +322,8 @@ class CoarseTileInfo:
     squeezed_advance_output: list[list[tuple[sympy.Expr, sympy.Expr]]] = field(
         default_factory=list
     )
+    counted_loop_plan: CountedLoopPlan | None = None
+    preheader_for_group: tuple[int, ...] | None = None
     propagation: "PropagationPlan | None" = None
 
 

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -74,6 +74,30 @@ def _current_fx_custom_meta() -> dict[str, Any]:
     return custom if isinstance(custom, dict) else {}
 
 
+def _in_persistent_expert_scope(custom_meta: dict[str, Any]) -> bool:
+    return any(
+        isinstance(value, dict)
+        and value.get("expert_execution") == "persistent_dense_expert"
+        for value in custom_meta.values()
+    )
+
+
+def _persistent_streamed_operand_role(custom_meta: dict[str, Any]) -> str | None:
+    roles = {
+        value["streamed_operand_role"]
+        for value in custom_meta.values()
+        if isinstance(value, dict) and "streamed_operand_role" in value
+    }
+    if not roles:
+        return None
+    if len(roles) != 1:
+        raise Unsupported(f"ambiguous persistent streamed operand roles: {roles}")
+    role = next(iter(roles))
+    if role not in {"gate_weight", "up_weight", "down_weight", "routing_weight"}:
+        raise Unsupported(f"unknown persistent streamed operand role {role!r}")
+    return role
+
+
 def register_spyre_lowering(
     op,
     name=None,
@@ -531,6 +555,8 @@ def lower_bmm(x, y):
         op_info[SHARED_WEIGHT_UNIT_BMM_INFO_KEY] = custom_meta[
             SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY
         ]
+    if _in_persistent_expert_scope(custom_meta):
+        op_info[PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY] = True
 
     if reduction_numel == 1:
         # Reduction degenerates to a pointwise mul
@@ -613,6 +639,131 @@ def lower_expert_shared_lhs_mm(x, expert_weights):
             "persistent_expert_shared_lhs": {"expert_dim": 0},
             PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY: True,
         },
+    )
+    result.realize()
+    return result
+
+
+@register_spyre_lowering(torch.ops.spyre.expert_shared_lhs_mm_prepacked.default)
+def lower_expert_shared_lhs_mm_prepacked(x, expert_weights):
+    """Lower ``[T,K] @ [K,E,N]`` without expanding the shared LHS."""
+
+    x.realize()
+    expert_weights.realize()
+    x_size = x.get_size()
+    weight_size = expert_weights.get_size()
+    if len(x_size) != 2 or len(weight_size) != 3 or x_size[1] != weight_size[0]:
+        raise Unsupported(
+            "expert_shared_lhs_mm_prepacked requires [T,K] and [K,E,N], "
+            f"got {x_size} and {weight_size}"
+        )
+    if x.get_dtype() != expert_weights.get_dtype():
+        raise Unsupported("x and expert_weights must have the same dtype")
+    role = _persistent_streamed_operand_role(_current_fx_custom_meta())
+    if role not in {"gate_weight", "up_weight"}:
+        raise Unsupported(
+            "prepacked shared-LHS projection requires a gate/up operand role"
+        )
+    x_loader = x.make_loader()
+    weight_loader = expert_weights.make_loader()
+
+    def inner_fn(index, reduction_index):
+        expert, row, column = index
+        (reduction,) = reduction_index
+        return (
+            x_loader([row, reduction]),
+            weight_loader([reduction, expert, column]),
+        )
+
+    result = SpyreReduction.create(
+        reduction_type=BATCH_MATMUL_OP,
+        input_node=[x, expert_weights],
+        device=x.get_device(),
+        dst_dtype=x.get_dtype(),
+        src_dtype=x.get_dtype(),
+        inner_fn=inner_fn,
+        ranges=[weight_size[1], x_size[0], weight_size[2]],
+        reduction_ranges=[x_size[1]],
+        op_info={
+            "persistent_expert_shared_lhs": {"expert_dim": 0},
+            PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY: role,
+        },
+    )
+    result.realize()
+    return result
+
+
+@register_spyre_lowering(torch.ops.spyre.expert_mm_prepacked.default)
+def lower_expert_mm_prepacked(x, expert_weights):
+    """Lower ``[E,T,K] @ [K,E,N]`` with a named streamed weight bank."""
+
+    x.realize()
+    expert_weights.realize()
+    x_size = x.get_size()
+    weight_size = expert_weights.get_size()
+    if (
+        len(x_size) != 3
+        or len(weight_size) != 3
+        or x_size[0] != weight_size[1]
+        or x_size[2] != weight_size[0]
+    ):
+        raise Unsupported(
+            "expert_mm_prepacked requires [E,T,K] and [K,E,N], "
+            f"got {x_size} and {weight_size}"
+        )
+    if x.get_dtype() != expert_weights.get_dtype():
+        raise Unsupported("x and expert_weights must have the same dtype")
+    role = _persistent_streamed_operand_role(_current_fx_custom_meta())
+    if role != "down_weight":
+        raise Unsupported("prepacked expert projection requires down_weight role")
+    x_loader = x.make_loader()
+    weight_loader = expert_weights.make_loader()
+
+    def inner_fn(index, reduction_index):
+        expert, row, column = index
+        (reduction,) = reduction_index
+        return (
+            x_loader([expert, row, reduction]),
+            weight_loader([reduction, expert, column]),
+        )
+
+    result = SpyreReduction.create(
+        reduction_type=BATCH_MATMUL_OP,
+        input_node=[x, expert_weights],
+        device=x.get_device(),
+        dst_dtype=x.get_dtype(),
+        src_dtype=x.get_dtype(),
+        inner_fn=inner_fn,
+        ranges=[x_size[0], x_size[1], weight_size[2]],
+        reduction_ranges=[x_size[2]],
+        op_info={PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY: role},
+    )
+    result.realize()
+    return result
+
+
+@register_spyre_lowering(torch.ops.spyre.expert_route_prepacked.default)
+def lower_expert_route_prepacked(routing_weight):
+    """Expose one expert-major routing plane as a named streamed operand."""
+
+    routing_weight.realize()
+    size = routing_weight.get_size()
+    if len(size) != 3 or size[2] != 1:
+        raise Unsupported(f"expert_route_prepacked requires [E,T,1], got {size}")
+    role = _persistent_streamed_operand_role(_current_fx_custom_meta())
+    if role != "routing_weight":
+        raise Unsupported("prepacked expert routing requires routing_weight role")
+    loader = routing_weight.make_loader()
+    result = Pointwise.create(
+        device=routing_weight.get_device(),
+        dtype=routing_weight.get_dtype(),
+        inner_fn=lambda index: loader(index),
+        ranges=size,
+        origin_node=routing_weight.get_origin_node(),
+        traceback=routing_weight.get_traceback(),
+    )
+    result.data.data._post_init_setattr(
+        "op_info", {PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY: role}
     )
     result.realize()
     return result

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -31,6 +31,7 @@ from .constants import (
     COPY_BACK_CANDIDATE_ATTR,
     BATCH_MATMUL_FP8_OP,
     DEPTHWISE_CONV2D_OP,
+    PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY,
     SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY,
     SHARED_WEIGHT_UNIT_BMM_INFO_KEY,
 )
@@ -558,6 +559,62 @@ def lower_bmm(x, y):
             f"bmm: x{list(x_size)} @ y{list(y_size)} -> {list(result_buf.get_size())}"
         )
 
+    return result
+
+
+@register_spyre_lowering(torch.ops.spyre.expert_shared_lhs_mm.default)
+def lower_expert_shared_lhs_mm(x, expert_weights):
+    """Lower ``[T,K] @ [E,K,N]`` without expanding X over E.
+
+    The expert coordinate indexes only the weight and output tensors. This is
+    the logical projection needed by a later persistent expert loop: tiling E
+    to one changes the streamed weight address while leaving the X address
+    invariant.
+    """
+    x.realize()
+    expert_weights.realize()
+    x_size = x.get_size()
+    weight_size = expert_weights.get_size()
+    if len(x_size) != 2 or len(weight_size) != 3:
+        raise Unsupported(
+            "expert_shared_lhs_mm requires [T,K] and [E,K,N], "
+            f"got {x_size} and {weight_size}"
+        )
+    if x_size[1] != weight_size[1]:
+        raise Unsupported(
+            "expert_shared_lhs_mm reduction dimensions differ: "
+            f"{x_size[1]} versus {weight_size[1]}"
+        )
+    if x.get_dtype() != expert_weights.get_dtype():
+        raise Unsupported("expert_shared_lhs_mm inputs must have the same dtype")
+
+    x_loader = x.make_loader()
+    weight_loader = expert_weights.make_loader()
+    ranges = [weight_size[0], x_size[0], weight_size[2]]
+
+    def inner_fn(index, reduction_index):
+        expert, row, column = index
+        (reduction,) = reduction_index
+        return (
+            x_loader([row, reduction]),
+            weight_loader([expert, reduction, column]),
+        )
+
+    result = SpyreReduction.create(
+        reduction_type=BATCH_MATMUL_OP,
+        input_node=[x, expert_weights],
+        device=x.get_device(),
+        dst_dtype=x.get_dtype(),
+        src_dtype=x.get_dtype(),
+        inner_fn=inner_fn,
+        ranges=ranges,
+        reduction_ranges=[x_size[1]],
+        op_info={
+            "persistent_expert_shared_lhs": {"expert_dim": 0},
+            PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY: True,
+        },
+    )
+    result.realize()
     return result
 
 

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -769,6 +769,48 @@ def lower_expert_route_prepacked(routing_weight):
     return result
 
 
+@register_spyre_lowering(torch.ops.spyre.expert_route_weighted_down.default)
+def lower_expert_route_weighted_down(down, routing_weight):
+    """Lower post-down route weighting while retaining route binding identity."""
+
+    down.realize()
+    routing_weight.realize()
+    down_size = down.get_size()
+    routing_size = routing_weight.get_size()
+    if (
+        len(down_size) != 3
+        or len(routing_size) != 3
+        or routing_size != [down_size[1], down_size[0], 1]
+    ):
+        raise Unsupported(
+            "expert_route_weighted_down requires down[E,T,H] and "
+            f"routing_weight[T,E,1], got {down_size} and {routing_size}"
+        )
+    if down.get_dtype() != routing_weight.get_dtype():
+        raise Unsupported("down and routing_weight must have the same dtype")
+    role = _persistent_streamed_operand_role(_current_fx_custom_meta())
+    if role != "routing_weight":
+        raise Unsupported("persistent route weighting requires routing_weight role")
+    down_loader = down.make_loader()
+    routing_loader = routing_weight.make_loader()
+
+    def inner_fn(index):
+        expert, row, feature = index
+        return down_loader(index) * routing_loader([row, expert, 0])
+
+    result = Pointwise.create(
+        device=down.get_device(),
+        dtype=down.get_dtype(),
+        inner_fn=inner_fn,
+        ranges=down_size,
+    )
+    result.data.data._post_init_setattr(
+        "op_info", {PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY: role}
+    )
+    result.realize()
+    return result
+
+
 @register_spyre_lowering(torch.ops.spyre.conv2d.default)
 def lower_depthwise_conv2d(x, w, stride, padding, dilation, groups):
     x = V.graph.get_buffer(x.realize())

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -836,9 +836,16 @@ def find_matmul_generated_var(
     generated_vars = (
         y_dep.index.free_symbols & out_dep.index.free_symbols
     ) - x_dep.index.free_symbols
+    # A counted shared-LHS expert matmul retains its statically-unit expert
+    # symbol after E is tiled to one.  It is not a physical generated axis.
+    if len(generated_vars) > 1:
+        generated_vars = {
+            var for var in generated_vars if sympy.sympify(out_dep.ranges[var]) != 1
+        }
     if len(generated_vars) != 1:
         raise Unsupported(
-            f"expected exactly 1 generated variable, got {generated_vars}"
+            f"expected exactly 1 generated variable, got {generated_vars}; "
+            f"output ranges={out_dep.ranges}"
         )
     return next(iter(generated_vars))
 

--- a/torch_spyre/_inductor/propagate_hints.py
+++ b/torch_spyre/_inductor/propagate_hints.py
@@ -14,6 +14,7 @@
 
 
 import dataclasses
+import hashlib
 from typing import Any
 
 import regex as re
@@ -91,6 +92,22 @@ def spyre_hint(**kwargs: Any):
     else:
         _id = 0
     return torch.fx.traceback.annotate({f"_hint_{_id}": kwargs})
+
+
+def compiler_hint(scope_id: str, **kwargs: Any):
+    """Attach compiler-owned metadata with a stable region identity.
+
+    Unlike :func:`spyre_hint`, this is not a user scheduling request and does
+    not consume Dynamo's per-trace hint counter.  Every operation emitted for
+    one selected compiler plan uses the same deterministic ID, while separate
+    semantic MoE nodes remain separate coarse-tile regions.
+    """
+
+    digest = hashlib.sha256(scope_id.encode("utf-8")).digest()
+    # Reserve the high bit of the positive 63-bit space so compiler IDs cannot
+    # collide with the small monotonically increasing user-hint IDs.
+    hint_id = (int.from_bytes(digest[:8], "big") & ((1 << 62) - 1)) | (1 << 62)
+    return torch.fx.traceback.annotate({f"_hint_{hint_id}": kwargs})
 
 
 def get_op_hints(op: Operation) -> dict[int, dict[str, Any]]:

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -63,6 +63,7 @@ from .constants import (
     REDUCTIONS_NON_STICK_DIM_ONLY,
     STAGGERED_EAS,
     TOPK_OPS,
+    PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY,
 )
 from .ir import (
     AllReduceAsyncFallback,
@@ -111,6 +112,15 @@ class PropArg(NamedTuple):
     dep: MemoryDep
     layout: FixedLayout
     layouts: list[SpyreTensorLayout]
+
+
+def _is_graph_input(name: str) -> bool:
+    source = V.graph.get_buffer(name)
+    if isinstance(source, TensorBox):
+        source = source.data
+    if isinstance(source, StorageBox):
+        source = source.data
+    return isinstance(source, InputBuffer)
 
 
 def _get_prop_args(reads) -> list[PropArg]:
@@ -1096,9 +1106,31 @@ def _multi_arg_pointwise_layouts(
     stick_size = get_elem_in_stick(out_dtype_for_layout)
     c_size = [concretize_expr(s) for s in output.size]
     c_stride = [concretize_expr(s) for s in output.stride]
+    op_info = getattr(op.data, "op_info", None) or {}
+    persistent_route_deps = tuple(
+        arg.dep
+        for arg in args
+        if op_info.get(PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY) == "routing_weight"
+        and _is_graph_input(arg.dep.name)
+    )
+    if op_info.get(PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY) == "routing_weight" and (
+        len(persistent_route_deps) != 1
+    ):
+        raise Unsupported(
+            f"{op.get_name()}: expected exactly one graph-input routing operand"
+        )
 
     def _is_supported_layout(dim_order):
         for arg in args:
+            if arg.dep in persistent_route_deps:
+                if not any(
+                    (coord := try_device_coordinates(stl, arg.dep, ind_sizes))
+                    is not None
+                    and is_stick_expr_offset_free(coord[-1], stick_size)
+                    for stl in arg.layouts
+                ):
+                    return False
+                continue
             # Project output dim_order to input, dropping leading dims missing due to broadcast.
             rank_diff = len(output.size) - len(arg.layout.size)
             projected_dim_order = [d - rank_diff for d in dim_order if d >= rank_diff]

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -129,7 +129,7 @@ def _loop_group_id(node: BaseSchedulerNode):
         if isinstance(snode, SchedulerNode) and snode.node is not None:
             loop_info = getattr(snode.node, "loop_info", None)
             if loop_info is not None:
-                return loop_info.loop_group_id
+                return loop_info.loop_group_id or None
     return None
 
 

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -86,9 +86,11 @@ from torch_spyre._inductor.scratchpad.utils import (
     _get_buffer_user_deps,
     _would_produce_lx_back_gap,
     OP_OUTPUT_GOOD_FOR_LX_REUSE,
+    hoisted_loop_lifetime_end_overrides,
+    is_loop_carried_lx_storage,
 )
 from torch_spyre._inductor.scratchpad.graph_editor import GraphEditor
-from torch_spyre._inductor.ir import FixedTiledLayout
+from torch_spyre._inductor.ir import FixedTiledLayout, SpyreEmptyFallback
 
 from torch_spyre._inductor import config
 from torch_spyre._inductor.logging_utils import get_inductor_logger
@@ -326,6 +328,8 @@ class ScratchpadAllocator:
     def _op_output_good_for_lx_reuse(
         self, op: Any, planned_lx_buffers: frozenset[str] = frozenset()
     ) -> bool:
+        if is_loop_carried_lx_storage(op):
+            return isinstance(op.layout, FixedTiledLayout)
         if not isinstance(op, ComputedBuffer):
             return False
         if isinstance(op.layout, MutationLayoutSHOULDREMOVE):
@@ -431,7 +435,7 @@ class ScratchpadAllocator:
             # MultiOutputLayout tuple op). There is nothing to place, and the
             # checks below would raise.
             return "unsized (no device layout)"
-        if name in mutated_buffers:
+        if name in mutated_buffers and not is_loop_carried_lx_storage(op):
             return "mutation target"
         if _is_tiled_advancing(op) or _is_read_advancing_anywhere(name, buf_user_deps):
             # LX addresses cannot be expressed as affine.apply symbols today (see
@@ -445,7 +449,8 @@ class ScratchpadAllocator:
         restickify = self._restickify_barrier(graph, name, uses)
         if restickify is not None:
             return restickify
-        if _extern_kernel_in_live_range(graph, uses):
+        extern_uses = uses[1:] if is_loop_carried_lx_storage(op) else uses
+        if _extern_kernel_in_live_range(graph, extern_uses):
             return "extern kernel user or live across extern kernel"
         if self._is_index_or_indirectly_accessed(graph, name, uses, op):
             # Index tensors and the value tensors they index into are read via
@@ -630,6 +635,7 @@ class ScratchpadAllocator:
         lifetimes: dict[str, list[int]],
         ncores: dict[str, int],
         ncores_reasons: dict[str, str],
+        lifetime_end_overrides: Optional[dict[str, int]] = None,
     ) -> list[LifetimeBoundBuffer]:
         """Build one :class:`LifetimeBoundBuffer` per buffer, barred or not.
 
@@ -644,11 +650,17 @@ class ScratchpadAllocator:
         :meth:`_input_residency_reason` and their footprint is computed
         here rather than read off ``mem_usage`` (which covers ops only).
         """
+        lifetime_end_overrides = lifetime_end_overrides or {}
         buffers: list[LifetimeBoundBuffer] = []
         for output_name, info in mem_usage.items():
             uses = lifetimes.get(output_name, [])
             if not uses:
                 continue
+            parents = [
+                parent
+                for parent in in_place.get(output_name, [])
+                if lifetime_end_overrides.get(parent, uses[0] + 1) == uses[0] + 1
+            ]
             buffers.append(
                 LifetimeBoundBuffer(
                     output_name,
@@ -662,8 +674,9 @@ class ScratchpadAllocator:
                     # to a consumer's in_place_parents, which would otherwise mutate
                     # this list inside the shared ``in_place`` dict (matches the copy
                     # in ``_build_cd_bound_buffers``).
-                    in_place_parents=list(in_place.get(output_name, [])),
+                    in_place_parents=parents,
                     residency_reason=reasons.get(output_name),
+                    lifetime_end_override=lifetime_end_overrides.get(output_name),
                 )
             )
 
@@ -869,6 +882,7 @@ class ScratchpadAllocator:
         t0 = time.perf_counter()
         if lifetimes is None:
             lifetimes = calculate_liveness(graph)
+        lifetime_end_overrides = hoisted_loop_lifetime_end_overrides(graph)
         ncores, ncores_reasons = get_ncores_for_buffers(graph)
         t1 = time.perf_counter()
         mem_usage = mem_usage_by_buf(graph, cache)
@@ -908,6 +922,7 @@ class ScratchpadAllocator:
             lifetimes=lifetimes,
             ncores=ncores,
             ncores_reasons=ncores_reasons,
+            lifetime_end_overrides=lifetime_end_overrides,
         )
         if lx_relayout_plans:
             by_name = {buffer.name: buffer for buffer in buffers}
@@ -943,6 +958,8 @@ class ScratchpadAllocator:
             return
         for buffer in buffers:
             buffer.uses = [2 * use + 1 for use in buffer.uses]
+            if buffer.lifetime_end_override is not None:
+                buffer.lifetime_end_override *= 2
 
         # Adjacent half-ticks rely on DSCs within a bundle executing serially;
         # otherwise the allocator's lifetime reuse is unsound beyond relayout too.
@@ -1080,6 +1097,10 @@ class ScratchpadAllocator:
 
             else:
                 self._set_one_allocation(buf, b.address)
+                if isinstance(buf, SpyreEmptyFallback) and is_loop_carried_lx_storage(
+                    buf
+                ):
+                    graph.removed_buffers.add(b.name)
 
         # Keep graph mutation last and in pre-scheduling: solver retries require
         # the original graph, and post-grad no-op elimination has already run.
@@ -1786,6 +1807,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
         all buffers are on the same total scale, ``in_place_parents`` need no
         filtering."""
         lifetimes = calculate_liveness(graph)
+        lifetime_end_overrides = hoisted_loop_lifetime_end_overrides(graph)
         mem_usage = mem_usage_by_buf(graph)
         in_place = {} if in_place is None else in_place
         op_by_name = {op.name: op for op in graph.operations}
@@ -1847,7 +1869,11 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             residency_reason = residency_by_buf[output_name]
 
             buf_divisions = divisions[output_name]
-            parents = list(in_place.get(output_name, []))
+            parents = [
+                parent
+                for parent in in_place.get(output_name, [])
+                if lifetime_end_overrides.get(parent, uses[0] + 1) == uses[0] + 1
+            ]
             size = info["size"]  # total footprint; solver divides per chosen cd
             parent_proj = info["op_inputs"].copy()
             cd_parent_matches = self._cd_parent_matches(
@@ -1910,6 +1936,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                     parents=parent_proj,
                     cd_parent_matches=cd_parent_matches,
                     residency_reason=residency_reason,
+                    lifetime_end_override=lifetime_end_overrides.get(output_name),
                     boundary=BufferType.Output
                     if output_name in graph_output_names
                     else BufferType.Intermediate,

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -88,6 +88,9 @@ from torch_spyre._inductor.scratchpad.utils import (
     OP_OUTPUT_GOOD_FOR_LX_REUSE,
     hoisted_loop_lifetime_end_overrides,
     is_loop_carried_lx_storage,
+    is_persistent_loop_body,
+    is_persistent_loop_preheader,
+    required_loop_lx_storage_names,
 )
 from torch_spyre._inductor.scratchpad.graph_editor import GraphEditor
 from torch_spyre._inductor.ir import FixedTiledLayout, SpyreEmptyFallback
@@ -102,6 +105,47 @@ from torch_spyre._inductor.scratchpad.lx_relayout import (
 from torch_spyre._inductor.pass_utils import _is_matmul_op
 
 logger = get_inductor_logger("scratchpad.allocator")
+
+
+def _safe_in_place_parents(
+    parents: Sequence[str], lifetime_end_overrides: dict[str, int]
+) -> list[str]:
+    """Drop alias edges whose parent must survive a counted loop."""
+
+    return [parent for parent in parents if parent not in lifetime_end_overrides]
+
+
+def _reject_required_loop_lx_relayouts(
+    plans: Sequence[LXRelayoutPlan], required_names: frozenset[str]
+) -> None:
+    """Fail closed until loop-lifetime facts compose with LX relayouts."""
+
+    touched = sorted(
+        (plan.source_name, plan.destination_name)
+        for plan in plans
+        if plan.source_name in required_names or plan.destination_name in required_names
+    )
+    if touched:
+        raise Unsupported(
+            f"scratchpad: LX relayout cannot touch persistent-loop storage: {touched}"
+        )
+
+
+def _validate_required_loop_lx_allocation(
+    required_names: frozenset[str], allocation: Sequence[LifetimeBoundBuffer]
+) -> None:
+    """Required persistent state must have a realized LX address."""
+
+    by_name = {buffer.name: buffer for buffer in allocation}
+    missing = sorted(
+        name
+        for name in required_names
+        if name not in by_name or by_name[name].address is None
+    )
+    if missing:
+        raise Unsupported(
+            f"scratchpad: persistent-loop LX storage was not realized: {missing}"
+        )
 
 
 # Keep these values synchronized with Deeptools' LX memory tracker:
@@ -231,6 +275,9 @@ class ScratchpadAllocator:
         solver = self._build_solver(buffers)
         allocation = self._solve(solver)
         accepted_lx_relayouts = self._finalize_lx_relayout_allocation(allocation)
+        _validate_required_loop_lx_allocation(
+            required_loop_lx_storage_names(graph), allocation
+        )
         self._post_solve(graph, allocation)
         reasons = self._get_spill_reasons(solver, allocation)
         self._push_allocation(graph, allocation, accepted_lx_relayouts)
@@ -328,7 +375,11 @@ class ScratchpadAllocator:
     def _op_output_good_for_lx_reuse(
         self, op: Any, planned_lx_buffers: frozenset[str] = frozenset()
     ) -> bool:
-        if is_loop_carried_lx_storage(op):
+        if (
+            is_loop_carried_lx_storage(op)
+            or is_persistent_loop_preheader(op)
+            or is_persistent_loop_body(op)
+        ):
             return isinstance(op.layout, FixedTiledLayout)
         if not isinstance(op, ComputedBuffer):
             return False
@@ -656,11 +707,9 @@ class ScratchpadAllocator:
             uses = lifetimes.get(output_name, [])
             if not uses:
                 continue
-            parents = [
-                parent
-                for parent in in_place.get(output_name, [])
-                if lifetime_end_overrides.get(parent, uses[0] + 1) == uses[0] + 1
-            ]
+            parents = _safe_in_place_parents(
+                in_place.get(output_name, []), lifetime_end_overrides
+            )
             buffers.append(
                 LifetimeBoundBuffer(
                     output_name,
@@ -882,6 +931,9 @@ class ScratchpadAllocator:
         t0 = time.perf_counter()
         if lifetimes is None:
             lifetimes = calculate_liveness(graph)
+        _reject_required_loop_lx_relayouts(
+            lx_relayout_plans, required_loop_lx_storage_names(graph)
+        )
         lifetime_end_overrides = hoisted_loop_lifetime_end_overrides(graph)
         ncores, ncores_reasons = get_ncores_for_buffers(graph)
         t1 = time.perf_counter()
@@ -1869,11 +1921,9 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             residency_reason = residency_by_buf[output_name]
 
             buf_divisions = divisions[output_name]
-            parents = [
-                parent
-                for parent in in_place.get(output_name, [])
-                if lifetime_end_overrides.get(parent, uses[0] + 1) == uses[0] + 1
-            ]
+            parents = _safe_in_place_parents(
+                in_place.get(output_name, []), lifetime_end_overrides
+            )
             size = info["size"]  # total footprint; solver divides per chosen cd
             parent_proj = info["op_inputs"].copy()
             cd_parent_matches = self._cd_parent_matches(

--- a/torch_spyre/_inductor/scratchpad/exhaustive_search.py
+++ b/torch_spyre/_inductor/scratchpad/exhaustive_search.py
@@ -147,6 +147,7 @@ class ExhaustiveSearchSolver(CoreDivisionLayoutSolver):
                     first_use_is_read=b.first_use_is_read,
                     in_place_parents=_valid_inplace_parents(b, chosen[b.name]),
                     residency_reason=_residency_reason(b, chosen[b.name]),
+                    lifetime_end_override=b.lifetime_end_override,
                 )
                 for b in buffers_list
             ]

--- a/torch_spyre/_inductor/scratchpad/plan_solver.py
+++ b/torch_spyre/_inductor/scratchpad/plan_solver.py
@@ -67,8 +67,9 @@ class LifetimeBoundBuffer:
     buffer written and read by the same op, i.e. with a single live tick, and
     would let such a buffer pass as an in-place parent.
 
-    ``start_time`` and ``end_time`` are convenience properties derived from
-    ``uses``: ``uses[0]`` and ``uses[-1] + 1`` respectively.
+    ``start_time`` is ``uses[0]``. ``end_time`` is normally ``uses[-1] + 1``;
+    a loop-carried buffer may extend address overlap with
+    ``lifetime_end_override`` without adding a synthetic read to ``uses``.
     """
 
     name: str

--- a/torch_spyre/_inductor/scratchpad/plan_solver.py
+++ b/torch_spyre/_inductor/scratchpad/plan_solver.py
@@ -80,6 +80,10 @@ class LifetimeBoundBuffer:
     # define the reason for excluding the buffer based on allocator
     # or solver logic paths.
     residency_reason: Optional[str] = None
+    # Optional exclusive lifetime end used for loop-carried values.  This is
+    # deliberately separate from ``uses``: it affects address overlap only,
+    # never read_count or spill/residency benefit.
+    lifetime_end_override: Optional[int] = None
     # Buffers that must be placed atomically with this one. Despite the name,
     # this is one-to-many: only the group root carries the complete partner list.
     paired_with: list["LifetimeBoundBuffer"] = field(
@@ -104,6 +108,12 @@ class LifetimeBoundBuffer:
             f"buffer {self.name} has uses={self.uses}, which is not strictly "
             "increasing; uses carries one distinct index per accessing operation"
         )
+        if self.lifetime_end_override is not None and self.uses:
+            assert self.lifetime_end_override >= self.uses[-1] + 1, (
+                f"buffer {self.name} has lifetime_end_override="
+                f"{self.lifetime_end_override} before nominal exclusive end "
+                f"{self.uses[-1] + 1}"
+            )
 
     @property
     def read_count(self) -> int:
@@ -126,7 +136,8 @@ class LifetimeBoundBuffer:
 
     @property
     def end_time(self) -> int:
-        return self.uses[-1] + 1
+        nominal = self.uses[-1] + 1
+        return max(nominal, self.lifetime_end_override or nominal)
 
     @property
     def min_footprint(self) -> int:

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -15,7 +15,7 @@
 
 import math
 from typing import Any, Optional
-from torch._inductor.dependencies import MemoryDep
+from torch._inductor.dependencies import MemoryDep, StarDep
 from torch._inductor.graph import GraphLowering
 from torch._inductor.ir import (
     Operation,
@@ -28,7 +28,8 @@ from torch._inductor.ops_handler import WrapperHandler
 import sympy
 
 from torch_spyre._inductor import config
-from torch_spyre._inductor.ir import FixedTiledLayout
+from torch_spyre._inductor.ir import FixedTiledLayout, SpyreEmptyFallback
+from torch_spyre._inductor.loop_info import LoopStoragePlan
 from torch_spyre._inductor.pass_utils import (
     _per_core_view_on_buf,
     concretize_expr,
@@ -79,6 +80,50 @@ def clone_at_graph_boundaries() -> bool:
     op suite), so coupling it here would silently turn on the boundary clone
     path in contexts that don't intend to exercise it."""
     return "clone" in OP_OUTPUT_GOOD_FOR_LX_REUSE
+
+
+def hoisted_loop_lifetime_end_overrides(graph: GraphLowering) -> dict[str, int]:
+    """Return exclusive allocator lifetime ends for invariant preheaders.
+
+    The static IR contains one copy and one instance of each loop-body op, so a
+    plain last-use analysis sees the final textual X consumer in iteration zero
+    and may reuse X's LX range later in that same body.  At runtime the next
+    iteration reads X again.  Keep this loop-carried interval separate from the
+    exact access list so read_count, residency decisions, and spill benefit do
+    not gain a synthetic read.
+    """
+
+    loop_end_by_outer_group: dict[int, int] = {}
+    for index, op in enumerate(graph.operations):
+        group_id = getattr(getattr(op, "loop_info", None), "loop_group_id", ())
+        if group_id:
+            loop_end_by_outer_group[group_id[0]] = index
+
+    overrides: dict[str, int] = {}
+    for op in graph.operations:
+        owner = getattr(getattr(op, "loop_info", None), "preheader_for_group", None)
+        if not owner:
+            continue
+        loop_end = loop_end_by_outer_group.get(owner[0])
+        if loop_end is None:
+            raise RuntimeError(
+                "hoisted coarse-tile preheader has no owning loop body: "
+                f"buffer={op.get_name()!r}, owner={owner!r}"
+            )
+        overrides[op.get_name()] = loop_end + 1
+    return overrides
+
+
+def is_loop_carried_lx_storage(op: Operation) -> bool:
+    """Whether ``op`` is typed allocation-only state for one counted loop."""
+
+    plan = getattr(op, "loop_storage_plan", None)
+    return (
+        isinstance(op, SpyreEmptyFallback)
+        and isinstance(plan, LoopStoragePlan)
+        and plan.kind == "loop_carried_accumulator"
+        and plan.memory_kind == "lx"
+    )
 
 
 def calculate_liveness(graph: GraphLowering) -> dict[str, list[int]]:
@@ -137,18 +182,12 @@ def mem_usage_by_buf(
         num_cores = num_cores_per_op.get(buf_name, -1)
         rw = op_read_writes(op)
         layout = buf.layout
-        # Only ComputedBuffers backed by a real Spyre device layout
-        # (FixedTiledLayout, which carries ``device_layout``) can be sized for
-        # scratchpad/LX residency. Mutation aliases and plain host FixedLayout
-        # buffers (e.g. fallback / CPU-roundtrip outputs) have no device_layout,
-        # so they get the unsized sentinel below. Testing for FixedTiledLayout
-        # here — rather than the broader ``isinstance(layout, FixedLayout)`` —
-        # avoids excluding genuine device buffers, which subclass FixedLayout
-        # and must be sized (see the ``layout.device_layout`` access below).
+        # Computed buffers and explicitly planned loop-carried storage are the
+        # only objects that own placeable device memory.
         if (
             isinstance(layout, MutationLayoutSHOULDREMOVE)
             or not isinstance(layout, FixedTiledLayout)
-            or not isinstance(op, ComputedBuffer)
+            or not (isinstance(op, ComputedBuffer) or is_loop_carried_lx_storage(op))
         ):
             mem_usage[buf_name] = {
                 "size": -1,
@@ -411,6 +450,10 @@ def _get_buffer_user_deps(
     for op in graph.operations:
         rw = op_read_writes(op)
         for dep in rw.reads | rw.writes:
+            if isinstance(dep, StarDep) and is_loop_carried_lx_storage(op):
+                # The fallback allocates storage but launches no writer. Real
+                # fill/combine/drain users determine physical ownership.
+                continue
             buf_user_deps.setdefault(dep.name, []).append((op, dep))
     return buf_user_deps
 

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -29,7 +29,7 @@ import sympy
 
 from torch_spyre._inductor import config
 from torch_spyre._inductor.ir import FixedTiledLayout, SpyreEmptyFallback
-from torch_spyre._inductor.loop_info import LoopStoragePlan
+from torch_spyre._inductor.loop_info import CountedLoopPlan, LoopStoragePlan
 from torch_spyre._inductor.pass_utils import (
     _per_core_view_on_buf,
     concretize_expr,
@@ -101,9 +101,10 @@ def hoisted_loop_lifetime_end_overrides(graph: GraphLowering) -> dict[str, int]:
 
     overrides: dict[str, int] = {}
     for op in graph.operations:
-        owner = getattr(getattr(op, "loop_info", None), "preheader_for_group", None)
-        if not owner:
+        storage = getattr(op, "loop_storage_plan", None)
+        if not isinstance(storage, LoopStoragePlan) or storage.kind != "loop_invariant":
             continue
+        owner = storage.owner_group
         loop_end = loop_end_by_outer_group.get(owner[0])
         if loop_end is None:
             raise RuntimeError(
@@ -122,7 +123,48 @@ def is_loop_carried_lx_storage(op: Operation) -> bool:
         isinstance(op, SpyreEmptyFallback)
         and isinstance(plan, LoopStoragePlan)
         and plan.kind == "loop_carried_accumulator"
+        and plan.execution_role == "output_accumulator"
         and plan.memory_kind == "lx"
+    )
+
+
+def is_persistent_loop_preheader(op: Operation) -> bool:
+    """Whether ``op`` is typed invariant storage for a persistent loop."""
+
+    plan = getattr(op, "loop_storage_plan", None)
+    return (
+        isinstance(plan, LoopStoragePlan)
+        and plan.kind == "loop_invariant"
+        and plan.execution_role == "input_activation"
+        and plan.memory_kind == "lx"
+    )
+
+
+def is_persistent_loop_body(op: Operation) -> bool:
+    """Whether the counted plan requires this loop-body result in LX."""
+
+    info = getattr(op, "loop_info", None)
+    plan = getattr(info, "counted_loop_plan", None)
+    return (
+        isinstance(op, ComputedBuffer)
+        and isinstance(plan, CountedLoopPlan)
+        and bool(info.loop_group_id)
+        and plan.body_memory_kind == "lx"
+    )
+
+
+def required_loop_lx_storage_names(graph: GraphLowering) -> frozenset[str]:
+    """Storage owners whose typed loop plan requires physical LX residency.
+
+    Loop-body operations may write through a ``MutationLayout`` into one of
+    these owners and therefore do not necessarily receive their own allocation
+    record. Their LX-only contract is verified on the final physical graph.
+    """
+
+    return frozenset(
+        op.get_name()
+        for op in graph.operations
+        if isinstance(getattr(op, "loop_storage_plan", None), LoopStoragePlan)
     )
 
 

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -144,6 +144,8 @@ def is_persistent_loop_body(op: Operation) -> bool:
     """Whether the counted plan requires this loop-body result in LX."""
 
     info = getattr(op, "loop_info", None)
+    if info is None:
+        return False
     plan = getattr(info, "counted_loop_plan", None)
     return (
         isinstance(op, ComputedBuffer)

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -52,6 +52,7 @@ from .scratchpad.lx_relayout import work_division_from_view
 from .pass_utils import (
     concretize_expr,
     concretize_index,
+    coeff_through_floor,
     compute_symbolic_bounds,
     finite_upper_or_none,
     apply_splits_from_index_coeff,
@@ -75,6 +76,28 @@ from torch_spyre._inductor.provenance import build_debug_handle
 import logging
 
 logger = get_inductor_logger("spyre_kernel")
+
+
+@dataclass(frozen=True)
+class LoopOperandBinding:
+    """Resolved per-iteration address change for one counted-loop operand."""
+
+    kind: str
+    device_element_offset: sympy.Expr
+
+    def __post_init__(self) -> None:
+        if self.kind != "sequential_affine":
+            raise Unsupported(f"unknown loop operand binding kind {self.kind!r}")
+
+
+def _tensor_args_advance_by_symbol(
+    args: Sequence["TensorArg"], symbol: sympy.Symbol
+) -> bool:
+    return any(
+        arg.device_tile_advance_expr is not None
+        and coeff_through_floor(arg.device_tile_advance_expr, symbol) != 0
+        for arg in args
+    )
 
 
 class RValue(ABC):
@@ -590,7 +613,7 @@ class SpyreKernel(Kernel[CSEVariable]):
         return self._tile_advance_symbols[level_idx]
 
     @staticmethod
-    def _host_dim_to_index_symbol(ir_node: Any, dim: int) -> sympy.Symbol:
+    def _host_dim_to_index_symbol(ir_node: Any, dim: int) -> sympy.Symbol | None:
         """Map a host-range positional dim index to its dep.index d{i} symbol.
 
         CoarseTileInfo.tiled_dims_per_read/output_tiled_dims store *host-range*
@@ -637,9 +660,13 @@ class SpyreKernel(Kernel[CSEVariable]):
                             break
                         red_it_idx += 1
         if mapped is None:
-            # Fallback: identity mapping (no unit dims to skip, or ir_node
-            # lacks a `data` attribute -- e.g. in unit tests using bare
-            # fixtures).
+            if hasattr(ir_node, "data") and hasattr(ir_node.data, "ranges"):
+                # A known unit output/reduction dimension has no iteration
+                # symbol. Returning d{dim} here can alias the next surviving
+                # dimension after squeeze and manufacture a false binding
+                # conflict.
+                return None
+            # Bare unit-test fixtures have no range information to squeeze.
             mapped = dim
         return sympy_index_symbol(f"d{mapped}")
 
@@ -677,6 +704,7 @@ class SpyreKernel(Kernel[CSEVariable]):
 
         op_name = ir_node.get_operation_name()
         squeezed_advance_per_level: list[list[tuple[sympy.Expr, sympy.Expr]]] = []
+        preserved_per_level: tuple[sympy.Expr, ...] = ()
 
         if is_input:
             read_deps = [
@@ -705,6 +733,16 @@ class SpyreKernel(Kernel[CSEVariable]):
             )
             if squeezed_advance_per_read and dep_idx < len(squeezed_advance_per_read):
                 squeezed_advance_per_level = squeezed_advance_per_read[dep_idx]
+            binding = (
+                loop_info.loop_operand_bindings[dep_idx]
+                if dep_idx < len(loop_info.loop_operand_bindings)
+                else None
+            )
+            preserved_per_level = (
+                binding.host_advance_per_level if binding is not None else ()
+            )
+            if binding is not None and binding.kind != "sequential_affine":
+                raise Unsupported(f"unknown loop operand binding kind {binding.kind!r}")
         else:
             write_deps = [
                 dep
@@ -719,32 +757,77 @@ class SpyreKernel(Kernel[CSEVariable]):
                 getattr(loop_info, "squeezed_advance_output", None) or []
             )
 
-        if not per_level_dims and not any(squeezed_advance_per_level):
+        if (
+            not per_level_dims
+            and not any(squeezed_advance_per_level)
+            and not any(preserved_per_level)
+        ):
             return None
 
         device_size = tensor.layout.device_layout.device_size
         stride_map = tensor.layout.device_layout.stride_map
 
         total_device_expr: "sympy.Expr | None" = None
-        n_levels = max(len(per_level_dims), len(squeezed_advance_per_level))
+        n_levels = max(
+            len(per_level_dims),
+            len(squeezed_advance_per_level),
+            len(preserved_per_level),
+        )
         for level_idx in range(n_levels):
-            dim_extent_pairs = (
+            planned_dim_extent_pairs = (
                 per_level_dims[level_idx] if level_idx < len(per_level_dims) else []
             )
+            # Planning records host dimensions before division.  Once a
+            # dimension is divided to one, Inductor may squeeze its symbol
+            # from the final dependency.  In that case the explicit binding,
+            # not the stale planned dimension, owns the address advance.
+            dim_extent_pairs = []
+            for dim, extent in planned_dim_extent_pairs:
+                index_symbol = self._host_dim_to_index_symbol(ir_node, dim)
+                if index_symbol is not None and index_symbol in dep.index.free_symbols:
+                    dim_extent_pairs.append((dim, extent))
             squeezed_pairs = (
                 squeezed_advance_per_level[level_idx]
                 if level_idx < len(squeezed_advance_per_level)
                 else []
             )
-            if not dim_extent_pairs and not squeezed_pairs:
+            # A typed binding is authoritative when division squeezed every
+            # tiled dim from this read.  Otherwise retain the ordinary
+            # per-dim and squeezed-dim machinery, which may represent a mix
+            # of surviving and squeezed dimensions at the same level.
+            requested_preserved_advance = (
+                preserved_per_level[level_idx]
+                if level_idx < len(preserved_per_level)
+                and preserved_per_level[level_idx] != 0
+                else sympy.Integer(0)
+            )
+            if dim_extent_pairs and requested_preserved_advance != 0:
+                raise Unsupported(
+                    "loop operand binding conflicts with surviving tiled dimensions "
+                    f"for {op_name} at loop level {level_idx}: "
+                    f"dims={dim_extent_pairs}, dep_index={dep.index}"
+                )
+            preserved_host_advance = (
+                requested_preserved_advance
+                if not dim_extent_pairs
+                else sympy.Integer(0)
+            )
+            if preserved_host_advance != 0:
+                squeezed_pairs = []
+            if (
+                not dim_extent_pairs
+                and not squeezed_pairs
+                and preserved_host_advance == 0
+            ):
                 continue
             level_symbol = self._get_or_mint_level_symbol(level_idx, op_name)
             host_expr = sympy.S.Zero
             if dim_extent_pairs:
-                tiled_dim_extents = {
-                    self._host_dim_to_index_symbol(ir_node, d): extent * level_symbol
-                    for d, extent in dim_extent_pairs
-                }
+                tiled_dim_extents = {}
+                for d, extent in dim_extent_pairs:
+                    index_symbol = self._host_dim_to_index_symbol(ir_node, d)
+                    assert index_symbol is not None
+                    tiled_dim_extents[index_symbol] = extent * level_symbol
                 subs = dict(tiled_dim_extents)
                 subs.update(
                     {
@@ -756,6 +839,8 @@ class SpyreKernel(Kernel[CSEVariable]):
                 host_expr += dep.index.subs(subs)
             for host_stride, extent in squeezed_pairs:
                 host_expr += level_symbol * extent * host_stride
+            if preserved_host_advance != 0:
+                host_expr += preserved_host_advance * level_symbol
             device_expr = tiling_expr_to_device_expr(device_size, stride_map, host_expr)
             total_device_expr = (
                 device_expr
@@ -764,6 +849,14 @@ class SpyreKernel(Kernel[CSEVariable]):
             )
 
         return total_device_expr
+
+    def _resolve_loop_operand_binding(
+        self, tensor: TensorAccess, is_input: bool, name: str
+    ) -> "LoopOperandBinding | None":
+        device_offset = self._general_tile_advance(tensor, is_input, name)
+        if device_offset is None:
+            return None
+        return LoopOperandBinding("sequential_affine", device_offset)
 
     def create_tensor_arg(
         self,
@@ -808,7 +901,9 @@ class SpyreKernel(Kernel[CSEVariable]):
             device_coords,
             tuple(it_space),
         )
-        device_tile_advance_expr = self._general_tile_advance(tensor, is_input, name)
+        loop_operand_binding = self._resolve_loop_operand_binding(
+            tensor, is_input, name
+        )
         tensor_arg = TensorArg(
             is_input,
             -1,
@@ -818,7 +913,11 @@ class SpyreKernel(Kernel[CSEVariable]):
             tensor.layout.allocation,
             element_arrangement=tensor.layout.device_layout.element_arrangement,
             name=opspec_name,
-            device_tile_advance_expr=device_tile_advance_expr,
+            device_tile_advance_expr=(
+                loop_operand_binding.device_element_offset
+                if loop_operand_binding is not None
+                else None
+            ),
             work_division=work_division,
         )
         if (
@@ -897,13 +996,16 @@ class SpyreKernel(Kernel[CSEVariable]):
         # nesting level), so max() is just a safety net; in practice both
         # lists have the same length and the per-level loop below never
         # silently drops an entry from the shorter one.
-        n_levels = max(len(raw_tiled_dims), len(raw_tiled_red_dims))
+        loop_count = li.loop_count if li is not None else []
+        n_levels = max(
+            len(raw_tiled_dims),
+            len(raw_tiled_red_dims),
+            len(loop_count),
+        )
 
         tiled_symbol_trip_counts: dict = {}
         tiled_syms: list[list] = []
         if n_levels > 0:
-            loop_count = li.loop_count if li is not None else []
-
             op_name = ir_node.get_operation_name()
             tiled_syms_per_level_outermost: list[list] = []
             for lvl in range(n_levels):
@@ -911,10 +1013,24 @@ class SpyreKernel(Kernel[CSEVariable]):
                 has_any_tiled_dim = (
                     lvl < len(raw_tiled_dims) and raw_tiled_dims[lvl]
                 ) or (lvl < len(raw_tiled_red_dims) and raw_tiled_red_dims[lvl])
-                if has_any_tiled_dim:
-                    level_syms.append(self._get_or_mint_level_symbol(lvl, op_name))
+                minted_level_symbol = self._tile_advance_symbols.get(lvl)
+                has_arg_advance = (
+                    minted_level_symbol is not None
+                    and _tensor_args_advance_by_symbol(args, minted_level_symbol)
+                )
+                if has_any_tiled_dim or has_arg_advance:
+                    level_syms.append(
+                        minted_level_symbol
+                        if minted_level_symbol is not None
+                        else self._get_or_mint_level_symbol(lvl, op_name)
+                    )
                 tiled_syms_per_level_outermost.append(level_syms)
-                if lvl < len(loop_count):
+                if level_syms:
+                    if lvl >= len(loop_count):
+                        raise Unsupported(
+                            "coarse-tile symbol has no enclosing loop trip count: "
+                            f"op={op_name!r}, level={lvl}, symbols={level_syms}"
+                        )
                     trip_count = int(loop_count[lvl])
                     for sym in level_syms:
                         tiled_symbol_trip_counts[sym] = trip_count

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -3206,6 +3206,13 @@ def _insert_one_read_copy(
             propagation=PropagationPlan(kind="loop_internal"),
         )
 
+    if sizing_op_info.counted_loop_plan is not None and loop_depth == 0:
+        copy_buf.loop_storage_plan = LoopStoragePlan(
+            kind="loop_invariant",
+            owner_group=sizing_op_info.loop_group_id,
+            execution_role="input_activation",
+        )
+
     V.graph.name_to_buffer[copy_name] = copy_buf
     operations.insert(insert_idx, copy_buf)
 
@@ -3730,6 +3737,90 @@ def _insert_combine_op(
     return combine_name
 
 
+def _is_unit_tiled_sum_contribution(
+    tiled_op: ComputedBuffer, *, pre_stickify: bool
+) -> bool:
+    """Whether a persistent sum can be materialized as one loop contribution."""
+
+    data = tiled_op.data
+    info = getattr(tiled_op, "loop_info", None)
+    propagation = getattr(info, "propagation", None)
+    reduction_plan = getattr(propagation, "reduction", None)
+    if not (
+        pre_stickify
+        and isinstance(data, Reduction)
+        and data.reduction_type == "sum"
+        and data.src_dtype == data.dtype
+        and getattr(propagation, "kind", None) == "reduction"
+        and reduction_plan is not None
+        and reduction_plan.reduction_type == "sum"
+        and not reduction_plan.is_nested
+        and len(info.loop_count) == 1
+        and isinstance(info.loop_count[0], (int, sympy.Integer))
+        and int(info.loop_count[0]) > 1
+        and info.loop_tiled_dims == [[]]
+        and info.loop_tiled_reduction_dims == [[0]]
+        and len(data.reduction_ranges) == 1
+        and isinstance(data.reduction_ranges[0], (int, sympy.Integer))
+        and int(data.reduction_ranges[0]) == 1
+    ):
+        return False
+
+    try:
+        reads = list(tiled_op.get_read_writes().reads)
+    except Exception:
+        return False
+    return len(reads) == 1 and isinstance(reads[0], MemoryDep)
+
+
+def _same_loop_consumers(
+    op: ComputedBuffer, operations: list[Operation]
+) -> list[ComputedBuffer]:
+    """Consumers that would observe a terminal result before the loop drains."""
+
+    outer_key = op.loop_info.loop_group_id[0]  # type: ignore[attr-defined]
+    return [
+        candidate
+        for candidate in operations
+        if isinstance(candidate, ComputedBuffer)
+        and candidate is not op
+        and _reads_buffer(candidate, op.get_name())
+        and _outer_loop_key(candidate) == outer_key
+    ]
+
+
+def _preflight_persistent_reduction(
+    op: ComputedBuffer,
+    operations: list[Operation],
+    *,
+    pre_stickify: bool,
+) -> None:
+    """Reject an unrealizable persistent reduction before mutating the graph."""
+
+    loop_info = op.loop_info  # type: ignore[attr-defined]
+    reduction_plan = loop_info.propagation.reduction
+    counted_plan = loop_info.counted_loop_plan
+    if counted_plan.carried_reduction.accumulation_dtype != "source":
+        raise Unsupported(
+            "persistent expert accumulator must use the source contribution dtype"
+        )
+    if (
+        counted_plan.carried_reduction.kind != "terminal_sum"
+        or reduction_plan.reduction_type != "sum"
+        or reduction_plan.is_nested
+        or not _is_unit_tiled_sum_contribution(op, pre_stickify=pre_stickify)
+    ):
+        raise Unsupported(
+            "persistent expert execution requires one flat, unit-tiled terminal sum"
+        )
+    consumers = _same_loop_consumers(op, operations)
+    if consumers:
+        raise Unsupported(
+            "coarse_tile: persistent reduction must be terminal; same-loop "
+            f"consumers would run before its drain ({[o.get_name() for o in consumers]})"
+        )
+
+
 def _collapse_unit_tiled_sum_contribution(
     tiled_op: ComputedBuffer,
     combine_name: str,
@@ -3755,33 +3846,7 @@ def _collapse_unit_tiled_sum_contribution(
 
     data = tiled_op.data
     info = getattr(tiled_op, "loop_info", None)
-    propagation = getattr(info, "propagation", None)
-    reduction_plan = getattr(propagation, "reduction", None)
-    if not (
-        pre_stickify
-        and isinstance(data, Reduction)
-        and data.reduction_type == "sum"
-        and data.src_dtype == data.dtype
-        and getattr(propagation, "kind", None) == "reduction"
-        and reduction_plan is not None
-        and reduction_plan.reduction_type == "sum"
-        and not reduction_plan.is_nested
-        and len(info.loop_count) == 1
-        and isinstance(info.loop_count[0], (int, sympy.Integer))
-        and int(info.loop_count[0]) > 1
-        and info.loop_tiled_dims == [[]]
-        and info.loop_tiled_reduction_dims == [[0]]
-        and len(data.reduction_ranges) == 1
-        and isinstance(data.reduction_ranges[0], (int, sympy.Integer))
-        and int(data.reduction_ranges[0]) == 1
-    ):
-        return tiled_op
-
-    try:
-        reads = list(tiled_op.get_read_writes().reads)
-    except Exception:
-        return tiled_op
-    if len(reads) != 1 or not isinstance(reads[0], MemoryDep):
+    if not _is_unit_tiled_sum_contribution(tiled_op, pre_stickify=pre_stickify):
         return tiled_op
 
     expected_index = operations.index(tiled_op) + 1
@@ -3800,6 +3865,7 @@ def _collapse_unit_tiled_sum_contribution(
         == LoopStoragePlan(
             kind="loop_carried_accumulator",
             owner_group=info.loop_group_id,
+            execution_role="output_accumulator",
         )
     ):
         return tiled_op
@@ -3968,9 +4034,7 @@ def _insert_flat_reduction_copy_op(
     group_indices = [
         i
         for i, op in enumerate(operations)
-        if isinstance(op, ComputedBuffer)
-        and getattr(getattr(op, "loop_info", None), "loop_group_id", (None,))[0]
-        == outer_key
+        if isinstance(op, ComputedBuffer) and _outer_loop_key(op) == outer_key
     ]
     assert group_indices, "flat reduction loop group must contain its tiled op"
     operations.insert(max(group_indices) + 1, copy_buf)
@@ -4035,12 +4099,8 @@ def _propagate_tiled_reduction_op(
     reduction_plan = loop_info.propagation.reduction
     counted_plan = loop_info.counted_loop_plan
     persistent = counted_plan is not None
-    if persistent and (
-        counted_plan.carried_reduction.kind != "terminal_sum"
-        or reduction_plan.reduction_type != "sum"
-        or reduction_plan.is_nested
-    ):
-        raise Unsupported("persistent expert execution requires one flat terminal sum")
+    if persistent:
+        _preflight_persistent_reduction(op, operations, pre_stickify=pre_stickify)
     identity = reduction_plan.identity
     op_size = tuple(op.layout.size)
 
@@ -4116,6 +4176,7 @@ def _propagate_tiled_reduction_op(
         accum_tile.loop_storage_plan = LoopStoragePlan(
             kind="loop_carried_accumulator",
             owner_group=loop_group_id,
+            execution_role="output_accumulator",
         )
         fill_target = accum_tile
         combine_target = accum_tile
@@ -4218,12 +4279,17 @@ def _propagate_tiled_reduction_op(
     # Insert combine op after the tiled reduction op (inside the loop).
     combine_name = _insert_combine_op(op, combine_target, operations, is_nested)
     if persistent:
+        original_op = op
         op = _collapse_unit_tiled_sum_contribution(
             op,
             combine_name,
             operations,
             pre_stickify=pre_stickify,
         )
+        if op is original_op:
+            raise RuntimeError(
+                "persistent reduction preflight and materialization disagreed"
+            )
 
     # For nested case, insert a copy op at the outer loop level that writes
     # accum_tile → accum_full, advancing accum_full across outer output tiles.
@@ -4289,11 +4355,7 @@ def _propagate_tiled_reduction_op(
         )
     ]
     if persistent and raw_inside_consumers:
-        raise Unsupported(
-            "coarse_tile: flat reduction with an LX accumulator requires a "
-            "terminal reduction; same-loop consumers would run before the "
-            f"post-loop drain ({[o.get_name() for o in raw_inside_consumers]})"
-        )
+        raise RuntimeError("persistent reduction gained a same-loop consumer")
     if persistent:
         inside_consumers = []
     elif is_nested:

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -96,6 +96,7 @@ from ..errors import Unsupported
 from ..logging_utils import get_inductor_logger
 from ..loop_info import (
     CountedLoopPlan,
+    LoopStoragePlan,
     LoopOperandBindingRequirement,
     CoarseTileInfo,
     PropagationPlan,
@@ -1630,7 +1631,7 @@ def _coarse_tile_common(
     # 1 (a tiled-reduction op may itself have needed a read copy-in) and
     # before Pass 3 -- a reduction op is never also copy_out (the plan's
     # kind routes each op to exactly one).
-    _insert_all_reduction_ops(operations)
+    _insert_all_reduction_ops(operations, pre_stickify=run_read_copies)
 
     # Pass 3: write copy-outs (full buffer + copy op + outside-consumer/
     # graph-output patching), using each op's now-stamped
@@ -3729,6 +3730,123 @@ def _insert_combine_op(
     return combine_name
 
 
+def _collapse_unit_tiled_sum_contribution(
+    tiled_op: ComputedBuffer,
+    combine_name: str,
+    operations: list[Operation],
+    *,
+    pre_stickify: bool,
+) -> ComputedBuffer:
+    """Replace one local, unit-extent tiled sum with its sole contribution.
+
+    A reduction-dimension coarse tile can have static extent one even though
+    its enclosing ``LoopSpec`` has more than one iteration.  In that case the
+    reduction DDL has no local dimension left to map: the only value in the
+    tile is already the tile's contribution, while the coarse-tile combine op
+    performs the real cross-iteration reduction into the fixed accumulator.
+
+    This rewrite is deliberately fail-closed.  It applies only to a flat,
+    single-level ``sum`` whose sole reduction dimension is tiled to one, and
+    only after the exact mutation combine inserted by ``_insert_combine_op``
+    is present immediately downstream and targets the marked fixed
+    accumulator.  Every wider reduction, nested topology, other monoid, or
+    incomplete combine structure remains a ``Reduction``.
+    """
+
+    data = tiled_op.data
+    info = getattr(tiled_op, "loop_info", None)
+    propagation = getattr(info, "propagation", None)
+    reduction_plan = getattr(propagation, "reduction", None)
+    if not (
+        pre_stickify
+        and isinstance(data, Reduction)
+        and data.reduction_type == "sum"
+        and data.src_dtype == data.dtype
+        and getattr(propagation, "kind", None) == "reduction"
+        and reduction_plan is not None
+        and reduction_plan.reduction_type == "sum"
+        and not reduction_plan.is_nested
+        and len(info.loop_count) == 1
+        and isinstance(info.loop_count[0], (int, sympy.Integer))
+        and int(info.loop_count[0]) > 1
+        and info.loop_tiled_dims == [[]]
+        and info.loop_tiled_reduction_dims == [[0]]
+        and len(data.reduction_ranges) == 1
+        and isinstance(data.reduction_ranges[0], (int, sympy.Integer))
+        and int(data.reduction_ranges[0]) == 1
+    ):
+        return tiled_op
+
+    try:
+        reads = list(tiled_op.get_read_writes().reads)
+    except Exception:
+        return tiled_op
+    if len(reads) != 1 or not isinstance(reads[0], MemoryDep):
+        return tiled_op
+
+    expected_index = operations.index(tiled_op) + 1
+    if expected_index >= len(operations):
+        return tiled_op
+    combine = operations[expected_index]
+    if not (
+        isinstance(combine, ComputedBuffer)
+        and combine.get_name() == combine_name
+        and isinstance(combine.data, Pointwise)
+        and isinstance(combine.layout, MutationLayoutSHOULDREMOVE)
+        and getattr(getattr(combine, "loop_info", None), "loop_group_id", None)
+        == info.loop_group_id
+        and _reads_buffer(combine, tiled_op.get_name())
+        and getattr(combine.layout.get_buffer(), "loop_storage_plan", None)
+        == LoopStoragePlan(
+            kind="loop_carried_accumulator",
+            owner_group=info.loop_group_id,
+        )
+    ):
+        return tiled_op
+
+    reduction_inner_fn = data.inner_fn
+
+    def contribution_inner_fn(index):
+        return reduction_inner_fn(index, [sympy.Integer(0)])
+
+    contribution_data = Pointwise(
+        device=tiled_op.get_device(),
+        dtype=tiled_op.get_dtype(),
+        inner_fn=contribution_inner_fn,
+        ranges=list(data.ranges),
+    )
+    # Layout propagation inspects the Loops body's FX origins (not only the
+    # enclosing ComputedBuffer's provenance) to recover the pointwise op
+    # semantics.  Keep that body provenance across the Reduction->Pointwise
+    # normalization just as the buffer replacement below keeps buffer
+    # provenance.
+    from ..provenance import preserve_provenance
+
+    preserve_provenance(
+        data,
+        contribution_data,
+        pass_name="coarse_tile",
+        reason="collapse static unit tiled sum to loop contribution",
+    )
+    from ..pass_utils import replace_computed_buffer_body
+
+    contribution = replace_computed_buffer_body(
+        tiled_op,
+        contribution_data,
+        operations,
+        pass_name="coarse_tile",
+        reason="collapse static unit tiled sum to loop contribution",
+    )
+    V.graph.name_to_buffer[contribution.get_name()] = contribution
+    logger.debug(
+        "coarse_tile: collapsed unit tiled sum %s to pointwise contribution; "
+        "cross-iteration sum remains owned by %s",
+        contribution.get_name(),
+        combine_name,
+    )
+    return contribution
+
+
 def _insert_reduction_copy_op(
     tiled_op: ComputedBuffer,
     accum_tile: ComputedBuffer,
@@ -3815,7 +3933,52 @@ def _insert_reduction_copy_op(
     operations.insert(insert_idx, copy_buf)
 
 
-def _insert_all_reduction_ops(operations: list[Operation]) -> None:
+def _insert_flat_reduction_copy_op(
+    tiled_op: ComputedBuffer,
+    accum_tile: ComputedBuffer,
+    accum_full: ComputedBuffer,
+    operations: list[Operation],
+) -> None:
+    """Drain a fixed tile accumulator once after a flat reduction loop.
+
+    Unlike ``_insert_reduction_copy_op`` there is no outer output-tile loop:
+    the entire output lives at one fixed address while the sole reduction
+    loop runs.  The copy therefore carries no ``loop_info`` and is placed
+    after the last operation in the loop group, yielding exactly one HBM
+    write after the loop terminates.
+    """
+    copy_data = Pointwise(
+        device=tiled_op.get_device(),
+        dtype=tiled_op.get_dtype(),
+        inner_fn=accum_tile.make_loader(),
+        ranges=list(tiled_op.data.ranges),
+    )
+    copy_name = V.graph.qualify_name(f"coarse_tile_reduce_copy_{tiled_op.get_name()}")
+    copy_buf = ComputedBuffer(
+        name=copy_name,
+        layout=MutationLayoutSHOULDREMOVE(TensorBox(StorageBox(accum_full))),
+        data=copy_data,
+    )
+    copy_buf.origins = tiled_op.origins
+    copy_buf.operation_name = copy_name
+    copy_buf._coarse_tile_force_live = True  # type: ignore[attr-defined]
+    V.graph.name_to_buffer[copy_name] = copy_buf
+
+    outer_key = tiled_op.loop_info.loop_group_id[0]  # type: ignore[attr-defined]
+    group_indices = [
+        i
+        for i, op in enumerate(operations)
+        if isinstance(op, ComputedBuffer)
+        and getattr(getattr(op, "loop_info", None), "loop_group_id", (None,))[0]
+        == outer_key
+    ]
+    assert group_indices, "flat reduction loop group must contain its tiled op"
+    operations.insert(max(group_indices) + 1, copy_buf)
+
+
+def _insert_all_reduction_ops(
+    operations: list[Operation], *, pre_stickify: bool
+) -> None:
     """Pass 2: build reduction machinery for every planned reduction op.
 
     Transformation's Pass 2 (see the plan/execute split design). Every op
@@ -3837,21 +4000,22 @@ def _insert_all_reduction_ops(operations: list[Operation]) -> None:
         propagation = getattr(loop_info, "propagation", None)
         if propagation is None or propagation.kind != "reduction":
             continue
-        _propagate_tiled_reduction_op(op, operations)
+        _propagate_tiled_reduction_op(op, operations, pre_stickify=pre_stickify)
 
 
 def _propagate_tiled_reduction_op(
     op: ComputedBuffer,
     operations: list[Operation],
+    *,
+    pre_stickify: bool,
 ) -> None:
     """Handle buffer propagation for a Reduction op tiled over a reduction dim.
 
     Strategy: fill-initialize + per-tile combine.
-      1. Allocate a HBM accumulation buffer sized to the full
-         (pre-outer-division) output shape (planned as
-         reduction.full_output_ranges), so that address advancement across
-         outer tiles writes each tile into the correct slice.  For flat
-         (reduction-only) tiling this equals op.data.ranges.
+      1. Allocate a final HBM buffer plus a fixed-address tile accumulator.
+         The tile accumulator is eligible for LX; the HBM buffer is written
+         once after a flat reduction loop or once per outer output tile for a
+         nested reduction.
       2. Insert a fill op that writes the reduction's identity value into the
          accumulation buffer.  For flat reduction tiling the fill has no
          loop_info and runs before all loops.  For nested tiling (outer
@@ -3869,6 +4033,14 @@ def _propagate_tiled_reduction_op(
     loop_info = op.loop_info
     loop_group_id = loop_info.loop_group_id
     reduction_plan = loop_info.propagation.reduction
+    counted_plan = loop_info.counted_loop_plan
+    persistent = counted_plan is not None
+    if persistent and (
+        counted_plan.carried_reduction.kind != "terminal_sum"
+        or reduction_plan.reduction_type != "sum"
+        or reduction_plan.is_nested
+    ):
+        raise Unsupported("persistent expert execution requires one flat terminal sum")
     identity = reduction_plan.identity
     op_size = tuple(op.layout.size)
 
@@ -3881,12 +4053,29 @@ def _propagate_tiled_reduction_op(
     # outer division, so full == per-tile.
     full_output_ranges = reduction_plan.full_output_ranges
 
-    # Insert HBM buffer before the first op in the loop group.
+    # Persistent execution inserts setup before both the loop and its typed
+    # invariant preheaders. Legacy reductions retain their original insertion
+    # point at the first loop operation.
     outer_key = loop_group_id[0]
-    group_start_idx = next(
+    first_loop_idx = next(
         i
         for i, o in enumerate(operations)
         if isinstance(o, ComputedBuffer) and _outer_loop_key(o) == outer_key
+    )
+    hoisted_preheaders = [
+        o
+        for o in operations
+        if isinstance(o, ComputedBuffer)
+        and (
+            owner := getattr(getattr(o, "loop_info", None), "preheader_for_group", None)
+        )
+        is not None
+        and owner[0] == outer_key
+    ]
+    group_start_idx = (
+        min([first_loop_idx, *(operations.index(o) for o in hoisted_preheaders)])
+        if persistent
+        else first_loop_idx
     )
 
     fill_loop_info = reduction_plan.outer_fill_loop_info
@@ -3907,13 +4096,9 @@ def _propagate_tiled_reduction_op(
             loop_group_id=loop_group_id[: len(fill_loop_info.loop_count)],
         )
 
-    if is_nested:
-        # Nested case: allocate separate tile-sized and full-sized buffers.
-        # accum_tile stays inside the inner K-loop (never advances there --
-        # its only readers are the combine op and the outer copy op, both of
-        # which build their own correct tiled_dims_per_read/output_tiled_dims
-        # from their own loop_info, so accum_tile itself needs no flag);
-        # accum_full accumulates across outer B-tiles via a copy op.
+    if persistent:
+        # The visible result remains in HBM. A distinct typed accumulator is
+        # filled once, updated at a fixed LX address, and drained once.
         accum_full = _allocate_full_buffer(
             op,
             full_output_ranges,
@@ -3921,18 +4106,39 @@ def _propagate_tiled_reduction_op(
             operations,
             group_start_idx,
         )
-        group_start_idx_after_full = operations.index(accum_full) + 1
         accum_tile = _allocate_full_buffer(
             op,
             per_tile_ranges,
             reduction_plan.per_tile_strides,
             operations,
-            group_start_idx_after_full,
+            operations.index(accum_full) + 1,
+        )
+        accum_tile.loop_storage_plan = LoopStoragePlan(
+            kind="loop_carried_accumulator",
+            owner_group=loop_group_id,
+        )
+        fill_target = accum_tile
+        combine_target = accum_tile
+    elif is_nested:
+        # Original nested-reduction path.
+        accum_full = _allocate_full_buffer(
+            op,
+            full_output_ranges,
+            reduction_plan.full_output_strides,
+            operations,
+            group_start_idx,
+        )
+        accum_tile = _allocate_full_buffer(
+            op,
+            per_tile_ranges,
+            reduction_plan.per_tile_strides,
+            operations,
+            operations.index(accum_full) + 1,
         )
         fill_target = accum_tile
         combine_target = accum_tile
     else:
-        # Flat case: single full-sized buffer.
+        # Original flat-reduction path: combine directly into the full buffer.
         accum_full = _allocate_full_buffer(
             op,
             full_output_ranges,
@@ -3995,14 +4201,29 @@ def _propagate_tiled_reduction_op(
     fill_buf._coarse_tile_force_live = True  # type: ignore[attr-defined]
     V.graph.name_to_buffer[fill_name] = fill_buf
     fill_target_idx = operations.index(fill_target)
-    # scalar_op was appended to graph.operations by register_operation(); move it
-    # to just after fill_target, then insert fill_buf after scalar_op.
+    # scalar_op was appended to graph.operations by register_operation(); move
+    # it to just after fill_target.  For a flat group with invariant read-copy
+    # preheaders, insert the Spyre fill *after* the final preheader.  This keeps
+    # every wrapper-only setup op before the contiguous Spyre sequence
+    #   read-copy -> fill -> sole reduction loop -> final drain
+    # so one fusion/allocation plan owns the preheader's LX lifetime.
     operations.remove(scalar_op)
     operations.insert(fill_target_idx + 1, scalar_op)
-    operations.insert(fill_target_idx + 2, fill_buf)
+    if persistent and hoisted_preheaders:
+        fill_insert_idx = max(operations.index(o) for o in hoisted_preheaders) + 1
+    else:
+        fill_insert_idx = operations.index(scalar_op) + 1
+    operations.insert(fill_insert_idx, fill_buf)
 
     # Insert combine op after the tiled reduction op (inside the loop).
     combine_name = _insert_combine_op(op, combine_target, operations, is_nested)
+    if persistent:
+        op = _collapse_unit_tiled_sum_contribution(
+            op,
+            combine_name,
+            operations,
+            pre_stickify=pre_stickify,
+        )
 
     # For nested case, insert a copy op at the outer loop level that writes
     # accum_tile → accum_full, advancing accum_full across outer output tiles.
@@ -4011,6 +4232,8 @@ def _propagate_tiled_reduction_op(
         _insert_reduction_copy_op(
             op, accum_tile, accum_full, fill_loop_info, operations
         )
+    elif persistent:
+        _insert_flat_reduction_copy_op(op, accum_tile, accum_full, operations)
 
     # The tiled reduction op's own write is per-tile scratch: it is drained by
     # the combine op every inner iteration and never read directly by the
@@ -4044,20 +4267,15 @@ def _propagate_tiled_reduction_op(
     # accumulated value for that tile. All inside consumers are safe to
     # redirect.
     #
-    # Flat (is_nested=False): the combine op accumulates directly into
-    # accum_full via MutationLayout inside the (possibly multi-level)
-    # reduction loop itself. A consumer is safe to redirect only if its own
-    # loop_tiled_dims exactly matches op's -- both then advance through
-    # accum_full along exactly the same dimensions at exactly the same rate,
-    # so by the time the consumer's tile is reached, every reduction-dim
-    # tile contributing to it has already combined. A consumer with EXTRA
-    # tiled dimensions (e.g. it also tiles a dim op's reduction loop doesn't,
-    # or vice versa) could run before accum_full is fully combined for its
-    # slice -- those consumers are left reading buf_name (per-tile scratch).
+    # Flat (is_nested=False): accum_full is intentionally stale until the
+    # post-loop drain.  No same-loop consumer may observe the reduction
+    # result; supporting one would require scheduling it after the loop, not
+    # merely renaming its input.  The D-AS-X proof has a terminal expert sum,
+    # so fail closed on every other flat topology.
     combine_name = V.graph.qualify_name(f"coarse_tile_combine_{buf_name}")
     copy_name = V.graph.qualify_name(f"coarse_tile_reduce_copy_{buf_name}")
     outer_key = loop_group_id[0]
-    inside_consumers = [
+    raw_inside_consumers = [
         o
         for o in operations
         if isinstance(o, ComputedBuffer)
@@ -4070,6 +4288,23 @@ def _propagate_tiled_reduction_op(
             == loop_info.loop_tiled_dims
         )
     ]
+    if persistent and raw_inside_consumers:
+        raise Unsupported(
+            "coarse_tile: flat reduction with an LX accumulator requires a "
+            "terminal reduction; same-loop consumers would run before the "
+            f"post-loop drain ({[o.get_name() for o in raw_inside_consumers]})"
+        )
+    if persistent:
+        inside_consumers = []
+    elif is_nested:
+        inside_consumers = raw_inside_consumers
+    else:
+        inside_consumers = [
+            consumer
+            for consumer in raw_inside_consumers
+            if getattr(getattr(consumer, "loop_info", None), "loop_tiled_dims", None)
+            == loop_info.loop_tiled_dims
+        ]
 
     all_consumers = outside_consumers + inside_consumers
     accum_name = accum_full.get_name()

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -3744,6 +3744,8 @@ def _is_unit_tiled_sum_contribution(
 
     data = tiled_op.data
     info = getattr(tiled_op, "loop_info", None)
+    if info is None:
+        return False
     propagation = getattr(info, "propagation", None)
     reduction_plan = getattr(propagation, "reduction", None)
     if not (
@@ -3846,6 +3848,8 @@ def _collapse_unit_tiled_sum_contribution(
 
     data = tiled_op.data
     info = getattr(tiled_op, "loop_info", None)
+    if info is None:
+        return tiled_op
     if not _is_unit_tiled_sum_contribution(tiled_op, pre_stickify=pre_stickify):
         return tiled_op
 

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -91,10 +91,12 @@ from torch.utils._ordered_set import OrderedSet
 from torch_spyre._C import SpyreTensorLayout
 
 from .. import config
-from ..constants import BATCH_MATMUL_OP
+from ..constants import BATCH_MATMUL_OP, PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY
 from ..errors import Unsupported
 from ..logging_utils import get_inductor_logger
 from ..loop_info import (
+    CountedLoopPlan,
+    LoopOperandBindingRequirement,
     CoarseTileInfo,
     PropagationPlan,
     ReadCopyEntry,
@@ -103,10 +105,75 @@ from ..loop_info import (
     copy_op_metadata,
 )
 from ..pass_utils import op_out_coords, host_coordinates, indirect_sizes_from_op
+from ..propagate_hints import get_op_hints
 from ..ir import FixedTiledLayout, SpyreConstantFallback, _resize_device_layout
 from .tile import compute_tile_index, compute_tile_stride
 
 logger = get_inductor_logger("coarse_tile")
+
+
+_PERSISTENT_EXPERT_HINT = "persistent_dense_expert"
+_PERSISTENT_STREAMED_ROLES = {
+    "gate_weight",
+    "up_weight",
+    "down_weight",
+    "routing_weight",
+}
+
+
+def _streamed_operand_role(op: ComputedBuffer) -> str | None:
+    op_info = getattr(op.data, "op_info", None) or {}
+    marked = op_info.get(PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY)
+    hinted = {
+        hint["streamed_operand_role"]
+        for hint in get_op_hints(op).values()
+        if "streamed_operand_role" in hint
+    }
+    roles = ({marked} if isinstance(marked, str) else set()) | hinted
+    if not roles:
+        return None
+    if len(roles) != 1 or not roles <= _PERSISTENT_STREAMED_ROLES:
+        raise Unsupported(f"invalid persistent streamed operand roles: {roles}")
+    return next(iter(roles))
+
+
+def _is_graph_input(name: str) -> bool:
+    source = V.graph.get_buffer(name)
+    if isinstance(source, TensorBox):
+        source = source.data
+    if isinstance(source, StorageBox):
+        source = source.data
+    return isinstance(source, InputBuffer)
+
+
+def _outer_loop_key(op: Operation) -> int | None:
+    group_id = getattr(getattr(op, "loop_info", None), "loop_group_id", ())
+    return group_id[0] if group_id else None
+
+
+def _counted_loop_plan_for_group(
+    group_ops: list[Operation], levels: list[tuple[int, int]]
+) -> CountedLoopPlan | None:
+    """Read the compiler-owned loop marker attached by the internal lowering."""
+
+    level_ids = {hint_id for hint_id, _count in levels}
+    markers = {
+        hint["expert_execution"]
+        for op in group_ops
+        if isinstance(op, ComputedBuffer)
+        for hint_id, hint in get_op_hints(op).items()
+        if hint_id in level_ids and "expert_execution" in hint
+    }
+    if not markers:
+        return None
+    if markers != {_PERSISTENT_EXPERT_HINT} or len(levels) != 1:
+        raise Unsupported(
+            "persistent expert execution requires one statically counted loop"
+        )
+    return CountedLoopPlan(
+        kind="persistent_dense_expert",
+        trip_count=int(levels[0][1]),
+    )
 
 
 class _RetiledBufferInfo(NamedTuple):
@@ -225,6 +292,7 @@ def plan_coarse_tile_groups(
     """
     plan: dict[int, CoarseTileInfo] = {}
     for group_idx, (group_ops, levels) in enumerate(groups):
+        counted_loop_plan = _counted_loop_plan_for_group(group_ops, levels)
         group_id: tuple[int, ...] = (group_idx,)
         nested_group_id: tuple[int, ...] = group_id + (0,) * (len(levels) - 1)
         counts = [count for _, count in levels]
@@ -300,6 +368,37 @@ def plan_coarse_tile_groups(
             tiled_dims_per_read = [
                 _tiled_dims_for_dep(dep, per_level_extents) for dep in read_deps
             ]
+            loop_operand_bindings: list[LoopOperandBindingRequirement | None]
+            if counted_loop_plan is None:
+                loop_operand_bindings = [None for _ in read_deps]
+            else:
+                loop_operand_bindings = []
+                streamed_role = _streamed_operand_role(op)
+                for dep in read_deps:
+                    per_dim = _host_tile_advances_for_dep(dep, per_level_extents)
+                    per_level = tuple(
+                        sum(
+                            (sympy.sympify(advance) for _dim, advance in level),
+                            sympy.Integer(0),
+                        )
+                        for level in per_dim
+                    )
+                    has_advance = any(per_level)
+                    is_named_stream = (
+                        streamed_role is not None
+                        and has_advance
+                        and _is_graph_input(dep.name)
+                    )
+                    loop_operand_bindings.append(
+                        LoopOperandBindingRequirement(
+                            kind="sequential_affine",
+                            host_advance_per_level=per_level,
+                            operand_role=streamed_role,
+                            source_name=dep.name,
+                        )
+                        if is_named_stream
+                        else None
+                    )
             output_tiled_dims = (
                 _tiled_dims_for_dep(write_deps[0], per_level_extents)
                 if write_deps
@@ -312,7 +411,9 @@ def plan_coarse_tile_groups(
                 loop_tiled_dims=op_tiled_dims,
                 loop_tiled_reduction_dims=op_tiled_reduction_dims,
                 tiled_dims_per_read=tiled_dims_per_read,
+                loop_operand_bindings=loop_operand_bindings,
                 output_tiled_dims=output_tiled_dims,
+                counted_loop_plan=counted_loop_plan,
             )
 
             logger.debug(
@@ -902,6 +1003,36 @@ def _tiled_dims_for_dep(
         [(d, extent) for d, extent in level.items() if d in dep_dims]
         for level in per_level_extents
     ]
+
+
+def _host_tile_advances_for_dep(
+    dep: MemoryDep,
+    per_level_extents: list[dict[int, Expr]],
+) -> list[list[tuple[int, Expr]]]:
+    """Preserve each tiled dim's flat host-element advance before division.
+
+    This is deliberately parallel to ``_tiled_dims_for_dep`` and is not the
+    normal tile-advance path.  It only supplies the information that cannot
+    be reconstructed later when division turns a tiled dim into size one and
+    Inductor squeezes its symbol from the final MemoryDep.  Evaluate one dim
+    at a time (all other symbols zero) and subtract the all-zero offset so a
+    constant/window offset is not mistaken for a per-iteration advance.
+    """
+    zero_subs = {sym: sympy.Integer(0) for sym in dep.index.free_symbols}
+    zero_offset = dep.index.subs(zero_subs)
+    result: list[list[tuple[int, Expr]]] = []
+    for level in per_level_extents:
+        level_advances: list[tuple[int, Expr]] = []
+        for dim, extent in level.items():
+            dim_symbol = sympy_index_symbol(f"d{dim}")
+            if dim_symbol not in dep.index.free_symbols:
+                continue
+            subs = dict(zero_subs)
+            subs[dim_symbol] = extent
+            advance = sympy.simplify(dep.index.subs(subs) - zero_offset)
+            level_advances.append((dim, advance))
+        result.append(level_advances)
+    return result
 
 
 def _stick_host_dim(op: ComputedBuffer, device_layout) -> int | None:
@@ -1856,9 +1987,7 @@ def _propagate_tiled_op(
     group_start_idx = next(
         i
         for i, o in enumerate(operations)
-        if isinstance(o, ComputedBuffer)
-        and getattr(getattr(o, "loop_info", None), "loop_group_id", (None,))[0]
-        == outer_key
+        if isinstance(o, ComputedBuffer) and _outer_loop_key(o) == outer_key
     )
     full_buf = _allocate_full_buffer(
         op, full_ranges, full_strides, operations, group_start_idx
@@ -2478,7 +2607,9 @@ def _insert_one_read_copy(
     copy_name: str,
     operations: list[Operation],
     insert_before_op: Operation,
-) -> str:
+    planned_dep_levels: tuple[tuple[tuple[int, Expr], ...], ...] | None = None,
+    binding_requirement: LoopOperandBindingRequirement | None = None,
+) -> tuple[str, list[Expr]]:
     """Build and insert one tile-sized copy op for a single full-buffer read.
 
     sizing_op reads (or is the first of a group of ops that all read) a
@@ -2514,8 +2645,9 @@ def _insert_one_read_copy(
     sizing_op (which only supplies loop_info/ranges/origins here and may
     coincide with insert_before_op but is not guaranteed to by contract).
 
-    Returns the inserted copy buffer's name (copy_buf.get_name()) -- callers
-    patch consumers separately via _patch_consumer_to_read_copy.
+    Returns the inserted copy buffer's name and the full dependency-position
+    stride vector used to patch consumers. The latter is returned as data,
+    rather than smuggled through a private buffer attribute.
     """
     insert_idx = operations.index(insert_before_op)
     full_buf = V.graph.get_buffer(dep.name)
@@ -2529,8 +2661,10 @@ def _insert_one_read_copy(
         full_buf = full_buf.data
     if isinstance(full_buf, StorageBox):
         full_buf = full_buf.data
+    sizing_loop_info = sizing_op.loop_info  # type: ignore[attr-defined]
+    persistent_copy = sizing_loop_info.counted_loop_plan is not None
 
-    tile_ranges = list(dep.size)
+    dep_ranges = list(dep.size)
     # Derive copy buffer strides using compute_tile_stride.
     # dep.size is the full loop iteration space (output + reduction dims) and
     # may have higher rank than the tensor (e.g. for a Reduction reading
@@ -2544,25 +2678,49 @@ def _insert_one_read_copy(
     # broadcast/absent (e.g. the N dim in a Reduction reading a[M,K]).
     active_idx = [i for i, c in enumerate(full_coeff) if c != 0]
 
+    tile_ranges: list[Expr]
     tile_strides: list[Expr]
+    dep_tile_strides: list[Expr] = [sympy.Integer(0)] * len(dep_ranges)
+    compact_dep_positions: list[int]
     if not active_idx:
+        # Preserve the existing scalar/all-broadcast representation. Persistent
+        # expert operands all have active dims; this protects legacy scalars.
+        tile_ranges = dep_ranges
         tile_strides = [sympy.Integer(0)] * len(tile_ranges)
-    else:
+        compact_dep_positions = list(range(len(dep_ranges)))
+    elif persistent_copy:
         active_full_sizes = [dep.size[i] for i in active_idx]
         active_full_strides = [full_coeff[i] for i in active_idx]
-        active_tile_ranges = [tile_ranges[i] for i in active_idx]
-        active_tile_strides = compute_tile_stride(
-            active_full_sizes, active_full_strides, active_tile_ranges
+        tile_ranges = [dep_ranges[i] for i in active_idx]
+        tile_strides = compute_tile_stride(
+            active_full_sizes, active_full_strides, tile_ranges
         )
-        # active_tile_strides[i] corresponds to active_idx[i]: both are indexed
-        # by position in the compressed active-dims space, so zip pairs each
-        # full dep.var_names position with its computed tile stride correctly.
+        compact_dep_positions = active_idx
+        for dep_pos, stride in zip(active_idx, tile_strides):
+            dep_tile_strides[dep_pos] = stride
+    else:
+        # Preserve the existing full-rank copy representation for every graph
+        # without an explicit persistent expert plan.
+        tile_ranges = dep_ranges
+        active_tile_strides = compute_tile_stride(
+            [dep.size[i] for i in active_idx],
+            [full_coeff[i] for i in active_idx],
+            [tile_ranges[i] for i in active_idx],
+        )
         tile_strides = [sympy.Integer(0)] * len(tile_ranges)
-        for pos, ts in zip(active_idx, active_tile_strides):
-            tile_strides[pos] = ts
+        for dep_pos, stride in zip(active_idx, active_tile_strides):
+            tile_strides[dep_pos] = stride
+        dep_tile_strides = list(tile_strides)
+        compact_dep_positions = list(range(len(dep_ranges)))
 
     def _copy_inner_fn(idx, _dep=dep, _full_name=full_buf.get_name()):
-        subs = dict(zip(_dep.var_names, idx))
+        # Pointwise iteration covers only dimensions the source dependency
+        # actually indexes.  Reduction output dimensions broadcast by this
+        # operand (e.g. N for X[M,K] in matmul) are not physical copy-buffer
+        # dimensions and must not inflate [Ttile,H] into [Ttile,F,H].
+        subs = {var: sympy.Integer(0) for var in _dep.var_names}
+        for compact_pos, dep_pos in enumerate(compact_dep_positions):
+            subs[_dep.var_names[dep_pos]] = idx[compact_pos]
         flat_index = sympy_subs(_dep.index, subs)
         return V.ops.load(_full_name, flat_index)
 
@@ -2756,7 +2914,6 @@ def _insert_one_read_copy(
     copy_buf.origins = sizing_op.origins
     copy_buf.operation_name = copy_name
     copy_op_metadata(sizing_op, copy_buf)
-
     # Fresh per-level tiled-dim decisions for copy_buf's own read/write —
     # mirroring _insert_copy_op's read/write split (see its comment), but
     # with the roles swapped: there, the copy's READ (of sizing_op's
@@ -2777,7 +2934,14 @@ def _insert_one_read_copy(
     # full_buf and of copy_buf's own output) via
     # SpyreKernel._general_tile_advance's positional dep-index lookup —
     # a semantic mismatch, not merely a magnitude one.
-    sizing_op_info = sizing_op.loop_info  # type: ignore[attr-defined]
+    sizing_op_info = sizing_loop_info
+    # ``tiled_dims_per_read`` was planned before range division, so it is
+    # the authoritative record of which loop levels this particular source
+    # read actually advances at.  Keep that record: post-division
+    # ``MemoryDep`` extraction squeezes unit dimensions, which is exactly
+    # what happens to the expert dimension when an E=2 expert loop is tiled
+    # down to one expert per iteration.  The shared activation is invariant
+    # at that inner level even though the consuming BMM is not.
     copy_ranges = list(copy_data.ranges)
     # sizing_op_info.loop_tiled_dims's dim keys are raw positional indices
     # into sizing_op.data.ranges (see CoarseTileInfo's docstring), which
@@ -2802,10 +2966,41 @@ def _insert_one_read_copy(
     squeezed_advance: list[list[tuple[Expr, Expr]]] = [
         [] for _ in sizing_op_info.loop_tiled_dims
     ]
+
+    def _require_unit_dim_advance(level_idx: int, dim: int) -> None:
+        if binding_requirement is None:
+            raise Unsupported(
+                f"coarse_tile: read copy of {dep.name!r} for "
+                f"{sizing_op.get_name()!r} needs the pre-division base stride "
+                f"for squeezed tiled dim {dim}, but no planning-time host "
+                "binding was planned"
+            )
+        if (
+            binding_requirement.kind != "sequential_affine"
+            or level_idx >= len(binding_requirement.host_advance_per_level)
+            or binding_requirement.host_advance_per_level[level_idx] == 0
+        ):
+            raise Unsupported(
+                f"coarse_tile: read copy of {dep.name!r} for "
+                f"{sizing_op.get_name()!r} advances along squeezed tiled dim "
+                f"{dim}, but its sequential-affine binding is missing"
+            )
+
     for d in {d for level in sizing_op_info.loop_tiled_dims for d in level}:
         levels_tiling_d = [
             i for i, dims in enumerate(sizing_op_info.loop_tiled_dims) if d in dims
         ]
+        if planned_dep_levels is not None:
+            levels_tiling_d = [
+                level_idx
+                for level_idx in levels_tiling_d
+                if any(
+                    planned_dim == d
+                    for planned_dim, _extent in planned_dep_levels[level_idx]
+                )
+            ]
+        if not levels_tiling_d:
+            continue
         if d not in squeeze_pos:
             # sizing_op.data.ranges[d] == 1 for this tiled dim (e.g. a
             # B-tiled group where the per-tile B extent is 1) -- it was
@@ -2831,17 +3026,44 @@ def _insert_one_read_copy(
             # stride_map-based dimension selection cannot be compared
             # against (see _insert_copy_op's write-side analogue for the
             # collision this caused when the two happened to diverge).
-            host_stride = sympy.prod(sizing_op.data.ranges[d + 1 :])
-            running = sympy.Integer(1)
-            for level_idx in reversed(levels_tiling_d):
-                squeezed_advance[level_idx].append((host_stride, running))
-                running = running * sizing_op_info.loop_count[level_idx]
+            if persistent_copy:
+                for level_idx in levels_tiling_d:
+                    _require_unit_dim_advance(level_idx, d)
+            else:
+                host_stride = sympy.prod(sizing_op.data.ranges[d + 1 :])
+                running = sympy.Integer(1)
+                for level_idx in reversed(levels_tiling_d):
+                    squeezed_advance[level_idx].append((host_stride, running))
+                    running = running * sizing_op_info.loop_count[level_idx]
             continue
         # The dict key must be a raw positional index into copy_buf's own
         # data.ranges (what SpyreKernel._host_dim_to_index_symbol will
         # later squeeze again when it runs against copy_buf) -- i.e. the
         # squeezed position computed above, not sizing_op's raw d.
-        copy_dim = squeeze_pos[d]
+        dep_dim = squeeze_pos.get(d)
+        copy_dim = (
+            compact_dep_positions.index(dep_dim)
+            if dep_dim in compact_dep_positions
+            else None
+        )
+        if copy_dim is None:
+            # A unit post-division dimension disappears from dep.size.  It
+            # is safe to omit only when planning already proved this source
+            # read invariant at every level tiling that dimension (the
+            # shared-LHS activation's expert dimension).  If the source read
+            # itself advances there (an expert weight bank), silently
+            # dropping it would reload expert zero on every iteration; that
+            # needs a separate preserved-base-stride mechanism.
+            if planned_dep_levels is None:
+                _require_unit_dim_advance(levels_tiling_d[-1], d)
+            else:
+                for level_idx in levels_tiling_d:
+                    if any(
+                        planned_dim == d
+                        for planned_dim, _extent in planned_dep_levels[level_idx]
+                    ):
+                        _require_unit_dim_advance(level_idx, d)
+            continue
         running = sympy.sympify(copy_ranges[copy_dim])
         for level_idx in reversed(levels_tiling_d):
             read_level_extents[level_idx][copy_dim] = running
@@ -2859,7 +3081,41 @@ def _insert_one_read_copy(
             for i, dims in enumerate(sizing_op_info.loop_tiled_reduction_dims)
             if d in dims
         ]
-        copy_dim_key = it_idx + reduction_squeeze_pos[d]
+        planned_dim_key = len(sizing_op.data.ranges) + d
+        if planned_dep_levels is not None:
+            levels_tiling_d = [
+                level_idx
+                for level_idx in levels_tiling_d
+                if any(
+                    planned_dim == planned_dim_key
+                    for planned_dim, _extent in planned_dep_levels[level_idx]
+                )
+            ]
+        if not levels_tiling_d:
+            continue
+        reduction_copy_dim = reduction_squeeze_pos.get(d)
+        if reduction_copy_dim is None:
+            if planned_dep_levels is None:
+                _require_unit_dim_advance(levels_tiling_d[-1], planned_dim_key)
+            else:
+                for level_idx in levels_tiling_d:
+                    if any(
+                        planned_dim == planned_dim_key
+                        for planned_dim, _extent in planned_dep_levels[level_idx]
+                    ):
+                        _require_unit_dim_advance(level_idx, planned_dim_key)
+            continue
+        dep_dim_key = it_idx + reduction_copy_dim
+        copy_dim_key = (
+            compact_dep_positions.index(dep_dim_key)
+            if dep_dim_key in compact_dep_positions
+            else None
+        )
+        if copy_dim_key is None:
+            raise Unsupported(
+                f"coarse_tile: tiled reduction dim {d} of read {dep.name!r} "
+                "has no active compact copy-buffer dimension"
+            )
         running = sympy.sympify(copy_ranges[copy_dim_key])
         for level_idx in reversed(levels_tiling_d):
             read_level_extents[level_idx][copy_dim_key] = running
@@ -2876,6 +3132,36 @@ def _insert_one_read_copy(
     output_tiled_dims = (
         _tiled_dims_for_dep(copy_writes[0], write_level_extents) if copy_writes else []
     )
+    # A copy-in follows the source read, not the consuming op's output.  In
+    # particular, a shared-LHS BMM has an inner expert loop while its 2-D X
+    # operand is invariant there.  Give the copy only the source-dependent
+    # loop prefix: it is emitted once immediately before the first nested
+    # level at which the source stops advancing.  Scheduler nesting then
+    # produces ``outer { copy X; inner expert { ... } }`` rather than
+    # reloading X in every expert iteration.
+    if planned_dep_levels is None:
+        # Legacy/hand-built CoarseTileInfo (including older unit fixtures)
+        # has no per-read planning record. Preserve the prior behavior and
+        # keep the copy in the full consumer nest. Unit-dim hoisting remains
+        # fail-closed above because invariance cannot be proven without the
+        # planning record.
+        loop_depth = len(sizing_op_info.loop_count)
+    else:
+        active_levels = [i for i, level in enumerate(planned_dep_levels) if level]
+        loop_depth = max(active_levels) + 1 if active_levels else 0
+    copy_loop_tiled_dims = [
+        sorted(level_extents) for level_extents in read_level_extents[:loop_depth]
+    ]
+    copy_binding_requirement = (
+        dataclasses.replace(
+            binding_requirement,
+            host_advance_per_level=binding_requirement.host_advance_per_level[
+                :loop_depth
+            ],
+        )
+        if binding_requirement is not None
+        else None
+    )
     # copy_buf is its own op, not sizing_op under another name -- it must
     # not inherit sizing_op_info.propagation. That plan was computed for
     # sizing_op's own boundary-crossing decision (kind may be "reduction"
@@ -2885,13 +3171,39 @@ def _insert_one_read_copy(
     # a "reduction"-kind plan leak onto this Pointwise passthrough buffer,
     # causing Pass 2 (_insert_all_reduction_ops) to misdispatch it into
     # _propagate_tiled_reduction_op.
-    copy_buf.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
-        sizing_op_info,
-        tiled_dims_per_read=tiled_dims_per_read,
-        output_tiled_dims=output_tiled_dims,
-        squeezed_advance_per_read=[squeezed_advance] if copy_reads else [],
-        propagation=PropagationPlan(kind="loop_internal"),
-    )
+    if loop_depth:
+        copy_buf.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
+            sizing_op_info,
+            loop_group_id=sizing_op_info.loop_group_id[:loop_depth],
+            loop_count=sizing_op_info.loop_count[:loop_depth],
+            loop_tiled_dims=copy_loop_tiled_dims,
+            loop_tiled_reduction_dims=[[] for _ in range(loop_depth)],
+            tiled_dims_per_read=[
+                per_level[:loop_depth] for per_level in tiled_dims_per_read
+            ],
+            squeezed_advance_per_read=(
+                [squeezed_advance[:loop_depth]] if copy_reads else []
+            ),
+            loop_operand_bindings=[copy_binding_requirement for _ in copy_reads],
+            output_tiled_dims=output_tiled_dims[:loop_depth],
+            propagation=PropagationPlan(kind="loop_internal"),
+        )
+    else:
+        # Keep typed ownership while using an empty scheduling path, so this
+        # operation remains a top-level preheader rather than entering the loop.
+        copy_buf.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
+            sizing_op_info,
+            loop_group_id=(),
+            loop_count=[],
+            loop_tiled_dims=[],
+            loop_tiled_reduction_dims=[],
+            tiled_dims_per_read=[[] for _ in copy_reads],
+            squeezed_advance_per_read=[[] for _ in copy_reads],
+            loop_operand_bindings=[None for _ in copy_reads],
+            output_tiled_dims=[],
+            preheader_for_group=sizing_op_info.loop_group_id,
+            propagation=PropagationPlan(kind="loop_internal"),
+        )
 
     V.graph.name_to_buffer[copy_name] = copy_buf
     operations.insert(insert_idx, copy_buf)
@@ -2901,7 +3213,7 @@ def _insert_one_read_copy(
         dep.name,
         copy_name,
     )
-    return copy_buf.get_name()
+    return copy_buf.get_name(), dep_tile_strides
 
 
 def _patch_consumer_to_read_copy(
@@ -2909,6 +3221,7 @@ def _patch_consumer_to_read_copy(
     dep: MemoryDep,
     copy_name: str,
     operations: list[Operation],
+    source_dep_tile_strides: list[Expr] | None = None,
 ) -> None:
     """Patch consumer's inner_fn to read copy_name instead of dep.name.
 
@@ -2955,7 +3268,11 @@ def _patch_consumer_to_read_copy(
         for op in operations
         if isinstance(op, ComputedBuffer) and op.get_name() == copy_name
     )
-    tile_strides = list(copy_buf.layout.stride)
+    tile_strides = list(
+        copy_buf.layout.stride
+        if source_dep_tile_strides is None
+        else source_dep_tile_strides
+    )
     tile_strides.extend(
         sympy.Integer(0) for _ in range(len(full_strides) - len(tile_strides))
     )
@@ -3018,8 +3335,17 @@ def _patch_consumer_to_read_copy(
             )
             for read_dep, per_level in zip(new_reads, new_loop_info.tiled_dims_per_read)
         ]
+        old_bindings = list(new_loop_info.loop_operand_bindings)
+        if len(old_bindings) < len(new_reads):
+            old_bindings.extend([None] * (len(new_reads) - len(old_bindings)))
+        new_bindings = [
+            None if read_dep.name == copy_name else binding
+            for read_dep, binding in zip(new_reads, old_bindings)
+        ]
         new_op.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
-            new_loop_info, tiled_dims_per_read=new_tiled_dims_per_read
+            new_loop_info,
+            tiled_dims_per_read=new_tiled_dims_per_read,
+            loop_operand_bindings=new_bindings,
         )
 
 
@@ -3084,6 +3410,82 @@ def _plan_read_copies(
             op_deps.sort(key=lambda pair: op_position[pair[0].get_operation_name()])
             sizing_op, sizing_dep = op_deps[0]
             sizing_info = sizing_op.loop_info  # type: ignore[attr-defined]
+            sizing_reads = [
+                dep
+                for dep in sizing_op.get_read_writes().reads
+                if isinstance(dep, MemoryDep)
+            ]
+            try:
+                sizing_dep_idx = sizing_reads.index(sizing_dep)
+            except ValueError as exc:
+                raise RuntimeError(
+                    f"_plan_read_copies: cannot match {sizing_dep!r} to a read "
+                    f"of sizing op {sizing_op.get_name()!r}"
+                ) from exc
+            planned_dep_levels = (
+                tuple(
+                    tuple((dim, extent) for dim, extent in level)
+                    for level in sizing_info.tiled_dims_per_read[sizing_dep_idx]
+                )
+                if sizing_info.counted_loop_plan is not None
+                and sizing_dep_idx < len(sizing_info.tiled_dims_per_read)
+                else None
+            )
+            binding_requirement = (
+                sizing_info.loop_operand_bindings[sizing_dep_idx]
+                if sizing_dep_idx < len(sizing_info.loop_operand_bindings)
+                else None
+            )
+            source = V.graph.get_buffer(sizing_dep.name)
+            if isinstance(source, TensorBox):
+                source = source.data
+            if isinstance(source, StorageBox):
+                source = source.data
+            op_info = getattr(sizing_op.data, "op_info", None) or {}
+            streamed_role = op_info.get(PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY)
+            direct_streamed_expert_weight = (
+                isinstance(source, InputBuffer)
+                and streamed_role in _PERSISTENT_STREAMED_ROLES
+                and planned_dep_levels is not None
+                and any(planned_dep_levels)
+                and binding_requirement is not None
+                and any(binding_requirement.host_advance_per_level)
+                and all(
+                    (getattr(op.data, "op_info", None) or {}).get(
+                        PERSISTENT_EXPERT_STREAM_WEIGHT_INFO_KEY
+                    )
+                    == streamed_role
+                    for op, _dep in op_deps
+                )
+            )
+            if direct_streamed_expert_weight:
+                # The marked operand already has the BMM kernel's selected
+                # layout. Keep the original HBM dependency on the
+                # consumer and let its preserved unit-expert host advance
+                # become the LoopSpec affine base update.  Inserting the
+                # ordinary tile copy here would add an HBM-to-HBM weight
+                # materialization on every expert iteration.
+                for consumer, consumer_dep in op_deps:
+                    consumer_reads = [
+                        dep
+                        for dep in consumer.get_read_writes().reads
+                        if isinstance(dep, MemoryDep)
+                    ]
+                    consumer_dep_idx = consumer_reads.index(consumer_dep)
+                    consumer_info = consumer.loop_info  # type: ignore[attr-defined]
+                    consumer_binding = (
+                        consumer_info.loop_operand_bindings[consumer_dep_idx]
+                        if consumer_dep_idx < len(consumer_info.loop_operand_bindings)
+                        else None
+                    )
+                    if consumer_binding is None or not any(
+                        consumer_binding.host_advance_per_level
+                    ):
+                        raise Unsupported(
+                            "coarse_tile: direct streamed expert weight has no "
+                            f"preserved loop advance for {consumer.get_name()!r}"
+                        )
+                continue
             for other_op, _dep in op_deps[1:]:
                 other_info = other_op.loop_info  # type: ignore[attr-defined]
                 # Only loop_count (the per-level trip counts) is a genuine
@@ -3123,6 +3525,8 @@ def _plan_read_copies(
                     consumer_op_names=tuple(
                         op.get_operation_name() for op, _dep in op_deps
                     ),
+                    planned_dep_levels=planned_dep_levels,
+                    binding_requirement=binding_requirement,
                 )
             )
         if entries:
@@ -3154,17 +3558,23 @@ def _insert_all_read_copy_ops(
             }
             sizing_op = name_to_op[entry.sizing_op_name]
             insert_before_op = name_to_op[entry.insert_before_op_name]
-            new_copy_name = _insert_one_read_copy(
+            new_copy_name, source_dep_tile_strides = _insert_one_read_copy(
                 sizing_op,
                 entry.dep,
                 entry.copy_name,
                 operations,
                 insert_before_op=insert_before_op,
+                planned_dep_levels=entry.planned_dep_levels,
+                binding_requirement=entry.binding_requirement,
             )
             for consumer_name in entry.consumer_op_names:
                 consumer = name_to_op[consumer_name]
                 _patch_consumer_to_read_copy(
-                    consumer, entry.dep, new_copy_name, operations
+                    consumer,
+                    entry.dep,
+                    new_copy_name,
+                    operations,
+                    source_dep_tile_strides,
                 )
 
 
@@ -3476,9 +3886,7 @@ def _propagate_tiled_reduction_op(
     group_start_idx = next(
         i
         for i, o in enumerate(operations)
-        if isinstance(o, ComputedBuffer)
-        and getattr(getattr(o, "loop_info", None), "loop_group_id", (None,))[0]
-        == outer_key
+        if isinstance(o, ComputedBuffer) and _outer_loop_key(o) == outer_key
     )
 
     fill_loop_info = reduction_plan.outer_fill_loop_info
@@ -3655,8 +4063,7 @@ def _propagate_tiled_reduction_op(
         if isinstance(o, ComputedBuffer)
         and o.get_name() not in (combine_name, copy_name)
         and _reads_buffer(o, buf_name)
-        and getattr(getattr(o, "loop_info", None), "loop_group_id", (None,))[0]
-        == outer_key
+        and _outer_loop_key(o) == outer_key
         and (
             is_nested
             or getattr(getattr(o, "loop_info", None), "loop_tiled_dims", None)

--- a/torch_spyre/csrc/perm_layout_native.cpp
+++ b/torch_spyre/csrc/perm_layout_native.cpp
@@ -68,8 +68,8 @@ struct StaticData {
   int n = 0;
   int64_t capacity = 0;
   int64_t alignment = kDefaultAlignment;
-  std::vector<int64_t> start;  // start_time == uses.front()
-  std::vector<int64_t> end;    // end_time == uses.back() + 1
+  std::vector<int64_t> start;  // LifetimeBoundBuffer.start_time
+  std::vector<int64_t> end;    // LifetimeBoundBuffer.end_time
   std::vector<double> weight;  // len(uses) + (first_use_is_read ? 0.0 : 0.5)
   // Time-overlap members of each buffer (order-independent, lifetimes only).
   std::vector<std::vector<int>> overlap;
@@ -181,8 +181,8 @@ class NativePermutationLayoutSolver {
         bool first_read = b.attr("first_use_is_read").cast<bool>();
         parent_names[i] =
             b.attr("in_place_parents").cast<std::vector<std::string>>();
-        st->start[i] = uses.front();
-        st->end[i] = uses.back() + 1;
+        st->start[i] = b.attr("start_time").cast<int64_t>();
+        st->end[i] = b.attr("end_time").cast<int64_t>();
         st->weight[i] =
             static_cast<double>(uses.size()) + (first_read ? 0.0 : 0.5);
       }
@@ -193,8 +193,8 @@ class NativePermutationLayoutSolver {
         // ValueError, so restate it as one and name the offending buffer.
         throw std::invalid_argument(
             "buffer " + std::to_string(i) +
-            ": could not read fields (name, size, uses, first_use_is_read, "
-            "in_place_parents)");
+            ": could not read fields (name, size, uses, start_time, end_time, "
+            "first_use_is_read, in_place_parents)");
       }
     }
 


### PR DESCRIPTION
# Keep persistent expert state in LX

Tracking: #3565

Local head: `ah/dense_expert_persistent_lx` at `834f7d6f`

Depends on Unit A: `ah/dense_expert_persistent_loop` at `a28991d4`.

Depends on draft PR #3815. Because this cross-fork draft targets `main`, its displayed diff temporarily includes earlier units until they merge.

## Purpose

Keep the shared input and the `[T,H]` output accumulator in LX across the complete expert loop, then write the result to HBM once.

## What this PR implements

- A typed carried-reduction and loop-storage plan.
- A plan-gated accumulator path with one fill, loop-carried adds, and one final drain.
- General lifetime-end overrides so the allocator keeps loop-invariant and loop-carried buffers live without inventing synthetic reads.
- LX allocation support for the explicitly planned accumulator.
- Compact X staging and a single allocation plan spanning preheader, loop, and drain.
- A unit expert-sum collapse when the real cross-expert sum is already represented by the loop-carried accumulator.
- Required persistent X and accumulator storage must receive physical LX addresses; spilling fails the plan.
- Lifetime overrides are honored by the Python, exhaustive-search, and native allocation paths.
- Persistent buffers cannot participate in LX relayout until relayout can preserve their loop lifetime contract.
- Loop-lifetime buffers cannot hand their storage to an in-place child.
- Persistent-reduction shape and consumer checks run before graph mutation, so a failed plan leaves no partial accumulator machinery behind.
- Only typed persistent loop storage skips wrapper allocation when placed in LX; ordinary LX-backed empty buffers keep their existing behavior.
- The carried accumulator explicitly uses the source contribution dtype. For the current FP16 path this preserves the validated FP16 accumulation contract rather than silently changing precision.

Unrelated reductions retain the existing path. This unit changes coarse tiling and the scratchpad allocator. Relative to Unit A, it contains 527 production insertions, 65 production deletions, 544 test insertions, and one test deletion across 12 files.

## Boundary

This PR expresses persistent LX state. Compatible 32-core ownership is supplied by the next unit.

## Validation

- Focused tests cover the carried accumulator and its dtype contract, lifetime override across every allocator path, required-LX enforcement, relayout isolation, in-place isolation, transactional failure, scoped wrapper allocation, and unchanged legacy paths.
- Ruff lint/format, Python bytecode compilation, `git diff --check`, and C++ formatting checks pass.
- Pytest was not run locally: the available Python environment does not contain `torch`, so the test harness fails during import. Runtime tests require a configured torch-spyre environment.

This unit changes the native permutation-layout solver interface to consume the general lifetime bounds. CI must rebuild the native extension; the relayout interaction is currently a safe fail-closed refusal, not composition.
