### PR TITLE
ci(perf): add quick PERF_PROFILE for a fast single-op benchmark

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -93,6 +93,21 @@ on:
         type: string
         default: full
 
+      # How much of the perf suite the perf job runs (TEST_TYPE=perf only).
+      # Forwarded to the Makefile as PERF_PROFILE:
+      #   full  -- the whole suite (the weekly benchmark; the default, so every
+      #            existing caller is byte-for-byte unchanged)
+      #   quick -- one small op. It still emits report.xml, so the ClickHouse
+      #            ingest path is identical; it just covers far fewer shapes.
+      #            Use it to iterate on the perf pipeline (runner bring-up,
+      #            ingest) without waiting for the full run.
+      # Ignored by every non-perf run.
+      perf_profile:
+        description: 'Perf suite size when test_type=perf: full | quick'
+        required: false
+        type: string
+        default: full
+
       # Spyre-Next integration path: test the PRE-BAKED dev image directly instead
       # of checking out + rebuilding torch-spyre on the runner. The ephemeral ARC
       # runner is FROM torch-spyre-dev, which already has the editable-installed
@@ -510,7 +525,8 @@ jobs:
           set -u
           # shellcheck disable=SC1091
           source "${VENV}/bin/activate"
-          make -C "${SRC_DIR}" tests TEST_TYPE=perf RESULTS_DIR="${RESULTS_DIR}"
+          make -C "${SRC_DIR}" tests TEST_TYPE=perf RESULTS_DIR="${RESULTS_DIR}" \
+            PERF_PROFILE="${{ inputs.perf_profile || 'full' }}"
 
       # The benchmark reports are not uploaded as workflow artifacts; the
       # results are consumed only by the ClickHouse ingest path.

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -111,6 +111,15 @@ on:
         required: false
         type: string
         default: dev
+      perf_profile:
+        description: >-
+          Perf suite size when test_type=perf: "full" (the whole suite, the
+          weekly default) or "quick" (one small op, far fewer shapes, still
+          writes report.xml so ingest is unchanged). Use quick to iterate on
+          the perf pipeline fast. Ignored by every non-perf run.
+        required: false
+        type: string
+        default: full
 
 concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.pull_request.html_url) || (github.event_name == 'workflow_dispatch'
@@ -163,6 +172,7 @@ jobs:
       ref: ${{ inputs.ref || '' }}
       repository: ${{ inputs.repository || '' }}
       test_type: ${{ inputs.test_type || 'device_critical' }}
+      perf_profile: ${{ inputs.perf_profile || 'full' }}
       prebaked_image: ${{ inputs.prebaked_image }}
     # ClickHouse connection for the perf job's inline benchmark ingest. Passed
     # explicitly (not `secrets: inherit`) so only what _test_matrix declares is

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ TEST_CONFIGS ?= tests/configs/torch_spyre_tests
 #                      not just TEST_CONFIGS -- so `make tests TEST_TYPE=trunk`
 #                      matches what actually runs on a push to main
 #   perf             — spyre-perf-suite benchmark (shells out, not a pytest
-#                      config suite); writes report.xml into RESULTS_DIR
+#                      config suite); writes report.xml into RESULTS_DIR.
+#                      Size is set by PERF_PROFILE (full|quick, default full).
 #   suite_<group>    — all configs inside the <group>/ sub-directory
 #                      (e.g. suite_inductor, suite_tensors)
 #   <label>          — any arbitrary label defined in test_suite_config.labels
@@ -47,6 +48,26 @@ TRUNK_CONFIG_DIRS := tests/configs/torch_spyre_tests tests/configs/model_ops_tes
 # ClickHouse push step (ingest_xml.py globs *.xml non-recursively) finds it
 # alongside every other suite's JUnit XML, with no per-suite subdirectory.
 RESULTS_DIR ?= /tmp/results
+
+# How much of the perf suite TEST_TYPE=perf runs:
+#   full   : the whole suite (all ops + Granite), minus experimental shapes.
+#            This is the default and matches the weekly benchmark.
+#   quick  : one small op (softmax at [1, 512, 4096]). It still emits the same
+#            report.txt/report.xml, so the ingest path is unchanged; it just
+#            covers far fewer shapes. Use it to iterate on the perf pipeline
+#            (runner bring-up, ingest, upload) without waiting for the full run.
+# Both modes shell out to the spyre-perf-suite console script and both pass an
+# explicit --report, so the report filename stays report.txt/report.xml in
+# either mode.
+PERF_PROFILE ?= full
+
+ifeq ($(PERF_PROFILE),quick)
+_PERF_SUITE_ARGS := --op softmax --shape 1 512 4096 --stacks torch-spyre
+else ifeq ($(PERF_PROFILE),full)
+_PERF_SUITE_ARGS := --no-experimental --stacks torch-spyre
+else
+$(error PERF_PROFILE must be 'full' or 'quick', got '$(PERF_PROFILE)')
+endif
 
 # Path to the OOT config checker script (relative to repo root)
 CHECK_SCRIPT  := tests/scripts/check_oot_configs.py
@@ -80,7 +101,7 @@ precommit: ## Run all pre-commit hooks against every file
 # ---------------------------------------------------------------------------
 
 .PHONY: tests
-tests: ## Run torch spyre tests. Narrow scope with TEST_TYPE=smoke|core|full|trunk|perf|suite_<group>. TEST_CONFIGS may point at a config directory (filtered by TEST_TYPE) or a single config yaml file (run directly); ignored when TEST_TYPE=trunk (see TRUNK_CONFIG_DIRS).
+tests: ## Run torch spyre tests. Narrow scope with TEST_TYPE=smoke|core|full|trunk|perf|suite_<group>. With TEST_TYPE=perf, PERF_PROFILE=full|quick picks the suite size (quick = one small op, still emits report.xml). TEST_CONFIGS may point at a config directory (filtered by TEST_TYPE) or a single config yaml file (run directly); ignored when TEST_TYPE=trunk (see TRUNK_CONFIG_DIRS).
 # TEST_TYPE=perf is a benchmark mode, not a pytest-config suite: it does not
 # run the OOT config machinery below. It shells out to the installed
 # spyre-perf-suite console script (a wheel dependency of the dev image) and
@@ -89,7 +110,7 @@ tests: ## Run torch spyre tests. Narrow scope with TEST_TYPE=smoke|core|full|tru
 # suite, so no new Makefile target or Jenkins wiring is needed.
 ifeq ($(TEST_TYPE),perf)
 	@mkdir -p "$(RESULTS_DIR)"
-	spyre-perf-suite --no-experimental --stacks torch-spyre \
+	spyre-perf-suite $(_PERF_SUITE_ARGS) \
 		--report "$(RESULTS_DIR)/report.txt"
 	@test -f "$(RESULTS_DIR)/report.xml" || \
 		{ echo "ERROR: spyre-perf-suite did not emit $(RESULTS_DIR)/report.xml" >&2; \


### PR DESCRIPTION
## What

Add a `PERF_PROFILE` knob so `TEST_TYPE=perf` can run either the full suite
(unchanged, the weekly benchmark) or a fast single-op subset for iterating on
the perf pipeline.

`Makefile`:

```
PERF_PROFILE ?= full
  full  : spyre-perf-suite --no-experimental --stacks torch-spyre   (today's behaviour)
  quick : spyre-perf-suite --op softmax --shape 1 512 4096 --stacks torch-spyre
```

Both profiles keep the explicit `--report "$(RESULTS_DIR)/report.txt"`, so both
emit `report.txt` and its sibling `report.xml`. The ClickHouse ingest path is
therefore identical for the two profiles; `quick` just covers far fewer shapes.
An unknown value is a hard `$(error)`.

Plumbed through the perf job:
- `_test_matrix.yaml`: new optional `perf_profile` input (default `full`),
  forwarded to the Makefile on the `make tests TEST_TYPE=perf` line.
- `integration-tests.yaml`: exposed as a `workflow_dispatch` input (default
  `full`) so the orchestrator/manual dispatch can select it. This is the 10th
  dispatch input, well within the current 25-input limit.

Every existing caller omits the input and gets `full`, so current behaviour is
byte-for-byte unchanged. Non-perf runs ignore it.

## Why

The full op suite takes several minutes on a scarce card runner. That is right
for the weekly run, but it makes debugging the x86 perf end-to-end chain
(ephemeral runner bring-up, benchmark step, inline ingest into `benchmark_runs`)
slow to iterate on. `quick` gives a run that still lands a row in ClickHouse but
finishes in a fraction of the time.

## Privacy

Unchanged and preserved: `report.txt`/`report.xml` are still written only on the
card runner and pushed to ClickHouse inline. Nothing is uploaded as a workflow
artifact and no report contents are echoed to the build log. `quick` does not
change any of that; it only changes which shapes the suite runs.

## Related

Complements ai-sw-acceleration/spyre-frameworks#1129 (merged), which fixed the
ARC runner idle-timeout that was killing in-progress perf jobs at the 10-minute
mark (the cause of the missing perf-step logs). That fix removes the infra kill;
this PR reduces how long the benchmark itself takes to iterate on.

## Validation

- `make -n tests TEST_TYPE=perf` -> full args (unchanged).
- `make -n tests TEST_TYPE=perf PERF_PROFILE=quick` -> single softmax op.
- `PERF_PROFILE=bogus` -> hard error, no run.
- `pre-commit run --all-files` clean on the three changed files (ruff/yamlfmt/
  actionlint).

On-card validation (Spyre x86 pod, dev image, 2 AIU devices, from the baked
`/home/senuser/torch-spyre` source + shared venv, same AIU setup the perf job
runs):

- `make tests TEST_TYPE=perf PERF_PROFILE=quick` -> exit 0 in ~16s, wrote a
  non-empty `report.xml` (7 testcases). The recipe's `test -f report.xml` guard
  passed. The softmax op ran on the `torch-spyre` stack with real kernel
  timings, so the report carries genuine benchmark cases the ClickHouse ingest
  picks up exactly as it does for the full run.

For comparison the full suite takes several minutes on the same card, so `quick`
is the fast iteration path it is meant to be. Numbers are kept off this public
PR by design.
