### PR TITLE
fix(ci): populate empty hardware-diagnostics columns

### DIFF
--- a/.github/scripts/parse_hw_failures.py
+++ b/.github/scripts/parse_hw_failures.py
@@ -163,7 +163,12 @@ RE_PCI_DEV_ID = re.compile(
 RE_OPENED = re.compile(r"Opened:\s*SEN:VFIO:TYPE1:(?P<v>[0-9a-f:.]+)")
 
 # Chip identifiers (also final-attempt only)
-RE_RAW_ECID = re.compile(r"Raw ECID\s*=\s*(?P<v>0x[0-9a-fA-F]+\s+0x[0-9a-fA-F]+)")
+# vfio_hal_mnt.cpp prints the first ECID word with a doubled prefix
+# ("Raw ECID = 0x0x0000000002038000 0x03e3..."), so `0x` must be repeatable —
+# a single-`0x` pattern matches nothing at all.
+RE_RAW_ECID = re.compile(
+    r"Raw ECID\s*=\s*(?P<v>(?:0x)+[0-9a-fA-F]+\s+(?:0x)+[0-9a-fA-F]+)"
+)
 RE_CHIP_COORDS = re.compile(
     r"CHIPY=(?P<chipy>0x[0-9a-fA-F]+)\s+CHIPX=(?P<chipx>0x[0-9a-fA-F]+)"
 )
@@ -171,7 +176,14 @@ RE_WAFER_ID = re.compile(r"Mfg WaferID\s*=\s*(?P<v>\S+)")
 RE_MFG_XY = re.compile(r"Mfg \(X,Y\)\s*=\s*\((?P<x>\d+),(?P<y>\d+)\)")
 RE_CARD_SERIAL = re.compile(r"Card 11S S/N\s*=\s*(?P<v>\S+)")
 
-# Log-line timestamps
+# Log-line timestamps.
+#
+# GHA prefixes virtually every log line with its own ISO-8601 stamp, so that is
+# the reliable source. RE_LOG_TS matches the runtime's DTLOG format instead,
+# which only appears once the device layer starts talking (~line 1600 of a
+# typical job log) — it is kept as a fallback for logs captured without the
+# GHA prefix.
+RE_GHA_TS = re.compile(r"^\ufeff?(?P<iso>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\s")
 RE_LOG_TS = re.compile(
     r"(?:ERRR|WARN|INFO|DBUG)\s+"
     r"(?P<day>\d{2})\.(?P<month>\d{2})\.(?P<year>\d{4})\s+"
@@ -215,6 +227,16 @@ def _ras_name_to_reason(name: str) -> str:
 
 
 def _parse_log_ts(line: str) -> str | None:
+    """Timestamp for a log line: GHA's ISO-8601 prefix, else the DTLOG stamp."""
+    m = RE_GHA_TS.match(line)
+    if m:
+        # GHA stamps are always UTC; drop the trailing Z so the value stays
+        # naive-UTC like the DTLOG branch below and the ClickHouse column.
+        try:
+            return datetime.fromisoformat(m["iso"].removesuffix("Z")).isoformat()
+        except ValueError:
+            pass
+
     m = RE_LOG_TS.search(line)
     if not m:
         return None
@@ -465,7 +487,9 @@ def parse_log(text: str, run_id: str, suite_hint: str = "") -> list[dict[str, An
         }
 
         # -------------------- Attempt start timestamp ----------------------------------------
-        for line in chunk_lines[:20]:
+        # Scan the whole chunk, not a leading window: a chunk opens with GHA
+        # setup output and the first parseable stamp can be far in.
+        for line in chunk_lines:
             ts = _parse_log_ts(line)
             if ts:
                 rec["attempt_start_ts"] = ts
@@ -575,16 +599,21 @@ def parse_log(text: str, run_id: str, suite_hint: str = "") -> list[dict[str, An
             or _first_env(RE_OPENED, chunk)
         )
         rec["aiu_world_rank0"] = _first_env(RE_AIU_RANK0, text)
-        rec["card_serial"] = _first_env(RE_CARD_SERIAL, chunk)
-        rec["chip_ecid_raw"] = _first_env(RE_RAW_ECID, chunk)
-        rec["chip_wafer_id"] = _first_env(RE_WAFER_ID, chunk)
 
-        m_xy = RE_MFG_XY.search(chunk)
+        # Same job-wide-constant reasoning as node_name/pci_device above: the
+        # card and chip identity block is printed once by the device-setup step,
+        # usually outside any attempt window, so it must be read from `text`.
+        # Scoping these to `chunk` populated them in only ~1% of rows.
+        rec["card_serial"] = _first_env(RE_CARD_SERIAL, text)
+        rec["chip_ecid_raw"] = _first_env(RE_RAW_ECID, text)
+        rec["chip_wafer_id"] = _first_env(RE_WAFER_ID, text)
+
+        m_xy = RE_MFG_XY.search(text)
         if m_xy:
             rec["chip_mfg_x"] = m_xy["x"]
             rec["chip_mfg_y"] = m_xy["y"]
 
-        m_coords = RE_CHIP_COORDS.search(chunk)
+        m_coords = RE_CHIP_COORDS.search(text)
         if m_coords:
             rec["chip_chipy"] = m_coords["chipy"]
             rec["chip_chipx"] = m_coords["chipx"]


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes three independent bugs in `.github/scripts/parse_hw_failures.py` that left columns of the
`hw_failure_diagnostics` ClickHouse table permanently or near-permanently empty. Measured over
416,354 production rows (2026-06-18 .. 2026-08-18):

| Column | Populated before | Root cause |
|---|---|---|
| `chip_ecid_raw` | **0 / 416354** | `vfio_hal_mnt.cpp` prints the first ECID word with a doubled prefix (`Raw ECID = 0x0x0000000002038000 0x03e3...`). `RE_RAW_ECID` required `0x[0-9a-fA-F]+`, which cannot match `0x0x...` because `x` is not a hex digit. Made the `0x` prefix repeatable. |
| `attempt_start_ts`, `first_error_ts` | **0 / 416354** | The scan window was `chunk_lines[:20]`, but the DTLOG format `RE_LOG_TS` matches (`INFO 18.08.2026 01:20:30.294822`) first appears around line **1668** of a typical job log. The leading lines are GHA runner boilerplate carrying ISO-8601 stamps (`2026-08-18T01:18:17.4439751Z`), a format `RE_LOG_TS` does not match, so the loop always fell through. Now prefers GHA's own ISO-8601 line prefix (present on 99% of lines), keeps DTLOG as a fallback, and scans the whole chunk. `first_error_ts` was empty transitively — it is only set from a parsed RAS event's timestamp. |
| `card_serial`, `chip_wafer_id`, `chip_mfg_*`, `chip_chip*` | **4347 / 416354 (1%)** | The device-setup step prints this identity block once, outside every per-attempt chunk — which is exactly why `node_name` and `pci_device` already read the full job `text`. These five were still scoped to `chunk`, so they only landed when the block happened to fall inside an attempt window. |

#### Which issue(s) this PR is related to:

<!-- none filed; found while auditing the Spyre CI/CD Cluster Monitor Grafana dashboard -->

#### Special notes for your reviewer:

Verified against real logs from runs
[32086831977](https://github.com/torch-spyre/torch-spyre/actions/runs/32086831977) (contains the
chip identity block), [32094969883](https://github.com/torch-spyre/torch-spyre/actions/runs/32094969883)
(12 RAS `DeviceOpenFail`, no chip block) and
[32103984315](https://github.com/torch-spyre/torch-spyre/actions/runs/32103984315):

- `attempt_start_ts`: 0/38 -> **37/38** records across 30 job logs
- `chip_ecid_raw`: 0 -> **3/3** of the records whose log actually contains the line
- With the identity block relocated before the first attempt banner (the real-world case the
  existing code comment describes), the chip/card fields go **0/3 -> 3/3**
- `first_error_ts`: 0 -> **2/4** on the RAS-bearing run, matching exactly the 2 records that have
  RAS events

No regressions: record counts, `outcome` distribution, `node_name` and `pci_device` are byte-identical
before and after on all three log sets. `ruff` reports no new findings (same 4 pre-existing).

`parse -> ingest` was additionally exercised end-to-end into a scratch database cloned from the
production `hw_failure_diagnostics` schema, confirming the new values satisfy the real column
types (`Nullable(DateTime64)` for both timestamps); the scratch database was dropped afterwards
and no test rows were written to production.

Worth knowing for review: a VFIO `DeviceOpenFail` means the device never opened, so no identity
block is ever printed — empty `card_serial`/`chip_ecid_raw` on those rows is correct behaviour, not
a remaining bug. Only about 1 job log in 30 contains the chip block at all.

#### Does this PR introduce a user-facing change?

No behaviour change to the test suites themselves. Columns that were previously empty in the
`hw_failure_diagnostics` table now populate, which unblocks per-card and per-chip attribution of
hardware failures in the Grafana dashboards. Existing rows are not backfilled.

#### Additional note:

Only `torch-spyre` ingests hardware diagnostics — `hf-adapters` and `spyre-inference` have
`push-to-clickhouse.yaml` workflows, but those write test results / model-support scans to
different tables and have no hardware-diagnostics path, so no companion PRs are needed.
