### PR TITLE
fix(oot): print non-zero ranks' logs when a distributed run fails

### DIFF
--- a/tests/oot_framework/run_test.sh
+++ b/tests/oot_framework/run_test.sh
@@ -1743,6 +1743,20 @@ _run_pytest_isolated() {
             # Run with split_output.sh wrapper
             _run_cmd torchrun --nproc-per-node "$_NPROC" --no-python bash "${_dir}/split_output.sh" python3 -u -m pytest "$_base" "${_args[@]}"
 
+            # split_output.sh tees only rank 0 to stdout, so on failure the
+            # non-zero ranks' output is the only record of the root cause --
+            # torchrun reports their exit code but not why (e.g. a card that
+            # failed to open). Emit them before the directory is removed.
+            if [[ "$(cat "$_exit_tmp" 2>/dev/null || echo 1)" != "0" ]]; then
+                for _rank_log in "${_LOGDIR}"/output-at-rank-*.txt; do
+                    [[ -f "$_rank_log" ]] || continue
+                    [[ "$_rank_log" == *output-at-rank-0.txt ]] && continue
+                    echo "===== BEGIN $(basename "$_rank_log") ====="
+                    cat "$_rank_log"
+                    echo "===== END $(basename "$_rank_log") ====="
+                done
+            fi
+
             # Clean up log directory
             rm -rf "${_LOGDIR}"
         else


### PR DESCRIPTION
## Problem

`split_output.sh` tees **only rank 0** to stdout; every other rank writes to `$_LOGDIR`, which `run_test.sh` removes as soon as `torchrun` returns. When a rank other than 0 is the root cause, `torchrun` reports its *exit code* but not its *reason*, so the job log shows only:

```
torch.distributed.elastic.multiprocessing.errors.ChildFailedError:
  rank : 1 (local_rank: 1)
  exitcode : 1 (pid: 1668)
  error_file: <N/A>
```

…and the actual error is destroyed before the artifact upload.

## What it cost

In [GHA run 32064409617](https://github.com/torch-spyre/torch-spyre/actions/runs/32064409617/job/95493631886) (`Test Multi-Spyre Reduce`, a merge-queue bounce), rank 1 died on:

```
RAS::VFIO::DeviceOpenFail  code 0x332b  errno "Device or resource busy"
Failed to open the IBM Spyre VFIO device.  /dev/vfio/73
```

That string appears **nowhere** in the job log. I could only recover it from the ClickHouse `test_cases.fail_message` column. That is the direct reason this class of merge-queue bounce looks inexplicable from the Actions UI — reviewers see a `ChildFailedError` with no cause, on a suite whose tests all printed `PASSED`.

## The fix

On failure only, dump the non-zero ranks' logs before the directory is removed. Rank 0 is skipped (already teed).

- **Failure path only** — a passing run produces no extra output.
- **Guarded on `$_exit_tmp`**, the local already written by `_run_cmd` immediately above; a missing/unreadable exit file is treated as failure (fail-open, so we don't hide a cause).
- **Safe when the glob matches nothing** — `[[ -f ]]` guard, verified.

## Verification

- `bash -n tests/oot_framework/run_test.sh` — clean
- Extracted the block and tested four paths: fail (ranks 1,2 emitted / rank 0 skipped), pass (no output), missing exit file (emits), no rank files at all (no output, rc=0)

## Related

- #3833 fixes the *teardown-kill* that turns these passing suites red; this PR makes the underlying rank failure visible. Complementary, no overlap.
- #3821 bounds the `_run_xdist_fallback` retry so a wedged card can't hold it forever — different call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
