### PR TITLE
fix(ci): treat VFIO device-busy as card contention with a real backoff

### DIFF
--- a/.github/actions/run-test-suite/action.yml
+++ b/.github/actions/run-test-suite/action.yml
@@ -42,6 +42,14 @@ inputs:
     description: How often (seconds) the stall watcher polls
     required: false
     default: '30'
+  card_release_timeout_secs:
+    description: >-
+      How long to wait for a still-held AIU card (VFIO device busy) before
+      starting a retry. The pod's VFIO devices are fixed at admission, so a
+      retry that begins while one is still held cannot succeed: there is no
+      other card to get, and re-running discovery only re-finds the same PFs.
+    required: false
+    default: '60'
   junit_xml_path:
     description: Full path for the --junit-xml report (leave empty to skip)
     required: false
@@ -70,6 +78,7 @@ runs:
         MAX_ATTEMPTS: ${{ inputs.max_attempts }}
         STALL_TIMEOUT_SECS: ${{ inputs.stall_timeout_secs }}
         STALL_CHECK_INTERVAL: ${{ inputs.stall_check_interval }}
+        CARD_RELEASE_TIMEOUT_SECS: ${{ inputs.card_release_timeout_secs }}
       run: |-
         set +e
         set +o pipefail
@@ -244,8 +253,16 @@ runs:
           fi
 
           echo "=== Attempt ${attempt} FAILED (exit=${TEST_EXIT}) ==="
+          # Backoff before the next attempt. Card contention needs longer than a
+          # plain rerun: the holder is a leftover process of the *previous*
+          # attempt inside this same pod, and the VFIO devices are fixed at pod
+          # admission, so there is no second card to fall back to.
+          _RETRY_SLEEP=10
           if grep -qE "ResponseTimeout|Exceeded max iterations|Fatal Python error: Aborted|LX logout" "$LOG_FILE"; then
             echo "    --> Hardware RAS timeout detected — will retry"
+          elif grep -qE 'RAS::VFIO::DeviceOpenFail|"code":"0x332b"|Device or resource busy' "$LOG_FILE"; then
+            echo "    --> Card still held (VFIO device busy) — will retry after ${CARD_RELEASE_TIMEOUT_SECS}s grace"
+            _RETRY_SLEEP=$CARD_RELEASE_TIMEOUT_SECS
           elif [[ $_STALLED_LAST_ATTEMPT -eq 1 ]]; then
             echo "    --> Stall detected — will retry with -n1 (xdist worker isolation)"
           else
@@ -253,7 +270,7 @@ runs:
           fi
 
           rm -f "$LOG_FILE" "$STALL_FLAG" "${STALL_FLAG}.done" "${STALL_FLAG}.stalled"
-          [[ $attempt -lt $MAX_ATTEMPTS ]] && sleep 10
+          [[ $attempt -lt $MAX_ATTEMPTS ]] && sleep "$_RETRY_SLEEP"
         done
 
         echo "=== All ${MAX_ATTEMPTS} attempts failed for ${{ inputs.suite_name }} ==="


### PR DESCRIPTION
## Problem

The retry classifier in `run-test-suite/action.yml` matches only RAS-timeout patterns:

```bash
grep -qE "ResponseTimeout|Exceeded max iterations|Fatal Python error: Aborted|LX logout"
```

A failure to **open the AIU card** matches none of them, so it is labelled `--> Non-hardware failure` and retried after a flat `sleep 10`.

That backoff is far too short for this failure. The card is held by a **leftover process of the previous attempt inside the same pod**, and a pod's VFIO devices are assigned at admission and fixed for its lifetime — so there is no second card to fall back to and nothing external to yield one. Re-running device discovery (the `pre_run` topology reset) only re-finds the same PFs.

## Evidence

[GHA run 32064409617](https://github.com/torch-spyre/torch-spyre/actions/runs/32064409617/job/95493631886), `Test Multi-Spyre Reduce` — all three attempts failed within ~40s of each other:

| time | event |
|---|---|
| 20:32:17 | attempt 2 starts; 8 tests **pass**; prints `COMPLETE: RTN=0` |
| 20:37:43 | stall-watcher kills it (300s of silence) → exit 137 |
| 20:37:53 | attempt 3 starts, **10s later** |
| 20:38:15 | `start_runtime()` → `/dev/vfio/73` **Device or resource busy** |

The holder survived the kill and was only reaped by the runner's own end-of-job cleanup (`Terminate orphan process: pid (1208) (python3)`).

Fleet scope from ClickHouse: 903 VFIO-busy cases across 96 runs in 4 days, **all** at `gha_run_attempt = 0`, and almost exclusively the Multi-Spyre suites (`test_broadcast` 104 cases, `test_gather` 68, `test_allgather` 60, `test_reduce` 56, `test_barrier` 55; only 3 non-distributed). Hourly rate spikes to 10 affected runs at 2026-08-17 19:00 UTC — the window of the reported merge-queue bounces.

## The fix

Match the card-contention signature explicitly and back off `card_release_timeout_secs` (default **60s**, overridable) instead of 10s:

```
--> Card still held (VFIO device busy) — will retry after 60s grace
```

Ordering is deliberate: RAS patterns are checked first (a RAS timeout that also mentions a busy device is still a RAS event), and card contention is checked before the stall branch, since a stalled attempt that left the card held needs the longer grace.

## Verification

- YAML parses; `bash -n` clean on the extracted `run:` script
- Classifier extracted and unit-tested over 7 cases using the **real** error string from ClickHouse: vfio→`VFIO|60`, RAS→`RAS|10`, RAS+vfio→`RAS|10`, stalled→`STALL|10`, other→`OTHER|10`, empty log→`OTHER|10`, vfio+stalled→`VFIO|60`

## Related

- #3833 stops the stall-watcher from killing a passing suite during teardown — that removes a major *source* of the leftover holder; this PR handles the case where one is nonetheless left behind. Complementary.
- #3835 makes the underlying rank error visible in the job log at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
