### PR TITLE
fix(ci): stop retries from erasing earlier attempts' JUnit reports

### DIFF
--- a/.github/actions/run-test-suite/action.yml
+++ b/.github/actions/run-test-suite/action.yml
@@ -241,6 +241,17 @@ runs:
           _JUNIT_FLAG=""
           if [[ -n "${{ inputs.junit_xml_path }}" ]]; then
             _JUNIT_FLAG="--junit-xml=${{ inputs.junit_xml_path }}"
+            # Each attempt writes the same path, so a retry overwrites its
+            # predecessor and only the LAST attempt is ever ingested. Keep the
+            # superseded XML under an -attemptN name so a suite that passed and
+            # was then killed in teardown is still visible downstream.
+            if [[ $attempt -gt 1 && -f "${{ inputs.junit_xml_path }}" ]]; then
+              _prev_attempt=$(( attempt - 1 ))
+              _keep="${{ inputs.junit_xml_path }}"
+              _keep="${_keep%.xml}-attempt${_prev_attempt}.xml"
+              cp -f "${{ inputs.junit_xml_path }}" "$_keep" 2>/dev/null \
+                && echo "Preserved attempt ${_prev_attempt} report: $(basename "$_keep")"
+            fi
           fi
 
           # Previous attempt stalled: isolate each test in its own xdist worker subprocess.

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -411,6 +411,8 @@ jobs:
           REPORT_NAME="$(basename "${CONFIG%.yaml}.xml")"
           echo "REPORT_NAME=${REPORT_NAME}" >> "$GITHUB_ENV"
           echo "REPORT_PATH=${GITHUB_WORKSPACE}/${REPORT_NAME}" >> "$GITHUB_ENV"
+          # Matches the -attemptN reports run-test-suite preserves on retry.
+          echo "REPORT_PATH_GLOB=${GITHUB_WORKSPACE}/${REPORT_NAME%.xml}-attempt*.xml" >> "$GITHUB_ENV"
 
       - name: Run ${{ matrix.suite.name }} tests
         id: run_tests
@@ -453,7 +455,11 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.REPORT_NAME }}
-          path: ${{ env.REPORT_PATH }}
+          # Glob picks up the -attemptN copies run-test-suite preserves when a
+          # retry would otherwise overwrite an earlier attempt's report.
+          path: |
+            ${{ env.REPORT_PATH }}
+            ${{ env.REPORT_PATH_GLOB }}
           if-no-files-found: warn
           retention-days: 10
 
@@ -718,6 +724,8 @@ jobs:
           REPORT_NAME="$(basename "${CONFIG%.yaml}.xml")"
           echo "REPORT_NAME=${REPORT_NAME}" >> "$GITHUB_ENV"
           echo "REPORT_PATH=${GITHUB_WORKSPACE}/${REPORT_NAME}" >> "$GITHUB_ENV"
+          # Matches the -attemptN reports run-test-suite preserves on retry.
+          echo "REPORT_PATH_GLOB=${GITHUB_WORKSPACE}/${REPORT_NAME%.xml}-attempt*.xml" >> "$GITHUB_ENV"
 
       - name: Run ${{ matrix.suite.name }} tests
         uses: ./.github/actions/run-test-suite
@@ -748,7 +756,11 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.REPORT_NAME }}
-          path: ${{ env.REPORT_PATH }}
+          # Glob picks up the -attemptN copies run-test-suite preserves when a
+          # retry would otherwise overwrite an earlier attempt's report.
+          path: |
+            ${{ env.REPORT_PATH }}
+            ${{ env.REPORT_PATH_GLOB }}
           if-no-files-found: warn
           retention-days: 10
 

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -409,10 +409,13 @@ jobs:
         run: |
           CONFIG="${{ matrix.suite.config }}"
           REPORT_NAME="$(basename "${CONFIG%.yaml}.xml")"
-          echo "REPORT_NAME=${REPORT_NAME}" >> "$GITHUB_ENV"
-          echo "REPORT_PATH=${GITHUB_WORKSPACE}/${REPORT_NAME}" >> "$GITHUB_ENV"
-          # Matches the -attemptN reports run-test-suite preserves on retry.
-          echo "REPORT_PATH_GLOB=${GITHUB_WORKSPACE}/${REPORT_NAME%.xml}-attempt*.xml" >> "$GITHUB_ENV"
+          # REPORT_PATH_GLOB matches the -attemptN reports run-test-suite
+          # preserves on retry.
+          {
+            echo "REPORT_NAME=${REPORT_NAME}"
+            echo "REPORT_PATH=${GITHUB_WORKSPACE}/${REPORT_NAME}"
+            echo "REPORT_PATH_GLOB=${GITHUB_WORKSPACE}/${REPORT_NAME%.xml}-attempt*.xml"
+          } >> "$GITHUB_ENV"
 
       - name: Run ${{ matrix.suite.name }} tests
         id: run_tests
@@ -722,10 +725,13 @@ jobs:
         run: |
           CONFIG="${{ matrix.suite.config }}"
           REPORT_NAME="$(basename "${CONFIG%.yaml}.xml")"
-          echo "REPORT_NAME=${REPORT_NAME}" >> "$GITHUB_ENV"
-          echo "REPORT_PATH=${GITHUB_WORKSPACE}/${REPORT_NAME}" >> "$GITHUB_ENV"
-          # Matches the -attemptN reports run-test-suite preserves on retry.
-          echo "REPORT_PATH_GLOB=${GITHUB_WORKSPACE}/${REPORT_NAME%.xml}-attempt*.xml" >> "$GITHUB_ENV"
+          # REPORT_PATH_GLOB matches the -attemptN reports run-test-suite
+          # preserves on retry.
+          {
+            echo "REPORT_NAME=${REPORT_NAME}"
+            echo "REPORT_PATH=${GITHUB_WORKSPACE}/${REPORT_NAME}"
+            echo "REPORT_PATH_GLOB=${GITHUB_WORKSPACE}/${REPORT_NAME%.xml}-attempt*.xml"
+          } >> "$GITHUB_ENV"
 
       - name: Run ${{ matrix.suite.name }} tests
         uses: ./.github/actions/run-test-suite


### PR DESCRIPTION
## Problem

`junit_xml_path` is a **fixed path**, so every retry attempt overwrites its predecessor. Only the *last* attempt is ever uploaded or ingested.

That is actively misleading for the failure mode where a suite **passes and is then killed during teardown**: the passing result is destroyed, and ClickHouse records the final attempt's errors instead.

## Evidence

Run `32064409617`, `Test Multi-Spyre Reduce` — what ClickHouse holds:

```
test_reduce.xml   total_tests=8  passed=0  failed=8  errors=8
```

What actually happened across the three attempts:

| attempt | outcome |
|---|---|
| 1 | **8 passed in 7.69s**, then died in torchrun teardown |
| 2 | **8 passed in 7.16s**, `RTN=0`, then stalled and was SIGKILLed |
| 3 | died at the first test on `RAS::VFIO::DeviceOpenFail` (card busy) |

So the tests themselves passed twice, and the recorded result claims 8 errors and 0 passes. Consequences:

- dashboard pass/fail counts are wrong for these suites
- any flaky-test ranking built on `test_cases.status` mis-ranks them
- the fact that the tests were fine — and that the failure was infrastructural — is invisible

## The fix

Before a retry overwrites the report, copy it aside as `<name>-attemptN.xml`, and widen the upload paths so those copies reach the ingester.

- The **final report keeps its existing path and name**, so every current consumer is unaffected.
- The ClickHouse ingester already globs `*.xml` in the unzip dir, so preserved attempts land as **additional rows** — no schema change, no ingester change.
- A run with **no retry produces no extra files**; the empty glob is covered by the upload's existing `if-no-files-found: warn`.
- `REPORT_PATH_GLOB` is defined at both `Derive report paths` sites, so it never expands empty.

## Verification

Both files parse as YAML; the embedded `run:` script is `bash -n` clean. Preservation logic exercised directly:

- attempt 1 (no prior file) → nothing preserved
- attempt 2 → `test_reduce-attempt1.xml` written, holding the **passing** `failures="0"` content
- attempt 3 → `test_reduce-attempt2.xml` written too
- final path still holds the last attempt's content, unchanged
- no-retry case → glob matches 0 files (warn, not fail)

## Scope note

This makes the earlier attempts *visible*. It does not attempt to change which attempt is treated as authoritative — that is a reporting-policy question worth deciding separately, and doing it here would change dashboard semantics silently.
