### PR TITLE
feat(cost-model): price the LX relayout shuffle instead of charging zero

### DIFF
--- a/tests/inductor/test_cost_model_pass.py
+++ b/tests/inductor/test_cost_model_pass.py
@@ -659,3 +659,108 @@ def test_an_untiled_kernel_gets_no_loop_headers(monkeypatch):
     text = cmp.build_report(ops).format()
     assert "not in a loop" not in text
     assert "runs" not in text
+
+
+# ---------------------------------------------------------------------------
+# LX relayout term
+# ---------------------------------------------------------------------------
+
+
+def _relayout_feats(bytes_, cores, run_bytes, split):
+    """A relayout copy as the extractor emits it: LX-only traffic + geometry."""
+    elems = bytes_ // 2
+    f = OpFeatures(
+        name="Pointwise",
+        is_reduction=False,
+        out_elems=elems,
+        cores=cores,
+        dtype_bytes=2,
+        args=[
+            ArgTraffic("buf_copy", "output", "lx", elems, False, [], []),
+            ArgTraffic("buf_src", "input", "lx", elems, False, [], []),
+        ],
+        is_lx_relayout=True,
+        relayout_bytes=bytes_,
+        relayout_run_elems=run_bytes // 2,
+        relayout_split=split,
+    )
+    # Same contract as _feats: the pass breaks a kernel at any op not on the
+    # Spyre device, so the fixture must answer get_device().
+    f.get_device = lambda: _Device(DEVICE_NAME)
+    return f
+
+
+@pytest.mark.parametrize(
+    ("bytes_", "cores", "run_bytes", "split", "measured_us"),
+    [
+        # Direct named-kernel measurements (main @ 65508a02); the law was fitted
+        # to these at mean +2.5% / RMS 10.0%, so assert to 20%.
+        (2097152, 8, 256, 4, 8.721),
+        (2097152, 8, 512, 2, 2.334),
+        (2097152, 4, 1024, 4, 7.221),
+        (2097152, 32, 1024, 4, 0.990),
+        (4194304, 8, 256, 4, 17.304),
+    ],
+)
+def test_relayout_term_reproduces_measured_rows(
+    bytes_, cores, run_bytes, split, measured_us
+):
+    f = _relayout_feats(bytes_, cores, run_bytes, split)
+    pred_us = cost_model.relayout_ns(f) / 1000.0
+    assert abs(pred_us - measured_us) / measured_us < 0.20
+    # The term is the whole price of an LX-only op: predict_ops == relayout_ns.
+    assert cost_model.predict_ops([f]) == pytest.approx(cost_model.relayout_ns(f))
+
+
+def test_relayout_term_is_zero_for_everything_else():
+    # An ordinary LX-resident op (fused-away intermediate) still prices at 0 --
+    # the term must not become a general LX-bandwidth charge, every other
+    # category's calibration rests on LX being free.
+    f = _feats("lxonly", write_mb=0, lx_mb=1, shared_input=False)
+    assert cost_model.relayout_ns(f) == 0.0
+    assert cost_model.predict_ops([f]) == 0.0
+
+
+def test_relayout_fields_survive_schema_roundtrip_and_old_records():
+    f = _relayout_feats(2097152, 8, 256, 4)
+    back = cost_model.op_from_dict(cost_model.op_to_dict(f))
+    assert cost_model.predict_ops([back]) == pytest.approx(cost_model.predict_ops([f]))
+    # A record written before the fields existed loads and prices unchanged.
+    d = cost_model.op_to_dict(f)
+    for key in (
+        "is_lx_relayout",
+        "relayout_bytes",
+        "relayout_run_elems",
+        "relayout_split",
+    ):
+        d.pop(key)
+    assert cost_model.predict_ops([cost_model.op_from_dict(d)]) == 0.0
+
+
+def test_relayout_split_clamps_to_fitted_range():
+    # Past split 8 the law over-predicts 12-40% (measured at 16): clamp, never
+    # extrapolate. Below 2 the fitted intercept would go negative: clamp up.
+    f16 = _relayout_feats(2097152, 16, 512, 16)
+    f8 = _relayout_feats(2097152, 16, 512, 8)
+    # The WHOLE term clamps: split 16 prices exactly as split 8. Measured, the
+    # unclamped law over-predicts split 16 by 12-40%; the clamp under-predicts
+    # it by ~15% -- bounded either way, and never an extrapolated log2.
+    assert cost_model.relayout_ns(f16) == pytest.approx(cost_model.relayout_ns(f8))
+    f1 = _relayout_feats(2097152, 8, 512, 1)
+    assert cost_model.relayout_ns(f1) > 0.0  # clamped up to 2: never negative
+
+
+def test_relayout_attribution_lands_on_the_relayout_op(monkeypatch):
+    # The shuffle moves no HBM bytes, so byte-share attribution alone showed it
+    # as 0.0 -- the misleading display that motivated the term. Its own cost
+    # must land on it, and the parts must still sum to the kernel total.
+    shuffle = _relayout_feats(2097152, 8, 256, 4)
+    neg = _feats("neg", write_mb=1)
+    ops = _ops([neg, shuffle], monkeypatch)
+    with config.patch({"cost_model": "1"}):
+        report = cmp.build_report(ops)
+    (group,) = report.groups
+    by_name = {o.name: o for o in group.ops}
+    rel_us = cost_model.relayout_ns(shuffle) / 1000.0
+    assert by_name["Pointwise"].predicted_us == pytest.approx(rel_us, rel=1e-6)
+    assert sum(o.predicted_us for o in group.ops) == pytest.approx(group.predicted_us)

--- a/tests/inductor/test_cost_model_pass.py
+++ b/tests/inductor/test_cost_model_pass.py
@@ -680,7 +680,6 @@ def _relayout_feats(bytes_, cores, run_bytes, split):
             ArgTraffic("buf_src", "input", "lx", elems, False, [], []),
         ],
         is_lx_relayout=True,
-        relayout_bytes=bytes_,
         relayout_run_elems=run_bytes // 2,
         relayout_split=split,
     )
@@ -729,7 +728,6 @@ def test_relayout_fields_survive_schema_roundtrip_and_old_records():
     d = cost_model.op_to_dict(f)
     for key in (
         "is_lx_relayout",
-        "relayout_bytes",
         "relayout_run_elems",
         "relayout_split",
     ):

--- a/tests/inductor/test_cost_model_pass.py
+++ b/tests/inductor/test_cost_model_pass.py
@@ -676,8 +676,8 @@ def _relayout_feats(bytes_, cores, run_bytes, split):
         cores=cores,
         dtype_bytes=2,
         args=[
-            ArgTraffic("buf_copy", "output", "lx", elems, False, [], []),
-            ArgTraffic("buf_src", "input", "lx", elems, False, [], []),
+            ArgTraffic("buf_copy", "output", True, elems, False, [], []),
+            ArgTraffic("buf_src", "input", True, elems, False, [], []),
         ],
         is_lx_relayout=True,
         relayout_run_elems=run_bytes // 2,

--- a/torch_spyre/_inductor/cost_model.py
+++ b/torch_spyre/_inductor/cost_model.py
@@ -237,9 +237,12 @@ class OpFeatures:
     # 2.3-24.2 us at 2.1 MB / 8 cores depending on slice geometry alone, so it gets an
     # additive term (see ``relayout_ns`` in predict_ops) keyed on these features.
     # ``is_lx_relayout`` derives from the planner's materialization registry, never
-    # inferred; the other three are 0 when it is False.
+    # inferred; the other two are 0 when it is False. The bytes moved are NOT a
+    # separate feature: a relayout copy is an identity clone, so they are exactly
+    # ``out_elems * dtype_bytes`` (grouped gathers (#3440) will multiply by
+    # ``cores / owners`` via a future ``relayout_owners`` feature, not by a bytes
+    # field).
     is_lx_relayout: bool = False
-    relayout_bytes: int = 0  # device bytes moved (output device_size x dtype)
     # Per-core contiguous run, in ELEMENTS, of the finer (governing) of the two
     # PerCoreViews: (device_size[d] // split[d]) * prod(device_size[d+1:]) for the
     # innermost split dim d. The 10x-at-fixed-bytes variable.
@@ -1040,11 +1043,12 @@ def relayout_ns(o: "OpFeatures", params: "CostParams | None" = None) -> float:
     error instead of extrapolating an unmeasured log2.
     """
     p = params or CostParams()
-    if not o.is_lx_relayout or o.relayout_bytes <= 0:
+    if not o.is_lx_relayout or o.out_elems <= 0:
         return 0.0
     if o.relayout_run_elems <= 0 or o.cores <= 0:
         return 0.0
-    per_core = o.relayout_bytes / o.cores
+    # Bytes moved == the copy's device bytes: a relayout is an identity clone.
+    per_core = o.out_elems * o.dtype_bytes / o.cores
     run_bytes = o.relayout_run_elems * o.dtype_bytes
     split = min(8, max(2, o.relayout_split))
     runs = per_core / run_bytes

--- a/torch_spyre/_inductor/cost_model.py
+++ b/torch_spyre/_inductor/cost_model.py
@@ -229,6 +229,25 @@ class OpFeatures:
     # (cross-row reduction: reduced var read with coeff!=1). "" -> default
     # 150+turnaround.
     hbm_pattern: str = ""
+    # LX RELAYOUT (PR #3439): an identity copy the scratchpad planner inserts when a
+    # producer and its consumers own an LX buffer under different per-core divisions.
+    # Its traffic is entirely LX, which this model charges at zero -- calibrated for
+    # ops whose LX traffic rides beside a larger HBM stream, and exactly wrong for the
+    # one op that is nothing but LX traffic. Measured on 53 configurations it costs
+    # 2.3-24.2 us at 2.1 MB / 8 cores depending on slice geometry alone, so it gets an
+    # additive term (see ``relayout_ns`` in predict_ops) keyed on these features.
+    # ``is_lx_relayout`` derives from the planner's materialization registry, never
+    # inferred; the other three are 0 when it is False.
+    is_lx_relayout: bool = False
+    relayout_bytes: int = 0  # device bytes moved (output device_size x dtype)
+    # Per-core contiguous run, in ELEMENTS, of the finer (governing) of the two
+    # PerCoreViews: (device_size[d] // split[d]) * prod(device_size[d+1:]) for the
+    # innermost split dim d. The 10x-at-fixed-bytes variable.
+    relayout_run_elems: int = 0
+    # Split factor of the governing side's innermost split dim. Sets the walked-span
+    # multiplier: the engine streams the whole strided span at ~K GB/s per core and a
+    # core keeps 1/split of it (BW*split measured constant at 588/540/549).
+    relayout_split: int = 0
 
     def read_bytes(self) -> int:
         """HBM bytes READ (input args). Each HBM arg is counted at its own device size,
@@ -475,6 +494,31 @@ class CostParams:
     # over-charged rather than the overlap under-modelled.
     loop_reread_scale: float = 0.85
     overlap_gamma: float = 1.0  # compute/HBM overlap: min(compute,HBM) partly hidden
+    # LX RELAYOUT (shuffle) term: per-core serial descriptor cost plus a stride-limited
+    # walk. Fitted 2026-08-17 on 21 direct per-kernel rows (main @ 65508a02, fp16,
+    # BUNDLE_SYMBOLIC_ARGS=0 -- a method #3741 has since removed; re-measuring needs
+    # the fused swap estimator at ~+/-8%): mean +2.5%, RMS 10.0% over bytes 0.52-4.19
+    # MB, cores 4-32, run 128-4096 B, split 2-8.
+    #
+    #   relayout_ns = runs_per_core * (a + b*log2(split)) + span_per_core / K
+    #     runs_per_core = bytes/cores / run_bytes
+    #     span_per_core = bytes/cores * split   (the engine walks the whole strided
+    #                                            span; a core keeps 1/split of it --
+    #                                            BW*split measured 588/540/549, so K
+    #                                            is per-core and split-invariant)
+    #
+    # The log2 in the per-run cost is FITTED, no mechanism behind it. VALID FOR SPLITS
+    # 2..8 ONLY: past 8 the law over-predicts 12-40% (measured at split 16), so the
+    # term clamps split into [2, 8] rather than extrapolate. Carries a +/-25% error
+    # bar from the non-governing side of the view pair -- reproducible scatter with no
+    # consistent direction (destination sweep, 10 pairs x 15 reps), so it is an error
+    # bar and not a term. Fanout was measured NOT to be a term (2/4/8 at fixed
+    # geometry, no trend). NO loop_trip factor: a relayout inside a coarse-tiling loop
+    # is structurally impossible today (the planner rejects coarse_tile_copy
+    # consumers).
+    relayout_run_a_ns: float = -1.14  # per-run cost intercept
+    relayout_run_b_ns: float = 3.92  # per-run cost log2(split) slope
+    relayout_span_gbps: float = 547.0  # per-core stride-limited walk rate
     # Matmul operand RE-READ (tile spill): the per-core OUTPUT-accumulator tile has area
     # (M/m)*(N/n); once it exceeds the on-chip capacity (~64K fp16 elems/core) it no
     # longer stays resident, so the operands are re-streamed from HBM. The re-read
@@ -976,6 +1020,37 @@ def mm_spill_frac(tile_area: float, params: CostParams | None = None) -> float:
     return min(
         p.mm_spill_cap,
         p.mm_spill_slope * log2(max(1.0, tile_area / p.mm_spill_area0)),
+    )
+
+
+def relayout_ns(o: "OpFeatures", params: "CostParams | None" = None) -> float:
+    """Additive cost of one LX relayout (shuffle) op; 0 for everything else.
+
+    A permutation across cores: every core moves its own per-core bytes, paying a
+    fixed cost per contiguous run plus a stride-limited walk over the whole span
+    (see the ``relayout_*`` CostParams for the fitted law, its derivation and its
+    validity range). Kept as a standalone function on purpose: the solver-objective
+    path (#3810) cannot lower ``log2`` or division by a decision variable, so it
+    evaluates THIS function per candidate division and folds the result into an
+    AddElement table -- one source of truth for both paths.
+
+    The split is clamped into [2, 8], the fitted range. Below 2 cannot occur for a
+    real ownership change (and would turn the fitted intercept negative); above 8
+    the law over-predicts by 12-40% (measured at split 16), so the clamp bounds the
+    error instead of extrapolating an unmeasured log2.
+    """
+    p = params or CostParams()
+    if not o.is_lx_relayout or o.relayout_bytes <= 0:
+        return 0.0
+    if o.relayout_run_elems <= 0 or o.cores <= 0:
+        return 0.0
+    per_core = o.relayout_bytes / o.cores
+    run_bytes = o.relayout_run_elems * o.dtype_bytes
+    split = min(8, max(2, o.relayout_split))
+    runs = per_core / run_bytes
+    return (
+        runs * (p.relayout_run_a_ns + p.relayout_run_b_ns * math.log2(split))
+        + per_core * split / p.relayout_span_gbps
     )
 
 
@@ -1566,7 +1641,16 @@ def predict_ops(ops: list, params: CostParams | None = None) -> float:
     # regresses mmwd 15.1 -> 17.6 and bmm_layout 20.2 -> 25.5. Compute and memory
     # OVERLAP: the engine streams operands while the array works, so a kernel takes the
     # LONGER of the two rather than their sum.
-    t = compute + mem_t - p.overlap_gamma * min(compute, mem_t)
+    # LX RELAYOUT (shuffle): an ownership-change identity copy is its own DSC inside
+    # the bundle, moves no HBM bytes, and DSCs in a bundle execute serially (the
+    # allocator's half-tick lifetime scheme depends on exactly that) -- so it ADDS to
+    # the kernel time rather than overlapping, and sits OUTSIDE the compute/memory
+    # overlap term below. Measured directly: fusing never recovers it (fused total
+    # == unfused sum +/- 2%), and it costs its full time beside a 223 us bmm exactly
+    # as beside a 25 us relu, so it does not hide behind PT-array work either. See
+    # relayout_ns() and the CostParams note for the fitted law and its validity range.
+    rel_ns = sum(relayout_ns(o, p) for o in ops)
+    t = compute + mem_t - p.overlap_gamma * min(compute, mem_t) + rel_ns
     # (A genuine-reduction cross-core ring-combine term once lived here; it is provably
     # bounded by ~cores * a tiny per-elem cost <= ~5 ns -- below run-to-run noise --
     # so it is dropped as inert. K is never split for matmul, so there is no matmul

--- a/torch_spyre/_inductor/cost_model_pass.py
+++ b/torch_spyre/_inductor/cost_model_pass.py
@@ -61,7 +61,7 @@ from torch._inductor.ir import ComputedBuffer
 
 from . import config
 from .constants import DEVICE_NAME
-from .cost_model import CostParams, _loop_reread_bytes, predict_ops
+from .cost_model import CostParams, _loop_reread_bytes, predict_ops, relayout_ns
 from .dump_cost_model import extract_op_features
 from .logging_utils import get_inductor_logger
 
@@ -336,15 +336,23 @@ def _price(feats, index, params) -> GroupCost | None:
     try:
         weights = [max(0, f.hbm_bytes()) for f in feats]
         total = sum(weights)
-        for f, w in zip(feats, weights):
+        # An LX relayout op's cost is ADDITIVE and PER-OP (its own term in
+        # predict_ops), not part of the bundle's HBM price -- and it moves no HBM
+        # bytes, so the byte-share split alone would show the one op that added
+        # real time as 0.0 (exactly the misleading display that motivated the
+        # term). Attribute each op its own relayout cost, and split only the
+        # remainder by HBM share; parts still sum to the kernel total.
+        rel_us = [relayout_ns(f, params) / 1000.0 for f in feats]
+        base_us = predicted_us - sum(rel_us)
+        for f, w, r in zip(feats, weights, rel_us):
             ops.append(
                 OpCost(
                     name=f.name,
                     loop_group_id=getattr(f, "_loop_group_id", None),
                     hbm_bytes=w,
                     lx_bytes=max(0, f.lx_bytes()),
-                    predicted_us=predicted_us
-                    * (w / total if total > 0 else 1.0 / max(1, len(feats))),
+                    predicted_us=r
+                    + base_us * (w / total if total > 0 else 1.0 / max(1, len(feats))),
                     **_per_iteration(f),
                 )
             )

--- a/torch_spyre/_inductor/dump_cost_model.py
+++ b/torch_spyre/_inductor/dump_cost_model.py
@@ -468,6 +468,65 @@ def _hbm_pattern(op, is_reduction: bool, out_dims) -> str:
         return ""
 
 
+def _per_core_run(view, device_dims) -> tuple:
+    """(contiguous device elements one core owns per run, split of the dim that
+    bounds it) for a PerCoreView over ``device_dims``.
+
+    The view's ``work_slice_dims`` is keyed by DEVICE-dim index, so the innermost
+    (largest-index) split dim bounds each core's contiguous run at
+    ``(device_dims[d] // split) * prod(device_dims[d+1:])``. Validated against real
+    plans: logical [8,256,512] lays out as [256,8,8,64], a ``{B:4,M:2}`` hint gives
+    view ((0,2),(2,4)) -> (8//4)*64 = 128 elements (256 B), the geometry the
+    relayout cost law was fitted at.
+    """
+    splits = dict(view.work_slice_dims)
+    if not splits:
+        return _prod_ints(device_dims), 1
+    d = max(splits)
+    inner = _prod_ints(device_dims[d + 1 :]) or 1
+    return (device_dims[d] // splits[d]) * inner, splits[d]
+
+
+def _relayout_features(op, out_elems, dtype_bytes, out_dims):
+    """(is_lx_relayout, relayout_bytes, relayout_run_elems, relayout_split) for one op.
+
+    The materialization registry is the authority: an op is a relayout copy iff the
+    scratchpad planner registered it (``graph._spyre_lx_relayout_copies``), so a plan
+    the allocator or scheduler later demoted never reaches here as a relayout. The
+    governing geometry is the FINER of the plan's two views (smaller per-core run);
+    the term's law is direction-symmetric (measured: 8.721 vs 8.701 us reversed), so
+    which side is source does not matter. All-zeros for every other op.
+    """
+    zeros = (False, 0, 0, 0)
+    try:
+        from torch._inductor.virtualized import V
+
+        from .scratchpad.lx_relayout import materialized_lx_relayouts
+
+        registry = materialized_lx_relayouts(V.graph)
+        if not registry:
+            return zeros
+        # The registry records the COPY BUFFER's name (materialize_lx_relayouts
+        # stores ``copy.get_name()``, e.g. "buf2"); ``get_operation_name()`` is the
+        # op name ("op2"), so match on the buffer name.
+        name = op.get_name()
+        plan = next(
+            (p for copy_name, p in registry.values() if copy_name == name), None
+        )
+        if plan is None:
+            return zeros
+        src = _per_core_run(plan.source_view, out_dims)
+        dst = _per_core_run(plan.destination_view, out_dims)
+        # Governing side = the finer view: smaller per-core run; on a run tie the
+        # LARGER split (at equal run the higher split measured ~3.6x slower).
+        run_elems, split = min(src, dst, key=lambda t: (t[0], -t[1]))
+        if run_elems <= 0 or split <= 0:
+            return zeros
+        return True, out_elems * dtype_bytes, run_elems, split
+    except Exception:  # noqa: BLE001 - a diagnostic feature must not sink a compile
+        return zeros
+
+
 def extract_op_features(
     op, work_slices=None, buffers: Optional[Mapping[str, "LifetimeBoundBuffer"]] = None
 ) -> OpFeatures:
@@ -663,6 +722,8 @@ def extract_op_features(
             )
         )
 
+    _rl = _relayout_features(op, out_elems, dtype_bytes, out_dims)
+
     return OpFeatures(
         name=_op_name(op),
         is_reduction=is_reduction,
@@ -684,6 +745,10 @@ def extract_op_features(
         matmul_m_split=matmul_m_split,
         matmul_n_split=matmul_n_split,
         hbm_pattern="" if is_matmul else _hbm_pattern(op, is_reduction, out_dims),
+        is_lx_relayout=_rl[0],
+        relayout_bytes=_rl[1],
+        relayout_run_elems=_rl[2],
+        relayout_split=_rl[3],
     )
 
 

--- a/torch_spyre/_inductor/dump_cost_model.py
+++ b/torch_spyre/_inductor/dump_cost_model.py
@@ -487,8 +487,8 @@ def _per_core_run(view, device_dims) -> tuple:
     return (device_dims[d] // splits[d]) * inner, splits[d]
 
 
-def _relayout_features(op, out_elems, dtype_bytes, out_dims):
-    """(is_lx_relayout, relayout_bytes, relayout_run_elems, relayout_split) for one op.
+def _relayout_features(op, out_dims):
+    """(is_lx_relayout, relayout_run_elems, relayout_split) for one op.
 
     The materialization registry is the authority: an op is a relayout copy iff the
     scratchpad planner registered it (``graph._spyre_lx_relayout_copies``), so a plan
@@ -497,7 +497,7 @@ def _relayout_features(op, out_elems, dtype_bytes, out_dims):
     the term's law is direction-symmetric (measured: 8.721 vs 8.701 us reversed), so
     which side is source does not matter. All-zeros for every other op.
     """
-    zeros = (False, 0, 0, 0)
+    zeros = (False, 0, 0)
     try:
         from torch._inductor.virtualized import V
 
@@ -522,7 +522,7 @@ def _relayout_features(op, out_elems, dtype_bytes, out_dims):
         run_elems, split = min(src, dst, key=lambda t: (t[0], -t[1]))
         if run_elems <= 0 or split <= 0:
             return zeros
-        return True, out_elems * dtype_bytes, run_elems, split
+        return True, run_elems, split
     except Exception:  # noqa: BLE001 - a diagnostic feature must not sink a compile
         return zeros
 
@@ -722,7 +722,7 @@ def extract_op_features(
             )
         )
 
-    _rl = _relayout_features(op, out_elems, dtype_bytes, out_dims)
+    _rl = _relayout_features(op, out_dims)
 
     return OpFeatures(
         name=_op_name(op),
@@ -746,9 +746,8 @@ def extract_op_features(
         matmul_n_split=matmul_n_split,
         hbm_pattern="" if is_matmul else _hbm_pattern(op, is_reduction, out_dims),
         is_lx_relayout=_rl[0],
-        relayout_bytes=_rl[1],
-        relayout_run_elems=_rl[2],
-        relayout_split=_rl[3],
+        relayout_run_elems=_rl[1],
+        relayout_split=_rl[2],
     )
 
 


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Prices the LX relayout shuffle (#3439) in the analytical cost model instead of charging it zero.

A relayout is an identity copy whose traffic is entirely on-chip, and the model charges LX traffic at zero — calibrated for ops whose LX bytes ride beside a larger HBM stream, and exactly wrong for the one op that is nothing *but* LX traffic. Every shuffle priced at **0.0 µs**:

```text
predicted total:       40.0 us over 1 kernel(s), 3 op(s)
           0           40.0  3
                       20.0    neg       HBM    2.1 MB   LX    2.1 MB
                       20.0    relu      HBM    2.1 MB   LX    2.1 MB
                        0.0    Pointwise HBM         -   LX    4.2 MB   <-- the shuffle
```

Measured, the same shuffle costs 8.7 µs — and 2.3–24.2 µs at those same bytes and cores depending on slice geometry alone. After this change the same report reads:

```text
predicted total:       48.8 us over 1 kernel(s), 3 op(s)
                       20.0    neg  ...
                       20.0    relu ...
                        8.8    Pointwise ...            (measured: 8.72)
```

**The term** (additive, per op, gated on the planner's materialization registry so it can never fire on ordinary LX-resident intermediates):

```text
relayout_ns = runs_per_core * (a + b*log2(split)) + span_per_core / K
  a = -1.14 ns, b = 3.92 ns, K = 547 GB/s per core
```

Fitted on 21 direct per-kernel device measurements: **mean +2.5 %, RMS 10.0 %** over bytes 0.52–4.19 MB, cores 4–32, contiguous runs 128–4096 B, splits 2–8. For scale, the model's existing categories run 5.0 % (broadcast) to 40 % (bmm). The split clamps into [2, 8] rather than extrapolate (past 8 the unclamped law over-predicts 12–40 %, measured at split 16).

Mechanism, briefly: the per-core rate is set by two geometry features derivable from the plan's `PerCoreView`s — the governing (finer) side's contiguous run and its split factor. The split multiplies the *walked* span: bandwidth × split measured constant (588/540/549 GB/s), i.e. the engine streams the whole strided span and a core keeps 1/split of it. Fanout was measured **not** to be a term; there is no `loop_trip` factor because a relayout inside a coarse-tiling loop is structurally impossible today.

The term is additive to `max(compute, mem)`: the shuffle is its own DSC and DSCs in a bundle execute serially — fused total equals unfused sum within 2 %, and it costs the same beside a 223 µs bmm as beside a 25 µs relu.

Also fixes the attribution: the per-op column splits a kernel's price by HBM-byte share, and the shuffle moves no HBM bytes, so the one op that added real time displayed as 0.0. Each op now carries its own relayout term, the remainder splits by byte share, and parts still sum to the kernel total.

#### Which issue(s) this PR is related to:

Prices the kernel introduced by #3439. Groundwork for a relayout-vs-demote profitability decision (today the planner takes any structurally valid relayout that fits, with no cost check).

#### Special notes for your reviewer:

- **Coordination with #3810:** `relayout_ns()` is deliberately a standalone pure function so the CP-SAT objective can evaluate it per candidate division into an `AddElement` table (the same idiom #3810 uses for `log2` of split symbols) instead of lowering `log2` of a decision variable. The two PRs collide on exactly one line (`t = ...` in `predict_ops`); whoever lands second has a one-line rebase.
- The extractor matches the registry on the copy buffer's `get_name()` — the registry records buffer names ("buf2"), not operation names ("op2").
- On a run-length tie between the two views, the larger split governs (at equal run, the higher split measured ~3.6× slower).
- Old records (written before these `OpFeatures` fields existed) load and price unchanged via `op_from_dict` defaults, so the offline scorer and reference database are unaffected.
- Known limits, stated in the `CostParams` comment: ±25 % scatter from the non-governing side of the view pair (reproducible, no consistent direction — an error bar, not a term), and ~9 % under-prediction at 32 cores.

#### Does this PR introduce a user-facing change?

Only when `SPYRE_DUMP_COST=1`: reports over graphs containing an LX relayout now include the shuffle's predicted cost instead of 0.0. Compilation output is unchanged (the pass is read-only and off by default).

#### Additional note:

Verified on device: producer/consumer under `{B:4,M:2} -> {B:2,M:4}` on 8 cores prices the shuffle at 8.78 µs vs 8.72 measured; an aligned pair (no relayout) is byte-identical to before. 60/60 cost-model-pass tests, pre-commit clean.
