### PR TITLE
fix(ci): skip benchmark_runs header for zero-record perf XMLs

### DIFF
--- a/.github/scripts/ingest_xml.py
+++ b/.github/scripts/ingest_xml.py
@@ -689,6 +689,17 @@ def main():
             if run_meta is None:
                 continue
 
+            # A perf run uploads report.xml alongside the spyre/cpu kernel-report
+            # XMLs. Those kernel reports are benchmark XMLs (classname carries
+            # "benchmark") but their testcase names do not match _PERF_NAME_RE, so
+            # they parse to zero rows. Inserting a run header for them creates an
+            # empty benchmark_runs entry that shows as a "run" with 0 ops/models on
+            # the dashboard. Skip the header when there is nothing to record; the
+            # kernel timings are already folded into report.xml's kernel_mean_ms.
+            if not benchmarks:
+                print(f"  No benchmark records in {xml_path.name} — skipping header")
+                continue
+
             # Deduplication: skip if source_file already in benchmark_runs
             existing = client.query(
                 "SELECT count() FROM benchmark_runs WHERE source_file = {sf:String}",


### PR DESCRIPTION
## Problem

A performance run uploads three XML files: `report.xml` plus the
`spyre_kernel_report_tsp.xml` and `cpu_kernel_report_tsp.xml` kernel reports.
`ingest_xml.py` processes each file independently and inserts one
`benchmark_runs` header per file.

The two kernel-report XMLs pass `is_benchmark_xml` (every testcase classname
contains `benchmark`), but their testcase names are kernel names, not the
`perf_{op}_{metric}_ms_{shapes}` pattern that `_PERF_NAME_RE` needs. They parse
to zero rows, yet a header is still inserted. On the dashboard each physical run
therefore appears as three runs: the real `report.xml` run plus two empty
entries that show `Operations: 0 / Models: 0` and `N/A` durations.

## Fix

Skip the `benchmark_runs` header insert when `parse_benchmark_xml` returns no
records. The kernel timings those files carry are already folded into
`report.xml`'s `kernel_mean_ms` column, so no data is lost. The row-bearing
`report.xml` path is unchanged.

## Verification

Parsed two representative fixtures against the patched script:

| file | `is_benchmark_xml` | benchmarks | result |
|---|---|---|---|
| `report.xml` (perf metric names) | True | 1 | header inserted |
| `cpu_kernel_report_tsp.xml` (kernel names) | True | 0 | header skipped |

Confirmed in dev ClickHouse that this exact 3-header pattern exists for every
recent s390x run; the empty entries are the kernel-report headers, and the real
numbers (19 ops + 4 models) sit on the sibling `report.xml` header.

Note: this stops new empty headers from being created. Existing empty headers
already in ClickHouse are not touched.
