### PR TITLE
Thin-slice bring-up, copy-only interleaved round trip

### DIFF
--- a/tests/scripts/check_test_coverage.sh
+++ b/tests/scripts/check_test_coverage.sh
@@ -58,6 +58,11 @@ IGNORED_TEST_FILES=(
   # lane provides, so it is skip-only in CI. Revisit when a KTIR/mlir_ktdp lane
   # exists.
   "inductor/test_ktir_emitter.py"
+  # 1p5-emulation thin slice: requires a synthetic multi-domain topology set via
+  # FLEX_NUM_MEMORY_DOMAINS / FLEX_MAX_REGIONS on the command line (read once at
+  # runtime start), on live 1p0-PF. No CI lane provides this, so the test skips
+  # itself under a default sweep. Revisit if a PF emulation lane is added.
+  "test_interleave_thin_slice.py"
 )
 
 # ── Ignore list: config files ─────────────────────────────────────────────────

--- a/tests/test_interleave_thin_slice.py
+++ b/tests/test_interleave_thin_slice.py
@@ -17,11 +17,10 @@
 """
 Copy-only thin slice: an interleaved tensor round-tripping on 1p0-PF.
 
-This is the Definition-of-Done milestone (T5) of the "emulate a 1p5 memory
-topology on 1p0-PF" epic. It drives an **interleaved** (multi-chunk) device
-allocation through the **eager** copy path — ``x.to("spyre")`` (H2D) then
-``.cpu()`` (D2H) — under a synthetic multi-domain topology, and requires the
-round-tripped values to match a ``Bind{0}`` baseline exactly.
+It drives an **interleaved** (multi-chunk) device allocation through the
+**eager** copy path — ``x.to("spyre")`` (H2D) then ``.cpu()`` (D2H) — under
+a synthetic multi-domain topology, and requires the round-tripped values to
+match a ``Bind{0}`` baseline exactly.
 
 Deliberately **no compute op and no torch.compile**: the compiled JobPlan
 builder still asserts single-chunk addresses, and interleaved compute is not
@@ -63,8 +62,7 @@ domain count, and the 1p0 default of 7 is not. Without these the test **skips**,
 which is what happens in a default ``pytest tests/`` sweep.
 
 Interleaved placement itself is requested in-process via a temporary gate
-(``TORCH_SPYRE_EMULATE_INTERLEAVE`` / ``_spyre_debug_set_emulate_interleave``),
-replaced by a real eligibility policy in T6.
+(``TORCH_SPYRE_EMULATE_INTERLEAVE`` / ``_spyre_debug_set_emulate_interleave``).
 
 Both placements are exercised in **one** process, on purpose: only one process
 may hold the Spyre device (see ``torch_spyre/__init__.py`` — "Spyre can't be
@@ -92,14 +90,13 @@ K_MAX_BUF_SIZE = 4 * 1024 * 1024
 SEN169_FP16_STEP = 2.0**-9
 
 # (case name, shape, dtype, bit_exact) — sizes chosen to stress the flex
-# multi-chunk DMA path (T4):
+# multi-chunk DMA path:
 #  * "aligned"    — device size divides evenly across the domains.
 #  * "one_stick" / "uneven_sticks" — the per-domain share is NOT a multiple of
 #    the 128 B device alignment, so flex rounds each chunk up and total_size()
 #    exceeds the tensor's storage size.
 #  * "large"      — 24 MiB, i.e. 6 MiB per chunk at 4 domains, so every chunk
-#    must itself be split into multiple <= kMaxBufSize transfers. This is what
-#    exercises T4's size-slice loop nested inside the per-chunk loop.
+#    must itself be split into multiple <= kMaxBufSize transfers.
 #
 # `bit_exact` is False exactly where the host and device encodings of the dtype
 # differ (fp16: IEEE_FP16 vs SEN169_FP16), which makes the *conversion* lossy
@@ -248,7 +245,7 @@ class TestInterleaveThinSlice(TestCase):
                     len({c["region_id"] for c in chunks}), self.num_domains
                 )
                 # A region carrying UNMAPPED_SEGMENT_ID has no device address
-                # and must never be dispatched (flex T3 Finding B / T4 guard).
+                # and must never be dispatched.
                 for chunk in chunks:
                     self.assertTrue(chunk["segment_mapped"], msg=str(chunk))
                 # Chunks are equal-sized and cover the whole tensor.
@@ -317,7 +314,7 @@ class TestInterleaveThinSlice(TestCase):
     def test_per_chunk_transfer_exceeds_buffer_size(self):
         """The "large" case must really put > 4 MiB in each chunk.
 
-        This is the only case that exercises T4's size-slice loop nested inside
+        This is the only case that exercises size-slice loop nested inside
         the per-chunk loop; assert the premise so the coverage cannot silently
         rot if the shape is edited.
         """

--- a/tests/test_interleave_thin_slice.py
+++ b/tests/test_interleave_thin_slice.py
@@ -1,0 +1,265 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Owner(s): ["module: cpp"]
+
+"""
+Copy-only thin slice: an interleaved tensor round-tripping on 1p0-PF.
+
+This is the Definition-of-Done milestone (T5) of the "emulate a 1p5 memory
+topology on 1p0-PF" epic. It drives an **interleaved** (multi-chunk) device
+allocation through the **eager** copy path — ``x.to("spyre")`` (H2D) then
+``.cpu()`` (D2H) — under a synthetic multi-domain topology, and requires the
+round-tripped values to match a ``Bind{0}`` baseline exactly.
+
+Deliberately **no compute op and no torch.compile**: the compiled JobPlan
+builder still asserts single-chunk addresses, and interleaved compute is not
+expressible in the 1p0 8-segment model at all. Copy-only is what the emulation
+proves on this silicon.
+
+## Running this test
+
+The synthetic topology comes from flex env knobs that are read once when the
+device runtime starts, so they must be set **on the pytest command line**:
+
+```bash
+FLEX_NUM_MEMORY_DOMAINS=4 FLEX_MAX_REGIONS=8 \
+    pytest tests/test_interleave_thin_slice.py -v
+```
+
+``FLEX_MAX_REGIONS`` is not optional: ``max_regions`` must be divisible by the
+domain count, and the 1p0 default of 7 is not. Without these the test **skips**,
+which is what happens in a default ``pytest tests/`` sweep.
+
+Interleaved placement itself is requested in-process via a temporary gate
+(``TORCH_SPYRE_EMULATE_INTERLEAVE`` / ``_spyre_debug_set_emulate_interleave``),
+replaced by a real eligibility policy in T6.
+
+Both placements are exercised in **one** process, on purpose: only one process
+may hold the Spyre device (see ``torch_spyre/__init__.py`` — "Spyre can't be
+used by more than one process"), so a subprocess baseline is not possible. The
+upside is a tighter control — the baseline differs from the interleaved run only
+in placement, not in topology.
+"""
+
+import contextlib
+import hashlib
+import unittest
+
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+SEED = 20260815
+DTYPE = torch.float16
+
+# kMaxBufSize in flex's PF DMA path: each chunk larger than this must itself be
+# split into multiple transfer buffers.
+K_MAX_BUF_SIZE = 4 * 1024 * 1024
+
+# (case name, shape) — sizes chosen to stress the flex multi-chunk DMA path (T4):
+#  * "aligned"    — device size divides evenly across the domains.
+#  * "one_stick" / "uneven_sticks" — the per-domain share is NOT a multiple of
+#    the 128 B device alignment, so flex rounds each chunk up and total_size()
+#    exceeds the tensor's storage size.
+#  * "large"      — 24 MiB, i.e. 6 MiB per chunk at 4 domains, so every chunk
+#    must itself be split into multiple <= kMaxBufSize transfers. This is what
+#    exercises T4's size-slice loop nested inside the per-chunk loop.
+CASES = [
+    ("one_stick", [64]),
+    ("aligned", [64, 64]),
+    ("uneven_sticks", [5, 64]),
+    ("large", [3072, 4096]),
+]
+
+FILL_SHAPE = [64, 64]
+# Exactly representable in fp16, and non-zero so a chunk that was never filled
+# cannot pass by happening to contain zeros. `torch.full` on spyre is
+# `torch.empty` + the device-side FillDMA (see torch_spyre/ops/eager.py).
+FILL_VALUE = 2.5
+
+
+@contextlib.contextmanager
+def _interleaved_placement(enabled: bool):
+    """Force interleaved (or Bind{0}) placement for allocations in this block."""
+    previous = torch.spyre._spyre_debug_set_emulate_interleave(enabled)
+    try:
+        yield
+    finally:
+        torch.spyre._spyre_debug_set_emulate_interleave(previous)
+
+
+def _digest(tensor: torch.Tensor) -> str:
+    return hashlib.sha256(tensor.contiguous().numpy().tobytes()).hexdigest()
+
+
+def _round_trip(shape, interleaved: bool) -> dict:
+    """Allocate + H2D + D2H one tensor and report what happened.
+
+    Only the allocation and upload run under the placement gate; the download
+    happens with the gate restored, so the round trip is driven by the tensor's
+    own address rather than by the flag still being set.
+    """
+    torch.manual_seed(SEED)
+    # Seeded in fp32 then narrowed, so every value is exactly representable in
+    # fp16 and the round trip must be bit-identical.
+    host = torch.randn(shape, dtype=torch.float32).to(DTYPE)
+
+    with _interleaved_placement(interleaved):
+        dev = host.to("spyre")
+
+    chunks = torch.spyre._spyre_debug_composite_chunks(dev)
+    back = dev.cpu()
+    return {
+        "shape": list(shape),
+        "host_bytes": host.untyped_storage().nbytes(),
+        "chunks": chunks,
+        "chunk_bytes_total": sum(c["size"] for c in chunks),
+        "exact": bool(torch.equal(back, host)),
+        "digest": _digest(back),
+    }
+
+
+def _fill_round_trip(interleaved: bool) -> dict:
+    """Fill a device tensor (no host source) and read it back."""
+    with _interleaved_placement(interleaved):
+        dev = torch.full(FILL_SHAPE, FILL_VALUE, dtype=DTYPE, device="spyre")
+
+    chunks = torch.spyre._spyre_debug_composite_chunks(dev)
+    back = dev.cpu()
+    return {
+        "chunks": chunks,
+        "all_filled": bool(torch.all(back == FILL_VALUE).item()),
+        "digest": _digest(back),
+    }
+
+
+class TestInterleaveThinSlice(TestCase):
+    """Copy-only interleaved round trip under an emulated multi-domain topology."""
+
+    num_domains = 0
+    interleaved: dict = {}
+    baseline: dict = {}
+    interleaved_fill: dict = {}
+    baseline_fill: dict = {}
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if not torch.spyre.is_initialized():
+            torch.spyre._lazy_init()
+
+        cls.num_domains = torch.spyre._spyre_debug_num_memory_domains()
+        if cls.num_domains < 2:
+            raise unittest.SkipTest(
+                "needs an emulated multi-domain topology; flex reports "
+                f"{cls.num_domains} memory domain(s). Re-run as: "
+                "FLEX_NUM_MEMORY_DOMAINS=4 FLEX_MAX_REGIONS=8 pytest "
+                "tests/test_interleave_thin_slice.py"
+            )
+
+        # The device work runs once and every test asserts on the result, so the
+        # suite does not re-upload 24 MiB per assertion.
+        cls.interleaved = {
+            name: _round_trip(shape, interleaved=True) for name, shape in CASES
+        }
+        cls.baseline = {
+            name: _round_trip(shape, interleaved=False) for name, shape in CASES
+        }
+        cls.interleaved_fill = _fill_round_trip(interleaved=True)
+        cls.baseline_fill = _fill_round_trip(interleaved=False)
+
+    def test_allocation_is_interleaved_across_all_domains(self):
+        """Each tensor must be N chunks, one per domain, all device-addressable.
+
+        Without this the numeric tests below would pass vacuously on a
+        single-chunk allocation if the interleave gate ever stopped firing.
+        """
+        for name, case in self.interleaved.items():
+            with self.subTest(case=name):
+                chunks = case["chunks"]
+                self.assertEqual(len(chunks), self.num_domains)
+                # One chunk per domain, each in its own region.
+                self.assertEqual(
+                    sorted(c["domain_id"] for c in chunks),
+                    list(range(self.num_domains)),
+                )
+                self.assertEqual(
+                    len({c["region_id"] for c in chunks}), self.num_domains
+                )
+                # A region carrying UNMAPPED_SEGMENT_ID has no device address
+                # and must never be dispatched (flex T3 Finding B / T4 guard).
+                for chunk in chunks:
+                    self.assertTrue(chunk["segment_mapped"], msg=str(chunk))
+                # Chunks are equal-sized and cover the whole tensor.
+                self.assertEqual(len({c["size"] for c in chunks}), 1)
+                self.assertGreaterEqual(case["chunk_bytes_total"], case["host_bytes"])
+
+    def test_baseline_allocation_is_single_chunk(self):
+        """With the gate off, allocation must stay exactly Bind{0}."""
+        for name, case in self.baseline.items():
+            with self.subTest(case=name):
+                self.assertEqual(len(case["chunks"]), 1)
+                self.assertEqual(case["chunks"][0]["domain_id"], 0)
+
+    def test_round_trip_is_exact(self):
+        """H2D → D2H of an interleaved tensor must be bit-identical."""
+        for name, case in self.interleaved.items():
+            with self.subTest(case=name):
+                self.assertTrue(case["exact"], msg=f"{name}: round trip differs")
+
+    def test_interleaved_matches_bind_baseline(self):
+        """Interleaved round-trip values must equal the Bind{0} baseline.
+
+        Stronger than the round-trip check on its own: it rules out a
+        scatter/gather bug that is self-consistent (same wrong permutation both
+        ways) but still disagrees with the trusted single-chunk path.
+        """
+        self.assertEqual(set(self.interleaved), set(self.baseline))
+        for name, case in self.interleaved.items():
+            with self.subTest(case=name):
+                self.assertEqual(case["digest"], self.baseline[name]["digest"])
+
+    def test_per_chunk_transfer_exceeds_buffer_size(self):
+        """The "large" case must really put > 4 MiB in each chunk.
+
+        This is the only case that exercises T4's size-slice loop nested inside
+        the per-chunk loop; assert the premise so the coverage cannot silently
+        rot if the shape is edited.
+        """
+        for chunk in self.interleaved["large"]["chunks"]:
+            self.assertGreater(chunk["size"], K_MAX_BUF_SIZE, msg=str(chunk))
+
+    def test_multi_chunk_fill_then_read_back(self):
+        """A filled interleaved tensor must carry the pattern in every chunk."""
+        self.assertEqual(len(self.interleaved_fill["chunks"]), self.num_domains)
+        self.assertTrue(self.interleaved_fill["all_filled"])
+        self.assertEqual(self.interleaved_fill["digest"], self.baseline_fill["digest"])
+
+    def test_layout_report(self):
+        """Not an assertion — print the observed layout for the gap ledger."""
+        for name, case in self.interleaved.items():
+            print(
+                f"\n{name} shape={case['shape']} host_bytes={case['host_bytes']}"
+                f" chunk_bytes_total={case['chunk_bytes_total']}"
+            )
+            for chunk in case["chunks"]:
+                print(
+                    f"  domain={chunk['domain_id']} region={chunk['region_id']}"
+                    f" offset={chunk['offset']} size={chunk['size']}"
+                    f" segment={chunk['segment_id']}"
+                )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/test_interleave_thin_slice.py
+++ b/tests/test_interleave_thin_slice.py
@@ -28,6 +28,26 @@ builder still asserts single-chunk addresses, and interleaved compute is not
 expressible in the 1p0 8-segment model at all. Copy-only is what the emulation
 proves on this silicon.
 
+## What "exact" means here, and why dtype matters
+
+The copy path is byte-lossless, but it is not *value*-lossless for every dtype,
+because H2D/D2H also convert between the host and device encodings of the dtype
+(``generate_dci`` → ``deeptools::ConvertData``):
+
+* ``float32`` is ``IEEE_FP32`` on **both** sides (``types_mapping.h``), so the
+  conversion is a pure layout shuffle and the round trip is **bit-exact**. The
+  exactness cases below are all fp32 for this reason.
+* ``float16`` is ``IEEE_FP16`` on the host but ``SEN169_FP16`` on the device — a
+  different 16-bit encoding, with one fewer mantissa bit. A round trip therefore
+  rounds, and ``torch.equal`` fails for arbitrary values. That is a property of
+  the dtype conversion, **not** of interleaving: it happens identically on the
+  single-chunk ``Bind{0}`` path.
+
+So fp16 coverage asserts the two things that are actually meaningful for it —
+digest parity with the ``Bind{0}`` baseline, and agreement with the host values
+to within one encoding step — rather than bit-exactness. A scatter/gather bug
+would break both.
+
 ## Running this test
 
 The synthetic topology comes from flex env knobs that are read once when the
@@ -61,13 +81,18 @@ import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 SEED = 20260815
-DTYPE = torch.float16
 
 # kMaxBufSize in flex's PF DMA path: each chunk larger than this must itself be
 # split into multiple transfer buffers.
 K_MAX_BUF_SIZE = 4 * 1024 * 1024
 
-# (case name, shape) — sizes chosen to stress the flex multi-chunk DMA path (T4):
+# One SEN169_FP16 mantissa step, relative. Round-to-nearest keeps the error at or
+# below half of this; the bound is deliberately one full step so the assertion
+# tests "same values, re-encoded" and not the rounding mode.
+SEN169_FP16_STEP = 2.0**-9
+
+# (case name, shape, dtype, bit_exact) — sizes chosen to stress the flex
+# multi-chunk DMA path (T4):
 #  * "aligned"    — device size divides evenly across the domains.
 #  * "one_stick" / "uneven_sticks" — the per-domain share is NOT a multiple of
 #    the 128 B device alignment, so flex rounds each chunk up and total_size()
@@ -75,17 +100,29 @@ K_MAX_BUF_SIZE = 4 * 1024 * 1024
 #  * "large"      — 24 MiB, i.e. 6 MiB per chunk at 4 domains, so every chunk
 #    must itself be split into multiple <= kMaxBufSize transfers. This is what
 #    exercises T4's size-slice loop nested inside the per-chunk loop.
+#
+# `bit_exact` is False exactly where the host and device encodings of the dtype
+# differ (fp16: IEEE_FP16 vs SEN169_FP16), which makes the *conversion* lossy
+# regardless of placement — see the module docstring. fp32 is IEEE_FP32 on both
+# sides, so those cases must round-trip bit-for-bit.
+#
+# Element counts differ between the fp32 and fp16 cases so that the byte sizes —
+# which is what the DMA path actually partitions — hit the same interesting
+# boundaries in both.
 CASES = [
-    ("one_stick", [64]),
-    ("aligned", [64, 64]),
-    ("uneven_sticks", [5, 64]),
-    ("large", [3072, 4096]),
+    ("one_stick", [32], torch.float32, True),
+    ("aligned", [64, 64], torch.float32, True),
+    ("uneven_sticks", [5, 32], torch.float32, True),
+    ("large", [3072, 2048], torch.float32, True),
+    ("half_aligned", [64, 64], torch.float16, False),
+    ("half_uneven_sticks", [5, 64], torch.float16, False),
 ]
 
 FILL_SHAPE = [64, 64]
-# Exactly representable in fp16, and non-zero so a chunk that was never filled
-# cannot pass by happening to contain zeros. `torch.full` on spyre is
-# `torch.empty` + the device-side FillDMA (see torch_spyre/ops/eager.py).
+FILL_DTYPE = torch.float16
+# Exactly representable in both fp16 encodings, and non-zero so a chunk that was
+# never filled cannot pass by happening to contain zeros. `torch.full` on spyre
+# is `torch.empty` + the device-side FillDMA (see torch_spyre/ops/eager.py).
 FILL_VALUE = 2.5
 
 
@@ -103,7 +140,18 @@ def _digest(tensor: torch.Tensor) -> str:
     return hashlib.sha256(tensor.contiguous().numpy().tobytes()).hexdigest()
 
 
-def _round_trip(shape, interleaved: bool) -> dict:
+def _max_relative_error(back: torch.Tensor, host: torch.Tensor) -> float:
+    """Largest relative deviation, in units of the host magnitude.
+
+    Exact zeros round-trip to exact zeros, so clamping the denominator only
+    guards the division; it cannot mask a real difference.
+    """
+    a = back.to(torch.float32)
+    b = host.to(torch.float32)
+    return float(((a - b).abs() / b.abs().clamp_min(2.0**-14)).max().item())
+
+
+def _round_trip(shape, dtype, interleaved: bool) -> dict:
     """Allocate + H2D + D2H one tensor and report what happened.
 
     Only the allocation and upload run under the placement gate; the download
@@ -111,9 +159,7 @@ def _round_trip(shape, interleaved: bool) -> dict:
     own address rather than by the flag still being set.
     """
     torch.manual_seed(SEED)
-    # Seeded in fp32 then narrowed, so every value is exactly representable in
-    # fp16 and the round trip must be bit-identical.
-    host = torch.randn(shape, dtype=torch.float32).to(DTYPE)
+    host = torch.randn(shape, dtype=torch.float32).to(dtype)
 
     with _interleaved_placement(interleaved):
         dev = host.to("spyre")
@@ -122,10 +168,12 @@ def _round_trip(shape, interleaved: bool) -> dict:
     back = dev.cpu()
     return {
         "shape": list(shape),
+        "dtype": str(dtype),
         "host_bytes": host.untyped_storage().nbytes(),
         "chunks": chunks,
         "chunk_bytes_total": sum(c["size"] for c in chunks),
         "exact": bool(torch.equal(back, host)),
+        "max_rel_err": _max_relative_error(back, host),
         "digest": _digest(back),
     }
 
@@ -133,7 +181,7 @@ def _round_trip(shape, interleaved: bool) -> dict:
 def _fill_round_trip(interleaved: bool) -> dict:
     """Fill a device tensor (no host source) and read it back."""
     with _interleaved_placement(interleaved):
-        dev = torch.full(FILL_SHAPE, FILL_VALUE, dtype=DTYPE, device="spyre")
+        dev = torch.full(FILL_SHAPE, FILL_VALUE, dtype=FILL_DTYPE, device="spyre")
 
     chunks = torch.spyre._spyre_debug_composite_chunks(dev)
     back = dev.cpu()
@@ -171,10 +219,12 @@ class TestInterleaveThinSlice(TestCase):
         # The device work runs once and every test asserts on the result, so the
         # suite does not re-upload 24 MiB per assertion.
         cls.interleaved = {
-            name: _round_trip(shape, interleaved=True) for name, shape in CASES
+            name: _round_trip(shape, dtype, interleaved=True)
+            for name, shape, dtype, _ in CASES
         }
         cls.baseline = {
-            name: _round_trip(shape, interleaved=False) for name, shape in CASES
+            name: _round_trip(shape, dtype, interleaved=False)
+            for name, shape, dtype, _ in CASES
         }
         cls.interleaved_fill = _fill_round_trip(interleaved=True)
         cls.baseline_fill = _fill_round_trip(interleaved=False)
@@ -213,10 +263,44 @@ class TestInterleaveThinSlice(TestCase):
                 self.assertEqual(case["chunks"][0]["domain_id"], 0)
 
     def test_round_trip_is_exact(self):
-        """H2D → D2H of an interleaved tensor must be bit-identical."""
-        for name, case in self.interleaved.items():
+        """H2D → D2H must be bit-identical where the dtype encoding is shared.
+
+        fp32 is IEEE_FP32 on host and device, so the copy path converts layout
+        only and nothing may change. Cases whose dtype is re-encoded on the
+        device are covered by the reduced-precision test below instead.
+        """
+        exact_cases = [name for name, _, _, bit_exact in CASES if bit_exact]
+        self.assertTrue(exact_cases, msg="no bit-exact case configured")
+        for name in exact_cases:
+            case = self.interleaved[name]
             with self.subTest(case=name):
-                self.assertTrue(case["exact"], msg=f"{name}: round trip differs")
+                self.assertTrue(
+                    case["exact"],
+                    msg=(
+                        f"{name} ({case['dtype']}): round trip differs; "
+                        f"max relative error {case['max_rel_err']:.3e}"
+                    ),
+                )
+
+    def test_reduced_precision_round_trip_is_within_one_encoding_step(self):
+        """Re-encoded dtypes must still come back as the same values.
+
+        fp16 is IEEE_FP16 on the host and SEN169_FP16 on the device — one
+        mantissa bit narrower — so a round trip rounds and cannot be bit-exact.
+        What must hold is that every element is still within one encoding step of
+        what went in: a mis-ordered scatter/gather would produce unrelated values
+        and miss this bound by orders of magnitude.
+        """
+        lossy_cases = [name for name, _, _, bit_exact in CASES if not bit_exact]
+        self.assertTrue(lossy_cases, msg="no reduced-precision case configured")
+        for name in lossy_cases:
+            case = self.interleaved[name]
+            with self.subTest(case=name):
+                self.assertLessEqual(
+                    case["max_rel_err"],
+                    SEN169_FP16_STEP,
+                    msg=f"{name} ({case['dtype']}): values changed, not just rounded",
+                )
 
     def test_interleaved_matches_bind_baseline(self):
         """Interleaved round-trip values must equal the Bind{0} baseline.
@@ -250,8 +334,11 @@ class TestInterleaveThinSlice(TestCase):
         """Not an assertion — print the observed layout for the gap ledger."""
         for name, case in self.interleaved.items():
             print(
-                f"\n{name} shape={case['shape']} host_bytes={case['host_bytes']}"
+                f"\n{name} {case['dtype']} shape={case['shape']}"
+                f" host_bytes={case['host_bytes']}"
                 f" chunk_bytes_total={case['chunk_bytes_total']}"
+                f" exact={case['exact']}"
+                f" max_rel_err={case['max_rel_err']:.3e}"
             )
             for chunk in case["chunks"]:
                 print(

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -580,6 +580,32 @@ PYBIND11_MODULE(_C, m) {
       },
       py::arg("device"), "Reset peak allocator statistics");
 
+  // ─── TEMPORARY (T5, 1p5-emulation epic) ──────────────────────────────────
+  // Debug-only introspection of a tensor's device chunk layout, so the
+  // copy-only thin-slice test can prove an allocation really is interleaved.
+  // Remove together with TORCH_SPYRE_EMULATE_INTERLEAVE when T6 lands.
+  m.def(
+      "_spyre_debug_composite_chunks",
+      [](const at::Tensor& tensor) {
+        py::list result;
+        for (const auto& chunk :
+             spyre::SpyreAllocator::debugCompositeChunks(tensor)) {
+          py::dict entry;
+          entry["domain_id"] = chunk.domain_id;
+          entry["region_id"] = chunk.region_id;
+          entry["offset"] = chunk.offset;
+          entry["size"] = chunk.size;
+          entry["segment_id"] = chunk.segment_id;
+          entry["segment_mapped"] = chunk.segment_mapped;
+          result.append(entry);
+        }
+        return result;
+      },
+      py::arg("tensor"),
+      "DEBUG/TEMPORARY: return the per-chunk layout "
+      "(domain_id, region_id, offset, size, segment_id, segment_mapped) of a "
+      "Spyre tensor's device allocation.");
+
   // ── Typed stream error API ───────────────────────────────────────────────
 
   py::enum_<spyre::SpyreStreamError>(m, "SpyreStreamError")

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -606,6 +606,21 @@ PYBIND11_MODULE(_C, m) {
       "(domain_id, region_id, offset, size, segment_id, segment_mapped) of a "
       "Spyre tensor's device allocation.");
 
+  m.def(
+      "_spyre_debug_set_emulate_interleave",
+      [](bool enabled) {
+        return spyre::SpyreAllocator::debugSetEmulateInterleave(enabled);
+      },
+      py::arg("enabled"),
+      "DEBUG/TEMPORARY: enable/disable interleaved tensor placement for the "
+      "rest of this process; returns the previous setting.");
+
+  m.def(
+      "_spyre_debug_num_memory_domains",
+      []() { return spyre::SpyreAllocator::debugNumMemoryDomains(); },
+      "DEBUG/TEMPORARY: number of memory domains flex reports (1 unless "
+      "FLEX_NUM_MEMORY_DOMAINS is set); 0 if the runtime is not started.");
+
   // ── Typed stream error API ───────────────────────────────────────────────
 
   py::enum_<spyre::SpyreStreamError>(m, "SpyreStreamError")

--- a/torch_spyre/csrc/spyre_allocator.cpp
+++ b/torch_spyre/csrc/spyre_allocator.cpp
@@ -15,6 +15,7 @@
  */
 #include "spyre_allocator.h"
 
+#include <atomic>
 #include <cstdlib>  // std::getenv
 #include <memory>
 #include <mutex>
@@ -53,14 +54,24 @@ namespace {
 //  - Interleaved tensors are usable on the **eager copy path only**. The
 //    compiled JobPlan builder still asserts single-chunk (T7/T8, gated by the
 //    T1 verdict), so do not set this in a process that compiles kernels.
-//  - Unset (the default) leaves behavior byte-for-byte identical to Bind{0}.
-bool emulateInterleaveEnabled() {
-  static const bool enabled = []() {
+//  - Off (the default) leaves behavior byte-for-byte identical to Bind{0}.
+//
+// The env var seeds the initial value, but the flag is a process-global that
+// `debugSetEmulateInterleave` can flip at runtime. That matters: only one
+// process may hold the Spyre device, so a test cannot compare an interleaved
+// run against a Bind{0} baseline by spawning a second process — both
+// placements have to be exercised in the same process, under the same topology.
+std::atomic<bool>& emulateInterleaveFlag() {
+  static std::atomic<bool> flag{[]() {
     const char* env = std::getenv("TORCH_SPYRE_EMULATE_INTERLEAVE");
     return env != nullptr && std::string_view(env) != "" &&
            std::string_view(env) != "0";
-  }();
-  return enabled;
+  }()};
+  return flag;
+}
+
+bool emulateInterleaveEnabled() {
+  return emulateInterleaveFlag().load(std::memory_order_relaxed);
 }
 
 }  // namespace
@@ -279,6 +290,22 @@ void SpyreAllocator::copy_data(void* dest, const void* src,
 uint64_t SpyreAllocator::compositeAddressToDmva(
     const flex::CompositeAddress& addr) const {
   return getFlexAllocator()->compositeAddressToDmva(addr);
+}
+
+// ─── TEMPORARY (T5, 1p5-emulation epic) ──────────────────────────────────────
+// Flip the interleave gate for the rest of this process; returns the previous
+// value so a caller can restore it. See emulateInterleaveFlag().
+bool SpyreAllocator::debugSetEmulateInterleave(bool enabled) {
+  return emulateInterleaveFlag().exchange(enabled, std::memory_order_relaxed);
+}
+
+// ─── TEMPORARY (T5, 1p5-emulation epic) ──────────────────────────────────────
+// Number of memory domains flex reports (1 unless FLEX_NUM_MEMORY_DOMAINS is
+// set), so a test can skip cleanly instead of asserting on a single-domain
+// topology. Requires the runtime to be started.
+size_t SpyreAllocator::debugNumMemoryDomains() {
+  auto flex_alloc = getFlexAllocator();
+  return flex_alloc ? flex_alloc->topology().num_domains() : 0;
 }
 
 // ─── TEMPORARY (T5, 1p5-emulation epic) ──────────────────────────────────────

--- a/torch_spyre/csrc/spyre_allocator.cpp
+++ b/torch_spyre/csrc/spyre_allocator.cpp
@@ -15,9 +15,13 @@
  */
 #include "spyre_allocator.h"
 
+#include <cstdlib>  // std::getenv
 #include <memory>
 #include <mutex>
+#include <numeric>
+#include <string_view>
 #include <utility>
+#include <vector>
 
 #include "logging.h"
 #include "module.h"
@@ -25,6 +29,41 @@
 #include "spyre_tensor_impl.h"
 
 namespace spyre {
+
+namespace {
+
+// ─── TEMPORARY (T5, 1p5-emulation epic) ──────────────────────────────────────
+// Coarse env gate that makes every *tensor* storage allocation interleave
+// across all memory domains flex reports, so the epic's copy-only thin slice
+// (allocate → H2D → D2H) can be exercised on real 1p0-PF silicon under an
+// emulated multi-domain topology:
+//
+//   FLEX_NUM_MEMORY_DOMAINS=4 FLEX_MAX_REGIONS=8 \
+//   TORCH_SPYRE_EMULATE_INTERLEAVE=1
+//
+// This is deliberately NOT an eligibility policy: it interleaves everything it
+// sees. T6 replaces it with a topology-derived directive that decides per
+// tensor; delete this gate then.
+//
+// Scope and safety:
+//  - Only the c10::Allocator entry point (`allocate(nbytes)`) consults it, so
+//    it affects tensor storages only. The program allocation uses the
+//    directive-taking overload with its own Bind{0} (prepare_kernel.cpp) and is
+//    untouched.
+//  - Interleaved tensors are usable on the **eager copy path only**. The
+//    compiled JobPlan builder still asserts single-chunk (T7/T8, gated by the
+//    T1 verdict), so do not set this in a process that compiles kernels.
+//  - Unset (the default) leaves behavior byte-for-byte identical to Bind{0}.
+bool emulateInterleaveEnabled() {
+  static const bool enabled = []() {
+    const char* env = std::getenv("TORCH_SPYRE_EMULATE_INTERLEAVE");
+    return env != nullptr && std::string_view(env) != "" &&
+           std::string_view(env) != "0";
+  }();
+  return enabled;
+}
+
+}  // namespace
 
 SpyreAllocator::SpyreAllocator() {
   // Callback registration is deferred until first allocation
@@ -143,6 +182,26 @@ void SpyreAllocator::recordRelease(size_t nbytes, void* data, int device_id) {
 }
 
 c10::DataPtr SpyreAllocator::allocate(size_t nbytes) {
+  // ─── TEMPORARY (T5, 1p5-emulation epic) ────────────────────────────────────
+  // See emulateInterleaveEnabled(). Skipped for nbytes == 0 so the empty
+  // allocation keeps returning early below without touching the runtime.
+  if (nbytes != 0 && emulateInterleaveEnabled()) {
+    auto flex_alloc = getFlexAllocator();
+    const size_t num_domains =
+        flex_alloc ? flex_alloc->topology().num_domains() : 1;
+    if (num_domains > 1) {
+      std::vector<uint32_t> domain_ids(num_domains);
+      std::iota(domain_ids.begin(), domain_ids.end(), 0U);
+      flex::AllocationDirective interleaved(flex::PlacementPolicy::Interleave,
+                                            std::move(domain_ids), std::nullopt,
+                                            flex::MemoryType::Tensor);
+      DEBUGINFO("TORCH_SPYRE_EMULATE_INTERLEAVE: interleaving ", nbytes,
+                " (bytes) across ", num_domains, " memory domains");
+      return SpyreAllocator::allocate(nbytes, interleaved);
+    }
+    // num_domains == 1: no domains to stripe across, fall through to Bind{0}.
+  }
+
   flex::AllocationDirective directive(flex::PlacementPolicy::Bind, {0},
                                       std::nullopt, flex::MemoryType::Tensor);
   return SpyreAllocator::allocate(nbytes, directive);
@@ -220,6 +279,35 @@ void SpyreAllocator::copy_data(void* dest, const void* src,
 uint64_t SpyreAllocator::compositeAddressToDmva(
     const flex::CompositeAddress& addr) const {
   return getFlexAllocator()->compositeAddressToDmva(addr);
+}
+
+// ─── TEMPORARY (T5, 1p5-emulation epic) ──────────────────────────────────────
+// Debug-only introspection: see CompositeChunkInfo in the header.
+std::vector<CompositeChunkInfo> SpyreAllocator::debugCompositeChunks(
+    const at::Tensor& tensor) {
+  TORCH_CHECK(tensor.is_privateuseone(),
+              "debugCompositeChunks: expected a Spyre tensor, got one on ",
+              tensor.device());
+  auto* ctx =
+      static_cast<SharedOwnerCtx*>(tensor.storage().data_ptr().get_context());
+  TORCH_CHECK(ctx != nullptr,
+              "debugCompositeChunks: tensor has no device allocation");
+
+  const auto& region_map = getFlexAllocator()->getIdToRegionMap();
+
+  std::vector<CompositeChunkInfo> out;
+  out.reserve(ctx->composite_addr.chunks().size());
+  for (const auto& chunk : ctx->composite_addr.chunks()) {
+    uint32_t segment_id = flex::UNMAPPED_SEGMENT_ID;
+    auto it = region_map.find(chunk.addr.region_id);
+    if (it != region_map.end() && it->second != nullptr) {
+      segment_id = it->second->segment_id();
+    }
+    out.push_back(CompositeChunkInfo{chunk.domain_id, chunk.addr.region_id,
+                                     chunk.addr.offset, chunk.size, segment_id,
+                                     segment_id != flex::UNMAPPED_SEGMENT_ID});
+  }
+  return out;
 }
 
 void SpyreAllocator::memoryPressureCallback(

--- a/torch_spyre/csrc/spyre_allocator.h
+++ b/torch_spyre/csrc/spyre_allocator.h
@@ -107,10 +107,18 @@ struct SpyreAllocator final : public c10::DeviceAllocator {
   uint64_t compositeAddressToDmva(const flex::CompositeAddress& addr) const;
 
   // ─── TEMPORARY (T5, 1p5-emulation epic) ────────────────────────────────────
-  // Return the chunk layout of a Spyre tensor's device allocation, for test
-  // assertions only. Remove with the interleave env gate when T6 lands.
+  // Test-only hooks for the copy-only thin slice. Remove with the interleave
+  // gate when T6 lands.
+  //
+  // Return the chunk layout of a Spyre tensor's device allocation.
   static std::vector<CompositeChunkInfo> debugCompositeChunks(
       const at::Tensor& tensor);
+  // Flip the interleave gate at runtime; returns the previous value. Needed
+  // because only one process may hold the device, so an interleaved run and its
+  // Bind{0} baseline must both happen in this process.
+  static bool debugSetEmulateInterleave(bool enabled);
+  // Memory domains flex reports; 0 if the runtime is not started.
+  static size_t debugNumMemoryDomains();
 };
 
 }  // namespace spyre

--- a/torch_spyre/csrc/spyre_allocator.h
+++ b/torch_spyre/csrc/spyre_allocator.h
@@ -15,14 +15,17 @@
  */
 #pragma once
 
+#include <ATen/core/Tensor.h>
 #include <c10/core/CachingDeviceAllocator.h>
 #include <c10/core/Device.h>
 #include <c10/core/Stream.h>
 
+#include <cstdint>
 #include <flex/flex.hpp>
 #include <memory>
 #include <mutex>
 #include <utility>
+#include <vector>
 
 namespace spyre {
 
@@ -32,6 +35,26 @@ struct SharedOwnerCtx {
 
   SharedOwnerCtx(flex::CompositeAddress addr, signed char dev_id)
       : composite_addr(std::move(addr)), device_id(dev_id) {}
+};
+
+// ─── TEMPORARY (T5, 1p5-emulation epic) ──────────────────────────────────────
+// Per-chunk description of a tensor's device allocation, exposed to Python so
+// the thin-slice test can assert that an allocation really is interleaved
+// (multi-chunk, one chunk per memory domain, every chunk backed by a real
+// XLat segment) rather than silently passing on a single-chunk allocation.
+//
+// Debug-only introspection. Remove together with the interleave env gate when
+// T6 replaces it with a real topology-derived eligibility policy.
+struct CompositeChunkInfo {
+  uint32_t domain_id;
+  uint64_t region_id;
+  uint64_t offset;
+  uint64_t size;
+  // Region's XLat segment id. Under an emulated multi-domain topology a surplus
+  // tensor region can carry UNMAPPED_SEGMENT_ID, meaning it has no device
+  // address and must never be dispatched (flex T3 Finding B / T4 backstop).
+  uint32_t segment_id;
+  bool segment_mapped;
 };
 
 // A custom allocator for our custom device, which returns a handle to the
@@ -82,6 +105,12 @@ struct SpyreAllocator final : public c10::DeviceAllocator {
   void copy_data(void* dest, const void* src, std::size_t count) const final;
 
   uint64_t compositeAddressToDmva(const flex::CompositeAddress& addr) const;
+
+  // ─── TEMPORARY (T5, 1p5-emulation epic) ────────────────────────────────────
+  // Return the chunk layout of a Spyre tensor's device allocation, for test
+  // assertions only. Remove with the interleave env gate when T6 lands.
+  static std::vector<CompositeChunkInfo> debugCompositeChunks(
+      const at::Tensor& tensor);
 };
 
 }  // namespace spyre


### PR DESCRIPTION
**DO NOT MERGE, FOR REVIEW ONLY**

#### What type of PR is this?

- [ ] bug
- [X] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Add tests to validate E2E path of multi-chunk tensor copy.
Full description of process flow in the comments of Flex issue 1453.

#### Which issue(s) this PR is related to:

Closes #3814 

Requires check-out and build of Flex with 1514, 1522, 1536 (last one should include the previous). 
These are Flex implementation of T2-T4, tracked in torch-spyre by: #3204 , #3411 , #3412 , #3413 

#### Additional note:

@JRosenkranz @thoangtrvn