### PR TITLE
ci: echo the exact run_test.sh command before running it

### DIFF
--- a/.github/actions/run-test-suite/action.yml
+++ b/.github/actions/run-test-suite/action.yml
@@ -275,6 +275,18 @@ runs:
             _PARALLEL_FLAG="--parallel"
           fi
 
+          # Print the exact command before running it. When run_test.sh fails
+          # early (e.g. "No YAML config file(s) found"), the log otherwise does
+          # not show what was actually passed, so the flag/config expansion is
+          # invisible. printf '%q' renders each word shell-quoted, so the line is
+          # copy-pasteable and cannot itself execute anything if a flag holds
+          # quotes or $(...). The unquoted vars split into words exactly as they
+          # do in the invocation below, so the printed and run word lists match.
+          printf '  command       :'
+          printf ' %q' env ${_DTLOG_PREFIX} bash tests/run_test.sh "$CONFIG" \
+            ${_PARALLEL_FLAG} ${{ inputs.extra_test_flags }} ${_SLOW_FLAG} ${_JUNIT_FLAG} ${_XDIST_FLAG}
+          printf '\n'
+
           env ${_DTLOG_PREFIX} bash tests/run_test.sh "$CONFIG" ${_PARALLEL_FLAG} ${{ inputs.extra_test_flags }} ${_SLOW_FLAG} ${_JUNIT_FLAG} ${_XDIST_FLAG} \
             >&"$FIFO_FD" 2>&1 &
           TEST_PID=$!


### PR DESCRIPTION
Print the full, expanded `run_test.sh` command right before the test action runs it.

## Why
When the runner invokes:

```
env ${_DTLOG_PREFIX} bash tests/run_test.sh "$CONFIG" ${_PARALLEL_FLAG} ${{ inputs.extra_test_flags }} ${_SLOW_FLAG} ${_JUNIT_FLAG} ${_XDIST_FLAG}
```

and `run_test.sh` exits early (for example `ERROR: No YAML config file(s) found in the arguments.`), the job log shows the pre-run banner (suite name, arch, flags) but never the actual command. So when the config path or a flag expands wrong, there is nothing in the log to show what was passed. That failure has been seen intermittently on the Multi-Spyre distributed suites.

## Change
In `.github/actions/run-test-suite/action.yml`, just before the invocation, print the command with `printf '%q'` over the same word list the shell runs. `%q` was chosen over a plain `echo "..."` on purpose:

- The line is shell-quoted and copy-pasteable.
- A flag that contains quotes, spaces, or `$(...)` is escaped in the output, not interpreted, so the diagnostic line can never itself break the script or execute anything.
- The unquoted flag vars split into words exactly as they do in the real invocation, so the printed word list matches what runs.

No behavior change: it is a pure log line.

## Example log lines
```
  command       : env bash tests/run_test.sh tests/configs/distributed_tests/test_allreduce_compiled.yaml --parallel -v --junit-xml=report.xml
  command       : env DTLOG_LEVEL=Info bash tests/run_test.sh tests/configs/distributed_tests/test_allreduce_compiled.yaml --parallel -v   # retry
  command       : env bash tests/run_test.sh '' --parallel -v                                                                     # empty config: now visible
```

The last case is the point: an empty or wrong `$CONFIG` shows up in the log instead of silently producing the misleading "No YAML config found" error.