### PR TITLE
fix(ci): replace broken actions4gh/setup-gh with direct gh CLI install

### DIFF
--- a/.github/workflows/build_test_pytorch_source.yaml
+++ b/.github/workflows/build_test_pytorch_source.yaml
@@ -228,8 +228,22 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
+      # actions4gh/setup-gh@v1.0.2 extracts the gh tarball but never lands
+      # the binary on PATH before it calls `gh auth login`, so every job
+      # fails with "spawn gh ENOENT" (upstream actions4gh/setup-gh#7, #11,
+      # unresolved). Install gh directly instead; downstream steps already
+      # set GH_TOKEN, which `gh` picks up implicitly, so no `gh auth login`
+      # call is needed here.
       - name: Setup the GitHub CLI
-        uses: actions4gh/setup-gh@v1.0.2
+        env:
+          GH_CLI_VERSION: 2.97.0
+        run: |
+          curl -fsSL \
+            "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz" \
+            -o "${RUNNER_TEMP}/gh-cli.tar.gz"
+          mkdir -p "${RUNNER_TEMP}/gh-cli"
+          tar -xzf "${RUNNER_TEMP}/gh-cli.tar.gz" -C "${RUNNER_TEMP}/gh-cli" --strip-components=1
+          echo "${RUNNER_TEMP}/gh-cli/bin" >> "${GITHUB_PATH}"
 
       - name: Write dispatch payload to file
         env:

--- a/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
+++ b/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
@@ -70,8 +70,22 @@ jobs:
           source .venv/bin/activate
           uv pip install clickhouse-connect regex
 
+      # actions4gh/setup-gh@v1.0.2 extracts the gh tarball but never lands
+      # the binary on PATH before it calls `gh auth login`, so every job
+      # fails with "spawn gh ENOENT" (upstream actions4gh/setup-gh#7, #11,
+      # unresolved). Install gh directly instead; downstream steps already
+      # set GH_TOKEN, which `gh` picks up implicitly, so no `gh auth login`
+      # call is needed here.
       - name: Setup the GitHub CLI
-        uses: actions4gh/setup-gh@v1.0.2
+        env:
+          GH_CLI_VERSION: 2.97.0
+        run: |
+          curl -fsSL \
+            "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz" \
+            -o "${RUNNER_TEMP}/gh-cli.tar.gz"
+          mkdir -p "${RUNNER_TEMP}/gh-cli"
+          tar -xzf "${RUNNER_TEMP}/gh-cli.tar.gz" -C "${RUNNER_TEMP}/gh-cli" --strip-components=1
+          echo "${RUNNER_TEMP}/gh-cli/bin" >> "${GITHUB_PATH}"
 
       - name: Download Job Logs
         env:

--- a/.github/workflows/push-model-ops-logs-to-clickhouse.yaml
+++ b/.github/workflows/push-model-ops-logs-to-clickhouse.yaml
@@ -73,8 +73,22 @@ jobs:
           source .venv/bin/activate
           uv pip install clickhouse-connect regex
 
+      # actions4gh/setup-gh@v1.0.2 extracts the gh tarball but never lands
+      # the binary on PATH before it calls `gh auth login`, so every job
+      # fails with "spawn gh ENOENT" (upstream actions4gh/setup-gh#7, #11,
+      # unresolved). Install gh directly instead; downstream steps already
+      # set GH_TOKEN, which `gh` picks up implicitly, so no `gh auth login`
+      # call is needed here.
       - name: Setup the GitHub CLI
-        uses: actions4gh/setup-gh@v1.0.2
+        env:
+          GH_CLI_VERSION: 2.97.0
+        run: |
+          curl -fsSL \
+            "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz" \
+            -o "${RUNNER_TEMP}/gh-cli.tar.gz"
+          mkdir -p "${RUNNER_TEMP}/gh-cli"
+          tar -xzf "${RUNNER_TEMP}/gh-cli.tar.gz" -C "${RUNNER_TEMP}/gh-cli" --strip-components=1
+          echo "${RUNNER_TEMP}/gh-cli/bin" >> "${GITHUB_PATH}"
 
       # -----------------------------------------------------------------
       # Download one raw log file per matrix job from the triggering run.

--- a/.github/workflows/push-to-clickhouse.yaml
+++ b/.github/workflows/push-to-clickhouse.yaml
@@ -112,8 +112,22 @@ jobs:
             .github/scripts/ingest_xml.py
           sparse-checkout-cone-mode: false
 
+      # actions4gh/setup-gh@v1.0.2 extracts the gh tarball but never lands
+      # the binary on PATH before it calls `gh auth login`, so every job
+      # fails with "spawn gh ENOENT" (upstream actions4gh/setup-gh#7, #11,
+      # unresolved). Install gh directly instead; downstream steps already
+      # set GH_TOKEN, which `gh` picks up implicitly, so no `gh auth login`
+      # call is needed here.
       - name: Setup the GitHub CLI
-        uses: actions4gh/setup-gh@v1.0.2
+        env:
+          GH_CLI_VERSION: 2.97.0
+        run: |
+          curl -fsSL \
+            "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz" \
+            -o "${RUNNER_TEMP}/gh-cli.tar.gz"
+          mkdir -p "${RUNNER_TEMP}/gh-cli"
+          tar -xzf "${RUNNER_TEMP}/gh-cli.tar.gz" -C "${RUNNER_TEMP}/gh-cli" --strip-components=1
+          echo "${RUNNER_TEMP}/gh-cli/bin" >> "${GITHUB_PATH}"
 
       - name: Resolve PR number
         id: resolve-pr


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

### Problem

`actions4gh/setup-gh@v1.0.2` (used in 4 workflows: `push-hw-diagnostics-to-clickhouse.yaml`,
`push-model-ops-logs-to-clickhouse.yaml`, `push-to-clickhouse.yaml`, `build_test_pytorch_source.yaml`) extracts the `gh` CLI tarball but never lands the binary on `PATH` before invoking `gh auth login --with-token`, causing every job to fail with: 

```python
Error: Command failed with ENOENT: gh auth login --with-token --hostname github.com spawn gh ENOENT
```

This is a known, unresolved upstream bug (`actions4gh/setup-gh` issues #7 and #11) — no newer release exists that fixes it.

### Fix

Replaced the `actions4gh/setup-gh@v1.0.2` step in all 4 workflows with an inline step that:

- Downloads the official `gh` CLI release tarball (v2.97.0) directly from `cli/cli` releases
- Extracts it and appends its `bin/` dir to `GITHUB_PATH`
- Skips the explicit `gh auth login` call entirely — downstream steps already set `GH_TOKEN` in their env, which `gh` picks up implicitly

### Verified locally

<img width="1584" height="426" alt="image" src="https://github.com/user-attachments/assets/9b641b43-ad92-415e-9226-8fe644e7fe39" />

