### PR TITLE
refactor(ci): write the suite tier to test_type, not trigger_type

### DIFF
--- a/.github/scripts/ingest_xml.py
+++ b/.github/scripts/ingest_xml.py
@@ -537,7 +537,7 @@ def insert_run(client, run_id: str, run: dict, args):
             "errors",
             "xpass",
             "duration_s",
-            "trigger_type",
+            "test_type",
         ],
     )
 


### PR DESCRIPTION
Part of a cross-repo rename standardizing the suite-tier column on `test_type`.

## Why

One concept had three names: `artifact_results.mode` (spyre-dashboard) and `trigger_type` in `test_runs` / `si_test_runs` / `hf_test_runs`. `mode` was the actively harmful spelling — everywhere else in the pipeline `mode` means the **build variant** (`torch-spyre-dev`), and that collision is why `artifact_results.mode` spent months holding variant names instead of tiers (401 of 492 live rows).

## What changes here

Only the ClickHouse column name in the insert’s `column_names`. Renamed **in place** so it stays index-aligned with the positional value list — reordering would silently transpose column values rather than error.

## What deliberately does NOT change

The `--trigger-type` CLI flag and `args.trigger_type` keep their names. The orchestrator probes the baked script’s `--help` for that exact flag and **silently omits the argument when absent** (`push_to_clickhouse.groovy`), so renaming the flag would make every image built from an older commit quietly fall back to `'unknown'` — no error, no UNSTABLE. The flag name is not the column name and coupling them buys nothing.

## Merge order

**The spyre-dashboard migration must land first** (`rename/test-type`, migration 015) — it is what renames the live column. `client.insert(column_names=[...])` raises on an unknown column, so if this merges first the ingest fails loudly rather than corrupting data.

## Related

- spyre-dashboard `rename/test-type` — migration 015 + DDL + readers
- spyre-frameworks `rename/test-type` — `artifact_results.mode` -> `test_type`