### PR TITLE
Emit opaque elementwise ops as linalg.generic + spyreop in the OpSpec→KTIR emitter

### DIFF
--- a/tests/inductor/test_ktir_emitter.py
+++ b/tests/inductor/test_ktir_emitter.py
@@ -66,7 +66,11 @@ module {
     %5 = ktdp.construct_access_tile %1[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
     %6 = ktdp.load %5 : <16x512x64xindex> -> tensor<16x512x64xf16>
     %7 = tensor.empty() : tensor<16x512x64xf16>
-    %8 = linalg.add ins(%4, %6 : tensor<16x512x64xf16>, tensor<16x512x64xf16>) outs(%7 : tensor<16x512x64xf16>) -> tensor<16x512x64xf16>
+    %8 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%4, %6 : tensor<16x512x64xf16>, tensor<16x512x64xf16>) outs(%7 : tensor<16x512x64xf16>) {
+    ^bb0(%in: f16, %in_0: f16, %out: f16):
+      %10 = arith.addf %in, %in_0 : f16
+      linalg.yield %10 : f16
+    } -> tensor<16x512x64xf16>
     %9 = ktdp.construct_access_tile %2[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
     ktdp.store %8, %9 : tensor<16x512x64xf16>, <16x512x64xindex>
     return
@@ -81,19 +85,20 @@ module {
         self.assertEqual(emitted, self.EXPECTED_ADD_KTIR)
 
     def test_registered_ops_reach_their_own_binding(self):
-        """A second op costs one recipe: same shape, different linalg builder.
+        """A second op costs one recipe: same shape, different payload builder.
 
-        Asserted as a delta against the golden rather than a second copy of it --
-        only the compute line differs.
+        Asserted as a delta against the golden rather than a second copy of it.
+        The emission is one shape for every pointwise op, so the delta is the
+        body's single line -- the generic's maps, iterators and operands do not
+        move.
         """
         from torch_spyre._inductor.codegen.ktir import generate_ktir
 
         emitted = generate_ktir("ktir_fused_mul_0", [make_op_spec("mul")])
-        self.assertIn("linalg.mul ins(", emitted)
-        self.assertNotIn("linalg.add", emitted)
-        # Everything either side of the compute op is unchanged by the op name.
+        self.assertIn("arith.mulf", emitted)
+        self.assertNotIn("arith.addf", emitted)
         self.assertEqual(
-            emitted.replace("linalg.mul", "linalg.add").replace(
+            emitted.replace("arith.mulf", "arith.addf").replace(
                 "@ktir_fused_mul_0", "@ktir_fused_add_0"
             ),
             self.EXPECTED_ADD_KTIR,
@@ -165,11 +170,19 @@ module {
     %6 = ktdp.construct_access_tile %1[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
     %7 = ktdp.load %6 : <16x512x64xindex> -> tensor<16x512x64xf16>
     %8 = tensor.empty() : tensor<16x512x64xf16>
-    %9 = linalg.add ins(%5, %7 : tensor<16x512x64xf16>, tensor<16x512x64xf16>) outs(%8 : tensor<16x512x64xf16>) -> tensor<16x512x64xf16>
+    %9 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%5, %7 : tensor<16x512x64xf16>, tensor<16x512x64xf16>) outs(%8 : tensor<16x512x64xf16>) {
+    ^bb0(%in: f16, %in_0: f16, %out: f16):
+      %15 = arith.addf %in, %in_0 : f16
+      linalg.yield %15 : f16
+    } -> tensor<16x512x64xf16>
     %10 = ktdp.construct_access_tile %2[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
     %11 = ktdp.load %10 : <16x512x64xindex> -> tensor<16x512x64xf16>
     %12 = tensor.empty() : tensor<16x512x64xf16>
-    %13 = linalg.mul ins(%9, %11 : tensor<16x512x64xf16>, tensor<16x512x64xf16>) outs(%12 : tensor<16x512x64xf16>) -> tensor<16x512x64xf16>
+    %13 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%9, %11 : tensor<16x512x64xf16>, tensor<16x512x64xf16>) outs(%12 : tensor<16x512x64xf16>) {
+    ^bb0(%in: f16, %in_0: f16, %out: f16):
+      %15 = arith.mulf %in, %in_0 : f16
+      linalg.yield %15 : f16
+    } -> tensor<16x512x64xf16>
     %14 = ktdp.construct_access_tile %3[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
     ktdp.store %13, %14 : tensor<16x512x64xf16>, <16x512x64xindex>
     return
@@ -200,9 +213,12 @@ module {
         self.assertEqual(emitted.count("ktdp.load"), 3)  # a, b, c -- not buf0
         self.assertEqual(emitted.count("ktdp.store"), 1)  # buf1 only
         self.assertEqual(emitted.count("ktdp.construct_memory_view"), 4)
-        [add] = [ln for ln in emitted.splitlines() if "linalg.add ins(" in ln]
-        [mul] = [ln for ln in emitted.splitlines() if "linalg.mul ins(" in ln]
-        self.assertIn(f"ins({add.split('=')[0].strip()},", mul)
+        # The threading itself: the second generic's first operand is the first
+        # generic's result, so buf0 never becomes a view or a load.
+        generics = [ln for ln in emitted.splitlines() if "linalg.generic" in ln]
+        self.assertEqual(len(generics), 2)
+        threaded = generics[0].split("=")[0].strip()
+        self.assertIn(f"ins({threaded},", generics[1])
 
 
 @unittest.skipUnless(
@@ -238,7 +254,11 @@ module {
     %8 = ktdp.construct_access_tile %2[%c0, %7, %c0] {access_tile_order = #map, access_tile_set = #set1} : memref<16x512x64xf16> -> !ktdp.access_tile<16x16x64xindex>
     %9 = ktdp.load %8 : <16x16x64xindex> -> tensor<16x16x64xf16>
     %10 = tensor.empty() : tensor<16x16x64xf16>
-    %11 = linalg.add ins(%6, %9 : tensor<16x16x64xf16>, tensor<16x16x64xf16>) outs(%10 : tensor<16x16x64xf16>) -> tensor<16x16x64xf16>
+    %11 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%6, %9 : tensor<16x16x64xf16>, tensor<16x16x64xf16>) outs(%10 : tensor<16x16x64xf16>) {
+    ^bb0(%in: f16, %in_2: f16, %out: f16):
+      %14 = arith.addf %in, %in_2 : f16
+      linalg.yield %14 : f16
+    } -> tensor<16x16x64xf16>
     %c16_1 = arith.constant 16 : index
     %12 = arith.muli %0, %c16_1 : index
     %13 = ktdp.construct_access_tile %3[%c0, %12, %c0] {access_tile_order = #map, access_tile_set = #set1} : memref<16x512x64xf16> -> !ktdp.access_tile<16x16x64xindex>
@@ -404,7 +424,11 @@ module {
         %5 = ktdp.construct_access_tile %1[%arg3, %arg4, %c0] {access_tile_order = #map, access_tile_set = #set1} : memref<2x256x64xf16> -> !ktdp.access_tile<1x1x64xindex>
         %6 = ktdp.load %5 : <1x1x64xindex> -> tensor<1x1x64xf16>
         %7 = tensor.empty() : tensor<1x1x64xf16>
-        %8 = linalg.add ins(%4, %6 : tensor<1x1x64xf16>, tensor<1x1x64xf16>) outs(%7 : tensor<1x1x64xf16>) -> tensor<1x1x64xf16>
+        %8 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%4, %6 : tensor<1x1x64xf16>, tensor<1x1x64xf16>) outs(%7 : tensor<1x1x64xf16>) {
+        ^bb0(%in: f16, %in_3: f16, %out: f16):
+          %10 = arith.addf %in, %in_3 : f16
+          linalg.yield %10 : f16
+        } -> tensor<1x1x64xf16>
         %9 = ktdp.construct_access_tile %2[%arg3, %arg4, %c0] {access_tile_order = #map, access_tile_set = #set1} : memref<2x256x64xf16> -> !ktdp.access_tile<1x1x64xindex>
         ktdp.store %8, %9 : tensor<1x1x64xf16>, <1x1x64xindex>
       }

--- a/tests/inductor/test_ktir_emitter.py
+++ b/tests/inductor/test_ktir_emitter.py
@@ -499,10 +499,11 @@ module {
 class TestOpaqueEmission(unittest.TestCase):
     """A unary ``spyreop`` intrinsic (``sqrt``) over the whole [16, 512, 64] tile.
 
-    The one emission shape the ``OPAQUE`` family adds is a ``linalg.generic``
-    whose body is a single ``spyreop`` scalar op: identity ``indexing_maps``,
-    all-``parallel`` iterators, and a ``^bb0`` that applies the intrinsic and
-    ``linalg.yield``s it.  The intrinsic owns its own f16->f32->approx->f16, so
+    A ``spyreop`` intrinsic emits the same one pointwise shape as every other
+    pointwise op: a ``linalg.generic`` whose body is a single ``spyreop`` scalar
+    op (the payload), with identity ``indexing_maps``, all-``parallel``
+    iterators, and a ``^bb0`` that applies the intrinsic and ``linalg.yield``s
+    it.  The intrinsic owns its own f16->f32->approx->f16, so
     there is no fp32 precision bracket (dataflow-scheduler#36).  The dataflow
     either side of the compute -- view, tile, load, store -- is exactly the
     pointwise form; only the compute lines differ from ``EXPECTED_ADD_KTIR``.

--- a/tests/inductor/test_ktir_emitter.py
+++ b/tests/inductor/test_ktir_emitter.py
@@ -58,9 +58,9 @@ class TestKtirEmitter(unittest.TestCase):
 module {
   func.func @ktir_fused_add_0(%arg0: index, %arg1: index, %arg2: index) attributes {grid = [1]} {
     %c0 = arith.constant 0 : index
-    %0 = ktdp.construct_memory_view %arg0, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
-    %1 = ktdp.construct_memory_view %arg1, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
-    %2 = ktdp.construct_memory_view %arg2, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %0 = ktdp.construct_memory_view %arg0, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.memory_space<global>} : memref<16x512x64xf16>
+    %1 = ktdp.construct_memory_view %arg1, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.memory_space<global>} : memref<16x512x64xf16>
+    %2 = ktdp.construct_memory_view %arg2, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.memory_space<global>} : memref<16x512x64xf16>
     %3 = ktdp.construct_access_tile %0[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
     %4 = ktdp.load %3 : <16x512x64xindex> -> tensor<16x512x64xf16>
     %5 = ktdp.construct_access_tile %1[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
@@ -156,10 +156,10 @@ class TestInternalBufferIsThreaded(unittest.TestCase):
 module {
   func.func @ktir_fused_add_mul_0(%arg0: index, %arg1: index, %arg2: index, %arg3: index) attributes {grid = [1]} {
     %c0 = arith.constant 0 : index
-    %0 = ktdp.construct_memory_view %arg0, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
-    %1 = ktdp.construct_memory_view %arg1, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
-    %2 = ktdp.construct_memory_view %arg2, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
-    %3 = ktdp.construct_memory_view %arg3, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %0 = ktdp.construct_memory_view %arg0, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.memory_space<global>} : memref<16x512x64xf16>
+    %1 = ktdp.construct_memory_view %arg1, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.memory_space<global>} : memref<16x512x64xf16>
+    %2 = ktdp.construct_memory_view %arg2, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.memory_space<global>} : memref<16x512x64xf16>
+    %3 = ktdp.construct_memory_view %arg3, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.memory_space<global>} : memref<16x512x64xf16>
     %4 = ktdp.construct_access_tile %0[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
     %5 = ktdp.load %4 : <16x512x64xindex> -> tensor<16x512x64xf16>
     %6 = ktdp.construct_access_tile %1[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
@@ -226,9 +226,9 @@ module {
   func.func @ktir_fused_add_0(%arg0: index, %arg1: index, %arg2: index) attributes {grid = [32]} {
     %c0 = arith.constant 0 : index
     %0 = ktdp.get_compute_tile_id : index
-    %1 = ktdp.construct_memory_view %arg0, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
-    %2 = ktdp.construct_memory_view %arg1, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
-    %3 = ktdp.construct_memory_view %arg2, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %1 = ktdp.construct_memory_view %arg0, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.memory_space<global>} : memref<16x512x64xf16>
+    %2 = ktdp.construct_memory_view %arg1, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.memory_space<global>} : memref<16x512x64xf16>
+    %3 = ktdp.construct_memory_view %arg2, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.memory_space<global>} : memref<16x512x64xf16>
     %c16 = arith.constant 16 : index
     %4 = arith.muli %0, %c16 : index
     %5 = ktdp.construct_access_tile %1[%c0, %4, %c0] {access_tile_order = #map, access_tile_set = #set1} : memref<16x512x64xf16> -> !ktdp.access_tile<16x16x64xindex>
@@ -309,8 +309,8 @@ module {
   func.func @ktir_sum_0(%arg0: index, %arg1: index) attributes {grid = [32]} {
     %c0 = arith.constant 0 : index
     %0 = ktdp.get_compute_tile_id : index
-    %1 = ktdp.construct_memory_view %arg0, sizes: [32, 256, 64], strides: [16384, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<32x256x64xf16>
-    %2 = ktdp.construct_memory_view %arg1, sizes: [32, 64], strides: [64, 1] {coordinate_set = #set1, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<32x64xf16>
+    %1 = ktdp.construct_memory_view %arg0, sizes: [32, 256, 64], strides: [16384, 64, 1] {coordinate_set = #set, memory_space = #ktdp.memory_space<global>} : memref<32x256x64xf16>
+    %2 = ktdp.construct_memory_view %arg1, sizes: [32, 64], strides: [64, 1] {coordinate_set = #set1, memory_space = #ktdp.memory_space<global>} : memref<32x64xf16>
     %3 = ktdp.construct_access_tile %1[%0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set2} : memref<32x256x64xf16> -> !ktdp.access_tile<1x256x64xindex>
     %4 = ktdp.load %3 : <1x256x64xindex> -> tensor<1x256x64xf16>
     %5 = tensor.empty() : tensor<1x64xf16>
@@ -388,9 +388,9 @@ class TestTiledLoopEmission(unittest.TestCase):
 module {
   func.func @ktir_tiled_add_0(%arg0: index, %arg1: index, %arg2: index) attributes {grid = [1]} {
     %c0 = arith.constant 0 : index
-    %0 = ktdp.construct_memory_view %arg0, sizes: [2, 256, 64], strides: [16384, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<2x256x64xf16>
-    %1 = ktdp.construct_memory_view %arg1, sizes: [2, 256, 64], strides: [16384, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<2x256x64xf16>
-    %2 = ktdp.construct_memory_view %arg2, sizes: [2, 256, 64], strides: [16384, 64, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<2x256x64xf16>
+    %0 = ktdp.construct_memory_view %arg0, sizes: [2, 256, 64], strides: [16384, 64, 1] {coordinate_set = #set, memory_space = #ktdp.memory_space<global>} : memref<2x256x64xf16>
+    %1 = ktdp.construct_memory_view %arg1, sizes: [2, 256, 64], strides: [16384, 64, 1] {coordinate_set = #set, memory_space = #ktdp.memory_space<global>} : memref<2x256x64xf16>
+    %2 = ktdp.construct_memory_view %arg2, sizes: [2, 256, 64], strides: [16384, 64, 1] {coordinate_set = #set, memory_space = #ktdp.memory_space<global>} : memref<2x256x64xf16>
     %c0_0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c2 = arith.constant 2 : index

--- a/tests/inductor/test_ktir_emitter.py
+++ b/tests/inductor/test_ktir_emitter.py
@@ -468,5 +468,105 @@ module {
         self.assertEqual(emitted, self.EXPECTED_TILED_ADD_KTIR)
 
 
+@unittest.skipUnless(
+    _mlir_ktdp_available(),
+    "mlir_ktdp with the func/arith/linalg/scf/tensor dialect bindings is not installed",
+)
+class TestOpaqueEmission(unittest.TestCase):
+    """A unary ``spyreop`` intrinsic (``sqrt``) over the whole [16, 512, 64] tile.
+
+    The one emission shape the ``OPAQUE`` family adds is a ``linalg.generic``
+    whose body is a single ``spyreop`` scalar op: identity ``indexing_maps``,
+    all-``parallel`` iterators, and a ``^bb0`` that applies the intrinsic and
+    ``linalg.yield``s it.  The intrinsic owns its own f16->f32->approx->f16, so
+    there is no fp32 precision bracket (dataflow-scheduler#36).  The dataflow
+    either side of the compute -- view, tile, load, store -- is exactly the
+    pointwise form; only the compute lines differ from ``EXPECTED_ADD_KTIR``.
+    """
+
+    EXPECTED_SQRT_KTIR = """\
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#set = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 15 >= 0, d1 >= 0, -d1 + 511 >= 0, d2 >= 0, -d2 + 63 >= 0)>
+module {
+  func.func @ktir_fused_sqrt_0(%arg0: index, %arg1: index) attributes {grid = [1]} {
+    %c0 = arith.constant 0 : index
+    %0 = ktdp.construct_memory_view %arg0, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.memory_space<global>} : memref<16x512x64xf16>
+    %1 = ktdp.construct_memory_view %arg1, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.memory_space<global>} : memref<16x512x64xf16>
+    %2 = ktdp.construct_access_tile %0[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    %3 = ktdp.load %2 : <16x512x64xindex> -> tensor<16x512x64xf16>
+    %4 = tensor.empty() : tensor<16x512x64xf16>
+    %5 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%3 : tensor<16x512x64xf16>) outs(%4 : tensor<16x512x64xf16>) {
+    ^bb0(%in: f16, %out: f16):
+      %7 = spyreop.sqrt %in : f16
+      linalg.yield %7 : f16
+    } -> tensor<16x512x64xf16>
+    %6 = ktdp.construct_access_tile %1[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    ktdp.store %5, %6 : tensor<16x512x64xf16>, <16x512x64xindex>
+    return
+  }
+}
+"""
+
+    def test_sqrt_golden(self):
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        emitted = generate_ktir("ktir_fused_sqrt_0", [make_op_spec("sqrt", inputs=1)])
+        self.assertEqual(emitted, self.EXPECTED_SQRT_KTIR)
+
+    def test_the_generic_body_is_a_single_spyreop(self):
+        """The body is one ``spyreop`` op with no fp32 bracket: the ``linalg.generic``
+        walks all-parallel, the op takes and yields the tile's own f16, and no
+        ``arith.extf``/``truncf`` widen/narrow appears."""
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        emitted = generate_ktir("ktir_fused_sqrt_0", [make_op_spec("sqrt", inputs=1)])
+        self.assertIn('iterator_types = ["parallel", "parallel", "parallel"]', emitted)
+        self.assertIn("spyreop.sqrt %in : f16", emitted)
+        self.assertIn("linalg.yield", emitted)
+        # No fp32 precision bracket: the intrinsic owns its own precision.
+        self.assertNotIn("arith.extf", emitted)
+        self.assertNotIn("arith.truncf", emitted)
+
+    def test_each_intrinsic_reaches_its_own_binding(self):
+        """A second intrinsic costs one recipe: same generic shape, different
+        ``spyreop`` op.  Asserted against ``sqrt`` so only the op name differs."""
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        emitted = generate_ktir("ktir_fused_exp_0", [make_op_spec("exp", inputs=1)])
+        self.assertIn("spyreop.exp %in : f16", emitted)
+        self.assertNotIn("spyreop.sqrt", emitted)
+        self.assertEqual(
+            emitted.replace("spyreop.exp", "spyreop.sqrt").replace(
+                "@ktir_fused_exp_0", "@ktir_fused_sqrt_0"
+            ),
+            self.EXPECTED_SQRT_KTIR,
+        )
+
+    def test_softplus_carries_its_beta_and_threshold(self):
+        """An intrinsic with scalar attributes: softplus reads ``beta``/
+        ``threshold`` from ``op_info["constants"]`` and prints them on the op,
+        the generic scaffold otherwise identical to the attribute-free case."""
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        spec = make_op_spec(
+            "softplus",
+            inputs=1,
+            op_info={"constants": {"softplusBeta": 1.0, "softplusThresh": 20.0}},
+        )
+        emitted = generate_ktir("ktir_fused_softplus_0", [spec])
+        self.assertIn(
+            "spyreop.softplus %in beta 1.000000e+00 threshold 2.000000e+01 : f16",
+            emitted,
+        )
+        # Same scaffold as the attribute-free intrinsics: only the op line differs.
+        self.assertEqual(
+            emitted.replace(
+                "spyreop.softplus %in beta 1.000000e+00 threshold 2.000000e+01 : f16",
+                "spyreop.sqrt %in : f16",
+            ).replace("@ktir_fused_softplus_0", "@ktir_fused_sqrt_0"),
+            self.EXPECTED_SQRT_KTIR,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_ktir_validate.py
+++ b/tests/inductor/test_ktir_validate.py
@@ -82,6 +82,7 @@ def make_op_spec(
     tiled: list | None = None,
     trips: dict | None = None,
     first_arg_index: int = 0,
+    op_info: dict | None = None,
 ) -> OpSpec:
     """A finished ``OpSpec``, defaulting to ``a + b`` at [16, 512, 64] fp16.
 
@@ -104,6 +105,8 @@ def make_op_spec(
       ``space`` replaces the iteration space outright (``{}`` for a tiled op).
     * ``tiled`` / ``trips`` are the loop-level symbols and trip counts, and
       ``first_arg_index`` continues the numbering for a second op in one kernel.
+    * ``op_info`` is the op's auxiliary dict (softplus's beta/threshold live in
+      ``op_info["constants"]``); it defaults to empty.
     """
     if allocations and baked:
         raise ValueError("make_op_spec: pass allocations= or baked=, not both")
@@ -156,7 +159,7 @@ def make_op_spec(
         is_reduction=is_reduction,
         iteration_space=space,
         args=args,
-        op_info={},
+        op_info=op_info or {},
         tiled_symbols=tiled or [],
         tiled_symbol_trip_counts=trips or {},
     )

--- a/torch_spyre/_inductor/codegen/ktir.py
+++ b/torch_spyre/_inductor/codegen/ktir.py
@@ -1161,26 +1161,22 @@ class Family(enum.Enum):
 
     ELEMENTWISE = enum.auto()
     REDUCTION = enum.auto()
-    OPAQUE = enum.auto()
 
     @classmethod
     def of(cls, spec: OpSpec) -> Family:
-        """The family ``spec`` asks for.
+        """The family ``spec`` asks for, read from the spec and nothing else.
 
-        The reduction-vs-pointwise choice is the spec's, read from
-        ``is_reduction`` rather than the op name: the same binding (``arith.addf``)
-        is a pointwise ``add`` or the combiner of a ``sum``.  Within the pointwise
-        shapes, ELEMENTWISE (a ``linalg`` named op) vs OPAQUE (a ``linalg.generic``
-        whose body is a single ``spyreop`` scalar intrinsic) is instead a property
-        of the op -- ``sqrt`` is never anything but opaque -- so it is read from
-        the recipe.
+        The choice is reduction-vs-pointwise, and it is the spec's, taken from
+        ``is_reduction`` rather than from the op name: one binding
+        (``arith.addf``) is a pointwise ``add`` or the combiner of a ``sum``.
+
+        *How* to build the payload is not a second family: every op's payload is
+        a scalar builder that goes in a region, so ``linalg.add`` and
+        ``spyreop.sqrt`` reach the same emission.  That keeps this a pure
+        function of the spec, which is what lets the recipe-vs-spec check in
+        ``_compute_step`` mean something.
         """
-        if spec.is_reduction:
-            return cls.REDUCTION
-        recipe = KtirBuilder.RECIPES.get(spec.op)
-        if recipe is not None and recipe.family is cls.OPAQUE:
-            return cls.OPAQUE
-        return cls.ELEMENTWISE
+        return cls.REDUCTION if spec.is_reduction else cls.ELEMENTWISE
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1580,34 +1576,40 @@ class KtirBuilder:
     #
     # A repeated key here is ruff F601, so an op cannot be declared twice.
     RECIPES: ClassVar[dict[str, Recipe]] = {
-        "add": Recipe(arity=2, family=Family.ELEMENTWISE, binding=lambda: linalg.add),
-        "mul": Recipe(arity=2, family=Family.ELEMENTWISE, binding=lambda: linalg.mul),
+        # Every binding is a *scalar* builder: what goes in the payload region,
+        # not a whole-op builder.  ``arith.addf`` is the pointwise add's payload
+        # and the sum's combiner -- the same function in both families.
+        "add": Recipe(arity=2, family=Family.ELEMENTWISE, binding=lambda: arith.addf),
+        "mul": Recipe(arity=2, family=Family.ELEMENTWISE, binding=lambda: arith.mulf),
         "sum": Recipe(arity=1, family=Family.REDUCTION, binding=lambda: arith.addf),
-        # Opaque unary ops: each maps directly to one ``spyreop`` scalar
-        # intrinsic, emitted as the body of a ``linalg.generic`` (see ``opaque``).
-        # The intrinsic owns its own f16->f32->approx->f16, so there is no fp32
-        # bracket.  Only the unary ``spyreop`` float ops live here; the
+        # Unary ops whose payload is one ``spyreop`` scalar intrinsic rather than
+        # an ``arith`` op.  That is the only difference from ``add``/``mul``: same
+        # family, same emission, different payload builder.  The intrinsic owns
+        # its own f16->f32->approx->f16, so there is no fp32 bracket.  The
         # pointwise-handler name is the key, the ``spyreop`` op the binding (they
         # differ for ``gelufwd`` -> ``spyreop.gelu``).  ``softplus`` also carries
-        # two scalar attributes, read from its ``op_info`` by ``attrs``.  Binary
-        # ops (realdiv) do not fit this unary shape yet, and ops with no
-        # ``spyreop`` equivalent (log, rsqrt, tanh, erf, silu, relufwd) are not
+        # two scalar attributes, read from its ``op_info`` by ``attrs``.  Ops with
+        # no ``spyreop`` equivalent (log, rsqrt, tanh, erf, silu, relufwd) are not
         # supported on this path.
-        "exp": Recipe(arity=1, family=Family.OPAQUE, binding=lambda: spyreop.exp),
-        "sqrt": Recipe(arity=1, family=Family.OPAQUE, binding=lambda: spyreop.sqrt),
+        "exp": Recipe(arity=1, family=Family.ELEMENTWISE, binding=lambda: spyreop.exp),
+        "sqrt": Recipe(
+            arity=1, family=Family.ELEMENTWISE, binding=lambda: spyreop.sqrt
+        ),
         "sigmoid": Recipe(
-            arity=1, family=Family.OPAQUE, binding=lambda: spyreop.sigmoid
+            arity=1, family=Family.ELEMENTWISE, binding=lambda: spyreop.sigmoid
         ),
         "reciprocal": Recipe(
-            arity=1, family=Family.OPAQUE, binding=lambda: spyreop.reciprocal
+            arity=1, family=Family.ELEMENTWISE, binding=lambda: spyreop.reciprocal
         ),
-        "gelufwd": Recipe(arity=1, family=Family.OPAQUE, binding=lambda: spyreop.gelu),
+        "gelufwd": Recipe(
+            arity=1, family=Family.ELEMENTWISE, binding=lambda: spyreop.gelu
+        ),
         "layernormscale": Recipe(
-            arity=1, family=Family.OPAQUE, binding=lambda: spyreop.layernormscale
+            arity=1, family=Family.ELEMENTWISE, binding=lambda: spyreop.layernormscale
         ),
         "softplus": Recipe(
             arity=1,
-            family=Family.OPAQUE,
+            family=Family.ELEMENTWISE,
             binding=lambda: spyreop.softplus,
             attrs=lambda info: {
                 "beta": float(info["constants"]["softplusBeta"]),
@@ -1617,64 +1619,51 @@ class KtirBuilder:
     }
 
     def elementwise(self, recipe: Recipe, ins: Sequence, step: ComputeStep):
-        """Apply ``recipe``'s builder to ``ins``, shaped by the result's tile.
+        """``recipe``'s scalar payload in an all-parallel ``linalg.generic``.
 
-        Returns the result value; what becomes of it is the caller's decision.
-        Every operand and the result share the result tile's extents.
+        One shape for every pointwise op, whatever its payload is: identity
+        ``indexing_maps`` and ``"parallel"`` iterators, so the generic walks every
+        element once and the body computes one output element from one element of
+        each operand.  Every operand and the result share the result tile's
+        extents and element type.
 
-        The destination is an uninitialised ``tensor.empty``, valid because an
-        elementwise op writes every element of it.
-        """
-        extents = list(step.out.extent)
-        elt_t = self.named_type(step.out.elems.value)
-        dest = self.val(tensor.EmptyOp(extents, elt_t))
-        return recipe.binding()(
-            *ins,
-            outs=[dest],
-            result_tensors=[ir.RankedTensorType.get(extents, elt_t)],
-        )
+        A ``linalg`` named op is not used even where one exists (``linalg.add``),
+        because the consumer generalizes named ops to exactly this form anyway --
+        ``ConstructThreeStagePipeline`` runs ``mlir::linalg::generalizeNamedOp``
+        over them -- and emitting it directly is byte-for-byte identical in the
+        compiled binary.  One shape means an op that has no named equivalent
+        (``spyreop.sqrt``) is not a second emission path, only a second payload.
 
-    def opaque(self, recipe: Recipe, ins: Sequence, step: ComputeStep):
-        """A unary ``spyreop`` scalar intrinsic as a ``linalg.generic`` body.
-
-        The op maps to one ``spyreop`` intrinsic (``recipe.binding()``), emitted
-        as the single-op body of an all-parallel ``linalg.generic`` over the
-        result tile: identity ``indexing_maps`` and ``"parallel"`` iterators, so
-        the generic walks every element once and the body computes one output
-        from one input.  The intrinsic owns its own f16->f32->approx->f16, so
-        there is no fp32 precision bracket (dataflow-scheduler#36); the operand,
-        the body value and the result all share the result tile's element type
-        and extents.
-
-        Any scalar attributes the intrinsic takes beyond its operand
-        (softplus's ``beta``/``threshold``) ride on ``step.attrs``, read from the
-        spec's ``op_info`` when the step was planned, and are passed through as
-        keyword arguments to the builder.
+        Any scalar attributes the payload takes beyond its operands (softplus's
+        ``beta``/``threshold``) ride on ``step.attrs``, read from the spec's
+        ``op_info`` when the step was planned, and are passed through as keyword
+        arguments.
 
         The destination is an uninitialised ``tensor.empty``, valid because the
-        generic writes every element of it (the mirror of ``elementwise``).
+        generic writes every element of it.  Returns the result value; what
+        becomes of it is the caller's decision.
         """
-        [source] = ins
         extents = list(step.out.extent)
         elt_t = self.named_type(step.out.elems.value)
         dest = self.val(tensor.EmptyOp(extents, elt_t))
         identity = ir.AffineMap.get_identity(len(extents))
-        intrinsic = recipe.binding()
+        payload = recipe.binding()
         attrs = dict(step.attrs)
+        arity = len(ins)
 
         # ``linalg.generic`` is a region op: the decorated function's return is
-        # yielded as the body terminator, and the block arguments (one per input,
-        # one per output; ``out`` is the unwritten accumulator) arrive
-        # positionally.  The decorator evaluates here and binds the op's single
-        # result value to ``body``.
+        # yielded as the body terminator, and the block arguments arrive
+        # positionally -- one per input, then the output (the unwritten
+        # accumulator, which a pointwise body ignores).  The decorator evaluates
+        # here and binds the op's single result value to ``body``.
         @linalg.generic(
-            inputs=[source],
+            inputs=list(ins),
             outputs=[dest],
-            indexing_maps=[identity, identity],
+            indexing_maps=[identity] * (arity + 1),
             iterator_types=["parallel"] * len(extents),
         )
-        def body(in_, out_):
-            return intrinsic(in_, **attrs)
+        def body(*args):
+            return payload(*args[:arity], **attrs)
 
         return body
 

--- a/torch_spyre/_inductor/codegen/ktir.py
+++ b/torch_spyre/_inductor/codegen/ktir.py
@@ -1440,10 +1440,16 @@ class KtirBuilder:
         sizes = [int(e) for e in buffer.layout.extent]
         strides = [int(s) for s in buffer.layout.strides]
         memref_t = ir.MemRefType.get(sizes, self.named_type(buffer.elems.storage))
-        # No Python builder is exposed for the ``spyre_memory_space`` enum
-        # attribute (only the ktdp *types* have getters), so this small enum
-        # literal is the one unavoidable textual attribute.
-        memory_space = ir.Attribute.parse(f"#ktdp.spyre_memory_space<{buffer.space}>")
+        # The dialect names memory spaces in its own data-parallel vocabulary:
+        # ``global`` (visible to every compute tile) and ``ct_local`` (one
+        # tile's scratchpad).  This emitter only builds HBM views today (LX /
+        # hbm_pool are rejected in ``_buffer``), which are ``global``.  No
+        # Python builder is exposed for the enum attribute (only the ktdp
+        # *types* have getters), so this small enum literal is textual; the
+        # mapping raises loudly if a space it does not translate ever reaches
+        # here.
+        kind = {"HBM": "global"}[buffer.space]
+        memory_space = ir.Attribute.parse(f"#ktdp.memory_space<{kind}>")
         return self.val(
             ktdp.construct_memory_view(
                 result=memref_t,

--- a/torch_spyre/_inductor/codegen/ktir.py
+++ b/torch_spyre/_inductor/codegen/ktir.py
@@ -78,14 +78,14 @@ from torch_spyre._inductor.pass_utils import coeff_through_floor
 # this module requires no dialect build.
 if TYPE_CHECKING:
     from mlir_ktdp import ir
-    from mlir_ktdp.dialects import arith, func, ktdp, linalg, scf, tensor
+    from mlir_ktdp.dialects import arith, func, ktdp, linalg, scf, spyreop, tensor
 else:
-    ir = arith = func = ktdp = linalg = scf = tensor = None
+    ir = arith = func = ktdp = linalg = scf = spyreop = tensor = None
 
 
 def _load_dialects() -> None:
     """Bind the dialect handles into this module, once.  The only import site."""
-    global ir, arith, func, ktdp, linalg, scf, tensor
+    global ir, arith, func, ktdp, linalg, scf, spyreop, tensor
     if ir is not None:
         return
     from mlir_ktdp import ir as _ir
@@ -94,15 +94,17 @@ def _load_dialects() -> None:
     from mlir_ktdp.dialects import ktdp as _ktdp
     from mlir_ktdp.dialects import linalg as _linalg
     from mlir_ktdp.dialects import scf as _scf
+    from mlir_ktdp.dialects import spyreop as _spyreop
     from mlir_ktdp.dialects import tensor as _tensor
 
-    ir, arith, func, ktdp, linalg, scf, tensor = (
+    ir, arith, func, ktdp, linalg, scf, spyreop, tensor = (
         _ir,
         _arith,
         _func,
         _ktdp,
         _linalg,
         _scf,
+        _spyreop,
         _tensor,
     )
 
@@ -312,6 +314,8 @@ class ComputeStep:
     ``store`` is ``False`` for an internal result, which is bound in scope for a
     later step instead of being stored through ``out``.  ``reduce_dims`` is the
     input tile axes a REDUCTION consumes, and empty for every other family.
+    ``attrs`` are scalar attributes the op's builder takes beyond its operands
+    (softplus's ``beta``/``threshold``), read once from the spec's ``op_info``.
     """
 
     op: str  # a KtirBuilder.RECIPES key
@@ -321,6 +325,7 @@ class ComputeStep:
     out_buf_id: str
     store: bool
     reduce_dims: tuple[int, ...] = ()
+    attrs: tuple[tuple[str, float], ...] = ()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1024,6 +1029,13 @@ class KernelPlan:
                     "same elements; dividing the within-stick axis or a reduced "
                     "axis (which needs a cross-core combine) reads like this"
                 )
+        # Scalar attributes the op's builder takes beyond its operands are read
+        # here, once, from the spec's ``op_info`` -- the same place-and-time
+        # discipline as ``reduce_dims`` -- so emission has nothing left to derive.
+        recipe = KtirBuilder.RECIPES[spec.op]
+        op_attrs: tuple[tuple[str, float], ...] = ()
+        if recipe.attrs is not None:
+            op_attrs = tuple(recipe.attrs(spec.op_info).items())
         return ComputeStep(
             op=spec.op,
             family=family,
@@ -1031,6 +1043,7 @@ class KernelPlan:
             out=accesses[buf_id(out)],
             out_buf_id=buf_id(out),
             reduce_dims=reduce_dims,
+            attrs=op_attrs,
             # An internal buffer never reaches memory: it is threaded as a value,
             # so it gets no store, no func parameter, no view and no address.
             store=not is_internal(out),
@@ -1148,12 +1161,26 @@ class Family(enum.Enum):
 
     ELEMENTWISE = enum.auto()
     REDUCTION = enum.auto()
+    OPAQUE = enum.auto()
 
     @classmethod
     def of(cls, spec: OpSpec) -> Family:
-        """The family ``spec`` asks for, read from the spec rather than the op
-        name: the same binding can be wanted in more than one shape."""
-        return cls.REDUCTION if spec.is_reduction else cls.ELEMENTWISE
+        """The family ``spec`` asks for.
+
+        The reduction-vs-pointwise choice is the spec's, read from
+        ``is_reduction`` rather than the op name: the same binding (``arith.addf``)
+        is a pointwise ``add`` or the combiner of a ``sum``.  Within the pointwise
+        shapes, ELEMENTWISE (a ``linalg`` named op) vs OPAQUE (a ``linalg.generic``
+        whose body is a single ``spyreop`` scalar intrinsic) is instead a property
+        of the op -- ``sqrt`` is never anything but opaque -- so it is read from
+        the recipe.
+        """
+        if spec.is_reduction:
+            return cls.REDUCTION
+        recipe = KtirBuilder.RECIPES.get(spec.op)
+        if recipe is not None and recipe.family is cls.OPAQUE:
+            return cls.OPAQUE
+        return cls.ELEMENTWISE
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1161,6 +1188,10 @@ class Recipe:
     arity: int
     family: Family
     binding: Callable[[], Any]
+    # How to read the op's scalar attributes from a spec's ``op_info``, for the
+    # few ops whose builder takes more than operands (softplus).  ``None`` when
+    # the op is a pure function of its operands, which is almost all of them.
+    attrs: Callable[[dict[str, Any]], dict[str, float]] | None = None
 
     def __post_init__(self) -> None:
         if self.arity < 1:
@@ -1552,6 +1583,37 @@ class KtirBuilder:
         "add": Recipe(arity=2, family=Family.ELEMENTWISE, binding=lambda: linalg.add),
         "mul": Recipe(arity=2, family=Family.ELEMENTWISE, binding=lambda: linalg.mul),
         "sum": Recipe(arity=1, family=Family.REDUCTION, binding=lambda: arith.addf),
+        # Opaque unary ops: each maps directly to one ``spyreop`` scalar
+        # intrinsic, emitted as the body of a ``linalg.generic`` (see ``opaque``).
+        # The intrinsic owns its own f16->f32->approx->f16, so there is no fp32
+        # bracket.  Only the unary ``spyreop`` float ops live here; the
+        # pointwise-handler name is the key, the ``spyreop`` op the binding (they
+        # differ for ``gelufwd`` -> ``spyreop.gelu``).  ``softplus`` also carries
+        # two scalar attributes, read from its ``op_info`` by ``attrs``.  Binary
+        # ops (realdiv) do not fit this unary shape yet, and ops with no
+        # ``spyreop`` equivalent (log, rsqrt, tanh, erf, silu, relufwd) are not
+        # supported on this path.
+        "exp": Recipe(arity=1, family=Family.OPAQUE, binding=lambda: spyreop.exp),
+        "sqrt": Recipe(arity=1, family=Family.OPAQUE, binding=lambda: spyreop.sqrt),
+        "sigmoid": Recipe(
+            arity=1, family=Family.OPAQUE, binding=lambda: spyreop.sigmoid
+        ),
+        "reciprocal": Recipe(
+            arity=1, family=Family.OPAQUE, binding=lambda: spyreop.reciprocal
+        ),
+        "gelufwd": Recipe(arity=1, family=Family.OPAQUE, binding=lambda: spyreop.gelu),
+        "layernormscale": Recipe(
+            arity=1, family=Family.OPAQUE, binding=lambda: spyreop.layernormscale
+        ),
+        "softplus": Recipe(
+            arity=1,
+            family=Family.OPAQUE,
+            binding=lambda: spyreop.softplus,
+            attrs=lambda info: {
+                "beta": float(info["constants"]["softplusBeta"]),
+                "threshold": float(info["constants"]["softplusThresh"]),
+            },
+        ),
     }
 
     def elementwise(self, recipe: Recipe, ins: Sequence, step: ComputeStep):
@@ -1571,6 +1633,50 @@ class KtirBuilder:
             outs=[dest],
             result_tensors=[ir.RankedTensorType.get(extents, elt_t)],
         )
+
+    def opaque(self, recipe: Recipe, ins: Sequence, step: ComputeStep):
+        """A unary ``spyreop`` scalar intrinsic as a ``linalg.generic`` body.
+
+        The op maps to one ``spyreop`` intrinsic (``recipe.binding()``), emitted
+        as the single-op body of an all-parallel ``linalg.generic`` over the
+        result tile: identity ``indexing_maps`` and ``"parallel"`` iterators, so
+        the generic walks every element once and the body computes one output
+        from one input.  The intrinsic owns its own f16->f32->approx->f16, so
+        there is no fp32 precision bracket (dataflow-scheduler#36); the operand,
+        the body value and the result all share the result tile's element type
+        and extents.
+
+        Any scalar attributes the intrinsic takes beyond its operand
+        (softplus's ``beta``/``threshold``) ride on ``step.attrs``, read from the
+        spec's ``op_info`` when the step was planned, and are passed through as
+        keyword arguments to the builder.
+
+        The destination is an uninitialised ``tensor.empty``, valid because the
+        generic writes every element of it (the mirror of ``elementwise``).
+        """
+        [source] = ins
+        extents = list(step.out.extent)
+        elt_t = self.named_type(step.out.elems.value)
+        dest = self.val(tensor.EmptyOp(extents, elt_t))
+        identity = ir.AffineMap.get_identity(len(extents))
+        intrinsic = recipe.binding()
+        attrs = dict(step.attrs)
+
+        # ``linalg.generic`` is a region op: the decorated function's return is
+        # yielded as the body terminator, and the block arguments (one per input,
+        # one per output; ``out`` is the unwritten accumulator) arrive
+        # positionally.  The decorator evaluates here and binds the op's single
+        # result value to ``body``.
+        @linalg.generic(
+            inputs=[source],
+            outputs=[dest],
+            indexing_maps=[identity, identity],
+            iterator_types=["parallel"] * len(extents),
+        )
+        def body(in_, out_):
+            return intrinsic(in_, **attrs)
+
+        return body
 
     def reduction(self, recipe: Recipe, ins: Sequence, step: ComputeStep):
         """``linalg.reduce`` over ``step.reduce_dims``, combining with ``recipe``.


### PR DESCRIPTION
This PR extends the OpSpec→KTIR emitter (`generate_ktir`, #3380) with the **opaque elementwise ops** item from the PR plan: the unary float ops that map to a single `spyreop`-dialect scalar intrinsic. It builds on the plan/emit architecture now on `main` (#3762 / #3763 / #3764) and stays emission-only — device execution is not part of this PR.

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds one new emission shape to `KtirBuilder` for opaque elementwise ops. An opaque op is emitted as a `linalg.generic` (identity indexing maps, all-`parallel` iterators) whose body is a single `spyreop` scalar intrinsic plus `linalg.yield`. The intrinsic takes `f16` directly and owns the f16→f32→approx→f16 conversion internally, so the body is one op with no cast bracket around it.

A new `Family.OPAQUE` selects this shape. `Family.of` keeps the reduction-vs-pointwise choice spec-driven (`is_reduction`), exactly as before; within the pointwise shapes, ELEMENTWISE (a `linalg` named op) vs OPAQUE (the `spyreop` body) is a property of the op, so it is read from the recipe. Adding each op is therefore one `RECIPES` entry bound to a `spyreop` builder, and the family is read from the recipe rather than a runtime switch — `spyreop` is the only way to emit an opaque op.

The ops covered are the unary float ops that have a `spyreop` intrinsic: `exp`, `sqrt`, `sigmoid`, `reciprocal`, `gelufwd` (→ `spyreop.gelu`), `layernormscale`, and `softplus`.

`softplus` carries two scalar attributes. A recipe may declare an `attrs` extractor that reads them from the spec's `op_info`; softplus pulls `beta`/`threshold` from `op_info["constants"]`. They are read once in `_compute_step` — the same place-and-time discipline as `reduce_dims` — onto the immutable `ComputeStep`, so emission derives nothing, and the op prints `spyreop.softplus %in beta ... threshold ... : f16`.

`realdiv` and the integer/address intrinsics do not fit the unary shape and are follow-ups.

Files changed:

- `_inductor/codegen/ktir.py` — the `spyreop` dialect handle; `Family.OPAQUE` and the op-aware `Family.of`; the `RECIPES` entries and the optional `Recipe.attrs` extractor; `ComputeStep.attrs`; and the `opaque()` emission method.
- `tests/inductor/test_ktir_emitter.py` — a full-text `sqrt` golden, an `exp` delta against it, an assertion that the generic body is a single `spyreop` op with no cast pair, and a softplus attrs check.
- `tests/inductor/test_ktir_validate.py` — `make_op_spec` gains an `op_info` parameter so the softplus attrs can be exercised.

#### Which issue(s) this PR is related to:

Related to #3380

#### Special notes for your reviewer:

- **Two commits.** `40de9d1` is a small base fix that changes the emitted memory-space spelling from `#ktdp.spyre_memory_space<HBM>` to `#ktdp.memory_space<global>` (the spelling the installed ktdp dialect accepts) and refreshes the existing goldens to match; it is orthogonal to the feature and can be dropped on rebase if the same rename lands on `main` first. `0ad76ba` is the opaque-op feature itself. Review them separately.
- **Gated and inert by default.** All behavior is behind `TORCH_SPYRE_KTIR=1`; with it unset the scheduler selects `sdsc` and this path is never reached.
- **Emission-only.** This PR pins the emitted MLIR with golden snapshot tests; the end-to-end test is not done yet. The emitted KTIR is correct but not yet schedulable: the installed `dbo-opt` does not register the `spyreop` dialect.
- **Tests:** `tests/inductor/test_ktir_emitter.py` (skips when `mlir_ktdp` is unavailable) pins the exact emitted MLIR for `sqrt` — load f16 → `linalg.generic` with a single `spyreop.sqrt %in : f16` body → store — asserts the body carries no `arith.extf`/`arith.truncf`, that a second op (`exp`) differs from it only in the intrinsic name, and that softplus carries its `beta`/`threshold`. The dataflow either side of the compute (view / tile / load / store) is the pointwise form, unchanged.

#### Does this PR introduce a user-facing change?

No new user-facing surface beyond the existing opt-in `TORCH_SPYRE_KTIR=1` path. It has no effect unless explicitly enabled, and does not yet execute on device.

#### Additional note:

Part of the ordered OpSpec→KTIR series (#3380): pointwise → fuse + work-division → dbo → ktir-cpu → loop → reduction → **opaque elementwise ops** → matmul → indirect access → dynamic symbols. Matmul and indirect access (both @tnakaike) follow this one.
