### PR TITLE
fix(ci): relabel old core/full/device_critical inductor configs to reachable tiers

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_cost_model_decode_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_cost_model_decode_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_cost_model_decode.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_cost_model_pass_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_cost_model_pass_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_cost_model_pass.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_hbm_pool_planning_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_hbm_pool_planning_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_hbm_pool_planning.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_kernel_provenance_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_kernel_provenance_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full]
+  labels: [unit, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_kernel_provenance.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_lx_extern_kernel_clobber.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_lx_extern_kernel_clobber.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [integration, regression, trunk]
+  labels: [unit, integration, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_lx_extern_kernel_clobber.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_lx_extern_kernel_clobber.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_lx_extern_kernel_clobber.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [integration, regression, trunk, device_critical]
+  labels: [integration, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_lx_extern_kernel_clobber.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_lx_extern_kernel_clobber.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_lx_extern_kernel_clobber.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [integration, regression, trunk, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_lx_extern_kernel_clobber.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_work_division_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_work_division_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [core, full, device_critical]
+  labels: [integration, regression, trunk, device_critical]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_work_division.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_work_division_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_work_division_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [integration, regression, trunk, device_critical]
+  labels: [integration, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_work_division.py
       unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_work_division_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_work_division_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
-  labels: [integration, regression, trunk]
+  labels: [unit, integration, regression, trunk]
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_work_division.py
       unlisted_test_mode: mandatory_success


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

**Problem:** 

 - Six inductor test configs were labeled `[core, full]`/`device_critical`, but no workflow caller ever passes those `test_type` values, so the configs were never selected by any PR, push, nightly, or integration run (#3856).

**Fix:** 

- Relabel the four pure-unit configs to `[unit, regression, trunk]` and the two `device_critical` configs (LX/scratchpad + work-division planning) to `[integration, regression, trunk]`, matching sibling inductor configs and the tiers `_test_matrix.yaml` actually runs.

#### Which issue(s) this PR is related to:

Fixes https://github.com/torch-spyre/torch-spyre/issues/3856