### PR TITLE
 feat(ci): retry failed test-matrix jobs on a fresh pod via workflow_run

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -341,6 +341,8 @@ jobs:
       !cancelled() &&
       (needs.build_torch_spyre.result == 'success' ||
        needs.build_torch_spyre.result == 'skipped')
+    # Don't let one failed suite fail this job -- test_result (below) decides pass/fail after test_retry gets a shot on a fresh pod, so a merge-queue entry isn't evicted before the retry runs.
+    continue-on-error: true
     runs-on:
       - x86_64
       - ${{ matrix.suite.runner || 'spyre_pf_x1' }}
@@ -456,6 +458,25 @@ jobs:
           path: ${{ env.REPORT_PATH }}
           if-no-files-found: warn
           retention-days: 10
+
+      # Records this leg's suite as a uniquely-named artifact so collect_failed_suites can rebuild a retry matrix without needing this job's own (continue-on-error-muddied) conclusion.
+      - name: Save suite descriptor for pod-level retry
+        if: failure()
+        shell: bash
+        run: |
+          mkdir -p "${RUNNER_TEMP}/failed_suite"
+          cat > "${RUNNER_TEMP}/failed_suite/suite.json" <<'JSONEOF'
+          ${{ toJSON(matrix.suite) }}
+          JSONEOF
+
+      - name: Upload failed-suite descriptor
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: failed-suite-${{ strategy.job-index }}
+          path: ${{ runner.temp }}/failed_suite/suite.json
+          if-no-files-found: error
+          retention-days: 1
 
   # ---------------------------------------------------------------------------
   # Job 1b: perf benchmark  (test_type=perf only, never per-PR)
@@ -641,6 +662,8 @@ jobs:
        needs.generate_matrix.outputs.resolved_test_type == 'suite_distributed') &&
       (needs.build_torch_spyre.result == 'success' ||
        needs.build_torch_spyre.result == 'skipped')
+    # See the `test` job above: continue-on-error keeps a single failed suite from prematurely failing the reusable workflow -- test_result decides pass/fail after the retry.
+    continue-on-error: true
     runs-on:
       - x86_64
       - spyre_pf_x2
@@ -752,6 +775,303 @@ jobs:
           if-no-files-found: warn
           retention-days: 10
 
+      # See the `test` job's identical step: lets collect_failed_suites rebuild a retry matrix without relying on this job's (continue-on-error-muddied) own conclusion.
+      - name: Save suite descriptor for pod-level retry
+        if: failure()
+        shell: bash
+        run: |
+          mkdir -p "${RUNNER_TEMP}/failed_suite"
+          cat > "${RUNNER_TEMP}/failed_suite/suite.json" <<'JSONEOF'
+          ${{ toJSON(matrix.suite) }}
+          JSONEOF
+
+      - name: Upload failed-suite descriptor
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: failed-suite-multi-${{ strategy.job-index }}
+          path: ${{ runner.temp }}/failed_suite/suite.json
+          if-no-files-found: error
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Job 2b: collect suites that need a pod-level retry -- reads the failed-suite-* / failed-suite-multi-* artifacts and rebuilds two retry matrices (generate_matrix's {"suite": [...]} shape) for test_retry / test_multi_spyre_retry below to consume via fromJSON.
+  # ---------------------------------------------------------------------------
+  collect_failed_suites:
+    name: Collect suites for pod-level retry
+    needs: [test, test_multi_spyre]
+    if: always()
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.collect.outputs.matrix }}
+      matrix_multi: ${{ steps.collect.outputs.matrix_multi }}
+      has_failed_single: ${{ steps.collect.outputs.has_failed_single }}
+      has_failed_multi: ${{ steps.collect.outputs.has_failed_multi }}
+    steps:
+      - name: Download failed-suite descriptors and build retry matrices
+        id: collect
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p failed_suites
+          ARTIFACTS=$(gh api \
+            "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+            --jq '[.artifacts[] | select(.name | startswith("failed-suite-")) | {id: .id, name: .name}]')
+
+          ARTIFACTS="$ARTIFACTS" python3 <<'PYEOF'
+          import json, os, subprocess
+          artifacts = json.loads(os.environ['ARTIFACTS'])
+          repo = "${{ github.repository }}"
+          for a in artifacts:
+              result = subprocess.run(
+                  ["gh", "api", f"/repos/{repo}/actions/artifacts/{a['id']}/zip"],
+                  capture_output=True, check=True,
+              )
+              out_dir = f"failed_suites/{a['name']}"
+              os.makedirs(out_dir, exist_ok=True)
+              zip_path = f"{out_dir}.zip"
+              with open(zip_path, "wb") as f:
+                  f.write(result.stdout)
+              subprocess.run(["unzip", "-q", "-o", zip_path, "-d", out_dir], check=True)
+          print(f"Downloaded {len(artifacts)} failed-suite descriptor(s).")
+          PYEOF
+
+          python3 <<'PYEOF'
+          import glob, json, os
+
+          def load(pattern):
+              suites = []
+              for path in sorted(glob.glob(pattern)):
+                  with open(path) as f:
+                      suites.append(json.load(f))
+              return suites
+
+          # "failed-suite-multi-N" (multi) vs "failed-suite-N" (single) -- the digit class keeps the single-card glob from also matching multi-card descriptors.
+          multi = load("failed_suites/failed-suite-multi-*/suite.json")
+          single = load("failed_suites/failed-suite-[0-9]*/suite.json")
+
+          print(f"Single-card suites to retry: {[s.get('name') for s in single]}")
+          print(f"Multi-card suites to retry : {[s.get('name') for s in multi]}")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"matrix={json.dumps({'suite': single})}\n")
+              f.write(f"matrix_multi={json.dumps({'suite': multi})}\n")
+              f.write(f"has_failed_single={'true' if single else 'false'}\n")
+              f.write(f"has_failed_multi={'true' if multi else 'false'}\n")
+          PYEOF
+
+  # ---------------------------------------------------------------------------
+  # Job 2c: single-card pod-level retry -- re-runs, on brand-new ARC pods, exactly the suites collect_failed_suites found failed; mirrors `test`'s steps. No further looping: a suite that fails again here is a genuine failure.
+  # ---------------------------------------------------------------------------
+  test_retry:
+    name: ${{ matrix.suite.name }} (pod-level retry)
+    needs: [generate_matrix, build_torch_spyre, collect_failed_suites]
+    if: >-
+      !cancelled() &&
+      needs.collect_failed_suites.outputs.has_failed_single == 'true' &&
+      (needs.build_torch_spyre.result == 'success' ||
+       needs.build_torch_spyre.result == 'skipped')
+    runs-on:
+      - x86_64
+      - ${{ matrix.suite.runner || 'spyre_pf_x1' }}
+      - ${{ inputs.runner_label }}
+      - ${{ inputs.image_label }}
+    timeout-minutes: 60
+    env:
+      CI: ''
+      TORCH_SPYRE_TEST_TYPE: ${{ needs.generate_matrix.outputs.resolved_test_type }}
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.collect_failed_suites.outputs.matrix) }}
+
+    steps:
+      - name: Checkout composite actions
+        if: ${{ !inputs.prebaked_image }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+
+      - name: Expose baked composite actions in the workspace
+        if: ${{ inputs.prebaked_image }}
+        run: ln -sfn "${PREBAKED_TORCH_SPYRE_DIR}/.github" "${GITHUB_WORKSPACE}/.github"
+
+      - if: ${{ !inputs.prebaked_image }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: torch-spyre
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
+          repository: ${{ inputs.repository || github.event.pull_request.head.repo.full_name || github.repository }}
+
+      - name: Check out pre-built PyTorch
+        if: ${{ inputs.checkout_pytorch }}
+        uses: ./.github/actions/checkout-pytorch
+
+      - uses: ./.github/actions/gather-runner-info
+        with:
+          verbose: 'true'
+          torch_spyre_dir: ${{ inputs.prebaked_image && env.PREBAKED_TORCH_SPYRE_DIR || 'torch-spyre' }}
+          runner_labels: ${{ format('["x86_64","{0}","{1}","{2}"]', matrix.suite.runner || 'spyre_pf_x1', inputs.runner_label, inputs.image_label) }}
+
+      - name: Install prebuilt torch-spyre
+        if: ${{ !inputs.prebaked_image && needs.build_torch_spyre.result == 'success' }}
+        uses: ./.github/actions/install-prebuilt-torch-spyre
+
+      - name: Derive report paths
+        run: |
+          CONFIG="${{ matrix.suite.config }}"
+          REPORT_NAME="$(basename "${CONFIG%.yaml}.xml")"
+          echo "REPORT_NAME=${REPORT_NAME}" >> "$GITHUB_ENV"
+          echo "REPORT_PATH=${GITHUB_WORKSPACE}/${REPORT_NAME}" >> "$GITHUB_ENV"
+
+      - name: Run ${{ matrix.suite.name }} tests (pod-level retry)
+        id: run_tests
+        uses: ./.github/actions/run-test-suite
+        with:
+          suite_name: ${{ matrix.suite.name }}
+          config: ${{ needs.generate_matrix.outputs.resolved_test_type == 'trunk' && format('tests/configs/{0}', matrix.suite.config) || format('tests/configs/torch_spyre_tests/{0}',
+            matrix.suite.config) }}
+          torch_spyre_dir: ${{ inputs.prebaked_image && env.PREBAKED_TORCH_SPYRE_DIR || 'torch-spyre' }}
+          venv_path: ${{ inputs.prebaked_image && env.PREBAKED_VENV_PATH || '.venv' }}
+          extra_test_flags: ${{ inputs.extra_test_flags }}
+          junit_xml_path: ${{ env.REPORT_PATH }}
+          report_name: ${{ env.REPORT_NAME }}
+          pre_run: |
+            set +u
+            unset _IBM_AIU_SETUP
+            rm -rf /tmp/etc/ibm/spyre/topo.json
+            source /etc/profile.d/ibm-aiu-setup.sh || exit 1
+
+      # overwrite: true replaces the failed first attempt's report (same REPORT_NAME) so downstream consumers see only the corrected result, not a name conflict.
+      - name: Upload JUnit XML report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ env.REPORT_NAME }}
+          path: ${{ env.REPORT_PATH }}
+          if-no-files-found: warn
+          retention-days: 10
+          overwrite: true
+
+  # ---------------------------------------------------------------------------
+  # Job 2d: multi-card pod-level retry -- mirrors test_multi_spyre.
+  # ---------------------------------------------------------------------------
+  test_multi_spyre_retry:
+    name: ${{ matrix.suite.name }} (pod-level retry)
+    needs: [generate_matrix, build_torch_spyre, collect_failed_suites]
+    if: >-
+      !cancelled() &&
+      needs.collect_failed_suites.outputs.has_failed_multi == 'true' &&
+      (needs.build_torch_spyre.result == 'success' ||
+       needs.build_torch_spyre.result == 'skipped')
+    runs-on:
+      - x86_64
+      - spyre_pf_x2
+      - ${{ inputs.runner_label }}
+      - ${{ inputs.image_label }}
+    timeout-minutes: 60
+    env:
+      CI: ''
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.collect_failed_suites.outputs.matrix_multi) }}
+
+    steps:
+      - name: Checkout composite actions
+        if: ${{ !inputs.prebaked_image }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+
+      - name: Expose baked composite actions in the workspace
+        if: ${{ inputs.prebaked_image }}
+        run: ln -sfn "${PREBAKED_TORCH_SPYRE_DIR}/.github" "${GITHUB_WORKSPACE}/.github"
+
+      - if: ${{ !inputs.prebaked_image }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: torch-spyre
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
+          repository: ${{ inputs.repository || github.event.pull_request.head.repo.full_name || github.repository }}
+
+      - name: Check out pre-built PyTorch
+        if: ${{ inputs.checkout_pytorch }}
+        uses: ./.github/actions/checkout-pytorch
+
+      - uses: ./.github/actions/gather-runner-info
+        with:
+          verbose: 'true'
+          torch_spyre_dir: ${{ inputs.prebaked_image && env.PREBAKED_TORCH_SPYRE_DIR || 'torch-spyre' }}
+          runner_labels: ${{ format('["x86_64","spyre_pf_x2","{0}","{1}"]', inputs.runner_label, inputs.image_label) }}
+
+      - name: Install prebuilt torch-spyre
+        if: ${{ !inputs.prebaked_image && needs.build_torch_spyre.result == 'success' }}
+        uses: ./.github/actions/install-prebuilt-torch-spyre
+
+      - name: Derive report paths
+        run: |
+          CONFIG="${{ matrix.suite.config }}"
+          REPORT_NAME="$(basename "${CONFIG%.yaml}.xml")"
+          echo "REPORT_NAME=${REPORT_NAME}" >> "$GITHUB_ENV"
+          echo "REPORT_PATH=${GITHUB_WORKSPACE}/${REPORT_NAME}" >> "$GITHUB_ENV"
+
+      - name: Run ${{ matrix.suite.name }} tests (pod-level retry)
+        uses: ./.github/actions/run-test-suite
+        with:
+          suite_name: ${{ matrix.suite.name }}
+          config: tests/configs/${{ matrix.suite.config }}
+          torch_spyre_dir: ${{ inputs.prebaked_image && env.PREBAKED_TORCH_SPYRE_DIR || 'torch-spyre' }}
+          venv_path: ${{ inputs.prebaked_image && env.PREBAKED_VENV_PATH || '.venv' }}
+          extra_test_flags: ${{ inputs.extra_test_flags_multi_spyre }}
+          parallel: 'false'
+          junit_xml_path: ${{ env.REPORT_PATH }}
+          report_name: ${{ env.REPORT_NAME }}
+          pre_run: |
+            set +u
+            unset _IBM_AIU_SETUP
+            rm -rf /tmp/etc/ibm/spyre/topo.json
+            source /etc/profile.d/ibm-aiu-setup.sh || exit 1
+
+      - name: Upload JUnit XML report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ env.REPORT_NAME }}
+          path: ${{ env.REPORT_PATH }}
+          if-no-files-found: warn
+          retention-days: 10
+          overwrite: true
+
+  # ---------------------------------------------------------------------------
+  # Job 2e: test matrix result -- the job that actually decides pass/fail for the reusable workflow (test/test_multi_spyre are continue-on-error, so this job's own conclusion is what needs.run-tests.result sees in tests.yml / tests-nightly.yml).
+  # ---------------------------------------------------------------------------
+  test_result:
+    name: Test matrix result
+    needs: [collect_failed_suites, test_retry, test_multi_spyre_retry]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate combined result
+        run: |
+          echo "Single-card suites retried : ${{ needs.collect_failed_suites.outputs.has_failed_single }}"
+          echo "Multi-card suites retried  : ${{ needs.collect_failed_suites.outputs.has_failed_multi }}"
+          echo "test_retry result          : ${{ needs.test_retry.result }}"
+          echo "test_multi_spyre_retry result : ${{ needs.test_multi_spyre_retry.result }}"
+
+          FAIL=0
+          if [[ "${{ needs.test_retry.result }}" == "failure" ]]; then
+            echo "::error::One or more single-card suites still failed after pod-level retry."
+            FAIL=1
+          fi
+          if [[ "${{ needs.test_multi_spyre_retry.result }}" == "failure" ]]; then
+            echo "::error::One or more multi-card suites still failed after pod-level retry."
+            FAIL=1
+          fi
+          exit "$FAIL"
+
   # ---------------------------------------------------------------------------
   # Job 3: Report test suites that ran zero tests
   #
@@ -762,7 +1082,8 @@ jobs:
   report_empty_suites:
     name: Report empty test suites
     runs-on: ubuntu-latest
-    needs: [generate_matrix, test, test_multi_spyre]
+    # Waits for the pod-level retries too, so a suite fixed by retry (overwrite: true replaces its report) is read post-correction.
+    needs: [generate_matrix, test, test_multi_spyre, test_retry, test_multi_spyre_retry]
     if: always()
 
     steps:

--- a/.github/workflows/retry-failed-tests.yaml
+++ b/.github/workflows/retry-failed-tests.yaml
@@ -1,27 +1,7 @@
 name: retry-failed-tests
 
-# Test-matrix-level retry: when "tests" or "tests-nightly" finishes with a
-# failure, reschedule the failed jobs (and their dependents) via
-# `gh run rerun --failed`. Unlike run-test-suite's in-suite retry (which
-# reruns inside the SAME pod/card -- see .github/actions/run-test-suite),
-# `gh run rerun` schedules brand-new jobs, so ARC hands them fresh ephemeral
-# pods on different cards. That clears pod- or card-scoped failures (a wedged
-# card, a leftover VFIO holder, a bad node) that the in-suite retry cannot,
-# since it never leaves the pod that produced the failure.
-#
-# Runs as a separate workflow_run-triggered workflow (the same pattern
-# push-to-clickhouse.yaml uses) rather than a job inside _test_matrix.yaml,
-# for two reasons:
-#   1. `gh run rerun` needs a COMPLETED run; a job inside the same run can't
-#      rerun its own still-in-progress workflow.
-#   2. workflow_run always executes with the base repo's permissions, even
-#      when the triggering run came from a fork PR (whose own GITHUB_TOKEN is
-#      read-only) -- so this works for fork PRs without weakening tests.yml's
-#      own token permissions.
-#
-# NOTE: like any workflow_run consumer, GitHub only looks at the copy of this
-# file on the repository's default branch -- a change here has no effect
-# until it lands on main, even for the PR that introduces it.
+# On failure of "tests"/"tests-nightly", reruns the failed jobs via `gh run rerun --failed` so ARC gives them a fresh pod/card (unlike run-test-suite's same-pod in-suite retry).
+# Separate workflow_run workflow, like push-to-clickhouse.yaml (gh run rerun needs a completed run; workflow_run keeps base-repo perms for fork PRs); only picks up changes from the default branch.
 on:
   workflow_run:
     workflows:
@@ -30,7 +10,7 @@ on:
     types: [completed]
 
 concurrency:
-  # One retry decision per triggering run; never cancel a rerun already in flight.
+  # One retry decision per triggering run; never cancel a rerun in flight.
   group: retry-failed-tests-${{ github.event.workflow_run.id }}
   cancel-in-progress: false
 
@@ -41,16 +21,28 @@ permissions:
 jobs:
   retry:
     name: Retry failed jobs on a fresh pod
-    runs-on: ubuntu-latest
-    # Only for an actual failure (not cancelled -- e.g. superseded by a newer
-    # push under tests.yml's cancel-in-progress concurrency group). Capped at
-    # one pod-level retry total: run_attempt is 1 on the original run and 2
-    # after the rerun below, so this condition is false the second time this
-    # workflow fires for the same run, giving exactly one retry.
+    # Cardless pool (like push-to-clickhouse.yaml's ingest job) -- only calls the GitHub API.
+    runs-on:
+      - x86_64
+      - spyre_pf_x0
+      - linux
+      - image_spyre_backend
+    # Only on an actual failure (not cancelled/superseded); run_attempt < 2 caps this at one retry.
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.run_attempt < 2
     steps:
+      - name: Setup the GitHub CLI
+        env:
+          GH_CLI_VERSION: 2.97.0
+        run: |
+          curl -fsSL \
+            "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz" \
+            -o "${RUNNER_TEMP}/gh-cli.tar.gz"
+          mkdir -p "${RUNNER_TEMP}/gh-cli"
+          tar -xzf "${RUNNER_TEMP}/gh-cli.tar.gz" -C "${RUNNER_TEMP}/gh-cli" --strip-components=1
+          echo "${RUNNER_TEMP}/gh-cli/bin" >> "${GITHUB_PATH}"
+
       - name: Rerun failed jobs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/retry-failed-tests.yaml
+++ b/.github/workflows/retry-failed-tests.yaml
@@ -1,0 +1,64 @@
+name: retry-failed-tests
+
+# Test-matrix-level retry: when "tests" or "tests-nightly" finishes with a
+# failure, reschedule the failed jobs (and their dependents) via
+# `gh run rerun --failed`. Unlike run-test-suite's in-suite retry (which
+# reruns inside the SAME pod/card -- see .github/actions/run-test-suite),
+# `gh run rerun` schedules brand-new jobs, so ARC hands them fresh ephemeral
+# pods on different cards. That clears pod- or card-scoped failures (a wedged
+# card, a leftover VFIO holder, a bad node) that the in-suite retry cannot,
+# since it never leaves the pod that produced the failure.
+#
+# Runs as a separate workflow_run-triggered workflow (the same pattern
+# push-to-clickhouse.yaml uses) rather than a job inside _test_matrix.yaml,
+# for two reasons:
+#   1. `gh run rerun` needs a COMPLETED run; a job inside the same run can't
+#      rerun its own still-in-progress workflow.
+#   2. workflow_run always executes with the base repo's permissions, even
+#      when the triggering run came from a fork PR (whose own GITHUB_TOKEN is
+#      read-only) -- so this works for fork PRs without weakening tests.yml's
+#      own token permissions.
+#
+# NOTE: like any workflow_run consumer, GitHub only looks at the copy of this
+# file on the repository's default branch -- a change here has no effect
+# until it lands on main, even for the PR that introduces it.
+on:
+  workflow_run:
+    workflows:
+      - tests # torch_spyre_tests.yaml: PR / push / merge-queue
+      - tests-nightly
+    types: [completed]
+
+concurrency:
+  # One retry decision per triggering run; never cancel a rerun already in flight.
+  group: retry-failed-tests-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: write # required by `gh run rerun`
+
+jobs:
+  retry:
+    name: Retry failed jobs on a fresh pod
+    runs-on: ubuntu-latest
+    # Only for an actual failure (not cancelled -- e.g. superseded by a newer
+    # push under tests.yml's cancel-in-progress concurrency group). Capped at
+    # one pod-level retry total: run_attempt is 1 on the original run and 2
+    # after the rerun below, so this condition is false the second time this
+    # workflow fires for the same run, giving exactly one retry.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt < 2
+    steps:
+      - name: Rerun failed jobs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Triggering workflow : ${{ github.event.workflow_run.name }}"
+          echo "Run                 : ${{ github.event.workflow_run.id }} (attempt ${{ github.event.workflow_run.run_attempt }})"
+          echo "Conclusion          : ${{ github.event.workflow_run.conclusion }}"
+          echo "Rerunning failed jobs on a fresh pod..."
+          gh run rerun "${{ github.event.workflow_run.id }}" \
+            --repo "${{ github.repository }}" \
+            --failed


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

## Summary

Adds test-matrix-level retry so a failed suite gets rescheduled onto a fresh pod/card instead of retried on the same one, in two complementary layers:

1. **In-run pod-level retry** ([_test_matrix.yaml](.github/workflows/_test_matrix.yaml)) — a failed `test`/`test_multi_spyre` suite is automatically re-run as a new job (`test_retry` / `test_multi_spyre_retry`) on a fresh ARC pod, **before** the required check (`run-spyre-unit-tests`) ever reports a conclusion.
2. **Post-completion safety net** ([retry-failed-tests.yaml](.github/workflows/retry-failed-tests.yaml)) — a `workflow_run`-triggered workflow watching `tests`/`tests-nightly` that runs `gh run rerun <run-id> --failed` once on failure, rescheduling only the jobs that actually failed (plus their dependents), not the whole matrix.

## Why

`run-test-suite`'s existing retry ([action.yml](.github/actions/run-test-suite/action.yml)) reruns *inside the same pod*, so it can't recover from failures tied to that specific pod/card:

- a wedged or unresponsive Spyre card
- a leftover process still holding the VFIO device after a kill
- a bad/flaky node in the runner pool
- any other pod-local state that survives a same-pod retry

Both layers above schedule the retry as a brand-new job, so ARC hands it a fresh pod instead.

## How the in-run retry works

- `test` / `test_multi_spyre` matrix legs are marked `continue-on-error: true` so one failed suite doesn't immediately fail the reusable workflow.
- A failed leg uploads a small descriptor artifact identifying itself (suite name + config).
- `collect_failed_suites` downloads those descriptors and builds a retry matrix from them.
- `test_retry` / `test_multi_spyre_retry` re-run exactly those suites on fresh pods — one retry only, no further looping; a suite failing again there is a genuine failure.
- `test_result` is the job that actually decides pass/fail for the whole reusable workflow call. `needs.run-tests.result` (read by `run-spyre-unit-tests` in `tests.yml`/`tests-nightly.yml`) picks this up automatically — **no changes needed in either caller workflow**.

This closes a race the post-completion retry alone can't: for `merge_group` runs, GitHub evicts a queue entry the moment its required check reports `failure`, and won't re-add it if the check later flips green. Retrying *before* that check ever reports avoids the eviction in the first place.

### Example: suite fails first attempt, passes on retry

Walking through it for a suite `X`:

1. **First attempt** (`test` job, leg `X`) fails. Because `continue-on-error: true` is set on `test`, this failure does **not** count toward the reusable workflow's overall conclusion — it just triggers the "save descriptor" step (`if: failure()`), which uploads `X`'s suite info as an artifact.
2. **`collect_failed_suites`** picks that artifact up and puts `X` into the retry matrix.
3. **`test_retry`** re-runs `X` on a fresh pod. It passes.
4. **`test_result`** is the job that actually decides the answer. Its logic only checks:
   ```bash
   if [[ "${{ needs.test_retry.result }}" == "failure" ]]; then FAIL=1; fi

## How the post-completion retry works

- Watches `tests`/`tests-nightly` via `workflow_run: types: [completed]`.

- On failure, calls `gh run rerun <run-id> --failed` — job-precise, not a blanket rerun.

- Bounded to **one** retry per run via `run_attempt < 2`, so a genuinely broken PR still ends up red.

- Runs on the cardless `spyre_pf_x0`/`image_spyre_backend` pool with `gh` installed manually (mirrors `push-to-clickhouse.yaml` — `actions4gh/setup-gh` is broken upstream).

- Works for fork PRs: `workflow_run` always executes with base-repo permissions, so it carries its own `actions: write` in this file only — `tests.yml`/`tests-nightly.yml` token scopes are untouched.

- Still subject to the merge-queue eviction race on its own — it remains useful as a backstop for failures the in-run layer doesn't cover (e.g. `build_torch_spyre` itself hitting a bad pod) and for the plain PR/nightly paths, where the race doesn't apply.

## Notes for reviewers

- `workflow_run` only picks up the copy of `retry-failed-tests.yaml` on the default branch — it has no effect until merged to `main`, and won't fire for the PR that introduces it.
- The in-run retry adds a small amount of per-run overhead: `collect_failed_suites` and `test_result` always run (cheap, `ubuntu-latest`); `test_retry`/`test_multi_spyre_retry` only run when something actually failed.
- `continue-on-error: true` on `test`/`test_multi_spyre` means a failing suite shows a neutral/yellow icon in the Actions UI instead of an immediate red X — `test_result`'s summary step is where the real pass/fail verdict is now logged.

