### PR TITLE
fix(ci): paginate ClickHouse ingest artifact listing to avoid dropping jobs past the first 30

### DIFF
--- a/.github/workflows/push-to-clickhouse.yaml
+++ b/.github/workflows/push-to-clickhouse.yaml
@@ -147,15 +147,23 @@ jobs:
       # name — a `select(.name | endswith(".xml"))` here dropped every artifact.
       # The ingest step globs *.xml in the unzip dir, so non-XML files that come
       # along are simply ignored.
+      #
+      # `--paginate` is required: the artifacts endpoint defaults to 30 per
+      # page, and a run with more jobs than that (e.g. the model-ops-tests /
+      # integration-tests matrices) silently lost every artifact past the
+      # first page, with no error — rows just never showed up in ClickHouse.
+      # `--paginate` applies `--jq` per page, so `--slurp` collects the raw
+      # per-page responses into an array first; the filter then flattens
+      # `.artifacts[]` across all of them.
       # ---------------------------------------------------------------------------
       - name: List artifacts from triggering run
         id: list-artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ARTIFACTS=$(gh api \
-            "/repos/${{ github.repository }}/actions/runs/${TRIGGERING_RUN_ID}/artifacts" \
-            --jq '[.artifacts[] | {id: .id, name: .name}]')
+          ARTIFACTS=$(gh api --paginate --slurp \
+            "/repos/${{ github.repository }}/actions/runs/${TRIGGERING_RUN_ID}/artifacts?per_page=100" \
+            --jq '[.[] | .artifacts[] | {id: .id, name: .name}]')
           echo "artifacts=$ARTIFACTS" >> "$GITHUB_OUTPUT"
           echo "Found artifacts:"
           echo "$ARTIFACTS" | python3 -c "import json,sys; [print(' •', a['name']) for a in json.load(sys.stdin)]"


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

### Problem

- `gh api` listed only the first 30 artifacts per run, silently dropping test results for runs with more jobs than that.

### Fix

- add `--paginate --slurp` so all artifact pages are fetched and flattened before ingest.

