### PR TITLE
ci(perf): skip empty-matrix test job in perf mode so the run does not false-fail

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -313,8 +313,15 @@ jobs:
     # That would make the `== 'skipped'` branch dead code and silently skip
     # every test on the RPM path. (The OR group must stay parenthesised because
     # `&&` binds tighter than `||`.)
+    #
+    # Skip cleanly in perf mode: generate_matrix emits an empty suite matrix
+    # for perf (the work runs in the `perf` job). An eligible job with a
+    # zero-entry matrix poisons this reusable workflow's aggregate result to
+    # `failure`, which then fails the caller's gate even though the perf job
+    # passed. A clean `if:`-false skip does not.
     if: >-
       !cancelled() &&
+      needs.generate_matrix.outputs.resolved_test_type != 'perf' &&
       (needs.build_torch_spyre.result == 'success' ||
        needs.build_torch_spyre.result == 'skipped')
     runs-on:


### PR DESCRIPTION
## Problem

Every `integration-tests (perf)` run concludes **failure** even though the
`Perf benchmark` job succeeds and ingests rows into ClickHouse. The only red
job is the terminal `Integration test result` gate, which reads
`needs.run-tests.result` and finds it `failure`.

Confirmed across all recent perf runs going back to 2026-08-15, on both
`perf-test` and `main` run numbers. Example: run 32251519277 has the `Perf
benchmark` job green and the `Integration test result` gate red, with the gate
log showing exactly `run-tests result: failure` then `exit 1`.

## Root cause

`run-tests` is the `_test_matrix.yaml` reusable workflow. Its `.result`
aggregates every job in that workflow. In perf mode, `generate_matrix`
deliberately emits an **empty** suite matrix (`{"suite":[]}`) because the perf
work runs in the dedicated `perf` job, not the pytest `test` matrix.

But the `test` job's `if:` only gated on the build result, so it stayed
**eligible**, and GitHub expanded its `strategy.matrix` to zero combinations.
An eligible job with a zero-entry matrix sets the reusable workflow's aggregate
conclusion to `failure` (the job tile shows "skipped" in the UI, which hid the
cause). That propagates to `needs.run-tests.result == 'failure'`, so the gate
exits 1.

The perf run and the ClickHouse ingest are unaffected: they run in the `perf`
job, which is gated correctly on `resolved_test_type == 'perf'`.

## Fix

Add `needs.generate_matrix.outputs.resolved_test_type != 'perf'` to the `test`
job `if:` so it skips **cleanly** in perf mode. A clean `if:`-false skip does
not fail the reusable workflow; only an eligible empty-matrix job does. The
`perf` job already carries the inverse guard.

`resolved_test_type` is already in this job's `env`, so it is available to the
`if:` with no other change. YAML validates; actionlint reports no new issues on
this expression.

## Verification

A `workflow_dispatch` reads its workflow files from the branch it targets on
the canonical repo, so this change can only be exercised once it is on an
upstream branch (`perf-test`). It cannot be pre-verified from a fork branch: the
fork override only feeds `actions/checkout` inside the jobs, not the workflow
YAML itself.

After merge to `perf-test`, the next perf run there should show the `test` job
skipped cleanly and the overall run **green** while still ingesting rows.
