### PR TITLE
fix(tests): repair two Gemma op-test helpers that fail at the CPU reference

### DIFF
--- a/tests/models/op_registry.py
+++ b/tests/models/op_registry.py
@@ -318,7 +318,10 @@ def _tensor_and_(x: torch.Tensor, other):
 
 
 def _tensor_or_(x: torch.Tensor, other):
-    return x.or_(other)
+    # torch.Tensor has no ``or_`` method; the in-place spelling of bitwise or
+    # is ``bitwise_or_`` (identical to logical or on the bool inputs these
+    # tests use). Kept in-place to match the adapter's is_inplace=True.
+    return x.bitwise_or_(other)
 
 
 def _tensor_copy_(x: torch.Tensor, source: torch.Tensor):

--- a/tests/oot_framework/oot_test_config_models.py
+++ b/tests/oot_framework/oot_test_config_models.py
@@ -953,6 +953,19 @@ class InputsEdits(BaseModel):
                         f"config so the constructor arg uses 'config_path' + "
                         f"'config_kwargs' instead of a bare '<config:...>' value."
                     )
+                # A dtype recorded as its repr (e.g. 'torch.bfloat16'). Left as
+                # a string it reaches the op as a positional arg and is
+                # misinterpreted -- x.to('torch.bfloat16') parses it as a
+                # DEVICE string and raises. kwargs already resolve dtypes;
+                # positional values get the same treatment. Gated on a known
+                # dtype name so device strings ('cpu', 'cuda:0') and any other
+                # 'torch.'-prefixed value fall through unchanged.
+                if (
+                    isinstance(val, str)
+                    and val.startswith("torch.")
+                    and val.removeprefix("torch.") in _VALID_DTYPE_STRINGS
+                ):
+                    val = _resolve_dtype_str(val)
                 if (
                     test_device is not None
                     and op_name == "torch.to"


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Repairs two Gemma op-test helpers that fail while computing the **CPU reference** — before Spyre is involved — so the ops they cover cannot be validated at all:

- **#3820**: `torch.or_` dispatches to `_tensor_or_`, which calls `x.or_(other)` — a method `torch.Tensor` does not have. Now `x.bitwise_or_(other)`: the in-place spelling that exists, identical to logical or on the bool inputs these tests use, matching the adapter's `is_inplace=True`.
- **#3823**: a dtype recorded in YAML as its repr (`'torch.bfloat16'`) reaches `torch.to` as a positional string and is parsed as a **device** string (`RuntimeError: Invalid device string`). Known dtype names now resolve in `build_cpu_args`' `InputArgValue` branch via the framework's own `_resolve_dtype_str`, gated on `_VALID_DTYPE_STRINGS` so device strings (`"cpu"`, `"cuda:0"`) and any other `torch.`-prefixed value fall through unchanged. Fixed at the parse point rather than inside `_tensor_to`, so any op taking a positional dtype benefits and positional args stay consistent with kwargs (kwmap dtypes already resolve).

#### Which issue(s) this PR is related to:

Fixes #3820
Fixes #3823

#### Special notes for your reviewer:

- **Relationship to #2351** (@kiszk): that PR fixes the same dtype-string bug on the **v1 path** (`runner.py::make_SampleInput`) and has been approved since June. This PR deliberately does not touch that file — it fixes the **v2 path** (`test_model_ops_v2.py` builds args via `oot_test_config_models.build_cpu_args`), which is where #3823's failing tests actually run. The two compose with no file overlap; #2351 just needs a merge.
- Verified on device against the in-tree Gemma-4-26B config (`PYTORCH_TEST_CONFIG=tests/configs/model_ops_tests/gemma-4-26B-A4B-it_spyre.yaml`): the four failing tests (`torch_or_` ×2, `torch_to` dtype-string ×2) now pass.
- A full-suite before/after differential (460 tests) shows **exactly those four fixed and zero regressions introduced**. The four failures remaining on `main` are pre-existing and tracked separately (#3824, #3769; `torch_empty_like__139_cpu_int64` appears to be unfiled).

#### Does this PR introduce a user-facing change?

No — test harness only; nothing under `torch_spyre/` changes.

#### Additional note:

These are the two quick wins from the current open-issue triage; the harness bugs were masking whether the underlying ops actually work on Spyre.
