### PR TITLE
fix(ci): drop --slurp from gh api artifact listing, incompatible with --jq

### DIFF
--- a/.github/workflows/push-to-clickhouse.yaml
+++ b/.github/workflows/push-to-clickhouse.yaml
@@ -152,18 +152,20 @@ jobs:
       # page, and a run with more jobs than that (e.g. the model-ops-tests /
       # integration-tests matrices) silently lost every artifact past the
       # first page, with no error — rows just never showed up in ClickHouse.
-      # `--paginate` applies `--jq` per page, so `--slurp` collects the raw
-      # per-page responses into an array first; the filter then flattens
-      # `.artifacts[]` across all of them.
+      # `--paginate` applies `--jq` per page and concatenates the filtered
+      # results across pages (`gh api` rejects `--slurp` combined with
+      # `--jq`), so the per-artifact objects come out as a JSON stream, not
+      # a single array; python3 slurps that stream into one array below.
       # ---------------------------------------------------------------------------
       - name: List artifacts from triggering run
         id: list-artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ARTIFACTS=$(gh api --paginate --slurp \
+          ARTIFACTS=$(gh api --paginate \
             "/repos/${{ github.repository }}/actions/runs/${TRIGGERING_RUN_ID}/artifacts?per_page=100" \
-            --jq '[.[] | .artifacts[] | {id: .id, name: .name}]')
+            --jq '.artifacts[] | {id: .id, name: .name}' \
+            | python3 -c "import json,sys; print(json.dumps([json.loads(l) for l in sys.stdin if l.strip()]))")
           echo "artifacts=$ARTIFACTS" >> "$GITHUB_OUTPUT"
           echo "Found artifacts:"
           echo "$ARTIFACTS" | python3 -c "import json,sys; [print(' •', a['name']) for a in json.load(sys.stdin)]"


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

- Follow-up to the earlier pagination fix: gh api rejects --slurp combined with --jq, so the artifact-listing step was crashing in production instead of ingesting anything.

- Switched to --paginate --jq alone and let Python slurp the resulting per-page JSON stream into one array.