### PR TITLE
feat(inductor): allow specifying STL on `torch.full`

### DIFF
--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -33,6 +33,7 @@ from torch.spyre import SpyreTensorLayout
 
 import torch_spyre._inductor.optimize_restickify as _optimize_restickify
 from torch._inductor.exc import InductorError
+from torch_spyre._C import DataFormats
 from utils_inductor import _compile_and_run, compare_with_cpu
 
 DEVICE = torch.device("spyre")
@@ -809,6 +810,91 @@ def test_full_plus_xt():
         lambda x: torch.full((S, S), 0.5, dtype=torch.float16, device=x.device) + x.t(),
         x,
     )
+
+
+def test_full_with_layout_plus_xt():
+    """torch.full with device_layout= arg (patched spyre_full) — layout pinned via the
+    monkey-patched torch.full; the hint is applied automatically — cost 0."""
+
+    def fn(x):
+        c = torch.full(
+            (S, S),
+            0.5,
+            dtype=torch.float16,
+            device=x.device,
+            device_layout=([2, S, 64], [S * S // 2, 1, S], DataFormats.SEN169_FP16),
+        )
+        return c + x.t()
+
+    x = torch.randn((S, S), dtype=torch.float16)
+    _compare(fn, x, optimal_cost=0)
+
+
+def test_full_with_layout_int_fill_value():
+    """Integer fill value with device_layout= — dtype defaults to float16, value silently
+    cast to float.  Correctness: result should equal torch.full(..., 1, dtype=float16)."""
+
+    def fn(x):
+        c = torch.full(
+            (S, S),
+            1,
+            device=x.device,
+            device_layout=([2, S, 64], [S * S // 2, 1, S], DataFormats.SEN169_FP16),
+        )
+        return c + x.t()
+
+    x = torch.randn((S, S), dtype=torch.float16)
+    _compare(fn, x, optimal_cost=0)
+
+
+def test_full_with_layout_unsupported_dtype():
+    """dtype=int32 with device_layout= must raise TypeError at the monkey-patch layer."""
+    with pytest.raises(TypeError):
+        torch.full(
+            (S, S),
+            1,
+            dtype=torch.int32,
+            device="spyre",
+            device_layout=([2, S, 64], [S * S // 2, 1, S], DataFormats.SEN169_FP16),
+        )
+
+
+def test_full_with_layout_unsupported_dtype_lowering():
+    """spyre::full_with_layout with dtype=int32 must raise at the lowering layer.
+
+    Exercises the Unsupported() guard in lower_full_with_layout directly,
+    bypassing the monkey-patch dtype check in spyre_full.
+    """
+
+    device_dtype = int(DataFormats.SEN169_FP16)
+
+    def fn(x):
+        return torch.ops.spyre.full_with_layout(
+            [S, S],
+            1.0,
+            x.device,
+            torch.int32,
+            [2, S, 64],
+            [S * S // 2, 1, S],
+            device_dtype,
+        )
+
+    x = torch.randn((S, S), dtype=torch.float16)
+    torch._dynamo.reset()
+    with pytest.raises(InductorError):
+        _compile_and_run(fn, (x,), DEVICE)
+
+
+def test_full_with_layout_bad_tuple():
+    """device_layout= with wrong arity must raise at the Python wrapper level."""
+    with pytest.raises((ValueError, TypeError)):
+        torch.full(
+            (S, S),
+            0.5,
+            dtype=torch.float16,
+            device="cpu",
+            device_layout=([2, S, 64], [S * S // 2, 1, S]),  # missing device_dtype
+        )
 
 
 def test_fill_plus_xt():

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -221,6 +221,45 @@ def _(
     return torch.empty(size, dtype=dtype, device="spyre")
 
 
+# No device_types="spyre" here: unlike sibling ops, this op must also handle
+# CPU execution (spyre_full routes through it unconditionally). The manual
+# device.type check below is the intentional CPU-fallback path; don't add
+# device_types= to clean up the asymmetry, it would break that fallback.
+@torch.library.custom_op("spyre::full_with_layout", mutates_args=())
+def spyre_full_with_layout(
+    size: Sequence[int],
+    fill_value: float,
+    device: torch.device,
+    dtype: torch.dtype,
+    device_size: Sequence[int],
+    stride_map: Sequence[int],
+    device_dtype: int,
+) -> torch.Tensor:
+    if device.type != "spyre":
+        return torch.full(list(size), fill_value, dtype=dtype, device=device)
+    from torch_spyre._C import DataFormats, SpyreTensorLayout, empty_with_layout
+
+    stl = SpyreTensorLayout(
+        list(device_size), list(stride_map), DataFormats(device_dtype)
+    )
+    t = empty_with_layout(tuple(size), stl, dtype, device, False, None)
+    t.fill_(fill_value)
+    return t
+
+
+@spyre_full_with_layout.register_fake
+def _(
+    size: Sequence[int],
+    fill_value: float,
+    device: torch.device,
+    dtype: torch.dtype,
+    device_size: Sequence[int],
+    stride_map: Sequence[int],
+    device_dtype: int,
+) -> torch.Tensor:
+    return torch.empty(size, dtype=dtype, device=device)
+
+
 @torch.library.custom_op("spyre::logical_not", mutates_args=(), device_types="spyre")
 def logical_not(input: torch.Tensor) -> torch.Tensor:
     pass

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -38,6 +38,7 @@ from . import config
 import torch_spyre._inductor.customops  # noqa: F401
 from torch_spyre.ops.fallbacks import fallback_ops
 from .ir import (
+    FixedTiledLayout,
     SpyreReduction,
     SpyreConstantFallback,
     SpyreEmptyFallback,
@@ -46,7 +47,7 @@ from .ir import (
     AllGatherAsyncFallback,
     AllReduceAsyncFallback,
 )
-from torch_spyre._C import get_elem_in_stick
+from torch_spyre._C import DataFormats, SpyreTensorLayout, get_elem_in_stick
 from torch._inductor.virtualized import V
 from torch.utils._ordered_set import OrderedSet
 from .errors import Unsupported
@@ -1416,6 +1417,35 @@ def lower_full(size, fill_value, dtype=None, layout=None, device=None, pin_memor
         inner_fn=inner_fn,
         ranges=list(size),
     )
+
+
+@register_spyre_lowering(
+    torch.ops.spyre.full_with_layout.default, type_promotion_kind=None
+)
+def lower_full_with_layout(
+    size, fill_value, device, dtype, device_size, stride_map, device_dtype
+):
+    if dtype not in (torch.float16, torch.float32):
+        raise Unsupported(
+            f"spyre::full_with_layout: unsupported dtype {dtype}; "
+            "device_layout= requires float16 or float32"
+        )
+    stl = SpyreTensorLayout(
+        list(device_size), list(stride_map), DataFormats(device_dtype)
+    )
+    result = lower_full(size, fill_value, dtype=dtype, device=device)
+    # Unwrap to the ComputedBuffer and stamp the FixedTiledLayout so
+    # propagate_layouts can read it via get_layout() in the is_constant_fill branch.
+    buf = result.data.data
+    assert isinstance(buf, ir.ComputedBuffer), (
+        f"lower_full returned unexpected IR structure: {type(buf)}; "
+        "expected TensorBox(StorageBox(ComputedBuffer))"
+    )
+    # Host strides are placeholders — finalize_layouts overwrites them later;
+    # only device_layout matters here.
+    contiguous_strides = ir.FlexibleLayout.contiguous_strides(list(size))
+    buf.layout = FixedTiledLayout(device, dtype, list(size), contiguous_strides, stl)
+    return result
 
 
 @register_spyre_lowering(torch.ops.spyre.constant.default, type_promotion_kind=None)

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -1936,9 +1936,14 @@ def propagate_spyre_tensor_layouts(
                 if is_constant_fill:
                     # Constant-fill ops (zeros_like, full, ones_like, ...) have no real
                     # memory layout — they can materialize in any stick orientation.
-                    # For now, using a single generic layout candidate to reduce beam
-                    # state space explosion.  Optimizations to follow.
-                    op.layouts = [generic_layout(op)]
+                    # spyre::full_with_layout stamps a FixedTiledLayout on the buffer
+                    # during lowering to pin it to a specific layout; otherwise fall back
+                    # to the generic single candidate.
+                    existing = op.get_layout()
+                    if isinstance(existing, FixedTiledLayout):
+                        op.layouts = [existing.device_layout]
+                    else:
+                        op.layouts = [generic_layout(op)]
                 else:
                     logger.warning(
                         f"{op.get_name()} has no propagatable args but reads non-constant "

--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -227,6 +227,40 @@ def _patch_tensor_for_spyre():
     torch._dynamo.allow_in_graph(torch.Tensor.to)
     torch.empty = spyre_empty
 
+    orig_full = torch.full
+
+    def spyre_full(size, fill_value, *, device_layout=None, **kwargs):
+        if device_layout is None:
+            return orig_full(size, fill_value, **kwargs)
+        device = kwargs.get("device")
+        # device_layout= only supports float16/float32; default to float16 (Spyre
+        # default dtype) rather than inferring from fill_value like real torch.full
+        # would — callers using device_layout= are explicitly targeting Spyre and
+        # must pass dtype= if they want float32.
+        dtype = kwargs.get("dtype") or torch.float16
+        if dtype not in (torch.float16, torch.float32):
+            raise TypeError(
+                f"torch.full with device_layout= only supports float16 and float32, got {dtype}"
+            )
+        device_size, stride_map, device_dtype = device_layout
+        return torch.ops.spyre.full_with_layout(
+            list(size),
+            float(fill_value),
+            device if device is not None else torch.device("spyre"),
+            dtype,
+            list(device_size),
+            list(stride_map),
+            int(device_dtype),
+        )
+
+    # spyre_full (unlike spyre_empty) calls DataFormats(device_dtype) — a pybind11 enum
+    # constructor — when device_layout= is provided.  Dynamo cannot trace through pybind11
+    # constructors and graph-breaks.  allow_in_graph makes Dynamo treat spyre_full as an
+    # opaque leaf (frontend only); AOTAutograd/Inductor still trace into it normally and
+    # see the torch.ops.spyre.full_with_layout call.
+    torch._dynamo.allow_in_graph(spyre_full)
+    torch.full = spyre_full
+
     # ── Optimal weight loading (issue #1339) ──────────────
     # Patch dim_order=[1,0] transfer + nn.Module.to override (issue #1339).
     try:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Constants created with `torch.full` (and similar fill ops) have no inherent stick orientation and the layout optimizers has freedom to select whatever layout it wants.  But there are scenarios where we would like to force a particular layout.

This PR adds a `device_layout=` keyword argument to `torch.full` that pins the constant to a specific `SpyreTensorLayout`, allowing the optimizer to pick a zero-cost layout for the operation.

```python
def fn(x):
    c = torch.full(
        (S, S), 0.5, dtype=torch.float16, device=x.device,
        device_layout=([2, S, 64], [S * S // 2, 1, S], DataFormats.SEN169_FP16),
    )
    return c + x.t()  # restickify cost = 0
```

The tuple argument mirrors the `SpyreTensorLayout` constructor: `(device_size, stride_map, device_dtype)`, but is not a `SpyreTensorLayout` because Dynamo cannot represent pybind11 C++ objects as graph constants (`AsPythonConstantNotImplementedError`).

## Implementation

The feature follows the same pattern as `spyre::empty` / `spyre_empty`:

**`customops.py`** — new `spyre::full_with_layout` custom op. Takes the layout as plain Python types (int lists + `device_dtype` as int) so Dynamo can trace it without recursing into pybind11 objects. The eager implementation allocates with `empty_with_layout` and fills the scalar value.

**`lowering.py`** — `lower_full_with_layout` calls `lower_full` to produce the standard `SpyreConstantFallback` + `Pointwise` IR, then stamps a `FixedTiledLayout` (constructed from the layout args) directly onto the resulting `ComputedBuffer`.

**`propagate_layouts.py`** — in the `is_constant_fill` branch, check whether the buffer already carries a `FixedTiledLayout`; if so use its `device_layout` as the single layout candidate instead of `generic_layout`.

**`_monkey_patch.py`** — monkey-patch `torch.full` with `spyre_full`, which strips the `device_layout` kwarg and routes through `spyre::full_with_layout`. Marked `allow_in_graph` so Dynamo treats it as a leaf and does not recurse into enum-to-int conversion inside the compiled function.

## Test

`test_full_with_layout_plus_xt` in `tests/inductor/test_restickify.py` verifies that `torch.full(..., device_layout=(...))` pins the constant to `x.t()`'s layout so that `c + x.t()` compiles with restickify cost 0.


#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

I first tried using `spyre::empty` with layout but inductor optimized them into `full` and the empty was lost.

I implemented via `spyre_hint` and it worked fine for simple cases, so that is an option if we want it.   But we want to avoid spyre hints when possible so presenting `full` here as a preferred option.