### PR TITLE
Fix 3840 topk lx partial write

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_scalar_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_scalar_config.yaml
@@ -38,7 +38,6 @@ test_suite_config:
             # pins conv output -- conv is not in OP_OUTPUT_GOOD_FOR_LX_REUSE --
             # so this is a test-only path (backend follow-up on PR #3284).
             - LxPlanning.*::test_conv2d_direct_.*_s2_lx_planning_(pointwise|reduction)
-            - LxPlanning.*::test_topk.*_lx_planning_(pointwise|reduction)
           mode: xfail
         - names:
             - LxPlanning.*::test_(all_dim|any_dim|count_nonzero|cummax|cummin|cumprod|logcumsumexp|max_default|median|mode_|nanmean|nanmedian|nanquantile|nansum|quantile|std_|topk|conv2d|dwise_conv2d|var_).*_lx_planning_(pointwise|reduction)

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -41,7 +41,7 @@ from torch_spyre._inductor.op_spec import IndirectAccess
 
 from . import config
 from .core_mapping import core_to_slice_mapping
-from .constants import ELIDED_COPY_BACK_ATTR, MATMUL_REDUCTION_OPS
+from .constants import ELIDED_COPY_BACK_ATTR, MATMUL_REDUCTION_OPS, TOPK_OPS
 from .ir import FixedTiledLayout, SpyreConstantFallback, SpyreEmptyFallback
 from .logging_utils import get_inductor_logger
 from .loop_info import copy_op_metadata
@@ -1591,6 +1591,15 @@ def _is_matmul_op(op: Operation) -> bool:
     )
 
 
+def is_topk(op: Operation) -> bool:
+    """Return True iff ``op`` is a ``ComputedBuffer`` computing a topk reduction."""
+    return (
+        isinstance(op, ComputedBuffer)
+        and isinstance(op.data, Reduction)
+        and op.data.reduction_type in TOPK_OPS
+    )
+
+
 # TODO: Select and store the core mapping before LX planning, then pass the
 # winning mapping to codegen.
 class _ViewPrep(NamedTuple):
@@ -1654,6 +1663,10 @@ def _prepare_per_core_view(
     buf_layout = buf_op.layout
     if not isinstance(buf_layout, FixedTiledLayout):
         return None
+
+    if is_topk(op):
+        return None
+
     dev_layout = buf_layout.device_layout
     device_size = dev_layout.device_size
     stride_map = dev_layout.stride_map
@@ -1712,6 +1725,7 @@ def _per_core_view_from_prep(
     # can't be placed on a device dim); cross-op view comparisons must treat it
     # as "no match", since its empty view means "couldn't tell", not "whole".
     unrepresentable = (PerCoreView(work_slice_dims=(), core_to_slot=()), False, False)
+
     # No real split -> whole-buffer view, representable regardless of layout. Must
     # precede the ``prep is None`` guard to match the original ordering.
     if not any(n > 1 for d in coeff_splits for n in d.values()):

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -62,7 +62,6 @@ from .constants import (
     ELIDED_COPY_BACK_ATTR,
     REDUCTIONS_NON_STICK_DIM_ONLY,
     STAGGERED_EAS,
-    TOPK_OPS,
 )
 from .ir import (
     AllReduceAsyncFallback,
@@ -83,6 +82,7 @@ from .pass_utils import (
     try_device_coordinates,
     indirect_info_from_op,
     is_stick_expr_offset_free,
+    is_topk,
     iter_var_id,
 )
 from .optimize_restickify import AllSameNode, AnyInNode, FixedInOutNode
@@ -1337,7 +1337,7 @@ def compute_layouts(
     if isinstance(data, Reduction) and data.reduction_type == "exx2":
         return _exx2_layout(op, output, output_dep, args)
 
-    if isinstance(data, Reduction) and data.reduction_type in TOPK_OPS:
+    if is_topk(op):
         return _topk_layouts(op, output, output_dep, args)
 
     aten_op = next(iter(data.origins)).target if data.origins else None

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -41,7 +41,7 @@ from torch._inductor.graph import GraphLowering
 from torch_spyre._C import ElementArrangement
 
 from .errors import Unsupported
-from .constants import BATCH_MATMUL_OP, DEVICE_NAME, TOPK_OPS, BATCH_MATMUL_FP8_OP
+from .constants import BATCH_MATMUL_OP, DEVICE_NAME, BATCH_MATMUL_FP8_OP
 from .ir import FixedTiledLayout
 from .pass_utils import (
     SchedNodeArg,
@@ -52,6 +52,7 @@ from .pass_utils import (
     get_mem_deps_from_rw,
     device_coordinates,
     iteration_space_from_op,
+    is_topk,
     splits_by_index_coeff,
     apply_splits_from_index_coeff,
     op_read_writes,
@@ -704,7 +705,7 @@ def enumerate_work_division_candidates(
     # work division where HBM bandwidth can saturate compute.
 
     it_space = iteration_space_from_op(op)
-    is_topk = isinstance(op.data, Reduction) and op.data.reduction_type in TOPK_OPS
+    op_is_topk = is_topk(op)
 
     input_tds, output_td = collect_tensor_deps(
         op, get_mem_deps_from_rw(op_read_writes(op))
@@ -722,7 +723,7 @@ def enumerate_work_division_candidates(
     reduction_vars = [v for v in it_space_adjusted if v not in coord_vars]
 
     topk_k_sym = None
-    if is_topk:
+    if op_is_topk:
         output_dims, _ = prioritize_dimensions(output_td, it_space_adjusted)
         topk_k_sym = _find_topk_k_symbol(output_dims, input_tds)
 
@@ -744,7 +745,7 @@ def enumerate_work_division_candidates(
     # Per-dim candidate factors, mirroring must_split_vars.valid_splits but with
     # no ``>= current_min`` floor (we want the full set, including 1).
     def factors(v: Symbol) -> list[int]:
-        if is_topk and v == topk_k_sym:
+        if op_is_topk and v == topk_k_sym:
             k_val = concretize_expr(it_space[v])
             return _topk_valid_k_splits(k_val, max_cores) or [1]
         if v in symbol_meta:

--- a/torch_spyre/_inductor/work_division_constraints.py
+++ b/torch_spyre/_inductor/work_division_constraints.py
@@ -35,7 +35,7 @@ from torch_spyre._C import ElementArrangement
 
 from .constants import BATCH_MATMUL_OP, BATCH_MATMUL_FP8_OP
 from .errors import Unsupported
-from .pass_utils import concretize_expr, indirect_info_from_op, op_read_writes
+from .pass_utils import concretize_expr, indirect_info_from_op, is_topk, op_read_writes
 from .logging_utils import get_inductor_logger
 from . import config
 
@@ -241,11 +241,7 @@ def topk_pinned_search_space_vars(ctx: WorkDivConstraintContext) -> ConstraintRe
     the top-k results. Splitting the search-space would require merging
     partial top-k results across cores, which the hardware does not support.
     """
-    from .constants import TOPK_OPS
-
-    if not isinstance(ctx.op.data, Reduction):
-        return ConstraintResult()
-    if ctx.op.data.reduction_type not in TOPK_OPS:
+    if not is_topk(ctx.op):
         return ConstraintResult()
 
     return ConstraintResult(pinned={v: 1 for v in ctx.reduction_vars})
@@ -260,12 +256,9 @@ def topk_k_split_constraint(ctx: WorkDivConstraintContext) -> ConstraintResult:
     work_distribution planner picks the minimal k-split rather than a
     larger one that leaves more cores for other dims.
     """
-    from .constants import TOPK_OPS
     from sympy import divisors
 
-    if not isinstance(ctx.op.data, Reduction):
-        return ConstraintResult()
-    if ctx.op.data.reduction_type not in TOPK_OPS:
+    if not is_topk(ctx.op):
         return ConstraintResult()
 
     # Find k's symbol (output dim absent from every input's device coords).


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [X] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
This change addresses a `xfail` tests introduced in https://github.com/torch-spyre/torch-spyre/pull/3782. 

The fix adds a check so calls to `topk` are returned to HBM without attempting to relayout scratchpad memory. The result of `topk` is up to 4 rows / core (k) when k is greater than 4 multiple cores are used with each core producing it's outputs in HBM. Thus, the final result must be produced from gathering all implicated cores into one location. Currently, scratchpad relayout requires a single slot be reused on each implicated core thus preluding merging all `topk` results via the LX ring buffer and requiring an eviction to HBM. To achieve thus, the result of `topk` was marked as unrepresentable in  `_prepare_per_core_view` as the result from the function is not a complete result unless a single core is implicated. This is a similar mechanism as partial reductions.

#### Which issue(s) this PR is related to:
Fixes: https://github.com/torch-spyre/torch-spyre/issues/3840

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
No

#### Additional note:
None
