### PR TITLE
fix(inductor): enable mid-stick torch.cat by sharing one mutation buffer layout

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -3646,6 +3646,17 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             },
             "param_sets": {
                 "2d64": (1, 32, 96, cached_randn((128, 256)), cached_randn((128, 64))),
+                # Offset sub-stick write: cols 32:64 land inside the first of
+                # the four 64-wide sticks spanning this 256-wide dim. start != 0,
+                # so relocation onto the dim-0 stick candidate handles it without
+                # needing stick-tail preserve.
+                "2d_substick_off32": (
+                    1,
+                    32,
+                    64,
+                    cached_randn((128, 256)),
+                    cached_randn((128, 32)),
+                ),
                 "2d128": (
                     1,
                     1,
@@ -3815,6 +3826,18 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                     128,
                     cached_randn((2, 8, 4, 128)),
                     cached_randn((2, 8, 4, 64)),
+                ),
+                # Offset sub-stick write on the stick (last) dim: cols 32:64 are
+                # the upper half of this dim's single 64-wide stick. The write is
+                # offset (start != 0), so relocation moves it off the stick dim.
+                # (The offset-free sub-stick start=0 case additionally needs
+                # stick-tail preserve and is out of scope.)
+                "substick_off32_3d": (
+                    2,
+                    32,
+                    64,
+                    cached_randn((3, 8, 64)),
+                    cached_randn((3, 8, 32)),
                 ),
             },
         },

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -1596,6 +1596,48 @@ def test_strict_transpose_0_last_clone(shape):
     _strict(lambda x: x.transpose(0, -1).clone(), x)
 
 
+# -------- torch.cat on the target-model shapes (#1094) ----------
+#
+# ``torch.cat`` lowers to two slice writes into one freshly cloned buffer, so a
+# concat whose split point is not a stick multiple makes both writes land in the
+# SAME stick: ``[..., :32]`` and ``[..., 32:64]`` of a 64-wide stick.  Neither
+# write can be lowered natively -- the offset write cannot express its stick
+# expression, and the offset-free ``:32`` write covers only half a stick, so
+# written whole it pads to a full stick and zeroes the tail, clobbering its
+# sibling.  Both must therefore relocate to one shared alternative layout that
+# moves the offset off the stick dim.
+#
+# The two inputs occupy disjoint fp16-exact bands ([0, 512) and [512, 1024)), so
+# ``_strict`` catches any element that crosses the concat boundary in either
+# direction.  Within one input the ramp wraps every 512 elements, so a
+# displacement that is an exact multiple of 512 along the ramp is invisible; the
+# boundary itself, which is what these shapes exercise, is not.
+CAT_MODEL_SHAPES = [
+    # Aligned 64+64: both writes are whole sticks, no relocation needed.
+    ((1, 8, 1, 64), (1, 8, 1, 64), -1),
+    ((1, 14, 64), (1, 14, 64), -1),
+    ((1, 32, 41, 64), (1, 32, 41, 64), -1),
+    # KV-cache append on a non-stick dim: 67+1 -> 68 planes of a full stick.
+    ((1, 8, 67, 128), (1, 8, 1, 128), 2),
+    # Mid-stick 32+32 -> 64 (rotary embedding): the split point falls inside one
+    # stick, so both writes share it and must relocate together.
+    ((1, 8, 11, 32), (1, 8, 11, 32), -1),
+    ((1, 8, 1, 32), (1, 8, 1, 32), -1),
+]
+
+
+@pytest.mark.parametrize(
+    "shapes",
+    CAT_MODEL_SHAPES,
+    ids=lambda p: f"{'x'.join(map(str, p[0]))}+{'x'.join(map(str, p[1]))}_dim{p[2]}",
+)
+def test_strict_cat_model_shapes(shapes):
+    a_shape, b_shape, dim = shapes
+    x = _arange(*a_shape, base=0, span=512)
+    y = _arange(*b_shape, base=512, span=512)
+    _strict(lambda x, y: torch.cat([x, y], dim=dim), x, y)
+
+
 # ======================================================================
 # Size-1 dims in and around the stick.
 #

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -29,10 +29,13 @@ from .pass_utils import redirect_computed_buffer_reads
 from torch._inductor.dependencies import MemoryDep, index_vars_squeeze
 from torch._inductor.graph import GraphLowering
 from torch._inductor.ir import (
+    BaseView,
+    Buffer,
     ComputedBuffer,
     FixedLayout,
     InputBuffer,
     IRNode,
+    MutableBox,
     MutationLayoutSHOULDREMOVE,
     Operation,
     ReinterpretView,
@@ -641,15 +644,83 @@ def finalize_layouts(graph: GraphLowering) -> None:
             logger.debug("restickify plan: (none)")
 
 
+def _retarget_internal_buf_mutation(
+    graph: GraphLowering, mutation_op: ComputedBuffer, target_name: str
+) -> None:
+    """Retarget an internal-buffer mutation onto the alt-layout buffer.
+
+    An internal buffer is compiler-allocated (a torch.cat output from empty() +
+    sliced mutate_to, say), so it has no caller address to preserve and no
+    pre-existing data. Unlike the graph-input path it needs neither a
+    pre-restickify nor a copy-back: propagate_spyre_tensor_layouts already chose
+    alt_stl and finalize_layouts wrapped it into the buffer's FixedTiledLayout,
+    so this only rebinds the write onto it.
+
+    Only single-level views are supported. Chained slices of realized storage
+    collapse into one view on SliceView.create's fast path; an unrealized operand
+    takes the generic reindex path and would arrive nested, which the target
+    identity assertion below rejects.
+    """
+    target_buf = graph.get_buffer(target_name)
+    # finalize_layouts has already wrapped alt_stl into the buffer's layout.
+    assert isinstance(target_buf.layout, FixedTiledLayout), (
+        f"internal-buf mutation target {target_name} is "
+        f"{type(target_buf.layout).__name__}, expected FixedTiledLayout"
+    )
+
+    original_layout = mutation_op.layout
+    assert isinstance(original_layout, MutationLayoutSHOULDREMOVE)
+    target = original_layout.target
+
+    if isinstance(target, BaseView):
+        inner = target.data
+        while isinstance(inner, MutableBox):
+            inner = inner.data
+        # By name, not identity: a mutate_to over a clone()'d base reaches a
+        # distinct ComputedBuffer sharing the target's name.
+        inner_name = inner.get_name() if isinstance(inner, Buffer) else None
+        assert inner_name == target_name, (
+            f"internal-buf mutation target {target_name} is a multi-level view "
+            f"({type(target).__name__} over {type(inner).__name__}); only "
+            f"single-level views are supported"
+        )
+        slice_layout = target.get_layout()
+        new_target = ReinterpretView(data=StorageBox(target_buf), layout=slice_layout)
+    else:
+        assert isinstance(target, (Buffer, MutableBox)), (
+            f"internal-buf mutation target {target_name} has unexpected target type "
+            f"{type(target).__name__}"
+        )
+        new_target = target_buf
+
+    mutation_op.layout = MutationLayoutSHOULDREMOVE(new_target)
+
+    logger.info(
+        "insert_post_mutation_restickify: internal target %s retargeted via %s "
+        "(alt layout, no copy-back)",
+        target_name,
+        mutation_op.get_name(),
+    )
+
+
 def insert_post_mutation_restickify(graph: GraphLowering) -> None:
     """
-    Insert pre/post ops around a slice mutation when the original layout cannot
-    express the required stick offset.
+    Move a slice mutation onto an alternate layout when the original layout
+    cannot express the required stick offset.
 
     In that case, propagate_layouts picks an alternate layout and stores
-    op._restickify_plan = (target_name, orig_stl, alt_stl). Because the
-    restickify op cannot write its output in place, the mutation writes into a
-    temporary buffer buf_tmp in alt_stl layout. This pass inserts:
+    op._restickify_plan = (target_name, orig_stl, alt_stl). What this pass then
+    does depends on the target kind:
+
+    An **internal buffer** is compiler-allocated, so it is already allocated in
+    alt_stl and has no caller address or prior data to preserve. Nothing is
+    inserted; the write is only rebound onto the alt-layout buffer. See
+    _retarget_internal_buf_mutation.
+
+    A **graph input** must keep its address and surrounding data, so it needs the
+    full sequence below. Because the restickify op cannot write its output in
+    place, the mutation writes into a temporary buffer buf_tmp in alt_stl layout.
+    This pass inserts:
 
       1. restickify op: arg0_1 (orig_stl) -> buf_tmp        (alt_stl)
       2. mutation op:   buf               -> buf_tmp[slice] (alt_stl)
@@ -682,7 +753,9 @@ def insert_post_mutation_restickify(graph: GraphLowering) -> None:
         assert isinstance(mutation_op, ComputedBuffer)
 
         graph_input = graph.graph_inputs.get(target_name)
-        assert graph_input is not None
+        if graph_input is None:
+            _retarget_internal_buf_mutation(graph, mutation_op, target_name)
+            continue
 
         # Create fresh layouts here, since reusing base_layout would overwrite
         # arg0_1's address during hbm_pool_planning.
@@ -710,8 +783,10 @@ def insert_post_mutation_restickify(graph: GraphLowering) -> None:
         original_layout = mutation_op.layout
         assert isinstance(original_layout, MutationLayoutSHOULDREMOVE)
         slice_layout = original_layout.target.get_layout()
-        # We only reach this pass because the write stick had a non-zero offset,
-        # so the slice layout must carry it.
+        # A graph-input mutation reaches this pass only with a non-zero write
+        # offset: propagate_layouts rejects the offset-free (sub-stick) case
+        # before committing an alt layout, so the slice layout must carry the
+        # offset here.
         assert slice_layout.offset != 0, (
             f"slice offset lost while retargeting mutation {mutation_name} "
             f"(target={type(original_layout.target).__name__}, "

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -123,7 +123,7 @@ class PropArg(NamedTuple):
     layouts: list[SpyreTensorLayout]
 
 
-def _get_prop_args(reads) -> list[PropArg]:
+def _get_prop_args(reads, strict: bool = True) -> list[PropArg]:
     # Local to this pass — the FixedLayout/FixedTiledLayout ambiguity only exists
     # during propagation and should not infect downstream passes.
     res: list[PropArg] = []
@@ -144,6 +144,8 @@ def _get_prop_args(reads) -> list[PropArg]:
                 res.append(PropArg(arg, layout, list(buf.layouts)))
             else:
                 if not isinstance(layout, FixedTiledLayout):
+                    if not strict:
+                        continue
                     raise RuntimeError(f"{buf} does not have FixedTiledLayout")
                 res.append(PropArg(arg, layout, [layout.device_layout]))
     return res
@@ -1940,27 +1942,194 @@ def _target_device_layout(target, name: str):
     return next(iter(layouts))
 
 
+def _concrete_int(expr) -> int | None:
+    """``expr`` as a plain int, or None if it is absent or stays symbolic."""
+    if expr is None:
+        return None
+    value = concretize_expr(expr)
+    if not isinstance(value, (int, sympy.Integer)):
+        return None
+    return int(value)
+
+
+def _mutation_layout_dtype(
+    target_layout: FixedLayout, target_stl: SpyreTensorLayout
+) -> torch.dtype:
+    """Logical dtype to size a mutation target's sticks by.
+
+    A bool target's stick size comes from the format it is physically stored in
+    (``target_stl``), not from ``target_layout.dtype`` -- see
+    ``bool_layout_dtype``'s docstring.
+    """
+    if target_layout.dtype != torch.bool:
+        return target_layout.dtype
+    return bool_layout_dtype(target_stl.device_dtype, "mutation target")
+
+
+def _is_substick_write(
+    write_stick: sympy.Expr,
+    target_layout: FixedLayout,
+    output_dep: MemoryDep,
+    stick_size: int,
+) -> bool:
+    """Whether an offset-free write covers only part of a full-stick dim.
+
+    A ``[..., :32]`` slice into a 64-wide stick is offset-free yet shorter than
+    the stick, and writing it natively zeroes the tail.
+    """
+    syms = write_stick.free_symbols
+    if len(syms) != 1:
+        return False
+    extent = _concrete_int(output_dep.ranges.get(next(iter(syms))))
+    if extent is None or not 0 < extent < stick_size:
+        return False
+    # A dim naturally narrower than one stick is not a truncation.
+    out_coords = host_coordinates(target_layout, output_dep, None)
+    dim = _pick_stick_dim(write_stick, out_coords)
+    if dim < 0:
+        return False
+    dim_size = _concrete_int(target_layout.size[dim])
+    if dim_size is None:
+        return False
+    return dim_size % stick_size == 0 and dim_size > extent
+
+
+def _align_single_source_producer(
+    target_buffer,
+    alt_stl: SpyreTensorLayout,
+    consumer_counts: dict[str, int],
+) -> None:
+    """Fuse a single-source mutation target into its producer by aligning layouts.
+
+    Putting the producer on ``alt_stl`` too makes the producer -> target edge
+    layout-identical, so the target collapses to an identity that fuses into the
+    producer's kernel instead of becoming a standalone restickify in its own
+    bundle. Purely an optimization.
+    """
+    if not isinstance(target_buffer, ComputedBuffer):
+        return
+    reads = [
+        r for r in target_buffer.get_read_writes().reads if isinstance(r, MemoryDep)
+    ]
+    if len(reads) != 1:
+        return
+    producer_name = reads[0].name
+    if producer_name in V.graph.graph_inputs:
+        return
+    if consumer_counts.get(producer_name, 0) != 1:
+        return
+    producer = V.graph.try_get_buffer(producer_name)
+    if not isinstance(producer, ComputedBuffer):
+        return
+    if not isinstance(producer.data, Pointwise):
+        return
+    producer.layouts = [alt_stl]
+
+
+def _scan_mutation_layout_inputs(
+    operations: list[Operation],
+) -> tuple[dict[str, SpyreTensorLayout], dict[str, int]]:
+    """One walk of ``operations`` gathering ``(alt_stls, consumer_counts)``.
+
+    Aliasing writes into one target must agree on a single alt layout, so
+    ``alt_stls`` is keyed by buffer rather than by op. An internal buffer takes
+    the first alt found and forces the rest onto it. A graph input is
+    caller-visible, so each of its writes is checked against the recorded alt
+    and a disagreement is reported rather than silently forced.
+    """
+    groups: dict[str, list[ComputedBuffer]] = {}
+    consumer_counts: Counter[str] = Counter()
+    for op in operations:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        for read in op.get_read_writes().reads:
+            if isinstance(read, MemoryDep):
+                consumer_counts[read.name] += 1
+        if not isinstance(op.layout, MutationLayoutSHOULDREMOVE):
+            continue
+        # A sliced mutate_to target collapses to a ReinterpretView.
+        target = op.layout.target
+        while isinstance(target, ReinterpretView):
+            target = target.data
+        # An unnamed target has no buffer to key a group by; the main loop
+        # skips it too.
+        name = target.get_name() if hasattr(target, "get_name") else ""
+        if not name:
+            continue
+        groups.setdefault(name, []).append(op)
+
+    alt_stls: dict[str, SpyreTensorLayout] = {}
+    for name, group in groups.items():
+        target_buffer = group[0].layout.get_buffer()
+        # A SpyreEmptyFallback has no device layout until its mutation writers
+        # have run, so it never carries an alt.
+        if isinstance(target_buffer, SpyreEmptyFallback):
+            continue
+        target_layout = target_buffer.get_layout()
+        if not isinstance(target_layout, FixedLayout):
+            continue
+        # A sliced target's own layout describes the slice, not the allocation,
+        # so synthesizing an STL from it would under-count its sticks.
+        target_stl = _target_device_layout(group[0].layout.target, name)
+        if target_stl is None:
+            target_stl = generic_layout(target_buffer)
+        is_graph_input = name in V.graph.graph_inputs
+        for op in group:
+            rw = op.get_read_writes()
+            output_dep = next(iter(rw.writes))
+            # Only the first read is offered, and strict=False drops it when it
+            # has no layout yet -- an internal buffer's producer, say. With no
+            # input the first offset-free candidate wins.
+            # TODO: offer the first read that survives _get_prop_args instead, so
+            # a leading scalar constant does not hide a usable input stick.
+            first_read = next(iter(rw.reads), None)
+            in_args = _get_prop_args([first_read], strict=False)
+            in_arg = in_args[0] if in_args else None
+            alt_stl = _find_alt_target_stl(
+                target_layout, target_stl, output_dep, in_arg
+            )
+            if alt_stl is None:
+                continue
+            if not is_graph_input:
+                alt_stls[name] = alt_stl
+                break
+            # TODO: support conflicting alts by chaining relayouts between
+            # writes through temp buffers.
+            prior_alt = alt_stls.get(name)
+            if prior_alt is not None and prior_alt != alt_stl:
+                raise Unsupported(
+                    f"multiple mutations to graph input {name} require "
+                    f"conflicting alternative layouts ({prior_alt!r} vs "
+                    f"{alt_stl!r}); chaining relayouts between writes is "
+                    f"not yet supported"
+                )
+            alt_stls[name] = alt_stl
+    return alt_stls, consumer_counts
+
+
 def _find_alt_target_stl(
     target_layout: FixedLayout,
     target_stl: SpyreTensorLayout,
     output_dep: MemoryDep,
+    in_arg: PropArg | None = None,
 ) -> SpyreTensorLayout | None:
+    """Alt SpyreTensorLayout with an offset-free stick expression for a mutation
+    target, or None if the current layout already works; raises Unsupported if no
+    alternative exists.
+
+    An offset write, or an offset-free sub-stick write (see
+    ``_is_substick_write``), needs its stick dim relocated. The first candidate
+    reachable from the write's input stick wins, meaning one an ordinary
+    stick-permutation restickify can produce, so a degenerate ``stick=0``
+    candidate cannot win a pairing the cost model would reject as a scatter.
+    Falls back to the first offset-free candidate.
     """
-    Find an alternative SpyreTensorLayout with an offset-free stick expression
-    for a mutation target. Returns None if the current layout is already valid,
-    or raises Unsupported if no valid alternative exists.
-    """
-    # A bool target's stick size comes from the format it is physically stored
-    # in (target_stl), not from target_layout.dtype -- see bool_layout_dtype's
-    # docstring.
-    dtype_for_layout = (
-        bool_layout_dtype(target_stl.device_dtype, "mutation target")
-        if target_layout.dtype == torch.bool
-        else target_layout.dtype
-    )
+    dtype_for_layout = _mutation_layout_dtype(target_layout, target_stl)
     stick_size = get_elem_in_stick(dtype_for_layout)
     write_stick = device_coordinates(target_stl, output_dep, None)[-1]
-    if is_stick_expr_offset_free(write_stick, stick_size):
+    if is_stick_expr_offset_free(write_stick, stick_size) and not (
+        _is_substick_write(write_stick, target_layout, output_dep, stick_size)
+    ):
         return None
 
     c_size = [concretize_expr(s) for s in target_layout.size]
@@ -1973,6 +2142,30 @@ def _find_alt_target_stl(
             f"no offset-free alternative stick dim for mutation target "
             f"(write stick {write_stick!r}, size={target_layout.size})"
         )
+
+    # Prefer a restickify-feasible candidate: a cost node holds one required STL,
+    # so an infeasible pairing cannot be renegotiated once committed -- see the
+    # FixedInOutNode TODO in _clone_layout.
+    if in_arg is not None:
+        in_stl = next(iter(in_arg.layouts))
+        in_dep = in_arg.dep
+        in_layout = in_arg.layout
+        in_host_coords = host_coordinates(in_layout, in_dep, None)
+        in_device_coords = device_coordinates(in_stl, in_dep, None)
+        for candidate in candidates:
+            target_stick = device_coordinates(candidate, output_dep, None)[-1]
+            if (
+                compute_restickify_target_layout(
+                    in_stl,
+                    in_layout,
+                    target_stick,
+                    in_host_coords,
+                    in_device_coords,
+                )
+                is not None
+            ):
+                return candidate
+
     return candidates[0]
 
 
@@ -2203,9 +2396,7 @@ def propagate_spyre_tensor_layouts(
                     tb.data.data.layout = new_layout
                 tb.layouts = [stl]
 
-    # Alt layout each graph input has been forced to by a mutation write, so a
-    # second write can detect a conflicting alt.
-    forced_mutation_alts: dict[str, SpyreTensorLayout] = {}
+    mutation_alts, mutation_consumer_counts = _scan_mutation_layout_inputs(operations)
 
     # Operations are in topological order (guaranteed by GraphLowering).
     # Visit them and use the input SpyreTensorLayouts and the operation being
@@ -2226,7 +2417,17 @@ def propagate_spyre_tensor_layouts(
                 # Look up the actual buffer node (unwraps TensorBox/StorageBox
                 # wrappers that coarse_tile.py places around SpyreEmptyFallback).
                 target_buf = V.graph.get_buffer(target_name) if target_name else None
+                graph_input = V.graph.graph_inputs.get(target_name)
                 target_stl = _target_device_layout(target, target_name)
+                if (
+                    target_stl is None
+                    and graph_input is None
+                    and not isinstance(target_buf, SpyreEmptyFallback)
+                ):
+                    # An internal buffer carries its STL on the producing op's
+                    # layouts, already assigned earlier in this ordered loop.
+                    layouts = getattr(target_buf, "layouts", None)
+                    target_stl = next(iter(layouts)) if layouts else None
                 if target_stl is None:
                     target_buf_layouts = getattr(target_buf, "layouts", None)
                     if not isinstance(target_buf, SpyreEmptyFallback) and (
@@ -2409,37 +2610,50 @@ def propagate_spyre_tensor_layouts(
                 output_dep = next(iter(rw.writes))
                 args = _get_prop_args(rw.reads)
 
-                # Find an alternative layout if the write has an unsupported stick
-                # expression (e.g. offset like v+32). Force the optimizer to use
-                # this layout for the mutation target.
-                # Note: SpyreEmptyFallback targets are not graph inputs so skip
-                # the alt-layout path (which only applies to graph inputs).
+                # An unsupported write stick expression (an offset like v+32, or
+                # an offset-free sub-stick write) needs the stick dim relocated
+                # onto an alt layout, chosen differently per target kind.
                 target_layout = target.get_layout()
-                if isinstance(target_layout, FixedLayout) and not isinstance(
-                    target_buf, SpyreEmptyFallback
-                ):
-                    alt_stl = _find_alt_target_stl(
-                        target_layout, target_stl, output_dep
-                    )
-                    if alt_stl is not None:
-                        graph_input = V.graph.graph_inputs.get(target_name)
-                        assert graph_input is not None
-                        # A graph input holds only one device layout, so two
-                        # writes needing different alts cannot both be expressed.
-                        # TODO: support this by chaining relayouts between writes
-                        # through temp buffers.
-                        prior_alt = forced_mutation_alts.get(target_name)
-                        if prior_alt is not None and prior_alt != alt_stl:
+                # The up-front scan is exhaustive, so a miss here means no alt is
+                # needed rather than none being available.
+                alt_stl = (
+                    mutation_alts.get(target_name)
+                    if isinstance(target_layout, FixedLayout)
+                    and not isinstance(target_buf, SpyreEmptyFallback)
+                    else None
+                )
+                if alt_stl is not None:
+                    assert isinstance(target_layout, FixedLayout)
+                    if graph_input is not None:
+                        write_stick = device_coordinates(target_stl, output_dep, None)[
+                            -1
+                        ]
+                        if is_stick_expr_offset_free(
+                            write_stick,
+                            get_elem_in_stick(
+                                _mutation_layout_dtype(target_layout, target_stl)
+                            ),
+                        ):
+                            # TODO: relocating this write needs a copy-back whose
+                            # write dep spans the caller's host space. The copy-back
+                            # takes N_ from its own write dep ranges, which describe
+                            # the relocated orientation, so its stick extent would
+                            # exceed the caller's allocation.
                             raise Unsupported(
-                                f"multiple mutations to graph input {target_name} "
-                                f"require conflicting alternative layouts "
-                                f"({prior_alt!r} vs {alt_stl!r}); chaining "
-                                f"relayouts between writes is not yet supported"
+                                f"offset-free sub-stick write to graph input "
+                                f"{target_name} is not yet supported (write stick "
+                                f"{write_stick!r}, size={target_layout.size})"
                             )
-                        forced_mutation_alts[target_name] = alt_stl
+                        # A graph input holds only one device layout.
                         graph_input.layouts = [alt_stl]
-                        op._restickify_plan = (target_name, target_stl, alt_stl)
-                        target_stl = alt_stl
+                    else:
+                        assert target_buf is not None
+                        target_buf.layouts = [alt_stl]
+                        _align_single_source_producer(
+                            target_buf, alt_stl, mutation_consumer_counts
+                        )
+                    op._restickify_plan = (target_name, target_stl, alt_stl)
+                    target_stl = alt_stl
                 op.layouts = [target_stl]
                 op.restick_cost_fn = AllSameNode.from_args(
                     args, [target_stl], output_dep, op


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

`torch.cat` whose split point is not a stick multiple previously returned wrong results silently. Such a concat lowers to **two slice writes into one freshly cloned buffer**, both landing in the *same* 64-wide stick — `[..., :32]` (offset-free but sub-stick) and `[..., 32:64]` (offset). Written natively, each pads its slice to a full stick and zeroes the tail, so whichever lands second clobbers the other.

The two writes already shared the buffer; what they did not share was a *layout*. This PR makes them agree on **one alternate layout** for that buffer, chosen once per mutation target, which moves the offset off the stick dim so both writes lower natively and the whole stick is covered.

The underlying capability is more general: offset and sub-stick slice writes into an **internal, compiler-allocated buffer** now compile at all.

```python
base[..., 32:64].copy_(src)   # into a buffer the compiler allocated, not an argument
```

---

### High-level overview

A mutation write needs its target's device layout to place the write inside a stick. When the write is offset (`[..., 32:64]`) or covers only part of a full-stick dim (`[..., :32]`), the target's natural layout cannot express it. The fix relocates the target onto an **alternate layout** whose stick dim is a different host dim, so the offset moves off the stick axis and every write becomes whole-stick.

The choice of alternate layout must be **per buffer, not per write** — aliasing siblings from one `cat` write into the same buffer and must agree. The work spans two passes that run in sequence.

**1. `propagate_layouts.py`** — decides the layout. One up-front scan picks a single alt per mutation target, so the main loop finds the decision already made instead of discovering a conflict per op:

```
propagate_spyre_tensor_layouts              # the pass; one walk over all operations
├── _scan_mutation_layout_inputs            # ADDED: up-front, one alt per target
│   ├── group aliasing writes by target buffer name
│   └── _find_alt_target_stl                #   first offset-free candidate becomes the shared alt
│       └── _is_substick_write              #   ADDED: offset-free yet shorter than a full stick?
└── for op in operations:                   # the mutation block
    ├── mutation_alts.get(target_name)      #   reuse the alt the scan committed
    ├── _align_single_source_producer        # ADDED: put the producer on the same alt so the
    │                                        #   copy edge is layout-identical and fuses
    └── op._restickify_plan = (...)          # hands the target + alt to insert_restickify
```

The scan resolves a group by target kind. An **internal buffer** takes the first alt found and forces the rest onto it, which the retarget below makes physically true for every writer. A **graph input** is caller-visible, so each of its writes is checked against the recorded alt and a disagreement raises `Unsupported` rather than being silently forced; chaining relayouts between conflicting writes is left as a `TODO`. Targets with no device layout yet — a `SpyreEmptyFallback` — are excluded.

`_find_alt_target_stl` gained an `in_arg` parameter so it prefers a candidate *reachable* from the write's input stick — one an ordinary stick-permutation restickify can actually produce — rather than letting a degenerate `stick=0` candidate win.

**2. `insert_restickify.py`** — applies the decision. An internal buffer has no caller-owned address and no pre-existing data, so unlike a graph input it needs **no copy-back**:

```
insert_post_mutation_restickify             # runs after insert_restickify
└── for op in tagged_ops:                   # ops carrying _restickify_plan
    ├── graph input?  -> existing copy-back path (unchanged)
    │                    pre-restickify, copy-back, set_spyre_tensor_layout
    └── _retarget_internal_buf_mutation     # ADDED: replaces assert graph_input is not None
        └── rebind the write onto the alt-layout buffer via a fresh ReinterpretView
```

The internal buffer is *born* in the alt layout — propagation commits it, `finalize_layouts` wraps it, `spyre_empty_with_layout` allocates it — so the retarget only rebinds the write; there is nothing to repair afterwards and no `set_spyre_tensor_layout` call. Only the graph-input arm emits one, and graph I/O is never HBM-pooled, so it needs no pooling exception to survive. **This PR therefore leaves `hbm_pool_planning.py` untouched.**

A genuine multi-level view is rejected by assert as a loud tripwire rather than shipping untestable recomposition.

#### Which issue(s) this PR is related to:

Fixes #1464 (Identity handling for values smaller than a stick along the stick dimension) — the follow-up promised in https://github.com/torch-spyre/torch-spyre/issues/1464#issuecomment-4693069453: #2595 enabled unaligned slices on *input* tensors, and this PR does the same for *output* (mutation) buffers. It is also step 2 of the plan in https://github.com/torch-spyre/torch-spyre/issues/1464#issuecomment-4507833586; step 3 (#1756) has since landed, so nothing else blocks #1464.

Related to #1094 (Enable/test torch.cat for Q2 & Q3 target models).

Scope note on #1464: it names `torch.stack` and `torch.nn.functional.pad` alongside `torch.cat`. The mutation-buffer mechanism fixed here is the one all three share, but only `torch.cat` is covered by tests — `stack` and `pad` are unverified and may need their own lowering work.

#### Special notes for your reviewer:

**One shape now raises instead of miscompiling.** An offset-free (`start=0`) sub-stick write into a **graph input** is rejected in `propagate_layouts` with a named `Unsupported`, before any alt layout is committed — preserving the stick tail across a copy-back is not representable on that path. On `main` this shape silently returns wrong results, so the raise is a strict improvement. The same write into an **internal** buffer is supported and goes through the relocation above.

**Known gap, deferred to a follow-up: a size-1 stick dim.** When the stick dim has size 1, Inductor collapses its range-1 loop and the stick access arrives as a bare integer constant with no loop variable. `is_stick_expr_offset_free` admits only `Mod(var, 64)`, a bare symbol, or literal `0`, so a nonzero constant offset (`[..., 3:4]`) matches no admitted form and raises. This is pre-existing, affects reads and writes through that one shared predicate, and no shape here reaches it — `torch.cat` on a size-1 stick dim is the case to watch.

**Test coverage.** `test_strict_cat_model_shapes` covers the target-model shapes: the four aligned and non-stick-dim shapes take the no-relocation path, and the two mid-stick 32+32 shapes relocate both writes onto one shared layout. The `slice_scatter` param sets `2d_substick_off32` and `substick_off32_3d` cover the offset sub-stick write on the compiled-op path, over a stick dim spanning four sticks and a single stick respectively.

**Not covered, for the record.** Neither `raise Unsupported` path has a test. No test produces an internal-buffer group whose writers want *different* alts, so the "first alt wins, force the rest" resolution is exercised only where all writers independently agree (measured: two multi-writer groups, both agreeing); its safety under genuine disagreement rests on the retarget rebinding every writer onto one buffer, not on test evidence.

#### Does this PR introduce a user-facing change?

Yes. `torch.cat` whose split point is not a stick multiple (e.g. the mid-stick 32+32 rotary-embedding concats) previously returned wrong results silently, with a zero exit status; it now compiles correctly. More generally, offset and sub-stick slice writes into compiler-allocated buffers no longer miscompile. One shape that previously miscompiled silently — an offset-free sub-stick write into a graph input — now raises `Unsupported` instead.
