### PR TITLE
Copy forced cleanup

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1851,7 +1851,7 @@ def test_copy_rmw_correction_512x256_A4_B4():
     run_coarse_tile_test(fn, inputs)
 
 
-# --- copy after reduction: copy_forced(x.amin(dim=0, out)) ---
+# --- copy after reduction: copy_forced(x.amin(dim=0), out) ---
 # copies sparse reduction result into a dense buffer
 
 
@@ -1890,7 +1890,7 @@ def test_copy_not_deleted():
 
 
 def test_copy_after_reduction_512x256_A4():
-    """copy_forced(x.amin(dim=0, out)) on [512,256] tiled A÷4 must be rejected."""
+    """copy_forced(x.amin(dim=0), out) on [512,256] tiled A÷4 must be rejected."""
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
 
     def fn(x):
@@ -1909,7 +1909,7 @@ def test_copy_after_reduction_512x256_A4():
 
 
 def test_copy_after_reduction_512x256_B4():
-    """copy_forced(x.amin(dim=0, out)) on [512,256] tiled B÷4."""
+    """copy_forced(x.amin(dim=0), out) on [512,256] tiled B÷4."""
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
 
     def fn(x):
@@ -1926,7 +1926,7 @@ def test_copy_after_reduction_512x256_B4():
 
 
 def test_copy_after_reduction_512x256_A4_B4():
-    """copy_forced(x.amin(dim=0, out)) on [512,256] tiled A÷4 B÷4 must be rejected."""
+    """copy_forced(x.amin(dim=0), out) on [512,256] tiled A÷4 B÷4 must be rejected."""
     inputs = [tensor("x", shape=(512, 256), dims=["A", "B"])]
 
     def fn(x):
@@ -1952,10 +1952,10 @@ def test_copy_after_reduction_512x256_A4_B4():
     "mutation_write_back copy_out fix (39.7% mismatch) -- distinct/deeper bug"
 )
 def test_copy_running_max_4d_H4_Lq4():
-    """copy_forced(maximum(real_max, amax(scores,dim=-2, running_max))) on [B,H,Lk,Lq] tiled H÷4 Lq÷4.
+    """copy_forced(maximum(real_max, amax(scores,dim=-2)), real_max) on [B,H,Lk,Lq] tiled H÷4 Lq÷4.
 
     Minimal flash-attention-style reproducer: 4D scores [B,H,Lk,Lq] reduced over
-    dim=-2 (Lk), then max with a running accumulator, then copy_ back.
+    dim=-2 (Lk), then max with a running accumulator, then copy_forced back.
     """
     B, H, Lk, Lq = 2, 32, 4096, 4096
     h_block_size = 4
@@ -1981,7 +1981,7 @@ def test_copy_running_max_4d_H4_Lq4():
     run_coarse_tile_test(fn, inputs)
 
 
-# --- copy + restickify: copy_forced(a.t(, c) + b) ---
+# --- copy + restickify: copy_forced(a.t() + b, c) ---
 # copy target receives a restickified input — tests copy layout after restickify
 
 
@@ -1990,7 +1990,7 @@ def test_copy_running_max_4d_H4_Lq4():
     "beam search when target has multiple candidates -- see issue #3845"
 )
 def test_copy_restickify_512x256_A4():
-    """copy_forced(a.t(, c)+b) on [256,512] result tiled A÷4 — copy of restickified add."""
+    """copy_forced(a.t()+b, c) on [256,512] result tiled A÷4 — copy of restickified add."""
     inputs = [
         tensor("a", shape=(512, 256), dims=["B", "A"]),
         tensor("b", shape=(256, 512), dims=["A", "B"]),
@@ -2012,7 +2012,7 @@ def test_copy_restickify_512x256_A4():
     "beam search when target has multiple candidates -- see issue #3845"
 )
 def test_copy_restickify_512x256_B4():
-    """copy_forced(a.t(, c)+b) on [256,512] result tiled B÷4."""
+    """copy_forced(a.t()+b, c) on [256,512] result tiled B÷4."""
     inputs = [
         tensor("a", shape=(512, 256), dims=["B", "A"]),
         tensor("b", shape=(256, 512), dims=["A", "B"]),
@@ -2034,7 +2034,7 @@ def test_copy_restickify_512x256_B4():
     "beam search when target has multiple candidates -- see issue #3845"
 )
 def test_copy_restickify_512x256_A4_B4():
-    """copy_forced(a.t(, c)+b) on [256,512] result tiled A÷4 B÷4."""
+    """copy_forced(a.t()+b, c) on [256,512] result tiled A÷4 B÷4."""
     inputs = [
         tensor("a", shape=(512, 256), dims=["B", "A"]),
         tensor("b", shape=(256, 512), dims=["A", "B"]),
@@ -2057,7 +2057,7 @@ def test_copy_restickify_512x256_A4_B4():
 
 
 def test_copy_accum_with_reduction_512x256_A4():
-    """copy_forced(acc * scale + x.amin(dim=1,keepdim=True, acc)) tiled A÷4."""
+    """copy_forced(acc * scale + x.amin(dim=1, keepdim=True), acc) tiled A÷4."""
     inputs = [
         tensor("acc", shape=(512, 256), dims=["A", "B"]),
         tensor("scale", shape=(512, 1), dims=["A", "B"]),
@@ -2082,7 +2082,7 @@ def test_copy_accum_with_reduction_512x256_A4():
     )
 )
 def test_copy_accum_with_reduction_512x256_B4():
-    """copy_forced(acc * scale + x.amin(dim=1,keepdim=True, acc)) tiled B÷4."""
+    """copy_forced(acc * scale + x.amin(dim=1, keepdim=True), acc) tiled B÷4."""
     inputs = [
         tensor("acc", shape=(512, 256), dims=["A", "B"]),
         tensor("scale", shape=(512, 1), dims=["A", "B"]),
@@ -2107,7 +2107,7 @@ def test_copy_accum_with_reduction_512x256_B4():
     )
 )
 def test_copy_accum_with_reduction_512x256_A4_B4():
-    """copy_forced(acc * scale + x.amin(dim=1,keepdim=True, acc)) tiled A÷4 B÷4."""
+    """copy_forced(acc * scale + x.amin(dim=1, keepdim=True), acc) tiled A÷4 B÷4."""
     inputs = [
         tensor("acc", shape=(512, 256), dims=["A", "B"]),
         tensor("scale", shape=(512, 1), dims=["A", "B"]),
@@ -2333,7 +2333,8 @@ def test_outside_consumer_copy_then_read_512x256_A4_B4():
 
 
 def test_outside_consumer_two_accum_512x256_A4():
-    """Flash-style: out=zeros, denom=zeros; tiled copy_; return out/denom — A÷4."""
+    """out=zeros, denom=zeros; tiled copy_forced(denom+amin(dim=0), denom) on
+    [512,512] A÷4 — reducing and tiling over the same dim must be rejected."""
     inputs = [
         tensor("x", shape=(512, 512), dims=["A", "B"]),
         tensor("scale", shape=(512, 512), dims=["A", "B"]),

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -1264,13 +1264,12 @@ def lower_spyre_from_d2d(src, dst, src_off, dst_off):
     lowering.mutate_to(dst, src)
 
 
-@register_spyre_lowering(torch.ops.spyre.copy_forced)
-def lower_spyre_copy_forced(src, dst):
-    # Custom lowering for copy_forced to ensure it creates
-    # a mutation layout in all cases.  mutate_to()
-    # has multiple code paths and does not always
-    # mutate
-
+def _build_mutation_lowering(src, dst):
+    # Shared lowering body for copy_forced and opaque_copy_: builds an
+    # explicit MutationLayoutSHOULDREMOVE buffer so the mutation into dst
+    # survives regardless of what the scheduler would otherwise decide.
+    # mutate_to() has multiple code paths and does not always mutate, so
+    # the buffer is constructed by hand here instead.
     src = lowering.to_dtype(src, dst.get_dtype())
     src = lowering.expand(src, dst.get_size())
 
@@ -1294,36 +1293,21 @@ def lower_spyre_copy_forced(src, dst):
     return dst
 
 
+@register_spyre_lowering(torch.ops.spyre.copy_forced)
+def lower_spyre_copy_forced(src, dst):
+    return _build_mutation_lowering(src, dst)
+
+
 @register_spyre_lowering(torch.ops.spyre.opaque_copy_)
 def lower_spyre_opaque_copy_(value, acc):
     # opaque_copy_ is functional at the FX/AOTAutograd level (see customops.py)
     # so that assert_functional_graph never sees a mutation. The real
-    # mutating write into acc is introduced here, at lowering time, by
-    # building the same MutationLayoutSHOULDREMOVE(acc) buffer that
-    # lower_spyre_copy_forced builds for copy_forced. Everything downstream
-    # that keys off MutationLayoutSHOULDREMOVE (e.g. wsr/coarse_tile.py)
-    # treats this identically to a copy_forced write.
-    value = lowering.to_dtype(value, acc.get_dtype())
-    value = lowering.expand(value, acc.get_size())
-
-    pw = Pointwise.create(
-        device=acc.get_device(),
-        dtype=acc.get_dtype(),
-        inner_fn=value.make_loader(),
-        ranges=list(acc.get_size()),
-    )
-
-    acc.realize()
-
-    buffer = ir.ComputedBuffer(
-        name=None,
-        layout=ir.MutationLayoutSHOULDREMOVE(acc),
-        data=pw.data.data,
-    )
-    buffer.name = V.graph.register_buffer(buffer)
-    V.graph.register_operation(buffer)
-
-    return acc
+    # mutating write into acc is introduced here, at lowering time, via the
+    # same MutationLayoutSHOULDREMOVE(acc) buffer that lower_spyre_copy_forced
+    # builds for copy_forced. Everything downstream that keys off
+    # MutationLayoutSHOULDREMOVE (e.g. wsr/coarse_tile.py) treats this
+    # identically to a copy_forced write.
+    return _build_mutation_lowering(value, acc)
 
 
 @register_spyre_lowering(torch.ops.spyre.overwrite)

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -648,7 +648,7 @@ def _plan_tiling_propagation(
                             operations,
                             name_to_group_outer_key,
                         )
-                    except Exception:
+                    except (AttributeError, TypeError):
                         target_is_graph_input = False
                         target_is_output = False
                         mut_target = None


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://g
ithub.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Follow-up to #3811 addressing review comments left on its approving
review. No functional/behavioral changes are intended; this is
docstring, dedup, and exception-narrowing cleanup plus one answered
question.

- **Docstring typos.** The mechanical `copy_f` → `copy_forced` rename
  in #3811 left several broken pseudo-signatures in
  `test_coarse_tile_e2e.py` docstrings, where the destination argument
  got spliced into the source argument list (e.g.
  `copy_forced(a.t(, c)+b)` instead of `copy_forced(a.t()+b, c)`).
  Fixed across the `copy_after_reduction`, `copy_restickify`,
  `copy_running_max_4d`, and `copy_accum_with_reduction` test groups
  and their group-header comments.
- **Duplicated lowering bodies.** `lower_spyre_copy_forced` and
  `lower_spyre_opaque_copy_` (`torch_spyre/_inductor/lowering.py`) had
  identical bodies differing only in parameter names. Extracted the
  shared `MutationLayoutSHOULDREMOVE`-buffer construction into
  `_build_mutation_lowering(src, dst)`, called by both.
- **Bare `except Exception`.** `_plan_tiling_propagation`'s
  `mutation_write_back` detection block
  (`torch_spyre/_inductor/wsr/coarse_tile.py`) caught bare `Exception`
  around `op.layout.get_buffer()`/`get_name()` and the outside-consumer
  lookup, silently falling through to `loop_internal` on any error.
  Narrowed to `(AttributeError, TypeError)`, the only exceptions
  plausible there given the `isinstance(op.layout,
  MutationLayoutSHOULDREMOVE)` check already performed just above. The
  unrelated `except Exception` in `_insert_copy_op` is left alone —
  it scans layouts of arbitrary ops across the whole operations list
  and is genuinely defensive there, per the reviewer's own note.
- **Stale test docstring / answered question.**
  `test_outside_consumer_two_accum_512x256_A4`'s docstring still
  described the original flash-style pass case (`[512,256]`,
  `sum(dim=1)`), but #3811 intentionally reshaped it to `[512,512]`,
  switched to `amin(dim=0)`, and converted it to a should-raise case —
  confirmed by #3811's own commit message: "reducing and tiling over
  the same dim is unsupported and should raise." This was an
  intentional construction of a should-raise case, not an accidental
  side effect. Updated the docstring to describe the actual test;
  left the function name unchanged (still `_512x256`) since nothing
  external references it and no rename was requested.

#### Which issue(s) this PR is related to:

Addresses review comments from
https://github.com/torch-spyre/torch-spyre/pull/3811#pullrequestreview-4975055470

Part of #206

#### Special notes for your reviewer:

- Verified the `except Exception` narrowing doesn't surface any
  previously-masked error: `test_coarse_tile_e2e.py` +
  `test_building_blocks.py` pass with identical skip/xfail counts
  before and after.
- Verified the lowering dedup with the `copy_forced`/`copy` test group
  in `test_coarse_tile_e2e.py` and the SDPA tests in
  `test_inductor_ops.py` (exercises `opaque_copy_`).
- All changes are comment/docstring/refactor-only except the
  exception-type narrowing, which is a no-op unless a previously
  silently-swallowed bug exists — none was found.

#### Does this PR introduce a user-facing change?

No.

#### Additional note:
