### PR TITLE
inductor/sdpa: canonicalize query layout in score matmul

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -7085,41 +7085,19 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_sdpa_bf16_gqa_decode_query_canonicalized(self):
-        """Layout regression test for the dense Gemma-4-12b **decode** garbage
-        bug (special-token gibberish like ``258882 '<image|>'`` on device while
-        prefill was already correct — root-caused in hf-adapters PR #379, fixed
-        in ``spyre__sdpa_overrideable``'s decomp).
+        """Layout regression test for the dense Gemma-4-12b decode bug.
 
-        The query reaches the SDPA score matmul transposed: physical
-        ``[B, S, H, D]`` but logical ``[B, H, S, D]``, the layout the adapter's
-        ``apply_rope_matmul`` ``view(B, S, H, D).transpose(1, 2)`` (+ RoPE
-        ``.sum(4)``) produces. In the *device* layout of that transposed view the
-        stick-major axis is ``head_dim``, so ``num_heads`` is NOT the outermost
-        device dim. As the FIRST operand of the score matmul the query's physical
-        stick layout picks which rows the matmul reads; in the full fused decode
-        graph the wrong sticks are read silently → finite but wrong output. K/V
-        are immune (second operand / value; the decomp's internal transpose
-        absorbs their layout), which is why a KV-side barrier is inert. The fix
-        copies the query into fresh contiguous ``[B, H, S, D]`` zeros (via
-        ``spyre.opaque_copy_``) before it drives the matmul, forcing ``num_heads``
-        back to the outermost device dim.
+        The query reaches the score matmul transposed (physical [B, S, H, D]
+        behind a logical [B, H, S, D] view, as apply_rope_matmul produces). As the
+        first matmul operand its device layout selects which rows are read, so in
+        the full graph the wrong sticks are read. The isolated op reads it
+        correctly, so this asserts the fix's mechanism rather than numerics: the
+        score matmul's query operand must have num_heads outermost in its device
+        layout (device_size[0] == num_heads; == 1 without the fix). End-to-end
+        numerics are covered by the hf-adapters gemma-4-12b token-compare test.
 
-        A standalone SDPA op CANNOT reproduce the *numerical* corruption: even
-        with the query carrying gemma's byte-exact transposed device layout, the
-        isolated matmul reads it correctly — the corruption is composition/scale
-        dependent (which is why PR #379 split the graph), and the end-to-end
-        numerics are guarded by hf-adapters' gemma-4-12b token-compare test. What
-        this test locks in instead is the fix's *mechanism*, which IS observable
-        in isolation: it asserts the score matmul's query operand reaches the
-        matmul with ``num_heads`` outermost in its device layout. Without the fix
-        ``device_size[0]`` is the (size-1) query length and ``num_heads`` sits at
-        an inner device dim → the assertion fails; with the fix
-        ``device_size[0] == num_heads``.
-
-        Covers both dense Gemma-4-12b decode attention types: sliding (16 query /
-        8 KV heads, head_dim 256) and full (16 query / 1 KV head, head_dim 512).
-        Sq=1 (a single decode step) matters: prefill was already correct in the
-        failing baseline; only the single-query decode step was corrupted."""
+        Covers both decode attention types, Sq=1: sliding (16/8 heads, head_dim
+        256) and full (16/1 heads, head_dim 512)."""
         from torch_spyre._inductor.constants import (
             BATCH_MATMUL_FP8_OP,
             BATCH_MATMUL_OP,
@@ -7159,8 +7137,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 mask = torch.zeros((1, 1, sq, skv), dtype=torch.bfloat16)
 
                 def fn(q_source, k, v, mask):
-                    # In-graph view+transpose reproduces the adapter's RoPE-output
-                    # query layout: physical [B, S, H, D], logical [B, H, S, D].
+                    # view+transpose gives the transposed query the adapter feeds.
                     q = q_source.view(1, sq, num_heads, head_dim).transpose(1, 2)
                     return F.scaled_dot_product_attention(
                         q,
@@ -7174,9 +7151,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
 
                 expected = fn(q_source, k, v, mask)
 
-                # Capture the device_size of every batch-matmul's first (x) input
-                # operand as the compiler emits its op-specs. For the score
-                # matmul that first operand is the query.
+                # Capture each batch-matmul's first (x) operand device_size.
                 bmm_x_sizes = []
                 orig_create_op_spec = SpyreKernel.create_op_spec
 
@@ -7204,10 +7179,8 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                         .flatten()
                     )
 
-                # The score matmul's query operand is the batch-matmul x-operand
-                # whose device layout holds exactly num_heads * head_dim elements
-                # (the value matmul's probs operand has num_heads * Sq * Skv, and
-                # the weight operands are larger). Sq == 1 here.
+                # The query operand is the x-operand with num_heads * head_dim
+                # elements (Sq == 1); other matmul operands have different sizes.
                 query_elems = num_heads * sq * head_dim
                 query_sizes = [ds for ds in bmm_x_sizes if math.prod(ds) == query_elems]
                 self.assertTrue(
@@ -7222,19 +7195,12 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                         ds[0],
                         num_heads,
                         msg=(
-                            f"[{name}] the score matmul's query operand reaches "
-                            f"the matmul with num_heads not outermost in its "
-                            f"device layout (device_size={ds}); the query-"
-                            f"canonicalization fix in spyre__sdpa_overrideable "
-                            f"should force device_size[0] == num_heads="
-                            f"{num_heads}. This is the dense Gemma-4-12b decode "
-                            f"transposed-query bug (hf-adapters PR #379)."
+                            f"[{name}] query operand device_size={ds}; expected "
+                            f"num_heads={num_heads} outermost (device_size[0])"
                         ),
                     )
 
-                # Sanity guard: the op still compiles and runs to finite output.
-                # (Isolated numerics match with or without the fix — see above —
-                # so this is not the fix-regression signal, only breakage bait.)
+                # Sanity guard: still compiles to finite output.
                 expected = expected.float().flatten()
                 cosine = F.cosine_similarity(actual, expected, dim=0).item()
                 self.assertTrue(

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -7084,6 +7084,167 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         )
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
+    def test_sdpa_bf16_gqa_decode_query_canonicalized(self):
+        """Layout regression test for the dense Gemma-4-12b **decode** garbage
+        bug (special-token gibberish like ``258882 '<image|>'`` on device while
+        prefill was already correct — root-caused in hf-adapters PR #379, fixed
+        in ``spyre__sdpa_overrideable``'s decomp).
+
+        The query reaches the SDPA score matmul transposed: physical
+        ``[B, S, H, D]`` but logical ``[B, H, S, D]``, the layout the adapter's
+        ``apply_rope_matmul`` ``view(B, S, H, D).transpose(1, 2)`` (+ RoPE
+        ``.sum(4)``) produces. In the *device* layout of that transposed view the
+        stick-major axis is ``head_dim``, so ``num_heads`` is NOT the outermost
+        device dim. As the FIRST operand of the score matmul the query's physical
+        stick layout picks which rows the matmul reads; in the full fused decode
+        graph the wrong sticks are read silently → finite but wrong output. K/V
+        are immune (second operand / value; the decomp's internal transpose
+        absorbs their layout), which is why a KV-side barrier is inert. The fix
+        copies the query into fresh contiguous ``[B, H, S, D]`` zeros (via
+        ``spyre.opaque_copy_``) before it drives the matmul, forcing ``num_heads``
+        back to the outermost device dim.
+
+        A standalone SDPA op CANNOT reproduce the *numerical* corruption: even
+        with the query carrying gemma's byte-exact transposed device layout, the
+        isolated matmul reads it correctly — the corruption is composition/scale
+        dependent (which is why PR #379 split the graph), and the end-to-end
+        numerics are guarded by hf-adapters' gemma-4-12b token-compare test. What
+        this test locks in instead is the fix's *mechanism*, which IS observable
+        in isolation: it asserts the score matmul's query operand reaches the
+        matmul with ``num_heads`` outermost in its device layout. Without the fix
+        ``device_size[0]`` is the (size-1) query length and ``num_heads`` sits at
+        an inner device dim → the assertion fails; with the fix
+        ``device_size[0] == num_heads``.
+
+        Covers both dense Gemma-4-12b decode attention types: sliding (16 query /
+        8 KV heads, head_dim 256) and full (16 query / 1 KV head, head_dim 512).
+        Sq=1 (a single decode step) matters: prefill was already correct in the
+        failing baseline; only the single-query decode step was corrupted."""
+        from torch_spyre._inductor.constants import (
+            BATCH_MATMUL_FP8_OP,
+            BATCH_MATMUL_OP,
+        )
+        from torch_spyre._inductor.spyre_kernel import SpyreKernel
+
+        # (name, num_heads, num_kv_heads, head_dim)
+        geometries = [("sliding", 16, 8, 256), ("full", 16, 1, 512)]
+        for name, num_heads, num_kv_heads, head_dim in geometries:
+            with self.subTest(attention=name):
+                sq, skv = 1, 64
+                generator = torch.Generator().manual_seed(1337)
+                q_source = (
+                    torch.randn(
+                        (1, sq, num_heads * head_dim),
+                        dtype=torch.bfloat16,
+                        generator=generator,
+                    )
+                    * 0.1
+                )
+                k = (
+                    torch.randn(
+                        (1, num_kv_heads, skv, head_dim),
+                        dtype=torch.bfloat16,
+                        generator=generator,
+                    )
+                    * 0.1
+                )
+                v = (
+                    torch.randn(
+                        (1, num_kv_heads, skv, head_dim),
+                        dtype=torch.bfloat16,
+                        generator=generator,
+                    )
+                    * 0.1
+                )
+                mask = torch.zeros((1, 1, sq, skv), dtype=torch.bfloat16)
+
+                def fn(q_source, k, v, mask):
+                    # In-graph view+transpose reproduces the adapter's RoPE-output
+                    # query layout: physical [B, S, H, D], logical [B, H, S, D].
+                    q = q_source.view(1, sq, num_heads, head_dim).transpose(1, 2)
+                    return F.scaled_dot_product_attention(
+                        q,
+                        k,
+                        v,
+                        attn_mask=mask,
+                        dropout_p=0.0,
+                        scale=1 / head_dim**0.5,
+                        enable_gqa=True,
+                    )
+
+                expected = fn(q_source, k, v, mask)
+
+                # Capture the device_size of every batch-matmul's first (x) input
+                # operand as the compiler emits its op-specs. For the score
+                # matmul that first operand is the query.
+                bmm_x_sizes = []
+                orig_create_op_spec = SpyreKernel.create_op_spec
+
+                def capturing_create_op_spec(
+                    self, op, is_reduction, args, op_info, *a, **kw
+                ):
+                    if op in (BATCH_MATMUL_OP, BATCH_MATMUL_FP8_OP) and args:
+                        bmm_x_sizes.append(list(args[0].device_size))
+                    return orig_create_op_spec(
+                        self, op, is_reduction, args, op_info, *a, **kw
+                    )
+
+                with mock.patch.object(
+                    SpyreKernel, "create_op_spec", capturing_create_op_spec
+                ):
+                    actual = (
+                        torch.compile(fn, dynamic=False)(
+                            q_source.to("spyre"),
+                            k.to("spyre"),
+                            v.to("spyre"),
+                            mask.to("spyre"),
+                        )
+                        .cpu()
+                        .float()
+                        .flatten()
+                    )
+
+                # The score matmul's query operand is the batch-matmul x-operand
+                # whose device layout holds exactly num_heads * head_dim elements
+                # (the value matmul's probs operand has num_heads * Sq * Skv, and
+                # the weight operands are larger). Sq == 1 here.
+                query_elems = num_heads * sq * head_dim
+                query_sizes = [
+                    ds for ds in bmm_x_sizes if math.prod(ds) == query_elems
+                ]
+                self.assertTrue(
+                    query_sizes,
+                    msg=(
+                        f"[{name}] no batch-matmul input operand with "
+                        f"{query_elems} elements found; captured {bmm_x_sizes}"
+                    ),
+                )
+                for ds in query_sizes:
+                    self.assertEqual(
+                        ds[0],
+                        num_heads,
+                        msg=(
+                            f"[{name}] the score matmul's query operand reaches "
+                            f"the matmul with num_heads not outermost in its "
+                            f"device layout (device_size={ds}); the query-"
+                            f"canonicalization fix in spyre__sdpa_overrideable "
+                            f"should force device_size[0] == num_heads="
+                            f"{num_heads}. This is the dense Gemma-4-12b decode "
+                            f"transposed-query bug (hf-adapters PR #379)."
+                        ),
+                    )
+
+                # Sanity guard: the op still compiles and runs to finite output.
+                # (Isolated numerics match with or without the fix — see above —
+                # so this is not the fix-regression signal, only breakage bait.)
+                expected = expected.float().flatten()
+                cosine = F.cosine_similarity(actual, expected, dim=0).item()
+                self.assertTrue(
+                    torch.isfinite(actual).all() and cosine >= 0.99,
+                    msg=f"[{name}] cosine={cosine:.8f}",
+                )
+
+    @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_implicit_loading(self):
         def test(end, device=None):
             return torch.arange(end, device=device, dtype=torch.float16)

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -7209,9 +7209,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 # (the value matmul's probs operand has num_heads * Sq * Skv, and
                 # the weight operands are larger). Sq == 1 here.
                 query_elems = num_heads * sq * head_dim
-                query_sizes = [
-                    ds for ds in bmm_x_sizes if math.prod(ds) == query_elems
-                ]
+                query_sizes = [ds for ds in bmm_x_sizes if math.prod(ds) == query_elems]
                 self.assertTrue(
                     query_sizes,
                     msg=(

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -427,51 +427,22 @@ def spyre__sdpa_overrideable(
         key = key.unsqueeze(2).expand(-1, -1, expansion, -1, -1).flatten(1, 2)
         value = value.unsqueeze(2).expand(-1, -1, expansion, -1, -1).flatten(1, 2)
 
-    # Canonicalize ``query``'s layout before it drives the score matmul below.
-    #
-    # ``query`` reaches this decomp transposed (physical [B, S, H, D], logical
-    # [B, H, S, D]) whenever it was built as ``...view(B, S, H, D).transpose(1, 2)``
-    # -- the standard attention path (e.g. hf-adapters' apply_rope_matmul, whose
-    # RoPE ``.sum(4)`` leaves the query transposed). As the FIRST matmul operand,
-    # ``query``'s physical stick layout picks which rows ``torch.matmul`` reads;
-    # matmul-layout Pass 1 accepts the transposed view as a zero-cost stick match
-    # whenever the physical stick coincidentally carries the needed loop var, so
-    # the matmul silently reads the wrong sticks and the attention output is wrong
-    # (Gemma 4 dense decode produced garbage special tokens, top-1 diverged with
-    # a per-token logit max-diff ~11; prefill was already correct). Key/value do
-    # NOT need this: they feed the matmul as the second operand / value, so the
-    # decomp's internal transpose absorbs their entry layout.
-    #
-    # spyre.opaque_copy_ (PR #3811) is a functional custom op whose Inductor
-    # lowering introduces a MutationLayoutSHOULDREMOVE write one stage after
-    # AOTAutograd's functional-graph check -- so it survives remove_noop_ops
-    # (an aten.clone/aten.copy here is in Inductor's noop_registry and gets
-    # eliminated before any Spyre restickify pass runs) AND is legal inside this
-    # decomp (reached via proxy-mode decomposition substitution, which never
-    # re-enters FunctionalTensorMode; a mutating copy_forced would trip
-    # assert_functional_graph). The copy into a FRESH CONTIGUOUS destination
-    # (torch.zeros, NOT zeros_like) forces a restickify to canonical [B, H, S, D]
-    # layout. Use the canonical copy ONLY in the matmul; ``query`` itself is left
-    # untouched because the output permute-dance below keys on ``query.stride()``
-    # to satisfy the meta kernel's output-stride assertion.
+    # query can arrive transposed (physical [B, S, H, D] behind a logical
+    # [B, H, S, D] view). As the first matmul operand its physical layout selects
+    # which rows are read, so the transposed view reads the wrong sticks. Copy
+    # into a fresh contiguous buffer to canonicalize; opaque_copy_ is used because
+    # a clone/copy would be dropped by Inductor's noop_registry before restickify.
+    # Use the copy only in the score matmul -- the output permute below keys on
+    # the original query.stride().
     query_c = torch.zeros(list(query.shape), device=query.device, dtype=query.dtype)
     query_m = torch.ops.spyre.opaque_copy_(query, query_c)
 
     kv_block_size = 64
     q_block_size = 64
 
-    # The output accumulator must NOT inherit ``query``'s physical layout.
-    # ``query`` reaches this decomp transposed (physical [B, S, H, D], logical
-    # [B, H, S, D]) whenever it was built as ``...view(B,S,H,D).transpose(1,2)``
-    # (the standard attention path, e.g. hf-adapters' apply_rope_matmul). With
-    # ``torch.zeros_like(query)`` the accumulator inherits that transposed stick
-    # layout, and the online-softmax ``opaque_copy_`` in-place writes fold a
-    # standard-layout ``matmul(exp_scores, value)`` result into a transposed
-    # accumulator -- a layout mismatch the in-place copy does not resolve, so
-    # the attention output is silently wrong (Gemma 4 E2B device garbage).
-    # Allocate a plain contiguous [B, H, S, D] accumulator instead; the final
-    # permute-dance below still re-materializes the output in query's layout to
-    # satisfy the meta kernel's stride assertion.
+    # Not zeros_like(query): a transposed query would give the accumulator a
+    # transposed layout, into which the online-softmax in-place writes fold the
+    # contiguous matmul(exp_scores, value) incorrectly. Allocate contiguous.
     output = torch.zeros(
         (batch_size, num_heads, max_seqlen_q, head_dim),
         device=query.device,

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -427,10 +427,58 @@ def spyre__sdpa_overrideable(
         key = key.unsqueeze(2).expand(-1, -1, expansion, -1, -1).flatten(1, 2)
         value = value.unsqueeze(2).expand(-1, -1, expansion, -1, -1).flatten(1, 2)
 
+    # Canonicalize ``query``'s layout before it drives the score matmul below.
+    #
+    # ``query`` reaches this decomp transposed (physical [B, S, H, D], logical
+    # [B, H, S, D]) whenever it was built as ``...view(B, S, H, D).transpose(1, 2)``
+    # -- the standard attention path (e.g. hf-adapters' apply_rope_matmul, whose
+    # RoPE ``.sum(4)`` leaves the query transposed). As the FIRST matmul operand,
+    # ``query``'s physical stick layout picks which rows ``torch.matmul`` reads;
+    # matmul-layout Pass 1 accepts the transposed view as a zero-cost stick match
+    # whenever the physical stick coincidentally carries the needed loop var, so
+    # the matmul silently reads the wrong sticks and the attention output is wrong
+    # (Gemma 4 dense decode produced garbage special tokens, top-1 diverged with
+    # a per-token logit max-diff ~11; prefill was already correct). Key/value do
+    # NOT need this: they feed the matmul as the second operand / value, so the
+    # decomp's internal transpose absorbs their entry layout.
+    #
+    # spyre.opaque_copy_ (PR #3811) is a functional custom op whose Inductor
+    # lowering introduces a MutationLayoutSHOULDREMOVE write one stage after
+    # AOTAutograd's functional-graph check -- so it survives remove_noop_ops
+    # (an aten.clone/aten.copy here is in Inductor's noop_registry and gets
+    # eliminated before any Spyre restickify pass runs) AND is legal inside this
+    # decomp (reached via proxy-mode decomposition substitution, which never
+    # re-enters FunctionalTensorMode; a mutating copy_forced would trip
+    # assert_functional_graph). The copy into a FRESH CONTIGUOUS destination
+    # (torch.zeros, NOT zeros_like) forces a restickify to canonical [B, H, S, D]
+    # layout. Use the canonical copy ONLY in the matmul; ``query`` itself is left
+    # untouched because the output permute-dance below keys on ``query.stride()``
+    # to satisfy the meta kernel's output-stride assertion.
+    query_c = torch.zeros(
+        list(query.shape), device=query.device, dtype=query.dtype
+    )
+    query_m = torch.ops.spyre.opaque_copy_(query, query_c)
+
     kv_block_size = 64
     q_block_size = 64
 
-    output = torch.zeros_like(query)
+    # The output accumulator must NOT inherit ``query``'s physical layout.
+    # ``query`` reaches this decomp transposed (physical [B, S, H, D], logical
+    # [B, H, S, D]) whenever it was built as ``...view(B,S,H,D).transpose(1,2)``
+    # (the standard attention path, e.g. hf-adapters' apply_rope_matmul). With
+    # ``torch.zeros_like(query)`` the accumulator inherits that transposed stick
+    # layout, and the online-softmax ``opaque_copy_`` in-place writes fold a
+    # standard-layout ``matmul(exp_scores, value)`` result into a transposed
+    # accumulator -- a layout mismatch the in-place copy does not resolve, so
+    # the attention output is silently wrong (Gemma 4 E2B device garbage).
+    # Allocate a plain contiguous [B, H, S, D] accumulator instead; the final
+    # permute-dance below still re-materializes the output in query's layout to
+    # satisfy the meta kernel's stride assertion.
+    output = torch.zeros(
+        (batch_size, num_heads, max_seqlen_q, head_dim),
+        device=query.device,
+        dtype=query.dtype,
+    )
 
     # FIXME: create a sparse M tensor via reduction
     M_reduced = torch.full(
@@ -481,7 +529,7 @@ def spyre__sdpa_overrideable(
                             -1, -2
                         )  # batch_size, num_heads, head_dim, max_seqlen_kv
                         scores = torch.matmul(
-                            query * scaling_factor, keys_T
+                            query_m * scaling_factor, keys_T
                         )  # batch_size, num_heads, max_seqlen_q, max_seqlen_kv
 
                         if is_causal:

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -454,9 +454,7 @@ def spyre__sdpa_overrideable(
     # layout. Use the canonical copy ONLY in the matmul; ``query`` itself is left
     # untouched because the output permute-dance below keys on ``query.stride()``
     # to satisfy the meta kernel's output-stride assertion.
-    query_c = torch.zeros(
-        list(query.shape), device=query.device, dtype=query.dtype
-    )
+    query_c = torch.zeros(list(query.shape), device=query.device, dtype=query.dtype)
     query_m = torch.ops.spyre.opaque_copy_(query, query_c)
 
     kv_block_size = 64


### PR DESCRIPTION
## Summary

The fused SDPA decomp (`spyre__sdpa_overrideable`) feeds `query` directly into the score matmul as the **first operand**. In a full model trace the query reaches SDPA **transposed** — a physical `[B, S, H, D]` buffer backing a logical `[B, H, S, D]` view, produced by the `view(B, S, H, D).transpose(1, 2)` in hf-adapters' RoPE (`apply_rope_matmul`'s `.sum(4)`). Because the first matmul operand's physical stick layout selects which rows are read, and the matmul-layout pass accepts the transposed view as zero-cost, the **wrong sticks are read across the whole graph**.

This surfaced as **garbage special-token output in gemma-4-12b dense decode** while prefill was correct.

## Fix

Two changes in `spyre__sdpa_overrideable`:

1. **Query canonicalization** — materialize a contiguous copy of `query` via `opaque_copy_` into a freshly-zeroed tensor and use that copy **only** as the score-matmul operand. This forces heads-outermost on the operand (`device_size[0] == num_heads`), the layout the matmul lowering expects.
2. **Explicit accumulator shape** — allocate the output as `[B, num_heads, max_seqlen_q, head_dim]` rather than `zeros_like(query)`, so the accumulator does not inherit the transposed query layout (the E2B fused-SDPA fix).

## Test

Adds `test_sdpa_bf16_gqa_decode_query_canonicalized`: compiles a GQA decode-shaped SDPA whose query arrives via the same `view + transpose`, then asserts (via a `create_op_spec` mock capturing `BATCH_MATMUL` operand `device_size`) that the score-matmul query operand is canonicalized (`device_size[0] == num_heads`). It **fails without the fix** (`device_size[0] == 1`) for both sliding (`16q/8kv/d256`) and full-attention (`16q/1kv/d512`) geometries.

## Note on repro scope

Standalone op-level numerical reproduction is **not achievable** — the corruption is a full-trace, cross-layer layout-solver phenomenon (seven escalating op-level reconstructions, including a pinned KV-cache decode with `nn.Linear` `dim_order=[1,0]` weights, all read the transposed query correctly). The test therefore locks the **layout mechanism**; end-to-end numerics are guarded by the hf-adapters gemma-4-12b token-comparison test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)