### PR TITLE
Check scatter destination layout compliance instead of shortcutting on it

### DIFF
--- a/tests/inductor/test_indirect_access_scatter.py
+++ b/tests/inductor/test_indirect_access_scatter.py
@@ -125,6 +125,36 @@ class TestScatter(IndirectAccessTestCase):
 
         self._stage_and_e2e(kernel, y, src, idx, expect=SCATTER_OP_SPEC)
 
+    def test_index_put_4d_dim2_default_layout_destination(self):
+        """Scatter on dim 2 of a 4-D destination that has the DEFAULT device layout.
+
+        Indirect access addresses the indexed dimension through the *device* layout and
+        requires it at device position 0. A destination allocated plainly --
+        ``torch.zeros(...).to("spyre")`` -- puts dim 2 elsewhere, so unless the layout
+        is enforced the scatter writes the wrong rows **silently, with no error**
+        (torch-spyre#3705).
+
+        The existing dim-0 and dim-1 scatter tests above do not cover this: their
+        shapes happen to place the indexed dim at device position 0 already. This is
+        the shape a decode-time query stick uses (``[batch, heads, 64, head_dim]``,
+        writing one row), which is where the silent corruption was first observed.
+        """
+        Bn, H, M, N, P = 1, 4, 64, 256, 1
+        dst = torch.zeros(Bn, H, M, N, dtype=torch.float16)
+        src = torch.rand(Bn, H, P, N, dtype=torch.float16)
+        # int64: index_copy_ requires a long index, unlike the index_put tests above.
+        idx = torch.tensor([7], dtype=torch.int64)
+
+        def kernel(dst, src, idx):
+            dst.index_copy_(2, idx, src)
+            return dst
+
+        expected = kernel(dst.clone(), src.clone(), idx.clone())
+        actual = torch.compile(kernel, dynamic=False)(
+            dst.clone().to("spyre"), src.to("spyre"), idx.to("spyre")
+        ).to("cpu")
+        torch.testing.assert_close(actual, expected)
+
     def test_index_put_p7(self):
         """y[idx] = src -- 1-D scatter with an odd (non-power-of-2) P=7."""
         M, N, P = 16, 1024, 7

--- a/torch_spyre/_inductor/enforce_indirect_access_layout.py
+++ b/torch_spyre/_inductor/enforce_indirect_access_layout.py
@@ -547,14 +547,6 @@ def _enforce_scatter_destination_layout(
         )
         return
 
-    # Shortcut: if target and output have the same device layout, they're compliant.
-    if target_stl == output_stl:
-        logger.debug(
-            "scatter_destination_check: %s target and output layouts match, compliant",
-            scatter_op.get_name(),
-        )
-        return
-
     # Compute write coordinates against the target's layout and find positions
     # of IndirectAccess markers.
     write_coords = device_coordinates(target_stl, write_dep, None)


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

`_enforce_scatter_destination_layout` returned early on `target_stl == output_stl`, commented as *"if target and output have the same device layout, they're compliant"*. Sameness is not compliance. `output_stl` comes from `MutationLayoutSHOULDREMOVE.real_layout()` and `target_stl` from the mutation target, so whenever the producer was **not** rewritten above (a graph input, for instance) the two are views of one buffer's committed layout and the comparison is a tautology.

It then returned *before* the compliance check and before `_insert_mutation_relayout_copy`, so a destination whose indexed dim is not at device position 0 was passed through untouched. Indirect access addresses the indexed dimension through the device layout, so the scatter wrote to the wrong rows — **silently, with no error** (#3705).

The shortcut was only ever sound *after* a producer rewrite, where the shared layout is compliant by construction. That case still costs nothing: the check below simply finds it compliant and does nothing. So the fix is to delete the shortcut and always run the check.

#### Which issue(s) this PR is related to:

Related to #3705 (indirect-access stores are not validated; non-compliant destinations are written to the wrong rows with no error).

#### Special notes for your reviewer:

- **Behavioural change worth knowing:** the pass now inserts a relayout copy in cases where it previously bailed out. Graphs that were silently producing wrong results become correct, and gain a copy. If anything depended on the non-repair, this is where it would surface.
- **Why the new test uses dim 2 of a 4-D destination.** The existing dim-0 and dim-1 scatter tests pass because their shapes already place the indexed dim at device position 0, which is why this survived. `[batch, heads, 64, head_dim]` writing one row along dim 2 does not, and is the shape a decode-time query stick uses — where the corruption was first observed (a write that reported success, left the destination's other rows non-zero, and returned the wrong row on read-back).
- Measured, both directions: the new test fails without this change and passes with it. Full `test_indirect_access_scatter.py` 27 passed / 8 xfailed. Wider inductor regression (scatter, gather, codegen, sliding-window, kv-window) 294 passed with no new failures.
- Not included deliberately: turning the remaining "cannot enforce" early returns into `raise Unsupported(...)`. Those fire when the target's layout is *unknown* rather than known-bad, so raising there would reject compliant graphs. Closing that half of #3705 wants its own change and its own evidence.

#### Does this PR introduce a user-facing change?

No API change. Indirect scatters onto a destination whose indexed dimension is not at device position 0 now produce correct results instead of silently writing to the wrong rows.