### PR TITLE
Unskip copy_forced mutation tests; assert on multi-candidate mutation target layout

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1677,10 +1677,6 @@ def test_restickify_pointwise_unsqueeze_mul_Lq2():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skip(
-    reason="mutation op and mutation target diverge on device layout in the "
-    "beam search when target has multiple candidates -- see issue #3845"
-)
 def test_copy_into_preallocated_512x256_A4():
     """copy_forced(a+b, c) on [512,256] tiled A÷4 — result written into zeros buffer."""
     inputs = [
@@ -1698,10 +1694,6 @@ def test_copy_into_preallocated_512x256_A4():
     run_coarse_tile_test(fn, inputs, loopspec=None)
 
 
-@pytest.mark.skip(
-    reason="mutation op and mutation target diverge on device layout in the "
-    "beam search when target has multiple candidates -- see issue #3845"
-)
 def test_copy_into_preallocated_512x256_B4():
     """copy_forced(a+b, c) on [512,256] tiled B÷4."""
     inputs = [
@@ -1720,10 +1712,6 @@ def test_copy_into_preallocated_512x256_B4():
     run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(
-    reason="mutation op and mutation target diverge on device layout in the "
-    "beam search when target has multiple candidates -- see issue #3845"
-)
 def test_copy_into_preallocated_512x256_A4_B4():
     """copy_forced(a+b, c) on [512,256] tiled A÷4 B÷4."""
     inputs = [
@@ -1985,10 +1973,6 @@ def test_copy_running_max_4d_H4_Lq4():
 # copy target receives a restickified input — tests copy layout after restickify
 
 
-@pytest.mark.skip(
-    reason="mutation op and mutation target diverge on device layout in the "
-    "beam search when target has multiple candidates -- see issue #3845"
-)
 def test_copy_restickify_512x256_A4():
     """copy_forced(a.t()+b, c) on [256,512] result tiled A÷4 — copy of restickified add."""
     inputs = [
@@ -2007,10 +1991,6 @@ def test_copy_restickify_512x256_A4():
     run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(
-    reason="mutation op and mutation target diverge on device layout in the "
-    "beam search when target has multiple candidates -- see issue #3845"
-)
 def test_copy_restickify_512x256_B4():
     """copy_forced(a.t()+b, c) on [256,512] result tiled B÷4."""
     inputs = [
@@ -2029,10 +2009,6 @@ def test_copy_restickify_512x256_B4():
     run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(
-    reason="mutation op and mutation target diverge on device layout in the "
-    "beam search when target has multiple candidates -- see issue #3845"
-)
 def test_copy_restickify_512x256_A4_B4():
     """copy_forced(a.t()+b, c) on [256,512] result tiled A÷4 B÷4."""
     inputs = [
@@ -2131,10 +2107,6 @@ def test_copy_accum_with_reduction_512x256_A4_B4():
 # --- two copies in same hint scope: copy_forced(a+b, c1); copy_forced(a*b, c2) ---
 
 
-@pytest.mark.skip(
-    reason="mutation op and mutation target diverge on device layout in the "
-    "beam search when target has multiple candidates -- see issue #3845"
-)
 def test_copy_two_copies_same_scope_512x256_A4():
     """Two copy_ ops in same hint scope tiled A÷4."""
     inputs = [
@@ -2156,10 +2128,6 @@ def test_copy_two_copies_same_scope_512x256_A4():
     run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(
-    reason="mutation op and mutation target diverge on device layout in the "
-    "beam search when target has multiple candidates -- see issue #3845"
-)
 def test_copy_two_copies_same_scope_512x256_B4():
     """Two copy_ ops in same hint scope tiled B÷4."""
     inputs = [
@@ -2181,10 +2149,6 @@ def test_copy_two_copies_same_scope_512x256_B4():
     run_coarse_tile_test(fn, inputs)
 
 
-@pytest.mark.skip(
-    reason="mutation op and mutation target diverge on device layout in the "
-    "beam search when target has multiple candidates -- see issue #3845"
-)
 def test_copy_two_copies_same_scope_512x256_A4_B4():
     """Two copy_ ops in same hint scope tiled A÷4 B÷4."""
     inputs = [
@@ -5926,11 +5890,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
         compare_with_cpu(fn, x, y, run_compile=True, run_eager=False)
 
-    @pytest.mark.skip(
-        reason="mutation op and mutation target diverge on device layout in "
-        "the beam search when target has multiple candidates -- see issue "
-        "#3845"
-    )
     def test_hint_nested_tiling_copy_mutation_correct(self):
         """Nested Lq/D tiling into a direct copy_forced() mutation (Case 3 rewire)."""
         from torch_spyre._inductor import spyre_hint
@@ -5953,11 +5912,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
         compare_with_cpu(fn, a, b, run_compile=True, run_eager=False)
 
-    @pytest.mark.skip(
-        reason="mutation op and mutation target diverge on device layout in "
-        "the beam search when target has multiple candidates -- see issue "
-        "#3845"
-    )
     def test_hint_nested_tiling_copy_mutation_divergent_input_layout(self):
         """Case 3 nested coarse-tiling where `a`'s device layout genuinely
         diverges from `b`'s -- exercises per-arg tile_advance_expr (each arg

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -1447,27 +1447,26 @@ def _target_device_layout(target, name: str):
     graph_input = V.graph.graph_inputs.get(name)
     layouts = getattr(graph_input, "layouts", None)
     if not layouts:
-        # Also check candidate layouts set by propagate_layouts on the producing
-        # ComputedBuffer (e.g. a constant-fill op that precedes the copy_forced).
+        # Also check candidate layouts on the producing ComputedBuffer —
+        # graph intermediates are not in graph_inputs.
         # Exclude SpyreEmptyFallback and SpyreConstantFallback: those are
-        # synthetic buffers whose layouts must be derived from their first
-        # writer, not locked here. Only use this when the producer has a
-        # single unambiguous candidate: with multiple candidates, arbitrarily
-        # picking next(iter(...)) here would lock the mutation op (and
-        # everything downstream of it) onto one candidate even when the
-        # beam search needs the freedom to pick a different one -- mirrors
-        # the same single-candidate guard in the copy-back elision pass
-        # above.
+        # synthetic buffers whose layouts are derived via separate paths.
+        # Exactly one candidate is required; the assert below enforces this.
         buf = V.graph.get_buffer(name) if name else None
         if buf is not None and not isinstance(
             buf, (SpyreEmptyFallback, SpyreConstantFallback)
         ):
             buf_layouts = getattr(buf, "layouts", None)
-            if buf_layouts and len(buf_layouts) == 1:
+            if buf_layouts:
                 layouts = buf_layouts
 
     if not layouts:
         return None
+    assert len(layouts) == 1, (
+        f"_target_device_layout: {name!r} has {len(layouts)} candidate layouts; "
+        f"multiple mutation ops writing the same target with different layouts "
+        f"is not yet supported"
+    )
     return next(iter(layouts))
 
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

## Summary

Two independent fixes that together close issue #3845.

### 1. Unskip 11 tests blocked by issue #3845

After PR #3811 merged and rebased with #3812, propagate layouts no longer encounters multiple mutation ops writing into the same buffer. The tests that were skipped pending that fix are now passing and have been unskipped:

- `test_copy_into_preallocated_512x256_{A4,B4,A4_B4}`
- `test_copy_restickify_512x256_{A4,B4,A4_B4}`
- `test_copy_two_copies_same_scope_512x256_{A4,B4,A4_B4}`
- `test_hint_nested_tiling_copy_mutation_correct`
- `test_hint_nested_tiling_copy_mutation_divergent_input_layout`


### 2. Assert in `_target_device_layout` when more than one candidate layout is present

`_target_device_layout` was silently dropping to `next(iter(layouts))` when a mutation target's producing `ComputedBuffer` had more than one candidate layout. With multiple candidates, picking arbitrarily would lock the mutation op and everything downstream onto one layout before the beam search gets to choose, producing silent wrong-code bugs.

The silent `len == 1` guard is replaced with an unconditional assert so any future change that assigns multiple layouts to a mutation target fails loudly rather than producing a subtly incorrect result.


#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

Granite passes:

## E2E Smoke Test Results

| Model | Status | Tokens | Generated Text | Load (s) | Gen (s) |
|-------|--------|--------|----------------|----------|---------|
| ibm-granite/granite-3.3-2b-instruct | PASS | 4 | ' Paris.\n\n' | 18.8 | 53.9 |
PASSED

