### PR TITLE
Drop use_symbols from test_sdsc_logging.py

### DIFF
--- a/tests/inductor/test_sdsc_logging.py
+++ b/tests/inductor/test_sdsc_logging.py
@@ -73,7 +73,6 @@ class TestSdscJsonLogging:
                             sdsc_counter=[0],
                             symbol_id_offset_counter=[0],
                             output_dir=tmpdir,
-                            use_symbols=False,
                         )
 
                 info_calls = mock_info.call_args_list
@@ -107,7 +106,6 @@ class TestSdscJsonLogging:
                             sdsc_counter=[0],
                             symbol_id_offset_counter=[0],
                             output_dir=tmpdir,
-                            use_symbols=False,
                         )
 
                 sdsc_json_calls = [
@@ -148,7 +146,6 @@ class TestBundleMlirLogging:
                             kernel_name="test_kernel",
                             output_dir=tmpdir,
                             specs=[],
-                            use_symbols=False,
                         )
 
                 mlir_calls = [
@@ -186,7 +183,6 @@ class TestBundleMlirLogging:
                             kernel_name="test_kernel",
                             output_dir=tmpdir,
                             specs=[],
-                            use_symbols=False,
                         )
 
                 mlir_calls = [


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

PR #3684 added test_sdsc_logging.py calling _compile_specs() and
generate_bundle() with use_symbols=False, but #3741 (merged a few days ago)
removed this parameter. 

Drop the stale use_symbols=False to match the cleanup #3741
applied to other test files to fix CI. 

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
