### PR TITLE
Enable persistent expert loops from coarse-tile hints

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -6953,6 +6953,66 @@ class TestCoarseTileMoEBroadcastMatmulE2E(InductorTestCase):
             fn, x, w, run_compile=True, run_eager=False, atol=0.05, rtol=0.05
         )
 
+    def test_hinted_dense_expert_loop_keeps_one_body(self):
+        """The complete dense expert body is emitted once inside an E loop."""
+
+        E, T, H, F = 2, 64, 64, 64
+        x = torch.randn(T, H, dtype=torch.float16) * 0.01
+        gate_backing = torch.randn(H, E, F, dtype=torch.float16) * 0.01
+        up_backing = torch.randn(H, E, F, dtype=torch.float16) * 0.01
+        down_backing = torch.randn(F, E, H, dtype=torch.float16) * 0.01
+        route_backing = torch.randn(T, E, 1, dtype=torch.float16) * 0.01
+        for name, extent in {"E": E, "T": T, "H": H, "F": F, "ONE": 1}.items():
+            _declare_tensor_dim(name, extent)
+
+        def fn(x, gate_backing, up_backing, down_backing, route_backing):
+            gate_w = gate_backing.permute(1, 0, 2)
+            up_w = up_backing.permute(1, 0, 2)
+            down_w = down_backing.permute(1, 0, 2)
+            route = route_backing.permute(1, 0, 2)
+            _name_tensor_dims(x, ["T", "H"])
+            _name_tensor_dims(gate_w, ["E", "H", "F"])
+            _name_tensor_dims(up_w, ["E", "H", "F"])
+            _name_tensor_dims(down_w, ["E", "F", "H"])
+            _name_tensor_dims(route, ["E", "T", "ONE"])
+            with spyre_hint(
+                num_tiles_per_dim={"E": E},
+                work_div={"T": 32},
+            ):
+                gate = torch.matmul(x.unsqueeze(0), gate_w)
+                up = torch.matmul(x.unsqueeze(0), up_w)
+                hidden = torch.nn.functional.gelu(gate, approximate="tanh") * up
+                down = torch.matmul(hidden, down_w)
+                return (down * route).sum(dim=0)
+
+        def check_source(source):
+            self.assertEqual(source.count("LoopSpec("), 1)
+            self.assertEqual(source.count("device_tile_advance_expr="), 4)
+            self.assertNotIn("'hbm_pool'", source)
+            self.assertNotIn("ReStickifyOpHBM", source)
+            self.assertIn("coarse_tile_reduction_drain", source)
+
+        with config.patch(
+            {
+                "sencores": 32,
+                "lx_planning": True,
+                "allow_all_ops_in_lx_planning": True,
+            }
+        ):
+            compare_with_cpu(
+                fn,
+                x,
+                gate_backing,
+                up_backing,
+                down_backing,
+                route_backing,
+                run_compile=True,
+                run_eager=False,
+                source_check=check_source,
+                atol=0.05,
+                rtol=0.05,
+            )
+
     @pytest.mark.skip(
         reason=(
             "Unsupported: expected exactly 1 generated variable, got {d0, d2}. "

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -705,6 +705,8 @@ class TestCoarseTileInfo(unittest.TestCase):
         )
         self.assertEqual(info.tiled_dims_per_read, [])
         self.assertEqual(info.output_tiled_dims, [])
+        self.assertFalse(info.hint_driven)
+        self.assertEqual(info.predivision_host_advance_per_read, [])
 
     def test_tile_advance_explicit(self):
         info = CoarseTileInfo(
@@ -2074,6 +2076,26 @@ class TestCoarseTileTiledDimsPerRead(unittest.TestCase):
         self.assertEqual(len(op.loop_info.tiled_dims_per_read), 2)
         for tiled_dims in op.loop_info.tiled_dims_per_read:
             self.assertEqual(tiled_dims, [[(0, Integer(512))], [(1, Integer(1024))]])
+
+    def test_predivision_advances_are_explicit_hint_only(self):
+        op = _make_real_pointwise_op(
+            ranges=[Integer(8), Integer(16)],
+            input_shapes_strides=[([8, 16], [16, 1])],
+            name="buf0",
+            hints=((1, 0),),
+        )
+        levels = [(1, Integer(2))]
+
+        automatic = plan_coarse_tile_groups([op], [([op], levels)])
+        explicit = plan_coarse_tile_groups([op], [([op], levels)], hint_driven=True)
+
+        self.assertFalse(automatic[id(op)].hint_driven)
+        self.assertEqual(automatic[id(op)].predivision_host_advance_per_read, [])
+        self.assertTrue(explicit[id(op)].hint_driven)
+        self.assertEqual(
+            explicit[id(op)].predivision_host_advance_per_read,
+            [[[(0, Integer(64))]]],
+        )
 
     def test_broadcast_input_has_zero_advance(self):
         # a (tiled input) + b (broadcast scalar-row input, stride [0, 1]).

--- a/tests/inductor/test_lx_extern_kernel_clobber.py
+++ b/tests/inductor/test_lx_extern_kernel_clobber.py
@@ -51,6 +51,7 @@ import torch
 import torch_spyre  # noqa: F401
 from torch._inductor.ir import ExternKernel
 from torch_spyre._inductor.scratchpad.allocator import _extern_kernel_in_live_range
+from torch_spyre._inductor.ir import SpyreEmptyFallback
 
 
 DEVICE = "spyre"
@@ -86,6 +87,13 @@ def test_extern_kernel_in_live_range():
     assert not _extern_kernel_in_live_range(spanning, [0])
     assert not _extern_kernel_in_live_range(_FakeGraph([plain, plain, plain]), [0, 2])
     assert not _extern_kernel_in_live_range(spanning, [])
+
+    # spyre.empty is represented as an ExternKernel in the IR, but codegen
+    # emits only a wrapper allocation for it. It launches no program and
+    # therefore cannot clobber a value already resident in LX.
+    empty = Mock(spec=SpyreEmptyFallback)
+    allocation_only = _FakeGraph([plain, empty, plain])
+    assert not _extern_kernel_in_live_range(allocation_only, [0, 2])
 
 
 @pytest.mark.parametrize("layers", [1, 4])

--- a/tests/inductor/test_perm_layout_solver.py
+++ b/tests/inductor/test_perm_layout_solver.py
@@ -1476,6 +1476,23 @@ class NativeSolverDifferentialTests(TestCase):
         self._assert_equal(py_plan, cpp_plan, "pokethrough fast path")
         self._assert_equal(ref_plan, cpp_plan, "pokethrough fast path vs reference")
 
+    def test_native_solver_honors_lifetime_end_override(self):
+        persistent = LifetimeBoundBuffer(
+            "persistent",
+            64,
+            [0, 1],
+            lifetime_end_override=5,
+        )
+        later = LifetimeBoundBuffer("later", 64, [2, 3])
+        buffers = [persistent, later]
+        permutation = [0, 1]
+
+        py_plan = PermutationBasedLayoutSolver(buffers, permutation, 10_000, 1)
+        cpp_plan = NativePermutationLayoutSolver(buffers, permutation, 10_000, 1)
+
+        self._assert_equal(py_plan, cpp_plan, "lifetime end override")
+        self.assertNotEqual(cpp_plan.addresses[0], cpp_plan.addresses[1])
+
     def test_random_mixed_sequences_match_python(self):
         seeds = 4000 if _STRESS else 800
         for seed in range(seeds):

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -268,6 +268,12 @@ class CoarseTileInfo:
         contribution as an extra term via ``tiling_expr_to_device_expr``
         rather than by substitution. Empty list means no such dims for this
         read (the common case).
+    predivision_host_advance_per_read:
+        Original input-address advance for each read and loop level, captured
+        while the tiled dimension still exists.  Parallel to
+        ``tiled_dims_per_read``; each item is ``(op_dim_index, host_elements)``.
+        This is used only when later range division squeezes that dimension
+        from the read dependency.
     squeezed_advance_output:
         The analogous per-level ``(host_stride, extent)`` list for this op's
         own write dependency, parallel to ``output_tiled_dims`` the same way
@@ -282,12 +288,18 @@ class CoarseTileInfo:
     loop_group_id: tuple[int, ...]
     loop_count: list[sympy.Expr]
     loop_tiled_dims: list[list[int]]
+    # True only for a loop requested by an explicit spyre_hint. Automatic
+    # span-overflow tiling must retain the existing compiler behavior.
+    hint_driven: bool = False
     loop_tiled_reduction_dims: list[list[int]] = field(default_factory=list)
     tiled_dims_per_read: list[list[list[tuple[int, sympy.Expr]]]] = field(
         default_factory=list
     )
     output_tiled_dims: list[list[tuple[int, sympy.Expr]]] = field(default_factory=list)
     squeezed_advance_per_read: list[list[list[tuple[sympy.Expr, sympy.Expr]]]] = field(
+        default_factory=list
+    )
+    predivision_host_advance_per_read: list[list[list[tuple[int, sympy.Expr]]]] = field(
         default_factory=list
     )
     squeezed_advance_output: list[list[tuple[sympy.Expr, sympy.Expr]]] = field(
@@ -311,6 +323,13 @@ _SPYRE_METADATA_ATTRS = (
     # coarse_tile._propagate_tiled_reduction_op, read by finalize_layouts in
     # insert_restickify.py to overwrite accum_full's generic layout.
     "_tiled_reduction_accum_name",
+    # Marks the ordinary fill output used as a fixed-address running sum.
+    # Scratchpad planning may admit this mutation target because a suffix
+    # drain, rather than the accumulator itself, is the graph output.
+    "_coarse_tile_loop_carried_lx",
+    # Temporary candidate consumed by layout propagation when a tiled matmul
+    # can read its advancing graph-input slice without the staging copy.
+    "_coarse_tile_direct_read_candidate",
 )
 
 

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -905,7 +905,10 @@ def find_reduction_var(x_dep: MemoryDep, out_dep: MemoryDep) -> sympy.Symbol:
 
 
 def find_matmul_generated_var(
-    y_dep: MemoryDep, x_dep: MemoryDep, out_dep: MemoryDep
+    y_dep: MemoryDep,
+    x_dep: MemoryDep,
+    out_dep: MemoryDep,
+    output_n_coord: sympy.Expr | None = None,
 ) -> sympy.Symbol:
     """Return the single loop variable that appears in y's and the output's index but not in x's.
 
@@ -915,6 +918,11 @@ def find_matmul_generated_var(
     generated_vars = (
         y_dep.index.free_symbols & out_dep.index.free_symbols
     ) - x_dep.index.free_symbols
+    # A broadcasted batch dimension is also present in y and the output but
+    # absent from x.  For matmul, N is the last logical output coordinate, so
+    # use that coordinate to distinguish N from broadcasted batch dimensions.
+    if len(generated_vars) > 1 and output_n_coord is not None:
+        generated_vars &= output_n_coord.free_symbols
     if len(generated_vars) != 1:
         raise Unsupported(
             f"expected exactly 1 generated variable, got {generated_vars}"

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -16,6 +16,7 @@
 from collections import Counter
 from typing import NamedTuple
 
+import dataclasses
 import logging
 import math
 
@@ -85,6 +86,7 @@ from .pass_utils import (
     is_stick_expr_offset_free,
     is_topk,
     iter_var_id,
+    replace_computed_buffer_body,
 )
 from .optimize_restickify import AllSameNode, AnyInNode, FixedInOutNode
 from .views import compute_coordinates, matching_dim
@@ -869,7 +871,16 @@ def _matmul_layouts(
     #   Input2 (y): stick on generated_var (loop var present in output, absent from x)
     #   Output:     stick on generated_var
     reduction_var = find_reduction_var(x.dep, output_dep)
-    generated_var = find_matmul_generated_var(y.dep, x.dep, output_dep)
+    generated_var = find_matmul_generated_var(
+        y.dep,
+        x.dep,
+        output_dep,
+        output_n_coord=(
+            out_coords[-1]
+            if getattr(op, "_coarse_tile_direct_read_candidate", None) is not None
+            else None
+        ),
+    )
 
     x_req_stl = find_stick_compatible_input_layout(
         x, reduction_var, data.reduction_type, "x"
@@ -1632,6 +1643,181 @@ def _resolve_copy_back_candidates(operations: list[Operation]) -> None:
         operations.remove(op)
 
 
+def _resolve_direct_read_copy_candidates(operations: list[Operation]) -> None:
+    """Remove a tiled matmul's staging copy when its HBM slice is usable directly.
+
+    Coarse tiling keeps the copy during layout propagation so the existing
+    full-buffer/tile-size machinery can find layouts normally.  It also saves
+    the matmul body and loop metadata from before that rewrite.  Here, after
+    layouts are known, reconstruct the direct read and commit it only when the
+    graph-input weight already carries the matmul's required stick dimension.
+    """
+    removed_copies: list[Operation] = []
+
+    for consumer in list(operations):
+        candidate = getattr(consumer, "_coarse_tile_direct_read_candidate", None)
+        if not isinstance(consumer, ComputedBuffer) or candidate is None:
+            continue
+
+        copy_op = next(
+            (
+                op
+                for op in operations
+                if isinstance(op, ComputedBuffer)
+                and op.get_name() == candidate.copy_name
+            ),
+            None,
+        )
+        if copy_op is None or not isinstance(copy_op.data, Pointwise):
+            continue
+
+        # A shared staging copy cannot be removed for only one consumer.
+        readers = [
+            op
+            for op in operations
+            if isinstance(op, ComputedBuffer)
+            and any(
+                isinstance(read, MemoryDep) and read.name == candidate.copy_name
+                for read in op.get_read_writes().reads
+            )
+        ]
+        if readers != [consumer]:
+            continue
+
+        direct_data = dataclasses.replace(
+            consumer.data, inner_fn=candidate.original_inner_fn
+        )
+        direct_op = ComputedBuffer(
+            name=consumer.get_name(),
+            layout=consumer.layout,
+            data=direct_data,
+            _split_size=consumer._split_size,
+            _original_inner_fn=consumer._original_inner_fn,
+            _original_ranges=consumer._original_ranges,
+            _original_reduction_ranges=consumer._original_reduction_ranges,
+        )
+        direct_op.operation_name = consumer.operation_name
+
+        read_writes = direct_op.get_read_writes()
+        output_dep = _one_mem_dep(read_writes.writes)
+        if output_dep is None:
+            continue
+        args = _get_prop_args(read_writes.reads)
+        x_dep, weight_dep = identify_matmul_inputs(
+            [arg.dep for arg in args], output_dep
+        )
+        if (
+            x_dep is None
+            or weight_dep is None
+            or weight_dep.name != candidate.source_name
+        ):
+            continue
+
+        weight_arg = next(arg for arg in args if arg.dep is weight_dep)
+        if len(weight_arg.layouts) != 1:
+            continue
+        out_coords = host_coordinates(direct_op.get_layout(), output_dep, None)
+        generated_var = find_matmul_generated_var(
+            weight_dep,
+            x_dep,
+            output_dep,
+            output_n_coord=out_coords[-1],
+        )
+        weight_stick = device_coordinates(weight_arg.layouts[0], weight_dep, None)[-1]
+        if generated_var not in weight_stick.free_symbols:
+            continue
+
+        # The copy's input metadata is the authoritative description of how
+        # to move from expert e to expert e+1. The direct matmul read has
+        # already squeezed that unit expert dimension from its index, so its
+        # ordinary tiled-dimension entry alone evaluates to zero. Transfer
+        # the copy's preserved host stride to the direct weight-read slot.
+        direct_reads = [dep for dep in read_writes.reads if isinstance(dep, MemoryDep)]
+        copy_reads = [
+            dep for dep in copy_op.get_read_writes().reads if isinstance(dep, MemoryDep)
+        ]
+        direct_weight_idx = next(
+            (
+                i
+                for i, dep in enumerate(direct_reads)
+                if dep.name == candidate.source_name
+            ),
+            None,
+        )
+        copy_source_idx = next(
+            (
+                i
+                for i, dep in enumerate(copy_reads)
+                if dep.name == candidate.source_name
+            ),
+            None,
+        )
+        copy_loop_info = getattr(copy_op, "loop_info", None)
+        if (
+            direct_weight_idx is None
+            or copy_source_idx is None
+            or copy_loop_info is None
+            or copy_source_idx >= len(copy_loop_info.tiled_dims_per_read)
+            or copy_source_idx >= len(copy_loop_info.squeezed_advance_per_read)
+            or not any(copy_loop_info.squeezed_advance_per_read[copy_source_idx])
+        ):
+            continue
+
+        direct_tiled_dims = list(candidate.original_loop_info.tiled_dims_per_read)
+        if direct_weight_idx >= len(direct_tiled_dims):
+            continue
+        direct_tiled_dims[direct_weight_idx] = copy_loop_info.tiled_dims_per_read[
+            copy_source_idx
+        ]
+        direct_squeezed = list(candidate.original_loop_info.squeezed_advance_per_read)
+        direct_squeezed.extend(
+            [] for _ in range(len(direct_reads) - len(direct_squeezed))
+        )
+        direct_squeezed[direct_weight_idx] = copy_loop_info.squeezed_advance_per_read[
+            copy_source_idx
+        ]
+        resolved_loop_info = dataclasses.replace(
+            candidate.original_loop_info,
+            tiled_dims_per_read=direct_tiled_dims,
+            squeezed_advance_per_read=direct_squeezed,
+        )
+
+        # Re-run only this matmul's layout rule against the real HBM input.
+        # This builds the downstream restickify-cost contract from the direct
+        # operand rather than retaining the temporary copy's contract.
+        try:
+            direct_layouts = compute_layouts(
+                direct_op, direct_op.get_layout(), output_dep, args
+            )
+        except Unsupported:
+            continue
+
+        replacement = replace_computed_buffer_body(
+            consumer,
+            direct_data,
+            operations,
+            pass_name="copy_elision",
+            reason="read advancing expert weight directly from HBM",
+        )
+        replacement.loop_info = resolved_loop_info  # type: ignore[attr-defined]
+        replacement.layouts = direct_layouts  # type: ignore[attr-defined]
+        replacement.restick_cost_fn = direct_op.restick_cost_fn  # type: ignore[attr-defined]
+        if hasattr(replacement, "_coarse_tile_direct_read_candidate"):
+            delattr(replacement, "_coarse_tile_direct_read_candidate")
+        V.graph.name_to_buffer[replacement.get_name()] = replacement
+        removed_copies.append(copy_op)
+        logger.info(
+            "removed tiled read copy %s; %s reads %s directly",
+            copy_op.get_name(),
+            replacement.get_name(),
+            candidate.source_name,
+        )
+
+    for copy_op in removed_copies:
+        V.graph.removed_buffers.add(copy_op.get_name())
+        operations.remove(copy_op)
+
+
 def _eager_view_input_layout(
     real_input: torch.Tensor,
     ptl: FixedLayout,
@@ -2045,6 +2231,7 @@ def propagate_spyre_tensor_layouts(
         else:
             logger.warning(f"unhandled operation type {type(op)}")
 
+    _resolve_direct_read_copy_candidates(operations)
     _resolve_copy_back_candidates(operations)
 
 

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -86,9 +86,10 @@ from torch_spyre._inductor.scratchpad.utils import (
     _get_buffer_user_deps,
     _would_produce_lx_back_gap,
     OP_OUTPUT_GOOD_FOR_LX_REUSE,
+    counted_loop_lifetime_end_overrides,
 )
 from torch_spyre._inductor.scratchpad.graph_editor import GraphEditor
-from torch_spyre._inductor.ir import FixedTiledLayout
+from torch_spyre._inductor.ir import FixedTiledLayout, SpyreEmptyFallback
 
 from torch_spyre._inductor import config
 from torch_spyre._inductor.logging_utils import get_inductor_logger
@@ -119,6 +120,14 @@ _LX_TRACKER_CAPACITY_BYTES = (
 _LX_ALLOCATION_GRANULARITY_BYTES = 128
 
 
+def _safe_in_place_parents(
+    parents: Sequence[str], lifetime_end_overrides: dict[str, int]
+) -> list[str]:
+    """Drop handoffs from parents that remain live through a counted loop."""
+
+    return [parent for parent in parents if parent not in lifetime_end_overrides]
+
+
 def _extern_kernel_in_live_range(graph: GraphLowering, uses: list[int]) -> bool:
     """True if an opaque extern kernel runs at any point while the buffer is live.
 
@@ -141,6 +150,7 @@ def _extern_kernel_in_live_range(graph: GraphLowering, uses: list[int]) -> bool:
         return False
     return any(
         isinstance(graph.operations[i], ExternKernel)
+        and not isinstance(graph.operations[i], SpyreEmptyFallback)
         for i in range(min(uses), max(uses) + 1)
     )
 
@@ -336,8 +346,10 @@ class ScratchpadAllocator:
             return False
         # A planned source intentionally bypasses the profitability allowlist:
         # the relayout planner has already applied its stricter structural gates.
-        return config.allow_all_ops_in_lx_planning or (
-            self._get_op_name(op) in OP_OUTPUT_GOOD_FOR_LX_REUSE
+        return (
+            getattr(op, "_coarse_tile_loop_carried_lx", False)
+            or config.allow_all_ops_in_lx_planning
+            or self._get_op_name(op) in OP_OUTPUT_GOOD_FOR_LX_REUSE
             or op.get_name() in planned_lx_buffers
         )
 
@@ -431,7 +443,9 @@ class ScratchpadAllocator:
             # MultiOutputLayout tuple op). There is nothing to place, and the
             # checks below would raise.
             return "unsized (no device layout)"
-        if name in mutated_buffers:
+        if name in mutated_buffers and not getattr(
+            op, "_coarse_tile_loop_carried_lx", False
+        ):
             return "mutation target"
         if _is_tiled_advancing(op) or _is_read_advancing_anywhere(name, buf_user_deps):
             # LX addresses cannot be expressed as affine.apply symbols today (see
@@ -630,6 +644,7 @@ class ScratchpadAllocator:
         lifetimes: dict[str, list[int]],
         ncores: dict[str, int],
         ncores_reasons: dict[str, str],
+        lifetime_end_overrides: Optional[dict[str, int]] = None,
     ) -> list[LifetimeBoundBuffer]:
         """Build one :class:`LifetimeBoundBuffer` per buffer, barred or not.
 
@@ -644,6 +659,7 @@ class ScratchpadAllocator:
         :meth:`_input_residency_reason` and their footprint is computed
         here rather than read off ``mem_usage`` (which covers ops only).
         """
+        lifetime_end_overrides = lifetime_end_overrides or {}
         buffers: list[LifetimeBoundBuffer] = []
         for output_name, info in mem_usage.items():
             uses = lifetimes.get(output_name, [])
@@ -662,8 +678,11 @@ class ScratchpadAllocator:
                     # to a consumer's in_place_parents, which would otherwise mutate
                     # this list inside the shared ``in_place`` dict (matches the copy
                     # in ``_build_cd_bound_buffers``).
-                    in_place_parents=list(in_place.get(output_name, [])),
+                    in_place_parents=_safe_in_place_parents(
+                        in_place.get(output_name, []), lifetime_end_overrides
+                    ),
                     residency_reason=reasons.get(output_name),
+                    lifetime_end_override=lifetime_end_overrides.get(output_name),
                 )
             )
 
@@ -695,6 +714,7 @@ class ScratchpadAllocator:
                     first_use_is_read=True,
                     in_place_parents=[],
                     residency_reason=reason,
+                    lifetime_end_override=lifetime_end_overrides.get(input_name),
                 )
             )
 
@@ -707,7 +727,7 @@ class ScratchpadAllocator:
             # consumer is a built candidate with matching per-core size, device
             # layout, a pointwise producer, and no core-division mismatch is there
             # anything safe to merge.
-            if reason is not None:
+            if reason is not None or input_name in lifetime_end_overrides:
                 continue
             last_use = uses[-1]
             consumer_op = graph.operations[last_use]
@@ -869,6 +889,7 @@ class ScratchpadAllocator:
         t0 = time.perf_counter()
         if lifetimes is None:
             lifetimes = calculate_liveness(graph)
+        lifetime_end_overrides = counted_loop_lifetime_end_overrides(graph)
         ncores, ncores_reasons = get_ncores_for_buffers(graph)
         t1 = time.perf_counter()
         mem_usage = mem_usage_by_buf(graph, cache)
@@ -908,6 +929,7 @@ class ScratchpadAllocator:
             lifetimes=lifetimes,
             ncores=ncores,
             ncores_reasons=ncores_reasons,
+            lifetime_end_overrides=lifetime_end_overrides,
         )
         if lx_relayout_plans:
             by_name = {buffer.name: buffer for buffer in buffers}
@@ -943,20 +965,25 @@ class ScratchpadAllocator:
             return
         for buffer in buffers:
             buffer.uses = [2 * use + 1 for use in buffer.uses]
+            if buffer.lifetime_end_override is not None:
+                buffer.lifetime_end_override *= 2
 
         # Adjacent half-ticks rely on DSCs within a bundle executing serially;
         # otherwise the allocator's lifetime reuse is unsound beyond relayout too.
         for source, plan, original_ticks in entries:
+            destination_end = source.lifetime_end_override
             consumer_ticks = [2 * tick + 1 for tick in original_ticks]
             transfer_tick = consumer_ticks[0] - 1
             source.uses = sorted(
                 {use for use in source.uses if use not in consumer_ticks}
                 | {transfer_tick}
             )
+            source.lifetime_end_override = None
             destination = LifetimeBoundBuffer(
                 plan.destination_name,
                 round_up_to_alignment(source.size, _LX_ALLOCATION_GRANULARITY_BYTES),
                 [transfer_tick, *consumer_ticks],
+                lifetime_end_override=destination_end,
             )
             buffers.insert(buffers.index(source), destination)
             source.paired_with.append(destination)
@@ -1708,6 +1735,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             op.name: self._op_inputs_good_for_lx_inplace(op) for op in graph.operations
         }
         lifetimes = calculate_liveness(graph)
+        lifetime_end_overrides = counted_loop_lifetime_end_overrides(graph)
         for buf_name, info in mem_usage.items():
             allow_inplace[buf_name] = []
             if not in_place_allowed[buf_name]:
@@ -1726,6 +1754,8 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                 # solver's ``_check_in_place_relationships`` would fail to resolve
                 # them). Skip them, matching the base allocator's guard.
                 if input_buf not in mem_usage or not lifetimes[input_buf]:
+                    continue
+                if input_buf in lifetime_end_overrides:
                     continue
                 in_layout = graph.get_buffer(input_buf).layout
                 if not hasattr(in_layout, "device_layout"):
@@ -1786,6 +1816,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
         all buffers are on the same total scale, ``in_place_parents`` need no
         filtering."""
         lifetimes = calculate_liveness(graph)
+        lifetime_end_overrides = counted_loop_lifetime_end_overrides(graph)
         mem_usage = mem_usage_by_buf(graph)
         in_place = {} if in_place is None else in_place
         op_by_name = {op.name: op for op in graph.operations}
@@ -1836,6 +1867,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                         parents=[],
                         cd_parent_matches={},
                         residency_reason=None,
+                        lifetime_end_override=lifetime_end_overrides.get(input_name),
                         boundary=BufferType.Input,
                     )
                 )
@@ -1847,7 +1879,9 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             residency_reason = residency_by_buf[output_name]
 
             buf_divisions = divisions[output_name]
-            parents = list(in_place.get(output_name, []))
+            parents = _safe_in_place_parents(
+                in_place.get(output_name, []), lifetime_end_overrides
+            )
             size = info["size"]  # total footprint; solver divides per chosen cd
             parent_proj = info["op_inputs"].copy()
             cd_parent_matches = self._cd_parent_matches(
@@ -1876,6 +1910,8 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             # clone, so they are skipped.
             out_layout = graph.get_buffer(output_name).layout
             for clone_name in last_consumer_clones.get(output_name, []):
+                if clone_name in lifetime_end_overrides:
+                    continue
                 if clone_name in parents:
                     continue
                 clone_layout = graph.get_buffer(clone_name).layout
@@ -1910,6 +1946,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                     parents=parent_proj,
                     cd_parent_matches=cd_parent_matches,
                     residency_reason=residency_reason,
+                    lifetime_end_override=lifetime_end_overrides.get(output_name),
                     boundary=BufferType.Output
                     if output_name in graph_output_names
                     else BufferType.Intermediate,

--- a/torch_spyre/_inductor/scratchpad/exhaustive_search.py
+++ b/torch_spyre/_inductor/scratchpad/exhaustive_search.py
@@ -147,6 +147,7 @@ class ExhaustiveSearchSolver(CoreDivisionLayoutSolver):
                     first_use_is_read=b.first_use_is_read,
                     in_place_parents=_valid_inplace_parents(b, chosen[b.name]),
                     residency_reason=_residency_reason(b, chosen[b.name]),
+                    lifetime_end_override=b.lifetime_end_override,
                 )
                 for b in buffers_list
             ]

--- a/torch_spyre/_inductor/scratchpad/plan_solver.py
+++ b/torch_spyre/_inductor/scratchpad/plan_solver.py
@@ -80,6 +80,10 @@ class LifetimeBoundBuffer:
     # define the reason for excluding the buffer based on allocator
     # or solver logic paths.
     residency_reason: Optional[str] = None
+    # Optional exclusive lifetime end for storage reused by a counted loop.
+    # Keep this separate from ``uses``: it changes address overlap, but must not
+    # manufacture a read or inflate residency/spill benefit.
+    lifetime_end_override: Optional[int] = None
     # Buffers that must be placed atomically with this one. Despite the name,
     # this is one-to-many: only the group root carries the complete partner list.
     paired_with: list["LifetimeBoundBuffer"] = field(
@@ -104,6 +108,12 @@ class LifetimeBoundBuffer:
             f"buffer {self.name} has uses={self.uses}, which is not strictly "
             "increasing; uses carries one distinct index per accessing operation"
         )
+        if self.lifetime_end_override is not None and self.uses:
+            assert self.lifetime_end_override >= self.uses[-1] + 1, (
+                f"buffer {self.name} has lifetime_end_override="
+                f"{self.lifetime_end_override} before nominal exclusive end "
+                f"{self.uses[-1] + 1}"
+            )
 
     @property
     def read_count(self) -> int:
@@ -126,7 +136,8 @@ class LifetimeBoundBuffer:
 
     @property
     def end_time(self) -> int:
-        return self.uses[-1] + 1
+        nominal = self.uses[-1] + 1
+        return max(nominal, self.lifetime_end_override or nominal)
 
     @property
     def min_footprint(self) -> int:

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -115,6 +115,62 @@ def calculate_liveness(graph: GraphLowering) -> dict[str, list[int]]:
     return liveness
 
 
+def counted_loop_lifetime_end_overrides(graph: GraphLowering) -> dict[str, int]:
+    """Return exclusive lifetime ends for values reused by counted loops.
+
+    The graph contains one textual copy of a loop body.  Ordinary liveness
+    therefore sees only the first runtime iteration and may reuse a value's LX
+    address later in that body, even though the next iteration reads it again.
+    A value born outside a loop and read inside it must stay alive through that
+    loop.  This records that storage fact without adding a fake read to
+    :func:`calculate_liveness`.
+    """
+
+    def group_path(op: Operation) -> tuple[int, ...]:
+        return tuple(getattr(getattr(op, "loop_info", None), "loop_group_id", ()) or ())
+
+    loop_end: dict[tuple[int, ...], int] = {}
+    birth_group: dict[str, tuple[int, ...]] = {
+        name: () for name in graph.graph_input_names
+    }
+    last_access: dict[str, int] = {}
+
+    for index, op in enumerate(graph.operations):
+        path = group_path(op)
+        for depth in range(1, len(path) + 1):
+            loop_end[path[:depth]] = index
+        rw = op_read_writes(op)
+        for dep in rw.writes:
+            birth_group.setdefault(dep.name, path)
+            last_access[dep.name] = index
+        for dep in rw.reads:
+            birth_group.setdefault(dep.name, ())
+            last_access[dep.name] = index
+
+    overrides: dict[str, int] = {}
+    for index, op in enumerate(graph.operations):
+        consumer_path = group_path(op)
+        loop_info = getattr(op, "loop_info", None)
+        if not consumer_path or not getattr(loop_info, "hint_driven", False):
+            continue
+        for dep in op_read_writes(op).reads:
+            producer_path = birth_group.get(dep.name, ())
+            common = 0
+            while (
+                common < len(producer_path)
+                and common < len(consumer_path)
+                and producer_path[common] == consumer_path[common]
+            ):
+                common += 1
+            if common == len(consumer_path):
+                continue
+            enclosing_loop = consumer_path[: common + 1]
+            end = loop_end[enclosing_loop] + 1
+            if end > last_access.get(dep.name, index) + 1:
+                overrides[dep.name] = max(overrides.get(dep.name, 0), end)
+    return overrides
+
+
 def mem_usage_by_buf(
     graph: GraphLowering,
     cache: Optional[dict] = None,

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -4192,6 +4192,11 @@ def _propagate_tiled_reduction_op(
     )
     use_loop_carried_accumulator = (
         loop_info.hint_driven
+        # Carrying one physical value through the loop requires a stable
+        # ownership contract.  A tiling-only hint does not provide one and
+        # must retain the ordinary reduction path; the persistent expert
+        # schedule supplies an explicit work_div hint for its row ownership.
+        and bool(getattr(op, "work_div_loop_info", None))
         and not is_nested
         and is_graph_output
         and not outside_consumers

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -3910,6 +3910,7 @@ def _collapse_loop_carried_unit_sum(
         isinstance(data, Reduction)
         and data.reduction_type == "sum"
         and data.src_dtype == data.dtype
+        and info is not None
         and getattr(propagation, "kind", None) == "reduction"
         and reduction_plan is not None
         and reduction_plan.reduction_type == "sum"

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -92,7 +92,7 @@ from torch.utils._ordered_set import OrderedSet
 from torch_spyre._C import SpyreTensorLayout
 
 from .. import config
-from ..constants import BATCH_MATMUL_OP
+from ..constants import BATCH_MATMUL_FP8_OP, BATCH_MATMUL_OP
 from ..errors import Unsupported
 from ..logging_utils import get_inductor_logger
 from ..loop_info import (
@@ -103,7 +103,13 @@ from ..loop_info import (
     ReductionPlan,
     copy_op_metadata,
 )
-from ..pass_utils import op_out_coords, host_coordinates, indirect_sizes_from_op
+from ..pass_utils import (
+    host_coordinates,
+    indirect_sizes_from_op,
+    iter_var_id,
+    iteration_space_from_op,
+    op_out_coords,
+)
 from ..ir import FixedTiledLayout, SpyreConstantFallback, _resize_device_layout
 from .tile import compute_tile_index, compute_tile_stride
 
@@ -116,6 +122,15 @@ class _RetiledBufferInfo(NamedTuple):
     old_stride: tuple[Expr, ...]
     new_stride: tuple[Expr, ...]
     old_size: tuple[Expr, ...]
+
+
+class _DirectReadCopyCandidate(NamedTuple):
+    """Enough state to restore a matmul's direct, advancing HBM read."""
+
+    copy_name: str
+    source_name: str
+    original_inner_fn: object
+    original_loop_info: CoarseTileInfo
 
 
 # ---------------------------------------------------------------------------
@@ -200,6 +215,8 @@ def _clear_cache(obj: object, key: str) -> None:
 def plan_coarse_tile_groups(
     operations: list[Operation],
     groups: list[tuple],
+    *,
+    hint_driven: bool = False,
 ) -> dict[int, CoarseTileInfo]:
     """Decide every op's coarse-tiling attributes without mutating the IR.
 
@@ -301,6 +318,14 @@ def plan_coarse_tile_groups(
             tiled_dims_per_read = [
                 _tiled_dims_for_dep(dep, per_level_extents, op) for dep in read_deps
             ]
+            predivision_host_advance_per_read = (
+                [
+                    _host_tile_advances_for_dep(dep, per_level_extents, op)
+                    for dep in read_deps
+                ]
+                if hint_driven
+                else []
+            )
             output_tiled_dims = (
                 _tiled_dims_for_dep(write_deps[0], per_level_extents, op)
                 if write_deps
@@ -311,8 +336,10 @@ def plan_coarse_tile_groups(
                 loop_group_id=nested_group_id,
                 loop_count=counts,
                 loop_tiled_dims=op_tiled_dims,
+                hint_driven=hint_driven,
                 loop_tiled_reduction_dims=op_tiled_reduction_dims,
                 tiled_dims_per_read=tiled_dims_per_read,
+                predivision_host_advance_per_read=(predivision_host_advance_per_read),
                 output_tiled_dims=output_tiled_dims,
             )
 
@@ -1042,6 +1069,32 @@ def _tiled_dims_for_dep(
     ]
 
 
+def _host_tile_advances_for_dep(
+    dep: MemoryDep,
+    per_level_extents: list[dict[int, Expr]],
+    ir_node: ComputedBuffer,
+) -> list[list[tuple[int, Expr]]]:
+    """Capture input-address advances before tiled unit dims are squeezed."""
+    zero_subs = {symbol: sympy.Integer(0) for symbol in dep.index.free_symbols}
+    zero_offset = dep.index.subs(zero_subs)
+    result: list[list[tuple[int, Expr]]] = []
+    raw_to_squeezed = _raw_to_squeezed_pos(ir_node)
+    for level in per_level_extents:
+        advances: list[tuple[int, Expr]] = []
+        for dim, extent in level.items():
+            squeezed_dim = raw_to_squeezed.get(dim)
+            if squeezed_dim is None:
+                continue
+            dim_symbol = sympy_index_symbol(f"d{squeezed_dim}")
+            if dim_symbol not in dep.index.free_symbols:
+                continue
+            subs = dict(zero_subs)
+            subs[dim_symbol] = extent
+            advances.append((dim, sympy.simplify(dep.index.subs(subs) - zero_offset)))
+        result.append(advances)
+    return result
+
+
 def _stick_host_dim(op: ComputedBuffer, device_layout) -> int | None:
     """Authoritative stick host-dim index for ``op``'s output, recovered from
     coordinate identity (issue #3116).
@@ -1447,6 +1500,40 @@ def _divide_reduction_ranges(
 # ---------------------------------------------------------------------------
 
 
+def _remap_work_div_loop_info_after_tiling(op: ComputedBuffer) -> None:
+    """Keep named work-division hints aligned after unit dims disappear."""
+
+    old = getattr(op, "work_div_loop_info", None)
+    if not old:
+        return
+    old_symbols = tuple(sorted(old, key=iter_var_id))
+    old_names = [list(old.get(symbol, [])) for symbol in old_symbols]
+    extents = list(op.data.ranges)
+    if isinstance(op.data, Reduction):
+        extents.extend(op.data.reduction_ranges)
+        # An in-graph named-dims hint describes the output tensor. Matmul's
+        # reduction axis is not an output dimension and therefore may be
+        # intentionally unnamed; work division only needs the output names.
+        if len(old_names) == len(op.data.ranges):
+            old_names.extend([] for _ in op.data.reduction_ranges)
+    if len(old_names) != len(extents):
+        raise Unsupported(
+            f"coarse_tile: cannot remap work division for {op.get_name()}: "
+            f"{len(old_names)} prior iteration dimensions for {len(extents)} ranges"
+        )
+    kept_names = [
+        names for names, extent in zip(old_names, extents) if sympy.sympify(extent) != 1
+    ]
+    new_symbols = tuple(iteration_space_from_op(op))
+    if len(new_symbols) != len(kept_names):
+        raise Unsupported(
+            f"coarse_tile: cannot remap work division for {op.get_name()}: "
+            f"{len(kept_names)} surviving named dimensions for "
+            f"{len(new_symbols)} iteration dimensions"
+        )
+    op.work_div_loop_info = dict(zip(new_symbols, kept_names))  # type: ignore[attr-defined]
+
+
 def _apply_plan(
     ops: list[Operation],
     stamped_group_id: tuple[int, ...],
@@ -1484,7 +1571,6 @@ def _apply_plan(
         info = plan.get(id(op))
         if info is None:
             continue
-
         for level_idx, (_, count) in enumerate(levels):
             opos_list = info.loop_tiled_dims[level_idx]
             rpos_list = info.loop_tiled_reduction_dims[level_idx]
@@ -1502,6 +1588,7 @@ def _apply_plan(
             if isinstance(op.data, Reduction):
                 _divide_reduction_ranges(op, count, rpos_list)
 
+        _remap_work_div_loop_info_after_tiling(op)
         op.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
             info, loop_group_id=stamped_group_id
         )
@@ -1541,7 +1628,13 @@ def coarse_tile_pre_stickify(
     and write copy-outs (Pass 3). See coarse_tile_post_stickify for the
     post-stickification counterpart, which never needs Pass 1.
     """
-    _coarse_tile_common(graph, groups, group_idx_offset, run_read_copies=True)
+    _coarse_tile_common(
+        graph,
+        groups,
+        group_idx_offset,
+        run_read_copies=True,
+        hint_driven=True,
+    )
 
 
 def coarse_tile_post_stickify(
@@ -1572,7 +1665,13 @@ def coarse_tile_post_stickify(
     with no layout-reconciliation benefit. See coarse_tile_pre_stickify for
     the pre-stickification counterpart.
     """
-    _coarse_tile_common(graph, groups, group_idx_offset, run_read_copies=False)
+    _coarse_tile_common(
+        graph,
+        groups,
+        group_idx_offset,
+        run_read_copies=False,
+        hint_driven=False,
+    )
 
 
 def _coarse_tile_common(
@@ -1580,6 +1679,7 @@ def _coarse_tile_common(
     groups: list[tuple],
     group_idx_offset: int,
     run_read_copies: bool,
+    hint_driven: bool,
 ) -> None:
     """Plan then transform: stamp loop_group_id / loop_count and scale ranges.
 
@@ -1601,7 +1701,7 @@ def _coarse_tile_common(
     # *real* group_id stamped onto ops (with group_idx_offset applied) is
     # recomputed below in the transformation loop and overwrites
     # info.loop_group_id via _apply_plan before it's ever read back out.
-    plan = plan_coarse_tile_groups(operations, groups)
+    plan = plan_coarse_tile_groups(operations, groups, hint_driven=hint_driven)
 
     # Planning continued: decide every op's propagation kind (loop-internal
     # / copy-out / reduction) with zero mutation, consumed by Pass 1/2/3
@@ -2762,7 +2862,33 @@ def _insert_one_read_copy(
     if isinstance(full_buf, StorageBox):
         full_buf = full_buf.data
 
-    tile_ranges = list(dep.size)
+    sizing_op_info = sizing_op.loop_info  # type: ignore[attr-defined]
+    dep_idx = None
+    if sizing_op_info.hint_driven:
+        sizing_reads = [
+            r for r in sizing_op.get_read_writes().reads if isinstance(r, MemoryDep)
+        ]
+        dep_idx = sizing_reads.index(dep)
+    planned_read_dims = (
+        sizing_op_info.tiled_dims_per_read[dep_idx]
+        if sizing_op_info.hint_driven
+        and dep_idx is not None
+        and dep_idx < len(sizing_op_info.tiled_dims_per_read)
+        else []
+    )
+    planned_squeezed = (
+        sizing_op_info.squeezed_advance_per_read[dep_idx]
+        if sizing_op_info.hint_driven
+        and dep_idx is not None
+        and dep_idx < len(sizing_op_info.squeezed_advance_per_read)
+        else []
+    )
+    loop_invariant = (
+        sizing_op_info.hint_driven
+        and not any(planned_read_dims)
+        and not any(planned_squeezed)
+    )
+
     # Derive copy buffer strides using compute_tile_stride.
     # dep.size is the full loop iteration space (output + reduction dims) and
     # may have higher rank than the tensor (e.g. for a Reduction reading
@@ -2774,20 +2900,22 @@ def _insert_one_read_copy(
     # sizing_op's own loop is already tiled (the common case -- this
     # function copies a full-size buffer INTO a tile), dep.size reflects the
     # reader's tile-local extent (e.g. 128 for a Lq-tiled read), not the
-    # buffer's true full/untiled extent (e.g. 256).  Passing that tile-local
+    # buffer's true full/untiled extent (e.g. 256). Passing that tile-local
     # value as both the "full size" and "tile size" arguments makes
     # compute_tile_stride's size//tile_size ratio 1 for every dim, a no-op
     # that leaves full_buf's own (too-large) stride on the physically
-    # smaller copy buffer.  Look up each active dim's true full size from
-    # full_buf.layout instead, matched by stride VALUE (full_coeff), not by
-    # position -- dep.var_names/active_idx are in dep's squeezed iteration
-    # space, while full_buf.layout.size/stride are in the buffer's own raw
-    # space, and the two do not line up positionally in general (broadcast
-    # inputs, reductions with more loop vars than the tensor has dims, etc).
+    # smaller copy buffer.
     full_coeff = [dep.index.coeff(v) for v in dep.var_names]
     # Positions with non-zero coeff are active tensor dims; zero coeff means
     # broadcast/absent (e.g. the N dim in a Reduction reading a[M,K]).
     active_idx = [i for i, c in enumerate(full_coeff) if c != 0]
+    # An invariant broadcast operand needs only its real tensor dimensions.
+    # Keeping absent loop dimensions here would materialize the broadcasted
+    # [E, ...] view instead of staging one compact copy for the whole loop.
+    compact_invariant = loop_invariant and bool(active_idx)
+    tile_ranges = (
+        [dep.size[i] for i in active_idx] if compact_invariant else list(dep.size)
+    )
 
     tile_strides: list[Expr]
     if not active_idx:
@@ -2820,19 +2948,34 @@ def _insert_one_read_copy(
                 if next_stride is None
                 else next_stride // active_full_strides[k]
             )
-        active_tile_ranges = [tile_ranges[i] for i in active_idx]
+        active_tile_ranges = [dep.size[i] for i in active_idx]
         active_tile_strides = compute_tile_stride(
             active_full_sizes, active_full_strides, active_tile_ranges
         )
         # active_tile_strides[i] corresponds to active_idx[i]: both are indexed
         # by position in the compressed active-dims space, so zip pairs each
         # full dep.var_names position with its computed tile stride correctly.
-        tile_strides = [sympy.Integer(0)] * len(tile_ranges)
-        for pos, ts in zip(active_idx, active_tile_strides):
-            tile_strides[pos] = ts
+        if compact_invariant:
+            tile_strides = active_tile_strides
+        else:
+            tile_strides = [sympy.Integer(0)] * len(tile_ranges)
+            for pos, ts in zip(active_idx, active_tile_strides):
+                tile_strides[pos] = ts
 
-    def _copy_inner_fn(idx, _dep=dep, _full_name=full_buf.get_name()):
-        subs = dict(zip(_dep.var_names, idx))
+    def _copy_inner_fn(
+        idx,
+        _dep=dep,
+        _full_name=full_buf.get_name(),
+        _active_idx=active_idx,
+        _compact=compact_invariant,
+    ):
+        if _compact:
+            full_idx = [sympy.Integer(0)] * len(_dep.var_names)
+            for pos, value in zip(_active_idx, idx):
+                full_idx[pos] = value
+        else:
+            full_idx = idx
+        subs = dict(zip(_dep.var_names, full_idx))
         flat_index = sympy_subs(_dep.index, subs)
         return V.ops.load(_full_name, flat_index)
 
@@ -3027,6 +3170,22 @@ def _insert_one_read_copy(
     copy_buf.operation_name = copy_name
     copy_op_metadata(sizing_op, copy_buf)
 
+    if loop_invariant:
+        if hasattr(copy_buf, "loop_info"):
+            del copy_buf.loop_info  # type: ignore[attr-defined]
+        # The copy has its own iteration symbols.  A named work-division map
+        # copied from the tiled consumer refers to the consumer's symbols and
+        # can therefore apply a row hint to the wrong copy dimension.  Let the
+        # ordinary divider decide this standalone invariant copy instead.
+        if hasattr(copy_buf, "work_div_loop_info"):
+            del copy_buf.work_div_loop_info  # type: ignore[attr-defined]
+        V.graph.name_to_buffer[copy_name] = copy_buf
+        operations.insert(insert_idx, copy_buf)
+        logger.debug(
+            "coarse_tile: invariant read copy-in %s -> %s", dep.name, copy_name
+        )
+        return copy_buf.get_name()
+
     # Fresh per-level tiled-dim decisions for copy_buf's own read/write —
     # mirroring _insert_copy_op's read/write split (see its comment), but
     # with the roles swapped: there, the copy's READ (of sizing_op's
@@ -3047,7 +3206,6 @@ def _insert_one_read_copy(
     # full_buf and of copy_buf's own output) via
     # SpyreKernel._general_tile_advance's positional dep-index lookup —
     # a semantic mismatch, not merely a magnitude one.
-    sizing_op_info = sizing_op.loop_info  # type: ignore[attr-defined]
     copy_ranges = list(copy_data.ranges)
     # sizing_op_info.loop_tiled_dims's dim keys are raw positional indices
     # into sizing_op.data.ranges (see CoarseTileInfo's docstring), which
@@ -3072,10 +3230,27 @@ def _insert_one_read_copy(
     squeezed_advance: list[list[tuple[Expr, Expr]]] = [
         [] for _ in sizing_op_info.loop_tiled_dims
     ]
+    planned_host_advances = (
+        sizing_op_info.predivision_host_advance_per_read[dep_idx]
+        if dep_idx is not None
+        and dep_idx < len(sizing_op_info.predivision_host_advance_per_read)
+        else []
+    )
     for d in {d for level in sizing_op_info.loop_tiled_dims for d in level}:
         levels_tiling_d = [
-            i for i, dims in enumerate(sizing_op_info.loop_tiled_dims) if d in dims
+            i
+            for i, dims in enumerate(sizing_op_info.loop_tiled_dims)
+            if d in dims
+            and (
+                not sizing_op_info.hint_driven
+                or (
+                    i < len(planned_read_dims)
+                    and any(planned_dim == d for planned_dim, _ in planned_read_dims[i])
+                )
+            )
         ]
+        if not levels_tiling_d:
+            continue
         if d not in squeeze_pos:
             # sizing_op.data.ranges[d] == 1 for this tiled dim (e.g. a
             # B-tiled group where the per-tile B extent is 1) -- it was
@@ -3087,6 +3262,25 @@ def _insert_one_read_copy(
             # find -- unlike a dim genuinely absent from *this* read among
             # several (broadcast), which tiled_dims_per_read/
             # _tiled_dims_for_dep already handle correctly.
+            if sizing_op_info.hint_driven:
+                # The dependency was analyzed before range division, so its
+                # recorded step is the address authority for a packed expert
+                # operand whose E dimension has now been squeezed away.
+                for level_idx in levels_tiling_d:
+                    advance_by_dim = (
+                        dict(planned_host_advances[level_idx])
+                        if level_idx < len(planned_host_advances)
+                        else {}
+                    )
+                    advance = advance_by_dim.get(d)
+                    if advance is None or advance == 0:
+                        raise Unsupported(
+                            f"coarse_tile: advancing read {dep.name!r} lost the "
+                            f"pre-division address step for tiled dim {d}"
+                        )
+                    squeezed_advance[level_idx].append((advance, sympy.Integer(1)))
+                continue
+
             #
             # But this raw dim being squeezed out of *sizing_op's own*
             # iteration space says nothing about whether *this specific
@@ -3258,6 +3452,7 @@ def _patch_consumer_to_read_copy(
     one) via replace_computed_buffer_body, exactly as today.
     """
     full_strides = [dep.index.coeff(v) for v in dep.var_names]
+    dep_full_strides = list(full_strides)
     # dep is sizing_op's own (upstream-Inductor-squeezed) MemoryDep for this
     # read, so dep.var_names only covers host dims sizing_op's tile-extent
     # keeps distinct -- a host dim tiled down to extent 1 (e.g. a B-tiled
@@ -3288,7 +3483,18 @@ def _patch_consumer_to_read_copy(
         for op in operations
         if isinstance(op, ComputedBuffer) and op.get_name() == copy_name
     )
-    tile_strides = list(copy_buf.layout.stride)
+    consumer_info = consumer.loop_info  # type: ignore[attr-defined]
+    copy_strides = list(copy_buf.layout.stride)
+    active_idx = [i for i, stride in enumerate(dep_full_strides) if stride != 0]
+    if consumer_info.hint_driven and len(copy_strides) == len(active_idx):
+        # A compact invariant copy drops broadcast loop dimensions.  Expand
+        # its real strides back into the consumer's iteration-space positions
+        # so absent dimensions remain fixed instead of shifting T/H strides.
+        tile_strides = [sympy.Integer(0)] * len(dep_full_strides)
+        for pos, stride in zip(active_idx, copy_strides):
+            tile_strides[pos] = stride
+    else:
+        tile_strides = copy_strides
     tile_strides.extend(
         sympy.Integer(0) for _ in range(len(full_strides) - len(tile_strides))
     )
@@ -3305,6 +3511,30 @@ def _patch_consumer_to_read_copy(
     from ..pass_utils import replace_computed_buffer_body
 
     orig_inner = consumer.data.inner_fn
+    original_loop_info = consumer_info
+    original_dep_idx = None
+    if original_loop_info.hint_driven:
+        original_reads = [
+            r for r in consumer.get_read_writes().reads if isinstance(r, MemoryDep)
+        ]
+        original_dep_idx = original_reads.index(dep)
+    original_read_advances = original_dep_idx is not None and (
+        (
+            original_dep_idx < len(original_loop_info.tiled_dims_per_read)
+            and any(original_loop_info.tiled_dims_per_read[original_dep_idx])
+        )
+        or (
+            original_dep_idx < len(original_loop_info.squeezed_advance_per_read)
+            and any(original_loop_info.squeezed_advance_per_read[original_dep_idx])
+        )
+    )
+    direct_read_candidate = (
+        original_loop_info.hint_driven
+        and original_read_advances
+        and dep.name in V.graph.graph_input_names
+        and isinstance(consumer.data, Reduction)
+        and consumer.data.reduction_type in (BATCH_MATMUL_OP, BATCH_MATMUL_FP8_OP)
+    )
 
     def new_inner_fn(*args, _map=name_map, _orig_inner=orig_inner):
         with V.set_ops_handler(_NameSwapHandler(V.ops, _map)):
@@ -3319,6 +3549,13 @@ def _patch_consumer_to_read_copy(
         reason="redirect consumer to copied inputs",
     )
     V.graph.name_to_buffer[new_op.get_name()] = new_op
+    if direct_read_candidate:
+        new_op._coarse_tile_direct_read_candidate = _DirectReadCopyCandidate(  # type: ignore[attr-defined]
+            copy_name,
+            dep.name,
+            orig_inner,
+            original_loop_info,
+        )
 
     # new_op.loop_info (copied from consumer by copy_op_metadata inside
     # replace_computed_buffer_body) still carries tiled_dims_per_read as
@@ -3653,6 +3890,94 @@ def _insert_combine_op(
     return combine_name
 
 
+def _collapse_loop_carried_unit_sum(
+    tiled_op: ComputedBuffer,
+    combine_name: str,
+    operations: list[Operation],
+) -> ComputedBuffer:
+    """Turn a one-value local sum into the value consumed by the loop add.
+
+    Tiling the expert reduction to one expert leaves no local reduction for
+    DeepTools to perform. The following combine op already owns the real
+    cross-expert sum, so emitting another ``sum`` is redundant and not
+    representable. Every wider or differently-shaped reduction stays intact.
+    """
+    data = tiled_op.data
+    info = getattr(tiled_op, "loop_info", None)
+    propagation = getattr(info, "propagation", None)
+    reduction_plan = getattr(propagation, "reduction", None)
+    if not (
+        isinstance(data, Reduction)
+        and data.reduction_type == "sum"
+        and data.src_dtype == data.dtype
+        and getattr(propagation, "kind", None) == "reduction"
+        and reduction_plan is not None
+        and reduction_plan.reduction_type == "sum"
+        and not reduction_plan.is_nested
+        and len(info.loop_count) == 1
+        and isinstance(info.loop_count[0], (int, sympy.Integer))
+        and int(info.loop_count[0]) > 1
+        and info.loop_tiled_dims == [[]]
+        and info.loop_tiled_reduction_dims == [[0]]
+        and len(data.reduction_ranges) == 1
+        and isinstance(data.reduction_ranges[0], (int, sympy.Integer))
+        and int(data.reduction_ranges[0]) == 1
+    ):
+        return tiled_op
+
+    reads = list(tiled_op.get_read_writes().reads)
+    if len(reads) != 1 or not isinstance(reads[0], MemoryDep):
+        return tiled_op
+    tiled_idx = operations.index(tiled_op)
+    if tiled_idx + 1 >= len(operations):
+        return tiled_op
+    combine = operations[tiled_idx + 1]
+    if not (
+        isinstance(combine, ComputedBuffer)
+        and combine.get_name() == combine_name
+        and isinstance(combine.data, Pointwise)
+        and isinstance(combine.layout, MutationLayoutSHOULDREMOVE)
+        and getattr(combine.layout.get_buffer(), "_coarse_tile_loop_carried_lx", False)
+        and _reads_buffer(combine, tiled_op.get_name())
+    ):
+        return tiled_op
+
+    reduction_inner_fn = data.inner_fn
+
+    def contribution_inner_fn(index):
+        return reduction_inner_fn(index, [sympy.Integer(0)])
+
+    contribution_data = Pointwise(
+        device=tiled_op.get_device(),
+        dtype=tiled_op.get_dtype(),
+        inner_fn=contribution_inner_fn,
+        ranges=list(data.ranges),
+    )
+    from ..provenance import preserve_provenance
+
+    preserve_provenance(
+        data,
+        contribution_data,
+        pass_name="coarse_tile",
+        reason="collapse unit expert sum to loop contribution",
+    )
+    from ..pass_utils import replace_computed_buffer_body
+
+    contribution = replace_computed_buffer_body(
+        tiled_op,
+        contribution_data,
+        operations,
+        pass_name="coarse_tile",
+        reason="collapse unit expert sum to loop contribution",
+    )
+    # Replacing Reduction(index=[T,H], reduction=[E]) with Pointwise([T,H])
+    # renumbers its iteration symbols.  Keep named work-division hints attached
+    # to the logical dimensions instead of the old symbolic positions.
+    _remap_work_div_loop_info_after_tiling(contribution)
+    V.graph.name_to_buffer[contribution.get_name()] = contribution
+    return contribution
+
+
 def _insert_reduction_copy_op(
     tiled_op: ComputedBuffer,
     accum_tile: ComputedBuffer,
@@ -3741,6 +4066,42 @@ def _insert_reduction_copy_op(
     operations.insert(insert_idx, copy_buf)
 
 
+def _insert_flat_reduction_drain_op(
+    tiled_op: ComputedBuffer,
+    accumulator: ComputedBuffer,
+    output: ComputedBuffer,
+    operations: list[Operation],
+) -> str:
+    """Copy one loop-carried accumulator to its HBM graph output.
+
+    Deliberately carries no loop_info: the scheduler emits it once, after the
+    counted reduction loop, rather than once per reduction tile.
+    """
+    drain_data = Pointwise(
+        device=tiled_op.get_device(),
+        dtype=tiled_op.get_dtype(),
+        inner_fn=accumulator.make_loader(),
+        ranges=list(tiled_op.data.ranges),
+    )
+    drain_name = V.graph.qualify_name(
+        f"coarse_tile_reduction_drain_{tiled_op.get_name()}"
+    )
+    drain_buf = ComputedBuffer(
+        name=drain_name,
+        layout=MutationLayoutSHOULDREMOVE(TensorBox(StorageBox(output))),
+        data=drain_data,
+    )
+    drain_buf.origins = tiled_op.origins
+    drain_buf.operation_name = drain_name
+    drain_buf._coarse_tile_force_live = True  # type: ignore[attr-defined]
+    V.graph.name_to_buffer[drain_name] = drain_buf
+
+    combine_name = V.graph.qualify_name(f"coarse_tile_combine_{tiled_op.get_name()}")
+    combine_buf = V.graph.name_to_buffer[combine_name]
+    operations.insert(operations.index(combine_buf) + 1, drain_buf)
+    return drain_name
+
+
 def _insert_all_reduction_ops(operations: list[Operation]) -> None:
     """Pass 2: build reduction machinery for every planned reduction op.
 
@@ -3819,6 +4180,24 @@ def _propagate_tiled_reduction_op(
 
     fill_loop_info = reduction_plan.outer_fill_loop_info
     is_nested = reduction_plan.is_nested
+
+    # A terminal, flat reduction has one fixed output-shaped value carried
+    # across the counted reduction loop.  Keep that value separate from its
+    # graph output so scratchpad planning can place the running sum in LX and
+    # a suffix op can drain it to HBM once.  Reductions whose output also
+    # advances, or which have another consumer, retain the existing path.
+    outside_consumers, is_graph_output = _find_outside_consumers(
+        op.get_name(), loop_group_id, operations
+    )
+    use_loop_carried_accumulator = (
+        loop_info.hint_driven
+        and not is_nested
+        and is_graph_output
+        and not outside_consumers
+        and op.data.reduction_type == "sum"
+        and all(not dims for dims in loop_info.loop_tiled_dims)
+        and any(loop_info.loop_tiled_reduction_dims)
+    )
 
     if fill_loop_info is not None:
         # outer_fill_loop_info was built at planning time, before _apply_plan
@@ -3905,11 +4284,37 @@ def _propagate_tiled_reduction_op(
         ranges=fill_ranges,
     )
     fill_name = V.graph.qualify_name(f"coarse_tile_fill_{op.get_name()}")
-    fill_buf = ComputedBuffer(
-        name=fill_name,
-        layout=MutationLayoutSHOULDREMOVE(TensorBox(StorageBox(fill_target))),
-        data=fill_data,
-    )
+    if use_loop_carried_accumulator:
+        # The fill's ordinary output is the loop-carried storage.  It is not a
+        # graph output; the drain below is the only HBM write of the sum.
+        if isinstance(fill_target.layout, FixedTiledLayout):
+            fill_layout: FixedLayout = FixedTiledLayout(
+                device,
+                dtype,
+                list(fill_target.layout.size),
+                list(fill_target.layout.stride),
+                fill_target.layout.device_layout,
+            )
+        else:
+            fill_layout = FixedLayout(
+                device,
+                dtype,
+                list(fill_target.layout.size),
+                list(fill_target.layout.stride),
+            )
+        fill_buf = ComputedBuffer(
+            name=fill_name,
+            layout=fill_layout,
+            data=fill_data,
+        )
+        fill_buf._coarse_tile_loop_carried_lx = True  # type: ignore[attr-defined]
+        combine_target = fill_buf
+    else:
+        fill_buf = ComputedBuffer(
+            name=fill_name,
+            layout=MutationLayoutSHOULDREMOVE(TensorBox(StorageBox(fill_target))),
+            data=fill_data,
+        )
     fill_buf.origins = op.origins
     fill_buf.operation_name = fill_name
     if fill_loop_info is not None:
@@ -3930,7 +4335,16 @@ def _propagate_tiled_reduction_op(
     operations.insert(fill_target_idx + 2, fill_buf)
 
     # Insert combine op after the tiled reduction op (inside the loop).
-    combine_name = _insert_combine_op(op, combine_target, operations, is_nested)
+    combine_name = _insert_combine_op(
+        op,
+        combine_target,
+        operations,
+        is_nested or use_loop_carried_accumulator,
+    )
+
+    if use_loop_carried_accumulator:
+        op = _collapse_loop_carried_unit_sum(op, combine_name, operations)
+        _insert_flat_reduction_drain_op(op, combine_target, accum_full, operations)
 
     # For nested case, insert a copy op at the outer loop level that writes
     # accum_tile → accum_full, advancing accum_full across outer output tiles.
@@ -3955,10 +4369,6 @@ def _propagate_tiled_reduction_op(
 
     # Patch consumers to read accum_full (the fully-assembled output).
     buf_name = op.get_name()
-    outside_consumers, is_graph_output = _find_outside_consumers(
-        buf_name, loop_group_id, operations
-    )
-
     # Consumers INSIDE the same outermost loop group may also need
     # redirecting: any such consumer that currently reads op's own per-tile
     # scratch buffer (buf_name) directly, rather than accum_full, sees

--- a/torch_spyre/csrc/perm_layout_native.cpp
+++ b/torch_spyre/csrc/perm_layout_native.cpp
@@ -195,8 +195,8 @@ class NativePermutationLayoutSolver {
         bool first_read = b.attr("first_use_is_read").cast<bool>();
         parent_names[i] =
             b.attr("in_place_parents").cast<std::vector<std::string>>();
-        st->start[i] = uses.front();
-        st->end[i] = uses.back() + 1;
+        st->start[i] = b.attr("start_time").cast<int64_t>();
+        st->end[i] = b.attr("end_time").cast<int64_t>();
         st->weight[i] =
             static_cast<double>(uses.size()) + (first_read ? 0.0 : 0.5);
         const bool read_after_write =


### PR DESCRIPTION
Fixes #3928
Part of #3565
Builds on the coarse-tiling size-one fixes merged in #3890

Related but not fixed:

- #3888 — broadcast matmul ambiguity for more than one expert per tile
- #3891 — eager-result host normalization performance regression

## Campaign status

Superseded by the focused split PRs #4075, #4039, #4040, #4096, #4078, #4041, and #4042. Every piece is now merged into `main` through `3358f39e`, and structural, numerical-correctness, and same-stack device-performance acceptance passed.

## Accepted performance

These measurements cover two different boundaries:

- Expert FFN only, chunked versus persistent: `373.1 ms → 42.6 ms` (`8.8×`).
- Full Gemma 4 26B prefill, batch size 1 and sequence length 512: `6.4 s → 1.6 s` (`4.0×`).

The first isolates the expert FFN; the second is the end-to-end model prefill result.

## What this does

Makes an explicit coarse-tiling hint sufficient to express the dense all-expert execution schedule:

- emit one expert body inside one counted device loop;
- stage the shared `[T,H]` input once in LX;
- advance the gate, up, down, and routing operands to the next expert each trip;
- keep the `[T,H]` running sum in LX through the loop and drain it once;
- remove temporary weight-copy operations only after layout propagation proves that the matmul can read the advancing HBM slice directly.

This reuses the existing hint, coarse-tiling, counted-loop, layout, work-division, scratchpad, and SuperDSC paths. It adds no model-facing operation or separate planner.

## Compiler gaps addressed

| Problem | Existing behavior | Fix | Compiler area |
|---|---|---|---|
| Lost expert address step | Tiling `E` to size 1 removes the symbol before the next-expert address step is reconstructed. | Preserve the input's original step before tiling and use it when the dimension disappears. | `coarse_tile.py`, `loop_info.py` |
| Temporary weight buffers | Coarse tiling stages each expert weight slice through a temporary buffer. | Remove the copy only after layout propagation proves the matmul can read the advancing HBM slice directly. | `coarse_tile.py`, `propagate_layouts.py` |
| No loop-carried sum | The terminal expert sum is represented as an ordinary tiled reduction. | Create one `[T,H]` accumulator, add one contribution per expert, and drain it once after the loop. | `coarse_tile.py` |
| Loop lifetime ends early | Scratchpad planning sees one textual loop body and can end `x` or accumulator lifetime before all trips finish. | Extend their allocation lifetime through the counted loop in both layout solvers. | `scratchpad/*`, `perm_layout_native.cpp` |
| Unstable row ownership | A running sum is unsafe when successive loop trips can assign rows to different cores. | Require explicit row work division before enabling the carried accumulator. | `coarse_tile.py`, work-division metadata |

## Scope

The new behavior is restricted to loops created by an explicit `spyre_hint`. Automatic span-overflow tiling keeps its existing behavior. If direct weight streaming cannot be proven safe, the existing copy remains.

The loop-carried reduction path accepts only a terminal flat `sum` with no other consumer. Ordinary and nested reductions keep the existing path.

The three commits contain 781 production additions and 107 test additions on current main. Most of the production code is the three physical requirements that hints did not previously express: preserving an address step after a tiled dimension becomes size one, carrying a value's LX lifetime across repeated loop iterations, and draining a terminal reduction once after the loop.

## Validation

- Reduced complete expert FFN (`E=2, T=64, H=64, F=64`) passes device correctness against CPU.
- Generated source has one loop body, four advancing operands, no activation `hbm_pool`, no in-loop HBM restickify, and one reduction drain.
- #3890's `E=128` shared-LHS broadcast-matmul correctness test passes on device.
- Focused compiler suites: 416 passed, 5 skipped. One pre-existing four-layer nested-launch case reached an unsupported DeepTools bundle opcode on the available pod; its one-layer form passed.
- After rebasing onto current main, Ruff, Python syntax, C++ formatting, commit signatures, DCO trailers, and `git diff --check` pass. Fresh CI is pending.

Performance effects from eager result-layout normalization are tracked separately in #3891. This PR does not use a latency threshold as a correctness gate.

## Current CI status

The PR head is based directly on current main (06cee473). All coarse-tiling and focused persistent-loop checks pass. The remaining failed device jobs are the same three broad suites failing on current main—matmul, LX reduction scalar, and reduction scalar—so they are not attributed to this PR.
