### PR TITLE
fix(ci): remove unreliable -m marker pre-flight that silently disabled --skip-slow

### DIFF
--- a/tests/oot_framework/run_test.sh
+++ b/tests/oot_framework/run_test.sh
@@ -2617,72 +2617,24 @@ for i in "${!RUN_FILES[@]}"; do
     fi
 
     # ---------------------------------------------------------------------------
-    # -m marker pre-flight
+    # -m is intentionally NOT pre-flighted here.
     #
-    # When a -m MARKEXPR is present, probe whether this specific file has any
-    # tests that match it before running.  The probe uses --collect-only which
-    # is fast as no test execution happens and runs from the file's own directory
-    # so conftest.py files are discovered correctly.
+    # This used to run a --collect-only probe first and strip -m from the real
+    # invocation whenever the probe reported 0 collected (exit code 5), on the
+    # theory that a 0-match probe means "this marker family isn't used in this
+    # file". That inference is unsound: a 0-collected probe can also mean the
+    # probe itself failed to complete cleanly (e.g. a slow cold collection of a
+    # large merged file), which is indistinguishable from a real 0-match once
+    # stderr is discarded. On a merged multi-config run, this silently dropped
+    # --skip-slow's `-m not slow__plat_<arch>` filter for large files like
+    # test_inductor_ops.py, letting ~1hr `test_large_matmul*` tests run
+    # unfiltered — see issue where standalone runs correctly filtered while
+    # `make tests TEST_TYPE=unit` did not.
     #
-    # If the probe finds 0 matching tests (exit code 5) the -m flag is stripped
-    # from _FILE_PYTEST_ARGS so the file's tests all run normally --
-    # the marker filter applies to files that USE that marker
-    # family; files that don't use it are unaffected. This fallback is for
-    # op__/dtype__/module__/platform__-style tags, where a per-file 0-match
-    # just means "this marker family isn't used here". It does NOT apply to
-    # testtype__<label> (see _OOTTestTypeMarkerPatcher): that tag is a
-    # whole-file inclusion marker driven by the config's
-    # test_suite_config.labels, so a 0-match genuinely means this file's
-    # config doesn't carry the requested label and the file must stay
-    # excluded, not fall back to running unfiltered. -m is left in place for
-    # that case; the real run below will also report 0 collected (exit 5),
-    # which the exit-code handling further down already treats as
-    # NOTEST/warning-only, not a failure.
-    #
+    # -m is always left in place; a genuine 0-match on the real run below
+    # already reports exit code 5, which the exit-code handling further down
+    # treats as NOTEST/warning-only, not a failure.
     # ---------------------------------------------------------------------------
-    _HAS_M=0
-    for _a in "${_EXTRA_NO_XML[@]+"${_EXTRA_NO_XML[@]}"}"; do
-        [[ "$_a" == "-m" ]] && { _HAS_M=1; break; }
-    done
-
-    if [[ $_HAS_M -eq 1 ]]; then
-        # Extract just the -m args for the probe (no --junit-xml, no -v, etc.)
-        _PROBE_ARGS=()
-        _take_next=0
-        for _a in "${_EXTRA_NO_XML[@]+"${_EXTRA_NO_XML[@]}"}"; do
-            if [[ $_take_next -eq 1 ]]; then
-                _PROBE_ARGS+=("$_a")
-                _take_next=0
-                continue
-            fi
-            if [[ "$_a" == "-m" ]]; then
-                _PROBE_ARGS+=("$_a")
-                _take_next=1
-            fi
-        done
-
-        # `|| _probe_exit=$?` is required: exit 5 (nothing collected) is the
-        # expected signal here, and under `set -e` a bare subshell would abort
-        # the whole run before the exit code could be inspected.
-        _probe_exit=0
-        (cd "$run_dir" && python3 -m pytest "$run_basename" \
-            "${_PROBE_ARGS[@]}" --collect-only -q 2>/dev/null) || _probe_exit=$?
-
-        if [[ $_probe_exit -eq 5 && "${_PROBE_ARGS[*]}" == *"testtype__"* ]]; then
-            echo "[torch_oot_device_tests_run] -m filter matched 0 tests in $(basename "$original_file") (testtype__ label not present) -- file excluded" >&2
-        elif [[ $_probe_exit -eq 5 ]]; then
-            # 0 tests match this marker in this file — strip -m from args.
-            echo "[torch_oot_device_tests_run] -m filter matched 0 tests in $(basename "$original_file"), running without -m" >&2
-            _ARGS_NO_M=()
-            _skip_m=0
-            for _a in "${_FILE_PYTEST_ARGS[@]+"${_FILE_PYTEST_ARGS[@]}"}"; do
-                if [[ $_skip_m -eq 1 ]]; then _skip_m=0; continue; fi
-                if [[ "$_a" == "-m" ]]; then _skip_m=1; continue; fi
-                _ARGS_NO_M+=("$_a")
-            done
-            _FILE_PYTEST_ARGS=("${_ARGS_NO_M[@]}")
-        fi
-    fi
 
     # -----------------------------------------------------------------------
     # Run pytest for this file.


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

## What this PR does

- **Removes the unreliable `-m` marker pre-flight probe in `run_test.sh`.** It ran a separate `--collect-only` probe before each file's real test run, and if that probe reported "0 collected" (pytest exit 5), it silently **stripped `-m` from the real run** — assuming the marker just wasn't used in that file. That's unsound: a probe glitch looks identical to a real 0-match once its stderr is discarded.

- **`-m` now always passes through unmodified.** A genuine 0-match on the real run already exits 5, which downstream code already treats as a harmless `NOTEST` warning — never a failure. `testtype__` markers were already exempt from the strip; this makes that the default for all markers.

- **Impact:** `make tests TEST_TYPE=unit PYTEST_ARGS="-v --skip-slow"` was silently running `test_large_matmul_*` (~1hr tests) because the probe against the merged 2302-test `test_inductor_ops.py` reported 0 collected and stripped `--skip-slow`'s `-m not slow__plat_<arch>` filter. The same config run standalone (104 tests) never hit this — smaller scale, probe behaved fine.

### Example (toy suite, `slow__plat_x86_64` standing in for `slow__plat_s390x`)

| | Before fix | After fix |
|---|---|---|
| Probe glitches, reports 0 collected | strips `-m` → real run: **303 passed** (all tests, including the 3 slow-tagged ones, ran) | no probe exists → real run: **300 passed, 3 deselected** (slow tests correctly excluded) |
