### PR TITLE
fix(tests): resolve model_ops device args against the test device

### DIFF
--- a/tests/models/test_model_ops_v2.py
+++ b/tests/models/test_model_ops_v2.py
@@ -415,6 +415,19 @@ class TestSpyreModelOps(TestCase):
             SampleInput=SampleInput,
         )
 
+        # `device` selects where the op runs, so it resolves to test_device.
+        # Tensors stay CPU-built so both samples hold identical values and
+        # _to_target_device keeps its layout-aware to_spyre() path.
+        device_kwargs = ops_item.sample_inputs_func.resolved_kwargs(
+            test_device=test_device,
+            seed=seed,
+            dtype=dtype,
+        )
+        device_arg_values = ops_item.sample_inputs_func.resolved_device_args(
+            test_device=test_device,
+            op_name=op_name,
+        )
+
         def _to_target_device(x: Any, arg_spec: Optional[Any] = None) -> Any:
             if torch.is_tensor(x):
                 if (
@@ -472,19 +485,28 @@ class TestSpyreModelOps(TestCase):
         ):
             test_args.append(_to_target_device(cpu_arg, spec_arg))
 
+        # torch.to names its destination positionally.
+        for idx, dev_value in device_arg_values.items():
+            if idx < len(test_args):
+                test_args[idx] = dev_value
+
         if test_args:
             test_sample = SampleInput(
                 test_args[0],
                 args=tuple(test_args[1:]),
-                # NOTE: kwargs are plain values only (dim, dtype, keepdim, etc.) — no
-                # current config passes a tensor/device_layout via kwargs, and
-                # resolved_kwargs() will raise if one ever tries to. If that changes,
-                # this needs the same arg_spec-based layout lookup as _to_target_device
-                # uses for positional args above.
-                kwargs={k: _to_target_device(v) for k, v in cpu_sample.kwargs.items()},
+                # NOTE: kwargs are plain values only (dim, dtype, keepdim, etc.) —
+                # resolved_kwargs() raises on a tensor/device_layout spec. If that
+                # changes, this needs the same arg_spec-based layout lookup as
+                # _to_target_device uses for positional args above.
+                kwargs={k: _to_target_device(v) for k, v in device_kwargs.items()},
             )
         else:
-            test_sample = cpu_sample.transform(lambda x: _to_target_device(x))
+            moved = cpu_sample.transform(lambda x: _to_target_device(x))
+            test_sample = SampleInput(
+                moved.input,
+                args=moved.args,
+                kwargs={k: _to_target_device(v) for k, v in device_kwargs.items()},
+            )
 
         # Adapter pre-hook (e.g. dropout sets training=False)
         if adapter.pre is not None:

--- a/tests/oot_framework/oot_test_config_models.py
+++ b/tests/oot_framework/oot_test_config_models.py
@@ -985,6 +985,29 @@ class InputsEdits(BaseModel):
 
         return cpu_args
 
+    def resolved_device_args(
+        self,
+        *,
+        test_device: Optional[torch.device],
+        op_name: str = "",
+    ) -> Dict[int, Any]:
+        """Return {arg_index: test_device} for positional device args.
+
+        ``torch.to("cuda:0")`` names its destination positionally, so it takes
+        the same substitution ``resolved_kwargs`` rule 2 applies to a ``device``
+        kwarg. Only indices holding a device are returned, so callers can overlay
+        them onto CPU-built args without disturbing other values.
+        """
+        out: Dict[int, Any] = {}
+        if test_device is None or op_name != "torch.to":
+            return out
+        for i, raw in enumerate(self.args):
+            arg = _parse_input_arg(raw) if isinstance(raw, dict) else raw
+            val = getattr(arg, "value", None)
+            if isinstance(val, str) and "cuda" in val:
+                out[i] = test_device
+        return out
+
     def resolved_kwargs(
         self,
         *,


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

A `device` kwarg — and `torch.to`'s positional destination — selects where an op runs, so it now resolves to the device under test.

`test_model_ops_db` built a single sample with `test_device="cpu"` and derived the device-side sample from it by mapping `_to_target_device` over the values. That helper relocates only tensors, so a plain device value passed straight through and the op ran on CPU. `_is_cpu_output` then read back the same `"cpu"` and expected a CPU result, so `_confirm_device` was satisfied and nothing surfaced.

The fix resolves kwargs a second time against the real `test_device` for the device sample, and adds `InputsEdits.resolved_device_args` for `torch.to`'s positional destination. Tensors stay CPU-built, so both samples hold identical values and the layout-aware `to_spyre()` path in `_to_target_device` is preserved — only the plain device values differ between the two samples.

`_is_cpu_output` needs no change: a config authored `device: cpu` still resolves to `"cpu"` (rule 2 only substitutes on `"cuda"`), so genuinely-CPU ops keep working and the existing assertion becomes meaningful again once it is fed a correctly-resolved device.

v1 (`tests/models/runner.py`) already resolves the device kwarg against the real `test_device`, so this brings v2 in line with it.

#### Which issue(s) this PR is related to:

Fixes #3894

#### Special notes for your reviewer:

**Why `build_cpu_args` is not simply called with the real device.** It passes tensors through `_move_to_test_device`, which would relocate them early and bypass the `arg_spec`-based `to_spyre()` layout path in `_to_target_device`. The substitution therefore has to stay at the plain-value layer, which is why the device kwargs are resolved separately rather than by re-running the whole builder on the device.

**The test result does not change, and that is expected.** `aten.arange` is not implemented on Spyre, so the op now dispatches to the device and falls back to CPU, emitting a new `FallbackWarning: aten.arange.default is falling back to cpu`. That warning is the visible evidence the op reaches the device at all; the fallback returns correct values, so the case stays `XPASS`. This PR restores real coverage rather than flipping a pass/fail.

**Verification.** Full `gpt-oss-20b_spyre.yaml`, before and after:

| | result |
|---|---|
| pre-fix | 46 xfailed, 189 xpassed, exit 0 |
| with fix | 46 xfailed, 189 xpassed, exit 0 |

Resolution behavior, including the negative case that keeps CPU ops working:

```
arange kwargs @spyre : {'device': device(type='spyre')}
authored device: cpu : {'device': 'cpu'}
to positional @spyre : {1: device(type='spyre')}
non-to op            : {}
```

Eager check that the device request now lands:

```
>>> torch.arange(11, device=torch.device('spyre'))
arange on spyre -> spyre:0 torch.int64
values: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
```

`pre-commit run --files` on both changed files passes (ruff check, ruff format, mypy).

**Follow-up worth considering, not included here.** No current config declares a `device` kwarg with zero positional args, but the kwargs-only branch is wired up the same way so such a config would behave correctly if one is added. Separately, `aten.arange` falling back to CPU on device is the reason this case cannot yet assert a real device computation — enabling it would let the xfail be dropped.

#### Does this PR introduce a user-facing change?

No. Test-framework only; no change to `torch_spyre/` runtime or codegen.

#### Additional note:

Affects 26 op entries across the `*_spyre.yaml` model configs, 20 of them factory ops (`arange`, `zeros`, `ones`, `full`, `randn`, ...). `device` nested inside a tensor spec was already handled correctly — those tensors go through `_to_target_device` — so only the top-level plain value was missed.