### PR TITLE
test(sdsc): drop removed use_symbols kwarg (fixes Test Sdsc Logging on main)

### DIFF
--- a/tests/inductor/test_sdsc_logging.py
+++ b/tests/inductor/test_sdsc_logging.py
@@ -73,7 +73,6 @@ class TestSdscJsonLogging:
                             sdsc_counter=[0],
                             symbol_id_offset_counter=[0],
                             output_dir=tmpdir,
-                            use_symbols=False,
                         )
 
                 info_calls = mock_info.call_args_list
@@ -107,7 +106,6 @@ class TestSdscJsonLogging:
                             sdsc_counter=[0],
                             symbol_id_offset_counter=[0],
                             output_dir=tmpdir,
-                            use_symbols=False,
                         )
 
                 sdsc_json_calls = [
@@ -148,7 +146,6 @@ class TestBundleMlirLogging:
                             kernel_name="test_kernel",
                             output_dir=tmpdir,
                             specs=[],
-                            use_symbols=False,
                         )
 
                 mlir_calls = [
@@ -186,7 +183,6 @@ class TestBundleMlirLogging:
                             kernel_name="test_kernel",
                             output_dir=tmpdir,
                             specs=[],
-                            use_symbols=False,
                         )
 
                 mlir_calls = [


### PR DESCRIPTION
## What

Removes the stale `use_symbols=False` keyword argument from the four `_compile_specs` / `generate_bundle` calls in `tests/inductor/test_sdsc_logging.py`.

## Why

`#3741` removed the `use_symbols` parameter from `_compile_specs()` and `generate_bundle()` in `torch_spyre/_inductor/codegen/bundle.py`. `#3684` later added `test_sdsc_logging.py`, which still passes `use_symbols=False`, so the `Inductor / Test Sdsc Logging` suite fails on every run with:

```
TypeError: _compile_specs() got an unexpected keyword argument 'use_symbols'
```

The current signatures are:

- `_compile_specs(specs, symbols, compiled, sdsc_counter, symbol_id_offset_counter, output_dir)`
- `generate_bundle(kernel_name, output_dir, specs, pool_size=0)`

Neither accepts `use_symbols`, and no source under `torch_spyre/` references it any more. This PR drops the kwarg from the four call sites so the suite runs against the current API. No production code changes.

## Scope

4 deleted lines in one test file. The test bodies otherwise stay the same (they mock `compile_op_spec` and assert on the SDSC/MLIR log calls), so behavior coverage is unchanged.
