### PR TITLE
fix(inductor): handle a matmul whose contraction spans two dims

### DIFF
--- a/tests/inductor/test_codegen.py
+++ b/tests/inductor/test_codegen.py
@@ -29,6 +29,7 @@ from torch_spyre._C import DataFormats
 from torch_spyre._inductor import config
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.codegen.compute_ops import (
+    check_bmm_dim_roles,
     SymbolKind,
     _per_core_symbolic_dim_info,
     _symbolic_split_info,
@@ -46,6 +47,68 @@ from torch_spyre._inductor.work_division import (
     _valid_divisor_basis,
     adjust_it_space_for_sticks,
 )
+
+
+class TestBmmDimRoles(InductorTestCase):
+    """The backend classifies a BMM's M/N/K roles by set arithmetic over the three
+    operands' ``layoutDimOrder_`` and requires N and K to be exactly one dim each
+    (``getMinParamBmm``, deeptools ``L3DlOpsScheduler.cpp``). When they are not, it
+    aborts inside ``DT_CHECK`` with no shape information, so codegen refuses first.
+
+    The real case: a decode-shaped attention output reaching ``o_proj`` as
+    ``[.., heads, head_dim]`` rather than one flattened dim, which happens when the
+    ``seqlen_q == 1`` reshape is layout-free and Inductor elides the materialisation
+    that would collapse it. K then spans two iteration symbols.
+    """
+
+    # The layouts observed on hardware, from the SDSC JSON of a Gemma 4 sliding
+    # layer at seqlen_q=1 (4 heads x 256) and at seqlen_q=64 respectively.
+    SPLIT_CONTRACTION = {
+        "INPUT": ["in", "out"],
+        "KERNEL": ["out", "in", "mb"],
+        "OUTPUT": ["mb"],
+    }
+    SINGLE_CONTRACTION = {
+        "INPUT": ["in", "mb"],
+        "KERNEL": ["in", "out"],
+        "OUTPUT": ["out", "mb"],
+    }
+
+    def test_split_contraction_is_refused(self):
+        with self.assertRaisesRegex(Unsupported, "contraction"):
+            check_bmm_dim_roles("batchmatmul", self.SPLIT_CONTRACTION)
+
+    def test_error_names_the_offending_dims_and_the_op(self):
+        """A bare refusal is not much better than the DT_CHECK it replaces."""
+        with self.assertRaisesRegex(Unsupported, r"batchmatmul"):
+            check_bmm_dim_roles("batchmatmul", self.SPLIT_CONTRACTION)
+        with self.assertRaisesRegex(Unsupported, r"in.*out|out.*in"):
+            check_bmm_dim_roles("batchmatmul", self.SPLIT_CONTRACTION)
+
+    def test_single_contraction_is_accepted(self):
+        check_bmm_dim_roles("batchmatmul", self.SINGLE_CONTRACTION)
+
+    def test_fp8_bmm_is_checked_too(self):
+        with self.assertRaisesRegex(Unsupported, "contraction"):
+            check_bmm_dim_roles("batchmatmulfp8", self.SPLIT_CONTRACTION)
+
+    def test_non_matmul_opfuncs_are_not_checked(self):
+        """Only matmul-family opfuncs use the INPUT/KERNEL/OUTPUT role contract."""
+        check_bmm_dim_roles("abs", self.SPLIT_CONTRACTION)
+
+    def test_split_output_channel_dim_is_refused(self):
+        """The N dim is DT_CHECKed the same way; refuse it for the same reason."""
+        layouts = {
+            "INPUT": ["in", "mb"],
+            "KERNEL": ["in", "out", "out2"],
+            "OUTPUT": ["out", "out2", "mb"],
+        }
+        with self.assertRaisesRegex(Unsupported, "output-channel"):
+            check_bmm_dim_roles("batchmatmul", layouts)
+
+    def test_incomplete_layout_set_is_left_alone(self):
+        """Some matmul paths carry a KERNEL_IDX or omit a role; do not guess."""
+        check_bmm_dim_roles("batchmatmul", {"INPUT": ["in"], "KERNEL": ["in"]})
 
 
 class TestSpyreConfig(InductorTestCase):

--- a/tests/inductor/test_matmul_split_contraction.py
+++ b/tests/inductor/test_matmul_split_contraction.py
@@ -1,0 +1,121 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A matmul whose activation is a view splitting the contraction across two dims.
+
+``lower_mm``/``lower_bmm`` give the reduction a single K range, but the read goes
+through the activation's loader. When that activation is a view over a differently
+shaped buffer -- a multi-head attention output arriving as ``[.., heads, head_dim]``
+-- the emitted index spans two dims of the base, the kernel's iteration space
+inherits two contraction symbols, and the backend scheduler rejects it
+(``getMinParamBmm`` DT_CHECKs exactly one; see ``check_bmm_dim_roles``).
+
+The shape that bites is ordinary decode-shaped attention: at ``seqlen_q == 1`` the
+``transpose(1, 2).reshape(1, 1, heads * head_dim)`` is layout-free, so nothing
+materialises it and the split survives. At ``seqlen_q > 1`` the same reshape must
+materialise, which collapses K and the check passes -- which is why this is
+seqlen-specific and easy to miss.
+
+Run:
+    SENCORES=1 python3 -m pytest tests/inductor/test_matmul_split_contraction.py -v
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch._inductor.test_case import TestCase as InductorTestCase
+
+HEAD_DIM = 256
+CACHE = 1088
+
+
+class _HeadRMSNorm(nn.Module):
+    """Per-head RMSNorm, the shape that re-exposes [heads, head_dim] around a matmul."""
+
+    def __init__(self, head_dim: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(head_dim))
+        self.eps = eps
+
+    def forward(self, x):
+        variance = (x * x).mean(-1, keepdim=True)
+        return x * torch.rsqrt(variance + self.eps) * self.weight
+
+
+def _attention_then_projection(heads: int, seqlen_q: int, dtype, device):
+    """Build (fn, args) for attention -> per-head norm -> output projection."""
+    torch.manual_seed(0)
+    features = heads * HEAD_DIM
+    o_proj = nn.Linear(features, features, bias=False).to(dtype).to(device)
+    norm = _HeadRMSNorm(HEAD_DIM).to(dtype).to(device)
+
+    query = torch.randn(1, heads, seqlen_q, HEAD_DIM, dtype=dtype).to(device)
+    key = torch.randn(1, 1, CACHE, HEAD_DIM, dtype=dtype).to(device)
+    value = torch.randn(1, 1, CACHE, HEAD_DIM, dtype=dtype).to(device)
+    mask = torch.zeros(1, 1, seqlen_q, CACHE, dtype=dtype).to(device)
+
+    def fn(query, key, value, mask):
+        attended = F.scaled_dot_product_attention(
+            query, key, value, attn_mask=mask, scale=1.0, enable_gqa=True
+        )
+        flat = attended.transpose(1, 2).reshape(1, seqlen_q, -1)
+        normed = norm(flat.view(1, seqlen_q, heads, HEAD_DIM)).view(1, seqlen_q, -1)
+        return o_proj(normed)
+
+    return fn, (query, key, value, mask)
+
+
+class TestMatmulSplitContraction(InductorTestCase):
+    def setUp(self):
+        super().setUp()
+        torch._dynamo.reset()
+
+    def _run_on_spyre(self, heads, seqlen_q):
+        fn, args = _attention_then_projection(heads, seqlen_q, torch.float16, "spyre")
+        with torch.no_grad():
+            return torch.compile(fn, dynamic=False)(*args).to("cpu").float()
+
+    def test_single_query_row_multi_head_compiles(self):
+        """The case that failed: 4 heads, seqlen_q=1, K split as 4 x 256."""
+        out = self._run_on_spyre(heads=4, seqlen_q=1)
+        self.assertEqual(tuple(out.shape), (1, 1, 4 * HEAD_DIM))
+        self.assertTrue(torch.isfinite(out).all())
+
+    def test_single_query_row_multi_head_is_numerically_right(self):
+        """Compiling is not enough -- a copy inserted on the wrong axis would still
+        compile and would silently permute the contraction."""
+        heads, seqlen_q = 4, 1
+        fn32, args32 = _attention_then_projection(heads, seqlen_q, torch.float32, "cpu")
+        with torch.no_grad():
+            expected = fn32(*args32)
+        actual = self._run_on_spyre(heads=heads, seqlen_q=seqlen_q)
+        torch.testing.assert_close(actual, expected, rtol=2e-2, atol=5e-2)
+
+    def test_multi_row_query_still_compiles(self):
+        """The path that already worked must keep working (no copy needed there)."""
+        out = self._run_on_spyre(heads=4, seqlen_q=64)
+        self.assertEqual(tuple(out.shape), (1, 64, 4 * HEAD_DIM))
+        self.assertTrue(torch.isfinite(out).all())
+
+    def test_single_head_single_row_still_compiles(self):
+        """One head leaves nothing to split; it compiled before this fix too."""
+        out = self._run_on_spyre(heads=1, seqlen_q=1)
+        self.assertEqual(tuple(out.shape), (1, 1, HEAD_DIM))
+        self.assertTrue(torch.isfinite(out).all())
+
+
+if __name__ == "__main__":
+    from torch._inductor.test_case import run_tests
+
+    run_tests()

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -18,7 +18,11 @@ import dataclasses
 from sympy import Symbol
 
 from torch_spyre._C import DataFormats, encode_constant
-from torch_spyre._inductor.constants import CONV2D_DIM_LABELS, DEPTHWISE_CONV2D_OP
+from torch_spyre._inductor.constants import (
+    CONV2D_DIM_LABELS,
+    DEPTHWISE_CONV2D_OP,
+    MATMUL_REDUCTION_OPS,
+)
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.op_spec import TensorWorkDivision
 from torch_spyre._inductor.pass_utils import coeff_through_floor
@@ -636,6 +640,56 @@ def _tensor_tiled_by_symbol(tensor, sym) -> bool:
     if tensor.device_tile_advance_expr is None:
         return False
     return bool(coeff_through_floor(tensor.device_tile_advance_expr, sym))
+
+
+def check_bmm_dim_roles(opfunc: str, layout_dim_orders: dict) -> None:
+    """Refuse a matmul whose dim roles the backend scheduler cannot classify.
+
+    ``getMinParamBmm`` (deeptools ``dcg/dcg_fe/scheduler/L3DlOpsScheduler.cpp``)
+    derives a BMM's roles by set arithmetic over the three operands'
+    ``layoutDimOrder_``, and ``DT_CHECK``s that two of them are exactly one dim::
+
+        N = (KERNEL & OUTPUT) - INPUT     # output channels
+        K = (INPUT  & KERNEL) - OUTPUT    # the contraction
+
+    A contraction spanning two iteration symbols reaches that check as
+    ``DT_CHECK(out_reuse_dim.size() == 1)`` and aborts the backend compiler with
+    no shape, op or dim information — the error names only the failed predicate.
+    Refusing here instead costs nothing and says which op and which dims.
+
+    How a split contraction arises in practice: a multi-head activation reaching
+    a matmul as ``[.., heads, head_dim]`` rather than one flattened dim. A
+    decode-shaped attention output does exactly that — at ``seqlen_q == 1`` the
+    reshape to ``[batch, 1, heads * head_dim]`` is layout-free, so the
+    materialisation that would collapse ``heads x head_dim`` into a single dim is
+    elided, and K stays two symbols. At ``seqlen_q > 1`` the same reshape must
+    materialise, which collapses it and the check passes.
+
+    ``MATMUL_REDUCTION_OPS`` only: other op families do not use the
+    INPUT/KERNEL/OUTPUT role contract. A layout set missing any of the three
+    roles is left alone rather than guessed at.
+    """
+    if opfunc not in MATMUL_REDUCTION_OPS:
+        return
+    try:
+        inputs = set(layout_dim_orders["INPUT"])
+        kernel = set(layout_dim_orders["KERNEL"])
+        output = set(layout_dim_orders["OUTPUT"])
+    except KeyError:
+        return
+
+    for role, dims in (
+        ("contraction (K)", (inputs & kernel) - output),
+        ("output-channel (N)", (kernel & output) - inputs),
+    ):
+        if len(dims) != 1:
+            raise Unsupported(
+                f"{opfunc} with a {role} dim spanning {len(dims)} dims "
+                f"{sorted(dims)}; the backend scheduler requires exactly one. "
+                f"layoutDimOrder_ INPUT={layout_dim_orders['INPUT']} "
+                f"KERNEL={layout_dim_orders['KERNEL']} "
+                f"OUTPUT={layout_dim_orders['OUTPUT']}"
+            )
 
 
 def generate_sdsc(
@@ -1307,6 +1361,14 @@ def generate_sdsc(
             extra["dsOffset"] = 0
             extra["allocateNode_"] = alloc_node
         return extra
+
+    check_bmm_dim_roles(
+        sdsc_spec.opfunc,
+        {
+            label: [str(dim) for dim in _filter_window_dims(info["dim_order"], label)]
+            for label, info in sdsc_spec.layouts.items()
+        },
+    )
 
     return (
         {

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -418,8 +418,50 @@ def lower_scaled_mm(
     return result
 
 
+def _contraction_read_is_flat(x) -> bool:
+    """True when reading ``x``'s contraction dim needs one dim of the base buffer.
+
+    ``lower_mm``/``lower_bmm`` give their reduction a single K range, but the read
+    goes through ``x.make_loader()``. When ``x`` is a view whose K spans more than
+    one dim of the buffer underneath — a multi-head activation arriving as
+    ``[.., heads, head_dim]`` — the emitted index carries *two* contraction symbols
+    into the kernel's iteration space, and the backend scheduler requires exactly
+    one (``getMinParamBmm``; see ``codegen.compute_ops.check_bmm_dim_roles``).
+
+    Deliberately not a contiguity test. Such an activation is contiguous in memory
+    — at ``seqlen == 1`` the ``transpose(1, 2)`` preceding the reshape is a no-op —
+    so ``ir.is_contiguous_storage_and_layout`` reports it flat and would miss it.
+    What matters is the shape of the buffer the loader indexes, so this compares
+    ``x``'s trailing dim against the base's. That also keeps an ordinary flattening
+    view copy-free: ``[B, M, K]`` read as ``[B*M, K]`` has the same trailing dim and
+    needs no copy.
+    """
+    node = x.data if isinstance(x, ir.TensorBox) else x
+    if isinstance(node, StorageBox):
+        node = node.data
+    if not isinstance(node, ir.BaseView):
+        return True
+    base_size = node.unwrap_view().get_size()
+    x_size = x.get_size()
+    if not base_size or not x_size:
+        return True
+    return V.graph.sizevars.statically_known_equals(x_size[-1], base_size[-1])
+
+
+def _flatten_contraction(x):
+    """Copy ``x`` when its contraction dim is not a single flat read.
+
+    The copy is what collapses a split contraction into one dim; it is skipped
+    whenever the read is already flat, so ordinary matmuls are untouched.
+    """
+    if _contraction_read_is_flat(x):
+        return x
+    return ir.ExternKernel.copy_input(x)
+
+
 @register_spyre_lowering(torch.ops.aten.mm.default)
 def lower_mm(x, y):
+    x = _flatten_contraction(x)
     x.realize()
     y.realize()
     x_loader = x.make_loader()
@@ -483,6 +525,7 @@ def lower_mm(x, y):
 @register_spyre_lowering(torch.ops.spyre.batched_matmul.default)
 @register_spyre_lowering(torch.ops.aten.bmm.default)
 def lower_bmm(x, y):
+    x = _flatten_contraction(x)
     x.realize()
     y.realize()
     x_loader = x.make_loader()


### PR DESCRIPTION
`getMinParamBmm` (deeptools `L3DlOpsScheduler.cpp`) derives a BMM's M/N/K roles by set arithmetic over the operands' `layoutDimOrder_` and `DT_CHECK`s that N and K are one dim each. A contraction spanning two iteration symbols hits `DT_CHECK(out_reuse_dim.size() == 1)` and aborts the backend compiler naming only the failed predicate — no op, no shape, no dims.

Repro: a decode-shaped attention output reaching `o_proj` as `[.., heads, head_dim]`. At `seqlen_q == 1` the reshape is layout-free, so the materialisation that would collapse `heads × head_dim` is elided and K stays two symbols; at `seqlen_q > 1` the reshape must materialise and the check passes. That seqlen dependence is why it's easy to miss.

Two parts:
- **Guard (`compute_ops.py`)** — refuse it in codegen, naming the op and offending dims instead of the bare backend `DT_CHECK` abort.
- **Fix (`lowering.py`)** — copy the activation when its K read is not flat, so the read carries one contraction symbol. The predicate compares the view's trailing dim against the base rather than testing contiguity: the offending activation *is* contiguous (the preceding transpose is a no-op at seqlen 1), so a contiguity test would miss it, while the trailing-dim comparison leaves an ordinary flattening view (`[B,M,K]`→`[B*M,K]`) copy-free.

Tests: the failing shape now compiles; its numerics against a float32 CPU reference (a copy on the wrong axis would compile while permuting K); and both already-working controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)