### PR TITLE
fix(inductor): reject an inexpressible layout candidate instead of raising

### DIFF
--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -1105,13 +1105,16 @@ def _multi_arg_pointwise_layouts(
             projected_dim_order = [d - rank_diff for d in dim_order if d >= rank_diff]
             c_in_size = [concretize_expr(s) for s in arg.layout.size]
             c_in_stride = [concretize_expr(s) for s in arg.layout.stride]
-            in_stl = SpyreTensorLayout(
-                c_in_size,
-                c_in_stride,
-                out_dtype_for_layout,
-                projected_dim_order,
-                output_ea,
-            )
+            try:
+                in_stl = SpyreTensorLayout(
+                    c_in_size,
+                    c_in_stride,
+                    out_dtype_for_layout,
+                    projected_dim_order,
+                    output_ea,
+                )
+            except RuntimeError:
+                return False
             coord = try_device_coordinates(in_stl, arg.dep, ind_sizes)
             if coord is None or not is_stick_expr_offset_free(coord[-1], stick_size):
                 return False


### PR DESCRIPTION
`_is_supported_layout` is a predicate over candidate `dim_order`s, but it built a `SpyreTensorLayout` without guarding it, so a candidate that cannot be expressed for one arg aborted the whole compile with `RuntimeError: Incompatible host_size and dim_order` instead of being rejected so the caller could try the next candidate.

Observed input (from instrumenting the raise site):
```
out_size  = [1, 4, 64, 256]       rank 4, a HOST size
in_size   = [1, 1, 4, 2, 1, 128]  rank 6, a DEVICE-split layout
rank_diff = -2
dim_order = [1, 2, 3, 0, -1]  ->  projected = [3, 4, 5, 2, 1]  (5 for 6 dims)
```

**Scope:** this only makes the failure legible; it does not fix the projection defect above it (two faults: `rank_diff` compares a host rank against a possibly device-split rank and only handles the positive case; the `-1` sentinel is shifted into a valid-looking index when `rank_diff` is negative). With those unfixed, every candidate for such an arg is now rejected and the caller reports "no supported output layout found" — actionable rather than a bare abort. The projection defect is to be filed separately with this instrumented evidence.

**No test:** the only known reproducer is a multi-arg pointwise whose arg carries a higher-rank device-split layout, which I could not reduce to a minimal case (five candidate reductions all compiled). Regression unchanged: 294 passed, 5 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)