### PR TITLE
ci: paginate artifact queries in retry gate and empty-suite check

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -816,9 +816,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p failed_suites
-          ARTIFACTS=$(gh api \
-            "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
-            --jq '[.artifacts[] | select(.name | startswith("failed-suite-")) | {id: .id, name: .name}]')
+          # --paginate: the artifacts endpoint defaults to 30 per page. A
+          # regression run uploads one XML per suite plus the wheel, well over
+          # one page, and an un-paginated query silently drops every descriptor
+          # past page 1: a suite whose failed-suite-<jobid> descriptor lands
+          # later is never retried and the gate reports green. --paginate
+          # applies --jq per page and concatenates the results (gh rejects
+          # --slurp combined with --jq), so emit a per-object JSON stream, not
+          # a wrapped array, and let python3 slurp the stream into one array.
+          # Same idiom as push-to-clickhouse.yaml.
+          ARTIFACTS=$(gh api --paginate \
+            "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?per_page=100" \
+            --jq '.artifacts[] | select(.name | startswith("failed-suite-")) | {id: .id, name: .name}' \
+            | python3 -c "import json,sys; print(json.dumps([json.loads(l) for l in sys.stdin if l.strip()]))")
 
           ARTIFACTS="$ARTIFACTS" python3 <<'PYEOF'
           import json, os, subprocess
@@ -1094,9 +1104,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p xml_artifacts
-          ARTIFACTS=$(gh api \
-            "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
-            --jq '[.artifacts[] | select(.name | endswith(".xml")) | {id: .id, name: .name}]')
+          # --paginate: same page-cap trap as collect_failed_suites; an
+          # un-paginated query would miss XML reports past the first page and
+          # under-report the empty-suite check. Emit a per-object JSON stream
+          # (gh rejects --slurp with --jq) and slurp it into one array.
+          ARTIFACTS=$(gh api --paginate \
+            "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?per_page=100" \
+            --jq '.artifacts[] | select(.name | endswith(".xml")) | {id: .id, name: .name}' \
+            | python3 -c "import json,sys; print(json.dumps([json.loads(l) for l in sys.stdin if l.strip()]))")
 
           ARTIFACTS="$ARTIFACTS" python3 <<'PYEOF'
           import json, os, subprocess


### PR DESCRIPTION
## Problem

The GitHub artifacts REST endpoint (`/repos/{repo}/actions/runs/{id}/artifacts`) returns **30 items per page** by default. Both `collect_failed_suites` and `report_empty_suites` in `_test_matrix.yaml` read the run's artifacts with an **un-paginated** `gh api` call, so any artifact past the first page is silently dropped.

For `collect_failed_suites` this is a correctness hole in the merge gate:

- Each `test` job runs with `continue-on-error: true`. A suite that fails uploads a `failed-suite-<jobid>` descriptor artifact.
- `collect_failed_suites` builds the pod-level retry matrix from those descriptors.
- `test_result` (the gate the required `Run Spyre unit tests` check keys off) fails **only** if a retry job fails.

A regression run uploads one XML per suite plus the wheel, which already exceeds one 30-artifact page. So a `failed-suite-*` descriptor that lands past artifact 30 is invisible to `collect_failed_suites`: the retry matrix is empty, no retry runs, and the gate reports green even though a suite failed.

## Concrete impact seen in production

This let PR #3684 merge as `83285d2` even though its `test_sdsc_logging` suite failed all three attempts:

- Merge-queue run [`32320577749`](https://github.com/torch-spyre/torch-spyre/actions/runs/32320577749) had **123** artifacts.
- The suite uploaded `failed-suite-79` (artifact id `9389712311`), but it was past the first page.
- `collect_failed_suites` reported `Downloaded 0 failed-suite descriptor(s)`, `has_failed_single=false`, so the retry was skipped and the gate passed.
- Every later PR then failed with `TypeError: generate_bundle() got an unexpected keyword argument 'use_symbols'` (fixed as a symptom by #3889; this PR fixes the CI hole that let it merge red).

## Relationship to #3872

#3872 (merged) fixed the same class of pagination bug in `push-to-clickhouse.yaml`. This PR fixes the two remaining un-paginated sites in `_test_matrix.yaml`, one of which (`collect_failed_suites`) is gate-critical. It uses the **same idiom** #3872 established: `gh api --paginate` with a per-object `--jq` stream that `python3` slurps into one array (`gh` rejects `--slurp` combined with `--jq`).

## Verification

Against the real run `32320577749`:

```
# old (un-paginated) query
gh api ".../runs/32320577749/artifacts" \
  --jq '[.artifacts[] | select(.name | startswith("failed-suite-"))]'
# => []   (the failing suite is invisible)

# new query (matches #3872's idiom)
gh api --paginate ".../runs/32320577749/artifacts?per_page=100" \
  --jq '.artifacts[] | select(.name | startswith("failed-suite-")) | {id, name}' \
  | python3 -c "import json,sys; print(json.dumps([json.loads(l) for l in sys.stdin if l.strip()]))"
# => [{"id": 9389712311, "name": "failed-suite-79"}]   (found)
```

`report_empty_suites` (warning-only) has the same page-cap trap and is fixed the same way.
