### PR TITLE
fix(eager): compile d2d copy and overwrite statically per shape

### DIFF
--- a/tests/inductor/test_offset_view_eager_ops.py
+++ b/tests/inductor/test_offset_view_eager_ops.py
@@ -144,3 +144,41 @@ class TestOffsetViewListArgs:
         got = torch.stack([k, v], dim=0).to("cpu")
         ref = torch.stack([qkv[..., Q : Q + KV], qkv[..., Q + KV : TOTAL]], dim=0)
         torch.testing.assert_close(got.float(), ref.float(), atol=ATOL, rtol=0)
+
+
+class TestPrefixViewSliceWrite:
+    """Eager d2d slice writes from a PREFIX VIEW must honor the view's size.
+
+    Regression test for #3826. ``copy_from_d2d`` is compiled through
+    ``compile_once``; without ``dynamic=False`` there, dynamo's auto-dynamic
+    promoted the source's row dim to a symbol after repeated calls at distinct
+    lengths, and the Spyre lowering silently baked ONE concrete extent into the
+    reused graph -- so a later write copied the frozen extent (the base's 64
+    rows on the reporting stack), overrunning the destination window. Found in
+    the wild as attention write-back corrupting other sequences in a batch.
+
+    The ladder below uses several distinct lengths on purpose: the first call
+    is always correct (fresh static trace) and the corruption only appears once
+    auto-dynamic would have kicked in, so a single-length test cannot regress
+    this.
+    """
+
+    def test_prefix_view_write_honors_view_extent_across_lengths(self):
+        torch.manual_seed(0)
+        for qlen in (16, 32, 48, 24, 40):
+            src_cpu = torch.randn(64, 32, 128, dtype=torch.float16)
+            dst = torch.zeros(96, 32, 128, dtype=torch.float16).to("spyre")
+            dst[32 : 32 + qlen] = src_cpu.to("spyre")[:qlen]
+            got = dst.to("cpu")
+            outside = torch.ones(96, dtype=torch.bool)
+            outside[32 : 32 + qlen] = False
+            assert torch.all(got[outside] == 0), (
+                f"qlen={qlen}: write escaped the destination window "
+                f"(view extent ignored)"
+            )
+            torch.testing.assert_close(
+                got[32 : 32 + qlen].float(),
+                src_cpu[:qlen].float(),
+                atol=1e-2,
+                rtol=0,
+            )

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -234,7 +234,16 @@ def _(input: torch.Tensor):
 @torch.library.custom_op(
     "spyre::copy_from_d2d", mutates_args=("dst",), device_types="spyre"
 )
-@compile_once("spyre.copy_from_d2d")
+# dynamic=False: dynamo's auto-dynamic promotes a SIZE to a symbol after the
+# second distinct value, exactly as it does for ints (fought off below with
+# specialize_int) -- and the Spyre lowering then silently bakes ONE concrete
+# extent into the SDSC while dynamo reuses the "dynamic" graph for every later
+# size. A d2d copy of a prefix view then writes the baked extent, not the
+# view's (#3826: overran dst and corrupted attention write-back downstream).
+# Static per-shape traces are the codebase's standing pattern -- every other
+# compile_once site already passes dynamic=False -- and cache_size_limit is
+# bumped to 1024 for precisely this one-binary-per-variant regime.
+@compile_once("spyre.copy_from_d2d", dynamic=False)
 def copy_from_d2d(
     src: torch.Tensor,
     dst: torch.Tensor,
@@ -324,7 +333,10 @@ def opaque_copy__cpu(value: torch.Tensor, acc: torch.Tensor) -> torch.Tensor:
 @torch.library.custom_op(
     "spyre::overwrite", mutates_args=("output",), device_types="spyre"
 )
-@compile_once("spyre.overwrite")
+# dynamic=False for the same reason as copy_from_d2d above (#3826): a varying
+# input size must trigger a fresh static trace, never an auto-dynamic graph
+# whose frozen extent scatters the wrong number of elements.
+@compile_once("spyre.overwrite", dynamic=False)
 def overwrite(
     input: torch.Tensor,
     output: torch.Tensor,


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes the eager d2d slice-write corruption in #3826: `dst[a:b] = src` from a prefix view wrote a **frozen extent** instead of the view's size once the process had performed such a write at a *different* view length — silently clobbering memory past the destination window.

**Root cause.** `spyre::copy_from_d2d` is compiled through `compile_once`, which called `torch.compile(op)` without `dynamic=False`. Dynamo's auto-dynamic promotes a **size** to a symbol after repeated calls at distinct values — exactly as it does for ints, which this op already fights off with `specialize_int` — and the Spyre lowering then silently bakes one concrete extent into the SDSC while dynamo reuses the "dynamic" graph for every later size. Measured on a 5-length ladder: after auto-dynamic kicks in, the reused graph writes its trace-time extent regardless of the runtime length (too few rows at 48, an 8-row overrun at 24; on @tdoublep's stack the baked value was the base's 64 rows — same mechanism, different frozen constant). This explains every row of the issue's excellent diagnosis table, including why `.clone()` fixes it, `.contiguous()` doesn't, and the first write in a process is always correct.

**Fix.** `dynamic=False`, so every shape gets its own static trace — the pattern every other `compile_once` site in the tree already uses, in the one-binary-per-variant regime `cache_size_limit=1024` exists for. `spyre::overwrite` (the scatter-write primitive) had the identical exposure — same `specialize_int` battle scars, same missing kwarg — and gets the identical fix.

#### Which issue(s) this PR is related to:

Fixes #3826

#### Special notes for your reviewer:

- The regression test is a **multi-length ladder on purpose**: the first trace is always correct and the corruption only appears once auto-dynamic would have kicked in, so a single-length test structurally cannot regress this. The test asserts both containment (no writes outside the window) and content.
- Verified: the issue's reproducer verbatim, a 5-length ladder (16/32/48/24/40 — all clean, `unique_graphs: 5`), and `test_overwrite.py` + `test_offset_view_eager_ops.py` (28 passed).
- **Deliberately not fixed here:** user-facing `torch.compile(dynamic=True)` on the same write corrupts from the *second* call, because the backend accepts a graph with a symbolic extent and silently specializes it. That is a separate, pre-existing gap in how the backend handles symbolic dims (it should refuse ones it cannot honor rather than freeze them), out of scope for this fix — this PR closes the eager door #3826 walked through, not that one.
- Based on `3e23d180` rather than current tip: `main` @ `ab6eb2f7` currently requires AIUPTI runtime headers (`AIUPTI_RUNTIME_TRACE_CBID_PARSE_RESPONSE`, #3591) newer than our pod's installed toolchain, so local device verification was run on the newest buildable base. No conflict with the intervening commits (`customops.py` auto-merges cleanly over #3811).

#### Does this PR introduce a user-facing change?

Eager d2d slice writes from views are now correct at every view length. Compile-time cost: one compiled copy program per distinct shape instead of a shared dynamic one — the regime the existing `cache_size_limit` bump was designed for.

#### Additional note:

Credit to @tdoublep for the diagnosis table in #3826, which narrowed this to a state-dependence signature before any code was read.

