### PR TITLE
Fix strided sub-stick access for dtype conversions

### DIFF
--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -21,6 +21,7 @@ from torch_spyre._C import SpyreTensorLayout
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.pass_utils import (
     device_coordinates,
+    is_stick_expr_offset_free,
     try_device_coordinates,
 )
 from torch_spyre._inductor.propagate_layouts import (
@@ -28,6 +29,7 @@ from torch_spyre._inductor.propagate_layouts import (
     _check_supported_input_sticks,
 )
 from torch_spyre._inductor.views import (
+    align_tensors,
     compute_coordinates,
     normalize_coordinates,
     tiling_expr_to_device_expr,
@@ -467,6 +469,91 @@ class TestNormalizeCoordinatesFusion(TestCase):
             ],
         )
         self.assertEqual([int(t.dim_size) for t in terms], [32, 64])
+
+
+class TestScaledModStickExpr(TestCase):
+    """Regression coverage for a strided (step>1) slice landing inside a
+    stick, e.g. ``t[:, ::2].to(torch.float32).to(torch.float16)`` on a
+    [4, 128] fp16 tensor.
+
+    sympy auto-canonicalizes ``Mod(2*d1, 64)`` to ``2*Mod(d1, 32)`` --
+    algebraically identical, just regrouped. Three independent spots assumed
+    the un-factored ``Mod(var, elems_per_stick)`` shape and broke on the
+    canonicalized one:
+
+    1. ``is_stick_expr_offset_free`` rejected the scaled-Mod form outright
+       (``Unexpected stick expression 2*(Mod(d1, 32))``).
+    2. ``align_tensors``'s split-tracking identified "the stick term" by
+       comparing variable identity (``var != stick_dim[i]``) rather than
+       position, so an unrelated outer ("which stick") term sharing the same
+       variable was mistaken for the stick term and had its ``mod`` dropped
+       from ``splits`` (``ValueError: 64 is not in list``).
+    3. ``align_tensors``'s "ensure stick dim var occurs twice" fallback
+       rebuilt the stick coordinate from scratch as plain ``var //
+       elems_per_stick`` / ``var % elems_per_stick``, silently discarding the
+       ``2x`` scale factor whenever the outer segment had been renamed to a
+       synthetic var (e.g. ``z0``) rather than reusing the original name.
+    """
+
+    def _dtype(self):
+        return SpyreTensorLayout([1, 1], torch.float16).device_dtype
+
+    def test_device_coordinates_accepts_scaled_mod(self):
+        dev = self._dtype()
+        d0, d1 = sympy.symbols("d0 d1", integer=True, nonnegative=True)
+        # arg0_1: [4, 128] fp16, tiled into 2 sticks of 64; dep reads every
+        # other column (the `::2` slice), ranges {d0: 4, d1: 64}.
+        dep = MemoryDep("buf", 128 * d0 + 2 * d1, (d0, d1), (4, 64))
+        stl = SpyreTensorLayout([2, 4, 64], [64, 128, 1], dev)
+        coords = device_coordinates(stl, dep, None)  # must not raise
+        self.assertEqual(coords[-1], 2 * sympy.Mod(d1, 32))
+
+    def test_is_stick_expr_offset_free_scaled_mod_forms(self):
+        d1 = sympy.Symbol("d1", integer=True, nonnegative=True)
+        # sympy's canonicalized coeff*Mod(var, N) form, coeff*N == stick size.
+        self.assertTrue(is_stick_expr_offset_free(sympy.Mod(2 * d1, 64), 64))
+        # Un-scaled forms still work as before.
+        self.assertTrue(is_stick_expr_offset_free(sympy.Mod(d1, 64), 64))
+        self.assertTrue(is_stick_expr_offset_free(d1, 64))
+        # A coefficient that does not evenly divide the stick size is not a
+        # representable stick expression.
+        self.assertFalse(is_stick_expr_offset_free(3 * sympy.Mod(d1, 64), 128))
+
+    def test_align_tensors_scaled_mod_stick_dim(self):
+        d0, d1 = sympy.symbols("d0 d1", integer=True, nonnegative=True)
+        iteration_space = {d0: (4, 1), d1: (64, 1)}
+        tensors = [
+            {
+                "size": [2, 4, 64],
+                "coordinates": [sympy.floor(d1 / 32), d0, 2 * sympy.Mod(d1, 32)],
+            },
+        ]
+        _, new_tensors = align_tensors(iteration_space, tensors)  # must not raise
+        # The final (stick-dim) coordinate must retain the *2 scale factor;
+        # it must not collapse to the unscaled `Mod(d1, 64)`.
+        self.assertEqual(new_tensors[0]["coordinates"][-1], 2 * sympy.Mod(d1, 32))
+
+    def test_align_tensors_matmul_unaffected(self):
+        # Matmul's "outer chunk" term legitimately shares its variable with
+        # the stick term (e.g. floor(c2/64) alongside Mod(c2, 64)) without
+        # any coefficient. This must decompose exactly as before the fix.
+        c0, c1, c2 = sympy.symbols("c0 c1 c2", integer=True, nonnegative=True)
+        iteration_space = {c0: (64, 4), c1: (256, 4), c2: (128, 2)}
+        tensors = [
+            {
+                "size": [2, 64, 64],
+                "coordinates": [sympy.floor(c2 / 64), c0, sympy.Mod(c2, 64)],
+            },
+        ]
+        new_splits, new_tensors = align_tensors(iteration_space, tensors)
+        self.assertEqual(new_splits, iteration_space)
+        self.assertEqual(
+            new_tensors[0],
+            {
+                "size": [2, 64, 64],
+                "coordinates": [sympy.floor(c2 / 64), c0, sympy.Mod(c2, 64)],
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -848,11 +848,34 @@ def find_matmul_generated_var(
     return next(iter(generated_vars))
 
 
+def _is_scaled_mod(stick_expr: sympy.Expr, elems_per_stick: int) -> bool:
+    """Check for sympy's canonicalized form of ``Mod(coeff * var, elems_per_stick)``.
+
+    ``sympy.Mod(coeff * var, coeff * N)`` auto-simplifies to
+    ``coeff * Mod(var, N)`` whenever ``coeff`` divides the modulus (e.g. a
+    strided/step>1 slice landing inside a single stick). This is the same
+    stick expression as the un-factored ``Mod(var, elems_per_stick)`` case
+    below — just algebraically regrouped by sympy — so it is equally
+    supported, not merely "may be valid".
+    """
+    if not (isinstance(stick_expr, sympy.Mul) and len(stick_expr.args) == 2):
+        return False
+    coeff, mod_term = stick_expr.args
+    if not isinstance(mod_term, sympy.Mod):
+        coeff, mod_term = mod_term, coeff
+    if not (isinstance(mod_term, sympy.Mod) and coeff.is_Integer and coeff > 0):
+        return False
+    base, modulus = mod_term.args
+    return len(base.free_symbols) == 1 and coeff * modulus == elems_per_stick
+
+
 def is_stick_expr_offset_free(stick_expr: sympy.Expr, elems_per_stick: int) -> bool:
     """Check if a stick expression is free of constant offsets.
 
     Returns True for stick expressions with no additive offset:
     - Mod(var, elems_per_stick) where var is a single symbol
+    - coeff * Mod(var, elems_per_stick // coeff) — sympy's canonicalized form
+      of the above when a coefficient divides the modulus (see _is_scaled_mod)
     - A bare variable (symbol)
     - Zero
     """
@@ -863,7 +886,12 @@ def is_stick_expr_offset_free(stick_expr: sympy.Expr, elems_per_stick: int) -> b
     )
     is_bare_var = stick_expr.is_symbol
     is_zero = stick_expr == sympy.S.Zero
-    return is_supported_mod or is_bare_var or is_zero
+    return (
+        is_supported_mod
+        or is_bare_var
+        or is_zero
+        or _is_scaled_mod(stick_expr, elems_per_stick)
+    )
 
 
 def _is_stick_expr_with_offset(stick_expr: sympy.Expr, elems_per_stick: int) -> bool:

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -661,14 +661,30 @@ def align_tensors(
     splits: dict[sympy.Symbol, sympy.Expr] = {var: set() for var in all_vars}
 
     for i, terms in enumerate(all_terms):
-        for num, den, var, mod, dim_size, offset in [astuple(term) for term in terms]:
+        n_terms = len(terms)
+        for j, term in enumerate(terms):
+            num, den, var, mod, dim_size, offset = astuple(term)
             if var is not None:
                 if den != stick_size[i] or var != stick_dim[i]:
                     # add den to splits unless stick dim and stick size
                     splits[var].add(den)
+                # Identify the stick term by position (it is always
+                # terms[-1]), not by comparing `var` to stick_dim[i]: a
+                # strided (step>1) access landing inside a stick can reuse
+                # the same variable for both the stick term and an outer
+                # (e.g. num-sticks-selector) term, and that outer term's
+                # `mod` can coincidentally equal the stick size too (e.g.
+                # when the variable's own full range equals the stick size).
+                # Comparing by variable alone would then wrongly treat the
+                # outer term as the stick term, dropping its mod from
+                # splits. den (above) does not need this: the outer term's
+                # den only equals stick_size for the genuine "elided outer
+                # stick dim" pattern (see the mirroring check at the
+                # reconstruction site below), which is safe to key off var.
+                is_stick_term = j == n_terms - 1
                 if (
                     mod != stick_size[i]
-                    or var != stick_dim[i]
+                    or not is_stick_term
                     or var in repeat_info.keys()
                 ):
                     # add mod to splits unless stick dim and stick size
@@ -794,8 +810,14 @@ def align_tensors(
         # add stick dim
         num, den, var, mod, dim_size, offset = astuple(terms[-1])
         size.append(dim_size)
+        # (var * num // den) generalizes to `var` for the common num=1, den=1
+        # case; the explicit scale is needed for a strided (step>1) access
+        # landing inside a stick (e.g. a `::2` slice feeding a same-size
+        # dtype conversion), where the stick coordinate is `coeff * var`, not
+        # bare `var`.
         coordinates.append(
-            (var % dim_size if var is not None else sympy.S.Zero) + offset
+            ((var * num // den) % dim_size if var is not None else sympy.S.Zero)
+            + offset
         )
         new_tensors.append({"size": size, "coordinates": coordinates})
 
@@ -829,6 +851,16 @@ def align_tensors(
         vars = t["coordinates"][-1].free_symbols
         if len(vars) == 1:
             stick_dim_var = next(iter(vars))
+            if len(remap.get(stick_dim_var, [stick_dim_var])) > 1:
+                # Already decomposed by the split/remap machinery above: its
+                # outer segment lives under a synthetic var (e.g. z0), not
+                # stick_dim_var itself, so the free-symbol scan below can
+                # never find it there. That is not a real gap -- skip this
+                # tensor rather than clobber the (already correct, and
+                # possibly scaled, e.g. `coeff * Mod(var, N)`) stick
+                # coordinate with a plain var // size / var % size pairing
+                # that ignores the split boundaries and any coefficient.
+                continue
             found = False
             for i in range(len(t["coordinates"]) - 1):
                 vars = t["coordinates"][i].free_symbols


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes the front-end half of  t[:, ::2].to(torch.float32).to(torch.float16) was raising Unsupported: Unexpected stick expression 2*(Mod(d1, 32)) on any tensor whose stride-2 (or other power-of-2 stride) slice lands inside a single hardware stick. 

sympy auto-canonicalizes Mod(2*d1, 64) to 2*Mod(d1, 32) — algebraically identical, just regrouped — whenever the slice's stride evenly divides the stick size. Three places in the compiler only recognized the un-factored Mod(var, N) shape and broke on the canonicalized one:

- pass_utils.py — is_stick_expr_offset_free rejected the scaled form outright, raising Unexpected stick expression.

- views.py, align_tensors — identified "the stick term" by comparing variable identity rather than position, so an unrelated outer term sharing the same variable was mistaken for the stick term and had its modulus dropped from splits, raising ValueError: 64 is not in list.

- views.py, align_tensors (silent) — the "ensure stick dim var occurs twice" fallback rebuilt the stick coordinate from scratch as plain var // N / var % N, discarding the scale factor whenever the outer segment had been renamed to a synthetic variable. This produced no exception — it would have compiled and silently read the wrong memory.

With this fix, the exact repro from #2851 compiles cleanly through torch-spyre's entire Python pipeline and produces a correct SDSC descriptor — but the native hardware compiler  still cannot schedule the resulting kernel: 

```DtException: Could not find any suitable dimension mapping. ```

#### Which issue(s) this PR is related to:
#2851 

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #2851 
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
