### PR TITLE
ci: scope pod-level retry gate to the current run attempt

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -476,11 +476,18 @@ jobs:
           ${{ toJSON(matrix.suite) }}
           JSONEOF
 
+      # The name carries github.run_attempt: the artifacts REST API is
+      # run-scoped, not attempt-scoped (there is no /attempts/N/artifacts
+      # endpoint and no attempt field on the artifact object), and a re-run
+      # keeps the earlier attempt's descriptors until they expire. Without the
+      # attempt in the name, collect_failed_suites on a later attempt reads a
+      # stale descriptor from a prior attempt and retries a suite that already
+      # passed. See retention-days:1 below -- it does not help within 24h.
       - name: Upload failed-suite descriptor
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: failed-suite-${{ strategy.job-index }}
+          name: failed-suite-${{ github.run_attempt }}-${{ strategy.job-index }}
           path: ${{ runner.temp }}/failed_suite/suite.json
           if-no-files-found: error
           retention-days: 1
@@ -794,11 +801,12 @@ jobs:
           ${{ toJSON(matrix.suite) }}
           JSONEOF
 
+      # github.run_attempt in the name: see the single-card upload above.
       - name: Upload failed-suite descriptor
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: failed-suite-multi-${{ strategy.job-index }}
+          name: failed-suite-multi-${{ github.run_attempt }}-${{ strategy.job-index }}
           path: ${{ runner.temp }}/failed_suite/suite.json
           if-no-files-found: error
           retention-days: 1
@@ -832,9 +840,18 @@ jobs:
           # --slurp combined with --jq), so emit a per-object JSON stream, not
           # a wrapped array, and let python3 slurp the stream into one array.
           # Same idiom as push-to-clickhouse.yaml.
+          #
+          # startswith("failed-suite-<attempt>-"): the artifacts endpoint is
+          # run-scoped, not attempt-scoped, and returns descriptors from every
+          # attempt of this run (a re-run keeps the prior attempt's artifacts
+          # until they expire). Selecting only the current attempt's descriptors
+          # stops a re-run from retrying a suite that failed on an earlier
+          # attempt but passed on this one. The upload steps stamp
+          # github.run_attempt into the name for exactly this filter.
+          ATTEMPT="${{ github.run_attempt }}"
           ARTIFACTS=$(gh api --paginate \
             "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?per_page=100" \
-            --jq '.artifacts[] | select(.name | startswith("failed-suite-")) | {id: .id, name: .name}' \
+            --jq ".artifacts[] | select(.name | startswith(\"failed-suite-${ATTEMPT}-\") or startswith(\"failed-suite-multi-${ATTEMPT}-\")) | {id: .id, name: .name}" \
             | python3 -c "import json,sys; print(json.dumps([json.loads(l) for l in sys.stdin if l.strip()]))")
 
           ARTIFACTS="$ARTIFACTS" python3 <<'PYEOF'
@@ -865,9 +882,14 @@ jobs:
                       suites.append(json.load(f))
               return suites
 
-          # "failed-suite-multi-N" (multi) vs "failed-suite-N" (single) -- the digit class keeps the single-card glob from also matching multi-card descriptors.
-          multi = load("failed_suites/failed-suite-multi-*/suite.json")
-          single = load("failed_suites/failed-suite-[0-9]*/suite.json")
+          # Names are failed-suite-<attempt>-<idx> (single) and
+          # failed-suite-multi-<attempt>-<idx> (multi); the --jq select above
+          # already scoped the download to this attempt. The single glob starts
+          # with a digit class so it matches "failed-suite-3-*" but never the
+          # "failed-suite-multi-*" descriptors (which start with a letter).
+          attempt = os.environ["GITHUB_RUN_ATTEMPT"]
+          multi = load(f"failed_suites/failed-suite-multi-{attempt}-*/suite.json")
+          single = load(f"failed_suites/failed-suite-{attempt}-[0-9]*/suite.json")
 
           print(f"Single-card suites to retry: {[s.get('name') for s in single]}")
           print(f"Multi-card suites to retry : {[s.get('name') for s in multi]}")


### PR DESCRIPTION
## Problem

The pod-level retry gate in `_test_matrix.yaml` retries a suite that already **passed**, when the workflow is re-run.

A failed `test` leg uploads a `failed-suite-<idx>` descriptor artifact; `collect_failed_suites` reads the run's artifacts and rebuilds a retry matrix from them. The artifacts REST API is **run-scoped, not attempt-scoped**: there is no `/runs/{id}/attempts/{n}/artifacts` endpoint (it returns 404), and the artifact object carries no attempt field. So on a re-run, `collect_failed_suites` reads descriptors left by an earlier `run_attempt`. Those descriptors have `retention-days: 1`, so they do not expire within the re-run window.

**Effect:** a suite that FAILED on an earlier attempt but PASSED on a later attempt still gets a pod-level retry on the later attempt. The retry re-runs an already-passing suite and burns a scarce single-card Spyre pod for no signal. It is not a correctness hole (the spurious retry passes), but it wastes hardware and time every time a re-run follows any earlier-attempt suite failure.

### Evidence

Run [`32413287636`](https://github.com/torch-spyre/torch-spyre/actions/runs/32413287636) on PR #2892, on attempt 3:

- **Attempt 2** ([view](https://github.com/torch-spyre/torch-spyre/actions/runs/32413287636/attempts/2)): `Inductor / Test Inductor Ops Lx Reduction Index B` [FAILED](https://github.com/torch-spyre/torch-spyre/actions/runs/32413287636/job/96575768785), so it uploaded `failed-suite-33` (created 2026-08-20 21:01:50Z). Attempt 2's own retry then passed.
- **Attempt 3** ([view](https://github.com/torch-spyre/torch-spyre/actions/runs/32413287636/attempts/3)): the same suite [PASSED cleanly](https://github.com/torch-spyre/torch-spyre/actions/runs/32413287636/job/96587866112) (`301 passed`, "Attempt 1 PASSED", no failed step, no descriptor saved).
- [`Collect suites for pod-level retry`](https://github.com/torch-spyre/torch-spyre/actions/runs/32413287636/job/96590127350) on attempt 3 still found `failed-suite-33` from attempt 2 (< 24h old) and spawned the spurious [`Test Inductor Ops Lx Reduction Index B (pod-level retry)`](https://github.com/torch-spyre/torch-spyre/actions/runs/32413287636/job/96590164827), which re-ran the already-passing suite.

The stale descriptor's `suite.json` is exactly that suite, and its `created_at` is inside the attempt-2 window (attempt 3 did not start until 21:26:15Z).

## Fix

Stamp `github.run_attempt` into the descriptor artifact name:

- `failed-suite-<attempt>-<idx>` (single card)
- `failed-suite-multi-<attempt>-<idx>` (multi card)

and select only the current attempt's descriptors in `collect_failed_suites`, both at the `--jq` API filter and at the glob loaders. This is the only reliable discriminator, since the API cannot filter by attempt.

Verified locally:
- The `--jq` `startswith("failed-suite-<attempt>-") or startswith("failed-suite-multi-<attempt>-")` filter selects only the current attempt's single and multi descriptors.
- The single glob `failed-suite-<attempt>-[0-9]*` matches single-card names but never `failed-suite-multi-*` (which starts with a letter after the second dash).

`actionlint` and `yamlfmt` pass.

## Scope / follow-up

This PR fixes the gate-critical `collect_failed_suites` path. `report_empty_suites` has the same run-scoped artifact query and can therefore read a stale-attempt XML report, but it is warning-only (never fails the workflow) and its report names are not attempt-stamped, so a clean attempt-scoping there needs a larger change touching downstream XML consumers. Left out of this PR.

Related: #3906 (pagination in the same gate) and #3872 (same pagination class in `push-to-clickhouse.yaml`).
