### PR TITLE
ci: retry gh api log-fetch in push-hw-diagnostics (fix HTTP 502 flake)

### DIFF
--- a/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
+++ b/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
@@ -83,30 +83,55 @@ jobs:
         run: |
           mkdir -p raw_logs
 
-          gh api \
-            "/repos/${{ github.repository }}/actions/runs/${TRIGGERING_RUN_ID}/jobs" \
-            --paginate \
-            --jq '.jobs[] | {id: .id, name: .name}' \
-          > /tmp/jobs.jsonl
-
           python3 - << 'PYEOF'
-          import json, os, re, subprocess
+          import json, os, subprocess, time
+          import regex as re
 
           repo = os.environ["GITHUB_REPOSITORY"]
-          jobs = [json.loads(l) for l in open("/tmp/jobs.jsonl") if l.strip()]
+          run_id = os.environ["TRIGGERING_RUN_ID"]
+
+          def gh_api(path, paginate=False, jq=None):
+              """Call `gh api` with retry/backoff.
+
+              GitHub's Actions API returns transient 5xx (seen: HTTP 502) often
+              enough to fail this job ~25% of the time. Retry so a flaky call
+              does not drop the whole diagnostics ingest.
+              """
+              cmd = ["gh", "api", path]
+              if paginate:
+                  cmd.append("--paginate")
+              if jq:
+                  cmd += ["--jq", jq]
+              last = None
+              for attempt in range(1, 6):
+                  r = subprocess.run(cmd, capture_output=True, env={**os.environ})
+                  if r.returncode == 0:
+                      return r.stdout
+                  last = (r.stderr or b"").decode(errors="replace").strip()
+                  print(f"  retry {attempt}/5 for {path}: {last}")
+                  time.sleep(2 * attempt)
+              raise RuntimeError(f"gh api failed after 5 attempts for {path}: {last}")
+
+          jobs_raw = gh_api(
+              f"/repos/{repo}/actions/runs/{run_id}/jobs",
+              paginate=True,
+              jq=".jobs[] | {id: .id, name: .name}",
+          ).decode()
+          jobs = [json.loads(l) for l in jobs_raw.splitlines() if l.strip()]
 
           for idx, j in enumerate(jobs):
-              safe   = re.sub(r"[^\w\s\-]", "", j["name"]).strip()
-              out    = f"raw_logs/{idx}_{safe}.txt"
-              result = subprocess.run(
-                  ["gh", "api", f"/repos/{repo}/actions/jobs/{j['id']}/logs"],
-                  capture_output=True, env={**os.environ},
-              )
-              if result.returncode == 0 and result.stdout:
-                  open(out, "wb").write(result.stdout)
+              safe = re.sub(r"[^\w\s\-]", "", j["name"]).strip()
+              out = f"raw_logs/{idx}_{safe}.txt"
+              try:
+                  data = gh_api(f"/repos/{repo}/actions/jobs/{j['id']}/logs")
+              except RuntimeError as exc:
+                  print(f"  SKIP  {j['name']} (no log: {exc})")
+                  continue
+              if data:
+                  open(out, "wb").write(data)
                   print(f"  OK  {out}")
               else:
-                  print(f"  SKIP  {j['name']} (no log)")
+                  print(f"  SKIP  {j['name']} (empty log)")
           PYEOF
 
       - name: Parse Logs


### PR DESCRIPTION
## Problem

The `push-hw-diagnostics-to-clickhouse` workflow fails about 25% of the
time on `main`, all with the same root cause: a transient GitHub Actions
API `HTTP 502` on the `gh api` calls in the **Download Job Logs** step.

The step runs under `bash -e` with no retry, so a single 5xx aborts it
with exit code 1. Because the later **Parse Logs** step never runs,
`JSON_FILE` is never written to `$GITHUB_ENV`, and the `always()`
**Upload JSON artifact** step then fails with:

```
##[error]Input required and not supplied: path
```

That secondary error is what the run surface shows, which hides the real
502.

### Recent failing runs (all same signature: `gh: Server Error (HTTP 502)`)

| Run | Result |
|---|---|
| https://github.com/torch-spyre/torch-spyre/actions/runs/32459334075 | failure (502 -> empty path) |
| https://github.com/torch-spyre/torch-spyre/actions/runs/32438411213 | failure (502) |
| https://github.com/torch-spyre/torch-spyre/actions/runs/32437128047 | failure (502 -> empty path) |
| https://github.com/torch-spyre/torch-spyre/actions/runs/32439322487 | failure |
| https://github.com/torch-spyre/torch-spyre/actions/runs/32437530860 | failure |

5 failures in the last ~20 runs, all on the same `head_sha` (so it is a
transient-infra flake, not a code regression: neighbouring runs on the
same sha pass).

## Fix

Move both `gh api` calls into one Python block with a small retry helper
(5 attempts, linear backoff):

- The jobs listing raises after exhausting retries (it is required).
- Each per-job log fetch is best-effort and skips on failure, as before.

A transient 5xx no longer drops the whole diagnostics ingest.

Also switch the embedded script to `import regex as re` to satisfy the
repo pre-commit hook (`Enforce import regex as re`).

## Test

Workflow-only change, validated locally:

- `python3 -c "import yaml; yaml.safe_load(...)"` -> YAML OK
- embedded heredoc `compile(...)` -> Python syntax OK
- `pre-commit run --files .github/workflows/push-hw-diagnostics-to-clickhouse.yaml`
  -> `Lint GitHub Actions workflow files` Passed, `Format YAML files` Passed.

Behaviour is exercised the next time `tests` completes on `main` and this
`workflow_run` fires; it can also be dispatched manually via the
`workflow_dispatch` `gha_run_id` input against any recent run.
