### PR TITLE
Remove tensorsoncpu tags from Gemma 4 YAML configs

### DIFF
--- a/tests/configs/model_ops_tests/gemma-4-12B-it.yaml
+++ b/tests/configs/model_ops_tests/gemma-4-12B-it.yaml
@@ -101,7 +101,6 @@ test_suite_config:
                     in get_placeholder_mask, code: special_image_mask = input_ids == self.config.image_token_id'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.eq.1
                 - name: torch.or_
                   sample_inputs_func:
@@ -121,7 +120,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L1034
                     in forward, code: multimodal_mask = image_mask | video_mask | audio_mask'
                   tags:
-                    - tensorsoncpu
                     - torch.or_.1
                 - name: torch.clone
                   sample_inputs_func:
@@ -138,7 +136,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L1039
                     in forward, code: llm_input_ids = input_ids.clone()'
                   tags:
-                    - tensorsoncpu
                     - torch.clone.1
                 - name: torch.where
                   sample_inputs_func:
@@ -163,7 +160,6 @@ test_suite_config:
                     in forward, code: llm_input_ids = torch.where(multimodal_mask, self.config.text_config.pad_token_id, llm_input_ids)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.where.1
                 - name: torch.nn.functional.embedding
                   sample_inputs_func:
@@ -194,7 +190,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.embedding.1
                 - name: torch.to
                   sample_inputs_func:
@@ -211,7 +206,6 @@ test_suite_config:
                     in forward, code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.to.1
                 - name: torch.mul
                   sample_inputs_func:
@@ -234,7 +228,6 @@ test_suite_config:
                     in forward, code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.mul.1
                 - name: torch.getitem
                   sample_inputs_func:
@@ -252,7 +245,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.1
                 - name: torch.float
                   sample_inputs_func:
@@ -268,7 +260,6 @@ test_suite_config:
                     in forward, code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.float.1
                 - name: torch.Tensor.expand
                   sample_inputs_func:
@@ -288,7 +279,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.expand.1
                 - name: torch.to
                   sample_inputs_func:
@@ -306,7 +296,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.to.2
                 - name: torch.getitem
                   sample_inputs_func:
@@ -325,7 +314,6 @@ test_suite_config:
                     in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.2
                 - name: torch.float
                   sample_inputs_func:
@@ -342,7 +330,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L274
                     in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
                   tags:
-                    - tensorsoncpu
                     - torch.float.2
                 - name: torch.float
                   sample_inputs_func:
@@ -358,7 +345,6 @@ test_suite_config:
                     in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.float.3
                 - name: torch.matmul
                   sample_inputs_func:
@@ -381,7 +367,6 @@ test_suite_config:
                     in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.matmul.1
                 - name: torch.transpose
                   sample_inputs_func:
@@ -400,7 +385,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.1
                 - name: torch.cat
                   sample_inputs_func:
@@ -425,7 +409,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.cat.1
                 - name: torch.cos
                   sample_inputs_func:
@@ -441,7 +424,6 @@ test_suite_config:
                     in forward, code: cos = emb.cos() * attention_scaling'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.cos.1
                 - name: torch.mul
                   sample_inputs_func:
@@ -459,7 +441,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mul.2
                 - name: torch.sin
                   sample_inputs_func:
@@ -475,7 +456,6 @@ test_suite_config:
                     in forward, code: sin = emb.sin() * attention_scaling'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.sin.1
                 - name: torch.to
                   sample_inputs_func:
@@ -493,7 +473,6 @@ test_suite_config:
                     in forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.to.3
                 - name: torch.getitem
                   sample_inputs_func:
@@ -511,7 +490,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.3
                 - name: torch.float
                   sample_inputs_func:
@@ -527,7 +505,6 @@ test_suite_config:
                     in forward, code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.float.4
                 - name: torch.Tensor.expand
                   sample_inputs_func:
@@ -547,7 +524,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.expand.2
                 - name: torch.to
                   sample_inputs_func:
@@ -565,7 +541,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.to.4
                 - name: torch.matmul
                   sample_inputs_func:
@@ -588,7 +563,6 @@ test_suite_config:
                     in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.matmul.2
                 - name: torch.transpose
                   sample_inputs_func:
@@ -607,7 +581,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.2
                 - name: torch.cat
                   sample_inputs_func:
@@ -632,7 +605,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.cat.2
                 - name: torch.cos
                   sample_inputs_func:
@@ -648,7 +620,6 @@ test_suite_config:
                     in forward, code: cos = emb.cos() * attention_scaling'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.cos.2
                 - name: torch.mul
                   sample_inputs_func:
@@ -666,7 +637,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mul.3
                 - name: torch.sin
                   sample_inputs_func:
@@ -682,7 +652,6 @@ test_suite_config:
                     in forward, code: sin = emb.sin() * attention_scaling'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.sin.2
                 - name: torch.to
                   sample_inputs_func:
@@ -700,7 +669,6 @@ test_suite_config:
                     in forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.to.5
                 - name: torch.float
                   sample_inputs_func:
@@ -716,7 +684,6 @@ test_suite_config:
                     in forward, code: normed_output = self._norm(hidden_states.float())'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.float.5
                 - name: torch.pow
                   sample_inputs_func:
@@ -734,7 +701,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.1
                 - name: torch.mean
                   sample_inputs_func:
@@ -754,7 +720,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mean.1
                 - name: torch.add
                   sample_inputs_func:
@@ -772,7 +737,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.add.1
                 - name: torch.pow
                   sample_inputs_func:
@@ -790,7 +754,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.2
                 - name: torch.mul
                   sample_inputs_func:
@@ -813,7 +776,6 @@ test_suite_config:
                     in _norm, code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.4
                 - name: torch.float
                   sample_inputs_func:
@@ -829,7 +791,6 @@ test_suite_config:
                     in forward, code: normed_output = normed_output * self.weight.float()'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.float.6
                 - name: torch.mul
                   sample_inputs_func:
@@ -852,7 +813,6 @@ test_suite_config:
                     in forward, code: normed_output = normed_output * self.weight.float()'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.5
                 - name: torch.type_as
                   sample_inputs_func:
@@ -876,7 +836,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - bf16operation
-                    - tensorsoncpu
                     - torch.type_as.1
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -901,7 +860,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.1
                 - name: torch.Tensor.view
                   sample_inputs_func:
@@ -919,7 +877,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.view.1
                 - name: torch.float
                   sample_inputs_func:
@@ -935,7 +892,6 @@ test_suite_config:
                     in forward, code: normed_output = self._norm(hidden_states.float())'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.float.7
                 - name: torch.pow
                   sample_inputs_func:
@@ -953,7 +909,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.3
                 - name: torch.mean
                   sample_inputs_func:
@@ -973,7 +928,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mean.2
                 - name: torch.add
                   sample_inputs_func:
@@ -991,7 +945,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.add.2
                 - name: torch.pow
                   sample_inputs_func:
@@ -1009,7 +962,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.4
                 - name: torch.mul
                   sample_inputs_func:
@@ -1032,7 +984,6 @@ test_suite_config:
                     in _norm, code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.6
                 - name: torch.float
                   sample_inputs_func:
@@ -1048,7 +999,6 @@ test_suite_config:
                     in forward, code: normed_output = normed_output * self.weight.float()'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.float.8
                 - name: torch.mul
                   sample_inputs_func:
@@ -1071,7 +1021,6 @@ test_suite_config:
                     in forward, code: normed_output = normed_output * self.weight.float()'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.7
                 - name: torch.type_as
                   sample_inputs_func:
@@ -1095,7 +1044,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - bf16operation
-                    - tensorsoncpu
                     - torch.type_as.2
                 - name: torch.unsqueeze
                   sample_inputs_func:
@@ -1113,7 +1061,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.unsqueeze.1
                 - name: torch.mul
                   sample_inputs_func:
@@ -1136,7 +1083,6 @@ test_suite_config:
                     in apply_rotary_pos_emb, code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.mul.8
                 - name: torch.getitem
                   sample_inputs_func:
@@ -1154,7 +1100,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.4
                 - name: torch.neg
                   sample_inputs_func:
@@ -1170,7 +1115,6 @@ test_suite_config:
                     in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.neg.1
                 - name: torch.cat
                   sample_inputs_func:
@@ -1195,7 +1139,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.cat.3
                 - name: torch.add
                   sample_inputs_func:
@@ -1218,7 +1161,6 @@ test_suite_config:
                     in apply_rotary_pos_emb, code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.add.3
                 - name: torch.transpose
                   sample_inputs_func:
@@ -1237,7 +1179,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.3
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -1262,7 +1203,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.2
                 - name: torch.Tensor.view
                   sample_inputs_func:
@@ -1280,7 +1220,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.view.2
                 - name: torch.float
                   sample_inputs_func:
@@ -1296,7 +1235,6 @@ test_suite_config:
                     in forward, code: normed_output = self._norm(hidden_states.float())'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.float.9
                 - name: torch.pow
                   sample_inputs_func:
@@ -1314,7 +1252,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.5
                 - name: torch.mean
                   sample_inputs_func:
@@ -1334,7 +1271,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mean.3
                 - name: torch.add
                   sample_inputs_func:
@@ -1352,7 +1288,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.add.4
                 - name: torch.pow
                   sample_inputs_func:
@@ -1370,7 +1305,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.6
                 - name: torch.mul
                   sample_inputs_func:
@@ -1393,7 +1327,6 @@ test_suite_config:
                     in _norm, code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.9
                 - name: torch.mul
                   sample_inputs_func:
@@ -1416,7 +1349,6 @@ test_suite_config:
                     in forward, code: normed_output = normed_output * self.weight.float()'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.10
                 - name: torch.type_as
                   sample_inputs_func:
@@ -1440,7 +1372,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - bf16operation
-                    - tensorsoncpu
                     - torch.type_as.3
                 - name: torch.mul
                   sample_inputs_func:
@@ -1463,7 +1394,6 @@ test_suite_config:
                     in apply_rotary_pos_emb, code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.mul.11
                 - name: torch.getitem
                   sample_inputs_func:
@@ -1481,7 +1411,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.5
                 - name: torch.neg
                   sample_inputs_func:
@@ -1497,7 +1426,6 @@ test_suite_config:
                     in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.neg.2
                 - name: torch.cat
                   sample_inputs_func:
@@ -1522,7 +1450,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.cat.4
                 - name: torch.add
                   sample_inputs_func:
@@ -1545,7 +1472,6 @@ test_suite_config:
                     in apply_rotary_pos_emb, code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.add.5
                 - name: torch.transpose
                   sample_inputs_func:
@@ -1564,7 +1490,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.4
                 - name: torch.zeros
                   sample_inputs_func:
@@ -1577,7 +1502,6 @@ test_suite_config:
                     self.keys = torch.zeros('
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.zeros.1
                 - name: torch.to
                   sample_inputs_func:
@@ -1596,7 +1520,6 @@ test_suite_config:
                     self.cumulative_length = self.cumulative_length.to(self.device)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.to.6
                 - name: torch.arange
                   sample_inputs_func:
@@ -1608,7 +1531,6 @@ test_suite_config:
                     = torch.arange(kv_length, device=self.device) + self.cumulative_length'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.arange.1
                 - name: torch.add
                   sample_inputs_func:
@@ -1634,7 +1556,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/cache_utils.py#L529 in update, code: cache_position
                     = torch.arange(kv_length, device=self.device) + self.cumulative_length'
                   tags:
-                    - tensorsoncpu
                     - torch.add.6
                 - name: torch.index_copy_
                   sample_inputs_func:
@@ -1668,7 +1589,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.index_copy_.1
                 - name: torch.add_
                   sample_inputs_func:
@@ -1686,7 +1606,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/cache_utils.py#L539 in update, code: self.cumulative_length.add_(kv_length)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.add_.1
                 - name: torch.getitem
                   sample_inputs_func:
@@ -1704,7 +1623,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.6
                 - name: torch.Tensor.expand
                   sample_inputs_func:
@@ -1726,7 +1644,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.expand.3
                 - name: torch.reshape
                   sample_inputs_func:
@@ -1744,7 +1661,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.1
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -1778,7 +1694,6 @@ test_suite_config:
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.1
                 - name: torch.transpose
                   sample_inputs_func:
@@ -1797,7 +1712,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.5
                 - name: torch.Tensor.contiguous
                   sample_inputs_func:
@@ -1813,7 +1727,6 @@ test_suite_config:
                     code: attn_output = attn_output.transpose(1, 2).contiguous()'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.Tensor.contiguous.1
                 - name: torch.reshape
                   sample_inputs_func:
@@ -1831,7 +1744,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.2
                 - name: torch.Tensor.contiguous
                   sample_inputs_func:
@@ -1847,7 +1759,6 @@ test_suite_config:
                     in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.Tensor.contiguous.2
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -1872,7 +1783,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.3
                 - name: torch.add
                   sample_inputs_func:
@@ -1895,7 +1805,6 @@ test_suite_config:
                     in forward, code: hidden_states = residual + hidden_states'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.add.7
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -1920,7 +1829,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.4
                 - name: torch.nn.functional.gelu
                   sample_inputs_func:
@@ -1937,7 +1845,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/activations.py#L51 in forward, code: return self.act(input)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.gelu.1
                 - name: torch.mul
                   sample_inputs_func:
@@ -1960,7 +1867,6 @@ test_suite_config:
                     in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.mul.12
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -1985,7 +1891,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.5
                 - name: torch.Tensor.mul
                   sample_inputs_func:
@@ -2008,7 +1913,6 @@ test_suite_config:
                     in forward, code: hidden_states *= self.layer_scalar'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.Tensor.mul.1
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -2042,7 +1946,6 @@ test_suite_config:
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.2
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -2076,7 +1979,6 @@ test_suite_config:
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.3
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -2110,7 +2012,6 @@ test_suite_config:
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.4
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -2144,7 +2045,6 @@ test_suite_config:
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.5
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -2169,7 +2069,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.6
                 - name: torch.float
                   sample_inputs_func:
@@ -2185,7 +2084,6 @@ test_suite_config:
                     in forward, code: normed_output = self._norm(hidden_states.float())'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.float.10
                 - name: torch.pow
                   sample_inputs_func:
@@ -2203,7 +2101,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.7
                 - name: torch.mean
                   sample_inputs_func:
@@ -2223,7 +2120,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mean.4
                 - name: torch.mul
                   sample_inputs_func:
@@ -2246,7 +2142,6 @@ test_suite_config:
                     in _norm, code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.13
                 - name: torch.float
                   sample_inputs_func:
@@ -2262,7 +2157,6 @@ test_suite_config:
                     in forward, code: normed_output = normed_output * self.weight.float()'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.float.11
                 - name: torch.mul
                   sample_inputs_func:
@@ -2285,7 +2179,6 @@ test_suite_config:
                     in forward, code: normed_output = normed_output * self.weight.float()'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.14
                 - name: torch.type_as
                   sample_inputs_func:
@@ -2309,7 +2202,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - bf16operation
-                    - tensorsoncpu
                     - torch.type_as.4
                 - name: torch.unsqueeze
                   sample_inputs_func:
@@ -2327,7 +2219,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.unsqueeze.2
                 - name: torch.mul
                   sample_inputs_func:
@@ -2350,7 +2241,6 @@ test_suite_config:
                     in apply_rotary_pos_emb, code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.mul.15
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2368,7 +2258,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.7
                 - name: torch.neg
                   sample_inputs_func:
@@ -2384,7 +2273,6 @@ test_suite_config:
                     in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.neg.3
                 - name: torch.cat
                   sample_inputs_func:
@@ -2409,7 +2297,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.cat.5
                 - name: torch.add
                   sample_inputs_func:
@@ -2432,7 +2319,6 @@ test_suite_config:
                     in apply_rotary_pos_emb, code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.add.8
                 - name: torch.transpose
                   sample_inputs_func:
@@ -2451,7 +2337,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.6
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -2476,7 +2361,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.7
                 - name: torch.float
                   sample_inputs_func:
@@ -2492,7 +2376,6 @@ test_suite_config:
                     in forward, code: normed_output = self._norm(hidden_states.float())'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.float.12
                 - name: torch.pow
                   sample_inputs_func:
@@ -2510,7 +2393,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.8
                 - name: torch.mean
                   sample_inputs_func:
@@ -2530,7 +2412,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mean.5
                 - name: torch.add
                   sample_inputs_func:
@@ -2548,7 +2429,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.add.9
                 - name: torch.pow
                   sample_inputs_func:
@@ -2566,7 +2446,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.9
                 - name: torch.mul
                   sample_inputs_func:
@@ -2589,7 +2468,6 @@ test_suite_config:
                     in _norm, code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.16
                 - name: torch.mul
                   sample_inputs_func:
@@ -2612,7 +2490,6 @@ test_suite_config:
                     in forward, code: normed_output = normed_output * self.weight.float()'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.17
                 - name: torch.type_as
                   sample_inputs_func:
@@ -2636,7 +2513,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - bf16operation
-                    - tensorsoncpu
                     - torch.type_as.5
                 - name: torch.mul
                   sample_inputs_func:
@@ -2659,7 +2535,6 @@ test_suite_config:
                     in apply_rotary_pos_emb, code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.mul.18
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2677,7 +2552,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.8
                 - name: torch.neg
                   sample_inputs_func:
@@ -2693,7 +2567,6 @@ test_suite_config:
                     in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.neg.4
                 - name: torch.cat
                   sample_inputs_func:
@@ -2718,7 +2591,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.cat.6
                 - name: torch.add
                   sample_inputs_func:
@@ -2741,7 +2613,6 @@ test_suite_config:
                     in apply_rotary_pos_emb, code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.add.10
                 - name: torch.transpose
                   sample_inputs_func:
@@ -2760,7 +2631,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.7
                 - name: torch.index_copy_
                   sample_inputs_func:
@@ -2794,7 +2664,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.index_copy_.2
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2812,7 +2681,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.9
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2830,7 +2698,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.10
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -2864,7 +2731,6 @@ test_suite_config:
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.6
                 - name: torch.transpose
                   sample_inputs_func:
@@ -2883,7 +2749,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.8
                 - name: torch.Tensor.contiguous
                   sample_inputs_func:
@@ -2899,7 +2764,6 @@ test_suite_config:
                     code: attn_output = attn_output.transpose(1, 2).contiguous()'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.Tensor.contiguous.3
                 - name: torch.reshape
                   sample_inputs_func:
@@ -2917,7 +2781,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.3
                 - name: torch.Tensor.contiguous
                   sample_inputs_func:
@@ -2933,7 +2796,6 @@ test_suite_config:
                     in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.Tensor.contiguous.4
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -2958,7 +2820,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.8
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -2992,7 +2853,6 @@ test_suite_config:
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.7
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -3026,7 +2886,6 @@ test_suite_config:
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.8
                 - name: torch.getitem
                   sample_inputs_func:
@@ -3044,7 +2903,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.11
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -3069,7 +2927,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.9
                 - name: torch.truediv
                   sample_inputs_func:
@@ -3087,7 +2944,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.truediv.1
                 - name: torch.tanh
                   sample_inputs_func:
@@ -3103,7 +2959,6 @@ test_suite_config:
                     in torch_dynamo_resume_in_forward_at_1313, code: logits = torch.tanh(logits)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.tanh.1
                 - name: torch.mul
                   sample_inputs_func:
@@ -3121,7 +2976,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.mul.19
                 - name: torch.eq
                   sample_inputs_func:
@@ -3140,7 +2994,6 @@ test_suite_config:
                     in get_placeholder_mask, code: special_image_mask = input_ids == self.config.image_token_id'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.eq.2
                 - name: torch.or_
                   sample_inputs_func:
@@ -3160,7 +3013,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L1034
                     in forward, code: multimodal_mask = image_mask | video_mask | audio_mask'
                   tags:
-                    - tensorsoncpu
                     - torch.or_.2
                 - name: torch.clone
                   sample_inputs_func:
@@ -3177,7 +3029,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L1039
                     in forward, code: llm_input_ids = input_ids.clone()'
                   tags:
-                    - tensorsoncpu
                     - torch.clone.2
                 - name: torch.where
                   sample_inputs_func:
@@ -3202,7 +3053,6 @@ test_suite_config:
                     in forward, code: llm_input_ids = torch.where(multimodal_mask, self.config.text_config.pad_token_id, llm_input_ids)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.where.2
                 - name: torch.nn.functional.embedding
                   sample_inputs_func:
@@ -3233,7 +3083,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.embedding.2
                 - name: torch.mul
                   sample_inputs_func:
@@ -3256,7 +3105,6 @@ test_suite_config:
                     in forward, code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.mul.20
                 - name: torch.getitem
                   sample_inputs_func:
@@ -3275,7 +3123,6 @@ test_suite_config:
                     in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.12
                 - name: torch.float
                   sample_inputs_func:
@@ -3292,7 +3139,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L274
                     in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
                   tags:
-                    - tensorsoncpu
                     - torch.float.13
                 - name: torch.float
                   sample_inputs_func:
@@ -3308,7 +3154,6 @@ test_suite_config:
                     in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.float.14
                 - name: torch.matmul
                   sample_inputs_func:
@@ -3331,7 +3176,6 @@ test_suite_config:
                     in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.matmul.3
                 - name: torch.transpose
                   sample_inputs_func:
@@ -3350,7 +3194,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.9
                 - name: torch.cat
                   sample_inputs_func:
@@ -3375,7 +3218,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.cat.7
                 - name: torch.cos
                   sample_inputs_func:
@@ -3391,7 +3233,6 @@ test_suite_config:
                     in forward, code: cos = emb.cos() * attention_scaling'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.cos.3
                 - name: torch.mul
                   sample_inputs_func:
@@ -3409,7 +3250,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mul.21
                 - name: torch.sin
                   sample_inputs_func:
@@ -3425,7 +3265,6 @@ test_suite_config:
                     in forward, code: sin = emb.sin() * attention_scaling'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.sin.3
                 - name: torch.to
                   sample_inputs_func:
@@ -3443,7 +3282,6 @@ test_suite_config:
                     in forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.to.7
                 - name: torch.matmul
                   sample_inputs_func:
@@ -3466,7 +3304,6 @@ test_suite_config:
                     in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.matmul.4
                 - name: torch.transpose
                   sample_inputs_func:
@@ -3485,7 +3322,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.10
                 - name: torch.cat
                   sample_inputs_func:
@@ -3510,7 +3346,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.cat.8
                 - name: torch.cos
                   sample_inputs_func:
@@ -3526,7 +3361,6 @@ test_suite_config:
                     in forward, code: cos = emb.cos() * attention_scaling'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.cos.4
                 - name: torch.mul
                   sample_inputs_func:
@@ -3544,7 +3378,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mul.22
                 - name: torch.sin
                   sample_inputs_func:
@@ -3560,7 +3393,6 @@ test_suite_config:
                     in forward, code: sin = emb.sin() * attention_scaling'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.sin.4
                 - name: torch.to
                   sample_inputs_func:
@@ -3578,7 +3410,6 @@ test_suite_config:
                     in forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.to.8
                 - name: torch.float
                   sample_inputs_func:
@@ -3594,7 +3425,6 @@ test_suite_config:
                     in forward, code: normed_output = self._norm(hidden_states.float())'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.float.15
                 - name: torch.pow
                   sample_inputs_func:
@@ -3612,7 +3442,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.10
                 - name: torch.mean
                   sample_inputs_func:
@@ -3632,7 +3461,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mean.6
                 - name: torch.add
                   sample_inputs_func:
@@ -3650,7 +3478,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.add.11
                 - name: torch.pow
                   sample_inputs_func:
@@ -3668,7 +3495,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.11
                 - name: torch.mul
                   sample_inputs_func:
@@ -3691,7 +3517,6 @@ test_suite_config:
                     in _norm, code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.23
                 - name: torch.mul
                   sample_inputs_func:
@@ -3714,7 +3539,6 @@ test_suite_config:
                     in forward, code: normed_output = normed_output * self.weight.float()'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.24
                 - name: torch.type_as
                   sample_inputs_func:
@@ -3738,7 +3562,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - bf16operation
-                    - tensorsoncpu
                     - torch.type_as.6
                 - name: torch.getitem
                   sample_inputs_func:
@@ -3756,7 +3579,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.13
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -3781,5 +3603,4 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.10

--- a/tests/configs/model_ops_tests/gemma-4-12B-it_spyre.yaml
+++ b/tests/configs/model_ops_tests/gemma-4-12B-it_spyre.yaml
@@ -101,7 +101,6 @@ test_suite_config:
                     in get_placeholder_mask, code: special_image_mask = input_ids == self.config.image_token_id'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.eq.1_spyre
                 - name: torch.or_
                   sample_inputs_func:
@@ -121,7 +120,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L1034
                     in forward, code: multimodal_mask = image_mask | video_mask | audio_mask'
                   tags:
-                    - tensorsoncpu
                     - torch.or_.1_spyre
                 - name: torch.clone
                   sample_inputs_func:
@@ -138,7 +136,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L1039
                     in forward, code: llm_input_ids = input_ids.clone()'
                   tags:
-                    - tensorsoncpu
                     - torch.clone.1_spyre
                 - name: torch.where
                   sample_inputs_func:
@@ -163,7 +160,6 @@ test_suite_config:
                     in forward, code: llm_input_ids = torch.where(multimodal_mask, self.config.text_config.pad_token_id, llm_input_ids)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.where.1_spyre
                 - name: torch.nn.functional.embedding
                   sample_inputs_func:
@@ -193,7 +189,6 @@ test_suite_config:
                     in forward, code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.embedding.1_spyre
                 - name: torch.to
                   sample_inputs_func:
@@ -210,7 +205,6 @@ test_suite_config:
                     in forward, code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.to.1_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -232,7 +226,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L558
                     in forward, code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.1_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -249,7 +242,6 @@ test_suite_config:
                     in forward, code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.1_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -264,7 +256,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L273
                     in forward, code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
-                    - tensorsoncpu
                     - torch.float.1_spyre
                 - name: torch.Tensor.expand
                   sample_inputs_func:
@@ -283,7 +274,6 @@ test_suite_config:
                     in forward, code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.expand.1_spyre
                 - name: torch.to
                   sample_inputs_func:
@@ -300,7 +290,6 @@ test_suite_config:
                     in forward, code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.to.2_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -319,7 +308,6 @@ test_suite_config:
                     in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.2_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -336,7 +324,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L274
                     in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
                   tags:
-                    - tensorsoncpu
                     - torch.float.2_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -351,7 +338,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L278
                     in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
-                    - tensorsoncpu
                     - torch.float.3_spyre
                 - name: torch.matmul
                   sample_inputs_func:
@@ -373,7 +359,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L278
                     in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
-                    - tensorsoncpu
                     - torch.matmul.1_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -391,7 +376,6 @@ test_suite_config:
                     in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.1_spyre
                 - name: torch.cat
                   sample_inputs_func:
@@ -415,7 +399,6 @@ test_suite_config:
                     in forward, code: emb = torch.cat((freqs, freqs), dim=-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.cat.1_spyre
                 - name: torch.cos
                   sample_inputs_func:
@@ -430,7 +413,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L280
                     in forward, code: cos = emb.cos() * attention_scaling'
                   tags:
-                    - tensorsoncpu
                     - torch.cos.1_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -447,7 +429,6 @@ test_suite_config:
                     in forward, code: cos = emb.cos() * attention_scaling'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mul.2_spyre
                 - name: torch.sin
                   sample_inputs_func:
@@ -462,7 +443,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L281
                     in forward, code: sin = emb.sin() * attention_scaling'
                   tags:
-                    - tensorsoncpu
                     - torch.sin.1_spyre
                 - name: torch.to
                   sample_inputs_func:
@@ -479,7 +459,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L283
                     in forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
                   tags:
-                    - tensorsoncpu
                     - torch.to.3_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -496,7 +475,6 @@ test_suite_config:
                     in forward, code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.3_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -511,7 +489,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L273
                     in forward, code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
-                    - tensorsoncpu
                     - torch.float.4_spyre
                 - name: torch.Tensor.expand
                   sample_inputs_func:
@@ -530,7 +507,6 @@ test_suite_config:
                     in forward, code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.expand.2_spyre
                 - name: torch.to
                   sample_inputs_func:
@@ -547,7 +523,6 @@ test_suite_config:
                     in forward, code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.to.4_spyre
                 - name: torch.matmul
                   sample_inputs_func:
@@ -569,7 +544,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L278
                     in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
-                    - tensorsoncpu
                     - torch.matmul.2_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -587,7 +561,6 @@ test_suite_config:
                     in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.2_spyre
                 - name: torch.cat
                   sample_inputs_func:
@@ -611,7 +584,6 @@ test_suite_config:
                     in forward, code: emb = torch.cat((freqs, freqs), dim=-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.cat.2_spyre
                 - name: torch.cos
                   sample_inputs_func:
@@ -626,7 +598,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L280
                     in forward, code: cos = emb.cos() * attention_scaling'
                   tags:
-                    - tensorsoncpu
                     - torch.cos.2_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -643,7 +614,6 @@ test_suite_config:
                     in forward, code: cos = emb.cos() * attention_scaling'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mul.3_spyre
                 - name: torch.sin
                   sample_inputs_func:
@@ -658,7 +628,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L281
                     in forward, code: sin = emb.sin() * attention_scaling'
                   tags:
-                    - tensorsoncpu
                     - torch.sin.2_spyre
                 - name: torch.to
                   sample_inputs_func:
@@ -675,7 +644,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L283
                     in forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
                   tags:
-                    - tensorsoncpu
                     - torch.to.5_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -690,7 +658,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L190
                     in forward, code: normed_output = self._norm(hidden_states.float())'
                   tags:
-                    - tensorsoncpu
                     - torch.float.5_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -707,7 +674,6 @@ test_suite_config:
                     in _norm, code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.1_spyre
                 - name: torch.mean
                   sample_inputs_func:
@@ -726,7 +692,6 @@ test_suite_config:
                     in _norm, code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mean.1_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -743,7 +708,6 @@ test_suite_config:
                     in _norm, code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.add.1_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -760,7 +724,6 @@ test_suite_config:
                     in _norm, code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.2_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -782,7 +745,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L187
                     in _norm, code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.4_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -797,7 +759,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L192
                     in forward, code: normed_output = normed_output * self.weight.float()'
                   tags:
-                    - tensorsoncpu
                     - torch.float.6_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -819,7 +780,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L192
                     in forward, code: normed_output = normed_output * self.weight.float()'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.5_spyre
                 - name: torch.type_as
                   sample_inputs_func:
@@ -841,7 +801,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L193
                     in forward, code: return normed_output.type_as(hidden_states)'
                   tags:
-                    - tensorsoncpu
                     - torch.type_as.1_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -865,7 +824,6 @@ test_suite_config:
                     in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.1_spyre
                 - name: torch.Tensor.view
                   sample_inputs_func:
@@ -882,7 +840,6 @@ test_suite_config:
                     in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.view.1_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -897,7 +854,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L190
                     in forward, code: normed_output = self._norm(hidden_states.float())'
                   tags:
-                    - tensorsoncpu
                     - torch.float.7_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -914,7 +870,6 @@ test_suite_config:
                     in _norm, code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.3_spyre
                 - name: torch.mean
                   sample_inputs_func:
@@ -933,7 +888,6 @@ test_suite_config:
                     in _norm, code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mean.2_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -950,7 +904,6 @@ test_suite_config:
                     in _norm, code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.add.2_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -967,7 +920,6 @@ test_suite_config:
                     in _norm, code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.4_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -989,7 +941,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L187
                     in _norm, code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.6_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -1004,7 +955,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L192
                     in forward, code: normed_output = normed_output * self.weight.float()'
                   tags:
-                    - tensorsoncpu
                     - torch.float.8_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -1026,7 +976,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L192
                     in forward, code: normed_output = normed_output * self.weight.float()'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.7_spyre
                 - name: torch.type_as
                   sample_inputs_func:
@@ -1048,7 +997,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L193
                     in forward, code: return normed_output.type_as(hidden_states)'
                   tags:
-                    - tensorsoncpu
                     - torch.type_as.2_spyre
                 - name: torch.unsqueeze
                   sample_inputs_func:
@@ -1065,7 +1013,6 @@ test_suite_config:
                     in apply_rotary_pos_emb, code: cos = cos.unsqueeze(unsqueeze_dim)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.unsqueeze.1_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -1087,7 +1034,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L312
                     in apply_rotary_pos_emb, code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.8_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -1104,7 +1050,6 @@ test_suite_config:
                     in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.4_spyre
                 - name: torch.neg
                   sample_inputs_func:
@@ -1119,7 +1064,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L290
                     in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
-                    - tensorsoncpu
                     - torch.neg.1_spyre
                 - name: torch.cat
                   sample_inputs_func:
@@ -1143,7 +1087,6 @@ test_suite_config:
                     in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.cat.3_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -1165,7 +1108,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L312
                     in apply_rotary_pos_emb, code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
-                    - tensorsoncpu
                     - torch.add.3_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -1183,7 +1125,6 @@ test_suite_config:
                     in forward, code: query_states = query_states.transpose(1, 2)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.3_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -1207,7 +1148,6 @@ test_suite_config:
                     in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.2_spyre
                 - name: torch.Tensor.view
                   sample_inputs_func:
@@ -1224,7 +1164,6 @@ test_suite_config:
                     in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.view.2_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -1239,7 +1178,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L190
                     in forward, code: normed_output = self._norm(hidden_states.float())'
                   tags:
-                    - tensorsoncpu
                     - torch.float.9_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -1256,7 +1194,6 @@ test_suite_config:
                     in _norm, code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.5_spyre
                 - name: torch.mean
                   sample_inputs_func:
@@ -1275,7 +1212,6 @@ test_suite_config:
                     in _norm, code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mean.3_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -1292,7 +1228,6 @@ test_suite_config:
                     in _norm, code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.add.4_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -1309,7 +1244,6 @@ test_suite_config:
                     in _norm, code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.6_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -1331,7 +1265,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L187
                     in _norm, code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.9_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -1353,7 +1286,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L192
                     in forward, code: normed_output = normed_output * self.weight.float()'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.10_spyre
                 - name: torch.type_as
                   sample_inputs_func:
@@ -1375,7 +1307,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L193
                     in forward, code: return normed_output.type_as(hidden_states)'
                   tags:
-                    - tensorsoncpu
                     - torch.type_as.3_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -1397,7 +1328,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L312
                     in apply_rotary_pos_emb, code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.11_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -1414,7 +1344,6 @@ test_suite_config:
                     in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.5_spyre
                 - name: torch.neg
                   sample_inputs_func:
@@ -1429,7 +1358,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L290
                     in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
-                    - tensorsoncpu
                     - torch.neg.2_spyre
                 - name: torch.cat
                   sample_inputs_func:
@@ -1453,7 +1381,6 @@ test_suite_config:
                     in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.cat.4_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -1475,7 +1402,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L312
                     in apply_rotary_pos_emb, code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
-                    - tensorsoncpu
                     - torch.add.5_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -1493,7 +1419,6 @@ test_suite_config:
                     in forward, code: key_states = key_states.transpose(1, 2)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.4_spyre
                 - name: torch.zeros
                   sample_inputs_func:
@@ -1506,7 +1431,6 @@ test_suite_config:
                     self.keys = torch.zeros('
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.zeros.1_spyre
                 - name: torch.to
                   sample_inputs_func:
@@ -1525,7 +1449,6 @@ test_suite_config:
                     self.cumulative_length = self.cumulative_length.to(self.device)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.to.6_spyre
                 - name: torch.arange
                   sample_inputs_func:
@@ -1537,7 +1460,6 @@ test_suite_config:
                     = torch.arange(kv_length, device=self.device) + self.cumulative_length'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.arange.1_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -1563,7 +1485,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/cache_utils.py#L529 in update, code: cache_position
                     = torch.arange(kv_length, device=self.device) + self.cumulative_length'
                   tags:
-                    - tensorsoncpu
                     - torch.add.6_spyre
                 - name: torch.index_copy_
                   sample_inputs_func:
@@ -1596,7 +1517,6 @@ test_suite_config:
                     cache_position, key_states)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.index_copy_.1_spyre
                 - name: torch.add_
                   sample_inputs_func:
@@ -1614,7 +1534,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/cache_utils.py#L539 in update, code: self.cumulative_length.add_(kv_length)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.add_.1_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -1631,7 +1550,6 @@ test_suite_config:
                     code: hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.6_spyre
                 - name: torch.Tensor.expand
                   sample_inputs_func:
@@ -1652,7 +1570,6 @@ test_suite_config:
                     code: hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.expand.3_spyre
                 - name: torch.reshape
                   sample_inputs_func:
@@ -1669,7 +1586,6 @@ test_suite_config:
                     code: return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.1_spyre
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -1702,7 +1618,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.1_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -1720,7 +1635,6 @@ test_suite_config:
                     code: attn_output = attn_output.transpose(1, 2).contiguous()'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.5_spyre
                 - name: torch.Tensor.contiguous
                   sample_inputs_func:
@@ -1735,7 +1649,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L164 in sdpa_attention_forward,
                     code: attn_output = attn_output.transpose(1, 2).contiguous()'
                   tags:
-                    - tensorsoncpu
                     - torch.Tensor.contiguous.1_spyre
                 - name: torch.reshape
                   sample_inputs_func:
@@ -1752,7 +1665,6 @@ test_suite_config:
                     in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.2_spyre
                 - name: torch.Tensor.contiguous
                   sample_inputs_func:
@@ -1767,7 +1679,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L472
                     in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
                   tags:
-                    - tensorsoncpu
                     - torch.Tensor.contiguous.2_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -1791,7 +1702,6 @@ test_suite_config:
                     in forward, code: attn_output = self.o_proj(attn_output)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.3_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -1813,7 +1723,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L534
                     in forward, code: hidden_states = residual + hidden_states'
                   tags:
-                    - tensorsoncpu
                     - torch.add.7_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -1837,7 +1746,6 @@ test_suite_config:
                     in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.4_spyre
                 - name: torch.nn.functional.gelu
                   sample_inputs_func:
@@ -1853,7 +1761,6 @@ test_suite_config:
                       approximate: tanh
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/activations.py#L51 in forward, code: return self.act(input)'
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.gelu.1_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -1875,7 +1782,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L492
                     in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.12_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -1899,7 +1805,6 @@ test_suite_config:
                     in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.5_spyre
                 - name: torch.Tensor.mul
                   sample_inputs_func:
@@ -1921,7 +1826,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L543
                     in forward, code: hidden_states *= self.layer_scalar'
                   tags:
-                    - tensorsoncpu
                     - torch.Tensor.mul.1_spyre
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -1954,7 +1858,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.2_spyre
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -1987,7 +1890,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.3_spyre
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -2020,7 +1922,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.4_spyre
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -2053,7 +1954,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.5_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -2077,7 +1977,6 @@ test_suite_config:
                     in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.6_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -2092,7 +1991,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L190
                     in forward, code: normed_output = self._norm(hidden_states.float())'
                   tags:
-                    - tensorsoncpu
                     - torch.float.10_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -2109,7 +2007,6 @@ test_suite_config:
                     in _norm, code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.7_spyre
                 - name: torch.mean
                   sample_inputs_func:
@@ -2128,7 +2025,6 @@ test_suite_config:
                     in _norm, code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mean.4_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -2150,7 +2046,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L187
                     in _norm, code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.13_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -2165,7 +2060,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L192
                     in forward, code: normed_output = normed_output * self.weight.float()'
                   tags:
-                    - tensorsoncpu
                     - torch.float.11_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -2187,7 +2081,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L192
                     in forward, code: normed_output = normed_output * self.weight.float()'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.14_spyre
                 - name: torch.type_as
                   sample_inputs_func:
@@ -2209,7 +2102,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L193
                     in forward, code: return normed_output.type_as(hidden_states)'
                   tags:
-                    - tensorsoncpu
                     - torch.type_as.4_spyre
                 - name: torch.unsqueeze
                   sample_inputs_func:
@@ -2226,7 +2118,6 @@ test_suite_config:
                     in apply_rotary_pos_emb, code: cos = cos.unsqueeze(unsqueeze_dim)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.unsqueeze.2_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -2248,7 +2139,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L312
                     in apply_rotary_pos_emb, code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.15_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2265,7 +2155,6 @@ test_suite_config:
                     in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.7_spyre
                 - name: torch.neg
                   sample_inputs_func:
@@ -2280,7 +2169,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L290
                     in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
-                    - tensorsoncpu
                     - torch.neg.3_spyre
                 - name: torch.cat
                   sample_inputs_func:
@@ -2304,7 +2192,6 @@ test_suite_config:
                     in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.cat.5_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -2326,7 +2213,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L312
                     in apply_rotary_pos_emb, code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
-                    - tensorsoncpu
                     - torch.add.8_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -2344,7 +2230,6 @@ test_suite_config:
                     in forward, code: query_states = query_states.transpose(1, 2)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.6_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -2368,7 +2253,6 @@ test_suite_config:
                     in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.7_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -2383,7 +2267,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L190
                     in forward, code: normed_output = self._norm(hidden_states.float())'
                   tags:
-                    - tensorsoncpu
                     - torch.float.12_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -2400,7 +2283,6 @@ test_suite_config:
                     in _norm, code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.8_spyre
                 - name: torch.mean
                   sample_inputs_func:
@@ -2419,7 +2301,6 @@ test_suite_config:
                     in _norm, code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mean.5_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -2436,7 +2317,6 @@ test_suite_config:
                     in _norm, code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.add.9_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -2453,7 +2333,6 @@ test_suite_config:
                     in _norm, code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.9_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -2475,7 +2354,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L187
                     in _norm, code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.16_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -2497,7 +2375,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L192
                     in forward, code: normed_output = normed_output * self.weight.float()'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.17_spyre
                 - name: torch.type_as
                   sample_inputs_func:
@@ -2519,7 +2396,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L193
                     in forward, code: return normed_output.type_as(hidden_states)'
                   tags:
-                    - tensorsoncpu
                     - torch.type_as.5_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -2541,7 +2417,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L312
                     in apply_rotary_pos_emb, code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.18_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2558,7 +2433,6 @@ test_suite_config:
                     in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.8_spyre
                 - name: torch.neg
                   sample_inputs_func:
@@ -2573,7 +2447,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L290
                     in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
-                    - tensorsoncpu
                     - torch.neg.4_spyre
                 - name: torch.cat
                   sample_inputs_func:
@@ -2597,7 +2470,6 @@ test_suite_config:
                     in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.cat.6_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -2619,7 +2491,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L312
                     in apply_rotary_pos_emb, code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
-                    - tensorsoncpu
                     - torch.add.10_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -2637,7 +2508,6 @@ test_suite_config:
                     in forward, code: key_states = key_states.transpose(1, 2)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.7_spyre
                 - name: torch.index_copy_
                   sample_inputs_func:
@@ -2670,7 +2540,6 @@ test_suite_config:
                     cache_position, key_states)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.index_copy_.2_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2687,7 +2556,6 @@ test_suite_config:
                     code: hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.9_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2704,7 +2572,6 @@ test_suite_config:
                     code: key = key[:, :, :q_length, :]'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.10_spyre
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -2737,7 +2604,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.6_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -2755,7 +2621,6 @@ test_suite_config:
                     code: attn_output = attn_output.transpose(1, 2).contiguous()'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.8_spyre
                 - name: torch.Tensor.contiguous
                   sample_inputs_func:
@@ -2770,7 +2635,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L164 in sdpa_attention_forward,
                     code: attn_output = attn_output.transpose(1, 2).contiguous()'
                   tags:
-                    - tensorsoncpu
                     - torch.Tensor.contiguous.3_spyre
                 - name: torch.reshape
                   sample_inputs_func:
@@ -2787,7 +2651,6 @@ test_suite_config:
                     in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.3_spyre
                 - name: torch.Tensor.contiguous
                   sample_inputs_func:
@@ -2802,7 +2665,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L472
                     in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
                   tags:
-                    - tensorsoncpu
                     - torch.Tensor.contiguous.4_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -2826,7 +2688,6 @@ test_suite_config:
                     in forward, code: attn_output = self.o_proj(attn_output)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.8_spyre
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -2859,7 +2720,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.7_spyre
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -2892,7 +2752,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.8_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2909,7 +2768,6 @@ test_suite_config:
                     in torch_dynamo_resume_in_forward_at_1313, code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.11_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -2933,7 +2791,6 @@ test_suite_config:
                     in torch_dynamo_resume_in_forward_at_1313, code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.9_spyre
                 - name: torch.truediv
                   sample_inputs_func:
@@ -2950,7 +2807,6 @@ test_suite_config:
                     in torch_dynamo_resume_in_forward_at_1313, code: logits = logits / final_logit_softcapping'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.truediv.1_spyre
                 - name: torch.tanh
                   sample_inputs_func:
@@ -2965,7 +2821,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L1338
                     in torch_dynamo_resume_in_forward_at_1313, code: logits = torch.tanh(logits)'
                   tags:
-                    - tensorsoncpu
                     - torch.tanh.1_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -2982,7 +2837,6 @@ test_suite_config:
                     in torch_dynamo_resume_in_forward_at_1313, code: logits = logits * final_logit_softcapping'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mul.19_spyre
                 - name: torch.eq
                   sample_inputs_func:
@@ -3001,7 +2855,6 @@ test_suite_config:
                     in get_placeholder_mask, code: special_image_mask = input_ids == self.config.image_token_id'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.eq.2_spyre
                 - name: torch.or_
                   sample_inputs_func:
@@ -3021,7 +2874,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L1034
                     in forward, code: multimodal_mask = image_mask | video_mask | audio_mask'
                   tags:
-                    - tensorsoncpu
                     - torch.or_.2_spyre
                 - name: torch.clone
                   sample_inputs_func:
@@ -3038,7 +2890,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L1039
                     in forward, code: llm_input_ids = input_ids.clone()'
                   tags:
-                    - tensorsoncpu
                     - torch.clone.2_spyre
                 - name: torch.where
                   sample_inputs_func:
@@ -3063,7 +2914,6 @@ test_suite_config:
                     in forward, code: llm_input_ids = torch.where(multimodal_mask, self.config.text_config.pad_token_id, llm_input_ids)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.where.2_spyre
                 - name: torch.nn.functional.embedding
                   sample_inputs_func:
@@ -3093,7 +2943,6 @@ test_suite_config:
                     in forward, code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.embedding.2_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -3115,7 +2964,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L558
                     in forward, code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.20_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -3134,7 +2982,6 @@ test_suite_config:
                     in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.12_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -3151,7 +2998,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L274
                     in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
                   tags:
-                    - tensorsoncpu
                     - torch.float.13_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -3166,7 +3012,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L278
                     in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
-                    - tensorsoncpu
                     - torch.float.14_spyre
                 - name: torch.matmul
                   sample_inputs_func:
@@ -3188,7 +3033,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L278
                     in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
-                    - tensorsoncpu
                     - torch.matmul.3_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -3206,7 +3050,6 @@ test_suite_config:
                     in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.9_spyre
                 - name: torch.cat
                   sample_inputs_func:
@@ -3230,7 +3073,6 @@ test_suite_config:
                     in forward, code: emb = torch.cat((freqs, freqs), dim=-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.cat.7_spyre
                 - name: torch.cos
                   sample_inputs_func:
@@ -3245,7 +3087,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L280
                     in forward, code: cos = emb.cos() * attention_scaling'
                   tags:
-                    - tensorsoncpu
                     - torch.cos.3_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -3262,7 +3103,6 @@ test_suite_config:
                     in forward, code: cos = emb.cos() * attention_scaling'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mul.21_spyre
                 - name: torch.sin
                   sample_inputs_func:
@@ -3277,7 +3117,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L281
                     in forward, code: sin = emb.sin() * attention_scaling'
                   tags:
-                    - tensorsoncpu
                     - torch.sin.3_spyre
                 - name: torch.to
                   sample_inputs_func:
@@ -3294,7 +3133,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L283
                     in forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
                   tags:
-                    - tensorsoncpu
                     - torch.to.7_spyre
                 - name: torch.matmul
                   sample_inputs_func:
@@ -3316,7 +3154,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L278
                     in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
-                    - tensorsoncpu
                     - torch.matmul.4_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -3334,7 +3171,6 @@ test_suite_config:
                     in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.10_spyre
                 - name: torch.cat
                   sample_inputs_func:
@@ -3358,7 +3194,6 @@ test_suite_config:
                     in forward, code: emb = torch.cat((freqs, freqs), dim=-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.cat.8_spyre
                 - name: torch.cos
                   sample_inputs_func:
@@ -3373,7 +3208,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L280
                     in forward, code: cos = emb.cos() * attention_scaling'
                   tags:
-                    - tensorsoncpu
                     - torch.cos.4_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -3390,7 +3224,6 @@ test_suite_config:
                     in forward, code: cos = emb.cos() * attention_scaling'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mul.22_spyre
                 - name: torch.sin
                   sample_inputs_func:
@@ -3405,7 +3238,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L281
                     in forward, code: sin = emb.sin() * attention_scaling'
                   tags:
-                    - tensorsoncpu
                     - torch.sin.4_spyre
                 - name: torch.to
                   sample_inputs_func:
@@ -3422,7 +3254,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L283
                     in forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
                   tags:
-                    - tensorsoncpu
                     - torch.to.8_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -3437,7 +3268,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L190
                     in forward, code: normed_output = self._norm(hidden_states.float())'
                   tags:
-                    - tensorsoncpu
                     - torch.float.15_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -3454,7 +3284,6 @@ test_suite_config:
                     in _norm, code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.10_spyre
                 - name: torch.mean
                   sample_inputs_func:
@@ -3473,7 +3302,6 @@ test_suite_config:
                     in _norm, code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mean.6_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -3490,7 +3318,6 @@ test_suite_config:
                     in _norm, code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.add.11_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -3507,7 +3334,6 @@ test_suite_config:
                     in _norm, code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.11_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -3529,7 +3355,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L187
                     in _norm, code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.23_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -3551,7 +3376,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L192
                     in forward, code: normed_output = normed_output * self.weight.float()'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.24_spyre
                 - name: torch.type_as
                   sample_inputs_func:
@@ -3573,7 +3397,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L193
                     in forward, code: return normed_output.type_as(hidden_states)'
                   tags:
-                    - tensorsoncpu
                     - torch.type_as.6_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -3590,7 +3413,6 @@ test_suite_config:
                     in torch_dynamo_resume_in_forward_at_1313, code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.13_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -3614,5 +3436,4 @@ test_suite_config:
                     in torch_dynamo_resume_in_forward_at_1313, code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.10_spyre

--- a/tests/configs/model_ops_tests/gemma-4-26B-A4B-it.yaml
+++ b/tests/configs/model_ops_tests/gemma-4-26B-A4B-it.yaml
@@ -101,7 +101,6 @@ test_suite_config:
                     code: special_image_mask = input_ids == self.config.image_token_id'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.eq.1
                 - name: torch.or_
                   sample_inputs_func:
@@ -121,7 +120,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2320 in forward,
                     code: multimodal_mask = image_mask | video_mask | audio_mask'
                   tags:
-                    - tensorsoncpu
                     - torch.or_.1
                 - name: torch.clone
                   sample_inputs_func:
@@ -138,7 +136,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2325 in forward,
                     code: llm_input_ids = input_ids.clone()'
                   tags:
-                    - tensorsoncpu
                     - torch.clone.1
                 - name: torch.where
                   sample_inputs_func:
@@ -163,7 +160,6 @@ test_suite_config:
                     code: llm_input_ids = torch.where(multimodal_mask, self.config.text_config.pad_token_id, llm_input_ids)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.where.1
                 - name: torch.nn.functional.embedding
                   sample_inputs_func:
@@ -194,7 +190,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.embedding.1
                 - name: torch.to
                   sample_inputs_func:
@@ -211,7 +206,6 @@ test_suite_config:
                     code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.to.1
                 - name: torch.mul
                   sample_inputs_func:
@@ -234,7 +228,6 @@ test_suite_config:
                     code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.mul.1
                 - name: torch.getitem
                   sample_inputs_func:
@@ -252,7 +245,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.1
                 - name: torch.float
                   sample_inputs_func:
@@ -268,7 +260,6 @@ test_suite_config:
                     code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.float.1
                 - name: torch.Tensor.expand
                   sample_inputs_func:
@@ -288,7 +279,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.expand.1
                 - name: torch.to
                   sample_inputs_func:
@@ -306,7 +296,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.to.2
                 - name: torch.getitem
                   sample_inputs_func:
@@ -325,7 +314,6 @@ test_suite_config:
                     code: position_ids_expanded = position_ids[:, None, :].float()'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.2
                 - name: torch.float
                   sample_inputs_func:
@@ -342,7 +330,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1171 in forward,
                     code: position_ids_expanded = position_ids[:, None, :].float()'
                   tags:
-                    - tensorsoncpu
                     - torch.float.2
                 - name: torch.float
                   sample_inputs_func:
@@ -358,7 +345,6 @@ test_suite_config:
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.float.3
                 - name: torch.matmul
                   sample_inputs_func:
@@ -381,7 +367,6 @@ test_suite_config:
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.matmul.1
                 - name: torch.transpose
                   sample_inputs_func:
@@ -400,7 +385,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.1
                 - name: torch.cat
                   sample_inputs_func:
@@ -425,7 +409,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.cat.1
                 - name: torch.cos
                   sample_inputs_func:
@@ -441,7 +424,6 @@ test_suite_config:
                     code: cos = emb.cos() * attention_scaling'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.cos.1
                 - name: torch.mul
                   sample_inputs_func:
@@ -459,7 +441,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mul.2
                 - name: torch.sin
                   sample_inputs_func:
@@ -475,7 +456,6 @@ test_suite_config:
                     code: sin = emb.sin() * attention_scaling'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.sin.1
                 - name: torch.to
                   sample_inputs_func:
@@ -493,7 +473,6 @@ test_suite_config:
                     code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.to.3
                 - name: torch.getitem
                   sample_inputs_func:
@@ -511,7 +490,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.3
                 - name: torch.float
                   sample_inputs_func:
@@ -527,7 +505,6 @@ test_suite_config:
                     code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.float.4
                 - name: torch.Tensor.expand
                   sample_inputs_func:
@@ -547,7 +524,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.expand.2
                 - name: torch.to
                   sample_inputs_func:
@@ -565,7 +541,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.to.4
                 - name: torch.matmul
                   sample_inputs_func:
@@ -588,7 +563,6 @@ test_suite_config:
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.matmul.2
                 - name: torch.transpose
                   sample_inputs_func:
@@ -607,7 +581,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.2
                 - name: torch.cat
                   sample_inputs_func:
@@ -632,7 +605,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.cat.2
                 - name: torch.cos
                   sample_inputs_func:
@@ -648,7 +620,6 @@ test_suite_config:
                     code: cos = emb.cos() * attention_scaling'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.cos.2
                 - name: torch.mul
                   sample_inputs_func:
@@ -666,7 +637,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mul.3
                 - name: torch.sin
                   sample_inputs_func:
@@ -682,7 +652,6 @@ test_suite_config:
                     code: sin = emb.sin() * attention_scaling'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.sin.2
                 - name: torch.to
                   sample_inputs_func:
@@ -700,7 +669,6 @@ test_suite_config:
                     code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.to.5
                 - name: torch.float
                   sample_inputs_func:
@@ -716,7 +684,6 @@ test_suite_config:
                     code: normed_output = self._norm(hidden_states.float())'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.float.5
                 - name: torch.pow
                   sample_inputs_func:
@@ -734,7 +701,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.1
                 - name: torch.mean
                   sample_inputs_func:
@@ -754,7 +720,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mean.1
                 - name: torch.add
                   sample_inputs_func:
@@ -772,7 +737,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.add.1
                 - name: torch.pow
                   sample_inputs_func:
@@ -790,7 +754,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.2
                 - name: torch.mul
                   sample_inputs_func:
@@ -813,7 +776,6 @@ test_suite_config:
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.4
                 - name: torch.float
                   sample_inputs_func:
@@ -829,7 +791,6 @@ test_suite_config:
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.float.6
                 - name: torch.mul
                   sample_inputs_func:
@@ -852,7 +813,6 @@ test_suite_config:
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.5
                 - name: torch.type_as
                   sample_inputs_func:
@@ -876,7 +836,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - bf16operation
-                    - tensorsoncpu
                     - torch.type_as.1
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -901,7 +860,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.1
                 - name: torch.Tensor.view
                   sample_inputs_func:
@@ -919,7 +877,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.view.1
                 - name: torch.float
                   sample_inputs_func:
@@ -935,7 +892,6 @@ test_suite_config:
                     code: normed_output = self._norm(hidden_states.float())'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.float.7
                 - name: torch.pow
                   sample_inputs_func:
@@ -953,7 +909,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.3
                 - name: torch.mean
                   sample_inputs_func:
@@ -973,7 +928,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mean.2
                 - name: torch.add
                   sample_inputs_func:
@@ -991,7 +945,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.add.2
                 - name: torch.pow
                   sample_inputs_func:
@@ -1009,7 +962,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.4
                 - name: torch.mul
                   sample_inputs_func:
@@ -1032,7 +984,6 @@ test_suite_config:
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.6
                 - name: torch.float
                   sample_inputs_func:
@@ -1048,7 +999,6 @@ test_suite_config:
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.float.8
                 - name: torch.mul
                   sample_inputs_func:
@@ -1071,7 +1021,6 @@ test_suite_config:
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.7
                 - name: torch.type_as
                   sample_inputs_func:
@@ -1095,7 +1044,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - bf16operation
-                    - tensorsoncpu
                     - torch.type_as.2
                 - name: torch.unsqueeze
                   sample_inputs_func:
@@ -1113,7 +1061,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.unsqueeze.1
                 - name: torch.mul
                   sample_inputs_func:
@@ -1136,7 +1083,6 @@ test_suite_config:
                     code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.mul.8
                 - name: torch.getitem
                   sample_inputs_func:
@@ -1154,7 +1100,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.4
                 - name: torch.neg
                   sample_inputs_func:
@@ -1170,7 +1115,6 @@ test_suite_config:
                     code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.neg.1
                 - name: torch.cat
                   sample_inputs_func:
@@ -1195,7 +1139,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.cat.3
                 - name: torch.add
                   sample_inputs_func:
@@ -1218,7 +1161,6 @@ test_suite_config:
                     code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.add.3
                 - name: torch.transpose
                   sample_inputs_func:
@@ -1237,7 +1179,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.3
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -1262,7 +1203,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.2
                 - name: torch.Tensor.view
                   sample_inputs_func:
@@ -1280,7 +1220,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.view.2
                 - name: torch.float
                   sample_inputs_func:
@@ -1296,7 +1235,6 @@ test_suite_config:
                     code: normed_output = self._norm(hidden_states.float())'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.float.9
                 - name: torch.pow
                   sample_inputs_func:
@@ -1314,7 +1252,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.5
                 - name: torch.mean
                   sample_inputs_func:
@@ -1334,7 +1271,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mean.3
                 - name: torch.add
                   sample_inputs_func:
@@ -1352,7 +1288,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.add.4
                 - name: torch.pow
                   sample_inputs_func:
@@ -1370,7 +1305,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.6
                 - name: torch.mul
                   sample_inputs_func:
@@ -1393,7 +1327,6 @@ test_suite_config:
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.9
                 - name: torch.mul
                   sample_inputs_func:
@@ -1416,7 +1349,6 @@ test_suite_config:
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.10
                 - name: torch.type_as
                   sample_inputs_func:
@@ -1440,7 +1372,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - bf16operation
-                    - tensorsoncpu
                     - torch.type_as.3
                 - name: torch.mul
                   sample_inputs_func:
@@ -1463,7 +1394,6 @@ test_suite_config:
                     code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.mul.11
                 - name: torch.getitem
                   sample_inputs_func:
@@ -1481,7 +1411,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.5
                 - name: torch.neg
                   sample_inputs_func:
@@ -1497,7 +1426,6 @@ test_suite_config:
                     code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.neg.2
                 - name: torch.cat
                   sample_inputs_func:
@@ -1522,7 +1450,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.cat.4
                 - name: torch.add
                   sample_inputs_func:
@@ -1545,7 +1472,6 @@ test_suite_config:
                     code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.add.5
                 - name: torch.transpose
                   sample_inputs_func:
@@ -1564,7 +1490,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.4
                 - name: torch.zeros
                   sample_inputs_func:
@@ -1577,7 +1502,6 @@ test_suite_config:
                     self.keys = torch.zeros('
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.zeros.1
                 - name: torch.to
                   sample_inputs_func:
@@ -1596,7 +1520,6 @@ test_suite_config:
                     self.cumulative_length = self.cumulative_length.to(self.device)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.to.6
                 - name: torch.arange
                   sample_inputs_func:
@@ -1608,7 +1531,6 @@ test_suite_config:
                     = torch.arange(kv_length, device=self.device) + self.cumulative_length'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.arange.1
                 - name: torch.add
                   sample_inputs_func:
@@ -1634,7 +1556,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/cache_utils.py#L529 in update, code: cache_position
                     = torch.arange(kv_length, device=self.device) + self.cumulative_length'
                   tags:
-                    - tensorsoncpu
                     - torch.add.6
                 - name: torch.index_copy_
                   sample_inputs_func:
@@ -1668,7 +1589,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.index_copy_.1
                 - name: torch.add_
                   sample_inputs_func:
@@ -1686,7 +1606,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/cache_utils.py#L539 in update, code: self.cumulative_length.add_(kv_length)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.add_.1
                 - name: torch.getitem
                   sample_inputs_func:
@@ -1704,7 +1623,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.6
                 - name: torch.Tensor.expand
                   sample_inputs_func:
@@ -1726,7 +1644,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.expand.3
                 - name: torch.reshape
                   sample_inputs_func:
@@ -1744,7 +1661,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.1
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -1778,7 +1694,6 @@ test_suite_config:
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.1
                 - name: torch.transpose
                   sample_inputs_func:
@@ -1797,7 +1712,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.5
                 - name: torch.Tensor.contiguous
                   sample_inputs_func:
@@ -1813,7 +1727,6 @@ test_suite_config:
                     code: attn_output = attn_output.transpose(1, 2).contiguous()'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.Tensor.contiguous.1
                 - name: torch.reshape
                   sample_inputs_func:
@@ -1831,7 +1744,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.2
                 - name: torch.Tensor.contiguous
                   sample_inputs_func:
@@ -1847,7 +1759,6 @@ test_suite_config:
                     code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.Tensor.contiguous.2
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -1872,7 +1783,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.3
                 - name: torch.add
                   sample_inputs_func:
@@ -1895,7 +1805,6 @@ test_suite_config:
                     code: hidden_states = residual + hidden_states'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.add.7
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -1920,7 +1829,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.4
                 - name: torch.nn.functional.gelu
                   sample_inputs_func:
@@ -1937,7 +1845,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/activations.py#L51 in forward, code: return self.act(input)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.gelu.1
                 - name: torch.mul
                   sample_inputs_func:
@@ -1960,7 +1867,6 @@ test_suite_config:
                     code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.mul.12
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -1985,7 +1891,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.5
                 - name: torch.reshape
                   sample_inputs_func:
@@ -2003,7 +1908,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.3
                 - name: torch.float
                   sample_inputs_func:
@@ -2019,7 +1923,6 @@ test_suite_config:
                     code: normed_output = self._norm(hidden_states.float())'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.float.10
                 - name: torch.pow
                   sample_inputs_func:
@@ -2037,7 +1940,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.7
                 - name: torch.mean
                   sample_inputs_func:
@@ -2057,7 +1959,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mean.4
                 - name: torch.add
                   sample_inputs_func:
@@ -2075,7 +1976,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.add.8
                 - name: torch.pow
                   sample_inputs_func:
@@ -2093,7 +1993,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.8
                 - name: torch.mul
                   sample_inputs_func:
@@ -2116,7 +2015,6 @@ test_suite_config:
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.13
                 - name: torch.type_as
                   sample_inputs_func:
@@ -2140,7 +2038,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - bf16operation
-                    - tensorsoncpu
                     - torch.type_as.4
                 - name: torch.mul
                   sample_inputs_func:
@@ -2163,7 +2060,6 @@ test_suite_config:
                     code: hidden_states = hidden_states * self.scale * self.scalar_root_size'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.mul.14
                 - name: torch.mul
                   sample_inputs_func:
@@ -2181,7 +2077,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.mul.15
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -2206,7 +2101,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.6
                 - name: torch.nn.functional.softmax
                   sample_inputs_func:
@@ -2225,7 +2119,6 @@ test_suite_config:
                     code: router_probabilities = nn.functional.softmax(expert_scores, dim=-1, dtype=torch.float32)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.softmax.1
                 - name: torch.topk
                   sample_inputs_func:
@@ -2244,7 +2137,6 @@ test_suite_config:
                     code: top_k_weights, top_k_index = torch.topk('
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.topk.1
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2270,7 +2162,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.7
                 - name: torch.sum
                   sample_inputs_func:
@@ -2289,7 +2180,6 @@ test_suite_config:
                     code: top_k_weights /= top_k_weights.sum(dim=-1, keepdim=True)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.sum.1
                 - name: torch.Tensor.truediv
                   sample_inputs_func:
@@ -2312,7 +2202,6 @@ test_suite_config:
                     code: top_k_weights /= top_k_weights.sum(dim=-1, keepdim=True)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.Tensor.truediv.1
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2337,7 +2226,6 @@ test_suite_config:
                     code: top_k_weights = top_k_weights * self.per_expert_scale[top_k_index]'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.getitem.8
                 - name: torch.mul
                   sample_inputs_func:
@@ -2361,7 +2249,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - bf16operation
-                    - tensorsoncpu
                     - torch.mul.16
                 - name: torch.mul
                   sample_inputs_func:
@@ -2384,7 +2271,6 @@ test_suite_config:
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.17
                 - name: torch.reshape
                   sample_inputs_func:
@@ -2402,7 +2288,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.4
                 - name: torch.reshape
                   sample_inputs_func:
@@ -2421,7 +2306,6 @@ test_suite_config:
                     code: expert_ids = top_k_index.reshape(-1)  # (S,)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.5
                 - name: torch.sort
                   sample_inputs_func:
@@ -2438,7 +2322,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L399 in grouped_mm_experts_forward,
                     code: expert_ids_g, perm = torch.sort(expert_ids)'
                   tags:
-                    - tensorsoncpu
                     - torch.sort.1
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2465,7 +2348,6 @@ test_suite_config:
                     code: expert_ids_g, perm = torch.sort(expert_ids)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.9
                 - name: torch.floordiv
                   sample_inputs_func:
@@ -2484,7 +2366,6 @@ test_suite_config:
                     code: selected_hidden_states_g = hidden_states[perm // num_top_k]'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.floordiv.1
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2509,7 +2390,6 @@ test_suite_config:
                     code: selected_hidden_states_g = hidden_states[perm // num_top_k]'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.getitem.10
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2534,7 +2414,6 @@ test_suite_config:
                     code: sample_weights_g = sample_weights[perm]'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.getitem.11
                 - name: torch.float
                   sample_inputs_func:
@@ -2551,7 +2430,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L407 in grouped_mm_experts_forward,
                     code: histc_input = expert_ids_g.float() if device.type in ("cpu", "mps") else expert_ids_g.int()'
                   tags:
-                    - tensorsoncpu
                     - torch.float.11
                 - name: torch.histc
                   sample_inputs_func:
@@ -2571,7 +2449,6 @@ test_suite_config:
                     code: tokens_per_expert = torch.histc(histc_input, bins=self.num_experts, min=0, max=self.num_experts - 1)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.histc.1
                 - name: torch.cumsum
                   sample_inputs_func:
@@ -2590,7 +2467,6 @@ test_suite_config:
                     code: offsets = torch.cumsum(tokens_per_expert, dim=0, dtype=torch.int32)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.cumsum.1
                 - name: torch.ge
                   sample_inputs_func:
@@ -2609,7 +2485,6 @@ test_suite_config:
                     code: sentinel_mask = (expert_ids_g >= self.num_experts).unsqueeze(-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.ge.1
                 - name: torch.unsqueeze
                   sample_inputs_func:
@@ -2625,7 +2500,6 @@ test_suite_config:
                     code: sentinel_mask = (expert_ids_g >= self.num_experts).unsqueeze(-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.unsqueeze.2
                 - name: torch.clamp_
                   sample_inputs_func:
@@ -2644,7 +2518,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L427 in grouped_mm_experts_forward,
                     code: expert_ids_g.clamp_(max=self.num_experts - 1)'
                   tags:
-                    - tensorsoncpu
                     - torch.clamp_.1
                 - name: torch.masked_fill_
                   sample_inputs_func:
@@ -2668,7 +2541,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.masked_fill_.1
                 - name: torch.transpose
                   sample_inputs_func:
@@ -2687,7 +2559,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.6
                 - name: torch.ops.transformers.grouped_mm_fallback
                   sample_inputs_func:
@@ -2710,7 +2581,6 @@ test_suite_config:
                     code: return torch.ops.transformers.grouped_mm_fallback(input, weight, offs=offs)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.ops.transformers.grouped_mm_fallback.1
                 - name: torch.chunk
                   sample_inputs_func:
@@ -2730,7 +2600,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.chunk.1
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2754,7 +2623,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.12
                 - name: torch.nn.functional.gelu
                   sample_inputs_func:
@@ -2771,7 +2639,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/activations.py#L51 in forward, code: return self.act(input)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.gelu.2
                 - name: torch.mul
                   sample_inputs_func:
@@ -2794,7 +2661,6 @@ test_suite_config:
                     code: return self.act_fn(gate) * up  # (S, intermediate_dim)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.mul.18
                 - name: torch.transpose
                   sample_inputs_func:
@@ -2813,7 +2679,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.7
                 - name: torch.ops.transformers.grouped_mm_fallback
                   sample_inputs_func:
@@ -2836,7 +2701,6 @@ test_suite_config:
                     code: return torch.ops.transformers.grouped_mm_fallback(input, weight, offs=offs)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.ops.transformers.grouped_mm_fallback.2
                 - name: torch.unsqueeze
                   sample_inputs_func:
@@ -2854,7 +2718,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.unsqueeze.3
                 - name: torch.mul
                   sample_inputs_func:
@@ -2878,7 +2741,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - bf16operation
-                    - tensorsoncpu
                     - torch.mul.19
                 - name: torch.masked_fill_
                   sample_inputs_func:
@@ -2902,7 +2764,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.masked_fill_.2
                 - name: torch.empty_like
                   sample_inputs_func:
@@ -2919,7 +2780,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L474 in torch_dynamo_resume_in_grouped_mm_experts_forward_at_463,
                     code: inv_perm = torch.empty_like(perm)'
                   tags:
-                    - tensorsoncpu
                     - torch.empty_like.1
                 - name: torch.setitem
                   sample_inputs_func:
@@ -2954,7 +2814,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L475 in torch_dynamo_resume_in_grouped_mm_experts_forward_at_463,
                     code: inv_perm[perm] = torch.arange(perm.size(0), device=device)'
                   tags:
-                    - tensorsoncpu
                     - torch.setitem.1
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2979,7 +2838,6 @@ test_suite_config:
                     code: weighted_out = weighted_out[inv_perm]  # (S, hidden_dim)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.getitem.13
                 - name: torch.Tensor.view
                   sample_inputs_func:
@@ -2999,7 +2857,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.view.3
                 - name: torch.sum
                   sample_inputs_func:
@@ -3017,7 +2874,6 @@ test_suite_config:
                     code: final_hidden_states = weighted_out.view(num_tokens, num_top_k, hidden_dim).sum(dim=1)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.sum.2
                 - name: torch.to
                   sample_inputs_func:
@@ -3035,7 +2891,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.to.7
                 - name: torch.reshape
                   sample_inputs_func:
@@ -3053,7 +2908,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.6
                 - name: torch.Tensor.mul
                   sample_inputs_func:
@@ -3076,7 +2930,6 @@ test_suite_config:
                     code: hidden_states *= self.layer_scalar'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.Tensor.mul.1
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -3110,7 +2963,6 @@ test_suite_config:
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.2
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -3144,7 +2996,6 @@ test_suite_config:
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.3
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -3178,7 +3029,6 @@ test_suite_config:
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.4
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -3212,7 +3062,6 @@ test_suite_config:
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.5
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -3237,7 +3086,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.7
                 - name: torch.float
                   sample_inputs_func:
@@ -3253,7 +3101,6 @@ test_suite_config:
                     code: normed_output = self._norm(hidden_states.float())'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.float.12
                 - name: torch.pow
                   sample_inputs_func:
@@ -3271,7 +3118,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.9
                 - name: torch.mean
                   sample_inputs_func:
@@ -3291,7 +3137,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mean.5
                 - name: torch.mul
                   sample_inputs_func:
@@ -3314,7 +3159,6 @@ test_suite_config:
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.20
                 - name: torch.float
                   sample_inputs_func:
@@ -3330,7 +3174,6 @@ test_suite_config:
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.float.13
                 - name: torch.mul
                   sample_inputs_func:
@@ -3353,7 +3196,6 @@ test_suite_config:
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.21
                 - name: torch.type_as
                   sample_inputs_func:
@@ -3377,7 +3219,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - bf16operation
-                    - tensorsoncpu
                     - torch.type_as.5
                 - name: torch.unsqueeze
                   sample_inputs_func:
@@ -3395,7 +3236,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.unsqueeze.4
                 - name: torch.mul
                   sample_inputs_func:
@@ -3418,7 +3258,6 @@ test_suite_config:
                     code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.mul.22
                 - name: torch.getitem
                   sample_inputs_func:
@@ -3436,7 +3275,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.14
                 - name: torch.neg
                   sample_inputs_func:
@@ -3452,7 +3290,6 @@ test_suite_config:
                     code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.neg.3
                 - name: torch.cat
                   sample_inputs_func:
@@ -3477,7 +3314,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.cat.5
                 - name: torch.add
                   sample_inputs_func:
@@ -3500,7 +3336,6 @@ test_suite_config:
                     code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.add.9
                 - name: torch.transpose
                   sample_inputs_func:
@@ -3519,7 +3354,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.8
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -3544,7 +3378,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.8
                 - name: torch.float
                   sample_inputs_func:
@@ -3560,7 +3393,6 @@ test_suite_config:
                     code: normed_output = self._norm(hidden_states.float())'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.float.14
                 - name: torch.pow
                   sample_inputs_func:
@@ -3578,7 +3410,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.10
                 - name: torch.mean
                   sample_inputs_func:
@@ -3598,7 +3429,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mean.6
                 - name: torch.add
                   sample_inputs_func:
@@ -3616,7 +3446,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.add.10
                 - name: torch.pow
                   sample_inputs_func:
@@ -3634,7 +3463,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.11
                 - name: torch.mul
                   sample_inputs_func:
@@ -3657,7 +3485,6 @@ test_suite_config:
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.23
                 - name: torch.mul
                   sample_inputs_func:
@@ -3680,7 +3507,6 @@ test_suite_config:
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.24
                 - name: torch.type_as
                   sample_inputs_func:
@@ -3704,7 +3530,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - bf16operation
-                    - tensorsoncpu
                     - torch.type_as.6
                 - name: torch.mul
                   sample_inputs_func:
@@ -3727,7 +3552,6 @@ test_suite_config:
                     code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.mul.25
                 - name: torch.getitem
                   sample_inputs_func:
@@ -3745,7 +3569,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.15
                 - name: torch.neg
                   sample_inputs_func:
@@ -3761,7 +3584,6 @@ test_suite_config:
                     code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.neg.4
                 - name: torch.cat
                   sample_inputs_func:
@@ -3786,7 +3608,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.cat.6
                 - name: torch.add
                   sample_inputs_func:
@@ -3809,7 +3630,6 @@ test_suite_config:
                     code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.add.11
                 - name: torch.transpose
                   sample_inputs_func:
@@ -3828,7 +3648,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.9
                 - name: torch.index_copy_
                   sample_inputs_func:
@@ -3862,7 +3681,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.index_copy_.2
                 - name: torch.getitem
                   sample_inputs_func:
@@ -3880,7 +3698,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.16
                 - name: torch.getitem
                   sample_inputs_func:
@@ -3898,7 +3715,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.17
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -3932,7 +3748,6 @@ test_suite_config:
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.6
                 - name: torch.transpose
                   sample_inputs_func:
@@ -3951,7 +3766,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.10
                 - name: torch.Tensor.contiguous
                   sample_inputs_func:
@@ -3967,7 +3781,6 @@ test_suite_config:
                     code: attn_output = attn_output.transpose(1, 2).contiguous()'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.Tensor.contiguous.3
                 - name: torch.reshape
                   sample_inputs_func:
@@ -3985,7 +3798,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.7
                 - name: torch.Tensor.contiguous
                   sample_inputs_func:
@@ -4001,7 +3813,6 @@ test_suite_config:
                     code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.Tensor.contiguous.4
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -4026,7 +3837,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.9
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -4060,7 +3870,6 @@ test_suite_config:
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.7
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -4094,7 +3903,6 @@ test_suite_config:
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.8
                 - name: torch.getitem
                   sample_inputs_func:
@@ -4112,7 +3920,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.18
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -4137,7 +3944,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.10
                 - name: torch.truediv
                   sample_inputs_func:
@@ -4155,7 +3961,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.truediv.1
                 - name: torch.tanh
                   sample_inputs_func:
@@ -4171,7 +3976,6 @@ test_suite_config:
                     code: logits = torch.tanh(logits)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.tanh.1
                 - name: torch.mul
                   sample_inputs_func:
@@ -4189,7 +3993,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.mul.26
                 - name: torch.eq
                   sample_inputs_func:
@@ -4208,7 +4011,6 @@ test_suite_config:
                     code: special_image_mask = input_ids == self.config.image_token_id'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.eq.2
                 - name: torch.or_
                   sample_inputs_func:
@@ -4228,7 +4030,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2320 in forward,
                     code: multimodal_mask = image_mask | video_mask | audio_mask'
                   tags:
-                    - tensorsoncpu
                     - torch.or_.2
                 - name: torch.clone
                   sample_inputs_func:
@@ -4245,7 +4046,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2325 in forward,
                     code: llm_input_ids = input_ids.clone()'
                   tags:
-                    - tensorsoncpu
                     - torch.clone.2
                 - name: torch.where
                   sample_inputs_func:
@@ -4270,7 +4070,6 @@ test_suite_config:
                     code: llm_input_ids = torch.where(multimodal_mask, self.config.text_config.pad_token_id, llm_input_ids)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.where.2
                 - name: torch.nn.functional.embedding
                   sample_inputs_func:
@@ -4301,7 +4100,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.embedding.2
                 - name: torch.mul
                   sample_inputs_func:
@@ -4324,7 +4122,6 @@ test_suite_config:
                     code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.mul.27
                 - name: torch.getitem
                   sample_inputs_func:
@@ -4343,7 +4140,6 @@ test_suite_config:
                     code: position_ids_expanded = position_ids[:, None, :].float()'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.19
                 - name: torch.float
                   sample_inputs_func:
@@ -4360,7 +4156,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1171 in forward,
                     code: position_ids_expanded = position_ids[:, None, :].float()'
                   tags:
-                    - tensorsoncpu
                     - torch.float.15
                 - name: torch.float
                   sample_inputs_func:
@@ -4376,7 +4171,6 @@ test_suite_config:
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.float.16
                 - name: torch.matmul
                   sample_inputs_func:
@@ -4399,7 +4193,6 @@ test_suite_config:
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.matmul.3
                 - name: torch.transpose
                   sample_inputs_func:
@@ -4418,7 +4211,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.11
                 - name: torch.cat
                   sample_inputs_func:
@@ -4443,7 +4235,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.cat.7
                 - name: torch.cos
                   sample_inputs_func:
@@ -4459,7 +4250,6 @@ test_suite_config:
                     code: cos = emb.cos() * attention_scaling'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.cos.3
                 - name: torch.mul
                   sample_inputs_func:
@@ -4477,7 +4267,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mul.28
                 - name: torch.sin
                   sample_inputs_func:
@@ -4493,7 +4282,6 @@ test_suite_config:
                     code: sin = emb.sin() * attention_scaling'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.sin.3
                 - name: torch.to
                   sample_inputs_func:
@@ -4511,7 +4299,6 @@ test_suite_config:
                     code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.to.8
                 - name: torch.matmul
                   sample_inputs_func:
@@ -4534,7 +4321,6 @@ test_suite_config:
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.matmul.4
                 - name: torch.transpose
                   sample_inputs_func:
@@ -4553,7 +4339,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.12
                 - name: torch.cat
                   sample_inputs_func:
@@ -4578,7 +4363,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.cat.8
                 - name: torch.cos
                   sample_inputs_func:
@@ -4594,7 +4378,6 @@ test_suite_config:
                     code: cos = emb.cos() * attention_scaling'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.cos.4
                 - name: torch.mul
                   sample_inputs_func:
@@ -4612,7 +4395,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mul.29
                 - name: torch.sin
                   sample_inputs_func:
@@ -4628,7 +4410,6 @@ test_suite_config:
                     code: sin = emb.sin() * attention_scaling'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.sin.4
                 - name: torch.to
                   sample_inputs_func:
@@ -4646,7 +4427,6 @@ test_suite_config:
                     code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.to.9
                 - name: torch.float
                   sample_inputs_func:
@@ -4662,7 +4442,6 @@ test_suite_config:
                     code: normed_output = self._norm(hidden_states.float())'
                   tags:
                     - bf16operation
-                    - tensorsoncpu
                     - torch.float.17
                 - name: torch.pow
                   sample_inputs_func:
@@ -4680,7 +4459,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.12
                 - name: torch.mean
                   sample_inputs_func:
@@ -4700,7 +4478,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.mean.7
                 - name: torch.add
                   sample_inputs_func:
@@ -4718,7 +4495,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.add.12
                 - name: torch.pow
                   sample_inputs_func:
@@ -4736,7 +4512,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - constant
-                    - tensorsoncpu
                     - torch.pow.13
                 - name: torch.mul
                   sample_inputs_func:
@@ -4759,7 +4534,6 @@ test_suite_config:
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.30
                 - name: torch.mul
                   sample_inputs_func:
@@ -4782,7 +4556,6 @@ test_suite_config:
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
                     - fp32operation
-                    - tensorsoncpu
                     - torch.mul.31
                 - name: torch.type_as
                   sample_inputs_func:
@@ -4806,7 +4579,6 @@ test_suite_config:
                   tags:
                     - fp32operation
                     - bf16operation
-                    - tensorsoncpu
                     - torch.type_as.7
                 - name: torch.getitem
                   sample_inputs_func:
@@ -4824,7 +4596,6 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.20
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -4849,5 +4620,4 @@ test_suite_config:
                   tags:
                     - bf16operation
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.11

--- a/tests/configs/model_ops_tests/gemma-4-26B-A4B-it_spyre.yaml
+++ b/tests/configs/model_ops_tests/gemma-4-26B-A4B-it_spyre.yaml
@@ -101,7 +101,6 @@ test_suite_config:
                     code: special_image_mask = input_ids == self.config.image_token_id'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.eq.1_spyre
                 - name: torch.or_
                   sample_inputs_func:
@@ -121,7 +120,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2320 in forward,
                     code: multimodal_mask = image_mask | video_mask | audio_mask'
                   tags:
-                    - tensorsoncpu
                     - torch.or_.1_spyre
                 - name: torch.clone
                   sample_inputs_func:
@@ -138,7 +136,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2325 in forward,
                     code: llm_input_ids = input_ids.clone()'
                   tags:
-                    - tensorsoncpu
                     - torch.clone.1_spyre
                 - name: torch.where
                   sample_inputs_func:
@@ -163,7 +160,6 @@ test_suite_config:
                     code: llm_input_ids = torch.where(multimodal_mask, self.config.text_config.pad_token_id, llm_input_ids)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.where.1_spyre
                 - name: torch.nn.functional.embedding
                   sample_inputs_func:
@@ -193,7 +189,6 @@ test_suite_config:
                     code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.embedding.1_spyre
                 - name: torch.to
                   sample_inputs_func:
@@ -210,7 +205,6 @@ test_suite_config:
                     code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.to.1_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -232,7 +226,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1476 in forward,
                     code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.1_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -249,7 +242,6 @@ test_suite_config:
                     code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.1_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -264,7 +256,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1170 in forward,
                     code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
-                    - tensorsoncpu
                     - torch.float.1_spyre
                 - name: torch.Tensor.expand
                   sample_inputs_func:
@@ -283,7 +274,6 @@ test_suite_config:
                     code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.expand.1_spyre
                 - name: torch.to
                   sample_inputs_func:
@@ -300,7 +290,6 @@ test_suite_config:
                     code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.to.2_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -319,7 +308,6 @@ test_suite_config:
                     code: position_ids_expanded = position_ids[:, None, :].float()'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.2_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -336,7 +324,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1171 in forward,
                     code: position_ids_expanded = position_ids[:, None, :].float()'
                   tags:
-                    - tensorsoncpu
                     - torch.float.2_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -351,7 +338,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1175 in forward,
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
-                    - tensorsoncpu
                     - torch.float.3_spyre
                 - name: torch.matmul
                   sample_inputs_func:
@@ -373,7 +359,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1175 in forward,
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
-                    - tensorsoncpu
                     - torch.matmul.1_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -391,7 +376,6 @@ test_suite_config:
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.1_spyre
                 - name: torch.cat
                   sample_inputs_func:
@@ -415,7 +399,6 @@ test_suite_config:
                     code: emb = torch.cat((freqs, freqs), dim=-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.cat.1_spyre
                 - name: torch.cos
                   sample_inputs_func:
@@ -430,7 +413,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1177 in forward,
                     code: cos = emb.cos() * attention_scaling'
                   tags:
-                    - tensorsoncpu
                     - torch.cos.1_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -447,7 +429,6 @@ test_suite_config:
                     code: cos = emb.cos() * attention_scaling'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mul.2_spyre
                 - name: torch.sin
                   sample_inputs_func:
@@ -462,7 +443,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1178 in forward,
                     code: sin = emb.sin() * attention_scaling'
                   tags:
-                    - tensorsoncpu
                     - torch.sin.1_spyre
                 - name: torch.to
                   sample_inputs_func:
@@ -479,7 +459,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1180 in forward,
                     code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
                   tags:
-                    - tensorsoncpu
                     - torch.to.3_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -496,7 +475,6 @@ test_suite_config:
                     code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.3_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -511,7 +489,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1170 in forward,
                     code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
-                    - tensorsoncpu
                     - torch.float.4_spyre
                 - name: torch.Tensor.expand
                   sample_inputs_func:
@@ -530,7 +507,6 @@ test_suite_config:
                     code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.expand.2_spyre
                 - name: torch.to
                   sample_inputs_func:
@@ -547,7 +523,6 @@ test_suite_config:
                     code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.to.4_spyre
                 - name: torch.matmul
                   sample_inputs_func:
@@ -569,7 +544,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1175 in forward,
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
-                    - tensorsoncpu
                     - torch.matmul.2_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -587,7 +561,6 @@ test_suite_config:
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.2_spyre
                 - name: torch.cat
                   sample_inputs_func:
@@ -611,7 +584,6 @@ test_suite_config:
                     code: emb = torch.cat((freqs, freqs), dim=-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.cat.2_spyre
                 - name: torch.cos
                   sample_inputs_func:
@@ -626,7 +598,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1177 in forward,
                     code: cos = emb.cos() * attention_scaling'
                   tags:
-                    - tensorsoncpu
                     - torch.cos.2_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -643,7 +614,6 @@ test_suite_config:
                     code: cos = emb.cos() * attention_scaling'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mul.3_spyre
                 - name: torch.sin
                   sample_inputs_func:
@@ -658,7 +628,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1178 in forward,
                     code: sin = emb.sin() * attention_scaling'
                   tags:
-                    - tensorsoncpu
                     - torch.sin.2_spyre
                 - name: torch.to
                   sample_inputs_func:
@@ -675,7 +644,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1180 in forward,
                     code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
                   tags:
-                    - tensorsoncpu
                     - torch.to.5_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -690,7 +658,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L212 in forward,
                     code: normed_output = self._norm(hidden_states.float())'
                   tags:
-                    - tensorsoncpu
                     - torch.float.5_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -707,7 +674,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.1_spyre
                 - name: torch.mean
                   sample_inputs_func:
@@ -726,7 +692,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mean.1_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -743,7 +708,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.add.1_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -760,7 +724,6 @@ test_suite_config:
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.2_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -782,7 +745,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L209 in _norm,
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.4_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -797,7 +759,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward,
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
-                    - tensorsoncpu
                     - torch.float.6_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -819,7 +780,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward,
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.5_spyre
                 - name: torch.type_as
                   sample_inputs_func:
@@ -841,7 +801,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L215 in forward,
                     code: return normed_output.type_as(hidden_states)'
                   tags:
-                    - tensorsoncpu
                     - torch.type_as.1_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -865,7 +824,6 @@ test_suite_config:
                     code: query_states = self.q_proj(hidden_states).view(hidden_shape)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.1_spyre
                 - name: torch.Tensor.view
                   sample_inputs_func:
@@ -882,7 +840,6 @@ test_suite_config:
                     code: query_states = self.q_proj(hidden_states).view(hidden_shape)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.view.1_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -897,7 +854,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L212 in forward,
                     code: normed_output = self._norm(hidden_states.float())'
                   tags:
-                    - tensorsoncpu
                     - torch.float.7_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -914,7 +870,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.3_spyre
                 - name: torch.mean
                   sample_inputs_func:
@@ -933,7 +888,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mean.2_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -950,7 +904,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.add.2_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -967,7 +920,6 @@ test_suite_config:
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.4_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -989,7 +941,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L209 in _norm,
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.6_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -1004,7 +955,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward,
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
-                    - tensorsoncpu
                     - torch.float.8_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -1026,7 +976,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward,
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.7_spyre
                 - name: torch.type_as
                   sample_inputs_func:
@@ -1048,7 +997,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L215 in forward,
                     code: return normed_output.type_as(hidden_states)'
                   tags:
-                    - tensorsoncpu
                     - torch.type_as.2_spyre
                 - name: torch.unsqueeze
                   sample_inputs_func:
@@ -1065,7 +1013,6 @@ test_suite_config:
                     code: cos = cos.unsqueeze(unsqueeze_dim)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.unsqueeze.1_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -1087,7 +1034,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L812 in apply_rotary_pos_emb,
                     code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.8_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -1104,7 +1050,6 @@ test_suite_config:
                     code: x1 = x[..., : x.shape[-1] // 2]'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.4_spyre
                 - name: torch.neg
                   sample_inputs_func:
@@ -1119,7 +1064,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L790 in rotate_half,
                     code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
-                    - tensorsoncpu
                     - torch.neg.1_spyre
                 - name: torch.cat
                   sample_inputs_func:
@@ -1143,7 +1087,6 @@ test_suite_config:
                     code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.cat.3_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -1165,7 +1108,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L812 in apply_rotary_pos_emb,
                     code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
-                    - tensorsoncpu
                     - torch.add.3_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -1183,7 +1125,6 @@ test_suite_config:
                     code: query_states = query_states.transpose(1, 2)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.3_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -1207,7 +1148,6 @@ test_suite_config:
                     code: key_states = self.k_proj(hidden_states).view(hidden_shape)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.2_spyre
                 - name: torch.Tensor.view
                   sample_inputs_func:
@@ -1224,7 +1164,6 @@ test_suite_config:
                     code: key_states = self.k_proj(hidden_states).view(hidden_shape)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.view.2_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -1239,7 +1178,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L212 in forward,
                     code: normed_output = self._norm(hidden_states.float())'
                   tags:
-                    - tensorsoncpu
                     - torch.float.9_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -1256,7 +1194,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.5_spyre
                 - name: torch.mean
                   sample_inputs_func:
@@ -1275,7 +1212,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mean.3_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -1292,7 +1228,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.add.4_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -1309,7 +1244,6 @@ test_suite_config:
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.6_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -1331,7 +1265,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L209 in _norm,
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.9_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -1353,7 +1286,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward,
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.10_spyre
                 - name: torch.type_as
                   sample_inputs_func:
@@ -1375,7 +1307,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L215 in forward,
                     code: return normed_output.type_as(hidden_states)'
                   tags:
-                    - tensorsoncpu
                     - torch.type_as.3_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -1397,7 +1328,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L812 in apply_rotary_pos_emb,
                     code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.11_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -1414,7 +1344,6 @@ test_suite_config:
                     code: x1 = x[..., : x.shape[-1] // 2]'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.5_spyre
                 - name: torch.neg
                   sample_inputs_func:
@@ -1429,7 +1358,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L790 in rotate_half,
                     code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
-                    - tensorsoncpu
                     - torch.neg.2_spyre
                 - name: torch.cat
                   sample_inputs_func:
@@ -1453,7 +1381,6 @@ test_suite_config:
                     code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.cat.4_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -1475,7 +1402,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L812 in apply_rotary_pos_emb,
                     code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
-                    - tensorsoncpu
                     - torch.add.5_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -1493,7 +1419,6 @@ test_suite_config:
                     code: key_states = key_states.transpose(1, 2)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.4_spyre
                 - name: torch.zeros
                   sample_inputs_func:
@@ -1506,7 +1431,6 @@ test_suite_config:
                     self.keys = torch.zeros('
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.zeros.1_spyre
                 - name: torch.to
                   sample_inputs_func:
@@ -1525,7 +1449,6 @@ test_suite_config:
                     self.cumulative_length = self.cumulative_length.to(self.device)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.to.6_spyre
                 - name: torch.arange
                   sample_inputs_func:
@@ -1537,7 +1460,6 @@ test_suite_config:
                     = torch.arange(kv_length, device=self.device) + self.cumulative_length'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.arange.1_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -1563,7 +1485,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/cache_utils.py#L529 in update, code: cache_position
                     = torch.arange(kv_length, device=self.device) + self.cumulative_length'
                   tags:
-                    - tensorsoncpu
                     - torch.add.6_spyre
                 - name: torch.index_copy_
                   sample_inputs_func:
@@ -1596,7 +1517,6 @@ test_suite_config:
                     cache_position, key_states)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.index_copy_.1_spyre
                 - name: torch.add_
                   sample_inputs_func:
@@ -1614,7 +1534,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/cache_utils.py#L539 in update, code: self.cumulative_length.add_(kv_length)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.add_.1_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -1631,7 +1550,6 @@ test_suite_config:
                     code: hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.6_spyre
                 - name: torch.Tensor.expand
                   sample_inputs_func:
@@ -1652,7 +1570,6 @@ test_suite_config:
                     code: hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.expand.3_spyre
                 - name: torch.reshape
                   sample_inputs_func:
@@ -1669,7 +1586,6 @@ test_suite_config:
                     code: return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.1_spyre
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -1702,7 +1618,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.1_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -1720,7 +1635,6 @@ test_suite_config:
                     code: attn_output = attn_output.transpose(1, 2).contiguous()'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.5_spyre
                 - name: torch.Tensor.contiguous
                   sample_inputs_func:
@@ -1735,7 +1649,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L164 in sdpa_attention_forward,
                     code: attn_output = attn_output.transpose(1, 2).contiguous()'
                   tags:
-                    - tensorsoncpu
                     - torch.Tensor.contiguous.1_spyre
                 - name: torch.reshape
                   sample_inputs_func:
@@ -1752,7 +1665,6 @@ test_suite_config:
                     code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.2_spyre
                 - name: torch.Tensor.contiguous
                   sample_inputs_func:
@@ -1767,7 +1679,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1294 in forward,
                     code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
                   tags:
-                    - tensorsoncpu
                     - torch.Tensor.contiguous.2_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -1791,7 +1702,6 @@ test_suite_config:
                     code: attn_output = self.o_proj(attn_output)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.3_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -1813,7 +1723,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1429 in forward,
                     code: hidden_states = residual + hidden_states'
                   tags:
-                    - tensorsoncpu
                     - torch.add.7_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -1837,7 +1746,6 @@ test_suite_config:
                     code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.4_spyre
                 - name: torch.nn.functional.gelu
                   sample_inputs_func:
@@ -1853,7 +1761,6 @@ test_suite_config:
                       approximate: tanh
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/activations.py#L51 in forward, code: return self.act(input)'
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.gelu.1_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -1875,7 +1782,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1089 in forward,
                     code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.12_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -1899,7 +1805,6 @@ test_suite_config:
                     code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.5_spyre
                 - name: torch.reshape
                   sample_inputs_func:
@@ -1916,7 +1821,6 @@ test_suite_config:
                     code: hidden_states_flat = residual.reshape(-1, residual.shape[-1])'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.3_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -1931,7 +1835,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L212 in forward,
                     code: normed_output = self._norm(hidden_states.float())'
                   tags:
-                    - tensorsoncpu
                     - torch.float.10_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -1948,7 +1851,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.7_spyre
                 - name: torch.mean
                   sample_inputs_func:
@@ -1967,7 +1869,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mean.4_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -1984,7 +1885,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.add.8_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -2001,7 +1901,6 @@ test_suite_config:
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.8_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -2023,7 +1922,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L209 in _norm,
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.13_spyre
                 - name: torch.type_as
                   sample_inputs_func:
@@ -2045,7 +1943,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L215 in forward,
                     code: return normed_output.type_as(hidden_states)'
                   tags:
-                    - tensorsoncpu
                     - torch.type_as.4_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -2067,7 +1964,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1354 in forward,
                     code: hidden_states = hidden_states * self.scale * self.scalar_root_size'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.14_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -2084,7 +1980,6 @@ test_suite_config:
                     code: hidden_states = hidden_states * self.scale * self.scalar_root_size'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mul.15_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -2108,7 +2003,6 @@ test_suite_config:
                     code: expert_scores = self.proj(hidden_states)  # [B*S, E]'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.6_spyre
                 - name: torch.nn.functional.softmax
                   sample_inputs_func:
@@ -2126,7 +2020,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1358 in forward,
                     code: router_probabilities = nn.functional.softmax(expert_scores, dim=-1, dtype=torch.float32)'
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.softmax.1_spyre
                 - name: torch.topk
                   sample_inputs_func:
@@ -2144,7 +2037,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1361 in forward,
                     code: top_k_weights, top_k_index = torch.topk('
                   tags:
-                    - tensorsoncpu
                     - torch.topk.1_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2169,7 +2061,6 @@ test_suite_config:
                     code: top_k_weights, top_k_index = torch.topk('
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.7_spyre
                 - name: torch.sum
                   sample_inputs_func:
@@ -2187,7 +2078,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1368 in forward,
                     code: top_k_weights /= top_k_weights.sum(dim=-1, keepdim=True)'
                   tags:
-                    - tensorsoncpu
                     - torch.sum.1_spyre
                 - name: torch.Tensor.truediv
                   sample_inputs_func:
@@ -2209,7 +2099,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1368 in forward,
                     code: top_k_weights /= top_k_weights.sum(dim=-1, keepdim=True)'
                   tags:
-                    - tensorsoncpu
                     - torch.Tensor.truediv.1_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2233,7 +2122,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1371 in forward,
                     code: top_k_weights = top_k_weights * self.per_expert_scale[top_k_index]'
                   tags:
-                    - tensorsoncpu
                     - torch.getitem.8_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -2255,7 +2143,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1371 in forward,
                     code: top_k_weights = top_k_weights * self.per_expert_scale[top_k_index]'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.16_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -2277,7 +2164,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward,
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.17_spyre
                 - name: torch.reshape
                   sample_inputs_func:
@@ -2294,7 +2180,6 @@ test_suite_config:
                     code: sample_weights = top_k_weights.reshape(-1)  # (S,)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.4_spyre
                 - name: torch.reshape
                   sample_inputs_func:
@@ -2313,7 +2198,6 @@ test_suite_config:
                     code: expert_ids = top_k_index.reshape(-1)  # (S,)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.5_spyre
                 - name: torch.sort
                   sample_inputs_func:
@@ -2330,7 +2214,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L399 in grouped_mm_experts_forward,
                     code: expert_ids_g, perm = torch.sort(expert_ids)'
                   tags:
-                    - tensorsoncpu
                     - torch.sort.1_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2357,7 +2240,6 @@ test_suite_config:
                     code: expert_ids_g, perm = torch.sort(expert_ids)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.9_spyre
                 - name: torch.floordiv
                   sample_inputs_func:
@@ -2376,7 +2258,6 @@ test_suite_config:
                     code: selected_hidden_states_g = hidden_states[perm // num_top_k]'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.floordiv.1_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2400,7 +2281,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L400 in grouped_mm_experts_forward,
                     code: selected_hidden_states_g = hidden_states[perm // num_top_k]'
                   tags:
-                    - tensorsoncpu
                     - torch.getitem.10_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2424,7 +2304,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L401 in grouped_mm_experts_forward,
                     code: sample_weights_g = sample_weights[perm]'
                   tags:
-                    - tensorsoncpu
                     - torch.getitem.11_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -2441,7 +2320,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L407 in grouped_mm_experts_forward,
                     code: histc_input = expert_ids_g.float() if device.type in ("cpu", "mps") else expert_ids_g.int()'
                   tags:
-                    - tensorsoncpu
                     - torch.float.11_spyre
                 - name: torch.histc
                   sample_inputs_func:
@@ -2460,7 +2338,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L408 in grouped_mm_experts_forward,
                     code: tokens_per_expert = torch.histc(histc_input, bins=self.num_experts, min=0, max=self.num_experts - 1)'
                   tags:
-                    - tensorsoncpu
                     - torch.histc.1_spyre
                 - name: torch.cumsum
                   sample_inputs_func:
@@ -2478,7 +2355,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L409 in grouped_mm_experts_forward,
                     code: offsets = torch.cumsum(tokens_per_expert, dim=0, dtype=torch.int32)'
                   tags:
-                    - tensorsoncpu
                     - torch.cumsum.1_spyre
                 - name: torch.ge
                   sample_inputs_func:
@@ -2497,7 +2373,6 @@ test_suite_config:
                     code: sentinel_mask = (expert_ids_g >= self.num_experts).unsqueeze(-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.ge.1_spyre
                 - name: torch.unsqueeze
                   sample_inputs_func:
@@ -2513,7 +2388,6 @@ test_suite_config:
                     code: sentinel_mask = (expert_ids_g >= self.num_experts).unsqueeze(-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.unsqueeze.2_spyre
                 - name: torch.clamp_
                   sample_inputs_func:
@@ -2532,7 +2406,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L427 in grouped_mm_experts_forward,
                     code: expert_ids_g.clamp_(max=self.num_experts - 1)'
                   tags:
-                    - tensorsoncpu
                     - torch.clamp_.1_spyre
                 - name: torch.masked_fill_
                   sample_inputs_func:
@@ -2555,7 +2428,6 @@ test_suite_config:
                     code: selected_hidden_states_g.masked_fill_(sentinel_mask, 0.0)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.masked_fill_.1_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -2573,7 +2445,6 @@ test_suite_config:
                     out = _grouped_mm(input, weight.transpose(-2, -1), offs=offs)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.6_spyre
                 - name: torch.ops.transformers.grouped_mm_fallback
                   sample_inputs_func:
@@ -2595,7 +2466,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L342 in torch_dynamo_resume_in__grouped_mm_at_332,
                     code: return torch.ops.transformers.grouped_mm_fallback(input, weight, offs=offs)'
                   tags:
-                    - tensorsoncpu
                     - torch.ops.transformers.grouped_mm_fallback.1_spyre
                 - name: torch.chunk
                   sample_inputs_func:
@@ -2614,7 +2484,6 @@ test_suite_config:
                     code: gate, up = gate_up_out.chunk(2, dim=-1)  # (S, intermediate_dim)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.chunk.1_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2637,7 +2506,6 @@ test_suite_config:
                     code: gate, up = gate_up_out.chunk(2, dim=-1)  # (S, intermediate_dim)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.12_spyre
                 - name: torch.nn.functional.gelu
                   sample_inputs_func:
@@ -2653,7 +2521,6 @@ test_suite_config:
                       approximate: tanh
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/activations.py#L51 in forward, code: return self.act(input)'
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.gelu.2_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -2675,7 +2542,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L526 in _default_apply_gate,
                     code: return self.act_fn(gate) * up  # (S, intermediate_dim)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.18_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -2693,7 +2559,6 @@ test_suite_config:
                     out = _grouped_mm(input, weight.transpose(-2, -1), offs=offs)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.7_spyre
                 - name: torch.ops.transformers.grouped_mm_fallback
                   sample_inputs_func:
@@ -2715,7 +2580,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L342 in torch_dynamo_resume_in__grouped_mm_at_332,
                     code: return torch.ops.transformers.grouped_mm_fallback(input, weight, offs=offs)'
                   tags:
-                    - tensorsoncpu
                     - torch.ops.transformers.grouped_mm_fallback.2_spyre
                 - name: torch.unsqueeze
                   sample_inputs_func:
@@ -2732,7 +2596,6 @@ test_suite_config:
                     code: weighted_out = proj_out * sample_weights_g.unsqueeze(-1)  # (S, hidden_dim)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.unsqueeze.3_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -2754,7 +2617,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L468 in torch_dynamo_resume_in_grouped_mm_experts_forward_at_463,
                     code: weighted_out = proj_out * sample_weights_g.unsqueeze(-1)  # (S, hidden_dim)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.19_spyre
                 - name: torch.masked_fill_
                   sample_inputs_func:
@@ -2777,7 +2639,6 @@ test_suite_config:
                     code: weighted_out.masked_fill_(sentinel_mask, 0.0)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.masked_fill_.2_spyre
                 - name: torch.empty_like
                   sample_inputs_func:
@@ -2794,7 +2655,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L474 in torch_dynamo_resume_in_grouped_mm_experts_forward_at_463,
                     code: inv_perm = torch.empty_like(perm)'
                   tags:
-                    - tensorsoncpu
                     - torch.empty_like.1_spyre
                 - name: torch.setitem
                   sample_inputs_func:
@@ -2829,7 +2689,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L475 in torch_dynamo_resume_in_grouped_mm_experts_forward_at_463,
                     code: inv_perm[perm] = torch.arange(perm.size(0), device=device)'
                   tags:
-                    - tensorsoncpu
                     - torch.setitem.1_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -2853,7 +2712,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L476 in torch_dynamo_resume_in_grouped_mm_experts_forward_at_463,
                     code: weighted_out = weighted_out[inv_perm]  # (S, hidden_dim)'
                   tags:
-                    - tensorsoncpu
                     - torch.getitem.13_spyre
                 - name: torch.Tensor.view
                   sample_inputs_func:
@@ -2872,7 +2730,6 @@ test_suite_config:
                     code: final_hidden_states = weighted_out.view(num_tokens, num_top_k, hidden_dim).sum(dim=1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.Tensor.view.3_spyre
                 - name: torch.sum
                   sample_inputs_func:
@@ -2889,7 +2746,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L482 in torch_dynamo_resume_in_grouped_mm_experts_forward_at_463,
                     code: final_hidden_states = weighted_out.view(num_tokens, num_top_k, hidden_dim).sum(dim=1)'
                   tags:
-                    - tensorsoncpu
                     - torch.sum.2_spyre
                 - name: torch.to
                   sample_inputs_func:
@@ -2906,7 +2762,6 @@ test_suite_config:
                     code: return final_hidden_states.to(hidden_states.dtype)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.to.7_spyre
                 - name: torch.reshape
                   sample_inputs_func:
@@ -2923,7 +2778,6 @@ test_suite_config:
                     code: hidden_states_2 = hidden_states_2.reshape(residual.shape)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.6_spyre
                 - name: torch.Tensor.mul
                   sample_inputs_func:
@@ -2945,7 +2799,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1461 in torch_dynamo_resume_in_forward_at_1442,
                     code: hidden_states *= self.layer_scalar'
                   tags:
-                    - tensorsoncpu
                     - torch.Tensor.mul.1_spyre
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -2978,7 +2831,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.2_spyre
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -3011,7 +2863,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.3_spyre
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -3044,7 +2895,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.4_spyre
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -3077,7 +2927,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.5_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -3101,7 +2950,6 @@ test_suite_config:
                     code: query_states = self.q_proj(hidden_states).view(hidden_shape)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.7_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -3116,7 +2964,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L212 in forward,
                     code: normed_output = self._norm(hidden_states.float())'
                   tags:
-                    - tensorsoncpu
                     - torch.float.12_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -3133,7 +2980,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.9_spyre
                 - name: torch.mean
                   sample_inputs_func:
@@ -3152,7 +2998,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mean.5_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -3174,7 +3019,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L209 in _norm,
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.20_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -3189,7 +3033,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward,
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
-                    - tensorsoncpu
                     - torch.float.13_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -3211,7 +3054,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward,
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.21_spyre
                 - name: torch.type_as
                   sample_inputs_func:
@@ -3233,7 +3075,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L215 in forward,
                     code: return normed_output.type_as(hidden_states)'
                   tags:
-                    - tensorsoncpu
                     - torch.type_as.5_spyre
                 - name: torch.unsqueeze
                   sample_inputs_func:
@@ -3250,7 +3091,6 @@ test_suite_config:
                     code: cos = cos.unsqueeze(unsqueeze_dim)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.unsqueeze.4_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -3272,7 +3112,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L812 in apply_rotary_pos_emb,
                     code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.22_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -3289,7 +3128,6 @@ test_suite_config:
                     code: x1 = x[..., : x.shape[-1] // 2]'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.14_spyre
                 - name: torch.neg
                   sample_inputs_func:
@@ -3304,7 +3142,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L790 in rotate_half,
                     code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
-                    - tensorsoncpu
                     - torch.neg.3_spyre
                 - name: torch.cat
                   sample_inputs_func:
@@ -3328,7 +3165,6 @@ test_suite_config:
                     code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.cat.5_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -3350,7 +3186,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L812 in apply_rotary_pos_emb,
                     code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
-                    - tensorsoncpu
                     - torch.add.9_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -3368,7 +3203,6 @@ test_suite_config:
                     code: query_states = query_states.transpose(1, 2)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.8_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -3392,7 +3226,6 @@ test_suite_config:
                     code: key_states = self.k_proj(hidden_states).view(hidden_shape)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.8_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -3407,7 +3240,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L212 in forward,
                     code: normed_output = self._norm(hidden_states.float())'
                   tags:
-                    - tensorsoncpu
                     - torch.float.14_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -3424,7 +3256,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.10_spyre
                 - name: torch.mean
                   sample_inputs_func:
@@ -3443,7 +3274,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mean.6_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -3460,7 +3290,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.add.10_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -3477,7 +3306,6 @@ test_suite_config:
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.11_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -3499,7 +3327,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L209 in _norm,
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.23_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -3521,7 +3348,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward,
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.24_spyre
                 - name: torch.type_as
                   sample_inputs_func:
@@ -3543,7 +3369,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L215 in forward,
                     code: return normed_output.type_as(hidden_states)'
                   tags:
-                    - tensorsoncpu
                     - torch.type_as.6_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -3565,7 +3390,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L812 in apply_rotary_pos_emb,
                     code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.25_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -3582,7 +3406,6 @@ test_suite_config:
                     code: x1 = x[..., : x.shape[-1] // 2]'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.15_spyre
                 - name: torch.neg
                   sample_inputs_func:
@@ -3597,7 +3420,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L790 in rotate_half,
                     code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
-                    - tensorsoncpu
                     - torch.neg.4_spyre
                 - name: torch.cat
                   sample_inputs_func:
@@ -3621,7 +3443,6 @@ test_suite_config:
                     code: return torch.cat((-x2, x1), dim=-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.cat.6_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -3643,7 +3464,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L812 in apply_rotary_pos_emb,
                     code: return (x * cos) + (rotate_half(x) * sin)'
                   tags:
-                    - tensorsoncpu
                     - torch.add.11_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -3661,7 +3481,6 @@ test_suite_config:
                     code: key_states = key_states.transpose(1, 2)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.9_spyre
                 - name: torch.index_copy_
                   sample_inputs_func:
@@ -3694,7 +3513,6 @@ test_suite_config:
                     cache_position, key_states)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.index_copy_.2_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -3711,7 +3529,6 @@ test_suite_config:
                     code: hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.16_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -3728,7 +3545,6 @@ test_suite_config:
                     code: key = key[:, :, :q_length, :]'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.17_spyre
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -3761,7 +3577,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.6_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -3779,7 +3594,6 @@ test_suite_config:
                     code: attn_output = attn_output.transpose(1, 2).contiguous()'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.10_spyre
                 - name: torch.Tensor.contiguous
                   sample_inputs_func:
@@ -3794,7 +3608,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L164 in sdpa_attention_forward,
                     code: attn_output = attn_output.transpose(1, 2).contiguous()'
                   tags:
-                    - tensorsoncpu
                     - torch.Tensor.contiguous.3_spyre
                 - name: torch.reshape
                   sample_inputs_func:
@@ -3811,7 +3624,6 @@ test_suite_config:
                     code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.reshape.7_spyre
                 - name: torch.Tensor.contiguous
                   sample_inputs_func:
@@ -3826,7 +3638,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1294 in forward,
                     code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
                   tags:
-                    - tensorsoncpu
                     - torch.Tensor.contiguous.4_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -3850,7 +3661,6 @@ test_suite_config:
                     code: attn_output = self.o_proj(attn_output)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.9_spyre
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -3883,7 +3693,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.7_spyre
                 - name: torch.nn.functional.scaled_dot_product_attention
                   sample_inputs_func:
@@ -3916,7 +3725,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
                   tags:
-                    - tensorsoncpu
                     - torch.nn.functional.scaled_dot_product_attention.8_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -3933,7 +3741,6 @@ test_suite_config:
                     code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.18_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -3957,7 +3764,6 @@ test_suite_config:
                     code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.10_spyre
                 - name: torch.truediv
                   sample_inputs_func:
@@ -3974,7 +3780,6 @@ test_suite_config:
                     code: logits = logits / final_logit_softcapping'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.truediv.1_spyre
                 - name: torch.tanh
                   sample_inputs_func:
@@ -3989,7 +3794,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2596 in torch_dynamo_resume_in_forward_at_2570,
                     code: logits = torch.tanh(logits)'
                   tags:
-                    - tensorsoncpu
                     - torch.tanh.1_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -4006,7 +3810,6 @@ test_suite_config:
                     code: logits = logits * final_logit_softcapping'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mul.26_spyre
                 - name: torch.eq
                   sample_inputs_func:
@@ -4025,7 +3828,6 @@ test_suite_config:
                     code: special_image_mask = input_ids == self.config.image_token_id'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.eq.2_spyre
                 - name: torch.or_
                   sample_inputs_func:
@@ -4045,7 +3847,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2320 in forward,
                     code: multimodal_mask = image_mask | video_mask | audio_mask'
                   tags:
-                    - tensorsoncpu
                     - torch.or_.2_spyre
                 - name: torch.clone
                   sample_inputs_func:
@@ -4062,7 +3863,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2325 in forward,
                     code: llm_input_ids = input_ids.clone()'
                   tags:
-                    - tensorsoncpu
                     - torch.clone.2_spyre
                 - name: torch.where
                   sample_inputs_func:
@@ -4087,7 +3887,6 @@ test_suite_config:
                     code: llm_input_ids = torch.where(multimodal_mask, self.config.text_config.pad_token_id, llm_input_ids)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.where.2_spyre
                 - name: torch.nn.functional.embedding
                   sample_inputs_func:
@@ -4117,7 +3916,6 @@ test_suite_config:
                     code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.embedding.2_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -4139,7 +3937,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1476 in forward,
                     code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.27_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -4158,7 +3955,6 @@ test_suite_config:
                     code: position_ids_expanded = position_ids[:, None, :].float()'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.19_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -4175,7 +3971,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1171 in forward,
                     code: position_ids_expanded = position_ids[:, None, :].float()'
                   tags:
-                    - tensorsoncpu
                     - torch.float.15_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -4190,7 +3985,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1175 in forward,
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
-                    - tensorsoncpu
                     - torch.float.16_spyre
                 - name: torch.matmul
                   sample_inputs_func:
@@ -4212,7 +4006,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1175 in forward,
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
-                    - tensorsoncpu
                     - torch.matmul.3_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -4230,7 +4023,6 @@ test_suite_config:
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.11_spyre
                 - name: torch.cat
                   sample_inputs_func:
@@ -4254,7 +4046,6 @@ test_suite_config:
                     code: emb = torch.cat((freqs, freqs), dim=-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.cat.7_spyre
                 - name: torch.cos
                   sample_inputs_func:
@@ -4269,7 +4060,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1177 in forward,
                     code: cos = emb.cos() * attention_scaling'
                   tags:
-                    - tensorsoncpu
                     - torch.cos.3_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -4286,7 +4076,6 @@ test_suite_config:
                     code: cos = emb.cos() * attention_scaling'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mul.28_spyre
                 - name: torch.sin
                   sample_inputs_func:
@@ -4301,7 +4090,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1178 in forward,
                     code: sin = emb.sin() * attention_scaling'
                   tags:
-                    - tensorsoncpu
                     - torch.sin.3_spyre
                 - name: torch.to
                   sample_inputs_func:
@@ -4318,7 +4106,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1180 in forward,
                     code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
                   tags:
-                    - tensorsoncpu
                     - torch.to.8_spyre
                 - name: torch.matmul
                   sample_inputs_func:
@@ -4340,7 +4127,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1175 in forward,
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
-                    - tensorsoncpu
                     - torch.matmul.4_spyre
                 - name: torch.transpose
                   sample_inputs_func:
@@ -4358,7 +4144,6 @@ test_suite_config:
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.transpose.12_spyre
                 - name: torch.cat
                   sample_inputs_func:
@@ -4382,7 +4167,6 @@ test_suite_config:
                     code: emb = torch.cat((freqs, freqs), dim=-1)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.cat.8_spyre
                 - name: torch.cos
                   sample_inputs_func:
@@ -4397,7 +4181,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1177 in forward,
                     code: cos = emb.cos() * attention_scaling'
                   tags:
-                    - tensorsoncpu
                     - torch.cos.4_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -4414,7 +4197,6 @@ test_suite_config:
                     code: cos = emb.cos() * attention_scaling'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mul.29_spyre
                 - name: torch.sin
                   sample_inputs_func:
@@ -4429,7 +4211,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1178 in forward,
                     code: sin = emb.sin() * attention_scaling'
                   tags:
-                    - tensorsoncpu
                     - torch.sin.4_spyre
                 - name: torch.to
                   sample_inputs_func:
@@ -4446,7 +4227,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1180 in forward,
                     code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
                   tags:
-                    - tensorsoncpu
                     - torch.to.9_spyre
                 - name: torch.float
                   sample_inputs_func:
@@ -4461,7 +4241,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L212 in forward,
                     code: normed_output = self._norm(hidden_states.float())'
                   tags:
-                    - tensorsoncpu
                     - torch.float.17_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -4478,7 +4257,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.12_spyre
                 - name: torch.mean
                   sample_inputs_func:
@@ -4497,7 +4275,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.mean.7_spyre
                 - name: torch.add
                   sample_inputs_func:
@@ -4514,7 +4291,6 @@ test_suite_config:
                     code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.add.12_spyre
                 - name: torch.pow
                   sample_inputs_func:
@@ -4531,7 +4307,6 @@ test_suite_config:
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.pow.13_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -4553,7 +4328,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L209 in _norm,
                     code: return hidden_states * torch.pow(mean_squared, -0.5)'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.30_spyre
                 - name: torch.mul
                   sample_inputs_func:
@@ -4575,7 +4349,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward,
                     code: normed_output = normed_output * self.weight.float()'
                   tags:
-                    - tensorsoncpu
                     - torch.mul.31_spyre
                 - name: torch.type_as
                   sample_inputs_func:
@@ -4597,7 +4370,6 @@ test_suite_config:
                   description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L215 in forward,
                     code: return normed_output.type_as(hidden_states)'
                   tags:
-                    - tensorsoncpu
                     - torch.type_as.7_spyre
                 - name: torch.getitem
                   sample_inputs_func:
@@ -4614,7 +4386,6 @@ test_suite_config:
                     code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.getitem.20_spyre
                 - name: torch.nn.functional.linear
                   sample_inputs_func:
@@ -4638,5 +4409,4 @@ test_suite_config:
                     code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
                   tags:
                     - constant
-                    - tensorsoncpu
                     - torch.nn.functional.linear.11_spyre

--- a/tests/resource/models/gemma-4-12B-it.yaml
+++ b/tests/resource/models/gemma-4-12B-it.yaml
@@ -22,7 +22,6 @@ cases:
       code: special_image_mask = input_ids == self.config.image_token_id'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.or_.1
     op: torch.or_
     inputs:
@@ -40,7 +39,6 @@ cases:
           device: cuda
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L1034 in forward,
       code: multimodal_mask = image_mask | video_mask | audio_mask'
-    marks: tensorsoncpu
   - name: torch.clone.1
     op: torch.clone
     inputs:
@@ -55,7 +53,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L1039 in forward,
       code: llm_input_ids = input_ids.clone()'
-    marks: tensorsoncpu
   - name: torch.where.1
     op: torch.where
     inputs:
@@ -79,7 +76,6 @@ cases:
       code: llm_input_ids = torch.where(multimodal_mask, self.config.text_config.pad_token_id, llm_input_ids)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.embedding.1
     op: torch.nn.functional.embedding
     inputs:
@@ -109,7 +105,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.to.1
     op: torch.to
     inputs:
@@ -125,7 +120,6 @@ cases:
       code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.1
     op: torch.mul
     inputs:
@@ -147,7 +141,6 @@ cases:
       code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.getitem.1
     op: torch.getitem
     inputs:
@@ -164,7 +157,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.float.1
     op: torch.float
     inputs:
@@ -179,7 +171,6 @@ cases:
       code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.Tensor.expand.1
     op: torch.Tensor.expand
     inputs:
@@ -198,7 +189,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.to.2
     op: torch.to
     inputs:
@@ -215,7 +205,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.getitem.2
     op: torch.getitem
     inputs:
@@ -233,7 +222,6 @@ cases:
       code: position_ids_expanded = position_ids[:, None, :].float()'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.2
     op: torch.float
     inputs:
@@ -248,7 +236,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L274 in forward,
       code: position_ids_expanded = position_ids[:, None, :].float()'
-    marks: tensorsoncpu
   - name: torch.float.3
     op: torch.float
     inputs:
@@ -263,7 +250,6 @@ cases:
       code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.matmul.1
     op: torch.matmul
     inputs:
@@ -285,7 +271,6 @@ cases:
       code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.transpose.1
     op: torch.transpose
     inputs:
@@ -303,7 +288,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.cat.1
     op: torch.cat
     inputs:
@@ -325,7 +309,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.cos.1
@@ -342,7 +325,6 @@ cases:
       code: cos = emb.cos() * attention_scaling'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.mul.2
     op: torch.mul
     inputs:
@@ -359,7 +341,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.sin.1
     op: torch.sin
     inputs:
@@ -374,7 +355,6 @@ cases:
       code: sin = emb.sin() * attention_scaling'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.to.3
     op: torch.to
     inputs:
@@ -389,7 +369,6 @@ cases:
       code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
     marks:
       - fp32operation
-      - tensorsoncpu
     kwmap:
       dtype: torch.bfloat16
   - name: torch.getitem.3
@@ -408,7 +387,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.float.4
     op: torch.float
     inputs:
@@ -423,7 +401,6 @@ cases:
       code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.Tensor.expand.2
     op: torch.Tensor.expand
     inputs:
@@ -442,7 +419,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.to.4
     op: torch.to
     inputs:
@@ -459,7 +435,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.matmul.2
     op: torch.matmul
     inputs:
@@ -481,7 +456,6 @@ cases:
       code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.transpose.2
     op: torch.transpose
     inputs:
@@ -499,7 +473,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.cat.2
     op: torch.cat
     inputs:
@@ -521,7 +494,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.cos.2
@@ -538,7 +510,6 @@ cases:
       code: cos = emb.cos() * attention_scaling'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.mul.3
     op: torch.mul
     inputs:
@@ -555,7 +526,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.sin.2
     op: torch.sin
     inputs:
@@ -570,7 +540,6 @@ cases:
       code: sin = emb.sin() * attention_scaling'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.to.5
     op: torch.to
     inputs:
@@ -585,7 +554,6 @@ cases:
       code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
     marks:
       - fp32operation
-      - tensorsoncpu
     kwmap:
       dtype: torch.bfloat16
   - name: torch.float.5
@@ -602,7 +570,6 @@ cases:
       code: normed_output = self._norm(hidden_states.float())'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.pow.1
     op: torch.pow
     inputs:
@@ -619,7 +586,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mean.1
     op: torch.mean
     inputs:
@@ -636,7 +602,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.1
@@ -655,7 +620,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.pow.2
     op: torch.pow
     inputs:
@@ -672,7 +636,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mul.4
     op: torch.mul
     inputs:
@@ -694,7 +657,6 @@ cases:
       code: return hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.float.6
     op: torch.float
     inputs:
@@ -709,7 +671,6 @@ cases:
       code: normed_output = normed_output * self.weight.float()'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.mul.5
     op: torch.mul
     inputs:
@@ -731,7 +692,6 @@ cases:
       code: normed_output = normed_output * self.weight.float()'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.type_as.1
     op: torch.type_as
     inputs:
@@ -754,7 +714,6 @@ cases:
     marks:
       - fp32operation
       - bf16operation
-      - tensorsoncpu
   - name: torch.nn.functional.linear.1
     op: torch.nn.functional.linear
     inputs:
@@ -778,7 +737,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.view.1
     op: torch.Tensor.view
     inputs:
@@ -795,7 +753,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.float.7
     op: torch.float
     inputs:
@@ -810,7 +767,6 @@ cases:
       code: normed_output = self._norm(hidden_states.float())'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.pow.3
     op: torch.pow
     inputs:
@@ -827,7 +783,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mean.2
     op: torch.mean
     inputs:
@@ -844,7 +799,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.2
@@ -863,7 +817,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.pow.4
     op: torch.pow
     inputs:
@@ -880,7 +833,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mul.6
     op: torch.mul
     inputs:
@@ -902,7 +854,6 @@ cases:
       code: return hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.float.8
     op: torch.float
     inputs:
@@ -917,7 +868,6 @@ cases:
       code: normed_output = normed_output * self.weight.float()'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.mul.7
     op: torch.mul
     inputs:
@@ -939,7 +889,6 @@ cases:
       code: normed_output = normed_output * self.weight.float()'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.type_as.2
     op: torch.type_as
     inputs:
@@ -962,7 +911,6 @@ cases:
     marks:
       - fp32operation
       - bf16operation
-      - tensorsoncpu
   - name: torch.unsqueeze.1
     op: torch.unsqueeze
     inputs:
@@ -979,7 +927,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.mul.8
     op: torch.mul
     inputs:
@@ -1001,7 +948,6 @@ cases:
       code: return (x * cos) + (rotate_half(x) * sin)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.getitem.4
     op: torch.getitem
     inputs:
@@ -1018,7 +964,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.neg.1
     op: torch.neg
     inputs:
@@ -1033,7 +978,6 @@ cases:
       code: return torch.cat((-x2, x1), dim=-1)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.cat.3
     op: torch.cat
     inputs:
@@ -1055,7 +999,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.add.3
@@ -1079,7 +1022,6 @@ cases:
       code: return (x * cos) + (rotate_half(x) * sin)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.transpose.3
     op: torch.transpose
     inputs:
@@ -1097,7 +1039,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.linear.2
     op: torch.nn.functional.linear
     inputs:
@@ -1121,7 +1062,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.view.2
     op: torch.Tensor.view
     inputs:
@@ -1138,7 +1078,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.float.9
     op: torch.float
     inputs:
@@ -1153,7 +1092,6 @@ cases:
       code: normed_output = self._norm(hidden_states.float())'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.pow.5
     op: torch.pow
     inputs:
@@ -1170,7 +1108,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mean.3
     op: torch.mean
     inputs:
@@ -1187,7 +1124,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.4
@@ -1206,7 +1142,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.pow.6
     op: torch.pow
     inputs:
@@ -1223,7 +1158,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mul.9
     op: torch.mul
     inputs:
@@ -1245,7 +1179,6 @@ cases:
       code: return hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.mul.10
     op: torch.mul
     inputs:
@@ -1267,7 +1200,6 @@ cases:
       code: normed_output = normed_output * self.weight.float()'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.type_as.3
     op: torch.type_as
     inputs:
@@ -1290,7 +1222,6 @@ cases:
     marks:
       - fp32operation
       - bf16operation
-      - tensorsoncpu
   - name: torch.mul.11
     op: torch.mul
     inputs:
@@ -1312,7 +1243,6 @@ cases:
       code: return (x * cos) + (rotate_half(x) * sin)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.getitem.5
     op: torch.getitem
     inputs:
@@ -1329,7 +1259,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.neg.2
     op: torch.neg
     inputs:
@@ -1344,7 +1273,6 @@ cases:
       code: return torch.cat((-x2, x1), dim=-1)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.cat.4
     op: torch.cat
     inputs:
@@ -1366,7 +1294,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.add.5
@@ -1390,7 +1317,6 @@ cases:
       code: return (x * cos) + (rotate_half(x) * sin)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.transpose.4
     op: torch.transpose
     inputs:
@@ -1408,7 +1334,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.zeros.1
     op: torch.zeros
     inputs:
@@ -1417,7 +1342,6 @@ cases:
       = torch.zeros('
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dtype: torch.bfloat16
       device: cpu
@@ -1438,7 +1362,6 @@ cases:
       = self.cumulative_length.to(self.device)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.arange.1
     op: torch.arange
     inputs:
@@ -1447,7 +1370,6 @@ cases:
       device=self.device) + self.cumulative_length'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       device: cpu
   - name: torch.add.6
@@ -1473,7 +1395,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/cache_utils.py#L529 in update, code: cache_position = torch.arange(kv_length,
       device=self.device) + self.cumulative_length'
-    marks: tensorsoncpu
   - name: torch.index_copy_.1
     op: torch.index_copy_
     inputs:
@@ -1506,7 +1427,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.add_.1
     op: torch.add_
     inputs:
@@ -1523,7 +1443,6 @@ cases:
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/cache_utils.py#L539 in update, code: self.cumulative_length.add_(kv_length)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.getitem.6
     op: torch.getitem
     inputs:
@@ -1540,7 +1459,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.expand.3
     op: torch.Tensor.expand
     inputs:
@@ -1561,7 +1479,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.reshape.1
     op: torch.reshape
     inputs:
@@ -1578,7 +1495,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.scaled_dot_product_attention.1
     op: torch.nn.functional.scaled_dot_product_attention
     inputs:
@@ -1607,7 +1523,6 @@ cases:
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -1629,7 +1544,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.contiguous.1
     op: torch.Tensor.contiguous
     inputs:
@@ -1644,7 +1558,6 @@ cases:
       code: attn_output = attn_output.transpose(1, 2).contiguous()'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.reshape.2
     op: torch.reshape
     inputs:
@@ -1661,7 +1574,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.contiguous.2
     op: torch.Tensor.contiguous
     inputs:
@@ -1676,7 +1588,6 @@ cases:
       code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.nn.functional.linear.3
     op: torch.nn.functional.linear
     inputs:
@@ -1700,7 +1611,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.add.7
     op: torch.add
     inputs:
@@ -1722,7 +1632,6 @@ cases:
       code: hidden_states = residual + hidden_states'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.nn.functional.linear.4
     op: torch.nn.functional.linear
     inputs:
@@ -1746,7 +1655,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.gelu.1
     op: torch.nn.functional.gelu
     inputs:
@@ -1760,7 +1668,6 @@ cases:
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/activations.py#L51 in forward, code: return self.act(input)'
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       approximate: tanh
   - name: torch.mul.12
@@ -1784,7 +1691,6 @@ cases:
       code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.nn.functional.linear.5
     op: torch.nn.functional.linear
     inputs:
@@ -1808,7 +1714,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.mul.1
     op: torch.Tensor.mul
     inputs:
@@ -1830,7 +1735,6 @@ cases:
       code: hidden_states *= self.layer_scalar'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.nn.functional.scaled_dot_product_attention.2
     op: torch.nn.functional.scaled_dot_product_attention
     inputs:
@@ -1859,7 +1763,6 @@ cases:
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -1892,7 +1795,6 @@ cases:
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -1925,7 +1827,6 @@ cases:
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -1958,7 +1859,6 @@ cases:
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -1986,7 +1886,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.float.10
     op: torch.float
     inputs:
@@ -2001,7 +1900,6 @@ cases:
       code: normed_output = self._norm(hidden_states.float())'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.pow.7
     op: torch.pow
     inputs:
@@ -2018,7 +1916,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mean.4
     op: torch.mean
     inputs:
@@ -2035,7 +1932,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.mul.13
@@ -2059,7 +1955,6 @@ cases:
       code: return hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.float.11
     op: torch.float
     inputs:
@@ -2074,7 +1969,6 @@ cases:
       code: normed_output = normed_output * self.weight.float()'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.mul.14
     op: torch.mul
     inputs:
@@ -2096,7 +1990,6 @@ cases:
       code: normed_output = normed_output * self.weight.float()'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.type_as.4
     op: torch.type_as
     inputs:
@@ -2119,7 +2012,6 @@ cases:
     marks:
       - fp32operation
       - bf16operation
-      - tensorsoncpu
   - name: torch.unsqueeze.2
     op: torch.unsqueeze
     inputs:
@@ -2136,7 +2028,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.mul.15
     op: torch.mul
     inputs:
@@ -2158,7 +2049,6 @@ cases:
       code: return (x * cos) + (rotate_half(x) * sin)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.getitem.7
     op: torch.getitem
     inputs:
@@ -2175,7 +2065,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.neg.3
     op: torch.neg
     inputs:
@@ -2190,7 +2079,6 @@ cases:
       code: return torch.cat((-x2, x1), dim=-1)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.cat.5
     op: torch.cat
     inputs:
@@ -2212,7 +2100,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.add.8
@@ -2236,7 +2123,6 @@ cases:
       code: return (x * cos) + (rotate_half(x) * sin)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.transpose.6
     op: torch.transpose
     inputs:
@@ -2254,7 +2140,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.linear.7
     op: torch.nn.functional.linear
     inputs:
@@ -2278,7 +2163,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.float.12
     op: torch.float
     inputs:
@@ -2293,7 +2177,6 @@ cases:
       code: normed_output = self._norm(hidden_states.float())'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.pow.8
     op: torch.pow
     inputs:
@@ -2310,7 +2193,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mean.5
     op: torch.mean
     inputs:
@@ -2327,7 +2209,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.9
@@ -2346,7 +2227,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.pow.9
     op: torch.pow
     inputs:
@@ -2363,7 +2243,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mul.16
     op: torch.mul
     inputs:
@@ -2385,7 +2264,6 @@ cases:
       code: return hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.mul.17
     op: torch.mul
     inputs:
@@ -2407,7 +2285,6 @@ cases:
       code: normed_output = normed_output * self.weight.float()'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.type_as.5
     op: torch.type_as
     inputs:
@@ -2430,7 +2307,6 @@ cases:
     marks:
       - fp32operation
       - bf16operation
-      - tensorsoncpu
   - name: torch.mul.18
     op: torch.mul
     inputs:
@@ -2452,7 +2328,6 @@ cases:
       code: return (x * cos) + (rotate_half(x) * sin)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.getitem.8
     op: torch.getitem
     inputs:
@@ -2469,7 +2344,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.neg.4
     op: torch.neg
     inputs:
@@ -2484,7 +2358,6 @@ cases:
       code: return torch.cat((-x2, x1), dim=-1)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.cat.6
     op: torch.cat
     inputs:
@@ -2506,7 +2379,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.add.10
@@ -2530,7 +2402,6 @@ cases:
       code: return (x * cos) + (rotate_half(x) * sin)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.transpose.7
     op: torch.transpose
     inputs:
@@ -2548,7 +2419,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.index_copy_.2
     op: torch.index_copy_
     inputs:
@@ -2581,7 +2451,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.getitem.9
     op: torch.getitem
     inputs:
@@ -2598,7 +2467,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.getitem.10
     op: torch.getitem
     inputs:
@@ -2615,7 +2483,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.scaled_dot_product_attention.6
     op: torch.nn.functional.scaled_dot_product_attention
     inputs:
@@ -2644,7 +2511,6 @@ cases:
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -2666,7 +2532,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.contiguous.3
     op: torch.Tensor.contiguous
     inputs:
@@ -2681,7 +2546,6 @@ cases:
       code: attn_output = attn_output.transpose(1, 2).contiguous()'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.reshape.3
     op: torch.reshape
     inputs:
@@ -2698,7 +2562,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.contiguous.4
     op: torch.Tensor.contiguous
     inputs:
@@ -2713,7 +2576,6 @@ cases:
       code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.nn.functional.linear.8
     op: torch.nn.functional.linear
     inputs:
@@ -2737,7 +2599,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.scaled_dot_product_attention.7
     op: torch.nn.functional.scaled_dot_product_attention
     inputs:
@@ -2766,7 +2627,6 @@ cases:
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -2799,7 +2659,6 @@ cases:
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -2820,7 +2679,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.linear.9
     op: torch.nn.functional.linear
     inputs:
@@ -2844,7 +2702,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.truediv.1
     op: torch.truediv
     inputs:
@@ -2861,7 +2718,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.tanh.1
     op: torch.tanh
     inputs:
@@ -2876,7 +2732,6 @@ cases:
       code: logits = torch.tanh(logits)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.mul.19
     op: torch.mul
     inputs:
@@ -2893,7 +2748,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.eq.2
     op: torch.eq
     inputs:
@@ -2911,7 +2765,6 @@ cases:
       code: special_image_mask = input_ids == self.config.image_token_id'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.or_.2
     op: torch.or_
     inputs:
@@ -2929,7 +2782,6 @@ cases:
           device: cuda
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L1034 in forward,
       code: multimodal_mask = image_mask | video_mask | audio_mask'
-    marks: tensorsoncpu
   - name: torch.clone.2
     op: torch.clone
     inputs:
@@ -2944,7 +2796,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L1039 in forward,
       code: llm_input_ids = input_ids.clone()'
-    marks: tensorsoncpu
   - name: torch.where.2
     op: torch.where
     inputs:
@@ -2968,7 +2819,6 @@ cases:
       code: llm_input_ids = torch.where(multimodal_mask, self.config.text_config.pad_token_id, llm_input_ids)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.embedding.2
     op: torch.nn.functional.embedding
     inputs:
@@ -2998,7 +2848,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.mul.20
     op: torch.mul
     inputs:
@@ -3020,7 +2869,6 @@ cases:
       code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.getitem.12
     op: torch.getitem
     inputs:
@@ -3038,7 +2886,6 @@ cases:
       code: position_ids_expanded = position_ids[:, None, :].float()'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.13
     op: torch.float
     inputs:
@@ -3053,7 +2900,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L274 in forward,
       code: position_ids_expanded = position_ids[:, None, :].float()'
-    marks: tensorsoncpu
   - name: torch.float.14
     op: torch.float
     inputs:
@@ -3068,7 +2914,6 @@ cases:
       code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.matmul.3
     op: torch.matmul
     inputs:
@@ -3090,7 +2935,6 @@ cases:
       code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.transpose.9
     op: torch.transpose
     inputs:
@@ -3108,7 +2952,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.cat.7
     op: torch.cat
     inputs:
@@ -3130,7 +2973,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.cos.3
@@ -3147,7 +2989,6 @@ cases:
       code: cos = emb.cos() * attention_scaling'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.mul.21
     op: torch.mul
     inputs:
@@ -3164,7 +3005,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.sin.3
     op: torch.sin
     inputs:
@@ -3179,7 +3019,6 @@ cases:
       code: sin = emb.sin() * attention_scaling'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.to.7
     op: torch.to
     inputs:
@@ -3194,7 +3033,6 @@ cases:
       code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
     marks:
       - fp32operation
-      - tensorsoncpu
     kwmap:
       dtype: torch.bfloat16
   - name: torch.matmul.4
@@ -3218,7 +3056,6 @@ cases:
       code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.transpose.10
     op: torch.transpose
     inputs:
@@ -3236,7 +3073,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.cat.8
     op: torch.cat
     inputs:
@@ -3258,7 +3094,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.cos.4
@@ -3275,7 +3110,6 @@ cases:
       code: cos = emb.cos() * attention_scaling'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.mul.22
     op: torch.mul
     inputs:
@@ -3292,7 +3126,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.sin.4
     op: torch.sin
     inputs:
@@ -3307,7 +3140,6 @@ cases:
       code: sin = emb.sin() * attention_scaling'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.to.8
     op: torch.to
     inputs:
@@ -3322,7 +3154,6 @@ cases:
       code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
     marks:
       - fp32operation
-      - tensorsoncpu
     kwmap:
       dtype: torch.bfloat16
   - name: torch.float.15
@@ -3339,7 +3170,6 @@ cases:
       code: normed_output = self._norm(hidden_states.float())'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.pow.10
     op: torch.pow
     inputs:
@@ -3356,7 +3186,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mean.6
     op: torch.mean
     inputs:
@@ -3373,7 +3202,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.11
@@ -3392,7 +3220,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.pow.11
     op: torch.pow
     inputs:
@@ -3409,7 +3236,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mul.23
     op: torch.mul
     inputs:
@@ -3431,7 +3257,6 @@ cases:
       code: return hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.mul.24
     op: torch.mul
     inputs:
@@ -3453,7 +3278,6 @@ cases:
       code: normed_output = normed_output * self.weight.float()'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.type_as.6
     op: torch.type_as
     inputs:
@@ -3476,7 +3300,6 @@ cases:
     marks:
       - fp32operation
       - bf16operation
-      - tensorsoncpu
   - name: torch.getitem.13
     op: torch.getitem
     inputs:
@@ -3493,7 +3316,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.linear.10
     op: torch.nn.functional.linear
     inputs:
@@ -3517,4 +3339,3 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu

--- a/tests/resource/models/gemma-4-12B-it_spyre.yaml
+++ b/tests/resource/models/gemma-4-12B-it_spyre.yaml
@@ -22,7 +22,6 @@ cases:
       code: special_image_mask = input_ids == self.config.image_token_id'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.or_.1_spyre
     op: torch.or_
     inputs:
@@ -40,7 +39,6 @@ cases:
           device: cuda
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L1034 in forward,
       code: multimodal_mask = image_mask | video_mask | audio_mask'
-    marks: tensorsoncpu
   - name: torch.clone.1_spyre
     op: torch.clone
     inputs:
@@ -55,7 +53,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L1039 in forward,
       code: llm_input_ids = input_ids.clone()'
-    marks: tensorsoncpu
   - name: torch.where.1_spyre
     op: torch.where
     inputs:
@@ -79,7 +76,6 @@ cases:
       code: llm_input_ids = torch.where(multimodal_mask, self.config.text_config.pad_token_id, llm_input_ids)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.embedding.1_spyre
     op: torch.nn.functional.embedding
     inputs:
@@ -108,7 +104,6 @@ cases:
       code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.to.1_spyre
     op: torch.to
     inputs:
@@ -124,7 +119,6 @@ cases:
       code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.1_spyre
     op: torch.mul
     inputs:
@@ -144,7 +138,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L558 in forward,
       code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
-    marks: tensorsoncpu
   - name: torch.getitem.1_spyre
     op: torch.getitem
     inputs:
@@ -160,7 +153,6 @@ cases:
       code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.1_spyre
     op: torch.float
     inputs:
@@ -173,7 +165,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L273 in forward,
       code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
-    marks: tensorsoncpu
   - name: torch.Tensor.expand.1_spyre
     op: torch.Tensor.expand
     inputs:
@@ -191,7 +182,6 @@ cases:
       code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.to.2_spyre
     op: torch.to
     inputs:
@@ -207,7 +197,6 @@ cases:
       code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.getitem.2_spyre
     op: torch.getitem
     inputs:
@@ -225,7 +214,6 @@ cases:
       code: position_ids_expanded = position_ids[:, None, :].float()'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.2_spyre
     op: torch.float
     inputs:
@@ -240,7 +228,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L274 in forward,
       code: position_ids_expanded = position_ids[:, None, :].float()'
-    marks: tensorsoncpu
   - name: torch.float.3_spyre
     op: torch.float
     inputs:
@@ -253,7 +240,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L278 in forward,
       code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
-    marks: tensorsoncpu
   - name: torch.matmul.1_spyre
     op: torch.matmul
     inputs:
@@ -273,7 +259,6 @@ cases:
           init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L278 in forward,
       code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
-    marks: tensorsoncpu
   - name: torch.transpose.1_spyre
     op: torch.transpose
     inputs:
@@ -290,7 +275,6 @@ cases:
       code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.cat.1_spyre
     op: torch.cat
     inputs:
@@ -311,7 +295,6 @@ cases:
       code: emb = torch.cat((freqs, freqs), dim=-1)'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.cos.1_spyre
@@ -326,7 +309,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L280 in forward,
       code: cos = emb.cos() * attention_scaling'
-    marks: tensorsoncpu
   - name: torch.mul.2_spyre
     op: torch.mul
     inputs:
@@ -342,7 +324,6 @@ cases:
       code: cos = emb.cos() * attention_scaling'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.sin.1_spyre
     op: torch.sin
     inputs:
@@ -355,7 +336,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L281 in forward,
       code: sin = emb.sin() * attention_scaling'
-    marks: tensorsoncpu
   - name: torch.to.3_spyre
     op: torch.to
     inputs:
@@ -368,7 +348,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L283 in forward,
       code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
-    marks: tensorsoncpu
     kwmap:
       dtype: torch.float16
   - name: torch.getitem.3_spyre
@@ -386,7 +365,6 @@ cases:
       code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.4_spyre
     op: torch.float
     inputs:
@@ -399,7 +377,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L273 in forward,
       code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
-    marks: tensorsoncpu
   - name: torch.Tensor.expand.2_spyre
     op: torch.Tensor.expand
     inputs:
@@ -417,7 +394,6 @@ cases:
       code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.to.4_spyre
     op: torch.to
     inputs:
@@ -433,7 +409,6 @@ cases:
       code: inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.matmul.2_spyre
     op: torch.matmul
     inputs:
@@ -453,7 +428,6 @@ cases:
           init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L278 in forward,
       code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
-    marks: tensorsoncpu
   - name: torch.transpose.2_spyre
     op: torch.transpose
     inputs:
@@ -470,7 +444,6 @@ cases:
       code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.cat.2_spyre
     op: torch.cat
     inputs:
@@ -491,7 +464,6 @@ cases:
       code: emb = torch.cat((freqs, freqs), dim=-1)'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.cos.2_spyre
@@ -506,7 +478,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L280 in forward,
       code: cos = emb.cos() * attention_scaling'
-    marks: tensorsoncpu
   - name: torch.mul.3_spyre
     op: torch.mul
     inputs:
@@ -522,7 +493,6 @@ cases:
       code: cos = emb.cos() * attention_scaling'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.sin.2_spyre
     op: torch.sin
     inputs:
@@ -535,7 +505,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L281 in forward,
       code: sin = emb.sin() * attention_scaling'
-    marks: tensorsoncpu
   - name: torch.to.5_spyre
     op: torch.to
     inputs:
@@ -548,7 +517,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L283 in forward,
       code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
-    marks: tensorsoncpu
     kwmap:
       dtype: torch.float16
   - name: torch.float.5_spyre
@@ -563,7 +531,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L190 in forward,
       code: normed_output = self._norm(hidden_states.float())'
-    marks: tensorsoncpu
   - name: torch.pow.1_spyre
     op: torch.pow
     inputs:
@@ -579,7 +546,6 @@ cases:
       code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mean.1_spyre
     op: torch.mean
     inputs:
@@ -595,7 +561,6 @@ cases:
       code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.1_spyre
@@ -613,7 +578,6 @@ cases:
       code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.pow.2_spyre
     op: torch.pow
     inputs:
@@ -629,7 +593,6 @@ cases:
       code: return hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.4_spyre
     op: torch.mul
     inputs:
@@ -649,7 +612,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L187 in _norm,
       code: return hidden_states * torch.pow(mean_squared, -0.5)'
-    marks: tensorsoncpu
   - name: torch.float.6_spyre
     op: torch.float
     inputs:
@@ -662,7 +624,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L192 in forward,
       code: normed_output = normed_output * self.weight.float()'
-    marks: tensorsoncpu
   - name: torch.mul.5_spyre
     op: torch.mul
     inputs:
@@ -682,7 +643,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L192 in forward,
       code: normed_output = normed_output * self.weight.float()'
-    marks: tensorsoncpu
   - name: torch.type_as.1_spyre
     op: torch.type_as
     inputs:
@@ -702,7 +662,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L193 in forward,
       code: return normed_output.type_as(hidden_states)'
-    marks: tensorsoncpu
   - name: torch.nn.functional.linear.1_spyre
     op: torch.nn.functional.linear
     inputs:
@@ -725,7 +684,6 @@ cases:
       code: query_states = self.q_proj(hidden_states).view(hidden_shape)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.view.1_spyre
     op: torch.Tensor.view
     inputs:
@@ -741,7 +699,6 @@ cases:
       code: query_states = self.q_proj(hidden_states).view(hidden_shape)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.7_spyre
     op: torch.float
     inputs:
@@ -754,7 +711,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L190 in forward,
       code: normed_output = self._norm(hidden_states.float())'
-    marks: tensorsoncpu
   - name: torch.pow.3_spyre
     op: torch.pow
     inputs:
@@ -770,7 +726,6 @@ cases:
       code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mean.2_spyre
     op: torch.mean
     inputs:
@@ -786,7 +741,6 @@ cases:
       code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.2_spyre
@@ -804,7 +758,6 @@ cases:
       code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.pow.4_spyre
     op: torch.pow
     inputs:
@@ -820,7 +773,6 @@ cases:
       code: return hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.6_spyre
     op: torch.mul
     inputs:
@@ -840,7 +792,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L187 in _norm,
       code: return hidden_states * torch.pow(mean_squared, -0.5)'
-    marks: tensorsoncpu
   - name: torch.float.8_spyre
     op: torch.float
     inputs:
@@ -853,7 +804,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L192 in forward,
       code: normed_output = normed_output * self.weight.float()'
-    marks: tensorsoncpu
   - name: torch.mul.7_spyre
     op: torch.mul
     inputs:
@@ -873,7 +823,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L192 in forward,
       code: normed_output = normed_output * self.weight.float()'
-    marks: tensorsoncpu
   - name: torch.type_as.2_spyre
     op: torch.type_as
     inputs:
@@ -893,7 +842,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L193 in forward,
       code: return normed_output.type_as(hidden_states)'
-    marks: tensorsoncpu
   - name: torch.unsqueeze.1_spyre
     op: torch.unsqueeze
     inputs:
@@ -909,7 +857,6 @@ cases:
       code: cos = cos.unsqueeze(unsqueeze_dim)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.8_spyre
     op: torch.mul
     inputs:
@@ -929,7 +876,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L312 in apply_rotary_pos_emb,
       code: return (x * cos) + (rotate_half(x) * sin)'
-    marks: tensorsoncpu
   - name: torch.getitem.4_spyre
     op: torch.getitem
     inputs:
@@ -945,7 +891,6 @@ cases:
       code: x1 = x[..., : x.shape[-1] // 2]'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.neg.1_spyre
     op: torch.neg
     inputs:
@@ -958,7 +903,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L290 in rotate_half,
       code: return torch.cat((-x2, x1), dim=-1)'
-    marks: tensorsoncpu
   - name: torch.cat.3_spyre
     op: torch.cat
     inputs:
@@ -979,7 +923,6 @@ cases:
       code: return torch.cat((-x2, x1), dim=-1)'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.add.3_spyre
@@ -1001,7 +944,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L312 in apply_rotary_pos_emb,
       code: return (x * cos) + (rotate_half(x) * sin)'
-    marks: tensorsoncpu
   - name: torch.transpose.3_spyre
     op: torch.transpose
     inputs:
@@ -1018,7 +960,6 @@ cases:
       code: query_states = query_states.transpose(1, 2)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.linear.2_spyre
     op: torch.nn.functional.linear
     inputs:
@@ -1041,7 +982,6 @@ cases:
       code: key_states = self.k_proj(hidden_states).view(hidden_shape)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.view.2_spyre
     op: torch.Tensor.view
     inputs:
@@ -1057,7 +997,6 @@ cases:
       code: key_states = self.k_proj(hidden_states).view(hidden_shape)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.9_spyre
     op: torch.float
     inputs:
@@ -1070,7 +1009,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L190 in forward,
       code: normed_output = self._norm(hidden_states.float())'
-    marks: tensorsoncpu
   - name: torch.pow.5_spyre
     op: torch.pow
     inputs:
@@ -1086,7 +1024,6 @@ cases:
       code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mean.3_spyre
     op: torch.mean
     inputs:
@@ -1102,7 +1039,6 @@ cases:
       code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.4_spyre
@@ -1120,7 +1056,6 @@ cases:
       code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.pow.6_spyre
     op: torch.pow
     inputs:
@@ -1136,7 +1071,6 @@ cases:
       code: return hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.9_spyre
     op: torch.mul
     inputs:
@@ -1156,7 +1090,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L187 in _norm,
       code: return hidden_states * torch.pow(mean_squared, -0.5)'
-    marks: tensorsoncpu
   - name: torch.mul.10_spyre
     op: torch.mul
     inputs:
@@ -1176,7 +1109,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L192 in forward,
       code: normed_output = normed_output * self.weight.float()'
-    marks: tensorsoncpu
   - name: torch.type_as.3_spyre
     op: torch.type_as
     inputs:
@@ -1196,7 +1128,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L193 in forward,
       code: return normed_output.type_as(hidden_states)'
-    marks: tensorsoncpu
   - name: torch.mul.11_spyre
     op: torch.mul
     inputs:
@@ -1216,7 +1147,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L312 in apply_rotary_pos_emb,
       code: return (x * cos) + (rotate_half(x) * sin)'
-    marks: tensorsoncpu
   - name: torch.getitem.5_spyre
     op: torch.getitem
     inputs:
@@ -1232,7 +1162,6 @@ cases:
       code: x1 = x[..., : x.shape[-1] // 2]'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.neg.2_spyre
     op: torch.neg
     inputs:
@@ -1245,7 +1174,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L290 in rotate_half,
       code: return torch.cat((-x2, x1), dim=-1)'
-    marks: tensorsoncpu
   - name: torch.cat.4_spyre
     op: torch.cat
     inputs:
@@ -1266,7 +1194,6 @@ cases:
       code: return torch.cat((-x2, x1), dim=-1)'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.add.5_spyre
@@ -1288,7 +1215,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L312 in apply_rotary_pos_emb,
       code: return (x * cos) + (rotate_half(x) * sin)'
-    marks: tensorsoncpu
   - name: torch.transpose.4_spyre
     op: torch.transpose
     inputs:
@@ -1305,7 +1231,6 @@ cases:
       code: key_states = key_states.transpose(1, 2)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.zeros.1_spyre
     op: torch.zeros
     inputs:
@@ -1314,7 +1239,6 @@ cases:
       = torch.zeros('
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dtype: torch.float16
       device: cpu
@@ -1335,7 +1259,6 @@ cases:
       = self.cumulative_length.to(self.device)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.arange.1_spyre
     op: torch.arange
     inputs:
@@ -1344,7 +1267,6 @@ cases:
       device=self.device) + self.cumulative_length'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       device: cpu
   - name: torch.add.6_spyre
@@ -1370,7 +1292,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/cache_utils.py#L529 in update, code: cache_position = torch.arange(kv_length,
       device=self.device) + self.cumulative_length'
-    marks: tensorsoncpu
   - name: torch.index_copy_.1_spyre
     op: torch.index_copy_
     inputs:
@@ -1402,7 +1323,6 @@ cases:
       cache_position, key_states)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.add_.1_spyre
     op: torch.add_
     inputs:
@@ -1419,7 +1339,6 @@ cases:
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/cache_utils.py#L539 in update, code: self.cumulative_length.add_(kv_length)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.getitem.6_spyre
     op: torch.getitem
     inputs:
@@ -1435,7 +1354,6 @@ cases:
       = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.expand.3_spyre
     op: torch.Tensor.expand
     inputs:
@@ -1455,7 +1373,6 @@ cases:
       = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.reshape.1_spyre
     op: torch.reshape
     inputs:
@@ -1471,7 +1388,6 @@ cases:
       hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.scaled_dot_product_attention.1_spyre
     op: torch.nn.functional.scaled_dot_product_attention
     inputs:
@@ -1498,7 +1414,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
-    marks: tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -1519,7 +1434,6 @@ cases:
       code: attn_output = attn_output.transpose(1, 2).contiguous()'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.contiguous.1_spyre
     op: torch.Tensor.contiguous
     inputs:
@@ -1532,7 +1446,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L164 in sdpa_attention_forward,
       code: attn_output = attn_output.transpose(1, 2).contiguous()'
-    marks: tensorsoncpu
   - name: torch.reshape.2_spyre
     op: torch.reshape
     inputs:
@@ -1548,7 +1461,6 @@ cases:
       code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.contiguous.2_spyre
     op: torch.Tensor.contiguous
     inputs:
@@ -1561,7 +1473,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L472 in forward,
       code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
-    marks: tensorsoncpu
   - name: torch.nn.functional.linear.3_spyre
     op: torch.nn.functional.linear
     inputs:
@@ -1584,7 +1495,6 @@ cases:
       code: attn_output = self.o_proj(attn_output)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.add.7_spyre
     op: torch.add
     inputs:
@@ -1604,7 +1514,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L534 in forward,
       code: hidden_states = residual + hidden_states'
-    marks: tensorsoncpu
   - name: torch.nn.functional.linear.4_spyre
     op: torch.nn.functional.linear
     inputs:
@@ -1627,7 +1536,6 @@ cases:
       code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.gelu.1_spyre
     op: torch.nn.functional.gelu
     inputs:
@@ -1639,7 +1547,6 @@ cases:
           device: cuda
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/activations.py#L51 in forward, code: return self.act(input)'
-    marks: tensorsoncpu
     kwmap:
       approximate: tanh
   - name: torch.mul.12_spyre
@@ -1661,7 +1568,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L492 in forward,
       code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
-    marks: tensorsoncpu
   - name: torch.nn.functional.linear.5_spyre
     op: torch.nn.functional.linear
     inputs:
@@ -1684,7 +1590,6 @@ cases:
       code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.mul.1_spyre
     op: torch.Tensor.mul
     inputs:
@@ -1704,7 +1609,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L543 in forward,
       code: hidden_states *= self.layer_scalar'
-    marks: tensorsoncpu
   - name: torch.nn.functional.scaled_dot_product_attention.2_spyre
     op: torch.nn.functional.scaled_dot_product_attention
     inputs:
@@ -1731,7 +1635,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
-    marks: tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -1762,7 +1665,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
-    marks: tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -1793,7 +1695,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
-    marks: tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -1824,7 +1725,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
-    marks: tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -1851,7 +1751,6 @@ cases:
       code: query_states = self.q_proj(hidden_states).view(hidden_shape)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.10_spyre
     op: torch.float
     inputs:
@@ -1864,7 +1763,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L190 in forward,
       code: normed_output = self._norm(hidden_states.float())'
-    marks: tensorsoncpu
   - name: torch.pow.7_spyre
     op: torch.pow
     inputs:
@@ -1880,7 +1778,6 @@ cases:
       code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mean.4_spyre
     op: torch.mean
     inputs:
@@ -1896,7 +1793,6 @@ cases:
       code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.mul.13_spyre
@@ -1918,7 +1814,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L187 in _norm,
       code: return hidden_states * torch.pow(mean_squared, -0.5)'
-    marks: tensorsoncpu
   - name: torch.float.11_spyre
     op: torch.float
     inputs:
@@ -1931,7 +1826,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L192 in forward,
       code: normed_output = normed_output * self.weight.float()'
-    marks: tensorsoncpu
   - name: torch.mul.14_spyre
     op: torch.mul
     inputs:
@@ -1951,7 +1845,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L192 in forward,
       code: normed_output = normed_output * self.weight.float()'
-    marks: tensorsoncpu
   - name: torch.type_as.4_spyre
     op: torch.type_as
     inputs:
@@ -1971,7 +1864,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L193 in forward,
       code: return normed_output.type_as(hidden_states)'
-    marks: tensorsoncpu
   - name: torch.unsqueeze.2_spyre
     op: torch.unsqueeze
     inputs:
@@ -1987,7 +1879,6 @@ cases:
       code: cos = cos.unsqueeze(unsqueeze_dim)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.15_spyre
     op: torch.mul
     inputs:
@@ -2007,7 +1898,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L312 in apply_rotary_pos_emb,
       code: return (x * cos) + (rotate_half(x) * sin)'
-    marks: tensorsoncpu
   - name: torch.getitem.7_spyre
     op: torch.getitem
     inputs:
@@ -2023,7 +1913,6 @@ cases:
       code: x1 = x[..., : x.shape[-1] // 2]'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.neg.3_spyre
     op: torch.neg
     inputs:
@@ -2036,7 +1925,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L290 in rotate_half,
       code: return torch.cat((-x2, x1), dim=-1)'
-    marks: tensorsoncpu
   - name: torch.cat.5_spyre
     op: torch.cat
     inputs:
@@ -2057,7 +1945,6 @@ cases:
       code: return torch.cat((-x2, x1), dim=-1)'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.add.8_spyre
@@ -2079,7 +1966,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L312 in apply_rotary_pos_emb,
       code: return (x * cos) + (rotate_half(x) * sin)'
-    marks: tensorsoncpu
   - name: torch.transpose.6_spyre
     op: torch.transpose
     inputs:
@@ -2096,7 +1982,6 @@ cases:
       code: query_states = query_states.transpose(1, 2)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.linear.7_spyre
     op: torch.nn.functional.linear
     inputs:
@@ -2119,7 +2004,6 @@ cases:
       code: key_states = self.k_proj(hidden_states).view(hidden_shape)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.12_spyre
     op: torch.float
     inputs:
@@ -2132,7 +2016,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L190 in forward,
       code: normed_output = self._norm(hidden_states.float())'
-    marks: tensorsoncpu
   - name: torch.pow.8_spyre
     op: torch.pow
     inputs:
@@ -2148,7 +2031,6 @@ cases:
       code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mean.5_spyre
     op: torch.mean
     inputs:
@@ -2164,7 +2046,6 @@ cases:
       code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.9_spyre
@@ -2182,7 +2063,6 @@ cases:
       code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.pow.9_spyre
     op: torch.pow
     inputs:
@@ -2198,7 +2078,6 @@ cases:
       code: return hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.16_spyre
     op: torch.mul
     inputs:
@@ -2218,7 +2097,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L187 in _norm,
       code: return hidden_states * torch.pow(mean_squared, -0.5)'
-    marks: tensorsoncpu
   - name: torch.mul.17_spyre
     op: torch.mul
     inputs:
@@ -2238,7 +2116,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L192 in forward,
       code: normed_output = normed_output * self.weight.float()'
-    marks: tensorsoncpu
   - name: torch.type_as.5_spyre
     op: torch.type_as
     inputs:
@@ -2258,7 +2135,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L193 in forward,
       code: return normed_output.type_as(hidden_states)'
-    marks: tensorsoncpu
   - name: torch.mul.18_spyre
     op: torch.mul
     inputs:
@@ -2278,7 +2154,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L312 in apply_rotary_pos_emb,
       code: return (x * cos) + (rotate_half(x) * sin)'
-    marks: tensorsoncpu
   - name: torch.getitem.8_spyre
     op: torch.getitem
     inputs:
@@ -2294,7 +2169,6 @@ cases:
       code: x1 = x[..., : x.shape[-1] // 2]'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.neg.4_spyre
     op: torch.neg
     inputs:
@@ -2307,7 +2181,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L290 in rotate_half,
       code: return torch.cat((-x2, x1), dim=-1)'
-    marks: tensorsoncpu
   - name: torch.cat.6_spyre
     op: torch.cat
     inputs:
@@ -2328,7 +2201,6 @@ cases:
       code: return torch.cat((-x2, x1), dim=-1)'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.add.10_spyre
@@ -2350,7 +2222,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L312 in apply_rotary_pos_emb,
       code: return (x * cos) + (rotate_half(x) * sin)'
-    marks: tensorsoncpu
   - name: torch.transpose.7_spyre
     op: torch.transpose
     inputs:
@@ -2367,7 +2238,6 @@ cases:
       code: key_states = key_states.transpose(1, 2)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.index_copy_.2_spyre
     op: torch.index_copy_
     inputs:
@@ -2399,7 +2269,6 @@ cases:
       cache_position, key_states)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.getitem.9_spyre
     op: torch.getitem
     inputs:
@@ -2415,7 +2284,6 @@ cases:
       = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.getitem.10_spyre
     op: torch.getitem
     inputs:
@@ -2431,7 +2299,6 @@ cases:
       code: key = key[:, :, :q_length, :]'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.scaled_dot_product_attention.6_spyre
     op: torch.nn.functional.scaled_dot_product_attention
     inputs:
@@ -2458,7 +2325,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
-    marks: tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -2479,7 +2345,6 @@ cases:
       code: attn_output = attn_output.transpose(1, 2).contiguous()'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.contiguous.3_spyre
     op: torch.Tensor.contiguous
     inputs:
@@ -2492,7 +2357,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L164 in sdpa_attention_forward,
       code: attn_output = attn_output.transpose(1, 2).contiguous()'
-    marks: tensorsoncpu
   - name: torch.reshape.3_spyre
     op: torch.reshape
     inputs:
@@ -2508,7 +2372,6 @@ cases:
       code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.contiguous.4_spyre
     op: torch.Tensor.contiguous
     inputs:
@@ -2521,7 +2384,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L472 in forward,
       code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
-    marks: tensorsoncpu
   - name: torch.nn.functional.linear.8_spyre
     op: torch.nn.functional.linear
     inputs:
@@ -2544,7 +2406,6 @@ cases:
       code: attn_output = self.o_proj(attn_output)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.scaled_dot_product_attention.7_spyre
     op: torch.nn.functional.scaled_dot_product_attention
     inputs:
@@ -2571,7 +2432,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
-    marks: tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -2602,7 +2462,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
-    marks: tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -2622,7 +2481,6 @@ cases:
       code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.linear.9_spyre
     op: torch.nn.functional.linear
     inputs:
@@ -2645,7 +2503,6 @@ cases:
       code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.truediv.1_spyre
     op: torch.truediv
     inputs:
@@ -2661,7 +2518,6 @@ cases:
       code: logits = logits / final_logit_softcapping'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.tanh.1_spyre
     op: torch.tanh
     inputs:
@@ -2674,7 +2530,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L1338 in torch_dynamo_resume_in_forward_at_1313,
       code: logits = torch.tanh(logits)'
-    marks: tensorsoncpu
   - name: torch.mul.19_spyre
     op: torch.mul
     inputs:
@@ -2690,7 +2545,6 @@ cases:
       code: logits = logits * final_logit_softcapping'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.eq.2_spyre
     op: torch.eq
     inputs:
@@ -2708,7 +2562,6 @@ cases:
       code: special_image_mask = input_ids == self.config.image_token_id'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.or_.2_spyre
     op: torch.or_
     inputs:
@@ -2726,7 +2579,6 @@ cases:
           device: cuda
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L1034 in forward,
       code: multimodal_mask = image_mask | video_mask | audio_mask'
-    marks: tensorsoncpu
   - name: torch.clone.2_spyre
     op: torch.clone
     inputs:
@@ -2741,7 +2593,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L1039 in forward,
       code: llm_input_ids = input_ids.clone()'
-    marks: tensorsoncpu
   - name: torch.where.2_spyre
     op: torch.where
     inputs:
@@ -2765,7 +2616,6 @@ cases:
       code: llm_input_ids = torch.where(multimodal_mask, self.config.text_config.pad_token_id, llm_input_ids)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.embedding.2_spyre
     op: torch.nn.functional.embedding
     inputs:
@@ -2794,7 +2644,6 @@ cases:
       code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.20_spyre
     op: torch.mul
     inputs:
@@ -2814,7 +2663,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L558 in forward,
       code: return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
-    marks: tensorsoncpu
   - name: torch.getitem.12_spyre
     op: torch.getitem
     inputs:
@@ -2832,7 +2680,6 @@ cases:
       code: position_ids_expanded = position_ids[:, None, :].float()'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.13_spyre
     op: torch.float
     inputs:
@@ -2847,7 +2694,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L274 in forward,
       code: position_ids_expanded = position_ids[:, None, :].float()'
-    marks: tensorsoncpu
   - name: torch.float.14_spyre
     op: torch.float
     inputs:
@@ -2860,7 +2706,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L278 in forward,
       code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
-    marks: tensorsoncpu
   - name: torch.matmul.3_spyre
     op: torch.matmul
     inputs:
@@ -2880,7 +2725,6 @@ cases:
           init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L278 in forward,
       code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
-    marks: tensorsoncpu
   - name: torch.transpose.9_spyre
     op: torch.transpose
     inputs:
@@ -2897,7 +2741,6 @@ cases:
       code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.cat.7_spyre
     op: torch.cat
     inputs:
@@ -2918,7 +2761,6 @@ cases:
       code: emb = torch.cat((freqs, freqs), dim=-1)'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.cos.3_spyre
@@ -2933,7 +2775,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L280 in forward,
       code: cos = emb.cos() * attention_scaling'
-    marks: tensorsoncpu
   - name: torch.mul.21_spyre
     op: torch.mul
     inputs:
@@ -2949,7 +2790,6 @@ cases:
       code: cos = emb.cos() * attention_scaling'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.sin.3_spyre
     op: torch.sin
     inputs:
@@ -2962,7 +2802,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L281 in forward,
       code: sin = emb.sin() * attention_scaling'
-    marks: tensorsoncpu
   - name: torch.to.7_spyre
     op: torch.to
     inputs:
@@ -2975,7 +2814,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L283 in forward,
       code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
-    marks: tensorsoncpu
     kwmap:
       dtype: torch.float16
   - name: torch.matmul.4_spyre
@@ -2997,7 +2835,6 @@ cases:
           init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L278 in forward,
       code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
-    marks: tensorsoncpu
   - name: torch.transpose.10_spyre
     op: torch.transpose
     inputs:
@@ -3014,7 +2851,6 @@ cases:
       code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.cat.8_spyre
     op: torch.cat
     inputs:
@@ -3035,7 +2871,6 @@ cases:
       code: emb = torch.cat((freqs, freqs), dim=-1)'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.cos.4_spyre
@@ -3050,7 +2885,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L280 in forward,
       code: cos = emb.cos() * attention_scaling'
-    marks: tensorsoncpu
   - name: torch.mul.22_spyre
     op: torch.mul
     inputs:
@@ -3066,7 +2900,6 @@ cases:
       code: cos = emb.cos() * attention_scaling'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.sin.4_spyre
     op: torch.sin
     inputs:
@@ -3079,7 +2912,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L281 in forward,
       code: sin = emb.sin() * attention_scaling'
-    marks: tensorsoncpu
   - name: torch.to.8_spyre
     op: torch.to
     inputs:
@@ -3092,7 +2924,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L283 in forward,
       code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
-    marks: tensorsoncpu
     kwmap:
       dtype: torch.float16
   - name: torch.float.15_spyre
@@ -3107,7 +2938,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L190 in forward,
       code: normed_output = self._norm(hidden_states.float())'
-    marks: tensorsoncpu
   - name: torch.pow.10_spyre
     op: torch.pow
     inputs:
@@ -3123,7 +2953,6 @@ cases:
       code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mean.6_spyre
     op: torch.mean
     inputs:
@@ -3139,7 +2968,6 @@ cases:
       code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.11_spyre
@@ -3157,7 +2985,6 @@ cases:
       code: mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.pow.11_spyre
     op: torch.pow
     inputs:
@@ -3173,7 +3000,6 @@ cases:
       code: return hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.23_spyre
     op: torch.mul
     inputs:
@@ -3193,7 +3019,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L187 in _norm,
       code: return hidden_states * torch.pow(mean_squared, -0.5)'
-    marks: tensorsoncpu
   - name: torch.mul.24_spyre
     op: torch.mul
     inputs:
@@ -3213,7 +3038,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L192 in forward,
       code: normed_output = normed_output * self.weight.float()'
-    marks: tensorsoncpu
   - name: torch.type_as.6_spyre
     op: torch.type_as
     inputs:
@@ -3233,7 +3057,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4_unified/modeling_gemma4_unified.py#L193 in forward,
       code: return normed_output.type_as(hidden_states)'
-    marks: tensorsoncpu
   - name: torch.getitem.13_spyre
     op: torch.getitem
     inputs:
@@ -3249,7 +3072,6 @@ cases:
       code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.linear.10_spyre
     op: torch.nn.functional.linear
     inputs:
@@ -3272,4 +3094,3 @@ cases:
       code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
     marks:
       - constant
-      - tensorsoncpu

--- a/tests/resource/models/gemma-4-26B-A4B-it.yaml
+++ b/tests/resource/models/gemma-4-26B-A4B-it.yaml
@@ -22,7 +22,6 @@ cases:
       code: special_image_mask = input_ids == self.config.image_token_id'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.or_.1
     op: torch.or_
     inputs:
@@ -40,7 +39,6 @@ cases:
           device: cuda
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2320 in forward, code: multimodal_mask
       = image_mask | video_mask | audio_mask'
-    marks: tensorsoncpu
   - name: torch.clone.1
     op: torch.clone
     inputs:
@@ -55,7 +53,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2325 in forward, code: llm_input_ids
       = input_ids.clone()'
-    marks: tensorsoncpu
   - name: torch.where.1
     op: torch.where
     inputs:
@@ -79,7 +76,6 @@ cases:
       = torch.where(multimodal_mask, self.config.text_config.pad_token_id, llm_input_ids)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.embedding.1
     op: torch.nn.functional.embedding
     inputs:
@@ -109,7 +105,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.to.1
     op: torch.to
     inputs:
@@ -125,7 +120,6 @@ cases:
       super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.1
     op: torch.mul
     inputs:
@@ -147,7 +141,6 @@ cases:
       super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.getitem.1
     op: torch.getitem
     inputs:
@@ -164,7 +157,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.float.1
     op: torch.float
     inputs:
@@ -179,7 +171,6 @@ cases:
       = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.Tensor.expand.1
     op: torch.Tensor.expand
     inputs:
@@ -198,7 +189,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.to.2
     op: torch.to
     inputs:
@@ -215,7 +205,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.getitem.2
     op: torch.getitem
     inputs:
@@ -233,7 +222,6 @@ cases:
       = position_ids[:, None, :].float()'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.2
     op: torch.float
     inputs:
@@ -248,7 +236,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1171 in forward, code: position_ids_expanded
       = position_ids[:, None, :].float()'
-    marks: tensorsoncpu
   - name: torch.float.3
     op: torch.float
     inputs:
@@ -263,7 +250,6 @@ cases:
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.matmul.1
     op: torch.matmul
     inputs:
@@ -285,7 +271,6 @@ cases:
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.transpose.1
     op: torch.transpose
     inputs:
@@ -303,7 +288,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.cat.1
     op: torch.cat
     inputs:
@@ -325,7 +309,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.cos.1
@@ -342,7 +325,6 @@ cases:
       = emb.cos() * attention_scaling'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.mul.2
     op: torch.mul
     inputs:
@@ -359,7 +341,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.sin.1
     op: torch.sin
     inputs:
@@ -374,7 +355,6 @@ cases:
       = emb.sin() * attention_scaling'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.to.3
     op: torch.to
     inputs:
@@ -389,7 +369,6 @@ cases:
       cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
     marks:
       - fp32operation
-      - tensorsoncpu
     kwmap:
       dtype: torch.bfloat16
   - name: torch.getitem.3
@@ -408,7 +387,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.float.4
     op: torch.float
     inputs:
@@ -423,7 +401,6 @@ cases:
       = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.Tensor.expand.2
     op: torch.Tensor.expand
     inputs:
@@ -442,7 +419,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.to.4
     op: torch.to
     inputs:
@@ -459,7 +435,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.matmul.2
     op: torch.matmul
     inputs:
@@ -481,7 +456,6 @@ cases:
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.transpose.2
     op: torch.transpose
     inputs:
@@ -499,7 +473,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.cat.2
     op: torch.cat
     inputs:
@@ -521,7 +494,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.cos.2
@@ -538,7 +510,6 @@ cases:
       = emb.cos() * attention_scaling'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.mul.3
     op: torch.mul
     inputs:
@@ -555,7 +526,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.sin.2
     op: torch.sin
     inputs:
@@ -570,7 +540,6 @@ cases:
       = emb.sin() * attention_scaling'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.to.5
     op: torch.to
     inputs:
@@ -585,7 +554,6 @@ cases:
       cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
     marks:
       - fp32operation
-      - tensorsoncpu
     kwmap:
       dtype: torch.bfloat16
   - name: torch.float.5
@@ -602,7 +570,6 @@ cases:
       = self._norm(hidden_states.float())'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.pow.1
     op: torch.pow
     inputs:
@@ -619,7 +586,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mean.1
     op: torch.mean
     inputs:
@@ -636,7 +602,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.1
@@ -655,7 +620,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.pow.2
     op: torch.pow
     inputs:
@@ -672,7 +636,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mul.4
     op: torch.mul
     inputs:
@@ -694,7 +657,6 @@ cases:
       hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.float.6
     op: torch.float
     inputs:
@@ -709,7 +671,6 @@ cases:
       = normed_output * self.weight.float()'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.mul.5
     op: torch.mul
     inputs:
@@ -731,7 +692,6 @@ cases:
       = normed_output * self.weight.float()'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.type_as.1
     op: torch.type_as
     inputs:
@@ -754,7 +714,6 @@ cases:
     marks:
       - fp32operation
       - bf16operation
-      - tensorsoncpu
   - name: torch.nn.functional.linear.1
     op: torch.nn.functional.linear
     inputs:
@@ -778,7 +737,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.view.1
     op: torch.Tensor.view
     inputs:
@@ -795,7 +753,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.float.7
     op: torch.float
     inputs:
@@ -810,7 +767,6 @@ cases:
       = self._norm(hidden_states.float())'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.pow.3
     op: torch.pow
     inputs:
@@ -827,7 +783,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mean.2
     op: torch.mean
     inputs:
@@ -844,7 +799,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.2
@@ -863,7 +817,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.pow.4
     op: torch.pow
     inputs:
@@ -880,7 +833,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mul.6
     op: torch.mul
     inputs:
@@ -902,7 +854,6 @@ cases:
       hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.float.8
     op: torch.float
     inputs:
@@ -917,7 +868,6 @@ cases:
       = normed_output * self.weight.float()'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.mul.7
     op: torch.mul
     inputs:
@@ -939,7 +889,6 @@ cases:
       = normed_output * self.weight.float()'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.type_as.2
     op: torch.type_as
     inputs:
@@ -962,7 +911,6 @@ cases:
     marks:
       - fp32operation
       - bf16operation
-      - tensorsoncpu
   - name: torch.unsqueeze.1
     op: torch.unsqueeze
     inputs:
@@ -979,7 +927,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.mul.8
     op: torch.mul
     inputs:
@@ -1001,7 +948,6 @@ cases:
       code: return (x * cos) + (rotate_half(x) * sin)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.getitem.4
     op: torch.getitem
     inputs:
@@ -1018,7 +964,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.neg.1
     op: torch.neg
     inputs:
@@ -1033,7 +978,6 @@ cases:
       return torch.cat((-x2, x1), dim=-1)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.cat.3
     op: torch.cat
     inputs:
@@ -1055,7 +999,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.add.3
@@ -1079,7 +1022,6 @@ cases:
       code: return (x * cos) + (rotate_half(x) * sin)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.transpose.3
     op: torch.transpose
     inputs:
@@ -1097,7 +1039,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.linear.2
     op: torch.nn.functional.linear
     inputs:
@@ -1121,7 +1062,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.view.2
     op: torch.Tensor.view
     inputs:
@@ -1138,7 +1078,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.float.9
     op: torch.float
     inputs:
@@ -1153,7 +1092,6 @@ cases:
       = self._norm(hidden_states.float())'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.pow.5
     op: torch.pow
     inputs:
@@ -1170,7 +1108,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mean.3
     op: torch.mean
     inputs:
@@ -1187,7 +1124,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.4
@@ -1206,7 +1142,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.pow.6
     op: torch.pow
     inputs:
@@ -1223,7 +1158,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mul.9
     op: torch.mul
     inputs:
@@ -1245,7 +1179,6 @@ cases:
       hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.mul.10
     op: torch.mul
     inputs:
@@ -1267,7 +1200,6 @@ cases:
       = normed_output * self.weight.float()'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.type_as.3
     op: torch.type_as
     inputs:
@@ -1290,7 +1222,6 @@ cases:
     marks:
       - fp32operation
       - bf16operation
-      - tensorsoncpu
   - name: torch.mul.11
     op: torch.mul
     inputs:
@@ -1312,7 +1243,6 @@ cases:
       code: return (x * cos) + (rotate_half(x) * sin)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.getitem.5
     op: torch.getitem
     inputs:
@@ -1329,7 +1259,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.neg.2
     op: torch.neg
     inputs:
@@ -1344,7 +1273,6 @@ cases:
       return torch.cat((-x2, x1), dim=-1)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.cat.4
     op: torch.cat
     inputs:
@@ -1366,7 +1294,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.add.5
@@ -1390,7 +1317,6 @@ cases:
       code: return (x * cos) + (rotate_half(x) * sin)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.transpose.4
     op: torch.transpose
     inputs:
@@ -1408,7 +1334,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.zeros.1
     op: torch.zeros
     inputs:
@@ -1417,7 +1342,6 @@ cases:
       = torch.zeros('
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dtype: torch.bfloat16
       device: cpu
@@ -1438,7 +1362,6 @@ cases:
       = self.cumulative_length.to(self.device)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.arange.1
     op: torch.arange
     inputs:
@@ -1447,7 +1370,6 @@ cases:
       device=self.device) + self.cumulative_length'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       device: cpu
   - name: torch.add.6
@@ -1473,7 +1395,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/cache_utils.py#L529 in update, code: cache_position = torch.arange(kv_length,
       device=self.device) + self.cumulative_length'
-    marks: tensorsoncpu
   - name: torch.index_copy_.1
     op: torch.index_copy_
     inputs:
@@ -1506,7 +1427,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.add_.1
     op: torch.add_
     inputs:
@@ -1523,7 +1443,6 @@ cases:
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/cache_utils.py#L539 in update, code: self.cumulative_length.add_(kv_length)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.getitem.6
     op: torch.getitem
     inputs:
@@ -1540,7 +1459,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.expand.3
     op: torch.Tensor.expand
     inputs:
@@ -1561,7 +1479,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.reshape.1
     op: torch.reshape
     inputs:
@@ -1578,7 +1495,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.scaled_dot_product_attention.1
     op: torch.nn.functional.scaled_dot_product_attention
     inputs:
@@ -1607,7 +1523,6 @@ cases:
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -1629,7 +1544,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.contiguous.1
     op: torch.Tensor.contiguous
     inputs:
@@ -1644,7 +1558,6 @@ cases:
       code: attn_output = attn_output.transpose(1, 2).contiguous()'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.reshape.2
     op: torch.reshape
     inputs:
@@ -1661,7 +1574,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.contiguous.2
     op: torch.Tensor.contiguous
     inputs:
@@ -1676,7 +1588,6 @@ cases:
       = attn_output.reshape(*input_shape, -1).contiguous()'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.nn.functional.linear.3
     op: torch.nn.functional.linear
     inputs:
@@ -1700,7 +1611,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.add.7
     op: torch.add
     inputs:
@@ -1722,7 +1632,6 @@ cases:
       = residual + hidden_states'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.nn.functional.linear.4
     op: torch.nn.functional.linear
     inputs:
@@ -1746,7 +1655,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.gelu.1
     op: torch.nn.functional.gelu
     inputs:
@@ -1760,7 +1668,6 @@ cases:
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/activations.py#L51 in forward, code: return self.act(input)'
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       approximate: tanh
   - name: torch.mul.12
@@ -1784,7 +1691,6 @@ cases:
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.nn.functional.linear.5
     op: torch.nn.functional.linear
     inputs:
@@ -1808,7 +1714,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.reshape.3
     op: torch.reshape
     inputs:
@@ -1825,7 +1730,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.float.10
     op: torch.float
     inputs:
@@ -1840,7 +1744,6 @@ cases:
       = self._norm(hidden_states.float())'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.pow.7
     op: torch.pow
     inputs:
@@ -1857,7 +1760,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mean.4
     op: torch.mean
     inputs:
@@ -1874,7 +1776,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.8
@@ -1893,7 +1794,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.pow.8
     op: torch.pow
     inputs:
@@ -1910,7 +1810,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mul.13
     op: torch.mul
     inputs:
@@ -1932,7 +1831,6 @@ cases:
       hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.type_as.4
     op: torch.type_as
     inputs:
@@ -1955,7 +1853,6 @@ cases:
     marks:
       - fp32operation
       - bf16operation
-      - tensorsoncpu
   - name: torch.mul.14
     op: torch.mul
     inputs:
@@ -1977,7 +1874,6 @@ cases:
       = hidden_states * self.scale * self.scalar_root_size'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.mul.15
     op: torch.mul
     inputs:
@@ -1994,7 +1890,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.linear.6
     op: torch.nn.functional.linear
     inputs:
@@ -2018,7 +1913,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.softmax.1
     op: torch.nn.functional.softmax
     inputs:
@@ -2033,7 +1927,6 @@ cases:
       = nn.functional.softmax(expert_scores, dim=-1, dtype=torch.float32)'
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       dim: -1
       dtype: torch.float32
@@ -2051,7 +1944,6 @@ cases:
       top_k_index = torch.topk('
     marks:
       - fp32operation
-      - tensorsoncpu
     kwmap:
       k: 8
       dim: -1
@@ -2079,7 +1971,6 @@ cases:
     marks:
       - constant
       - fp32operation
-      - tensorsoncpu
   - name: torch.sum.1
     op: torch.sum
     inputs:
@@ -2094,7 +1985,6 @@ cases:
       /= top_k_weights.sum(dim=-1, keepdim=True)'
     marks:
       - fp32operation
-      - tensorsoncpu
     kwmap:
       dim: -1
       keepdim: true
@@ -2119,7 +2009,6 @@ cases:
       /= top_k_weights.sum(dim=-1, keepdim=True)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.getitem.8
     op: torch.getitem
     inputs:
@@ -2143,7 +2032,6 @@ cases:
       = top_k_weights * self.per_expert_scale[top_k_index]'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.mul.16
     op: torch.mul
     inputs:
@@ -2166,7 +2054,6 @@ cases:
     marks:
       - fp32operation
       - bf16operation
-      - tensorsoncpu
   - name: torch.mul.17
     op: torch.mul
     inputs:
@@ -2188,7 +2075,6 @@ cases:
       = normed_output * self.weight.float()'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.reshape.4
     op: torch.reshape
     inputs:
@@ -2205,7 +2091,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.reshape.5
     op: torch.reshape
     inputs:
@@ -2223,7 +2108,6 @@ cases:
       expert_ids = top_k_index.reshape(-1)  # (S,)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.sort.1
     op: torch.sort
     inputs:
@@ -2238,7 +2122,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L399 in grouped_mm_experts_forward, code:
       expert_ids_g, perm = torch.sort(expert_ids)'
-    marks: tensorsoncpu
   - name: torch.getitem.9
     op: torch.getitem
     inputs:
@@ -2264,7 +2147,6 @@ cases:
       expert_ids_g, perm = torch.sort(expert_ids)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.floordiv.1
     op: torch.floordiv
     inputs:
@@ -2282,7 +2164,6 @@ cases:
       selected_hidden_states_g = hidden_states[perm // num_top_k]'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.getitem.10
     op: torch.getitem
     inputs:
@@ -2306,7 +2187,6 @@ cases:
       selected_hidden_states_g = hidden_states[perm // num_top_k]'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.getitem.11
     op: torch.getitem
     inputs:
@@ -2330,7 +2210,6 @@ cases:
       sample_weights_g = sample_weights[perm]'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.float.11
     op: torch.float
     inputs:
@@ -2345,7 +2224,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L407 in grouped_mm_experts_forward, code:
       histc_input = expert_ids_g.float() if device.type in ("cpu", "mps") else expert_ids_g.int()'
-    marks: tensorsoncpu
   - name: torch.histc.1
     op: torch.histc
     inputs:
@@ -2360,7 +2238,6 @@ cases:
       tokens_per_expert = torch.histc(histc_input, bins=self.num_experts, min=0, max=self.num_experts - 1)'
     marks:
       - fp32operation
-      - tensorsoncpu
     kwmap:
       bins: 128
       min: 0
@@ -2379,7 +2256,6 @@ cases:
       offsets = torch.cumsum(tokens_per_expert, dim=0, dtype=torch.int32)'
     marks:
       - fp32operation
-      - tensorsoncpu
     kwmap:
       dim: 0
       dtype: torch.int32
@@ -2400,7 +2276,6 @@ cases:
       sentinel_mask = (expert_ids_g >= self.num_experts).unsqueeze(-1)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.unsqueeze.2
     op: torch.unsqueeze
     inputs:
@@ -2415,7 +2290,6 @@ cases:
       sentinel_mask = (expert_ids_g >= self.num_experts).unsqueeze(-1)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.clamp_.1
     op: torch.clamp_
     inputs:
@@ -2430,7 +2304,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L427 in grouped_mm_experts_forward, code:
       expert_ids_g.clamp_(max=self.num_experts - 1)'
-    marks: tensorsoncpu
     kwmap:
       max: 127
   - name: torch.masked_fill_.1
@@ -2455,7 +2328,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.transpose.6
     op: torch.transpose
     inputs:
@@ -2473,7 +2345,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.ops.transformers.grouped_mm_fallback.1
     op: torch.ops.transformers.grouped_mm_fallback
     inputs:
@@ -2495,7 +2366,6 @@ cases:
       code: return torch.ops.transformers.grouped_mm_fallback(input, weight, offs=offs)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.chunk.1
     op: torch.chunk
     inputs:
@@ -2512,7 +2382,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.getitem.12
@@ -2537,7 +2406,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.gelu.2
     op: torch.nn.functional.gelu
     inputs:
@@ -2551,7 +2419,6 @@ cases:
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/activations.py#L51 in forward, code: return self.act(input)'
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       approximate: tanh
   - name: torch.mul.18
@@ -2575,7 +2442,6 @@ cases:
       self.act_fn(gate) * up  # (S, intermediate_dim)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.transpose.7
     op: torch.transpose
     inputs:
@@ -2593,7 +2459,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.ops.transformers.grouped_mm_fallback.2
     op: torch.ops.transformers.grouped_mm_fallback
     inputs:
@@ -2615,7 +2480,6 @@ cases:
       code: return torch.ops.transformers.grouped_mm_fallback(input, weight, offs=offs)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.unsqueeze.3
     op: torch.unsqueeze
     inputs:
@@ -2632,7 +2496,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mul.19
     op: torch.mul
     inputs:
@@ -2655,7 +2518,6 @@ cases:
     marks:
       - fp32operation
       - bf16operation
-      - tensorsoncpu
   - name: torch.masked_fill_.2
     op: torch.masked_fill_
     inputs:
@@ -2678,7 +2540,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.empty_like.1
     op: torch.empty_like
     inputs:
@@ -2693,7 +2554,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L474 in torch_dynamo_resume_in_grouped_mm_experts_forward_at_463,
       code: inv_perm = torch.empty_like(perm)'
-    marks: tensorsoncpu
   - name: torch.setitem.1
     op: torch.setitem
     inputs:
@@ -2726,7 +2586,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L475 in torch_dynamo_resume_in_grouped_mm_experts_forward_at_463,
       code: inv_perm[perm] = torch.arange(perm.size(0), device=device)'
-    marks: tensorsoncpu
   - name: torch.getitem.13
     op: torch.getitem
     inputs:
@@ -2750,7 +2609,6 @@ cases:
       code: weighted_out = weighted_out[inv_perm]  # (S, hidden_dim)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.Tensor.view.3
     op: torch.Tensor.view
     inputs:
@@ -2769,7 +2627,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.sum.2
     op: torch.sum
     inputs:
@@ -2784,7 +2641,6 @@ cases:
       code: final_hidden_states = weighted_out.view(num_tokens, num_top_k, hidden_dim).sum(dim=1)'
     marks:
       - fp32operation
-      - tensorsoncpu
     kwmap:
       dim: 1
   - name: torch.to.7
@@ -2803,7 +2659,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.reshape.6
     op: torch.reshape
     inputs:
@@ -2820,7 +2675,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.mul.1
     op: torch.Tensor.mul
     inputs:
@@ -2842,7 +2696,6 @@ cases:
       code: hidden_states *= self.layer_scalar'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.nn.functional.scaled_dot_product_attention.2
     op: torch.nn.functional.scaled_dot_product_attention
     inputs:
@@ -2871,7 +2724,6 @@ cases:
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -2904,7 +2756,6 @@ cases:
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -2937,7 +2788,6 @@ cases:
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -2970,7 +2820,6 @@ cases:
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -2998,7 +2847,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.float.12
     op: torch.float
     inputs:
@@ -3013,7 +2861,6 @@ cases:
       = self._norm(hidden_states.float())'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.pow.9
     op: torch.pow
     inputs:
@@ -3030,7 +2877,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mean.5
     op: torch.mean
     inputs:
@@ -3047,7 +2893,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.mul.20
@@ -3071,7 +2916,6 @@ cases:
       hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.float.13
     op: torch.float
     inputs:
@@ -3086,7 +2930,6 @@ cases:
       = normed_output * self.weight.float()'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.mul.21
     op: torch.mul
     inputs:
@@ -3108,7 +2951,6 @@ cases:
       = normed_output * self.weight.float()'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.type_as.5
     op: torch.type_as
     inputs:
@@ -3131,7 +2973,6 @@ cases:
     marks:
       - fp32operation
       - bf16operation
-      - tensorsoncpu
   - name: torch.unsqueeze.4
     op: torch.unsqueeze
     inputs:
@@ -3148,7 +2989,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.mul.22
     op: torch.mul
     inputs:
@@ -3170,7 +3010,6 @@ cases:
       code: return (x * cos) + (rotate_half(x) * sin)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.getitem.14
     op: torch.getitem
     inputs:
@@ -3187,7 +3026,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.neg.3
     op: torch.neg
     inputs:
@@ -3202,7 +3040,6 @@ cases:
       return torch.cat((-x2, x1), dim=-1)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.cat.5
     op: torch.cat
     inputs:
@@ -3224,7 +3061,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.add.9
@@ -3248,7 +3084,6 @@ cases:
       code: return (x * cos) + (rotate_half(x) * sin)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.transpose.8
     op: torch.transpose
     inputs:
@@ -3266,7 +3101,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.linear.8
     op: torch.nn.functional.linear
     inputs:
@@ -3290,7 +3124,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.float.14
     op: torch.float
     inputs:
@@ -3305,7 +3138,6 @@ cases:
       = self._norm(hidden_states.float())'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.pow.10
     op: torch.pow
     inputs:
@@ -3322,7 +3154,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mean.6
     op: torch.mean
     inputs:
@@ -3339,7 +3170,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.10
@@ -3358,7 +3188,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.pow.11
     op: torch.pow
     inputs:
@@ -3375,7 +3204,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mul.23
     op: torch.mul
     inputs:
@@ -3397,7 +3225,6 @@ cases:
       hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.mul.24
     op: torch.mul
     inputs:
@@ -3419,7 +3246,6 @@ cases:
       = normed_output * self.weight.float()'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.type_as.6
     op: torch.type_as
     inputs:
@@ -3442,7 +3268,6 @@ cases:
     marks:
       - fp32operation
       - bf16operation
-      - tensorsoncpu
   - name: torch.mul.25
     op: torch.mul
     inputs:
@@ -3464,7 +3289,6 @@ cases:
       code: return (x * cos) + (rotate_half(x) * sin)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.getitem.15
     op: torch.getitem
     inputs:
@@ -3481,7 +3305,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.neg.4
     op: torch.neg
     inputs:
@@ -3496,7 +3319,6 @@ cases:
       return torch.cat((-x2, x1), dim=-1)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.cat.6
     op: torch.cat
     inputs:
@@ -3518,7 +3340,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.add.11
@@ -3542,7 +3363,6 @@ cases:
       code: return (x * cos) + (rotate_half(x) * sin)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.transpose.9
     op: torch.transpose
     inputs:
@@ -3560,7 +3380,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.index_copy_.2
     op: torch.index_copy_
     inputs:
@@ -3593,7 +3412,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.getitem.16
     op: torch.getitem
     inputs:
@@ -3610,7 +3428,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.getitem.17
     op: torch.getitem
     inputs:
@@ -3627,7 +3444,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.scaled_dot_product_attention.6
     op: torch.nn.functional.scaled_dot_product_attention
     inputs:
@@ -3656,7 +3472,6 @@ cases:
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -3678,7 +3493,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.contiguous.3
     op: torch.Tensor.contiguous
     inputs:
@@ -3693,7 +3507,6 @@ cases:
       code: attn_output = attn_output.transpose(1, 2).contiguous()'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.reshape.7
     op: torch.reshape
     inputs:
@@ -3710,7 +3523,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.contiguous.4
     op: torch.Tensor.contiguous
     inputs:
@@ -3725,7 +3537,6 @@ cases:
       = attn_output.reshape(*input_shape, -1).contiguous()'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.nn.functional.linear.9
     op: torch.nn.functional.linear
     inputs:
@@ -3749,7 +3560,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.scaled_dot_product_attention.7
     op: torch.nn.functional.scaled_dot_product_attention
     inputs:
@@ -3778,7 +3588,6 @@ cases:
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -3811,7 +3620,6 @@ cases:
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
     marks:
       - bf16operation
-      - tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -3832,7 +3640,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.linear.10
     op: torch.nn.functional.linear
     inputs:
@@ -3856,7 +3663,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.truediv.1
     op: torch.truediv
     inputs:
@@ -3873,7 +3679,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.tanh.1
     op: torch.tanh
     inputs:
@@ -3888,7 +3693,6 @@ cases:
       code: logits = torch.tanh(logits)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.mul.26
     op: torch.mul
     inputs:
@@ -3905,7 +3709,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.eq.2
     op: torch.eq
     inputs:
@@ -3923,7 +3726,6 @@ cases:
       code: special_image_mask = input_ids == self.config.image_token_id'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.or_.2
     op: torch.or_
     inputs:
@@ -3941,7 +3743,6 @@ cases:
           device: cuda
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2320 in forward, code: multimodal_mask
       = image_mask | video_mask | audio_mask'
-    marks: tensorsoncpu
   - name: torch.clone.2
     op: torch.clone
     inputs:
@@ -3956,7 +3757,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2325 in forward, code: llm_input_ids
       = input_ids.clone()'
-    marks: tensorsoncpu
   - name: torch.where.2
     op: torch.where
     inputs:
@@ -3980,7 +3780,6 @@ cases:
       = torch.where(multimodal_mask, self.config.text_config.pad_token_id, llm_input_ids)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.embedding.2
     op: torch.nn.functional.embedding
     inputs:
@@ -4010,7 +3809,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.mul.27
     op: torch.mul
     inputs:
@@ -4032,7 +3830,6 @@ cases:
       super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.getitem.19
     op: torch.getitem
     inputs:
@@ -4050,7 +3847,6 @@ cases:
       = position_ids[:, None, :].float()'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.15
     op: torch.float
     inputs:
@@ -4065,7 +3861,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1171 in forward, code: position_ids_expanded
       = position_ids[:, None, :].float()'
-    marks: tensorsoncpu
   - name: torch.float.16
     op: torch.float
     inputs:
@@ -4080,7 +3875,6 @@ cases:
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.matmul.3
     op: torch.matmul
     inputs:
@@ -4102,7 +3896,6 @@ cases:
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.transpose.11
     op: torch.transpose
     inputs:
@@ -4120,7 +3913,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.cat.7
     op: torch.cat
     inputs:
@@ -4142,7 +3934,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.cos.3
@@ -4159,7 +3950,6 @@ cases:
       = emb.cos() * attention_scaling'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.mul.28
     op: torch.mul
     inputs:
@@ -4176,7 +3966,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.sin.3
     op: torch.sin
     inputs:
@@ -4191,7 +3980,6 @@ cases:
       = emb.sin() * attention_scaling'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.to.8
     op: torch.to
     inputs:
@@ -4206,7 +3994,6 @@ cases:
       cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
     marks:
       - fp32operation
-      - tensorsoncpu
     kwmap:
       dtype: torch.bfloat16
   - name: torch.matmul.4
@@ -4230,7 +4017,6 @@ cases:
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.transpose.12
     op: torch.transpose
     inputs:
@@ -4248,7 +4034,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.cat.8
     op: torch.cat
     inputs:
@@ -4270,7 +4055,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.cos.4
@@ -4287,7 +4071,6 @@ cases:
       = emb.cos() * attention_scaling'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.mul.29
     op: torch.mul
     inputs:
@@ -4304,7 +4087,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.sin.4
     op: torch.sin
     inputs:
@@ -4319,7 +4101,6 @@ cases:
       = emb.sin() * attention_scaling'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.to.9
     op: torch.to
     inputs:
@@ -4334,7 +4115,6 @@ cases:
       cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
     marks:
       - fp32operation
-      - tensorsoncpu
     kwmap:
       dtype: torch.bfloat16
   - name: torch.float.17
@@ -4351,7 +4131,6 @@ cases:
       = self._norm(hidden_states.float())'
     marks:
       - bf16operation
-      - tensorsoncpu
   - name: torch.pow.12
     op: torch.pow
     inputs:
@@ -4368,7 +4147,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mean.7
     op: torch.mean
     inputs:
@@ -4385,7 +4163,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.12
@@ -4404,7 +4181,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.pow.13
     op: torch.pow
     inputs:
@@ -4421,7 +4197,6 @@ cases:
     marks:
       - fp32operation
       - constant
-      - tensorsoncpu
   - name: torch.mul.30
     op: torch.mul
     inputs:
@@ -4443,7 +4218,6 @@ cases:
       hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.mul.31
     op: torch.mul
     inputs:
@@ -4465,7 +4239,6 @@ cases:
       = normed_output * self.weight.float()'
     marks:
       - fp32operation
-      - tensorsoncpu
   - name: torch.type_as.7
     op: torch.type_as
     inputs:
@@ -4488,7 +4261,6 @@ cases:
     marks:
       - fp32operation
       - bf16operation
-      - tensorsoncpu
   - name: torch.getitem.20
     op: torch.getitem
     inputs:
@@ -4505,7 +4277,6 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.linear.11
     op: torch.nn.functional.linear
     inputs:
@@ -4529,4 +4300,3 @@ cases:
     marks:
       - bf16operation
       - constant
-      - tensorsoncpu

--- a/tests/resource/models/gemma-4-26B-A4B-it_spyre.yaml
+++ b/tests/resource/models/gemma-4-26B-A4B-it_spyre.yaml
@@ -22,7 +22,6 @@ cases:
       code: special_image_mask = input_ids == self.config.image_token_id'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.or_.1_spyre
     op: torch.or_
     inputs:
@@ -40,7 +39,6 @@ cases:
           device: cuda
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2320 in forward, code: multimodal_mask
       = image_mask | video_mask | audio_mask'
-    marks: tensorsoncpu
   - name: torch.clone.1_spyre
     op: torch.clone
     inputs:
@@ -55,7 +53,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2325 in forward, code: llm_input_ids
       = input_ids.clone()'
-    marks: tensorsoncpu
   - name: torch.where.1_spyre
     op: torch.where
     inputs:
@@ -79,7 +76,6 @@ cases:
       = torch.where(multimodal_mask, self.config.text_config.pad_token_id, llm_input_ids)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.embedding.1_spyre
     op: torch.nn.functional.embedding
     inputs:
@@ -108,7 +104,6 @@ cases:
       super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.to.1_spyre
     op: torch.to
     inputs:
@@ -124,7 +119,6 @@ cases:
       super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.1_spyre
     op: torch.mul
     inputs:
@@ -144,7 +138,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1476 in forward, code: return
       super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
-    marks: tensorsoncpu
   - name: torch.getitem.1_spyre
     op: torch.getitem
     inputs:
@@ -160,7 +153,6 @@ cases:
       = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.1_spyre
     op: torch.float
     inputs:
@@ -173,7 +165,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1170 in forward, code: inv_freq_expanded
       = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
-    marks: tensorsoncpu
   - name: torch.Tensor.expand.1_spyre
     op: torch.Tensor.expand
     inputs:
@@ -191,7 +182,6 @@ cases:
       = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.to.2_spyre
     op: torch.to
     inputs:
@@ -207,7 +197,6 @@ cases:
       = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.getitem.2_spyre
     op: torch.getitem
     inputs:
@@ -225,7 +214,6 @@ cases:
       = position_ids[:, None, :].float()'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.2_spyre
     op: torch.float
     inputs:
@@ -240,7 +228,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1171 in forward, code: position_ids_expanded
       = position_ids[:, None, :].float()'
-    marks: tensorsoncpu
   - name: torch.float.3_spyre
     op: torch.float
     inputs:
@@ -253,7 +240,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1175 in forward, code: freqs
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
-    marks: tensorsoncpu
   - name: torch.matmul.1_spyre
     op: torch.matmul
     inputs:
@@ -273,7 +259,6 @@ cases:
           init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1175 in forward, code: freqs
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
-    marks: tensorsoncpu
   - name: torch.transpose.1_spyre
     op: torch.transpose
     inputs:
@@ -290,7 +275,6 @@ cases:
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.cat.1_spyre
     op: torch.cat
     inputs:
@@ -311,7 +295,6 @@ cases:
       = torch.cat((freqs, freqs), dim=-1)'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.cos.1_spyre
@@ -326,7 +309,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1177 in forward, code: cos
       = emb.cos() * attention_scaling'
-    marks: tensorsoncpu
   - name: torch.mul.2_spyre
     op: torch.mul
     inputs:
@@ -342,7 +324,6 @@ cases:
       = emb.cos() * attention_scaling'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.sin.1_spyre
     op: torch.sin
     inputs:
@@ -355,7 +336,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1178 in forward, code: sin
       = emb.sin() * attention_scaling'
-    marks: tensorsoncpu
   - name: torch.to.3_spyre
     op: torch.to
     inputs:
@@ -368,7 +348,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1180 in forward, code: return
       cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
-    marks: tensorsoncpu
     kwmap:
       dtype: torch.float16
   - name: torch.getitem.3_spyre
@@ -386,7 +365,6 @@ cases:
       = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.4_spyre
     op: torch.float
     inputs:
@@ -399,7 +377,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1170 in forward, code: inv_freq_expanded
       = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
-    marks: tensorsoncpu
   - name: torch.Tensor.expand.2_spyre
     op: torch.Tensor.expand
     inputs:
@@ -417,7 +394,6 @@ cases:
       = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.to.4_spyre
     op: torch.to
     inputs:
@@ -433,7 +409,6 @@ cases:
       = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.matmul.2_spyre
     op: torch.matmul
     inputs:
@@ -453,7 +428,6 @@ cases:
           init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1175 in forward, code: freqs
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
-    marks: tensorsoncpu
   - name: torch.transpose.2_spyre
     op: torch.transpose
     inputs:
@@ -470,7 +444,6 @@ cases:
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.cat.2_spyre
     op: torch.cat
     inputs:
@@ -491,7 +464,6 @@ cases:
       = torch.cat((freqs, freqs), dim=-1)'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.cos.2_spyre
@@ -506,7 +478,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1177 in forward, code: cos
       = emb.cos() * attention_scaling'
-    marks: tensorsoncpu
   - name: torch.mul.3_spyre
     op: torch.mul
     inputs:
@@ -522,7 +493,6 @@ cases:
       = emb.cos() * attention_scaling'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.sin.2_spyre
     op: torch.sin
     inputs:
@@ -535,7 +505,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1178 in forward, code: sin
       = emb.sin() * attention_scaling'
-    marks: tensorsoncpu
   - name: torch.to.5_spyre
     op: torch.to
     inputs:
@@ -548,7 +517,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1180 in forward, code: return
       cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
-    marks: tensorsoncpu
     kwmap:
       dtype: torch.float16
   - name: torch.float.5_spyre
@@ -563,7 +531,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L212 in forward, code: normed_output
       = self._norm(hidden_states.float())'
-    marks: tensorsoncpu
   - name: torch.pow.1_spyre
     op: torch.pow
     inputs:
@@ -579,7 +546,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mean.1_spyre
     op: torch.mean
     inputs:
@@ -595,7 +561,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.1_spyre
@@ -613,7 +578,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.pow.2_spyre
     op: torch.pow
     inputs:
@@ -629,7 +593,6 @@ cases:
       hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.4_spyre
     op: torch.mul
     inputs:
@@ -649,7 +612,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L209 in _norm, code: return
       hidden_states * torch.pow(mean_squared, -0.5)'
-    marks: tensorsoncpu
   - name: torch.float.6_spyre
     op: torch.float
     inputs:
@@ -662,7 +624,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward, code: normed_output
       = normed_output * self.weight.float()'
-    marks: tensorsoncpu
   - name: torch.mul.5_spyre
     op: torch.mul
     inputs:
@@ -682,7 +643,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward, code: normed_output
       = normed_output * self.weight.float()'
-    marks: tensorsoncpu
   - name: torch.type_as.1_spyre
     op: torch.type_as
     inputs:
@@ -702,7 +662,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L215 in forward, code: return
       normed_output.type_as(hidden_states)'
-    marks: tensorsoncpu
   - name: torch.nn.functional.linear.1_spyre
     op: torch.nn.functional.linear
     inputs:
@@ -725,7 +684,6 @@ cases:
       = self.q_proj(hidden_states).view(hidden_shape)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.view.1_spyre
     op: torch.Tensor.view
     inputs:
@@ -741,7 +699,6 @@ cases:
       = self.q_proj(hidden_states).view(hidden_shape)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.7_spyre
     op: torch.float
     inputs:
@@ -754,7 +711,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L212 in forward, code: normed_output
       = self._norm(hidden_states.float())'
-    marks: tensorsoncpu
   - name: torch.pow.3_spyre
     op: torch.pow
     inputs:
@@ -770,7 +726,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mean.2_spyre
     op: torch.mean
     inputs:
@@ -786,7 +741,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.2_spyre
@@ -804,7 +758,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.pow.4_spyre
     op: torch.pow
     inputs:
@@ -820,7 +773,6 @@ cases:
       hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.6_spyre
     op: torch.mul
     inputs:
@@ -840,7 +792,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L209 in _norm, code: return
       hidden_states * torch.pow(mean_squared, -0.5)'
-    marks: tensorsoncpu
   - name: torch.float.8_spyre
     op: torch.float
     inputs:
@@ -853,7 +804,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward, code: normed_output
       = normed_output * self.weight.float()'
-    marks: tensorsoncpu
   - name: torch.mul.7_spyre
     op: torch.mul
     inputs:
@@ -873,7 +823,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward, code: normed_output
       = normed_output * self.weight.float()'
-    marks: tensorsoncpu
   - name: torch.type_as.2_spyre
     op: torch.type_as
     inputs:
@@ -893,7 +842,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L215 in forward, code: return
       normed_output.type_as(hidden_states)'
-    marks: tensorsoncpu
   - name: torch.unsqueeze.1_spyre
     op: torch.unsqueeze
     inputs:
@@ -909,7 +857,6 @@ cases:
       code: cos = cos.unsqueeze(unsqueeze_dim)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.8_spyre
     op: torch.mul
     inputs:
@@ -929,7 +876,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L812 in apply_rotary_pos_emb,
       code: return (x * cos) + (rotate_half(x) * sin)'
-    marks: tensorsoncpu
   - name: torch.getitem.4_spyre
     op: torch.getitem
     inputs:
@@ -945,7 +891,6 @@ cases:
       x1 = x[..., : x.shape[-1] // 2]'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.neg.1_spyre
     op: torch.neg
     inputs:
@@ -958,7 +903,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L790 in rotate_half, code:
       return torch.cat((-x2, x1), dim=-1)'
-    marks: tensorsoncpu
   - name: torch.cat.3_spyre
     op: torch.cat
     inputs:
@@ -979,7 +923,6 @@ cases:
       return torch.cat((-x2, x1), dim=-1)'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.add.3_spyre
@@ -1001,7 +944,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L812 in apply_rotary_pos_emb,
       code: return (x * cos) + (rotate_half(x) * sin)'
-    marks: tensorsoncpu
   - name: torch.transpose.3_spyre
     op: torch.transpose
     inputs:
@@ -1018,7 +960,6 @@ cases:
       = query_states.transpose(1, 2)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.linear.2_spyre
     op: torch.nn.functional.linear
     inputs:
@@ -1041,7 +982,6 @@ cases:
       = self.k_proj(hidden_states).view(hidden_shape)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.view.2_spyre
     op: torch.Tensor.view
     inputs:
@@ -1057,7 +997,6 @@ cases:
       = self.k_proj(hidden_states).view(hidden_shape)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.9_spyre
     op: torch.float
     inputs:
@@ -1070,7 +1009,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L212 in forward, code: normed_output
       = self._norm(hidden_states.float())'
-    marks: tensorsoncpu
   - name: torch.pow.5_spyre
     op: torch.pow
     inputs:
@@ -1086,7 +1024,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mean.3_spyre
     op: torch.mean
     inputs:
@@ -1102,7 +1039,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.4_spyre
@@ -1120,7 +1056,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.pow.6_spyre
     op: torch.pow
     inputs:
@@ -1136,7 +1071,6 @@ cases:
       hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.9_spyre
     op: torch.mul
     inputs:
@@ -1156,7 +1090,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L209 in _norm, code: return
       hidden_states * torch.pow(mean_squared, -0.5)'
-    marks: tensorsoncpu
   - name: torch.mul.10_spyre
     op: torch.mul
     inputs:
@@ -1176,7 +1109,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward, code: normed_output
       = normed_output * self.weight.float()'
-    marks: tensorsoncpu
   - name: torch.type_as.3_spyre
     op: torch.type_as
     inputs:
@@ -1196,7 +1128,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L215 in forward, code: return
       normed_output.type_as(hidden_states)'
-    marks: tensorsoncpu
   - name: torch.mul.11_spyre
     op: torch.mul
     inputs:
@@ -1216,7 +1147,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L812 in apply_rotary_pos_emb,
       code: return (x * cos) + (rotate_half(x) * sin)'
-    marks: tensorsoncpu
   - name: torch.getitem.5_spyre
     op: torch.getitem
     inputs:
@@ -1232,7 +1162,6 @@ cases:
       x1 = x[..., : x.shape[-1] // 2]'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.neg.2_spyre
     op: torch.neg
     inputs:
@@ -1245,7 +1174,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L790 in rotate_half, code:
       return torch.cat((-x2, x1), dim=-1)'
-    marks: tensorsoncpu
   - name: torch.cat.4_spyre
     op: torch.cat
     inputs:
@@ -1266,7 +1194,6 @@ cases:
       return torch.cat((-x2, x1), dim=-1)'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.add.5_spyre
@@ -1288,7 +1215,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L812 in apply_rotary_pos_emb,
       code: return (x * cos) + (rotate_half(x) * sin)'
-    marks: tensorsoncpu
   - name: torch.transpose.4_spyre
     op: torch.transpose
     inputs:
@@ -1305,7 +1231,6 @@ cases:
       = key_states.transpose(1, 2)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.zeros.1_spyre
     op: torch.zeros
     inputs:
@@ -1314,7 +1239,6 @@ cases:
       = torch.zeros('
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dtype: torch.float16
       device: cpu
@@ -1335,7 +1259,6 @@ cases:
       = self.cumulative_length.to(self.device)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.arange.1_spyre
     op: torch.arange
     inputs:
@@ -1344,7 +1267,6 @@ cases:
       device=self.device) + self.cumulative_length'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       device: cpu
   - name: torch.add.6_spyre
@@ -1370,7 +1292,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/cache_utils.py#L529 in update, code: cache_position = torch.arange(kv_length,
       device=self.device) + self.cumulative_length'
-    marks: tensorsoncpu
   - name: torch.index_copy_.1_spyre
     op: torch.index_copy_
     inputs:
@@ -1402,7 +1323,6 @@ cases:
       cache_position, key_states)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.add_.1_spyre
     op: torch.add_
     inputs:
@@ -1419,7 +1339,6 @@ cases:
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/cache_utils.py#L539 in update, code: self.cumulative_length.add_(kv_length)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.getitem.6_spyre
     op: torch.getitem
     inputs:
@@ -1435,7 +1354,6 @@ cases:
       = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.expand.3_spyre
     op: torch.Tensor.expand
     inputs:
@@ -1455,7 +1373,6 @@ cases:
       = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.reshape.1_spyre
     op: torch.reshape
     inputs:
@@ -1471,7 +1388,6 @@ cases:
       hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.scaled_dot_product_attention.1_spyre
     op: torch.nn.functional.scaled_dot_product_attention
     inputs:
@@ -1498,7 +1414,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
-    marks: tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -1519,7 +1434,6 @@ cases:
       code: attn_output = attn_output.transpose(1, 2).contiguous()'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.contiguous.1_spyre
     op: torch.Tensor.contiguous
     inputs:
@@ -1532,7 +1446,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L164 in sdpa_attention_forward,
       code: attn_output = attn_output.transpose(1, 2).contiguous()'
-    marks: tensorsoncpu
   - name: torch.reshape.2_spyre
     op: torch.reshape
     inputs:
@@ -1548,7 +1461,6 @@ cases:
       = attn_output.reshape(*input_shape, -1).contiguous()'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.contiguous.2_spyre
     op: torch.Tensor.contiguous
     inputs:
@@ -1561,7 +1473,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1294 in forward, code: attn_output
       = attn_output.reshape(*input_shape, -1).contiguous()'
-    marks: tensorsoncpu
   - name: torch.nn.functional.linear.3_spyre
     op: torch.nn.functional.linear
     inputs:
@@ -1584,7 +1495,6 @@ cases:
       = self.o_proj(attn_output)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.add.7_spyre
     op: torch.add
     inputs:
@@ -1604,7 +1514,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1429 in forward, code: hidden_states
       = residual + hidden_states'
-    marks: tensorsoncpu
   - name: torch.nn.functional.linear.4_spyre
     op: torch.nn.functional.linear
     inputs:
@@ -1627,7 +1536,6 @@ cases:
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.gelu.1_spyre
     op: torch.nn.functional.gelu
     inputs:
@@ -1639,7 +1547,6 @@ cases:
           device: cuda
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/activations.py#L51 in forward, code: return self.act(input)'
-    marks: tensorsoncpu
     kwmap:
       approximate: tanh
   - name: torch.mul.12_spyre
@@ -1661,7 +1568,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1089 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
-    marks: tensorsoncpu
   - name: torch.nn.functional.linear.5_spyre
     op: torch.nn.functional.linear
     inputs:
@@ -1684,7 +1590,6 @@ cases:
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.reshape.3_spyre
     op: torch.reshape
     inputs:
@@ -1700,7 +1605,6 @@ cases:
       = residual.reshape(-1, residual.shape[-1])'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.10_spyre
     op: torch.float
     inputs:
@@ -1713,7 +1617,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L212 in forward, code: normed_output
       = self._norm(hidden_states.float())'
-    marks: tensorsoncpu
   - name: torch.pow.7_spyre
     op: torch.pow
     inputs:
@@ -1729,7 +1632,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mean.4_spyre
     op: torch.mean
     inputs:
@@ -1745,7 +1647,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.8_spyre
@@ -1763,7 +1664,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.pow.8_spyre
     op: torch.pow
     inputs:
@@ -1779,7 +1679,6 @@ cases:
       hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.13_spyre
     op: torch.mul
     inputs:
@@ -1799,7 +1698,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L209 in _norm, code: return
       hidden_states * torch.pow(mean_squared, -0.5)'
-    marks: tensorsoncpu
   - name: torch.type_as.4_spyre
     op: torch.type_as
     inputs:
@@ -1819,7 +1717,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L215 in forward, code: return
       normed_output.type_as(hidden_states)'
-    marks: tensorsoncpu
   - name: torch.mul.14_spyre
     op: torch.mul
     inputs:
@@ -1839,7 +1736,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1354 in forward, code: hidden_states
       = hidden_states * self.scale * self.scalar_root_size'
-    marks: tensorsoncpu
   - name: torch.mul.15_spyre
     op: torch.mul
     inputs:
@@ -1855,7 +1751,6 @@ cases:
       = hidden_states * self.scale * self.scalar_root_size'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.linear.6_spyre
     op: torch.nn.functional.linear
     inputs:
@@ -1878,7 +1773,6 @@ cases:
       = self.proj(hidden_states)  # [B*S, E]'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.softmax.1_spyre
     op: torch.nn.functional.softmax
     inputs:
@@ -1891,7 +1785,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1358 in forward, code: router_probabilities
       = nn.functional.softmax(expert_scores, dim=-1, dtype=torch.float32)'
-    marks: tensorsoncpu
     kwmap:
       dim: -1
       dtype: torch.float16
@@ -1907,7 +1800,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1361 in forward, code: top_k_weights,
       top_k_index = torch.topk('
-    marks: tensorsoncpu
     kwmap:
       k: 8
       dim: -1
@@ -1934,7 +1826,6 @@ cases:
       top_k_index = torch.topk('
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.sum.1_spyre
     op: torch.sum
     inputs:
@@ -1947,7 +1838,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1368 in forward, code: top_k_weights
       /= top_k_weights.sum(dim=-1, keepdim=True)'
-    marks: tensorsoncpu
     kwmap:
       dim: -1
       keepdim: true
@@ -1970,7 +1860,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1368 in forward, code: top_k_weights
       /= top_k_weights.sum(dim=-1, keepdim=True)'
-    marks: tensorsoncpu
   - name: torch.getitem.8_spyre
     op: torch.getitem
     inputs:
@@ -1992,7 +1881,6 @@ cases:
             high: 128
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1371 in forward, code: top_k_weights
       = top_k_weights * self.per_expert_scale[top_k_index]'
-    marks: tensorsoncpu
   - name: torch.mul.16_spyre
     op: torch.mul
     inputs:
@@ -2012,7 +1900,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1371 in forward, code: top_k_weights
       = top_k_weights * self.per_expert_scale[top_k_index]'
-    marks: tensorsoncpu
   - name: torch.mul.17_spyre
     op: torch.mul
     inputs:
@@ -2032,7 +1919,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward, code: normed_output
       = normed_output * self.weight.float()'
-    marks: tensorsoncpu
   - name: torch.reshape.4_spyre
     op: torch.reshape
     inputs:
@@ -2048,7 +1934,6 @@ cases:
       sample_weights = top_k_weights.reshape(-1)  # (S,)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.reshape.5_spyre
     op: torch.reshape
     inputs:
@@ -2066,7 +1951,6 @@ cases:
       expert_ids = top_k_index.reshape(-1)  # (S,)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.sort.1_spyre
     op: torch.sort
     inputs:
@@ -2081,7 +1965,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L399 in grouped_mm_experts_forward, code:
       expert_ids_g, perm = torch.sort(expert_ids)'
-    marks: tensorsoncpu
   - name: torch.getitem.9_spyre
     op: torch.getitem
     inputs:
@@ -2107,7 +1990,6 @@ cases:
       expert_ids_g, perm = torch.sort(expert_ids)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.floordiv.1_spyre
     op: torch.floordiv
     inputs:
@@ -2125,7 +2007,6 @@ cases:
       selected_hidden_states_g = hidden_states[perm // num_top_k]'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.getitem.10_spyre
     op: torch.getitem
     inputs:
@@ -2147,7 +2028,6 @@ cases:
             high: 34
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L400 in grouped_mm_experts_forward, code:
       selected_hidden_states_g = hidden_states[perm // num_top_k]'
-    marks: tensorsoncpu
   - name: torch.getitem.11_spyre
     op: torch.getitem
     inputs:
@@ -2169,7 +2049,6 @@ cases:
             high: 272
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L401 in grouped_mm_experts_forward, code:
       sample_weights_g = sample_weights[perm]'
-    marks: tensorsoncpu
   - name: torch.float.11_spyre
     op: torch.float
     inputs:
@@ -2184,7 +2063,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L407 in grouped_mm_experts_forward, code:
       histc_input = expert_ids_g.float() if device.type in ("cpu", "mps") else expert_ids_g.int()'
-    marks: tensorsoncpu
   - name: torch.histc.1_spyre
     op: torch.histc
     inputs:
@@ -2197,7 +2075,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L408 in grouped_mm_experts_forward, code:
       tokens_per_expert = torch.histc(histc_input, bins=self.num_experts, min=0, max=self.num_experts - 1)'
-    marks: tensorsoncpu
     kwmap:
       bins: 128
       min: 0
@@ -2214,7 +2091,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L409 in grouped_mm_experts_forward, code:
       offsets = torch.cumsum(tokens_per_expert, dim=0, dtype=torch.int32)'
-    marks: tensorsoncpu
     kwmap:
       dim: 0
       dtype: torch.float16
@@ -2235,7 +2111,6 @@ cases:
       sentinel_mask = (expert_ids_g >= self.num_experts).unsqueeze(-1)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.unsqueeze.2_spyre
     op: torch.unsqueeze
     inputs:
@@ -2250,7 +2125,6 @@ cases:
       sentinel_mask = (expert_ids_g >= self.num_experts).unsqueeze(-1)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.clamp_.1_spyre
     op: torch.clamp_
     inputs:
@@ -2265,7 +2139,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L427 in grouped_mm_experts_forward, code:
       expert_ids_g.clamp_(max=self.num_experts - 1)'
-    marks: tensorsoncpu
     kwmap:
       max: 127
   - name: torch.masked_fill_.1_spyre
@@ -2289,7 +2162,6 @@ cases:
       selected_hidden_states_g.masked_fill_(sentinel_mask, 0.0)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.transpose.6_spyre
     op: torch.transpose
     inputs:
@@ -2306,7 +2178,6 @@ cases:
       weight.transpose(-2, -1), offs=offs)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.ops.transformers.grouped_mm_fallback.1_spyre
     op: torch.ops.transformers.grouped_mm_fallback
     inputs:
@@ -2326,7 +2197,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L342 in torch_dynamo_resume_in__grouped_mm_at_332,
       code: return torch.ops.transformers.grouped_mm_fallback(input, weight, offs=offs)'
-    marks: tensorsoncpu
   - name: torch.chunk.1_spyre
     op: torch.chunk
     inputs:
@@ -2342,7 +2212,6 @@ cases:
       up = gate_up_out.chunk(2, dim=-1)  # (S, intermediate_dim)'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.getitem.12_spyre
@@ -2366,7 +2235,6 @@ cases:
       up = gate_up_out.chunk(2, dim=-1)  # (S, intermediate_dim)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.gelu.2_spyre
     op: torch.nn.functional.gelu
     inputs:
@@ -2378,7 +2246,6 @@ cases:
           device: cuda
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/activations.py#L51 in forward, code: return self.act(input)'
-    marks: tensorsoncpu
     kwmap:
       approximate: tanh
   - name: torch.mul.18_spyre
@@ -2400,7 +2267,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L526 in _default_apply_gate, code: return
       self.act_fn(gate) * up  # (S, intermediate_dim)'
-    marks: tensorsoncpu
   - name: torch.transpose.7_spyre
     op: torch.transpose
     inputs:
@@ -2417,7 +2283,6 @@ cases:
       weight.transpose(-2, -1), offs=offs)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.ops.transformers.grouped_mm_fallback.2_spyre
     op: torch.ops.transformers.grouped_mm_fallback
     inputs:
@@ -2437,7 +2302,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L342 in torch_dynamo_resume_in__grouped_mm_at_332,
       code: return torch.ops.transformers.grouped_mm_fallback(input, weight, offs=offs)'
-    marks: tensorsoncpu
   - name: torch.unsqueeze.3_spyre
     op: torch.unsqueeze
     inputs:
@@ -2453,7 +2317,6 @@ cases:
       code: weighted_out = proj_out * sample_weights_g.unsqueeze(-1)  # (S, hidden_dim)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.19_spyre
     op: torch.mul
     inputs:
@@ -2473,7 +2336,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L468 in torch_dynamo_resume_in_grouped_mm_experts_forward_at_463,
       code: weighted_out = proj_out * sample_weights_g.unsqueeze(-1)  # (S, hidden_dim)'
-    marks: tensorsoncpu
   - name: torch.masked_fill_.2_spyre
     op: torch.masked_fill_
     inputs:
@@ -2495,7 +2357,6 @@ cases:
       code: weighted_out.masked_fill_(sentinel_mask, 0.0)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.empty_like.1_spyre
     op: torch.empty_like
     inputs:
@@ -2510,7 +2371,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L474 in torch_dynamo_resume_in_grouped_mm_experts_forward_at_463,
       code: inv_perm = torch.empty_like(perm)'
-    marks: tensorsoncpu
   - name: torch.setitem.1_spyre
     op: torch.setitem
     inputs:
@@ -2543,7 +2403,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L475 in torch_dynamo_resume_in_grouped_mm_experts_forward_at_463,
       code: inv_perm[perm] = torch.arange(perm.size(0), device=device)'
-    marks: tensorsoncpu
   - name: torch.getitem.13_spyre
     op: torch.getitem
     inputs:
@@ -2565,7 +2424,6 @@ cases:
             high: 272
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L476 in torch_dynamo_resume_in_grouped_mm_experts_forward_at_463,
       code: weighted_out = weighted_out[inv_perm]  # (S, hidden_dim)'
-    marks: tensorsoncpu
   - name: torch.Tensor.view.3_spyre
     op: torch.Tensor.view
     inputs:
@@ -2583,7 +2441,6 @@ cases:
       code: final_hidden_states = weighted_out.view(num_tokens, num_top_k, hidden_dim).sum(dim=1)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.sum.2_spyre
     op: torch.sum
     inputs:
@@ -2596,7 +2453,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/moe.py#L482 in torch_dynamo_resume_in_grouped_mm_experts_forward_at_463,
       code: final_hidden_states = weighted_out.view(num_tokens, num_top_k, hidden_dim).sum(dim=1)'
-    marks: tensorsoncpu
     kwmap:
       dim: 1
   - name: torch.to.7_spyre
@@ -2614,7 +2470,6 @@ cases:
       code: return final_hidden_states.to(hidden_states.dtype)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.reshape.6_spyre
     op: torch.reshape
     inputs:
@@ -2630,7 +2485,6 @@ cases:
       code: hidden_states_2 = hidden_states_2.reshape(residual.shape)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.mul.1_spyre
     op: torch.Tensor.mul
     inputs:
@@ -2650,7 +2504,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1461 in torch_dynamo_resume_in_forward_at_1442,
       code: hidden_states *= self.layer_scalar'
-    marks: tensorsoncpu
   - name: torch.nn.functional.scaled_dot_product_attention.2_spyre
     op: torch.nn.functional.scaled_dot_product_attention
     inputs:
@@ -2677,7 +2530,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
-    marks: tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -2708,7 +2560,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
-    marks: tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -2739,7 +2590,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
-    marks: tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -2770,7 +2620,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
-    marks: tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -2797,7 +2646,6 @@ cases:
       = self.q_proj(hidden_states).view(hidden_shape)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.12_spyre
     op: torch.float
     inputs:
@@ -2810,7 +2658,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L212 in forward, code: normed_output
       = self._norm(hidden_states.float())'
-    marks: tensorsoncpu
   - name: torch.pow.9_spyre
     op: torch.pow
     inputs:
@@ -2826,7 +2673,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mean.5_spyre
     op: torch.mean
     inputs:
@@ -2842,7 +2688,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.mul.20_spyre
@@ -2864,7 +2709,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L209 in _norm, code: return
       hidden_states * torch.pow(mean_squared, -0.5)'
-    marks: tensorsoncpu
   - name: torch.float.13_spyre
     op: torch.float
     inputs:
@@ -2877,7 +2721,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward, code: normed_output
       = normed_output * self.weight.float()'
-    marks: tensorsoncpu
   - name: torch.mul.21_spyre
     op: torch.mul
     inputs:
@@ -2897,7 +2740,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward, code: normed_output
       = normed_output * self.weight.float()'
-    marks: tensorsoncpu
   - name: torch.type_as.5_spyre
     op: torch.type_as
     inputs:
@@ -2917,7 +2759,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L215 in forward, code: return
       normed_output.type_as(hidden_states)'
-    marks: tensorsoncpu
   - name: torch.unsqueeze.4_spyre
     op: torch.unsqueeze
     inputs:
@@ -2933,7 +2774,6 @@ cases:
       code: cos = cos.unsqueeze(unsqueeze_dim)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.22_spyre
     op: torch.mul
     inputs:
@@ -2953,7 +2793,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L812 in apply_rotary_pos_emb,
       code: return (x * cos) + (rotate_half(x) * sin)'
-    marks: tensorsoncpu
   - name: torch.getitem.14_spyre
     op: torch.getitem
     inputs:
@@ -2969,7 +2808,6 @@ cases:
       x1 = x[..., : x.shape[-1] // 2]'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.neg.3_spyre
     op: torch.neg
     inputs:
@@ -2982,7 +2820,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L790 in rotate_half, code:
       return torch.cat((-x2, x1), dim=-1)'
-    marks: tensorsoncpu
   - name: torch.cat.5_spyre
     op: torch.cat
     inputs:
@@ -3003,7 +2840,6 @@ cases:
       return torch.cat((-x2, x1), dim=-1)'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.add.9_spyre
@@ -3025,7 +2861,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L812 in apply_rotary_pos_emb,
       code: return (x * cos) + (rotate_half(x) * sin)'
-    marks: tensorsoncpu
   - name: torch.transpose.8_spyre
     op: torch.transpose
     inputs:
@@ -3042,7 +2877,6 @@ cases:
       = query_states.transpose(1, 2)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.linear.8_spyre
     op: torch.nn.functional.linear
     inputs:
@@ -3065,7 +2899,6 @@ cases:
       = self.k_proj(hidden_states).view(hidden_shape)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.14_spyre
     op: torch.float
     inputs:
@@ -3078,7 +2911,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L212 in forward, code: normed_output
       = self._norm(hidden_states.float())'
-    marks: tensorsoncpu
   - name: torch.pow.10_spyre
     op: torch.pow
     inputs:
@@ -3094,7 +2926,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mean.6_spyre
     op: torch.mean
     inputs:
@@ -3110,7 +2941,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.10_spyre
@@ -3128,7 +2958,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.pow.11_spyre
     op: torch.pow
     inputs:
@@ -3144,7 +2973,6 @@ cases:
       hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.23_spyre
     op: torch.mul
     inputs:
@@ -3164,7 +2992,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L209 in _norm, code: return
       hidden_states * torch.pow(mean_squared, -0.5)'
-    marks: tensorsoncpu
   - name: torch.mul.24_spyre
     op: torch.mul
     inputs:
@@ -3184,7 +3011,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward, code: normed_output
       = normed_output * self.weight.float()'
-    marks: tensorsoncpu
   - name: torch.type_as.6_spyre
     op: torch.type_as
     inputs:
@@ -3204,7 +3030,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L215 in forward, code: return
       normed_output.type_as(hidden_states)'
-    marks: tensorsoncpu
   - name: torch.mul.25_spyre
     op: torch.mul
     inputs:
@@ -3224,7 +3049,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L812 in apply_rotary_pos_emb,
       code: return (x * cos) + (rotate_half(x) * sin)'
-    marks: tensorsoncpu
   - name: torch.getitem.15_spyre
     op: torch.getitem
     inputs:
@@ -3240,7 +3064,6 @@ cases:
       x1 = x[..., : x.shape[-1] // 2]'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.neg.4_spyre
     op: torch.neg
     inputs:
@@ -3253,7 +3076,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L790 in rotate_half, code:
       return torch.cat((-x2, x1), dim=-1)'
-    marks: tensorsoncpu
   - name: torch.cat.6_spyre
     op: torch.cat
     inputs:
@@ -3274,7 +3096,6 @@ cases:
       return torch.cat((-x2, x1), dim=-1)'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.add.11_spyre
@@ -3296,7 +3117,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L812 in apply_rotary_pos_emb,
       code: return (x * cos) + (rotate_half(x) * sin)'
-    marks: tensorsoncpu
   - name: torch.transpose.9_spyre
     op: torch.transpose
     inputs:
@@ -3313,7 +3133,6 @@ cases:
       = key_states.transpose(1, 2)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.index_copy_.2_spyre
     op: torch.index_copy_
     inputs:
@@ -3345,7 +3164,6 @@ cases:
       cache_position, key_states)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.getitem.16_spyre
     op: torch.getitem
     inputs:
@@ -3361,7 +3179,6 @@ cases:
       = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.getitem.17_spyre
     op: torch.getitem
     inputs:
@@ -3377,7 +3194,6 @@ cases:
       code: key = key[:, :, :q_length, :]'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.scaled_dot_product_attention.6_spyre
     op: torch.nn.functional.scaled_dot_product_attention
     inputs:
@@ -3404,7 +3220,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
-    marks: tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -3425,7 +3240,6 @@ cases:
       code: attn_output = attn_output.transpose(1, 2).contiguous()'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.contiguous.3_spyre
     op: torch.Tensor.contiguous
     inputs:
@@ -3438,7 +3252,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L164 in sdpa_attention_forward,
       code: attn_output = attn_output.transpose(1, 2).contiguous()'
-    marks: tensorsoncpu
   - name: torch.reshape.7_spyre
     op: torch.reshape
     inputs:
@@ -3454,7 +3267,6 @@ cases:
       = attn_output.reshape(*input_shape, -1).contiguous()'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.Tensor.contiguous.4_spyre
     op: torch.Tensor.contiguous
     inputs:
@@ -3467,7 +3279,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1294 in forward, code: attn_output
       = attn_output.reshape(*input_shape, -1).contiguous()'
-    marks: tensorsoncpu
   - name: torch.nn.functional.linear.9_spyre
     op: torch.nn.functional.linear
     inputs:
@@ -3490,7 +3301,6 @@ cases:
       = self.o_proj(attn_output)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.scaled_dot_product_attention.7_spyre
     op: torch.nn.functional.scaled_dot_product_attention
     inputs:
@@ -3517,7 +3327,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
-    marks: tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -3548,7 +3357,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/integrations/sdpa_attention.py#L154 in sdpa_attention_forward,
       code: attn_output = torch.nn.functional.scaled_dot_product_attention('
-    marks: tensorsoncpu
     kwmap:
       dropout_p: 0.0
       scale: 1.0
@@ -3568,7 +3376,6 @@ cases:
       code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.linear.10_spyre
     op: torch.nn.functional.linear
     inputs:
@@ -3591,7 +3398,6 @@ cases:
       code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.truediv.1_spyre
     op: torch.truediv
     inputs:
@@ -3607,7 +3413,6 @@ cases:
       code: logits = logits / final_logit_softcapping'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.tanh.1_spyre
     op: torch.tanh
     inputs:
@@ -3620,7 +3425,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2596 in torch_dynamo_resume_in_forward_at_2570,
       code: logits = torch.tanh(logits)'
-    marks: tensorsoncpu
   - name: torch.mul.26_spyre
     op: torch.mul
     inputs:
@@ -3636,7 +3440,6 @@ cases:
       code: logits = logits * final_logit_softcapping'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.eq.2_spyre
     op: torch.eq
     inputs:
@@ -3654,7 +3457,6 @@ cases:
       code: special_image_mask = input_ids == self.config.image_token_id'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.or_.2_spyre
     op: torch.or_
     inputs:
@@ -3672,7 +3474,6 @@ cases:
           device: cuda
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2320 in forward, code: multimodal_mask
       = image_mask | video_mask | audio_mask'
-    marks: tensorsoncpu
   - name: torch.clone.2_spyre
     op: torch.clone
     inputs:
@@ -3687,7 +3488,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L2325 in forward, code: llm_input_ids
       = input_ids.clone()'
-    marks: tensorsoncpu
   - name: torch.where.2_spyre
     op: torch.where
     inputs:
@@ -3711,7 +3511,6 @@ cases:
       = torch.where(multimodal_mask, self.config.text_config.pad_token_id, llm_input_ids)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.embedding.2_spyre
     op: torch.nn.functional.embedding
     inputs:
@@ -3740,7 +3539,6 @@ cases:
       super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.27_spyre
     op: torch.mul
     inputs:
@@ -3760,7 +3558,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1476 in forward, code: return
       super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)'
-    marks: tensorsoncpu
   - name: torch.getitem.19_spyre
     op: torch.getitem
     inputs:
@@ -3778,7 +3575,6 @@ cases:
       = position_ids[:, None, :].float()'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.float.15_spyre
     op: torch.float
     inputs:
@@ -3793,7 +3589,6 @@ cases:
             high: 1000
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1171 in forward, code: position_ids_expanded
       = position_ids[:, None, :].float()'
-    marks: tensorsoncpu
   - name: torch.float.16_spyre
     op: torch.float
     inputs:
@@ -3806,7 +3601,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1175 in forward, code: freqs
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
-    marks: tensorsoncpu
   - name: torch.matmul.3_spyre
     op: torch.matmul
     inputs:
@@ -3826,7 +3620,6 @@ cases:
           init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1175 in forward, code: freqs
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
-    marks: tensorsoncpu
   - name: torch.transpose.11_spyre
     op: torch.transpose
     inputs:
@@ -3843,7 +3636,6 @@ cases:
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.cat.7_spyre
     op: torch.cat
     inputs:
@@ -3864,7 +3656,6 @@ cases:
       = torch.cat((freqs, freqs), dim=-1)'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.cos.3_spyre
@@ -3879,7 +3670,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1177 in forward, code: cos
       = emb.cos() * attention_scaling'
-    marks: tensorsoncpu
   - name: torch.mul.28_spyre
     op: torch.mul
     inputs:
@@ -3895,7 +3685,6 @@ cases:
       = emb.cos() * attention_scaling'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.sin.3_spyre
     op: torch.sin
     inputs:
@@ -3908,7 +3697,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1178 in forward, code: sin
       = emb.sin() * attention_scaling'
-    marks: tensorsoncpu
   - name: torch.to.8_spyre
     op: torch.to
     inputs:
@@ -3921,7 +3709,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1180 in forward, code: return
       cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
-    marks: tensorsoncpu
     kwmap:
       dtype: torch.float16
   - name: torch.matmul.4_spyre
@@ -3943,7 +3730,6 @@ cases:
           init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1175 in forward, code: freqs
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
-    marks: tensorsoncpu
   - name: torch.transpose.12_spyre
     op: torch.transpose
     inputs:
@@ -3960,7 +3746,6 @@ cases:
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.cat.8_spyre
     op: torch.cat
     inputs:
@@ -3981,7 +3766,6 @@ cases:
       = torch.cat((freqs, freqs), dim=-1)'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       dim: -1
   - name: torch.cos.4_spyre
@@ -3996,7 +3780,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1177 in forward, code: cos
       = emb.cos() * attention_scaling'
-    marks: tensorsoncpu
   - name: torch.mul.29_spyre
     op: torch.mul
     inputs:
@@ -4012,7 +3795,6 @@ cases:
       = emb.cos() * attention_scaling'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.sin.4_spyre
     op: torch.sin
     inputs:
@@ -4025,7 +3807,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1178 in forward, code: sin
       = emb.sin() * attention_scaling'
-    marks: tensorsoncpu
   - name: torch.to.9_spyre
     op: torch.to
     inputs:
@@ -4038,7 +3819,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L1180 in forward, code: return
       cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
-    marks: tensorsoncpu
     kwmap:
       dtype: torch.float16
   - name: torch.float.17_spyre
@@ -4053,7 +3833,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L212 in forward, code: normed_output
       = self._norm(hidden_states.float())'
-    marks: tensorsoncpu
   - name: torch.pow.12_spyre
     op: torch.pow
     inputs:
@@ -4069,7 +3848,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mean.7_spyre
     op: torch.mean
     inputs:
@@ -4085,7 +3863,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
     kwmap:
       keepdim: true
   - name: torch.add.12_spyre
@@ -4103,7 +3880,6 @@ cases:
       = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.pow.13_spyre
     op: torch.pow
     inputs:
@@ -4119,7 +3895,6 @@ cases:
       hidden_states * torch.pow(mean_squared, -0.5)'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.mul.30_spyre
     op: torch.mul
     inputs:
@@ -4139,7 +3914,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L209 in _norm, code: return
       hidden_states * torch.pow(mean_squared, -0.5)'
-    marks: tensorsoncpu
   - name: torch.mul.31_spyre
     op: torch.mul
     inputs:
@@ -4159,7 +3933,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L214 in forward, code: normed_output
       = normed_output * self.weight.float()'
-    marks: tensorsoncpu
   - name: torch.type_as.7_spyre
     op: torch.type_as
     inputs:
@@ -4179,7 +3952,6 @@ cases:
           init: rand
     description: 'https://github.com/huggingface/transformers/blob/v5.14.1/src/transformers/models/gemma4/modeling_gemma4.py#L215 in forward, code: return
       normed_output.type_as(hidden_states)'
-    marks: tensorsoncpu
   - name: torch.getitem.20_spyre
     op: torch.getitem
     inputs:
@@ -4195,7 +3967,6 @@ cases:
       code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
     marks:
       - constant
-      - tensorsoncpu
   - name: torch.nn.functional.linear.11_spyre
     op: torch.nn.functional.linear
     inputs:
@@ -4218,4 +3989,3 @@ cases:
       code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
     marks:
       - constant
-      - tensorsoncpu


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [X] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Removes incorrect tensorsoncpu tags from all Gemma 4 model op test YAML files. The tags were wrongly applied during capture — all input tensors in these YAMLs are defined with device: cuda, so the ops are expected to run on device (Spyre), not on CPU. This fix aligns the Gemma 4 YAMLs with the convention used by other model YAMLs in the repo.

**Files fixed:**

tests/configs/model_ops_tests/gemma-4-12B-it.yaml
tests/configs/model_ops_tests/gemma-4-12B-it_spyre.yaml
tests/configs/model_ops_tests/gemma-4-26B-A4B-it.yaml
tests/configs/model_ops_tests/gemma-4-26B-A4B-it_spyre.yaml
tests/resource/models/gemma-4-12B-it.yaml
tests/resource/models/gemma-4-12B-it_spyre.yaml
tests/resource/models/gemma-4-26B-A4B-it.yaml
tests/resource/models/gemma-4-26B-A4B-it_spyre.yaml

#### Which issue(s) this PR is related to:
Fixes [#3917](https://github.com/torch-spyre/torch-spyre/issues/3917)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No.

#### Additional note:
