### PR TITLE
Handle aliased mutation buffers in propagate_layouts

### DIFF
--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -595,6 +595,39 @@ def test_bmm_with_inplace_mutation():
     _compare(func, x, weight, cache)
 
 
+def test_mutation_target_multi_candidate_layout_unsupported():
+    """Issue #3845: a mutation op and its target can diverge on device layout in
+    the beam search.  ``c = a + b`` is an ordinary ComputedBuffer with two
+    genuine candidate STLs (row-stick vs. column-stick, since 128x256 is
+    non-square); ``copy_forced(d, c)`` then mutates it.  Unlike the
+    SpyreEmptyFallback accumulator case above (test_bmm_with_inplace_mutation,
+    where the target starts as a fresh torch.zeros() buffer and already has
+    working multi-candidate coupling), propagate_layouts has no mechanism to
+    couple an ordinary pre-existing ComputedBuffer target's eventual layout
+    choice to the mutation op's -- so _target_device_layout hits its
+    ``assert len(layouts) == 1`` guard (added by #3884) instead of silently
+    picking a possibly-wrong layout.  This reproducer is independent of
+    coarse_tiling and spyre_hint, isolating the root propagate_layouts gap.
+    Once the beam-search coupling is implemented, this should compile and
+    match CPU -- update this test to a correctness check at that point.
+    """
+    M, N = 128, 256
+    a = torch.randn((M, N), dtype=torch.float16) * 0.01
+    b = torch.randn((M, N), dtype=torch.float16) * 0.01
+    d = torch.randn((M, N), dtype=torch.float16) * 0.01
+
+    def fn(a, b, d):
+        c = a + b
+        torch.ops.spyre.copy_forced(d, c)
+        return c
+
+    with pytest.raises(
+        InductorError,
+        match=r"has 2 candidate layouts",
+    ):
+        _compile_and_run(fn, (a, b, d), DEVICE)
+
+
 # Optimizer correctness + optimality tests: verify both output values and
 # minimum-cost restickify plan across a range of graph patterns.
 

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -595,21 +595,19 @@ def test_bmm_with_inplace_mutation():
     _compare(func, x, weight, cache)
 
 
-def test_mutation_target_multi_candidate_layout_unsupported():
+def test_mutation_target_multi_candidate_layout():
     """Issue #3845: a mutation op and its target can diverge on device layout in
     the beam search.  ``c = a + b`` is an ordinary ComputedBuffer with two
     genuine candidate STLs (row-stick vs. column-stick, since 128x256 is
     non-square); ``copy_forced(d, c)`` then mutates it.  Unlike the
     SpyreEmptyFallback accumulator case above (test_bmm_with_inplace_mutation,
     where the target starts as a fresh torch.zeros() buffer and already has
-    working multi-candidate coupling), propagate_layouts has no mechanism to
-    couple an ordinary pre-existing ComputedBuffer target's eventual layout
-    choice to the mutation op's -- so _target_device_layout hits its
-    ``assert len(layouts) == 1`` guard (added by #3884) instead of silently
-    picking a possibly-wrong layout.  This reproducer is independent of
+    working multi-candidate coupling), the mutation op here has no genuine
+    MemoryDep read-edge to its target at all -- propagate_layouts synthesizes
+    a coupling edge from the target's own write MemoryDep so the beam search
+    can price the constraint that this op's output STL must match whatever
+    the target eventually commits to.  This reproducer is independent of
     coarse_tiling and spyre_hint, isolating the root propagate_layouts gap.
-    Once the beam-search coupling is implemented, this should compile and
-    match CPU -- update this test to a correctness check at that point.
     """
     M, N = 128, 256
     a = torch.randn((M, N), dtype=torch.float16) * 0.01
@@ -621,11 +619,7 @@ def test_mutation_target_multi_candidate_layout_unsupported():
         torch.ops.spyre.copy_forced(d, c)
         return c
 
-    with pytest.raises(
-        InductorError,
-        match=r"has 2 candidate layouts",
-    ):
-        _compile_and_run(fn, (a, b, d), DEVICE)
+    _compare(fn, a, b, d)
 
 
 # Optimizer correctness + optimality tests: verify both output values and

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -1493,13 +1493,8 @@ def _target_device_layout(target, name: str):
             if buf_layouts:
                 layouts = buf_layouts
 
-    if not layouts:
+    if not layouts or len(layouts) != 1:
         return None
-    assert len(layouts) == 1, (
-        f"_target_device_layout: {name!r} has {len(layouts)} candidate layouts; "
-        f"multiple mutation ops writing the same target with different layouts "
-        f"is not yet supported"
-    )
     return next(iter(layouts))
 
 
@@ -1783,6 +1778,42 @@ def propagate_spyre_tensor_layouts(
                 target_buf = V.graph.get_buffer(target_name) if target_name else None
                 target_stl = _target_device_layout(target, target_name)
                 if target_stl is None:
+                    target_buf_layouts = getattr(target_buf, "layouts", None)
+                    if not isinstance(target_buf, SpyreEmptyFallback) and (
+                        target_buf_layouts and len(target_buf_layouts) > 1
+                    ):
+                        # target_buf is an ordinary multi-candidate ComputedBuffer
+                        # (issue #3845): the mutation op (e.g. copy_forced) has no
+                        # genuine MemoryDep read-edge to target_buf, so none of the
+                        # existing per-arg propagation machinery can see or price
+                        # the constraint that this op's output STL must match
+                        # whatever target_buf eventually commits to. Synthesize a
+                        # coupling edge by reusing target_buf's own write MemoryDep
+                        # (real index/shape, since copy_forced requires identical
+                        # shapes) as an extra "input" arg, and let AllSameNode price
+                        # it exactly like any other input alongside the real reads.
+                        assert target_buf is not None
+                        target_write_dep = _one_mem_dep(
+                            target_buf.get_read_writes().writes
+                        )
+                        assert target_write_dep is not None, (
+                            f"{op.get_name()}: mutation target {target_name!r} "
+                            f"must have exactly one write MemoryDep to synthesize "
+                            f"a coupling edge"
+                        )
+                        rw = op.get_read_writes()
+                        output_dep = next(iter(rw.writes))
+                        args = _get_prop_args(rw.reads)
+                        target_arg = PropArg(
+                            target_write_dep,
+                            target_buf.get_layout(),
+                            list(target_buf_layouts),
+                        )
+                        op.layouts = list(target_buf_layouts)
+                        op.restick_cost_fn = AllSameNode.from_args(
+                            [*args, target_arg], op.layouts, output_dep, op
+                        )
+                        continue
                     if not isinstance(target_buf, SpyreEmptyFallback):
                         # op gets no .layouts/.restick_cost_fn at all; any
                         # downstream consumer that requires them (e.g.


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://g
ithub.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes a gap in the restickify beam search where a mutation op
(`MutationLayoutSHOULDREMOVE`, e.g. `copy_forced`) and its mutation
target could diverge on device layout, because the mutation op has no
genuine `MemoryDep` read-edge to its target — `op.get_read_writes().reads`
never includes the target's name, only the op's real operands (e.g. the
copy source). Every beam-search cost mechanism
(`AllSameNode`/`EdgeCostMap`/`Frontier`/`compute_future_min_cost` in
`optimize_restickify.py`) is keyed entirely off real `MemoryDep` reads, so
this class of mutation op was structurally invisible to the layout-coupling
machinery. `_target_device_layout`'s `assert len(layouts) == 1` (added in
#3884) was the only thing standing between this gap and silently
committing to a possibly-wrong layout — it just turned the silent
wrong-layout risk into a loud assertion failure whenever the target had
more than one genuine candidate STL.

Root cause was confirmed empirically (not just inferred from the issue's
prose): a live diagnostic on a minimal `c = a + b; copy_forced(d, c)`
reproducer showed the mutation op's `reads` were `['arg2_1']` (the copy
source `d`) with zero mention of the target buffer `c`, unlike the
already-working `SpyreEmptyFallback` accumulator case (`z = z + x`), which
genuinely reads back its own prior value and so is naturally visible to
this machinery.

The fix: in `propagate_spyre_tensor_layouts`'s `MutationLayoutSHOULDREMOVE`
dispatch, when the mutation target is an ordinary (non-`SpyreEmptyFallback`)
buffer with more than one candidate device layout, synthesize a coupling
edge instead of asserting. The target's own write `MemoryDep` is real,
correctly shaped, and shape-identical to the mutation op's own write
(`copy_forced` requires identical shapes), so it can stand in for the
missing read edge: wrap it in a synthetic input `PropArg`, feed it through
`AllSameNode.from_args` alongside the op's real reads, and set
`op.layouts` to the target's own candidate list. This lets the beam
search see and price the constraint that the mutation op's output STL
must match whatever the target eventually commits to — the same way it
already does for the `SpyreEmptyFallback` accumulator case, just
constructing the read-back edge synthetically since it doesn't exist as a
real dependency for this class of op.

`_target_device_layout` itself is relaxed to return `None` (instead of
asserting) when there are multiple candidates, letting the call site
above take over. Its only other caller, `_resolve_copy_back_candidates`,
already treats `None` as "skip the copy-back elision," so this is
behavior-preserving there.

A regression test (`test_mutation_target_multi_candidate_layout` in
`tests/inductor/test_restickify.py`) reproduces the issue independent of
coarse_tiling and `spyre_hint`, using `copy_forced` directly on an
ordinary two-candidate-STL `ComputedBuffer` (`c = a + b` on a
non-square 128x256 shape). It was added first as a failing reproducer
(`pytest.raises(InductorError, match="has 2 candidate layouts")`), then
converted to a real correctness check (`_compare(fn, a, b, d)`) once the
fix landed.

#### Which issue(s) this PR is related to:

Fixes #3845

#### Special notes for your reviewer:

- The `MutationLayoutSHOULDREMOVE` dispatch block in `propagate_layouts.py`
  also contains a pre-existing, unrelated `_find_alt_target_stl`/
  `forced_mutation_alts` mechanism for graph-input targets with
  unsupported stick offsets. That mechanism is untouched by this change
  and continues to run after the new synthetic-coupling branch (it's
  scoped to graph-input targets and doesn't overlap with the new branch's
  ordinary-`ComputedBuffer`-target case).
- The new branch mirrors the existing `SpyreEmptyFallback`
  accumulator/pointwise pattern just above it in the same function
  (rebuild the cost function with all args including the accumulator
  read-back) — the only difference is that here the "read-back" edge has
  to be constructed synthetically from the target's write dep, since it
  doesn't exist as a real read on the mutation op.
- Full validation run: `tests/inductor/test_restickify.py` (325 passed),
  `tests/inductor/test_coarse_tile_e2e.py` + `tests/inductor/test_building_blocks.py`
  (199 passed, 41 skipped, 1 pre-existing unrelated xfail), and
  `pre-commit run --all-files` clean.
- This issue was filed independently of coarse_tiling, and the reproducer
  test confirms the root gap is in `propagate_layouts` generically, not
  specific to coarse-tiled or `spyre_hint`-annotated graphs.

#### Does this PR introduce a user-facing change?

No behavior change for existing passing graphs. Graphs that previously
hit the `_target_device_layout` assertion (mutation op targeting a
multi-candidate buffer) will now compile successfully instead of raising
`InductorError`.

#### Additional note: