### PR TITLE
fix(scratchpad): unwrap MutationLayoutSHOULDREMOVE in _output_stride_to_device_size

### DIFF
--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -1509,6 +1509,71 @@ class TestInplaceEdgeGate(unittest.TestCase):
                 )
 
 
+class TestInPlaceMutationCoOptimizing(BaseTestScratchpadUsage):
+    """Plain in-place mutations compile under the co-optimizing greedy path
+    (issue #3940).
+
+    With ``co_optimizing_lx_planning=True`` and the default ``greedy`` solver,
+    ``ExhaustiveSearchSolver`` runs with ``prune=True``, so
+    ``_split_fits_sticks`` calls ``_output_stride_to_device_size`` on every op.
+    An op whose buffer is mutated in place carries
+    ``MutationLayoutSHOULDREMOVE``, which has no ``device_layout`` -- the
+    helper must unwrap it via ``real_layout()``. Sliced mutations
+    (``x[:, 32:96] = ...``) never reach the helper because the
+    offset-mutation component routes them to a fixed division first, which is
+    exactly what masked this; hence the plain-mutation cases here."""
+
+    def _compile_and_compare(self, fn, args, cpu_args=None):
+        if cpu_args is None:
+            cpu_args = tuple(t.to("cpu") for t in args)
+        cpu_result = fn(*cpu_args)
+        with ts_inductor_config.patch(
+            lx_planning=True,
+            layout_solver="greedy",
+            co_optimizing_lx_planning=True,
+        ):
+            device_result = torch.compile(fn, fullgraph=True)(*args).to("cpu")
+        torch.testing.assert_close(device_result, cpu_result, atol=1e-2, rtol=1e-3)
+
+    def test_inplace_add(self):
+        def fn(dst, a):
+            dst.add_(a)
+            return dst * 2.0
+
+        self._compile_and_compare(
+            fn, (self.rand_device((64, 256)), self.rand_device((64, 256)))
+        )
+
+    def test_inplace_copy(self):
+        def fn(dst, a, b):
+            dst.copy_(a + b)
+            return dst
+
+        self._compile_and_compare(
+            fn,
+            (
+                torch.zeros(64, 256, dtype=torch.float16, device="spyre"),
+                self.rand_device((64, 256)),
+                self.rand_device((64, 256)),
+            ),
+        )
+
+    def test_inplace_index_copy(self):
+        def fn(cache, idx, v):
+            cache.index_copy_(2, idx, v)
+            return cache
+
+        cache = torch.zeros(1, 8, 128, 64, dtype=torch.float16, device="spyre")
+        idx = torch.tensor([3], dtype=torch.int32, device="spyre")
+        v = self.rand_device((1, 8, 1, 64))
+        # CPU index_copy_ requires an int64 index; Spyre wants int32.
+        self._compile_and_compare(
+            fn,
+            (cache, idx, v),
+            cpu_args=(cache.to("cpu"), idx.to("cpu").long(), v.to("cpu")),
+        )
+
+
 class TestBoundaryCloneInPlace(BaseTestScratchpadUsage):
     """In-place reuse of boundary-clone buffers in the greedy build path (#3212).
 

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -1131,7 +1131,12 @@ def _output_stride_to_device_size(op: Operation) -> dict[int, int]:
     splittable size for an output dim by its coefficient in the write index.
     (Mirrors _per_core_view_on_buf's stride→device-dim placement.)
     """
-    dev_layout = op.layout.device_layout
+    layout = op.layout
+    if isinstance(layout, MutationLayoutSHOULDREMOVE):
+        # In-place mutations keep the mutation wrapper at pre-scheduler time;
+        # the committed device layout lives on the mutation target.
+        layout = layout.real_layout()
+    dev_layout = layout.device_layout
     device_size = dev_layout.device_size
     stride_map = dev_layout.stride_map
     elems_per_stick = dev_layout.device_dtype.elems_per_stick()


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

`CO_OPTIMIZING_LX_PLANNING=1` with the default greedy solver runs `ExhaustiveSearchSolver` with `prune=True`, so `_split_fits_sticks` calls `_output_stride_to_device_size` on every op.
An op whose buffer is mutated in place carries Inductor's `MutationLayoutSHOULDREMOVE` wrapper, which has no `device_layout`, so any graph with a plain in-place mutation (`add_`, `copy_`, `index_copy_`) crashed during pre-scheduling.
Sliced mutations were unaffected because the offset-mutation component routes them to a fixed division first, which is exactly what masked this issue.

This PR unwraps the mutation layout via `real_layout()`, the idiom already used by `work_division._resolve_layout` and others; the mutation target's committed `FixedTiledLayout` is the layout that split divisibility must be checked against.
Fixing the shared helper covers all three call sites (`_split_fits_sticks`, `_matmul_axis_parse`, `_reduction_bm_axes`).

Adds `TestInPlaceMutationCoOptimizing` regression tests covering `add_`, `copy_`, and `index_copy_` under `co_optimizing_lx_planning=True` with the greedy solver, comparing device results against CPU.

#### Which issue(s) this PR is related to:

Fixes #3940

#### Special notes for your reviewer:

The passing `dst[:, 32:96] = a` case from the issue is covered by the existing offset-mutation routing, not by this change; the new tests pin the three previously crashing cases.

#### Does this PR introduce a user-facing change?

No. Compilation no longer crashes when `CO_OPTIMIZING_LX_PLANNING=1` is set on graphs with in-place mutations.

#### Additional note:
