### PR TITLE
fix(pass_utils): resolve broadcast-batch/generated-dim ambiguity in matmul layout propagation

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -6977,28 +6977,21 @@ class TestCoarseTileMoEBroadcastMatmulE2E(InductorTestCase):
             fn, x, w, run_compile=True, run_eager=False, atol=0.05, rtol=0.05
         )
 
-    @pytest.mark.skip(
-        reason=(
-            "Unsupported: expected exactly 1 generated variable, got {d0, d2}. "
-            "find_matmul_generated_var (pass_utils.py) identifies the matmul's "
-            "N dim as 'in y and the output, absent from x' -- but here E is "
-            "also 'in y and the output, absent from x' (a broadcast batch dim "
-            "with no corresponding dim in x at all), and with tile size 2 its "
-            "per-tile loop var (d0) still appears in y's/the output's index, "
-            "so it satisfies the same set membership as the true N dim (F, "
-            "d2). The two are structurally indistinguishable by pure "
-            "set-arithmetic on MemoryDep.index.free_symbols once x lacks a "
-            "batch dim outright; d0 and d2 both have real nonzero coefficients "
-            "in y_dep/out_dep and are absent from x_dep.index.free_symbols. "
-            "At tile size 1 (see test_unsqueeze_broadcast_matmul_tile_E_correct) "
-            "E's per-tile loop var is constant-folded away entirely, so the "
-            "ambiguity never arises -- this is a distinct, real bug in "
-            "propagate_layouts.py/pass_utils.py, not in coarse_tile.py. "
-            "See issue #3888."
-        )
-    )
-    def test_unsqueeze_broadcast_matmul_tile_E_64_correct(self):
-        """[1,T,H]@[E,H,F] -> [E,T,F] tiled over E with 64 tiles (2 experts/tile)."""
+    def test_unsqueeze_broadcast_matmul_tile_E_64_rejected(self):
+        """[1,T,H]@[E,H,F] tiled over E with 64 tiles (2 experts/tile) is rejected.
+
+        Coarse-tiling a matmul's broadcast batch dim (x has no E dim here)
+        with more than 1 element per tile is not supported: the backend's
+        SDSC batched-matmul scheduling primitive requires exactly 1
+        broadcast element per kernel invocation
+        (``inp0_reuse_dim.size() == 1``), and aborts deep in the native
+        device compiler if that's violated. torch-spyre now rejects this
+        configuration at plan time with a clear message instead of letting
+        it reach the native compiler -- see issue #3927 for the backend
+        limitation this is tracking. 1 expert/tile
+        (test_unsqueeze_broadcast_matmul_tile_E_correct,
+        num_tiles_per_dim={"E": E}) is unaffected and continues to work.
+        """
         from torch_spyre._inductor import spyre_hint
 
         E, T, H, F = 128, 64, 64, 64
@@ -7015,9 +7008,10 @@ class TestCoarseTileMoEBroadcastMatmulE2E(InductorTestCase):
             with spyre_hint(num_tiles_per_dim={"E": 64}):
                 return torch.matmul(x.unsqueeze(0), w)
 
-        compare_with_cpu(
-            fn, x, w, run_compile=True, run_eager=False, atol=0.05, rtol=0.05
-        )
+        with pytest.raises(InductorError, match="coarse-tiling broadcast batch dim"):
+            compare_with_cpu(
+                fn, x, w, run_compile=True, run_eager=False, atol=0.05, rtol=0.05
+            )
 
 
 class TestCoarseTileNestedReductionE2E(InductorTestCase):

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -904,17 +904,83 @@ def find_reduction_var(x_dep: MemoryDep, out_dep: MemoryDep) -> sympy.Symbol:
     return next(iter(reduction_vars))
 
 
+def broadcast_batch_vars(op: Operation, x_dep: MemoryDep, out_dep: MemoryDep) -> set:
+    """Return output loop vars for dims coarse-tiled that x is broadcast over.
+
+    When a matmul operand (x) is broadcast over a batch dim (e.g. torch.matmul
+    of a [T,H] tensor unsqueezed against a [E,H,F] weight) AND that dim is
+    coarse-tiled with >1 element per tile, the tile-loop variable for that dim
+    survives in the output's (and y's) index expression -- unlike at 1
+    element/tile, where the per-tile address offset is a pure constant handled
+    entirely outside the per-tile index expression. This makes the leftover
+    batch-dim loop var indistinguishable from the true generated (N) dim via
+    set membership on dep.index.free_symbols alone (see issue #3888): both are
+    "in y and the output, but not in x".
+
+    op.loop_info.loop_tiled_dims (stamped by coarse-tiling before layout
+    propagation runs, per passes.py's pass ordering) lists, per nesting
+    level, the raw op.data.ranges positions this loop group tiles -- for the
+    innermost tile-body op itself, output_tiled_dims/tiled_dims_per_read are
+    both empty (this op's own write is already the tile-local slice, so it
+    has nothing further to report), so loop_tiled_dims is the only surviving
+    signal identifying which raw dims the enclosing loop nest tiles at all.
+    A raw tiled dim is a spurious "excess" batch var iff x's own read lacks
+    that dim's squeezed symbol entirely (broadcast), rather than genuinely
+    being tiled on it too.
+    """
+    loop_info = getattr(op, "loop_info", None)
+    if loop_info is None or not loop_info.loop_tiled_dims:
+        return set()
+
+    # Map each squeezed output-dim position (index into out_dep.var_names) to
+    # its raw op.data.ranges position -- mirrors
+    # SpyreKernel._host_dim_to_index_symbol's squeeze arithmetic, restricted to
+    # the output (non-reduction) side.
+    ranges = getattr(op.data, "ranges", None)
+    if ranges is None:
+        return set()
+    raw_to_squeezed: dict[int, int] = {}
+    it_idx = 0
+    for host_idx, r in enumerate(ranges):
+        if int(r) != 1:
+            raw_to_squeezed[host_idx] = it_idx
+            it_idx += 1
+
+    excess: set = set()
+    for level_dims in loop_info.loop_tiled_dims:
+        for pos in level_dims:
+            squeezed = raw_to_squeezed.get(pos)
+            if squeezed is None or squeezed >= len(out_dep.var_names):
+                continue
+            var = out_dep.var_names[squeezed]
+            # x is genuinely tiled on this dim too -- not a broadcast dim.
+            if var in x_dep.index.free_symbols:
+                continue
+            excess.add(var)
+    return excess
+
+
 def find_matmul_generated_var(
-    y_dep: MemoryDep, x_dep: MemoryDep, out_dep: MemoryDep
+    y_dep: MemoryDep,
+    x_dep: MemoryDep,
+    out_dep: MemoryDep,
+    op: Operation | None = None,
 ) -> sympy.Symbol:
     """Return the single loop variable that appears in y's and the output's index but not in x's.
 
     This is the N (generation) dimension of a matmul.
+
+    When op is given, excludes candidates that are actually a coarse-tiled
+    batch dim x is broadcast over rather than the true generated dim -- see
+    broadcast_batch_vars.
+
     Raises Unsupported if the count is not exactly 1.
     """
     generated_vars = (
         y_dep.index.free_symbols & out_dep.index.free_symbols
     ) - x_dep.index.free_symbols
+    if op is not None and len(generated_vars) > 1:
+        generated_vars = generated_vars - broadcast_batch_vars(op, x_dep, out_dep)
     if len(generated_vars) != 1:
         raise Unsupported(
             f"expected exactly 1 generated variable, got {generated_vars}"

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -974,6 +974,14 @@ def find_matmul_generated_var(
     batch dim x is broadcast over rather than the true generated dim -- see
     broadcast_batch_vars.
 
+    coarse_tile.py's plan-time check (_check_matmul_broadcast_batch_tiling)
+    already rejects the >1-element/tile broadcast-batch configuration before
+    layout propagation runs, so in the tiled case this disambiguation should
+    only ever need to resolve the (always-supported) 1-element/tile case. The
+    two checks are intentionally layered as belt-and-suspenders: the plan-time
+    check gives an early, precise diagnostic; this one keeps propagation
+    correct even if that guard is ever loosened or bypassed.
+
     Raises Unsupported if the count is not exactly 1.
     """
     generated_vars = (

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -869,7 +869,7 @@ def _matmul_layouts(
     #   Input2 (y): stick on generated_var (loop var present in output, absent from x)
     #   Output:     stick on generated_var
     reduction_var = find_reduction_var(x.dep, output_dep)
-    generated_var = find_matmul_generated_var(y.dep, x.dep, output_dep)
+    generated_var = find_matmul_generated_var(y.dep, x.dep, output_dep, op)
 
     x_req_stl = find_stick_compatible_input_layout(
         x, reduction_var, data.reduction_type, "x"

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -92,7 +92,7 @@ from torch.utils._ordered_set import OrderedSet
 from torch_spyre._C import SpyreTensorLayout
 
 from .. import config
-from ..constants import BATCH_MATMUL_OP
+from ..constants import BATCH_MATMUL_OP, MATMUL_REDUCTION_OPS
 from ..errors import Unsupported
 from ..logging_utils import get_inductor_logger
 from ..loop_info import (
@@ -103,7 +103,12 @@ from ..loop_info import (
     ReductionPlan,
     copy_op_metadata,
 )
-from ..pass_utils import op_out_coords, host_coordinates, indirect_sizes_from_op
+from ..pass_utils import (
+    op_out_coords,
+    host_coordinates,
+    identify_matmul_inputs,
+    indirect_sizes_from_op,
+)
 from ..ir import FixedTiledLayout, SpyreConstantFallback, _resize_device_layout
 from .tile import compute_tile_index, compute_tile_stride
 
@@ -305,6 +310,10 @@ def plan_coarse_tile_groups(
                 _tiled_dims_for_dep(write_deps[0], per_level_extents, op)
                 if write_deps
                 else []
+            )
+
+            _check_matmul_broadcast_batch_tiling(
+                op, read_deps, write_deps, per_level_extents
             )
 
             plan[id(op)] = CoarseTileInfo(
@@ -1040,6 +1049,89 @@ def _tiled_dims_for_dep(
         ]
         for level in per_level_extents
     ]
+
+
+def _check_matmul_broadcast_batch_tiling(
+    op: ComputedBuffer,
+    read_deps: list[MemoryDep],
+    write_deps: list[MemoryDep],
+    per_level_extents: list[dict[int, Expr]],
+) -> None:
+    """Reject coarse-tiling a matmul's broadcast batch dim with >1 elem/tile.
+
+    torch-spyre#3888: when a matmul operand (x) is broadcast over a batch
+    dim (e.g. torch.matmul(x.unsqueeze(0), w) with no real batch dim on x)
+    and that dim is coarse-tiled with more than one element per tile, the
+    backend's SDSC batched-matmul scheduling primitive cannot express the
+    result: the native device compiler aborts with
+    ``sbf-ddc: DtException: inp0_reuse_dim.size() == 1`` in
+    ``L3DlOpsScheduler.cpp``. Confirmed via the generated ``sdsc_*.json``:
+    tile size 1 (one batch element per tile) never materializes a reuse-dim
+    key on the matmul's ``N_`` dims at all (128 separate kernel invocations);
+    tile size 2 stamps ``N_.kj_ = 2`` and the native scheduler rejects it.
+    This is a genuine backend limitation, not a torch-spyre layout bug --
+    see issue #3927 for the writeup shared with the deeptools backend team.
+
+    Rather than emit a kernel the native compiler will reject, raise
+    Unsupported here at plan time so the failure is immediate and points at
+    the actual cause instead of an opaque subprocess crash deep in codegen.
+    """
+    if not (
+        isinstance(op.data, Reduction)
+        and op.data.reduction_type in MATMUL_REDUCTION_OPS
+    ):
+        return
+    if len(read_deps) != 2 or not write_deps:
+        return
+
+    out_dep = write_deps[0]
+    x_dep, y_dep = identify_matmul_inputs(read_deps, out_dep)
+    if x_dep is None or y_dep is None:
+        return
+
+    # Candidates for "absent from x, present in y and the output": the true
+    # generated (N) dim of the matmul is always exactly one such var. A
+    # *second* one is only possible when x is broadcast over an extra batch
+    # dim it carries no symbol for at all (see issue #3888/#3927) -- that
+    # excess var, not the legitimate N var, is what this check must flag.
+    candidates = (
+        y_dep.index.free_symbols & out_dep.index.free_symbols
+    ) - x_dep.index.free_symbols
+    if len(candidates) <= 1:
+        return  # unambiguous N var (or none) -- nothing to flag.
+
+    # Ambiguous: more than one var is absent from x but present in y and the
+    # output. Exactly one is the true generated (N) dim; the rest are excess
+    # broadcast-batch vars x carries no symbol for at all. broadcast_batch_vars
+    # (issue #3888) resolves this via op.loop_info.loop_tiled_dims, but that
+    # isn't stamped yet at plan time -- so here we can only tell "ambiguous"
+    # from "unambiguous", not which candidate is the real N dim. Treat every
+    # candidate whose *tiled* extent exceeds 1 element/tile as excess: the
+    # real N dim's own generation loop is not a coarse-tile dim (it's the
+    # matmul's inherent output dim, not something plan_coarse_tile_groups
+    # tiles down), so it will not appear in per_level_extents at all.
+    excess_dims = {
+        int(str(sym)[1:])
+        for sym in candidates
+        if str(sym).startswith("d") and str(sym)[1:].isdigit()
+    }
+    raw_to_squeezed = _raw_to_squeezed_pos(op)
+
+    for level in per_level_extents:
+        for raw_dim, extent in level.items():
+            if raw_to_squeezed.get(raw_dim, raw_dim) not in excess_dims:
+                continue
+            if isinstance(extent, (int, sympy.Integer)) and int(extent) <= 1:
+                continue  # one broadcast element per tile -- backend handles this.
+            raise Unsupported(
+                f"matmul {op.get_name()!r}: coarse-tiling broadcast batch "
+                f"dim d{raw_dim} with {extent} elements/tile is not "
+                "supported -- the backend's batched-matmul scheduling "
+                "primitive requires exactly 1 broadcast element per kernel "
+                "invocation (inp0_reuse_dim.size() == 1). Retile this "
+                "dimension with 1 element per tile (num_tiles_per_dim == "
+                "the dim's full size), or see issue #3927."
+            )
 
 
 def _stick_host_dim(op: ComputedBuffer, device_layout) -> int | None:

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -1110,6 +1110,14 @@ def _check_matmul_broadcast_batch_tiling(
     # real N dim's own generation loop is not a coarse-tile dim (it's the
     # matmul's inherent output dim, not something plan_coarse_tile_groups
     # tiles down), so it will not appear in per_level_extents at all.
+    #
+    # Candidate symbols are always Inductor's dense "d{N}" iteration vars
+    # (same numbering _raw_to_squeezed_pos/_host_dim_to_index_symbol assign
+    # squeezed dims), so the str(sym).startswith("d") parse below recovers
+    # the squeezed index. A future Inductor change to variable naming would
+    # make this silently skip the candidate rather than raise -- if that
+    # happens, the excess dim falls through to the native compiler's opaque
+    # inp0_reuse_dim.size() == 1 abort instead of this clean Unsupported.
     excess_dims = {
         int(str(sym)[1:])
         for sym in candidates
@@ -1119,7 +1127,13 @@ def _check_matmul_broadcast_batch_tiling(
 
     for level in per_level_extents:
         for raw_dim, extent in level.items():
-            if raw_to_squeezed.get(raw_dim, raw_dim) not in excess_dims:
+            # .get(raw_dim) (no fallback): a raw_dim absent from
+            # raw_to_squeezed was squeezed out (unit-size, extent == 1) and
+            # has no d{i} symbol at all, so it can never legitimately match
+            # an excess_dims entry (those are squeezed indices). Falling
+            # back to raw_dim itself would risk an accidental collision with
+            # an unrelated squeezed index; None never collides.
+            if raw_to_squeezed.get(raw_dim) not in excess_dims:
                 continue
             if isinstance(extent, (int, sympy.Integer)) and int(extent) <= 1:
                 continue  # one broadcast element per tile -- backend handles this.


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

find_matmul_generated_var identifies a matmul's N dim as the loop var present in y and the output but absent from x. When x is broadcast over a batch dim (e.g. torch.matmul(x.unsqueeze(0), w)) and that dim is coarse-tiled with >1 element per tile, the batch dim's leftover loop var satisfies the same set-membership test as the true N dim, making the two indistinguishable by pure free-symbol arithmetic and raising a spurious "expected exactly 1 generated variable" error.

Add broadcast_batch_vars(), which uses op.loop_info.loop_tiled_dims (available once layout propagation runs, after coarse-tiling) to identify which candidate is the spurious broadcast var rather than the real N dim, and use it to disambiguate in find_matmul_generated_var.

This unblocks compilation but exposes a second, distinct problem: the disambiguated case still asks the SDSC backend to batch more than one broadcast-reuse element of Input1 into a single kernel invocation, which the native compiler's batched-matmul scheduler cannot express (aborts with `inp0_reuse_dim.size() == 1`). Reject that configuration in Python at coarse-tiling plan time instead, with a clear message pointing at issue #3927 (filed with the backend/deeptools team to discuss relaxing this constraint), rather than letting it reach the native compiler.

#### Which issue(s) this PR is related to:
Fixes #3888.

#### Special notes for your reviewer:

If we can resolve #3927, we can take out the rejection code added to coarse_tiling in this PR (but will still need the other fix).

#### Does this PR introduce a user-facing change?

#### Additional note:
