### PR TITLE
Monkey-patch safetensors for Spyre-aware loading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dynamic = ["version"]
 # against is `tools/ktir-mlir-frontend.pin`, which explains the rest.
 
 [project.optional-dependencies]
+safetensors = ["safetensors>=0.8.0"]
 # ortools is now a base dependency (on wheel-supported arches) since layout_solver
 # defaults to "cpsat" -- see `dependencies` above. This extra is kept as a no-op
 # alias so existing `--extra cpsat` / `.[cpsat]` call sites (e.g. spyre-frameworks'
@@ -72,6 +73,7 @@ build = [ # no-isolation build
 ]
 test = [
     "pytest~=9.0",
+    "safetensors>=0.8.0",
     "pydantic",             # needed by test framework to support pydantic models for config
     "pytest-xdist",         # -n1 worker isolation for segfault resilience
 #    "torch_sendnn",        # must be installed manually

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -112,6 +112,8 @@ pyyaml==6.0.3
     #   torch-spyre
 regex==2026.7.19
     # via torch-spyre
+safetensors==0.8.0
+    # via torch-spyre
 setuptools==81.0.0
     # via
     #   torch

--- a/tests/configs/torch_spyre_tests/tensors/test_safetensors_patch_monkey_patch_config.yaml
+++ b/tests/configs/torch_spyre_tests/tensors/test_safetensors_patch_monkey_patch_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [unit, regression, integration, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/tensor/test_safetensors_patch_monkey_patch.py
+      unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/tensors/test_safetensors_patch_monkey_patch_spyre_config.yaml
+++ b/tests/configs/torch_spyre_tests/tensors/test_safetensors_patch_monkey_patch_spyre_config.yaml
@@ -1,0 +1,6 @@
+test_suite_config:
+  labels: [unit, regression, integration, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/tensor/test_safetensors_patch_monkey_patch_spyre.py
+      unlisted_test_mode: mandatory_success
+

--- a/tests/tensor/test_model_utils.py
+++ b/tests/tensor/test_model_utils.py
@@ -14,6 +14,8 @@
 
 # Owner(s): ["module: spyre"]
 
+import unittest
+
 import torch
 import torch.nn as nn
 from torch.testing._internal.common_utils import (
@@ -39,6 +41,21 @@ DLFLOAT16_RTOL = 2e-3
 DLFLOAT16_ATOL = 1e-4
 
 
+def _spyre_available() -> bool:
+    """Return True iff a physical Spyre device is accessible."""
+    try:
+        from torch_spyre.constants import DEVICE_NAME
+
+        torch.zeros(1, dtype=torch.float16, device=DEVICE_NAME)
+        return True
+    except Exception:
+        return False
+
+
+#: Decorator: skip the test when no Spyre hardware is present.
+requires_spyre = unittest.skipUnless(_spyre_available(), "requires Spyre hardware")
+
+
 @instantiate_parametrized_tests
 class TestLoadModelToSpyre(TestCase):
     """Tests for torch_spyre.model_utils (issue #1339)."""
@@ -48,6 +65,7 @@ class TestLoadModelToSpyre(TestCase):
 
     # ── core layout (issue #1339) ──────────────────────────────────
 
+    @requires_spyre
     def test_linear_weight_has_dim_order_swapped(self):
         """A 2D Linear weight gets stickified on dim 0 (out_features).
         For a (1024, 4096) weight, that's 1024/64 = 16 sticks on dim 0.
@@ -59,6 +77,7 @@ class TestLoadModelToSpyre(TestCase):
         layout = get_spyre_tensor_layout(dev)
         self.assertEqual(layout.device_size[0], 16)
 
+    @requires_spyre
     def test_dim_order_rejects_non_2d(self):
         """The dim_order helper only accepts 2D weights."""
         with self.assertRaises(AssertionError):
@@ -66,6 +85,7 @@ class TestLoadModelToSpyre(TestCase):
 
     # ── embedding gather-optimal (indirect-access) layout ──────────
 
+    @requires_spyre
     def test_embedding_has_indirect_access_layout(self):
         """A 2D Embedding table gets device dims [rows, D // eps, eps] with the
         vocab dim outermost. For a (1000, 256) fp16 table, eps=64, so the
@@ -83,6 +103,7 @@ class TestLoadModelToSpyre(TestCase):
             dev.cpu(), w, rtol=DLFLOAT16_RTOL, atol=DLFLOAT16_ATOL
         )
 
+    @requires_spyre
     def test_embedding_stick_size_is_dtype_aware(self):
         """elems_per_stick is 32 at fp32, so a (1000, 256) fp32 table splits
         into 256/32 = 8 sticks, not 4."""
@@ -97,6 +118,7 @@ class TestLoadModelToSpyre(TestCase):
         # to IEEE_FP32, so this round-trip is lossless -- defaults suffice.
         torch.testing.assert_close(dev.cpu(), w)
 
+    @requires_spyre
     def test_embedding_non_tiling_hidden_dim_warns_and_falls_back(self):
         """A hidden dim that isn't a multiple of the stick size warns and
         returns None so the caller uses the default layout."""
@@ -105,11 +127,13 @@ class TestLoadModelToSpyre(TestCase):
             dev = _dma_to_spyre_indirect_access(w)
         self.assertIsNone(dev)
 
+    @requires_spyre
     def test_indirect_access_rejects_non_2d(self):
         """The indirect-access helper only accepts 2D tables."""
         with self.assertRaises(AssertionError):
             _dma_to_spyre_indirect_access(torch.randn(4, dtype=torch.float16))
 
+    @requires_spyre
     def test_moe_expert_weight_layout(self):
         from torch_spyre._C import get_spyre_tensor_layout
 
@@ -122,6 +146,7 @@ class TestLoadModelToSpyre(TestCase):
             device_weight.cpu(), weight, rtol=DLFLOAT16_RTOL, atol=DLFLOAT16_ATOL
         )
 
+    @requires_spyre
     def test_moe_per_expert_scale_layout(self):
         from torch_spyre._C import get_spyre_tensor_layout
 
@@ -133,6 +158,7 @@ class TestLoadModelToSpyre(TestCase):
         self.assertEqual(list(layout.device_size), [3, 1, 64])
         torch.testing.assert_close(device_scale.cpu(), scale[:, None].expand(-1, 64))
 
+    @requires_spyre
     def test_load_model_routes_embedding_through_indirect_access(self):
         """An nn.Embedding table lands on Spyre with the indirect-access layout
         (vocab dim outermost), not the default layout."""
@@ -145,6 +171,7 @@ class TestLoadModelToSpyre(TestCase):
         layout = get_spyre_tensor_layout(model.weight)
         self.assertEqual(list(layout.device_size), [1000, 4, 64])
 
+    @requires_spyre
     def test_load_model_embedding_non_tiling_falls_back(self):
         """An embedding whose hidden dim doesn't tile still loads (default
         layout) and warns."""
@@ -155,6 +182,7 @@ class TestLoadModelToSpyre(TestCase):
 
     # ── routing ────────────────────────────────────────────────────
 
+    @requires_spyre
     def test_load_model_routes_linear_weight_through_dim_order(self):
         """Linear weight ends up on Spyre with dim_order layout;
         other params (bias) use default layout."""
@@ -169,6 +197,7 @@ class TestLoadModelToSpyre(TestCase):
         weight_layout = get_spyre_tensor_layout(model.weight)
         self.assertEqual(weight_layout.device_size[0], 2)
 
+    @requires_spyre
     def test_load_model_handles_layernorm(self):
         """Non-Linear params/buffers reach Spyre via the default path."""
         model = nn.LayerNorm(128, dtype=torch.float16)
@@ -178,6 +207,7 @@ class TestLoadModelToSpyre(TestCase):
 
     # ── _apply is honored (matches nn.Module.to semantics) ─────────
 
+    @requires_spyre
     def test_submodule_apply_override_keeps_params_on_cpu(self):
         """A child that overrides _apply governs its own subtree: its params
         stay on CPU while a sibling Linear still gets the dim_order layout."""
@@ -204,6 +234,7 @@ class TestLoadModelToSpyre(TestCase):
         self.assertEqual(model.lin.weight.device.type, "spyre")
         self.assertEqual(get_spyre_tensor_layout(model.lin.weight).device_size[0], 2)
 
+    @requires_spyre
     def test_instance_apply_override_keeps_params_on_cpu(self):
         """An instance-level _apply monkeypatch (the runner's Attention pattern)
         is honored just like a class-level override."""
@@ -223,6 +254,7 @@ class TestLoadModelToSpyre(TestCase):
             (torch.bfloat16, torch.float16),
         ],
     )
+    @requires_spyre
     def test_explicit_dtype_is_honored(self, src_dtype, target_dtype):
         """model.to('spyre', dtype=X) puts every param on device as X.
         copy_tensor (PR #2258) converts during the DMA."""
@@ -232,6 +264,7 @@ class TestLoadModelToSpyre(TestCase):
             self.assertEqual(p.device.type, "spyre")
             self.assertEqual(p.dtype, target_dtype)
 
+    @requires_spyre
     def test_dtype_none_preserves_source(self):
         """Without dtype, each tensor keeps its source dtype on device."""
         model = nn.Linear(64, 128, dtype=torch.float32)
@@ -239,6 +272,7 @@ class TestLoadModelToSpyre(TestCase):
         self.assertEqual(model.weight.dtype, torch.float32)
         self.assertEqual(model.bias.dtype, torch.float32)
 
+    @requires_spyre
     def test_unsupported_dtype_raises(self):
         """Dtypes that map to DataFormats.INVALID are rejected."""
         model = nn.Linear(4, 4)
@@ -247,6 +281,7 @@ class TestLoadModelToSpyre(TestCase):
 
     # ── idempotency ────────────────────────────────────────────────
 
+    @requires_spyre
     def test_load_model_idempotent(self):
         """Second call on an already-loaded model is a no-op
         (params already on Spyre are skipped)."""
@@ -258,6 +293,7 @@ class TestLoadModelToSpyre(TestCase):
 
     # ── nn.Module.to() patch ───────────────────────────────────────
 
+    @requires_spyre
     def test_patch_module_to_is_idempotent(self):
         original = nn.Module.to
         try:
@@ -269,6 +305,7 @@ class TestLoadModelToSpyre(TestCase):
         finally:
             nn.Module.to = original
 
+    @requires_spyre
     def test_model_to_spyre_applies_optimal_layout(self):
         """End-to-end: model.to('spyre') routes through the patched
         nn.Module.to and lands the Linear weight with dim_order layout."""

--- a/tests/tensor/test_safetensors_patch_monkey_patch.py
+++ b/tests/tensor/test_safetensors_patch_monkey_patch.py
@@ -1,0 +1,1025 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Owner(s): ["module: spyre"]
+
+"""
+Tests for the safetensors monkey-patch (_patch_safetensors_for_spyre).
+
+All tests are CPU-only: the Spyre DMA hook is replaced by a stub that leaves
+tensors on CPU, so no hardware is required.  The stub has the same signature as
+_spyre_tensor_from_safetensors (4 args: cpu_tensor, name, device, target_dtype).
+
+Test scope (mirrors reviewer requests):
+  - _classify_safetensors_key correctness and false-positive elimination
+  - Non-Spyre passthrough: load_file and safe_open with device='cpu'
+  - Double-patch idempotency for all three entry points
+  - load_file Spyre path — values match the originals
+  - load_model tied weights, strict=True and strict=False
+  - load_model dtype preservation (fp16, bf16, fp32) using target_dtype=None
+  - load_model target_dtype opt-in conversion
+  - load_model invalid target_dtype raises early
+  - offset_keys() forwarding (file-offset order, not alphabetical order)
+  - _SpyreSafeOpen.__getattr__ forward-compat delegation
+
+Additional corner cases:
+  - safe_open Spyre path — get_tensor and get_slice reach the hook
+  - load_model missing key (strict=True raises, strict=False reports)
+  - load_model shape mismatch raises RuntimeError
+  - load_model size-1 model with no parameters or buffers
+  - integer buffer (position ids) — not coerced by target_dtype
+  - numpy framework passthrough (safe_open(framework='np') not intercepted)
+  - safe_open device with index (device='spyre:1') still routes to _SpyreSafeOpen
+"""
+
+import os
+import tempfile
+import unittest
+import unittest.mock as mock
+from typing import Dict
+
+import torch
+import torch.nn as nn
+from torch.testing._internal.common_utils import (
+    TestCase,
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+)
+
+# ── safetensors availability ──────────────────────────────────────────────────
+try:
+    import safetensors  # noqa: F401
+    import safetensors.torch as _st_torch
+
+    HAS_SAFETENSORS = True
+except ImportError:
+    HAS_SAFETENSORS = False
+
+requires_safetensors = unittest.skipUnless(
+    HAS_SAFETENSORS, "safetensors>=0.8.0 not installed"
+)
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _write_safetensors(tensors: Dict[str, torch.Tensor]) -> str:
+    """Write a dict of CPU tensors to a temp .safetensors file, return path."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".safetensors", delete=False)
+    tmp.close()
+    _st_torch.save_file(tensors, tmp.name)
+    return tmp.name
+
+
+def _identity_hook(cpu_tensor, name, device, target_dtype=None):
+    """Stub Spyre hook: returns the tensor unchanged (stays on CPU).
+
+    Accepts the same 4-arg signature as _spyre_tensor_from_safetensors after
+    the target_dtype threading patch.  target_dtype is intentionally ignored —
+    CPU-stub tests either pass target_dtype=None (dtype preserved) or rely on
+    the mock to intercept the call before any coercion occurs.
+    """
+    return cpu_tensor
+
+
+def _patch_hook(monkeypatch_target):
+    """Context-manager that replaces _spyre_tensor_from_safetensors with the
+    identity stub so tests run without a real Spyre device."""
+    return mock.patch(
+        "torch_spyre._monkey_patch._spyre_tensor_from_safetensors",
+        side_effect=_identity_hook,
+    )
+
+
+# ── classification ────────────────────────────────────────────────────────────
+
+
+class TestClassifySafetensorsKey(TestCase):
+    """Unit tests for _classify_safetensors_key — no I/O, no hardware."""
+
+    def _classify(self, name, ndim):
+        from torch_spyre._monkey_patch import _classify_safetensors_key
+
+        return _classify_safetensors_key(name, ndim)
+
+    # ── embedding detection ────────────────────────────────────────────────
+
+    def test_embed_tokens_weight_is_embedding(self):
+        self.assertEqual(self._classify("model.embed_tokens.weight", 2), "embedding")
+
+    def test_wte_weight_is_embedding(self):
+        self.assertEqual(self._classify("transformer.wte.weight", 2), "embedding")
+
+    def test_wpe_weight_is_embedding(self):
+        self.assertEqual(self._classify("transformer.wpe.weight", 2), "embedding")
+
+    def test_embedding_weight_is_embedding(self):
+        self.assertEqual(self._classify("model.embedding.weight", 2), "embedding")
+
+    def test_embeddings_weight_is_embedding(self):
+        self.assertEqual(
+            self._classify("bert.embeddings.word_embeddings.weight", 2), "embedding"
+        )
+
+    def test_pos_embed_weight_is_embedding(self):
+        self.assertEqual(self._classify("vit.pos_embed.weight", 2), "embedding")
+
+    # ── false-positive fixes ───────────────────────────────────────────────
+
+    def test_embed_out_weight_is_linear(self):
+        """GPT-NeoX output head — module name 'embed_out', not a recognised
+        embedding name segment, so must classify as linear."""
+        self.assertEqual(self._classify("model.embed_out.weight", 2), "linear")
+
+    def test_embed_layer_norm_weight_is_linear(self):
+        self.assertEqual(self._classify("model.embed_layer_norm.weight", 2), "linear")
+
+    def test_embedding_projection_weight_is_linear(self):
+        self.assertEqual(
+            self._classify("model.embedding_projection.weight", 2), "linear"
+        )
+
+    def test_wtemp_weight_is_linear(self):
+        """'wtemp' contains 'wte' as a substring but is not a valid module name."""
+        self.assertEqual(self._classify("some.wtemp.weight", 2), "linear")
+
+    def test_lm_head_weight_is_linear(self):
+        self.assertEqual(self._classify("lm_head.weight", 2), "linear")
+
+    # ── linear detection ──────────────────────────────────────────────────
+
+    def test_q_proj_weight_is_linear(self):
+        self.assertEqual(
+            self._classify("model.layers.0.self_attn.q_proj.weight", 2), "linear"
+        )
+
+    def test_up_proj_weight_is_linear(self):
+        self.assertEqual(
+            self._classify("model.layers.0.mlp.up_proj.weight", 2), "linear"
+        )
+
+    # ── other ─────────────────────────────────────────────────────────────
+
+    def test_1d_tensor_is_other(self):
+        self.assertEqual(
+            self._classify("model.layers.0.input_layernorm.weight", 1), "other"
+        )
+
+    def test_bias_is_other(self):
+        self.assertEqual(self._classify("model.layers.0.q_proj.bias", 2), "other")
+
+    def test_bare_name_no_dot_is_other(self):
+        """A key with no dot separator (no module prefix) is neither embedding
+        nor linear because we cannot confirm it has a module name context."""
+        self.assertEqual(self._classify("weight", 2), "other")
+
+    def test_3d_tensor_is_other(self):
+        self.assertEqual(self._classify("model.embed_tokens.weight", 3), "other")
+
+
+# ── non-Spyre passthrough ─────────────────────────────────────────────────────
+
+
+@requires_safetensors
+class TestNonSpyrePassthrough(TestCase):
+    """Non-Spyre device paths must fall through to the original functions
+    completely — no hook involvement."""
+
+    def setUp(self):
+        torch.manual_seed(0)
+        self.tensors = {
+            "a": torch.randn(4, 8, dtype=torch.float16),
+            "b": torch.randn(3, dtype=torch.float32),
+        }
+        self.path = _write_safetensors(self.tensors)
+
+    def tearDown(self):
+        os.unlink(self.path)
+
+    def test_load_file_cpu_passthrough(self):
+        """load_file(device='cpu') must not invoke the Spyre hook."""
+        with _patch_hook(None) as mock_hook:
+            result = _st_torch.load_file(self.path, device="cpu")
+        mock_hook.assert_not_called()
+        for key, orig in self.tensors.items():
+            torch.testing.assert_close(result[key], orig)
+
+    def test_safe_open_cpu_passthrough(self):
+        """safe_open(device='cpu') must not return _SpyreSafeOpen."""
+        import safetensors as _st_mod
+        from torch_spyre._monkey_patch import _SpyreSafeOpen
+
+        with _st_mod.safe_open(self.path, framework="pt", device="cpu") as f:
+            self.assertNotIsInstance(f, _SpyreSafeOpen)
+            for key in f.keys():
+                torch.testing.assert_close(f.get_tensor(key), self.tensors[key])
+
+    def test_load_model_non_spyre_passthrough(self):
+        """load_model(device='cpu') must delegate to the original function."""
+        model = nn.Linear(8, 4, dtype=torch.float16, bias=False)
+        tensors = {"weight": torch.randn(4, 8, dtype=torch.float16)}
+        path = _write_safetensors(tensors)
+        try:
+            with _patch_hook(None) as mock_hook:
+                missing, unexpected = _st_torch.load_model(model, path, device="cpu")
+            mock_hook.assert_not_called()
+            # Upstream load_model returns (set(), list) for missing/unexpected.
+            self.assertEqual(set(missing), set())
+            self.assertEqual(unexpected, [])
+        finally:
+            os.unlink(path)
+
+
+# ── double-patch idempotency ──────────────────────────────────────────────────
+
+
+@requires_safetensors
+class TestDoublePatchIdempotency(TestCase):
+    """Calling _patch_safetensors_for_spyre() a second time must be a no-op:
+    the sentinel prevents re-wrapping already-patched functions."""
+
+    def test_double_patch_idempotent(self):
+        from torch_spyre._monkey_patch import _patch_safetensors_for_spyre
+        import safetensors as _st_mod
+
+        # Record the patched objects after the first application (which already
+        # ran at import time via _patch_tensor_for_spyre).
+        safe_open_after_first = _st_mod.safe_open
+        load_file_after_first = _st_torch.load_file
+        load_model_after_first = _st_torch.load_model
+
+        # Second call — must be a no-op.
+        _patch_safetensors_for_spyre()
+
+        self.assertIs(_st_mod.safe_open, safe_open_after_first)
+        self.assertIs(_st_torch.load_file, load_file_after_first)
+        self.assertIs(_st_torch.load_model, load_model_after_first)
+
+
+# ── load_file Spyre path ──────────────────────────────────────────────────────
+
+
+@requires_safetensors
+class TestSpyreLoadFile(TestCase):
+    """load_file(device='spyre') routes through the hook and returns correct
+    values (verified with the identity stub)."""
+
+    def setUp(self):
+        torch.manual_seed(1)
+        self.tensors = {
+            "model.embed_tokens.weight": torch.randn(32, 16, dtype=torch.float16),
+            "model.layers.0.self_attn.q_proj.weight": torch.randn(
+                16, 16, dtype=torch.float16
+            ),
+            "model.layers.0.input_layernorm.weight": torch.randn(
+                16, dtype=torch.float16
+            ),
+        }
+        self.path = _write_safetensors(self.tensors)
+
+    def tearDown(self):
+        os.unlink(self.path)
+
+    def test_load_file_spyre_calls_hook(self):
+        """The hook must be called once per tensor."""
+        with _patch_hook(None) as mock_hook:
+            _st_torch.load_file(self.path, device="spyre")
+        self.assertEqual(mock_hook.call_count, len(self.tensors))
+
+    def test_load_file_spyre_values_correct(self):
+        """Identity-stub: returned tensors must match originals bit-for-bit."""
+        with _patch_hook(None):
+            result = _st_torch.load_file(self.path, device="spyre")
+        for key, orig in self.tensors.items():
+            torch.testing.assert_close(result[key], orig)
+
+
+# ── safe_open Spyre path ──────────────────────────────────────────────────────
+
+
+@requires_safetensors
+class TestSpyreSafeOpenPath(TestCase):
+    """safe_open(device='spyre') must route get_tensor and get_slice through
+    the hook and return the correct values."""
+
+    def setUp(self):
+        torch.manual_seed(4)
+        self.tensors = {
+            "model.embed_tokens.weight": torch.randn(16, 8, dtype=torch.float16),
+            "model.layers.0.mlp.down_proj.weight": torch.randn(
+                8, 16, dtype=torch.float16
+            ),
+        }
+        self.path = _write_safetensors(self.tensors)
+
+    def tearDown(self):
+        os.unlink(self.path)
+
+    def test_get_tensor_routes_through_hook(self):
+        """get_tensor() on a Spyre safe_open must call the hook for each key."""
+        import safetensors as _st_mod
+
+        with _patch_hook(None) as mock_hook:
+            with _st_mod.safe_open(self.path, framework="pt", device="spyre") as f:
+                for key in f.keys():
+                    _ = f.get_tensor(key)
+        self.assertEqual(mock_hook.call_count, len(self.tensors))
+
+    def test_get_tensor_values_correct(self):
+        """Identity stub: get_tensor() values must match the originals."""
+        import safetensors as _st_mod
+
+        with _patch_hook(None):
+            with _st_mod.safe_open(self.path, framework="pt", device="spyre") as f:
+                for key in f.keys():
+                    torch.testing.assert_close(f.get_tensor(key), self.tensors[key])
+
+    def test_get_slice_routes_through_hook(self):
+        """get_slice()[...] must route through the hook after gathering bytes
+        on CPU (avoiding a Spyre → Spyre double-copy)."""
+        import safetensors as _st_mod
+
+        with _patch_hook(None) as mock_hook:
+            with _st_mod.safe_open(self.path, framework="pt", device="spyre") as f:
+                key = "model.layers.0.mlp.down_proj.weight"
+                _ = f.get_slice(key)[:4, :]
+        mock_hook.assert_called_once()
+
+    def test_device_with_index_routes_to_spyre_safe_open(self):
+        """safe_open(device='spyre:1') must also route to _SpyreSafeOpen,
+        not fall through to the original (which would reject the device string)."""
+        import safetensors as _st_mod
+        from torch_spyre._monkey_patch import _SpyreSafeOpen
+
+        with _patch_hook(None):
+            obj = _st_mod.safe_open(self.path, framework="pt", device="spyre:1")
+        self.assertIsInstance(obj, _SpyreSafeOpen)
+
+    def test_numpy_framework_passthrough(self):
+        """safe_open(framework='np') must not be intercepted even for
+        device='spyre' — numpy tensors go through the original path."""
+        import safetensors as _st_mod
+        from torch_spyre._monkey_patch import _SpyreSafeOpen
+
+        # The original Rust safe_open will reject 'spyre' device for numpy,
+        # which proves the dispatch did NOT go to _SpyreSafeOpen.
+        with self.assertRaises(Exception):
+            # We only need to confirm it is NOT _SpyreSafeOpen that was returned.
+            # Any error from the Rust layer is acceptable.
+            obj = _st_mod.safe_open(self.path, framework="np", device="spyre")
+            self.assertNotIsInstance(obj, _SpyreSafeOpen)
+
+
+# ── load_model tied weights ───────────────────────────────────────────────────
+
+
+@requires_safetensors
+class TestLoadModelTiedWeights(TestCase):
+    """Tied parameters must remain shared after load_model and must not appear
+    in unexpected_keys."""
+
+    class _TiedModel(nn.Module):
+        """embed.weight and lm_head.weight are the same tensor object."""
+
+        def __init__(self, dtype=torch.float16):
+            super().__init__()
+            self.embed = nn.Embedding(8, 4, dtype=dtype)
+            self.lm_head = nn.Linear(4, 8, bias=False, dtype=dtype)
+            # Tie the weights — the checkpoint stores only embed.weight.
+            self.lm_head.weight = self.embed.weight
+
+    def _make_checkpoint(self, dtype=torch.float16):
+        """Write a checkpoint that contains only embed.weight (tied scenario)."""
+        tensors = {"embed.weight": torch.randn(8, 4, dtype=dtype)}
+        path = _write_safetensors(tensors)
+        return path, tensors["embed.weight"]
+
+    def test_tied_weights_strict_true_does_not_raise(self):
+        """strict=True must not raise when the checkpoint omits lm_head.weight
+        because it is a tied duplicate of embed.weight."""
+        model = self._TiedModel(dtype=torch.float16)
+        path, _ = self._make_checkpoint(dtype=torch.float16)
+        try:
+            with _patch_hook(None):
+                # Must not raise RuntimeError about unexpected/missing keys.
+                missing, unexpected = _st_torch.load_model(
+                    model, path, strict=True, device="spyre"
+                )
+            self.assertEqual(missing, [])
+            self.assertEqual(unexpected, [])
+        finally:
+            os.unlink(path)
+
+    def test_tied_weights_strict_false_does_not_raise(self):
+        """strict=False: same requirement — lm_head.weight must not appear in
+        unexpected_keys and the tie must be preserved."""
+        model = self._TiedModel(dtype=torch.float16)
+        path, _ = self._make_checkpoint(dtype=torch.float16)
+        try:
+            with _patch_hook(None):
+                missing, unexpected = _st_torch.load_model(
+                    model, path, strict=False, device="spyre"
+                )
+            self.assertEqual(missing, [])
+            self.assertEqual(unexpected, [])
+        finally:
+            os.unlink(path)
+
+    def test_tied_weights_preserved_after_load(self):
+        """After load_model, embed.weight and lm_head.weight must still be the
+        same object (tie must not be severed)."""
+        model = self._TiedModel(dtype=torch.float16)
+        path, _ = self._make_checkpoint(dtype=torch.float16)
+        try:
+            with _patch_hook(None):
+                _st_torch.load_model(model, path, strict=False, device="spyre")
+            self.assertIs(
+                model.embed.weight,
+                model.lm_head.weight,
+                "Weight tie was severed by load_model",
+            )
+        finally:
+            os.unlink(path)
+
+    def test_tied_weights_data_loaded(self):
+        """Both tied aliases must reflect the checkpoint data."""
+        model = self._TiedModel(dtype=torch.float16)
+        path, checkpoint_weight = self._make_checkpoint(dtype=torch.float16)
+        try:
+            with _patch_hook(None):
+                _st_torch.load_model(model, path, strict=False, device="spyre")
+            # Identity stub: tensors are on CPU, so compare directly.
+            torch.testing.assert_close(model.embed.weight, checkpoint_weight)
+            torch.testing.assert_close(model.lm_head.weight, checkpoint_weight)
+        finally:
+            os.unlink(path)
+
+
+# ── load_model missing keys and shape mismatch ───────────────────────────────
+
+
+@requires_safetensors
+class TestLoadModelKeyErrors(TestCase):
+    """Correctness of missing/unexpected key reporting and shape validation."""
+
+    def test_missing_key_strict_true_raises(self):
+        """A key present in the model but absent from the checkpoint must cause
+        RuntimeError under strict=True."""
+        model = nn.Linear(8, 4, bias=False, dtype=torch.float16)
+        # Checkpoint is completely empty — weight is missing.
+        tensors = {"unrelated": torch.randn(2, dtype=torch.float16)}
+        path = _write_safetensors(tensors)
+        try:
+            with _patch_hook(None):
+                with self.assertRaises(RuntimeError):
+                    _st_torch.load_model(model, path, strict=True, device="spyre")
+        finally:
+            os.unlink(path)
+
+    def test_missing_key_strict_false_reported(self):
+        """Under strict=False, a missing key must appear in missing_keys and
+        not raise."""
+        model = nn.Linear(8, 4, bias=False, dtype=torch.float16)
+        tensors = {"unrelated": torch.randn(2, dtype=torch.float16)}
+        path = _write_safetensors(tensors)
+        try:
+            with _patch_hook(None):
+                missing, unexpected = _st_torch.load_model(
+                    model, path, strict=False, device="spyre"
+                )
+            self.assertIn("weight", missing)
+            self.assertIn("unrelated", unexpected)
+        finally:
+            os.unlink(path)
+
+    def test_shape_mismatch_raises(self):
+        """A checkpoint tensor with a different shape from the model parameter
+        must raise RuntimeError with a clear message before any assignment."""
+        model = nn.Linear(8, 4, bias=False, dtype=torch.float16)
+        # Checkpoint weight has the wrong shape.
+        tensors = {"weight": torch.randn(4, 16, dtype=torch.float16)}
+        path = _write_safetensors(tensors)
+        try:
+            with _patch_hook(None):
+                with self.assertRaises(RuntimeError, msg="size mismatch"):
+                    _st_torch.load_model(model, path, strict=True, device="spyre")
+        finally:
+            os.unlink(path)
+
+    def test_empty_model_loads_cleanly(self):
+        """A model with no parameters or buffers must return empty lists and
+        not raise."""
+
+        class _Empty(nn.Module):
+            pass
+
+        tensors = {"unused": torch.randn(2, dtype=torch.float16)}
+        path = _write_safetensors(tensors)
+        try:
+            with _patch_hook(None):
+                missing, unexpected = _st_torch.load_model(
+                    _Empty(), path, strict=False, device="spyre"
+                )
+            self.assertEqual(missing, [])
+            self.assertIn("unused", unexpected)
+        finally:
+            os.unlink(path)
+
+
+# ── integer buffer — not coerced by target_dtype ─────────────────────────────
+
+
+@requires_safetensors
+class TestIntegerBufferNotCoerced(TestCase):
+    """Integer buffers (e.g. position_ids) must never be cast to a float dtype
+    by the dma_target_dtype guard in _spyre_tensor_from_safetensors."""
+
+    def test_int_buffer_reaches_hook_as_int(self):
+        """When target_dtype=torch.float16 is threaded through, integer tensors
+        must still arrive at the hook with their original integer dtype."""
+
+        class _ModelWithIntBuffer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(4, 4, bias=False, dtype=torch.float16)
+                self.register_buffer("position_ids", torch.arange(4, dtype=torch.int64))
+
+        tensors = {
+            "linear.weight": torch.randn(4, 4, dtype=torch.float16),
+            "position_ids": torch.arange(4, dtype=torch.int64),
+        }
+        path = _write_safetensors(tensors)
+        received_dtypes = {}
+
+        def _recording_hook(cpu_tensor, name, device, target_dtype=None):
+            received_dtypes[name] = cpu_tensor.dtype
+            return cpu_tensor
+
+        try:
+            with mock.patch(
+                "torch_spyre._monkey_patch._spyre_tensor_from_safetensors",
+                side_effect=_recording_hook,
+            ):
+                _st_torch.load_file(path, device="spyre", target_dtype=torch.float16)
+            # The hook must see the int64 buffer as int64, not float16.
+            self.assertEqual(received_dtypes["position_ids"], torch.int64)
+            self.assertEqual(received_dtypes["linear.weight"], torch.float16)
+        finally:
+            os.unlink(path)
+
+
+# ── load_model dtype preservation ────────────────────────────────────────────
+
+
+@requires_safetensors
+@instantiate_parametrized_tests
+class TestLoadModelDtypePreservation(TestCase):
+    """load_model dtype handling after the target_dtype threading patch.
+
+    Default behaviour (target_dtype unset, resolves to fp16):
+      - The hook coerces floating-point tensors to fp16 during DMA.
+      - load_model does NOT raise a dtype mismatch — it logs and accepts the
+        coercion, since the Parameter replacement sets the model's dtype to
+        whatever the Spyre tensor carries.
+
+    Explicit opt-out (target_dtype=None):
+      - No coercion; checkpoint dtype is preserved on device.
+      - load_model raises RuntimeError when checkpoint dtype != model dtype.
+
+    Explicit opt-in (target_dtype=torch.bfloat16, etc.):
+      - All floating-point tensors are converted to that dtype during DMA.
+      - Verified via the identity stub: returned dtype matches target_dtype.
+    """
+
+    # ── target_dtype=None: checkpoint dtype preserved ──────────────────────
+
+    @parametrize(
+        "dtype",
+        [torch.float16, torch.bfloat16, torch.float32],
+    )
+    def test_checkpoint_dtype_preserved_when_coercion_disabled(self, dtype):
+        """target_dtype=None disables coercion; the parameter dtype on the
+        (CPU-stub) device must equal the checkpoint dtype."""
+        model = nn.Linear(8, 4, bias=False, dtype=dtype)
+        tensors = {"weight": torch.randn(4, 8, dtype=dtype)}
+        path = _write_safetensors(tensors)
+        try:
+            with _patch_hook(None):
+                missing, unexpected = _st_torch.load_model(
+                    model, path, strict=True, device="spyre", target_dtype=None
+                )
+            self.assertEqual(missing, [])
+            self.assertEqual(unexpected, [])
+            self.assertEqual(model.weight.dtype, dtype)
+        finally:
+            os.unlink(path)
+
+    @parametrize(
+        "model_dtype,ckpt_dtype",
+        [
+            (torch.bfloat16, torch.float16),
+            (torch.float32, torch.float16),
+            (torch.float16, torch.bfloat16),
+        ],
+    )
+    def test_dtype_mismatch_raises_when_coercion_disabled(
+        self, model_dtype, ckpt_dtype
+    ):
+        """target_dtype=None: a mismatch between checkpoint and model dtype must
+        raise RuntimeError rather than silently accepting corrupt data."""
+        model = nn.Linear(8, 4, bias=False, dtype=model_dtype)
+        tensors = {"weight": torch.randn(4, 8, dtype=ckpt_dtype)}
+        path = _write_safetensors(tensors)
+        try:
+            with _patch_hook(None):
+                with self.assertRaises(RuntimeError, msg="dtype mismatch"):
+                    _st_torch.load_model(
+                        model, path, strict=True, device="spyre", target_dtype=None
+                    )
+        finally:
+            os.unlink(path)
+
+    # ── default (target_dtype=_UNSET → fp16): coercion happens ────────────
+
+    @parametrize(
+        "ckpt_dtype",
+        [torch.bfloat16, torch.float32],
+    )
+    def test_default_coercion_to_fp16_does_not_raise(self, ckpt_dtype):
+        """Default path (target_dtype not passed): floating-point tensors are
+        coerced to fp16 by the hook; load_model must NOT raise a dtype error
+        even when the model was initialised with a different dtype.
+
+        Uses the identity stub so no real DMA occurs; the stub ignores
+        target_dtype and returns the cpu tensor as-is, meaning the coercion
+        check is exercised via the coercion_disabled=False branch in load_model.
+        """
+        # Model uses ckpt_dtype; after load the parameter dtype will become
+        # whatever the stub returns (also ckpt_dtype here, because the stub is
+        # identity), but load_model must not treat that as an error.
+        model = nn.Linear(8, 4, bias=False, dtype=ckpt_dtype)
+        tensors = {"weight": torch.randn(4, 8, dtype=ckpt_dtype)}
+        path = _write_safetensors(tensors)
+        try:
+            # No target_dtype kwarg → _UNSET default → coercion_disabled=False.
+            with _patch_hook(None):
+                missing, unexpected = _st_torch.load_model(
+                    model, path, strict=True, device="spyre"
+                )
+            self.assertEqual(missing, [])
+            self.assertEqual(unexpected, [])
+        finally:
+            os.unlink(path)
+
+    # ── explicit target_dtype opt-in ───────────────────────────────────────
+
+    @parametrize(
+        "ckpt_dtype,target_dtype",
+        [
+            (torch.float32, torch.float16),
+            (torch.bfloat16, torch.float16),
+            (torch.float16, torch.bfloat16),
+        ],
+    )
+    def test_explicit_target_dtype_passed_to_hook(self, ckpt_dtype, target_dtype):
+        """When target_dtype is given, the value must reach the hook so the DMA
+        can perform the conversion.  Verified by inspecting the kwarg the mock
+        received — no real hardware required."""
+        tensors = {"weight": torch.randn(4, 8, dtype=ckpt_dtype)}
+        path = _write_safetensors(tensors)
+        try:
+            with _patch_hook(None) as mock_hook:
+                _st_torch.load_file(path, device="spyre", target_dtype=target_dtype)
+            # Confirm the hook was called with the expected target_dtype kwarg.
+            for call in mock_hook.call_args_list:
+                _, kwargs = call
+                self.assertEqual(
+                    kwargs.get("target_dtype"),
+                    target_dtype,
+                    "target_dtype was not threaded through to the hook",
+                )
+        finally:
+            os.unlink(path)
+
+    def test_invalid_target_dtype_raises_early(self):
+        """An unsupported target_dtype (e.g. complex64) must raise ValueError
+        from _validate_target_dtype before any DMA attempt."""
+        model = nn.Linear(8, 4, bias=False, dtype=torch.float16)
+        tensors = {"weight": torch.randn(4, 8, dtype=torch.float16)}
+        path = _write_safetensors(tensors)
+        try:
+            with self.assertRaises(ValueError):
+                _st_torch.load_model(
+                    model,
+                    path,
+                    strict=True,
+                    device="spyre",
+                    target_dtype=torch.complex64,
+                )
+        finally:
+            os.unlink(path)
+
+
+# ── offset_keys forwarding ────────────────────────────────────────────────────
+
+
+@requires_safetensors
+class TestOffsetKeysForwarding(TestCase):
+    """_SpyreSafeOpen.offset_keys() must delegate to the underlying handle's
+    offset_keys(), not to keys().  On a simple file they coincide, so we verify
+    the delegation by mocking the underlying handle."""
+
+    def setUp(self):
+        torch.manual_seed(2)
+        self.tensors = {"z": torch.randn(2, 2), "a": torch.randn(2, 2)}
+        self.path = _write_safetensors(self.tensors)
+
+    def tearDown(self):
+        os.unlink(self.path)
+
+    def test_offset_keys_delegates_to_handle(self):
+        """offset_keys() must call self._handle.offset_keys(), not .keys().
+
+        The safetensors Rust safe_open object is a C extension with read-only
+        slots, so mock.patch.object cannot patch its methods directly.  Instead
+        we wrap _handle in a thin Python proxy that records calls and then
+        verify _SpyreSafeOpen.offset_keys() routed through offset_keys and not
+        keys.
+        """
+        from torch_spyre._monkey_patch import _SpyreSafeOpen
+
+        obj = _SpyreSafeOpen(self.path, framework="pt")
+        with obj:
+            real_handle = obj._handle
+            offset_keys_calls = []
+            keys_calls = []
+
+            class _Proxy:
+                def offset_keys(self):
+                    offset_keys_calls.append(1)
+                    return real_handle.offset_keys()
+
+                def keys(self):
+                    keys_calls.append(1)
+                    return real_handle.keys()
+
+                def __getattr__(self, name):
+                    return getattr(real_handle, name)
+
+            obj._handle = _Proxy()
+            _ = obj.offset_keys()
+
+        self.assertEqual(len(offset_keys_calls), 1, "offset_keys() not called")
+        self.assertEqual(len(keys_calls), 0, "keys() called unexpectedly")
+
+    def test_get_tensors_uses_offset_keys(self):
+        """get_tensors() must iterate via offset_keys() for read locality."""
+        from torch_spyre._monkey_patch import _SpyreSafeOpen
+
+        obj = _SpyreSafeOpen(self.path, framework="pt")
+        with obj:
+            real_handle = obj._handle
+            offset_keys_calls = []
+
+            class _Proxy:
+                def offset_keys(self):
+                    offset_keys_calls.append(1)
+                    return real_handle.offset_keys()
+
+                def __getattr__(self, name):
+                    return getattr(real_handle, name)
+
+            obj._handle = _Proxy()
+            with _patch_hook(None):
+                _ = obj.get_tensors()
+
+        self.assertGreater(
+            len(offset_keys_calls), 0, "offset_keys() not called by get_tensors()"
+        )
+
+
+# ── __getattr__ forward-compat delegation ────────────────────────────────────
+
+
+@requires_safetensors
+class TestSpyreSafeOpenGetattr(TestCase):
+    """_SpyreSafeOpen.__getattr__ must delegate unknown attributes to the
+    underlying handle, making the wrapper forward-compatible with new
+    safetensors API additions."""
+
+    def setUp(self):
+        torch.manual_seed(3)
+        self.path = _write_safetensors({"x": torch.randn(2, 2)})
+
+    def tearDown(self):
+        os.unlink(self.path)
+
+    def test_known_handle_attribute_forwarded(self):
+        """An attribute on the underlying handle that _SpyreSafeOpen does not
+        explicitly implement must be transparently accessible.
+
+        The safetensors Rust safe_open object is a C extension with read-only
+        slots, so we cannot attach attributes to it directly.  Replace _handle
+        with a plain Python object that has the sentinel attribute.
+        """
+        from torch_spyre._monkey_patch import _SpyreSafeOpen
+
+        obj = _SpyreSafeOpen(self.path, framework="pt")
+        with obj:
+            real_handle = obj._handle
+
+            class _HandleWithExtra:
+                _future_api = "sentinel"
+
+                def __getattr__(self, name):
+                    return getattr(real_handle, name)
+
+            obj._handle = _HandleWithExtra()
+            self.assertEqual(obj._future_api, "sentinel")
+
+    def test_missing_attribute_raises_attr_error(self):
+        """An attribute that neither _SpyreSafeOpen nor its handle has must
+        raise AttributeError, not silently return None."""
+        from torch_spyre._monkey_patch import _SpyreSafeOpen
+
+        obj = _SpyreSafeOpen(self.path, framework="pt")
+        with obj:
+            with self.assertRaises(AttributeError):
+                _ = obj._definitely_does_not_exist_xyzzy
+
+
+# ── stable key ordering ───────────────────────────────────────────────────────
+#
+# NOTE: within a single process, PYTHONHASHSEED (and therefore str-set
+# iteration order) is fixed for the process's whole lifetime. Rebuilding a
+# set from the same elements in the same order N times in a loop — even a
+# buggy `return list(some_set)` — reproduces the same order every time
+# *within that run*. Looping and comparing runs against each other therefore
+# cannot detect a regression back to set-based ordering; it only detects
+# non-determinism *within* a process, which a set never actually exhibits
+# either. Asserting against a specific, predicted order (derived from
+# model/checkpoint construction order) is what actually pins the contract:
+# a set-based implementation would only match this by chance, and — because
+# PYTHONHASHSEED is randomized per process by default — would fail this
+# assertion on most CI runs, not just in adversarial ones.
+
+
+@requires_safetensors
+class TestStableKeyOrdering(TestCase):
+    """missing_keys and unexpected_keys must be returned in a stable,
+    deterministic order — not set-iteration order."""
+
+    def test_missing_keys_order_is_stable(self):
+        """missing_keys must follow named_parameters() traversal order
+        (registration order: a, b, c), not set-iteration order."""
+
+        class MultiParamModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = nn.Linear(4, 4, bias=False, dtype=torch.float16)
+                self.b = nn.Linear(4, 4, bias=False, dtype=torch.float16)
+                self.c = nn.Linear(4, 4, bias=False, dtype=torch.float16)
+
+        # Checkpoint contains only a.weight; b.weight and c.weight are missing,
+        # and must be reported in that declaration order — not reversed, and
+        # not whatever order a Python set of the same two strings would give
+        # under some other PYTHONHASHSEED.
+        expected = ["b.weight", "c.weight"]
+
+        tensors = {"a.weight": torch.randn(4, 4, dtype=torch.float16)}
+        path = _write_safetensors(tensors)
+        try:
+            for _ in range(5):
+                model = MultiParamModel()
+                with _patch_hook(None):
+                    missing, _ = _st_torch.load_model(
+                        model, path, strict=False, device="spyre"
+                    )
+                self.assertEqual(
+                    missing,
+                    expected,
+                    f"missing_keys order does not match expected traversal "
+                    f"order: got {missing}, expected {expected}",
+                )
+        finally:
+            os.unlink(path)
+
+    def test_unexpected_keys_order_is_stable(self):
+        """unexpected_keys must preserve checkpoint insertion/offset order
+        (extra_z before extra_a, since that's how the file was written),
+        not set-iteration order."""
+        tensors = {
+            "weight": torch.randn(4, 4, dtype=torch.float16),
+            "extra_z": torch.randn(4, dtype=torch.float16),
+            "extra_a": torch.randn(4, dtype=torch.float16),
+        }
+        # "weight" is consumed by the model; the two extras remain unexpected
+        # in whatever order they actually appear in the checkpoint. Don't
+        # hardcode an assumption about that order here: safetensors'
+        # save_file does NOT preserve input dict insertion order — it sorts
+        # tensor names before writing (verified against 0.8.0: a dict built
+        # as {"weight", "extra_z", "extra_a"} is written to disk as
+        # extra_a, extra_z, weight). Read the real on-disk order back via
+        # offset_keys() so this test tracks safetensors' actual behavior
+        # instead of an assumption about it that could go stale on a future
+        # safetensors version.
+        path = _write_safetensors(tensors)
+        try:
+            with safetensors.safe_open(path, framework="pt", device="cpu") as f:
+                on_disk_order = f.offset_keys()
+            expected = [k for k in on_disk_order if k != "weight"]
+            self.assertEqual(
+                expected,
+                ["extra_a", "extra_z"],
+                "sanity check: expected on-disk order itself looks wrong "
+                f"({expected}) — either safetensors' serialization order "
+                "changed, or _write_safetensors changed. Investigate before "
+                "trusting the rest of this test.",
+            )
+
+            for _ in range(5):
+                m = nn.Linear(4, 4, bias=False, dtype=torch.float16)
+                with _patch_hook(None):
+                    _, unexpected = _st_torch.load_model(
+                        m, path, strict=False, device="spyre"
+                    )
+                self.assertEqual(
+                    unexpected,
+                    expected,
+                    f"unexpected_keys order does not match on-disk checkpoint "
+                    f"order: got {unexpected}, expected {expected}",
+                )
+        finally:
+            os.unlink(path)
+
+    def test_missing_keys_order_immune_to_hash_seed(self):
+        """Cross-process check: the same call made under different
+        PYTHONHASHSEED values must return identical order. This is the
+        specific property a set-based implementation violates (string-set
+        iteration order depends on the hash seed) and that
+        test_missing_keys_order_is_stable, run once per process, cannot
+        observe on its own."""
+        import subprocess
+        import sys
+
+        script = """
+import sys, torch, torch.nn as nn
+sys.path.insert(0, {test_dir!r})
+from test_safetensors_patch_monkey_patch import (
+    _write_safetensors, _patch_hook, _st_torch
+)
+
+class MultiParamModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.a = nn.Linear(4, 4, bias=False, dtype=torch.float16)
+        self.b = nn.Linear(4, 4, bias=False, dtype=torch.float16)
+        self.c = nn.Linear(4, 4, bias=False, dtype=torch.float16)
+
+tensors = {{"a.weight": torch.randn(4, 4, dtype=torch.float16)}}
+path = _write_safetensors(tensors)
+model = MultiParamModel()
+with _patch_hook(None):
+    missing, _ = _st_torch.load_model(model, path, strict=False, device="spyre")
+print(",".join(missing))
+""".format(test_dir=os.path.dirname(os.path.abspath(__file__)))
+
+        orders = set()
+        for seed in ("0", "1", "2", "3"):
+            env = dict(os.environ, PYTHONHASHSEED=seed)
+            result = subprocess.run(
+                [sys.executable, "-c", script],
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=60,
+            )
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"subprocess with PYTHONHASHSEED={seed} failed:\n{result.stderr}",
+            )
+            orders.add(result.stdout.strip())
+
+        self.assertEqual(
+            len(orders),
+            1,
+            f"missing_keys order changed across PYTHONHASHSEED values: {orders} "
+            f"— this indicates set-iteration order is leaking through instead "
+            f"of a deterministic traversal order.",
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/tensor/test_safetensors_patch_monkey_patch_spyre.py
+++ b/tests/tensor/test_safetensors_patch_monkey_patch_spyre.py
@@ -1,0 +1,554 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Owner(s): ["module: spyre"]
+
+"""
+Hardware integration tests for the safetensors monkey-patch.
+
+Every test in this file requires a physical Spyre device. The CPU-only logic
+(routing, key handling, tied weights, ordering) is covered by
+test_safetensors_patch.py. This file covers what only Spyre hardware can verify:
+
+  - Correct DMA layout selection actually applied on device
+    (embedding → indirect-access, linear weight → dim_order=[1,0])
+  - target_dtype coercion actually performed during DMA
+  - Round-trip value correctness: write → load_file(device='spyre') → .cpu()
+  - load_model on a meta-device model populates all parameters on Spyre
+  - load_model with tied weights: both aliases land on Spyre, tie preserved,
+    inference produces finite output
+  - Integer buffer not coerced to float by target_dtype
+
+Run with:
+    pytest tests/tensor/test_safetensors_patch_spyre.py -v
+"""
+
+import os
+import tempfile
+from typing import Dict
+
+import pytest
+import torch
+import torch.nn as nn
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+# ── hardware availability guard ───────────────────────────────────────────────
+
+
+def _spyre_available() -> bool:
+    try:
+        import torch_spyre  # noqa: F401
+        from torch_spyre.constants import DEVICE_NAME
+
+        torch.zeros(1, dtype=torch.float16, device=DEVICE_NAME)
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _spyre_available(), reason="requires an available Spyre device"
+)
+
+# ── safetensors availability guard ────────────────────────────────────────────
+
+try:
+    import safetensors.torch as _st_torch
+
+    HAS_SAFETENSORS = True
+except ImportError:
+    HAS_SAFETENSORS = False
+
+pytestmark = [
+    pytest.mark.skipif(
+        not _spyre_available(), reason="requires an available Spyre device"
+    ),
+    pytest.mark.skipif(not HAS_SAFETENSORS, reason="safetensors>=0.8.0 not installed"),
+]
+
+# ── constants (match test_model_utils.py tolerances) ─────────────────────────
+
+# fp16 lands on device as DLFLOAT16 (SEN169_FP16, 9 mantissa bits):
+# round-trip is never bit-exact (2**-10 half-ULP, subnormals halved).
+DLFLOAT16_RTOL = 2e-3
+DLFLOAT16_ATOL = 1e-4
+
+# bf16 has 7 mantissa bits; DMA round-trip error is bounded by 2**-7 half-ULP.
+BFLOAT16_RTOL = 1e-2
+BFLOAT16_ATOL = 1e-3
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _write_safetensors(tensors: Dict[str, torch.Tensor]) -> str:
+    """Write CPU tensors to a temp .safetensors file, return path."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".safetensors", delete=False)
+    tmp.close()
+    _st_torch.save_file(tensors, tmp.name)
+    return tmp.name
+
+
+# ── DMA layout selection ──────────────────────────────────────────────────────
+
+
+class TestDmaLayoutSelection(TestCase):
+    """load_file(device='spyre') must select the correct DMA layout for each
+    tensor kind: embedding → indirect-access, linear weight → dim_order=[1,0],
+    everything else → default."""
+
+    def setUp(self):
+        torch.manual_seed(0xAFFE)
+
+    def test_embedding_key_gets_indirect_access_layout(self):
+        """An embedding-named key loaded via load_file must land with the
+        indirect-access layout (vocab dim outermost, hidden split into sticks).
+
+        For a (1000, 256) fp16 table: eps=64, device_size=[1000, 4, 64].
+        """
+        from torch_spyre._C import get_spyre_tensor_layout
+
+        tensors = {
+            "model.embed_tokens.weight": torch.randn(1000, 256, dtype=torch.float16)
+        }
+        path = _write_safetensors(tensors)
+        try:
+            result = _st_torch.load_file(path, device="spyre")
+            layout = get_spyre_tensor_layout(result["model.embed_tokens.weight"])
+            self.assertEqual(list(layout.device_size), [1000, 4, 64])
+        finally:
+            os.unlink(path)
+
+    def test_linear_weight_key_gets_dim_order_layout(self):
+        """A linear-weight key loaded via load_file must land with
+        dim_order=[1,0] stickification (out_features sticks on dim 0).
+
+        For a (128, 64) weight: device_size[0] = 128/64 = 2.
+        """
+        from torch_spyre._C import get_spyre_tensor_layout
+
+        tensors = {
+            "model.layers.0.self_attn.q_proj.weight": torch.randn(
+                128, 64, dtype=torch.float16
+            )
+        }
+        path = _write_safetensors(tensors)
+        try:
+            result = _st_torch.load_file(path, device="spyre")
+            layout = get_spyre_tensor_layout(
+                result["model.layers.0.self_attn.q_proj.weight"]
+            )
+            self.assertEqual(layout.device_size[0], 2)  # 128 / 64
+        finally:
+            os.unlink(path)
+
+    def test_other_key_gets_default_layout(self):
+        """A bias or 1-D norm param must reach Spyre via the default layout
+        and round-trip correctly."""
+        tensors = {
+            "model.layers.0.input_layernorm.weight": torch.randn(
+                128, dtype=torch.float16
+            )
+        }
+        path = _write_safetensors(tensors)
+        try:
+            result = _st_torch.load_file(path, device="spyre")
+            self.assertEqual(
+                result["model.layers.0.input_layernorm.weight"].device.type, "spyre"
+            )
+        finally:
+            os.unlink(path)
+
+    def test_false_positive_embed_out_gets_dim_order_layout(self):
+        """GPT-NeoX 'embed_out' module is a Linear output head, not an
+        embedding table.  It must receive dim_order=[1,0], not indirect-access.
+
+        For a (256, 128) weight: device_size[0] = 256/64 = 4 under dim_order.
+        Under indirect-access it would be device_size=[256, 2, 64], which is
+        WRONG for a matmul weight.
+        """
+        from torch_spyre._C import get_spyre_tensor_layout
+
+        tensors = {"model.embed_out.weight": torch.randn(256, 128, dtype=torch.float16)}
+        path = _write_safetensors(tensors)
+        try:
+            result = _st_torch.load_file(path, device="spyre")
+            layout = get_spyre_tensor_layout(result["model.embed_out.weight"])
+            # dim_order layout: device_size[0] = out_features / 64
+            self.assertEqual(layout.device_size[0], 4)  # 256 / 64
+        finally:
+            os.unlink(path)
+
+
+# ── round-trip value correctness ─────────────────────────────────────────────
+
+
+class TestRoundTripValues(TestCase):
+    """write → load_file(device='spyre') → .cpu() must reproduce original
+    values within the documented DMA tolerances."""
+
+    def setUp(self):
+        torch.manual_seed(1)
+
+    def test_fp16_round_trip(self):
+        """fp16 tensor round-trips within DLFLOAT16 tolerance."""
+        orig = torch.randn(64, 128, dtype=torch.float16)
+        path = _write_safetensors({"weight": orig})
+        try:
+            result = _st_torch.load_file(path, device="spyre")
+            torch.testing.assert_close(
+                result["weight"].cpu(),
+                orig,
+                rtol=DLFLOAT16_RTOL,
+                atol=DLFLOAT16_ATOL,
+            )
+        finally:
+            os.unlink(path)
+
+    def test_fp32_round_trip(self):
+        """fp32 tensor round-trips losslessly when coercion is disabled.
+
+        The default path (target_dtype=_UNSET) coerces fp32 to fp16 during DMA
+        (the Spyre hardware requirement). Use target_dtype=None to opt out of
+        coercion and verify the lossless IEEE_FP32 path.
+        """
+        orig = torch.randn(64, 128, dtype=torch.float32)
+        # Use a non-embedding key so the default layout is used (not
+        # indirect-access, which is gather-optimised for embedding tables).
+        path = _write_safetensors({"model.layers.0.bias": orig})
+        try:
+            result = _st_torch.load_file(path, device="spyre", target_dtype=None)
+            self.assertEqual(result["model.layers.0.bias"].dtype, torch.float32)
+            torch.testing.assert_close(result["model.layers.0.bias"].cpu(), orig)
+        finally:
+            os.unlink(path)
+
+    def test_target_dtype_bf16_to_fp16_converted_on_device(self):
+        """load_file(target_dtype=torch.float16) on a bf16 checkpoint must
+        produce fp16 tensors on Spyre — the coercion happens in copy_tensor
+        during the DMA, not on CPU."""
+        orig_bf16 = torch.randn(64, 128, dtype=torch.bfloat16)
+        path = _write_safetensors({"weight": orig_bf16})
+        try:
+            result = _st_torch.load_file(
+                path, device="spyre", target_dtype=torch.float16
+            )
+            self.assertEqual(result["weight"].dtype, torch.float16)
+            # Value round-trip: bf16 → fp16 narrowing is within fp16 tolerance.
+            torch.testing.assert_close(
+                result["weight"].cpu().to(torch.float32),
+                orig_bf16.to(torch.float32),
+                rtol=DLFLOAT16_RTOL,
+                atol=DLFLOAT16_ATOL,
+            )
+        finally:
+            os.unlink(path)
+
+    def test_target_dtype_fp32_to_bf16_converted_on_device(self):
+        """load_file(target_dtype=torch.bfloat16) on an fp32 checkpoint
+        produces bf16 tensors on Spyre."""
+        orig_fp32 = torch.randn(64, 128, dtype=torch.float32)
+        path = _write_safetensors({"weight": orig_fp32})
+        try:
+            result = _st_torch.load_file(
+                path, device="spyre", target_dtype=torch.bfloat16
+            )
+            self.assertEqual(result["weight"].dtype, torch.bfloat16)
+            torch.testing.assert_close(
+                result["weight"].cpu().to(torch.float32),
+                orig_fp32,
+                rtol=BFLOAT16_RTOL,
+                atol=BFLOAT16_ATOL,
+            )
+        finally:
+            os.unlink(path)
+
+    def test_integer_buffer_not_coerced_to_float(self):
+        """An int64 position_ids buffer must land on Spyre as int64 even when
+        target_dtype=torch.float16 is set — the is_floating_point guard must
+        fire."""
+        tensors = {
+            "weight": torch.randn(64, 64, dtype=torch.float16),
+            "position_ids": torch.arange(64, dtype=torch.int64),
+        }
+        path = _write_safetensors(tensors)
+        try:
+            result = _st_torch.load_file(
+                path, device="spyre", target_dtype=torch.float16
+            )
+            self.assertEqual(result["position_ids"].dtype, torch.int64)
+            self.assertEqual(result["weight"].dtype, torch.float16)
+        finally:
+            os.unlink(path)
+
+
+# ── load_model meta-device population ────────────────────────────────────────
+
+
+class TestLoadModelMetaDevice(TestCase):
+    """The core motivation for _spyre_load_model: copy_() is a no-op on meta
+    tensors, so load_state_dict silently leaves params on meta.  The direct
+    _parameters replacement must move every param to Spyre."""
+
+    def setUp(self):
+        torch.manual_seed(2)
+
+    def test_all_parameters_leave_meta_after_load(self):
+        """Every parameter must be on Spyre (not meta) after load_model."""
+        model = nn.Linear(128, 64, dtype=torch.float16, device="meta")
+        tensors = {
+            "weight": torch.randn(64, 128, dtype=torch.float16),
+            "bias": torch.randn(64, dtype=torch.float16),
+        }
+        path = _write_safetensors(tensors)
+        try:
+            _st_torch.load_model(model, path, strict=True, device="spyre")
+            for name, param in model.named_parameters():
+                self.assertEqual(
+                    param.device.type,
+                    "spyre",
+                    f"{name} is still on {param.device} after load_model",
+                )
+        finally:
+            os.unlink(path)
+
+    def test_meta_model_no_parameters_remain_on_meta(self):
+        """A deeper meta-device model — all submodule parameters must reach
+        Spyre, not just the top-level ones."""
+
+        class _TwoLayer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.fc1 = nn.Linear(128, 64, dtype=torch.float16, device="meta")
+                self.fc2 = nn.Linear(64, 32, dtype=torch.float16, device="meta")
+
+            def forward(self, x):
+                return self.fc2(torch.relu(self.fc1(x)))
+
+        model = _TwoLayer()
+        tensors = {
+            "fc1.weight": torch.randn(64, 128, dtype=torch.float16),
+            "fc1.bias": torch.randn(64, dtype=torch.float16),
+            "fc2.weight": torch.randn(32, 64, dtype=torch.float16),
+            "fc2.bias": torch.randn(32, dtype=torch.float16),
+        }
+        path = _write_safetensors(tensors)
+        try:
+            _st_torch.load_model(model, path, strict=True, device="spyre")
+            meta_params = [
+                name for name, p in model.named_parameters() if p.device.type == "meta"
+            ]
+            self.assertEqual(
+                meta_params,
+                [],
+                f"Parameters still on meta after load_model: {meta_params}",
+            )
+        finally:
+            os.unlink(path)
+
+    def test_meta_model_with_target_dtype(self):
+        """target_dtype converts during DMA; meta params must land on Spyre
+        as the requested dtype, not remain on meta."""
+        model = nn.Linear(64, 32, dtype=torch.bfloat16, device="meta")
+        tensors = {
+            "weight": torch.randn(32, 64, dtype=torch.bfloat16),
+            "bias": torch.randn(32, dtype=torch.bfloat16),
+        }
+        path = _write_safetensors(tensors)
+        try:
+            _st_torch.load_model(
+                model,
+                path,
+                strict=True,
+                device="spyre",
+                target_dtype=torch.float16,
+            )
+            for name, param in model.named_parameters():
+                self.assertEqual(param.device.type, "spyre")
+                self.assertEqual(param.dtype, torch.float16)
+        finally:
+            os.unlink(path)
+
+
+# ── load_model tied weights on hardware ──────────────────────────────────────
+
+
+class TestLoadModelTiedWeightsHardware(TestCase):
+    """The tied-weight blocker from the review: lm_head.weight tied to
+    embed.weight, checkpoint stores only embed.weight.
+
+    Hardware tests confirm:
+      - both aliases land on Spyre (not meta, not CPU)
+      - the Python object identity of the tie is preserved on Spyre
+      - a forward pass through the tied model produces finite output
+    """
+
+    class _TiedLM(nn.Module):
+        """Minimal language-model with a tied embed/lm_head."""
+
+        def __init__(self, vocab=64, hidden=128, dtype=torch.float16):
+            super().__init__()
+            self.embed = nn.Embedding(vocab, hidden, dtype=dtype)
+            self.lm_head = nn.Linear(hidden, vocab, bias=False, dtype=dtype)
+            self.lm_head.weight = self.embed.weight  # tie
+
+        def forward(self, input_ids):
+            x = self.embed(input_ids)  # (B, T, H)
+            return self.lm_head(x)  # (B, T, V)
+
+    def setUp(self):
+        torch.manual_seed(3)
+
+    def _make_checkpoint(self, vocab=64, hidden=128, dtype=torch.float16):
+        tensors = {"embed.weight": torch.randn(vocab, hidden, dtype=dtype)}
+        path = _write_safetensors(tensors)
+        return path, tensors["embed.weight"]
+
+    def test_both_tied_aliases_on_spyre(self):
+        """After load_model, both embed.weight and lm_head.weight must be on
+        Spyre, not meta or CPU."""
+        model = self._TiedLM()
+        path, _ = self._make_checkpoint()
+        try:
+            _st_torch.load_model(model, path, strict=True, device="spyre")
+            self.assertEqual(model.embed.weight.device.type, "spyre")
+            self.assertEqual(model.lm_head.weight.device.type, "spyre")
+        finally:
+            os.unlink(path)
+
+    def test_tied_weight_identity_preserved_on_spyre(self):
+        """embed.weight and lm_head.weight must be the same Python object after
+        load_model — the tie must not be severed by the parameter replacement."""
+        model = self._TiedLM()
+        path, _ = self._make_checkpoint()
+        try:
+            _st_torch.load_model(model, path, strict=True, device="spyre")
+            self.assertIs(
+                model.embed.weight,
+                model.lm_head.weight,
+                "Weight tie severed: embed.weight is not lm_head.weight after load",
+            )
+        finally:
+            os.unlink(path)
+
+    def test_tied_model_forward_produces_finite_output(self):
+        """A forward pass through the tied model after load_model must produce
+        finite, non-NaN logits.  NaN/Inf would indicate a corrupt lm_head
+        (unloaded, wrong layout, or severed tie)."""
+        model = self._TiedLM(vocab=64, hidden=128)
+        path, _ = self._make_checkpoint(vocab=64, hidden=128)
+        try:
+            _st_torch.load_model(model, path, strict=True, device="spyre")
+            input_ids = torch.randint(0, 64, (1, 8), device="spyre")
+            logits = model(input_ids)
+            cpu_logits = logits.cpu().float()
+            self.assertFalse(
+                torch.isnan(cpu_logits).any().item(),
+                "Forward pass produced NaN — lm_head may be unloaded or severed",
+            )
+            self.assertFalse(
+                torch.isinf(cpu_logits).any().item(),
+                "Forward pass produced Inf — possible dtype overflow in lm_head",
+            )
+        finally:
+            os.unlink(path)
+
+    def test_tied_model_embed_lm_head_values_match(self):
+        """Because lm_head.weight IS embed.weight, a matmul with a known input
+        must be equivalent to an embedding lookup followed by a dot product."""
+        vocab, hidden = 64, 128
+        model = self._TiedLM(vocab=vocab, hidden=hidden)
+        path, ckpt_weight = self._make_checkpoint(vocab=vocab, hidden=hidden)
+        try:
+            _st_torch.load_model(model, path, strict=True, device="spyre")
+            # Both aliases must carry identical values.
+            torch.testing.assert_close(
+                model.embed.weight.cpu(),
+                model.lm_head.weight.cpu(),
+                rtol=0.0,
+                atol=0.0,
+                msg="embed.weight and lm_head.weight values differ after load",
+            )
+        finally:
+            os.unlink(path)
+
+
+# ── safe_open layout and round-trip ──────────────────────────────────────────
+
+
+class TestSafeOpenHardware(TestCase):
+    """safe_open(device='spyre') end-to-end: layout selection and value
+    correctness via get_tensor and get_slice."""
+
+    def setUp(self):
+        torch.manual_seed(4)
+        self.tensors = {
+            "model.embed_tokens.weight": torch.randn(256, 128, dtype=torch.float16),
+            "model.layers.0.q_proj.weight": torch.randn(128, 128, dtype=torch.float16),
+            "model.layers.0.input_layernorm.weight": torch.randn(
+                128, dtype=torch.float16
+            ),
+        }
+        self.path = _write_safetensors(self.tensors)
+
+    def tearDown(self):
+        os.unlink(self.path)
+
+    def test_get_tensor_values_round_trip(self):
+        """All tensors loaded via safe_open get_tensor must round-trip within
+        DLFLOAT16 tolerance."""
+        import safetensors as _st_mod
+
+        with _st_mod.safe_open(self.path, framework="pt", device="spyre") as f:
+            for key in f.keys():
+                result = f.get_tensor(key).cpu()
+                torch.testing.assert_close(
+                    result,
+                    self.tensors[key],
+                    rtol=DLFLOAT16_RTOL,
+                    atol=DLFLOAT16_ATOL,
+                )
+
+    def test_get_slice_values_round_trip(self):
+        """A partial slice via get_slice must round-trip correctly."""
+        import safetensors as _st_mod
+
+        key = "model.layers.0.q_proj.weight"
+        orig_slice = self.tensors[key][:32, :]  # first 32 rows
+
+        with _st_mod.safe_open(self.path, framework="pt", device="spyre") as f:
+            result = f.get_slice(key)[:32, :].cpu()
+
+        torch.testing.assert_close(
+            result,
+            orig_slice,
+            rtol=DLFLOAT16_RTOL,
+            atol=DLFLOAT16_ATOL,
+        )
+
+    def test_embedding_tensor_on_device_has_indirect_access_layout(self):
+        """Embedding tensor loaded via safe_open must have the indirect-access
+        layout on Spyre."""
+        from torch_spyre._C import get_spyre_tensor_layout
+        import safetensors as _st_mod
+
+        with _st_mod.safe_open(self.path, framework="pt", device="spyre") as f:
+            emb = f.get_tensor("model.embed_tokens.weight")
+
+        layout = get_spyre_tensor_layout(emb)
+        # (256, 128) fp16: eps=64, device_size=[256, 2, 64]
+        self.assertEqual(list(layout.device_size), [256, 2, 64])
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
+
+import torch
+import torch.nn as nn
 
 from torch._dynamo.guards import GuardBuilder
 
@@ -501,6 +504,485 @@ def _patch_invoke_subgraph_decompositions():
 
     _spyre_extract_nested_region_config._spyre_decomp_patched = True
     mod._extract_nested_region_config = _spyre_extract_nested_region_config
+
+    # ── Safetensors Spyre-aware loading (monkey-patch for safetensors PR #804) ──
+    # safetensors PR #804 adds _register_device_transfer_hook() to the Rust core
+    # and _is_custom_device(). Until that PR is merged we monkey-patch the three
+    # public Python entry points instead. When PR #804 lands, delete
+    # _patch_safetensors_for_spyre() and its call here, then add in
+    # _autoload_impl():
+    #
+    #   from safetensors import _register_device_transfer_hook
+    #   _register_device_transfer_hook(DEVICE_NAME, _spyre_tensor_from_safetensors)
+    # ─────────────────────────────────────────────────────────────────────────────
+    try:
+        _patch_safetensors_for_spyre()
+    except Exception as e:  # pragma: no cover - safetensors may not be installed
+        import warnings
+
+        warnings.warn(f"Failed to install safetensors Spyre patches: {e}")
+
+
+# ── Safetensors hook + monkey-patch ──────────────────────────────────────────
+#
+# Hook signature (matches PR #804 _register_device_transfer_hook contract):
+#
+#   hook(cpu_tensor: torch.Tensor, name: str, device) -> torch.Tensor
+#
+# Where:
+#   cpu_tensor — tensor freshly loaded from disk, on CPU (may be a
+#                memoryview-backed zero-copy view from mmap).
+#   name       — tensor key in the safetensors file, e.g.
+#                "model.layers.0.self_attn.q_proj.weight". Used to select the
+#                optimal Spyre DMA layout.
+#   device     — original device argument (str or torch.device). Passed
+#                through for potential device-index handling ("spyre:1").
+#
+# Tensor-type heuristics from key names
+# ──────────────────────────────────────
+# In a flat safetensors dict we have no nn.Module to call isinstance() on, so
+# we recover the tensor kind from its key name — a convention stable across
+# virtually all HuggingFace and standard PyTorch checkpoints:
+#
+#   Embedding table  – 2D tensor whose lowercased key contains any fragment
+#                      from _EMBEDDING_KEY_FRAGMENTS.
+#                      Shape: [vocab_size, hidden_dim] or [max_pos, hidden_dim].
+#                      → _dma_to_spyre_indirect_access (gather-optimal layout).
+#                        Falls back to default if hidden_dim % eps != 0.
+#
+#   Linear weight    – 2D tensor whose key ends with ".weight" and is NOT
+#                      classified as an embedding. Covers q/k/v/o projections,
+#                      MLP up/gate/down, free lm_head, etc.
+#                      → _dma_to_spyre_dim_order_swapped (dim_order=[1,0],
+#                        matmul-optimal).
+#
+#   lm_head (tied)   – When lm_head is tied to the embedding table the caller
+#                      should use load_model_to_spyre (which has nn.Module
+#                      context). load_file / safe_open see it as a free 2D
+#                      weight and apply dim_order=[1,0], which is correct for
+#                      the matmul path and merely sub-optimal for the tied case.
+#
+#   Everything else  – bias, layer-norm params, 1-D buffers, etc.
+#                      → _dma_to_spyre_default (stickify last dim).
+# ─────────────────────────────────────────────────────────────────────────────
+
+_EMBEDDING_KEY_FRAGMENTS: tuple = (
+    "embed",  # embeddings, embed_tokens, embedding, …
+    "wte",  # GPT-2 word-token embeddings
+    "wpe",  # GPT-2 word-position embeddings
+    "tok_embed",
+    "word_embed",
+    "token_embed",
+    "pos_embed",
+    "patch_embed",
+)
+
+
+def _classify_safetensors_key(name: str, ndim: int) -> str:
+    """Return ``'embedding'``, ``'linear'``, or ``'other'``.
+
+    Pure name-convention + ndim heuristic; no model object required.
+    """
+    if ndim != 2:
+        return "other"
+    name_lower = name.lower()
+    for frag in _EMBEDDING_KEY_FRAGMENTS:
+        if frag in name_lower:
+            return "embedding"
+    if name_lower.endswith(".weight"):
+        return "linear"
+    return "other"
+
+
+def _spyre_tensor_from_safetensors(
+    cpu_tensor: "torch.Tensor",
+    name: str,
+    device,  # str | torch.device — honoured by forward-compat; index unused for now
+) -> "torch.Tensor":
+    """Spyre device-transfer hook for safetensors (PR #804 contract).
+
+    Receives a CPU tensor loaded from a safetensors file and returns a tensor
+    on the Spyre device with the optimal layout for the tensor's role.
+
+    Layout selection (mirrors ``_transfer_module`` in model_utils.py):
+      - 2D embedding-named tensor  → indirect-access layout (gather-optimal).
+        Falls back to default if ``hidden_dim % elems_per_stick != 0``.
+      - 2D Linear weight           → ``dim_order=[1, 0]`` (matmul-optimal).
+      - Everything else            → default Spyre layout (stickify last dim).
+    """
+    from torch_spyre.model_utils import (
+        _dma_to_spyre_default,
+        _dma_to_spyre_dim_order_swapped,
+        _dma_to_spyre_indirect_access,
+    )
+    from torch_spyre._inductor.logging_utils import get_inductor_logger
+
+    logger = get_inductor_logger("model_utils")
+
+    if cpu_tensor.dtype != torch.float16 and cpu_tensor.dtype.is_floating_point:
+        cpu_tensor = cpu_tensor.to(dtype=torch.float16)
+    # The mmap fast-path in safetensors gives us a memoryview-backed
+    # frombuffer view. Make it contiguous before any Spyre DMA call.
+    if not cpu_tensor.is_contiguous():
+        cpu_tensor = cpu_tensor.contiguous()
+
+    kind = _classify_safetensors_key(name, cpu_tensor.ndim)
+
+    if kind == "embedding":
+        result = _dma_to_spyre_indirect_access(cpu_tensor)
+        if result is not None:
+            logger.debug(
+                "safetensors: %s shape=%s -> Spyre indirect-access (gather) layout",
+                name,
+                list(cpu_tensor.shape),
+            )
+            return result
+        # _dma_to_spyre_indirect_access warned already; fall through to default.
+        logger.debug(
+            "safetensors: %s shape=%s -> Spyre default layout (embedding fallback)",
+            name,
+            list(cpu_tensor.shape),
+        )
+        return _dma_to_spyre_default(cpu_tensor)
+
+    if kind == "linear":
+        logger.debug(
+            "safetensors: %s shape=%s -> Spyre dim_order=[1, 0]",
+            name,
+            list(cpu_tensor.shape),
+        )
+        return _dma_to_spyre_dim_order_swapped(cpu_tensor)
+
+    # "other": bias, norms, 1-D buffers, etc.
+    logger.debug(
+        "safetensors: %s shape=%s -> Spyre default layout",
+        name,
+        list(cpu_tensor.shape),
+    )
+    return _dma_to_spyre_default(cpu_tensor)
+
+
+class _SpyreSafeOpen:
+    """Context-manager wrapper around ``safetensors.safe_open`` for Spyre.
+
+    Opened with ``device="cpu"`` internally; each ``get_tensor`` / ``get_tensors``
+    / slice call transfers the result to Spyre via ``_spyre_tensor_from_safetensors``.
+
+    All non-tensor methods (``keys``, ``metadata``, ``get_slice``,
+    ``offset_keys``) are forwarded verbatim so callers that iterate keys or
+    read metadata work without changes.
+
+    ``get_slice`` returns a ``_SpyreSafeSlice`` wrapper that applies the hook
+    on ``__getitem__``, matching the slice-dispatch behaviour that safetensors
+    PR #804 patch-2 adds to the Rust core.
+    """
+
+    def __init__(
+        self,
+        filename,
+        framework: str,
+        backend: str = "mmap",
+    ):
+        import safetensors as _st_mod
+
+        # Open on CPU so the Rust core handles mmap / pread normally.
+        self._handle = _st_mod._orig_safe_open(
+            filename, framework=framework, device="cpu", backend=backend
+        )
+
+    def __enter__(self) -> "_SpyreSafeOpen":
+        self._handle.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        return self._handle.__exit__(*args)
+
+    # ── forwarded metadata ───────────────────────────────────────────────────
+
+    def keys(self) -> List[str]:
+        return self._handle.keys()
+
+    def offset_keys(self) -> List[str]:
+        """Alias for ``keys()``; present for callers that use the older API."""
+        return self._handle.keys()
+
+    def metadata(self) -> Optional[Dict[str, str]]:
+        return self._handle.metadata()
+
+    # ── Spyre-aware tensor accessors ─────────────────────────────────────────
+
+    def get_tensor(self, key: str) -> "torch.Tensor":
+        """Load ``key`` on CPU then DMA to Spyre with the optimal layout."""
+        cpu_tensor = self._handle.get_tensor(key)
+        return _spyre_tensor_from_safetensors(cpu_tensor, key, DEVICE_NAME)
+
+    def get_tensors(self) -> Dict[str, "torch.Tensor"]:
+        """Load all tensors and DMA each to Spyre with the optimal layout.
+
+        Matches the ``safe_open.get_tensors()`` API added by safetensors PR #786.
+        """
+        result: Dict[str, "torch.Tensor"] = {}
+        for key in self._handle.keys():
+            result[key] = self.get_tensor(key)
+        return result
+
+    def get_slice(self, key: str) -> "_SpyreSafeSlice":
+        """Return a ``_SpyreSafeSlice`` that applies the Spyre hook on indexing."""
+        return _SpyreSafeSlice(self._handle.get_slice(key), key)
+
+
+class _SpyreSafeSlice:
+    """Slice wrapper: applies ``_spyre_tensor_from_safetensors`` on ``__getitem__``.
+
+    Matches the behaviour added to ``PySafeSlice.__getitem__`` by safetensors
+    PR #804 patch-2 (``slice_custom_device``): gather bytes on CPU first,
+    then invoke the hook. This avoids the double-dispatch problem that would
+    arise if we applied the hook inside the Rust slice path (Spyre → Spyre copy).
+    """
+
+    def __init__(self, cpu_slice, name: str):
+        self._cpu_slice = cpu_slice
+        self._name = name
+
+    def __getitem__(self, slices) -> "torch.Tensor":
+        # The underlying CPU slice gives us a contiguous CPU tensor.
+        cpu_tensor = self._cpu_slice[slices]
+        return _spyre_tensor_from_safetensors(cpu_tensor, self._name, DEVICE_NAME)
+
+
+def _patch_safetensors_for_spyre() -> None:
+    """Monkey-patch safetensors for Spyre-aware loading.
+
+    Patches three public entry points so that ``device="spyre"`` transparently
+    applies optimal Spyre DMA layout per tensor via
+    ``_spyre_tensor_from_safetensors``:
+
+    1. ``safetensors.safe_open(path, framework="pt", device="spyre")``
+       Returns ``_SpyreSafeOpen`` (opens on CPU internally, dispatches each
+       ``get_tensor`` / ``get_tensors`` / slice through the hook).
+
+    2. ``safetensors.torch.load_file(filename, device="spyre")``
+       Delegates to the patched ``safe_open`` so ``f.get_tensors()`` goes
+       through the hook path.
+
+    3. ``safetensors.torch.load_model(model, filename, device="spyre")``
+       Loads the state dict on CPU, uses ``_assign_tensors_to_model`` (PR #804's
+       direct-assignment path) to install tensors that have already been moved
+       to Spyre by the hook. Falls back to ``load_model_to_spyre`` for the
+       full nn.Linear / nn.Embedding isinstance optimisation.
+
+    All patches are idempotent (``_spyre_patched`` sentinel). Non-Spyre
+    device paths fall through to the originals.
+
+    Removal note — when safetensors PR #804 merges
+    ────────────────────────────────────────────────
+    Delete this function and its call in ``_patch_tensor_for_spyre``.
+    Add in ``_autoload_impl``::
+
+        from safetensors import _register_device_transfer_hook
+        _register_device_transfer_hook(DEVICE_NAME, _spyre_tensor_from_safetensors)
+    """
+    try:
+        import safetensors as _st_mod
+        import safetensors.torch as _st_torch
+    except ImportError:
+        return  # safetensors not installed
+
+    # ── 1. Wrap safetensors.safe_open ────────────────────────────────────────
+    # Stash the original Rust class under _orig_safe_open so _SpyreSafeOpen
+    # can always reach it regardless of further patching.
+    if not hasattr(_st_mod, "_orig_safe_open"):
+        _st_mod._orig_safe_open = _st_mod.safe_open
+
+    if not getattr(_st_mod.safe_open, "_spyre_patched", False):
+        _orig = _st_mod._orig_safe_open
+
+        class _SpyreSafeOpenDispatch:
+            """Route ``device="spyre"`` to ``_SpyreSafeOpen``; pass everything else through."""
+
+            _spyre_patched = True
+
+            def __new__(
+                cls, filename, framework: str, device=None, backend: str = "mmap"
+            ):
+                if (
+                    device is not None
+                    and str(device).split(":")[0] == DEVICE_NAME
+                    and framework == "pt"
+                ):
+                    return _SpyreSafeOpen(
+                        filename, framework=framework, backend=backend
+                    )
+                return _orig(
+                    filename, framework=framework, device=device, backend=backend
+                )
+
+        _st_mod.safe_open = _SpyreSafeOpenDispatch
+        # Also update the name imported by safetensors.torch so that
+        # ``from safetensors.torch import safe_open`` resolves correctly.
+        if hasattr(_st_torch, "safe_open"):
+            _st_torch.safe_open = _SpyreSafeOpenDispatch
+
+    # ── 2. Patch safetensors.torch.load_file ─────────────────────────────────
+    # Capture the un-patched load_file unconditionally — _spyre_load_model
+    # (block 3) needs it for the CPU load regardless of whether block 2 runs.
+    _orig_load_file = getattr(_st_torch.load_file, "__wrapped__", None) or (
+        _st_torch.load_file
+        if not getattr(_st_torch.load_file, "_spyre_patched", False)
+        else None
+    )
+    if _orig_load_file is None:
+        # Already patched; recover the original from the closure attribute we
+        # store below, or fall back to the live (patched) function — the
+        # Spyre path inside it still loads CPU correctly for non-Spyre device.
+        _orig_load_file = getattr(_st_torch.load_file, "_orig", _st_torch.load_file)
+
+    if not getattr(_st_torch.load_file, "_spyre_patched", False):
+        _unpatched_load_file = _st_torch.load_file
+
+        def _spyre_load_file(
+            filename,
+            device: Union[str, int] = "cpu",
+            *,
+            backend: str = "mmap",
+        ) -> Dict[str, "torch.Tensor"]:
+            if str(device).split(":")[0] != DEVICE_NAME:
+                return _unpatched_load_file(filename, device=device, backend=backend)
+            # Route through the patched safe_open so get_tensors() applies
+            # the Spyre hook per tensor.
+            with _st_mod.safe_open(
+                filename, framework="pt", device=DEVICE_NAME, backend=backend
+            ) as f:
+                return f.get_tensors()
+
+        _spyre_load_file._spyre_patched = True  # type: ignore[attr-defined]
+        _spyre_load_file._orig = _unpatched_load_file  # type: ignore[attr-defined]
+        _st_torch.load_file = _spyre_load_file
+
+    # ── 3. Patch safetensors.torch.load_model ────────────────────────────────
+    # The key issue with meta-device models:
+    #   model.load_state_dict(cpu_tensors) calls copy_() into each meta parameter,
+    #   which is a no-op — the parameter stays on meta. A subsequent
+    #   load_model_to_spyre() then tries to DMA from meta → Spyre and crashes.
+    #
+    # Correct flow (mirrors PR #804's assign=True path):
+    #   1. load_file(device="spyre") — each tensor is ALREADY on Spyre with
+    #      the optimal layout via _spyre_tensor_from_safetensors.
+    #   2. _assign_tensors_to_model() — directly replaces model._parameters[name]
+    #      with the Spyre tensor; no copy_() involved, works on meta models.
+    #   3. No load_model_to_spyre() needed — tensors are already on Spyre.
+    if not getattr(_st_torch.load_model, "_spyre_patched", False):
+        _orig_load_model = _st_torch.load_model
+
+        def _spyre_load_model(
+            model: "torch.nn.Module",
+            filename,
+            strict: bool = True,
+            device: Union[str, int] = "cpu",
+            *,
+            assign: Optional[bool] = None,
+            backend: str = "mmap",
+        ):
+            if str(device).split(":")[0] != DEVICE_NAME:
+                return _orig_load_model(
+                    model, filename, strict=strict, device=device, backend=backend
+                )
+
+            # Load state dict directly to Spyre — each tensor gets the optimal
+            # layout for its role (embedding/linear/other) via the hook.
+            # Use _st_torch.load_file (our patched version) rather than the
+            # local _spyre_load_file name, which may not be bound if block 2
+            # was skipped due to idempotency.
+            state_dict = _st_torch.load_file(
+                filename, device=DEVICE_NAME, backend=backend
+            )
+
+            # Duplicate-name removal (tied weights etc.) — same logic as the
+            # upstream safetensors load_model.
+            model_sd = model.state_dict()
+            to_removes = _st_torch._remove_duplicate_names(
+                model_sd, preferred_names=list(state_dict.keys())
+            )
+
+            # Directly assign tensors into model._parameters / _buffers so that
+            # meta-device parameters are replaced rather than copy_()'d into.
+            # This matches PR #804's _assign_tensors_to_model path.
+            missing_keys: List[str] = []
+            unexpected_keys: List[str] = list(state_dict.keys())
+
+            for name, param in model.named_parameters():
+                if name not in state_dict:
+                    missing_keys.append(name)
+                    continue
+                spyre_tensor = state_dict[name]
+                if spyre_tensor.shape != param.shape:
+                    raise RuntimeError(
+                        f"size mismatch for {name}: copying a param with shape "
+                        f"{spyre_tensor.shape} from checkpoint, the shape in "
+                        f"current model is {param.shape}."
+                    )
+                if spyre_tensor.dtype != param.dtype:
+                    raise RuntimeError(
+                        f"dtype mismatch for {name}: checkpoint has "
+                        f"{spyre_tensor.dtype}, model expects {param.dtype}."
+                    )
+                parts = name.rsplit(".", 1)
+                parent = model.get_submodule(parts[0]) if len(parts) == 2 else model
+                attr = parts[-1]
+                if name in unexpected_keys:
+                    unexpected_keys.remove(name)
+                parent._parameters[attr] = nn.Parameter(
+                    spyre_tensor, requires_grad=param.requires_grad
+                )
+
+            for name, buf in model.named_buffers():
+                if name not in state_dict:
+                    missing_keys.append(name)
+                    continue
+                spyre_tensor = state_dict[name]
+                if spyre_tensor.shape != buf.shape:
+                    raise RuntimeError(
+                        f"size mismatch for {name}: copying a buffer with shape "
+                        f"{spyre_tensor.shape} from checkpoint, the shape in "
+                        f"current model is {buf.shape}."
+                    )
+                if spyre_tensor.dtype != buf.dtype:
+                    raise RuntimeError(
+                        f"dtype mismatch for {name}: checkpoint has "
+                        f"{spyre_tensor.dtype}, model expects {buf.dtype}."
+                    )
+                parts = name.rsplit(".", 1)
+                parent = model.get_submodule(parts[0]) if len(parts) == 2 else model
+                attr = parts[-1]
+                if name in unexpected_keys:
+                    unexpected_keys.remove(name)
+                parent._buffers[attr] = spyre_tensor
+
+            # Reconcile tied-weight duplicates (same logic as upstream load_model).
+            missing_set = set(missing_keys)
+            for to_remove_group in to_removes.values():
+                for to_remove in to_remove_group:
+                    if to_remove not in missing_set:
+                        unexpected_keys.append(to_remove)
+                    else:
+                        missing_set.remove(to_remove)
+
+            if strict and (missing_set or unexpected_keys):
+                missing_str = ", ".join(f'"{k}"' for k in sorted(missing_set))
+                unexpected_str = ", ".join(f'"{k}"' for k in sorted(unexpected_keys))
+                error = (
+                    f"Error(s) in loading state_dict for {model.__class__.__name__}:"
+                )
+                if missing_set:
+                    error += f"\n    Missing key(s) in state_dict: {missing_str}"
+                if unexpected_keys:
+                    error += f"\n    Unexpected key(s) in state_dict: {unexpected_str}"
+                raise RuntimeError(error)
+
+            return list(missing_set), unexpected_keys
+
+        _spyre_load_model._spyre_patched = True  # type: ignore[attr-defined]
+        _st_torch.load_model = _spyre_load_model
 
 
 def _patch_fx_graph_hash():

--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
+
+import torch
+import torch.nn as nn
 
 from torch._dynamo.guards import GuardBuilder
 
@@ -351,6 +354,485 @@ def _patch_tensor_for_spyre():
     # preventing incorrect disk cache hits across process boundaries.
     # ──────────────────────────────────────────────────────────────────────────
     _patch_fx_graph_hash()
+
+    # ── Safetensors Spyre-aware loading (monkey-patch for safetensors PR #804) ──
+    # safetensors PR #804 adds _register_device_transfer_hook() to the Rust core
+    # and _is_custom_device(). Until that PR is merged we monkey-patch the three
+    # public Python entry points instead. When PR #804 lands, delete
+    # _patch_safetensors_for_spyre() and its call here, then add in
+    # _autoload_impl():
+    #
+    #   from safetensors import _register_device_transfer_hook
+    #   _register_device_transfer_hook(DEVICE_NAME, _spyre_tensor_from_safetensors)
+    # ─────────────────────────────────────────────────────────────────────────────
+    try:
+        _patch_safetensors_for_spyre()
+    except Exception as e:  # pragma: no cover - safetensors may not be installed
+        import warnings
+
+        warnings.warn(f"Failed to install safetensors Spyre patches: {e}")
+
+
+# ── Safetensors hook + monkey-patch ──────────────────────────────────────────
+#
+# Hook signature (matches PR #804 _register_device_transfer_hook contract):
+#
+#   hook(cpu_tensor: torch.Tensor, name: str, device) -> torch.Tensor
+#
+# Where:
+#   cpu_tensor — tensor freshly loaded from disk, on CPU (may be a
+#                memoryview-backed zero-copy view from mmap).
+#   name       — tensor key in the safetensors file, e.g.
+#                "model.layers.0.self_attn.q_proj.weight". Used to select the
+#                optimal Spyre DMA layout.
+#   device     — original device argument (str or torch.device). Passed
+#                through for potential device-index handling ("spyre:1").
+#
+# Tensor-type heuristics from key names
+# ──────────────────────────────────────
+# In a flat safetensors dict we have no nn.Module to call isinstance() on, so
+# we recover the tensor kind from its key name — a convention stable across
+# virtually all HuggingFace and standard PyTorch checkpoints:
+#
+#   Embedding table  – 2D tensor whose lowercased key contains any fragment
+#                      from _EMBEDDING_KEY_FRAGMENTS.
+#                      Shape: [vocab_size, hidden_dim] or [max_pos, hidden_dim].
+#                      → _dma_to_spyre_indirect_access (gather-optimal layout).
+#                        Falls back to default if hidden_dim % eps != 0.
+#
+#   Linear weight    – 2D tensor whose key ends with ".weight" and is NOT
+#                      classified as an embedding. Covers q/k/v/o projections,
+#                      MLP up/gate/down, free lm_head, etc.
+#                      → _dma_to_spyre_dim_order_swapped (dim_order=[1,0],
+#                        matmul-optimal).
+#
+#   lm_head (tied)   – When lm_head is tied to the embedding table the caller
+#                      should use load_model_to_spyre (which has nn.Module
+#                      context). load_file / safe_open see it as a free 2D
+#                      weight and apply dim_order=[1,0], which is correct for
+#                      the matmul path and merely sub-optimal for the tied case.
+#
+#   Everything else  – bias, layer-norm params, 1-D buffers, etc.
+#                      → _dma_to_spyre_default (stickify last dim).
+# ─────────────────────────────────────────────────────────────────────────────
+
+_EMBEDDING_KEY_FRAGMENTS: tuple = (
+    "embed",  # embeddings, embed_tokens, embedding, …
+    "wte",  # GPT-2 word-token embeddings
+    "wpe",  # GPT-2 word-position embeddings
+    "tok_embed",
+    "word_embed",
+    "token_embed",
+    "pos_embed",
+    "patch_embed",
+)
+
+
+def _classify_safetensors_key(name: str, ndim: int) -> str:
+    """Return ``'embedding'``, ``'linear'``, or ``'other'``.
+
+    Pure name-convention + ndim heuristic; no model object required.
+    """
+    if ndim != 2:
+        return "other"
+    name_lower = name.lower()
+    for frag in _EMBEDDING_KEY_FRAGMENTS:
+        if frag in name_lower:
+            return "embedding"
+    if name_lower.endswith(".weight"):
+        return "linear"
+    return "other"
+
+
+def _spyre_tensor_from_safetensors(
+    cpu_tensor: "torch.Tensor",
+    name: str,
+    device,  # str | torch.device — honoured by forward-compat; index unused for now
+) -> "torch.Tensor":
+    """Spyre device-transfer hook for safetensors (PR #804 contract).
+
+    Receives a CPU tensor loaded from a safetensors file and returns a tensor
+    on the Spyre device with the optimal layout for the tensor's role.
+
+    Layout selection (mirrors ``_transfer_module`` in model_utils.py):
+      - 2D embedding-named tensor  → indirect-access layout (gather-optimal).
+        Falls back to default if ``hidden_dim % elems_per_stick != 0``.
+      - 2D Linear weight           → ``dim_order=[1, 0]`` (matmul-optimal).
+      - Everything else            → default Spyre layout (stickify last dim).
+    """
+    from torch_spyre.model_utils import (
+        _dma_to_spyre_default,
+        _dma_to_spyre_dim_order_swapped,
+        _dma_to_spyre_indirect_access,
+    )
+    from torch_spyre._inductor.logging_utils import get_inductor_logger
+
+    logger = get_inductor_logger("model_utils")
+
+    if cpu_tensor.dtype != torch.float16 and cpu_tensor.dtype.is_floating_point:
+        cpu_tensor = cpu_tensor.to(dtype=torch.float16)
+    # The mmap fast-path in safetensors gives us a memoryview-backed
+    # frombuffer view. Make it contiguous before any Spyre DMA call.
+    if not cpu_tensor.is_contiguous():
+        cpu_tensor = cpu_tensor.contiguous()
+
+    kind = _classify_safetensors_key(name, cpu_tensor.ndim)
+
+    if kind == "embedding":
+        result = _dma_to_spyre_indirect_access(cpu_tensor)
+        if result is not None:
+            logger.debug(
+                "safetensors: %s shape=%s -> Spyre indirect-access (gather) layout",
+                name,
+                list(cpu_tensor.shape),
+            )
+            return result
+        # _dma_to_spyre_indirect_access warned already; fall through to default.
+        logger.debug(
+            "safetensors: %s shape=%s -> Spyre default layout (embedding fallback)",
+            name,
+            list(cpu_tensor.shape),
+        )
+        return _dma_to_spyre_default(cpu_tensor)
+
+    if kind == "linear":
+        logger.debug(
+            "safetensors: %s shape=%s -> Spyre dim_order=[1, 0]",
+            name,
+            list(cpu_tensor.shape),
+        )
+        return _dma_to_spyre_dim_order_swapped(cpu_tensor)
+
+    # "other": bias, norms, 1-D buffers, etc.
+    logger.debug(
+        "safetensors: %s shape=%s -> Spyre default layout",
+        name,
+        list(cpu_tensor.shape),
+    )
+    return _dma_to_spyre_default(cpu_tensor)
+
+
+class _SpyreSafeOpen:
+    """Context-manager wrapper around ``safetensors.safe_open`` for Spyre.
+
+    Opened with ``device="cpu"`` internally; each ``get_tensor`` / ``get_tensors``
+    / slice call transfers the result to Spyre via ``_spyre_tensor_from_safetensors``.
+
+    All non-tensor methods (``keys``, ``metadata``, ``get_slice``,
+    ``offset_keys``) are forwarded verbatim so callers that iterate keys or
+    read metadata work without changes.
+
+    ``get_slice`` returns a ``_SpyreSafeSlice`` wrapper that applies the hook
+    on ``__getitem__``, matching the slice-dispatch behaviour that safetensors
+    PR #804 patch-2 adds to the Rust core.
+    """
+
+    def __init__(
+        self,
+        filename,
+        framework: str,
+        backend: str = "mmap",
+    ):
+        import safetensors as _st_mod
+
+        # Open on CPU so the Rust core handles mmap / pread normally.
+        self._handle = _st_mod._orig_safe_open(
+            filename, framework=framework, device="cpu", backend=backend
+        )
+
+    def __enter__(self) -> "_SpyreSafeOpen":
+        self._handle.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        return self._handle.__exit__(*args)
+
+    # ── forwarded metadata ───────────────────────────────────────────────────
+
+    def keys(self) -> List[str]:
+        return self._handle.keys()
+
+    def offset_keys(self) -> List[str]:
+        """Alias for ``keys()``; present for callers that use the older API."""
+        return self._handle.keys()
+
+    def metadata(self) -> Optional[Dict[str, str]]:
+        return self._handle.metadata()
+
+    # ── Spyre-aware tensor accessors ─────────────────────────────────────────
+
+    def get_tensor(self, key: str) -> "torch.Tensor":
+        """Load ``key`` on CPU then DMA to Spyre with the optimal layout."""
+        cpu_tensor = self._handle.get_tensor(key)
+        return _spyre_tensor_from_safetensors(cpu_tensor, key, DEVICE_NAME)
+
+    def get_tensors(self) -> Dict[str, "torch.Tensor"]:
+        """Load all tensors and DMA each to Spyre with the optimal layout.
+
+        Matches the ``safe_open.get_tensors()`` API added by safetensors PR #786.
+        """
+        result: Dict[str, "torch.Tensor"] = {}
+        for key in self._handle.keys():
+            result[key] = self.get_tensor(key)
+        return result
+
+    def get_slice(self, key: str) -> "_SpyreSafeSlice":
+        """Return a ``_SpyreSafeSlice`` that applies the Spyre hook on indexing."""
+        return _SpyreSafeSlice(self._handle.get_slice(key), key)
+
+
+class _SpyreSafeSlice:
+    """Slice wrapper: applies ``_spyre_tensor_from_safetensors`` on ``__getitem__``.
+
+    Matches the behaviour added to ``PySafeSlice.__getitem__`` by safetensors
+    PR #804 patch-2 (``slice_custom_device``): gather bytes on CPU first,
+    then invoke the hook. This avoids the double-dispatch problem that would
+    arise if we applied the hook inside the Rust slice path (Spyre → Spyre copy).
+    """
+
+    def __init__(self, cpu_slice, name: str):
+        self._cpu_slice = cpu_slice
+        self._name = name
+
+    def __getitem__(self, slices) -> "torch.Tensor":
+        # The underlying CPU slice gives us a contiguous CPU tensor.
+        cpu_tensor = self._cpu_slice[slices]
+        return _spyre_tensor_from_safetensors(cpu_tensor, self._name, DEVICE_NAME)
+
+
+def _patch_safetensors_for_spyre() -> None:
+    """Monkey-patch safetensors for Spyre-aware loading.
+
+    Patches three public entry points so that ``device="spyre"`` transparently
+    applies optimal Spyre DMA layout per tensor via
+    ``_spyre_tensor_from_safetensors``:
+
+    1. ``safetensors.safe_open(path, framework="pt", device="spyre")``
+       Returns ``_SpyreSafeOpen`` (opens on CPU internally, dispatches each
+       ``get_tensor`` / ``get_tensors`` / slice through the hook).
+
+    2. ``safetensors.torch.load_file(filename, device="spyre")``
+       Delegates to the patched ``safe_open`` so ``f.get_tensors()`` goes
+       through the hook path.
+
+    3. ``safetensors.torch.load_model(model, filename, device="spyre")``
+       Loads the state dict on CPU, uses ``_assign_tensors_to_model`` (PR #804's
+       direct-assignment path) to install tensors that have already been moved
+       to Spyre by the hook. Falls back to ``load_model_to_spyre`` for the
+       full nn.Linear / nn.Embedding isinstance optimisation.
+
+    All patches are idempotent (``_spyre_patched`` sentinel). Non-Spyre
+    device paths fall through to the originals.
+
+    Removal note — when safetensors PR #804 merges
+    ────────────────────────────────────────────────
+    Delete this function and its call in ``_patch_tensor_for_spyre``.
+    Add in ``_autoload_impl``::
+
+        from safetensors import _register_device_transfer_hook
+        _register_device_transfer_hook(DEVICE_NAME, _spyre_tensor_from_safetensors)
+    """
+    try:
+        import safetensors as _st_mod
+        import safetensors.torch as _st_torch
+    except ImportError:
+        return  # safetensors not installed
+
+    # ── 1. Wrap safetensors.safe_open ────────────────────────────────────────
+    # Stash the original Rust class under _orig_safe_open so _SpyreSafeOpen
+    # can always reach it regardless of further patching.
+    if not hasattr(_st_mod, "_orig_safe_open"):
+        _st_mod._orig_safe_open = _st_mod.safe_open
+
+    if not getattr(_st_mod.safe_open, "_spyre_patched", False):
+        _orig = _st_mod._orig_safe_open
+
+        class _SpyreSafeOpenDispatch:
+            """Route ``device="spyre"`` to ``_SpyreSafeOpen``; pass everything else through."""
+
+            _spyre_patched = True
+
+            def __new__(
+                cls, filename, framework: str, device=None, backend: str = "mmap"
+            ):
+                if (
+                    device is not None
+                    and str(device).split(":")[0] == DEVICE_NAME
+                    and framework == "pt"
+                ):
+                    return _SpyreSafeOpen(
+                        filename, framework=framework, backend=backend
+                    )
+                return _orig(
+                    filename, framework=framework, device=device, backend=backend
+                )
+
+        _st_mod.safe_open = _SpyreSafeOpenDispatch
+        # Also update the name imported by safetensors.torch so that
+        # ``from safetensors.torch import safe_open`` resolves correctly.
+        if hasattr(_st_torch, "safe_open"):
+            _st_torch.safe_open = _SpyreSafeOpenDispatch
+
+    # ── 2. Patch safetensors.torch.load_file ─────────────────────────────────
+    # Capture the un-patched load_file unconditionally — _spyre_load_model
+    # (block 3) needs it for the CPU load regardless of whether block 2 runs.
+    _orig_load_file = getattr(_st_torch.load_file, "__wrapped__", None) or (
+        _st_torch.load_file
+        if not getattr(_st_torch.load_file, "_spyre_patched", False)
+        else None
+    )
+    if _orig_load_file is None:
+        # Already patched; recover the original from the closure attribute we
+        # store below, or fall back to the live (patched) function — the
+        # Spyre path inside it still loads CPU correctly for non-Spyre device.
+        _orig_load_file = getattr(_st_torch.load_file, "_orig", _st_torch.load_file)
+
+    if not getattr(_st_torch.load_file, "_spyre_patched", False):
+        _unpatched_load_file = _st_torch.load_file
+
+        def _spyre_load_file(
+            filename,
+            device: Union[str, int] = "cpu",
+            *,
+            backend: str = "mmap",
+        ) -> Dict[str, "torch.Tensor"]:
+            if str(device).split(":")[0] != DEVICE_NAME:
+                return _unpatched_load_file(filename, device=device, backend=backend)
+            # Route through the patched safe_open so get_tensors() applies
+            # the Spyre hook per tensor.
+            with _st_mod.safe_open(
+                filename, framework="pt", device=DEVICE_NAME, backend=backend
+            ) as f:
+                return f.get_tensors()
+
+        _spyre_load_file._spyre_patched = True  # type: ignore[attr-defined]
+        _spyre_load_file._orig = _unpatched_load_file  # type: ignore[attr-defined]
+        _st_torch.load_file = _spyre_load_file
+
+    # ── 3. Patch safetensors.torch.load_model ────────────────────────────────
+    # The key issue with meta-device models:
+    #   model.load_state_dict(cpu_tensors) calls copy_() into each meta parameter,
+    #   which is a no-op — the parameter stays on meta. A subsequent
+    #   load_model_to_spyre() then tries to DMA from meta → Spyre and crashes.
+    #
+    # Correct flow (mirrors PR #804's assign=True path):
+    #   1. load_file(device="spyre") — each tensor is ALREADY on Spyre with
+    #      the optimal layout via _spyre_tensor_from_safetensors.
+    #   2. _assign_tensors_to_model() — directly replaces model._parameters[name]
+    #      with the Spyre tensor; no copy_() involved, works on meta models.
+    #   3. No load_model_to_spyre() needed — tensors are already on Spyre.
+    if not getattr(_st_torch.load_model, "_spyre_patched", False):
+        _orig_load_model = _st_torch.load_model
+
+        def _spyre_load_model(
+            model: "torch.nn.Module",
+            filename,
+            strict: bool = True,
+            device: Union[str, int] = "cpu",
+            *,
+            assign: Optional[bool] = None,
+            backend: str = "mmap",
+        ):
+            if str(device).split(":")[0] != DEVICE_NAME:
+                return _orig_load_model(
+                    model, filename, strict=strict, device=device, backend=backend
+                )
+
+            # Load state dict directly to Spyre — each tensor gets the optimal
+            # layout for its role (embedding/linear/other) via the hook.
+            # Use _st_torch.load_file (our patched version) rather than the
+            # local _spyre_load_file name, which may not be bound if block 2
+            # was skipped due to idempotency.
+            state_dict = _st_torch.load_file(
+                filename, device=DEVICE_NAME, backend=backend
+            )
+
+            # Duplicate-name removal (tied weights etc.) — same logic as the
+            # upstream safetensors load_model.
+            model_sd = model.state_dict()
+            to_removes = _st_torch._remove_duplicate_names(
+                model_sd, preferred_names=list(state_dict.keys())
+            )
+
+            # Directly assign tensors into model._parameters / _buffers so that
+            # meta-device parameters are replaced rather than copy_()'d into.
+            # This matches PR #804's _assign_tensors_to_model path.
+            missing_keys: List[str] = []
+            unexpected_keys: List[str] = list(state_dict.keys())
+
+            for name, param in model.named_parameters():
+                if name not in state_dict:
+                    missing_keys.append(name)
+                    continue
+                spyre_tensor = state_dict[name]
+                if spyre_tensor.shape != param.shape:
+                    raise RuntimeError(
+                        f"size mismatch for {name}: copying a param with shape "
+                        f"{spyre_tensor.shape} from checkpoint, the shape in "
+                        f"current model is {param.shape}."
+                    )
+                if spyre_tensor.dtype != param.dtype:
+                    raise RuntimeError(
+                        f"dtype mismatch for {name}: checkpoint has "
+                        f"{spyre_tensor.dtype}, model expects {param.dtype}."
+                    )
+                parts = name.rsplit(".", 1)
+                parent = model.get_submodule(parts[0]) if len(parts) == 2 else model
+                attr = parts[-1]
+                if name in unexpected_keys:
+                    unexpected_keys.remove(name)
+                parent._parameters[attr] = nn.Parameter(
+                    spyre_tensor, requires_grad=param.requires_grad
+                )
+
+            for name, buf in model.named_buffers():
+                if name not in state_dict:
+                    missing_keys.append(name)
+                    continue
+                spyre_tensor = state_dict[name]
+                if spyre_tensor.shape != buf.shape:
+                    raise RuntimeError(
+                        f"size mismatch for {name}: copying a buffer with shape "
+                        f"{spyre_tensor.shape} from checkpoint, the shape in "
+                        f"current model is {buf.shape}."
+                    )
+                if spyre_tensor.dtype != buf.dtype:
+                    raise RuntimeError(
+                        f"dtype mismatch for {name}: checkpoint has "
+                        f"{spyre_tensor.dtype}, model expects {buf.dtype}."
+                    )
+                parts = name.rsplit(".", 1)
+                parent = model.get_submodule(parts[0]) if len(parts) == 2 else model
+                attr = parts[-1]
+                if name in unexpected_keys:
+                    unexpected_keys.remove(name)
+                parent._buffers[attr] = spyre_tensor
+
+            # Reconcile tied-weight duplicates (same logic as upstream load_model).
+            missing_set = set(missing_keys)
+            for to_remove_group in to_removes.values():
+                for to_remove in to_remove_group:
+                    if to_remove not in missing_set:
+                        unexpected_keys.append(to_remove)
+                    else:
+                        missing_set.remove(to_remove)
+
+            if strict and (missing_set or unexpected_keys):
+                missing_str = ", ".join(f'"{k}"' for k in sorted(missing_set))
+                unexpected_str = ", ".join(f'"{k}"' for k in sorted(unexpected_keys))
+                error = (
+                    f"Error(s) in loading state_dict for {model.__class__.__name__}:"
+                )
+                if missing_set:
+                    error += f"\n    Missing key(s) in state_dict: {missing_str}"
+                if unexpected_keys:
+                    error += f"\n    Unexpected key(s) in state_dict: {unexpected_str}"
+                raise RuntimeError(error)
+
+            return list(missing_set), unexpected_keys
+
+        _spyre_load_model._spyre_patched = True  # type: ignore[attr-defined]
+        _st_torch.load_model = _spyre_load_model
 
 
 def _patch_fx_graph_hash():

--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -15,15 +15,23 @@
 
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
-import torch
-import torch.nn as nn
-
 from torch._dynamo.guards import GuardBuilder
 
 from torch_spyre.constants import DEVICE_NAME
 
 if TYPE_CHECKING:
+    import torch
+
     from torch_spyre._C import SpyreTensorLayout
+
+
+# Sentinel distinguishing "caller didn't pass target_dtype" (-> resolves to
+# torch.float16, the Spyre DMA hardware requirement) from an explicit
+# ``target_dtype=None`` (-> disable dtype coercion, keep the checkpoint's own
+# dtype). Defined without importing torch at module scope, matching this
+# file's lazy-import convention (torch is only guaranteed importable once
+# this module's patch functions actually run).
+_UNSET = object()
 
 
 def _add_ea(src_tensor, res_tensor) -> None:
@@ -505,15 +513,8 @@ def _patch_invoke_subgraph_decompositions():
     _spyre_extract_nested_region_config._spyre_decomp_patched = True
     mod._extract_nested_region_config = _spyre_extract_nested_region_config
 
-    # ── Safetensors Spyre-aware loading (monkey-patch for safetensors PR #804) ──
-    # safetensors PR #804 adds _register_device_transfer_hook() to the Rust core
-    # and _is_custom_device(). Until that PR is merged we monkey-patch the three
-    # public Python entry points instead. When PR #804 lands, delete
-    # _patch_safetensors_for_spyre() and its call here, then add in
-    # _autoload_impl():
-    #
-    #   from safetensors import _register_device_transfer_hook
-    #   _register_device_transfer_hook(DEVICE_NAME, _spyre_tensor_from_safetensors)
+    # ── Safetensors Spyre-aware loading (monkey-patch) ──────────────────────────
+    # Monkey-patches the three public Python entry points to support device="spyre".
     # ─────────────────────────────────────────────────────────────────────────────
     try:
         _patch_safetensors_for_spyre()
@@ -525,7 +526,7 @@ def _patch_invoke_subgraph_decompositions():
 
 # ── Safetensors hook + monkey-patch ──────────────────────────────────────────
 #
-# Hook signature (matches PR #804 _register_device_transfer_hook contract):
+# Hook signature:
 #
 #   hook(cpu_tensor: torch.Tensor, name: str, device) -> torch.Tensor
 #
@@ -544,8 +545,8 @@ def _patch_invoke_subgraph_decompositions():
 # we recover the tensor kind from its key name — a convention stable across
 # virtually all HuggingFace and standard PyTorch checkpoints:
 #
-#   Embedding table  – 2D tensor whose lowercased key contains any fragment
-#                      from _EMBEDDING_KEY_FRAGMENTS.
+#   Embedding table  – 2D ``.weight`` tensor with an embedding module name as
+#                      a dot-delimited key segment.
 #                      Shape: [vocab_size, hidden_dim] or [max_pos, hidden_dim].
 #                      → _dma_to_spyre_indirect_access (gather-optimal layout).
 #                        Falls back to default if hidden_dim % eps != 0.
@@ -556,18 +557,20 @@ def _patch_invoke_subgraph_decompositions():
 #                      → _dma_to_spyre_dim_order_swapped (dim_order=[1,0],
 #                        matmul-optimal).
 #
-#   lm_head (tied)   – When lm_head is tied to the embedding table the caller
-#                      should use load_model_to_spyre (which has nn.Module
-#                      context). load_file / safe_open see it as a free 2D
-#                      weight and apply dim_order=[1,0], which is correct for
-#                      the matmul path and merely sub-optimal for the tied case.
+#   lm_head          – load_file / safe_open have no model context, so an
+#                      lm_head is treated as a Linear weight. This is always
+#                      correct, but may be sub-optimal when the model later ties
+#                      it to an embedding table.
 #
 #   Everything else  – bias, layer-norm params, 1-D buffers, etc.
 #                      → _dma_to_spyre_default (stickify last dim).
 # ─────────────────────────────────────────────────────────────────────────────
 
-_EMBEDDING_KEY_FRAGMENTS: tuple = (
-    "embed",  # embeddings, embed_tokens, embedding, …
+_EMBEDDING_MODULE_NAMES: tuple = (
+    "embed",
+    "embedding",
+    "embeddings",
+    "embed_tokens",
     "wte",  # GPT-2 word-token embeddings
     "wpe",  # GPT-2 word-position embeddings
     "tok_embed",
@@ -585,11 +588,12 @@ def _classify_safetensors_key(name: str, ndim: int) -> str:
     """
     if ndim != 2:
         return "other"
-    name_lower = name.lower()
-    for frag in _EMBEDDING_KEY_FRAGMENTS:
-        if frag in name_lower:
-            return "embedding"
-    if name_lower.endswith(".weight"):
+    parts = name.lower().split(".")
+    if parts[-1] != "weight":
+        return "other"
+    if any(part in _EMBEDDING_MODULE_NAMES for part in parts[:-1]):
+        return "embedding"
+    if len(parts) > 1:
         return "linear"
     return "other"
 
@@ -598,8 +602,9 @@ def _spyre_tensor_from_safetensors(
     cpu_tensor: "torch.Tensor",
     name: str,
     device,  # str | torch.device — honoured by forward-compat; index unused for now
+    target_dtype=_UNSET,
 ) -> "torch.Tensor":
-    """Spyre device-transfer hook for safetensors (PR #804 contract).
+    """Spyre device-transfer hook for safetensors.
 
     Receives a CPU tensor loaded from a safetensors file and returns a tensor
     on the Spyre device with the optimal layout for the tensor's role.
@@ -609,6 +614,15 @@ def _spyre_tensor_from_safetensors(
         Falls back to default if ``hidden_dim % elems_per_stick != 0``.
       - 2D Linear weight           → ``dim_order=[1, 0]`` (matmul-optimal).
       - Everything else            → default Spyre layout (stickify last dim).
+
+    ``target_dtype`` selects the on-device float dtype for floating-point
+    tensors, threaded through to the ``_dma_to_spyre_*`` helpers in
+    model_utils.py (same ``target_dtype`` parameter they already expose).
+    Left unspecified, it resolves to ``torch.float16`` — the Spyre DMA
+    hardware requirement. Pass ``target_dtype=None`` explicitly to disable
+    coercion and keep the checkpoint's own dtype (e.g. for CPU-stub tests
+    with no hardware DMA constraint). Non-floating-point tensors (e.g. int
+    buffers) are never coerced, regardless of ``target_dtype``.
     """
     from torch_spyre.model_utils import (
         _dma_to_spyre_default,
@@ -619,8 +633,25 @@ def _spyre_tensor_from_safetensors(
 
     logger = get_inductor_logger("model_utils")
 
-    if cpu_tensor.dtype != torch.float16 and cpu_tensor.dtype.is_floating_point:
-        cpu_tensor = cpu_tensor.to(dtype=torch.float16)
+    if target_dtype is _UNSET:
+        import torch
+
+        target_dtype = torch.float16
+
+    # Only floating-point tensors are eligible for coercion — an int buffer
+    # (e.g. position ids) must never be cast to a float dtype.
+    dma_target_dtype = target_dtype if cpu_tensor.dtype.is_floating_point else None
+
+    # Cast on CPU *before* the DMA helpers see this tensor, using the same
+    # dma_target_dtype that's about to be threaded into them
+    # copy_tensor's DMA path is measurably faster on a same-dtype
+    # transfer than on a cross-dtype one (e.g. bf16 checkpoint -> fp16
+    # device), so casting here with PyTorch's own vectorized `.to()` and
+    # handing the DMA helpers an already-matching dtype avoids that cost.
+    # Passing target_dtype=None disables this entirely, same as before.
+    if dma_target_dtype is not None and cpu_tensor.dtype != dma_target_dtype:
+        cpu_tensor = cpu_tensor.to(dtype=dma_target_dtype)
+
     # The mmap fast-path in safetensors gives us a memoryview-backed
     # frombuffer view. Make it contiguous before any Spyre DMA call.
     if not cpu_tensor.is_contiguous():
@@ -629,7 +660,9 @@ def _spyre_tensor_from_safetensors(
     kind = _classify_safetensors_key(name, cpu_tensor.ndim)
 
     if kind == "embedding":
-        result = _dma_to_spyre_indirect_access(cpu_tensor)
+        result = _dma_to_spyre_indirect_access(
+            cpu_tensor, target_dtype=dma_target_dtype
+        )
         if result is not None:
             logger.debug(
                 "safetensors: %s shape=%s -> Spyre indirect-access (gather) layout",
@@ -643,7 +676,7 @@ def _spyre_tensor_from_safetensors(
             name,
             list(cpu_tensor.shape),
         )
-        return _dma_to_spyre_default(cpu_tensor)
+        return _dma_to_spyre_default(cpu_tensor, target_dtype=dma_target_dtype)
 
     if kind == "linear":
         logger.debug(
@@ -651,7 +684,9 @@ def _spyre_tensor_from_safetensors(
             name,
             list(cpu_tensor.shape),
         )
-        return _dma_to_spyre_dim_order_swapped(cpu_tensor)
+        return _dma_to_spyre_dim_order_swapped(
+            cpu_tensor, target_dtype=dma_target_dtype
+        )
 
     # "other": bias, norms, 1-D buffers, etc.
     logger.debug(
@@ -659,7 +694,7 @@ def _spyre_tensor_from_safetensors(
         name,
         list(cpu_tensor.shape),
     )
-    return _dma_to_spyre_default(cpu_tensor)
+    return _dma_to_spyre_default(cpu_tensor, target_dtype=dma_target_dtype)
 
 
 class _SpyreSafeOpen:
@@ -673,8 +708,16 @@ class _SpyreSafeOpen:
     read metadata work without changes.
 
     ``get_slice`` returns a ``_SpyreSafeSlice`` wrapper that applies the hook
-    on ``__getitem__``, matching the slice-dispatch behaviour that safetensors
-    PR #804 patch-2 adds to the Rust core.
+    on ``__getitem__``, matching the slice-dispatch behaviour of the Rust core.
+
+    ``target_dtype`` (default: unset, which resolves to ``torch.float16`` —
+    the Spyre DMA hardware requirement) is stored and threaded through to
+    every tensor access. Pass ``target_dtype=None`` to disable coercion.
+
+    The stored ``_target_dtype`` attribute may be ``_UNSET`` (the sentinel
+    meaning "resolve to fp16 at DMA time") rather than an actual
+    ``torch.dtype``.  Inspect ``_target_dtype is _UNSET`` rather than
+    comparing it to a dtype in any code that reads this attribute.
     """
 
     def __init__(
@@ -682,6 +725,7 @@ class _SpyreSafeOpen:
         filename,
         framework: str,
         backend: str = "mmap",
+        target_dtype=_UNSET,
     ):
         import safetensors as _st_mod
 
@@ -689,6 +733,7 @@ class _SpyreSafeOpen:
         self._handle = _st_mod._orig_safe_open(
             filename, framework=framework, device="cpu", backend=backend
         )
+        self._target_dtype = target_dtype
 
     def __enter__(self) -> "_SpyreSafeOpen":
         self._handle.__enter__()
@@ -703,8 +748,8 @@ class _SpyreSafeOpen:
         return self._handle.keys()
 
     def offset_keys(self) -> List[str]:
-        """Alias for ``keys()``; present for callers that use the older API."""
-        return self._handle.keys()
+        """Return keys in file-offset order for sequential-read locality."""
+        return self._handle.offset_keys()
 
     def metadata(self) -> Optional[Dict[str, str]]:
         return self._handle.metadata()
@@ -714,40 +759,47 @@ class _SpyreSafeOpen:
     def get_tensor(self, key: str) -> "torch.Tensor":
         """Load ``key`` on CPU then DMA to Spyre with the optimal layout."""
         cpu_tensor = self._handle.get_tensor(key)
-        return _spyre_tensor_from_safetensors(cpu_tensor, key, DEVICE_NAME)
+        return _spyre_tensor_from_safetensors(
+            cpu_tensor, key, DEVICE_NAME, target_dtype=self._target_dtype
+        )
 
     def get_tensors(self) -> Dict[str, "torch.Tensor"]:
-        """Load all tensors and DMA each to Spyre with the optimal layout.
-
-        Matches the ``safe_open.get_tensors()`` API added by safetensors PR #786.
-        """
+        """Load all tensors and DMA each to Spyre with the optimal layout."""
         result: Dict[str, "torch.Tensor"] = {}
-        for key in self._handle.keys():
+        for key in self._handle.offset_keys():
             result[key] = self.get_tensor(key)
         return result
 
     def get_slice(self, key: str) -> "_SpyreSafeSlice":
         """Return a ``_SpyreSafeSlice`` that applies the Spyre hook on indexing."""
-        return _SpyreSafeSlice(self._handle.get_slice(key), key)
+        return _SpyreSafeSlice(
+            self._handle.get_slice(key), key, target_dtype=self._target_dtype
+        )
+
+    def __getattr__(self, name):
+        """Forward methods added by future safetensors releases."""
+        return getattr(self._handle, name)
 
 
 class _SpyreSafeSlice:
     """Slice wrapper: applies ``_spyre_tensor_from_safetensors`` on ``__getitem__``.
 
-    Matches the behaviour added to ``PySafeSlice.__getitem__`` by safetensors
-    PR #804 patch-2 (``slice_custom_device``): gather bytes on CPU first,
-    then invoke the hook. This avoids the double-dispatch problem that would
-    arise if we applied the hook inside the Rust slice path (Spyre → Spyre copy).
+    Gathers bytes on CPU first, then invokes the hook. This avoids the
+    double-dispatch problem that would arise if we applied the hook inside
+    the Rust slice path (Spyre → Spyre copy).
     """
 
-    def __init__(self, cpu_slice, name: str):
+    def __init__(self, cpu_slice, name: str, target_dtype=_UNSET):
         self._cpu_slice = cpu_slice
         self._name = name
+        self._target_dtype = target_dtype
 
     def __getitem__(self, slices) -> "torch.Tensor":
         # The underlying CPU slice gives us a contiguous CPU tensor.
         cpu_tensor = self._cpu_slice[slices]
-        return _spyre_tensor_from_safetensors(cpu_tensor, self._name, DEVICE_NAME)
+        return _spyre_tensor_from_safetensors(
+            cpu_tensor, self._name, DEVICE_NAME, target_dtype=self._target_dtype
+        )
 
 
 def _patch_safetensors_for_spyre() -> None:
@@ -766,21 +818,13 @@ def _patch_safetensors_for_spyre() -> None:
        through the hook path.
 
     3. ``safetensors.torch.load_model(model, filename, device="spyre")``
-       Loads the state dict on CPU, uses ``_assign_tensors_to_model`` (PR #804's
-       direct-assignment path) to install tensors that have already been moved
-       to Spyre by the hook. Falls back to ``load_model_to_spyre`` for the
-       full nn.Linear / nn.Embedding isinstance optimisation.
+       Loads the state dict directly to Spyre via the patched load_file, then
+       assigns each tensor into the model with direct _parameters / _buffers
+       replacement, avoiding the copy_() no-op that breaks meta-device models.
 
     All patches are idempotent (``_spyre_patched`` sentinel). Non-Spyre
     device paths fall through to the originals.
 
-    Removal note — when safetensors PR #804 merges
-    ────────────────────────────────────────────────
-    Delete this function and its call in ``_patch_tensor_for_spyre``.
-    Add in ``_autoload_impl``::
-
-        from safetensors import _register_device_transfer_hook
-        _register_device_transfer_hook(DEVICE_NAME, _spyre_tensor_from_safetensors)
     """
     try:
         import safetensors as _st_mod
@@ -803,7 +847,12 @@ def _patch_safetensors_for_spyre() -> None:
             _spyre_patched = True
 
             def __new__(
-                cls, filename, framework: str, device=None, backend: str = "mmap"
+                cls,
+                filename,
+                framework: str,
+                device=None,
+                backend: str = "mmap",
+                target_dtype=_UNSET,
             ):
                 if (
                     device is not None
@@ -811,8 +860,13 @@ def _patch_safetensors_for_spyre() -> None:
                     and framework == "pt"
                 ):
                     return _SpyreSafeOpen(
-                        filename, framework=framework, backend=backend
+                        filename,
+                        framework=framework,
+                        backend=backend,
+                        target_dtype=target_dtype,
                     )
+                # Non-Spyre device: the original safe_open has no
+                # target_dtype concept, so it is intentionally not forwarded.
                 return _orig(
                     filename, framework=framework, device=device, backend=backend
                 )
@@ -824,19 +878,6 @@ def _patch_safetensors_for_spyre() -> None:
             _st_torch.safe_open = _SpyreSafeOpenDispatch
 
     # ── 2. Patch safetensors.torch.load_file ─────────────────────────────────
-    # Capture the un-patched load_file unconditionally — _spyre_load_model
-    # (block 3) needs it for the CPU load regardless of whether block 2 runs.
-    _orig_load_file = getattr(_st_torch.load_file, "__wrapped__", None) or (
-        _st_torch.load_file
-        if not getattr(_st_torch.load_file, "_spyre_patched", False)
-        else None
-    )
-    if _orig_load_file is None:
-        # Already patched; recover the original from the closure attribute we
-        # store below, or fall back to the live (patched) function — the
-        # Spyre path inside it still loads CPU correctly for non-Spyre device.
-        _orig_load_file = getattr(_st_torch.load_file, "_orig", _st_torch.load_file)
-
     if not getattr(_st_torch.load_file, "_spyre_patched", False):
         _unpatched_load_file = _st_torch.load_file
 
@@ -845,13 +886,18 @@ def _patch_safetensors_for_spyre() -> None:
             device: Union[str, int] = "cpu",
             *,
             backend: str = "mmap",
+            target_dtype=_UNSET,
         ) -> Dict[str, "torch.Tensor"]:
             if str(device).split(":")[0] != DEVICE_NAME:
                 return _unpatched_load_file(filename, device=device, backend=backend)
             # Route through the patched safe_open so get_tensors() applies
             # the Spyre hook per tensor.
             with _st_mod.safe_open(
-                filename, framework="pt", device=DEVICE_NAME, backend=backend
+                filename,
+                framework="pt",
+                device=DEVICE_NAME,
+                backend=backend,
+                target_dtype=target_dtype,
             ) as f:
                 return f.get_tensors()
 
@@ -865,7 +911,7 @@ def _patch_safetensors_for_spyre() -> None:
     #   which is a no-op — the parameter stays on meta. A subsequent
     #   load_model_to_spyre() then tries to DMA from meta → Spyre and crashes.
     #
-    # Correct flow (mirrors PR #804's assign=True path):
+    # Correct flow:
     #   1. load_file(device="spyre") — each tensor is ALREADY on Spyre with
     #      the optimal layout via _spyre_tensor_from_safetensors.
     #   2. _assign_tensors_to_model() — directly replaces model._parameters[name]
@@ -882,11 +928,17 @@ def _patch_safetensors_for_spyre() -> None:
             *,
             assign: Optional[bool] = None,
             backend: str = "mmap",
+            target_dtype=_UNSET,
         ):
             if str(device).split(":")[0] != DEVICE_NAME:
                 return _orig_load_model(
                     model, filename, strict=strict, device=device, backend=backend
                 )
+
+            if target_dtype is not None and target_dtype is not _UNSET:
+                from torch_spyre.model_utils import _validate_target_dtype
+
+                _validate_target_dtype(target_dtype)
 
             # Load state dict directly to Spyre — each tensor gets the optimal
             # layout for its role (embedding/linear/other) via the hook.
@@ -894,48 +946,74 @@ def _patch_safetensors_for_spyre() -> None:
             # local _spyre_load_file name, which may not be bound if block 2
             # was skipped due to idempotency.
             state_dict = _st_torch.load_file(
-                filename, device=DEVICE_NAME, backend=backend
+                filename, device=DEVICE_NAME, backend=backend, target_dtype=target_dtype
             )
 
-            # Duplicate-name removal (tied weights etc.) — same logic as the
-            # upstream safetensors load_model.
-            model_sd = model.state_dict()
-            to_removes = _st_torch._remove_duplicate_names(
-                model_sd, preferred_names=list(state_dict.keys())
-            )
+            import torch.nn as nn
+            from torch_spyre._inductor.logging_utils import get_inductor_logger
 
-            # Directly assign tensors into model._parameters / _buffers so that
-            # meta-device parameters are replaced rather than copy_()'d into.
-            # This matches PR #804's _assign_tensors_to_model path.
+            logger = get_inductor_logger("model_utils")
+            # Coercion is only "off" when the caller explicitly passed
+            # target_dtype=None. If unspecified (_UNSET), the hook above
+            # already resolved it to torch.float16 per-tensor — a dtype
+            # mismatch against the model's own dtype is then expected and
+            # intentional (the Spyre DMA hardware requirement), not an error.
+            coercion_disabled = target_dtype is None
+
+            # Group aliases before assignment. named_parameters() normally
+            # deduplicates tied parameters; replacing only the first name would
+            # silently sever the tie and leave the other alias unloaded.
+            parameter_groups: Dict[int, List[tuple]] = {}
+            for name, param in model.named_parameters(remove_duplicate=False):
+                parameter_groups.setdefault(id(param), []).append((name, param))
+
             missing_keys: List[str] = []
-            unexpected_keys: List[str] = list(state_dict.keys())
-
-            for name, param in model.named_parameters():
-                if name not in state_dict:
-                    missing_keys.append(name)
+            consumed_keys = set()
+            for aliases in parameter_groups.values():
+                checkpoint_names = [name for name, _ in aliases if name in state_dict]
+                if not checkpoint_names:
+                    missing_keys.append(aliases[0][0])
                     continue
-                spyre_tensor = state_dict[name]
+
+                checkpoint_name = checkpoint_names[0]
+                spyre_tensor = state_dict[checkpoint_name]
+                param = aliases[0][1]
                 if spyre_tensor.shape != param.shape:
                     raise RuntimeError(
-                        f"size mismatch for {name}: copying a param with shape "
+                        f"size mismatch for {checkpoint_name}: copying a param with shape "
                         f"{spyre_tensor.shape} from checkpoint, the shape in "
                         f"current model is {param.shape}."
                     )
                 if spyre_tensor.dtype != param.dtype:
-                    raise RuntimeError(
-                        f"dtype mismatch for {name}: checkpoint has "
-                        f"{spyre_tensor.dtype}, model expects {param.dtype}."
+                    if coercion_disabled:
+                        raise RuntimeError(
+                            f"dtype mismatch for {checkpoint_name}: checkpoint has "
+                            f"{spyre_tensor.dtype}, model expects {param.dtype}."
+                        )
+                    # target_dtype coerced this tensor on the way in (e.g. the
+                    # Spyre fp16 DMA requirement) — the model's post-load
+                    # dtype for this param is now spyre_tensor.dtype by
+                    # construction, since this is a Parameter replacement,
+                    # not a copy_(). Not an error, but worth a trace.
+                    logger.info(
+                        "%s: model dtype %s coerced to %s on Spyre load "
+                        "(target_dtype=%s)",
+                        checkpoint_name,
+                        param.dtype,
+                        spyre_tensor.dtype,
+                        target_dtype,
                     )
-                parts = name.rsplit(".", 1)
-                parent = model.get_submodule(parts[0]) if len(parts) == 2 else model
-                attr = parts[-1]
-                if name in unexpected_keys:
-                    unexpected_keys.remove(name)
-                parent._parameters[attr] = nn.Parameter(
+
+                replacement = nn.Parameter(
                     spyre_tensor, requires_grad=param.requires_grad
                 )
+                for name, _ in aliases:
+                    parts = name.rsplit(".", 1)
+                    parent = model.get_submodule(parts[0]) if len(parts) == 2 else model
+                    parent._parameters[parts[-1]] = replacement
+                consumed_keys.update(checkpoint_names)
 
-            for name, buf in model.named_buffers():
+            for name, buf in model.named_buffers(remove_duplicate=False):
                 if name not in state_dict:
                     missing_keys.append(name)
                     continue
@@ -947,39 +1025,39 @@ def _patch_safetensors_for_spyre() -> None:
                         f"current model is {buf.shape}."
                     )
                 if spyre_tensor.dtype != buf.dtype:
-                    raise RuntimeError(
-                        f"dtype mismatch for {name}: checkpoint has "
-                        f"{spyre_tensor.dtype}, model expects {buf.dtype}."
+                    if coercion_disabled:
+                        raise RuntimeError(
+                            f"dtype mismatch for {name}: checkpoint has "
+                            f"{spyre_tensor.dtype}, model expects {buf.dtype}."
+                        )
+                    logger.info(
+                        "%s: model dtype %s coerced to %s on Spyre load "
+                        "(target_dtype=%s)",
+                        name,
+                        buf.dtype,
+                        spyre_tensor.dtype,
+                        target_dtype,
                     )
                 parts = name.rsplit(".", 1)
                 parent = model.get_submodule(parts[0]) if len(parts) == 2 else model
-                attr = parts[-1]
-                if name in unexpected_keys:
-                    unexpected_keys.remove(name)
-                parent._buffers[attr] = spyre_tensor
+                parent._buffers[parts[-1]] = spyre_tensor
+                consumed_keys.add(name)
 
-            # Reconcile tied-weight duplicates (same logic as upstream load_model).
-            missing_set = set(missing_keys)
-            for to_remove_group in to_removes.values():
-                for to_remove in to_remove_group:
-                    if to_remove not in missing_set:
-                        unexpected_keys.append(to_remove)
-                    else:
-                        missing_set.remove(to_remove)
+            unexpected_keys = [name for name in state_dict if name not in consumed_keys]
 
-            if strict and (missing_set or unexpected_keys):
-                missing_str = ", ".join(f'"{k}"' for k in sorted(missing_set))
-                unexpected_str = ", ".join(f'"{k}"' for k in sorted(unexpected_keys))
+            if strict and (missing_keys or unexpected_keys):
+                missing_str = ", ".join(f'"{k}"' for k in missing_keys)
+                unexpected_str = ", ".join(f'"{k}"' for k in unexpected_keys)
                 error = (
                     f"Error(s) in loading state_dict for {model.__class__.__name__}:"
                 )
-                if missing_set:
+                if missing_keys:
                     error += f"\n    Missing key(s) in state_dict: {missing_str}"
                 if unexpected_keys:
                     error += f"\n    Unexpected key(s) in state_dict: {unexpected_str}"
                 raise RuntimeError(error)
 
-            return list(missing_set), unexpected_keys
+            return missing_keys, unexpected_keys
 
         _spyre_load_model._spyre_patched = True  # type: ignore[attr-defined]
         _st_torch.load_model = _spyre_load_model

--- a/uv.lock
+++ b/uv.lock
@@ -1174,6 +1174,30 @@ wheels = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/a0/f718cda65b05407d228f97602cf60dca269c979867aa5beb25410de26cd3/safetensors-0.8.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c554f85858e05226d3c2828e32395e677434685d6d94594a41643361c5e837f0", size = 473568, upload-time = "2026-06-09T07:52:18.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/65a7de0af421317bb36a067241e4235fff194eed60b961ed6d3f59a3fc60/safetensors-0.8.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a46e5ff292c356d6991e60942ba7f79817682d3a2cef0702136448cb9c4d235", size = 502844, upload-time = "2026-06-09T07:52:07.624Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4f/3175c9d75634e0e0dda0082794193521035edd7c70a6f212bf33ca06ddf4/safetensors-0.8.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4124502b78f03534117c848f87a39b8f31e577b15eff423bf8bfb95f2a8c30d0", size = 511823, upload-time = "2026-06-09T07:52:09.565Z" },
+    { url = "https://files.pythonhosted.org/packages/20/87/846c289e7aa2299eff406335717cf43ce8777194ece8aad75772e0411615/safetensors-0.8.0-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc0a787ba8a35be368ee3574edfa2b1ad389eebd0a72e482ae275490e3f6c98", size = 633461, upload-time = "2026-06-09T07:52:11.128Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/8d64d9df2c45d5ded401df889d0ad90882804ca172d79ec4f0df8f727fe0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040070828e36dc8e122178bbbd5830ff9e97920affb84cbe0f46442497bed358", size = 545148, upload-time = "2026-06-09T07:52:13.603Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/f203ff3a3ddfe19308efc83c5a3a29ed02bf786732ec35e68bf9162f3365/safetensors-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd6f3f93c9a0a7cc2788ee63fb763353d4bd2e89b0751bc78fcf7dda00bea774", size = 516040, upload-time = "2026-06-09T07:52:16.29Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fb/cdaed17ceb2948784fd9c36b6fd3e951b608547cea81a48e8ee6f8cfdfcb/safetensors-0.8.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:fcdd41ec4628fee5799f807c73c353629130fbd942aa23d83c623dd6c9d52d78", size = 513832, upload-time = "2026-06-09T07:52:12.37Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/49/1e15de264dcc3b77943d2d0c56a95809956883b1c2d6d585c792523f180b/safetensors-0.8.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e9f537aa183a38ace122d27303dcd986b26bd2a7591f9181d7f0c396f4677ca", size = 559930, upload-time = "2026-06-09T07:52:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/43/bf38443278eab4b1be1fce2931e2b012ad9cb7df52ada751d0aab8f7659a/safetensors-0.8.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87eec7ffed2b809f05a398a8becb7d013f19f7837cd15d9748580d6cf30dbaf4", size = 678670, upload-time = "2026-06-09T07:52:20.032Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e3/68cd3fa5b48488e84add63e04cb12f3bc28ae4638c06d4508c6e88823d0e/safetensors-0.8.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4a95ae2b05d7726d751da4ebf626a2ca782b706e101bd894c95bc2450b1cffcc", size = 786679, upload-time = "2026-06-09T07:52:21.322Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/1c19c509d56e01f4fbb3d0a2e597450f6cc04d1d56cf52defb0a62dfd715/safetensors-0.8.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae091f16662658bdc019a4ff6cb4c085bb7d725eb5978b183ffd265863b6d2d", size = 765683, upload-time = "2026-06-09T07:52:22.594Z" },
+    { url = "https://files.pythonhosted.org/packages/27/43/41c1621732edd934d868a00d1b891584c892a7b62a9aab82ea5a0a5623ee/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3f/73ccf82579412b4a71c4ca673f10b5f1f888d7cf5af7fe24f27d30307be4/safetensors-0.8.0-cp310-abi3-win32.whl", hash = "sha256:2ddf52eac562eda224f99acfa7889d02968c1fd59a5b011ae7d8137c37e9c02d", size = 342401, upload-time = "2026-06-09T07:52:28.895Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6d/3fba214c1e5e0f69991677ec3bc17023f0421776975e1de0c682dca475e2/safetensors-0.8.0-cp310-abi3-win_amd64.whl", hash = "sha256:096ec1a98435df7beb08853bb5aa9081a84f23d0adc67ed1a0a10550f608373f", size = 355540, upload-time = "2026-06-09T07:52:27.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fc/7eedc3510d97878876e32774eebbeb61c43f148a96e915c84229a3e967aa/safetensors-0.8.0-cp310-abi3-win_arm64.whl", hash = "sha256:f7838e5135a406ad3e02efdcb8cf2e5397d368b0154537c4fec682dbc544d452", size = 340500, upload-time = "2026-06-09T07:52:26.745Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "81.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1213,13 +1237,13 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "networkx", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "sympy", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:e76f9bcecc52b8ff711239a2f7547d5353df95878ab232f0773c1d95928b92f8", upload-time = "2026-07-08T12:26:13Z" },
@@ -1249,13 +1273,13 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
-    { name = "networkx", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
-    { name = "setuptools", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
-    { name = "sympy", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:6e9817dbdf5ea76789babd46e457eac5bf14ff566cf85f8addbfdff2d56601ce", upload-time = "2026-07-08T19:27:52Z" },
@@ -1325,10 +1349,14 @@ lint = [
     { name = "types-pyyaml" },
     { name = "uv" },
 ]
+safetensors = [
+    { name = "safetensors" },
+]
 test = [
     { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-xdist" },
+    { name = "safetensors" },
 ]
 
 [package.metadata]
@@ -1351,6 +1379,8 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'build'" },
     { name = "regex" },
     { name = "regex", marker = "extra == 'build'" },
+    { name = "safetensors", marker = "extra == 'safetensors'", specifier = ">=0.8.0" },
+    { name = "safetensors", marker = "extra == 'test'", specifier = ">=0.8.0" },
     { name = "setuptools", marker = "extra == 'build'", specifier = ">=77.0.3" },
     { name = "torch", specifier = "~=2.13.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torch", marker = "extra == 'build'", specifier = "~=2.13.0", index = "https://download.pytorch.org/whl/cpu" },
@@ -1358,7 +1388,7 @@ requires-dist = [
     { name = "uv", marker = "extra == 'lint'", specifier = "~=0.11.15" },
     { name = "wheel", marker = "extra == 'build'" },
 ]
-provides-extras = ["cpsat", "build", "test", "lint"]
+provides-extras = ["safetensors", "cpsat", "build", "test", "lint"]
 
 [[package]]
 name = "types-pyyaml"


### PR DESCRIPTION
Patch the three public safetensors entry points so that device="spyre" transparently applies the optimal Spyre DMA layout per tensor:

  safetensors.safe_open(path, framework="pt", device="spyre")
    Returns _SpyreSafeOpen, a context-manager wrapper that opens the
    file on CPU internally and dispatches every get_tensor() /
    get_tensors() / get_slice()[...] call through the Spyre hook.
    Covers both the mmap and pread backends.

  safetensors.torch.load_file(filename, device="spyre")
    Delegates to the patched safe_open so f.get_tensors() goes through
    the hook path.

  safetensors.torch.load_model(model, filename, device="spyre")
    Loads the state dict directly to Spyre via the patched load_file,
    then assigns each tensor into the model with direct _parameters /
    _buffers replacement. This avoids the copy_() no-op that breaks
    meta-device models: load_state_dict on a meta model is silent but
    leaves all parameters on meta, causing a subsequent DMA call to
    crash with "Unsupported copy types: src on meta dst on spyre".

The central hook _spyre_tensor_from_safetensors(cpu_tensor, name, device) selects the optimal Spyre DMA path from the tensor's key name and shape:

  - 2D key containing "embed"/"wte"/"wpe"/etc. → _dma_to_spyre_indirect_access (gather-optimal layout) falls back to default if hidden_dim % elems_per_stick != 0
  - 2D key ending in ".weight" (Linear weight) → _dma_to_spyre_dim_order_swapped (dim_order=[1,0], matmul-optimal)
  - everything else (bias, norms, 1-D buffers) → _dma_to_spyre_default (stickify last dim)

All three patches are idempotent and guarded by _spyre_patched sentinels. Non-Spyre device paths fall through to the originals with zero overhead. safetensors is an optional dependency; if not installed the patch block is skipped silently.

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
