### PR TITLE
fix: move in_progress callback CRCR

### DIFF
--- a/.github/workflows/build_test_pytorch_source.yaml
+++ b/.github/workflows/build_test_pytorch_source.yaml
@@ -178,17 +178,22 @@ jobs:
             --pytorch-sha "${{ inputs.pytorch_sha }}" \
             --torch-spyre-sha "${{ github.sha }}"
 
-      - name: Report CI started to pytorch/pytorch
-        # Only repository_dispatch (real PR-triggered CI) needs an
-        # in_progress ping -- pytorch/pytorch's CRCR only watches those
-        # runs live. Nightly (schedule) doesn't need one, and
-        # workflow_dispatch (manual/ad-hoc) is never relayed at all.
-        if: github.event_name == 'repository_dispatch'
-        continue-on-error: true
-        uses: pytorch/test-infra/.github/actions/cross-repo-ci-relay-callback@main
-        with:
-          status: in_progress
-          job-name: linux-x86_64 / pytorch / test
+      # upstream HUD requires same check_run_id
+      # however check_run_id differs across jobs
+      # therefore we need to have both the callbacks
+      # under the same job.
+      # so moving this to final job.
+      # - name: Report CI started to pytorch/pytorch
+      #   # Only repository_dispatch (real PR-triggered CI) needs an
+      #   # in_progress ping -- pytorch/pytorch's CRCR only watches those
+      #   # runs live. Nightly (schedule) doesn't need one, and
+      #   # workflow_dispatch (manual/ad-hoc) is never relayed at all.
+      #   if: github.event_name == 'repository_dispatch'
+      #   continue-on-error: true
+      #   uses: pytorch/test-infra/.github/actions/cross-repo-ci-relay-callback@main
+      #   with:
+      #     status: in_progress
+      #     job-name: linux-x86_64 / pytorch / test
 
   # ---------------------------------------------------------------------------
   # Run every upstream-beta suite (as a per-suite matrix, with retry/stall-
@@ -250,6 +255,18 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-cli"
           tar -xzf "${RUNNER_TEMP}/gh-cli.tar.gz" -C "${RUNNER_TEMP}/gh-cli" --strip-components=1
           echo "${RUNNER_TEMP}/gh-cli/bin" >> "${GITHUB_PATH}"
+
+      - name: Report CI started to pytorch/pytorch
+        # Only repository_dispatch (real PR-triggered CI) needs an
+        # in_progress ping -- pytorch/pytorch's CRCR only watches those
+        # runs live. Nightly (schedule) doesn't need one, and
+        # workflow_dispatch (manual/ad-hoc) is never relayed at all.
+        if: github.event_name == 'repository_dispatch'
+        continue-on-error: true
+        uses: pytorch/test-infra/.github/actions/cross-repo-ci-relay-callback@main
+        with:
+          status: in_progress
+          job-name: linux-x86_64 / pytorch / test
 
       - name: Write dispatch payload to file
         env:


### PR DESCRIPTION
upstream HUD requires same check_run_id however check_run_id differs across jobs therefore we need to have both the callbacks under the same job, so moving in_progress callback to final job.