### PR TITLE
Coarse tiling stage1

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -74,6 +74,7 @@ from torch_spyre._inductor.constants import (
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.loop_info import CoarseTileInfo, copy_op_metadata
 from torch_spyre._inductor.pass_utils import coeff_through_floor
+from torch_spyre._inductor.propagate_hints import DimHint
 from torch_spyre._inductor.wsr.coarse_tile import (
     _LOOPS_FREE_SYMS_KEY,
     _REDUCTION_FREE_SYMS_KEY,
@@ -92,6 +93,21 @@ from torch_spyre._inductor.wsr.coarse_tile import (
     coarse_tile_post_stickify,
     coarse_tile_pre_stickify,
     plan_coarse_tile_groups,
+    reduction_loop_vars,
+)
+from torch_spyre._inductor.scratchpad.coarse_tiling import (
+    CoarseTilingPass,
+    _derive_group_idx_offset,
+    _derive_hint_id_base,
+    derive_tiling_groups,
+    tile_spec_to_dim_hints,
+)
+from torch_spyre._inductor.scratchpad.plan_solver import (
+    CoreDivision,
+    CoreDivisionBuffer,
+    TileAxis,
+    TileSpec,
+    ceil_div,
 )
 from torch_spyre._inductor.op_spec import LoopSpec, OpSpec, TensorArg, UnimplementedOp
 from torch_spyre._inductor.fusion import spyre_fuse_nodes
@@ -7432,6 +7448,363 @@ class TestSpyreKernelPoolSize(unittest.TestCase):
 
         default_kernel = SpyreKernel()
         self.assertEqual(default_kernel.pool_size, 0)
+
+
+class TestTileSpecRepresentation(unittest.TestCase):
+    """TileAxis/TileSpec/CoreDivision.tiling and the min_footprint win."""
+
+    def test_empty_spec_is_untiled_and_inert(self):
+        u = TileSpec()
+        self.assertTrue(u.is_untiled)
+        self.assertEqual(u.depth, 0)
+        self.assertEqual(u.tile_count, 1)
+        self.assertEqual(u.output_tile_count, 1)
+        self.assertTrue(u.is_clean)
+        self.assertEqual(u.label, "untiled")
+
+    def test_ordered_and_hashable_equality_is_same_shape(self):
+        a = TileSpec((TileAxis(0, 4), TileAxis(1, 2)))
+        b = TileSpec((TileAxis(0, 4), TileAxis(1, 2)))
+        swapped = TileSpec((TileAxis(1, 2), TileAxis(0, 4)))
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        # Levels nest, so swapping them is a different plan (unlike divisions).
+        self.assertNotEqual(a, swapped)
+        # Hashable: usable as a dict/set key (the group-derivation key).
+        self.assertEqual(len({a, b, swapped}), 2)
+
+    def test_output_axis_scalars(self):
+        a = TileSpec((TileAxis(0, 4), TileAxis(1, 2)))
+        self.assertEqual(a.depth, 2)
+        self.assertEqual(a.tile_count, 8)
+        self.assertEqual(a.output_tile_count, 8)
+        self.assertTrue(a.is_clean)
+        self.assertEqual(a.label, "d0:4/d1:2")
+
+    def test_reduction_axis_excluded_from_output_tile_count(self):
+        r = TileSpec((TileAxis(0, 4), TileAxis(2, 3, is_reduction=True)))
+        # Reduction level counts in tile_count but not in output_tile_count.
+        self.assertEqual(r.tile_count, 12)
+        self.assertEqual(r.output_tile_count, 4)
+        self.assertFalse(r.is_clean)
+        self.assertEqual(r.label, "d0:4/~d2:3")
+
+    def test_core_division_tiling_defaults_untiled_and_inert(self):
+        cd = CoreDivision(output_splits={0: 2})
+        self.assertEqual(cd.tiling, TileSpec())
+        self.assertTrue(cd.tiling.is_untiled)
+        # Distinct CoreDivisions do not share one mutable default.
+        self.assertIsNot(CoreDivision().tiling, CoreDivision().tiling)
+
+    def test_min_footprint_inert_when_untiled(self):
+        buf = CoreDivisionBuffer(
+            name="x",
+            size=1024,
+            uses=[0, 1],
+            core_divisions=[CoreDivision(output_splits={0: 2})],
+        )
+        self.assertEqual(buf.min_footprint, ceil_div(1024, 2))
+
+    def test_min_footprint_shrinks_by_output_tile_count(self):
+        spec = TileSpec((TileAxis(0, 4), TileAxis(1, 2)))  # 8 output tiles
+        buf = CoreDivisionBuffer(
+            name="y",
+            size=1024,
+            uses=[0, 1],
+            core_divisions=[CoreDivision(output_splits={0: 2}, tiling=spec)],
+        )
+        self.assertEqual(buf.min_footprint, ceil_div(1024, 2 * spec.output_tile_count))
+
+    def test_min_footprint_reduction_level_does_not_shrink_accumulator(self):
+        # The reduction-tiled op's own buffer is the accumulator: full extent.
+        spec = TileSpec((TileAxis(0, 4), TileAxis(1, 3, is_reduction=True)))
+        buf = CoreDivisionBuffer(
+            name="z",
+            size=1024,
+            uses=[0, 1],
+            core_divisions=[CoreDivision(output_splits={0: 2}, tiling=spec)],
+        )
+        self.assertEqual(buf.min_footprint, ceil_div(1024, 2 * spec.output_tile_count))
+
+
+class TestTileSpecLoweringOutput(unittest.TestCase):
+    """tile_spec_to_dim_hints on output axes — same DimHints as the hint path."""
+
+    def setUp(self):
+        self.enterContext(
+            patch(
+                "torch_spyre._inductor.scratchpad.coarse_tiling.op_out_coords",
+                side_effect=_mock_op_out_coords,
+            )
+        )
+
+    def _op(self, n_dims, name="op0"):
+        op = _make_op(_make_pointwise([Integer(64)] * n_dims), name)
+        op._test_out_coords = [sympy.Symbol(f"c{i}") for i in range(n_dims)]
+        return op
+
+    def test_single_output_axis(self):
+        op = self._op(2)
+        spec = TileSpec((TileAxis(0, 4),))
+        hints = tile_spec_to_dim_hints(op, spec, [7])
+        self.assertEqual(len(hints), 1)
+        h = hints[0]
+        self.assertEqual(h.split_count, 4)
+        self.assertEqual(h.loop_var, sympy.Symbol("c0"))
+        self.assertFalse(h.is_reduction)
+        self.assertEqual(h.hint_id, 7)
+
+    def test_nested_output_axes_get_their_own_loop_vars(self):
+        op = self._op(3)
+        spec = TileSpec((TileAxis(0, 4), TileAxis(2, 2)))
+        hints = tile_spec_to_dim_hints(op, spec, [0, 1])
+        self.assertEqual(
+            [h.loop_var for h in hints], [sympy.Symbol("c0"), sympy.Symbol("c2")]
+        )
+        self.assertEqual([h.split_count for h in hints], [4, 2])
+        self.assertEqual([h.hint_id for h in hints], [0, 1])
+
+    def test_hint_id_count_must_match_axis_count(self):
+        op = self._op(2)
+        spec = TileSpec((TileAxis(0, 4),))
+        with self.assertRaises(ValueError):
+            tile_spec_to_dim_hints(op, spec, [0, 1])
+
+    def test_host_dim_out_of_bounds_raises(self):
+        op = self._op(2)
+        spec = TileSpec((TileAxis(5, 4),))
+        # unsupported because too few loop ids are provided
+        with self.assertRaises(Unsupported):
+            tile_spec_to_dim_hints(op, spec, [0])
+
+
+class TestTileSpecLoweringReduction(unittest.TestCase):
+    """The reduction-axis lowering is the inverse of reduction_loop_vars."""
+
+    def setUp(self):
+        gm = fx.symbolic_trace(lambda: None)
+        self._graph_ctx = V.set_graph_handler(GraphLowering(gm))
+        self._graph_ctx.__enter__()
+
+    def tearDown(self):
+        self._graph_ctx.__exit__(None, None, None)
+
+    def test_reduction_axis_resolves_via_reduction_loop_vars(self):
+        # out[d0] = sum_{d1} in[d0, d1]; one reduction loop var.
+        op = _make_real_reduction_op(
+            ranges=[Integer(8)],
+            reduction_ranges=[Integer(16)],
+            input_shape_stride=([8, 16], [16, 1]),
+            name="buf0",
+            hints=((1, 0),),
+        )
+        red_vars = reduction_loop_vars(op)
+        self.assertEqual(len(red_vars), 1)
+        spec = TileSpec((TileAxis(0, 4, is_reduction=True),))
+        hints = tile_spec_to_dim_hints(op, spec, [3])
+        self.assertEqual(len(hints), 1)
+        h = hints[0]
+        self.assertTrue(h.is_reduction)
+        self.assertEqual(h.split_count, 4)
+        self.assertEqual(h.hint_id, 3)
+        # The inverse relationship: the lowered loop_var is exactly the one
+        # reduction_loop_vars reports at that position.
+        self.assertEqual(h.loop_var, red_vars[0])
+        self.assertEqual(_loop_var_to_reduction_ranges_pos_public(op, h.loop_var), 0)
+
+    def test_reduction_host_dim_out_of_bounds_raises(self):
+        op = _make_real_reduction_op(
+            ranges=[Integer(8)],
+            reduction_ranges=[Integer(16)],
+            input_shape_stride=([8, 16], [16, 1]),
+            name="buf0",
+            hints=((1, 0),),
+        )
+        spec = TileSpec((TileAxis(3, 4, is_reduction=True),))  # only 1 red var
+        with self.assertRaises(Unsupported):
+            tile_spec_to_dim_hints(op, spec, [0])
+
+    def test_reduction_axis_on_pointwise_raises(self):
+        op = _make_real_pointwise_op(
+            ranges=[Integer(8), Integer(16)],
+            input_shapes_strides=[([8, 16], [16, 1])],
+            name="buf0",
+            hints=((0, 0),),
+        )
+        spec = TileSpec((TileAxis(0, 4, is_reduction=True),))
+        with self.assertRaises(Unsupported):
+            tile_spec_to_dim_hints(op, spec, [0])
+
+
+def _loop_var_to_reduction_ranges_pos_public(op, sym):
+    from torch_spyre._inductor.wsr.coarse_tile import (
+        _loop_var_to_reduction_ranges_pos,
+    )
+
+    return _loop_var_to_reduction_ranges_pos(op, sym)
+
+
+class TestDeriveTilingGroups(unittest.TestCase):
+    """derive_tiling_groups — consecutive runs of ops sharing a TileSpec."""
+
+    def _graph_of(self, names):
+        return _graph([_make_op(_make_pointwise([Integer(64)]), n) for n in names])
+
+    def _names(self, groups):
+        return [[o.get_operation_name() for o in ops] for ops, _ in groups]
+
+    def test_consecutive_run_grouped_untiled_breaks(self):
+        g = self._graph_of(["op0", "op1", "op2", "op3", "op4"])
+        spec = TileSpec((TileAxis(0, 4),))
+        # op1,op2 tiled and consecutive -> one group; op4 tiled alone; op0/op3
+        # untiled -> break the runs.
+        choices = {"op1": spec, "op2": spec, "op4": spec}
+        groups = derive_tiling_groups(g, choices)
+        self.assertEqual(self._names(groups), [["op1", "op2"], ["op4"]])
+
+    def test_spec_change_breaks_the_run(self):
+        g = self._graph_of(["op0", "op1"])
+        s1 = TileSpec((TileAxis(0, 4),))
+        s2 = TileSpec((TileAxis(0, 2),))
+        groups = derive_tiling_groups(g, {"op0": s1, "op1": s2})
+        self.assertEqual([len(ops) for ops, _ in groups], [1, 1])
+        self.assertEqual([spec for _, spec in groups], [s1, s2])
+
+    def test_empty_and_all_untiled_produce_no_groups(self):
+        g = self._graph_of(["op0", "op1"])
+        self.assertEqual(derive_tiling_groups(g, {}), [])
+        self.assertEqual(derive_tiling_groups(g, {"op0": TileSpec()}), [])
+
+
+class TestDerivedBases(unittest.TestCase):
+    """Hint-id and group-idx bases are derived off the graph, never reserved."""
+
+    def test_hint_id_base_avoids_existing_hints(self):
+        op = _make_op(_make_pointwise([Integer(64)]), "op0")
+        op.dim_hints = []
+        self.assertEqual(_derive_hint_id_base(_graph([op])), 0)
+        op.dim_hints = [
+            DimHint(
+                dim_names=["a"],
+                split_count=2,
+                loop_var=None,
+                is_reduction=False,
+                hint_id=10005,
+            )
+        ]
+        self.assertEqual(_derive_hint_id_base(_graph([op])), 10006)
+
+    def test_group_idx_offset_avoids_existing_loop_group_ids(self):
+        op = _make_op(_make_pointwise([Integer(64)]), "op0")
+        self.assertEqual(_derive_group_idx_offset(_graph([op])), 0)
+        op.loop_info = CoarseTileInfo(
+            loop_group_id=(3,), loop_count=[Integer(2)], loop_tiled_dims=[[0]]
+        )
+        self.assertEqual(_derive_group_idx_offset(_graph([op])), 4)
+
+
+class TestCoarseTilingPassEquivalence(unittest.TestCase):
+    """CoarseTilingPass reduces to the hint path.
+
+    Both paths call the same coarse_tile(); the pass just builds its (groups,
+    group_idx_offset, dim_hints) inputs from a TileSpec instead of pre-stamped
+    hints. Feeding structurally identical inputs to the identical function
+    yields identical output, which is asserted end-to-end here on the stamped
+    loop_info and the divided ranges.
+    """
+
+    def setUp(self):
+        self.enterContext(
+            patch(
+                "torch_spyre._inductor.wsr.coarse_tile.op_out_coords",
+                side_effect=_mock_op_out_coords,
+            )
+        )
+        self.enterContext(
+            patch(
+                "torch_spyre._inductor.scratchpad.coarse_tiling.op_out_coords",
+                side_effect=_mock_op_out_coords,
+            )
+        )
+
+    def _bare(self, ranges, name):
+        op = _make_op(_make_pointwise([Integer(r) for r in ranges]), name)
+        op._test_out_coords = [sympy.Symbol(f"c{i}") for i in range(len(ranges))]
+        op.dim_hints = []
+        return op
+
+    def _loop_fields(self, op):
+        li = op.loop_info
+        return (
+            tuple(li.loop_group_id),
+            list(li.loop_count),
+            [list(x) for x in li.loop_tiled_dims],
+        )
+
+    def test_single_level_matches_hint_path(self):
+        # Reference: hint path, hint_id 0, group 0.
+        ref = _make_hinted_op(_make_pointwise([Integer(256)]), "op0", hints=((0, 0),))
+        coarse_tile_pre_stickify(_graph([ref]), [([ref], [(0, Integer(4))])])
+        ref_fields = self._loop_fields(ref)
+        ref_range = ref.data.ranges[0]
+
+        # CoarseTilingPass: same tiling expressed as a TileSpec.
+        got = self._bare([256], "op0")
+        CoarseTilingPass({"op0": TileSpec((TileAxis(0, 4),))}).apply_pass(_graph([got]))
+        self.assertEqual(self._loop_fields(got), ref_fields)
+        self.assertEqual(got.data.ranges[0], ref_range)
+        # And the win is visible: dim 0 divided by 4.
+        self.assertEqual(got.data.ranges[0], Integer(64))
+
+    def test_nested_two_level_matches_hint_path(self):
+        ref = _make_hinted_op(
+            _make_pointwise([Integer(256), Integer(128)]), "op0", hints=((0, 0), (1, 1))
+        )
+        coarse_tile_pre_stickify(
+            _graph([ref]), [([ref], [(0, Integer(4)), (1, Integer(2))])]
+        )
+        ref_fields = self._loop_fields(ref)
+        ref_ranges = list(ref.data.ranges)
+
+        got = self._bare([256, 128], "op0")
+        CoarseTilingPass(
+            {"op0": TileSpec((TileAxis(0, 4), TileAxis(1, 2)))}
+        ).apply_pass(_graph([got]))
+        self.assertEqual(self._loop_fields(got), ref_fields)
+        self.assertEqual(list(got.data.ranges), ref_ranges)
+        self.assertEqual(list(got.data.ranges), [Integer(64), Integer(64)])
+
+    def test_pass_inputs_match_hint_path_structurally(self):
+        # Two independent ops in one group: prove the group derivation and
+        # hint-id minting produce exactly the coarse_tile inputs the hint path
+        # would, without running the mutation (robust against mock read-edges).
+        got0 = self._bare([256], "op0")
+        got1 = self._bare([256], "op1")
+        g = _graph([got0, got1])
+        spec = TileSpec((TileAxis(0, 4),))
+        groups_specs = derive_tiling_groups(g, {"op0": spec, "op1": spec})
+        self.assertEqual(len(groups_specs), 1)
+        group_ops, group_spec = groups_specs[0]
+        self.assertEqual([o.get_operation_name() for o in group_ops], ["op0", "op1"])
+        # One group, base 0 -> hint_ids [0], every op in the group shares it.
+        base = _derive_hint_id_base(g)
+        self.assertEqual(base, 0)
+        hints0 = tile_spec_to_dim_hints(got0, group_spec, [base])
+        hints1 = tile_spec_to_dim_hints(got1, group_spec, [base])
+        self.assertEqual(hints0[0].hint_id, hints1[0].hint_id)
+        self.assertEqual(hints0[0].split_count, 4)
+
+    def test_empty_choices_is_a_noop(self):
+        # The pass leaves op count unchanged when it does nothing
+        # (untiled/absent choices).
+        ops = [self._bare([64], "op0"), self._bare([64], "op1")]
+        g = _graph(ops)
+        CoarseTilingPass({}).apply_pass(g)
+        self.assertEqual(len(g.operations), 2)
+        for op in ops:
+            self.assertFalse(
+                hasattr(op, "loop_info") and isinstance(op.loop_info, CoarseTileInfo)
+            )
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/scratchpad/coarse_tiling.py
+++ b/torch_spyre/_inductor/scratchpad/coarse_tiling.py
@@ -1,0 +1,225 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Declarative coarse tiling, applied inside the scratchpad planning pass.
+
+This is stage 1 of the coarse-tiling optimization: a tiling stated as data (a
+:class:`~torch_spyre._inductor.scratchpad.plan_solver.TileSpec` per op) and
+*applied* to a real graph through a :class:`ScratchpadOptimizationPass`. The
+tiling is an input here, not a search -- candidate enumeration and the solver
+that chooses among tilings arrive in later stages.
+
+The pass mints hint ids and a group-id offset from bases derived off the graph
+(never a reserved constant), so a tiling applied here cannot collide with a
+hint-driven group already stamped pre-stickification at pass 430. It reuses the
+existing ``coarse_tile`` machinery verbatim; the only new work is lowering a
+``TileSpec`` to per-op ``DimHint``s and deriving groups as consecutive runs of
+ops that share a spec.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import sympy
+
+from torch._inductor.graph import GraphLowering
+from torch._inductor.ir import ComputedBuffer, Operation, Reduction
+
+from ..errors import Unsupported
+from ..pass_utils import op_out_coords
+from ..propagate_hints import DimHint
+from ..wsr.coarse_tile import (
+    coarse_tile_post_stickify,
+    reduction_loop_vars,
+    validate_coarse_tile_groups,
+)
+from .passes import ScratchpadOptimizationPass
+from .plan_solver import TileSpec
+
+
+def tile_spec_to_dim_hints(
+    op: ComputedBuffer,
+    spec: TileSpec,
+    hint_ids: Sequence[int],
+) -> list[DimHint]:
+    """Lower a :class:`TileSpec` into per-op :class:`DimHint`s.
+
+    Each :class:`TileAxis` becomes one ``DimHint`` carrying the axis's split
+    count and the op's *own* loop variable for that axis, paired with the group's
+    ``hint_id`` for that level. ``hint_ids`` has one entry per axis, outermost
+    first, matching the group's ``levels``.
+
+    The output-axis case is exactly ``_dims_to_hints`` (span overflow): resolve
+    the loop var from ``op_out_coords(op)[host_dim]``. The reduction-axis case is
+    the inverse of :func:`reduction_loop_vars` -- ``host_dim`` positionally
+    indexes the op's ordered reduction loop variables.
+    """
+    if len(hint_ids) != len(spec.axes):
+        raise ValueError(
+            f"tile_spec_to_dim_hints: {len(hint_ids)} hint_ids for "
+            f"{len(spec.axes)} axes on {op.get_name()}"
+        )
+    out_coords = op_out_coords(op)
+    red_vars: list[sympy.Symbol] | None = None
+    hints: list[DimHint] = []
+    for axis, hint_id in zip(spec.axes, hint_ids):
+        if axis.is_reduction:
+            if not isinstance(op.data, Reduction):
+                raise Unsupported(
+                    f"coarse tiling: reduction axis host_dim={axis.host_dim} "
+                    f"requested on non-Reduction op {op.get_name()}."
+                )
+            if red_vars is None:
+                red_vars = reduction_loop_vars(op)
+            if axis.host_dim >= len(red_vars):
+                raise Unsupported(
+                    f"coarse tiling: reduction host_dim={axis.host_dim} is out "
+                    f"of bounds for {len(red_vars)} reduction loop variables on "
+                    f"{op.get_name()}."
+                )
+            loop_var = red_vars[axis.host_dim]
+        else:
+            if axis.host_dim >= len(out_coords):
+                raise Unsupported(
+                    f"coarse tiling: host_dim={axis.host_dim} is out of bounds "
+                    f"for {len(out_coords)} output coordinates on {op.get_name()}."
+                )
+            coord = out_coords[axis.host_dim]
+            free_symbols = coord.free_symbols
+            if len(free_symbols) != 1:
+                raise Unsupported(
+                    f"coarse tiling: host_dim={axis.host_dim} output coordinate "
+                    f"{coord} on {op.get_name()} has {len(free_symbols)} free "
+                    "symbols; expected exactly one loop var."
+                )
+            loop_var = next(iter(free_symbols))
+        hints.append(
+            DimHint(
+                dim_names=["_coarse_tile"],
+                split_count=axis.count,
+                loop_var=loop_var,
+                is_reduction=axis.is_reduction,
+                hint_id=hint_id,
+            )
+        )
+    return hints
+
+
+def derive_tiling_groups(
+    graph: GraphLowering,
+    choices: Mapping[str, TileSpec],
+) -> list[tuple[list[Operation], TileSpec]]:
+    """Group consecutive ops that share the same non-empty :class:`TileSpec`.
+
+    Mirrors ``hints_to_coarse_tile_groups``' consecutive-run shape with the hint
+    key replaced by the chosen ``TileSpec``: a run breaks whenever an op is
+    untiled (absent from ``choices`` or mapped to the empty spec) or its spec
+    differs from the run's. Contiguity is a hard requirement, not an
+    optimization -- ``validate_coarse_tile_groups`` and ``_apply_plan`` both rely
+    on each group occupying one contiguous stretch of the operation list, so a
+    connected component that skipped an intervening untiled op would be rejected
+    at apply time.
+
+    ``choices`` is keyed by operation name (``op.get_operation_name()``).
+    """
+    groups: list[tuple[list[Operation], TileSpec]] = []
+    current_ops: list[Operation] = []
+    current_spec: TileSpec | None = None
+    for op in graph.operations:
+        spec = choices.get(op.get_operation_name())
+        if spec is not None and spec.is_untiled:
+            spec = None
+        if spec is not None and spec == current_spec:
+            current_ops.append(op)
+        else:
+            if current_ops:
+                assert current_spec is not None
+                groups.append((current_ops, current_spec))
+            current_ops = [op] if spec is not None else []
+            current_spec = spec
+    if current_ops:
+        assert current_spec is not None
+        groups.append((current_ops, current_spec))
+    return groups
+
+
+def _derive_hint_id_base(graph: GraphLowering) -> int:
+    """``max(hint_id present in the graph, default=-1) + 1``.
+
+    Derived, never a reserved constant: whatever hint ids a pre-stickification
+    hint-driven group already minted, this pass mints strictly above them, so
+    ``validate_coarse_tile_groups`` can never see a hint id in two groups.
+    """
+    ids = [h.hint_id for op in graph.operations for h in getattr(op, "dim_hints", [])]
+    return max(ids, default=-1) + 1
+
+
+def _derive_group_idx_offset(graph: GraphLowering) -> int:
+    """``max(loop_group_id[0] present, default=-1) + 1`` -- the same derivation
+    ``_maybe_coarse_tile_span_overflow`` uses to avoid a ``loop_group_id``
+    collision with a hint-driven group stamped pre-stickification."""
+    used = [
+        op.loop_info.loop_group_id[0]
+        for op in graph.operations
+        if getattr(op, "loop_info", None) is not None
+    ]
+    return max(used, default=-1) + 1
+
+
+class CoarseTilingPass(ScratchpadOptimizationPass):
+    """Apply a declared coarse tiling to a graph, inside the scratchpad pass.
+
+    Stage 1: the tiling is an *input* (``choices``: operation name -> TileSpec),
+    not a search. Consecutive ops sharing a non-empty spec form one loop group;
+    the pass mints hint ids and a group-id offset from bases derived off the
+    graph, stamps each op's ``dim_hints``, validates group contiguity, then calls
+    ``coarse_tile``. With empty (or all-untiled) ``choices`` it is a no-op and
+    the op count is unchanged -- which is what keeps it inert while
+    ``auto_coarse_tiling`` is off.
+    """
+
+    def __init__(self, choices: Mapping[str, TileSpec]):
+        self._choices = dict(choices)
+
+    def apply_pass(self, graph: GraphLowering) -> None:
+        groups_specs = derive_tiling_groups(graph, self._choices)
+        if not groups_specs:
+            return
+        # Both bases are derived off the graph *before* this pass stamps any of
+        # its own hints/groups, so pre-existing (hint-driven) ids are avoided
+        # and the ids this pass mints increase monotonically.
+        next_hint_id = _derive_hint_id_base(graph)
+        group_idx_offset = _derive_group_idx_offset(graph)
+        groups: list[tuple] = []
+        for group_ops, spec in groups_specs:
+            hint_ids = list(range(next_hint_id, next_hint_id + len(spec.axes)))
+            next_hint_id += len(spec.axes)
+            levels = [
+                (hint_id, sympy.Integer(axis.count))
+                for hint_id, axis in zip(hint_ids, spec.axes)
+            ]
+            for op in group_ops:
+                op.dim_hints = tile_spec_to_dim_hints(op, spec, hint_ids)
+            groups.append((group_ops, levels))
+        validate_coarse_tile_groups(groups)
+        # This pass runs inside scratchpad/LX planning -- after stickification
+        # (insert_restickify) and the post-stickify span-overflow WSR pass -- so
+        # every op already carries a committed FixedTiledLayout. Use the
+        # post-stickify entry point (run_read_copies=False): a read copy-in here
+        # would only be a useless HBM-to-HBM copy, exactly as the sibling
+        # post-stickify consumer (_maybe_coarse_tile_span_overflow) does.
+        coarse_tile_post_stickify(
+            graph, groups=groups, group_idx_offset=group_idx_offset
+        )

--- a/torch_spyre/_inductor/scratchpad/plan_solver.py
+++ b/torch_spyre/_inductor/scratchpad/plan_solver.py
@@ -138,6 +138,77 @@ class LifetimeBoundBuffer:
         return self.start_time < other.end_time and other.start_time < self.end_time
 
 
+@dataclass(frozen=True)
+class TileAxis:
+    """One coarse-tiling level.
+
+    ``host_dim`` is a *positional* index: into ``op_out_coords(op)`` for an
+    output axis, or into the op's ordered reduction loop variables (see
+    :func:`wsr.coarse_tile.reduction_loop_vars`) for a reduction axis.
+    ``is_reduction`` selects which frame ``host_dim`` indexes. ``count`` is the
+    split factor -- how many equal tiles the axis is cut into.
+    """
+
+    host_dim: int
+    count: int
+    is_reduction: bool = False
+
+
+@dataclass(frozen=True)
+class TileSpec:
+    """An ordered, outermost-first tuple of :class:`TileAxis` levels.
+
+    Ordered -- where the core-division splits are dicts and so order-free --
+    because tile levels *nest*: swapping two levels is a different plan. Frozen
+    and hashable so ``==`` is exactly the "same tiling shape" test the group
+    derivation keys on. The empty spec is *untiled*, and is the inert default
+    every :class:`CoreDivision` carries while ``auto_coarse_tiling`` is off.
+    """
+
+    axes: tuple[TileAxis, ...] = ()
+
+    @property
+    def is_untiled(self) -> bool:
+        return not self.axes
+
+    @property
+    def depth(self) -> int:
+        """Number of nested tile levels."""
+        return len(self.axes)
+
+    @property
+    def tile_count(self) -> int:
+        """Total number of loop tiles across every level (all axes)."""
+        return math.prod(a.count for a in self.axes)
+
+    @property
+    def output_tile_count(self) -> int:
+        """Product of the split factors over output (non-reduction) axes only.
+
+        This is the factor by which a tiled op's own per-tile scratch shrinks,
+        and so the factor :attr:`CoreDivisionBuffer.min_footprint` divides by. A
+        reduction-tiled level does *not* shrink that buffer -- the op's own
+        output is the accumulator, which keeps the full output extent -- so
+        reduction axes are excluded here even though they count in
+        :attr:`tile_count`.
+        """
+        return math.prod(a.count for a in self.axes if not a.is_reduction)
+
+    @property
+    def is_clean(self) -> bool:
+        """True when no reduction axis is tiled (mirrors
+        :attr:`CoreDivision.is_clean`)."""
+        return not any(a.is_reduction for a in self.axes)
+
+    @property
+    def label(self) -> str:
+        if not self.axes:
+            return "untiled"
+        return "/".join(
+            f"{'~' if a.is_reduction else ''}d{a.host_dim}:{a.count}" for a in self.axes
+        )
+
+
 @dataclass
 class CoreDivision:
     """One permissible core-division of a buffer's producing op.
@@ -146,10 +217,16 @@ class CoreDivision:
     produced by :func:`pass_utils.splits_by_index_coeff` -- exactly the shape
     stored in ``op.op_it_space_splits``. Solvers are expected to use these to size
     the buffer (per-core footprint = total / ``output_partition``).
+
+    ``tiling`` pairs a coarse tiling onto this division as *one* candidate rather
+    than a parallel list. A division is only meaningful relative to a tiling
+    (the legal set and the coeff encoding both move with it), so the two must be
+    chosen together. The empty :class:`TileSpec` is untiled and inert.
     """
 
     output_splits: dict[int, int] = field(default_factory=dict)
     reduction_splits: dict[int, int] = field(default_factory=dict)
+    tiling: TileSpec = field(default_factory=TileSpec)
 
     @property
     def cores_used(self) -> int:
@@ -206,11 +283,19 @@ class CoreDivisionBuffer(LifetimeBoundBuffer):
     def min_footprint(self) -> int:
         """Smallest per-core footprint any candidate division allows. With no
         candidates there is nothing to divide by, so it falls back to ``size``
-        (the placement-only case ``_wrap`` also dispatches on)."""
+        (the placement-only case ``_wrap`` also dispatches on).
+
+        A tiled candidate's own buffer is per-tile scratch, so its footprint
+        shrinks by the output tile count as well as the core count -- this is
+        the LX-residency win entering the footprint math. Reduction tile levels
+        are excluded (see :attr:`TileSpec.output_tile_count`); with
+        ``auto_coarse_tiling`` off every ``cd.tiling`` is empty and this reduces
+        to the previous ``ceil_div(size, output_partition)`` exactly."""
         if not self.core_divisions:
             return self.size
         return min(
-            ceil_div(self.size, cd.output_partition) for cd in self.core_divisions
+            ceil_div(self.size, cd.output_partition * cd.tiling.output_tile_count)
+            for cd in self.core_divisions
         )
 
 

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -1220,24 +1220,34 @@ def _loop_var_to_ranges_pos(out_coords: list, sym: sympy.Symbol) -> int | None:
     return None
 
 
-def _loop_var_to_reduction_ranges_pos(
-    op: ComputedBuffer, sym: sympy.Symbol
-) -> int | None:
-    """Return position of loop variable sym in op.data.reduction_ranges, or None.
+def reduction_loop_vars(op: ComputedBuffer) -> list[sympy.Symbol]:
+    """Return the op's reduction loop variables, ordered as in
+    ``op.data.reduction_ranges``.
 
     Uses dep-tracking symbols (d0, d1, ...) rather than SymT.R0_INDEX symbols
     (r0_0, r0_1, ...) which are a different namespace.  Finds reduction symbols
     by set-subtracting output index symbols from input index symbols, in
     dep.ranges order (which matches reduction_ranges order).
+
+    This is the single source of truth for that derivation. Both directions go
+    through it: ``_loop_var_to_reduction_ranges_pos`` (loop_var -> position) and
+    coarse tiling's reduction-axis lowering (its inverse, position -> loop_var,
+    in ``scratchpad.coarse_tiling.tile_spec_to_dim_hints``).
     """
     assert isinstance(op.data, Reduction)
     rw = op.get_read_writes()
     out_dep = next(iter(rw.writes))
     out_syms = out_dep.index.free_symbols
     in_dep = next(d for d in rw.reads if hasattr(d, "index"))
-    reduction_syms = [s for s in in_dep.ranges if s not in out_syms]
+    return [s for s in in_dep.ranges if s not in out_syms]
+
+
+def _loop_var_to_reduction_ranges_pos(
+    op: ComputedBuffer, sym: sympy.Symbol
+) -> int | None:
+    """Return position of loop variable sym in op.data.reduction_ranges, or None."""
     try:
-        return reduction_syms.index(sym)
+        return reduction_loop_vars(op).index(sym)
     except ValueError:
         return None
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [X] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
This PR implements the basic interfaces and machinery to express coarse tiling on a per op basis. In coming PRs, these interfaces will be used to express the valid sets of coarse tiling and then also a optimized set of tiling options spanning all considered ops.

Specifically, `TileSpec` and `TileAxis` implement a nested expression of which host axes are tiled where each `TileSpec` represents a valid tiling strategy for a given op. The axes within `TileSpec` are the tiling parameters for each axis. The loop order of the axes is the order in which they are added to the spec. Buffer size now accounts for tiling as well.

The implementation for conversion between specs and hints is provided such that when a solver emits `TileSpec` on an op it can be converted to SDSC using mostly existing machinery. This conversion mechanics are provided as a post solver pass on the graph where the complete solver solution is available and final loop id's can be derived. This approach is compatible with all allocators.

#### Which issue(s) this PR is related to:
https://github.com/torch-spyre/torch-spyre/issues/3932

#### Special notes for your reviewer:
There are a series of follow up PRs which implement full coarse tiling.

#### Does this PR introduce a user-facing change?
No

#### Additional note:
None
