### PR TITLE
fix(eager): raise device-mismatch error for cross-device ops mixing spyre and CPU tensors

### DIFF
--- a/tests/inductor/test_inductor_dtype_scalars.py
+++ b/tests/inductor/test_inductor_dtype_scalars.py
@@ -779,7 +779,10 @@ class TestNegativeScalarOperations:
             pytest.xfail(reason=f"Nested compile unsupported on Spyre path: {err}")
 
     def test_cpu_scalar_tensor_with_spyre_tensor(self, execution_mode):
-        """CPU scalar tensor × Spyre tensor should raise device mismatch error."""
+        """CPU scalar tensor x Spyre tensor should compute successfully: a single
+        non-write 0-dim CPU tensor is exempt from the device-mismatch check
+        (mirrors TensorIterator's ``allow_cpu_scalars_``; see
+        ``test_cross_device_scalar_op_allowed`` in ``tests/test_spyre.py``)."""
         # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1598
         if execution_mode == "compiled":
             pytest.xfail(
@@ -792,18 +795,7 @@ class TestNegativeScalarOperations:
 
         x = cached_randn((128, 128), dtype=torch.float16)
 
-        with pytest.raises(
-            (RuntimeError, torch._inductor.exc.InductorError)
-        ) as exc_info:
-            _compare_modes(
-                execution_mode, cpu_scalar_spyre_tensor, x, atol=1e-3, rtol=1e-3
-            )
-
-        error_msg = str(exc_info.value)
-        print(error_msg)
-        assert any(
-            kw in error_msg.lower() for kw in ["device", "layout", "cpu", "spyre"]
-        )
+        _compare_modes(execution_mode, cpu_scalar_spyre_tensor, x, atol=1e-3, rtol=1e-3)
 
     def test_cpu_tensor_with_spyre_tensor(self, execution_mode):
         """CPU regular tensor × Spyre tensor should raise device mismatch error."""

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -383,6 +383,36 @@ class TestSpyre(TestCase):
             )
             self._assert_roundtrip_close(x, x_cpu, dtype)
 
+    def test_cross_device_inplace_error_msg(self):
+        # Mirrors upstream test_cross_device_inplace_error_msg: the CPU tensor is the write target, so it must raise despite the scalar exemption below.
+        a = torch.tensor(2.0)
+        b = torch.tensor(2.0, device="spyre")
+        with self.assertRaisesRegex(
+            RuntimeError, "Expected all tensors to be on the same device"
+        ):
+            a += b
+
+    def test_cross_device_scalar_op_allowed(self):
+        # A single 0-dim CPU tensor as a non-write operand may mix with a spyre tensor (TensorIterator's allow_cpu_scalars_ exemption).
+        spyre_t = torch.tensor(2.0, device="spyre")
+        cpu_scalar = torch.tensor(3.0)
+
+        result = spyre_t + cpu_scalar
+        self.assertEqual(result.device.type, "spyre")
+        self.assertEqual(result.to("cpu"), torch.tensor(5.0))
+
+        spyre_t += cpu_scalar
+        self.assertEqual(spyre_t.to("cpu"), torch.tensor(5.0))
+
+    def test_cross_device_nonscalar_op_rejected(self):
+        # The CPU-scalar exemption only covers 0-dim tensors; a non-scalar CPU tensor must still raise.
+        spyre_t = torch.tensor([1.0, 2.0], device="spyre")
+        cpu_t = torch.tensor([1.0, 2.0])
+        with self.assertRaisesRegex(
+            RuntimeError, "Expected all tensors to be on the same device"
+        ):
+            spyre_t + cpu_t
+
     @pytest.mark.xfail(reason="data-dependent output not supported", strict=True)
     def test_data_dependent_output(self):
         cpu_a = torch.randn(10)

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -208,7 +208,7 @@ def _remap_result(result, lookup):
 
 
 def _check_same_device(operands):
-    """Raise if tensor ``(value, is_write)`` operands span more than one device, 
+    """Raise if tensor ``(value, is_write)`` operands span more than one device,
     exempting a single non-write 0-dim CPU tensor (mirrors TensorIterator's ``allow_cpu_scalars_``
     unlike ``fallbacks._ensure_device``, which moves tensors instead of rejecting)."""
     mandatory_device = None

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -207,6 +207,30 @@ def _remap_result(result, lookup):
     return _map_result(result, lambda t: lookup.get(id(t), t))
 
 
+def _check_same_device(args, kwargs):
+    """Raise if the tensor arguments span more than one device."""
+    devices = set()
+
+    def collect(x):
+        if isinstance(x, torch.Tensor):
+            devices.add(x.device)
+        elif isinstance(x, (list, tuple)):
+            for e in x:
+                collect(e)
+
+    for a in args:
+        collect(a)
+    for v in kwargs.values():
+        collect(v)
+
+    if len(devices) > 1:
+        d0, d1 = sorted(devices, key=str)[:2]
+        raise RuntimeError(
+            "Expected all tensors to be on the same device, but found at "
+            f"least two devices, {d0} and {d1}!"
+        )
+
+
 def _make_offset_safe_dispatch(op):
     """Build a dispatch wrapper that keeps nonzero-offset Spyre tensors correct
     across the standalone-compiled kernel.
@@ -228,6 +252,7 @@ def _make_offset_safe_dispatch(op):
     normalize_results = not (write_positions or write_names)
 
     def dispatch(*args, compiled=None, **kwargs):
+        _check_same_device(args, kwargs)
         write_back = []  # (clone, original) for each substituted write view
 
         def prep_write(x):

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -207,28 +207,38 @@ def _remap_result(result, lookup):
     return _map_result(result, lambda t: lookup.get(id(t), t))
 
 
-def _check_same_device(args, kwargs):
-    """Raise if the tensor arguments span more than one device."""
-    devices = set()
+def _check_same_device(operands):
+    """Raise if tensor ``(value, is_write)`` operands span more than one device, 
+    exempting a single non-write 0-dim CPU tensor (mirrors TensorIterator's ``allow_cpu_scalars_``
+    unlike ``fallbacks._ensure_device``, which moves tensors instead of rejecting)."""
+    mandatory_device = None
+    scalar_exempted = False
 
-    def collect(x):
+    def visit(x, is_write):
+        nonlocal mandatory_device, scalar_exempted
         if isinstance(x, torch.Tensor):
-            devices.add(x.device)
+            if (
+                not is_write
+                and not scalar_exempted
+                and x.device.type == "cpu"
+                and x.dim() == 0
+            ):
+                scalar_exempted = True
+                return
+            if mandatory_device is None:
+                mandatory_device = x.device
+            elif x.device != mandatory_device:
+                raise RuntimeError(
+                    "Expected all tensors to be on the same device, but "
+                    f"found at least two devices, {mandatory_device} and "
+                    f"{x.device}!"
+                )
         elif isinstance(x, (list, tuple)):
             for e in x:
-                collect(e)
+                visit(e, is_write)
 
-    for a in args:
-        collect(a)
-    for v in kwargs.values():
-        collect(v)
-
-    if len(devices) > 1:
-        d0, d1 = sorted(devices, key=str)[:2]
-        raise RuntimeError(
-            "Expected all tensors to be on the same device, but found at "
-            f"least two devices, {d0} and {d1}!"
-        )
+    for value, is_write in operands:
+        visit(value, is_write)
 
 
 def _make_offset_safe_dispatch(op):
@@ -252,7 +262,10 @@ def _make_offset_safe_dispatch(op):
     normalize_results = not (write_positions or write_names)
 
     def dispatch(*args, compiled=None, **kwargs):
-        _check_same_device(args, kwargs)
+        _check_same_device(
+            [(a, i in write_positions) for i, a in enumerate(args)]
+            + [(v, k in write_names) for k, v in kwargs.items()]
+        )
         write_back = []  # (clone, original) for each substituted write view
 
         def prep_write(x):
@@ -416,6 +429,12 @@ def _make_inplace_kernel(functional_op):
     """
 
     def kernel(self, *args, **kwargs):
+        # functional_op's schema has no write arg marking self as output, so check device write-status here first.
+        _check_same_device(
+            [(self, True)]
+            + [(a, False) for a in args]
+            + [(v, False) for v in kwargs.values()]
+        )
         result = functional_op(self, *args, **kwargs)
         # PyTorch's in-place contract: the promoted result dtype must be
         # castable back to ``self``. ``copy_`` would happily downcast (int32

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -210,20 +210,27 @@ def _remap_result(result, lookup):
 def _check_same_device(operands):
     """Raise if tensor ``(value, is_write)`` operands span more than one device,
     exempting a single non-write 0-dim CPU tensor (mirrors TensorIterator's ``allow_cpu_scalars_``
-    unlike ``fallbacks._ensure_device``, which moves tensors instead of rejecting)."""
+    unlike ``fallbacks._ensure_device``, which moves tensors instead of rejecting).
+
+    Returns ``(mandatory_device, exempted_tensor)``: the device every
+    non-exempt operand agreed on (``None`` if there were none), and the
+    exempted CPU scalar tensor if one was found (``None`` otherwise) -- the
+    caller must still materialize it onto ``mandatory_device`` before handing
+    it to a standalone-compiled kernel, which cannot accept a raw CPU input.
+    """
     mandatory_device = None
-    scalar_exempted = False
+    exempted = None
 
     def visit(x, is_write):
-        nonlocal mandatory_device, scalar_exempted
+        nonlocal mandatory_device, exempted
         if isinstance(x, torch.Tensor):
             if (
                 not is_write
-                and not scalar_exempted
+                and exempted is None
                 and x.device.type == "cpu"
                 and x.dim() == 0
             ):
-                scalar_exempted = True
+                exempted = x
                 return
             if mandatory_device is None:
                 mandatory_device = x.device
@@ -239,6 +246,17 @@ def _check_same_device(operands):
 
     for value, is_write in operands:
         visit(value, is_write)
+
+    return mandatory_device, exempted
+
+
+def _replace_tensor(x, old, new):
+    """Substitute ``old`` for ``new`` by identity, recursing into list/tuple."""
+    if x is old:
+        return new
+    if isinstance(x, (list, tuple)):
+        return type(x)(_replace_tensor(e, old, new) for e in x)
+    return x
 
 
 def _make_offset_safe_dispatch(op):
@@ -262,10 +280,17 @@ def _make_offset_safe_dispatch(op):
     normalize_results = not (write_positions or write_names)
 
     def dispatch(*args, compiled=None, **kwargs):
-        _check_same_device(
+        device, exempted = _check_same_device(
             [(a, i in write_positions) for i, a in enumerate(args)]
             + [(v, k in write_names) for k, v in kwargs.items()]
         )
+        if exempted is not None:
+            # The compiled kernel only accepts spyre-device inputs -- move the
+            # exempted CPU scalar over rather than leaving it for Inductor,
+            # which has no notion of a live CPU graph input.
+            moved = exempted.to(device)
+            args = tuple(_replace_tensor(a, exempted, moved) for a in args)
+            kwargs = {k: _replace_tensor(v, exempted, moved) for k, v in kwargs.items()}
         write_back = []  # (clone, original) for each substituted write view
 
         def prep_write(x):

--- a/torch_spyre/ops/fallbacks.py
+++ b/torch_spyre/ops/fallbacks.py
@@ -140,6 +140,7 @@ def register_fallback(ops, device="cpu"):
             return torch.get_default_device()
 
         if len(devices) > 1:
+            # Unlike eager._check_same_device, no CPU-scalar exemption: fallback ops always move tensors to one resolved device.
             raise RuntimeError(
                 f"Expected all tensors to be on the same device, but found: {devices}"
             )


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

### Problem:

 PrivateUse1 (spyre) outranks CPU in dispatch-key priority, so ops mixing a CPU tensor with a spyre tensor silently ran on the spyre kernel instead of raising, failing upstream PyTorch's `test_binary_ufuncs.py::test_cross_device_inplace_error_msg`.

### Fix

- check tensor-argument devices in the shared eager dispatch wrapper and raise RuntimeError on mismatch, matching native CPU/CUDA behavior.

Fixes:

```bash
  _ TestBinaryUfuncsDevicePRIVATEUSE1.test_cross_device_inplace_error_msg_spyre __
  Traceback (most recent call last):
    File "torch/testing/_internal/common_utils.py", line 3553, in wrapper
      method(*args, **kwargs)
    File "torch/testing/_internal/common_device_type.py", line 551, in instantiated_test
      result = test(self, **param_kwargs)
    File "pytorch/test/test_binary_ufuncs.py", line 1326, in test_cross_device_inplace_error_msg
      with self.assertRaisesRegex(
    File "unittest/case.py", line 263, in __exit__
      self._raiseFailure("{} not raised".format(exc_name))
  AssertionError: RuntimeError not raised

  FAILED test_binary_ufuncs__oot_wrapper.py::TestBinaryUfuncsDevicePRIVATEUSE1::test_cross_device_inplace_error_msg_spyre
  1 failed, 48 passed, 1112 deselected in 5.09s
  ```