### PR TITLE
Updated default solver to CPSAT

### DIFF
--- a/tests/inductor/test_fallback_kernel.py
+++ b/tests/inductor/test_fallback_kernel.py
@@ -423,7 +423,12 @@ class TestInGraphCpuComputedBuffers(unittest.TestCase):
         gate (mem_usage_by_buf over the filtered graph_view)."""
         self._run_and_check(self)
 
-    @config.patch({"co_optimizing_lx_planning": True})
+    # Pin greedy: this covers the co-opt allocator over the greedy inner solver
+    # (ExhaustiveSearchSolver-wrapped), the path this CPU-buffer guard was written
+    # for. The cpsat *joint* co-opt path does not yet apply the same guard, but
+    # co_optimizing_lx_planning is off by default so it is never on the default
+    # compile path; enabling cpsat co-opt is deferred to the co-opt follow-up.
+    @config.patch({"co_optimizing_lx_planning": True, "layout_solver": "greedy"})
     def test_cpu_pointwise_chain_compiles_co_optimizing(self):
         """Co-optimizing allocator: `mem_usage_by_buf` runs on the RAW graph in
         `_build_cd_bound_buffers` / `_determine_in_place_division_invariant`,

--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -1917,7 +1917,11 @@ class TestBoundaryCloneInPlace(BaseTestScratchpadUsage):
                 }
 
         with self.pre_scheduling_iterating_pass(visit):
-            with ts_inductor_config.patch(lx_planning=True):
+            # In-place reuse of boundary-clone buffers is a paired-buffer feature
+            # of the greedy build path (only the greedy solver sets
+            # supports_paired_buffers). Pin it so the slot-sharing assertion holds
+            # regardless of the default layout_solver.
+            with ts_inductor_config.patch(lx_planning=True, layout_solver="greedy"):
                 result = torch.compile(fn, fullgraph=True)(x).to("cpu")
 
         # Group LX-resident buffers by address; a shared address == in-place reuse.

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -676,6 +676,10 @@ def test_lx_relayout_normalizes_ownership_and_lowers_only_in_superdsc():
         "lx_planning": True,
         "allow_all_ops_in_lx_planning": True,
         "lx_planner_relayout": True,
+        # LX relayout needs a paired-buffer-capable solver; only the greedy
+        # solver sets supports_paired_buffers. Pin it explicitly so this test
+        # keeps exercising relayout regardless of the default layout_solver.
+        "layout_solver": "greedy",
     }
 )
 @pytest.mark.parametrize("second_consumer", ["pointwise", "matmul_lhs", "matmul_rhs"])

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -159,7 +159,7 @@ bundle_symbolic_args: bool = os.environ.get("BUNDLE_SYMBOLIC_ARGS", "1") == "1"
 # TODO(isuruf): Change to firstfit when deeptools PR4298 lands
 layout_solver: Literal[
     "greedy", "bestfit", "firstfit", "cpsat", "simulated_annealing"
-] = os.environ.get("LAYOUT_SOLVER", "greedy")  # type: ignore[assignment]
+] = os.environ.get("LAYOUT_SOLVER", "cpsat")  # type: ignore[assignment]
 
 # OpSpec validation at pipeline stage boundaries. Enabled by default to catch
 # invariant violations early. Set SPYRE_VALIDATE_OP_SPECS=0 to disable.


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [X] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
This PR makes cp-sat the default solver for scratchpad planning. Co-optimization will be deferred to a later PR once the cost model is refined.

#### Which issue(s) this PR is related to:
https://github.com/torch-spyre/torch-spyre/issues/3932

#### Special notes for your reviewer:
Several follow PRs will be needed to add relayout to CP-SAT as well as a data driven testing to test feature parity between solvers.

#### Does this PR introduce a user-facing change?
Yes.

#### Additional note:
CC: @dgrove-oss @chichun-charlie-liu @cyang49