### PR TITLE
Compute known opnames for OpSpec validation directly from their canonical definitions

### DIFF
--- a/tests/inductor/test_op_spec_validation.py
+++ b/tests/inductor/test_op_spec_validation.py
@@ -348,11 +348,13 @@ class TestValidateOpSpecsErrors(unittest.TestCase):
 
     def test_unknown_op_no_output_passes(self):
         """Unknown/synthetic ops without output args are valid."""
-        c0 = Symbol("c0")
         op = OpSpec(
             op="synthetic_test_op",
             is_reduction=False,
-            iteration_space={c0: (Integer(128), 1)},
+            iteration_space={
+                _C_ROW: (Integer(128), 1),
+                _C_COL: (Integer(256), 1),
+            },
             args=[_make_tensor_arg(is_input=True, arg_index=0)],
             op_info={},
             tiled_symbols=[],
@@ -364,7 +366,7 @@ class TestValidateOpSpecsErrors(unittest.TestCase):
         op = _make_valid_op_spec()
         op.args[0] = dataclasses.replace(op.args[0], allocation={"bad_key": 42})
         with self.assertRaises(OpSpecValidationError) as ctx:
-            validate_op_specs([op], stage="test")
+            validate_op_specs([op], stage="before_bundle_generation")
         self.assertIn("exactly one of hbm/lx/hbm_pool", str(ctx.exception))
 
     def test_allocation_multiple_keys(self):
@@ -374,7 +376,7 @@ class TestValidateOpSpecsErrors(unittest.TestCase):
             op.args[0], allocation={"hbm": 0x1000, "lx": 0x2000}
         )
         with self.assertRaises(OpSpecValidationError) as ctx:
-            validate_op_specs([op], stage="test")
+            validate_op_specs([op], stage="before_bundle_generation")
         self.assertIn("exactly one of hbm/lx/hbm_pool", str(ctx.exception))
 
 

--- a/tests/inductor/test_op_spec_validation.py
+++ b/tests/inductor/test_op_spec_validation.py
@@ -80,7 +80,7 @@ def _make_matmul_op_spec() -> OpSpec:
         _make_tensor_arg(is_input=False, arg_index=2),
     ]
     return OpSpec(
-        op="matmul",
+        op="batchmatmul",
         is_reduction=True,
         iteration_space={
             _C_ROW: (Integer(128), 1),

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -208,6 +208,28 @@ CONV2D_FWD_OP = "conv2d"
 # purposes of codegen dispatch (_is_conv). DEPTHWISE_CONV2D_OP is defined above.
 CONV_OPS = {CONV2D_FWD_OP, DEPTHWISE_CONV2D_OP}
 
+# Two-input reductions dispatched together in spyre_kernel.store_reduction:
+# matmul (activation @ weight) and conv2d (activation * weight, reduced over
+# in/ki/kj) both build [input, weight, output] tensor args.
+TWO_INPUT_REDUCTION_OPS = frozenset(
+    {BATCH_MATMUL_OP, BATCH_MATMUL_FP8_OP, CONV2D_FWD_OP}
+)
+
+# Depthwise conv is a two-input reduction like TWO_INPUT_REDUCTION_OPS but is
+# dispatched in its own branch in spyre_kernel.store_reduction because it
+# builds its tensor args differently (one filter per input channel).
+DEPTHWISE_CONV_REDUCTION_OPS = frozenset({DEPTHWISE_CONV2D_OP})
+
+# Single-input reductions: everything store_reduction dispatches to its
+# fallback branch (exactly one input TensorArg). These are PyTorch/Inductor
+# reduction_type strings (sum/mean/max/min/prod) plus Spyre-specific reduction
+# ops (exx2, topkvalue/topkindex, avgpoolfwd) -- there is no upstream registry
+# of supported reduction_type strings to derive this from, so it is written
+# down here explicitly.
+SINGLE_INPUT_REDUCTION_OPS = frozenset(
+    {"sum", "mean", "max", "min", "prod", "exx2", *TOPK_OPS, AVGPOOL2D_OP}
+)
+
 # Populate more valid labels from deeptools here if needed
 INPUT_DIM_LABELS = ["mb", "x", "y", "i", "j", "ki", "kj"]
 OUTPUT_DIM_LABELS = ["out"]

--- a/torch_spyre/_inductor/dtype_ops.py
+++ b/torch_spyre/_inductor/dtype_ops.py
@@ -167,3 +167,8 @@ class DtypeOpTable:
     @classmethod
     def is_dtype_op(cls, op: str) -> bool:
         return op in cls._TYPECAST_OP_NAMES
+
+    @classmethod
+    def op_names(cls) -> frozenset[str]:
+        """All op names this table can produce (e.g. for op-name validation)."""
+        return frozenset(cls._TYPECAST_OP_NAMES)

--- a/torch_spyre/_inductor/op_spec_validation.py
+++ b/torch_spyre/_inductor/op_spec_validation.py
@@ -29,67 +29,69 @@ Invariants checked:
 
 from __future__ import annotations
 
+import ast
 from collections.abc import Sequence
+import functools
+import inspect
+import textwrap
 
 import regex
 import sympy
 
+from . import constants
+from .dtype_ops import DtypeOpTable
 from .logging_utils import get_inductor_logger
 from .op_spec import IndirectAccess, LoopSpec, OpSpec, TensorArg, UnimplementedOp
 
 logger = get_inductor_logger("op_spec_validation")
 
-# Known op names from SpyreOpFuncs and special ops
-MATMUL_OPS = frozenset({"matmul", "batchmatmul", "batchmatmulfp8"})
 
-REDUCTION_OPS = frozenset({"sum", "mean", "max", "min", "topkvalue", "topkindex"})
+@functools.lru_cache(maxsize=1)
+def _pointwise_ops() -> frozenset[str]:
+    """Op names produced by SpyreOpFuncs's static methods.
 
-POINTWISE_OPS = frozenset(
-    {
-        "abs",
-        "add",
-        "clip",
-        "equal",
-        "exp",
-        "floor",
-        "greaterequal",
-        "greaterthan",
-        "gelufwd",
-        "layernormnorm",
-        "layernormscale",
-        "lesserequal",
-        "lesserthan",
-        "log",
-        "maximum",
-        "minimum",
-        "mul",
-        "notequal",
-        "neg",
-        "reciprocal",
-        "qfp8ch",
-        "relufwd",
-        "rsqrt",
-        "sigmoid",
-        "softplus",
-        "sqrt",
-        "sub",
-        "tanh",
-        "realdiv",
-        "silu",
-        "where3",
-    }
-)
+    Statically extracts the literal op-name argument from each method's
+    ``return PointwiseOp("name", ...)`` statement(s), rather than calling the
+    methods (which would require guessing each method's call signature,
+    including varargs like ``layernormnorm`` and keyword args like
+    ``softplus``). Methods whose op name is computed rather than a literal
+    (e.g. ``to_dtype``, resolved via DtypeOpTable) contribute no literal and
+    are correctly excluded -- those are dtype-cast ops, not pointwise ops.
 
-DTYPE_OPS = frozenset(
-    {
-        "identity",
-        "dl16tofp32",
-        "fp32todl16",
-        "fp8todl16",
-    }
-)
+    Imported and evaluated lazily (rather than at module load) because
+    spyre_kernel imports validate_op_specs from this module, so resolving
+    SpyreOpFuncs at op_spec_validation's own import time would be circular.
+    """
+    from .spyre_kernel import SpyreOpFuncs
 
-SPECIAL_OPS = frozenset({"ReStickifyOpHBM"})
+    tree = ast.parse(textwrap.dedent(inspect.getsource(SpyreOpFuncs)))
+    (class_node,) = tree.body
+    names: set[str] = set()
+    for node in ast.walk(class_node):
+        if not isinstance(node, ast.Return) or node.value is None:
+            continue
+        call = node.value
+        if (
+            isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Name)
+            and call.func.id == "PointwiseOp"
+            and call.args
+            and isinstance(call.args[0], ast.Constant)
+            and isinstance(call.args[0].value, str)
+        ):
+            names.add(call.args[0].value)
+    return frozenset(names)
+
+
+# Known op names, derived by inspecting the modules that actually define
+# them so this file cannot silently drift out of sync as ops are added.
+MATMUL_OPS = constants.MATMUL_REDUCTION_OPS
+
+REDUCTION_OPS = constants.SINGLE_INPUT_REDUCTION_OPS
+
+DTYPE_OPS = DtypeOpTable.op_names()
+
+SPECIAL_OPS = frozenset({constants.RESTICKIFY_OP})
 
 BINARY_OPS = frozenset(
     {
@@ -108,7 +110,22 @@ BINARY_OPS = frozenset(
     }
 )
 
-ALL_KNOWN_OPS = MATMUL_OPS | REDUCTION_OPS | POINTWISE_OPS | DTYPE_OPS | SPECIAL_OPS
+
+@functools.lru_cache(maxsize=1)
+def _all_known_ops() -> frozenset[str]:
+    return MATMUL_OPS | REDUCTION_OPS | _pointwise_ops() | DTYPE_OPS | SPECIAL_OPS
+
+
+def __getattr__(name: str):
+    # POINTWISE_OPS/ALL_KNOWN_OPS are computed lazily (see _pointwise_ops) to
+    # avoid a circular import with spyre_kernel, but are still exposed as
+    # plain module attributes for callers/tests via PEP 562.
+    if name == "POINTWISE_OPS":
+        return _pointwise_ops()
+    if name == "ALL_KNOWN_OPS":
+        return _all_known_ops()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 VALID_ALLOCATION_KEYS = frozenset({"hbm", "lx", "hbm_pool"})
 
@@ -253,7 +270,7 @@ def _check_mandatory_fields(op_spec: OpSpec, stage: str) -> None:
 
 def _check_op_name(op_spec: OpSpec, stage: str) -> None:
     """OS-2: Op name should be a known operation."""
-    if op_spec.op not in ALL_KNOWN_OPS:
+    if op_spec.op not in _all_known_ops():
         logger.warning(
             "Unknown op name %r in OpSpec at stage %s. "
             "This may be valid for new ops not yet registered.",
@@ -363,7 +380,7 @@ def _check_args(op_spec: OpSpec, stage: str) -> None:
 
         _check_allocation(op_spec, arg, i, stage)
 
-    if not has_output and op_spec.op in ALL_KNOWN_OPS:
+    if not has_output and op_spec.op in _all_known_ops():
         raise OpSpecValidationError(
             op_spec,
             "OpSpec must have at least one output TensorArg (is_input=False)",
@@ -529,7 +546,7 @@ def _check_op_specific_constraints(op_spec: OpSpec, stage: str) -> None:
             stage,
         )
 
-    if op in POINTWISE_OPS and op_spec.is_reduction:
+    if op in _pointwise_ops() and op_spec.is_reduction:
         raise OpSpecValidationError(
             op_spec,
             f"pointwise op {op!r} must have is_reduction=False",

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -38,13 +38,13 @@ from .constants import (
     SPYRE_FP32_OPS,
     BATCH_MATMUL_OP,
     BATCH_MATMUL_FP8_OP,
-    CONV2D_FWD_OP,
     CONV_OPS,
+    DEPTHWISE_CONV_REDUCTION_OPS,
     IDENTITY_OP,
     POOL_OPS,
     RESTICKIFY_OP,
     SEGMENT_OFFSETS,
-    DEPTHWISE_CONV2D_OP,
+    TWO_INPUT_REDUCTION_OPS,
     SHARED_WEIGHT_UNIT_BMM_INFO_KEY,
 )
 from . import config as _spyre_config
@@ -1211,7 +1211,7 @@ class SpyreKernel(Kernel[CSEVariable]):
                 f"device_size={list(layout.device_layout.device_size)}, op_info={op_info}"
             )
 
-        if value.op in [BATCH_MATMUL_OP, BATCH_MATMUL_FP8_OP, CONV2D_FWD_OP]:
+        if value.op in TWO_INPUT_REDUCTION_OPS:
             # Two-input reductions: matmul (activation @ weight) and conv2d
             # (activation * weight, reduced over in/ki/kj). Both build
             # [input, weight, output] tensor args.
@@ -1229,7 +1229,7 @@ class SpyreKernel(Kernel[CSEVariable]):
                 self.create_tensor_arg(False, real_dst_name, dst),
             ]
             self.op_specs.append(self.create_op_spec(value.op, True, args, op_info))
-        elif value.op == DEPTHWISE_CONV2D_OP:
+        elif value.op in DEPTHWISE_CONV_REDUCTION_OPS:
             if (
                 len(value.arguments) < 2
                 or (not isinstance(value.arguments[0], TensorAccess))


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CO
NTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [x] documentation
- [x] cleanup

#### What this PR does:

Replaces the hand-maintained `MATMUL_OPS`/`REDUCTION_OPS`/`POINTWISE_OPS`/`DTYPE_OPS`
frozensets in `op_spec_validation.py` with sets derived from the modules that
actually define these ops, so op-name validation can no longer silently drift
out of sync with the compiler.

Concretely:

- `constants.py` gains `TWO_INPUT_REDUCTION_OPS`, `DEPTHWISE_CONV_REDUCTION_OPS`,
  and `SINGLE_INPUT_REDUCTION_OPS`, and `spyre_kernel.store_reduction`'s dispatch
  is rewritten to use these named constants instead of inline literal
  conditions — so the dispatch logic and the validator now share one source of
  truth.
- `DtypeOpTable` gains an `op_names()` classmethod; `op_spec_validation.DTYPE_OPS`
  now derives from it instead of a separately hardcoded set (which was missing
  `fp32toint32`/`int32tofp32`).
- `op_spec_validation.MATMUL_OPS`/`REDUCTION_OPS` now derive from the new
  `constants.py` buckets.
- `op_spec_validation.POINTWISE_OPS` is now computed lazily by statically
  AST-walking `SpyreOpFuncs`'s source for `return PointwiseOp("literal", ...)`
  statements, rather than being hand-copied. This required deferring evaluation
  (via `functools.lru_cache` + a module `__getattr__`) to avoid a circular
  import with `spyre_kernel.py`.
- Dropped the dead `"matmul"` (unbatched) op string from `MATMUL_OPS` — grepping
  the codebase found zero producers of that literal anywhere; the real,
  in-use op is `"batchmatmul"`. Updated the one test fixture that referenced it.

Also fixes three pre-existing, unrelated test-authoring bugs found while
verifying the above change didn't regress `test_op_spec_validation.py`
(confirmed pre-existing by reproducing on unmodified `main`):

- `test_allocation_invalid_keys` / `test_allocation_multiple_keys` called
  `validate_op_specs` with `stage="test"`, but `_check_allocation` only runs at
  `stage="before_bundle_generation"` — so the assertion under test never
  actually executed. Fixed to use the correct stage.
- `test_unknown_op_no_output_passes` built an `OpSpec` with `iteration_space`
  keyed on a local `Symbol("c0")`, while its `TensorArg` (from the shared
  `_make_tensor_arg` fixture) references the module-level `_C_ROW`/`_C_COL`
  symbols in `device_coordinates` — an unintentional symbol-consistency
  violation. Fixed to use `_C_ROW`/`_C_COL` to match the fixture.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

- `SPECIAL_OPS` (just `ReStickifyOpHBM`) is intentionally left as a
  hand-maintained singleton, now sourced from `constants.RESTICKIFY_OP` instead
  of a duplicated string literal — it isn't produced by `SpyreOpFuncs`, isn't a
  reduction dispatched through `store_reduction`, and isn't in `DtypeOpTable`,
  so there's no natural source-of-truth module to derive it from.
- `_preserve_shared_weight_unit_bmm_dim`'s narrower bmm-only check (excludes
  conv2d) was intentionally left unchanged and not conflated with the new
  `TWO_INPUT_REDUCTION_OPS`.
- Split into two commits: the derivation redesign, then the unrelated
  pre-existing test-authoring fixes, so they can be reviewed/reverted
  independently.

#### Does this PR introduce a user-facing change?

No. Internal compiler validation logic only; no change to generated code,
supported ops, or public API.

#### Additional note:

Ran locally: `tests/inductor/test_op_spec_validation.py` (50/50 passed),
`tests/inductor/test_building_blocks.py` (11/11 passed), and
`pre-commit run --all-files` on the changed files (clean). Did not run the
full `tests/inductor/test_inductor_ops.py` suite locally (too slow); CI covers
it.
