### PR TITLE
Validate stick constraints in Op Spec Validation

### DIFF
--- a/tests/inductor/test_op_spec_validation.py
+++ b/tests/inductor/test_op_spec_validation.py
@@ -28,6 +28,7 @@ from torch_spyre._C import DataFormats
 from torch_spyre._inductor.op_spec import LoopSpec, OpSpec, TensorArg, UnimplementedOp
 from torch_spyre._inductor.op_spec_validation import (
     BINARY_OPS,
+    STICK_STAGE,
     OpSpecValidationError,
     _is_unimplemented_op,
     validate_op_specs,
@@ -487,6 +488,385 @@ class TestBinaryOpsConstant(unittest.TestCase):
             "lesserequal",
         }
         self.assertTrue(comparisons.issubset(BINARY_OPS))
+
+
+# ---------------------------------------------------------------------------
+# Tests: stick constraints (OS-8)
+# ---------------------------------------------------------------------------
+
+
+class TestStickConstraints(unittest.TestCase):
+    def test_uniform_same_stick_passes(self):
+        validate_op_specs([_make_valid_op_spec("add")], stage=STICK_STAGE)
+
+    def test_uniform_different_sticks_raises(self):
+        c_other = Symbol("c_other")
+        op = _make_valid_op_spec("add")
+        op.iteration_space[c_other] = (Integer(64), 1)
+        op.args[1] = dataclasses.replace(
+            op.args[1],
+            device_coordinates=[_C_COL // 64, _C_ROW, sympy.Mod(c_other, 64)],
+        )
+        with self.assertRaises(OpSpecValidationError) as ctx:
+            validate_op_specs([op], stage=STICK_STAGE)
+        self.assertIn("different stick loop variables", str(ctx.exception))
+
+    def test_restickify_different_sticks_passes(self):
+        c_other = Symbol("c_other")
+        op = _make_valid_op_spec("ReStickifyOpHBM")
+        op.iteration_space[c_other] = (Integer(64), 1)
+        op.args = [
+            _make_tensor_arg(is_input=True, arg_index=0),
+            dataclasses.replace(
+                _make_tensor_arg(is_input=False, arg_index=1),
+                device_coordinates=[_C_COL // 64, _C_ROW, sympy.Mod(c_other, 64)],
+            ),
+        ]
+        validate_op_specs([op], stage=STICK_STAGE)
+
+    def test_restickify_same_sticks_raises(self):
+        op = _make_valid_op_spec("ReStickifyOpHBM")
+        op.args = [
+            _make_tensor_arg(is_input=True, arg_index=0),
+            _make_tensor_arg(is_input=False, arg_index=1),
+        ]
+        with self.assertRaises(OpSpecValidationError) as ctx:
+            validate_op_specs([op], stage=STICK_STAGE)
+        self.assertIn(
+            "ReStickifyOpHBM input and output must have different stick loop variables",
+            str(ctx.exception),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: _check_stick_norm (exx2)
+# ---------------------------------------------------------------------------
+
+# For these ops the input has the normalization (reduction) dim in its coords
+# and the output does not — the reduction symbol is _C_ROW here.
+# The stick symbol (_C_COL) must equal the reduction symbol to be valid, so
+# we build fixtures where either _C_ROW or _C_COL is the stick.
+
+
+def _make_norm_op_spec(op: str, stick_is_reduction_dim: bool) -> OpSpec:
+    """Build a minimal exx2-like reduction OpSpec.
+
+    Input has both _C_ROW and _C_COL in its coords; output only has _C_COL.
+    So _C_ROW is the reduction symbol.
+
+    If stick_is_reduction_dim=True, the input stick coord uses _C_ROW (valid).
+    If False, the input stick coord uses _C_COL (invalid — wrong dim in stick).
+    """
+    if stick_is_reduction_dim:
+        # Stick = _C_ROW (the reduction dim) — valid
+        in_coords = [_C_COL // 64, sympy.Mod(_C_ROW, 64)]
+        in_size = [4, 64]
+    else:
+        # Stick = _C_COL (a non-reduction dim) — invalid
+        in_coords = [_C_ROW, sympy.Mod(_C_COL, 64)]
+        in_size = [128, 64]
+
+    out_coords = [_C_COL // 64, sympy.Mod(_C_COL, 64)]
+    out_size = [4, 64]
+
+    input_arg = TensorArg(
+        is_input=True,
+        arg_index=0,
+        device_dtype=DataFormats.SEN169_FP16,
+        device_size=in_size,
+        device_coordinates=in_coords,
+        allocation={"hbm": 0x400000000},
+    )
+    output_arg = TensorArg(
+        is_input=False,
+        arg_index=1,
+        device_dtype=DataFormats.SEN169_FP16,
+        device_size=out_size,
+        device_coordinates=out_coords,
+        allocation={"hbm": 0x500000000},
+    )
+    return OpSpec(
+        op=op,
+        is_reduction=True,
+        iteration_space={
+            _C_ROW: (Integer(64), 1),
+            _C_COL: (Integer(256), 1),
+        },
+        args=[input_arg, output_arg],
+        op_info={},
+        tiled_symbols=[],
+    )
+
+
+class TestNormStick(unittest.TestCase):
+    def test_exx2_stick_is_reduction_dim_passes(self):
+        validate_op_specs(
+            [_make_norm_op_spec("exx2", stick_is_reduction_dim=True)],
+            stage=STICK_STAGE,
+        )
+
+    def test_exx2_stick_is_non_reduction_dim_raises(self):
+        with self.assertRaises(OpSpecValidationError) as ctx:
+            validate_op_specs(
+                [_make_norm_op_spec("exx2", stick_is_reduction_dim=False)],
+                stage=STICK_STAGE,
+            )
+        self.assertIn("stick symbol must be the reduction", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# Tests: _check_topk_stick
+# ---------------------------------------------------------------------------
+
+# Topk coord layout:
+#   input:  [_C_FEAT (reduction dim), Mod(_C_STICK, 64)]
+#   output: [_C_K    (k dim),         Mod(_C_STICK, 64)]
+# _C_FEAT is input-only  → reduction symbol.
+# _C_K    is output-only → k symbol.
+# _C_STICK is shared     → surviving stick dimension (valid in stick).
+
+_C_FEAT = Symbol("c_feat")
+_C_K = Symbol("c_k")
+_C_STICK = Symbol("c_stick")
+
+
+def _make_topk_op_spec(
+    op: str,
+    input_stick: sympy.Expr,
+    output_stick: sympy.Expr,
+) -> OpSpec:
+    """Build a minimal topkvalue/topkindex-like OpSpec.
+
+    Input coords: [_C_FEAT, input_stick]
+    Output coords: [_C_K,   output_stick]
+
+    _C_FEAT is the reduction symbol (input-only).
+    _C_K is the k symbol (output-only).
+    _C_STICK (used in the default valid case) is a shared surviving symbol.
+    """
+    input_arg = TensorArg(
+        is_input=True,
+        arg_index=0,
+        device_dtype=DataFormats.SEN169_FP16,
+        device_size=[128, 64],
+        device_coordinates=[_C_FEAT, input_stick],
+        allocation={"hbm": 0x400000000},
+    )
+    output_arg = TensorArg(
+        is_input=False,
+        arg_index=1,
+        device_dtype=DataFormats.SEN169_FP16,
+        device_size=[8, 64],
+        device_coordinates=[_C_K, output_stick],
+        allocation={"hbm": 0x500000000},
+    )
+    return OpSpec(
+        op=op,
+        is_reduction=True,
+        iteration_space={
+            _C_FEAT: (Integer(128), 1),
+            _C_K: (Integer(8), 1),
+            _C_STICK: (Integer(256), 1),
+        },
+        args=[input_arg, output_arg],
+        op_info={},
+        tiled_symbols=[],
+    )
+
+
+class TestTopkStick(unittest.TestCase):
+    def test_topkvalue_surviving_stick_passes(self):
+        validate_op_specs(
+            [
+                _make_topk_op_spec(
+                    "topkvalue", sympy.Mod(_C_STICK, 64), sympy.Mod(_C_STICK, 64)
+                )
+            ],
+            stage=STICK_STAGE,
+        )
+
+    def test_topkvalue_reduction_dim_in_stick_raises(self):
+        with self.assertRaises(OpSpecValidationError) as ctx:
+            validate_op_specs(
+                [
+                    _make_topk_op_spec(
+                        "topkvalue",
+                        sympy.Mod(_C_FEAT, 64),
+                        sympy.Mod(_C_STICK, 64),
+                    )
+                ],
+                stage=STICK_STAGE,
+            )
+        self.assertIn("reduction or k dimension", str(ctx.exception))
+
+    def test_topkindex_surviving_stick_passes(self):
+        validate_op_specs(
+            [
+                _make_topk_op_spec(
+                    "topkindex", sympy.Mod(_C_STICK, 64), sympy.Mod(_C_STICK, 64)
+                )
+            ],
+            stage=STICK_STAGE,
+        )
+
+    def test_topkindex_k_dim_in_stick_raises(self):
+        with self.assertRaises(OpSpecValidationError) as ctx:
+            validate_op_specs(
+                [
+                    _make_topk_op_spec(
+                        "topkindex",
+                        sympy.Mod(_C_STICK, 64),
+                        sympy.Mod(_C_K, 64),  # k dim in output stick — invalid
+                    )
+                ],
+                stage=STICK_STAGE,
+            )
+        self.assertIn("reduction or k dimension", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# Tests: _check_matmul_stick
+# ---------------------------------------------------------------------------
+
+# Batchmatmul semantic dimensions:
+#   _C_K_MM  = reduction_sym  (in Input1, Input2; absent from Output)
+#   _C_N_MM  = generated_sym  (in Input2, Output; absent from Input1)
+#   _C_M_MM  = preserved_sym  (in Input1, Output; absent from Input2)
+#   _C_B_MM  = noreuse_sym    (in all three — batch dim)
+#
+# Required stick symbols:
+#   Input1 stick = _C_K_MM  (reduction)
+#   Input2 stick = _C_N_MM  (generated)
+#   Output stick = _C_N_MM  (generated)
+
+_C_K_MM = Symbol("c_k_mm")
+_C_N_MM = Symbol("c_n_mm")
+_C_M_MM = Symbol("c_m_mm")
+_C_B_MM = Symbol("c_b_mm")
+
+
+def _make_bmm_stick_op_spec(
+    op: str,
+    input1_stick: sympy.Expr,
+    input2_stick: sympy.Expr,
+    output_stick: sympy.Expr,
+) -> OpSpec:
+    """Build a minimal batchmatmul-like OpSpec.
+
+    Input1 (x): coords [_C_B_MM, _C_M_MM, input1_stick]  (K is reduction_sym)
+    Input2 (y): coords [_C_B_MM, _C_K_MM, input2_stick]  (N is generated_sym)
+    Output:     coords [_C_B_MM, _C_M_MM, output_stick]
+    """
+    input1 = TensorArg(
+        is_input=True,
+        arg_index=0,
+        device_dtype=DataFormats.SEN169_FP16,
+        device_size=[8, 16, 64],
+        device_coordinates=[_C_B_MM, _C_M_MM, input1_stick],
+        allocation={"hbm": 0x400000000},
+    )
+    input2 = TensorArg(
+        is_input=True,
+        arg_index=1,
+        device_dtype=DataFormats.SEN169_FP16,
+        device_size=[8, 64, 64],
+        device_coordinates=[_C_B_MM, _C_K_MM, input2_stick],
+        allocation={"hbm": 0x500000000},
+    )
+    output = TensorArg(
+        is_input=False,
+        arg_index=2,
+        device_dtype=DataFormats.SEN169_FP16,
+        device_size=[8, 16, 64],
+        device_coordinates=[_C_B_MM, _C_M_MM, output_stick],
+        allocation={"hbm": 0x600000000},
+    )
+    return OpSpec(
+        op=op,
+        is_reduction=True,
+        iteration_space={
+            _C_B_MM: (Integer(8), 1),
+            _C_K_MM: (Integer(64), 1),
+            _C_N_MM: (Integer(64), 1),
+            _C_M_MM: (Integer(16), 1),
+        },
+        args=[input1, input2, output],
+        op_info={},
+        tiled_symbols=[],
+    )
+
+
+class TestMatmulStick(unittest.TestCase):
+    def test_batchmatmul_valid_passes(self):
+        validate_op_specs(
+            [
+                _make_bmm_stick_op_spec(
+                    "batchmatmul",
+                    sympy.Mod(_C_K_MM, 64),
+                    sympy.Mod(_C_N_MM, 64),
+                    sympy.Mod(_C_N_MM, 64),
+                )
+            ],
+            stage=STICK_STAGE,
+        )
+
+    def test_input1_wrong_stick_raises(self):
+        with self.assertRaises(OpSpecValidationError) as ctx:
+            validate_op_specs(
+                [
+                    _make_bmm_stick_op_spec(
+                        "batchmatmul",
+                        sympy.Mod(_C_N_MM, 64),  # wrong: N instead of K
+                        sympy.Mod(_C_N_MM, 64),
+                        sympy.Mod(_C_N_MM, 64),
+                    )
+                ],
+                stage=STICK_STAGE,
+            )
+        self.assertIn("Input1 stick", str(ctx.exception))
+
+    def test_input2_wrong_stick_raises(self):
+        with self.assertRaises(OpSpecValidationError) as ctx:
+            validate_op_specs(
+                [
+                    _make_bmm_stick_op_spec(
+                        "batchmatmul",
+                        sympy.Mod(_C_K_MM, 64),
+                        sympy.Mod(_C_K_MM, 64),  # wrong: K instead of N
+                        sympy.Mod(_C_N_MM, 64),
+                    )
+                ],
+                stage=STICK_STAGE,
+            )
+        self.assertIn("Input2 stick", str(ctx.exception))
+
+    def test_output_wrong_stick_raises(self):
+        with self.assertRaises(OpSpecValidationError) as ctx:
+            validate_op_specs(
+                [
+                    _make_bmm_stick_op_spec(
+                        "batchmatmul",
+                        sympy.Mod(_C_K_MM, 64),
+                        sympy.Mod(_C_N_MM, 64),
+                        sympy.Mod(_C_K_MM, 64),  # wrong: K instead of N
+                    )
+                ],
+                stage=STICK_STAGE,
+            )
+        self.assertIn("Output stick", str(ctx.exception))
+
+    def test_batchmatmulfp8_valid_passes(self):
+        validate_op_specs(
+            [
+                _make_bmm_stick_op_spec(
+                    "batchmatmulfp8",
+                    sympy.Mod(_C_K_MM, 64),
+                    sympy.Mod(_C_N_MM, 64),
+                    sympy.Mod(_C_N_MM, 64),
+                )
+            ],
+            stage=STICK_STAGE,
+        )
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/op_spec_validation.py
+++ b/torch_spyre/_inductor/op_spec_validation.py
@@ -127,6 +127,11 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+NORM_OPS = frozenset({"exx2"})
+TOPK_OPS = frozenset(constants.TOPK_OPS)
+
+STICK_STAGE = "after_simplification"
+
 VALID_ALLOCATION_KEYS = frozenset({"hbm", "lx", "hbm_pool"})
 
 
@@ -230,6 +235,7 @@ def _validate_op_spec(op_spec: OpSpec, stage: str, loop_depth: int) -> None:
     _check_args(op_spec, stage)
     _check_symbol_consistency(op_spec, stage)
     _check_tiled_symbols(op_spec, stage, loop_depth)
+    _check_stick_constraints(op_spec, stage)
     _check_op_specific_constraints(op_spec, stage)
 
 
@@ -507,6 +513,269 @@ def _check_tiled_symbols(op_spec: OpSpec, stage: str, loop_depth: int) -> None:
                 len(op_spec.tiled_symbols),
                 loop_depth,
             )
+
+
+def _arg_free_syms(arg: TensorArg) -> set[sympy.Symbol]:
+    syms: set[sympy.Symbol] = set()
+    for coord in arg.device_coordinates:
+        if isinstance(coord, sympy.Expr):
+            syms.update(coord.free_symbols)
+    return syms
+
+
+def _arg_stick_syms(arg: TensorArg) -> set[sympy.Symbol]:
+    if not arg.device_coordinates:
+        return set()
+    return arg.device_coordinates[-1].free_symbols
+
+
+def _indirect_index_tensor_names(op_spec: OpSpec) -> set[str]:
+    """Return names of index tensors referenced via IndirectAccess in any arg's coords.
+
+    At after_simplification, indirect symbols have been replaced with
+    IndirectAccess(tensor_name).  The index tensor is the arg whose name
+    appears as the argument to IndirectAccess in another arg's coordinates.
+    """
+    names: set[str] = set()
+    for arg in op_spec.args:
+        for coord in arg.device_coordinates:
+            if isinstance(coord, sympy.Expr):
+                for node in sympy.preorder_traversal(coord):
+                    if isinstance(node, IndirectAccess):
+                        names.add(str(node.args[0]))
+    return names
+
+
+def _check_stick_constraints(op_spec: OpSpec, stage: str) -> None:
+    """Verify stick constraints for all op classes.
+
+    Only runs after IndirectAccess substitution (after_simplification and
+    later) so that index tensors are identifiable and excluded.
+    """
+    if stage != STICK_STAGE:
+        return
+
+    op = op_spec.op
+
+    if op in MATMUL_OPS:
+        _check_stick_matmul(op_spec, stage)
+    elif op in NORM_OPS:
+        _check_stick_norm(op_spec, stage)
+    elif op in TOPK_OPS:
+        _check_stick_topk(op_spec, stage)
+    elif op == constants.RESTICKIFY_OP:
+        _check_stick_restickify(op_spec, stage)
+    elif op in _pointwise_ops() | DTYPE_OPS | REDUCTION_OPS:
+        # avgpoolfwd is in REDUCTION_OPS but its full constraint (window dims
+        # must not appear in the stick) is deferred — _check_stick_all_same
+        # only catches the case where different args have different sticks.
+        _check_stick_all_same(op_spec, stage)
+
+
+def _check_stick_all_same(op_spec: OpSpec, stage: str) -> None:
+    """All non-index-tensor args must share the same stick symbol.
+
+    Used for pointwise, dtype-cast, and non-topk/norm reduction ops.
+    """
+    index_tensor_names = _indirect_index_tensor_names(op_spec)
+    stick_vars: set[sympy.Symbol] = set()
+    for arg in op_spec.args:
+        # Gather index args have arg.name set at creation (opspec_name= in
+        # create_tensor_arg); args without a name are never index tensors.
+        if arg.name is not None and arg.name in index_tensor_names:
+            continue
+        syms = _arg_stick_syms(arg)
+        if syms:
+            stick_vars.add(next(iter(syms)))
+
+    if len(stick_vars) > 1:
+        coords_str = ", ".join(
+            str(arg.device_coordinates[-1])
+            for arg in op_spec.args
+            if arg.device_coordinates
+        )
+        raise OpSpecValidationError(
+            op_spec,
+            "args have different stick loop variables",
+            f"stick symbols={stick_vars!r}; stick coordinates: {coords_str}",
+            stage,
+        )
+
+
+def _check_stick_restickify(op_spec: OpSpec, stage: str) -> None:
+    """ReStickifyOpHBM: input and output must have different stick symbols."""
+    stick_vars: set[sympy.Symbol] = set()
+    for arg in op_spec.args:
+        syms = _arg_stick_syms(arg)
+        if syms:
+            stick_vars.add(next(iter(syms)))
+
+    if len(stick_vars) < 2:
+        coords_str = ", ".join(
+            str(arg.device_coordinates[-1])
+            for arg in op_spec.args
+            if arg.device_coordinates
+        )
+        raise OpSpecValidationError(
+            op_spec,
+            "ReStickifyOpHBM input and output must have different stick loop variables",
+            f"stick symbols={stick_vars!r}; stick coordinates: {coords_str}",
+            stage,
+        )
+
+
+def _check_stick_norm(op_spec: OpSpec, stage: str) -> None:
+    """exx2: the input stick symbol must be the reduction (normalization) symbol.
+
+    The reduction symbol is the free symbol present in input coords but absent
+    from output coords.
+    """
+    input_syms: set[sympy.Symbol] = set()
+    for arg in op_spec.args:
+        if arg.is_input:
+            input_syms.update(_arg_free_syms(arg))
+
+    output_syms: set[sympy.Symbol] = set()
+    for arg in op_spec.args:
+        if not arg.is_input:
+            output_syms.update(_arg_free_syms(arg))
+
+    reduction_syms = input_syms - output_syms
+    if not reduction_syms:
+        return
+
+    stick_syms: set[sympy.Symbol] = set()
+    for arg in op_spec.args:
+        if arg.is_input:
+            stick_syms.update(_arg_stick_syms(arg))
+
+    if not stick_syms & reduction_syms:
+        raise OpSpecValidationError(
+            op_spec,
+            f"{op_spec.op} stick symbol must be the reduction (normalization) symbol",
+            f"stick symbols={stick_syms!r}, reduction symbols={reduction_syms!r}",
+            stage,
+        )
+
+
+def _check_stick_topk(op_spec: OpSpec, stage: str) -> None:
+    """topkvalue/topkindex: neither the reduction dim nor the k dim may be in the stick.
+
+    reduction_sym = in input coords, absent from output coords.
+    k_sym         = in output coords, absent from input coords (the kept-k axis).
+    Any surviving dimension is allowed in the stick.
+    """
+    input_syms: set[sympy.Symbol] = set()
+    for arg in op_spec.args:
+        if arg.is_input:
+            input_syms.update(_arg_free_syms(arg))
+
+    output_syms: set[sympy.Symbol] = set()
+    for arg in op_spec.args:
+        if not arg.is_input:
+            output_syms.update(_arg_free_syms(arg))
+
+    forbidden_syms = (input_syms - output_syms) | (output_syms - input_syms)
+    if not forbidden_syms:
+        return
+
+    stick_syms: set[sympy.Symbol] = set()
+    for arg in op_spec.args:
+        stick_syms.update(_arg_stick_syms(arg))
+
+    bad_syms = stick_syms & forbidden_syms
+    if bad_syms:
+        reduction_syms = input_syms - output_syms
+        k_syms = output_syms - input_syms
+        parts = []
+        if bad_syms & reduction_syms:
+            parts.append(f"reduction symbols {bad_syms & reduction_syms!r}")
+        if bad_syms & k_syms:
+            parts.append(f"k symbols {bad_syms & k_syms!r}")
+        raise OpSpecValidationError(
+            op_spec,
+            f"{op_spec.op} stick must not contain the reduction or k dimension",
+            f"stick contains {' and '.join(parts)}; "
+            f"stick symbols={stick_syms!r}, forbidden={forbidden_syms!r}",
+            stage,
+        )
+
+
+def _check_stick_matmul(op_spec: OpSpec, stage: str) -> None:
+    """batchmatmul/batchmatmulfp8: verify Input1/Input2/Output stick roles.
+
+    Dimension roles identified by set arithmetic on coord free symbols:
+      reduction_sym: in Input1 and Input2, absent from Output
+      generated_sym: in Input2 and Output, absent from Input1
+
+    Input2 (y) is the input whose symbols overlap with the output but not the
+    other input. Returns early if the two inputs cannot be distinguished
+    (symmetric arg symbols — degenerate case).
+
+    Required stick (innermost coord free symbol):
+      Input1: reduction_sym  (all dtypes — for FP8/INT8/INT4 multi-dim sticks
+                               the innermost element is still reduction_sym)
+      Input2: generated_sym  (all dtypes — innermost element is generated_sym)
+      Output: generated_sym  (always DF16)
+    """
+    inputs = [a for a in op_spec.args if a.is_input]
+    outputs = [a for a in op_spec.args if not a.is_input]
+
+    if len(inputs) < 2 or len(outputs) < 1:
+        return
+
+    out_syms: set[sympy.Symbol] = set()
+    for arg in outputs:
+        out_syms.update(_arg_free_syms(arg))
+
+    a_syms = _arg_free_syms(inputs[0])
+    b_syms = _arg_free_syms(inputs[1])
+
+    gen_from_b = (b_syms & out_syms) - a_syms
+    gen_from_a = (a_syms & out_syms) - b_syms
+
+    if gen_from_b:
+        x_arg, y_arg = inputs[0], inputs[1]
+        generated_sym = next(iter(gen_from_b))
+    elif gen_from_a:
+        x_arg, y_arg = inputs[1], inputs[0]
+        generated_sym = next(iter(gen_from_a))
+    else:
+        return
+
+    reduction_syms = _arg_free_syms(x_arg) - out_syms
+    if not reduction_syms:
+        return
+    reduction_sym = next(iter(reduction_syms))
+
+    out_stick: set[sympy.Symbol] = set()
+    for arg in outputs:
+        out_stick.update(_arg_stick_syms(arg))
+
+    errors = []
+    if reduction_sym not in _arg_stick_syms(x_arg):
+        errors.append(
+            f"Input1 stick must contain reduction_sym={reduction_sym!r}; "
+            f"got {_arg_stick_syms(x_arg)!r}"
+        )
+    if generated_sym not in _arg_stick_syms(y_arg):
+        errors.append(
+            f"Input2 stick must contain generated_sym={generated_sym!r}; "
+            f"got {_arg_stick_syms(y_arg)!r}"
+        )
+    if generated_sym not in out_stick:
+        errors.append(
+            f"Output stick must contain generated_sym={generated_sym!r}; "
+            f"got {out_stick!r}"
+        )
+
+    if errors:
+        raise OpSpecValidationError(
+            op_spec,
+            f"{op_spec.op} stick constraint violated",
+            "; ".join(errors),
+            stage,
+        )
 
 
 def _check_op_specific_constraints(op_spec: OpSpec, stage: str) -> None:

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -965,23 +965,6 @@ class SpyreKernel(Kernel[CSEVariable]):
             )
             debug_handle = None
 
-        if not is_reduction and op != "ReStickifyOpHBM" and not indirect_var_names:
-            stick_vars = {
-                next(iter(arg.device_coordinates[-1].free_symbols))
-                for arg in args
-                if arg.device_coordinates and arg.device_coordinates[-1].free_symbols
-            }
-            assert len(stick_vars) <= 1, (
-                f"create_op_spec: stick mismatch for op={op!r} "
-                f"ir_chain={getattr(debug_handle, 'ir_chain', '?')}: "
-                f"args have different stick loop variables: "
-                + ", ".join(
-                    str(arg.device_coordinates[-1])
-                    for arg in args
-                    if arg.device_coordinates
-                )
-            )
-
         # Carry the node's full logical output ranges (NCHW, incl. unit dims)
         # so codegen can derive surviving dim roles and the channel count from
         # live IR instead of a lowering-time size snapshot.  Store raw ranges


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds symbolic stick-layout checks to the existing `validate_op_specs` pass, catching stick mismatches at compile time with a clear error message rather than producing a silent wrong-code or a cryptic low-level failure.

## What changed

Different op classes have different rules as specified in [torch spyre stick constraints:](https://github.com/torch-spyre/interface-specs/blob/main/0248-SdscBundleSpec/SuperDSC-Bundle.md):

- **Pointwise, reductions, dtype ops**: all args must share the same stick symbol.
- **ReStickifyOpHBM**: input and output must have *different* stick symbols (that is the point of a restickify).
- **exx2**: the input stick must be the reduction (normalization) symbol, not a surviving dimension.
- **topkvalue / topkindex**: neither the reduction dimension nor the k dimension may appear in any arg's stick.
- **batchmatmul / batchmatmulfp8**: Input1's stick must carry the reduction symbol; Input2 and Output must carry the generated symbol. Input1 vs Input2 are identified by set arithmetic on coordinate free symbols, so the check is arg-order-independent.

Ops with `indirect\d+` symbols or `IndirectAccess` in any coordinate are skipped — their stick layout is data-dependent and cannot be checked symbolically. This covers both the pre-simplification stage (where indirect symbols are plain `indirect0`, `indirect1`, ...) and the post-simplification stage (where they have been substituted with `IndirectAccess(tensor_name)`).

The old ad-hoc `assert` in `spyre_kernel.py` that partially covered the pointwise case is removed; this pass replaces and extends it.

## What is not checked

Pooling (window dimensions are not yet in OpSpec), quantization (dtype-dependent stick counts vary by quantization family), and convolution INT4 multi-dim stick details are deferred. These are noted in `stick_validator_todo.md`.


#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
