### PR TITLE
Fix layout optimizer abstraction violations for mutation ops

### DIFF
--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -622,6 +622,24 @@ def test_mutation_target_multi_candidate_layout():
     _compare(fn, a, b, d)
 
 
+def test_mutation_target_restick_on_src_not_target():
+    # d is (N, M) so d.t() is (M, N) col-major — a different layout than c = a+b
+    # (row-major).  The restickify must land on d.t() (src), not on c (the mutation
+    # target).  validate_no_restickify_on_mutation_targets is wired into passes.py by
+    # this PR and fires during compilation if the target is incorrectly restickified.
+    M, N = 128, 256
+    a = torch.randn((M, N), dtype=torch.float16) * 0.01
+    b = torch.randn((M, N), dtype=torch.float16) * 0.01
+    d = torch.randn((N, M), dtype=torch.float16) * 0.01
+
+    def fn(a, b, d):
+        c = a + b
+        torch.ops.spyre.copy_forced(d.t(), c)
+        return c
+
+    _compare(fn, a, b, d, optimal_cost=M * N)
+
+
 # Optimizer correctness + optimality tests: verify both output values and
 # minimum-cost restickify plan across a range of graph patterns.
 

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -561,3 +561,38 @@ def insert_post_mutation_restickify(graph: GraphLowering) -> None:
             target_name,
             mutation_name,
         )
+
+
+def validate_no_restickify_on_mutation_targets(graph: GraphLowering) -> None:
+    """Assert that no restickify was inserted on a mutation target buffer.
+
+    A mutation op (MutationLayoutSHOULDREMOVE) writes directly into its target buffer.
+    Restickifying that buffer would redirect the write to a temporary, silently breaking
+    the in-place semantics.
+
+    Must run after insert_restickify (so restickify_plan is populated) and before
+    the scheduler (which resolves MutationLayoutSHOULDREMOVE to a concrete buffer
+    address, after which mutation target identity is no longer recoverable).
+    """
+    assert hasattr(graph, "restickify_plan"), (
+        "validate_no_restickify_on_mutation_targets must run after insert_restickify"
+    )
+    restickify_plan = graph.restickify_plan
+    for op in graph.operations:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        layout = op.get_layout()
+        if not isinstance(layout, MutationLayoutSHOULDREMOVE):
+            continue
+        target = layout.target
+        while isinstance(target, ReinterpretView):
+            target = target.data
+        if not hasattr(target, "get_name"):
+            continue
+        target_name = target.get_name()
+        for entry in restickify_plan.get(op.get_name(), []):
+            if entry["arg_name"] == target_name:
+                raise AssertionError(
+                    f"restickify inserted on mutation target buffer {target_name!r} "
+                    f"as input to its own mutation op {op.get_name()!r}"
+                )

--- a/torch_spyre/_inductor/optimize_restickify.py
+++ b/torch_spyre/_inductor/optimize_restickify.py
@@ -176,23 +176,51 @@ class RestickNodeCost(abc.ABC):
 
 
 class AllSameNode(RestickNodeCost):
-    """Cost node for ops that require all inputs and the output to be stick compatible (eg pointwise ops)."""
+    """Cost node for ops that require all inputs and outputs to share the same stick layout.
+
+    Accepts multiple output deps via out_deps (e.g. mutation ops where two ops
+    write the same buffer). Restickify may only be inserted on input edges;
+    co-output edges enforce layout equality but never trigger restickify insertion.
+    """
 
     @classmethod
-    def from_args(cls, args, out_layouts, out_dep, op):
+    def from_args(cls, args, out_layouts, out_deps, op):
+        """Build an AllSameNode from input PropArgs and output dep(s).
+
+        out_deps is either a single MemoryDep (normal ops) or a list whose first
+        entry is the primary output dep and whose remaining entries are co-output
+        MemoryDeps (e.g. the shared mutation buffer in copy_forced). Co-output deps
+        must agree on the same layout but are not eligible for restickify insertion.
+        """
         assert out_layouts, "AllSameNode.from_args: out_layouts is empty"
-        edge_costs = [
+        if not isinstance(out_deps, list):
+            out_deps = [out_deps]
+        out_dep = out_deps[0]  # reference output dep for stick-compatibility checks
+        co_output_deps = out_deps[1:]
+        input_edge_costs = [
             EdgeCostMap(arg.dep, arg.layouts, out_layouts, out_dep, op) for arg in args
         ]
-        return cls(edge_costs)
+        output_edge_costs = [
+            EdgeCostMap(
+                dep, V.graph.get_buffer(dep.name).layouts, out_layouts, out_dep, op
+            )
+            for dep in co_output_deps
+        ]
+        return cls(input_edge_costs, output_edge_costs)
+
+    def __init__(self, input_edge_costs: list, output_edge_costs: "list | None" = None):
+        super().__init__(input_edge_costs + (output_edge_costs or []))
+        self._input_edge_costs = input_edge_costs
 
     def cost(
         self, in_layouts: "list[SpyreTensorLayout]", out_stl: "SpyreTensorLayout"
     ) -> float:
+        # edge_costs includes both input and co-output edges; co-output entries enforce
+        # layout equality (0 if matching, INF if not) but never trigger restickify insertion.
         return sum(ec.cost(lk, out_stl) for ec, lk in zip(self.edge_costs, in_layouts))
 
     def required_input_stls(self, out_stl):
-        return [(ec, out_stl) for ec in self.edge_costs]
+        return [(ec, out_stl) for ec in self._input_edge_costs]
 
     def min_input_cost(self, dep_name, in_stl, out_stl):
         # next() takes the first match; if dep_name appears twice (x+x), both edges
@@ -400,14 +428,13 @@ def greedy_local_min_cost(operations: list) -> None:
 
         # Collect each input arg's committed layout (finalized by earlier topo iterations).
         in_layouts = []
-        for dep in op.get_read_writes().reads:
-            if isinstance(dep, MemoryDep):
-                buf = V.graph.get_buffer(dep.name)
-                assert hasattr(buf, "committed_stl"), (
-                    f"buffer {dep.name} has no committed_stl — "
-                    "topological order violated or input not committed"
-                )
-                in_layouts.append(buf.committed_stl)
+        for ec in cost_fn.edge_costs:
+            buf = V.graph.get_buffer(ec.dep.name)
+            assert hasattr(buf, "committed_stl"), (
+                f"buffer {ec.dep.name} has no committed_stl — "
+                "topological order violated or input not committed"
+            )
+            in_layouts.append(buf.committed_stl)
 
         assert op.layouts, (
             f"op {op.get_name()} has restick_cost_fn but no candidate output layouts"
@@ -521,11 +548,9 @@ def compute_future_min_cost(
     for op in operations:
         if not hasattr(op, "layouts"):
             continue
-        for dep in op.get_read_writes().reads:
-            if (
-                isinstance(dep, MemoryDep)
-                and op.get_name() not in downstream_seen[dep.name]
-            ):
+        for ec in op.restick_cost_fn.edge_costs:
+            dep = ec.dep
+            if op.get_name() not in downstream_seen[dep.name]:
                 downstream[dep.name].append(op)
                 downstream_seen[dep.name].add(op.get_name())
 
@@ -570,11 +595,11 @@ def _compute_last_use(operations: list, step_of: "dict[str, int]") -> "dict[str,
     for op in operations:
         if not hasattr(op, "layouts"):
             continue
-        for dep in op.get_read_writes().reads:
-            if isinstance(dep, MemoryDep) and dep.name in step_of:
+        for ec in op.restick_cost_fn.edge_costs:
+            if ec.dep.name in step_of:
                 consumer_step = step_of[op.get_name()]
-                if last_use.get(dep.name, -1) < consumer_step:
-                    last_use[dep.name] = consumer_step
+                if last_use.get(ec.dep.name, -1) < consumer_step:
+                    last_use[ec.dep.name] = consumer_step
     return last_use
 
 
@@ -648,7 +673,7 @@ def beam_global_min_cost(operations: list) -> None:
             f"op {op.get_name()} has layouts but no restick_cost_fn"
         )
         cost_fn = op.restick_cost_fn
-        deps = [dep for dep in op.get_read_writes().reads if isinstance(dep, MemoryDep)]
+        deps = [ec.dep for ec in op.restick_cost_fn.edge_costs]
 
         op_future = future_min_cost.get(op.get_name(), {})
         next_states = []

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -69,6 +69,7 @@ from .insert_restickify import (
     finalize_layouts,
     insert_post_mutation_restickify,
     insert_restickify,
+    validate_no_restickify_on_mutation_targets,
 )
 from .enforce_indirect_access_layout import enforce_indirect_access_layout
 from .hbm_pool_planning import hbm_pool_planning
@@ -465,6 +466,7 @@ class CustomPreSchedulingPasses:
             optimize_restickify_locations,
             finalize_layouts,
             insert_restickify,
+            validate_no_restickify_on_mutation_targets,
             enforce_indirect_access_layout,
             insert_post_mutation_restickify,
             insert_restickify_padding,

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -1783,15 +1783,13 @@ def propagate_spyre_tensor_layouts(
                         target_buf_layouts and len(target_buf_layouts) > 1
                     ):
                         # target_buf is an ordinary multi-candidate ComputedBuffer
-                        # (issue #3845): the mutation op (e.g. copy_forced) has no
-                        # genuine MemoryDep read-edge to target_buf, so none of the
-                        # existing per-arg propagation machinery can see or price
-                        # the constraint that this op's output STL must match
-                        # whatever target_buf eventually commits to. Synthesize a
-                        # coupling edge by reusing target_buf's own write MemoryDep
-                        # (real index/shape, since copy_forced requires identical
-                        # shapes) as an extra "input" arg, and let AllSameNode price
-                        # it exactly like any other input alongside the real reads.
+                        # (issue #3845): this mutation op (e.g. copy_forced) and
+                        # target_buf are co-outputs — both write the same buffer, so
+                        # they must commit to the same layout. Pass target_buf as a
+                        # co-output to AllSameNode so the beam search enforces exact
+                        # layout equality. Restickify may only be inserted on real
+                        # input edges (e.g. the src tensor); the output buffer itself
+                        # cannot be restickified.
                         assert target_buf is not None
                         target_write_dep = _one_mem_dep(
                             target_buf.get_read_writes().writes
@@ -1803,15 +1801,13 @@ def propagate_spyre_tensor_layouts(
                         )
                         rw = op.get_read_writes()
                         output_dep = next(iter(rw.writes))
-                        args = _get_prop_args(rw.reads)
-                        target_arg = PropArg(
-                            target_write_dep,
-                            target_buf.get_layout(),
-                            list(target_buf_layouts),
-                        )
-                        op.layouts = list(target_buf_layouts)
+                        args = _get_prop_args(rw.reads)  # real inputs only (e.g. src)
+                        op.layouts = list(
+                            target_buf_layouts
+                        )  # inherit target's candidates
+                        # target_write_dep is the co-output: same buffer, must agree on layout
                         op.restick_cost_fn = AllSameNode.from_args(
-                            [*args, target_arg], op.layouts, output_dep, op
+                            args, op.layouts, [output_dep, target_write_dep], op
                         )
                         continue
                     if not isinstance(target_buf, SpyreEmptyFallback):
@@ -1839,17 +1835,17 @@ def propagate_spyre_tensor_layouts(
                         target_name,
                         type(target_buf).__name__,
                     )
-                    # SpyreEmptyFallback accumulator has no device layout yet.
+                    # SpyreEmptyFallback target has no device layout yet.
                     # Treat the mutation op like a normal pointwise op: run
-                    # _multi_arg_pointwise_layouts with the "new value" inputs
-                    # (excluding the running accumulator read-back).  This
-                    # enforces the same input-compatibility and slice constraints
-                    # as a regular add, so the backend DDL slice check passes.
+                    # _multi_arg_pointwise_layouts with the non-target inputs.
+                    # This enforces input-compatibility and slice constraints,
+                    # so the backend DDL slice check passes.
                     rw = op.get_read_writes()
                     output_dep = next(iter(rw.writes))
                     all_args = _get_prop_args(rw.reads)
-                    # Exclude the running accumulator itself (dep.name == target_name)
-                    # from the layout constraint: it IS the output, not a new input.
+                    # Exclude the target read-back (dep.name == target_name) from
+                    # layout candidate derivation: it IS the output buffer, not an
+                    # independent input.
                     new_value_args = [a for a in all_args if a.dep.name != target_name]
                     if not new_value_args:
                         # No real inputs — fall back to unconstrained candidates.
@@ -1863,20 +1859,13 @@ def propagate_spyre_tensor_layouts(
                         isinstance(op.data, Reduction)
                         and op.data.reduction_type == BATCH_MATMUL_OP
                     ):
-                        # Tiled matmul/bmm accumulator: op computes a per-tile
-                        # partial matmul and writes it into a slice of the
-                        # full-size accumulator. x and y are the two genuine
-                        # matmul operands (never the accumulator read-back —
-                        # mirrors the non-accumulator BATCH_MATMUL_OP dispatch
-                        # in compute_layouts, whose args also never include the
-                        # reduction's own output buffer). _matmul_layouts
-                        # derives a single out_stl deterministically from
-                        # accum_layout and installs its own FixedInOutNode, so
-                        # the accumulator is automatically pinned to that same
-                        # out_stl -- no separate AllSameNode join is needed.
+                        # x and y are the two genuine matmul inputs (not the target
+                        # read-back). _matmul_layouts derives a single out_stl
+                        # deterministically from the target layout and installs its
+                        # own FixedInOutNode, so no separate AllSameNode join is needed.
                         assert len(new_value_args) == 2, (
-                            "BATCH_MATMUL_OP accumulator op should have exactly "
-                            f"two non-accumulator inputs, got {len(new_value_args)} "
+                            "BATCH_MATMUL_OP mutation op should have exactly "
+                            f"two non-target inputs, got {len(new_value_args)} "
                             f"for {op.get_name()}"
                         )
                         accum_layout = target_buf.get_layout()
@@ -1886,16 +1875,11 @@ def propagate_spyre_tensor_layouts(
                         target_buf.layouts = candidates
                         op.layouts = candidates
                     elif isinstance(op.data, Reduction):
-                        # Tiled-reduction accumulator: op computes a per-tile
-                        # partial reduction and writes it into a slice of the
-                        # full-size accumulator. The "new value" input is the
-                        # reduction's own un-reduced, higher-rank input, so
-                        # this must go through the same per-arg reduction
-                        # layout logic compute_layouts uses for ordinary
-                        # reductions (_single_arg_op_layout), not the
+                        # The non-target input is the reduction's un-reduced,
+                        # higher-rank input. Must use _single_arg_op_layout, not the
                         # broadcast-oriented pointwise join path.
                         assert len(new_value_args) == 1, (
-                            "Reduction op should have exactly one non-accumulator "
+                            "Reduction mutation op should have exactly one non-target "
                             f"input, got {len(new_value_args)} for {op.get_name()}"
                         )
                         accum_layout = target_buf.get_layout()
@@ -1916,13 +1900,12 @@ def propagate_spyre_tensor_layouts(
                             raise Unsupported(
                                 f"{op.get_name()}: no supported output layout "
                                 f"found for any of {len(in_arg.layouts)} "
-                                f"candidate input layouts; accum size="
+                                f"candidate input layouts; target size="
                                 f"{accum_layout.size}"
                             )
-                        # The accumulator read-back (target_name) is also a
-                        # real input to this op and its stick must match the
-                        # output, so build the cost function from all_args
-                        # (not just in_arg) — mirrors the pointwise branch.
+                        # The target read-back is also a real input whose stick
+                        # must match the output — include all_args so the beam
+                        # search enforces that constraint.
                         op.restick_cost_fn = AllSameNode.from_args(
                             all_args, candidates, output_dep, op
                         )
@@ -1933,12 +1916,10 @@ def propagate_spyre_tensor_layouts(
                         candidates = _multi_arg_pointwise_layouts(
                             op, accum_layout, output_dep, new_value_args
                         )
-                        # op.restick_cost_fn was set by _multi_arg_pointwise_layouts
-                        # using only new_value_args.  The accumulator read-back
-                        # (target_name) is also a real input to this add and its
-                        # stick must match the output.  Rebuild the cost function
-                        # with all_args so the beam search enforces that constraint
-                        # and doesn't commit the accumulator to a mismatched layout.
+                        # _multi_arg_pointwise_layouts used only new_value_args to
+                        # derive candidates. Rebuild the cost function with all_args
+                        # so the target read-back is also included: its stick must
+                        # match the output at runtime.
                         op.restick_cost_fn = AllSameNode.from_args(
                             all_args, candidates, output_dep, op
                         )


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:
Two bugs in the layout optimizer related to mutation ops (`copy_forced`), plus a validation pass to catch regressions. The beam search was bypassing its own cost node abstraction to read the IR directly, and the co-output layout constraint introduced in PR #3949 was modelled as a fake input rather than what it actually is — a second output.

## Background

`copy_forced(src, dst)` lowers to two ops sharing the same output buffer: one computes the value, the other writes `src` into it in-place. Both must commit to the same layout — a co-output constraint.

## Bug 1: beam search bypassed the cost node abstraction

In four places across the beam search and greedy optimizer, the code was calling `op.get_read_writes().reads` directly to determine which input buffers an op depends on, rather than asking `cost_fn.edge_costs`. This meant that any dep the cost node chose to model (e.g. a co-output coupling edge) was invisible to the optimizer's liveness tracking, downstream cost estimation, and state expansion. The cost node was only consulted for pricing, not for graph structure — a fundamental abstraction violation.

All four sites are fixed to iterate `cost_fn.edge_costs` instead, making the cost node the single authoritative source of what edges matter for an op.

## Bug 2: PR #3949's co-output was modelled as a fake input

PR #3949 introduced layout coupling for mutation ops by appending `target_buf`'s write dep as a fake input arg (`target_arg`) to `AllSameNode`. This worked well enough for pricing — `AllSameNode` would enforce that the fake input's layout matched the output — but it was semantically wrong. `buf0` is not an input to the mutation op; it is a second output. Modelling it as an input meant `insert_restickify` could in principle schedule a restickify on `buf0`, which would redirect the in-place write to a temporary and silently break the mutation semantics.

## Fix: AllSameNode with explicit co-output support

`AllSameNode.from_args` now accepts `out_deps` as either a single `MemoryDep` (the normal case) or a list where the first entry is the primary output dep and subsequent entries are co-output deps. Co-output deps are stored separately from input edge costs: they participate in `edge_costs` (so the beam search sees them) but are excluded from `_input_edge_costs` (so `required_input_stls` never schedules a restickify on them).

In `propagate_layouts`, the mutation op path no longer synthesizes a fake input arg. Instead it passes `target_write_dep` directly as a co-output, and `AllSameNode` looks up the target buffer's candidate layouts from the graph. The constraint is expressed as what it actually is: two ops writing the same buffer that must agree on a layout.

## Validation

A new compilation pass `validate_no_restickify_on_mutation_targets` runs immediately after `insert_restickify`. It collects the set of mutation target buffer names (still readable via `MutationLayoutSHOULDREMOVE` at this stage) and asserts none of them appear in `restickify_plan`. This is the only window where both pieces of information are simultaneously available — after this point the scheduler resolves mutation layouts to concrete addresses and target identity is gone.

## Tests

`test_mutation_target_multi_candidate_layout` (from PR #3949) covers the basic co-output layout coupling case. A new test, `test_mutation_target_layout_coupling_with_transposed_src`, uses a transposed source tensor whose layout differs from the destination, forcing a restickify to be inserted on the source. This confirms that restickify is correctly placed on the real input edge rather than the shared output buffer.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
