### PR TITLE
fix: H2D copy into Spyre sub-view uses read-modify-write to avoid DCI stick-boundary limitation

### DIFF
--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -701,6 +701,33 @@ class TestSpyre(TestCase):
         self.assertTrue(torch.all(result[n:-n] == sentinel))
         self.assertEqual(result[-n:], cpu_src[-n:])  # tail at offset N-n
 
+    def test_h2d_subview_copy_preserves_out_of_slot_dtype_precision(self):
+        """H2D copy into a sub-view must not degrade out-of-slot elements.
+
+        When src and dst differ in dtype, the internal staging buffer must use
+        dst's dtype so that existing device elements are read and written back
+        at full precision.  Out-of-slot elements are never touched by the copy
+        and must be bitwise identical after the round-trip.
+
+        Uses int32 for the base so the tail check is bitwise exact — no
+        floating-point tolerance can mask a corruption.  The float16 source
+        still exercises the dtype-mismatch path in the staging buffer.
+        """
+        N = 64
+        n = 9  # sub-stick head slice
+
+        sentinel = 0x12345678
+        spyre_base = torch.full((N,), sentinel, dtype=torch.int32, device="spyre")
+        spyre_base[:n].copy_(torch.ones(n, dtype=torch.float16))
+
+        result = spyre_base.cpu()
+
+        self.assertEqual(result[:n], torch.ones(n, dtype=torch.int32))
+        # Bitwise check: out-of-slot elements must be untouched
+        self.assertTrue(
+            torch.all(result[n:] == sentinel),
+            msg=f"out-of-slot elements corrupted: {result[n:]}",
+        )
 
     def test_scalar_tensor(self):
         """Test to ensure we have scalar tensor on Spyre"""

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -677,6 +677,31 @@ class TestSpyre(TestCase):
             ),
         )
 
+    def test_h2d_copy_into_subview(self):
+        """H2D copy into a slice of a larger Spyre allocation must write to the
+        correct position without corrupting surrounding device elements.
+
+        Regression: copying CPU data into spyre[:n] or spyre[-n:] (where n is
+        smaller than one stick's worth of elements) raised
+        'Invalid device sizes and stride map for host sizes and strides'.
+        """
+        N = 64  # small enough that both bugs fire without a huge allocation
+        n = 9   # smaller than one stick (32 elems for int32, 64 for float16)
+        sentinel = -1
+
+        # --- int32: verify head and tail slices land at correct offsets ---
+        cpu_src = torch.arange(N, dtype=torch.int32)
+        spyre_base = torch.full(N, sentinel, dtype=torch.int32, device="spyre")
+
+        spyre_base[:n].copy_(cpu_src[:n])
+        spyre_base[-n:].copy_(cpu_src[-n:])
+
+        result = spyre_base.cpu()
+        self.assertEqual(result[:n], cpu_src[:n])    # head at offset 0
+        self.assertTrue(torch.all(result[n:-n] == sentinel))
+        self.assertEqual(result[-n:], cpu_src[-n:])  # tail at offset N-n
+
+
     def test_scalar_tensor(self):
         """Test to ensure we have scalar tensor on Spyre"""
         scalar = torch.tensor(3.14, dtype=torch.float16, device="spyre")

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -637,7 +637,7 @@ at::Tensor spyre_copy_from(const at::Tensor& self, const at::Tensor& dst,
       // Step 1: D2H — read the current full allocation into a CPU buffer.
       alloc_view = at::as_strided(dst, alloc_sizes, alloc_strides,
                                   /*storage_offset=*/0);
-      cpu_alloc = at::empty(alloc_sizes, self.options());
+      cpu_alloc = at::empty(alloc_sizes, self.options().dtype(dst.scalar_type()));
       stream.copyAsync(alloc_view, cpu_alloc);
       stream.synchronize();
       // Step 2: CPU patch — overwrite only the target slot.
@@ -684,7 +684,10 @@ at::Tensor spyre_copy_from(const at::Tensor& self, const at::Tensor& dst,
   }
 
   stream.copyAsync(*copy_from, *copy_to);
-  if (!non_blocking) {
+  if (!non_blocking || (staging && dst.is_cpu())) {
+    // Always synchronize before reading cpu_alloc in the D2H staging path:
+    // copyAsync passes a raw void* and does not retain tensor ownership, so
+    // cpu_alloc must be fully written before we apply the logical view below.
     stream.synchronize();
   }
 

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -604,10 +604,50 @@ at::Tensor spyre_copy_from(const at::Tensor& self, const at::Tensor& dst,
   at::Tensor cpu_alloc;
   const at::Tensor* copy_from = &self;
   const at::Tensor* copy_to = &dst;
-  bool non_overlapping_and_dense = true;
+  bool staging = false;
 
   if (dst.is_privateuseone()) {
     stream = getCurrentStream(dst.device());
+    // H2D sub-view staging path: when the destination Spyre tensor is a
+    // sub-view of its physical allocation (dma_numel > dst.numel()), the DCI
+    // layer cannot represent a partial write into the middle of a tiled device
+    // allocation because the DCSI iteration space must align with stick
+    // boundaries.
+    //
+    // We use a read-modify-write:
+    //   1. D2H: DMA the full physical allocation into a CPU staging buffer.
+    //   2. CPU: overwrite only the sub-view slot with self.
+    //   3. H2D: DMA the staging buffer back — now with the full layout and
+    //           zero offset, which the DCI engine handles correctly.
+    //
+    // This is safe even when `dst` has a non-zero storage_offset: step 1 reads
+    // the current on-device values; step 2 patches exactly the right slot
+    // (same sizes/strides/storage_offset as dst); step 3 writes the whole
+    // allocation back atomically from the CPU side.
+    auto* spyre_impl =
+        static_cast<SpyreTensorImpl*>(dst.unsafeGetTensorImpl());
+    int64_t dma_numel = 1;
+    for (auto s : spyre_impl->dma_sizes) dma_numel *= s;
+    const bool physical_exceeds_logical = (dma_numel > dst.numel());
+
+    if (physical_exceeds_logical) {
+      staging = true;
+      c10::IntArrayRef alloc_sizes(spyre_impl->dma_sizes);
+      c10::IntArrayRef alloc_strides(spyre_impl->dma_strides);
+      // Step 1: D2H — read the current full allocation into a CPU buffer.
+      alloc_view = at::as_strided(dst, alloc_sizes, alloc_strides,
+                                  /*storage_offset=*/0);
+      cpu_alloc = at::empty(alloc_sizes, self.options());
+      stream.copyAsync(alloc_view, cpu_alloc);
+      stream.synchronize();
+      // Step 2: CPU patch — overwrite only the target slot.
+      at::Tensor cpu_slot =
+          cpu_alloc.as_strided(dst.sizes(), dst.strides(), dst.storage_offset());
+      cpu_slot.copy_(self);
+      // Step 3: H2D — write the full staging buffer back to the device.
+      copy_from = &cpu_alloc;
+      copy_to = &alloc_view;
+    }
   } else {
     stream = getCurrentStream(self.device());
     // D2H staging path: DMA the full physical allocation into a CPU buffer
@@ -631,7 +671,7 @@ at::Tensor spyre_copy_from(const at::Tensor& self, const at::Tensor& dst,
 
       if (!self.unsafeGetTensorImpl()->is_non_overlapping_and_dense_default() ||
           physical_exceeds_logical) {
-        non_overlapping_and_dense = false;
+        staging = true;
         c10::IntArrayRef alloc_sizes(spyre_impl->dma_sizes);
         c10::IntArrayRef alloc_strides(spyre_impl->dma_strides);
         alloc_view = at::as_strided(self, alloc_sizes, alloc_strides,
@@ -648,7 +688,8 @@ at::Tensor spyre_copy_from(const at::Tensor& self, const at::Tensor& dst,
     stream.synchronize();
   }
 
-  if (!non_overlapping_and_dense) {
+  if (staging && dst.is_cpu()) {
+    // D2H post-staging: apply the logical view onto the CPU destination.
     at::Tensor cpu_view = cpu_alloc.as_strided(self.sizes(), self.strides(),
                                                self.storage_offset());
     dst.copy_(cpu_view);


### PR DESCRIPTION
## Related Issue

- #3976 

## Problem

`tensor.copy_(src)` raised `RuntimeError: Invalid device sizes and stride map for host sizes and strides` whenever the Spyre destination was a sub-view of a larger allocation (e.g. `spyre[:9].copy_(cpu[:9])` on a tensor originally allocated with `N=64`).

## Fix

A **read-modify-write** in `spyre_copy_from` (`spyre_mem.cpp`), triggered whenever `dma_numel > dst.numel()`:

1. **D2H** — DMA the full physical allocation into a CPU staging buffer.
2. **CPU patch** — write `self` into the correct slot via `as_strided(dst.sizes(), dst.strides(), dst.storage_offset())`.
3. **H2D** — DMA the patched buffer back with offset = 0.

Steps 1 and 3 always present a full-allocation, zero-offset tensor to the DCI engine, which it handles correctly.  No changes to `generate_dci`, `get_device_stride_infos`, or the flex DCI layer are required.

## Performance

The extra D2H roundtrip is only incurred for H2D copies into sub-views.  Every case that falls into this path was previously either crashing or producing silently wrong output — there is no previously-correct operation that becomes slower.  Full-allocation H2D copies (`dma_numel == dst.numel()`) are unaffected.

The cost is proportional to the **full physical allocation**, not the sub-view size. For large allocations with small slices this is wasteful, but it is the minimum necessary given that the DCI engine cannot address mid-stick device offsets.  A future optimisation could avoid the roundtrip when the sub-view is stick-aligned (i.e. `storage_offset % elems_per_stick == 0` and `numel % elems_per_stick == 0`).