### PR TITLE
fix(coarse-tile): rebuild cross-group reads correctly

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -232,6 +232,33 @@ def test_abs_256x256_A4():
     run_coarse_tile_test(fn, inputs)
 
 
+def test_two_chained_groups_512x256_A4():
+    """Two SEQUENTIAL hint groups chained through a value (issue #4008).
+
+    z = abs(x)+y under one A/4 scope, then out = z*2 under a SEPARATE A/4
+    scope. The cross-group edge must read group 1's full HBM materialization:
+    Pass 1 interposes a read-copy staging op that takes over the consumer's
+    read, so Pass 3's copy-out patching must resolve consumers by their
+    actual current reads (the planning-time name list alone patched an op
+    that no longer performed the read, and group 2 then striding-read the
+    128-row per-tile scratch - 94.6% mismatch)."""
+    inputs = [
+        tensor("x", shape=(512, 256), dims=["A", "B"]),
+        tensor("y", shape=(512, 256), dims=["A", "B"]),
+    ]
+
+    def fn(x, y):
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                z = torch.abs(x) + y
+        with spyre_hint(num_tiles_per_dim={"A": 4}):
+            with spyre_hint(expected_named_dims=["A", "B"]):
+                out = z * 2
+        return out
+
+    run_coarse_tile_test(fn, inputs)
+
+
 def test_abs_256x256_B4():
     """abs [256,256] tiled B÷4 → 64 elems/tile (1 stick)."""
     inputs = [tensor("x", shape=(256, 256), dims=["A", "B"])]

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import logging
 from collections import defaultdict
 from typing import cast
@@ -23,6 +24,7 @@ from .ir import FixedTiledLayout, SpyreEmptyFallback
 from .optimize_restickify import EdgeCostMap
 from .logging_utils import get_inductor_logger
 from .pass_utils import redirect_computed_buffer_reads
+from torch._inductor.dependencies import MemoryDep
 from torch._inductor.graph import GraphLowering
 from torch._inductor.ir import (
     ComputedBuffer,
@@ -205,8 +207,45 @@ def insert_restickify_on_node_inputs(
         # carries loop_info (loop_group_id + loop_count).  The restickify node
         # is inserted inside the same loop group, so it must inherit loop_info
         # to remain contiguous in build_loop_scheduler_nodes.
+        #
+        # It must inherit a COPY, not the consumer's own object: the restickify
+        # node is a per-iteration stage of old_name, so it TAKES OVER the
+        # consumer's per-read tile advance for that dependency (its own read of
+        # old_name strides through the source), its output is per-iteration
+        # scratch that never advances, and the consumer's read of the stage
+        # must stop advancing. Sharing one CoarseTileInfo (the old behavior)
+        # makes that transfer impossible - both ops kept the advance, so a
+        # coarse-tiled consumer of a cross-loop-group full buffer read the
+        # 1-tile stage with a striding index and ran off its end (issue #4008).
         if hasattr(op, "loop_info"):
-            restick_buff.loop_info = op.loop_info
+            consumer_li = op.loop_info
+            n_levels = len(getattr(consumer_li, "loop_count", []) or [])
+            reads_per_dim = getattr(consumer_li, "tiled_dims_per_read", None)
+            if n_levels and reads_per_dim is not None:
+                mem_deps = [
+                    d for d in op.get_read_writes().reads if isinstance(d, MemoryDep)
+                ]
+                dep_idxs = [
+                    i
+                    for i, d in enumerate(mem_deps)
+                    if d.name == old_name and i < len(reads_per_dim)
+                ]
+                dep_advance = (
+                    copy.deepcopy(reads_per_dim[dep_idxs[0]])
+                    if dep_idxs
+                    else [[] for _ in range(n_levels)]
+                )
+                restick_li = copy.copy(consumer_li)
+                restick_li.tiled_dims_per_read = [dep_advance]
+                restick_li.output_tiled_dims = [[] for _ in range(n_levels)]
+                restick_buff.loop_info = restick_li
+                if dep_idxs:
+                    consumer_li.tiled_dims_per_read = [
+                        [[] for _ in range(n_levels)] if i in dep_idxs else entry
+                        for i, entry in enumerate(reads_per_dim)
+                    ]
+            else:
+                restick_buff.loop_info = consumer_li
 
     # Patch inner_fn once with the full name_map covering all restickified args.
     redirect_computed_buffer_reads(

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -2038,16 +2038,45 @@ def _propagate_tiled_op(
     loop_group_id = loop_info.loop_group_id
     buf_name = op.get_name()
 
-    # Resolve planning-time consumer names to their current objects --
-    # Pass 1/2 may have spliced replacements into `operations` under the
-    # same names since planning ran (see PropagationPlan's docstring on
-    # name stability).
-    outside_consumers = [
-        o
-        for o in operations
-        if isinstance(o, ComputedBuffer)
-        and o.get_name() in propagation.outside_consumer_names
-    ]
+    # Resolve consumers at TRANSFORM time, by actual reads rather than by
+    # the planning-time name list. Pass 1/2 may have spliced replacements
+    # into `operations` under the same names since planning ran (see
+    # PropagationPlan's docstring on name stability) -- and Pass 1 may have
+    # rewired a planned consumer in another tiled group through a read-copy
+    # staging op, which then performs the group's actual read of buf_name.
+    # Patching only the planned names would miss that staging op, leaving
+    # it draining this op's per-tile scratch while the full buffer goes
+    # unread (issue #4008: 94.6% wrong on two chained hint groups). Any
+    # current reader outside this op's outermost loop group needs the
+    # redirect; the in-group copy-out drain reads buf_name by design and is
+    # excluded by the group test exactly like the planning-time analog
+    # (_find_outside_consumers_planned).
+    own_outer_key = loop_group_id[0]
+    planned_names = set(propagation.outside_consumer_names)
+    outside_consumers = []
+    for o in operations:
+        if not isinstance(o, ComputedBuffer) or o is op:
+            continue
+        if not _reads_buffer(o, buf_name):
+            continue
+        o_outer = getattr(getattr(o, "loop_info", None), "loop_group_id", (None,))[0]
+        # Union of both consumer notions: a planned name that still reads
+        # buf_name may legitimately share this group's outer key (a deferred
+        # reduction consumer such as softmax's div - see
+        # _consumers_reading_incomplete_reduction), so the group test alone
+        # would wrongly drop it.
+        if o_outer != own_outer_key or o.get_name() in planned_names:
+            outside_consumers.append(o)
+    resolved_names = {o.get_name() for o in outside_consumers}
+    if resolved_names != planned_names:
+        logger.debug(
+            "coarse_tile: copy-out %s consumer set changed between planning "
+            "and transform: planned=%s resolved=%s (read-copy staging ops "
+            "take over their consumer's read)",
+            buf_name,
+            sorted(planned_names),
+            sorted(resolved_names),
+        )
     is_graph_output = propagation.is_graph_output
 
     full_ranges = propagation.full_ranges


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Two chained coarse-tile hint groups produced 94.6% wrong results: the second group striding-read the first group's 128-row per-tile scratch instead of its full HBM materialization.
Out rows 0-127 held tile 3's data (the last tile the scratch was overwritten with) and the rest read past the buffer.
Two stacked defects produced the one symptom.

**1. Pass-ordering blind spot in the copy-out consumer patching** (`coarse_tile.py`, `_propagate_tiled_op`).
Pass 1 interposes a read-copy staging op that takes over a cross-group consumer's read of the scratch.
Pass 3 then patched consumers from the planning-time name list, which predates the staging op: the redirect landed on an op that no longer performed the read, the staging op kept draining the scratch, and the untouched full buffer was scheduled dead and freed.
The fix resolves consumers at transform time, as the union of current out-of-group readers (catches staging ops) and planned names that still read the buffer (preserves same-outer-group deferred reduction consumers such as softmax's `div`, which the group test alone would wrongly drop; `test_softmax_2d_512x256_dim1_B4` regressed under an out-of-group-only resolution and pinned this).
A debug log reports when the resolved set diverges from the planned one.

**2. `loop_info` aliasing in `insert_restickify`.**
The interposed restickify node shared the consumer's `CoarseTileInfo` object, so the per-read tile advance could not be transferred: both ops advanced, and a coarse-tiled consumer of a cross-group full buffer read the one-tile stage with a striding index and ran off its end.
The restickify node now gets its own copy: its read takes over the dep's advance (it strides the source), its output is per-iteration scratch that never advances, and the consumer's advance for that dep is cleared.
This restores the invariant every healthy staging chain already exhibits: readers of stages never advance.

#### Which issue(s) this PR is related to:

Fixes #4008

#### Special notes for your reviewer:

The issue's reproducer is added verbatim as `test_two_chained_groups_512x256_A4`.
Verified on device: the reproducer passes (was 123989/131072 mismatched), and `test_coarse_tile_e2e.py`, `test_coarse_tiling.py`, `test_restickify.py`, and `test_work_division_hint.py` pass 849/849 together.
The second defect was only exposed after fixing the first (tile 0 became correct while tiles 1-3 stayed wrong), so the two fixes are intentionally one commit: neither is sufficient alone for the cross-group case.

#### Does this PR introduce a user-facing change?

No. Chained coarse-tile hint groups now compute correct results.

#### Additional note:

The same two mechanisms are worth checking in the coarse-tiling stage4/stage6 restructures, which the issue was originally filed to probe.
