### PR TITLE
Merge live ranges for same-bundle aliased pool buffers

### DIFF
--- a/tests/inductor/test_hbm_pool_planning.py
+++ b/tests/inductor/test_hbm_pool_planning.py
@@ -494,6 +494,81 @@ class TestHbmPoolPlanningPerBundle(unittest.TestCase):
         self.assertNotIn("hbm_pool", target_buf.get_layout().allocation)
         self.assertNotIn("hbm_pool", alias_buf.get_layout().allocation)
 
+    def test_aliased_buffer_within_same_bundle_shares_one_merged_live_range(self):
+        """Regression test for issue #3980: two buffer *names* that share
+        the exact same FixedTiledLayout.allocation dict object -- as
+        enforce_indirect_access_layout.py's _insert_mutation_relayout_copy
+        produces for a non-compliant scatter destination, via
+        propagate_layouts.py's propagate_mutation_layouts resolving
+        MutationLayoutSHOULDREMOVE.real_layout() to the *same* layout
+        instance as its copy-in buffer's -- are truly one physical storage
+        location. Pool-allocating them safely (rather than excluding them
+        outright, which would regress coarse_tiling's pervasive use of
+        mutation buffers) requires treating their live range as the union
+        of both names' individual ranges, not each in isolation.
+
+        Before the fix, "target" and "alias" (sharing one allocation dict)
+        were each given their own live range from their own reads/writes
+        and separately allocated -- two distinct offsets written into the
+        one shared dict, the second clobbering the first. The fix merges
+        alias-group members into one (min start, max end) range and
+        allocates once per group.
+
+        This test isolates the *merge* itself (not just the single-write
+        aliasing, which would trivially "pass" even unfixed since both
+        names share one dict): "target" is read late (read_target, step 3)
+        while "alias" is written+read early (steps 1-2). "other" is written
+        and read in between (step 2's write, step 2's read) -- overlapping
+        alias's naive [1,2] range but *not* target's own naive [0,0] range.
+        Only the merged [0,3] range correctly keeps "other" from reusing
+        target/alias's block while target is still live.
+        """
+        target = _make_ftl_buffer("target", host_size=(64,))
+        write_target = _make_snode_with_rw("write_target", writes=["target"], reads=[])
+
+        _make_ftl_buffer_aliased("alias", alias_of=target, host_size=(64,))
+        write_alias = _make_snode_with_rw("write_alias", writes=["alias"], reads=[])
+        read_alias = _make_snode_with_rw("read_alias", writes=[], reads=["alias"])
+
+        _make_ftl_buffer("other", host_size=(64,))
+        write_other = _make_snode_with_rw("write_other", writes=["other"], reads=[])
+        read_other = _make_snode_with_rw("read_other", writes=[], reads=["other"])
+
+        read_target = _make_snode_with_rw("read_target", writes=[], reads=["target"])
+
+        # Steps: 0=write_target, 1=write_alias, 2=[read_alias, write_other,
+        # read_other] (fused into one timestep), 3=read_target.
+        step2 = FusedSchedulerNode(MagicMock(), [read_alias, write_other, read_other])
+        bundle = FusedSchedulerNode(
+            MagicMock(), [write_target, write_alias, step2, read_target]
+        )
+
+        hbm_pool_planning([bundle])
+
+        target_buf = V.graph.get_buffer("target")
+        alias_buf = V.graph.get_buffer("alias")
+        other_buf = V.graph.get_buffer("other")
+
+        # Both aliased names are pool-eligible now (same-bundle aliasing no
+        # longer bars pool allocation outright)...
+        self.assertIn("hbm_pool", target_buf.get_layout().allocation)
+        self.assertIn("hbm_pool", alias_buf.get_layout().allocation)
+        self.assertIn("hbm_pool", other_buf.get_layout().allocation)
+        # ...sharing the exact same offset, since they are one physical
+        # storage location (same underlying allocation dict).
+        self.assertEqual(
+            target_buf.get_layout().allocation["hbm_pool"],
+            alias_buf.get_layout().allocation["hbm_pool"],
+        )
+        # "other" must not reuse target/alias's block: with the naive
+        # (unmerged) per-name ranges, alias's range [1, 2] would end before
+        # other's start [2], wrongly freeing the block for reuse while
+        # target (whose own real read is at step 3) still needs it.
+        self.assertNotEqual(
+            target_buf.get_layout().allocation["hbm_pool"],
+            other_buf.get_layout().allocation["hbm_pool"],
+        )
+
     def test_buffer_that_overflows_pool_falls_back_to_standalone_hbm(self):
         """When MAX_POOL_SIZE_BYTES is too small to hold every pool-eligible
         buffer, the ones that fit get an hbm_pool allocation and the

--- a/torch_spyre/_inductor/hbm_pool_planning.py
+++ b/torch_spyre/_inductor/hbm_pool_planning.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+from typing import Callable
 from sympy import Symbol
 from torch._inductor.scheduler import (
     BaseSchedulerNode,
@@ -123,11 +124,26 @@ def _compute_size_bytes(name: str) -> int:
 def _compute_live_ranges(
     nodes: list[BaseSchedulerNode],
     pool_candidates: set[str],
+    alloc_id_of: "Callable[[str], int | None]",
 ) -> dict[str, tuple[int, int]]:
     """Return {buf_name: (start_step, end_step)} for each pool candidate.
 
     start_step: timestep of the node that writes the buffer.
     end_step: last timestep at which any node reads the buffer.
+
+    Two or more candidate names can share the same underlying
+    FixedTiledLayout.allocation dict object -- see `_alloc_id` -- when a
+    MutationLayoutSHOULDREMOVE retarget (e.g. the copy-in/retarget/copy-back
+    sequence enforce_indirect_access_layout.py's
+    _insert_mutation_relayout_copy inserts for a non-compliant scatter
+    destination) makes one op's layout literally *be* another buffer's
+    layout instance. Since they are truly one physical storage location,
+    their live range must be the union of every aliased name's individual
+    range -- not each name's own range in isolation -- or the allocator
+    could place another buffer's block on top of storage one of the
+    aliased names still needs. Every name in such a group gets the exact
+    same merged (start, end) here so the caller can allocate it once (via
+    `alloc_id_of`) using a range that is safe for every alias.
     """
     start: dict[str, int] = {}
     end: dict[str, int] = {}
@@ -145,6 +161,20 @@ def _compute_live_ranges(
     for name in pool_candidates:
         if name in start:
             live_ranges[name] = (start[name], end.get(name, len(nodes) + 1))
+
+    # Merge ranges within each alias group (same id(layout.allocation)).
+    group_range: dict[int, tuple[int, int]] = {}
+    for name, (s, e) in live_ranges.items():
+        alloc_id = alloc_id_of(name)
+        if alloc_id is None:
+            continue
+        gs, ge = group_range.get(alloc_id, (s, e))
+        group_range[alloc_id] = (min(gs, s), max(ge, e))
+    for name in live_ranges:
+        alloc_id = alloc_id_of(name)
+        if alloc_id is not None and alloc_id in group_range:
+            live_ranges[name] = group_range[alloc_id]
+
     return live_ranges
 
 
@@ -417,8 +447,31 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
             live_range_nodes = [bundle]
         else:
             live_range_nodes = bundle.get_nodes()
-        live_ranges = _compute_live_ranges(live_range_nodes, bundle_candidates)
+        live_ranges = _compute_live_ranges(
+            live_range_nodes, bundle_candidates, _alloc_id
+        )
         sorted_bufs = sorted(live_ranges.items(), key=_alloc_sort_key)
+
+        # Two or more candidate names can resolve to the same
+        # id(layout.allocation) (see _alloc_id / _compute_live_ranges) --
+        # they are one physical storage location sharing one merged live
+        # range, and must be allocated exactly once. Group by alloc_id
+        # here (preserving sorted_bufs's (start, end, name) order for the
+        # group's position) so the loop below allocates once per group and
+        # then writes the resulting offset into every member name.
+        alloc_groups: dict[str, list[str]] = {}
+        group_of_alloc_id: dict[int, str] = {}
+        alloc_order: list[str] = []
+        for name, _ in sorted_bufs:
+            alloc_id = _alloc_id(name)
+            rep = group_of_alloc_id.get(alloc_id) if alloc_id is not None else None
+            if rep is not None:
+                alloc_groups[rep].append(name)
+                continue
+            if alloc_id is not None:
+                group_of_alloc_id[alloc_id] = name
+            alloc_groups[name] = [name]
+            alloc_order.append(name)
 
         allocator = Allocator(MAX_POOL_SIZE_BYTES)
 
@@ -426,7 +479,9 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
         pending_frees: list[tuple[int, int, int]] = []
         overflowed = 0
 
-        for name, (start, end) in sorted_bufs:
+        for rep_name in alloc_order:
+            start, end = live_ranges[rep_name]
+            grouped_names = alloc_groups[rep_name]
             # Free any blocks whose live range ended before this start step.
             still_live = []
             for entry in pending_frees:
@@ -437,7 +492,7 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
                     still_live.append(entry)
             pending_frees = still_live
 
-            size = _compute_size_bytes(name)
+            size = _compute_size_bytes(rep_name)
             offset = allocator.allocate(size)
 
             if offset is None:
@@ -450,47 +505,53 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
                     "hbm_pool_planning: bundle=%s  %s  live=[%d,%d]  size=%d  "
                     "does not fit in pool -- falling back to standalone HBM",
                     bundle_name,
-                    name,
+                    grouped_names,
                     start,
                     end,
                     size,
                 )
                 continue
 
-            # Assign pool offset directly to layout.allocation.
-            buf = V.graph.get_buffer(name)
-            layout = buf.maybe_get_layout()
+            # Assign pool offset directly to layout.allocation. Every name
+            # in grouped_names shares the exact same layout/allocation dict
+            # object, so this single write is visible to all of them.
+            layout = V.graph.get_buffer(rep_name).maybe_get_layout()
             assert isinstance(layout, FixedTiledLayout)
             if config.bundle_symbolic_args:
                 layout.allocation["hbm_pool"] = offset
             else:
                 layout.allocation["hbm_pool"] = INTERMEDIATES_SEGMENT + offset
 
-            if isinstance(buf, SpyreEmptyFallback):
-                # SpyreEmptyFallback.should_allocate() returns False once
-                # pool-allocated, so the wrapper never emits an AllocateLine
-                # for it. Base Inductor's free machinery
-                # (Scheduler.free_buffers -> codegen_free -> can_reuse) does
-                # not consult should_allocate(); it frees any buffer whose
-                # last use has passed regardless of whether it was ever
-                # allocated. Without this, the generated wrapper emits
-                # `del buf27` with no prior `buf27 = ...`, raising
-                # UnboundLocalError. free_buffers() itself subtracts
-                # V.graph.removed_buffers before iterating, so adding the
-                # name here keeps it out of codegen entirely.
-                V.graph.removed_buffers.add(name)
-
             pending_frees.append((end, offset, size))
-
             logger.debug(
                 "hbm_pool_planning: bundle=%s  %s  live=[%d,%d]  size=%d  offset=%d",
                 bundle_name,
-                name,
+                grouped_names,
                 start,
                 end,
                 size,
                 offset,
             )
+
+            # SpyreEmptyFallback.should_allocate()/removed_buffers is a
+            # per-*name* codegen concern (each name is still emitted as its
+            # own statement even though several share one storage
+            # location), so this must run once for every name in the group.
+            for name in grouped_names:
+                buf = V.graph.get_buffer(name)
+                if isinstance(buf, SpyreEmptyFallback):
+                    # SpyreEmptyFallback.should_allocate() returns False once
+                    # pool-allocated, so the wrapper never emits an
+                    # AllocateLine for it. Base Inductor's free machinery
+                    # (Scheduler.free_buffers -> codegen_free -> can_reuse)
+                    # does not consult should_allocate(); it frees any buffer
+                    # whose last use has passed regardless of whether it was
+                    # ever allocated. Without this, the generated wrapper
+                    # emits `del buf27` with no prior `buf27 = ...`, raising
+                    # UnboundLocalError. free_buffers() itself subtracts
+                    # V.graph.removed_buffers before iterating, so adding the
+                    # name here keeps it out of codegen entirely.
+                    V.graph.removed_buffers.add(name)
 
         peak = allocator.get_peak_usage()
         pool_extent = allocator.get_pool_end()
@@ -506,7 +567,7 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
             "hbm_pool_planning: bundle=%s assigned %d intermediates, peak concurrent "
             "usage %.2f GB, pool extent %.2f GB / %.2f GB",
             bundle_name,
-            len(sorted_bufs) - overflowed,
+            len(alloc_order) - overflowed,
             peak / _BYTES_PER_GB,
             pool_extent / _BYTES_PER_GB,
             MAX_POOL_SIZE_BYTES / _BYTES_PER_GB,


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes a silent buffer-offset clobber in `hbm_pool_planning.py` when two
distinct buffer *names* alias the same underlying storage within a single
SDSC bundle.

`enforce_indirect_access_layout.py`'s `_insert_mutation_relayout_copy`
constructs one `FixedTiledLayout` for a non-compliant scatter's copy-in
buffer, and `propagate_layouts.py`'s `propagate_mutation_layouts` resolves
the retargeted scatter's `MutationLayoutSHOULDREMOVE.real_layout()` to that
*same* layout instance — so two buffer names can share one
`FixedTiledLayout.allocation` dict. `hbm_pool_planning`'s `_is_cross_bundle`
alloc_id guard only excluded aliasing that spans *different* bundles; when
both aliased names were written within the *same* bundle, they were treated
as two independent pool candidates. The allocator then computed two
different offsets and wrote them both into the one shared `.allocation`
dict — the second write silently clobbered the first, corrupting the
buffer's actual device address.

Rather than excluding same-bundle aliased buffers from the pool (simpler,
but overly conservative — mutation buffers of this shape are pervasive in
coarse_tiling, so this would block a lot of otherwise-poolable memory), the
fix extends the live-range analysis so aliased names can still be safely
pool-allocated:

- `_compute_live_ranges` gained a third parameter, `alloc_id_of`, backed by
  the existing `_alloc_id(name) -> id(layout.allocation)` helper. After
  computing each candidate's individual `(start, end)`, a merging pass
  groups names by `alloc_id_of(name)` and overwrites every name's live
  range with the group's union `(min(starts), max(ends))` — aliased names
  are one physical storage location, so their live range must be the union
  of every alias's range, not each in isolation.
- The allocation loop now groups `sorted_bufs` by `alloc_id` and calls
  `allocator.allocate()` exactly once per group (using the merged range),
  writing a single safe offset into the shared `.allocation` dict.
- Per-name codegen bookkeeping (`SpyreEmptyFallback`/`removed_buffers`)
  still runs once for every name in a group, since each name is still
  emitted as its own statement in codegen even though storage is shared.
- Cross-bundle aliasing exclusion (`_is_cross_bundle`) is unchanged — pools
  are bundle-scoped, so aliasing that spans bundles is still excluded
  entirely; only the same-bundle case is now handled via merged live
  ranges instead of being a silent corruption.

#### Which issue(s) this PR is related to:

Related to #3980 (`HBM_POOL_PLANNING=1` causes compiled greedy decode via
vLLM to emit garbage tokens). This same-bundle aliasing bug was found while
investigating #3980 and is a real, independently-reproducible corruption —
but **does not resolve #3980's actual symptom**: re-running the real vLLM
repro with this fix applied still reproduces the garbage-token output.
Ground-truth operand-level tracing across all pool-eligible bundles in a
minimal repro run subsequently ruled out HBM-pool offset reuse entirely as
the cause of #3980 — that investigation is ongoing separately (currently
paused pending a colleague's parallel investigation into the
IndirectAccess/block-table index computation). #3980 should remain open
after this PR merges.

#### Special notes for your reviewer:

- New regression test:
  `test_aliased_buffer_within_same_bundle_shares_one_merged_live_range` in
  `tests/inductor/test_hbm_pool_planning.py`. It proves both aliased names
  become pool-eligible with one shared offset, and that the merge is
  load-bearing: a third, unrelated buffer cannot reuse the aliased pair's
  block while it's still live under the *merged* range, even though it
  would fit under either alias's individual, unmerged range.
- Verification performed:
  - `test_hbm_pool_planning.py`: 20/20 pass.
  - `test_hbm_pool_planning.py` + `test_building_blocks.py` together: 31/31
    pass.
  - Real-hardware `test_coarse_tile_e2e.py` with `HBM_POOL_PLANNING=1`: 188
    passed, 41 skipped, 1 xfailed (pre-existing, unrelated writer-advance
    issue) — no regressions in coarse_tiling's mutation-buffer-heavy
    workloads under pool planning.
  - `pre-commit run --all-files` on the changed files: clean.

#### Does this PR introduce a user-facing change?

No behavior change for callers. `HBM_POOL_PLANNING=1` now pool-allocates a
class of same-bundle aliased mutation buffers that would previously have
silently produced wrong device addresses (a correctness fix, not an API or
default change).

#### Additional note:

This is the first of (at least) two distinct bugs uncovered during the
#3980 investigation. The second — why the real vLLM decode path still
produces garbage tokens under `HBM_POOL_PLANNING=1` even with this fix
applied — remains open and is being tracked separately under #3980 itself.