### PR TITLE
fix(inductor): enforce hard work-division constraints across planners

### DIFF
--- a/tests/inductor/test_work_division.py
+++ b/tests/inductor/test_work_division.py
@@ -215,9 +215,12 @@ class TestHardForbiddenSplits(unittest.TestCase):
             committed_splits={batch: 2},
         )
 
+        def forbidden_constraint(_ctx):
+            return ConstraintResult(forbidden={batch})
+
         with patch(
             "torch_spyre._inductor.work_division_constraints.indirect_access_constraints",
-            return_value=ConstraintResult(forbidden={batch}),
+            new=forbidden_constraint,
         ):
             with self.assertRaisesRegex(Unsupported, "hard-forbidden split"):
                 collect_work_division_constraints(ctx)
@@ -260,6 +263,127 @@ class TestHardForbiddenSplits(unittest.TestCase):
 
         self.assertGreater(unrestricted[batch], 1)
         self.assertEqual(restricted[batch], 1)
+
+
+class TestPrunedScratchpadWorkDivisionConstraints(unittest.TestCase):
+    _ALLOCATOR_TARGET = "torch_spyre._inductor.scratchpad.allocator"
+
+    def _case(self):
+        from torch_spyre._inductor.scratchpad.allocator import CoOptimizingAllocator
+
+        batch, m = _isym("batch"), _isym("m")
+        op = _computed_buffer((4, 64), name="constrained_out")
+
+        # write = 64 * batch + m. The safe seed splits only M; the synthesized
+        # alternative uses the same M split and additionally splits batch.
+        safe = ({1: 8}, {})
+        unsafe = ({64: 4, 1: 8}, {})
+        op.op_it_space_splits = safe
+        rw = MagicMock()
+        rw.writes = [MagicMock(index=64 * batch + m)]
+        rw.reads = []
+
+        graph = MagicMock()
+        graph.operations = [op]
+        allocator = CoOptimizingAllocator(
+            layout_planning=MagicMock(),
+            size=1 << 20,
+            prune=True,
+        )
+        return allocator, graph, op, rw, batch, m, safe, unsafe
+
+    def _patch_candidate_context(self, op, rw, batch, m, unsafe):
+        def constraints(candidate_op):
+            self.assertIs(candidate_op, op)
+            return ConstraintResult(forbidden={batch})
+
+        return (
+            patch(
+                f"{self._ALLOCATOR_TARGET}.ops_in_offset_mutation_component",
+                return_value=set(),
+            ),
+            patch(
+                f"{self._ALLOCATOR_TARGET}._find_distinct_matmul_splits",
+                return_value=((), ()),
+            ),
+            patch(
+                f"{self._ALLOCATOR_TARGET}._enum_split_options",
+                return_value=[op.op_it_space_splits, unsafe],
+            ),
+            patch(
+                f"{self._ALLOCATOR_TARGET}.collect_op_work_division_constraints",
+                side_effect=constraints,
+            ),
+            patch(
+                f"{self._ALLOCATOR_TARGET}.op_read_writes",
+                return_value=rw,
+            ),
+            patch(
+                f"{self._ALLOCATOR_TARGET}.iteration_space_from_op",
+                return_value={batch: 4, m: 64},
+            ),
+        )
+
+    def test_pruned_candidates_and_commit_keep_forbidden_dim_unsplit(self):
+        from torch_spyre._inductor.pass_utils import apply_splits_from_index_coeff
+        from torch_spyre._inductor.scratchpad.plan_solver import CoreDivisionBuffer
+
+        allocator, graph, op, rw, batch, m, safe, unsafe = self._case()
+        with ExitStack() as stack:
+            for ctx in self._patch_candidate_context(op, rw, batch, m, unsafe):
+                stack.enter_context(ctx)
+
+            divisions = allocator._division_map(graph)[op.name]
+            self.assertEqual(
+                [(cd.output_splits, cd.reduction_splits) for cd in divisions],
+                [safe],
+            )
+
+            allocation = [
+                CoreDivisionBuffer(
+                    name=op.name,
+                    size=128,
+                    uses=[0],
+                    core_divisions=divisions,
+                    chosen_division=0,
+                )
+            ]
+            allocator._commit_divisions(graph, allocation)
+
+        per_sym = apply_splits_from_index_coeff(
+            op.op_it_space_splits,
+            rw.writes[0].index,
+            rw.writes[0].index,
+            {batch: 4, m: 64},
+        )
+        self.assertEqual(per_sym[batch], 1)
+
+    def test_commit_rejects_hard_forbidden_split_as_backstop(self):
+        from torch_spyre._inductor.scratchpad.plan_solver import (
+            CoreDivision,
+            CoreDivisionBuffer,
+        )
+
+        allocator, graph, op, rw, batch, m, _, unsafe = self._case()
+        allocation = [
+            CoreDivisionBuffer(
+                name=op.name,
+                size=128,
+                uses=[0],
+                core_divisions=[
+                    CoreDivision(
+                        output_splits=dict(unsafe[0]),
+                        reduction_splits=dict(unsafe[1]),
+                    )
+                ],
+                chosen_division=0,
+            )
+        ]
+        with ExitStack() as stack:
+            for ctx in self._patch_candidate_context(op, rw, batch, m, unsafe):
+                stack.enter_context(ctx)
+            with self.assertRaisesRegex(Unsupported, "hard-forbidden dim"):
+                allocator._commit_divisions(graph, allocation)
 
 
 class TestConvSpatialBlockedVars(unittest.TestCase):

--- a/tests/inductor/test_work_division.py
+++ b/tests/inductor/test_work_division.py
@@ -23,10 +23,12 @@ from torch._inductor.dependencies import MemoryDep
 from torch._inductor.ir import ComputedBuffer, FlexibleLayout, Pointwise, Reduction
 
 from torch_spyre._C import ElementArrangement, SpyreTensorLayout
+from torch_spyre._inductor.constants import BATCH_MATMUL_OP
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.ir import FixedTiledLayout
 from torch_spyre._inductor.work_division import (
     TensorDep,
+    _cost_model_matmul_planner,
     _default_split,
     multi_dim_iteration_space_split,
     span_reduction_pass,
@@ -198,6 +200,66 @@ class TestCoordinateMaskBlockedVars(unittest.TestCase):
         )
         result = coordinate_mask_blocked_vars(ctx)
         self.assertEqual(result.blocked, set())
+
+
+class TestHardForbiddenSplits(unittest.TestCase):
+    _PLACEHOLDER_TD = _tensor_dep("placeholder", (4,), (_isym("_placeholder"),))
+
+    def test_committed_hard_forbidden_split_raises(self):
+        batch = _isym("batch")
+        op = _computed_buffer((4,), name="constrained_out")
+        ctx = _make_context(
+            op,
+            self._PLACEHOLDER_TD,
+            it_space={batch: 4},
+            committed_splits={batch: 2},
+        )
+
+        with patch(
+            "torch_spyre._inductor.work_division_constraints.indirect_access_constraints",
+            return_value=ConstraintResult(forbidden={batch}),
+        ):
+            with self.assertRaisesRegex(Unsupported, "hard-forbidden split"):
+                collect_work_division_constraints(ctx)
+
+    def test_cost_model_keeps_forbidden_batch_unsplit(self):
+        batch, m, n, k = (_isym(name) for name in ("batch", "m", "n", "k"))
+        op = _computed_buffer(
+            (4, 64, 256),
+            name="matmul_out",
+            reduction_type=BATCH_MATMUL_OP,
+            reduction_ranges=(128,),
+        )
+        output_td = _tensor_dep("matmul_out", (4, 64, 256), (batch, m, n))
+        input_tds = [
+            _tensor_dep("lhs", (4, 64, 128), (batch, m, k)),
+            _tensor_dep("rhs", (4, 128, 256), (batch, k, n)),
+        ]
+        it_space_adjusted = {batch: 4, m: 64, n: 4, k: 2}
+        initial_splits = {sym: 1 for sym in it_space_adjusted}
+
+        def prefer_batch_split(batch_cost_arg, *_args, **_kwargs):
+            return 0 if batch_cost_arg[1] > 1 else 1
+
+        planner_args = (
+            op,
+            initial_splits,
+            it_space_adjusted,
+            output_td,
+            {n: 64, k: 64},
+            {},
+            32,
+            input_tds,
+        )
+        with patch(
+            "torch_spyre._inductor.work_division._matmul_split_cost",
+            side_effect=prefer_batch_split,
+        ):
+            unrestricted = _cost_model_matmul_planner(*planner_args)
+            restricted = _cost_model_matmul_planner(*planner_args, forbidden={batch})
+
+        self.assertGreater(unrestricted[batch], 1)
+        self.assertEqual(restricted[batch], 1)
 
 
 class TestConvSpatialBlockedVars(unittest.TestCase):

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -255,6 +255,20 @@ class TestNamedWorkDivisionHint(InductorTestCase):
                 pinned={m: 1},
             )
 
+    def test_apply_work_div_hint_rejects_hard_forbidden_split(self):
+        batch = Symbol("batch")
+        op = self._fake_op({batch: ["batch"]})
+
+        with self.assertRaisesRegex(Exception, "hard-forbidden dim"):
+            _wd._apply_user_hint(
+                op,
+                {batch: 2},
+                {batch: 4},
+                self._fake_output_td([batch]),
+                max_cores=32,
+                forbidden={batch},
+            )
+
     @config.patch({"sencores": 8})
     def test_pointwise_work_div_hint_applied(self):
         M, N = 128, 64

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -46,7 +46,11 @@ from torch_spyre._inductor.pass_utils import (
     _per_core_view_from_prep,
     op_short_name,
 )
-from torch_spyre._inductor.work_division import enumerate_work_division_candidates
+from torch_spyre._inductor.work_division import (
+    _first_non_indirect_read_index,
+    collect_op_work_division_constraints,
+    enumerate_work_division_candidates,
+)
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.scratchpad.plan_solver import (
     CoreDivision,
@@ -1498,6 +1502,51 @@ def _enum_split_options(
     ]
 
 
+def _filter_forbidden_split_options(
+    op: Operation,
+    options: list[tuple[dict, dict]],
+) -> list[tuple[dict, dict]]:
+    """Remove pruned candidates that split a hard-forbidden iteration symbol.
+
+    The pruned co-optimizer synthesizes alternatives after the normal work-
+    division passes have run. Reuse their constraint collector here so a later
+    optimization cannot violate an earlier correctness contract, including
+    matmul batch ownership and indirect-access table addressing.
+    """
+    if not isinstance(op, ComputedBuffer) or not isinstance(
+        op.data, (Pointwise, Reduction)
+    ):
+        return options
+
+    forbidden = collect_op_work_division_constraints(op).forbidden
+    if not forbidden:
+        return options
+
+    rw = op_read_writes(op)
+    write_index = next(iter(rw.writes)).index
+    read_index = _first_non_indirect_read_index(rw, write_index)
+    iter_space = iteration_space_from_op(op)
+
+    valid: list[tuple[dict, dict]] = []
+    rejected: set[sympy.Symbol] = set()
+    for option in options:
+        per_sym = apply_splits_from_index_coeff(
+            option, write_index, read_index, iter_space
+        )
+        violations = {sym for sym in forbidden if per_sym.get(sym, 1) > 1}
+        if violations:
+            rejected |= violations
+        else:
+            valid.append(option)
+
+    if not valid:
+        raise Unsupported(
+            f"{op.get_name()}: every scratchpad core-division candidate splits "
+            f"hard-forbidden dim(s) {sorted(str(sym) for sym in rejected)}."
+        )
+    return valid
+
+
 def _canonical_key(splits: tuple[dict, dict]) -> tuple:
     """Hashable key for a (output_splits, reduction_splits) pair."""
     out, red = splits
@@ -1602,9 +1651,13 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             if op.name in fixed_division_ops:
                 divs = [_fixed_core_division(op)]
             elif self.prune:
+                options = _filter_forbidden_split_options(
+                    op,
+                    _enum_split_options(op, matmul_bases, matmul_roles),
+                )
                 divs = [
                     CoreDivision(output_splits=dict(out), reduction_splits=dict(red))
-                    for out, red in _enum_split_options(op, matmul_bases, matmul_roles)
+                    for out, red in options
                 ]
             else:
                 divs = self._enumerate_core_divisions(op, max_cores)
@@ -1683,6 +1736,10 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             if op is None or buf.chosen_division is None:
                 continue
             cd = buf.core_divisions[buf.chosen_division]
+            _filter_forbidden_split_options(
+                op,
+                [(cd.output_splits, cd.reduction_splits)],
+            )
             op.op_it_space_splits = (
                 dict(cd.output_splits),
                 dict(cd.reduction_splits),

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -910,11 +910,13 @@ def _apply_user_hint(
     max_cores: int,
     blocked: set[Symbol] | None = None,
     pinned: dict[Symbol, int] | None = None,
+    forbidden: set[Symbol] | None = None,
 ) -> dict[Symbol, int]:
     """Apply splits in insertion order, pruning lower-priority overflows."""
     op_name = op.get_name()
     blocked = blocked or set()
     pinned = pinned or {}
+    forbidden = forbidden or set()
 
     splits: dict[Symbol, int] = {}
     cores_used = 1
@@ -940,6 +942,10 @@ def _apply_user_hint(
         if split > 1 and sym in blocked:
             raise Unsupported(
                 f"work_division_hint: {op_name} cannot split constrained dim {sym}."
+            )
+        if split > 1 and sym in forbidden:
+            raise Unsupported(
+                f"work_division_hint: {op_name} cannot split hard-forbidden dim {sym}."
             )
         if sym in pinned and split != pinned[sym]:
             raise Unsupported(
@@ -1260,6 +1266,7 @@ def work_distribution_pass(
                 max_cores,
                 blocked,
                 constraint_result.pinned,
+                constraint_result.forbidden,
             )
             dropped = {
                 s: v for s, v in committed_splits.items() if user_splits.get(s, 1) < v
@@ -1527,6 +1534,7 @@ def _cost_model_matmul_planner(
     committed_splits: dict[Symbol, int],
     max_cores: int,
     input_tds: list[TensorDep],
+    forbidden: set[Symbol] | None = None,
 ) -> dict[Symbol, int]:
     """Override the default split for a matmul / bmm with the lowest-cost
     feasible (b, m, n, k) per _matmul_split_cost.
@@ -1541,6 +1549,7 @@ def _cost_model_matmul_planner(
         return splits
     if committed_splits:
         return splits
+    forbidden = forbidden or set()
 
     # Classify the output coord dims: the stickified one is N, the rest index
     # rows. Of those row dims, M is the one appearing in a single input (the
@@ -1593,13 +1602,20 @@ def _cost_model_matmul_planner(
     B_total = math.prod(batch_sizes)
 
     b_combos = (
-        list(itertools.product(*([int(d) for d in divisors(s)] for s in batch_sizes)))
+        list(
+            itertools.product(
+                *(
+                    [1] if bd in forbidden else [int(d) for d in divisors(size)]
+                    for bd, size in zip(batch_dims, batch_sizes)
+                )
+            )
+        )
         if batch_dims
         else [()]
     )
-    m_divs = [int(d) for d in divisors(M_e)]
-    n_divs = [int(d) for d in divisors(n_sticks)]
-    k_divs = [int(d) for d in divisors(k_sticks)]
+    m_divs = [1] if m_dim in forbidden else [int(d) for d in divisors(M_e)]
+    n_divs = [1] if n_dim in forbidden else [int(d) for d in divisors(n_sticks)]
+    k_divs = [1] if k_dim in forbidden else [int(d) for d in divisors(k_sticks)]
 
     # For batchmatmulfp8 with QFP8WT kernels, do not split K
     if has_qfp8wt_tensor(input_tds + [output_td]):
@@ -1896,6 +1912,7 @@ def _cost_model_divide_op(op: ComputedBuffer, max_cores: int) -> bool:
         committed_splits,
         max_cores,
         input_tds,
+        constraint_result.forbidden,
     )
     if splits == default_splits:
         return False

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -65,6 +65,7 @@ from .pass_utils import (
 )
 from .propagate_hints import get_op_hints
 from .work_division_constraints import (
+    ConstraintResult,
     WorkDivConstraintContext,
     collect_work_division_constraints,
     has_qfp8wt_tensor,
@@ -761,6 +762,51 @@ def apply_splits(
     op.op_it_space_splits = splits_by_index_coeff(splits, write_index, read_index)
 
 
+def _work_division_constraint_context(
+    op: ComputedBuffer,
+    committed_splits: dict[Symbol, int] | None = None,
+) -> tuple[WorkDivConstraintContext, SymbolMeta]:
+    """Build the canonical constraint context for an op.
+
+    Work division and later phases that may replace its decision must derive
+    constraints from the same tensor dependencies and stick-adjusted iteration
+    space. Keeping that setup here prevents the scratchpad co-optimizer from
+    accidentally using a weaker interpretation.
+    """
+    it_space = iteration_space_from_op(op)
+    input_tds, output_td = collect_tensor_deps(
+        op, get_mem_deps_from_rw(op_read_writes(op))
+    )
+    all_tds = input_tds + [output_td]
+    symbol_meta = _collect_symbol_metadata(it_space)
+    it_space_adjusted, stick_vars = adjust_it_space_for_sticks(
+        it_space, all_tds, symbol_meta
+    )
+    coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
+    reduction_vars = [v for v in it_space_adjusted if v not in coord_vars]
+    return (
+        WorkDivConstraintContext(
+            op=op,
+            it_space=it_space,
+            it_space_adjusted=it_space_adjusted,
+            output_td=output_td,
+            input_tds=input_tds,
+            stick_vars=stick_vars,
+            reduction_vars=reduction_vars,
+            committed_splits=committed_splits or {},
+        ),
+        symbol_meta,
+    )
+
+
+def collect_op_work_division_constraints(
+    op: ComputedBuffer,
+) -> ConstraintResult:
+    """Collect constraints for a later phase that may replace work division."""
+    ctx, _ = _work_division_constraint_context(op)
+    return collect_work_division_constraints(ctx)
+
+
 def enumerate_work_division_candidates(
     op: ComputedBuffer,
     max_cores: int,
@@ -781,41 +827,22 @@ def enumerate_work_division_candidates(
     # TODO: Enumerate compute bound ops and for seeds or compute optimized
     # work division where HBM bandwidth can saturate compute.
 
-    it_space = iteration_space_from_op(op)
-    op_is_topk = is_topk(op)
-
-    input_tds, output_td = collect_tensor_deps(
-        op, get_mem_deps_from_rw(op_read_writes(op))
-    )
+    constraint_ctx, symbol_meta = _work_division_constraint_context(op)
+    it_space = constraint_ctx.it_space
+    it_space_adjusted = constraint_ctx.it_space_adjusted
+    input_tds = constraint_ctx.input_tds
+    output_td = constraint_ctx.output_td
+    stick_vars = constraint_ctx.stick_vars
+    reduction_vars = constraint_ctx.reduction_vars
     all_tds = input_tds + [output_td]
-
-    symbol_meta = _collect_symbol_metadata(it_space)
-    it_space_adjusted, stick_vars = adjust_it_space_for_sticks(
-        it_space, all_tds, symbol_meta
-    )
-
-    # Reduction (K) dims are the iteration vars absent from the output tensor's
-    # device coordinates (mirrors prioritize_dimensions / splits_by_index_coeff).
-    coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
-    reduction_vars = [v for v in it_space_adjusted if v not in coord_vars]
+    op_is_topk = is_topk(op)
 
     topk_k_sym = None
     if op_is_topk:
         output_dims, _ = prioritize_dimensions(output_td, it_space_adjusted)
         topk_k_sym = _find_topk_k_symbol(output_dims, input_tds)
 
-    constraint_result = collect_work_division_constraints(
-        WorkDivConstraintContext(
-            op=op,
-            it_space=it_space,
-            it_space_adjusted=it_space_adjusted,
-            output_td=output_td,
-            input_tds=input_tds,
-            stick_vars=stick_vars,
-            reduction_vars=reduction_vars,
-            committed_splits={},
-        )
-    )
+    constraint_result = collect_work_division_constraints(constraint_ctx)
     blocked = constraint_result.blocked
     pinned = constraint_result.pinned
     forbidden = constraint_result.forbidden
@@ -851,7 +878,7 @@ def enumerate_work_division_candidates(
             splits[v] > 1 for v in blocked
         ):
             return False
-        if any(  # a shared-table data dim must never be split (hard-forbidden)
+        if any(  # a hard-forbidden dim must never be split
             splits[v] > 1 for v in forbidden
         ):
             return False

--- a/torch_spyre/_inductor/work_division_constraints.py
+++ b/torch_spyre/_inductor/work_division_constraints.py
@@ -136,6 +136,19 @@ def collect_work_division_constraints(
         forbidden |= result.forbidden
         force_output |= result.force_output
 
+        committed_forbidden = {
+            sym: ctx.committed_splits[sym]
+            for sym in result.forbidden
+            if ctx.committed_splits.get(sym, 1) > 1
+        }
+        if committed_forbidden:
+            raise Unsupported(
+                f"{ctx.op.get_name()}: hard-forbidden split(s) "
+                f"{[(str(sym), split) for sym, split in committed_forbidden.items()]} "
+                f"from {constraint.__name__} conflict with an earlier "
+                f"work-division commitment."
+            )
+
         for sym, split in result.pinned.items():
             committed_split = ctx.committed_splits.get(sym)
             if committed_split is not None and committed_split != split:


### PR DESCRIPTION
## Summary

- Enforce hard-forbidden work-division dimensions in named hints and the matmul cost model.
- Reject conflicts with an earlier committed split.
- Centralize constraint collection so later planning phases use the same interpretation.
- Filter pruned scratchpad core-division candidates and revalidate the selected candidate before commit.

## Why

Hard-forbidden dimensions are correctness constraints, not planner preferences. They were already used for indirect-access layouts, but some decision paths could still split them, and the pruned scratchpad co-optimizer could replace an earlier safe decision.

This is generic infrastructure for the matmul ownership fix that follows.

## Stack

1. This PR
2. #4026
3. #4027

Each follow-up is stacked on the preceding branch. They target `main`, so their displayed diffs will shrink as prerequisites merge.

Supersedes the work-division portion of #3953.

## Validation

- `tests/inductor/test_work_division.py`
- `tests/inductor/test_work_division_hint.py`
- 61 passed, 2 expected xfails
- Pre-commit checks on the full PR diff