### PR TITLE
fix(inductor): preserve batched matmul layout ownership

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -68,6 +68,7 @@ from torch_spyre._inductor.codegen.superdsc import (
     parse_op_spec,
 )
 from torch_spyre._inductor.constants import (
+    MATMUL_NO_BATCH_SPLIT_ATTR,
     SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY,
     SHARED_WEIGHT_UNIT_BMM_INFO_KEY,
 )
@@ -7184,6 +7185,16 @@ class TestCopyOpMetadataAttrCoverage(unittest.TestCase):
         dst = SimpleNamespace()
         copy_op_metadata(src, dst)
         self.assertFalse(hasattr(dst, "_coarse_tile_dim_advance"))
+
+    def test_copy_op_metadata_preserves_matmul_no_batch_split_contract(self):
+        batch = Symbol("batch")
+        src = SimpleNamespace()
+        setattr(src, MATMUL_NO_BATCH_SPLIT_ATTR, frozenset({batch}))
+        dst = SimpleNamespace()
+
+        copy_op_metadata(src, dst)
+
+        self.assertEqual(getattr(dst, MATMUL_NO_BATCH_SPLIT_ATTR), frozenset({batch}))
 
 
 class TestCoeffThroughFloor(unittest.TestCase):

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -168,6 +168,7 @@ def test_planner_and_sdsc_use_the_same_mapping(monkeypatch, op, reduction_contig
     assert representable
     assert dict(planner_view.core_to_slot) == sdsc_output_mapping
 
+
 @pytest.mark.parametrize(
     "mixed_coord",
     [

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -201,7 +201,7 @@ def test_matmul_layout_normalization_rejects_mixed_axis_roles(mixed_coord):
     )
 
 
-def test_matmul_layout_normalization_keeps_outer_stick_tile_innermost():
+def test_matmul_layout_normalization_moves_batch_before_outer_stick_tile():
     batch, row, k = sympy.symbols("batch row k")
     layout = pass_utils_module.SpyreTensorLayout(
         [64, 2, 16, 64],
@@ -217,5 +217,23 @@ def test_matmul_layout_normalization_keeps_outer_stick_tile_innermost():
     )
 
     assert normalized is not None
-    assert list(normalized.device_size) == [16, 64, 2, 64]
-    assert list(normalized.stride_map) == [8192, 128, 64, 1]
+    assert list(normalized.device_size) == [64, 16, 2, 64]
+    assert list(normalized.stride_map) == [128, 8192, 64, 1]
+
+
+def test_matmul_layout_normalization_leaves_unbatched_axes_unchanged():
+    row, k = sympy.symbols("row k")
+    layout = pass_utils_module.SpyreTensorLayout(
+        [2, 64, 64],
+        [64, 128, 1],
+        DataFormats.SEN169_FP16,
+    )
+
+    normalized = pass_utils_module.normalize_matmul_input_layout(
+        layout,
+        [sympy.floor(k / 64), row, sympy.Mod(k, 64)],
+        k,
+        set(),
+    )
+
+    assert normalized is layout

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -167,3 +167,55 @@ def test_planner_and_sdsc_use_the_same_mapping(monkeypatch, op, reduction_contig
     }
     assert representable
     assert dict(planner_view.core_to_slot) == sdsc_output_mapping
+
+@pytest.mark.parametrize(
+    "mixed_coord",
+    [
+        lambda batch, k_tile: 8 * batch + k_tile,
+        lambda batch, k_tile: 16 * k_tile + batch,
+    ],
+    ids=["batch-major", "stick-major"],
+)
+def test_matmul_layout_normalization_rejects_mixed_axis_roles(mixed_coord):
+    """Symbol sets alone cannot prove ownership order within a physical axis."""
+    batch, k_tile = sympy.symbols("batch k_tile")
+    layout = pass_utils_module.SpyreTensorLayout(
+        [16, 8, 64],
+        [512, 64, 1],
+        DataFormats.SEN169_FP16,
+    )
+    device_coords = [
+        mixed_coord(batch, k_tile),
+        batch,
+        sympy.Mod(k_tile, 64),
+    ]
+
+    assert (
+        pass_utils_module.normalize_matmul_input_layout(
+            layout,
+            device_coords,
+            k_tile,
+            {batch},
+        )
+        is None
+    )
+
+
+def test_matmul_layout_normalization_keeps_outer_stick_tile_innermost():
+    batch, row, k = sympy.symbols("batch row k")
+    layout = pass_utils_module.SpyreTensorLayout(
+        [64, 2, 16, 64],
+        [128, 64, 8192, 1],
+        DataFormats.SEN169_FP16,
+    )
+
+    normalized = pass_utils_module.normalize_matmul_input_layout(
+        layout,
+        [row, sympy.floor(k / 64), batch, sympy.Mod(k, 64)],
+        k,
+        {batch},
+    )
+
+    assert normalized is not None
+    assert list(normalized.device_size) == [16, 64, 2, 64]
+    assert list(normalized.stride_map) == [8192, 128, 64, 1]

--- a/tests/inductor/test_padding.py
+++ b/tests/inductor/test_padding.py
@@ -183,7 +183,19 @@ class TestInsertPaddingIR(unittest.TestCase):
         return [op for op in ops if isinstance(op, SpyreConstantFallback)]
 
     def _assert_constant_pad_nd_ops(self, ops: list[Operation]) -> None:
-        """Assert the constant_pad_nd 4-op pattern."""
+        """Assert the constant_pad_nd 4-op pattern.
+
+        Layout propagation may insert ownership-normalizing restickifies before
+        the matmul alongside the padding sequence.  Restrict this structural
+        assertion to operations originating from the pad node so those required
+        input-layout copies do not look like extra padding operations.
+        """
+
+        padded_buf_op = next(iter(self._padded_buf_ops(ops)), None)
+        self.assertIsNotNone(padded_buf_op, "Expected 1 output buffer")
+        assert padded_buf_op is not None
+        pad_origin = padded_buf_op.origin_node
+        ops = [op for op in ops if pad_origin in op.origins]
 
         # Expected 4 operations (all with FixedTiledLayout):
         # 1. ComputedBuffer: output buffer allocation
@@ -230,8 +242,11 @@ class TestInsertPaddingIR(unittest.TestCase):
             "One mutation op should read from constant buffer",
         )
         self.assertTrue(
-            any("arg" in name for op in mutation_ops for name in op.get_read_names()),
-            "One mutation op should read from input buffer",
+            any(
+                op.get_read_names() and constant_op.name not in op.get_read_names()
+                for op in mutation_ops
+            ),
+            "One mutation op should read from the source tensor",
         )
 
     # ------------------------------------------------------------------
@@ -697,9 +712,8 @@ class TestInsertPaddingIR(unittest.TestCase):
         reduction = mm.data
         assert isinstance(reduction, Reduction)
         self.assertEqual(int(reduction.reduction_ranges[0]), K)
-        # ops_before contains a restickify op for x in addition to the 4-op
-        # padding sequence for y, so _assert_constant_pad_nd_ops (which expects
-        # exactly 4 ops) cannot be used here.  Correctness is verified by assert_close.
+        ops_before = self._ops_before(ops, mm)
+        self._assert_constant_pad_nd_ops(ops_before)
         torch.testing.assert_close(fn(x_cpu, y_cpu), result.cpu(), atol=0.1, rtol=0.1)
 
 

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -564,6 +564,33 @@ def test_bmm_xt_yt(bmm_tensors_ab_ba):
     _compare(lambda x, y: torch.matmul(x.transpose(1, 2), y.transpose(1, 2)), x, y)
 
 
+def test_bmm_x_restickifies_interleaved_tiles_with_broadcast_batch():
+    """The lhs K tiles must remain adjacent to K even when rhs broadcasts H.
+
+    Decode SDPA's value matmul has x=[B,H,M,K] and y=[B,1,K,N].  The rhs does
+    not carry H, but H is still a batch axis of the output and must precede x's
+    K tiles.  The input layout below is K-stick-compatible while physically
+    nesting H after K_outer, so it requires a relayout before batchmatmul.
+    """
+    # SDPA pads its single query row to a 64-row block. Keep M=64 so the
+    # relayout exchanges M and H ownership across the BMM core split.
+    batch, heads, m, k, n = 1, 16, 64, 128, 512
+    x = torch.randn((batch, heads, m, k), dtype=torch.float16) * 0.1
+    y = torch.randn((batch, 1, k, n), dtype=torch.float16) * 0.1
+    x_layout = SpyreTensorLayout(
+        list(x.size()), list(x.stride()), x.dtype, [1, 0, 2, 3]
+    )
+    assert list(x_layout.device_size) == [1, m, 2, heads, 64]
+
+    _compare(
+        torch.matmul,
+        x,
+        y,
+        device_args=[x.to(device_layout=x_layout), y.to(DEVICE)],
+        optimal_cost=x.numel() + y.numel(),
+    )
+
+
 # ------- FallbackKernel + restickify regression test ---------
 
 

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -587,7 +587,7 @@ def test_bmm_x_restickifies_interleaved_tiles_with_broadcast_batch():
         x,
         y,
         device_args=[x.to(device_layout=x_layout), y.to(DEVICE)],
-        optimal_cost=x.numel() + y.numel(),
+        optimal_cost=x.numel(),
     )
 
 

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -1342,19 +1342,19 @@ def _is_restickify_op(op) -> bool:
 
 
 def _restickify_readers_by_source(fn, *args):
-    """Run fn on Spyre and return {producer_name: [restickify buffer names]},
-    a map of every source buffer to the restickify ops that read it, captured
-    from graph.operations right after insert_restickify splices them in."""
+    """Capture restickify readers and their FX metadata after insertion."""
     import torch_spyre._inductor.passes as _passes
 
     insert_restickify = _passes.insert_restickify
     by_source: dict[str, list[str]] = {}
+    fx_metas = []
 
     def capturing_insert_restickify(graph):
         insert_restickify(graph)
         for op in graph.operations:
             if not _is_restickify_op(op):
                 continue
+            fx_metas.append(next(iter(op.origins)).meta)
             for read in op.get_read_writes().reads:
                 name = getattr(read, "name", None)
                 if name is not None:
@@ -1362,21 +1362,22 @@ def _restickify_readers_by_source(fn, *args):
 
     with patch.object(_passes, "insert_restickify", capturing_insert_restickify):
         _compile_and_run(fn, args, DEVICE)
-    return by_source
+    return by_source, fx_metas
 
 
-def test_shared_producer_gets_two_restickify_nodes():
+def test_shared_producer_gets_two_restickify_nodes_with_fx_metadata():
     """insert_restickify keys its plan by consumer, not by source, so a producer
     that fans out to two consumers each wanting a different layout gets a
     *separate* restickify node per consumer -- both reading the one producer.
-    We assert the two-node shape directly rather than via the fusion log."""
+    The inserted nodes must retain tensor metadata needed by later IR passes."""
     (x, za, zb), fn = _shared_producer_two_restickify_case()
-    by_source = _restickify_readers_by_source(fn, x, za, zb)
+    by_source, fx_metas = _restickify_readers_by_source(fn, x, za, zb)
     shared = [src for src, readers in by_source.items() if len(readers) >= 2]
     assert shared, (
         "expected one producer read by >=2 restickify nodes, got "
         f"{ {s: r for s, r in by_source.items()} }"
     )
+    assert fx_metas and all("val" in meta for meta in fx_metas)
 
 
 # ------- Restickify padding: strict (distinct values + torch.equal) ---------

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -564,6 +564,33 @@ def test_bmm_xt_yt(bmm_tensors_ab_ba):
     _compare(lambda x, y: torch.matmul(x.transpose(1, 2), y.transpose(1, 2)), x, y)
 
 
+def test_bmm_shared_batch_does_not_reorder_outer_stick_tiles():
+    """A batch axis carried by both operands does not need canonicalization."""
+    batch, m, k, n = 4, 1, 128, 128
+    x = torch.randn((batch, m, k), dtype=torch.float16) * 0.1
+    y = torch.randn((batch, k, n), dtype=torch.float16) * 0.1
+
+    _compare(torch.matmul, x, y, optimal_cost=0)
+
+
+def test_bmm_shared_batch_with_sufficient_output_work_avoids_copy():
+    """M/N work that fills every core makes outer-tile order irrelevant."""
+    batch, m, k, n = 4, 64, 128, 256
+    x = torch.randn((batch, m, k), dtype=torch.float16) * 0.1
+    y = torch.randn((batch, k, n), dtype=torch.float16) * 0.1
+
+    _compare(torch.matmul, x, y, optimal_cost=0)
+
+
+def test_bmm_shared_batch_with_exposed_unequal_tiles_reorders():
+    """Decode-like BMMs need canonical ownership when K/N tile counts differ."""
+    batch, m, k, n = 4, 1, 128, 256
+    x = torch.randn((batch, m, k), dtype=torch.float16) * 0.1
+    y = torch.randn((batch, k, n), dtype=torch.float16) * 0.1
+
+    _compare(torch.matmul, x, y, optimal_cost=x.numel() + y.numel())
+
+
 def test_bmm_x_restickifies_interleaved_tiles_with_broadcast_batch():
     """The lhs K tiles must remain adjacent to K even when rhs broadcasts H.
 

--- a/tests/inductor/test_work_division.py
+++ b/tests/inductor/test_work_division.py
@@ -23,7 +23,10 @@ from torch._inductor.dependencies import MemoryDep
 from torch._inductor.ir import ComputedBuffer, FlexibleLayout, Pointwise, Reduction
 
 from torch_spyre._C import ElementArrangement, SpyreTensorLayout
-from torch_spyre._inductor.constants import BATCH_MATMUL_OP
+from torch_spyre._inductor.constants import (
+    BATCH_MATMUL_OP,
+    MATMUL_NO_BATCH_SPLIT_ATTR,
+)
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.ir import FixedTiledLayout
 from torch_spyre._inductor.work_division import (
@@ -40,6 +43,7 @@ from torch_spyre._inductor.work_division_constraints import (
     conv_spatial_blocked_vars,
     coordinate_mask_blocked_vars,
     indirect_access_constraints,
+    matmul_ownership_forbidden_split_vars,
     qfp8wt_matmul_k_pinned,
     qfp8wt_pinned_vars,
 )
@@ -200,6 +204,52 @@ class TestCoordinateMaskBlockedVars(unittest.TestCase):
         )
         result = coordinate_mask_blocked_vars(ctx)
         self.assertEqual(result.blocked, set())
+
+
+class TestMatmulOwnershipForbiddenSplitVars(unittest.TestCase):
+    _PLACEHOLDER_TD = _tensor_dep("matmul_placeholder", (4,), (_isym("_placeholder"),))
+
+    def test_marked_batch_var_is_hard_forbidden(self):
+        batch = _isym("batch")
+        op = _computed_buffer((4,), name="matmul_out")
+        setattr(op, MATMUL_NO_BATCH_SPLIT_ATTR, frozenset({batch}))
+        ctx = _make_context(
+            op,
+            self._PLACEHOLDER_TD,
+            it_space={batch: 4},
+        )
+
+        result = matmul_ownership_forbidden_split_vars(ctx)
+
+        self.assertEqual(result.forbidden, {batch})
+
+    def test_missing_marked_batch_var_raises(self):
+        batch = _isym("batch")
+        other = _isym("other")
+        op = _computed_buffer((4,), name="matmul_out")
+        setattr(op, MATMUL_NO_BATCH_SPLIT_ATTR, frozenset({batch}))
+        ctx = _make_context(
+            op,
+            self._PLACEHOLDER_TD,
+            it_space={other: 4},
+        )
+
+        with self.assertRaisesRegex(Unsupported, "no longer present"):
+            matmul_ownership_forbidden_split_vars(ctx)
+
+    def test_committed_split_on_marked_batch_var_raises(self):
+        batch = _isym("batch")
+        op = _computed_buffer((4,), name="matmul_out")
+        setattr(op, MATMUL_NO_BATCH_SPLIT_ATTR, frozenset({batch}))
+        ctx = _make_context(
+            op,
+            self._PLACEHOLDER_TD,
+            it_space={batch: 4},
+            committed_splits={batch: 2},
+        )
+
+        with self.assertRaisesRegex(Unsupported, "hard-forbidden split"):
+            collect_work_division_constraints(ctx)
 
 
 class TestHardForbiddenSplits(unittest.TestCase):

--- a/tests/inductor/test_work_division.py
+++ b/tests/inductor/test_work_division.py
@@ -215,9 +215,12 @@ class TestHardForbiddenSplits(unittest.TestCase):
             committed_splits={batch: 2},
         )
 
+        def forbidden_constraint(_ctx):
+            return ConstraintResult(forbidden={batch})
+
         with patch(
             "torch_spyre._inductor.work_division_constraints.indirect_access_constraints",
-            return_value=ConstraintResult(forbidden={batch}),
+            new=forbidden_constraint,
         ):
             with self.assertRaisesRegex(Unsupported, "hard-forbidden split"):
                 collect_work_division_constraints(ctx)
@@ -260,6 +263,127 @@ class TestHardForbiddenSplits(unittest.TestCase):
 
         self.assertGreater(unrestricted[batch], 1)
         self.assertEqual(restricted[batch], 1)
+
+
+class TestPrunedScratchpadWorkDivisionConstraints(unittest.TestCase):
+    _ALLOCATOR_TARGET = "torch_spyre._inductor.scratchpad.allocator"
+
+    def _case(self):
+        from torch_spyre._inductor.scratchpad.allocator import CoOptimizingAllocator
+
+        batch, m = _isym("batch"), _isym("m")
+        op = _computed_buffer((4, 64), name="constrained_out")
+
+        # write = 64 * batch + m. The safe seed splits only M; the synthesized
+        # alternative uses the same M split and additionally splits batch.
+        safe = ({1: 8}, {})
+        unsafe = ({64: 4, 1: 8}, {})
+        op.op_it_space_splits = safe
+        rw = MagicMock()
+        rw.writes = [MagicMock(index=64 * batch + m)]
+        rw.reads = []
+
+        graph = MagicMock()
+        graph.operations = [op]
+        allocator = CoOptimizingAllocator(
+            layout_planning=MagicMock(),
+            size=1 << 20,
+            prune=True,
+        )
+        return allocator, graph, op, rw, batch, m, safe, unsafe
+
+    def _patch_candidate_context(self, op, rw, batch, m, unsafe):
+        def constraints(candidate_op):
+            self.assertIs(candidate_op, op)
+            return ConstraintResult(forbidden={batch})
+
+        return (
+            patch(
+                f"{self._ALLOCATOR_TARGET}.ops_in_offset_mutation_component",
+                return_value=set(),
+            ),
+            patch(
+                f"{self._ALLOCATOR_TARGET}._find_distinct_matmul_splits",
+                return_value=((), ()),
+            ),
+            patch(
+                f"{self._ALLOCATOR_TARGET}._enum_split_options",
+                return_value=[op.op_it_space_splits, unsafe],
+            ),
+            patch(
+                f"{self._ALLOCATOR_TARGET}.collect_op_work_division_constraints",
+                side_effect=constraints,
+            ),
+            patch(
+                f"{self._ALLOCATOR_TARGET}.op_read_writes",
+                return_value=rw,
+            ),
+            patch(
+                f"{self._ALLOCATOR_TARGET}.iteration_space_from_op",
+                return_value={batch: 4, m: 64},
+            ),
+        )
+
+    def test_pruned_candidates_and_commit_keep_forbidden_dim_unsplit(self):
+        from torch_spyre._inductor.pass_utils import apply_splits_from_index_coeff
+        from torch_spyre._inductor.scratchpad.plan_solver import CoreDivisionBuffer
+
+        allocator, graph, op, rw, batch, m, safe, unsafe = self._case()
+        with ExitStack() as stack:
+            for ctx in self._patch_candidate_context(op, rw, batch, m, unsafe):
+                stack.enter_context(ctx)
+
+            divisions = allocator._division_map(graph)[op.name]
+            self.assertEqual(
+                [(cd.output_splits, cd.reduction_splits) for cd in divisions],
+                [safe],
+            )
+
+            allocation = [
+                CoreDivisionBuffer(
+                    name=op.name,
+                    size=128,
+                    uses=[0],
+                    core_divisions=divisions,
+                    chosen_division=0,
+                )
+            ]
+            allocator._commit_divisions(graph, allocation)
+
+        per_sym = apply_splits_from_index_coeff(
+            op.op_it_space_splits,
+            rw.writes[0].index,
+            rw.writes[0].index,
+            {batch: 4, m: 64},
+        )
+        self.assertEqual(per_sym[batch], 1)
+
+    def test_commit_rejects_hard_forbidden_split_as_backstop(self):
+        from torch_spyre._inductor.scratchpad.plan_solver import (
+            CoreDivision,
+            CoreDivisionBuffer,
+        )
+
+        allocator, graph, op, rw, batch, m, _, unsafe = self._case()
+        allocation = [
+            CoreDivisionBuffer(
+                name=op.name,
+                size=128,
+                uses=[0],
+                core_divisions=[
+                    CoreDivision(
+                        output_splits=dict(unsafe[0]),
+                        reduction_splits=dict(unsafe[1]),
+                    )
+                ],
+                chosen_division=0,
+            )
+        ]
+        with ExitStack() as stack:
+            for ctx in self._patch_candidate_context(op, rw, batch, m, unsafe):
+                stack.enter_context(ctx)
+            with self.assertRaisesRegex(Unsupported, "hard-forbidden dim"):
+                allocator._commit_divisions(graph, allocation)
 
 
 class TestConvSpatialBlockedVars(unittest.TestCase):

--- a/tests/inductor/test_work_division.py
+++ b/tests/inductor/test_work_division.py
@@ -23,10 +23,12 @@ from torch._inductor.dependencies import MemoryDep
 from torch._inductor.ir import ComputedBuffer, FlexibleLayout, Pointwise, Reduction
 
 from torch_spyre._C import ElementArrangement, SpyreTensorLayout
+from torch_spyre._inductor.constants import BATCH_MATMUL_OP
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.ir import FixedTiledLayout
 from torch_spyre._inductor.work_division import (
     TensorDep,
+    _cost_model_matmul_planner,
     _default_split,
     multi_dim_iteration_space_split,
     span_reduction_pass,
@@ -198,6 +200,66 @@ class TestCoordinateMaskBlockedVars(unittest.TestCase):
         )
         result = coordinate_mask_blocked_vars(ctx)
         self.assertEqual(result.blocked, set())
+
+
+class TestHardForbiddenSplits(unittest.TestCase):
+    _PLACEHOLDER_TD = _tensor_dep("placeholder", (4,), (_isym("_placeholder"),))
+
+    def test_committed_hard_forbidden_split_raises(self):
+        batch = _isym("batch")
+        op = _computed_buffer((4,), name="constrained_out")
+        ctx = _make_context(
+            op,
+            self._PLACEHOLDER_TD,
+            it_space={batch: 4},
+            committed_splits={batch: 2},
+        )
+
+        with patch(
+            "torch_spyre._inductor.work_division_constraints.indirect_access_constraints",
+            return_value=ConstraintResult(forbidden={batch}),
+        ):
+            with self.assertRaisesRegex(Unsupported, "hard-forbidden split"):
+                collect_work_division_constraints(ctx)
+
+    def test_cost_model_keeps_forbidden_batch_unsplit(self):
+        batch, m, n, k = (_isym(name) for name in ("batch", "m", "n", "k"))
+        op = _computed_buffer(
+            (4, 64, 256),
+            name="matmul_out",
+            reduction_type=BATCH_MATMUL_OP,
+            reduction_ranges=(128,),
+        )
+        output_td = _tensor_dep("matmul_out", (4, 64, 256), (batch, m, n))
+        input_tds = [
+            _tensor_dep("lhs", (4, 64, 128), (batch, m, k)),
+            _tensor_dep("rhs", (4, 128, 256), (batch, k, n)),
+        ]
+        it_space_adjusted = {batch: 4, m: 64, n: 4, k: 2}
+        initial_splits = {sym: 1 for sym in it_space_adjusted}
+
+        def prefer_batch_split(batch_cost_arg, *_args, **_kwargs):
+            return 0 if batch_cost_arg[1] > 1 else 1
+
+        planner_args = (
+            op,
+            initial_splits,
+            it_space_adjusted,
+            output_td,
+            {n: 64, k: 64},
+            {},
+            32,
+            input_tds,
+        )
+        with patch(
+            "torch_spyre._inductor.work_division._matmul_split_cost",
+            side_effect=prefer_batch_split,
+        ):
+            unrestricted = _cost_model_matmul_planner(*planner_args)
+            restricted = _cost_model_matmul_planner(*planner_args, forbidden={batch})
+
+        self.assertGreater(unrestricted[batch], 1)
+        self.assertEqual(restricted[batch], 1)
 
 
 class TestConvSpatialBlockedVars(unittest.TestCase):

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -255,6 +255,20 @@ class TestNamedWorkDivisionHint(InductorTestCase):
                 pinned={m: 1},
             )
 
+    def test_apply_work_div_hint_rejects_hard_forbidden_split(self):
+        batch = Symbol("batch")
+        op = self._fake_op({batch: ["batch"]})
+
+        with self.assertRaisesRegex(Exception, "hard-forbidden dim"):
+            _wd._apply_user_hint(
+                op,
+                {batch: 2},
+                {batch: 4},
+                self._fake_output_td([batch]),
+                max_cores=32,
+                forbidden={batch},
+            )
+
     @config.patch({"sencores": 8})
     def test_pointwise_work_div_hint_applied(self):
         M, N = 128, 64

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -50,7 +50,10 @@ from torch_spyre._inductor.scratchpad.lx_relayout import (
 )
 from torch_spyre._inductor.op_spec import OpSpec, TensorArg, TensorWorkDivision
 from torch_spyre._inductor.pass_utils import PerCoreView
-from torch_spyre._inductor.scratchpad.allocator import ScratchpadAllocator
+from torch_spyre._inductor.scratchpad.allocator import (
+    ScratchpadAllocator,
+    _is_outer_layout_restickify,
+)
 from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
 from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
 from torch_spyre._inductor.spyre_kernel import _remap_work_division, simplify_op_spec
@@ -830,6 +833,51 @@ def test_lx_relayout_consumers_share_destination_view(second_consumer):
     if not shares_destination:
         expected_destinations.add("sympify('c0'): 8")
     assert {pair[1] for pair in divisions} == expected_destinations
+
+
+@pytest.mark.parametrize(
+    "output_stick_stride,expected",
+    [(1, True), (128, False)],
+    ids=["outer-layout", "different-stick"],
+)
+def test_outer_layout_restickify_requires_global_addressing(
+    output_stick_stride, expected
+):
+    input_stl = SimpleNamespace(
+        device_size=[64, 2, 16, 64],
+        stride_map=[128, 64, 8192, 1],
+    )
+    output_stl = SimpleNamespace(
+        device_size=[16, 64, 2, 64],
+        stride_map=[8192, 128, 64, output_stick_stride],
+    )
+    input_layout = SimpleNamespace(device_layout=input_stl)
+    output_layout = SimpleNamespace(device_layout=output_stl)
+    read = SimpleNamespace(name="source")
+    op = SimpleNamespace(get_layout=lambda: output_layout)
+    graph = SimpleNamespace(
+        get_buffer=lambda _name: SimpleNamespace(get_layout=lambda: input_layout)
+    )
+
+    with (
+        mock_patch(
+            "torch_spyre._inductor.scratchpad.allocator.op_short_name",
+            return_value="restickify",
+        ),
+        mock_patch(
+            "torch_spyre._inductor.scratchpad.allocator.op_read_writes",
+            return_value=SimpleNamespace(reads=[read]),
+        ),
+        mock_patch(
+            "torch_spyre._inductor.scratchpad.allocator.FixedTiledLayout",
+            SimpleNamespace,
+        ),
+        mock_patch(
+            "torch_spyre._inductor.scratchpad.allocator.MemoryDep",
+            SimpleNamespace,
+        ),
+    ):
+        assert _is_outer_layout_restickify(graph, op) is expected
 
 
 def test_lx_relayout_allocation_is_atomic_in_one_greedy_solve(caplog):

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -118,6 +118,11 @@ ELIDED_COPY_BACK_ATTR = "_spyre_writes_copy_back_target"
 SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY = "_spyre_shared_weight_unit_bmm"
 SHARED_WEIGHT_UNIT_BMM_INFO_KEY = "shared_weight_unit_bmm"
 
+# Set of matmul output batch symbols whose physical input layouts are safe only
+# while those dimensions remain unsplit across cores. Layout propagation stamps
+# this on the ComputedBuffer and work division enforces it as a hard constraint.
+MATMUL_NO_BATCH_SPLIT_ATTR = "_spyre_matmul_no_batch_split_vars"
+
 
 SEGMENT_OFFSETS = [
     0x0,

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -158,6 +158,12 @@ def _create_restickify_node(
         restick_fx_node = fx_graph.create_node(
             "call_function", torch.ops.spyre.restickify.default, (fx_arg_node,)
         )
+    # Restickify changes only the physical device layout.  Its logical tensor
+    # metadata (shape, dtype, stride, and any custom hints) is identical to the
+    # source node's.  Later IR passes such as BMM padding inspect ``meta["val"]``
+    # on the restickify origin, so preserve the complete FX metadata before
+    # lowering the new node.
+    restick_fx_node.meta.update(fx_arg_node.meta)
     # Lower the FX node; run_node registers the output in graph.buffers and graph.operations.
     restick_tb = graph_lowering.run_node(restick_fx_node)
     restick_buff = restick_tb.data.data  # TensorBox -> StorageBox -> ComputedBuffer

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -25,6 +25,8 @@ from typing import TYPE_CHECKING, Literal
 
 import sympy
 
+from .constants import MATMUL_NO_BATCH_SPLIT_ATTR
+
 if TYPE_CHECKING:
     from torch._inductor.dependencies import MemoryDep
     from torch._inductor.ir import ComputedBuffer
@@ -304,6 +306,7 @@ _SPYRE_METADATA_ATTRS = (
     "dim_hints",
     "work_div_loop_info",
     "loop_info",
+    MATMUL_NO_BATCH_SPLIT_ATTR,
     "_restickify_plan",
     "_input_layout_overrides",
     "_emit_set_layout",

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1538,6 +1538,77 @@ def compute_restickify_target_layout(
     return SpyreTensorLayout(device_size, stride_map, stl.device_dtype)
 
 
+def normalize_matmul_input_layout(
+    stl: SpyreTensorLayout,
+    device_coords: list[sympy.Expr],
+    stick_var: sympy.Symbol,
+    batch_vars: set[sympy.Symbol],
+) -> SpyreTensorLayout:
+    """Keep a matmul stick variable's outer tiles physically next to its stick.
+
+    Matmul kernels consume the outer tiles of their stick dimension as one
+    contiguous ownership block.  Merely putting ``stick_var`` on the inner
+    stick is insufficient: a non-unit batch axis between an outer stick tile
+    and the inner stick changes which core owns each tile.
+
+    Unit axes do not affect physical ownership, so leave their positions alone
+    and stable-sort only non-unit outer axes.  This avoids manufacturing distinct
+    layouts for harmless padding axes.
+    """
+    assert len(device_coords) == len(stl.device_size)
+    if stick_var not in device_coords[-1].free_symbols:
+        return stl
+
+    device_size = list(stl.device_size)
+    stride_map = list(stl.stride_map)
+    physical_axes = [axis for axis, size in enumerate(device_size[:-1]) if size > 1]
+
+    def matmul_axis_role(axis: int) -> int:
+        axis_vars = device_coords[axis].free_symbols
+        if axis_vars & batch_vars:
+            return 0
+        if stick_var in axis_vars:
+            return 1
+        return 2
+
+    ordered_axes = sorted(
+        physical_axes,
+        key=matmul_axis_role,
+    )
+    if ordered_axes == physical_axes:
+        return stl
+
+    old_size = list(device_size)
+    old_stride = list(stride_map)
+    for destination, source in zip(physical_axes, ordered_axes):
+        device_size[destination] = old_size[source]
+        stride_map[destination] = old_stride[source]
+    return SpyreTensorLayout(
+        device_size,
+        stride_map,
+        stl.device_dtype,
+        stl.element_arrangement,
+    )
+
+
+def matmul_batch_vars(op: ComputedBuffer) -> set[sympy.Symbol]:
+    """Return variables carried by the matmul output's leading batch axes.
+
+    A batch axis may be broadcast by either input, so intersecting both input
+    dependencies loses precisely the GQA/value-matmul case where the rhs has a
+    unit head dimension. Matmul's output contract identifies batch axes
+    unambiguously: every logical dimension before M and N.
+    """
+    write_deps = [
+        dep for dep in op_read_writes(op).writes if isinstance(dep, MemoryDep)
+    ]
+    if not write_deps:
+        return set()
+
+    output_coords = host_coordinates(op.layout, write_deps[0], None)
+    return set().union(*(coord.free_symbols for coord in output_coords[:-2]))
+
+
 def stick_compatible(coords: "list[list[sympy.Expr]]") -> bool:
     """Return True if all tensors are stick-compatible.
 
@@ -1597,9 +1668,27 @@ def compute_restickify_needed(
         return True, None
     assert idc, "device_coordinates returned empty list for input"
     assert out_idc, "device_coordinates returned empty list for output"
+    is_matmul = (
+        op is not None
+        and getattr(getattr(op, "data", None), "reduction_type", None)
+        in MATMUL_REDUCTION_OPS
+    )
+    target_stick_vars = out_idc[-1].free_symbols
+    matmul_stick_var = (
+        next(iter(target_stick_vars))
+        if is_matmul and len(target_stick_vars) == 1
+        else None
+    )
+    batch_vars = matmul_batch_vars(op) if is_matmul else set()
     # Input stick with an offset always needs restickify to remove the offset.
     in_stick_offset_free = is_stick_expr_offset_free(idc[-1], in_stl.elems_per_stick())
     if in_stick_offset_free and stick_compatible([idc, out_idc]):
+        if matmul_stick_var is not None:
+            normalized = normalize_matmul_input_layout(
+                in_stl, idc, matmul_stick_var, batch_vars
+            )
+            if normalized != in_stl:
+                return True, normalized
         return False, None
     ic = host_coordinates(in_host, in_dep, ind_sizes)
     target_stick = out_idc[-1]
@@ -1612,9 +1701,16 @@ def compute_restickify_needed(
         if reduction_vars:
             red_var = next(iter(reduction_vars))
             target_stick = sympy.Mod(red_var, in_stl.elems_per_stick())
-    return True, compute_restickify_target_layout(
+    target_stl = compute_restickify_target_layout(
         in_stl, in_host, target_stick, ic, idc
     )
+    if target_stl is not None and matmul_stick_var is not None:
+        target_idc = try_device_coordinates(target_stl, in_dep, ind_sizes)
+        if target_idc is not None:
+            target_stl = normalize_matmul_input_layout(
+                target_stl, target_idc, matmul_stick_var, batch_vars
+            )
+    return True, target_stl
 
 
 def copy_fx_custom_meta(src: "torch.fx.Node", dst: "torch.fx.Node") -> None:

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1543,7 +1543,7 @@ def normalize_matmul_input_layout(
     device_coords: list[sympy.Expr],
     stick_var: sympy.Symbol,
     batch_vars: set[sympy.Symbol],
-) -> SpyreTensorLayout:
+) -> SpyreTensorLayout | None:
     """Keep a matmul stick variable's outer tiles physically next to its stick.
 
     Matmul kernels consume the outer tiles of their stick dimension as one
@@ -1554,6 +1554,12 @@ def normalize_matmul_input_layout(
     Unit axes do not affect physical ownership, so leave their positions alone
     and stable-sort only non-unit outer axes.  This avoids manufacturing distinct
     layouts for harmless padding axes.
+
+    Return ``None`` when a non-unit physical coordinate mixes the stick variable
+    with a batch variable.  Free-symbol membership cannot distinguish, for
+    example, ``8 * batch + k_tile`` from ``16 * k_tile + batch``; accepting
+    either expression based only on its symbols could silently choose the wrong
+    physical ownership order.
     """
     assert len(device_coords) == len(stl.device_size)
     if stick_var not in device_coords[-1].free_symbols:
@@ -1563,13 +1569,24 @@ def normalize_matmul_input_layout(
     stride_map = list(stl.stride_map)
     physical_axes = [axis for axis, size in enumerate(device_size[:-1]) if size > 1]
 
+    for axis in physical_axes:
+        axis_vars = device_coords[axis].free_symbols
+        if stick_var in axis_vars and axis_vars & batch_vars:
+            return None
+
+    # There is no outer ownership block to protect when the stick dimension
+    # fits in one stick.  Reordering batch and unrelated matmul axes in that
+    # case only creates a redundant full-tensor copy.
+    if not any(stick_var in device_coords[axis].free_symbols for axis in physical_axes):
+        return stl
+
     def matmul_axis_role(axis: int) -> int:
         axis_vars = device_coords[axis].free_symbols
         if axis_vars & batch_vars:
             return 0
         if stick_var in axis_vars:
-            return 1
-        return 2
+            return 2
+        return 1
 
     ordered_axes = sorted(
         physical_axes,
@@ -1591,22 +1608,30 @@ def normalize_matmul_input_layout(
     )
 
 
-def matmul_batch_vars(op: ComputedBuffer) -> set[sympy.Symbol]:
-    """Return variables carried by the matmul output's leading batch axes.
+def matmul_output_batch_vars(
+    output_layout: FixedLayout,
+    output_dep: MemoryDep,
+) -> set[sympy.Symbol]:
+    """Return variables carried by a matmul output's leading batch axes.
 
     A batch axis may be broadcast by either input, so intersecting both input
     dependencies loses precisely the GQA/value-matmul case where the rhs has a
     unit head dimension. Matmul's output contract identifies batch axes
     unambiguously: every logical dimension before M and N.
     """
+    output_coords = host_coordinates(output_layout, output_dep, None)
+    return set().union(*(coord.free_symbols for coord in output_coords[:-2]))
+
+
+def matmul_batch_vars(op: ComputedBuffer) -> set[sympy.Symbol]:
+    """Return the output batch variables for a lowered matmul operation."""
     write_deps = [
         dep for dep in op_read_writes(op).writes if isinstance(dep, MemoryDep)
     ]
     if not write_deps:
         return set()
 
-    output_coords = host_coordinates(op.layout, write_deps[0], None)
-    return set().union(*(coord.free_symbols for coord in output_coords[:-2]))
+    return matmul_output_batch_vars(op.layout, write_deps[0])
 
 
 def stick_compatible(coords: "list[list[sympy.Expr]]") -> bool:
@@ -1687,6 +1712,15 @@ def compute_restickify_needed(
             normalized = normalize_matmul_input_layout(
                 in_stl, idc, matmul_stick_var, batch_vars
             )
+            if normalized is None:
+                # The source's physical ownership order is ambiguous.  Do not
+                # accept it as a zero-cost matmul input.  The required input
+                # layout is an independent target selected by propagation, so
+                # use it only if its ownership order can be validated.
+                normalized_target = normalize_matmul_input_layout(
+                    out_stl, out_idc, matmul_stick_var, batch_vars
+                )
+                return True, normalized_target
             if normalized != in_stl:
                 return True, normalized
         return False, None
@@ -1706,10 +1740,11 @@ def compute_restickify_needed(
     )
     if target_stl is not None and matmul_stick_var is not None:
         target_idc = try_device_coordinates(target_stl, in_dep, ind_sizes)
-        if target_idc is not None:
-            target_stl = normalize_matmul_input_layout(
-                target_stl, target_idc, matmul_stick_var, batch_vars
-            )
+        if target_idc is None:
+            return True, None
+        target_stl = normalize_matmul_input_layout(
+            target_stl, target_idc, matmul_stick_var, batch_vars
+        )
     return True, target_stl
 
 

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1551,9 +1551,10 @@ def normalize_matmul_input_layout(
     stick is insufficient: a non-unit batch axis between an outer stick tile
     and the inner stick changes which core owns each tile.
 
-    Unit axes do not affect physical ownership, so leave their positions alone
-    and stable-sort only non-unit outer axes.  This avoids manufacturing distinct
-    layouts for harmless padding axes.
+    Unit axes do not affect physical ownership.  Among non-unit axes, reorder
+    only the batch and outer-stick ownership subsequence so every batch axis
+    precedes the outer stick tile.  Unrelated axes keep their physical slots;
+    moving them would manufacture full-tensor copies for ordinary 2D matmuls.
 
     Return ``None`` when a non-unit physical coordinate mixes the stick variable
     with a batch variable.  Free-symbol membership cannot distinguish, for
@@ -1582,22 +1583,24 @@ def normalize_matmul_input_layout(
 
     def matmul_axis_role(axis: int) -> int:
         axis_vars = device_coords[axis].free_symbols
-        if axis_vars & batch_vars:
-            return 0
-        if stick_var in axis_vars:
-            return 2
-        return 1
+        return 0 if axis_vars & batch_vars else 1
 
-    ordered_axes = sorted(
-        physical_axes,
+    ownership_axes = [
+        axis
+        for axis in physical_axes
+        if device_coords[axis].free_symbols & batch_vars
+        or stick_var in device_coords[axis].free_symbols
+    ]
+    ordered_ownership_axes = sorted(
+        ownership_axes,
         key=matmul_axis_role,
     )
-    if ordered_axes == physical_axes:
+    if ordered_ownership_axes == ownership_axes:
         return stl
 
     old_size = list(device_size)
     old_stride = list(stride_map)
-    for destination, source in zip(physical_axes, ordered_axes):
+    for destination, source in zip(ownership_axes, ordered_ownership_axes):
         device_size[destination] = old_size[source]
         stride_map[destination] = old_stride[source]
     return SpyreTensorLayout(

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -22,6 +22,7 @@ import regex
 import torch
 import sympy
 from sympy import Expr, Symbol
+from sympy.polys.polyerrors import PolynomialError
 from torch._inductor.ir import (
     Buffer,
     ComputedBuffer,
@@ -1552,9 +1553,11 @@ def normalize_matmul_input_layout(
     and the inner stick changes which core owns each tile.
 
     Unit axes do not affect physical ownership.  Among non-unit axes, reorder
-    only the batch and outer-stick ownership subsequence so every batch axis
-    precedes the outer stick tile.  Unrelated axes keep their physical slots;
-    moving them would manufacture full-tensor copies for ordinary 2D matmuls.
+    only the broadcast-batch and outer-stick ownership subsequence so every
+    relevant batch axis precedes the outer stick tile.  Batch axes carried by
+    both operands already share a physical ownership frame and must not be
+    normalized: doing so manufactures full-tensor copies for ordinary BMMs.
+    Unrelated axes keep their physical slots.
 
     Return ``None`` when a non-unit physical coordinate mixes the stick variable
     with a batch variable.  Free-symbol membership cannot distinguish, for
@@ -1626,15 +1629,53 @@ def matmul_output_batch_vars(
     return set().union(*(coord.free_symbols for coord in output_coords[:-2]))
 
 
+def matmul_ownership_batch_vars(
+    output_layout: FixedLayout,
+    output_dep: MemoryDep,
+    input_deps: list[MemoryDep],
+) -> set[sympy.Symbol]:
+    """Return output batch variables broadcast by at least one matmul operand.
+
+    A batch variable used affinely and one-to-one by both operands gives the
+    kernel a common ownership coordinate, so preserving its existing position
+    relative to the stick's outer tiles is safe.  Canonicalizing those shared
+    axes adds large, redundant copies to ordinary BMMs.  A variable missing
+    from either operand, or reused through a non-affine expression such as
+    ``floor(head / group)``, has no common input ownership frame; these are the
+    GQA/broadcast axes that must precede the outer stick tile.
+
+    Be conservative when the lowered reduction does not expose exactly two
+    tensor reads: retain all output batch variables rather than assuming an
+    axis is shared.
+    """
+    output_batch_vars = matmul_output_batch_vars(output_layout, output_dep)
+    if len(input_deps) != 2:
+        return output_batch_vars
+
+    def is_direct_axis(dep: MemoryDep, var: sympy.Symbol) -> bool:
+        try:
+            return sympy.Poly(dep.index, var).degree() == 1
+        except PolynomialError:
+            return False
+
+    shared_input_vars = {
+        var
+        for var in output_batch_vars
+        if all(is_direct_axis(dep, var) for dep in input_deps)
+    }
+    return output_batch_vars - shared_input_vars
+
+
 def matmul_batch_vars(op: ComputedBuffer) -> set[sympy.Symbol]:
-    """Return the output batch variables for a lowered matmul operation."""
+    """Return ownership-relevant batch variables for a lowered matmul."""
     write_deps = [
         dep for dep in op_read_writes(op).writes if isinstance(dep, MemoryDep)
     ]
     if not write_deps:
         return set()
 
-    return matmul_output_batch_vars(op.layout, write_deps[0])
+    read_deps = [dep for dep in op_read_writes(op).reads if isinstance(dep, MemoryDep)]
+    return matmul_ownership_batch_vars(op.layout, write_deps[0], read_deps)
 
 
 def stick_compatible(coords: "list[list[sympy.Expr]]") -> bool:
@@ -1708,6 +1749,25 @@ def compute_restickify_needed(
         else None
     )
     batch_vars = matmul_batch_vars(op) if is_matmul else set()
+    if matmul_stick_var is not None:
+        assert op is not None
+        write_deps = [
+            dep for dep in op_read_writes(op).writes if isinstance(dep, MemoryDep)
+        ]
+        all_batch_vars = (
+            matmul_output_batch_vars(op.layout, write_deps[0]) if write_deps else set()
+        )
+        normalized_required = normalize_matmul_input_layout(
+            out_stl, out_idc, matmul_stick_var, all_batch_vars
+        )
+        if normalized_required is None:
+            return True, None
+        # Propagation canonicalizes shared axes only when the operands disagree
+        # about their ownership order.  The required layout records that
+        # decision.  Enforce every output batch axis when it is canonical;
+        # otherwise retain only the broadcast/reused axes selected above.
+        if normalized_required == out_stl:
+            batch_vars = all_batch_vars
     # Input stick with an offset always needs restickify to remove the offset.
     in_stick_offset_free = is_stick_expr_offset_free(idc[-1], in_stl.elems_per_stick())
     if in_stick_offset_free and stick_compatible([idc, out_idc]):

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -85,6 +85,7 @@ from .pass_utils import (
     is_stick_expr_offset_free,
     is_topk,
     iter_var_id,
+    normalize_matmul_input_layout,
 )
 from .optimize_restickify import AllSameNode, AnyInNode, FixedInOutNode
 from .views import compute_coordinates, matching_dim
@@ -794,6 +795,8 @@ def find_stick_compatible_input_layout(
     reduction_var: sympy.Symbol,
     reduction_type: str,
     label: str,
+    *,
+    matmul_batch_vars: set[sympy.Symbol] | None = None,
 ) -> SpyreTensorLayout:
     """Find the required STL for a matmul input by iterating all candidate layouts.
 
@@ -815,6 +818,10 @@ def find_stick_compatible_input_layout(
     # to know if this input's stick coord already carries the target loop variable.
     for stl, dev_coords in candidates:
         if reduction_var in dev_coords[-1].free_symbols:
+            if matmul_batch_vars is not None:
+                return normalize_matmul_input_layout(
+                    stl, dev_coords, reduction_var, matmul_batch_vars
+                )
             return stl
 
     # Pass 2: can be restickified — find the resolvable device coord for reduction_var
@@ -830,6 +837,13 @@ def find_stick_compatible_input_layout(
             stl, arg.layout, target_stick_expr, arg_host_coords, dev_coords
         )
         if result is not None:
+            if matmul_batch_vars is not None:
+                result_coords = try_device_coordinates(result, arg.dep, None)
+                if result_coords is None:
+                    continue
+                result = normalize_matmul_input_layout(
+                    result, result_coords, reduction_var, matmul_batch_vars
+                )
             return result
 
     raise Unsupported(
@@ -870,12 +884,21 @@ def _matmul_layouts(
     #   Output:     stick on generated_var
     reduction_var = find_reduction_var(x.dep, output_dep)
     generated_var = find_matmul_generated_var(y.dep, x.dep, output_dep)
+    batch_vars = set().union(*(coord.free_symbols for coord in out_coords[:-2]))
 
     x_req_stl = find_stick_compatible_input_layout(
-        x, reduction_var, data.reduction_type, "x"
+        x,
+        reduction_var,
+        data.reduction_type,
+        "x",
+        matmul_batch_vars=batch_vars,
     )
     y_req_stl = find_stick_compatible_input_layout(
-        y, generated_var, data.reduction_type, "y"
+        y,
+        generated_var,
+        data.reduction_type,
+        "y",
+        matmul_batch_vars=batch_vars,
     )
 
     out_stick_dim = next(

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -85,6 +85,7 @@ from .pass_utils import (
     is_stick_expr_offset_free,
     is_topk,
     iter_var_id,
+    matmul_ownership_batch_vars,
     matmul_output_batch_vars,
     normalize_matmul_input_layout,
 )
@@ -890,22 +891,118 @@ def _matmul_layouts(
     #   Output:     stick on generated_var
     reduction_var = find_reduction_var(x.dep, output_dep)
     generated_var = find_matmul_generated_var(y.dep, x.dep, output_dep)
-    batch_vars = matmul_output_batch_vars(output, output_dep)
 
     x_req_stl = find_stick_compatible_input_layout(
         x,
         reduction_var,
         data.reduction_type,
         "x",
-        matmul_batch_vars=batch_vars,
     )
     y_req_stl = find_stick_compatible_input_layout(
         y,
         generated_var,
         data.reduction_type,
         "y",
-        matmul_batch_vars=batch_vars,
     )
+
+    all_batch_vars = matmul_output_batch_vars(output, output_dep)
+    batch_vars = matmul_ownership_batch_vars(output, output_dep, [x.dep, y.dep])
+
+    def batch_outer_order(
+        stl: SpyreTensorLayout,
+        dep: MemoryDep,
+        stick_var: sympy.Symbol,
+        batch_var: sympy.Symbol,
+    ) -> int | None:
+        """Return -1/1 when batch is before/after the outer stick tiles."""
+        coords = try_device_coordinates(stl, dep, None)
+        if coords is None:
+            return None
+        physical_axes = [
+            axis for axis, size in enumerate(stl.device_size[:-1]) if size > 1
+        ]
+        batch_axes = [
+            axis for axis in physical_axes if batch_var in coords[axis].free_symbols
+        ]
+        stick_axes = [
+            axis for axis in physical_axes if stick_var in coords[axis].free_symbols
+        ]
+        if not batch_axes or not stick_axes:
+            return None
+        if set(batch_axes) & set(stick_axes):
+            return 0
+        if max(batch_axes) < min(stick_axes):
+            return -1
+        if min(batch_axes) > max(stick_axes):
+            return 1
+        return 0
+
+    def outer_stick_tiles(
+        stl: SpyreTensorLayout,
+        dep: MemoryDep,
+        stick_var: sympy.Symbol,
+    ) -> int | None:
+        coords = try_device_coordinates(stl, dep, None)
+        if coords is None:
+            return None
+        axes = [
+            axis
+            for axis in range(len(stl.device_size) - 1)
+            if stick_var in coords[axis].free_symbols
+        ]
+        if not axes:
+            return 1
+        return math.prod(int(stl.device_size[axis]) for axis in axes)
+
+    output_m = concretize_expr(output.size[-2])
+    output_n = concretize_expr(output.size[-1])
+    output_nonbatch_work = output_m * math.ceil(
+        output_n / get_elem_in_stick(output.dtype)
+    )
+    x_outer_tiles = outer_stick_tiles(x_req_stl, x.dep, reduction_var)
+    y_outer_tiles = outer_stick_tiles(y_req_stl, y.dep, generated_var)
+    batch_may_split = output_nonbatch_work < config.sencores
+    unequal_outer_tiles = (
+        x_outer_tiles is not None
+        and y_outer_tiles is not None
+        and x_outer_tiles != y_outer_tiles
+    )
+
+    # Direct shared batch axes can keep a non-canonical order only when both
+    # operands agree on it and the output's M/N work can occupy every core.
+    # Decode GQA is the important counterexample: M/N alone cannot fill the
+    # machine, so heads participate in core ownership; if K_outer and N_outer
+    # have different cardinalities, placing heads after them maps the same head
+    # to different cores on the two inputs.  Canonicalize just those exposed or
+    # conflicting axes.
+    for batch_var in all_batch_vars - batch_vars:
+        orders = {
+            order
+            for order in (
+                batch_outer_order(x_req_stl, x.dep, reduction_var, batch_var),
+                batch_outer_order(y_req_stl, y.dep, generated_var, batch_var),
+            )
+            if order is not None
+        }
+        exposed_unequal_tiles = batch_may_split and unequal_outer_tiles and 1 in orders
+        if 0 in orders or len(orders) > 1 or exposed_unequal_tiles:
+            batch_vars.add(batch_var)
+
+    if batch_vars:
+        x_req_stl = find_stick_compatible_input_layout(
+            x,
+            reduction_var,
+            data.reduction_type,
+            "x",
+            matmul_batch_vars=batch_vars,
+        )
+        y_req_stl = find_stick_compatible_input_layout(
+            y,
+            generated_var,
+            data.reduction_type,
+            "y",
+            matmul_batch_vars=batch_vars,
+        )
 
     out_stick_dim = next(
         (i for i, c in enumerate(out_coords) if generated_var in c.free_symbols),

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -85,6 +85,7 @@ from .pass_utils import (
     is_stick_expr_offset_free,
     is_topk,
     iter_var_id,
+    matmul_output_batch_vars,
     normalize_matmul_input_layout,
 )
 from .optimize_restickify import AllSameNode, AnyInNode, FixedInOutNode
@@ -819,9 +820,12 @@ def find_stick_compatible_input_layout(
     for stl, dev_coords in candidates:
         if reduction_var in dev_coords[-1].free_symbols:
             if matmul_batch_vars is not None:
-                return normalize_matmul_input_layout(
+                normalized = normalize_matmul_input_layout(
                     stl, dev_coords, reduction_var, matmul_batch_vars
                 )
+                if normalized is None:
+                    continue
+                return normalized
             return stl
 
     # Pass 2: can be restickified — find the resolvable device coord for reduction_var
@@ -844,6 +848,8 @@ def find_stick_compatible_input_layout(
                 result = normalize_matmul_input_layout(
                     result, result_coords, reduction_var, matmul_batch_vars
                 )
+                if result is None:
+                    continue
             return result
 
     raise Unsupported(
@@ -884,7 +890,7 @@ def _matmul_layouts(
     #   Output:     stick on generated_var
     reduction_var = find_reduction_var(x.dep, output_dep)
     generated_var = find_matmul_generated_var(y.dep, x.dep, output_dep)
-    batch_vars = set().union(*(coord.free_symbols for coord in out_coords[:-2]))
+    batch_vars = matmul_output_batch_vars(output, output_dep)
 
     x_req_stl = find_stick_compatible_input_layout(
         x,

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -60,6 +60,7 @@ from .constants import (
     COPY_BACK_CANDIDATE_ATTR,
     DEVICE_NAME,
     ELIDED_COPY_BACK_ATTR,
+    MATMUL_NO_BATCH_SPLIT_ATTR,
     REDUCTIONS_NON_STICK_DIM_ONLY,
     STAGGERED_EAS,
 )
@@ -968,13 +969,14 @@ def _matmul_layouts(
         and x_outer_tiles != y_outer_tiles
     )
 
-    # Direct shared batch axes can keep a non-canonical order only when both
-    # operands agree on it and the output's M/N work can occupy every core.
-    # Decode GQA is the important counterexample: M/N alone cannot fill the
-    # machine, so heads participate in core ownership; if K_outer and N_outer
-    # have different cardinalities, placing heads after them maps the same head
-    # to different cores on the two inputs.  Canonicalize just those exposed or
-    # conflicting axes.
+    # Direct shared batch axes can keep a non-canonical order when both operands
+    # agree on it and either their outer-stick tile counts agree or work division
+    # keeps that batch axis unsplit. Decode GQA is the important counterexample:
+    # if K_outer and N_outer have different cardinalities, placing heads after
+    # them maps the same head to different cores once heads participate in core
+    # ownership. Canonicalize axes that may split now; otherwise record the
+    # no-split requirement for the later work-division passes.
+    no_batch_split_vars: set[sympy.Symbol] = set()
     for batch_var in all_batch_vars - batch_vars:
         orders = {
             order
@@ -984,9 +986,21 @@ def _matmul_layouts(
             )
             if order is not None
         }
-        exposed_unequal_tiles = batch_may_split and unequal_outer_tiles and 1 in orders
-        if 0 in orders or len(orders) > 1 or exposed_unequal_tiles:
+        exposed_unequal_tiles = unequal_outer_tiles and 1 in orders
+        if 0 in orders or len(orders) > 1:
             batch_vars.add(batch_var)
+        elif exposed_unequal_tiles:
+            if batch_may_split:
+                batch_vars.add(batch_var)
+            else:
+                no_batch_split_vars.add(batch_var)
+
+    if no_batch_split_vars:
+        setattr(
+            op,
+            MATMUL_NO_BATCH_SPLIT_ATTR,
+            frozenset(no_batch_split_vars),
+        )
 
     if batch_vars:
         x_req_stl = find_stick_compatible_input_layout(

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -46,7 +46,11 @@ from torch_spyre._inductor.pass_utils import (
     _per_core_view_from_prep,
     op_short_name,
 )
-from torch_spyre._inductor.work_division import enumerate_work_division_candidates
+from torch_spyre._inductor.work_division import (
+    _first_non_indirect_read_index,
+    collect_op_work_division_constraints,
+    enumerate_work_division_candidates,
+)
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.scratchpad.plan_solver import (
     CoreDivision,
@@ -1498,6 +1502,51 @@ def _enum_split_options(
     ]
 
 
+def _filter_forbidden_split_options(
+    op: Operation,
+    options: list[tuple[dict, dict]],
+) -> list[tuple[dict, dict]]:
+    """Remove pruned candidates that split a hard-forbidden iteration symbol.
+
+    The pruned co-optimizer synthesizes alternatives after the normal work-
+    division passes have run. Reuse their constraint collector here so a later
+    optimization cannot violate an earlier correctness contract, including
+    matmul batch ownership and indirect-access table addressing.
+    """
+    if not isinstance(op, ComputedBuffer) or not isinstance(
+        op.data, (Pointwise, Reduction)
+    ):
+        return options
+
+    forbidden = collect_op_work_division_constraints(op).forbidden
+    if not forbidden:
+        return options
+
+    rw = op_read_writes(op)
+    write_index = next(iter(rw.writes)).index
+    read_index = _first_non_indirect_read_index(rw, write_index)
+    iter_space = iteration_space_from_op(op)
+
+    valid: list[tuple[dict, dict]] = []
+    rejected: set[sympy.Symbol] = set()
+    for option in options:
+        per_sym = apply_splits_from_index_coeff(
+            option, write_index, read_index, iter_space
+        )
+        violations = {sym for sym in forbidden if per_sym.get(sym, 1) > 1}
+        if violations:
+            rejected |= violations
+        else:
+            valid.append(option)
+
+    if not valid:
+        raise Unsupported(
+            f"{op.get_name()}: every scratchpad core-division candidate splits "
+            f"hard-forbidden dim(s) {sorted(str(sym) for sym in rejected)}."
+        )
+    return valid
+
+
 def _canonical_key(splits: tuple[dict, dict]) -> tuple:
     """Hashable key for a (output_splits, reduction_splits) pair."""
     out, red = splits
@@ -1602,9 +1651,13 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             if op.name in fixed_division_ops:
                 divs = [_fixed_core_division(op)]
             elif self.prune:
+                options = _filter_forbidden_split_options(
+                    op,
+                    _enum_split_options(op, matmul_bases, matmul_roles),
+                )
                 divs = [
                     CoreDivision(output_splits=dict(out), reduction_splits=dict(red))
-                    for out, red in _enum_split_options(op, matmul_bases, matmul_roles)
+                    for out, red in options
                 ]
             else:
                 divs = self._enumerate_core_divisions(op, max_cores)
@@ -1683,6 +1736,10 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             if op is None or buf.chosen_division is None:
                 continue
             cd = buf.core_divisions[buf.chosen_division]
+            _filter_forbidden_split_options(
+                op,
+                [(cd.output_splits, cd.reduction_splits)],
+            )
             op.op_it_space_splits = (
                 dict(cd.output_splits),
                 dict(cd.reduction_splits),

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -123,6 +123,44 @@ _LX_TRACKER_CAPACITY_BYTES = (
 _LX_ALLOCATION_GRANULARITY_BYTES = 128
 
 
+def _is_outer_layout_restickify(graph: GraphLowering, op: Operation) -> bool:
+    """Return whether ``op`` reorders outer device axes without moving the stick.
+
+    These ownership-normalizing copies are emitted as ordinary identities:
+    :func:`is_restickify_coords` classifies only a change of the within-stick
+    host dimension as ``ReStickifyOpHBM``.  HBM can address the identity's
+    physically distinct outer-axis layout globally, but an LX allocation is a
+    packed per-core slice and cannot preserve that global ownership frame.
+    Keep such outputs in HBM until the identity emitter can represent this
+    HBM-to-LX ownership transition explicitly.
+    """
+    if op_short_name(op) != "restickify":
+        return False
+    output_layout = op.get_layout()
+    if not isinstance(output_layout, FixedTiledLayout):
+        return False
+    reads = [dep for dep in op_read_writes(op).reads if isinstance(dep, MemoryDep)]
+    if len(reads) != 1:
+        return False
+    read = reads[0]
+    input_layout = getattr(op, "_input_layout_overrides", {}).get(read.name)
+    if input_layout is None:
+        input_buf = graph.get_buffer(read.name)
+        if input_buf is None:
+            return False
+        input_layout = input_buf.get_layout()
+    if not isinstance(input_layout, FixedTiledLayout):
+        return False
+
+    input_stl = input_layout.device_layout
+    output_stl = output_layout.device_layout
+    same_stick = input_stl.stride_map[-1] == output_stl.stride_map[-1]
+    outer_layout_changed = list(input_stl.device_size) != list(
+        output_stl.device_size
+    ) or list(input_stl.stride_map) != list(output_stl.stride_map)
+    return same_stick and outer_layout_changed
+
+
 def _extern_kernel_in_live_range(graph: GraphLowering, uses: list[int]) -> bool:
     """True if an opaque extern kernel runs at any point while the buffer is live.
 
@@ -430,6 +468,8 @@ class ScratchpadAllocator:
         """
         if op is None or not self._op_output_good_for_lx_reuse(op, planned_lx_buffers):
             return "op not allowed"
+        if _is_outer_layout_restickify(graph, op):
+            return "outer-layout restickify output requires global addressing"
         if not hasattr(getattr(op, "layout", None), "device_layout"):
             # No device layout => no computable footprint (e.g. a
             # MultiOutputLayout tuple op). There is nothing to place, and the

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -910,11 +910,13 @@ def _apply_user_hint(
     max_cores: int,
     blocked: set[Symbol] | None = None,
     pinned: dict[Symbol, int] | None = None,
+    forbidden: set[Symbol] | None = None,
 ) -> dict[Symbol, int]:
     """Apply splits in insertion order, pruning lower-priority overflows."""
     op_name = op.get_name()
     blocked = blocked or set()
     pinned = pinned or {}
+    forbidden = forbidden or set()
 
     splits: dict[Symbol, int] = {}
     cores_used = 1
@@ -940,6 +942,10 @@ def _apply_user_hint(
         if split > 1 and sym in blocked:
             raise Unsupported(
                 f"work_division_hint: {op_name} cannot split constrained dim {sym}."
+            )
+        if split > 1 and sym in forbidden:
+            raise Unsupported(
+                f"work_division_hint: {op_name} cannot split hard-forbidden dim {sym}."
             )
         if sym in pinned and split != pinned[sym]:
             raise Unsupported(
@@ -1260,6 +1266,7 @@ def work_distribution_pass(
                 max_cores,
                 blocked,
                 constraint_result.pinned,
+                constraint_result.forbidden,
             )
             dropped = {
                 s: v for s, v in committed_splits.items() if user_splits.get(s, 1) < v
@@ -1527,6 +1534,7 @@ def _cost_model_matmul_planner(
     committed_splits: dict[Symbol, int],
     max_cores: int,
     input_tds: list[TensorDep],
+    forbidden: set[Symbol] | None = None,
 ) -> dict[Symbol, int]:
     """Override the default split for a matmul / bmm with the lowest-cost
     feasible (b, m, n, k) per _matmul_split_cost.
@@ -1541,6 +1549,7 @@ def _cost_model_matmul_planner(
         return splits
     if committed_splits:
         return splits
+    forbidden = forbidden or set()
 
     # Classify the output coord dims: the stickified one is N, the rest index
     # rows. Of those row dims, M is the one appearing in a single input (the
@@ -1593,13 +1602,20 @@ def _cost_model_matmul_planner(
     B_total = math.prod(batch_sizes)
 
     b_combos = (
-        list(itertools.product(*([int(d) for d in divisors(s)] for s in batch_sizes)))
+        list(
+            itertools.product(
+                *(
+                    [1] if bd in forbidden else [int(d) for d in divisors(size)]
+                    for bd, size in zip(batch_dims, batch_sizes)
+                )
+            )
+        )
         if batch_dims
         else [()]
     )
-    m_divs = [int(d) for d in divisors(M_e)]
-    n_divs = [int(d) for d in divisors(n_sticks)]
-    k_divs = [int(d) for d in divisors(k_sticks)]
+    m_divs = [1] if m_dim in forbidden else [int(d) for d in divisors(M_e)]
+    n_divs = [1] if n_dim in forbidden else [int(d) for d in divisors(n_sticks)]
+    k_divs = [1] if k_dim in forbidden else [int(d) for d in divisors(k_sticks)]
 
     # For batchmatmulfp8 with QFP8WT kernels, do not split K
     if has_qfp8wt_tensor(input_tds + [output_td]):
@@ -1896,6 +1912,7 @@ def _cost_model_divide_op(op: ComputedBuffer, max_cores: int) -> bool:
         committed_splits,
         max_cores,
         input_tds,
+        constraint_result.forbidden,
     )
     if splits == default_splits:
         return False

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -65,6 +65,7 @@ from .pass_utils import (
 )
 from .propagate_hints import get_op_hints
 from .work_division_constraints import (
+    ConstraintResult,
     WorkDivConstraintContext,
     collect_work_division_constraints,
     has_qfp8wt_tensor,
@@ -761,6 +762,51 @@ def apply_splits(
     op.op_it_space_splits = splits_by_index_coeff(splits, write_index, read_index)
 
 
+def _work_division_constraint_context(
+    op: ComputedBuffer,
+    committed_splits: dict[Symbol, int] | None = None,
+) -> tuple[WorkDivConstraintContext, SymbolMeta]:
+    """Build the canonical constraint context for an op.
+
+    Work division and later phases that may replace its decision must derive
+    constraints from the same tensor dependencies and stick-adjusted iteration
+    space. Keeping that setup here prevents the scratchpad co-optimizer from
+    accidentally using a weaker interpretation.
+    """
+    it_space = iteration_space_from_op(op)
+    input_tds, output_td = collect_tensor_deps(
+        op, get_mem_deps_from_rw(op_read_writes(op))
+    )
+    all_tds = input_tds + [output_td]
+    symbol_meta = _collect_symbol_metadata(it_space)
+    it_space_adjusted, stick_vars = adjust_it_space_for_sticks(
+        it_space, all_tds, symbol_meta
+    )
+    coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
+    reduction_vars = [v for v in it_space_adjusted if v not in coord_vars]
+    return (
+        WorkDivConstraintContext(
+            op=op,
+            it_space=it_space,
+            it_space_adjusted=it_space_adjusted,
+            output_td=output_td,
+            input_tds=input_tds,
+            stick_vars=stick_vars,
+            reduction_vars=reduction_vars,
+            committed_splits=committed_splits or {},
+        ),
+        symbol_meta,
+    )
+
+
+def collect_op_work_division_constraints(
+    op: ComputedBuffer,
+) -> ConstraintResult:
+    """Collect constraints for a later phase that may replace work division."""
+    ctx, _ = _work_division_constraint_context(op)
+    return collect_work_division_constraints(ctx)
+
+
 def enumerate_work_division_candidates(
     op: ComputedBuffer,
     max_cores: int,
@@ -781,41 +827,22 @@ def enumerate_work_division_candidates(
     # TODO: Enumerate compute bound ops and for seeds or compute optimized
     # work division where HBM bandwidth can saturate compute.
 
-    it_space = iteration_space_from_op(op)
-    op_is_topk = is_topk(op)
-
-    input_tds, output_td = collect_tensor_deps(
-        op, get_mem_deps_from_rw(op_read_writes(op))
-    )
+    constraint_ctx, symbol_meta = _work_division_constraint_context(op)
+    it_space = constraint_ctx.it_space
+    it_space_adjusted = constraint_ctx.it_space_adjusted
+    input_tds = constraint_ctx.input_tds
+    output_td = constraint_ctx.output_td
+    stick_vars = constraint_ctx.stick_vars
+    reduction_vars = constraint_ctx.reduction_vars
     all_tds = input_tds + [output_td]
-
-    symbol_meta = _collect_symbol_metadata(it_space)
-    it_space_adjusted, stick_vars = adjust_it_space_for_sticks(
-        it_space, all_tds, symbol_meta
-    )
-
-    # Reduction (K) dims are the iteration vars absent from the output tensor's
-    # device coordinates (mirrors prioritize_dimensions / splits_by_index_coeff).
-    coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
-    reduction_vars = [v for v in it_space_adjusted if v not in coord_vars]
+    op_is_topk = is_topk(op)
 
     topk_k_sym = None
     if op_is_topk:
         output_dims, _ = prioritize_dimensions(output_td, it_space_adjusted)
         topk_k_sym = _find_topk_k_symbol(output_dims, input_tds)
 
-    constraint_result = collect_work_division_constraints(
-        WorkDivConstraintContext(
-            op=op,
-            it_space=it_space,
-            it_space_adjusted=it_space_adjusted,
-            output_td=output_td,
-            input_tds=input_tds,
-            stick_vars=stick_vars,
-            reduction_vars=reduction_vars,
-            committed_splits={},
-        )
-    )
+    constraint_result = collect_work_division_constraints(constraint_ctx)
     blocked = constraint_result.blocked
     pinned = constraint_result.pinned
     forbidden = constraint_result.forbidden
@@ -851,7 +878,7 @@ def enumerate_work_division_candidates(
             splits[v] > 1 for v in blocked
         ):
             return False
-        if any(  # a shared-table data dim must never be split (hard-forbidden)
+        if any(  # a hard-forbidden dim must never be split
             splits[v] > 1 for v in forbidden
         ):
             return False

--- a/torch_spyre/_inductor/work_division_constraints.py
+++ b/torch_spyre/_inductor/work_division_constraints.py
@@ -33,7 +33,11 @@ from sympy import Expr, Symbol
 from torch._inductor.ir import ComputedBuffer, Reduction
 from torch_spyre._C import ElementArrangement
 
-from .constants import BATCH_MATMUL_OP, BATCH_MATMUL_FP8_OP
+from .constants import (
+    BATCH_MATMUL_OP,
+    BATCH_MATMUL_FP8_OP,
+    MATMUL_NO_BATCH_SPLIT_ATTR,
+)
 from .errors import Unsupported
 from .pass_utils import (
     concretize_expr,
@@ -82,7 +86,7 @@ class ConstraintResult:
     honour but span reduction may still override to satisfy the memory-span
     limit), a ``forbidden`` dim is filtered out of the span-reduction candidate
     set too, so it is never split under any circumstance. Used for shared
-    gather/scatter table data dims.
+    gather/scatter table data dims and layout-dependent matmul batch ownership.
 
     ``force_output`` dims are promoted to output-split priority even when they
     don't appear in the output coordinates (a scatter's index-entry dim, whose
@@ -120,6 +124,7 @@ def collect_work_division_constraints(
         topk_pinned_search_space_vars,
         topk_k_split_constraint,
         indirect_access_constraints,
+        matmul_ownership_forbidden_split_vars,
     ):
         result = constraint(ctx)
 
@@ -188,6 +193,27 @@ def coordinate_mask_blocked_vars(ctx: WorkDivConstraintContext) -> ConstraintRes
         and concretize_expr(ctx.it_space[v]) % ctx.stick_vars[v] != 0
     }
     return ConstraintResult(blocked=blocked)
+
+
+def matmul_ownership_forbidden_split_vars(
+    ctx: WorkDivConstraintContext,
+) -> ConstraintResult:
+    """Keep batch ownership compatible with zero-copy matmul input layouts.
+
+    Layout propagation may retain batch-after-outer-stick layouts when it can
+    avoid a copy by requiring the corresponding output batch dimensions to stay
+    unsplit. The symbols are stamped on the matmul op so this later phase can
+    enforce that cross-pass contract.
+    """
+    forbidden = set(getattr(ctx.op, MATMUL_NO_BATCH_SPLIT_ATTR, ()))
+    missing = forbidden - set(ctx.it_space_adjusted)
+    if missing:
+        raise Unsupported(
+            f"{ctx.op.get_name()}: matmul no-batch-split dim(s) "
+            f"{sorted(str(sym) for sym in missing)} are no longer present in "
+            f"the work-division iteration space."
+        )
+    return ConstraintResult(forbidden=forbidden)
 
 
 def conv_spatial_blocked_vars(ctx: WorkDivConstraintContext) -> ConstraintResult:

--- a/torch_spyre/_inductor/work_division_constraints.py
+++ b/torch_spyre/_inductor/work_division_constraints.py
@@ -136,6 +136,19 @@ def collect_work_division_constraints(
         forbidden |= result.forbidden
         force_output |= result.force_output
 
+        committed_forbidden = {
+            sym: ctx.committed_splits[sym]
+            for sym in result.forbidden
+            if ctx.committed_splits.get(sym, 1) > 1
+        }
+        if committed_forbidden:
+            raise Unsupported(
+                f"{ctx.op.get_name()}: hard-forbidden split(s) "
+                f"{[(str(sym), split) for sym, split in committed_forbidden.items()]} "
+                f"from {constraint.__name__} conflict with an earlier "
+                f"work-division commitment."
+            )
+
         for sym, split in result.pinned.items():
             committed_split = ctx.committed_splits.get(sym)
             if committed_split is not None and committed_split != split:


### PR DESCRIPTION
## Summary

- Validate matmul input layouts using physical ownership, including mixed-coordinate rejection.
- Normalize only layouts whose batch/outer-stick order is incompatible with the matmul consumer.
- Preserve restickify layout metadata and keep unsafe outer-layout restickify buffers in HBM.
- For safe shared-batch zero-copy layouts, stamp the affected batch symbols as hard-forbidden from splitting.
- Preserve that contract when ComputedBuffers and metadata are copied.

## Examples

For `B=4, M=64, K=128, N=256`:

- Small-`M` layouts with unequal outer tile counts are restickified when batch can participate in work division.
- Large-`M` layouts can stay zero-copy, but `B` is marked unsplittable and #4025 enforces that through every planner.
- If the two outer tile counts agree, the existing zero-copy layout remains valid with no added restriction.

## Stack

1. #4025
2. This PR
3. #4027

This PR depends on #4025. All stack branches target `main`; this diff will shrink when #4025 merges.

Supersedes the matmul ownership and restickify portion of #3953.

## Validation

- Ownership, core mapping, padding, restickify, work-division, and metadata tests
- 421 passed, 2 expected xfails, 3 subtests passed
- Pre-commit checks on the incremental PR diff