### PR TITLE
Fix the OpSpec lab's HBM pool handling for the current sdsc ABI

### DIFF
--- a/docs/source/user_guide/debugging/op_spec_lab.md
+++ b/docs/source/user_guide/debugging/op_spec_lab.md
@@ -53,7 +53,7 @@ emitted file is one kernel, not one operation. The softmax above is six.
 | Option | Use it when |
 |---|---|
 | `--kernel NAME` | Only emit kernels whose name contains `NAME` |
-| `--save-inputs` | Dump recorded argument values to a `.pt`, for a replay whose inputs are the real ones. Pool contents are not captured; integer args otherwise replay as zeros |
+| `--save-inputs` | Dump recorded argument values to a `.pt`, for a replay whose inputs are the real ones. Without it, integer args replay as zeros |
 | `--no-execute` | Stub the backend compile and launch, so no device is needed |
 | `--no-explain-header` | Omit the decoded explanation from each emitted file |
 
@@ -204,7 +204,7 @@ capture time, so `KERNEL ARGS` shows them in the frozen header but not under
 | Field | Meaning |
 |---|---|
 | `is_input` | Read or written by *this op*. The same `arg_index` can be both across a kernel. |
-| `arg_index` | Position in the kernel's argument list. Negative means it is not a kernel arg. Not the `.run()` position when there is a pool: the pool is prepended and uncounted, so `arg0` is `.run()`'s second argument. |
+| `arg_index` | Position in the kernel's argument list, and in `.run()`'s, including when the kernel uses an HBM pool -- the pool is allocated inside the bundle, not passed in. Negative means it is not a kernel arg. |
 | `device_dtype` | On-device format, e.g. `SEN169_FP16`. This is what sets the stick size. |
 | `device_size` | The tiled device shape, `[..., sticks, rows, elems_per_stick]`. The last dim is always elements per stick. |
 | `device_coordinates` | One sympy expression per device dim, mapping an iteration point to a position. An `IndirectAccess` here means the coordinate is a runtime-loaded value. |
@@ -489,7 +489,7 @@ a line the first three do not have:
 
 ```
 # Kernel args:     4 in the spec, 4 observed at .run()
-# Pool:            32768 bytes, passed to .run() ahead of the args
+# Pool:            32768 bytes, allocated by the bundle
 ```
 
 **3. Read the header.** Seven OpSpecs this time, and the intermediates that could
@@ -542,10 +542,11 @@ the tensors buys a smaller pool rather than no pool.
 
 **What to notice**
 
-- *Ahead of* is the part to internalise: the pool is `.run()`'s first argument and
-  is **not** `arg0`. The kernel args keep their own numbering.
-- A replay needs only `POOL_BYTES`, never the offset map. `make_pool` allocates a
-  flat 1-D uint8 tensor of that size and the offsets take care of themselves.
+- The pool is **not** an argument. The bundle allocates it itself, as
+  `%pool = sdscbundle.device_mem_allocate 32768 bytes` on the first line of
+  `bundle.mlir`, so `.run()` receives the four kernel args and nothing else.
+- A replay needs only `POOL_SIZE`, never the offset map: the size reaches
+  `sdsc()` and the offsets in the spec take care of themselves.
 - Three allocation kinds have now appeared across the four examples: `hbm @ n` for
   a kernel arg (01), `lx @ offset` for a scratchpad intermediate (02), and
   `hbm_pool @ offset` for one that spilled (04).

--- a/tests/op_specs/capture.py
+++ b/tests/op_specs/capture.py
@@ -33,8 +33,8 @@ both ways compiles it twice (see :func:`dedup_key`).
 Options:
     --out DIR         where to write the scripts (default: ./captured)
     --kernel NAME     only emit kernels whose name contains NAME
-    --save-inputs     also dump recorded input values (and pool bytes) to a .pt
-                      beside each script, for byte-exact replay
+    --save-inputs     also dump recorded input values to a .pt beside each
+                      script, for byte-exact replay
     --no-execute      capture without a device or dxp_standalone (see below)
     --no-explain-header
                       omit the decoded OpSpec explanation from each script
@@ -63,11 +63,7 @@ from torch._inductor.utils import IndentedBuffer
 import torch_spyre  # noqa: F401  -- registers the "spyre" device
 from torch_spyre._inductor import config as spyre_config
 from torch_spyre._inductor.op_spec import IndirectAccess, TensorArg
-from torch_spyre._inductor.spyre_kernel import (
-    _codegen_op_spec_list,
-    _iter_op_specs,
-    uses_hbm_pool,
-)
+from torch_spyre._inductor.spyre_kernel import _codegen_op_spec_list, _iter_op_specs
 from torch_spyre.execution.async_compile import SpyreAsyncCompile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -132,6 +128,10 @@ class KernelRecord:
     that has already exited.  ``sencores`` is provenance only -- work division is
     already baked into ``iteration_space``.  ``bundle_symbolic_args`` is not, and
     the emitted script pins it: see ``pin_bundle_symbolic_args`` in runner.py.
+
+    ``pool_size`` comes from the ``sdsc()`` keyword, not from anything observed at
+    ``.run()``: the bundle allocates its own pool via ``device_mem_allocate``, so
+    no pool tensor is passed at launch.
     """
 
     name: str
@@ -139,28 +139,19 @@ class KernelRecord:
     index: int
     sencores: int
     bundle_symbolic_args: bool
+    pool_size: int = 0
     args: list = dataclasses.field(default_factory=list)
-    pool_bytes: int = 0
     observed_run: bool = False
 
 
 def _record_args(rec: KernelRecord, args: tuple, save_inputs: bool) -> None:
     """Record shape/dtype/device-layout for each .run() argument.
 
-    The pool's *size* is recorded but never its contents, even under
-    ``save_inputs``: ``pool.cpu()`` on the flat SENINT8 pool tensor corrupts the
-    heap and aborts the process, which no try/except can catch.  Replays get an
-    uninitialized pool, as production does for a graph's first kernel.
-
-    So the pool must be identified by the same predicate ``call_kernel`` used to
-    prepend it -- ``uses_hbm_pool``, shared rather than reimplemented, because a
-    copy that drifted would mean calling ``.cpu()`` on the pool.
+    Every argument is a kernel arg: since #3707 the HBM pool is allocated inside
+    the bundle rather than passed in, so there is nothing to skip here and
+    ``arg_index`` is the ``.run()`` position for every spec.
     """
-    remaining = list(args)
-    if uses_hbm_pool(rec.specs) and remaining:
-        pool = remaining.pop(0)
-        rec.pool_bytes = int(pool.numel())
-    for tensor in remaining:
+    for tensor in args:
         layout = tensor.device_tensor_layout()
         rec.args.append(
             ArgRecord(
@@ -209,16 +200,18 @@ def capture_kernels(save_inputs: bool = False, no_execute: bool = False):
     records: list = []
     real_sdsc = SpyreAsyncCompile.sdsc
 
-    def spy(self, kernel_name, specs):
+    def spy(self, kernel_name, specs, pool_size=0):
         rec = KernelRecord(
             name=kernel_name,
             specs=list(specs),
             index=len(records),
             sencores=spyre_config.sencores,
             bundle_symbolic_args=spyre_config.bundle_symbolic_args,
+            pool_size=pool_size,
         )
         records.append(rec)
-        return _RunRecorder(real_sdsc(self, kernel_name, specs), rec, save_inputs)
+        runner = real_sdsc(self, kernel_name, specs, pool_size=pool_size)
+        return _RunRecorder(runner, rec, save_inputs)
 
     with contextlib.ExitStack() as stack:
         stack.enter_context(inductor_config.patch({"force_disable_caches": True}))
@@ -317,11 +310,8 @@ def _provenance(rec: KernelRecord, source: str, total: int, no_execute: bool) ->
         f"Kernel args:     {n_spec_args} in the spec, "
         f"{len(rec.args)} observed at .run()",
     ]
-    if rec.pool_bytes:
-        lines.append(
-            f"Pool:            {rec.pool_bytes} bytes, passed to .run() "
-            "ahead of the args"
-        )
+    if rec.pool_size:
+        lines.append(f"Pool:            {rec.pool_size} bytes, allocated by the bundle")
     lines += [
         "",
         "Run it:",
@@ -359,7 +349,7 @@ def _explain_header(rec: KernelRecord) -> str:
             rec.specs,
             kernel_name=rec.name,
             args=rec.args or None,
-            pool_bytes=rec.pool_bytes,
+            pool_size=rec.pool_size,
         )
     except Exception as exc:
         block = f"# (explain header unavailable: {type(exc).__name__}: {exc})"
@@ -402,7 +392,7 @@ from torch_spyre._inductor.op_spec import (
 )
 
 KERNEL_NAME = "{rec.name}"
-POOL_BYTES = {rec.pool_bytes}
+POOL_SIZE = {rec.pool_size}
 BUNDLE_SYMBOLIC_ARGS = {rec.bundle_symbolic_args}
 # Named after this file, not the kernel: two graphs can share a fused kernel
 # name, and write_kernel disambiguates the scripts (name_1.py) -- so a
@@ -422,7 +412,7 @@ LAYOUTS = [
 ops = {spec_source(rec.specs)}
 
 def build_tensors():
-    """Return (host tensors, pool bytes or None) for this kernel's args.
+    """Return the host tensors for this kernel's args, in arg_index order.
 
     Replays a .inputs.pt sitting beside this script, otherwise synthesizes.
     Integer args get zeros, not random values: they are usually indirect-access
@@ -431,7 +421,7 @@ def build_tensors():
     if os.path.exists(INPUTS_PT):
         saved = torch.load(INPUTS_PT)
         print(f"inputs: replayed from {{INPUTS_PT}}")
-        return saved["tensors"], saved["pool"]
+        return saved["tensors"]
     torch.manual_seed(0xAFFE)
     tensors = []
     for shape, dtype in SHAPES:
@@ -443,21 +433,19 @@ def build_tensors():
             tensors.append(torch.rand(shape, dtype=src).to(dtype))
         else:
             tensors.append(torch.zeros(shape, dtype=dtype))
-    return tensors, None
+    return tensors
 
 
 {runner_template()}
 
 
 if __name__ == "__main__":
-    host_tensors, pool_contents = build_tensors()
     main(
         KERNEL_NAME,
         ops,
-        host_tensors,
+        build_tensors(),
         layouts=LAYOUTS,
-        pool_bytes=POOL_BYTES,
-        pool_contents=pool_contents,
+        pool_size=POOL_SIZE,
         bundle_symbolic_args=BUNDLE_SYMBOLIC_ARGS,
     )
 '''
@@ -477,10 +465,8 @@ def write_kernel(
         f.write(emit_script(rec, source, total, no_execute, explain_header))
     if save_inputs and rec.observed_run:
         # Keyed on the script path, so a disambiguated script gets its own .pt.
-        # "pool" is always None -- see _record_args -- but stays in the dict so
-        # the schema does not depend on whether the kernel used one.
         torch.save(
-            {"tensors": [a.values for a in rec.args], "pool": None},
+            {"tensors": [a.values for a in rec.args]},
             os.path.splitext(path)[0] + ".inputs.pt",
         )
     return path
@@ -585,12 +571,10 @@ def main(argv=None) -> int:
         written += 1
         n_ops = sum(1 for _ in _iter_op_specs(rec.specs))
         detail = f"{n_ops} OpSpec(s), {len(rec.args)} arg(s)"
-        if rec.pool_bytes:
-            detail += f", {rec.pool_bytes}-byte pool"
+        if rec.pool_size:
+            detail += f", {rec.pool_size}-byte pool"
         note = "" if rec.observed_run else "  [no .run() seen -- shapes unfilled]"
         print(f"  {path}  ({detail}){note}")
-        if args.save_inputs and rec.pool_bytes:
-            print("    note: arg values saved; pool contents are not captured")
 
     if written == 0:
         raise SystemExit("nothing written")

--- a/tests/op_specs/explain.py
+++ b/tests/op_specs/explain.py
@@ -201,11 +201,11 @@ def _table(rows: list, headers: list, indent: str, pad: str = "") -> list:
 # ---------------------------------------------------------------------------
 
 
-def _title(kernel_name, specs, args, pool_bytes) -> list:
+def _title(kernel_name, specs, args, pool_size) -> list:
     n_ops = sum(1 for _ in _iter_op_specs(specs))
     n_args = len(args) if args else len(_kernel_arg_roles(specs))
     facts = f"{n_ops} OpSpec{'s' if n_ops != 1 else ''} - {n_args} kernel args"
-    facts += " - no pool" if not pool_bytes else f" - {pool_bytes}-byte pool"
+    facts += " - no pool" if not pool_size else f" - {pool_size}-byte pool"
     name = kernel_name or "(unnamed OpSpec list)"
     gap = WIDTH - 2 - len(name) - len(facts)
     if gap < 1:
@@ -218,23 +218,23 @@ def _title(kernel_name, specs, args, pool_bytes) -> list:
     return ["=" * WIDTH, *header, "=" * WIDTH, ""]
 
 
-def _kernel_args_section(specs, args, pool_bytes) -> list:
+def _kernel_args_section(specs, args, pool_size) -> list:
     """The tensors .run() receives, in arg_index order.
 
     ``args`` is optional: capture.py has the host shapes observed at launch,
     where a hand-written spec has only what the TensorArgs carry.
     """
     roles = _kernel_arg_roles(specs)
-    if not roles and not pool_bytes:
+    if not roles and not pool_size:
         return []
 
     caption = "what .run() receives, in arg_index order"
     header = "KERNEL ARGS" + " " * max(WIDTH - 11 - len(caption), 1) + caption
     lines = [header]
 
-    if pool_bytes:
+    if pool_size:
         lines.append(
-            f"  pool           {pool_bytes} bytes (uint8) -- passed first to .run()"
+            f"  pool           {pool_size} bytes -- allocated by the bundle, not an arg"
         )
 
     # Fall back to the TensorArgs when no observed-launch info was supplied.
@@ -577,7 +577,7 @@ def _walk(specs, depth, counter, n_ops, verbose) -> list:
     return lines
 
 
-def render(specs, *, kernel_name=None, args=None, pool_bytes=0, verbose=False) -> str:
+def render(specs, *, kernel_name=None, args=None, pool_size=0, verbose=False) -> str:
     """Return a human-readable explanation of an OpSpec list.
 
     ``specs`` is a list of OpSpec / LoopSpec / UnimplementedOp.  ``args``
@@ -586,8 +586,8 @@ def render(specs, *, kernel_name=None, args=None, pool_bytes=0, verbose=False) -
     """
     specs = list(specs)
     n_ops = sum(1 for _ in _iter_op_specs(specs))
-    lines = _title(kernel_name, specs, args, pool_bytes)
-    lines += _kernel_args_section(specs, args, pool_bytes)
+    lines = _title(kernel_name, specs, args, pool_size)
+    lines += _kernel_args_section(specs, args, pool_size)
     # 1-based: "OP 0/7" against an "of 7" denominator reads as an off-by-one.
     lines += _walk(specs, 0, [1], n_ops, verbose)
     return "\n".join(lines).rstrip() + "\n"

--- a/tests/op_specs/runner.py
+++ b/tests/op_specs/runner.py
@@ -28,7 +28,6 @@ import sys
 
 import torch
 
-from torch_spyre._C import DataFormats, SpyreTensorLayout, spyre_empty_with_layout
 from torch_spyre._inductor import config as spyre_config
 from torch_spyre._inductor.codegen.bundle import generate_bundle
 from torch_spyre.execution.async_compile import SpyreAsyncCompile
@@ -42,9 +41,9 @@ from torch_spyre.execution.async_compile import SpyreAsyncCompile
 def ensure_runtime() -> None:
     """Bring the Spyre runtime up before any layout-aware allocation.
 
-    ``spyre_empty_with_layout`` and ``t.to(device_layout=...)`` reach the C++
-    allocator directly, bypassing the dispatcher that triggers ``startRuntime()``.
-    Without this they fail on a fresh process with ContextNotCreated.
+    ``t.to(device_layout=...)`` reaches the C++ allocator directly, bypassing the
+    dispatcher that triggers ``startRuntime()``.  Without this it fails on a fresh
+    process with ContextNotCreated.
     """
     torch.empty(1, dtype=torch.float16).to(torch.device("spyre"))
 
@@ -70,25 +69,6 @@ def pin_bundle_symbolic_args(value) -> None:
     spyre_config.bundle_symbolic_args = value
 
 
-def make_pool(pool_bytes: int, contents=None) -> torch.Tensor:
-    """Allocate the flat HBM intermediates pool passed as a kernel's first arg.
-
-    The pool is an opaque byte-addressed region that ``hbm_pool`` tensors sit
-    inside at fixed offsets, so a 1-D uint8 tensor of that many bytes is the
-    right shape.  ``contents`` seeds it when a replay has bytes to seed it with;
-    a capture never does, so an uninitialized pool is the norm.
-    """
-    ensure_runtime()
-    layout = SpyreTensorLayout(
-        device_size=[pool_bytes],
-        stride_map=[1],
-        device_dtype=DataFormats.SENINT8,
-    )
-    if contents is not None:
-        return contents.to("spyre", device_layout=layout)
-    return spyre_empty_with_layout((pool_bytes,), (1,), torch.uint8, layout)
-
-
 def to_device(tensors: list, layouts=None) -> list:
     """Move host tensors to Spyre, honouring an explicit layout when given.
 
@@ -108,42 +88,35 @@ def to_device(tensors: list, layouts=None) -> list:
     return out
 
 
-def bundle_op_specs(name: str, ops: list, out_dir: str) -> list:
+def bundle_op_specs(name: str, ops: list, out_dir: str, pool_size=0) -> list:
     """Write sdsc_N.json + bundle.mlir for ``ops`` into ``out_dir``.
 
     Needs no device and no backend compiler.  Returns the directory listing.
+    ``pool_size`` must be non-zero whenever any TensorArg is ``hbm_pool``-
+    allocated: the bundle emits its own ``device_mem_allocate`` of that size.
     """
     os.makedirs(out_dir, exist_ok=True)
-    generate_bundle(name, out_dir, list(ops))
+    generate_bundle(name, out_dir, list(ops), pool_size=pool_size)
     return sorted(os.listdir(out_dir))
 
 
-def run_op_specs(
-    name: str,
-    ops: list,
-    tensors: list,
-    layouts=None,
-    pool_bytes=0,
-    pool_contents=None,
-):
+def run_op_specs(name: str, ops: list, tensors: list, layouts=None, pool_size=0):
     """Compile ``ops`` and run them on the device against ``tensors``.
 
     ``tensors[i]`` is the host tensor for the TensorArg with ``arg_index=i``,
     and results are written back into it in place -- compute any reference
     value first.  ``copy_`` rather than ``t[:] =``: a 0-dim scalar arg has no
-    valid slice.  ``pool_bytes`` must be non-zero whenever any TensorArg is
-    ``hbm_pool``-allocated; the pool is passed ahead of the kernel args.
-    Returns the artifact directory.
+    valid slice.  Every tensor is a kernel arg: the HBM pool, when there is one,
+    is allocated inside the bundle rather than passed at launch, so ``pool_size``
+    only has to reach ``sdsc``.  Returns the artifact directory.
     """
     dev_tensors = to_device(tensors, layouts)
-    pool = make_pool(pool_bytes, pool_contents) if pool_bytes else None
 
-    runner = SpyreAsyncCompile().sdsc(name, list(ops))
+    runner = SpyreAsyncCompile().sdsc(name, list(ops), pool_size=pool_size)
     code_dir = getattr(runner, "code_dir", None)
     print(f"artifacts: {code_dir}")
 
-    run_args = dev_tensors if pool is None else [pool] + dev_tensors
-    runner.run(*run_args)
+    runner.run(*dev_tensors)
 
     for t, dt in zip(tensors, dev_tensors):
         t.copy_(dt.cpu())
@@ -155,8 +128,7 @@ def main(
     ops: list,
     tensors: list,
     layouts=None,
-    pool_bytes=0,
-    pool_contents=None,
+    pool_size=0,
     bundle_symbolic_args=None,
     argv=None,
 ):
@@ -208,26 +180,19 @@ def main(
                 render(
                     ops,
                     kernel_name=name,
-                    pool_bytes=pool_bytes,
+                    pool_size=pool_size,
                     verbose=args.explain_verbose,
                 )
             )
 
     if args.stage == "bundle":
         out_dir = args.out_dir or os.path.join("op_spec_out", name)
-        listing = bundle_op_specs(name, ops, out_dir)
+        listing = bundle_op_specs(name, ops, out_dir, pool_size=pool_size)
         print(f"artifacts: {os.path.abspath(out_dir)}")
         print(f"contents: {listing}")
         return out_dir
 
-    code_dir = run_op_specs(
-        name,
-        ops,
-        tensors,
-        layouts=layouts,
-        pool_bytes=pool_bytes,
-        pool_contents=pool_contents,
-    )
+    code_dir = run_op_specs(name, ops, tensors, layouts=layouts, pool_size=pool_size)
     # Only after a launch: before one these are still the inputs.
     for i, t in enumerate(tensors):
         print(f"arg{i} {tuple(t.shape)} {t.dtype}: {t.flatten()[:6].tolist()}")
@@ -246,7 +211,7 @@ import os
 
 import torch
 
-from torch_spyre._C import DataFormats, SpyreTensorLayout, spyre_empty_with_layout
+from torch_spyre._C import DataFormats, SpyreTensorLayout
 from torch_spyre._inductor import config as spyre_config
 from torch_spyre._inductor.codegen.bundle import generate_bundle
 from torch_spyre.execution.async_compile import SpyreAsyncCompile
@@ -255,7 +220,6 @@ from torch_spyre.execution.async_compile import SpyreAsyncCompile
 _TEMPLATE_FUNCS = (
     ensure_runtime,
     pin_bundle_symbolic_args,
-    make_pool,
     to_device,
     bundle_op_specs,
     run_op_specs,

--- a/tests/op_specs/test_op_spec_lab.py
+++ b/tests/op_specs/test_op_spec_lab.py
@@ -21,6 +21,7 @@ that it still works when someone reaches for it.  Everything here is pure Python
 
 import ast
 import builtins
+import inspect
 import os
 import sys
 import types
@@ -78,9 +79,16 @@ def _add_op(debug_handle=None):
 
 
 def _pool_op():
-    """An add whose output spilled to the HBM pool, so .run() gets a pool first."""
+    """An add whose output spilled to the HBM pool, leaving two kernel args.
+
+    ``arg_index=-1`` is what makes this a *real* pool spec rather than one that
+    only looks like it: ``generate_bundle`` keys its ``device_mem_allocate`` on
+    the pooled tensor being an intermediate, so with a non-negative arg_index it
+    emits no pool at all and accepts ``pool_size=0`` without complaint.
+    """
     op = _add_op()
     op.args[2].allocation = {"hbm_pool": 0}
+    op.args[2].arg_index = -1
     return op
 
 
@@ -95,12 +103,7 @@ class _FakeLayout:
 
 
 class _FakeTensor:
-    """A stand-in for a device tensor, counting the .cpu() calls it receives.
-
-    The pool must never get one: per _record_args, ``pool.cpu()`` on the flat
-    SENINT8 pool aborts the process, so "was .cpu() called" is the assertion that
-    matters and a real tensor could not make it.
-    """
+    """A stand-in for a device tensor, counting the .cpu() calls it receives."""
 
     def __init__(self, shape=(128, 256), dtype=torch.float16, numel=32768):
         self.shape = shape
@@ -130,6 +133,11 @@ class _FakeRunner:
         self.launches.append(args)
 
 
+def _fake_sdsc(self, kernel_name, specs, pool_size=0):
+    """Stand in for sdsc() with its real signature, so the spy is called as it is."""
+    return _FakeRunner()
+
+
 def _arg_record(dtype=torch.float16):
     return capture.ArgRecord(
         shape=(128, 256),
@@ -141,17 +149,17 @@ def _arg_record(dtype=torch.float16):
     )
 
 
-def _record(name="sdsc_add_0", pool_bytes=0):
+def _record(name="sdsc_add_0", pool_size=0):
     return capture.KernelRecord(
         name=name,
         specs=[_add_op()],
         index=0,
         sencores=32,
         bundle_symbolic_args=True,
+        pool_size=pool_size,
         # A distinct record per arg: sharing one object made a test that retyped
         # arg0 silently retype all three.
         args=[_arg_record() for _ in range(3)],
-        pool_bytes=pool_bytes,
         observed_run=True,
     )
 
@@ -196,9 +204,10 @@ def test_render_discloses_that_a_layout_label_is_not_a_role():
 
 
 def test_render_reports_the_pool_it_was_given():
-    out = explain.render([_add_op()], kernel_name="k", pool_bytes=32768)
+    out = explain.render([_add_op()], kernel_name="k", pool_size=32768)
     assert "32768-byte pool" in out  # title
-    assert "32768 bytes (uint8) -- passed first to .run()" in out
+    # The bundle emits its own device_mem_allocate, so the pool is not an arg.
+    assert "32768 bytes -- allocated by the bundle, not an arg" in out
     assert "no pool" in explain.render([_add_op()], kernel_name="k")
 
 
@@ -301,16 +310,63 @@ def test_emitted_script_executes_its_definitions():
     break every future capture at *its* import time.  ``__main__`` does not fire
     under exec, so nothing is compiled or launched.
     """
-    src = capture.emit_script(_record(pool_bytes=32768), "prog.py", 1, False)
+    src = capture.emit_script(_record(pool_size=32768), "prog.py", 1, False)
     namespace: dict = {"__file__": "/tmp/captured/sdsc_add_0.py"}
     exec(compile(src, "<emitted>", "exec"), namespace)  # noqa: S102
     assert namespace["KERNEL_NAME"] == "sdsc_add_0"
-    assert namespace["POOL_BYTES"] == 32768
+    assert namespace["POOL_SIZE"] == 32768
     assert len(namespace["ops"]) == 1
     assert len(namespace["LAYOUTS"]) == 3
     # Keyed on the script, not the kernel: two graphs can share a fused name, and
     # a kernel-keyed .pt would be clobbered by the second capture.
     assert namespace["INPUTS_PT"] == "/tmp/captured/sdsc_add_0.inputs.pt"
+
+
+def test_emitted_script_forwards_the_pool_size():
+    """A pool kernel bundles only if pool_size reaches sdsc().
+
+    ``generate_bundle`` asserts ``0 < pool_size`` whenever a pool symbol is
+    present, so an emitted script that drops it fails in codegen -- no device
+    needed to get it wrong.
+    """
+    src = capture.emit_script(_record(pool_size=32768), "prog.py", 1, False)
+    assert "POOL_SIZE = 32768" in src
+    assert "pool_size=POOL_SIZE" in src
+
+
+def test_bundling_a_pool_spec_emits_the_pool_allocation(tmp_path):
+    """Bundle a pool spec for real -- no device, no mock, no dxp_standalone.
+
+    The unmocked call is the point: ``generate_bundle`` is where a dropped
+    pool_size actually bites, and it asserts ``0 < pool_size`` only when it sees
+    a pool symbol. So this fails on a lab that forgets to forward the size, where
+    a mocked ``generate_bundle`` would happily record the call and pass.
+    """
+    with spyre_config.patch(bundle_symbolic_args=True):  # type: ignore[attr-defined]
+        listing = runner.bundle_op_specs(
+            "k", [_pool_op()], str(tmp_path), pool_size=32768
+        )
+        assert "bundle.mlir" in listing
+        mlir = (tmp_path / "bundle.mlir").read_text()
+        assert "sdscbundle.device_mem_allocate 32768 bytes" in mlir
+
+        with pytest.raises(AssertionError, match="pool_size=0 out of range"):
+            runner.bundle_op_specs("k", [_pool_op()], str(tmp_path / "dropped"))
+
+
+def test_run_op_specs_forwards_the_pool_size():
+    """The replay path, which is where a dropped pool_size would go unnoticed."""
+    tensors = [torch.zeros(4, dtype=torch.float16) for _ in range(2)]
+    fake = _FakeRunner()
+    with (
+        patch.object(runner, "to_device", lambda ts, layouts=None: list(ts)),
+        patch.object(SpyreAsyncCompile, "sdsc", return_value=fake) as sdsc,
+    ):
+        runner.run_op_specs("k", [_pool_op()], tensors, pool_size=32768)
+
+    assert sdsc.call_args.kwargs["pool_size"] == 32768
+    # The pool is not an argument any more, so only the kernel args reach .run().
+    assert len(fake.launches[0]) == 2
 
 
 def test_runner_template_is_self_contained():
@@ -362,36 +418,45 @@ def test_write_kernel_disambiguates_script_and_pt_together(tmp_path):
         assert os.path.exists(os.path.splitext(path)[0] + ".inputs.pt")
 
 
-def test_record_args_pops_the_pool_and_never_reads_it():
-    """The pool is .run()'s first argument, identified by the shared predicate.
+def test_spy_accepts_everything_sdsc_accepts():
+    """The spy stands in for sdsc(), so it must take sdsc()'s parameters.
 
-    ``uses_hbm_pool`` is what ``call_kernel`` used to prepend the pool, so
-    _record_args has to reach the same verdict. Getting it wrong is not a bad
-    label: it means calling .cpu() on the flat pool tensor, which aborts the
-    process rather than failing an assertion.
+    #3707 added ``pool_size`` and the spy did not follow, which left every
+    pool-using program uncapturable -- a TypeError raised through the Inductor
+    backend -- while this suite stayed green, because every other test here
+    patches sdsc itself and never exercises the real signature.
+    """
+    real = inspect.signature(SpyreAsyncCompile.sdsc)
+    with capture.capture_kernels():
+        spy = inspect.signature(SpyreAsyncCompile.sdsc)
+
+    assert list(spy.parameters) == list(real.parameters)
+
+
+def test_record_args_keeps_every_arg_for_a_pool_kernel():
+    """Nothing is skipped even when the kernel spills to the pool.
+
+    Since #3707 the bundle allocates its own pool via ``device_mem_allocate``, so
+    no pool tensor is passed at launch and ``arg_index`` is the ``.run()``
+    position for every arg. Popping one here would silently drop arg0 from the
+    capture and record its ``numel()`` as a byte count.
     """
     rec = capture.KernelRecord(
         name="k", specs=[_pool_op()], index=0, sencores=32, bundle_symbolic_args=True
     )
-    pool = _FakeTensor(shape=(32768,), dtype=torch.uint8, numel=32768)
-    args = (pool, _FakeTensor(), _FakeTensor(), _FakeTensor())
+    capture._record_args(rec, tuple(_FakeTensor() for _ in range(2)), save_inputs=True)
 
-    capture._record_args(rec, args, save_inputs=True)
-
-    assert rec.pool_bytes == 32768
-    assert len(rec.args) == 3
-    assert pool.cpu_calls == 0
+    assert rec.pool_size == 0  # only the sdsc() keyword sets this
+    assert len(rec.args) == 2
     assert all(a.values is not None for a in rec.args)
 
 
-def test_record_args_keeps_every_arg_when_there_is_no_pool():
-    """Nothing is popped for a pool-free kernel, so arg0 stays arg0."""
+def test_record_args_records_the_layout_of_every_arg():
     rec = capture.KernelRecord(
         name="k", specs=[_add_op()], index=0, sencores=32, bundle_symbolic_args=True
     )
     capture._record_args(rec, tuple(_FakeTensor() for _ in range(3)), save_inputs=False)
 
-    assert rec.pool_bytes == 0
     assert len(rec.args) == 3
     assert rec.args[0].device_dtype_name == "SEN169_FP16"
     assert rec.args[0].element_arrangement_name == "STANDARD"
@@ -437,7 +502,7 @@ def test_capture_writes_what_it_recorded_before_the_target_crashed(tmp_path, cap
     )
     out_dir = tmp_path / "captured"
 
-    with patch.object(SpyreAsyncCompile, "sdsc", lambda self, n, s: _FakeRunner()):
+    with patch.object(SpyreAsyncCompile, "sdsc", _fake_sdsc):
         status = capture.main([str(program), "--out", str(out_dir)])
 
     # Not 0: a caller has to be able to tell a partial capture from a whole one
@@ -454,7 +519,7 @@ def test_capture_of_a_clean_program_exits_zero(tmp_path):
     program = _stub_sdsc_program(tmp_path, body)
     out_dir = tmp_path / "captured"
 
-    with patch.object(SpyreAsyncCompile, "sdsc", lambda self, n, s: _FakeRunner()):
+    with patch.object(SpyreAsyncCompile, "sdsc", _fake_sdsc):
         assert capture.main([str(program), "--out", str(out_dir)]) == 0
 
     assert (out_dir / "sdsc_ok_0.py").exists()
@@ -502,7 +567,7 @@ def test_build_tensors_synthesizes_fp8_args():
     src = capture.emit_script(rec, "prog.py", 1, False)
     exec(compile(src, "<emitted>", "exec"), namespace)  # noqa: S102
 
-    tensors, _ = namespace["build_tensors"]()
+    tensors = namespace["build_tensors"]()
 
     assert tensors[0].dtype == torch.float8_e4m3fn
     assert tuple(tensors[0].shape) == (128, 256)


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes the OpSpec lab's HBM pool handling, which broke when the pool moved into the SDSC bundle: `sdsc()` gained a `pool_size` keyword, the bundle emits its own `device_mem_allocate`, and `call_kernel` stopped prepending a pool tensor to `.run()`. The lab still implemented the old model, so capturing any pool-using program failed with `TypeError: spy() got an unexpected keyword argument 'pool_size'` — the guide's own example 04 among them.

Three defects, each hiding behind the last. The spy did not accept `pool_size`. `runner.py` did not forward it, so `generate_bundle` asserted `0 < pool_size` for a spec carrying a pool symbol. And `_record_args` still popped `.run()`'s first argument as the pool — now a real kernel arg — so once the first two were fixed the capture *succeeded* while silently dropping arg0 and recording its `numel()` as a byte count.

`pool_bytes` becomes `pool_size` throughout, since the quantity changed meaning: a bundle-level allocation size, not a host tensor's length. `make_pool` and `pool_contents` are deleted rather than left describing a model the backend no longer has.

#### Which issue(s) this PR is related to:

#4030 

#### Special notes for your reviewer:

The suite stayed green through all of this because every test hand-builds specs and patches `sdsc` itself — including two stubs that shared the defect. So the new coverage matters as much as the fix, and both new tests are device-free:

- `test_spy_accepts_everything_sdsc_accepts` compares the spy's signature against the real `sdsc`, so the next keyword fails here, not in a capture.
- `test_bundling_a_pool_spec_emits_the_pool_allocation` bundles a pool spec for real. This needed `_pool_op()` corrected to `arg_index=-1`: `generate_bundle` keys its pool on the tensor being an intermediate, so the old fixture emitted no pool and accepted `pool_size=0.

Each defect was reverted individually to confirm a named test catches it. Verified on device: example 04 captures as `(7 OpSpec(s), 4 arg(s), 32768-byte pool)`, the bundle carries `device_mem_allocate 32768 bytes`, and the standalone replay matches the compiled result to fp16 precision. Examples 01–03 and the `--save-inputs` round trip were rerun unchanged.

#### Does this PR introduce a user-facing change?

No

#### Additional note:
