### PR TITLE
fix(inductor): don't split fused gather data dims

### DIFF
--- a/tests/inductor/test_indirect_access_internals.py
+++ b/tests/inductor/test_indirect_access_internals.py
@@ -63,6 +63,9 @@ from torch_spyre._inductor.op_spec import (  # noqa: E402
     TensorArg,
     UnimplementedOp,
 )
+from torch_spyre._inductor.pass_utils import (  # noqa: E402
+    _non_indirect_coord_syms,
+)
 from torch_spyre.execution.async_compile import SpyreAsyncCompile  # noqa: E402
 
 
@@ -153,6 +156,41 @@ class TestIndirectAccessAtom(IndirectAccessTestCase):
         self.assertEqual(len(out.atoms(IndirectAccess)), 2)
         self.assertNotIn(t0, out.free_symbols)
         self.assertNotIn(t1, out.free_symbols)
+
+
+# ===========================================================================
+# Layer 1b: Split-guard symbol extraction from device coordinates
+# ===========================================================================
+class TestNonIndirectCoordSyms(IndirectAccessTestCase):
+    """The syms this reports are the ones work division must not split, so a
+    shared gather table keeps the same base address on every core.
+    """
+
+    def test_pure_data_coords_all_reported(self):
+        c0, c1 = sympy.symbols("c0 c1")
+        self.assertEqual(_non_indirect_coord_syms([c0, c1]), {c0, c1})
+
+    def test_bare_indirect_coord_reports_nothing(self):
+        idx = sympy.Symbol("idx")
+        self.assertEqual(_non_indirect_coord_syms([IndirectAccess(idx)]), set())
+
+    def test_fused_entry_coord_still_reports_its_data_sym(self):
+        """A paged cache folds block index and within-block offset into one
+        coordinate; d0 addresses into the shared table (#3984).
+        """
+        d0 = sympy.Symbol("d0")
+        coord = d0 + 128 * IndirectAccess(sympy.Symbol("idx"))
+        self.assertEqual(_non_indirect_coord_syms([coord]), {d0})
+
+    def test_fused_coord_alongside_plain_coords(self):
+        d0, d1, d2 = sympy.symbols("d0 d1 d2")
+        coords = [
+            d0 + 128 * IndirectAccess(sympy.Symbol("idx")),
+            d1,
+            sympy.floor(d2 / 64),
+            sympy.Mod(d2, 64),
+        ]
+        self.assertEqual(_non_indirect_coord_syms(coords), {d0, d1, d2})
 
 
 # ===========================================================================

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1169,6 +1169,14 @@ def _non_indirect_coord_syms(coords: list[Expr]) -> set[Symbol]:
     syms: set[Symbol] = set()
     for coord in coords:
         if hasattr(coord, "has") and coord.has(IndirectAccess):
+            # A coordinate can mix the runtime-chosen row with data syms when
+            # the layout folds the row dim into an outer one -- a paged KV cache
+            # reads as `d0 + 128*IndirectAccess(idx)`. Those data syms still
+            # address into the shared table, so report them (#3984).
+            inner: set[Symbol] = set()
+            for term in coord.atoms(IndirectAccess):
+                inner |= term.free_symbols
+            syms |= coord.free_symbols - inner
             continue
         syms |= coord.free_symbols
     return syms


### PR DESCRIPTION
## Description

A shared gather table's device coordinate is not always either the runtime-chosen row or a
data coordinate. When the layout folds the indexed dim into an outer one, one coordinate is
both — the paged KV cache in `spyre-inference` reads as `d0 + 128*IndirectAccess(idx)`, with
128 the block size and `d0` the token within the block.

`_non_indirect_coord_syms` skipped any coordinate containing an `IndirectAccess`, so `d0`
never reached the forbidden set and work division split it 32 ways, giving every core a
different base into a table all of them must address identically — the miscompile #2699's
docstring warns about. The enforcement path itself is fine: the embedding gather in the same
graph correctly gets `forbidden=['d1']`. Only the symbol collection had a hole, and #3950
removed the `InductorError` that had been masking it.

This is the only indirect op in the failing vLLM run that receives a multicore split — the
embedding gather and both KV scatters already emit `cores=1`:

```
shared_coords=[['d0 + 128*IndirectAccess(arg0_1)', 'd1', 'floor(d2/64)', 'Mod(d2, 64)']]
before:  forbidden=['d1', 'd2']         -> cores=32 -> garbage output
after:   forbidden=['d0', 'd1', 'd2']   -> cores=1  -> correct output
```

`test_paged_kv` misses this because its 3-D cache yields a bare `IndirectAccess` entry
coordinate, never a fused one.

Known limitation: the fused-coordinate gather now runs single-core, so #2699's multicore does
not apply to it. Splitting a fused coordinate properly means offsetting each core's base by
the split amount — a change to the split machinery, not to this guard.

## Related Issues

Fixes #3984. Guard added in #2699, unmasked by #3950.

## Test Plan

Validated at `b4c056b` (#3950) — the rev where #3984 reproduces and the newest commit that
builds against the `ibm-*` RPMs on the test host. Both touched files are byte-identical
between `b4c056b` and `main`.

- [x] `test_indirect_access_internals.py` — 73 passed (69 pre-existing + 4 new). The two
      fused-coordinate tests fail against unpatched `pass_utils`.
- [x] `test_indirect_access_gather.py::TestGather_cores32::test_paged_kv` — passed
- [x] `TestEmbeddingAllIndexBuckets_cores32::test_gather_{01,05,16,32}_index_sticks` — passed.
      These assert the multicore split width, so they check the fix does not over-restrict.
- [x] A `spyre-inference` compiled generation that returned garbage text before the fix
      returns the reference text after it; `tests/test_compile.py::test_basic_llm_inference`
      passes (compiled end-to-end, exact output-text comparison).
- [x] `ruff check` / `ruff format` clean at the pinned `v0.14.5`.
- [ ] Full CI suite.

Not covered: a device-level regression test. Standalone probes at the same arg shapes do not
fuse the entry coordinate (they emit `cores=1`), so the fusion depends on something else in
the vLLM graph; the unit tests pin the guard behaviour instead.
