### PR TITLE
Preserve scratchpad lifetimes across counted loops

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1801,6 +1801,69 @@ class TestCoarseTile(unittest.TestCase):
         finally:
             graph_ctx.__exit__(None, None, None)
 
+    def test_post_stickify_loop_extends_crossing_lifetime(self):
+        """A value born before an automatically-tiled counted loop and read
+        inside it must stay live through the loop (issue #4035).
+
+        Same clobber the ``persistent``/``later`` repro in
+        test_perm_layout_solver.py guards at the solver level, but here the
+        ``lifetime_end_override`` is *computed* by
+        ``counted_loop_lifetime_end_overrides`` for a loop built by the
+        automatic span-overflow entry point, ``coarse_tile_post_stickify``
+        -- not hand-passed, and not hint-driven.  The liveness gap comes
+        from the graph holding one textual copy of the loop body regardless
+        of how the loop was constructed, so overrides must cover this path
+        exactly as they cover explicit ``spyre_hint`` loops.
+        """
+        from collections import namedtuple
+
+        from torch_spyre._inductor.scratchpad.utils import (
+            counted_loop_lifetime_end_overrides,
+        )
+
+        _dep = namedtuple("_dep", ["name"])
+
+        def _stub_read_writes(op, reads, writes):
+            op.get_read_writes.return_value = SimpleNamespace(
+                reads={_dep(name) for name in reads},
+                writes={_dep(name) for name in writes},
+            )
+
+        # Op 0 is born outside the loop; ops 1-3 form one counted loop.
+        # ``reader_x`` reads across the loop boundary; ``reader_i`` reads a
+        # value born inside the same loop.
+        crossing = _make_op(_make_pointwise([Integer(16)]), "crossing")
+        _stub_read_writes(crossing, reads=["arg0"], writes=["crossing"])
+        body_writer = _make_hinted_op(_make_pointwise([Integer(16)]), "body_writer")
+        _stub_read_writes(body_writer, reads=["arg1"], writes=["internal"])
+        reader_x = _make_hinted_op(_make_pointwise([Integer(16)]), "reader_x")
+        _stub_read_writes(reader_x, reads=["crossing"], writes=["reader_x_out"])
+        reader_i = _make_hinted_op(_make_pointwise([Integer(16)]), "reader_i")
+        _stub_read_writes(reader_i, reads=["internal"], writes=["reader_i_out"])
+
+        operations = [crossing, body_writer, reader_x, reader_i]
+        coarse_tile_post_stickify(
+            _graph(operations),
+            [([body_writer, reader_x, reader_i], [(0, Integer(4))])],
+        )
+
+        # The loop body stays ops 1..3: nothing was inserted, the op outside
+        # the group was not stamped, and the group ops carry the loop id.
+        self.assertEqual(len(operations), 4)
+        self.assertFalse(hasattr(crossing, "loop_info"))
+        self.assertEqual(reader_i.loop_info.loop_group_id, (0,))
+
+        overrides = counted_loop_lifetime_end_overrides(
+            SimpleNamespace(operations=operations, graph_input_names=["arg0", "arg1"])
+        )
+
+        # Values born before the loop and read inside it -- the computed
+        # buffer ``crossing`` and the graph input ``arg1`` -- live through
+        # the loop's textual end (exclusive index 4).  ``internal`` is born
+        # and consumed inside the loop: no extension.  ``arg0`` is only read
+        # outside the loop: no extension.
+        self.assertEqual(overrides, {"crossing": 4, "arg1": 4})
+
     def test_end_to_end_shares_one_copy_across_group(self):
         """Full coarse_tile() entry point: two hint-driven ops in one group
         both reading the same full InputBuffer at the same index must end

--- a/tests/inductor/test_perm_layout_solver.py
+++ b/tests/inductor/test_perm_layout_solver.py
@@ -1476,6 +1476,23 @@ class NativeSolverDifferentialTests(TestCase):
         self._assert_equal(py_plan, cpp_plan, "pokethrough fast path")
         self._assert_equal(ref_plan, cpp_plan, "pokethrough fast path vs reference")
 
+    def test_native_solver_honors_lifetime_end_override(self):
+        persistent = LifetimeBoundBuffer(
+            "persistent",
+            64,
+            [0, 1],
+            lifetime_end_override=5,
+        )
+        later = LifetimeBoundBuffer("later", 64, [2, 3])
+        buffers = [persistent, later]
+        permutation = [0, 1]
+
+        py_plan = PermutationBasedLayoutSolver(buffers, permutation, 10_000, 1)
+        cpp_plan = NativePermutationLayoutSolver(buffers, permutation, 10_000, 1)
+
+        self._assert_equal(py_plan, cpp_plan, "lifetime end override")
+        self.assertNotEqual(cpp_plan.addresses[0], cpp_plan.addresses[1])
+
     def test_random_mixed_sequences_match_python(self):
         seeds = 4000 if _STRESS else 800
         for seed in range(seeds):

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -872,6 +872,71 @@ def test_lx_relayout_allocation_is_atomic_in_one_greedy_solve(caplog):
     )
 
 
+def _assert_live_buffers_do_not_share_addresses(buffers, limit):
+    allocator = ScratchpadAllocator(GreedyLayoutSolver, limit)
+    allocation = allocator._solve(allocator._build_solver(buffers))
+    assert all(buffer.address is not None for buffer in allocation)
+    for index, left in enumerate(allocation):
+        for right in allocation[index + 1 :]:
+            if not left.overlaps_in_time(right):
+                continue
+            assert left.address + left.size <= right.address or (
+                right.address + right.size <= left.address
+            )
+
+
+def test_lx_relayout_copies_loop_lifetime_to_every_destination():
+    plans = [
+        _relayout_plan("source", ("consumer_a", "consumer_b")),
+        LXRelayoutPlan(
+            "source",
+            ("consumer_c",),
+            _SOURCE_VIEW,
+            PerCoreView(((1, 8),), ((1, _CORE_ID),)),
+            8,
+        ),
+    ]
+    graph = SimpleNamespace(
+        operations=[
+            SimpleNamespace(get_name=lambda name=name: name)
+            for name in ("producer", "consumer_a", "consumer_b", "consumer_c")
+        ]
+    )
+    source = LifetimeBoundBuffer("source", 64, [0, 1, 2, 3], lifetime_end_override=6)
+    source.lx_relayout_plans = list(plans)
+    buffers = [source]
+    ScratchpadAllocator(GreedyLayoutSolver, 256)._append_lx_relayout_destinations(
+        graph, buffers
+    )
+
+    assert source.lifetime_end_override is None
+    assert [buffer.lifetime_end_override for buffer in source.paired_with] == [12, 12]
+    tail = LifetimeBoundBuffer("tail", 64, [8, 11])
+    buffers.append(tail)
+    _assert_live_buffers_do_not_share_addresses(buffers, 384)
+
+
+def test_lx_relayout_keeps_source_lifetime_for_later_original_reader():
+    graph = SimpleNamespace(
+        operations=[
+            SimpleNamespace(get_name=lambda name=name: name)
+            for name in ("producer", "relayout_consumer", "ordinary_consumer")
+        ]
+    )
+    source = LifetimeBoundBuffer("source", 64, [0, 1, 2], lifetime_end_override=4)
+    source.lx_relayout_plans = [_relayout_plan("source", "relayout_consumer")]
+    buffers = [source]
+    ScratchpadAllocator(GreedyLayoutSolver, 192)._append_lx_relayout_destinations(
+        graph, buffers
+    )
+
+    assert source.lifetime_end_override == 8
+    assert source.paired_with[0].lifetime_end_override == 8
+    tail = LifetimeBoundBuffer("tail", 64, [6, 7])
+    buffers.append(tail)
+    _assert_live_buffers_do_not_share_addresses(buffers, 384)
+
+
 @config.patch({"lx_planner_relayout": True})
 def test_lx_relayout_warns_for_unsupported_solver(caplog):
     class UnsupportedSolver:

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -16,6 +16,7 @@ import functools
 import logging
 import math
 import time
+from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import replace
 from typing import Any, Callable, cast, Optional
@@ -86,6 +87,7 @@ from torch_spyre._inductor.scratchpad.utils import (
     _get_buffer_user_deps,
     _would_produce_lx_back_gap,
     OP_OUTPUT_NOT_GOOD_FOR_LX_REUSE,
+    counted_loop_lifetime_end_overrides,
 )
 from torch_spyre._inductor.scratchpad.graph_editor import GraphEditor
 from torch_spyre._inductor.ir import FixedTiledLayout
@@ -117,6 +119,14 @@ _LX_TRACKER_CAPACITY_BYTES = (
     _LX_PHYSICAL_CAPACITY_BYTES - _LX_PROGRAM_DEBUG_RESERVATION_BYTES
 )
 _LX_ALLOCATION_GRANULARITY_BYTES = 128
+
+
+def _safe_in_place_parents(
+    parents: Sequence[str], lifetime_end_overrides: dict[str, int]
+) -> list[str]:
+    """Drop handoffs from parents that remain live through a counted loop."""
+
+    return [parent for parent in parents if parent not in lifetime_end_overrides]
 
 
 def _extern_kernel_in_live_range(graph: GraphLowering, uses: list[int]) -> bool:
@@ -630,6 +640,7 @@ class ScratchpadAllocator:
         lifetimes: dict[str, list[int]],
         ncores: dict[str, int],
         ncores_reasons: dict[str, str],
+        lifetime_end_overrides: Optional[dict[str, int]] = None,
     ) -> list[LifetimeBoundBuffer]:
         """Build one :class:`LifetimeBoundBuffer` per buffer, barred or not.
 
@@ -644,6 +655,7 @@ class ScratchpadAllocator:
         :meth:`_input_residency_reason` and their footprint is computed
         here rather than read off ``mem_usage`` (which covers ops only).
         """
+        lifetime_end_overrides = lifetime_end_overrides or {}
         buffers: list[LifetimeBoundBuffer] = []
         for output_name, info in mem_usage.items():
             uses = lifetimes.get(output_name, [])
@@ -662,8 +674,11 @@ class ScratchpadAllocator:
                     # to a consumer's in_place_parents, which would otherwise mutate
                     # this list inside the shared ``in_place`` dict (matches the copy
                     # in ``_build_cd_bound_buffers``).
-                    in_place_parents=list(in_place.get(output_name, [])),
+                    in_place_parents=_safe_in_place_parents(
+                        in_place.get(output_name, []), lifetime_end_overrides
+                    ),
                     residency_reason=reasons.get(output_name),
+                    lifetime_end_override=lifetime_end_overrides.get(output_name),
                 )
             )
 
@@ -695,6 +710,7 @@ class ScratchpadAllocator:
                     first_use_is_read=True,
                     in_place_parents=[],
                     residency_reason=reason,
+                    lifetime_end_override=lifetime_end_overrides.get(input_name),
                 )
             )
 
@@ -707,7 +723,7 @@ class ScratchpadAllocator:
             # consumer is a built candidate with matching per-core size, device
             # layout, a pointwise producer, and no core-division mismatch is there
             # anything safe to merge.
-            if reason is not None:
+            if reason is not None or input_name in lifetime_end_overrides:
                 continue
             last_use = uses[-1]
             consumer_op = graph.operations[last_use]
@@ -869,6 +885,7 @@ class ScratchpadAllocator:
         t0 = time.perf_counter()
         if lifetimes is None:
             lifetimes = calculate_liveness(graph)
+        lifetime_end_overrides = counted_loop_lifetime_end_overrides(graph)
         ncores, ncores_reasons = get_ncores_for_buffers(graph)
         t1 = time.perf_counter()
         mem_usage = mem_usage_by_buf(graph, cache)
@@ -908,6 +925,7 @@ class ScratchpadAllocator:
             lifetimes=lifetimes,
             ncores=ncores,
             ncores_reasons=ncores_reasons,
+            lifetime_end_overrides=lifetime_end_overrides,
         )
         if lx_relayout_plans:
             by_name = {buffer.name: buffer for buffer in buffers}
@@ -943,23 +961,53 @@ class ScratchpadAllocator:
             return
         for buffer in buffers:
             buffer.uses = [2 * use + 1 for use in buffer.uses]
+            if buffer.lifetime_end_override is not None:
+                buffer.lifetime_end_override *= 2
 
         # Adjacent half-ticks rely on DSCs within a bundle executing serially;
         # otherwise the allocator's lifetime reuse is unsound beyond relayout too.
-        for source, plan, original_ticks in entries:
-            consumer_ticks = [2 * tick + 1 for tick in original_ticks]
-            transfer_tick = consumer_ticks[0] - 1
-            source.uses = sorted(
-                {use for use in source.uses if use not in consumer_ticks}
-                | {transfer_tick}
-            )
-            destination = LifetimeBoundBuffer(
-                plan.destination_name,
-                round_up_to_alignment(source.size, _LX_ALLOCATION_GRANULARITY_BYTES),
-                [transfer_tick, *consumer_ticks],
-            )
-            buffers.insert(buffers.index(source), destination)
-            source.paired_with.append(destination)
+        entries_by_source: dict[
+            str, list[tuple[LifetimeBoundBuffer, LXRelayoutPlan, list[int]]]
+        ] = defaultdict(list)
+        for entry in entries:
+            entries_by_source[entry[0].name].append(entry)
+
+        for source_entries in entries_by_source.values():
+            source = source_entries[0][0]
+            original_end = source.lifetime_end_override
+            transfer_ticks = []
+            for _, plan, original_ticks in source_entries:
+                consumer_ticks = [2 * tick + 1 for tick in original_ticks]
+                transfer_tick = consumer_ticks[0] - 1
+                transfer_ticks.append(transfer_tick)
+                source.uses = sorted(
+                    {use for use in source.uses if use not in consumer_ticks}
+                    | {transfer_tick}
+                )
+                nominal_destination_end = consumer_ticks[-1] + 1
+                destination_end = (
+                    original_end
+                    if original_end is not None
+                    and original_end > nominal_destination_end
+                    else None
+                )
+                destination = LifetimeBoundBuffer(
+                    plan.destination_name,
+                    round_up_to_alignment(
+                        source.size, _LX_ALLOCATION_GRANULARITY_BYTES
+                    ),
+                    [transfer_tick, *consumer_ticks],
+                    lifetime_end_override=destination_end,
+                )
+                buffers.insert(buffers.index(source), destination)
+                source.paired_with.append(destination)
+
+            # Once relayout owns every later read, the extended lifetime moves
+            # from the source to its destinations. A same-view reader after the
+            # last transfer still needs the original source through the loop.
+            remaining_reads = source.uses[0 if source.first_use_is_read else 1 :]
+            if not any(use > max(transfer_ticks) for use in remaining_reads):
+                source.lifetime_end_override = None
 
     def _allocated_lx_relayout_sources(
         self, allocation: Sequence[LifetimeBoundBuffer]
@@ -1713,6 +1761,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             op.name: self._op_inputs_good_for_lx_inplace(op) for op in graph.operations
         }
         lifetimes = calculate_liveness(graph)
+        lifetime_end_overrides = counted_loop_lifetime_end_overrides(graph)
         for buf_name, info in mem_usage.items():
             allow_inplace[buf_name] = []
             if not in_place_allowed[buf_name]:
@@ -1731,6 +1780,8 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                 # solver's ``_check_in_place_relationships`` would fail to resolve
                 # them). Skip them, matching the base allocator's guard.
                 if input_buf not in mem_usage or not lifetimes[input_buf]:
+                    continue
+                if input_buf in lifetime_end_overrides:
                     continue
                 in_layout = graph.get_buffer(input_buf).layout
                 if not hasattr(in_layout, "device_layout"):
@@ -1787,10 +1838,12 @@ class CoOptimizingAllocator(ScratchpadAllocator):
 
         Every buffer carries its candidate ``divisions`` and is sized by its
         *total* device footprint plus its producer edges (``parent_proj``); the
-        solver picks a division and divides by its ``output_partition``. Because
-        all buffers are on the same total scale, ``in_place_parents`` need no
-        filtering."""
+        solver picks a division and divides by its ``output_partition``.
+        Counted-loop lifetimes still filter unsafe in-place handoffs before the
+        solver compares those total footprints.
+        """
         lifetimes = calculate_liveness(graph)
+        lifetime_end_overrides = counted_loop_lifetime_end_overrides(graph)
         mem_usage = mem_usage_by_buf(graph)
         in_place = {} if in_place is None else in_place
         op_by_name = {op.name: op for op in graph.operations}
@@ -1841,6 +1894,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                         parents=[],
                         cd_parent_matches={},
                         residency_reason=None,
+                        lifetime_end_override=lifetime_end_overrides.get(input_name),
                         boundary=BufferType.Input,
                     )
                 )
@@ -1852,7 +1906,9 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             residency_reason = residency_by_buf[output_name]
 
             buf_divisions = divisions[output_name]
-            parents = list(in_place.get(output_name, []))
+            parents = _safe_in_place_parents(
+                in_place.get(output_name, []), lifetime_end_overrides
+            )
             size = info["size"]  # total footprint; solver divides per chosen cd
             parent_proj = info["op_inputs"].copy()
             cd_parent_matches = self._cd_parent_matches(
@@ -1881,6 +1937,8 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             # clone, so they are skipped.
             out_layout = graph.get_buffer(output_name).layout
             for clone_name in last_consumer_clones.get(output_name, []):
+                if clone_name in lifetime_end_overrides:
+                    continue
                 if clone_name in parents:
                     continue
                 clone_layout = graph.get_buffer(clone_name).layout
@@ -1915,6 +1973,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                     parents=parent_proj,
                     cd_parent_matches=cd_parent_matches,
                     residency_reason=residency_reason,
+                    lifetime_end_override=lifetime_end_overrides.get(output_name),
                     boundary=BufferType.Output
                     if output_name in graph_output_names
                     else BufferType.Intermediate,

--- a/torch_spyre/_inductor/scratchpad/exhaustive_search.py
+++ b/torch_spyre/_inductor/scratchpad/exhaustive_search.py
@@ -147,6 +147,7 @@ class ExhaustiveSearchSolver(CoreDivisionLayoutSolver):
                     first_use_is_read=b.first_use_is_read,
                     in_place_parents=_valid_inplace_parents(b, chosen[b.name]),
                     residency_reason=_residency_reason(b, chosen[b.name]),
+                    lifetime_end_override=b.lifetime_end_override,
                 )
                 for b in buffers_list
             ]

--- a/torch_spyre/_inductor/scratchpad/plan_solver.py
+++ b/torch_spyre/_inductor/scratchpad/plan_solver.py
@@ -80,6 +80,10 @@ class LifetimeBoundBuffer:
     # define the reason for excluding the buffer based on allocator
     # or solver logic paths.
     residency_reason: Optional[str] = None
+    # Optional exclusive lifetime end for storage reused by a counted loop.
+    # Keep this separate from ``uses``: it changes address overlap, but must not
+    # manufacture a read or inflate residency/spill benefit.
+    lifetime_end_override: Optional[int] = None
     # Buffers that must be placed atomically with this one. Despite the name,
     # this is one-to-many: only the group root carries the complete partner list.
     paired_with: list["LifetimeBoundBuffer"] = field(
@@ -104,6 +108,12 @@ class LifetimeBoundBuffer:
             f"buffer {self.name} has uses={self.uses}, which is not strictly "
             "increasing; uses carries one distinct index per accessing operation"
         )
+        if self.lifetime_end_override is not None and self.uses:
+            assert self.lifetime_end_override >= self.uses[-1] + 1, (
+                f"buffer {self.name} has lifetime_end_override="
+                f"{self.lifetime_end_override} before nominal exclusive end "
+                f"{self.uses[-1] + 1}"
+            )
 
     @property
     def read_count(self) -> int:
@@ -126,7 +136,8 @@ class LifetimeBoundBuffer:
 
     @property
     def end_time(self) -> int:
-        return self.uses[-1] + 1
+        nominal = self.uses[-1] + 1
+        return max(nominal, self.lifetime_end_override or nominal)
 
     @property
     def min_footprint(self) -> int:

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -102,6 +102,61 @@ def calculate_liveness(graph: GraphLowering) -> dict[str, list[int]]:
     return liveness
 
 
+def counted_loop_lifetime_end_overrides(graph: GraphLowering) -> dict[str, int]:
+    """Return exclusive lifetime ends for values reused by counted loops.
+
+    The graph contains one textual copy of a loop body.  Ordinary liveness
+    therefore sees only the first runtime iteration and may reuse a value's LX
+    address later in that body, even though the next iteration reads it again.
+    A value born outside a loop and read inside it must stay alive through that
+    loop.  This records that storage fact without adding a fake read to
+    :func:`calculate_liveness`.
+    """
+
+    def group_path(op: Operation) -> tuple[int, ...]:
+        return tuple(getattr(getattr(op, "loop_info", None), "loop_group_id", ()) or ())
+
+    loop_end: dict[tuple[int, ...], int] = {}
+    birth_group: dict[str, tuple[int, ...]] = {
+        name: () for name in graph.graph_input_names
+    }
+    last_access: dict[str, int] = {}
+
+    for index, op in enumerate(graph.operations):
+        path = group_path(op)
+        for depth in range(1, len(path) + 1):
+            loop_end[path[:depth]] = index
+        rw = op_read_writes(op)
+        for dep in rw.writes:
+            birth_group.setdefault(dep.name, path)
+            last_access[dep.name] = index
+        for dep in rw.reads:
+            birth_group.setdefault(dep.name, ())
+            last_access[dep.name] = index
+
+    overrides: dict[str, int] = {}
+    for index, op in enumerate(graph.operations):
+        consumer_path = group_path(op)
+        if not consumer_path:
+            continue
+        for dep in op_read_writes(op).reads:
+            producer_path = birth_group.get(dep.name, ())
+            common = 0
+            while (
+                common < len(producer_path)
+                and common < len(consumer_path)
+                and producer_path[common] == consumer_path[common]
+            ):
+                common += 1
+            if common == len(consumer_path):
+                continue
+            enclosing_loop = consumer_path[: common + 1]
+            end = loop_end[enclosing_loop] + 1
+            if end > last_access.get(dep.name, index) + 1:
+                overrides[dep.name] = max(overrides.get(dep.name, 0), end)
+    return overrides
+
+
 def mem_usage_by_buf(
     graph: GraphLowering,
     cache: Optional[dict] = None,

--- a/torch_spyre/csrc/perm_layout_native.cpp
+++ b/torch_spyre/csrc/perm_layout_native.cpp
@@ -195,8 +195,8 @@ class NativePermutationLayoutSolver {
         bool first_read = b.attr("first_use_is_read").cast<bool>();
         parent_names[i] =
             b.attr("in_place_parents").cast<std::vector<std::string>>();
-        st->start[i] = uses.front();
-        st->end[i] = uses.back() + 1;
+        st->start[i] = b.attr("start_time").cast<int64_t>();
+        st->end[i] = b.attr("end_time").cast<int64_t>();
         st->weight[i] =
             static_cast<double>(uses.size()) + (first_read ? 0.0 : 0.5);
         const bool read_after_write =


### PR DESCRIPTION
Fixes #4035
Split from #3928
Tracking: #3565

## Campaign status

Merged. The full dense expert-loop compiler implementation and acceptance are complete in `main` through #4042 (`3358f39e`). Structural, numerical-correctness, and same-stack device-performance gates have passed.

## This PR owns

A counted loop is stored once in compiler IR but executes repeatedly on the device. Ordinary textual liveness sees one stored body and can therefore reuse an LX address before the last runtime loop trip has finished reading it.

This PR adds `lifetime_end_override` to the general scratchpad buffer record and carries it through the Python and native layout solvers. The override extends address overlap only; it does not fabricate a read or inflate reuse/profitability scoring.

For LX relayout, the source lifetime is captured before the handoff and copied to every relayout destination. The original source keeps the extension only when a later ordinary reader still needs that layout.

## This PR does not own

- operand address-step recovery (#4040);
- invariant-input staging (#4078);
- copy elision (#4041);
- named work-division lineage through size-one tiling (#4096);
- carried-reduction shape or row ownership (#4042).

The behavior is origin-neutral: any counted loop may request the storage lifetime. It is not gated on how the loop was created.

## Validation

- Production diff: +149/-23; focused tests: +145/-0.
- Exact-branch native extension build passed; optional CCL was disabled because the pod headers did not match this checkout.
- `test_perm_layout_solver.py`: 151 passed, 4 skipped.
- Coarse-tiling and work-division focused suites: 363 passed, 1 skipped, 2 expected failures.
- Scratchpad suites: 309 passed, 91 skipped, 11 expected failures, 14 subtests passed.
- Current GitHub test matrix and linters are green.
- Commit is DCO-signed and GPG-signed.

## Integration contract

The integration test must prove that the invariant input and carried accumulator occupy distinct LX addresses for the full counted loop. This PR supplies the lifetime fact; it does not decide which values are selected for LX.


