### PR TITLE
Elide proven-compatible tiled matmul read copies

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -6796,8 +6796,8 @@ class TestCoarseTileMoEBroadcastMatmulE2E(InductorTestCase):
             fn, x, w, run_compile=True, run_eager=False, atol=0.05, rtol=0.05
         )
 
-    def test_unsqueeze_broadcast_matmul_emits_expert_weight_step(self):
-        """Activation stays fixed while weights advance by one expert slab."""
+    def test_unsqueeze_broadcast_matmul_reads_expert_weights_directly(self):
+        """Activation stays fixed while weights advance without staging."""
         from torch_spyre._inductor import spyre_hint
 
         E, T, H, F = 3, 64, 64, 64
@@ -6861,6 +6861,97 @@ class TestCoarseTileMoEBroadcastMatmulE2E(InductorTestCase):
         # TensorArg addresses are in df16 sticks.  64 sticks * 64 elements
         # per stick is one H*F = 4096-element expert slab.
         self.assertEqual(int(weight_step.group(1)) * 64, H * F)
+        self.assertNotIn("coarse_tile_read_copy_0_arg1_1", source_codes[0])
+
+    def test_unsqueeze_broadcast_matmul_keeps_copy_when_proof_declines(self):
+        """A failed proof leaves the original staging copy authoritative."""
+        from torch_spyre._inductor import spyre_hint
+
+        E, T, H, F = 3, 64, 64, 64
+        x = torch.randn(T, H, dtype=torch.float16).to("spyre")
+        w = torch.randn(E, H, F, dtype=torch.float16).to("spyre")
+        _declare_tensor_dim("E", E)
+        _declare_tensor_dim("T", T)
+        _declare_tensor_dim("H", H)
+        _declare_tensor_dim("F", F)
+
+        def fn(x, w):
+            _name_tensor_dims(x, ["T", "H"])
+            _name_tensor_dims(w, ["E", "H", "F"])
+            with spyre_hint(num_tiles_per_dim={"E": E}):
+                return torch.matmul(x.unsqueeze(0), w)
+
+        with (
+            mock_patch(_LAUNCH_JOBPLAN),
+            mock_patch(_PREPARE_KERNEL),
+            mock_patch("subprocess.run"),
+            mock_patch(
+                "torch_spyre._inductor.read_copy_elision._prove_matmul_direct_read",
+                return_value=(None, "forced test decline"),
+            ),
+        ):
+            _, source_codes = run_and_get_code(torch.compile(fn), x, w)
+
+        src = source_codes[0]
+        self.assertIn("coarse_tile_read_copy_0_arg1_1", src)
+
+    def test_unsqueeze_broadcast_matmul_keeps_copy_for_different_core_views(self):
+        """A legal but different source ownership cannot replace the copy."""
+        from torch_spyre._inductor import spyre_hint
+
+        E, T, H, F = 3, 64, 64, 64
+        x = torch.randn(T, H, dtype=torch.float16).to("spyre")
+        w = torch.randn(E, H, F, dtype=torch.float16).to("spyre")
+        _declare_tensor_dim("E", E)
+        _declare_tensor_dim("T", T)
+        _declare_tensor_dim("H", H)
+        _declare_tensor_dim("F", F)
+
+        def fn(x, w):
+            _name_tensor_dims(x, ["T", "H"])
+            _name_tensor_dims(w, ["E", "H", "F"])
+            with spyre_hint(num_tiles_per_dim={"E": E}):
+                return torch.matmul(x.unsqueeze(0), w)
+
+        with (
+            mock_patch(_LAUNCH_JOBPLAN),
+            mock_patch(_PREPARE_KERNEL),
+            mock_patch("subprocess.run"),
+            mock_patch(
+                "torch_spyre._inductor.read_copy_elision._per_core_view_on_buf",
+                side_effect=[
+                    ("output", None, True),
+                    ("output", None, True),
+                    ("staged-weight", None, True),
+                    ("direct-weight", None, True),
+                ],
+            ),
+        ):
+            _, source_codes = run_and_get_code(torch.compile(fn), x, w)
+
+        self.assertIn("coarse_tile_read_copy_0_arg1_1", source_codes[0])
+
+    def test_unsqueeze_broadcast_matmul_distinguishes_experts_exactly(self):
+        """Each trip reads its own weight slab, not expert zero or stale HBM."""
+        from torch_spyre._inductor import spyre_hint
+
+        E, T, H, F = 3, 64, 64, 64
+        x = torch.eye(T, H, dtype=torch.float16)
+        w = torch.stack(
+            [torch.eye(H, F, dtype=torch.float16) * scale for scale in range(1, E + 1)]
+        )
+        _declare_tensor_dim("E", E)
+        _declare_tensor_dim("T", T)
+        _declare_tensor_dim("H", H)
+        _declare_tensor_dim("F", F)
+
+        def fn(x, w):
+            _name_tensor_dims(x, ["T", "H"])
+            _name_tensor_dims(w, ["E", "H", "F"])
+            with spyre_hint(num_tiles_per_dim={"E": E}):
+                return torch.matmul(x.unsqueeze(0), w)
+
+        compare_with_cpu(fn, x, w, run_compile=True, run_eager=False, atol=0, rtol=0)
 
     def test_unsqueeze_broadcast_matmul_tile_E_poisoned_correct(self):
         """Same pattern as test_unsqueeze_broadcast_matmul_tile_E_correct,

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -5782,6 +5782,61 @@ class TestReadCopyPlanDataclasses(unittest.TestCase):
             plan.entries = ()
 
 
+class TestReadCopyElisionProof(unittest.TestCase):
+    def test_record_is_frozen(self):
+        from torch_spyre._inductor.loop_info import ReadCopyElisionRecord
+
+        record = ReadCopyElisionRecord(
+            consumer_name="op0",
+            copy_name="copy0",
+            source_name="weight",
+            direct_inner_fn=lambda: None,
+        )
+
+        with self.assertRaises(Exception):
+            record.copy_name = "other"
+
+    def test_local_bounds_are_measured_in_source_elements(self):
+        from torch._inductor.dependencies import MemoryDep
+        from torch_spyre._inductor.read_copy_elision import _affine_bounds
+
+        d0, d1, d2 = sympy.symbols("d0 d1 d2", integer=True)
+        dep = MemoryDep(
+            name="weight",
+            index=4096 * d0 + 64 * d1 + d2,
+            var_names=(d0, d1, d2),
+            size=(Integer(1), Integer(64), Integer(64)),
+        )
+
+        self.assertEqual(_affine_bounds(dep), (0, 4095))
+
+    def test_loop_bound_covers_every_expert_step(self):
+        from torch_spyre._inductor.read_copy_elision import _loop_advance_bound
+
+        info = CoarseTileInfo(
+            loop_group_id=(0,),
+            loop_count=[Integer(3)],
+            loop_tiled_dims=[[0]],
+            tiled_dims_per_read=[[[]]],
+            squeezed_advance_per_read=[[[(Integer(4096), Integer(1))]]],
+        )
+
+        self.assertEqual(_loop_advance_bound(info, 0), (0, 8192))
+
+    def test_unsqueezed_loop_step_is_not_elided(self):
+        from torch_spyre._inductor.read_copy_elision import _loop_advance_bound
+
+        info = CoarseTileInfo(
+            loop_group_id=(0,),
+            loop_count=[Integer(3)],
+            loop_tiled_dims=[[0]],
+            tiled_dims_per_read=[[[(0, Integer(1))]]],
+            squeezed_advance_per_read=[[[(Integer(4096), Integer(1))]]],
+        )
+
+        self.assertIsNone(_loop_advance_bound(info, 0))
+
+
 class TestInsertAllReadCopyOps(unittest.TestCase):
     """_insert_all_read_copy_ops executes a precomputed ReadCopyPlan."""
 
@@ -7858,6 +7913,22 @@ class TestCopyOpMetadataAttrCoverage(unittest.TestCase):
         dst = SimpleNamespace()
         copy_op_metadata(src, dst)
         self.assertFalse(hasattr(dst, "_coarse_tile_dim_advance"))
+
+    def test_copy_op_metadata_invalidates_read_copy_elision_record(self):
+        from torch_spyre._inductor.loop_info import ReadCopyElisionRecord
+
+        src = SimpleNamespace()
+        src._read_copy_elision_record = ReadCopyElisionRecord(
+            consumer_name="op0",
+            copy_name="copy0",
+            source_name="weight",
+            direct_inner_fn=lambda: None,
+        )
+        dst = SimpleNamespace()
+
+        copy_op_metadata(src, dst)
+
+        self.assertFalse(hasattr(dst, "_read_copy_elision_record"))
 
 
 class TestCoeffThroughFloor(unittest.TestCase):

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -94,6 +94,10 @@ ignore_work_division_hints: bool = (
 
 ignore_wsr_hints: bool = os.environ.get("SPYRE_INDUCTOR_IGNORE_HINTS", "0") == "1"
 
+# Temporary kill switch for removing a proven-redundant read copy after LX
+# planning.  A failed proof leaves the original graph unchanged.
+read_copy_elision: bool = _get_env_bool("SPYRE_READ_COPY_ELISION", True)
+
 # Per-pass operation logging for CustomPreSchedulingPasses.
 # Set to "all" or "1" to log after every pass, or a comma-separated list of
 # pass function names (e.g., "split_multi_ops,insert_restickify") to log only

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -212,6 +212,25 @@ class ReadCopyPlan:
     entries: tuple["ReadCopyEntry", ...]
 
 
+@dataclass(frozen=True)
+class ReadCopyElisionRecord:
+    """Direct-read form saved while a consumer is redirected through a copy.
+
+    Coarse tiling keeps the copy authoritative until layout selection, work
+    division, and LX planning finish.  A later pass may restore
+    ``direct_inner_fn`` only when the final physical plan proves that reading
+    ``source_name`` directly is equivalent.  The record is deliberately not
+    copied by :func:`copy_op_metadata`: rebuilding the consumer body
+    invalidates the saved direct form unless that pass explicitly recreates
+    the record.
+    """
+
+    consumer_name: str
+    copy_name: str
+    source_name: str
+    direct_inner_fn: object
+
+
 @dataclass
 class CoarseTileInfo:
     """Loop metadata stamped on a ``ComputedBuffer`` by the coarse-tiling pass.

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -91,6 +91,7 @@ from .scheduler import (
 from .constants import DEVICE_NAME
 from .deadcode_elimination import deadcode_elimination
 from .dedup_constants import dedup_and_promote_constants
+from .read_copy_elision import elide_proven_read_copies
 from .wsr.coarse_tile import coarse_tile_post_stickify, coarse_tile_pre_stickify
 from .dump_cost_model import dump_cost_model
 
@@ -485,6 +486,9 @@ class CustomPreSchedulingPasses:
             #
             # LX Planning
             _maybe_scratchpad_planning,
+            # Preserve copies through physical planning, then remove only
+            # those whose direct-read form is proven equivalent.
+            elide_proven_read_copies,
         ]
 
     def __call__(self, graph: GraphLowering) -> None:

--- a/torch_spyre/_inductor/read_copy_elision.py
+++ b/torch_spyre/_inductor/read_copy_elision.py
@@ -1,0 +1,409 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Remove read copies only after the final pre-scheduling plan proves safety."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import sympy
+from torch._inductor.dependencies import MemoryDep
+from torch._inductor.graph import GraphLowering
+from torch._inductor.ir import (
+    ComputedBuffer,
+    InputBuffer,
+    Operation,
+    Reduction,
+    StorageBox,
+    TensorBox,
+)
+from torch._inductor.virtualized import V
+
+from . import config
+from .constants import MATMUL_REDUCTION_OPS
+from .ir import FixedTiledLayout
+from .logging_utils import get_inductor_logger
+from .loop_info import CoarseTileInfo, ReadCopyElisionRecord, copy_op_metadata
+from .pass_utils import (
+    _per_core_view_on_buf,
+    device_coordinates,
+    find_matmul_generated_var,
+    identify_matmul_inputs,
+    replace_computed_buffer_body,
+)
+from .wsr.coarse_tile import (
+    validate_reader_tile_advance,
+    validate_writer_tile_advance,
+)
+
+logger = get_inductor_logger("read_copy_elision")
+
+
+def _memory_deps(deps) -> list[MemoryDep]:
+    return [dep for dep in deps if isinstance(dep, MemoryDep)]
+
+
+def _one_memory_dep(deps) -> MemoryDep | None:
+    result = _memory_deps(deps)
+    return result[0] if len(result) == 1 else None
+
+
+def _unwrap_buffer(buf):
+    if isinstance(buf, TensorBox):
+        buf = buf.data
+    if isinstance(buf, StorageBox):
+        buf = buf.data
+    return buf
+
+
+def _static_int(expr: sympy.Expr) -> int | None:
+    expr = sympy.sympify(expr)
+    if not expr.is_number or expr.is_integer is False:
+        return None
+    try:
+        return int(expr)
+    except TypeError:
+        return None
+
+
+def _affine_bounds(dep: MemoryDep) -> tuple[int, int] | None:
+    """Inclusive min/max source indexes for one invocation, in elements."""
+    expr = sympy.expand(dep.index)
+    zero_subs = {var: sympy.Integer(0) for var in dep.var_names}
+    constant = sympy.expand(expr.subs(zero_subs))
+    lo = _static_int(constant)
+    if lo is None:
+        return None
+    hi = lo
+    residual = expr - constant
+    for var, size_expr in zip(dep.var_names, dep.size):
+        coeff = sympy.expand(expr).coeff(var)
+        coeff_i = _static_int(coeff)
+        size_i = _static_int(size_expr)
+        if coeff_i is None or size_i is None or size_i < 1:
+            return None
+        residual -= coeff * var
+        delta = coeff_i * (size_i - 1)
+        lo += min(0, delta)
+        hi += max(0, delta)
+    if sympy.simplify(residual) != 0:
+        return None
+    return lo, hi
+
+
+def _loop_advance_bound(
+    loop_info: CoarseTileInfo, dep_idx: int
+) -> tuple[int, int] | None:
+    """Inclusive address change across loop trips, in source elements."""
+    if dep_idx >= len(loop_info.tiled_dims_per_read):
+        return None
+    if any(loop_info.tiled_dims_per_read[dep_idx]):
+        return None
+    squeezed = (
+        loop_info.squeezed_advance_per_read[dep_idx]
+        if dep_idx < len(loop_info.squeezed_advance_per_read)
+        else []
+    )
+    if not any(squeezed):
+        return None
+
+    lo = 0
+    hi = 0
+    for level_idx, trip_expr in enumerate(loop_info.loop_count):
+        trip_count = _static_int(trip_expr)
+        if trip_count is None or trip_count < 1:
+            return None
+        pairs = squeezed[level_idx] if level_idx < len(squeezed) else []
+        step = 0
+        for stride_expr, extent_expr in pairs:
+            stride = _static_int(stride_expr)
+            extent = _static_int(extent_expr)
+            if stride is None or extent is None:
+                return None
+            step += stride * extent
+        delta = step * (trip_count - 1)
+        lo += min(0, delta)
+        hi += max(0, delta)
+    return lo, hi
+
+
+def _copy_readers(operations: list[Operation], copy_name: str) -> list[ComputedBuffer]:
+    readers = []
+    for op in operations:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        if any(
+            dep.name == copy_name for dep in _memory_deps(op.get_read_writes().reads)
+        ):
+            readers.append(op)
+    return readers
+
+
+def _clone_direct_consumer(
+    consumer: ComputedBuffer, record: ReadCopyElisionRecord
+) -> ComputedBuffer:
+    direct_data = dataclasses.replace(consumer.data, inner_fn=record.direct_inner_fn)
+    direct_op = ComputedBuffer(
+        name=consumer.get_name(),
+        layout=consumer.layout,
+        data=direct_data,
+        _split_size=consumer._split_size,
+        _original_inner_fn=consumer._original_inner_fn,
+        _original_ranges=consumer._original_ranges,
+        _original_reduction_ranges=consumer._original_reduction_ranges,
+    )
+    direct_op.operation_name = consumer.operation_name
+    direct_op.origins = consumer.origins
+    copy_op_metadata(consumer, direct_op)
+    for attr in ("layouts", "restick_cost_fn", "op_it_space_splits"):
+        if hasattr(consumer, attr):
+            setattr(direct_op, attr, getattr(consumer, attr))
+    return direct_op
+
+
+def _prove_matmul_direct_read(
+    consumer: ComputedBuffer,
+    copy_op: ComputedBuffer,
+    record: ReadCopyElisionRecord,
+) -> tuple[ComputedBuffer, str] | tuple[None, str]:
+    """Build, but do not install, a direct-read matmul when every fact holds."""
+    if consumer.get_name() != record.consumer_name:
+        return None, "consumer identity changed"
+    if not isinstance(consumer.data, Reduction):
+        return None, "consumer is not a reduction"
+    if consumer.data.reduction_type not in MATMUL_REDUCTION_OPS:
+        return None, "consumer is not a matmul"
+
+    copy_layout = copy_op.get_layout()
+    if not isinstance(copy_layout, FixedTiledLayout):
+        return None, "copy has no final device layout"
+    if "lx" in copy_layout.allocation:
+        return None, "LX planning retained the copy"
+
+    direct_op = _clone_direct_consumer(consumer, record)
+    direct_rw = direct_op.get_read_writes()
+    direct_reads = _memory_deps(direct_rw.reads)
+    output_dep = _one_memory_dep(direct_rw.writes)
+    if output_dep is None or len(direct_reads) != 2:
+        return None, "matmul dependencies are ambiguous"
+    x_dep, weight_dep = identify_matmul_inputs(direct_reads, output_dep)
+    if x_dep is None or weight_dep is None or weight_dep.name != record.source_name:
+        return None, "saved source is not the matmul weight"
+    direct_source_idx = direct_reads.index(weight_dep)
+
+    current_rw = consumer.get_read_writes()
+    current_reads = _memory_deps(current_rw.reads)
+    current_output = _one_memory_dep(current_rw.writes)
+    copy_deps = [dep for dep in current_reads if dep.name == record.copy_name]
+    if current_output is None or len(copy_deps) != 1:
+        return None, "consumer no longer reads the saved copy exactly once"
+    copy_dep = copy_deps[0]
+    current_non_weight = [dep for dep in current_reads if dep != copy_dep]
+    direct_non_weight = [dep for dep in direct_reads if dep != weight_dep]
+    if current_non_weight != direct_non_weight:
+        return None, "another matmul input changed after recording"
+    if current_output != output_dep or consumer.get_layout() != direct_op.get_layout():
+        return None, "output layout or index changed"
+
+    copy_reads = _memory_deps(copy_op.get_read_writes().reads)
+    copy_source_indices = [
+        idx for idx, dep in enumerate(copy_reads) if dep.name == record.source_name
+    ]
+    copy_loop_info = getattr(copy_op, "loop_info", None)
+    current_loop_info = getattr(consumer, "loop_info", None)
+    if (
+        len(copy_source_indices) != 1
+        or not isinstance(copy_loop_info, CoarseTileInfo)
+        or not isinstance(current_loop_info, CoarseTileInfo)
+    ):
+        return None, "copy has no complete loop-address record"
+    copy_source_idx = copy_source_indices[0]
+    if copy_source_idx >= len(copy_loop_info.tiled_dims_per_read):
+        return None, "copy has no tiled-dimension record for its source"
+
+    tiled_dims = [
+        [list(level) for level in per_read]
+        for per_read in current_loop_info.tiled_dims_per_read
+    ]
+    squeezed = [
+        [list(level) for level in per_read]
+        for per_read in current_loop_info.squeezed_advance_per_read
+    ]
+    if direct_source_idx >= len(tiled_dims):
+        return None, "direct-read metadata does not match its dependencies"
+    squeezed.extend([] for _ in range(len(direct_reads) - len(squeezed)))
+    tiled_dims[direct_source_idx] = [
+        list(level) for level in copy_loop_info.tiled_dims_per_read[copy_source_idx]
+    ]
+    copy_squeezed = (
+        copy_loop_info.squeezed_advance_per_read[copy_source_idx]
+        if copy_source_idx < len(copy_loop_info.squeezed_advance_per_read)
+        else []
+    )
+    squeezed[direct_source_idx] = [list(level) for level in copy_squeezed]
+    resolved_loop_info = dataclasses.replace(
+        current_loop_info,
+        tiled_dims_per_read=tiled_dims,
+        squeezed_advance_per_read=squeezed,
+    )
+    direct_op.loop_info = resolved_loop_info  # type: ignore[attr-defined]
+
+    source = _unwrap_buffer(V.graph.get_buffer(record.source_name))
+    if not isinstance(source, InputBuffer):
+        return None, "source is not a graph input"
+    source_layout = source.get_layout()
+    if not isinstance(source_layout, FixedTiledLayout):
+        return None, "source has no final device layout"
+
+    try:
+        generated_var = find_matmul_generated_var(
+            weight_dep, x_dep, output_dep, direct_op
+        )
+        source_stick = device_coordinates(
+            source_layout.device_layout, weight_dep, None
+        )[-1]
+    except Exception as exc:
+        return None, f"source layout is not directly readable: {exc}"
+    if generated_var not in source_stick.free_symbols:
+        return None, "source stick dimension is not the matmul output dimension"
+
+    local_bounds = _affine_bounds(weight_dep)
+    advance_bounds = _loop_advance_bound(resolved_loop_info, direct_source_idx)
+    source_numel = _static_int(sympy.prod(source_layout.size))
+    if local_bounds is None or advance_bounds is None or source_numel is None:
+        return None, "source element range is not statically provable"
+    lo = local_bounds[0] + advance_bounds[0]
+    hi = local_bounds[1] + advance_bounds[1]
+    if lo < 0 or hi >= source_numel:
+        return None, f"source element range [{lo}, {hi}] exceeds [0, {source_numel})"
+
+    old_view, _, old_ok = _per_core_view_on_buf(
+        consumer, current_output, current_output.name
+    )
+    new_view, _, new_ok = _per_core_view_on_buf(direct_op, output_dep, output_dep.name)
+    copy_view, _, copy_ok = _per_core_view_on_buf(consumer, copy_dep, record.copy_name)
+    source_view, _, source_ok = _per_core_view_on_buf(
+        direct_op, weight_dep, record.source_name
+    )
+    if not old_ok or not new_ok or old_view != new_view:
+        return None, "output core ownership changed"
+    if not copy_ok or not source_ok:
+        return None, "weight core ownership is not representable"
+    # Representability alone is insufficient: both views may be legal while
+    # assigning different source slices to the same core.  The staging copy
+    # is the behavior being replaced, so the direct HBM read must preserve
+    # its exact physical core-to-slice map.
+    if copy_view != source_view:
+        return None, (
+            "direct source ownership does not match the staged copy: "
+            f"{source_view} != {copy_view}"
+        )
+    if getattr(consumer, "op_it_space_splits", None) != getattr(
+        direct_op, "op_it_space_splits", None
+    ):
+        return None, "work division changed"
+
+    return direct_op, "proved"
+
+
+def _validate_proposal(
+    operations: list[Operation],
+    consumer: ComputedBuffer,
+    direct_op: ComputedBuffer,
+    copy_op: ComputedBuffer,
+) -> str | None:
+    proposed = [
+        direct_op if op is consumer else op for op in operations if op is not copy_op
+    ]
+    try:
+        validate_writer_tile_advance(proposed)
+        validate_reader_tile_advance(proposed)
+    except Exception as exc:
+        return f"coarse-tile validation failed: {exc}"
+    return None
+
+
+def elide_proven_read_copies(graph: GraphLowering) -> None:
+    """Remove only copies whose post-allocation direct-read proof succeeds."""
+    if not config.read_copy_elision:
+        return
+
+    operations = graph.operations
+    for consumer in list(operations):
+        record = getattr(consumer, "_read_copy_elision_record", None)
+        if not isinstance(consumer, ComputedBuffer) or not isinstance(
+            record, ReadCopyElisionRecord
+        ):
+            continue
+        copy_op = next(
+            (
+                op
+                for op in operations
+                if isinstance(op, ComputedBuffer) and op.get_name() == record.copy_name
+            ),
+            None,
+        )
+        if copy_op is None:
+            logger.info(
+                "read-copy elision declined for %s: copy is absent",
+                record.consumer_name,
+            )
+            continue
+        if _copy_readers(operations, record.copy_name) != [consumer]:
+            logger.info(
+                "read-copy elision declined for %s: copy has other readers",
+                record.consumer_name,
+            )
+            continue
+
+        direct_op, detail = _prove_matmul_direct_read(consumer, copy_op, record)
+        if direct_op is None:
+            logger.info(
+                "read-copy elision declined for %s: %s",
+                record.consumer_name,
+                detail,
+            )
+            continue
+        validation_error = _validate_proposal(operations, consumer, direct_op, copy_op)
+        if validation_error is not None:
+            logger.info(
+                "read-copy elision declined for %s: %s",
+                record.consumer_name,
+                validation_error,
+            )
+            continue
+
+        replacement = replace_computed_buffer_body(
+            consumer,
+            direct_op.data,
+            operations,
+            pass_name="read_copy_elision",
+            reason="read advancing matmul weights directly from HBM",
+        )
+        replacement.loop_info = direct_op.loop_info  # type: ignore[attr-defined]
+        for attr in ("layouts", "restick_cost_fn", "op_it_space_splits"):
+            if hasattr(direct_op, attr):
+                setattr(replacement, attr, getattr(direct_op, attr))
+        if hasattr(replacement, "_read_copy_elision_record"):
+            del replacement._read_copy_elision_record  # type: ignore[attr-defined]
+        V.graph.name_to_buffer[replacement.get_name()] = replacement
+        graph.removed_buffers.add(copy_op.get_name())
+        operations.remove(copy_op)
+        logger.info(
+            "removed read copy %s; %s reads %s directly",
+            copy_op.get_name(),
+            replacement.get_name(),
+            record.source_name,
+        )

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -100,6 +100,7 @@ from ..loop_info import (
     CoarseTileInfo,
     PropagationPlan,
     ReadCopyEntry,
+    ReadCopyElisionRecord,
     ReadCopyPlan,
     ReductionPlan,
     copy_op_metadata,
@@ -4027,6 +4028,32 @@ def _patch_consumer_to_read_copy(
     from ..pass_utils import replace_computed_buffer_body
 
     orig_inner = consumer.data.inner_fn
+    existing_record = getattr(consumer, "_read_copy_elision_record", None)
+    original_loop_info = consumer.loop_info  # type: ignore[attr-defined]
+    original_reads = [
+        read for read in consumer.get_read_writes().reads if isinstance(read, MemoryDep)
+    ]
+    original_dep_idx = next(
+        (idx for idx, original_dep in enumerate(original_reads) if original_dep == dep),
+        None,
+    )
+    original_read_advances = original_dep_idx is not None and (
+        (
+            original_dep_idx < len(original_loop_info.tiled_dims_per_read)
+            and any(original_loop_info.tiled_dims_per_read[original_dep_idx])
+        )
+        or (
+            original_dep_idx < len(original_loop_info.squeezed_advance_per_read)
+            and any(original_loop_info.squeezed_advance_per_read[original_dep_idx])
+        )
+    )
+    direct_read_candidate = (
+        not loop_invariant
+        and original_read_advances
+        and dep.name in V.graph.graph_input_names
+        and isinstance(consumer.data, Reduction)
+        and consumer.data.reduction_type in MATMUL_REDUCTION_OPS
+    )
 
     def new_inner_fn(*args, _map=name_map, _orig_inner=orig_inner):
         with V.set_ops_handler(_NameSwapHandler(V.ops, _map)):
@@ -4041,6 +4068,27 @@ def _patch_consumer_to_read_copy(
         reason="redirect consumer to copied inputs",
     )
     V.graph.name_to_buffer[new_op.get_name()] = new_op
+    if isinstance(existing_record, ReadCopyElisionRecord):
+
+        def updated_direct_inner(
+            *args,
+            _map=name_map,
+            _direct_inner=existing_record.direct_inner_fn,
+        ):
+            with V.set_ops_handler(_NameSwapHandler(V.ops, _map)):
+                return _direct_inner(*args)
+
+        new_op._read_copy_elision_record = dataclasses.replace(  # type: ignore[attr-defined]
+            existing_record,
+            direct_inner_fn=updated_direct_inner,
+        )
+    if direct_read_candidate:
+        new_op._read_copy_elision_record = ReadCopyElisionRecord(  # type: ignore[attr-defined]
+            consumer_name=new_op.get_name(),
+            copy_name=copy_name,
+            source_name=dep.name,
+            direct_inner_fn=orig_inner,
+        )
 
     # new_op.loop_info (copied from consumer by copy_op_metadata inside
     # replace_computed_buffer_body) still carries tiled_dims_per_read as


### PR DESCRIPTION
Fixes #4037
Split from #3928
Tracking: #3565

## Campaign status

Merged. The full dense expert-loop compiler implementation and acceptance are complete in `main` through #4042 (`3358f39e`). Structural, numerical-correctness, and same-stack device-performance gates have passed.

## This PR owns

After invariant activation staging, an advancing expert weight could still pass through a temporary HBM copy: the copy read one expert slab, wrote it to HBM, and the matmul immediately read it back.

This PR added the post-allocation pass `elide_proven_read_copies`. Coarse tiling records a possible direct form beside the consumer, while the original copy remains authoritative through layout selection, work division, and LX planning. The later pass removes the copy only when it proves all final physical facts:

- source and consumer identities are unchanged;
- the source is a directly readable graph input with the required stick dimension;
- the full affine address range, including every loop advance, remains inside the source tensor;
- output layout, ownership, and work division are unchanged;
- the direct source and staged copy have the same representable core-to-slice map;
- the resulting graph passes the existing reader/writer tile-advance validators.

The rewrite is transactional: it validates a replacement first. A missing or changed fact keeps the original copy.

## Validation at merge

- Incremental diff: production +484/-0; tests +164/-2.
- One DCO-signed and GPG-signed incremental commit.
- Coverage includes direct weight reads, proof declines, different physical core views, poisoned HBM, shape collisions, bounds, and exact per-expert numerics.
- Generated-source checks are per operand: activation does not advance; weight advances by exactly one expert slab.

## Integration contract

The final program must read the four advancing graph inputs directly, preserve their physical ownership and address bounds, and contain no temporary HBM weight-copy buffers. If any proof fails, correctness wins: the copy remains.

