### PR TITLE
Carry hinted terminal sums through counted loops

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -6599,7 +6599,297 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
                 return x.sum(dim=0)
 
-        compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=0.05, rtol=0.05)
+        def check_source(source):
+            self.assertNotIn("coarse_tile_reduction_drain", source)
+
+        compare_with_cpu(
+            fn,
+            x,
+            run_compile=True,
+            run_eager=False,
+            source_check=check_source,
+            atol=0.05,
+            rtol=0.05,
+        )
+
+    def test_hinted_terminal_sum_is_carried_in_lx(self):
+        """A terminal E sum keeps one [T,H] running value in LX."""
+
+        E, T, H = 2, 64, 64
+        base = torch.linspace(-4.0, 4.0, E * T * H, dtype=torch.float32)
+        values = base.reshape(E, T, H).to(torch.float16)
+        _declare_tensor_dim("E", E)
+        _declare_tensor_dim("T", T)
+        _declare_tensor_dim("H", H)
+
+        def fn(values):
+            _name_tensor_dims(values, ["E", "T", "H"])
+            with spyre_hint(
+                num_tiles_per_dim={"E": E},
+                work_div={"T": 32},
+            ):
+                return values.sum(dim=0)
+
+        def check_source(source):
+            self.assertIn("LoopSpec(", source)
+            self.assertIn("coarse_tile_reduction_drain", source)
+            self.assertIn("'lx'", source)
+
+        with config.patch({"sencores": 32, "lx_planning": True}):
+            compare_with_cpu(
+                fn,
+                values,
+                run_compile=True,
+                run_eager=False,
+                source_check=check_source,
+                atol=0.05,
+                rtol=0.05,
+            )
+
+    def test_hinted_terminal_sum_e128_matches_ordinary_and_cpu(self):
+        """The E=128 carried sum preserves the existing reduction result."""
+
+        E, T, H = 128, 64, 64
+        values = (
+            torch.linspace(-3.0, 4.0, E * T * H, dtype=torch.float32)
+            .reshape(E, T, H)
+            .to(torch.float16)
+        )
+        _declare_tensor_dim("E", E)
+        _declare_tensor_dim("T", T)
+        _declare_tensor_dim("H", H)
+
+        def ordinary(values):
+            return values.sum(dim=0)
+
+        def carried(values):
+            _name_tensor_dims(values, ["E", "T", "H"])
+            with spyre_hint(
+                num_tiles_per_dim={"E": E},
+                work_div={"T": 32},
+            ):
+                return values.sum(dim=0)
+
+        def check_source(source):
+            self.assertIn("LoopSpec(count=sympify('128')", source)
+            self.assertIn("coarse_tile_reduction_drain", source)
+            self.assertIn("'lx'", source)
+
+        with config.patch({"sencores": 32, "lx_planning": True}):
+            ordinary_result = _compile_and_run(ordinary, (values,), "spyre")
+            _declare_tensor_dim("E", E)
+            _declare_tensor_dim("T", T)
+            _declare_tensor_dim("H", H)
+            carried_result = _compile_and_run(
+                carried, (values,), "spyre", source_check=check_source
+            )
+
+        cpu_result = ordinary(values)
+        torch.testing.assert_close(carried_result, ordinary_result, atol=1.0, rtol=0.05)
+        torch.testing.assert_close(carried_result, cpu_result, atol=1.0, rtol=0.05)
+
+    def test_carried_sum_hbm_fallback_is_correct_and_visible(self):
+        """Capacity spill keeps correct execution and emits a warning."""
+
+        E, T, H = 2, 64, 64
+        values = torch.randn(E, T, H, dtype=torch.float16) * 0.1
+        _declare_tensor_dim("E", E)
+        _declare_tensor_dim("T", T)
+        _declare_tensor_dim("H", H)
+
+        def fn(values):
+            _name_tensor_dims(values, ["E", "T", "H"])
+            with spyre_hint(
+                num_tiles_per_dim={"E": E},
+                work_div={"T": 32},
+            ):
+                return values.sum(dim=0)
+
+        def check_source(source):
+            self.assertIn("coarse_tile_reduction_drain", source)
+            self.assertNotIn("'lx'", source)
+
+        with (
+            config.patch(
+                {
+                    "sencores": 32,
+                    "lx_planning": True,
+                    "dxp_lx_frac_avail": 1.0,
+                }
+            ),
+            self.assertLogs("spyre.inductor.scheduler", level="WARNING") as logs,
+        ):
+            compare_with_cpu(
+                fn,
+                values,
+                run_compile=True,
+                run_eager=False,
+                source_check=check_source,
+                atol=0.05,
+                rtol=0.05,
+            )
+        self.assertTrue(any("remained in HBM" in line for line in logs.output))
+
+    def test_carried_sum_requires_explicit_work_div(self):
+        """Without row ownership, the existing reduction path is unchanged."""
+
+        E, T, H = 4, 64, 64
+        values = torch.randn(E, T, H, dtype=torch.float16) * 0.1
+        _declare_tensor_dim("E", E)
+        _declare_tensor_dim("T", T)
+        _declare_tensor_dim("H", H)
+
+        def fn(values):
+            _name_tensor_dims(values, ["E", "T", "H"])
+            with spyre_hint(num_tiles_per_dim={"E": 2}):
+                return values.sum(dim=0)
+
+        def check_source(source):
+            self.assertNotIn("coarse_tile_reduction_drain", source)
+
+        compare_with_cpu(
+            fn,
+            values,
+            run_compile=True,
+            run_eager=False,
+            source_check=check_source,
+            atol=0.05,
+            rtol=0.05,
+        )
+
+    def test_carried_sum_does_not_apply_without_an_expert_loop(self):
+        """E=1 remains an ordinary reduction because there is nothing to carry."""
+
+        E, T, H = 1, 64, 64
+        values = torch.randn(E, T, H, dtype=torch.float16) * 0.1
+        _declare_tensor_dim("E", E)
+        _declare_tensor_dim("T", T)
+        _declare_tensor_dim("H", H)
+
+        def fn(values):
+            _name_tensor_dims(values, ["E", "T", "H"])
+            with spyre_hint(
+                num_tiles_per_dim={"E": E},
+                work_div={"T": 32},
+            ):
+                return values.sum(dim=0)
+
+        def check_source(source):
+            self.assertNotIn("coarse_tile_reduction_drain", source)
+
+        compare_with_cpu(
+            fn,
+            values,
+            run_compile=True,
+            run_eager=False,
+            source_check=check_source,
+            atol=0.05,
+            rtol=0.05,
+        )
+
+    def test_carried_sum_does_not_apply_to_nested_tiling(self):
+        """Tiling an output axis keeps the existing nested-reduction path."""
+
+        E, T, H = 4, 64, 64
+        values = torch.randn(E, T, H, dtype=torch.float16) * 0.1
+        _declare_tensor_dim("E", E)
+        _declare_tensor_dim("T", T)
+        _declare_tensor_dim("H", H)
+
+        def fn(values):
+            _name_tensor_dims(values, ["E", "T", "H"])
+            with spyre_hint(
+                num_tiles_per_dim={"T": 2},
+                work_div={"T": 32},
+            ):
+                with spyre_hint(num_tiles_per_dim={"E": 2}):
+                    return values.sum(dim=0)
+
+        def check_source(source):
+            self.assertNotIn("coarse_tile_reduction_drain", source)
+
+        compare_with_cpu(
+            fn,
+            values,
+            run_compile=True,
+            run_eager=False,
+            source_check=check_source,
+            atol=0.05,
+            rtol=0.05,
+        )
+
+    def test_carried_sum_requires_terminal_reduction(self):
+        """A sum with a consumer retains the existing unsupported result."""
+
+        E, T, H = 4, 64, 64
+        values = torch.randn(E, T, H, dtype=torch.float16) * 0.1
+        _declare_tensor_dim("E", E)
+        _declare_tensor_dim("T", T)
+        _declare_tensor_dim("H", H)
+
+        def fn(values):
+            _name_tensor_dims(values, ["E", "T", "H"])
+            with spyre_hint(
+                num_tiles_per_dim={"E": 2},
+                work_div={"T": 32},
+            ):
+                reduced = values.sum(dim=0)
+                return reduced + 1
+
+        with self.assertRaisesRegex(
+            Exception, "partial reduction result consumed before accumulation"
+        ):
+            _compile_and_run(fn, (values,), "spyre")
+
+    def test_carried_sum_rejects_reduction_dim_work_div(self):
+        """The hint must name an output row, not the reduced expert dim."""
+
+        E, T, H = 4, 64, 64
+        values = torch.randn(E, T, H, dtype=torch.float16) * 0.1
+        _declare_tensor_dim("E", E)
+        _declare_tensor_dim("T", T)
+        _declare_tensor_dim("H", H)
+
+        def fn(values):
+            _name_tensor_dims(values, ["E", "T", "H"])
+            with spyre_hint(
+                num_tiles_per_dim={"E": 2},
+                work_div={"E": 2},
+            ):
+                return values.sum(dim=0)
+
+        with self.assertRaisesRegex(Exception, "work_div on an output row dimension"):
+            _compile_and_run(fn, (values,), "spyre")
+
+    def test_carried_sum_does_not_apply_to_max(self):
+        """Only sums are converted into loop-carried accumulators."""
+
+        E, T, H = 4, 64, 64
+        values = torch.randn(E, T, H, dtype=torch.float16)
+        _declare_tensor_dim("E", E)
+        _declare_tensor_dim("T", T)
+        _declare_tensor_dim("H", H)
+
+        def fn(values):
+            _name_tensor_dims(values, ["E", "T", "H"])
+            with spyre_hint(
+                num_tiles_per_dim={"E": 2},
+                work_div={"T": 32},
+            ):
+                return values.amax(dim=0)
+
+        def check_source(source):
+            self.assertNotIn("coarse_tile_reduction_drain", source)
+
+        compare_with_cpu(
+            fn,
+            values,
+            run_compile=True,
+            run_eager=False,
+            source_check=check_source,
+            atol=1e-3,
+            rtol=1e-3,
+        )
 
     def test_hint_tiled_reduction_dim0_max_correct(self):
         """x.amax(dim=0) tiled over B produces correct results."""

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -43,6 +43,8 @@ import torch_spyre._inductor.wsr.propagate_named_dims as _pnd
 from torch_spyre._C import DataFormats
 from torch_spyre._inductor.codegen.superdsc import compile_op_spec, parse_op_spec
 from torch_spyre._inductor.constants import IDENTITY_OP
+from torch_spyre._inductor.errors import Unsupported
+from torch_spyre._inductor.loop_info import CarriedReductionRecord
 from torch_spyre._inductor.scratchpad.lx_relayout import (
     LXRelayoutPlan,
     work_division_from_view,
@@ -1095,6 +1097,85 @@ def test_lx_relayout_scheduler_demotes_groups_but_not_ordinary_unary():
     run_registered("projection")
     run_registered("missing")
     run_registered("missing_buffer")
+
+
+class _CarriedReductionDep:
+    def __init__(self, name):
+        self.name = name
+
+
+def _verify_carried_reduction(drift=None, wrong_logical_dim=False):
+    accumulator = "fill"
+    row = Symbol("row")
+    other = Symbol("other")
+    record = CarriedReductionRecord(
+        accumulator_name=accumulator,
+        row_dim_name="T",
+        required_row_split=8,
+        fill_name="fill",
+        combine_name="combine",
+        drain_name="drain",
+    )
+    dep = _CarriedReductionDep(accumulator)
+    nodes = [
+        _RelayoutNode("fill", writes=(dep,)),
+        _RelayoutNode("combine", reads=(dep,), writes=(dep,)),
+        _RelayoutNode("drain", reads=(dep,)),
+    ]
+    for node in nodes:
+        node.node._carried_reduction_record = record
+        node.node.work_div_loop_info = {row: ["T"], other: ["H"]}
+
+    layout = _relayout_layout(0, _SOURCE_VIEW)
+    graph = SimpleNamespace(
+        try_get_buffer=lambda name: (
+            SimpleNamespace(get_layout=lambda: layout) if name == accumulator else None
+        )
+    )
+
+    def view(node, _dep, _name):
+        realized = _DESTINATION_VIEW if node.name == drift else _SOURCE_VIEW
+        return realized, False, True
+
+    def work_division(_view, _coordinates, _symbols):
+        symbol = other if wrong_logical_dim else row
+        return SimpleNamespace(work_slices={symbol: 8})
+
+    with (
+        mock_patch.object(scheduler_module, "SchedulerNode", _RelayoutNode),
+        mock_patch.object(scheduler_module, "MemoryDep", _CarriedReductionDep),
+        mock_patch.object(scheduler_module, "FixedTiledLayout", SimpleNamespace),
+        mock_patch.object(scheduler_module, "V", SimpleNamespace(graph=graph)),
+        mock_patch.object(scheduler_module, "per_core_view_scheduled", view),
+        mock_patch.object(
+            scheduler_module, "try_device_coordinates", return_value=[row]
+        ),
+        mock_patch.object(
+            scheduler_module, "iteration_space", return_value={row: 64, other: 64}
+        ),
+        mock_patch.object(
+            scheduler_module, "work_division_from_view", side_effect=work_division
+        ),
+    ):
+        return scheduler_module.verify_carried_reduction_ownership(nodes)
+
+
+def test_carried_reduction_verifier_accepts_matching_final_ownership():
+    assert [node.name for node in _verify_carried_reduction()] == [
+        "fill",
+        "combine",
+        "drain",
+    ]
+
+
+def test_carried_reduction_verifier_rejects_final_ownership_drift():
+    with pytest.raises(Unsupported, match="does not match accumulator ownership"):
+        _verify_carried_reduction(drift="drain")
+
+
+def test_carried_reduction_verifier_rejects_same_count_on_wrong_dimension():
+    with pytest.raises(Unsupported, match="expected only T split=8"):
+        _verify_carried_reduction(wrong_logical_dim=True)
 
 
 def aot_backend(gm: GraphModule, example_inputs: Sequence[InputType]):

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -976,7 +976,12 @@ class _RelayoutNode:
 
 
 def _relayout_layout(address, view):
-    return SimpleNamespace(allocation={"lx": address}, lx_view=view)
+    # FixedTiledLayout always carries the final physical device layout.  Keep
+    # that field in the test double so ownership verification exercises the
+    # same contract as the real post-allocation pipeline.
+    return SimpleNamespace(
+        allocation={"lx": address}, lx_view=view, device_layout=object()
+    )
 
 
 def test_lx_relayout_scheduler_checks_final_ownership_projection():

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -1109,10 +1109,14 @@ class _CarriedReductionDep:
         self.name = name
 
 
-def _verify_carried_reduction(drift=None, wrong_logical_dim=False):
+def _verify_carried_reduction(
+    drift=None, wrong_logical_dim=False, scheduled_rank_mismatch=False
+):
     accumulator = "fill"
-    row = Symbol("row")
-    other = Symbol("other")
+    operation_row = Symbol("d0")
+    operation_other = Symbol("d1")
+    scheduled_row = Symbol("c0")
+    scheduled_other = Symbol("c1")
     record = CarriedReductionRecord(
         accumulator_name=accumulator,
         row_dim_name="T",
@@ -1129,7 +1133,10 @@ def _verify_carried_reduction(drift=None, wrong_logical_dim=False):
     ]
     for node in nodes:
         node.node._carried_reduction_record = record
-        node.node.work_div_loop_info = {row: ["T"], other: ["H"]}
+        node.node.work_div_loop_info = {
+            operation_row: ["T"],
+            operation_other: ["H"],
+        }
 
     layout = _relayout_layout(0, _SOURCE_VIEW)
     graph = SimpleNamespace(
@@ -1143,7 +1150,7 @@ def _verify_carried_reduction(drift=None, wrong_logical_dim=False):
         return realized, False, True
 
     def work_division(_view, _coordinates, _symbols):
-        symbol = other if wrong_logical_dim else row
+        symbol = scheduled_other if wrong_logical_dim else scheduled_row
         return SimpleNamespace(work_slices={symbol: 8})
 
     with (
@@ -1153,10 +1160,21 @@ def _verify_carried_reduction(drift=None, wrong_logical_dim=False):
         mock_patch.object(scheduler_module, "V", SimpleNamespace(graph=graph)),
         mock_patch.object(scheduler_module, "per_core_view_scheduled", view),
         mock_patch.object(
-            scheduler_module, "try_device_coordinates", return_value=[row]
+            scheduler_module, "try_device_coordinates", return_value=[scheduled_row]
         ),
         mock_patch.object(
-            scheduler_module, "iteration_space", return_value={row: 64, other: 64}
+            scheduler_module,
+            "iteration_space_from_op",
+            return_value={operation_row: 64, operation_other: 64},
+        ),
+        mock_patch.object(
+            scheduler_module,
+            "iteration_space",
+            return_value=(
+                {scheduled_row: 64}
+                if scheduled_rank_mismatch
+                else {scheduled_row: 64, scheduled_other: 64}
+            ),
         ),
         mock_patch.object(
             scheduler_module, "work_division_from_view", side_effect=work_division
@@ -1181,6 +1199,11 @@ def test_carried_reduction_verifier_rejects_final_ownership_drift():
 def test_carried_reduction_verifier_rejects_same_count_on_wrong_dimension():
     with pytest.raises(Unsupported, match="expected only T split=8"):
         _verify_carried_reduction(wrong_logical_dim=True)
+
+
+def test_carried_reduction_verifier_rejects_scheduler_rank_change():
+    with pytest.raises(Unsupported, match="changed iteration rank"):
+        _verify_carried_reduction(scheduled_rank_mismatch=True)
 
 
 def aot_backend(gm: GraphModule, example_inputs: Sequence[InputType]):

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -31,6 +31,26 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True)
+class CarriedReductionSpec:
+    """Planning-time requirement for one value carried through a tiled loop."""
+
+    row_dim_name: str
+    required_row_split: int
+
+
+@dataclass(frozen=True)
+class CarriedReductionRecord:
+    """Shared identity and ownership contract for a realized carried sum."""
+
+    accumulator_name: str
+    row_dim_name: str
+    required_row_split: int
+    fill_name: str
+    combine_name: str
+    drain_name: str
+
+
+@dataclass(frozen=True)
 class ReductionPlan:
     """Planned shape/identity/nesting data for a tiled-reduction op.
 
@@ -84,6 +104,7 @@ class ReductionPlan:
     outer_fill_loop_info: "CoarseTileInfo | None"
     full_output_strides: tuple[sympy.Expr, ...]
     per_tile_strides: tuple[sympy.Expr, ...]
+    carried: CarriedReductionSpec | None = None
 
 
 @dataclass(frozen=True)
@@ -353,6 +374,9 @@ _SPYRE_METADATA_ATTRS = (
     # coarse_tile._propagate_tiled_reduction_op, read by finalize_layouts in
     # insert_restickify.py to promote accum_full to FixedTiledLayout when needed.
     "_tiled_reduction_accum_name",
+    # One immutable record shared by the fill, loop combine, and final drain
+    # of a loop-carried reduction.  Post-fusion verification consumes it.
+    "_carried_reduction_record",
 )
 
 

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -87,6 +87,7 @@ from .scheduler import (
     align_lx_producer_loop_order,
     build_loop_scheduler_nodes,
     demote_incoherent_lx_buffers,
+    verify_carried_reduction_ownership,
 )
 from .constants import DEVICE_NAME
 from .deadcode_elimination import deadcode_elimination
@@ -295,7 +296,12 @@ class CustomPostFusionPasses(_SpyreNodePassPipeline):
         # hbm_pool_planning runs after spyre_fuse_nodes so it can compute
         # bundle-scoped live ranges.
         super().__init__(
-            [demote_incoherent_lx_buffers, spyre_fuse_nodes, hbm_pool_planning]
+            [
+                demote_incoherent_lx_buffers,
+                spyre_fuse_nodes,
+                hbm_pool_planning,
+                verify_carried_reduction_ownership,
+            ]
         )
 
 

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -38,6 +38,7 @@ from .ir import FixedTiledLayout
 from .pass_utils import (
     PerCoreView,
     iteration_space,
+    iteration_space_from_op,
     per_core_view_scheduled,
     try_device_coordinates,
 )
@@ -735,7 +736,28 @@ def verify_carried_reduction_ownership(
                 raise Unsupported(
                     f"carried reduction {op_name} {access} has no final work division"
                 )
-            named_dims = getattr(node.node, "work_div_loop_info", {})
+
+            # Scheduler dependency extraction alpha-renames operation symbols
+            # (for example, d0 -> c0) without changing dimension order.  The
+            # carried-reduction rewrite is explicitly limited to
+            # order-preserving pointwise stages, so translate the names across
+            # that rename here.  This is not a general positional-remapping
+            # facility: a rank change fails closed, and no other rewrite uses
+            # this path.
+            operation_symbols = tuple(iteration_space_from_op(node.node))
+            scheduled_symbols = tuple(iteration_space(node))
+            if len(operation_symbols) != len(scheduled_symbols):
+                raise Unsupported(
+                    f"carried reduction {op_name} {access} changed iteration rank "
+                    "before final ownership verification"
+                )
+            operation_named_dims = getattr(node.node, "work_div_loop_info", {})
+            named_dims = {
+                scheduled_symbol: operation_named_dims.get(operation_symbol, [])
+                for operation_symbol, scheduled_symbol in zip(
+                    operation_symbols, scheduled_symbols
+                )
+            }
             row_symbols = [
                 symbol
                 for symbol in realized_division.work_slices

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -708,16 +708,52 @@ def verify_carried_reduction_ownership(
                     f"does not match accumulator ownership {expected_view}"
                 )
 
-        assert expected_view is not None
-        realized_cores = sympy_product(
-            factor for _, factor in expected_view.work_slice_dims
-        )
-        if sympy.simplify(realized_cores - record.required_row_split) != 0:
-            raise Unsupported(
-                f"carried reduction {record.accumulator_name} expected "
-                f"{record.row_dim_name} split={record.required_row_split}, but "
-                f"final ownership is {expected_view}"
+            # Equal physical views are necessary but not sufficient.  A
+            # 32-way split over H and a 32-way split over T can have the same
+            # total core count while assigning different logical rows to a
+            # core.  Project the final physical view back into this stage's
+            # scheduled loop symbols, then require the one split to be the
+            # row dimension named by the immutable carried-reduction record.
+            coordinates = try_device_coordinates(layout.device_layout, dep, None)
+            if coordinates is None:
+                raise Unsupported(
+                    f"carried reduction {op_name} {access} cannot map final "
+                    "accumulator coordinates back to operation loops"
+                )
+            try:
+                realized_division = work_division_from_view(
+                    view,
+                    coordinates,
+                    tuple(iteration_space(node)),
+                )
+            except ValueError as exc:
+                raise Unsupported(
+                    f"carried reduction {op_name} {access} cannot project final "
+                    f"ownership into operation loops: {exc}"
+                ) from exc
+            if realized_division is None:
+                raise Unsupported(
+                    f"carried reduction {op_name} {access} has no final work division"
+                )
+            named_dims = getattr(node.node, "work_div_loop_info", {})
+            row_symbols = [
+                symbol
+                for symbol in realized_division.work_slices
+                if record.row_dim_name in named_dims.get(symbol, [])
+            ]
+            expected_splits = (
+                {row_symbols[0]: record.required_row_split}
+                if len(row_symbols) == 1
+                else None
             )
+            if realized_division.work_slices != expected_splits:
+                raise Unsupported(
+                    f"carried reduction {op_name} {access} expected only "
+                    f"{record.row_dim_name} split={record.required_row_split}, but "
+                    f"final logical splits are {realized_division.work_slices}"
+                )
+
+        assert expected_view is not None
 
     return nodes
 

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Sequence, Union
+from typing import Iterator, Sequence, Union
 
 import sympy
 
@@ -49,6 +49,7 @@ from .scratchpad.lx_relayout import (
 )
 from .op_spec import LoopSpec
 from . import config as _spyre_config
+from .errors import Unsupported
 
 logger = get_inductor_logger("scheduler")
 
@@ -589,6 +590,134 @@ def demote_incoherent_lx_buffers(
         if culprit is None:
             continue
         demote(source_by_copy.get(name, name), culprit)
+
+    return nodes
+
+
+def verify_carried_reduction_ownership(
+    nodes: list[BaseSchedulerNode],
+) -> list[BaseSchedulerNode]:
+    """Verify the final physical contract of every loop-carried reduction.
+
+    This runs after fusion, LX demotion, and HBM-pool planning.  Earlier split
+    metadata is only an input request; the scheduled per-core views checked
+    here are the ownership codegen will actually emit.
+    """
+
+    def all_scheduler_nodes(
+        items: Sequence[BaseSchedulerNode],
+    ) -> Iterator[SchedulerNode]:
+        for item in items:
+            if isinstance(item, FusedSchedulerNode):
+                yield from all_scheduler_nodes(item.get_nodes())
+            elif isinstance(item, SchedulerNode):
+                yield item
+
+    grouped: dict[object, dict[str, SchedulerNode]] = {}
+    for node in all_scheduler_nodes(nodes):
+        record = getattr(node.node, "_carried_reduction_record", None)
+        if record is not None:
+            grouped.setdefault(record, {})[node.get_name()] = node
+
+    for record, by_name in grouped.items():
+        expected_names = {
+            record.fill_name,
+            record.combine_name,
+            record.drain_name,
+        }
+        missing = expected_names - by_name.keys()
+        if missing:
+            raise Unsupported(
+                "carried reduction lost physical stages after fusion: "
+                f"accumulator={record.accumulator_name}, missing={sorted(missing)}"
+            )
+
+        accumulator = V.graph.try_get_buffer(record.accumulator_name)
+        if accumulator is None:
+            raise Unsupported(
+                f"carried reduction accumulator {record.accumulator_name} is missing"
+            )
+        layout = accumulator.get_layout()
+        if not isinstance(layout, FixedTiledLayout):
+            raise Unsupported(
+                f"carried reduction accumulator {record.accumulator_name} has "
+                f"non-device layout {type(layout).__name__}"
+            )
+        if "lx" not in layout.allocation:
+            logger.warning(
+                "carried reduction %s remained in HBM; execution is correct but "
+                "the persistent-LX performance contract was not realized",
+                record.accumulator_name,
+            )
+            continue
+
+        checks = (
+            (record.fill_name, "write"),
+            (record.combine_name, "read"),
+            (record.combine_name, "write"),
+            (record.drain_name, "read"),
+        )
+        expected_view = layout.lx_view
+        for op_name, access in checks:
+            node = by_name[op_name]
+            deps = (
+                node.read_writes.reads if access == "read" else node.read_writes.writes
+            )
+            dep = next(
+                (
+                    candidate
+                    for candidate in deps
+                    if isinstance(candidate, MemoryDep)
+                    and candidate.name == record.accumulator_name
+                ),
+                None,
+            )
+            if dep is None and access == "write" and op_name == record.combine_name:
+                # MutationLayout's scheduled write is named after the combine
+                # op, while its storage target is the carried accumulator.
+                memory_deps = [
+                    candidate for candidate in deps if isinstance(candidate, MemoryDep)
+                ]
+                dep = memory_deps[0] if len(memory_deps) == 1 else None
+            if dep is None and access == "read" and op_name == record.drain_name:
+                # Mutation propagation names this dependency after the latest
+                # in-place writer, but it still reads the accumulator storage.
+                memory_deps = [
+                    candidate for candidate in deps if isinstance(candidate, MemoryDep)
+                ]
+                dep = memory_deps[0] if len(memory_deps) == 1 else None
+            if dep is None:
+                raise Unsupported(
+                    f"carried reduction {op_name} lost its {access} of "
+                    f"{record.accumulator_name}; deps="
+                    f"{[(type(candidate).__name__, candidate.name) for candidate in deps]}"
+                )
+            view, _, representable = per_core_view_scheduled(
+                node, dep, record.accumulator_name
+            )
+            if not representable:
+                raise Unsupported(
+                    f"carried reduction {op_name} {access} ownership is not "
+                    "representable"
+                )
+            if expected_view is None:
+                expected_view = view
+            elif view != expected_view:
+                raise Unsupported(
+                    f"carried reduction {op_name} {access} ownership {view} "
+                    f"does not match accumulator ownership {expected_view}"
+                )
+
+        assert expected_view is not None
+        realized_cores = sympy_product(
+            factor for _, factor in expected_view.work_slice_dims
+        )
+        if sympy.simplify(realized_cores - record.required_row_split) != 0:
+            raise Unsupported(
+                f"carried reduction {record.accumulator_name} expected "
+                f"{record.row_dim_name} split={record.required_row_split}, but "
+                f"final ownership is {expected_view}"
+            )
 
     return nodes
 

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -96,6 +96,7 @@ from torch_spyre._inductor.ir import FixedTiledLayout, SpyreEmptyFallback
 
 from torch_spyre._inductor import config
 from torch_spyre._inductor.logging_utils import get_inductor_logger
+from torch_spyre._inductor.loop_info import CarriedReductionRecord
 from torch_spyre._inductor.scratchpad.lx_relayout import (
     LXRelayoutPlan,
     collect_lx_relayout_plans,
@@ -154,6 +155,16 @@ def _extern_kernel_in_live_range(graph: GraphLowering, uses: list[int]) -> bool:
         isinstance(graph.operations[i], ExternKernel)
         and not isinstance(graph.operations[i], SpyreEmptyFallback)
         for i in range(min(uses), max(uses) + 1)
+    )
+
+
+def _is_carried_reduction_storage(op: Any) -> bool:
+    """True only for the accumulator named by its shared physical contract."""
+
+    record = getattr(op, "_carried_reduction_record", None)
+    return (
+        isinstance(record, CarriedReductionRecord)
+        and record.accumulator_name == op.get_name()
     )
 
 
@@ -368,7 +379,7 @@ class ScratchpadAllocator:
         # A planned source intentionally bypasses the profitability denylist:
         # the relayout planner has already applied its stricter structural gates.
         return (
-            getattr(op, "_coarse_tile_loop_carried_lx", False)
+            _is_carried_reduction_storage(op)
             or config.allow_all_ops_in_lx_planning
             or self._get_op_name(op) not in OP_OUTPUT_NOT_GOOD_FOR_LX_REUSE
             or op.get_name() in planned_lx_buffers
@@ -464,13 +475,11 @@ class ScratchpadAllocator:
             # MultiOutputLayout tuple op). There is nothing to place, and the
             # checks below would raise.
             return "unsized (no device layout)"
-        if name in mutated_buffers and not getattr(
-            op, "_coarse_tile_loop_carried_lx", False
-        ):
+        if name in mutated_buffers and not _is_carried_reduction_storage(op):
             return "mutation target"
-        # A marked carried accumulator has exactly one in-loop mutator and a
-        # closed fill -> combine -> drain lifetime.  The general mutation gate
-        # remains unchanged for every other buffer.
+        # The shared carried-reduction contract names exactly one accumulator
+        # with one in-loop mutator and a closed fill -> combine -> drain
+        # lifetime.  The general mutation gate remains unchanged otherwise.
         if _is_tiled_advancing(op) or _is_read_advancing_anywhere(name, buf_user_deps):
             # LX addresses cannot be expressed as affine.apply symbols today (see
             # compute_ops.py's is_tiled_lx check), so a buffer whose address

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -367,8 +367,10 @@ class ScratchpadAllocator:
             return False
         # A planned source intentionally bypasses the profitability denylist:
         # the relayout planner has already applied its stricter structural gates.
-        return config.allow_all_ops_in_lx_planning or (
-            self._get_op_name(op) not in OP_OUTPUT_NOT_GOOD_FOR_LX_REUSE
+        return (
+            getattr(op, "_coarse_tile_loop_carried_lx", False)
+            or config.allow_all_ops_in_lx_planning
+            or self._get_op_name(op) not in OP_OUTPUT_NOT_GOOD_FOR_LX_REUSE
             or op.get_name() in planned_lx_buffers
         )
 
@@ -462,8 +464,13 @@ class ScratchpadAllocator:
             # MultiOutputLayout tuple op). There is nothing to place, and the
             # checks below would raise.
             return "unsized (no device layout)"
-        if name in mutated_buffers:
+        if name in mutated_buffers and not getattr(
+            op, "_coarse_tile_loop_carried_lx", False
+        ):
             return "mutation target"
+        # A marked carried accumulator has exactly one in-loop mutator and a
+        # closed fill -> combine -> drain lifetime.  The general mutation gate
+        # remains unchanged for every other buffer.
         if _is_tiled_advancing(op) or _is_read_advancing_anywhere(name, buf_user_deps):
             # LX addresses cannot be expressed as affine.apply symbols today (see
             # compute_ops.py's is_tiled_lx check), so a buffer whose address

--- a/torch_spyre/_inductor/work_division_constraints.py
+++ b/torch_spyre/_inductor/work_division_constraints.py
@@ -103,6 +103,7 @@ def collect_work_division_constraints(
     blocked: set[Symbol] = set()
     allowed_splits: dict[Symbol, frozenset[int]] = {}
     for constraint in (
+        carried_reduction_pinned_row,
         coordinate_mask_blocked_vars,
         conv_spatial_blocked_vars,
         reduction_window_blocked_vars,
@@ -151,6 +152,33 @@ def collect_work_division_constraints(
             allowed_splits[sym] = allowed
 
     return ConstraintResult(blocked=blocked, allowed_splits=allowed_splits)
+
+
+def carried_reduction_pinned_row(
+    ctx: WorkDivConstraintContext,
+) -> ConstraintResult:
+    """Keep every stage of a carried sum on its declared output-row split."""
+
+    record = getattr(ctx.op, "_carried_reduction_record", None)
+    if record is None:
+        return ConstraintResult()
+
+    loop_var_dims = getattr(ctx.op, "work_div_loop_info", {})
+    candidates = [
+        sym
+        for sym in ctx.it_space_adjusted
+        if record.row_dim_name in loop_var_dims.get(sym, [])
+    ]
+    if len(candidates) != 1:
+        raise Unsupported(
+            f"{ctx.op.get_name()}: carried reduction row "
+            f"{record.row_dim_name!r} resolved to {candidates}"
+        )
+    return ConstraintResult(
+        allowed_splits={
+            candidates[0]: frozenset({record.required_row_split}),
+        }
+    )
 
 
 def coordinate_mask_blocked_vars(ctx: WorkDivConstraintContext) -> ConstraintResult:

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -4699,9 +4699,7 @@ def _collapse_loop_carried_unit_sum(
     )
     from ..pass_utils import replace_computed_buffer_body
 
-    old_loop_symbols = list(iteration_space_from_op(tiled_op))[: len(data.ranges)]
-    old_dim_names = getattr(tiled_op, "work_div_loop_info", {})
-    output_names = [list(old_dim_names.get(sym, [])) for sym in old_loop_symbols]
+    before_symbols = _capture_logical_iteration_symbols(tiled_op)
 
     contribution = replace_computed_buffer_body(
         tiled_op,
@@ -4710,15 +4708,13 @@ def _collapse_loop_carried_unit_sum(
         pass_name="coarse_tile",
         reason="collapse one-expert sum to loop contribution",
     )
-    # This exact rewrite preserves output-dimension order.  Reattach the names
-    # only here; a general positional remap would be unsound for other rewrites.
-    new_loop_symbols = list(iteration_space_from_op(contribution))
-    if len(new_loop_symbols) != len(output_names):
-        raise Unsupported(
-            f"coarse_tile: carried sum {tiled_op.get_name()} changed output rank"
-        )
-    contribution.work_div_loop_info = dict(  # type: ignore[attr-defined]
-        zip(new_loop_symbols, output_names)
+    _apply_work_div_symbol_remap(
+        contribution,
+        _order_preserving_symbol_remap(
+            contribution,
+            before_symbols,
+            _capture_logical_iteration_symbols(contribution),
+        ),
     )
     V.graph.name_to_buffer[contribution.get_name()] = contribution
     return contribution
@@ -4728,19 +4724,19 @@ def _copy_carried_output_dim_names(
     source: ComputedBuffer,
     target: ComputedBuffer,
 ) -> None:
-    """Copy output-dim identity across this order-preserving local rewrite."""
+    """Copy named dimensions across this order-preserving local rewrite."""
 
-    source_symbols = list(iteration_space_from_op(source))[: len(source.data.ranges)]
-    target_symbols = list(iteration_space_from_op(target))[: len(target.data.ranges)]
-    if len(source_symbols) != len(target_symbols):
-        raise Unsupported(
-            f"coarse_tile: carried sum {source.get_name()} changed output rank"
-        )
-    source_names = getattr(source, "work_div_loop_info", {})
-    target.work_div_loop_info = {  # type: ignore[attr-defined]
-        target_sym: list(source_names.get(source_sym, []))
-        for source_sym, target_sym in zip(source_symbols, target_symbols)
-    }
+    target.work_div_loop_info = dict(  # type: ignore[attr-defined]
+        getattr(source, "work_div_loop_info", {})
+    )
+    _apply_work_div_symbol_remap(
+        target,
+        _order_preserving_symbol_remap(
+            target,
+            _capture_logical_iteration_symbols(source),
+            _capture_logical_iteration_symbols(target),
+        ),
+    )
 
 
 def _insert_flat_reduction_drain_op(

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -97,6 +97,8 @@ from ..constants import BATCH_MATMUL_OP, MATMUL_REDUCTION_OPS
 from ..errors import Unsupported
 from ..logging_utils import get_inductor_logger
 from ..loop_info import (
+    CarriedReductionRecord,
+    CarriedReductionSpec,
     CoarseTileInfo,
     PropagationPlan,
     ReadCopyEntry,
@@ -105,6 +107,7 @@ from ..loop_info import (
     ReductionPlan,
     copy_op_metadata,
 )
+from ..propagate_hints import get_op_hints
 from ..pass_utils import (
     op_out_coords,
     host_coordinates,
@@ -268,6 +271,81 @@ class _IterationSymbolRemap(NamedTuple):
 class _DivideRangesResult(NamedTuple):
     retiled_info: _RetiledBufferInfo | None
     symbol_remap: _IterationSymbolRemap | None
+
+
+def _work_division_names(op: ComputedBuffer) -> dict[str, int]:
+    """Return the explicit named work-division request attached to ``op``."""
+
+    result: dict[str, int] = {}
+    for _, hint_dict in sorted(get_op_hints(op).items()):
+        result.update(hint_dict.get("work_div") or {})
+    return result
+
+
+def _plan_carried_sum(
+    op: ComputedBuffer,
+    info: CoarseTileInfo,
+    *,
+    is_graph_output: bool,
+    outside_consumer_names: list[str],
+    is_nested: bool,
+) -> CarriedReductionSpec | None:
+    """Recognize the one safe shape for an LX-resident loop-carried sum.
+
+    The work-division hint names the output row dimension.  Resolve it here,
+    before any IR is rewritten, so a misspelled or reduction-dimension hint
+    cannot create a carried accumulator with ambiguous ownership.
+    """
+
+    data = op.data
+    if not (
+        isinstance(data, Reduction)
+        and data.reduction_type == "sum"
+        and getattr(data, "src_dtype", object()) == getattr(data, "dtype", None)
+        and not is_nested
+        and is_graph_output
+        and not outside_consumer_names
+        and len(info.loop_count) == 1
+        and all(not dims for dims in info.loop_tiled_dims)
+        and info.loop_tiled_reduction_dims == [[0]]
+        and len(data.reduction_ranges) == 1
+    ):
+        return None
+
+    requested = _work_division_names(op)
+    if not requested:
+        return None
+
+    named_symbols = getattr(op, "work_div_loop_info", {})
+    output_symbols = set(list(iteration_space_from_op(op))[: len(data.ranges)])
+    resolved: list[tuple[str, int]] = []
+    unresolved: list[str] = []
+    for name, split in requested.items():
+        symbols = [sym for sym, names in named_symbols.items() if name in names]
+        if len(symbols) != 1 or symbols[0] not in output_symbols:
+            unresolved.append(name)
+            continue
+        if isinstance(split, bool) or not isinstance(split, (int, sympy.Integer)):
+            raise Unsupported(
+                f"coarse_tile: carried sum {op.get_name()} work_div {name!r} "
+                f"must be a positive integer, got {split!r}"
+            )
+        split = int(split)
+        if split < 1:
+            raise Unsupported(
+                f"coarse_tile: carried sum {op.get_name()} work_div {name!r} "
+                f"must be positive, got {split}"
+            )
+        resolved.append((name, split))
+
+    if unresolved or len(resolved) != 1:
+        raise Unsupported(
+            f"coarse_tile: carried sum {op.get_name()} requires exactly one "
+            "work_div on an output row dimension; "
+            f"resolved={resolved}, unresolved={unresolved}"
+        )
+    name, split = resolved[0]
+    return CarriedReductionSpec(name, split)
 
 
 # ---------------------------------------------------------------------------
@@ -788,6 +866,16 @@ def _plan_tiling_propagation(
                                 f"scopes so the reduction dim is not tiled "
                                 f"alongside another tiled output dim."
                             )
+                consumer_names, is_graph_output = _find_outside_consumers_planned(
+                    buf_name, info.loop_group_id, operations, name_to_group_outer_key
+                )
+                carried = _plan_carried_sum(
+                    op,
+                    info,
+                    is_graph_output=is_graph_output,
+                    outside_consumer_names=consumer_names,
+                    is_nested=outer_fill_loop_info is not None,
+                )
                 reduction_plan = ReductionPlan(
                     reduction_type=reduction_type,
                     identity=identity,
@@ -797,9 +885,7 @@ def _plan_tiling_propagation(
                     outer_fill_loop_info=outer_fill_loop_info,
                     full_output_strides=full_output_strides,
                     per_tile_strides=per_tile_strides,
-                )
-                consumer_names, is_graph_output = _find_outside_consumers_planned(
-                    buf_name, info.loop_group_id, operations, name_to_group_outer_key
+                    carried=carried,
                 )
                 info.propagation = PropagationPlan(
                     kind="reduction",
@@ -3410,6 +3496,7 @@ def _insert_one_read_copy(
     )
 
     tile_strides: list[Expr]
+    active_full_strides: list[Expr] = []
     if not active_idx:
         tile_strides = [sympy.Integer(0)] * len(tile_ranges)
     else:
@@ -3897,6 +3984,43 @@ def _insert_one_read_copy(
             for i, dims in enumerate(sizing_op_info.loop_tiled_reduction_dims)
             if d in dims
         ]
+        if d not in reduction_squeeze_pos:
+            reduction_plan = getattr(
+                getattr(sizing_op_info, "propagation", None), "reduction", None
+            )
+            if getattr(reduction_plan, "carried", None) is None:
+                raise Unsupported(
+                    "coarse_tile: size-one reduction tiles require an explicit "
+                    "carried-reduction plan"
+                )
+            # The tiled reduction extent became one, so Inductor removed its
+            # loop symbol.  Preserve its source-buffer address step explicitly
+            # instead of indexing a symbol map that cannot contain it.
+            d_full_size = sympy.Integer(1)
+            for level_idx in reversed(levels_tiling_d):
+                d_full_size *= sizing_op_info.loop_count[level_idx]
+
+            full_sizes = list(full_buf.get_size())
+            full_strides = list(full_buf.layout.stride)
+            active_stride_counts = collections.Counter(active_full_strides)
+            candidates: list[Expr] = []
+            for size, stride in zip(full_sizes, full_strides):
+                if active_stride_counts[stride] > 0:
+                    active_stride_counts[stride] -= 1
+                    continue
+                if sympy.simplify(size - d_full_size) == 0:
+                    candidates.append(stride)
+            if len(candidates) != 1:
+                raise Unsupported(
+                    f"coarse_tile: cannot recover squeezed reduction dim {d} "
+                    f"for read {dep.name}: full_size={d_full_size}, "
+                    f"candidate_strides={candidates}"
+                )
+            running = sympy.Integer(1)
+            for level_idx in reversed(levels_tiling_d):
+                squeezed_advance[level_idx].append((candidates[0], running))
+                running *= sizing_op_info.loop_count[level_idx]
+            continue
         copy_dim_key = it_idx + reduction_squeeze_pos[d]
         running = sympy.sympify(copy_ranges[copy_dim_key])
         for level_idx in reversed(levels_tiling_d):
@@ -4512,6 +4636,149 @@ def _insert_combine_op(
     return combine_name
 
 
+def _collapse_loop_carried_unit_sum(
+    tiled_op: ComputedBuffer,
+    combine_name: str,
+    operations: list[Operation],
+) -> ComputedBuffer:
+    """Replace a one-expert local sum by its single contribution.
+
+    The combine op performs the real cross-expert sum.  Once coarse tiling has
+    reduced the expert extent to one, retaining a second Reduction is both
+    redundant and unrepresentable by the backend.
+    """
+
+    data = tiled_op.data
+    info = getattr(tiled_op, "loop_info", None)
+    plan = getattr(getattr(info, "propagation", None), "reduction", None)
+    if not (
+        isinstance(data, Reduction)
+        and data.reduction_type == "sum"
+        and data.src_dtype == data.dtype
+        and info is not None
+        and plan is not None
+        and plan.carried is not None
+        and len(data.reduction_ranges) == 1
+        and sympy.sympify(data.reduction_ranges[0]) == 1
+    ):
+        raise Unsupported(
+            f"coarse_tile: carried sum {tiled_op.get_name()} did not reduce "
+            "to one contribution per loop iteration"
+        )
+
+    combine = V.graph.name_to_buffer.get(combine_name)
+    if not (
+        isinstance(combine, ComputedBuffer)
+        and isinstance(combine.data, Pointwise)
+        and isinstance(combine.layout, MutationLayoutSHOULDREMOVE)
+        and _reads_buffer(combine, tiled_op.get_name())
+    ):
+        raise Unsupported(
+            f"coarse_tile: carried sum {tiled_op.get_name()} has no matching "
+            f"combine op {combine_name}"
+        )
+
+    reduction_inner_fn = data.inner_fn
+
+    def contribution_inner_fn(index):
+        return reduction_inner_fn(index, [sympy.Integer(0)])
+
+    contribution_data = Pointwise(
+        device=tiled_op.get_device(),
+        dtype=tiled_op.get_dtype(),
+        inner_fn=contribution_inner_fn,
+        ranges=list(data.ranges),
+    )
+    from ..provenance import preserve_provenance
+
+    preserve_provenance(
+        data,
+        contribution_data,
+        pass_name="coarse_tile",
+        reason="collapse one-expert sum to loop contribution",
+    )
+    from ..pass_utils import replace_computed_buffer_body
+
+    old_loop_symbols = list(iteration_space_from_op(tiled_op))[: len(data.ranges)]
+    old_dim_names = getattr(tiled_op, "work_div_loop_info", {})
+    output_names = [list(old_dim_names.get(sym, [])) for sym in old_loop_symbols]
+
+    contribution = replace_computed_buffer_body(
+        tiled_op,
+        contribution_data,
+        operations,
+        pass_name="coarse_tile",
+        reason="collapse one-expert sum to loop contribution",
+    )
+    # This exact rewrite preserves output-dimension order.  Reattach the names
+    # only here; a general positional remap would be unsound for other rewrites.
+    new_loop_symbols = list(iteration_space_from_op(contribution))
+    if len(new_loop_symbols) != len(output_names):
+        raise Unsupported(
+            f"coarse_tile: carried sum {tiled_op.get_name()} changed output rank"
+        )
+    contribution.work_div_loop_info = dict(  # type: ignore[attr-defined]
+        zip(new_loop_symbols, output_names)
+    )
+    V.graph.name_to_buffer[contribution.get_name()] = contribution
+    return contribution
+
+
+def _copy_carried_output_dim_names(
+    source: ComputedBuffer,
+    target: ComputedBuffer,
+) -> None:
+    """Copy output-dim identity across this order-preserving local rewrite."""
+
+    source_symbols = list(iteration_space_from_op(source))[: len(source.data.ranges)]
+    target_symbols = list(iteration_space_from_op(target))[: len(target.data.ranges)]
+    if len(source_symbols) != len(target_symbols):
+        raise Unsupported(
+            f"coarse_tile: carried sum {source.get_name()} changed output rank"
+        )
+    source_names = getattr(source, "work_div_loop_info", {})
+    target.work_div_loop_info = {  # type: ignore[attr-defined]
+        target_sym: list(source_names.get(source_sym, []))
+        for source_sym, target_sym in zip(source_symbols, target_symbols)
+    }
+
+
+def _insert_flat_reduction_drain_op(
+    tiled_op: ComputedBuffer,
+    accumulator: ComputedBuffer,
+    output: ComputedBuffer,
+    combine_name: str,
+    operations: list[Operation],
+) -> ComputedBuffer:
+    """Drain a carried accumulator to its graph output once after the loop."""
+
+    device = tiled_op.get_device()
+    assert device is not None
+    drain_data = Pointwise(
+        device=device,
+        dtype=tiled_op.get_dtype(),
+        inner_fn=accumulator.make_loader(),
+        ranges=list(tiled_op.data.ranges),
+    )
+    drain_name = V.graph.qualify_name(
+        f"coarse_tile_reduction_drain_{tiled_op.get_name()}"
+    )
+    drain_buf = ComputedBuffer(
+        name=drain_name,
+        layout=MutationLayoutSHOULDREMOVE(TensorBox(StorageBox(output))),
+        data=drain_data,
+    )
+    drain_buf.origins = tiled_op.origins
+    drain_buf.operation_name = drain_name
+    drain_buf._coarse_tile_force_live = True  # type: ignore[attr-defined]
+    V.graph.name_to_buffer[drain_name] = drain_buf
+
+    combine_buf = V.graph.name_to_buffer[combine_name]
+    assert isinstance(combine_buf, ComputedBuffer)
+    operations.insert(operations.index(combine_buf) + 1, drain_buf)
+    return drain_buf
+
+
 def _insert_reduction_copy_op(
     tiled_op: ComputedBuffer,
     accum_tile: ComputedBuffer,
@@ -4678,6 +4945,8 @@ def _propagate_tiled_reduction_op(
 
     fill_loop_info = reduction_plan.outer_fill_loop_info
     is_nested = reduction_plan.is_nested
+    carried = reduction_plan.carried
+    use_loop_carried_accumulator = carried is not None
 
     if fill_loop_info is not None:
         # outer_fill_loop_info was built at planning time, before _apply_plan
@@ -4740,6 +5009,7 @@ def _propagate_tiled_reduction_op(
     # redundant but harmless.
     dtype = op.get_dtype()
     device = op.get_device()
+    assert device is not None
 
     scalar_op = SpyreConstantFallback(
         torch.ops.spyre.constant.default, float(identity), dtype, device
@@ -4764,11 +5034,39 @@ def _propagate_tiled_reduction_op(
         ranges=fill_ranges,
     )
     fill_name = V.graph.qualify_name(f"coarse_tile_fill_{op.get_name()}")
-    fill_buf = ComputedBuffer(
-        name=fill_name,
-        layout=MutationLayoutSHOULDREMOVE(TensorBox(StorageBox(fill_target))),
-        data=fill_data,
-    )
+    if use_loop_carried_accumulator:
+        # This ordinary buffer is the one value carried across expert-loop
+        # iterations.  It is deliberately separate from the HBM graph output,
+        # which the suffix drain writes once after the loop.
+        if isinstance(fill_target.layout, FixedTiledLayout):
+            fill_layout: FixedLayout = FixedTiledLayout(
+                device,
+                dtype,
+                list(fill_target.layout.size),
+                list(fill_target.layout.stride),
+                fill_target.layout.device_layout,
+            )
+        else:
+            fill_layout = FixedLayout(
+                device,
+                dtype,
+                list(fill_target.layout.size),
+                list(fill_target.layout.stride),
+            )
+        fill_buf = ComputedBuffer(
+            name=fill_name,
+            layout=fill_layout,
+            data=fill_data,
+        )
+        fill_buf._coarse_tile_loop_carried_lx = True  # type: ignore[attr-defined]
+        _copy_carried_output_dim_names(op, fill_buf)
+        combine_target = fill_buf
+    else:
+        fill_buf = ComputedBuffer(
+            name=fill_name,
+            layout=MutationLayoutSHOULDREMOVE(TensorBox(StorageBox(fill_target))),
+            data=fill_data,
+        )
     fill_buf.origins = op.origins
     fill_buf.operation_name = fill_name
     if fill_loop_info is not None:
@@ -4789,7 +5087,33 @@ def _propagate_tiled_reduction_op(
     operations.insert(fill_target_idx + 2, fill_buf)
 
     # Insert combine op after the tiled reduction op (inside the loop).
-    combine_name = _insert_combine_op(op, combine_target, operations, is_nested)
+    combine_name = _insert_combine_op(
+        op,
+        combine_target,
+        operations,
+        is_nested or use_loop_carried_accumulator,
+    )
+
+    if carried is not None:
+        combine_buf = V.graph.name_to_buffer[combine_name]
+        assert isinstance(combine_buf, ComputedBuffer)
+        _copy_carried_output_dim_names(op, combine_buf)
+        op = _collapse_loop_carried_unit_sum(op, combine_name, operations)
+        drain_buf = _insert_flat_reduction_drain_op(
+            op, combine_target, accum_full, combine_name, operations
+        )
+        _copy_carried_output_dim_names(op, drain_buf)
+        record = CarriedReductionRecord(
+            accumulator_name=combine_target.get_name(),
+            row_dim_name=carried.row_dim_name,
+            required_row_split=carried.required_row_split,
+            fill_name=fill_name,
+            combine_name=combine_name,
+            drain_name=drain_buf.get_name(),
+        )
+        fill_buf._carried_reduction_record = record  # type: ignore[attr-defined]
+        combine_buf._carried_reduction_record = record  # type: ignore[attr-defined]
+        drain_buf._carried_reduction_record = record  # type: ignore[attr-defined]
 
     # For nested case, insert a copy op at the outer loop level that writes
     # accum_tile → accum_full, advancing accum_full across outer output tiles.

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -5058,7 +5058,6 @@ def _propagate_tiled_reduction_op(
             layout=fill_layout,
             data=fill_data,
         )
-        fill_buf._coarse_tile_loop_carried_lx = True  # type: ignore[attr-defined]
         _copy_carried_output_dim_names(op, fill_buf)
         combine_target = fill_buf
     else:


### PR DESCRIPTION
Fixes #4038
Split from #3928
Tracking: #3565

## Campaign status

Merged. The full dense expert-loop compiler implementation and acceptance are complete in `main` through #4042 (`3358f39e`). Structural, numerical-correctness, and same-stack device-performance gates have passed.

## Accepted performance

These measurements cover two different boundaries:

- Expert FFN only, chunked versus persistent: `373.1 ms → 42.6 ms` (`8.8×`).
- Full Gemma 4 26B prefill, batch size 1 and sequence length 512: `6.4 s → 1.6 s` (`4.0×`).

The first isolates the expert FFN; the second is the end-to-end model prefill result.

## This PR owns

A supported terminal expert sum becomes one `[T,H]` value carried through the counted expert loop:

```text
fill accumulator once
for each expert:
    accumulator += weighted expert output
drain accumulator once
```

The carried form is eligible only for a flat terminal `sum`, one expert loop, matching source/accumulator dtype, and exactly one explicit `work_div` on an output row dimension. Coarse tiling resolves that named dimension before rewriting; a missing, wrong, or reduction-dimension hint retains or rejects the carried form before mutation.

Planning creates one immutable `CarriedReductionRecord` shared by fill, combine, and drain. It contains the accumulator identity, logical row name, required split, and the three stage identities.

After `demote_incoherent_lx_buffers → spyre_fuse_nodes → hbm_pool_planning`, `verify_carried_reduction_ownership` recursively finds the final fused stages and checks:

- the accumulator's final memory location;
- fill-write, combine-read/write, and drain-read physical views via `per_core_view_scheduled()`;
- exact equality of those views with the accumulator's LX view;
- projection back to logical loop symbols, requiring only the recorded row dimension at the recorded split.

An LX-resident ownership mismatch is a hard compile error. An HBM fallback remains correct and emits a warning; final integration performance acceptance requires LX.

## This PR does not own

- counted-loop lifetime (#4039, merged);
- operand movement (#4040, merged);
- named work-division lineage (#4096, merged);
- invariant activation staging (#4078, merged);
- direct weight-copy elision (#4041, merged);
- general dimension recovery through arbitrary reorders.

## Why #4096 is required

#4042 collapses `Reduction[T,H;E]` into a carried `Pointwise[T,H]` contribution. This is an order-preserving rank change, but the surviving scheduler symbols are renumbered.

Merged #4096 captures logical dimensions before that rewrite, returns a checked old-symbol to new-symbol mapping, and lets this PR move the recorded row request through it. #4042 calls that shared mechanism rather than keeping a second positional remap. Arbitrary reorder-aware lineage remains out of scope and fails visibly.

## Current-main compatibility

Current `main` expresses hard work-division requirements as legal split domains. The carried row contract contributes the singleton domain `{required_row_split}` through `ConstraintResult.allowed_splits`; it does not add another scheduler or mutate a realized division.

The carried-sum plan also composes with `main`'s flat-reduction safety rejection: unsafe same-group consumers are rejected first; only a safe terminal reduction can become carried state.

## Validation

- Refreshed base/head: `main@3855d111 → 97fc388c`.
- Incremental diff: production +594/-14; tests +401/-2.
- The refresh over merged #4041 is exactly patch-equivalent for all six commits.
- All six commits are DCO-signed and GPG-signed.
- `git diff --check` and `py_compile` pass.
- Prior focused validation of the unchanged patch: coarse-tiling plus work-division suites 376 passed, 1 skipped, 2 expected failures; focused carried-sum coverage 9 passed; focused work-division coverage 39 passed, 2 expected failures.
- Device coverage includes the pure carried-sum reproduction, poisoned HBM, E=128 comparison against ordinary device reduction and CPU, and HBM fallback correctness/diagnostic.
- Negative controls cover no `work_div`, wrong-dimension `work_div`, E=1, nested tiling, competing consumer, and non-sum reduction.
- Final-verifier tests cover matching ownership, physical drift, scheduler renaming, rank-change rejection, and the same split count applied to the wrong logical dimension.
- Fresh GitHub CI is running on the current-main refresh. Any device-startup error is classified separately from a numerical test failure.

## Integration contract

The final program must prove one LX accumulator, stable row ownership across all expert trips, zero expert-expanded HBM intermediate, one post-loop drain, device correctness, and performance. The merged prerequisites supply loop lifetime, operand movement, dimension lineage, invariant staging, and direct advancing weight reads; this PR supplies the carried-sum structure and final physical verifier.

