### PR TITLE
Add a test for RMSNorm fp32 upcast with downcast after mul

### DIFF
--- a/tests/inductor/test_inductor_normalization_scalars.py
+++ b/tests/inductor/test_inductor_normalization_scalars.py
@@ -134,7 +134,9 @@ class TestNormalizationScalarOperations:
             (1e-5, 2, 12, 4096),
         ],
     )
-    def test_rmsnorm_fp32_upcast(self, execution_mode, eps, batch, seq, hidden):
+    def test_rmsnorm_fp32_upcast_downcast_before_mul(
+        self, execution_mode, eps, batch, seq, hidden
+    ):
         """RMSNorm with explicit FP16→FP32 upcast for numerical stability (issue #2508).
 
         Pattern: x.to(fp32) → pow(2) → mean(-1) → rsqrt → mul → weight * result.to(fp16)
@@ -150,6 +152,41 @@ class TestNormalizationScalarOperations:
             variance = x_fp32.pow(2).mean(-1, keepdim=True)
             x_normed = x_fp32 * torch.rsqrt(variance + eps)
             return weight * x_normed.to(x.dtype)
+
+        x = cached_randn((batch, seq, hidden), dtype=torch.float16)
+        weight = cached_randn((hidden,), differentiation="weight")
+        _compare_modes(
+            execution_mode, rmsnorm_fp32_upcast, x, weight, atol=1e-2, rtol=1e-2
+        )
+
+    @pytest.mark.parametrize(
+        "eps,batch,seq,hidden",
+        [
+            (1e-5, 1, 1, 4096),
+            (1e-5, 1, 12, 4096),
+            (1e-5, 1, 64, 4096),
+            (1e-5, 2, 1, 4096),
+            (1e-5, 2, 12, 4096),
+        ],
+    )
+    def test_rmsnorm_fp32_upcast_downcast_after_mul(
+        self, execution_mode, eps, batch, seq, hidden
+    ):
+        """RMSNorm with explicit FP16→FP32 upcast for numerical stability (issue #3580).
+
+        Pattern: x.to(fp32) → pow(2) → mean(-1) → rsqrt → mul → (weight * result).to(fp16)
+        This relies on EA propagation tracking DL16_TO_FP32 through the compute graph.
+        """
+        # EA propagation is a compile-time feature; eager runs the ops but without
+        # the layout-awareness that this pattern requires.
+        if execution_mode == "eager":
+            pytest.skip(reason="EA propagation is compile-time only")
+
+        def rmsnorm_fp32_upcast(x, weight):
+            x_fp32 = x.to(torch.float32)
+            variance = x_fp32.pow(2).mean(-1, keepdim=True)
+            x_normed = x_fp32 * torch.rsqrt(variance + eps)
+            return (weight * x_normed).to(x.dtype)
 
         x = cached_randn((batch, seq, hidden), dtype=torch.float16)
         weight = cached_randn((hidden,), differentiation="weight")


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Add a test for an RMSNorm pattern where fp16 hidden states are upcast to fp32 for numerical stability, the final mul is performed in fp32, and the result is then downcast to fp16. This differs slightly from a test case added in PR #2927, where the downcast is performed before the final mul.

hidden_states.to(fp32) → pow(2) → mean(-1) → rsqrt → mul → (weight * result).to(fp16)

#### Which issue(s) this PR is related to:

Issue #3580 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
