### PR TITLE
ci: run ClickHouse ingest jobs on the dedicated ingest runner set

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -18,3 +18,5 @@ self-hosted-runner:
     - image_spyre_backend
     - image_torch_spyre
     - image_spyre_inference
+    # cardless ClickHouse-ingest set (spyre-frameworks #1235/#1236)
+    - image_ingest

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -18,5 +18,4 @@ self-hosted-runner:
     - image_spyre_backend
     - image_torch_spyre
     - image_spyre_inference
-    # cardless ClickHouse-ingest set (spyre-frameworks #1235/#1236)
     - image_ingest

--- a/.github/actions/build-torch-spyre-wheel/action.yml
+++ b/.github/actions/build-torch-spyre-wheel/action.yml
@@ -33,6 +33,11 @@ runs:
   steps:
     - name: Install uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        # Pin uv rather than resolving "latest": a just-published release is not yet on
+        # releases.astral.sh, so every runner 404s there and falls back to GitHub
+        # Releases, which rate-limits (429) once the fleet requests it concurrently.
+        version: "0.12.5"
 
     - name: Restore ccache
       id: ccache_restore

--- a/.github/actions/build-torch-spyre-wheel/action.yml
+++ b/.github/actions/build-torch-spyre-wheel/action.yml
@@ -32,12 +32,14 @@ runs:
   using: composite
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
-        # Pin uv rather than resolving "latest": a just-published release is not yet on
-        # releases.astral.sh, so every runner 404s there and falls back to GitHub
-        # Releases, which rate-limits (429) once the fleet requests it concurrently.
-        version: 0.12.5
+        # latest-known, not "latest": it resolves to the newest uv whose checksum is
+        # bundled INTO this setup-uv pin, resolved locally with no release lookup. A
+        # just-published release is not yet mirrored on releases.astral.sh, so "latest"
+        # 404s there and falls back to GitHub Releases, which rate-limits (429) once the
+        # fleet requests it concurrently. Bumping setup-uv moves this version forward.
+        version: latest-known
 
     - name: Restore ccache
       id: ccache_restore

--- a/.github/actions/build-torch-spyre-wheel/action.yml
+++ b/.github/actions/build-torch-spyre-wheel/action.yml
@@ -37,7 +37,7 @@ runs:
         # Pin uv rather than resolving "latest": a just-published release is not yet on
         # releases.astral.sh, so every runner 404s there and falls back to GitHub
         # Releases, which rate-limits (429) once the fleet requests it concurrently.
-        version: "0.12.5"
+        version: 0.12.5
 
     - name: Restore ccache
       id: ccache_restore

--- a/.github/actions/ingest-xml-to-clickhouse/action.yml
+++ b/.github/actions/ingest-xml-to-clickhouse/action.yml
@@ -156,12 +156,14 @@ runs:
 
     - name: Install uv
       if: steps.gate.outputs.configured == 'true'
-      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
-        # Pin uv rather than resolving "latest": a just-published release is not yet on
-        # releases.astral.sh, so every runner 404s there and falls back to GitHub
-        # Releases, which rate-limits (429) once the fleet requests it concurrently.
-        version: 0.12.5
+        # latest-known, not "latest": it resolves to the newest uv whose checksum is
+        # bundled INTO this setup-uv pin, resolved locally with no release lookup. A
+        # just-published release is not yet mirrored on releases.astral.sh, so "latest"
+        # 404s there and falls back to GitHub Releases, which rate-limits (429) once the
+        # fleet requests it concurrently. Bumping setup-uv moves this version forward.
+        version: latest-known
 
     - name: Setup venv and dependencies
       if: steps.gate.outputs.configured == 'true'

--- a/.github/actions/ingest-xml-to-clickhouse/action.yml
+++ b/.github/actions/ingest-xml-to-clickhouse/action.yml
@@ -157,6 +157,11 @@ runs:
     - name: Install uv
       if: steps.gate.outputs.configured == 'true'
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        # Pin uv rather than resolving "latest": a just-published release is not yet on
+        # releases.astral.sh, so every runner 404s there and falls back to GitHub
+        # Releases, which rate-limits (429) once the fleet requests it concurrently.
+        version: "0.12.5"
 
     - name: Setup venv and dependencies
       if: steps.gate.outputs.configured == 'true'

--- a/.github/actions/ingest-xml-to-clickhouse/action.yml
+++ b/.github/actions/ingest-xml-to-clickhouse/action.yml
@@ -161,7 +161,7 @@ runs:
         # Pin uv rather than resolving "latest": a just-published release is not yet on
         # releases.astral.sh, so every runner 404s there and falls back to GitHub
         # Releases, which rate-limits (429) once the fleet requests it concurrently.
-        version: "0.12.5"
+        version: 0.12.5
 
     - name: Setup venv and dependencies
       if: steps.gate.outputs.configured == 'true'

--- a/.github/actions/install-prebuilt-torch-spyre/action.yml
+++ b/.github/actions/install-prebuilt-torch-spyre/action.yml
@@ -22,12 +22,14 @@ runs:
   using: composite
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
-        # Pin uv rather than resolving "latest": a just-published release is not yet on
-        # releases.astral.sh, so every runner 404s there and falls back to GitHub
-        # Releases, which rate-limits (429) once the fleet requests it concurrently.
-        version: 0.12.5
+        # latest-known, not "latest": it resolves to the newest uv whose checksum is
+        # bundled INTO this setup-uv pin, resolved locally with no release lookup. A
+        # just-published release is not yet mirrored on releases.astral.sh, so "latest"
+        # 404s there and falls back to GitHub Releases, which rate-limits (429) once the
+        # fleet requests it concurrently. Bumping setup-uv moves this version forward.
+        version: latest-known
 
     - name: Download prebuilt wheel
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/actions/install-prebuilt-torch-spyre/action.yml
+++ b/.github/actions/install-prebuilt-torch-spyre/action.yml
@@ -27,7 +27,7 @@ runs:
         # Pin uv rather than resolving "latest": a just-published release is not yet on
         # releases.astral.sh, so every runner 404s there and falls back to GitHub
         # Releases, which rate-limits (429) once the fleet requests it concurrently.
-        version: "0.12.5"
+        version: 0.12.5
 
     - name: Download prebuilt wheel
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/actions/install-prebuilt-torch-spyre/action.yml
+++ b/.github/actions/install-prebuilt-torch-spyre/action.yml
@@ -23,6 +23,11 @@ runs:
   steps:
     - name: Install uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        # Pin uv rather than resolving "latest": a just-published release is not yet on
+        # releases.astral.sh, so every runner 404s there and falls back to GitHub
+        # Releases, which rate-limits (429) once the fleet requests it concurrently.
+        version: "0.12.5"
 
     - name: Download prebuilt wheel
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/build_test_pytorch_source.yaml
+++ b/.github/workflows/build_test_pytorch_source.yaml
@@ -86,6 +86,11 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          # Pin uv rather than resolving "latest": a just-published release is not yet on
+          # releases.astral.sh, so every runner 404s there and falls back to GitHub
+          # Releases, which rate-limits (429) once the fleet requests it concurrently.
+          version: "0.12.5"
 
       - name: Write dispatch payload to file
         env:
@@ -241,6 +246,11 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          # Pin uv rather than resolving "latest": a just-published release is not yet on
+          # releases.astral.sh, so every runner 404s there and falls back to GitHub
+          # Releases, which rate-limits (429) once the fleet requests it concurrently.
+          version: "0.12.5"
 
       # actions4gh/setup-gh@v1.0.2 extracts the gh tarball but never lands
       # the binary on PATH before it calls `gh auth login`, so every job

--- a/.github/workflows/build_test_pytorch_source.yaml
+++ b/.github/workflows/build_test_pytorch_source.yaml
@@ -85,12 +85,14 @@ jobs:
           verbose: 'true'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          # Pin uv rather than resolving "latest": a just-published release is not yet on
-          # releases.astral.sh, so every runner 404s there and falls back to GitHub
-          # Releases, which rate-limits (429) once the fleet requests it concurrently.
-          version: 0.12.5
+          # latest-known, not "latest": it resolves to the newest uv whose checksum is
+          # bundled INTO this setup-uv pin, resolved locally with no release lookup. A
+          # just-published release is not yet mirrored on releases.astral.sh, so "latest"
+          # 404s there and falls back to GitHub Releases, which rate-limits (429) once the
+          # fleet requests it concurrently. Bumping setup-uv moves this version forward.
+          version: latest-known
 
       - name: Write dispatch payload to file
         env:
@@ -245,12 +247,14 @@ jobs:
           path: torch-spyre
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          # Pin uv rather than resolving "latest": a just-published release is not yet on
-          # releases.astral.sh, so every runner 404s there and falls back to GitHub
-          # Releases, which rate-limits (429) once the fleet requests it concurrently.
-          version: 0.12.5
+          # latest-known, not "latest": it resolves to the newest uv whose checksum is
+          # bundled INTO this setup-uv pin, resolved locally with no release lookup. A
+          # just-published release is not yet mirrored on releases.astral.sh, so "latest"
+          # 404s there and falls back to GitHub Releases, which rate-limits (429) once the
+          # fleet requests it concurrently. Bumping setup-uv moves this version forward.
+          version: latest-known
 
       # actions4gh/setup-gh@v1.0.2 extracts the gh tarball but never lands
       # the binary on PATH before it calls `gh auth login`, so every job

--- a/.github/workflows/build_test_pytorch_source.yaml
+++ b/.github/workflows/build_test_pytorch_source.yaml
@@ -90,7 +90,7 @@ jobs:
           # Pin uv rather than resolving "latest": a just-published release is not yet on
           # releases.astral.sh, so every runner 404s there and falls back to GitHub
           # Releases, which rate-limits (429) once the fleet requests it concurrently.
-          version: "0.12.5"
+          version: 0.12.5
 
       - name: Write dispatch payload to file
         env:
@@ -250,7 +250,7 @@ jobs:
           # Pin uv rather than resolving "latest": a just-published release is not yet on
           # releases.astral.sh, so every runner 404s there and falls back to GitHub
           # Releases, which rate-limits (429) once the fleet requests it concurrently.
-          version: "0.12.5"
+          version: 0.12.5
 
       # actions4gh/setup-gh@v1.0.2 extracts the gh tarball but never lands
       # the binary on PATH before it calls `gh auth login`, so every job

--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -31,7 +31,7 @@ jobs:
           # Pin uv rather than resolving "latest": a just-published release is not yet on
           # releases.astral.sh, so every runner 404s there and falls back to GitHub
           # Releases, which rate-limits (429) once the fleet requests it concurrently.
-          version: "0.12.5"
+          version: 0.12.5
       - name: Recompile requirements
         run: ./tools/update-requirements.sh
 

--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -26,12 +26,14 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
-      - uses: astral-sh/setup-uv@6ee6290f1cbc4156c0bdd66691b2c144ef8df19a  # v7.1.3
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          # Pin uv rather than resolving "latest": a just-published release is not yet on
-          # releases.astral.sh, so every runner 404s there and falls back to GitHub
-          # Releases, which rate-limits (429) once the fleet requests it concurrently.
-          version: 0.12.5
+          # latest-known, not "latest": it resolves to the newest uv whose checksum is
+          # bundled INTO this setup-uv pin, resolved locally with no release lookup. A
+          # just-published release is not yet mirrored on releases.astral.sh, so "latest"
+          # 404s there and falls back to GitHub Releases, which rate-limits (429) once the
+          # fleet requests it concurrently. Bumping setup-uv moves this version forward.
+          version: latest-known
       - name: Recompile requirements
         run: ./tools/update-requirements.sh
 

--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -27,6 +27,11 @@ jobs:
         with:
           python-version: '3.12'
       - uses: astral-sh/setup-uv@6ee6290f1cbc4156c0bdd66691b2c144ef8df19a  # v7.1.3
+        with:
+          # Pin uv rather than resolving "latest": a just-published release is not yet on
+          # releases.astral.sh, so every runner 404s there and falls back to GitHub
+          # Releases, which rate-limits (429) once the fleet requests it concurrently.
+          version: "0.12.5"
       - name: Recompile requirements
         run: ./tools/update-requirements.sh
 

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -37,7 +37,6 @@ jobs:
           # releases.astral.sh, so every runner 404s there and falls back to GitHub
           # Releases, which rate-limits (429) once the fleet requests it concurrently.
           version: "0.12.5"
-        with:
           enable-cache: true
           cache-dependency-glob: requirements/*
       - run: uv venv

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -31,12 +31,14 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install uv
-        uses: astral-sh/setup-uv@6ee6290f1cbc4156c0bdd66691b2c144ef8df19a # v7.1.3
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          # Pin uv rather than resolving "latest": a just-published release is not yet on
-          # releases.astral.sh, so every runner 404s there and falls back to GitHub
-          # Releases, which rate-limits (429) once the fleet requests it concurrently.
-          version: 0.12.5
+          # latest-known, not "latest": it resolves to the newest uv whose checksum is
+          # bundled INTO this setup-uv pin, resolved locally with no release lookup. A
+          # just-published release is not yet mirrored on releases.astral.sh, so "latest"
+          # 404s there and falls back to GitHub Releases, which rate-limits (429) once the
+          # fleet requests it concurrently. Bumping setup-uv moves this version forward.
+          version: latest-known
           enable-cache: true
           cache-dependency-glob: requirements/*
       - run: uv venv

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -36,7 +36,7 @@ jobs:
           # Pin uv rather than resolving "latest": a just-published release is not yet on
           # releases.astral.sh, so every runner 404s there and falls back to GitHub
           # Releases, which rate-limits (429) once the fleet requests it concurrently.
-          version: "0.12.5"
+          version: 0.12.5
           enable-cache: true
           cache-dependency-glob: requirements/*
       - run: uv venv

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -33,6 +33,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@6ee6290f1cbc4156c0bdd66691b2c144ef8df19a # v7.1.3
         with:
+          # Pin uv rather than resolving "latest": a just-published release is not yet on
+          # releases.astral.sh, so every runner 404s there and falls back to GitHub
+          # Releases, which rate-limits (429) once the fleet requests it concurrently.
+          version: "0.12.5"
+        with:
           enable-cache: true
           cache-dependency-glob: requirements/*
       - run: uv venv

--- a/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
+++ b/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
@@ -59,7 +59,7 @@ jobs:
           # Pin uv rather than resolving "latest": a just-published release is not yet on
           # releases.astral.sh, so every runner 404s there and falls back to GitHub
           # Releases, which rate-limits (429) once the fleet requests it concurrently.
-          version: "0.12.5"
+          version: 0.12.5
 
       - name: setup venv
         run: |

--- a/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
+++ b/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
@@ -54,12 +54,14 @@ jobs:
             .github/scripts/ingest_hw_diagnostics.py
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          # Pin uv rather than resolving "latest": a just-published release is not yet on
-          # releases.astral.sh, so every runner 404s there and falls back to GitHub
-          # Releases, which rate-limits (429) once the fleet requests it concurrently.
-          version: 0.12.5
+          # latest-known, not "latest": it resolves to the newest uv whose checksum is
+          # bundled INTO this setup-uv pin, resolved locally with no release lookup. A
+          # just-published release is not yet mirrored on releases.astral.sh, so "latest"
+          # 404s there and falls back to GitHub Releases, which rate-limits (429) once the
+          # fleet requests it concurrently. Bumping setup-uv moves this version forward.
+          version: latest-known
 
       - name: setup venv
         run: |

--- a/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
+++ b/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
@@ -55,6 +55,11 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          # Pin uv rather than resolving "latest": a just-published release is not yet on
+          # releases.astral.sh, so every runner 404s there and falls back to GitHub
+          # Releases, which rate-limits (429) once the fleet requests it concurrently.
+          version: "0.12.5"
 
       - name: setup venv
         run: |

--- a/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
+++ b/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
@@ -25,9 +25,8 @@ jobs:
     name: Parse logs -> ClickHouse
     runs-on:
       - x86_64
-      - spyre_pf_x0
       - linux
-      - image_spyre_backend
+      - image_ingest
     timeout-minutes: 15
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -78,8 +77,21 @@ jobs:
       # call is needed here.
       - name: Setup the GitHub CLI
         env:
-          GH_CLI_VERSION: 2.97.0
+          # Offline floor only: used when api.github.com can't be reached to resolve the
+          # latest release, so a transient API failure degrades to a known-good gh instead
+          # of failing the job.
+          GH_CLI_VERSION_FLOOR: 2.98.0
         run: |
+          set -euo pipefail
+          # Track the latest gh release rather than a pin: nothing here depends on a
+          # specific gh version, and a pin silently rots (this fleet had 2.92.0 and 2.97.0
+          # drifting apart across workflows).
+          GH_CLI_VERSION="$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest \
+                              | jq -r '.tag_name // empty' | sed 's/^v//')" || GH_CLI_VERSION=""
+          if [ -z "$GH_CLI_VERSION" ]; then
+            echo "api.github.com unreachable; flooring to ${GH_CLI_VERSION_FLOOR}"
+            GH_CLI_VERSION="${GH_CLI_VERSION_FLOOR}"
+          fi
           curl -fsSL \
             "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz" \
             -o "${RUNNER_TEMP}/gh-cli.tar.gz"

--- a/.github/workflows/push-model-ops-logs-to-clickhouse.yaml
+++ b/.github/workflows/push-model-ops-logs-to-clickhouse.yaml
@@ -59,12 +59,14 @@ jobs:
             .github/scripts/ingest_model_ops.py
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          # Pin uv rather than resolving "latest": a just-published release is not yet on
-          # releases.astral.sh, so every runner 404s there and falls back to GitHub
-          # Releases, which rate-limits (429) once the fleet requests it concurrently.
-          version: 0.12.5
+          # latest-known, not "latest": it resolves to the newest uv whose checksum is
+          # bundled INTO this setup-uv pin, resolved locally with no release lookup. A
+          # just-published release is not yet mirrored on releases.astral.sh, so "latest"
+          # 404s there and falls back to GitHub Releases, which rate-limits (429) once the
+          # fleet requests it concurrently. Bumping setup-uv moves this version forward.
+          version: latest-known
 
       - name: Setup venv
         run: |

--- a/.github/workflows/push-model-ops-logs-to-clickhouse.yaml
+++ b/.github/workflows/push-model-ops-logs-to-clickhouse.yaml
@@ -60,6 +60,11 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          # Pin uv rather than resolving "latest": a just-published release is not yet on
+          # releases.astral.sh, so every runner 404s there and falls back to GitHub
+          # Releases, which rate-limits (429) once the fleet requests it concurrently.
+          version: "0.12.5"
 
       - name: Setup venv
         run: |

--- a/.github/workflows/push-model-ops-logs-to-clickhouse.yaml
+++ b/.github/workflows/push-model-ops-logs-to-clickhouse.yaml
@@ -64,7 +64,7 @@ jobs:
           # Pin uv rather than resolving "latest": a just-published release is not yet on
           # releases.astral.sh, so every runner 404s there and falls back to GitHub
           # Releases, which rate-limits (429) once the fleet requests it concurrently.
-          version: "0.12.5"
+          version: 0.12.5
 
       - name: Setup venv
         run: |

--- a/.github/workflows/push-model-ops-logs-to-clickhouse.yaml
+++ b/.github/workflows/push-model-ops-logs-to-clickhouse.yaml
@@ -27,9 +27,8 @@ jobs:
     name: Parse model-ops logs -> ClickHouse
     runs-on:
       - x86_64
-      - spyre_pf_x0
       - linux
-      - image_spyre_backend
+      - image_ingest
     timeout-minutes: 15
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -81,8 +80,21 @@ jobs:
       # call is needed here.
       - name: Setup the GitHub CLI
         env:
-          GH_CLI_VERSION: 2.97.0
+          # Offline floor only: used when api.github.com can't be reached to resolve the
+          # latest release, so a transient API failure degrades to a known-good gh instead
+          # of failing the job.
+          GH_CLI_VERSION_FLOOR: 2.98.0
         run: |
+          set -euo pipefail
+          # Track the latest gh release rather than a pin: nothing here depends on a
+          # specific gh version, and a pin silently rots (this fleet had 2.92.0 and 2.97.0
+          # drifting apart across workflows).
+          GH_CLI_VERSION="$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest \
+                              | jq -r '.tag_name // empty' | sed 's/^v//')" || GH_CLI_VERSION=""
+          if [ -z "$GH_CLI_VERSION" ]; then
+            echo "api.github.com unreachable; flooring to ${GH_CLI_VERSION_FLOOR}"
+            GH_CLI_VERSION="${GH_CLI_VERSION_FLOOR}"
+          fi
           curl -fsSL \
             "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz" \
             -o "${RUNNER_TEMP}/gh-cli.tar.gz"

--- a/.github/workflows/push-pytorch-dispatch-to-clickhouse.yaml
+++ b/.github/workflows/push-pytorch-dispatch-to-clickhouse.yaml
@@ -94,6 +94,11 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          # Pin uv rather than resolving "latest": a just-published release is not yet on
+          # releases.astral.sh, so every runner 404s there and falls back to GitHub
+          # Releases, which rate-limits (429) once the fleet requests it concurrently.
+          version: "0.12.5"
 
       - name: Setup venv
         run: |
@@ -274,6 +279,11 @@ jobs:
       - name: Install uv
         if: steps.extract.outputs.should_build == 'false'
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          # Pin uv rather than resolving "latest": a just-published release is not yet on
+          # releases.astral.sh, so every runner 404s there and falls back to GitHub
+          # Releases, which rate-limits (429) once the fleet requests it concurrently.
+          version: "0.12.5"
 
       - name: Record gate rejection in ClickHouse
         if: steps.extract.outputs.should_build == 'false'

--- a/.github/workflows/push-pytorch-dispatch-to-clickhouse.yaml
+++ b/.github/workflows/push-pytorch-dispatch-to-clickhouse.yaml
@@ -93,12 +93,14 @@ jobs:
           printf '%s' "$PAYLOAD_JSON" > payload.json
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          # Pin uv rather than resolving "latest": a just-published release is not yet on
-          # releases.astral.sh, so every runner 404s there and falls back to GitHub
-          # Releases, which rate-limits (429) once the fleet requests it concurrently.
-          version: 0.12.5
+          # latest-known, not "latest": it resolves to the newest uv whose checksum is
+          # bundled INTO this setup-uv pin, resolved locally with no release lookup. A
+          # just-published release is not yet mirrored on releases.astral.sh, so "latest"
+          # 404s there and falls back to GitHub Releases, which rate-limits (429) once the
+          # fleet requests it concurrently. Bumping setup-uv moves this version forward.
+          version: latest-known
 
       - name: Setup venv
         run: |
@@ -278,12 +280,14 @@ jobs:
 
       - name: Install uv
         if: steps.extract.outputs.should_build == 'false'
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          # Pin uv rather than resolving "latest": a just-published release is not yet on
-          # releases.astral.sh, so every runner 404s there and falls back to GitHub
-          # Releases, which rate-limits (429) once the fleet requests it concurrently.
-          version: 0.12.5
+          # latest-known, not "latest": it resolves to the newest uv whose checksum is
+          # bundled INTO this setup-uv pin, resolved locally with no release lookup. A
+          # just-published release is not yet mirrored on releases.astral.sh, so "latest"
+          # 404s there and falls back to GitHub Releases, which rate-limits (429) once the
+          # fleet requests it concurrently. Bumping setup-uv moves this version forward.
+          version: latest-known
 
       - name: Record gate rejection in ClickHouse
         if: steps.extract.outputs.should_build == 'false'

--- a/.github/workflows/push-pytorch-dispatch-to-clickhouse.yaml
+++ b/.github/workflows/push-pytorch-dispatch-to-clickhouse.yaml
@@ -98,7 +98,7 @@ jobs:
           # Pin uv rather than resolving "latest": a just-published release is not yet on
           # releases.astral.sh, so every runner 404s there and falls back to GitHub
           # Releases, which rate-limits (429) once the fleet requests it concurrently.
-          version: "0.12.5"
+          version: 0.12.5
 
       - name: Setup venv
         run: |
@@ -283,7 +283,7 @@ jobs:
           # Pin uv rather than resolving "latest": a just-published release is not yet on
           # releases.astral.sh, so every runner 404s there and falls back to GitHub
           # Releases, which rate-limits (429) once the fleet requests it concurrently.
-          version: "0.12.5"
+          version: 0.12.5
 
       - name: Record gate rejection in ClickHouse
         if: steps.extract.outputs.should_build == 'false'

--- a/.github/workflows/push-pytorch-dispatch-to-clickhouse.yaml
+++ b/.github/workflows/push-pytorch-dispatch-to-clickhouse.yaml
@@ -68,9 +68,8 @@ jobs:
     if: github.event_name == 'repository_dispatch'
     runs-on:
       - x86_64
-      - spyre_pf_x0
       - linux
-      - image_spyre_backend
+      - image_ingest
     timeout-minutes: 10
 
     env:
@@ -132,9 +131,8 @@ jobs:
     name: Gate on merged PR to main, extract build SHA
     runs-on:
       - x86_64
-      - spyre_pf_x0
       - linux
-      - image_spyre_backend
+      - image_ingest
     outputs:
       pytorch_sha: ${{ steps.extract.outputs.pytorch_sha }}
       should_build: ${{ steps.extract.outputs.should_build }}

--- a/.github/workflows/push-to-clickhouse.yaml
+++ b/.github/workflows/push-to-clickhouse.yaml
@@ -47,9 +47,8 @@ jobs:
     name: Ingest XML -> ClickHouse
     runs-on:
       - x86_64
-      - spyre_pf_x0
       - linux
-      - image_spyre_backend
+      - image_ingest
     timeout-minutes: 15
     # Skip if the triggering workflow was cancelled (but ingest failures are fine)
     if: |
@@ -122,8 +121,21 @@ jobs:
       # call is needed here.
       - name: Setup the GitHub CLI
         env:
-          GH_CLI_VERSION: 2.97.0
+          # Offline floor only: used when api.github.com can't be reached to resolve the
+          # latest release, so a transient API failure degrades to a known-good gh instead
+          # of failing the job.
+          GH_CLI_VERSION_FLOOR: 2.98.0
         run: |
+          set -euo pipefail
+          # Track the latest gh release rather than a pin: nothing here depends on a
+          # specific gh version, and a pin silently rots (this fleet had 2.92.0 and 2.97.0
+          # drifting apart across workflows).
+          GH_CLI_VERSION="$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest \
+                              | jq -r '.tag_name // empty' | sed 's/^v//')" || GH_CLI_VERSION=""
+          if [ -z "$GH_CLI_VERSION" ]; then
+            echo "api.github.com unreachable; flooring to ${GH_CLI_VERSION_FLOOR}"
+            GH_CLI_VERSION="${GH_CLI_VERSION_FLOOR}"
+          fi
           curl -fsSL \
             "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz" \
             -o "${RUNNER_TEMP}/gh-cli.tar.gz"


### PR DESCRIPTION
## Problem

The ClickHouse ingest jobs select a **card-bearing** runner today, so they compete for the 20 shared `cards0` slots with every other `cards0` job — and pull a **~10.9 GiB** spyre product image to do work that is purely: download a GH artifact, `uv pip install clickhouse-connect`, POST to ClickHouse.

They never import `torch_spyre`, never touch a card, and never read the PVC (verified across the workflows, the ingest scripts, and the composite action — zero `/storage-1` references).

## Change

Repoint them at the cardless **`image_ingest`** ARC runner set: GitHub's own ARC runner image, ~522 MiB (**21x smaller**), runner pre-baked, on its **own `maxRunners` pool**.

Dropping `spyre_pf_x0` from the selector is the point — the ingest set deliberately does **not** advertise it, so these jobs stop consuming card-bearing capacity and an ingest burst can no longer exhaust the shared `cards0` pool.

## Validation

- All touched workflows parse as YAML; every ingest job now resolves to `[x86_64, linux, image_ingest]`
- No `working-directory` / `senuser` / `/storage-1` dependency in any moved job (checked before moving)
- Deps unaffected: each job installs `uv` via `astral-sh/setup-uv` then `uv pip install`s into a job-local venv. Verified end-to-end on the ingest image — `clickhouse-connect` 1.7.2 + `regex` install and import, 39 MiB total against the 10 GiB ephemeral limit

## :warning: Merge order

**Do not merge until the `image_ingest` runner set is live on the cluster** (the runner-set definition merged and ArgoCD reconciled). Until then no runner advertises `image_ingest` and these jobs would queue indefinitely. Draft until that lands.

Context: the ingest workflows are also the main source of the leaked `EphemeralRunner` CRs that have been wedging `cards0`/`cards1-spyrebackend` (stuck ARC finalizers — `status.phase` never written). This isolates the blast radius; it does not fix that leak.

## gh CLI now tracks latest

The pinned `gh` version is replaced by latest-release resolution, with an offline floor for when `api.github.com` is unreachable. Nothing here depends on a specific `gh` version, and the pins had already drifted apart across the fleet (2.92.0 in some workflows, 2.97.0 in others). Verified end-to-end on the ingest image: resolves 2.98.0, downloads, runs.
