### PR TITLE
feat: Revise upstream tests

### DIFF
--- a/tests/configs/upstream_tests_beta/inductor-test_pattern_matcher.yaml
+++ b/tests/configs/upstream_tests_beta/inductor-test_pattern_matcher.yaml
@@ -29,6 +29,10 @@ test_suite_config:
             - TestPatternMatcherLogging::test_failed_match_constant_args_format_string
             - TestPatternMatcherLogging::test_gumbel_max_trick
             - TestPatternMatcherLogging::test_pattern_match_debug_output
+            - TestPatternMatcherLogging::test_pattern_match_debug_all_nodes
+            - TestPatternMatcherLogging::test_pattern_match_debug_multiple_nodes
+            - TestPatternMatcherLogging::test_per_pattern_counter
+            - TestPatternMatcherLogging::test_per_pattern_counter_accumulation
             - TestPatternMatcher::test_addmm
             - TestPatternMatcher::test_addmm_alpha_beta_with_pointwise
             - TestPatternMatcher::test_addmm_broadcasting_bias

--- a/tests/configs/upstream_tests_beta/test_binary_ufuncs.yaml
+++ b/tests/configs/upstream_tests_beta/test_binary_ufuncs.yaml
@@ -9,9 +9,7 @@ test_suite_config:
         # They are classified as mandatory_success due to the critical nature of these operations.
         # Spyre's limitations in dtype support and type conversion during tensor operations are most relevant.
         - names:
-            - TestBinaryUfuncs::test_cross_device_inplace_error_msg
             - TestBinaryUfuncs::test_floor_divide_zero
-            - TestBinaryUfuncs::test_sub_typing
           mode: mandatory_success
         # These tests exercise binary operations (add, bitwise_and, clamp_max, etc.) with unsupported dtypes (bool, int64).
         # They are classified as mandatory_success because these operations are essential but currently unsupported on Spyre.
@@ -228,6 +226,10 @@ test_suite_config:
             - TestBinaryUfuncs::test_xlogy_xlog1py_bfloat16
             - TestBinaryUfuncs::test_zeta
           mode: skip  # does not engage the torch-spyre layer
+        - names:
+            - TestBinaryUfuncs::test_cross_device_inplace_error_msg
+            - TestBinaryUfuncs::test_sub_typing
+          mode: skip
 
   global:
     supported_dtypes:

--- a/tests/configs/upstream_tests_beta/test_spectral_ops.yaml
+++ b/tests/configs/upstream_tests_beta/test_spectral_ops.yaml
@@ -12,7 +12,6 @@ test_suite_config:
             - TestFFT::test_empty_fft
             - TestFFT::test_fft_half_and_bfloat16_errors
             - TestFFT::test_fftn_invalid
-            - TestFFT::test_istft_throws
           mode: mandatory_success
         # These tests exercise FFT operations with various dtypes and tensor shapes.
         # They are classified as xfail due to unsupported dtypes (ComplexFloat, ComplexDouble, Half) on the Spyre backend.
@@ -63,6 +62,9 @@ test_suite_config:
             - TestFFT::test_stft_requires_complex
             - TestFFT::test_stft_requires_window
           mode: skip  # does not engage the torch-spyre layer
+        - names:
+            - TestFFT::test_istft_throws
+          mode: skip
 
   global:
     supported_dtypes:


### PR DESCRIPTION
We plan to move the below tests to skip since they are failing with the moving PyTorch as part of CRCR. They will be triaged and enabled in the future.

- test_binary_ufuncs__oot_wrapper.py::TestBinaryUfuncsDevicePRIVATEUSE1::test_cross_device_inplace_error_msg_spyre
- test_binary_ufuncs__oot_wrapper.py::TestBinaryUfuncsDevicePRIVATEUSE1::test_sub_typing_spyre
- test_spectral_ops__oot_wrapper.py::TestFFTPRIVATEUSE1::test_istft_throws_spyre
- test_pattern_matcher__oot_wrapper.py::TestPatternMatcherLoggingPRIVATEUSE1::test_failed_match_constant_args_format_string
- test_pattern_matcher__oot_wrapper.py::TestPatternMatcherLoggingPRIVATEUSE1::test_gumbel_max_trick
- test_pattern_matcher__oot_wrapper.py::TestPatternMatcherLoggingPRIVATEUSE1::test_pattern_match_debug_all_nodes
- test_pattern_matcher__oot_wrapper.py::TestPatternMatcherLoggingPRIVATEUSE1::test_pattern_match_debug_multiple_nodes
- test_pattern_matcher__oot_wrapper.py::TestPatternMatcherLoggingPRIVATEUSE1::test_pattern_match_debug_output
- test_pattern_matcher__oot_wrapper.py::TestPatternMatcherLoggingPRIVATEUSE1::test_per_pattern_counter
- test_pattern_matcher__oot_wrapper.py::TestPatternMatcherLoggingPRIVATEUSE1::test_per_pattern_counter_accumulation
- 