### PR TITLE
fix(inductor): repoint MutationLayoutSHOULDREMOVE.target on buffer rename

### DIFF
--- a/tests/inductor/test_inductor_fx_passes.py
+++ b/tests/inductor/test_inductor_fx_passes.py
@@ -20,9 +20,22 @@ from unittest.mock import patch
 
 import sympy
 import torch
+from torch import fx
+from torch._inductor.graph import GraphLowering
+from torch._inductor.ir import (
+    ComputedBuffer,
+    FixedLayout,
+    InputBuffer,
+    MutationLayoutSHOULDREMOVE,
+    Pointwise,
+    StorageBox,
+    TensorBox,
+)
+from torch._inductor.virtualized import V
 
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.pass_utils import (
+    _repoint_mutation_targets,
     compute_granularity,
     compute_max_size,
     compute_symbolic_bounds,
@@ -370,6 +383,99 @@ class TestPassUtils(unittest.TestCase):
         max_size, granularity = result
         assert max_size == 256
         assert granularity == 8
+
+
+class TestRepointMutationTargets(unittest.TestCase):
+    """Unit tests for ``pass_utils._repoint_mutation_targets``.
+
+    Regression coverage for issue #3944/#3945: reconstructing a
+    ``ComputedBuffer`` (``replace_computed_buffer_body``,
+    ``redirect_computed_buffer_reads``) must not leave a mutation op's
+    ``MutationLayoutSHOULDREMOVE.target`` pointing at the orphaned
+    pre-reconstruction object. These tests exercise ``_repoint_mutation_targets``
+    directly against real IR objects, independent of any particular pass
+    that calls it, so the fix stays pinned even if coarse-tiling (the pass
+    that originally exposed the bug) is refactored away.
+    """
+
+    def setUp(self):
+        gm = fx.symbolic_trace(lambda: None)
+        self._graph_ctx = V.set_graph_handler(GraphLowering(gm))
+        self._graph_ctx.__enter__()
+        self.addCleanup(self._graph_ctx.__exit__, None, None, None)
+
+    @staticmethod
+    def _make_buffer(name):
+        """A minimal real ComputedBuffer(Pointwise) reading one InputBuffer."""
+        inp = InputBuffer(
+            name=f"in_{name}",
+            layout=FixedLayout(torch.device("cpu"), torch.float32, [8], [1]),
+        )
+        V.graph.name_to_buffer[inp.get_name()] = inp
+        box = TensorBox(StorageBox(inp))
+        pw = Pointwise.create(
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+            inner_fn=lambda index: box.make_loader()(index),
+            ranges=[8],
+        )
+        buf = ComputedBuffer(
+            name=name,
+            layout=FixedLayout(torch.device("cpu"), torch.float32, [8], None),
+            data=pw.data.data,  # TensorBox -> StorageBox -> Pointwise
+        )
+        buf.operation_name = name
+        V.graph.name_to_buffer[name] = buf
+        return buf
+
+    def test_bare_target_repointed(self):
+        old_buf = self._make_buffer("old")
+        new_buf = self._make_buffer("new")
+        mutation_layout = MutationLayoutSHOULDREMOVE(old_buf)
+        mut_op = SimpleNamespace(layout=mutation_layout)
+
+        _repoint_mutation_targets([mut_op], old_buf, new_buf)
+
+        self.assertIs(mutation_layout.target, new_buf)
+
+    def test_boxed_target_repointed(self):
+        """target wrapped as TensorBox(StorageBox(old_buf))."""
+        old_buf = self._make_buffer("old")
+        new_buf = self._make_buffer("new")
+        wrapped_target = TensorBox(StorageBox(old_buf))
+        mutation_layout = MutationLayoutSHOULDREMOVE(wrapped_target)
+        mut_op = SimpleNamespace(layout=mutation_layout)
+
+        _repoint_mutation_targets([mut_op], old_buf, new_buf)
+
+        # The wrapper object identity itself is untouched -- only the
+        # innermost slot holding old_buf is repointed.
+        self.assertIs(mutation_layout.target, wrapped_target)
+        self.assertIs(wrapped_target.data.data, new_buf)
+
+    def test_unrelated_op_untouched(self):
+        """An op whose target already points elsewhere must not be touched."""
+        old_buf = self._make_buffer("old")
+        new_buf = self._make_buffer("new")
+        other_buf = self._make_buffer("other")
+        mutation_layout = MutationLayoutSHOULDREMOVE(other_buf)
+        mut_op = SimpleNamespace(layout=mutation_layout)
+
+        _repoint_mutation_targets([mut_op], old_buf, new_buf)
+
+        self.assertIs(mutation_layout.target, other_buf)
+
+    def test_non_mutation_op_untouched(self):
+        """An op with a plain (non-mutation) layout must be skipped safely."""
+        old_buf = self._make_buffer("old")
+        new_buf = self._make_buffer("new")
+        plain_op = SimpleNamespace(layout=old_buf.layout)
+
+        # Must not raise even though `plain_op.layout` isn't a
+        # MutationLayoutSHOULDREMOVE.
+        _repoint_mutation_targets([plain_op], old_buf, new_buf)
+
+        self.assertIs(plain_op.layout, old_buf.layout)
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1627,6 +1627,45 @@ def copy_fx_custom_meta(src: "torch.fx.Node", dst: "torch.fx.Node") -> None:
         dst.meta["custom"] = src.meta["custom"]
 
 
+def _repoint_mutation_targets(
+    operations: list[Operation], old_buf: Buffer, new_buf: Buffer
+) -> None:
+    """Repoint any ``MutationLayoutSHOULDREMOVE.target`` chain aimed at ``old_buf``.
+
+    Reconstructing a ``ComputedBuffer`` (see ``replace_computed_buffer_body``,
+    ``redirect_computed_buffer_reads``) swaps the new object into ``operations``
+    and ``V.graph.name_to_buffer``, but a mutation op elsewhere in the graph may
+    hold a direct object reference to the old buffer via
+    ``MutationLayoutSHOULDREMOVE.target`` -- set once, at the mutation op's
+    original lowering time, and never re-resolved by name afterwards (unlike
+    ordinary reads, which always go through ``V.graph.get_buffer(name)``).  Left
+    unpatched, that op keeps mutating the orphaned old object forever: its
+    layout is never promoted past ``FixedLayout``, which later fails the
+    ``isinstance(layout, FixedTiledLayout)`` assert in
+    ``work_division._resolve_layout`` (see issue #3944/#3945).
+
+    ``target`` may be the bare buffer, or wrapped in one or more
+    ``MutableBox``/``BaseView`` layers (``TensorBox(StorageBox(buf))``,
+    ``ReinterpretView``, ...) -- both wrapper families expose the next layer
+    as ``.data``, so a single attribute name covers both.
+    """
+    for candidate in operations:
+        layout = getattr(candidate, "layout", None)
+        if not isinstance(layout, MutationLayoutSHOULDREMOVE):
+            continue
+        target = layout.target
+        if target is old_buf:
+            layout.target = new_buf
+            continue
+        holder = target
+        while hasattr(holder, "data"):
+            inner = holder.data
+            if inner is old_buf:
+                holder.data = new_buf
+                break
+            holder = inner
+
+
 def replace_computed_buffer_body(
     op: ComputedBuffer,
     new_data: Loops,
@@ -1644,7 +1683,9 @@ def replace_computed_buffer_body(
     ``origin_node``, and the ``_split_size`` / ``_original_*`` fields used by
     ``get_default_sizes_body``.  The ``get_default_sizes_body`` cache is
     cleared on the new buffer so stale size results from the old body are not
-    reused.
+    reused.  Also repoints any ``MutationLayoutSHOULDREMOVE.target`` elsewhere
+    in ``operations`` that referenced the old object (see
+    ``_repoint_mutation_targets``).
 
     Returns the replacement ComputedBuffer.
     """
@@ -1666,6 +1707,7 @@ def replace_computed_buffer_body(
 
     op_idx = operations.index(op)
     operations[op_idx] = new_buf
+    _repoint_mutation_targets(operations, op, new_buf)
     return new_buf
 
 
@@ -1704,7 +1746,10 @@ def redirect_computed_buffer_reads(
     remapped buffer resolves to its replacement, then reconstructs the frozen
     ``ComputedBuffer`` so the instance-keyed ``get_default_sizes_body`` cache is
     cleanly invalidated (the reconstruct is the reason both this helper and
-    ``replace_computed_buffer_body`` rebuild rather than mutate in place).
+    ``replace_computed_buffer_body`` rebuild rather than mutate in place). Also
+    repoints any ``MutationLayoutSHOULDREMOVE.target`` elsewhere in
+    ``operations`` that referenced the old object (see
+    ``_repoint_mutation_targets``).
 
     Returns the replacement ComputedBuffer.
     """
@@ -1735,6 +1780,7 @@ def redirect_computed_buffer_reads(
     op_idx = operations.index(op)
     operations[op_idx] = new_buf
     V.graph.name_to_buffer[new_buf.get_name()] = new_buf
+    _repoint_mutation_targets(operations, op, new_buf)
 
     # Invalidate the sizes/body cache so it is recomputed on next access with
     # the patched inner_fn.

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1657,6 +1657,9 @@ def _repoint_mutation_targets(
         if target is old_buf:
             layout.target = new_buf
             continue
+        # Buffer/ComputedBuffer (a bare target) has no `.data`, so the walk
+        # is guaranteed to terminate there without wrongly descending into
+        # an already-bare buffer.
         holder = target
         while hasattr(holder, "data"):
             inner = holder.data


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torc
h-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes a compile-time crash — `AssertionError: Expected FixedTiledLayout
for <buf>, got FixedLayout` raised from `work_division._resolve_layout`
— that occurs when a coarse-tiled graph contains both a `ComputedBuffer`
reconstruction and a mutation op (`copy_`) targeting the object being
reconstructed.

**Root cause:** `ComputedBuffer` is a frozen dataclass, so whenever a
compiler pass needs to change its `data` (not just wrap `inner_fn`), it
constructs a new `ComputedBuffer` and swaps it into
`operations`/`V.graph.name_to_buffer`. Two shared helpers in
`pass_utils.py` do this: `replace_computed_buffer_body` and
`redirect_computed_buffer_reads`.

That swap correctly updates anything that resolves the buffer **by
name** (`V.graph.get_buffer(...)`, `graph.operations`). But a mutation
op's `MutationLayoutSHOULDREMOVE.target` is a **direct object
reference**, set once at the mutation op's original FX-lowering time and
never re-resolved by name afterward. If the buffer it points at is later
reconstructed, `target` keeps pointing at the orphaned pre-reconstruction
object, which is never seen again by any pass that walks
`graph.operations` — so it never gets promoted past its original
`FixedLayout`, while the new object that actually ends up in the graph
correctly gets promoted to `FixedTiledLayout`. `work_division._resolve_layout`
follows `MutationLayoutSHOULDREMOVE.target` directly, sees the stale
`FixedLayout` object, and asserts.

This is the same hazard class `_patch_graph_outputs` in `coarse_tile.py`
already guards against for `V.graph.graph_outputs` references — just not
previously generalized to mutation targets.

For #3944/#3945 specifically, the reconstruction is triggered by
`_patch_consumer_to_read_copy` in `coarse_tile.py` (via
`_insert_all_read_copy_ops` ← `coarse_tile_pre_stickify` ←
`_maybe_coarse_tile_hints`), which reconstructs a buffer that is also the
target of a `copy_forced`-style mutation op elsewhere in the graph.

**Fix:** Added `_repoint_mutation_targets(operations, old_buf, new_buf)`
in `pass_utils.py` and call it from both `replace_computed_buffer_body`
and `redirect_computed_buffer_reads`, right after each swaps the new
buffer into `operations`. It walks every op's
`MutationLayoutSHOULDREMOVE.target` and repoints it from `old_buf` to
`new_buf`, handling the three shapes a target can take: the bare buffer,
wrapped in `MutableBox`/`StorageBox`/`TensorBox` layers, or wrapped in a
`BaseView` (e.g. `ReinterpretView`). Both wrapper families expose their
next layer via the same `.data` attribute, so a single duck-typed walk
covers all cases without needing type-specific branches.

Because every `ComputedBuffer` reconstruction site in the codebase
funnels through one of these two helpers, this is a single fix that
covers all of them: `coarse_tile.py` (`_patch_consumer_to_read_copy`,
`_patch_consumers`, `_patch_retiled_load_indexes`), `padding.py` (the
matmul-padding rebuild, the restickify-padding redirect),
`split_multi_ops.py` (the split-ops body rewrite), and
`insert_restickify.py` (`insert_restickify_on_node_inputs`).

#### Which issue(s) this PR is related to:

Fixes #3944, #3945

#### Special notes for your reviewer:

Confirmed the crash mechanism via live object-identity tracing
(`id(target_buf) != id(V.graph.get_buffer(name))` before the fix).

**On unifying with `_patch_graph_outputs`:** looked into this per review
feedback. `_patch_graph_outputs`'s two call sites (`coarse_tile.py:2100`,
`:4012`) pass it `(old_name, full_buf)`/`(old_name, accum_full)`, where
`full_buf`/`accum_full` come from `_allocate_full_buffer` — a **freshly
allocated**, logically distinct buffer (a new `spyre.empty`), not a
reconstruction of the op named `old_name`. That's a deliberate "this
graph output now comes from a different tensor" edit. `_repoint_mutation_targets`
instead repairs an *accidental* dangling reference left behind when
`replace_computed_buffer_body`/`redirect_computed_buffer_reads`
reconstruct a `ComputedBuffer` while preserving its name/identity-in-spirit.
Both walk a "some other place might still reference the old object"
pattern, but the pairs they operate on arise from different operations
(reconstruction-of-self vs. intentional-substitution-of-a-consumer's-source),
so I kept them as two separate, narrowly-scoped helpers rather than
forcing a shared abstraction over a coincidental shape resemblance. Happy
to revisit if a third hazard site shows up that's actually the same
shape as one of these.

No skipped tests are un-skipped in this PR. I checked every test named
in #3944/#3945, plus the other tests sharing the same
`"finalize_layouts: restickify infeasible for copy ops across loop
groups"` skip reason as the confirmed repro:

| Test | Result after this fix |
|---|---|
| `test_flash_v2_tile_H` | Crash fixed. New failure: numerical mismatch (`inf`, ~98% mismatched elements) |
| `test_flash_v2_tile_Lq` | Crash fixed. New failure: numerical mismatch (`inf`, ~80% mismatched elements) |
| `test_flash_v2_tile_H_Lq` | Crash fixed. New failure: numerical mismatch (`inf`, ~95% mismatched elements) |
| `test_hint_flash_attention_v2` | Crash fixed. New failure: numerical mismatch (`inf`, ~99% mismatched elements) |
| `test_hint_flash_attention_v3_b2` | Unaffected — fails separately on a hardware tensor-span limit (per-core tensor exceeds 256 MB), unrelated to this bug |
| `test_flash_tile_B_H`, `test_flash_v2_tile_B`, `test_flash_v2_tile_B_H`, `test_flash_v3_tile_B`, `test_flash_v3_tile_B_H` | 
Unaffected — all skip for an unrelated `KeyError: 0 — B tiling not yet supported` |

Every test that previously hit this exact crash now compiles
successfully, but immediately hits a second, apparently pre-existing
numerical-correctness bug in the flash-attention-v2/hint-based
causal-mask + running-max (`copy_forced`) accumulator path — consistently
producing `inf` around the same output region. This looks like a
distinct bug that this crash was previously masking, not something
introduced by this fix. I'm treating it as separate from this PR; none
of the skips above can be lifted until it's root-caused. No tracking
issue filed yet for that follow-up — will file one once it's triaged
further and link it from the skip reasons at that point.

Also added `TestRepointMutationTargets` in
`tests/inductor/test_inductor_fx_passes.py` — direct unit coverage for
`_repoint_mutation_targets` (bare target, `TensorBox`/`StorageBox`-wrapped
target, unrelated-target no-op, non-mutation-op no-op) that doesn't
depend on the flash-attention path, so the fix stays pinned even if
coarse-tiling changes shape later.

Testing done:

```
python3 -m pytest tests/inductor/test_coarse_tile_e2e.py tests/inductor/test_building_blocks.py -q
# 201 passed, 43 skipped, 1 xfailed (pre-existing, unrelated correctness xfail)
python3 -m pytest tests/inductor/test_inductor_fx_passes.py -q
# 26 passed (includes new TestRepointMutationTargets)
pre-commit run --all-files
# clean
```

#### Does this PR introduce a user-facing change?

No. Internal compiler fix — no public API changes.

#### Additional note:
