### PR TITLE
LX Relayouts: Add grouped LX broadcasts

### DIFF
--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -633,7 +633,15 @@ _DESTINATION_VIEW = PerCoreView(((0, 8),), ((0, _CORE_ID),), num_cores=8)
 def _relayout_plan(source="source", consumers="consumer"):
     if isinstance(consumers, str):
         consumers = (consumers,)
-    return LXRelayoutPlan(source, consumers, _SOURCE_VIEW, _DESTINATION_VIEW, 8)
+    return LXRelayoutPlan(
+        source,
+        consumers,
+        _SOURCE_VIEW,
+        _DESTINATION_VIEW,
+        8,
+        source_footprint_bytes=8,
+        destination_footprint_bytes=8,
+    )
 
 
 def _collect_mock_relayout_plans(
@@ -700,7 +708,8 @@ def _collect_mock_relayout_plans(
 def _assert_plan_survives_final_view_validation(plan, device_size):
     plan = replace(
         plan,
-        max_footprint_bytes=max(plan.max_footprint_bytes, 512),
+        source_footprint_bytes=max(plan.source_footprint_bytes, 512),
+        destination_footprint_bytes=max(plan.destination_footprint_bytes, 512),
         source_address=0,
         destination_address=1024,
     )
@@ -781,7 +790,8 @@ def test_grouped_gather_records_geometry_without_persisting_new_placement():
         32,
         kind="gather",
         group_geometry=geometry,
-        max_footprint_bytes=512,
+        source_footprint_bytes=512,
+        destination_footprint_bytes=512,
     )
     _assert_plan_survives_final_view_validation(plan, (4, 8, 64))
     assert [
@@ -795,6 +805,25 @@ def test_grouped_gather_records_geometry_without_persisting_new_placement():
         len({tuple(owners[core].items()) for core in range(start, start + 8)}) == 1
         for start in range(0, 32, 8)
     )
+
+
+def test_grouped_gather_preserves_real_owner_order():
+    source = PerCoreView(
+        ((0, 4), (1, 8)),
+        ((0, Mod(_CORE_ID, 4)), (1, Mod(floor(_CORE_ID / 4), 8))),
+        num_cores=32,
+    )
+    destination = PerCoreView(
+        ((0, 4),),
+        ((0, Mod(_CORE_ID, 4)),),
+        num_cores=32,
+    )
+
+    grouped = lx_relayout_module._grouped_gather_geometry(source, destination, 32)
+    assert grouped is not None
+    grouped_source, grouped_destination, _ = grouped
+    assert grouped_source is source
+    assert grouped_destination is destination
 
 
 def test_partition_footprint_counts_strided_span_not_elements():
@@ -874,7 +903,8 @@ def test_final_view_ignores_alignment_only_singleton_dimensions():
 def test_final_view_validation_requires_one_shared_physical_view():
     plan = replace(
         _relayout_plan(),
-        max_footprint_bytes=1024,
+        source_footprint_bytes=1024,
+        destination_footprint_bytes=1024,
         source_address=0,
         destination_address=2048,
     )
@@ -974,7 +1004,8 @@ def test_final_view_validation_rejects_padded_span_above_plan():
         source_view,
         destination_view,
         4,
-        max_footprint_bytes=element_count_bound,
+        source_footprint_bytes=element_count_bound,
+        destination_footprint_bytes=element_count_bound,
         source_address=0,
         destination_address=4096,
     )
@@ -1378,6 +1409,8 @@ def test_lx_relayout_allocation_is_atomic_in_one_greedy_solve(caplog):
             _SOURCE_VIEW,
             alternate_view,
             8,
+            source_footprint_bytes=8,
+            destination_footprint_bytes=8,
         ),
     ]
     allocator = ScratchpadAllocator(GreedyLayoutSolver, 256)
@@ -1418,6 +1451,70 @@ def test_lx_relayout_allocation_is_atomic_in_one_greedy_solve(caplog):
     )
 
 
+def test_lx_relayout_allocates_each_paired_member_at_its_own_footprint():
+    source_footprint = 16_768
+    destination_footprint = 803_200
+    plan = replace(
+        _relayout_plan(),
+        source_footprint_bytes=source_footprint,
+        destination_footprint_bytes=destination_footprint,
+    )
+    graph = SimpleNamespace(
+        operations=[
+            SimpleNamespace(get_name=lambda: "producer"),
+            SimpleNamespace(get_name=lambda: "consumer"),
+        ]
+    )
+    mem_usage = {
+        "source": {
+            "size_per_core": source_footprint,
+            "core_div_mismatch": False,
+        }
+    }
+    allocator = ScratchpadAllocator(
+        GreedyLayoutSolver, source_footprint + destination_footprint
+    )
+
+    def build_buffers(_graph, _in_place, usage, _reasons, **_kwargs):
+        return [LifetimeBoundBuffer("source", usage["source"]["size_per_core"], [0, 1])]
+
+    with (
+        mock_patch.object(
+            allocator_module, "counted_loop_lifetime_end_overrides", return_value={}
+        ),
+        mock_patch.object(
+            allocator_module,
+            "get_ncores_for_buffers",
+            return_value=({"source": 8}, {}),
+        ),
+        mock_patch.object(allocator_module, "mem_usage_by_buf", return_value=mem_usage),
+        mock_patch.object(
+            allocator,
+            "_partition_footprints",
+            return_value={"source": source_footprint},
+        ),
+        mock_patch.object(allocator, "_residency_reasons", return_value={}),
+        mock_patch.object(allocator, "_determine_in_place", return_value={}),
+        mock_patch.object(allocator, "_build_bound_buffers", side_effect=build_buffers),
+    ):
+        buffers = allocator._generate_buffers(
+            graph,
+            lifetimes={"source": [0, 1]},
+            lx_relayout_plans=[plan],
+        )
+
+    allocator._append_lx_relayout_destinations(graph, buffers)
+    source = next(buffer for buffer in buffers if buffer.name == "source")
+    destination = next(
+        buffer for buffer in buffers if buffer.name == plan.destination_name
+    )
+    assert source.size == source_footprint
+    assert destination.size == destination_footprint
+
+    allocation = allocator._solve(allocator._build_solver(buffers), graph)
+    assert allocator._allocated_lx_relayout_sources(allocation) == {"source"}
+
+
 def _assert_live_buffers_do_not_share_addresses(graph, buffers, limit):
     allocator = ScratchpadAllocator(GreedyLayoutSolver, limit)
     allocation = allocator._solve(allocator._build_solver(buffers), graph)
@@ -1440,6 +1537,8 @@ def test_lx_relayout_copies_loop_lifetime_to_every_destination():
             _SOURCE_VIEW,
             PerCoreView(((1, 8),), ((1, _CORE_ID),)),
             8,
+            source_footprint_bytes=8,
+            destination_footprint_bytes=8,
         ),
     ]
     graph = SimpleNamespace(

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -37,6 +37,7 @@ from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code, InputType
 
 from torch_spyre._inductor import config, spyre_hint
+import torch_spyre._inductor.scratchpad.allocator as allocator_module
 import torch_spyre._inductor.scratchpad.lx_relayout as lx_relayout_module
 import torch_spyre._inductor.scheduler as scheduler_module
 import torch_spyre._inductor.work_division as _wd
@@ -46,6 +47,7 @@ from torch_spyre._inductor.codegen.superdsc import compile_op_spec, parse_op_spe
 from torch_spyre._inductor.constants import IDENTITY_OP
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.loop_info import CarriedReductionRecord
+from torch_spyre._inductor.core_mapping import remap_work_division
 from torch_spyre._inductor.scratchpad.lx_relayout import (
     FinalLXView,
     LXRelayoutPlan,
@@ -56,7 +58,6 @@ from torch_spyre._inductor.pass_utils import PerCoreView
 from torch_spyre._inductor.scratchpad.allocator import ScratchpadAllocator
 from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
 from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
-from torch_spyre._inductor.core_mapping import remap_work_division
 from torch_spyre._inductor.spyre_kernel import simplify_op_spec
 
 _LAUNCH_JOBPLAN = "torch_spyre.execution.kernel_runner.launch_jobplan"
@@ -616,6 +617,24 @@ def test_partition_footprint_counts_strided_span_not_elements():
         )
         == 19 * 128
     )
+
+
+def test_partition_footprints_skip_buffers_without_concrete_layout():
+    dep = SimpleNamespace(name="multi_output")
+
+    def unavailable_layout():
+        raise NotImplementedError("MultiOutputLayout")
+
+    graph = SimpleNamespace(
+        operations=[SimpleNamespace()],
+        try_get_buffer=lambda _name: SimpleNamespace(get_layout=unavailable_layout),
+    )
+    read_writes = SimpleNamespace(reads=[], writes=[dep])
+    with (
+        mock_patch.object(allocator_module, "MemoryDep", SimpleNamespace),
+        mock_patch.object(allocator_module, "op_read_writes", return_value=read_writes),
+    ):
+        assert ScratchpadAllocator._partition_footprints(graph, {dep.name: 1}) == {}
 
 
 def test_final_view_maps_stick_split_to_outer_device_dimension():

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -636,24 +636,161 @@ def _relayout_plan(source="source", consumers="consumer"):
     return LXRelayoutPlan(source, consumers, _SOURCE_VIEW, _DESTINATION_VIEW, 8)
 
 
+def _collect_mock_relayout_plans(
+    source_view,
+    destination_view,
+    coordinates,
+    symbols,
+    *,
+    num_cores,
+    matmul=False,
+):
+    source_dep = SimpleNamespace(name="source", is_indirect=lambda: False)
+    other_dep = SimpleNamespace(name="other", is_indirect=lambda: False)
+    producer = SimpleNamespace(
+        layout=SimpleNamespace(device_layout=SimpleNamespace()),
+        data=SimpleNamespace(),
+        get_name=lambda: "source",
+    )
+    consumer = SimpleNamespace(
+        layout=SimpleNamespace(),
+        data=SimpleNamespace(),
+        get_name=lambda: "consumer",
+    )
+    graph = SimpleNamespace(operations=[producer, consumer])
+
+    def read_writes(op):
+        if op is producer:
+            return SimpleNamespace(reads=[], writes=[source_dep])
+        reads = [source_dep, other_dep] if matmul else [source_dep]
+        return SimpleNamespace(reads=reads, writes=[])
+
+    with (
+        mock_patch.object(lx_relayout_module, "MemoryDep", SimpleNamespace),
+        mock_patch.object(lx_relayout_module, "ComputedBuffer", SimpleNamespace),
+        mock_patch.object(lx_relayout_module, "FixedTiledLayout", SimpleNamespace),
+        mock_patch.object(lx_relayout_module, "Pointwise", SimpleNamespace),
+        mock_patch.object(
+            lx_relayout_module, "op_read_writes", side_effect=read_writes
+        ),
+        mock_patch.object(
+            lx_relayout_module,
+            "_per_core_view_on_buf",
+            side_effect=[
+                (source_view, False, True),
+                (destination_view, False, True),
+            ],
+        ),
+        mock_patch.object(lx_relayout_module, "_op_num_cores", return_value=num_cores),
+        mock_patch.object(
+            lx_relayout_module, "try_device_coordinates", return_value=coordinates
+        ),
+        mock_patch.object(
+            lx_relayout_module, "iteration_space_from_op", return_value=symbols
+        ),
+        mock_patch.object(lx_relayout_module, "_is_matmul_op", return_value=matmul),
+        mock_patch.object(
+            lx_relayout_module, "op_short_name", return_value="pointwise"
+        ),
+        mock_patch.object(lx_relayout_module, "partition_footprint", return_value=512),
+    ):
+        return lx_relayout_module.collect_lx_relayout_plans(graph)
+
+
+def _assert_plan_survives_final_view_validation(plan, device_size):
+    plan = replace(
+        plan,
+        max_footprint_bytes=max(plan.max_footprint_bytes, 512),
+        source_address=0,
+        destination_address=1024,
+    )
+
+    def final_view(view):
+        splits = dict(view.work_slice_dims)
+        extents = tuple(
+            (extent + splits.get(dim, 1) - 1) // splits.get(dim, 1)
+            for dim, extent in enumerate(device_size)
+            if extent != 1
+        )
+        return FinalLXView(
+            view,
+            tuple(extent for extent in device_size if extent != 1),
+            tuple(sorted(extents[:-1])) + (extents[-1],),
+            512,
+        )
+
+    source = final_view(plan.source_view)
+    destination = final_view(plan.destination_view)
+    views = {
+        ("producer", "source"): source,
+        ("copy", "source"): source,
+        ("copy", plan.destination_name): destination,
+        ("consumer", plan.destination_name): destination,
+    }
+    layout = SimpleNamespace(device_layout=SimpleNamespace(device_size=device_size))
+    graph = SimpleNamespace(
+        try_get_buffer=lambda name: (
+            SimpleNamespace(get_layout=lambda: layout)
+            if name in {"source", plan.destination_name}
+            else None
+        )
+    )
+    with mock_patch.object(lx_relayout_module, "FixedTiledLayout", SimpleNamespace):
+        assert lx_relayout_module.validate_final_views(graph, plan, views) is None
+
+
+def test_same_splits_with_different_core_owners_are_relayouted():
+    m, n = Symbol("m"), Symbol("n")
+    source = PerCoreView(
+        ((0, 2), (1, 2)),
+        ((0, floor(_CORE_ID / 2)), (1, Mod(_CORE_ID, 2))),
+        num_cores=4,
+    )
+    destination = PerCoreView(
+        ((0, 2), (1, 2)),
+        ((0, Mod(_CORE_ID, 2)), (1, floor(_CORE_ID / 2))),
+        num_cores=4,
+    )
+    plans = _collect_mock_relayout_plans(
+        source, destination, [m, n, Integer(0)], (m, n), num_cores=4
+    )
+    assert len(plans) == 1 and plans[0].kind == "shuffle"
+    _assert_plan_survives_final_view_validation(plans[0], (4, 4, 64))
+
+
 def test_grouped_gather_records_geometry_without_persisting_new_placement():
     source = PerCoreView(
         ((0, 4), (1, 8)),
         ((0, Mod(_CORE_ID, 4)), (1, Mod(floor(_CORE_ID / 4), 8))),
+        num_cores=32,
     )
-    destination = PerCoreView(((0, 4),), ((0, Mod(_CORE_ID, 4)),))
+    destination = PerCoreView(
+        ((0, 4),),
+        ((0, Mod(_CORE_ID, 4)),),
+        num_cores=32,
+    )
 
     grouped = lx_relayout_module._grouped_gather_geometry(source, destination, 32)
     assert grouped is not None
     grouped_source, grouped_destination, geometry = grouped
-    assert lx_relayout_module._compatible_partitions(
-        grouped_source, grouped_destination, 32
+    plan = LXRelayoutPlan(
+        "source",
+        ("consumer",),
+        grouped_source,
+        grouped_destination,
+        32,
+        kind="gather",
+        group_geometry=geometry,
+        max_footprint_bytes=512,
     )
-    assert [(item.source_split, item.destination_split) for item in geometry] == [
+    _assert_plan_survives_final_view_validation(plan, (4, 8, 64))
+    assert [
+        (item.source_split, item.destination_split) for item in plan.group_geometry
+    ] == [
         (4, 4),
         (8, 1),
     ]
-    owners = lx_relayout_module._core_slices(grouped_destination, 32)
+    owners = lx_relayout_module._core_slices(plan.destination_view, 32)
     assert all(
         len({tuple(owners[core].items()) for core in range(start, start + 8)}) == 1
         for start in range(0, 32, 8)
@@ -968,52 +1105,16 @@ def test_lx_relayout_planner_rejects_equal_projected_ownership():
     assert source_view != destination_view
     assert source_work_division == destination_work_division
 
-    source_dep = SimpleNamespace(name="source", is_indirect=lambda: False)
-    producer = SimpleNamespace(
-        layout=SimpleNamespace(device_layout=SimpleNamespace()),
-        data=SimpleNamespace(),
-        get_name=lambda: "source",
+    assert (
+        _collect_mock_relayout_plans(
+            source_view,
+            destination_view,
+            coordinates,
+            (m,),
+            num_cores=32,
+        )
+        == []
     )
-    consumer = SimpleNamespace(
-        layout=SimpleNamespace(),
-        data=SimpleNamespace(),
-        get_name=lambda: "consumer",
-    )
-    graph = SimpleNamespace(operations=[producer, consumer])
-
-    def read_writes(op):
-        if op is producer:
-            return SimpleNamespace(reads=[], writes=[source_dep])
-        return SimpleNamespace(reads=[source_dep], writes=[])
-
-    with (
-        mock_patch.object(lx_relayout_module, "MemoryDep", SimpleNamespace),
-        mock_patch.object(lx_relayout_module, "ComputedBuffer", SimpleNamespace),
-        mock_patch.object(lx_relayout_module, "FixedTiledLayout", SimpleNamespace),
-        mock_patch.object(lx_relayout_module, "Pointwise", SimpleNamespace),
-        mock_patch.object(
-            lx_relayout_module, "op_read_writes", side_effect=read_writes
-        ),
-        mock_patch.object(
-            lx_relayout_module,
-            "_per_core_view_on_buf",
-            side_effect=[
-                (source_view, False, True),
-                (destination_view, False, True),
-            ],
-        ),
-        mock_patch.object(lx_relayout_module, "_op_num_cores", return_value=32),
-        mock_patch.object(
-            lx_relayout_module, "try_device_coordinates", return_value=coordinates
-        ),
-        mock_patch.object(
-            lx_relayout_module, "iteration_space_from_op", return_value=(m,)
-        ),
-        mock_patch.object(
-            lx_relayout_module, "op_short_name", return_value="pointwise"
-        ),
-    ):
-        assert lx_relayout_module.collect_lx_relayout_plans(graph) == []
 
 
 def _compile_spec(spec, normalize=True):

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections.abc import Sequence
+from contextlib import nullcontext
 from dataclasses import replace
 import logging
 import logging.handlers
@@ -640,12 +641,14 @@ def test_final_view_ignores_alignment_only_singleton_dimensions():
         [8, 64],
         [c, Mod(c, 64)],
         {c: (8, 1)},
+        physical_span_bytes=512,
     )
     expanded = lx_relayout_module.final_view_from_work_division(
         division,
         [1, 1, 8, 64],
         [0, 0, c, Mod(c, 64)],
         {c: (8, 1)},
+        physical_span_bytes=512,
     )
     assert expanded == compact
 
@@ -692,6 +695,85 @@ def test_final_view_validation_requires_one_shared_physical_view():
             slice_shape=(2, 4, 64),
         )
         assert "destination users derived 2 final views" in (
+            lx_relayout_module.validate_final_views(
+                graph,
+                plan,
+                views,
+                destination_name="destination",
+            )
+            or ""
+        )
+        views[("consumer", "destination")] = destination
+        oversized_source = replace(
+            source,
+            physical_span_bytes=2048,
+        )
+        views[("producer", "source")] = oversized_source
+        views[("copy", "source")] = oversized_source
+        assert "physical span 2048 exceeds planned 1024" in (
+            lx_relayout_module.validate_final_views(
+                graph,
+                plan,
+                views,
+                destination_name="destination",
+            )
+            or ""
+        )
+
+
+def test_final_view_validation_rejects_padded_span_above_plan():
+    source_view = PerCoreView(
+        ((0, 2), (1, 2)),
+        ((0, floor(_CORE_ID / 2)), (1, Mod(_CORE_ID, 2))),
+        num_cores=4,
+    )
+    destination_view = PerCoreView(
+        ((0, 2), (1, 2)),
+        ((0, Mod(_CORE_ID, 2)), (1, floor(_CORE_ID / 2))),
+        num_cores=4,
+    )
+    element_count_bound = 3 * 3 * 128
+    physical_span = lx_relayout_module.partition_physical_span_bytes(
+        (5, 5, 64),
+        (512, 64, 1),
+        64,
+        {0: 2, 1: 2},
+    )
+    assert physical_span == 19 * 128 > element_count_bound
+
+    plan = LXRelayoutPlan(
+        "source",
+        ("consumer",),
+        source_view,
+        destination_view,
+        4,
+        max_footprint_bytes=element_count_bound,
+        source_address=0,
+        destination_address=4096,
+    )
+    source = FinalLXView(
+        source_view,
+        (5, 5, 64),
+        (3, 3, 64),
+        physical_span,
+    )
+    destination = replace(source, ownership=destination_view)
+    views = {
+        ("producer", "source"): source,
+        ("copy", "source"): source,
+        ("copy", "destination"): destination,
+        ("consumer", "destination"): destination,
+    }
+    layout = SimpleNamespace(device_layout=SimpleNamespace(device_size=(5, 5, 64)))
+    graph = SimpleNamespace(
+        try_get_buffer=lambda name: (
+            SimpleNamespace(get_layout=lambda: layout)
+            if name in {"source", "destination"}
+            else None
+        )
+    )
+    with mock_patch.object(lx_relayout_module, "FixedTiledLayout", SimpleNamespace):
+        assert "physical span 2432 exceeds planned 1152" in (
             lx_relayout_module.validate_final_views(
                 graph,
                 plan,
@@ -1023,10 +1105,12 @@ def test_lx_relayout_consumers_share_destination_view(second_consumer):
     }
 )
 @pytest.mark.parametrize(
-    ("num_heads", "key_length", "query_length", "key_split"),
-    ((4, 128, 8, 8), (8, 64, 4, 4)),
+    ("num_heads", "key_length", "query_length", "key_split", "force_fallback"),
+    ((4, 128, 8, 8, False), (8, 64, 4, 4, False), (4, 128, 8, 8, True)),
 )
-def test_grouped_lx_gather_device(num_heads, key_length, query_length, key_split):
+def test_grouped_lx_gather_device(
+    num_heads, key_length, query_length, key_split, force_fallback
+):
     torch.manual_seed(0)
     value = torch.randn(num_heads, key_length, 64, dtype=torch.float16)
     attention = torch.randn(num_heads, query_length, key_length, dtype=torch.float16)
@@ -1049,10 +1133,23 @@ def test_grouped_lx_gather_device(num_heads, key_length, query_length, key_split
         _name_tensor_dims(attention.to("spyre"), ["H", "Lq", "Lk"]),
     )
     torch._inductor.codecache.FxGraphCache.clear()
-    actual, code = run_and_get_code(
-        torch.compile(fn, dynamic=False, options={"epilogue_fusion": False}),
-        *device_args,
+    clone_counter = scheduler_module.counters["torch_spyre"][
+        "lx_relayout_gate_demoted_with_hbm_clone"
+    ]
+    preview = (
+        mock_patch.object(
+            scheduler_module,
+            "_preview_final_lx_views",
+            side_effect=ValueError("forced fallback"),
+        )
+        if force_fallback
+        else nullcontext()
     )
+    with preview:
+        actual, code = run_and_get_code(
+            torch.compile(fn, dynamic=False, options={"epilogue_fusion": False}),
+            *device_args,
+        )
     torch.testing.assert_close(actual.cpu(), fn(value, attention), rtol=2e-2, atol=1e-1)
     identities = [
         block
@@ -1060,8 +1157,17 @@ def test_grouped_lx_gather_device(num_heads, key_length, query_length, key_split
         if "op='identity'" in block[:100]
     ]
     assert len(identities) == 1
-    assert identities[0].count("allocation={'lx':") == 2
-    assert identities[0].count("TensorWorkDivision(") == 2
+    if force_fallback:
+        assert "allocation={'lx':" not in identities[0]
+        assert (
+            scheduler_module.counters["torch_spyre"][
+                "lx_relayout_gate_demoted_with_hbm_clone"
+            ]
+            > clone_counter
+        )
+    else:
+        assert identities[0].count("allocation={'lx':") == 2
+        assert identities[0].count("TensorWorkDivision(") == 2
 
 
 def test_lx_relayout_allocation_is_atomic_in_one_greedy_solve(caplog):
@@ -1304,6 +1410,29 @@ def test_lx_relayout_scheduler_demotes_groups_but_not_ordinary_unary():
                 True,
             )
 
+        final_view = FinalLXView(
+            PerCoreView((), (), num_cores=1),
+            (64,),
+            (64,),
+            128,
+        )
+
+        def preview(node, *, relayout_copy):
+            del relayout_copy
+            return (
+                {
+                    (node.name, dep.name): final_view
+                    for dep in (*node.read_writes.reads, *node.read_writes.writes)
+                    if dep.name in buffers
+                    and "lx" in buffers[dep.name].get_layout().allocation
+                },
+                False,
+            )
+
+        clone_counter = scheduler_module.counters["torch_spyre"][
+            "lx_relayout_gate_demoted_with_hbm_clone"
+        ]
+
         with (
             mock_patch.object(scheduler_module, "SchedulerNode", _RelayoutNode),
             mock_patch.object(scheduler_module, "MemoryDep", SimpleNamespace),
@@ -1314,7 +1443,7 @@ def test_lx_relayout_scheduler_demotes_groups_but_not_ordinary_unary():
             mock_patch.object(
                 scheduler_module,
                 "_preview_final_lx_views",
-                return_value=({}, False),
+                side_effect=preview,
             ),
             mock_patch.object(
                 scheduler_module,
@@ -1326,6 +1455,12 @@ def test_lx_relayout_scheduler_demotes_groups_but_not_ordinary_unary():
             config.patch({"lx_planning": True}),
         ):
             scheduler_module.demote_incoherent_lx_buffers(nodes)
+        assert (
+            scheduler_module.counters["torch_spyre"][
+                "lx_relayout_gate_demoted_with_hbm_clone"
+            ]
+            == clone_counter + 1
+        )
         assert graph._spyre_lx_relayout_copies == {}
         assert "lx" not in layouts["source"].allocation
         if drift != "missing_buffer":
@@ -1441,6 +1576,46 @@ def test_carried_reduction_verifier_rejects_same_count_on_wrong_dimension():
 def test_carried_reduction_verifier_rejects_scheduler_rank_change():
     with pytest.raises(Unsupported, match="changed iteration rank"):
         _verify_carried_reduction(scheduled_rank_mismatch=True)
+
+
+def test_final_view_gate_demotes_ordinary_buffer_without_a_preview_view():
+    dep = SimpleNamespace(name="ordinary")
+    layout = _relayout_layout(0, _SOURCE_VIEW)
+    nodes = [
+        _RelayoutNode("producer", writes=(dep,), layout=layout),
+        _RelayoutNode("consumer", reads=(dep,)),
+    ]
+    buffer = SimpleNamespace(get_layout=lambda: layout)
+    graph = SimpleNamespace(
+        _spyre_lx_relayout_copies={},
+        try_get_buffer=lambda name: buffer if name == "ordinary" else None,
+        get_buffer=lambda name: buffer,
+    )
+    with (
+        mock_patch.object(scheduler_module, "SchedulerNode", _RelayoutNode),
+        mock_patch.object(scheduler_module, "MemoryDep", SimpleNamespace),
+        mock_patch.object(scheduler_module, "FixedTiledLayout", SimpleNamespace),
+        mock_patch.object(scheduler_module, "V", SimpleNamespace(graph=graph)),
+        mock_patch.object(
+            scheduler_module,
+            "per_core_view_scheduled",
+            return_value=(_SOURCE_VIEW, False, True),
+        ),
+        mock_patch.object(
+            scheduler_module,
+            "_ownership_projectable",
+            return_value=True,
+        ),
+        mock_patch.object(
+            scheduler_module,
+            "_preview_final_lx_views",
+            return_value=({}, False),
+        ),
+        config.patch({"lx_planning": True}),
+    ):
+        scheduler_module.demote_incoherent_lx_buffers(nodes)
+
+    assert "lx" not in layout.allocation
 
 
 def aot_backend(gm: GraphModule, example_inputs: Sequence[InputType]):

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -771,6 +771,15 @@ def test_final_view_validation_requires_one_shared_physical_view():
             )
             is None
         )
+        assert "source users derived 0 final views" in (
+            lx_relayout_module.validate_final_views(
+                graph,
+                plan,
+                {},
+                destination_name="destination",
+            )
+            or ""
+        )
         views[("consumer", "destination")] = replace(
             destination,
             slice_shape=(2, 4, 64),
@@ -870,8 +879,13 @@ def test_grouped_gather_mapping_is_derived_after_alignment():
     source = TensorWorkDivision(
         {h: 4, local: 8},
         {h: Mod(floor(_CORE_ID / 8), 4), local: Mod(_CORE_ID, 8)},
+        num_cores=32,
     )
-    destination = TensorWorkDivision({h: 4}, {h: Mod(_CORE_ID, 4)})
+    destination = TensorWorkDivision(
+        {h: 4},
+        {h: Mod(_CORE_ID, 4)},
+        num_cores=32,
+    )
     args = [
         TensorArg(
             True,
@@ -1500,13 +1514,16 @@ def test_lx_relayout_scheduler_demotes_groups_but_not_ordinary_unary():
             128,
         )
 
-        def preview(node, *, relayout_copy):
+        def preview(node, *, relayout_copy, tracked_buffers):
             del relayout_copy
+            if drift == "mapping" and node.name == "consumer":
+                raise ValueError("no operation core mapping satisfies LX ownership")
             return (
                 {
                     (node.name, dep.name): final_view
                     for dep in (*node.read_writes.reads, *node.read_writes.writes)
-                    if dep.name in buffers
+                    if dep.name in tracked_buffers
+                    and dep.name in buffers
                     and "lx" in buffers[dep.name].get_layout().allocation
                 },
                 False,
@@ -1555,6 +1572,7 @@ def test_lx_relayout_scheduler_demotes_groups_but_not_ordinary_unary():
     run_registered("source")
     run_registered("consumer")
     run_registered("projection")
+    run_registered("mapping")
     run_registered("missing")
     run_registered("missing_buffer")
 
@@ -1661,7 +1679,7 @@ def test_carried_reduction_verifier_rejects_scheduler_rank_change():
         _verify_carried_reduction(scheduled_rank_mismatch=True)
 
 
-def test_final_view_gate_demotes_ordinary_buffer_without_a_preview_view():
+def test_final_view_gate_leaves_ordinary_lx_to_existing_validation():
     dep = SimpleNamespace(name="ordinary")
     layout = _relayout_layout(0, _SOURCE_VIEW)
     nodes = [
@@ -1692,13 +1710,13 @@ def test_final_view_gate_demotes_ordinary_buffer_without_a_preview_view():
         mock_patch.object(
             scheduler_module,
             "_preview_final_lx_views",
-            return_value=({}, False),
+            side_effect=AssertionError("ordinary LX must not enter the relayout gate"),
         ),
         config.patch({"lx_planning": True}),
     ):
         scheduler_module.demote_incoherent_lx_buffers(nodes)
 
-    assert "lx" not in layout.allocation
+    assert "lx" in layout.allocation
 
 
 def aot_backend(gm: GraphModule, example_inputs: Sequence[InputType]):

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -13,11 +13,15 @@
 # limitations under the License.
 
 from collections.abc import Sequence
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from dataclasses import replace
+import json
 import logging
 import logging.handlers
+import os
+from pathlib import Path
 import regex as re
+import subprocess
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch as mock_patch
@@ -42,6 +46,7 @@ import torch_spyre._inductor.scratchpad.lx_relayout as lx_relayout_module
 import torch_spyre._inductor.scheduler as scheduler_module
 import torch_spyre._inductor.work_division as _wd
 import torch_spyre._inductor.wsr.propagate_named_dims as _pnd
+import torch_spyre.execution.async_compile as async_compile_module
 from torch_spyre._C import DataFormats
 from torch_spyre._inductor.codegen.superdsc import compile_op_spec, parse_op_spec
 from torch_spyre._inductor.constants import IDENTITY_OP
@@ -66,6 +71,63 @@ _PREPARE_KERNEL = "torch_spyre.execution.kernel_runner.prepare_kernel"
 
 _declare_tensor_dim = _pnd.declare_tensor_dim
 _name_tensor_dims = _pnd.name_tensor_dims
+
+
+@contextmanager
+def _capture_backend_output_dirs():
+    output_dirs = []
+    get_output_dir = async_compile_module.get_output_dir
+
+    def capture(kernel_name):
+        output_dir = get_output_dir(kernel_name)
+        output_dirs.append(Path(output_dir))
+        return output_dir
+
+    with mock_patch.object(async_compile_module, "get_output_dir", side_effect=capture):
+        yield output_dirs
+
+
+def _assert_lx_only_relayout_payload(output_dirs):
+    for output_dir in output_dirs:
+        subprocess.run(
+            ["dxp_standalone", "-d", output_dir, "--use-dxp"],
+            check=True,
+            env={**os.environ, "DXP_DEBUG": "1"},
+        )
+    payloads = [
+        json.loads(path.read_text())
+        for output_dir in output_dirs
+        for path in output_dir.glob("debug/sdsc_*/*.out.out.out.json")
+    ]
+    assert payloads, "DeepTools emitted no debug SDSC payloads"
+
+    op_names = []
+    lx_ops = []
+
+    def visit(value):
+        if isinstance(value, dict):
+            op = value.get("op")
+            if isinstance(op, dict) and op.get("name") == "STCDPOpLx":
+                lx_ops.append(value)
+            for key, child in value.items():
+                if key == "name" and isinstance(child, str):
+                    op_names.append(child)
+                visit(child)
+        elif isinstance(value, list):
+            for child in value:
+                visit(child)
+
+    for payload in payloads:
+        visit(payload)
+
+    assert len(lx_ops) == 1
+    assert not any(
+        token in name.lower()
+        for name in op_names
+        for token in ("dma", "restickify", "stcdpophbm")
+    )
+    labeled_ds = lx_ops[0]["labeledDs_"]
+    assert labeled_ds and all(ds["hbmSize_"] == 0 for ds in labeled_ds)
 
 
 class TestNamedWorkDivisionHint(InductorTestCase):
@@ -1164,7 +1226,8 @@ def test_grouped_lx_gather_device(
         if force_fallback
         else nullcontext()
     )
-    with preview:
+    backend = nullcontext([]) if force_fallback else _capture_backend_output_dirs()
+    with preview, backend as output_dirs:
         actual, code = run_and_get_code(
             torch.compile(fn, dynamic=False, options={"epilogue_fusion": False}),
             *device_args,
@@ -1187,6 +1250,7 @@ def test_grouped_lx_gather_device(
     else:
         assert identities[0].count("allocation={'lx':") == 2
         assert identities[0].count("TensorWorkDivision(") == 2
+        _assert_lx_only_relayout_payload(output_dirs)
 
 
 def test_lx_relayout_allocation_is_atomic_in_one_greedy_solve(caplog):

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -767,6 +767,66 @@ def test_same_splits_with_different_core_owners_are_relayouted():
     _assert_plan_survives_final_view_validation(plans[0], (4, 4, 64))
 
 
+def test_relayout_semantics_have_one_edge_deriver_and_lowering_registry():
+    source = PerCoreView(
+        ((0, 4),),
+        ((0, _CORE_ID),),
+        num_cores=4,
+    )
+    destination = PerCoreView(
+        ((0, 2),),
+        ((0, floor(_CORE_ID / 2)),),
+        num_cores=4,
+    )
+
+    edges = lx_relayout_module._transfer_edges(source, destination, 4, 4)
+    assert edges == frozenset(
+        {
+            (0, 0),
+            (0, 1),
+            (1, 0),
+            (1, 1),
+            (2, 2),
+            (2, 3),
+            (3, 2),
+            (3, 3),
+        }
+    )
+    classified = lx_relayout_module.classify_relayout_views(source, destination, 4)
+    assert classified is not None and classified[0] == "gather"
+    assert set(lx_relayout_module._LOWERING_CERTIFIERS) == {"gather", "shuffle"}
+
+
+def test_physical_view_equality_uses_owner_semantics_not_sympy_spelling():
+    canonical = PerCoreView(
+        ((0, 4),),
+        ((0, Mod(_CORE_ID, 4)),),
+        num_cores=4,
+    )
+    equivalent = PerCoreView(
+        ((0, 4),),
+        ((0, _CORE_ID),),
+        num_cores=4,
+    )
+    assert lx_relayout_module.per_core_views_equal(canonical, equivalent)
+    assert lx_relayout_module.classify_relayout_views(canonical, equivalent, 4) is None
+
+
+def test_lx_validation_registry_has_stable_extension_partitions():
+    plan = _relayout_plan()
+    graph = SimpleNamespace(
+        _spyre_lx_relayout_copies={plan.edge: (plan.destination_name, plan)}
+    )
+    lx_relayout_module.register_lx_validation_buffers(
+        graph, "explicit_view", ("explicit",)
+    )
+    partitions = lx_relayout_module.lx_validation_partitions(graph)
+    assert partitions == {
+        "relayout": {"source", plan.destination_name},
+        "explicit_view": {"explicit"},
+    }
+
+
 def test_grouped_gather_records_geometry_without_persisting_new_placement():
     source = PerCoreView(
         ((0, 4), (1, 8)),

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -794,7 +794,11 @@ def test_relayout_semantics_have_one_edge_deriver_and_lowering_registry():
     )
     classified = lx_relayout_module.classify_relayout_views(source, destination, 4)
     assert classified is not None and classified[0] == "gather"
-    assert set(lx_relayout_module._LOWERING_CERTIFIERS) == {"gather", "shuffle"}
+    assert set(lx_relayout_module._LOWERING_CERTIFIERS) == {
+        "broadcast",
+        "gather",
+        "shuffle",
+    }
 
 
 def test_physical_view_equality_uses_owner_semantics_not_sympy_spelling():
@@ -1157,6 +1161,71 @@ def test_grouped_gather_mapping_is_derived_after_alignment():
     ] == [owner for owner in range(4) for _ in range(8)]
 
 
+@config.patch({"sencores": 32})
+def test_grouped_broadcast_derives_distinct_physical_core_domains():
+    h = Symbol("h")
+    source_view = PerCoreView(((0, 2),), ((0, Mod(_CORE_ID, 2)),), num_cores=2)
+    destination_view = PerCoreView(
+        ((0, 2),), ((0, floor(_CORE_ID / 16)),), num_cores=32
+    )
+    grouped = lx_relayout_module._grouped_broadcast_geometry(
+        source_view, destination_view, 2, 32
+    )
+    assert grouped is not None
+    source_view, destination_view, geometry = grouped
+    plan = LXRelayoutPlan(
+        "source",
+        ("consumer",),
+        source_view,
+        destination_view,
+        2,
+        kind="broadcast",
+        group_geometry=geometry,
+        max_footprint_bytes=512,
+    )
+    _assert_plan_survives_final_view_validation(plan, (2, 64))
+    assert [
+        (item.source_split, item.destination_split) for item in plan.group_geometry
+    ] == [(2, 2)]
+
+    coordinates = [h, Integer(0)]
+    args = [
+        TensorArg(
+            True,
+            -1,
+            DataFormats.SEN169_FP16,
+            [2, 64],
+            coordinates,
+            {"lx": 0},
+            work_division=work_division_from_view(source_view, coordinates, (h,)),
+        ),
+        TensorArg(
+            False,
+            -1,
+            DataFormats.SEN169_FP16,
+            [2, 64],
+            coordinates,
+            {"lx": 1024},
+            work_division=work_division_from_view(destination_view, coordinates, (h,)),
+        ),
+    ]
+    root, allocations = _compile_spec(
+        OpSpec(IDENTITY_OP, False, {h: (Integer(2), 2)}, args, {})
+    )
+    assert set(root["dscs_"][0]) == {"shuffle"}
+    assert root["numCoresUsed_"] == 32
+    source_map, destination_map = [
+        node["coordinates_"]["coreIdToWkSlice_"] for node in allocations
+    ]
+    assert set(source_map) == {"0", "1"}
+    source_owners = [tuple(source_map[str(core)].values()) for core in range(2)]
+    destination_owners = [
+        tuple(destination_map[str(core)].values()) for core in range(32)
+    ]
+    assert source_owners[0] != source_owners[1]
+    assert destination_owners == [owner for owner in source_owners for _ in range(16)]
+
+
 def test_lx_relayout_activation_policy_is_source_wide():
     dep = SimpleNamespace(name="input")
     producer = SimpleNamespace()
@@ -1457,6 +1526,52 @@ def test_grouped_lx_gather_device(
         assert identities[0].count("allocation={'lx':") == 2
         assert identities[0].count("TensorWorkDivision(") == 2
         _assert_lx_only_relayout_payload(output_dirs)
+
+
+@config.patch(
+    {
+        "sencores": 32,
+        "lx_planning": True,
+        "allow_all_ops_in_lx_planning": True,
+        "lx_planner_relayout": True,
+        "layout_solver": "greedy",
+    }
+)
+def test_grouped_lx_broadcast_device():
+    torch.manual_seed(0)
+    probs = torch.randn(1, 8, 512, 128, dtype=torch.float16)
+    value_pages = torch.randn(2, 8, 128, 128, dtype=torch.float16)
+    page_table = torch.zeros(2, 32, dtype=torch.int32)
+
+    def fn(probs, value_pages, page_table):
+        page = value_pages.index_select(0, page_table[0, :1])
+        return torch.matmul(probs, page)
+
+    device_args = tuple(arg.to("spyre") for arg in (probs, value_pages, page_table))
+    torch._inductor.codecache.FxGraphCache.clear()
+    with _capture_backend_output_dirs() as output_dirs:
+        actual, code = run_and_get_code(
+            torch.compile(fn, dynamic=False, options={"epilogue_fusion": False}),
+            *device_args,
+        )
+    torch.testing.assert_close(
+        actual.cpu(), fn(probs, value_pages, page_table), rtol=2e-2, atol=2e-1
+    )
+    identities = [
+        block
+        for block in "\n".join(code).split("OpSpec(")
+        if "op='identity'" in block[:100]
+    ]
+    relayouts = [
+        block
+        for block in identities
+        if block.count("allocation={'lx':") == 2
+        and block.count("TensorWorkDivision(") == 2
+    ]
+    assert len(relayouts) == 1
+    assert "num_cores=1" in relayouts[0]
+    assert "num_cores=32" in relayouts[0]
+    _assert_lx_only_relayout_payload(output_dirs)
 
 
 def test_lx_relayout_allocation_is_atomic_in_one_greedy_solve(caplog):

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -1161,6 +1161,17 @@ def test_grouped_gather_mapping_is_derived_after_alignment():
     ] == [owner for owner in range(4) for _ in range(8)]
 
 
+def test_grouped_broadcast_preserves_real_owner_order():
+    source = PerCoreView(((0, 2),), ((0, Mod(_CORE_ID, 2)),), num_cores=2)
+    destination = PerCoreView(((0, 2),), ((0, Mod(_CORE_ID, 2)),), num_cores=32)
+
+    grouped = lx_relayout_module._grouped_broadcast_geometry(source, destination, 2, 32)
+    assert grouped is not None
+    grouped_source, grouped_destination, _ = grouped
+    assert grouped_source is source
+    assert grouped_destination is destination
+
+
 @config.patch({"sencores": 32})
 def test_grouped_broadcast_derives_distinct_physical_core_domains():
     h = Symbol("h")

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -46,6 +46,7 @@ from torch_spyre._inductor.constants import IDENTITY_OP
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.loop_info import CarriedReductionRecord
 from torch_spyre._inductor.scratchpad.lx_relayout import (
+    FinalLXView,
     LXRelayoutPlan,
     work_division_from_view,
 )
@@ -614,6 +615,91 @@ def test_partition_footprint_counts_strided_span_not_elements():
         )
         == 19 * 128
     )
+
+
+def test_final_view_maps_stick_split_to_outer_device_dimension():
+    c = Symbol("c")
+    division = TensorWorkDivision(
+        {c: 2},
+        {c: Mod(_CORE_ID, 2)},
+        num_cores=2,
+    )
+    view = lx_relayout_module.view_from_work_division(
+        division,
+        [floor(c / 64), Mod(c, 64)],
+        {c: (128, 2)},
+    )
+    assert view.work_slice_dims == ((0, 2),)
+
+
+def test_final_view_ignores_alignment_only_singleton_dimensions():
+    c = Symbol("c")
+    division = TensorWorkDivision({}, {}, num_cores=1)
+    compact = lx_relayout_module.final_view_from_work_division(
+        division,
+        [8, 64],
+        [c, Mod(c, 64)],
+        {c: (8, 1)},
+    )
+    expanded = lx_relayout_module.final_view_from_work_division(
+        division,
+        [1, 1, 8, 64],
+        [0, 0, c, Mod(c, 64)],
+        {c: (8, 1)},
+    )
+    assert expanded == compact
+
+
+def test_final_view_validation_requires_one_shared_physical_view():
+    plan = replace(
+        _relayout_plan(),
+        max_footprint_bytes=1024,
+        source_address=0,
+        destination_address=2048,
+    )
+    layout = SimpleNamespace(device_layout=SimpleNamespace(device_size=(8, 4, 64)))
+    graph = SimpleNamespace(
+        try_get_buffer=lambda name: (
+            SimpleNamespace(get_layout=lambda: layout)
+            if name in {"source", "destination"}
+            else None
+        )
+    )
+    source = FinalLXView(
+        replace(_SOURCE_VIEW, num_cores=8), (8, 4, 64), (2, 2, 64), 512
+    )
+    destination = FinalLXView(
+        replace(_DESTINATION_VIEW, num_cores=8), (8, 4, 64), (1, 4, 64), 512
+    )
+    views = {
+        ("producer", "source"): source,
+        ("copy", "source"): source,
+        ("copy", "destination"): destination,
+        ("consumer", "destination"): destination,
+    }
+    with mock_patch.object(lx_relayout_module, "FixedTiledLayout", SimpleNamespace):
+        assert (
+            lx_relayout_module.validate_final_views(
+                graph,
+                plan,
+                views,
+                destination_name="destination",
+            )
+            is None
+        )
+        views[("consumer", "destination")] = replace(
+            destination,
+            slice_shape=(2, 4, 64),
+        )
+        assert "destination users derived 2 final views" in (
+            lx_relayout_module.validate_final_views(
+                graph,
+                plan,
+                views,
+                destination_name="destination",
+            )
+            or ""
+        )
 
 
 def test_grouped_gather_mapping_is_derived_after_alignment():
@@ -1225,6 +1311,11 @@ def test_lx_relayout_scheduler_demotes_groups_but_not_ordinary_unary():
             mock_patch.object(lx_relayout_module, "FixedTiledLayout", SimpleNamespace),
             mock_patch.object(scheduler_module, "V", SimpleNamespace(graph=graph)),
             mock_patch.object(scheduler_module, "per_core_view_scheduled", view),
+            mock_patch.object(
+                scheduler_module,
+                "_preview_final_lx_views",
+                return_value=({}, False),
+            ),
             mock_patch.object(
                 scheduler_module,
                 "_ownership_projectable",

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -571,6 +571,101 @@ def _relayout_plan(source="source", consumers="consumer"):
     return LXRelayoutPlan(source, consumers, _SOURCE_VIEW, _DESTINATION_VIEW, 8)
 
 
+def test_grouped_gather_records_geometry_without_persisting_new_placement():
+    source = PerCoreView(
+        ((0, 4), (1, 8)),
+        ((0, Mod(_CORE_ID, 4)), (1, Mod(floor(_CORE_ID / 4), 8))),
+    )
+    destination = PerCoreView(((0, 4),), ((0, Mod(_CORE_ID, 4)),))
+
+    grouped = lx_relayout_module._grouped_gather_geometry(source, destination, 32)
+    assert grouped is not None
+    grouped_source, grouped_destination, geometry = grouped
+    assert lx_relayout_module._compatible_partitions(
+        grouped_source, grouped_destination, 32
+    )
+    assert [(item.source_split, item.destination_split) for item in geometry] == [
+        (4, 4),
+        (8, 1),
+    ]
+    owners = lx_relayout_module._core_slices(grouped_destination, 32)
+    assert all(
+        len({tuple(owners[core].items()) for core in range(start, start + 8)}) == 1
+        for start in range(0, 32, 8)
+    )
+
+
+def test_partition_footprint_counts_strided_span_not_elements():
+    assert (
+        lx_relayout_module.partition_physical_span_bytes(
+            (5, 5, 64),
+            (320, 64, 1),
+            64,
+            {0: 2, 1: 2},
+        )
+        == 13 * 128
+    )
+    assert (
+        lx_relayout_module.partition_physical_span_bytes(
+            (5, 5, 64),
+            (512, 64, 1),
+            64,
+            {0: 2, 1: 2},
+        )
+        == 19 * 128
+    )
+
+
+def test_grouped_gather_mapping_is_derived_after_alignment():
+    h, local = Symbol("h"), Symbol("local")
+    source = TensorWorkDivision(
+        {h: 4, local: 8},
+        {h: Mod(floor(_CORE_ID / 8), 4), local: Mod(_CORE_ID, 8)},
+    )
+    destination = TensorWorkDivision({h: 4}, {h: Mod(_CORE_ID, 4)})
+    args = [
+        TensorArg(
+            True,
+            -1,
+            DataFormats.SEN169_FP16,
+            [4, 8, 64],
+            [h, local, Integer(0)],
+            {"lx": 0},
+            work_division=source,
+        ),
+        TensorArg(
+            False,
+            -1,
+            DataFormats.SEN169_FP16,
+            [4, 8, 64],
+            [h, local, Integer(0)],
+            {"lx": 1024},
+            work_division=destination,
+        ),
+    ]
+    spec = OpSpec(
+        IDENTITY_OP,
+        False,
+        {h: (Integer(4), 4), local: (Integer(8), 8)},
+        args,
+        {},
+    )
+
+    simplify_op_spec(spec)
+    source_owner, destination_owner = [arg.work_division for arg in spec.args]
+    assert source_owner is not None and destination_owner is not None
+    assert source_owner.core_id_to_work_slice != source.core_id_to_work_slice
+    destination_dim = next(iter(destination_owner.core_id_to_work_slice))
+    assert [
+        int(
+            destination_owner.core_id_to_work_slice[destination_dim].subs(
+                _CORE_ID, core
+            )
+        )
+        for core in range(32)
+    ] == [owner for owner in range(4) for _ in range(8)]
+
+
 def test_lx_relayout_activation_policy_is_source_wide():
     dep = SimpleNamespace(name="input")
     producer = SimpleNamespace()
@@ -830,6 +925,57 @@ def test_lx_relayout_consumers_share_destination_view(second_consumer):
     if not shares_destination:
         expected_destinations.add("sympify('c0'): 8")
     assert {pair[1] for pair in divisions} == expected_destinations
+
+
+@config.patch(
+    {
+        "sencores": 32,
+        "lx_planning": True,
+        "allow_all_ops_in_lx_planning": True,
+        "lx_planner_relayout": True,
+        "layout_solver": "greedy",
+    }
+)
+@pytest.mark.parametrize(
+    ("num_heads", "key_length", "query_length", "key_split"),
+    ((4, 128, 8, 8), (8, 64, 4, 4)),
+)
+def test_grouped_lx_gather_device(num_heads, key_length, query_length, key_split):
+    torch.manual_seed(0)
+    value = torch.randn(num_heads, key_length, 64, dtype=torch.float16)
+    attention = torch.randn(num_heads, query_length, key_length, dtype=torch.float16)
+    for name, size in (
+        ("H", num_heads),
+        ("Lk", key_length),
+        ("Lq", query_length),
+        ("D", 64),
+    ):
+        _declare_tensor_dim(name, size)
+
+    def fn(value, attention):
+        with spyre_hint(work_div={"H": num_heads, "Lk": key_split}):
+            hidden = torch.neg(value)
+        with spyre_hint(work_div={"H": num_heads, "Lq": query_length}):
+            return torch.bmm(attention, hidden)
+
+    device_args = (
+        _name_tensor_dims(value.to("spyre"), ["H", "Lk", "D"]),
+        _name_tensor_dims(attention.to("spyre"), ["H", "Lq", "Lk"]),
+    )
+    torch._inductor.codecache.FxGraphCache.clear()
+    actual, code = run_and_get_code(
+        torch.compile(fn, dynamic=False, options={"epilogue_fusion": False}),
+        *device_args,
+    )
+    torch.testing.assert_close(actual.cpu(), fn(value, attention), rtol=2e-2, atol=1e-1)
+    identities = [
+        block
+        for block in "\n".join(code).split("OpSpec(")
+        if "op='identity'" in block[:100]
+    ]
+    assert len(identities) == 1
+    assert identities[0].count("allocation={'lx':") == 2
+    assert identities[0].count("TensorWorkDivision(") == 2
 
 
 def test_lx_relayout_allocation_is_atomic_in_one_greedy_solve(caplog):

--- a/torch_spyre/_inductor/core_mapping.py
+++ b/torch_spyre/_inductor/core_mapping.py
@@ -347,6 +347,8 @@ def core_mappings_equal(
         for dim in left
         for core in range(num_cores)
     )
+
+
 def partition_physical_span_bytes(
     device_size: Sequence[int],
     stride_map: Sequence[int],

--- a/torch_spyre/_inductor/core_mapping.py
+++ b/torch_spyre/_inductor/core_mapping.py
@@ -347,3 +347,32 @@ def core_mappings_equal(
         for dim in left
         for core in range(num_cores)
     )
+def partition_physical_span_bytes(
+    device_size: Sequence[int],
+    stride_map: Sequence[int],
+    elems_per_stick: int,
+    split_by_device_dim: Mapping[int, int],
+) -> int:
+    """Return the largest per-core physical span for a partition.
+
+    A slice is a rectangle cut from the original strided tensor. Its storage
+    span can exceed its element count because rows may retain padding between
+    them. The final device dimension is one 128-byte stick and is never split.
+    """
+
+    if len(device_size) != len(stride_map) or not device_size:
+        raise ValueError("device size and stride map must have the same rank")
+    if elems_per_stick <= 0:
+        raise ValueError("elems_per_stick must be positive")
+
+    max_offset_elems = 0
+    for dim, (extent, stride) in enumerate(zip(device_size[:-1], stride_map[:-1])):
+        split = int(split_by_device_dim.get(dim, 1))
+        if split <= 0:
+            raise ValueError(f"invalid split {split} on device dimension {dim}")
+        slice_extent = math.ceil(int(extent) / split)
+        if int(stride) > 0:
+            max_offset_elems += (slice_extent - 1) * int(stride)
+
+    sticks = math.ceil((max_offset_elems + elems_per_stick) / elems_per_stick)
+    return sticks * 128

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -2381,6 +2381,42 @@ class PerCoreView:
     num_cores: int | None = None
 
 
+def per_core_views_equal(left: PerCoreView, right: PerCoreView) -> bool:
+    """Whether two physical views assign every core the same tensor slice.
+
+    SymPy expressions are implementation spellings, not ownership.  Compare
+    the concrete slot selected for every physical core so semantically equal
+    expressions cannot create a false relayout or a false mismatch.
+    """
+
+    left_splits = dict(left.work_slice_dims)
+    right_splits = dict(right.work_slice_dims)
+    left_slots = dict(left.core_to_slot)
+    right_slots = dict(right.core_to_slot)
+    if (
+        len(left_splits) != len(left.work_slice_dims)
+        or len(right_splits) != len(right.work_slice_dims)
+        or len(left_slots) != len(left.core_to_slot)
+        or len(right_slots) != len(right.core_to_slot)
+        or left_splits != right_splits
+        or left_slots.keys() != right_slots.keys()
+        or left.num_cores is None
+        or left.num_cores != right.num_cores
+    ):
+        return False
+
+    core_id = Symbol("core_id")
+    try:
+        return all(
+            int(left_slots[dim].subs(core_id, core))
+            == int(right_slots[dim].subs(core_id, core))
+            for dim in left_slots
+            for core in range(left.num_cores)
+        )
+    except (TypeError, ValueError):
+        return False
+
+
 def _is_matmul_op(op: Operation) -> bool:
     return (
         isinstance(op, ComputedBuffer)

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -40,13 +40,12 @@ from torch.utils._ordered_set import OrderedSet
 from .spyre_kernel import SpyreKernel
 from .ir import FixedTiledLayout
 from .pass_utils import (
+    AlignmentAccess,
     PerCoreView,
     _is_matmul_op,
-    alignment_coordinates,
-    indirect_sizes_from_op,
+    build_operation_alignment_inputs,
     iteration_space,
     iteration_space_from_op,
-    iteration_space_with_splits,
     per_core_view_scheduled,
     try_device_coordinates,
 )
@@ -68,9 +67,8 @@ from .scratchpad.lx_relayout import (
     work_division_from_view,
 )
 from .op_spec import LoopSpec, TensorWorkDivision
-from .views import align_tensors
+from .views import align_tensors_pure
 from . import config as _spyre_config
-from .errors import Unsupported
 
 logger = get_inductor_logger("scheduler")
 
@@ -486,6 +484,7 @@ def _preview_final_lx_views(
     node: SchedulerNode,
     *,
     relayout_copy: bool,
+    tracked_buffers: set[str],
 ) -> tuple[dict[tuple[str, str], FinalLXView], bool]:
     """Run codegen's pure alignment and derive this op's final physical views.
 
@@ -503,18 +502,6 @@ def _preview_final_lx_views(
         raise ValueError(f"{node.get_name()} has no computed operation")
 
     raw_iteration_space = iteration_space(node)
-    aligned_input_space = iteration_space_with_splits(op, rw, raw_iteration_space)
-    indirect_sizes = indirect_sizes_from_op(op)
-    if indirect_sizes:
-        # Re-executing the op to recover indirect ranges can create equivalent
-        # SymPy symbols with different assumptions. Bind the scheduler's actual
-        # index symbol to the recovered range, just as codegen does directly.
-        size_by_name = {str(dim): size for dim, size in indirect_sizes.items()}
-        for dep in (*reads, *writes):
-            for dim in dep.index.free_symbols - raw_iteration_space.keys():
-                if dim not in indirect_sizes and str(dim) in size_by_name:
-                    indirect_sizes[dim] = size_by_name[str(dim)]
-    repeat_info: dict[sympy.Symbol, dict] = {}
     entries = []
     for dep in (*reads, *writes):
         buffer = V.graph.try_get_buffer(dep.name)
@@ -526,39 +513,32 @@ def _preview_final_lx_views(
             continue
         if not isinstance(layout, FixedTiledLayout):
             continue
-        coordinates = alignment_coordinates(
-            layout.device_layout,
-            dep.index,
-            raw_iteration_space,
-            indirect_sizes,
-            repeat_info_out=repeat_info,
-        )
+        entries.append((dep.name, layout, dep.index))
+
+    alignment_inputs = build_operation_alignment_inputs(
+        raw_iteration_space,
+        [AlignmentAccess(layout.device_layout, index) for _, layout, index in entries],
+        op=op,
+        read_writes=rw,
+    )
+    divisions = []
+    for (_, layout, _), tensor in zip(entries, alignment_inputs.tensors):
+        coordinates = tensor["coordinates"]
         division = work_division_from_view(
             layout.lx_view if "lx" in layout.allocation else None,
             coordinates,
             tuple(raw_iteration_space),
         )
-        entries.append((dep.name, layout, coordinates, division))
+        divisions.append(division)
 
-    final_space, final_tensors, dimension_remap = align_tensors(
-        aligned_input_space,
-        [
-            {
-                "size": list(layout.device_layout.device_size),
-                "coordinates": coordinates,
-            }
-            for _, layout, coordinates, _ in entries
-        ],
-        indirect_sizes,
-        repeat_info=repeat_info,
-    )
+    final_space, final_tensors, dimension_remap = align_tensors_pure(alignment_inputs)
     changed = any(
         len(new_dims) != 1 or new_dims[0][0] != old_dim
         for old_dim, new_dims in dimension_remap.items()
     )
     remapped = [
         remap_work_division(division, dimension_remap) if division is not None else None
-        for *_, division in entries
+        for division in divisions
     ]
     finalized = finalize_tensor_work_divisions(final_space, remapped)
 
@@ -586,10 +566,8 @@ def _preview_final_lx_views(
         )
 
     result: dict[tuple[str, str], FinalLXView] = {}
-    for (name, layout, _, _), tensor, division in zip(
-        entries, final_tensors, finalized
-    ):
-        if "lx" not in layout.allocation:
+    for (name, layout, _), tensor, division in zip(entries, final_tensors, finalized):
+        if "lx" not in layout.allocation or name not in tracked_buffers:
             continue
         effective = division if relayout_copy else operation_division
         if effective is None:
@@ -644,6 +622,11 @@ def demote_incoherent_lx_buffers(
         copy_name: plan.source_name for copy_name, plan in plans_by_copy.items()
     }
     relayout_sources = set(source_by_copy.values())
+    relayout_buffers = {
+        name
+        for copy_name, plan in plans_by_copy.items()
+        for name in (plan.source_name, copy_name)
+    }
 
     copy_reads = set()
     valid_copy_nodes = set()
@@ -687,6 +670,24 @@ def demote_incoherent_lx_buffers(
         if copy_name not in seen_copies:
             invalid_sources[plan.source_name] = f"missing relayout copy {copy_name}"
 
+    # Validation coverage is partitioned by the plan registry. Ordinary LX
+    # buffers retain the scheduler's established view-equality validation;
+    # registered non-canonical handoffs use the graph-wide C4 gate below.
+    # Future non-canonical residency must first register its buffers here.
+    resident_relayout_buffers = {
+        name
+        for name in relayout_buffers
+        if (layout := _fixed_tiled_layout(name)) is not None
+        and "lx" in layout.allocation
+    }
+    resident_lx_buffers = set(lx_names) | resident_relayout_buffers
+    registered_lx_buffers = resident_lx_buffers & relayout_buffers
+    ordinary_lx_buffers = OrderedSet(
+        name for name in lx_names if name not in relayout_buffers
+    )
+    assert registered_lx_buffers.isdisjoint(set(ordinary_lx_buffers))
+    assert registered_lx_buffers | set(ordinary_lx_buffers) == resident_lx_buffers
+
     demoted = set()
 
     def demote(source_name: str, reason: str) -> None:
@@ -708,7 +709,7 @@ def demote_incoherent_lx_buffers(
     for source_name, reason in invalid_sources.items():
         demote(source_name, reason)
 
-    for name in lx_names:
+    for name in ordinary_lx_buffers:
         ref = None
         culprit = None
         expected = _lx_view(name)
@@ -772,9 +773,13 @@ def demote_incoherent_lx_buffers(
         for dep in accesses:
             demote(source_by_copy.get(dep.name, dep.name), reason)
 
+    if not relayout_buffers:
+        set_final_lx_views(V.graph, {})
+        return nodes
+
     # Preview the same alignment calculation codegen will run, while atomic
     # fallback is still possible. This is the graph-wide proof point: all
-    # producer, copy, and consumer views coexist here.
+    # producer, copy, and consumer views for each relayout coexist here.
     source_by_buffer = {
         plan.source_name: plan.source_name for plan in plans_by_copy.values()
     }
@@ -792,15 +797,19 @@ def demote_incoherent_lx_buffers(
         }
         if not lx_buffers:
             continue
+        tracked_buffers = lx_buffers & relayout_buffers
+        if not tracked_buffers:
+            continue
         try:
             views, changed = _preview_final_lx_views(
                 node,
                 relayout_copy=node.get_name() in valid_copy_nodes,
+                tracked_buffers=tracked_buffers,
             )
         except (Unsupported, ValueError) as exc:
             reason = f"{node.get_name()} alignment preview failed: {exc}"
             counters["torch_spyre"]["lx_relayout_gate_preview_failures"] += 1
-            for name in lx_buffers:
+            for name in tracked_buffers:
                 demote(source_by_buffer.get(name, name), reason)
             continue
         previewed_ops += 1
@@ -809,24 +818,6 @@ def demote_incoherent_lx_buffers(
 
     counters["torch_spyre"]["lx_relayout_gate_previewed_ops"] += previewed_ops
     counters["torch_spyre"]["lx_relayout_gate_alignment_changed_ops"] += changed_ops
-
-    relayout_buffers = {
-        name
-        for copy_name, plan in plans_by_copy.items()
-        for name in (plan.source_name, copy_name)
-    }
-    for name in lx_names - relayout_buffers:
-        buffer_views = {
-            view
-            for (_, buffer_name), view in preview_views.items()
-            if buffer_name == name
-        }
-        if len(buffer_views) != 1:
-            counters["torch_spyre"]["lx_relayout_gate_ordinary_mismatch"] += 1
-            demote(
-                name,
-                f"ordinary LX handoff derived {len(buffer_views)} final views",
-            )
 
     checked_groups = 0
     for copy_name, plan in list(materialized_lx_relayouts(V.graph).values()):
@@ -849,7 +840,11 @@ def demote_incoherent_lx_buffers(
     accepted_views: dict[tuple[str, str], FinalLXView] = {}
     for key, final_view in preview_views.items():
         layout = _fixed_tiled_layout(key[1])
-        if layout is not None and "lx" in layout.allocation:
+        if (
+            key[1] in relayout_buffers
+            and layout is not None
+            and "lx" in layout.allocation
+        ):
             accepted_views[key] = final_view
     set_final_lx_views(V.graph, accepted_views)
     logger.debug(

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -857,13 +857,13 @@ def demote_incoherent_lx_buffers(
     )
 
     accepted_views: dict[tuple[str, str], FinalLXView] = {}
-    for key, view in preview_views.items():
+    for key, final_view in preview_views.items():
         buffer = V.graph.try_get_buffer(key[1])
         if buffer is None:
             continue
         layout = buffer.get_layout()
         if isinstance(layout, FixedTiledLayout) and "lx" in layout.allocation:
-            accepted_views[key] = view
+            accepted_views[key] = final_view
     set_final_lx_views(V.graph, accepted_views)
     logger.debug(
         "LX final-view gate: previewed_ops=%d alignment_changed_ops=%d "

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -46,6 +46,7 @@ from .pass_utils import (
     build_operation_alignment_inputs,
     iteration_space,
     iteration_space_from_op,
+    per_core_views_equal,
     per_core_view_scheduled,
     try_device_coordinates,
 )
@@ -59,6 +60,8 @@ from .logging_utils import get_inductor_logger
 from .scratchpad.lx_relayout import (
     FinalLXView,
     demote_lx_relayout_group,
+    final_lx_views_equal,
+    lx_validation_partitions,
     materialized_lx_relayouts,
     set_final_lx_views,
     validate_final_views,
@@ -586,7 +589,7 @@ def _preview_final_lx_views(
         )
         key = (node.get_name(), name)
         previous = result.setdefault(key, view)
-        if previous != view:
+        if not final_lx_views_equal(previous, view):
             raise ValueError(f"{node.get_name()} accesses {name} with two final views")
     return result, changed
 
@@ -653,7 +656,7 @@ def demote_incoherent_lx_buffers(
             if (
                 source_view is None
                 or destination_view is None
-                or source_view == destination_view
+                or per_core_views_equal(source_view, destination_view)
                 or len(reads) != 1
                 or len(writes) != 1
                 or reads[0].name != plan.source_name
@@ -670,10 +673,10 @@ def demote_incoherent_lx_buffers(
         if copy_name not in seen_copies:
             invalid_sources[plan.source_name] = f"missing relayout copy {copy_name}"
 
-    # Validation coverage is partitioned by the plan registry. Ordinary LX
-    # buffers retain the scheduler's established view-equality validation;
-    # registered non-canonical handoffs use the graph-wide C4 gate below.
-    # Future non-canonical residency must first register its buffers here.
+    # Validation coverage is partitioned by a registry. Ordinary LX buffers
+    # retain the scheduler's established view-equality validation; registered
+    # non-canonical ownership uses its named graph-wide validator. Every LX
+    # resident buffer must belong to exactly one partition.
     resident_relayout_buffers = {
         name
         for name in relayout_buffers
@@ -681,12 +684,23 @@ def demote_incoherent_lx_buffers(
         and "lx" in layout.allocation
     }
     resident_lx_buffers = set(lx_names) | resident_relayout_buffers
-    registered_lx_buffers = resident_lx_buffers & relayout_buffers
+    validation_partitions = {
+        category: resident_lx_buffers & names
+        for category, names in lx_validation_partitions(V.graph).items()
+    }
+    registered_lx_buffers = set().union(*validation_partitions.values())
     ordinary_lx_buffers = OrderedSet(
-        name for name in lx_names if name not in relayout_buffers
+        name for name in lx_names if name not in registered_lx_buffers
     )
-    assert registered_lx_buffers.isdisjoint(set(ordinary_lx_buffers))
-    assert registered_lx_buffers | set(ordinary_lx_buffers) == resident_lx_buffers
+    all_partitions = [*validation_partitions.values(), set(ordinary_lx_buffers)]
+    assert all(
+        left.isdisjoint(right)
+        for index, left in enumerate(all_partitions)
+        for right in all_partitions[index + 1 :]
+    ), "LX buffer belongs to more than one validation partition"
+    assert set().union(*all_partitions) == resident_lx_buffers, (
+        "every LX buffer must have exactly one validation authority"
+    )
 
     demoted = set()
 

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -48,11 +48,34 @@ from .scratchpad.lx_relayout import (
     materialized_lx_relayouts,
     work_division_from_view,
 )
-from .op_spec import LoopSpec
+from .op_spec import LoopSpec, TensorWorkDivision
 from . import config as _spyre_config
 from .errors import Unsupported
 
 logger = get_inductor_logger("scheduler")
+
+
+def _scheduled_work_division(
+    node: SchedulerNode,
+    dep: MemoryDep,
+    name: str,
+    view: PerCoreView,
+) -> TensorWorkDivision | None:
+    """Project a physical partition into final scheduled loop symbols."""
+
+    buffer = V.graph.try_get_buffer(name)
+    if buffer is None:
+        return None
+    layout = buffer.get_layout()
+    if not isinstance(layout, FixedTiledLayout):
+        return None
+    coordinates = try_device_coordinates(layout.device_layout, dep, None)
+    if coordinates is None:
+        return None
+    try:
+        return work_division_from_view(view, coordinates, tuple(iteration_space(node)))
+    except ValueError:
+        return None
 
 
 def _ownership_projectable(
@@ -61,22 +84,7 @@ def _ownership_projectable(
     name: str,
     view: PerCoreView,
 ) -> bool:
-    """Whether final scheduled coordinates can carry ``view`` into codegen."""
-
-    buffer = V.graph.try_get_buffer(name)
-    if buffer is None:
-        return False
-    layout = buffer.get_layout()
-    if not isinstance(layout, FixedTiledLayout):
-        return False
-    coordinates = try_device_coordinates(layout.device_layout, dep, None)
-    if coordinates is None:
-        return False
-    try:
-        work_division_from_view(view, coordinates, tuple(iteration_space(node)))
-    except ValueError:
-        return False
-    return True
+    return _scheduled_work_division(node, dep, name, view) is not None
 
 
 class CountedLoopSchedulerNode(FusedSchedulerNode):
@@ -362,7 +370,10 @@ def _lx_view(name: str):
     buffer = V.graph.try_get_buffer(name)
     if buffer is None:
         return None
-    layout = buffer.get_layout()
+    try:
+        layout = buffer.get_layout()
+    except NotImplementedError:
+        return None
     if not isinstance(layout, FixedTiledLayout):
         return None
     if "lx" not in layout.allocation:
@@ -452,32 +463,13 @@ def align_lx_producer_loop_order(
 def demote_incoherent_lx_buffers(
     nodes: list[BaseSchedulerNode],
 ) -> list[BaseSchedulerNode]:
-    """Post-fusion pass: drop an LX buffer whose users disagree on core->slice.
+    """Reject LX groups that final scheduled loops cannot represent safely.
 
-    LX planning runs before the Scheduler exists, so it reasons about each op's
-    *pre*-scheduler ranges. ``core_to_slice_mapping`` is positional -- it hands
-    ``core_id`` strides out in iteration-space order -- and Inductor's
-    ``loop_ordering_after_fusion`` may permute a fused op's ranges after planning
-    has already committed. When it permutes one user of an LX buffer and not
-    another, the two disagree about which core owns which slice: each core writes
-    one slice and reads back a different one. LX is per-core scratchpad with no
-    other copy, so the read is silently wrong (#2062).
-
-    Planning cannot see that permutation, so re-check here, where the ranges are
-    final, and demote any buffer whose users no longer agree. Clearing ``"lx"``
-    is all that is needed: this runs before ``hbm_pool_planning``, which claims
-    exactly the intermediates LX did not, so a demoted buffer lands in the HBM
-    intermediates segment on its way through.
-
-    Deliberately verification-only -- it never *adds* residency and never
-    rewrites a loop order, so it cannot perturb a graph whose users already
-    agree.
-
-    Complements :func:`align_lx_producer_loop_order`, which runs pre-fusion and
-    rewrites a producer's loop order to match its consumers'. That pass fixes the
-    incoherence it can reach; this one is the backstop for what it cannot -- a
-    disagreement introduced after it ran, or a view too irregular to represent --
-    where the only safe answer is to give up LX residency.
+    The planner preserves physical partition geometry, not a final core map.
+    After fusion this pass checks that every producer, copy, and consumer can
+    still project that geometry into its scheduled loops. The final mapping is
+    derived later from those loops. A failed check demotes the complete source
+    group before HBM-pool planning, so no partial relayout survives.
     """
     if not _spyre_config.lx_planning:
         return nodes
@@ -501,6 +493,7 @@ def demote_incoherent_lx_buffers(
     relayout_sources = set(source_by_copy.values())
 
     copy_reads = set()
+    valid_copy_nodes = set()
     invalid_sources = {}
     seen_copies = set()
     for node in scheduled:
@@ -535,6 +528,7 @@ def demote_incoherent_lx_buffers(
             ):
                 invalid_sources[plan.source_name] = f"invalid relayout copy {dep.name}"
             else:
+                valid_copy_nodes.add(node.get_name())
                 copy_reads.add((node.get_name(), plan.source_name))
     for copy_name, plan in plans_by_copy.items():
         if copy_name not in seen_copies:
@@ -576,8 +570,11 @@ def demote_incoherent_lx_buffers(
                 culprit = f"{node.get_name()} view unrepresentable"
                 break
             if expected is not None:
-                if view != expected:
-                    culprit = f"{node.get_name()} view {view} != {expected}"
+                if view.work_slice_dims != expected.work_slice_dims:
+                    culprit = (
+                        f"{node.get_name()} split geometry "
+                        f"{view.work_slice_dims} != {expected.work_slice_dims}"
+                    )
                     break
                 if not _ownership_projectable(node, dep, name, expected):
                     culprit = f"{node.get_name()} ownership unprojectable"
@@ -591,6 +588,37 @@ def demote_incoherent_lx_buffers(
         if culprit is None:
             continue
         demote(source_by_copy.get(name, name), culprit)
+
+    # An ordinary operation has one execution mapping. Accepted LX tensors may
+    # constrain it, but they cannot demand different split counts for one loop.
+    for node in scheduled:
+        accesses = [
+            dep
+            for dep in (*node.read_writes.reads, *node.read_writes.writes)
+            if isinstance(dep, MemoryDep) and _lx_view(dep.name) is not None
+        ]
+        if len(accesses) < 2 or node.get_name() in valid_copy_nodes:
+            continue
+        merged_splits = {}
+        conflict = False
+        for dep in accesses:
+            view = _lx_view(dep.name)
+            assert view is not None
+            division = _scheduled_work_division(node, dep, dep.name, view)
+            if division is None:
+                continue
+            for dim, split in division.work_slices.items():
+                previous = merged_splits.setdefault(dim, int(split))
+                if previous != int(split):
+                    conflict = True
+                    break
+            if conflict:
+                break
+        if not conflict:
+            continue
+        reason = f"{node.get_name()} has incompatible LX split geometry"
+        for dep in accesses:
+            demote(source_by_copy.get(dep.name, dep.name), reason)
 
     return nodes
 

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -75,6 +75,17 @@ from .errors import Unsupported
 logger = get_inductor_logger("scheduler")
 
 
+def _fixed_tiled_layout(name: str) -> FixedTiledLayout | None:
+    buffer = V.graph.try_get_buffer(name)
+    if buffer is None:
+        return None
+    try:
+        layout = buffer.get_layout()
+    except NotImplementedError:
+        return None
+    return layout if isinstance(layout, FixedTiledLayout) else None
+
+
 def _scheduled_work_division(
     node: SchedulerNode,
     dep: MemoryDep,
@@ -83,11 +94,8 @@ def _scheduled_work_division(
 ) -> TensorWorkDivision | None:
     """Project a physical partition into final scheduled loop symbols."""
 
-    buffer = V.graph.try_get_buffer(name)
-    if buffer is None:
-        return None
-    layout = buffer.get_layout()
-    if not isinstance(layout, FixedTiledLayout):
+    layout = _fixed_tiled_layout(name)
+    if layout is None:
         return None
     coordinates = try_device_coordinates(layout.device_layout, dep, None)
     if coordinates is None:
@@ -387,14 +395,8 @@ def _lx_resident(node: SchedulerNode) -> bool:
 
 
 def _lx_view(name: str):
-    buffer = V.graph.try_get_buffer(name)
-    if buffer is None:
-        return None
-    try:
-        layout = buffer.get_layout()
-    except NotImplementedError:
-        return None
-    if not isinstance(layout, FixedTiledLayout):
+    layout = _fixed_tiled_layout(name)
+    if layout is None:
         return None
     if "lx" not in layout.allocation:
         return None
@@ -697,12 +699,10 @@ def demote_incoherent_lx_buffers(
             counters["torch_spyre"]["lx_relayout_gate_demoted_with_hbm_clone"] += 1
             demote_lx_relayout_group(V.graph, source_name, reason)
             return
-        buffer = V.graph.try_get_buffer(source_name)
-        if buffer is not None:
-            layout = buffer.get_layout()
-            if isinstance(layout, FixedTiledLayout):
-                layout.allocation.pop("lx", None)
-                layout.lx_view = None
+        layout = _fixed_tiled_layout(source_name)
+        if layout is not None:
+            layout.allocation.pop("lx", None)
+            layout.lx_view = None
         logger.info("demoted %s out of LX: %s", source_name, reason)
 
     for source_name, reason in invalid_sources.items():
@@ -787,11 +787,8 @@ def demote_incoherent_lx_buffers(
             dep.name
             for dep in (*node.read_writes.reads, *node.read_writes.writes)
             if isinstance(dep, MemoryDep)
-            and (
-                (buffer := V.graph.try_get_buffer(dep.name)) is not None
-                and isinstance((layout := buffer.get_layout()), FixedTiledLayout)
-                and "lx" in layout.allocation
-            )
+            and (layout := _fixed_tiled_layout(dep.name)) is not None
+            and "lx" in layout.allocation
         }
         if not lx_buffers:
             continue
@@ -851,11 +848,8 @@ def demote_incoherent_lx_buffers(
 
     accepted_views: dict[tuple[str, str], FinalLXView] = {}
     for key, final_view in preview_views.items():
-        buffer = V.graph.try_get_buffer(key[1])
-        if buffer is None:
-            continue
-        layout = buffer.get_layout()
-        if isinstance(layout, FixedTiledLayout) and "lx" in layout.allocation:
+        layout = _fixed_tiled_layout(key[1])
+        if layout is not None and "lx" in layout.allocation:
             accepted_views[key] = final_view
     set_final_lx_views(V.graph, accepted_views)
     logger.debug(

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -14,6 +14,8 @@
 
 from typing import Iterator, Sequence, Union
 
+import math
+
 import sympy
 
 from torch._inductor.utils import IndentedBuffer
@@ -23,6 +25,7 @@ from torch._inductor.utils import (
     sympy_product,
 )
 from torch._inductor.dependencies import MemoryDep
+from torch._inductor.ir import ComputedBuffer
 from torch._inductor.scheduler import (
     BaseScheduling,
     BaseSchedulerNode,
@@ -31,24 +34,41 @@ from torch._inductor.scheduler import (
 )
 from torch._inductor.virtualized import V
 from torch._inductor.codecache import code_hash
+from torch._dynamo.utils import counters
 from torch.utils._ordered_set import OrderedSet
 
 from .spyre_kernel import SpyreKernel
 from .ir import FixedTiledLayout
 from .pass_utils import (
     PerCoreView,
+    _is_matmul_op,
+    apply_splits_from_index_coeff,
+    concretize_index,
+    indirect_sizes_from_op,
     iteration_space,
     iteration_space_from_op,
     per_core_view_scheduled,
+    select_work_division_transport_indexes,
     try_device_coordinates,
 )
+from .core_mapping import (
+    derive_operation_mapping,
+    finalize_tensor_work_divisions,
+    remap_work_division,
+)
+from .errors import Unsupported
 from .logging_utils import get_inductor_logger
 from .scratchpad.lx_relayout import (
+    FinalLXView,
     demote_lx_relayout_group,
     materialized_lx_relayouts,
+    set_final_lx_views,
+    validate_final_views,
+    final_view_from_work_division,
     work_division_from_view,
 )
 from .op_spec import LoopSpec, TensorWorkDivision
+from .views import align_tensors, compute_coordinates
 from . import config as _spyre_config
 from .errors import Unsupported
 
@@ -460,6 +480,145 @@ def align_lx_producer_loop_order(
     return nodes
 
 
+def _preview_final_lx_views(
+    node: SchedulerNode,
+    *,
+    relayout_copy: bool,
+) -> tuple[dict[tuple[str, str], FinalLXView], bool]:
+    """Run codegen's pure alignment and derive this op's final physical views.
+
+    The preview is read-only. It consumes scheduler-final ranges and tensor
+    coordinates, then uses the same alignment and mapping helpers as codegen.
+    """
+
+    rw = node.read_writes
+    reads = [dep for dep in rw.reads if isinstance(dep, MemoryDep)]
+    writes = [dep for dep in rw.writes if isinstance(dep, MemoryDep)]
+    if not writes:
+        raise ValueError(f"{node.get_name()} has no concrete output dependency")
+    op = node.node
+    if not isinstance(op, ComputedBuffer):
+        raise ValueError(f"{node.get_name()} has no computed operation")
+
+    raw_iteration_space = iteration_space(node)
+    write_index, read_index = select_work_division_transport_indexes(
+        op, rw, raw_iteration_space
+    )
+    split_by_dim = apply_splits_from_index_coeff(
+        getattr(op, "op_it_space_splits", ({}, {})),
+        write_index,
+        read_index,
+        raw_iteration_space,
+    )
+    aligned_input_space = {
+        dim: (extent, int(split_by_dim.get(dim, 1)))
+        for dim, extent in raw_iteration_space.items()
+    }
+    indirect_sizes = indirect_sizes_from_op(op)
+    if indirect_sizes:
+        # Re-executing the op to recover indirect ranges can create equivalent
+        # SymPy symbols with different assumptions. Bind the scheduler's actual
+        # index symbol to the recovered range, just as codegen does directly.
+        size_by_name = {str(dim): size for dim, size in indirect_sizes.items()}
+        for dep in (*reads, *writes):
+            for dim in dep.index.free_symbols - raw_iteration_space.keys():
+                if dim not in indirect_sizes and str(dim) in size_by_name:
+                    indirect_sizes[dim] = size_by_name[str(dim)]
+    repeat_info: dict[sympy.Symbol, dict] = {}
+    entries = []
+    for dep in (*reads, *writes):
+        buffer = V.graph.try_get_buffer(dep.name)
+        if buffer is None:
+            continue
+        try:
+            layout = buffer.get_layout()
+        except NotImplementedError:
+            continue
+        if not isinstance(layout, FixedTiledLayout):
+            continue
+        index = concretize_index(dep.index, set(raw_iteration_space))
+        coordinates = compute_coordinates(
+            layout.device_layout.device_size,
+            layout.device_layout.stride_map,
+            raw_iteration_space,
+            index,
+            indirect_sizes,
+            repeat_info_out=repeat_info,
+        )
+        division = work_division_from_view(
+            layout.lx_view if "lx" in layout.allocation else None,
+            coordinates,
+            tuple(raw_iteration_space),
+        )
+        entries.append((dep.name, layout, coordinates, division))
+
+    final_space, final_tensors, dimension_remap = align_tensors(
+        aligned_input_space,
+        [
+            {
+                "size": list(layout.device_layout.device_size),
+                "coordinates": coordinates,
+            }
+            for _, layout, coordinates, _ in entries
+        ],
+        indirect_sizes,
+        repeat_info=repeat_info,
+    )
+    changed = any(
+        len(new_dims) != 1 or new_dims[0][0] != old_dim
+        for old_dim, new_dims in dimension_remap.items()
+    )
+    remapped = [
+        remap_work_division(division, dimension_remap) if division is not None else None
+        for *_, division in entries
+    ]
+    finalized = finalize_tensor_work_divisions(final_space, remapped)
+
+    operation_division = None
+    if not relayout_copy:
+        contiguous_dim = (
+            next(reversed(final_space))
+            if final_space
+            and _is_matmul_op(op)
+            and _spyre_config.core_id_k_fast_emission
+            else None
+        )
+        mapping = derive_operation_mapping(
+            final_space,
+            finalized,
+            contiguous_dim=contiguous_dim,
+        )
+        work_slices = {
+            dim: int(split) for dim, (_, split) in final_space.items() if int(split) > 1
+        }
+        operation_division = TensorWorkDivision(
+            work_slices,
+            {dim: mapping[dim] for dim in work_slices},
+            num_cores=math.prod(int(split) for _, split in final_space.values()),
+        )
+
+    result: dict[tuple[str, str], FinalLXView] = {}
+    for (name, layout, _, _), tensor, division in zip(
+        entries, final_tensors, finalized
+    ):
+        if "lx" not in layout.allocation:
+            continue
+        effective = division if relayout_copy else operation_division
+        if effective is None:
+            raise ValueError(f"{node.get_name()} has no final ownership for {name}")
+        view = final_view_from_work_division(
+            effective,
+            tensor["size"],
+            tensor["coordinates"],
+            final_space,
+        )
+        key = (node.get_name(), name)
+        previous = result.setdefault(key, view)
+        if previous != view:
+            raise ValueError(f"{node.get_name()} accesses {name} with two final views")
+    return result, changed
+
+
 def demote_incoherent_lx_buffers(
     nodes: list[BaseSchedulerNode],
 ) -> list[BaseSchedulerNode]:
@@ -599,7 +758,7 @@ def demote_incoherent_lx_buffers(
         ]
         if len(accesses) < 2 or node.get_name() in valid_copy_nodes:
             continue
-        merged_splits = {}
+        merged_splits: dict[sympy.Symbol, int] = {}
         conflict = False
         for dep in accesses:
             view = _lx_view(dep.name)
@@ -619,6 +778,101 @@ def demote_incoherent_lx_buffers(
         reason = f"{node.get_name()} has incompatible LX split geometry"
         for dep in accesses:
             demote(source_by_copy.get(dep.name, dep.name), reason)
+
+    # Preview the same alignment calculation codegen will run, while atomic
+    # fallback is still possible. This is the graph-wide proof point: all
+    # producer, copy, and consumer views coexist here.
+    source_by_buffer = {
+        plan.source_name: plan.source_name for plan in plans_by_copy.values()
+    }
+    source_by_buffer.update(source_by_copy)
+    preview_views: dict[tuple[str, str], FinalLXView] = {}
+    changed_ops = 0
+    previewed_ops = 0
+    for node in scheduled:
+        lx_buffers = {
+            dep.name
+            for dep in (*node.read_writes.reads, *node.read_writes.writes)
+            if isinstance(dep, MemoryDep)
+            and (
+                (buffer := V.graph.try_get_buffer(dep.name)) is not None
+                and isinstance((layout := buffer.get_layout()), FixedTiledLayout)
+                and "lx" in layout.allocation
+            )
+        }
+        if not lx_buffers:
+            continue
+        try:
+            views, changed = _preview_final_lx_views(
+                node,
+                relayout_copy=node.get_name() in valid_copy_nodes,
+            )
+        except (Unsupported, ValueError) as exc:
+            reason = f"{node.get_name()} alignment preview failed: {exc}"
+            counters["torch_spyre"]["lx_relayout_gate_preview_failures"] += 1
+            for name in lx_buffers:
+                demote(source_by_buffer.get(name, name), reason)
+            continue
+        previewed_ops += 1
+        changed_ops += int(changed)
+        preview_views.update(views)
+
+    counters["torch_spyre"]["lx_relayout_gate_previewed_ops"] += previewed_ops
+    counters["torch_spyre"]["lx_relayout_gate_alignment_changed_ops"] += changed_ops
+
+    relayout_buffers = {
+        name
+        for copy_name, plan in plans_by_copy.items()
+        for name in (plan.source_name, copy_name)
+    }
+    for name in lx_names - relayout_buffers:
+        buffer_views = {
+            view
+            for (_, buffer_name), view in preview_views.items()
+            if buffer_name == name
+        }
+        if len(buffer_views) > 1:
+            counters["torch_spyre"]["lx_relayout_gate_ordinary_mismatch"] += 1
+            demote(
+                name,
+                f"ordinary LX handoff derived {len(buffer_views)} final views",
+            )
+
+    checked_groups = 0
+    for copy_name, plan in list(materialized_lx_relayouts(V.graph).values()):
+        if plan.source_name in demoted:
+            continue
+        checked_groups += 1
+        if validation_reason := validate_final_views(
+            V.graph,
+            plan,
+            preview_views,
+            destination_name=copy_name,
+        ):
+            counters["torch_spyre"]["lx_relayout_gate_group_mismatch"] += 1
+            demote(plan.source_name, validation_reason)
+    counters["torch_spyre"]["lx_relayout_gate_checked_groups"] += checked_groups
+    counters["torch_spyre"]["lx_relayout_gate_demoted_groups"] += len(
+        demoted & relayout_sources
+    )
+
+    accepted_views: dict[tuple[str, str], FinalLXView] = {}
+    for key, view in preview_views.items():
+        buffer = V.graph.try_get_buffer(key[1])
+        if buffer is None:
+            continue
+        layout = buffer.get_layout()
+        if isinstance(layout, FixedTiledLayout) and "lx" in layout.allocation:
+            accepted_views[key] = view
+    set_final_lx_views(V.graph, accepted_views)
+    logger.debug(
+        "LX final-view gate: previewed_ops=%d alignment_changed_ops=%d "
+        "checked_groups=%d demoted_groups=%d",
+        previewed_ops,
+        changed_ops,
+        checked_groups,
+        len(demoted & relayout_sources),
+    )
 
     return nodes
 

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -42,13 +42,12 @@ from .ir import FixedTiledLayout
 from .pass_utils import (
     PerCoreView,
     _is_matmul_op,
-    apply_splits_from_index_coeff,
-    concretize_index,
+    alignment_coordinates,
     indirect_sizes_from_op,
     iteration_space,
     iteration_space_from_op,
+    iteration_space_with_splits,
     per_core_view_scheduled,
-    select_work_division_transport_indexes,
     try_device_coordinates,
 )
 from .core_mapping import (
@@ -65,10 +64,11 @@ from .scratchpad.lx_relayout import (
     set_final_lx_views,
     validate_final_views,
     final_view_from_work_division,
+    partition_footprint,
     work_division_from_view,
 )
 from .op_spec import LoopSpec, TensorWorkDivision
-from .views import align_tensors, compute_coordinates
+from .views import align_tensors
 from . import config as _spyre_config
 from .errors import Unsupported
 
@@ -501,19 +501,7 @@ def _preview_final_lx_views(
         raise ValueError(f"{node.get_name()} has no computed operation")
 
     raw_iteration_space = iteration_space(node)
-    write_index, read_index = select_work_division_transport_indexes(
-        op, rw, raw_iteration_space
-    )
-    split_by_dim = apply_splits_from_index_coeff(
-        getattr(op, "op_it_space_splits", ({}, {})),
-        write_index,
-        read_index,
-        raw_iteration_space,
-    )
-    aligned_input_space = {
-        dim: (extent, int(split_by_dim.get(dim, 1)))
-        for dim, extent in raw_iteration_space.items()
-    }
+    aligned_input_space = iteration_space_with_splits(op, rw, raw_iteration_space)
     indirect_sizes = indirect_sizes_from_op(op)
     if indirect_sizes:
         # Re-executing the op to recover indirect ranges can create equivalent
@@ -536,12 +524,10 @@ def _preview_final_lx_views(
             continue
         if not isinstance(layout, FixedTiledLayout):
             continue
-        index = concretize_index(dep.index, set(raw_iteration_space))
-        coordinates = compute_coordinates(
-            layout.device_layout.device_size,
-            layout.device_layout.stride_map,
+        coordinates = alignment_coordinates(
+            layout.device_layout,
+            dep.index,
             raw_iteration_space,
-            index,
             indirect_sizes,
             repeat_info_out=repeat_info,
         )
@@ -606,11 +592,17 @@ def _preview_final_lx_views(
         effective = division if relayout_copy else operation_division
         if effective is None:
             raise ValueError(f"{node.get_name()} has no final ownership for {name}")
+        physical_span_bytes = (
+            partition_footprint(layout, layout.lx_view)
+            if layout.lx_view is not None
+            else None
+        )
         view = final_view_from_work_division(
             effective,
             tensor["size"],
             tensor["coordinates"],
             final_space,
+            physical_span_bytes=physical_span_bytes,
         )
         key = (node.get_name(), name)
         previous = result.setdefault(key, view)
@@ -702,6 +694,7 @@ def demote_incoherent_lx_buffers(
         if source_name in relayout_sources:
             # Scheduling supplies the final ownership verdict; the relayout
             # layer owns atomic group fallback and registry cleanup.
+            counters["torch_spyre"]["lx_relayout_gate_demoted_with_hbm_clone"] += 1
             demote_lx_relayout_group(V.graph, source_name, reason)
             return
         buffer = V.graph.try_get_buffer(source_name)
@@ -831,7 +824,7 @@ def demote_incoherent_lx_buffers(
             for (_, buffer_name), view in preview_views.items()
             if buffer_name == name
         }
-        if len(buffer_views) > 1:
+        if len(buffer_views) != 1:
             counters["torch_spyre"]["lx_relayout_gate_ordinary_mismatch"] += 1
             demote(
                 name,

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -997,15 +997,21 @@ class ScratchpadAllocator:
             if name in partition_footprints:
                 info["size_per_core"] = partition_footprints[name]
         for plan in lx_relayout_plans:
+            core_counts = {
+                plan.source_name: plan.source_view.num_cores or plan.num_cores,
+                plan.destination_name: plan.destination_view.num_cores
+                or plan.num_cores,
+            }
             footprints = {
                 plan.source_name: plan.source_footprint_bytes,
                 plan.destination_name: plan.destination_footprint_bytes,
             }
-            for name, footprint in footprints.items():
+            for name, num_cores in core_counts.items():
                 if name not in mem_usage:
                     continue
-                ncores[name] = plan.num_cores
+                ncores[name] = num_cores
                 ncores_reasons.pop(name, None)
+                footprint = footprints[name]
                 footprint = footprint or partition_footprints.get(name, 0)
                 # A source shared by multiple relayouts keeps the largest
                 # source bound. Each private destination keeps its own bound.

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -942,7 +942,8 @@ class ScratchpadAllocator:
                 ncores[name] = plan.num_cores
                 ncores_reasons.pop(name, None)
                 mem_usage[name]["size_per_core"] = (
-                    mem_usage[name]["size"] // plan.num_cores
+                    plan.max_footprint_bytes
+                    or mem_usage[name]["size"] // plan.num_cores
                 )
                 mem_usage[name]["core_div_mismatch"] = False
         t2 = time.perf_counter()
@@ -1040,7 +1041,8 @@ class ScratchpadAllocator:
                 destination = LifetimeBoundBuffer(
                     plan.destination_name,
                     round_up_to_alignment(
-                        source.size, _LX_ALLOCATION_GRANULARITY_BYTES
+                        plan.max_footprint_bytes or source.size,
+                        _LX_ALLOCATION_GRANULARITY_BYTES,
                     ),
                     [transfer_tick, *consumer_ticks],
                     lifetime_end_override=destination_end,

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -45,9 +45,11 @@ from torch_spyre._inductor.pass_utils import (
     op_read_writes,
     _prepare_per_core_view,
     _per_core_view_from_prep,
+    _per_core_view_on_buf,
     _is_matmul_op,
     op_short_name,
 )
+from torch_spyre._inductor.core_mapping import partition_physical_span_bytes
 from torch_spyre._inductor.work_division import (
     enumerate_work_division_candidates,
     work_division_splits_are_legal,
@@ -686,6 +688,7 @@ class ScratchpadAllocator:
         lifetimes: dict[str, list[int]],
         ncores: dict[str, int],
         ncores_reasons: dict[str, str],
+        partition_footprints: dict[str, int],
         lifetime_end_overrides: Optional[dict[str, int]] = None,
     ) -> list[LifetimeBoundBuffer]:
         """Build one :class:`LifetimeBoundBuffer` per buffer, barred or not.
@@ -747,7 +750,7 @@ class ScratchpadAllocator:
                 ncores_reasons=ncores_reasons,
                 division_is_fixed=True,
             )
-            clone_size = self._input_footprint(graph, input_name, ncores)
+            clone_size = partition_footprints.get(input_name, 0)
             buffers.append(
                 LifetimeBoundBuffer(
                     input_name,
@@ -854,18 +857,66 @@ class ScratchpadAllocator:
         )
 
     @staticmethod
-    def _input_footprint(
-        graph: GraphLowering, name: str, ncores: dict[str, int]
-    ) -> int:
-        """Per-core LX footprint of a cloned graph input, or 0 when it has no
-        computable one (in which case ``input_residency_reason`` has already
-        barred it, so the value is never used)."""
-        layout = getattr(graph.get_buffer(name), "layout", None)
-        dev_layout = getattr(layout, "device_layout", None)
-        num_cores = ncores.get(name, -1)
-        if dev_layout is None or num_cores < 1:
-            return 0
-        return math.prod(dev_layout.device_size[:-1]) * 128 // num_cores
+    def _partition_footprints(
+        graph: GraphLowering, ncores: dict[str, int]
+    ) -> dict[str, int]:
+        """Largest physical per-core span for every committed partition."""
+
+        footprints: dict[str, int] = {}
+        cache: dict = {}
+        for op in graph.operations:
+            for dep in (*op_read_writes(op).writes, *op_read_writes(op).reads):
+                if not isinstance(dep, MemoryDep):
+                    continue
+                num_cores = ncores.get(dep.name, -1)
+                if num_cores < 1:
+                    continue
+                buffer = graph.try_get_buffer(dep.name)
+                if buffer is None:
+                    continue
+                layout = buffer.get_layout()
+                if not isinstance(layout, FixedTiledLayout):
+                    continue
+                view, partial, representable = _per_core_view_on_buf(
+                    op, dep, dep.name, cache
+                )
+                if not representable or partial or view.num_cores != num_cores:
+                    continue
+                device_layout = layout.device_layout
+                footprint = partition_physical_span_bytes(
+                    tuple(int(size) for size in device_layout.device_size),
+                    tuple(int(stride) for stride in device_layout.stride_map),
+                    int(device_layout.elems_per_stick()),
+                    dict(view.work_slice_dims),
+                )
+                # The physical span is the ragged/padded-layout bound.  Keep
+                # the historical equal-share size as a lower bound so this
+                # refinement can never shrink an ordinary LX allocation.
+                full_size = math.prod(device_layout.device_size[:-1]) * 128
+                equal_share = math.ceil(full_size / num_cores / 128) * 128
+                footprint = max(footprint, equal_share)
+                footprints[dep.name] = max(footprints.get(dep.name, 0), footprint)
+
+        # The residency gate bars partitions with no valid view. Keep a padded,
+        # full-buffer span as a conservative value so they cannot look cheap if
+        # a future caller reaches allocation before that verdict.
+        for name, num_cores in ncores.items():
+            if num_cores < 1 or name in footprints:
+                continue
+            buffer = graph.try_get_buffer(name)
+            if buffer is None:
+                continue
+            layout = buffer.get_layout()
+            if not isinstance(layout, FixedTiledLayout):
+                continue
+            device_layout = layout.device_layout
+            footprints[name] = partition_physical_span_bytes(
+                tuple(int(size) for size in device_layout.device_size),
+                tuple(int(stride) for stride in device_layout.stride_map),
+                int(device_layout.elems_per_stick()),
+                {},
+            )
+        return footprints
 
     def _determine_in_place(
         self,
@@ -935,17 +986,24 @@ class ScratchpadAllocator:
         ncores, ncores_reasons = get_ncores_for_buffers(graph)
         t1 = time.perf_counter()
         mem_usage = mem_usage_by_buf(graph, cache)
+        partition_footprints = self._partition_footprints(graph, ncores)
+        for name, info in mem_usage.items():
+            if name in partition_footprints:
+                info["size_per_core"] = partition_footprints[name]
         for plan in lx_relayout_plans:
-            for name in (plan.source_name, plan.destination_name):
-                if name not in mem_usage:
-                    continue
-                ncores[name] = plan.num_cores
-                ncores_reasons.pop(name, None)
-                mem_usage[name]["size_per_core"] = (
-                    plan.max_footprint_bytes
-                    or mem_usage[name]["size"] // plan.num_cores
-                )
-                mem_usage[name]["core_div_mismatch"] = False
+            name = plan.source_name
+            if name not in mem_usage:
+                continue
+            ncores[name] = plan.num_cores
+            ncores_reasons.pop(name, None)
+            footprint = plan.max_footprint_bytes or partition_footprints.get(name, 0)
+            # One source may feed differently shaped destinations. Its shared
+            # allocation must satisfy the largest member of the atomic group,
+            # independent of plan iteration order.
+            mem_usage[name]["size_per_core"] = max(
+                mem_usage[name]["size_per_core"], footprint
+            )
+            mem_usage[name]["core_div_mismatch"] = False
         t2 = time.perf_counter()
         if timings is not None:
             timings["residency"] += t1 - t0
@@ -972,6 +1030,7 @@ class ScratchpadAllocator:
             lifetimes=lifetimes,
             ncores=ncores,
             ncores_reasons=ncores_reasons,
+            partition_footprints=partition_footprints,
             lifetime_end_overrides=lifetime_end_overrides,
         )
         if lx_relayout_plans:

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -997,19 +997,22 @@ class ScratchpadAllocator:
             if name in partition_footprints:
                 info["size_per_core"] = partition_footprints[name]
         for plan in lx_relayout_plans:
-            name = plan.source_name
-            if name not in mem_usage:
-                continue
-            ncores[name] = plan.num_cores
-            ncores_reasons.pop(name, None)
-            footprint = plan.max_footprint_bytes or partition_footprints.get(name, 0)
-            # One source may feed differently shaped destinations. Its shared
-            # allocation must satisfy the largest member of the atomic group,
-            # independent of plan iteration order.
-            mem_usage[name]["size_per_core"] = max(
-                mem_usage[name]["size_per_core"], footprint
-            )
-            mem_usage[name]["core_div_mismatch"] = False
+            footprints = {
+                plan.source_name: plan.source_footprint_bytes,
+                plan.destination_name: plan.destination_footprint_bytes,
+            }
+            for name, footprint in footprints.items():
+                if name not in mem_usage:
+                    continue
+                ncores[name] = plan.num_cores
+                ncores_reasons.pop(name, None)
+                footprint = footprint or partition_footprints.get(name, 0)
+                # A source shared by multiple relayouts keeps the largest
+                # source bound. Each private destination keeps its own bound.
+                mem_usage[name]["size_per_core"] = max(
+                    mem_usage[name]["size_per_core"], footprint
+                )
+                mem_usage[name]["core_div_mismatch"] = False
         t2 = time.perf_counter()
         if timings is not None:
             timings["residency"] += t1 - t0
@@ -1106,7 +1109,7 @@ class ScratchpadAllocator:
                 destination = LifetimeBoundBuffer(
                     plan.destination_name,
                     round_up_to_alignment(
-                        plan.max_footprint_bytes or source.size,
+                        plan.destination_footprint_bytes or source.size,
                         _LX_ALLOCATION_GRANULARITY_BYTES,
                     ),
                     [transfer_tick, *consumer_ticks],

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -874,7 +874,10 @@ class ScratchpadAllocator:
                 buffer = graph.try_get_buffer(dep.name)
                 if buffer is None:
                     continue
-                layout = buffer.get_layout()
+                try:
+                    layout = buffer.get_layout()
+                except NotImplementedError:
+                    continue
                 if not isinstance(layout, FixedTiledLayout):
                     continue
                 view, partial, representable = _per_core_view_on_buf(
@@ -906,7 +909,10 @@ class ScratchpadAllocator:
             buffer = graph.try_get_buffer(name)
             if buffer is None:
                 continue
-            layout = buffer.get_layout()
+            try:
+                layout = buffer.get_layout()
+            except NotImplementedError:
+                continue
             if not isinstance(layout, FixedTiledLayout):
                 continue
             device_layout = layout.device_layout

--- a/torch_spyre/_inductor/scratchpad/lx_relayout.py
+++ b/torch_spyre/_inductor/scratchpad/lx_relayout.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import dataclasses
 import math
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Literal, cast
 
 import sympy
@@ -48,6 +48,7 @@ from .utils import _op_num_cores
 logger = get_inductor_logger("lx_relayout")
 _DESTINATION_PREFIX = "__spyre_lx_relayout__"
 _REGISTRY = "_spyre_lx_relayout_copies"
+_FINAL_VIEWS = "_spyre_lx_final_views"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -57,6 +58,9 @@ class RelayoutDimension:
     device_dim: int
     source_split: int
     destination_split: int
+    group_count: int
+    group_size: int
+    multiplicity: int
     ordering_tag: Literal["contiguous_groups"]
 
 
@@ -80,6 +84,16 @@ class LXRelayoutPlan:
     @property
     def edge(self) -> tuple[str, str]:
         return self.source_name, self.destination_name
+
+
+@dataclasses.dataclass(frozen=True)
+class FinalLXView:
+    """One tensor's final emitted physical shape and ownership."""
+
+    ownership: PerCoreView
+    device_size: tuple[int, ...]
+    slice_shape: tuple[int, ...]
+    minimum_footprint_bytes: int
 
 
 def work_division_from_view(
@@ -118,6 +132,18 @@ def materialized_lx_relayouts(
     return getattr(graph, _REGISTRY, {})
 
 
+def final_lx_views(graph: GraphLowering) -> dict[tuple[str, str], FinalLXView]:
+    """Final post-alignment physical views accepted by the graph-wide gate."""
+
+    return getattr(graph, _FINAL_VIEWS, {})
+
+
+def set_final_lx_views(
+    graph: GraphLowering, views: dict[tuple[str, str], FinalLXView]
+) -> None:
+    setattr(graph, _FINAL_VIEWS, views)
+
+
 def _discard_lx_relayout_group(graph: GraphLowering, source_name: str) -> set[str]:
     copies = materialized_lx_relayouts(graph)
     removed = set()
@@ -125,6 +151,10 @@ def _discard_lx_relayout_group(graph: GraphLowering, source_name: str) -> set[st
         if edge[0] == source_name:
             removed.add(copy_name)
             del copies[edge]
+    cached = final_lx_views(graph)
+    for key in list(cached):
+        if key[1] == source_name or key[1] in removed:
+            del cached[key]
     return removed
 
 
@@ -166,6 +196,103 @@ def _core_slices(view: PerCoreView, num_cores: int) -> dict[int, dict[int, int]]
             row[dim] = slot
         result[core] = row
     return result
+
+
+def view_from_work_division(
+    division: TensorWorkDivision,
+    device_coordinates: Sequence[sympy.Expr],
+    iteration_space: Mapping[sympy.Symbol, tuple[sympy.Expr, int]],
+) -> PerCoreView:
+    """Convert final loop-symbol ownership back to a physical device view."""
+
+    split_by_device_dim: dict[int, int] = {}
+    slot_by_device_dim: dict[int, sympy.Expr] = {}
+    for loop_dim, split in division.work_slices.items():
+        matches = [
+            device_dim
+            for device_dim, coordinate in enumerate(device_coordinates)
+            if loop_dim in coordinate.free_symbols
+        ]
+        # An operation may split a loop that this tensor broadcasts across
+        # (for example the query dimension of a BMM input). That loop chooses
+        # execution cores, but it does not further partition this tensor.
+        if not matches:
+            continue
+        if len(matches) > 1:
+            extent = int(iteration_space[loop_dim][0])
+            slice_extent = math.ceil(extent / int(split))
+            physical_matches = []
+            for device_dim in matches:
+                coordinate = device_coordinates[device_dim]
+                other_dims = coordinate.free_symbols - {loop_dim}
+                coordinate = coordinate.xreplace({dim: 0 for dim in other_dims})
+                values = []
+                for slot in range(int(split)):
+                    start = slot * slice_extent
+                    end = min(extent, start + slice_extent) - 1
+                    if start >= extent:
+                        break
+                    first = sympy.simplify(coordinate.xreplace({loop_dim: start}))
+                    last = sympy.simplify(coordinate.xreplace({loop_dim: end}))
+                    if first != last:
+                        break
+                    values.append(first)
+                if len(values) == int(split) and len(set(values)) == int(split):
+                    physical_matches.append(device_dim)
+            matches = physical_matches
+        if len(matches) != 1:
+            raise ValueError(
+                f"cannot map final loop {loop_dim} to one device dimension"
+            )
+        device_dim = matches[0]
+        slot = sympy.sympify(division.core_id_to_work_slice[loop_dim])
+        previous = (
+            split_by_device_dim.get(device_dim),
+            slot_by_device_dim.get(device_dim),
+        )
+        if previous[0] is not None and previous != (int(split), slot):
+            raise ValueError(
+                f"conflicting final ownership on device dimension {device_dim}"
+            )
+        split_by_device_dim[device_dim] = int(split)
+        slot_by_device_dim[device_dim] = slot
+    return PerCoreView(
+        tuple(sorted(split_by_device_dim.items())),
+        tuple(sorted(slot_by_device_dim.items())),
+        num_cores=division.num_cores,
+    )
+
+
+def final_view_from_work_division(
+    division: TensorWorkDivision,
+    device_size: Sequence[int],
+    device_coordinates: Sequence[sympy.Expr],
+    iteration_space: Mapping[sympy.Symbol, tuple[sympy.Expr, int]],
+) -> FinalLXView:
+    """Build the physical view described by a finalized tensor argument."""
+
+    size = tuple(int(extent) for extent in device_size)
+    ownership = view_from_work_division(division, device_coordinates, iteration_space)
+    kept_dims = [dim for dim, extent in enumerate(size) if extent != 1]
+    canonical_dim = {dim: index for index, dim in enumerate(kept_dims)}
+    ownership = PerCoreView(
+        tuple((canonical_dim[dim], split) for dim, split in ownership.work_slice_dims),
+        tuple((canonical_dim[dim], slot) for dim, slot in ownership.core_to_slot),
+        num_cores=ownership.num_cores,
+    )
+    canonical_size = tuple(size[dim] for dim in kept_dims)
+    splits = dict(ownership.work_slice_dims)
+    extents = tuple(
+        math.ceil(extent / int(splits.get(dim, 1)))
+        for dim, extent in enumerate(canonical_size)
+    )
+    slice_shape = tuple(sorted(extents[:-1])) + (extents[-1],)
+    return FinalLXView(
+        ownership=ownership,
+        device_size=canonical_size,
+        slice_shape=slice_shape,
+        minimum_footprint_bytes=math.prod(extents[:-1]) * 128,
+    )
 
 
 def _view_from_splits(
@@ -216,6 +343,9 @@ def _grouped_gather_geometry(
                 device_dim=dim,
                 source_split=source_split,
                 destination_split=destination_split,
+                group_count=destination_split,
+                group_size=source_split // destination_split,
+                multiplicity=source_split // destination_split,
                 ordering_tag="contiguous_groups",
             )
         )
@@ -240,6 +370,30 @@ def _partition_footprint(layout: FixedTiledLayout, view: PerCoreView) -> int:
         tuple(int(stride) for stride in device_layout.stride_map),
         int(device_layout.elems_per_stick()),
         dict(view.work_slice_dims),
+    )
+
+
+def _geometry_topology(
+    geometry: Sequence[RelayoutDimension],
+) -> tuple[tuple[int, int, int, int, int, str], ...]:
+    """Return the layout-normalization-invariant collective geometry.
+
+    Device-dimension numbers may change when a tensor layout is normalized.
+    The split contraction and grouping structure must not.
+    """
+
+    return tuple(
+        sorted(
+            (
+                item.source_split,
+                item.destination_split,
+                item.group_count,
+                item.group_size,
+                item.multiplicity,
+                item.ordering_tag,
+            )
+            for item in geometry
+        )
     )
 
 
@@ -286,6 +440,100 @@ def _compatible_partitions(
         return False
     multiplicity = num_cores // destination_slices
     return multiplicity == 1 or (fanout[0] == multiplicity and fanin[0] == multiplicity)
+
+
+def validate_final_views(
+    graph: GraphLowering,
+    plan: LXRelayoutPlan,
+    views: dict[tuple[str, str], FinalLXView],
+    *,
+    destination_name: str | None = None,
+) -> str | None:
+    """Validate one complete relayout group after scheduler alignment preview."""
+
+    destination_name = destination_name or plan.destination_name
+    source_views = {
+        view
+        for (_, buffer_name), view in views.items()
+        if buffer_name == plan.source_name
+    }
+    destination_views = {
+        view
+        for (_, buffer_name), view in views.items()
+        if buffer_name == destination_name
+    }
+    if len(source_views) != 1:
+        return f"source users derived {len(source_views)} final views"
+    if len(destination_views) != 1:
+        return f"destination users derived {len(destination_views)} final views"
+    source = next(iter(source_views))
+    destination = next(iter(destination_views))
+
+    if (
+        source.ownership.num_cores != plan.num_cores
+        or destination.ownership.num_cores != plan.num_cores
+    ):
+        return "final view physical core count changed"
+    if source == destination:
+        return "final source and destination views no longer require a relayout"
+    if not _compatible_partitions(
+        source.ownership, destination.ownership, plan.num_cores
+    ):
+        return "final source and destination partitions are not a complete transfer"
+
+    if plan.kind == "gather":
+        classified = _grouped_gather_geometry(
+            source.ownership,
+            destination.ownership,
+            plan.num_cores,
+        )
+        if classified is None:
+            return "final views are not a grouped gather"
+        geometry = classified[2]
+        if _geometry_topology(geometry) != _geometry_topology(plan.group_geometry):
+            return f"final grouped-gather geometry changed: {geometry}"
+    elif plan.kind != "shuffle":
+        return f"unsupported relayout kind {plan.kind}"
+
+    for name, view in (
+        (plan.source_name, source),
+        (destination_name, destination),
+    ):
+        buffer = graph.try_get_buffer(name)
+        if buffer is None:
+            return f"missing final buffer {name}"
+        layout = buffer.get_layout()
+        if not isinstance(layout, FixedTiledLayout):
+            return f"final buffer {name} has no fixed tiled layout"
+        planned_view = (
+            plan.source_view if name == plan.source_name else plan.destination_view
+        )
+        planned_size = tuple(int(extent) for extent in layout.device_layout.device_size)
+        planned_splits = dict(planned_view.work_slice_dims)
+        planned_extents = tuple(
+            math.ceil(extent / int(planned_splits.get(dim, 1)))
+            for dim, extent in enumerate(planned_size)
+            if extent != 1
+        )
+        planned_shape = tuple(sorted(planned_extents[:-1])) + (planned_extents[-1],)
+        if view.slice_shape != planned_shape:
+            return (
+                f"final {name} slice shape {view.slice_shape} differs from planned "
+                f"{planned_shape}"
+            )
+        if view.minimum_footprint_bytes > plan.max_footprint_bytes:
+            return (
+                f"final {name} minimum footprint {view.minimum_footprint_bytes} "
+                f"exceeds planned "
+                f"{plan.max_footprint_bytes}"
+            )
+
+    if plan.source_address is None or plan.destination_address is None:
+        return "relayout group has no committed LX addresses"
+    # The allocator validates disjointness using each concrete buffer size.
+    # Repeating that check with this edge's maximum bound is incorrect for a
+    # source shared by differently sized destinations.
+    return None
 
 
 def _single_write(op: ComputedBuffer, name: str) -> MemoryDep | None:
@@ -465,7 +713,7 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                         "source ownership cannot be projected to producer"
                     )
 
-        plans_by_destination = {}
+        plans_by_destination: dict[tuple, list[str]] = {}
         if rejection_reason is None:
             source_geometry = source_view.work_slice_dims
             for (

--- a/torch_spyre/_inductor/scratchpad/lx_relayout.py
+++ b/torch_spyre/_inductor/scratchpad/lx_relayout.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import dataclasses
 import math
 from collections.abc import Sequence
-from typing import cast
+from typing import Literal, cast
 
 import sympy
 from torch._inductor.dependencies import MemoryDep
@@ -30,6 +30,7 @@ from torch._inductor.ir import (
 )
 
 from .. import config
+from ..core_mapping import derive_partition_mapping, partition_physical_span_bytes
 from ..ir import FixedTiledLayout
 from ..logging_utils import get_inductor_logger
 from ..op_spec import TensorWorkDivision
@@ -50,12 +51,25 @@ _REGISTRY = "_spyre_lx_relayout_copies"
 
 
 @dataclasses.dataclass(frozen=True)
+class RelayoutDimension:
+    """One device dimension's source-to-destination partition geometry."""
+
+    device_dim: int
+    source_split: int
+    destination_split: int
+    ordering_tag: Literal["contiguous_groups"]
+
+
+@dataclasses.dataclass(frozen=True)
 class LXRelayoutPlan:
     source_name: str
     consumer_names: tuple[str, ...]
     source_view: PerCoreView
     destination_view: PerCoreView
     num_cores: int
+    kind: Literal["shuffle", "gather"] = "shuffle"
+    group_geometry: tuple[RelayoutDimension, ...] = ()
+    max_footprint_bytes: int = 0
     source_address: int | None = None
     destination_address: int | None = None
 
@@ -154,6 +168,81 @@ def _core_slices(view: PerCoreView, num_cores: int) -> dict[int, dict[int, int]]
     return result
 
 
+def _view_from_splits(
+    split_by_device_dim: dict[int, int], num_cores: int
+) -> PerCoreView:
+    """Build v1 planning ownership with the shared late-mapping formula."""
+
+    dims = tuple(sympy.Symbol(f"device_dim_{dim}") for dim in split_by_device_dim)
+    mapping = derive_partition_mapping(
+        dims,
+        tuple(split_by_device_dim.values()),
+        num_cores,
+    )
+    device_dim_by_symbol = dict(zip(dims, split_by_device_dim))
+    return PerCoreView(
+        tuple(split_by_device_dim.items()),
+        tuple(
+            (device_dim_by_symbol[dim], expression)
+            for dim, expression in mapping.items()
+            if split_by_device_dim[device_dim_by_symbol[dim]] > 1
+        ),
+        num_cores=num_cores,
+    )
+
+
+def _grouped_gather_geometry(
+    source: PerCoreView, destination: PerCoreView, num_cores: int
+) -> tuple[PerCoreView, PerCoreView, tuple[RelayoutDimension, ...]] | None:
+    """Classify a full source partition contracting into repeated owners."""
+
+    source_splits = dict(source.work_slice_dims)
+    destination_splits = dict(destination.work_slice_dims)
+    if math.prod(source_splits.values()) != num_cores:
+        return None
+    destination_owners = math.prod(destination_splits.values())
+    if not 0 < destination_owners < num_cores:
+        return None
+
+    dimensions = tuple(dict.fromkeys((*source_splits, *destination_splits)))
+    geometry = []
+    for dim in dimensions:
+        source_split = source_splits.get(dim, 1)
+        destination_split = destination_splits.get(dim, 1)
+        if source_split < destination_split or source_split % destination_split:
+            return None
+        geometry.append(
+            RelayoutDimension(
+                device_dim=dim,
+                source_split=source_split,
+                destination_split=destination_split,
+                ordering_tag="contiguous_groups",
+            )
+        )
+
+    if (
+        destination_owners
+        * math.prod(item.source_split // item.destination_split for item in geometry)
+        != num_cores
+    ):
+        return None
+    grouped_source = _view_from_splits(source_splits, num_cores)
+    grouped_destination = _view_from_splits(destination_splits, num_cores)
+    if not _compatible_partitions(grouped_source, grouped_destination, num_cores):
+        return None
+    return grouped_source, grouped_destination, tuple(geometry)
+
+
+def _partition_footprint(layout: FixedTiledLayout, view: PerCoreView) -> int:
+    device_layout = layout.device_layout
+    return partition_physical_span_bytes(
+        tuple(int(size) for size in device_layout.device_size),
+        tuple(int(stride) for stride in device_layout.stride_map),
+        int(device_layout.elems_per_stick()),
+        dict(view.work_slice_dims),
+    )
+
+
 def _overlap(a: int, an: int, b: int, bn: int) -> bool:
     return a * bn < (b + 1) * an and b * an < (a + 1) * bn
 
@@ -161,6 +250,8 @@ def _overlap(a: int, an: int, b: int, bn: int) -> bool:
 def _compatible_partitions(
     source: PerCoreView, destination: PerCoreView, num_cores: int
 ) -> bool:
+    """Whether every destination receives a uniform, complete partition."""
+
     source_map = _core_slices(source, num_cores)
     destination_map = _core_slices(destination, num_cores)
     source_splits = dict(source.work_slice_dims)
@@ -182,18 +273,19 @@ def _compatible_partitions(
     }
     fanout = [sum(src == core for src, _ in edges) for core in range(num_cores)]
     fanin = [sum(dst == core for _, dst in edges) for core in range(num_cores)]
-    return bool(edges) and all(
-        (
-            len(set(fanout)) == 1,
-            len(set(fanin)) == 1,
-            len({tuple(sorted(row.items())) for row in source_map.values()})
-            == num_cores,
-            len({tuple(sorted(row.items())) for row in destination_map.values()})
-            == num_cores,
-            math.prod(source_splits.values()) == num_cores,
-            math.prod(destination_splits.values()) == num_cores,
-        )
+    if not edges or len(set(fanout)) != 1 or len(set(fanin)) != 1:
+        return False
+    source_owners = len({tuple(sorted(row.items())) for row in source_map.values()})
+    destination_owners = len(
+        {tuple(sorted(row.items())) for row in destination_map.values()}
     )
+    if source_owners != num_cores or math.prod(source_splits.values()) != num_cores:
+        return False
+    destination_slices = math.prod(destination_splits.values())
+    if destination_owners != destination_slices or num_cores % destination_slices:
+        return False
+    multiplicity = num_cores // destination_slices
+    return multiplicity == 1 or (fanout[0] == multiplicity and fanin[0] == multiplicity)
 
 
 def _single_write(op: ComputedBuffer, name: str) -> MemoryDep | None:
@@ -272,24 +364,10 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
         if not _is_activation_source(operations, producer):
             continue
 
-        producer_coordinates = try_device_coordinates(
-            producer.layout.device_layout, write, None
-        )
-        if producer_coordinates is None:
-            continue
-        try:
-            work_division_from_view(
-                source_view,
-                producer_coordinates,
-                tuple(iteration_space_from_op(producer)),
-            )
-        except ValueError:
-            continue
-
         # Relayout copies sharing one source are allocated and materialized as
         # one atomic group. Any unsupported consumer therefore rejects the
         # group; supported consumers keep using the original buffer instead.
-        consumers_by_view: dict[PerCoreView, list[str]] = {}
+        consumer_views = []
         seen_consumers = set()
         rejection_reason = None
         for consumer, dep in consumer_reads:
@@ -330,52 +408,143 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                 rejection_reason = "consumer coordinates are unavailable"
                 break
             consumer_symbols = tuple(iteration_space_from_op(consumer))
-            try:
-                source_work_division = work_division_from_view(
-                    source_view, consumer_coordinates, consumer_symbols
+            consumer_views.append(
+                (
+                    consumer_name,
+                    consumer,
+                    deps,
+                    view,
+                    consumer_coordinates,
+                    consumer_symbols,
                 )
-            except ValueError:
-                rejection_reason = "source ownership cannot be projected to consumer"
-                break
-            assert source_work_division is not None
-            if view == source_view:
-                continue
-            is_matmul = _is_matmul_op(consumer)
-            if is_matmul and len(deps) != 2:
-                rejection_reason = "matmul consumer does not have two inputs"
-                break
-            if not is_matmul and not isinstance(consumer.data, Pointwise):
-                rejection_reason = "consumer is neither pointwise nor matmul"
-                break
-            if not _compatible_partitions(source_view, view, num_cores):
-                rejection_reason = "source and destination partitions are incompatible"
-                break
-            try:
-                destination_work_division = work_division_from_view(
-                    view, consumer_coordinates, consumer_symbols
+            )
+
+        grouped_source = None
+        grouped_destinations = {}
+        grouped_geometry = {}
+        if rejection_reason is None:
+            for consumer_name, consumer, _, view, _, _ in consumer_views:
+                destination_owners = math.prod(dict(view.work_slice_dims).values())
+                if destination_owners >= num_cores:
+                    continue
+                if not _is_matmul_op(consumer):
+                    rejection_reason = "grouped gather requires a matmul consumer"
+                    break
+                grouped = _grouped_gather_geometry(source_view, view, num_cores)
+                if grouped is None:
+                    rejection_reason = (
+                        "grouped destination does not evenly contract the source"
+                    )
+                    break
+                candidate_source, destination, geometry = grouped
+                if grouped_source is not None and candidate_source != grouped_source:
+                    rejection_reason = (
+                        "consumers require different grouped source geometry"
+                    )
+                    break
+                grouped_source = candidate_source
+                grouped_destinations[consumer_name] = destination
+                grouped_geometry[consumer_name] = geometry
+
+        source_view = grouped_source or source_view
+        producer_coordinates = try_device_coordinates(
+            producer.layout.device_layout, write, None
+        )
+        if rejection_reason is None:
+            if producer_coordinates is None:
+                rejection_reason = "producer coordinates are unavailable"
+            else:
+                try:
+                    work_division_from_view(
+                        source_view,
+                        producer_coordinates,
+                        tuple(iteration_space_from_op(producer)),
+                    )
+                except ValueError:
+                    rejection_reason = (
+                        "source ownership cannot be projected to producer"
+                    )
+
+        plans_by_destination = {}
+        if rejection_reason is None:
+            source_geometry = source_view.work_slice_dims
+            for (
+                consumer_name,
+                consumer,
+                deps,
+                raw_view,
+                consumer_coordinates,
+                consumer_symbols,
+            ) in consumer_views:
+                destination_view = grouped_destinations.get(consumer_name, raw_view)
+                if raw_view.work_slice_dims == source_geometry:
+                    destination_view = source_view
+                try:
+                    source_work_division = work_division_from_view(
+                        source_view, consumer_coordinates, consumer_symbols
+                    )
+                except ValueError:
+                    rejection_reason = (
+                        "source ownership cannot be projected to consumer"
+                    )
+                    break
+                assert source_work_division is not None
+                if destination_view == source_view:
+                    continue
+                is_matmul = _is_matmul_op(consumer)
+                if is_matmul and len(deps) != 2:
+                    rejection_reason = "matmul consumer does not have two inputs"
+                    break
+                if not is_matmul and not isinstance(consumer.data, Pointwise):
+                    rejection_reason = "consumer is neither pointwise nor matmul"
+                    break
+                if not _compatible_partitions(source_view, destination_view, num_cores):
+                    rejection_reason = (
+                        "source and destination partitions are incompatible"
+                    )
+                    break
+                try:
+                    destination_work_division = work_division_from_view(
+                        destination_view, consumer_coordinates, consumer_symbols
+                    )
+                except ValueError:
+                    rejection_reason = (
+                        "destination ownership cannot be projected to consumer"
+                    )
+                    break
+                assert destination_work_division is not None
+                if reason := _unsupported_relayout_transition_reason(
+                    source_work_division, destination_work_division
+                ):
+                    rejection_reason = reason
+                    break
+                kind = "gather" if consumer_name in grouped_geometry else "shuffle"
+                geometry = grouped_geometry.get(consumer_name, ())
+                footprint = max(
+                    _partition_footprint(producer.layout, source_view),
+                    _partition_footprint(producer.layout, destination_view),
                 )
-            except ValueError:
-                rejection_reason = (
-                    "destination ownership cannot be projected to consumer"
-                )
-                break
-            assert destination_work_division is not None
-            if reason := _unsupported_relayout_transition_reason(
-                source_work_division, destination_work_division
-            ):
-                rejection_reason = reason
-                break
-            consumers_by_view.setdefault(view, []).append(consumer_name)
-        else:
+                key = (destination_view, kind, geometry, footprint)
+                plans_by_destination.setdefault(key, []).append(consumer_name)
+
+        if rejection_reason is None:
             result.extend(
                 LXRelayoutPlan(
-                    source_name,
-                    tuple(consumer_names),
-                    source_view,
-                    destination_view,
-                    num_cores,
+                    source_name=source_name,
+                    consumer_names=tuple(consumer_names),
+                    source_view=source_view,
+                    destination_view=destination_view,
+                    num_cores=num_cores,
+                    kind=kind,
+                    group_geometry=geometry,
+                    max_footprint_bytes=footprint,
                 )
-                for destination_view, consumer_names in consumers_by_view.items()
+                for (
+                    destination_view,
+                    kind,
+                    geometry,
+                    footprint,
+                ), consumer_names in plans_by_destination.items()
             )
         if rejection_reason is not None:
             logger.debug(

--- a/torch_spyre/_inductor/scratchpad/lx_relayout.py
+++ b/torch_spyre/_inductor/scratchpad/lx_relayout.py
@@ -93,7 +93,7 @@ class FinalLXView:
     ownership: PerCoreView
     device_size: tuple[int, ...]
     slice_shape: tuple[int, ...]
-    minimum_footprint_bytes: int
+    physical_span_bytes: int | None
 
 
 def work_division_from_view(
@@ -268,8 +268,16 @@ def final_view_from_work_division(
     device_size: Sequence[int],
     device_coordinates: Sequence[sympy.Expr],
     iteration_space: Mapping[sympy.Symbol, tuple[sympy.Expr, int]],
+    *,
+    physical_span_bytes: int | None,
 ) -> FinalLXView:
-    """Build the physical view described by a finalized tensor argument."""
+    """Build the view described by a finalized tensor argument.
+
+    Alignment may factor or insert descriptor dimensions, so its ``device_size``
+    cannot be combined with the original layout strides.  The exact physical
+    span is therefore carried from the committed physical partition while the
+    final ownership and slice shape are derived from the aligned descriptor.
+    """
 
     size = tuple(int(extent) for extent in device_size)
     ownership = view_from_work_division(division, device_coordinates, iteration_space)
@@ -291,7 +299,7 @@ def final_view_from_work_division(
         ownership=ownership,
         device_size=canonical_size,
         slice_shape=slice_shape,
-        minimum_footprint_bytes=math.prod(extents[:-1]) * 128,
+        physical_span_bytes=physical_span_bytes,
     )
 
 
@@ -363,7 +371,7 @@ def _grouped_gather_geometry(
     return grouped_source, grouped_destination, tuple(geometry)
 
 
-def _partition_footprint(layout: FixedTiledLayout, view: PerCoreView) -> int:
+def partition_footprint(layout: FixedTiledLayout, view: PerCoreView) -> int:
     device_layout = layout.device_layout
     return partition_physical_span_bytes(
         tuple(int(size) for size in device_layout.device_size),
@@ -521,9 +529,11 @@ def validate_final_views(
                 f"final {name} slice shape {view.slice_shape} differs from planned "
                 f"{planned_shape}"
             )
-        if view.minimum_footprint_bytes > plan.max_footprint_bytes:
+        if view.physical_span_bytes is None:
+            return f"final {name} has no committed physical span"
+        if view.physical_span_bytes > plan.max_footprint_bytes:
             return (
-                f"final {name} minimum footprint {view.minimum_footprint_bytes} "
+                f"final {name} physical span {view.physical_span_bytes} "
                 f"exceeds planned "
                 f"{plan.max_footprint_bytes}"
             )
@@ -769,8 +779,8 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                 kind = "gather" if consumer_name in grouped_geometry else "shuffle"
                 geometry = grouped_geometry.get(consumer_name, ())
                 footprint = max(
-                    _partition_footprint(producer.layout, source_view),
-                    _partition_footprint(producer.layout, destination_view),
+                    partition_footprint(producer.layout, source_view),
+                    partition_footprint(producer.layout, destination_view),
                 )
                 key = (destination_view, kind, geometry, footprint)
                 plans_by_destination.setdefault(key, []).append(consumer_name)

--- a/torch_spyre/_inductor/scratchpad/lx_relayout.py
+++ b/torch_spyre/_inductor/scratchpad/lx_relayout.py
@@ -725,7 +725,6 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
 
         plans_by_destination: dict[tuple, list[str]] = {}
         if rejection_reason is None:
-            source_geometry = source_view.work_slice_dims
             for (
                 consumer_name,
                 consumer,
@@ -735,8 +734,6 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                 consumer_symbols,
             ) in consumer_views:
                 destination_view = grouped_destinations.get(consumer_name, raw_view)
-                if raw_view.work_slice_dims == source_geometry:
-                    destination_view = source_view
                 try:
                     source_work_division = work_division_from_view(
                         source_view, consumer_coordinates, consumer_symbols

--- a/torch_spyre/_inductor/scratchpad/lx_relayout.py
+++ b/torch_spyre/_inductor/scratchpad/lx_relayout.py
@@ -440,6 +440,8 @@ def _grouped_broadcast_geometry(
                 ordering_tag="contiguous_groups",
             )
         )
+    # Split counts classify the geometry; the actual views are the ownership
+    # contract. Never replace their core order with a reconstructed default.
     if not _compatible_partitions(
         source,
         destination,

--- a/torch_spyre/_inductor/scratchpad/lx_relayout.py
+++ b/torch_spyre/_inductor/scratchpad/lx_relayout.py
@@ -30,7 +30,7 @@ from torch._inductor.ir import (
 )
 
 from .. import config
-from ..core_mapping import derive_partition_mapping, partition_physical_span_bytes
+from ..core_mapping import partition_physical_span_bytes
 from ..ir import FixedTiledLayout
 from ..logging_utils import get_inductor_logger
 from ..op_spec import TensorWorkDivision
@@ -73,7 +73,8 @@ class LXRelayoutPlan:
     num_cores: int
     kind: Literal["shuffle", "gather"] = "shuffle"
     group_geometry: tuple[RelayoutDimension, ...] = ()
-    max_footprint_bytes: int = 0
+    source_footprint_bytes: int = 0
+    destination_footprint_bytes: int = 0
     source_address: int | None = None
     destination_address: int | None = None
 
@@ -84,6 +85,12 @@ class LXRelayoutPlan:
     @property
     def edge(self) -> tuple[str, str]:
         return self.source_name, self.destination_name
+
+    @property
+    def max_footprint_bytes(self) -> int:
+        """Largest member span, for diagnostics rather than allocation."""
+
+        return max(self.source_footprint_bytes, self.destination_footprint_bytes)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -303,29 +310,6 @@ def final_view_from_work_division(
     )
 
 
-def _view_from_splits(
-    split_by_device_dim: dict[int, int], num_cores: int
-) -> PerCoreView:
-    """Build v1 planning ownership with the shared late-mapping formula."""
-
-    dims = tuple(sympy.Symbol(f"device_dim_{dim}") for dim in split_by_device_dim)
-    mapping = derive_partition_mapping(
-        dims,
-        tuple(split_by_device_dim.values()),
-        num_cores,
-    )
-    device_dim_by_symbol = dict(zip(dims, split_by_device_dim))
-    return PerCoreView(
-        tuple(split_by_device_dim.items()),
-        tuple(
-            (device_dim_by_symbol[dim], expression)
-            for dim, expression in mapping.items()
-            if split_by_device_dim[device_dim_by_symbol[dim]] > 1
-        ),
-        num_cores=num_cores,
-    )
-
-
 def _grouped_gather_geometry(
     source: PerCoreView, destination: PerCoreView, num_cores: int
 ) -> tuple[PerCoreView, PerCoreView, tuple[RelayoutDimension, ...]] | None:
@@ -364,11 +348,11 @@ def _grouped_gather_geometry(
         != num_cores
     ):
         return None
-    grouped_source = _view_from_splits(source_splits, num_cores)
-    grouped_destination = _view_from_splits(destination_splits, num_cores)
-    if not _compatible_partitions(grouped_source, grouped_destination, num_cores):
+    # Split counts classify the geometry; the actual views are the ownership
+    # contract. Never replace their core order with a reconstructed default.
+    if not _compatible_partitions(source, destination, num_cores):
         return None
-    return grouped_source, grouped_destination, tuple(geometry)
+    return source, destination, tuple(geometry)
 
 
 def partition_footprint(layout: FixedTiledLayout, view: PerCoreView) -> int:
@@ -503,9 +487,9 @@ def validate_final_views(
     elif plan.kind != "shuffle":
         return f"unsupported relayout kind {plan.kind}"
 
-    for name, view in (
-        (plan.source_name, source),
-        (destination_name, destination),
+    for name, planned_bound, view in (
+        (plan.source_name, plan.source_footprint_bytes, source),
+        (destination_name, plan.destination_footprint_bytes, destination),
     ):
         buffer = graph.try_get_buffer(name)
         if buffer is None:
@@ -531,11 +515,11 @@ def validate_final_views(
             )
         if view.physical_span_bytes is None:
             return f"final {name} has no committed physical span"
-        if view.physical_span_bytes > plan.max_footprint_bytes:
+        if view.physical_span_bytes > planned_bound:
             return (
                 f"final {name} physical span {view.physical_span_bytes} "
                 f"exceeds planned "
-                f"{plan.max_footprint_bytes}"
+                f"{planned_bound}"
             )
 
     if plan.source_address is None or plan.destination_address is None:
@@ -775,11 +759,17 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                     break
                 kind = "gather" if consumer_name in grouped_geometry else "shuffle"
                 geometry = grouped_geometry.get(consumer_name, ())
-                footprint = max(
-                    partition_footprint(producer.layout, source_view),
-                    partition_footprint(producer.layout, destination_view),
+                source_footprint = partition_footprint(producer.layout, source_view)
+                destination_footprint = partition_footprint(
+                    producer.layout, destination_view
                 )
-                key = (destination_view, kind, geometry, footprint)
+                key = (
+                    destination_view,
+                    kind,
+                    geometry,
+                    source_footprint,
+                    destination_footprint,
+                )
                 plans_by_destination.setdefault(key, []).append(consumer_name)
 
         if rejection_reason is None:
@@ -792,13 +782,15 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                     num_cores=num_cores,
                     kind=kind,
                     group_geometry=geometry,
-                    max_footprint_bytes=footprint,
+                    source_footprint_bytes=source_footprint,
+                    destination_footprint_bytes=destination_footprint,
                 )
                 for (
                     destination_view,
                     kind,
                     geometry,
-                    footprint,
+                    source_footprint,
+                    destination_footprint,
                 ), consumer_names in plans_by_destination.items()
             )
         if rejection_reason is not None:

--- a/torch_spyre/_inductor/scratchpad/lx_relayout.py
+++ b/torch_spyre/_inductor/scratchpad/lx_relayout.py
@@ -41,6 +41,7 @@ from ..pass_utils import (
     iteration_space_from_op,
     op_short_name,
     op_read_writes,
+    per_core_views_equal,
     try_device_coordinates,
 )
 from .utils import _op_num_cores
@@ -49,6 +50,7 @@ logger = get_inductor_logger("lx_relayout")
 _DESTINATION_PREFIX = "__spyre_lx_relayout__"
 _REGISTRY = "_spyre_lx_relayout_copies"
 _FINAL_VIEWS = "_spyre_lx_final_views"
+_VALIDATION_PARTITIONS = "_spyre_lx_validation_partitions"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -103,6 +105,17 @@ class FinalLXView:
     physical_span_bytes: int | None
 
 
+def final_lx_views_equal(left: FinalLXView, right: FinalLXView) -> bool:
+    """Whether two final descriptors carry the same accepted ownership claim."""
+
+    return (
+        left.device_size == right.device_size
+        and left.slice_shape == right.slice_shape
+        and left.physical_span_bytes == right.physical_span_bytes
+        and per_core_views_equal(left.ownership, right.ownership)
+    )
+
+
 def work_division_from_view(
     view: PerCoreView | None,
     device_coordinates: Sequence[sympy.Expr],
@@ -149,6 +162,44 @@ def set_final_lx_views(
     graph: GraphLowering, views: dict[tuple[str, str], FinalLXView]
 ) -> None:
     setattr(graph, _FINAL_VIEWS, views)
+
+
+def register_lx_validation_buffers(
+    graph: GraphLowering, category: str, names: Sequence[str]
+) -> None:
+    """Register non-ordinary LX buffers with their validation authority.
+
+    Ordinary LX remains on the established scheduled-view validation path.
+    New non-canonical ownership must register a named partition before it can
+    bypass that path; the scheduler asserts that every resident buffer belongs
+    to exactly one partition.
+    """
+
+    assert category != "ordinary", "ordinary LX is the unregistered partition"
+    partitions = getattr(graph, _VALIDATION_PARTITIONS, None)
+    if partitions is None:
+        partitions = {}
+        setattr(graph, _VALIDATION_PARTITIONS, partitions)
+    partitions.setdefault(category, set()).update(names)
+
+
+def lx_validation_partitions(graph: GraphLowering) -> dict[str, set[str]]:
+    """Return all explicitly registered LX validation partitions."""
+
+    result = {
+        category: set(names)
+        for category, names in getattr(graph, _VALIDATION_PARTITIONS, {}).items()
+    }
+    relayout = {
+        name
+        for copy_name, plan in materialized_lx_relayouts(graph).values()
+        for name in (plan.source_name, copy_name)
+    }
+    result.setdefault("relayout", set()).update(relayout)
+    # The category exists from the foundation PR even before a feature uses it.
+    # This keeps totality registry-driven when explicit-view residency is added.
+    result.setdefault("explicit_view", set())
+    return result
 
 
 def _discard_lx_relayout_group(graph: GraphLowering, source_name: str) -> set[str]:
@@ -393,45 +444,162 @@ def _overlap(a: int, an: int, b: int, bn: int) -> bool:
     return a * bn < (b + 1) * an and b * an < (a + 1) * bn
 
 
+def _transfer_edges(
+    source: PerCoreView,
+    destination: PerCoreView,
+    source_num_cores: int,
+    destination_num_cores: int,
+) -> frozenset[tuple[int, int]]:
+    """Derive movement from ownership, independent of collective names.
+
+    An edge ``(s, d)`` exists exactly when source core ``s`` owns tensor
+    elements needed by destination core ``d``.  Gather, broadcast, and shuffle
+    are certified shapes of this one fact; they must never derive a different
+    movement graph.
+    """
+
+    source_map = _core_slices(source, source_num_cores)
+    destination_map = _core_slices(destination, destination_num_cores)
+    source_splits = dict(source.work_slice_dims)
+    destination_splits = dict(destination.work_slice_dims)
+    dimensions = set(source_splits) | set(destination_splits)
+    return frozenset(
+        (source_core, destination_core)
+        for source_core, source_slice in source_map.items()
+        for destination_core, destination_slice in destination_map.items()
+        if all(
+            _overlap(
+                source_slice.get(dim, 0),
+                source_splits.get(dim, 1),
+                destination_slice.get(dim, 0),
+                destination_splits.get(dim, 1),
+            )
+            for dim in dimensions
+        )
+    )
+
+
 def _compatible_partitions(
-    source: PerCoreView, destination: PerCoreView, num_cores: int
+    source: PerCoreView,
+    destination: PerCoreView,
+    source_num_cores: int,
+    destination_num_cores: int | None = None,
 ) -> bool:
     """Whether every destination receives a uniform, complete partition."""
 
-    source_map = _core_slices(source, num_cores)
-    destination_map = _core_slices(destination, num_cores)
+    destination_num_cores = destination_num_cores or source_num_cores
+    source_map = _core_slices(source, source_num_cores)
+    destination_map = _core_slices(destination, destination_num_cores)
     source_splits = dict(source.work_slice_dims)
     destination_splits = dict(destination.work_slice_dims)
-    dims = set(source_splits) | set(destination_splits)
-    edges = {
-        (s_core, d_core)
-        for s_core, s_slice in source_map.items()
-        for d_core, d_slice in destination_map.items()
-        if all(
-            _overlap(
-                s_slice.get(dim, 0),
-                source_splits.get(dim, 1),
-                d_slice.get(dim, 0),
-                destination_splits.get(dim, 1),
-            )
-            for dim in dims
-        )
-    }
-    fanout = [sum(src == core for src, _ in edges) for core in range(num_cores)]
-    fanin = [sum(dst == core for _, dst in edges) for core in range(num_cores)]
+    edges = _transfer_edges(
+        source, destination, source_num_cores, destination_num_cores
+    )
+    fanout = [sum(src == core for src, _ in edges) for core in range(source_num_cores)]
+    fanin = [
+        sum(dst == core for _, dst in edges) for core in range(destination_num_cores)
+    ]
     if not edges or len(set(fanout)) != 1 or len(set(fanin)) != 1:
         return False
     source_owners = len({tuple(sorted(row.items())) for row in source_map.values()})
     destination_owners = len(
         {tuple(sorted(row.items())) for row in destination_map.values()}
     )
-    if source_owners != num_cores or math.prod(source_splits.values()) != num_cores:
+    if (
+        source_owners != source_num_cores
+        or math.prod(source_splits.values()) != source_num_cores
+    ):
         return False
     destination_slices = math.prod(destination_splits.values())
-    if destination_owners != destination_slices or num_cores % destination_slices:
+    if (
+        destination_owners != destination_slices
+        or destination_num_cores % destination_slices
+    ):
         return False
-    multiplicity = num_cores // destination_slices
+    if source_num_cores != destination_num_cores:
+        return fanout[0] == destination_num_cores // source_num_cores and fanin[0] == 1
+    multiplicity = source_num_cores // destination_slices
     return multiplicity == 1 or (fanout[0] == multiplicity and fanin[0] == multiplicity)
+
+
+def _shuffle_geometry(
+    source: PerCoreView,
+    destination: PerCoreView,
+    source_num_cores: int,
+    destination_num_cores: int,
+) -> tuple[PerCoreView, PerCoreView, tuple[RelayoutDimension, ...]] | None:
+    """Certify the existing one-to-one shuffle lowering."""
+
+    if source_num_cores != destination_num_cores or per_core_views_equal(
+        source, destination
+    ):
+        return None
+    if not _compatible_partitions(
+        source, destination, source_num_cores, destination_num_cores
+    ):
+        return None
+    edges = _transfer_edges(
+        source, destination, source_num_cores, destination_num_cores
+    )
+    if any(
+        sum(src == core for src, _ in edges) != 1
+        or sum(dst == core for _, dst in edges) != 1
+        for core in range(source_num_cores)
+    ):
+        return None
+    return source, destination, ()
+
+
+def _gather_geometry(
+    source: PerCoreView,
+    destination: PerCoreView,
+    source_num_cores: int,
+    destination_num_cores: int,
+) -> tuple[PerCoreView, PerCoreView, tuple[RelayoutDimension, ...]] | None:
+    """Adapter giving grouped gather the common classifier signature."""
+
+    if source_num_cores != destination_num_cores:
+        return None
+    return _grouped_gather_geometry(source, destination, source_num_cores)
+
+
+# Existing lowering functions are the registry.  The table adds no plan IR: it
+# only makes the authority order explicit.  A surviving fast path must certify
+# the same edge set derived by ``_transfer_edges`` before its name is recorded
+# in ``LXRelayoutPlan.kind``.
+_LOWERING_CERTIFIERS = {
+    "gather": _gather_geometry,
+    "shuffle": _shuffle_geometry,
+}
+_LOWERING_PRIORITY = ("gather", "shuffle")
+
+
+def classify_relayout_views(
+    source: PerCoreView,
+    destination: PerCoreView,
+    source_num_cores: int,
+    destination_num_cores: int | None = None,
+    *,
+    allowed_kinds: Sequence[str] | None = None,
+) -> tuple[str, tuple[RelayoutDimension, ...]] | None:
+    """Choose a certified lowering for one already-described view pair.
+
+    Ownership is the fact.  The returned name is merely the first existing
+    lowering, in deterministic priority order, whose certifier agrees with the
+    shared movement graph.  Unsupported movement remains an HBM fallback.
+    """
+
+    destination_num_cores = destination_num_cores or source_num_cores
+    allowed = set(allowed_kinds) if allowed_kinds is not None else None
+    for kind in _LOWERING_PRIORITY:
+        if allowed is not None and kind not in allowed:
+            continue
+        classified = _LOWERING_CERTIFIERS[kind](
+            source, destination, source_num_cores, destination_num_cores
+        )
+        if classified is not None:
+            return kind, classified[2]
+    return None
 
 
 def validate_final_views(
@@ -444,48 +612,52 @@ def validate_final_views(
     """Validate one complete relayout group after scheduler alignment preview."""
 
     destination_name = destination_name or plan.destination_name
-    source_views = {
+    source_views = [
         view
         for (_, buffer_name), view in views.items()
         if buffer_name == plan.source_name
-    }
-    destination_views = {
+    ]
+    destination_views = [
         view
         for (_, buffer_name), view in views.items()
         if buffer_name == destination_name
-    }
-    if len(source_views) != 1:
-        return f"source users derived {len(source_views)} final views"
-    if len(destination_views) != 1:
-        return f"destination users derived {len(destination_views)} final views"
-    source = next(iter(source_views))
-    destination = next(iter(destination_views))
+    ]
+    if not source_views:
+        return "schedule drift: source users derived 0 final views"
+    if not destination_views:
+        return "schedule drift: destination users derived 0 final views"
+    source = source_views[0]
+    destination = destination_views[0]
+
+    if any(not final_lx_views_equal(source, view) for view in source_views[1:]):
+        return f"schedule drift: source users derived {len(source_views)} final views"
+    if any(
+        not final_lx_views_equal(destination, view) for view in destination_views[1:]
+    ):
+        return (
+            "schedule drift: destination users derived "
+            f"{len(destination_views)} final views"
+        )
 
     if (
         source.ownership.num_cores != plan.num_cores
         or destination.ownership.num_cores != plan.num_cores
     ):
-        return "final view physical core count changed"
-    if source == destination:
-        return "final source and destination views no longer require a relayout"
-    if not _compatible_partitions(
-        source.ownership, destination.ownership, plan.num_cores
-    ):
-        return "final source and destination partitions are not a complete transfer"
+        return "schedule drift: final view physical core count changed"
+    if per_core_views_equal(source.ownership, destination.ownership):
+        return "schedule drift: final views no longer require a relayout"
 
-    if plan.kind == "gather":
-        classified = _grouped_gather_geometry(
-            source.ownership,
-            destination.ownership,
-            plan.num_cores,
-        )
-        if classified is None:
-            return "final views are not a grouped gather"
-        geometry = classified[2]
-        if _geometry_topology(geometry) != _geometry_topology(plan.group_geometry):
-            return f"final grouped-gather geometry changed: {geometry}"
-    elif plan.kind != "shuffle":
-        return f"unsupported relayout kind {plan.kind}"
+    classified = classify_relayout_views(
+        source.ownership,
+        destination.ownership,
+        plan.num_cores,
+        allowed_kinds=(plan.kind,),
+    )
+    if classified is None:
+        return f"cannot emit: final views do not satisfy {plan.kind}"
+    _, geometry = classified
+    if _geometry_topology(geometry) != _geometry_topology(plan.group_geometry):
+        return f"schedule drift: {plan.kind} geometry changed: {geometry}"
 
     for name, planned_bound, view in (
         (plan.source_name, plan.source_footprint_bytes, source),
@@ -517,13 +689,14 @@ def validate_final_views(
             return f"final {name} has no committed physical span"
         if view.physical_span_bytes > planned_bound:
             return (
-                f"final {name} physical span {view.physical_span_bytes} "
+                f"allocation: final {name} physical span "
+                f"{view.physical_span_bytes} "
                 f"exceeds planned "
                 f"{planned_bound}"
             )
 
     if plan.source_address is None or plan.destination_address is None:
-        return "relayout group has no committed LX addresses"
+        return "allocation: relayout group has no committed LX addresses"
     # The allocator validates disjointness using each concrete buffer size.
     # Repeating that check with this edge's maximum bound is incorrect for a
     # source shared by differently sized destinations.
@@ -679,7 +852,9 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                     )
                     break
                 candidate_source, destination, geometry = grouped
-                if grouped_source is not None and candidate_source != grouped_source:
+                if grouped_source is not None and not per_core_views_equal(
+                    candidate_source, grouped_source
+                ):
                     rejection_reason = (
                         "consumers require different grouped source geometry"
                     )
@@ -728,7 +903,7 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                     )
                     break
                 assert source_work_division is not None
-                if destination_view == source_view:
+                if per_core_views_equal(destination_view, source_view):
                     continue
                 is_matmul = _is_matmul_op(consumer)
                 if is_matmul and len(deps) != 2:
@@ -737,10 +912,17 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                 if not is_matmul and not isinstance(consumer.data, Pointwise):
                     rejection_reason = "consumer is neither pointwise nor matmul"
                     break
-                if not _compatible_partitions(source_view, destination_view, num_cores):
-                    rejection_reason = (
-                        "source and destination partitions are incompatible"
-                    )
+                expected_kind = (
+                    "gather" if consumer_name in grouped_geometry else "shuffle"
+                )
+                classified = classify_relayout_views(
+                    source_view,
+                    destination_view,
+                    num_cores,
+                    allowed_kinds=(expected_kind,),
+                )
+                if classified is None:
+                    rejection_reason = "cannot emit: unsupported ownership transfer"
                     break
                 try:
                     destination_work_division = work_division_from_view(
@@ -757,8 +939,11 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                 ):
                     rejection_reason = reason
                     break
-                kind = "gather" if consumer_name in grouped_geometry else "shuffle"
-                geometry = grouped_geometry.get(consumer_name, ())
+                kind, geometry = classified
+                planned_geometry = grouped_geometry.get(consumer_name, ())
+                if _geometry_topology(geometry) != _geometry_topology(planned_geometry):
+                    rejection_reason = "cannot emit: lowering geometry disagrees"
+                    break
                 source_footprint = partition_footprint(producer.layout, source_view)
                 destination_footprint = partition_footprint(
                     producer.layout, destination_view
@@ -822,7 +1007,7 @@ def materialize_lx_relayouts(graph: GraphLowering, plans: list[LXRelayoutPlan]) 
         copies[plan.edge] = (copy.get_name(), plan)
 
         assert plan.source_address is not None and plan.destination_address is not None
-        assert plan.source_view != plan.destination_view
+        assert not per_core_views_equal(plan.source_view, plan.destination_view)
         source_layout = cast(FixedTiledLayout, source.layout)
         copy_layout = cast(FixedTiledLayout, copy.layout)
         source_layout.allocation["lx"] = plan.source_address

--- a/torch_spyre/_inductor/scratchpad/lx_relayout.py
+++ b/torch_spyre/_inductor/scratchpad/lx_relayout.py
@@ -73,7 +73,7 @@ class LXRelayoutPlan:
     source_view: PerCoreView
     destination_view: PerCoreView
     num_cores: int
-    kind: Literal["shuffle", "gather"] = "shuffle"
+    kind: Literal["shuffle", "gather", "broadcast"] = "shuffle"
     group_geometry: tuple[RelayoutDimension, ...] = ()
     source_footprint_bytes: int = 0
     destination_footprint_bytes: int = 0
@@ -406,6 +406,50 @@ def _grouped_gather_geometry(
     return source, destination, tuple(geometry)
 
 
+def _grouped_broadcast_geometry(
+    source: PerCoreView,
+    destination: PerCoreView,
+    source_num_cores: int,
+    destination_num_cores: int,
+) -> tuple[PerCoreView, PerCoreView, tuple[RelayoutDimension, ...]] | None:
+    """Classify a complete source partition spread over more physical cores."""
+
+    source_splits = dict(source.work_slice_dims)
+    destination_splits = dict(destination.work_slice_dims)
+    if (
+        source_num_cores >= destination_num_cores
+        or math.prod(source_splits.values()) != source_num_cores
+        or destination_num_cores % math.prod(destination_splits.values())
+    ):
+        return None
+
+    geometry = []
+    for dim in dict.fromkeys((*source_splits, *destination_splits)):
+        source_split = source_splits.get(dim, 1)
+        destination_split = destination_splits.get(dim, 1)
+        if destination_split < source_split or destination_split % source_split:
+            return None
+        geometry.append(
+            RelayoutDimension(
+                device_dim=dim,
+                source_split=source_split,
+                destination_split=destination_split,
+                group_count=source_split,
+                group_size=destination_split // source_split,
+                multiplicity=destination_split // source_split,
+                ordering_tag="contiguous_groups",
+            )
+        )
+    if not _compatible_partitions(
+        source,
+        destination,
+        source_num_cores,
+        destination_num_cores,
+    ):
+        return None
+    return source, destination, tuple(geometry)
+
+
 def partition_footprint(layout: FixedTiledLayout, view: PerCoreView) -> int:
     device_layout = layout.device_layout
     return partition_physical_span_bytes(
@@ -563,15 +607,29 @@ def _gather_geometry(
     return _grouped_gather_geometry(source, destination, source_num_cores)
 
 
+def _broadcast_geometry(
+    source: PerCoreView,
+    destination: PerCoreView,
+    source_num_cores: int,
+    destination_num_cores: int,
+) -> tuple[PerCoreView, PerCoreView, tuple[RelayoutDimension, ...]] | None:
+    """Adapter giving grouped broadcast the common classifier signature."""
+
+    return _grouped_broadcast_geometry(
+        source, destination, source_num_cores, destination_num_cores
+    )
+
+
 # Existing lowering functions are the registry.  The table adds no plan IR: it
 # only makes the authority order explicit.  A surviving fast path must certify
 # the same edge set derived by ``_transfer_edges`` before its name is recorded
 # in ``LXRelayoutPlan.kind``.
 _LOWERING_CERTIFIERS = {
+    "broadcast": _broadcast_geometry,
     "gather": _gather_geometry,
     "shuffle": _shuffle_geometry,
 }
-_LOWERING_PRIORITY = ("gather", "shuffle")
+_LOWERING_PRIORITY = ("broadcast", "gather", "shuffle")
 
 
 def classify_relayout_views(
@@ -639,9 +697,11 @@ def validate_final_views(
             f"{len(destination_views)} final views"
         )
 
+    source_num_cores = plan.source_view.num_cores or plan.num_cores
+    destination_num_cores = plan.destination_view.num_cores or plan.num_cores
     if (
-        source.ownership.num_cores != plan.num_cores
-        or destination.ownership.num_cores != plan.num_cores
+        source.ownership.num_cores != source_num_cores
+        or destination.ownership.num_cores != destination_num_cores
     ):
         return "schedule drift: final view physical core count changed"
     if per_core_views_equal(source.ownership, destination.ownership):
@@ -650,7 +710,8 @@ def validate_final_views(
     classified = classify_relayout_views(
         source.ownership,
         destination.ownership,
-        plan.num_cores,
+        source_num_cores,
+        destination_num_cores,
         allowed_kinds=(plan.kind,),
     )
     if classified is None:
@@ -770,7 +831,7 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
         source_view, partial, representable = _per_core_view_on_buf(
             producer, write, source_name, cache
         )
-        num_cores = _op_num_cores(producer)
+        source_num_cores = _op_num_cores(producer)
         if source_view is None or partial or not representable:
             continue
 
@@ -805,16 +866,21 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
             view, consumer_partial, representable = _per_core_view_on_buf(
                 consumer, dep, source_name, cache
             )
+            consumer_num_cores = _op_num_cores(consumer)
+            if view is None or consumer_partial or not representable:
+                rejection_reason = "consumer ownership is partial or unrepresentable"
+                break
+            if consumer_num_cores < source_num_cores:
+                rejection_reason = "consumer uses fewer physical cores than producer"
+                break
+            if consumer_num_cores > source_num_cores and not _is_matmul_op(consumer):
+                rejection_reason = "grouped broadcast requires a matmul consumer"
+                break
             if (
-                view is None
-                or consumer_partial
-                or not representable
-                or _op_num_cores(consumer) != num_cores
+                consumer_num_cores > source_num_cores
+                and consumer_num_cores != config.sencores
             ):
-                rejection_reason = (
-                    "consumer ownership is partial, unrepresentable, or uses a "
-                    "different core count"
-                )
+                rejection_reason = "grouped broadcast must target all compute cores"
                 break
             consumer_coordinates = try_device_coordinates(
                 producer.layout.device_layout, dep, None
@@ -831,21 +897,56 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                     view,
                     consumer_coordinates,
                     consumer_symbols,
+                    consumer_num_cores,
                 )
             )
 
         grouped_source = None
         grouped_destinations = {}
         grouped_geometry = {}
+        grouped_kinds = {}
         if rejection_reason is None:
-            for consumer_name, consumer, _, view, _, _ in consumer_views:
+            for (
+                consumer_name,
+                consumer,
+                _,
+                view,
+                _,
+                _,
+                consumer_num_cores,
+            ) in consumer_views:
+                if consumer_num_cores > source_num_cores:
+                    grouped = _grouped_broadcast_geometry(
+                        source_view,
+                        view,
+                        source_num_cores,
+                        consumer_num_cores,
+                    )
+                    if grouped is None:
+                        rejection_reason = (
+                            "grouped destination does not evenly replicate the source"
+                        )
+                        break
+                    candidate_source, destination, geometry = grouped
+                    if grouped_source is not None and not per_core_views_equal(
+                        candidate_source, grouped_source
+                    ):
+                        rejection_reason = (
+                            "consumers require different grouped source geometry"
+                        )
+                        break
+                    grouped_source = candidate_source
+                    grouped_destinations[consumer_name] = destination
+                    grouped_geometry[consumer_name] = geometry
+                    grouped_kinds[consumer_name] = "broadcast"
+                    continue
                 destination_owners = math.prod(dict(view.work_slice_dims).values())
-                if destination_owners >= num_cores:
+                if destination_owners >= source_num_cores:
                     continue
                 if not _is_matmul_op(consumer):
                     rejection_reason = "grouped gather requires a matmul consumer"
                     break
-                grouped = _grouped_gather_geometry(source_view, view, num_cores)
+                grouped = _grouped_gather_geometry(source_view, view, source_num_cores)
                 if grouped is None:
                     rejection_reason = (
                         "grouped destination does not evenly contract the source"
@@ -862,6 +963,7 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                 grouped_source = candidate_source
                 grouped_destinations[consumer_name] = destination
                 grouped_geometry[consumer_name] = geometry
+                grouped_kinds[consumer_name] = "gather"
 
         source_view = grouped_source or source_view
         producer_coordinates = try_device_coordinates(
@@ -891,6 +993,7 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                 raw_view,
                 consumer_coordinates,
                 consumer_symbols,
+                consumer_num_cores,
             ) in consumer_views:
                 destination_view = grouped_destinations.get(consumer_name, raw_view)
                 try:
@@ -912,13 +1015,12 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                 if not is_matmul and not isinstance(consumer.data, Pointwise):
                     rejection_reason = "consumer is neither pointwise nor matmul"
                     break
-                expected_kind = (
-                    "gather" if consumer_name in grouped_geometry else "shuffle"
-                )
+                expected_kind = grouped_kinds.get(consumer_name, "shuffle")
                 classified = classify_relayout_views(
                     source_view,
                     destination_view,
-                    num_cores,
+                    source_num_cores,
+                    consumer_num_cores,
                     allowed_kinds=(expected_kind,),
                 )
                 if classified is None:
@@ -964,7 +1066,7 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                     consumer_names=tuple(consumer_names),
                     source_view=source_view,
                     destination_view=destination_view,
-                    num_cores=num_cores,
+                    num_cores=source_num_cores,
                     kind=kind,
                     group_geometry=geometry,
                     source_footprint_bytes=source_footprint,

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass, field
+import math
 from typing import Any, Callable, Self, Sequence, Tuple, Union
 from abc import ABC
 import itertools
@@ -56,7 +57,12 @@ from .core_mapping import (
 )
 from .errors import Unsupported
 from .ir import FixedTiledLayout
-from .scratchpad.lx_relayout import work_division_from_view
+from .scratchpad.lx_relayout import (
+    final_view_from_work_division,
+    final_lx_views,
+    partition_footprint,
+    work_division_from_view,
+)
 from .pass_utils import (
     AlignmentAccess,
     concretize_expr,
@@ -81,6 +87,7 @@ from .op_spec import (
     LoopSpec,
     OpSpec,
     TensorArg,
+    TensorWorkDivision,
     UnimplementedOp as OpSpecUnimplementedOp,
     format_op_spec_list,
     is_lx_relayout_identity,
@@ -587,6 +594,8 @@ class SpyreKernel(Kernel[CSEVariable]):
         ] = {}
         self._alignment_access_by_tensor_arg: dict[int, AlignmentAccess] = {}
         self._alignment_inputs_by_spec: dict[int, AlignmentInputs] = {}
+        self._buffer_name_by_tensor_arg: dict[int, str] = {}
+        self._node_name_by_spec: dict[int, str] = {}
         self.pool_size: int = pool_size
 
     def indirect_var_names(self) -> "frozenset[str] | None":
@@ -858,6 +867,7 @@ class SpyreKernel(Kernel[CSEVariable]):
         self._alignment_access_by_tensor_arg[id(tensor_arg)] = AlignmentAccess(
             tensor.layout.device_layout, tensor.index
         )
+        self._buffer_name_by_tensor_arg[id(tensor_arg)] = name
         if (
             "lx" not in tensor.layout.allocation
             and "hbm_pool" not in tensor.layout.allocation
@@ -1057,7 +1067,61 @@ class SpyreKernel(Kernel[CSEVariable]):
         }
         if op != RESTICKIFY_OP:
             self._alignment_inputs_by_spec[id(op_spec)] = alignment_inputs
+        assert self.current_node is not None
+        self._node_name_by_spec[id(op_spec)] = self.current_node.get_name()
         return op_spec
+
+    def _validate_final_lx_views(self, op_spec: OpSpec) -> None:
+        """Assert codegen reproduced the graph-wide gate's accepted views."""
+
+        cached = final_lx_views(V.graph)
+        if not cached:
+            return
+        node_name = self._node_name_by_spec.get(id(op_spec))
+        if node_name is None:
+            return
+        is_relayout = is_lx_relayout_identity(op_spec.op, op_spec.args)
+        operation_division = None
+        if not is_relayout:
+            assert op_spec.core_id_to_work_slice is not None
+            work_slices = {
+                dim: int(split)
+                for dim, (_, split) in op_spec.iteration_space.items()
+                if int(split) > 1
+            }
+            operation_division = TensorWorkDivision(
+                work_slices,
+                {dim: op_spec.core_id_to_work_slice[dim] for dim in work_slices},
+                num_cores=math.prod(
+                    int(split) for _, split in op_spec.iteration_space.values()
+                ),
+            )
+
+        for arg in op_spec.args:
+            if "lx" not in arg.allocation:
+                continue
+            name = self._buffer_name_by_tensor_arg.get(id(arg))
+            if name is None:
+                raise RuntimeError("LX tensor is missing its codegen buffer identity")
+            expected = cached.get((node_name, name))
+            if expected is None:
+                raise RuntimeError(
+                    f"LX final-view gate has no result for {node_name} reading {name}"
+                )
+            division = arg.work_division if is_relayout else operation_division
+            if division is None:
+                raise RuntimeError(f"LX tensor {name} has no final work division")
+            actual = final_view_from_work_division(
+                division,
+                arg.device_size,
+                arg.device_coordinates,
+                op_spec.iteration_space,
+            )
+            if actual != expected:
+                raise RuntimeError(
+                    f"LX final view changed after the graph-wide gate for "
+                    f"{node_name}:{name}: {actual} != {expected}"
+                )
 
     def remove_kernel_local_buffers(self) -> None:
         """Remove buffers that have a scratchpad or temporary allocation from the kernel's arg list."""
@@ -1338,6 +1402,7 @@ class SpyreKernel(Kernel[CSEVariable]):
                 repeat_info=self._alignment_repeat_info_by_spec.get(id(op_spec)),
                 alignment_inputs=self._alignment_inputs_by_spec.get(id(op_spec)),
             )
+            self._validate_final_lx_views(op_spec)
 
         if _spyre_config.validate_op_specs:
             validate_op_specs(self.op_specs, stage="after_simplification")

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -60,6 +60,7 @@ from .ir import FixedTiledLayout
 from .scratchpad.lx_relayout import (
     final_view_from_work_division,
     final_lx_views,
+    final_lx_views_equal,
     partition_footprint,
     work_division_from_view,
 )
@@ -1127,7 +1128,7 @@ class SpyreKernel(Kernel[CSEVariable]):
                     else None
                 ),
             )
-            if actual != expected:
+            if not final_lx_views_equal(actual, expected):
                 raise RuntimeError(
                     f"LX final view changed after the graph-wide gate for "
                     f"{node_name}:{name}: {actual} != {expected}"

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -1111,11 +1111,21 @@ class SpyreKernel(Kernel[CSEVariable]):
             division = arg.work_division if is_relayout else operation_division
             if division is None:
                 raise RuntimeError(f"LX tensor {name} has no final work division")
+            buffer = V.graph.try_get_buffer(name)
+            if buffer is None or not isinstance(
+                (layout := buffer.get_layout()), FixedTiledLayout
+            ):
+                raise RuntimeError(f"LX tensor {name} has no fixed tiled layout")
             actual = final_view_from_work_division(
                 division,
                 arg.device_size,
                 arg.device_coordinates,
                 op_spec.iteration_space,
+                physical_span_bytes=(
+                    partition_footprint(layout, layout.lx_view)
+                    if layout.lx_view is not None
+                    else None
+                ),
             )
             if actual != expected:
                 raise RuntimeError(

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -1105,9 +1105,9 @@ class SpyreKernel(Kernel[CSEVariable]):
                 raise RuntimeError("LX tensor is missing its codegen buffer identity")
             expected = cached.get((node_name, name))
             if expected is None:
-                raise RuntimeError(
-                    f"LX final-view gate has no result for {node_name} reading {name}"
-                )
+                # The graph-wide cache proves relayout handoffs. Ordinary LX
+                # residency keeps using the scheduler's existing validation.
+                continue
             division = arg.work_division if is_relayout else operation_division
             if division is None:
                 raise RuntimeError(f"LX tensor {name} has no final work division")


### PR DESCRIPTION
## Superseded by #3440

The grouped-broadcast commits from this PR were folded unchanged into #3440.
The combined PR extends the merged #3439 LX-relayout foundation with grouped
gather and broadcast lowering.

Please continue review and discussion on #3440. The broadcast commit segment is unchanged; the combined branch has since added a focused compatibility fix preserving #3439's full-partition shuffle behavior.
