### PR TITLE
Convert LX-reuse op filter from an allowlist to a denylist

### DIFF
--- a/docs/source/compiler/scratchpad_planning.md
+++ b/docs/source/compiler/scratchpad_planning.md
@@ -331,7 +331,7 @@ The checks, in evaluation order (the first failure is the reason reported):
 
 | Reason | Why |
 |---|---|
-| `op not allowed` | not a `ComputedBuffer`, a mutation layout, or an op name outside `OP_OUTPUT_GOOD_FOR_LX_REUSE` (the debug flag `config.allow_all_ops_in_lx_planning` bypasses the op-name gate) |
+| `op not allowed` | not a `ComputedBuffer`, a mutation layout, or an op name inside `OP_OUTPUT_NOT_GOOD_FOR_LX_REUSE` (the debug flag `config.allow_all_ops_in_lx_planning` bypasses the op-name gate) |
 | `unsized (no device layout)` | no computable footprint (e.g. a `MultiOutputLayout` tuple op) |
 | `mutation target` | filled by offset writes, so one LX base mis-addresses it |
 | `tiled (advancing)` | LX addresses cannot be `affine.apply` symbols; the advancing-tile check reads `loop_info` (the sole source of truth for per-tile geometry) |

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_scalar_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_lx_reduction_scalar_config.yaml
@@ -35,8 +35,9 @@ test_suite_config:
             # identity copy reads the strided-conv output buffer densely and the
             # spatial elements shuffle). Non-strided direct convs are correct
             # under LX (all 16 stride-1 direct cases pass). Production never
-            # pins conv output -- conv is not in OP_OUTPUT_GOOD_FOR_LX_REUSE --
-            # so this is a test-only path (backend follow-up on PR #3284).
+            # pins conv output -- "convolution"/"conv2d" are in
+            # OP_OUTPUT_NOT_GOOD_FOR_LX_REUSE -- so this is a test-only path
+            # (backend follow-up on PR #3284).
             - LxPlanning.*::test_conv2d_direct_.*_s2_lx_planning_(pointwise|reduction)
           mode: xfail
         - names:

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -6107,7 +6107,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         lx_planning is disabled here so the `a = x + y` intermediate isn't
         claimed by LX scratchpad planning first -- with LX planning on,
         `add`/`mul`/`sub` outputs are all LX-eligible by default (see
-        OP_OUTPUT_GOOD_FOR_LX_REUSE in scratchpad/utils.py) and may win the
+        OP_OUTPUT_NOT_GOOD_FOR_LX_REUSE in scratchpad/utils.py) and may win the
         scratchpad before hbm_pool_planning ever sees them, leaving every
         bundle's pool_size at 0 and proving nothing about the plumbing this
         test exists to check.
@@ -6294,7 +6294,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
         With lx_planning enabled, the `a = x + y` intermediate is claimed by
         LX scratchpad planning before hbm_pool_planning ever sees it (see
-        OP_OUTPUT_GOOD_FOR_LX_REUSE in scratchpad/utils.py), so this bundle
+        OP_OUTPUT_NOT_GOOD_FOR_LX_REUSE in scratchpad/utils.py), so this bundle
         has no pool-eligible buffer and define_kernel() must omit the
         pool_size kwarg entirely rather than emit pool_size=0.
         """

--- a/tests/inductor/test_fallback_kernel.py
+++ b/tests/inductor/test_fallback_kernel.py
@@ -372,11 +372,11 @@ class TestInGraphCpuComputedBuffers(unittest.TestCase):
     """CPU pointwise ComputedBuffers in a mixed graph must not crash scratchpad planning.
 
     A convert fallback returns a CPU tensor; a chain of pointwise ops
-    (add/sub/mul -- all in OP_OUTPUT_GOOD_FOR_LX_REUSE) then runs on it inside
-    the same graph, before converting back to Spyre. propagate_layouts SKIPS
-    those CPU ComputedBuffers (device != spyre), leaving them a plain
+    (add/sub/mul -- none in OP_OUTPUT_NOT_GOOD_FOR_LX_REUSE) then runs on it
+    inside the same graph, before converting back to Spyre. propagate_layouts
+    SKIPS those CPU ComputedBuffers (device != spyre), leaving them a plain
     `FixedLayout` with no `device_layout`. The scratchpad planner's op gate
-    (`_op_output_good_for_lx_reuse`) whitelisted by op NAME only, so a CPU
+    (`_op_output_good_for_lx_reuse`) filtered by op NAME only, so a CPU
     add/sub/mul passed the gate, entered graph_view, and reached
     `mem_usage_by_buf`, which read `layout.device_layout` and raised
     `'FixedLayout' object has no attribute 'device_layout'`. The gate now also

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -85,7 +85,7 @@ from torch_spyre._inductor.scratchpad.utils import (
     _is_read_advancing_anywhere,
     _get_buffer_user_deps,
     _would_produce_lx_back_gap,
-    OP_OUTPUT_GOOD_FOR_LX_REUSE,
+    OP_OUTPUT_NOT_GOOD_FOR_LX_REUSE,
 )
 from torch_spyre._inductor.scratchpad.graph_editor import GraphEditor
 from torch_spyre._inductor.ir import FixedTiledLayout
@@ -334,10 +334,10 @@ class ScratchpadAllocator:
         # with no device_layout and can never be LX-pinned.
         if not isinstance(op.layout, FixedTiledLayout):
             return False
-        # A planned source intentionally bypasses the profitability allowlist:
+        # A planned source intentionally bypasses the profitability denylist:
         # the relayout planner has already applied its stricter structural gates.
         return config.allow_all_ops_in_lx_planning or (
-            self._get_op_name(op) in OP_OUTPUT_GOOD_FOR_LX_REUSE
+            self._get_op_name(op) not in OP_OUTPUT_NOT_GOOD_FOR_LX_REUSE
             or op.get_name() in planned_lx_buffers
         )
 

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -38,29 +38,16 @@ from torch_spyre._inductor.pass_utils import (
 from torch._inductor.ir import MutationLayoutSHOULDREMOVE, ComputedBuffer
 from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
 
-# Op outputs eligible for LX-pinning. `amax` is the lowered form of
-# `max`; both names are listed to match whichever the IR shows.
-OP_OUTPUT_GOOD_FOR_LX_REUSE = frozenset(
+# Op outputs NOT eligible for LX-pinning; every other op is eligible by
+# default. `convolution` is aten's direct-conv op name and `conv2d` is the
+# depthwise (`torch.ops.spyre.conv2d`) op name -- both are listed because a
+# stride-2 direct-lowered conv miscomputes (shuffled spatial elements) when
+# its output is pinned to LX; see the direct-lowering codegen follow-up
+# tracked from PR #3284.
+OP_OUTPUT_NOT_GOOD_FOR_LX_REUSE = frozenset(
     {
-        "max",
-        "amax",
-        "maximum",
-        "sum",
-        "clone",
-        "exp",
-        "sub",
-        "mul",
-        "mean",
-        "add",
-        "rsqrt",
-        "neg",
-        "mm",
-        "bmm",
-        "batched_matmul",
-        "div",
-        "realdiv",
-        "expand",
-        "silu",
+        "convolution",
+        "conv2d",
     }
 )
 
@@ -73,12 +60,12 @@ def clone_at_graph_boundaries() -> bool:
     """True when clone ops are eligible for LX, enabling clone insertion at graph
     input/output boundaries so those buffers can also be LX-pinned.
 
-    Gated by listing "clone" in OP_OUTPUT_GOOD_FOR_LX_REUSE. It intentionally
-    does NOT consult ``allow_all_ops_in_lx_planning``: that flag widens
-    intermediate-output eligibility and is set broadly (e.g. the LX-planning
-    op suite), so coupling it here would silently turn on the boundary clone
-    path in contexts that don't intend to exercise it."""
-    return "clone" in OP_OUTPUT_GOOD_FOR_LX_REUSE
+    Gated by "clone" being absent from OP_OUTPUT_NOT_GOOD_FOR_LX_REUSE. It
+    intentionally does NOT consult ``allow_all_ops_in_lx_planning``: that flag
+    widens intermediate-output eligibility and is set broadly (e.g. the
+    LX-planning op suite), so coupling it here would silently turn on the
+    boundary clone path in contexts that don't intend to exercise it."""
+    return "clone" not in OP_OUTPUT_NOT_GOOD_FOR_LX_REUSE
 
 
 def calculate_liveness(graph: GraphLowering) -> dict[str, list[int]]:


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [X] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

- OP_OUTPUT_GOOD_FOR_LX_REUSE was a whitelist of ~19 op names eligible for LX-pinning; every other op was implicitly excluded from the profitability gate in ScratchpadAllocator._op_output_good_for_lx_reuse, on top of the allocator's independent correctness gates (tiled/advancing, restickify barrier, extern kernel, indirect access, partial read, core division mismatch, back gap).

- Flip it to OP_OUTPUT_NOT_GOOD_FOR_LX_REUSE, a denylist, so every op is LX-eligible by default and only explicitly listed ops are excluded. 
- The only entries needed for correctness are "convolution" and "conv2d": a stride-2 direct-lowered conv miscomputes (shuffled spatial elements) when its output is pinned to LX (see the xfail note in test_inductor_ops_lx_reduction_scalar_config.yaml, tracked from PR #3284). 
- clone_at_graph_boundaries() is inverted to match ("clone" not in the denylist), preserving today's always-on boundary cloning.
- Updated stale comments/docs referencing the old constant name.


#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No

#### Additional note:
