### PR TITLE
fix(tests): resolve positional dtype args in model-ops YAML cases

### DIFF
--- a/tests/configs/torch_spyre_tests/test_runner_helpers_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_runner_helpers_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [unit, regression, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/models/test_runner_helpers.py
+      unlisted_test_mode: mandatory_success

--- a/tests/models/runner.py
+++ b/tests/models/runner.py
@@ -297,10 +297,16 @@ def make_SampleInput(
                     val = ast.literal_eval(val)
                 except (ValueError, SyntaxError):
                     pass
+                # A dtype written as a YAML scalar ("torch.float32") is not a
+                # Python literal, so ast.literal_eval leaves it a str and .to()
+                # then rejects it as a device string. Resolve it here, the same
+                # way the kwmap branch below resolves a dtype= kwarg.
+                if isinstance(val, str) and val.startswith("torch."):
+                    val = parse_dtype(val)
                 # if test target is tensor.to("cuda:0"), replace "cuda:0" with test_device
                 op_name = case.get("op")
                 if test_device is not None and op_name == "torch.to":
-                    if "cuda" in val:
+                    if isinstance(val, str) and "cuda" in val:
                         val = test_device
             cpu_args.append(val)  # python scalar or list, etc.
         elif "py" in inp:

--- a/tests/models/test_runner_helpers.py
+++ b/tests/models/test_runner_helpers.py
@@ -1,0 +1,82 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the model-ops YAML -> SampleInput conversion helpers."""
+
+import pytest
+import torch
+
+from .runner import make_SampleInput
+
+_CPU = torch.device("cpu")
+
+
+def _case(op, *value_entries):
+    """Build a minimal case dict: one f32 input tensor plus literal args."""
+    inputs = [{"tensor": {"shape": [2, 3], "dtype": "torch.float32", "init": "rand"}}]
+    inputs.extend({"value": v} for v in value_entries)
+    return {"op": op, "inputs": inputs}
+
+
+def _sample(case, test_device=_CPU):
+    return make_SampleInput(case, 0, torch.float16, test_device)
+
+
+@pytest.mark.parametrize(
+    "spec,expected",
+    [("torch.float32", torch.float32), ("torch.bfloat16", torch.bfloat16)],
+)
+def test_positional_dtype_string_becomes_dtype(spec, expected):
+    """A ``value:`` dtype scalar must reach the op as a real torch.dtype.
+
+    ``ast.literal_eval`` cannot parse ``torch.float32`` (it is an attribute
+    expression, not a literal), so an unconverted string used to reach
+    ``Tensor.to`` positionally and fail as ``Invalid device string``.
+    """
+    sample = _sample(_case("torch.to", spec))
+    assert sample.args[0] is expected
+
+
+def test_positional_dtype_survives_the_call():
+    """The converted arg must actually drive the cast."""
+    sample = _sample(_case("torch.to", "torch.bfloat16"))
+    assert sample.input.to(*sample.args).dtype is torch.bfloat16
+
+
+def test_device_and_dtype_positional_args_keep_their_roles():
+    """``.to(device, dtype)``: the device is remapped, the dtype is resolved."""
+    sample = _sample(_case("torch.to", "cuda:0", "torch.bfloat16"))
+    assert sample.args == (_CPU, torch.bfloat16)
+
+
+def test_cuda_device_string_is_remapped_to_test_device():
+    sample = _sample(_case("torch.to", "cuda:0"))
+    assert sample.args[0] == _CPU
+
+
+def test_non_dtype_strings_are_left_alone():
+    """Only ``torch.``-prefixed scalars are dtypes; other strings pass through."""
+    sample = _sample(_case("torch._C._log_api_usage_once", "python.nn_module"))
+    assert sample.args[0] == "python.nn_module"
+
+
+def test_literal_tuple_strings_still_parse():
+    """Guard the pre-existing ast.literal_eval path against regressions."""
+    sample = _sample(_case("torch.reshape", "(1, 1, -1, 128)"))
+    assert sample.args[0] == (1, 1, -1, 128)
+
+
+def test_unknown_torch_dtype_fails_loudly():
+    """A typo'd dtype must raise a clear error, not 'Invalid device string'."""
+    with pytest.raises(ValueError, match="Unknown torch dtype"):
+        _sample(_case("torch.to", "torch.bfloat32"))


### PR DESCRIPTION
## Problem

The model-ops YAML records a dtype argument two ways, and `make_SampleInput` only converted one:

| YAML form | Before |
|---|---|
| `kwmap: {dtype: torch.bfloat16}` | ✅ `parse_dtype(value)` (`runner.py:313`) |
| `- value: torch.float32` (positional) | ❌ stayed a `str` (`runner.py:293-305`) |

The positional branch uses `ast.literal_eval`, which can't parse `torch.float32` (an attribute expression, not a literal). The `except` swallows the error, so the raw string reaches `Tensor.to` as arg 0 and PyTorch parses it as a device:

```
RuntimeError: Invalid device string: 'torch.float32'
```

## Fix

```python
if isinstance(val, str) and val.startswith("torch."):
    val = parse_dtype(val)
```

Reuses the helper already in the file. Gated on the `torch.` prefix so device strings, literal tuples and `python.nn_module` are untouched — across all 16 model YAMLs, `torch.bfloat16` and `torch.float32` are the only `torch.`-prefixed values.

Second change is **mandatory**: once `val` can be a `torch.dtype`, the pre-existing `if "cuda" in val` raises `TypeError: argument of type 'torch.dtype' is not iterable`, hence the added `isinstance` guard.

## Result

`test_model_ops.py -k torch_to_`, default markers: **65 failed / 37 passed → 39 failed / 63 passed (+26)**, with zero `Invalid device string` remaining. The failures that remain are pre-existing backend issues the harness error was masking — follow-up PRs.

One behavior note: the two Mistral `.to("cuda:0", "torch.bfloat16")` cases now take the real D2D path for the first time (warning + CPU round-trip) instead of erroring in argument parsing.

## Tests

New `tests/models/test_runner_helpers.py`, 8 cases — these helpers had no unit tests. Verified non-vacuous: with the fix reverted, 5 fail and the 3 regression guards still pass. Registered via `tests/configs/torch_spyre_tests/test_runner_helpers_config.yaml` so they run on every PR in the `tests` workflow.

## Scope

Test-harness only; no backend change. No existing CI result changes — the model-ops jobs run `test_model_ops_v2.py`, whose schema has zero positional dtypes, and `runner.py` is imported only by `test_model_ops.py`, which no CI config references. `Refs #3083`, `Refs #2454` — not `Fixes`, since the numerical failures keep #2454 open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
