### PR TITLE
Do not treat spyre.empty as an LX clobber

### DIFF
--- a/tests/inductor/test_lx_extern_kernel_clobber.py
+++ b/tests/inductor/test_lx_extern_kernel_clobber.py
@@ -50,6 +50,7 @@ import torch
 
 import torch_spyre  # noqa: F401
 from torch._inductor.ir import ExternKernel
+from torch_spyre._inductor.ir import SpyreEmptyFallback
 from torch_spyre._inductor.scratchpad.allocator import _extern_kernel_in_live_range
 
 
@@ -86,6 +87,12 @@ def test_extern_kernel_in_live_range():
     assert not _extern_kernel_in_live_range(spanning, [0])
     assert not _extern_kernel_in_live_range(_FakeGraph([plain, plain, plain]), [0, 2])
     assert not _extern_kernel_in_live_range(spanning, [])
+
+    # spyre.empty is represented as an ExternKernel in the IR, but its codegen
+    # only allocates storage. It launches no program and cannot clobber LX.
+    empty = Mock(spec=SpyreEmptyFallback)
+    allocation_only = _FakeGraph([plain, empty, plain])
+    assert not _extern_kernel_in_live_range(allocation_only, [0, 2])
 
 
 @pytest.mark.parametrize("layers", [1, 4])

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -88,7 +88,7 @@ from torch_spyre._inductor.scratchpad.utils import (
     OP_OUTPUT_NOT_GOOD_FOR_LX_REUSE,
 )
 from torch_spyre._inductor.scratchpad.graph_editor import GraphEditor
-from torch_spyre._inductor.ir import FixedTiledLayout
+from torch_spyre._inductor.ir import FixedTiledLayout, SpyreEmptyFallback
 
 from torch_spyre._inductor import config
 from torch_spyre._inductor.logging_utils import get_inductor_logger
@@ -141,6 +141,7 @@ def _extern_kernel_in_live_range(graph: GraphLowering, uses: list[int]) -> bool:
         return False
     return any(
         isinstance(graph.operations[i], ExternKernel)
+        and not isinstance(graph.operations[i], SpyreEmptyFallback)
         for i in range(min(uses), max(uses) + 1)
     )
 


### PR DESCRIPTION
Tracking: #3565
Prerequisite for #4042

## Campaign status

Merged. The full dense expert-loop compiler implementation and acceptance are complete in `main` through #4042 (`3358f39e`). Structural, numerical-correctness, and same-stack device-performance gates have passed.

## This PR owns

`SpyreEmptyFallback` is represented as an `ExternKernel`, but its code generation only allocates storage; it launches no external program and cannot overwrite an LX value.

The scratchpad clobber check now excludes only `SpyreEmptyFallback` from opaque extern kernels. Real extern kernels remain barriers.

## This PR does not own

- forcing any buffer into LX;
- relaxing the mutation-target rule;
- creating or verifying the carried expert sum (#4042).

This fix only lets an otherwise legal buffer qualify for LX planning. The allocator still decides whether it fits and remains profitable.

## Why the dependency is required

Without this classification, the allocator sees the allocation-only `spyre.empty` inside the live range and rejects the carried accumulator as if an unknown external program could clobber LX. #4042's final verifier can prove placement only after this false blocker is removed.

## Validation

- Production diff: +2/-1; focused tests: +7/-0.
- Positive test: `SpyreEmptyFallback` does not block LX eligibility.
- Negative control: a real extern kernel still blocks LX eligibility.
- Local Ruff format/check, `py_compile`, and `git diff --check` pass on current `main`.
- Commit `df13f044` is DCO-signed and GPG-signed.
- All completed code, lint, focused, and compiler-matrix checks pass. One broad device job was cancelled by a hardware RAS response timeout; the required aggregate copied that cancellation and needs a maintainer rerun. See the explicit CI-status comment below.


