### PR TITLE
Preserve unit-tile operand steps

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -6872,6 +6872,41 @@ class TestCoarseTileMoEBroadcastMatmulE2E(InductorTestCase):
             fn, x, w, run_compile=True, run_eager=False, atol=0.05, rtol=0.05
         )
 
+    def test_unsqueeze_broadcast_matmul_emits_expert_weight_step(self):
+        """The read of packed weights advances once per expert loop trip."""
+        from torch_spyre._inductor import spyre_hint
+
+        E, T, H, F = 3, 64, 64, 64
+        x = torch.randn(T, H, dtype=torch.float16).to("spyre")
+        w = torch.randn(E, H, F, dtype=torch.float16).to("spyre")
+        _declare_tensor_dim("E", E)
+        _declare_tensor_dim("T", T)
+        _declare_tensor_dim("H", H)
+        _declare_tensor_dim("F", F)
+
+        def fn(x, w):
+            _name_tensor_dims(x, ["T", "H"])
+            _name_tensor_dims(w, ["E", "H", "F"])
+            with spyre_hint(num_tiles_per_dim={"E": E}):
+                return torch.matmul(x.unsqueeze(0), w)
+
+        with (
+            mock_patch(_LAUNCH_JOBPLAN),
+            mock_patch(_PREPARE_KERNEL),
+            mock_patch("subprocess.run"),
+        ):
+            _, source_codes = run_and_get_code(torch.compile(fn), x, w)
+
+        src = source_codes[0]
+        weight_copy = re.search(
+            r"op='identity'.*?arg_index=1.*?"
+            r"device_tile_advance_expr=sympify\('([^']+)'\)",
+            src,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(weight_copy)
+        self.assertIn("_tile_adv_coarse_tile_read_copy", weight_copy.group(1))
+
     def test_unsqueeze_broadcast_matmul_tile_E_poisoned_correct(self):
         """Same pattern as test_unsqueeze_broadcast_matmul_tile_E_correct,
         but relies on the session-scoped `_poison_device_hbm` fixture (see

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -2111,6 +2111,28 @@ class TestCoarseTileTiledDimsPerRead(unittest.TestCase):
         # only dim 1 (M=4, extent 1024, tiled at level 1) survives.
         self.assertEqual(broadcast_tiled_dims, [[], [(1, Integer(1024))]])
 
+    def test_unit_tile_keeps_predivision_input_step(self):
+        op = _make_real_pointwise_op(
+            ranges=[Integer(3), Integer(64)],
+            input_shapes_strides=[([3, 64], [64, 1])],
+            name="buf0",
+            hints=((1, 0),),
+        )
+        levels = [(1, Integer(3))]
+        plan = plan_coarse_tile_groups([op], [([op], levels)])
+
+        self.assertEqual(
+            plan[id(op)].predivision_unit_step_per_read,
+            [[[(0, Integer(64), Integer(1))]]],
+        )
+
+        _apply_plan([op], (0,), levels, {op.get_operation_name(): 0}, plan)
+        self.assertEqual(op.loop_info.tiled_dims_per_read, [[[]]])
+        self.assertEqual(
+            op.loop_info.squeezed_advance_per_read,
+            [[[(Integer(64), Integer(1))]]],
+        )
+
     def test_reduction_dim_advance_is_offset_by_output_dims(self):
         # out[d0] = sum_{d1} in[d0, d1].  in is [8, 16], row-major
         # (stride [16, 1]).  Output dim 0 (K=2 outer) is a real output dim;
@@ -5294,6 +5316,7 @@ class TestReadCopyPlanDataclasses(unittest.TestCase):
             dep=dep,
             insert_before_op_name="op0",
             sizing_op_name="op0",
+            sizing_read_index=0,
             consumer_op_names=("op0", "op1"),
         )
         self.assertEqual(entry.copy_name, "coarse_tile_read_copy_group0_a_0")

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -165,6 +165,9 @@ class ReadCopyEntry:
         get_operation_name() of the op supplying tiled_op.loop_info for
         the copy's own read/write-level-extent computation (the first
         consuming op, per the sizing-invariant in the design doc).
+    sizing_read_index:
+        Position of ``dep`` in the sizing op's original MemoryDep list.
+        Recorded before copy insertion rewrites any of those reads.
     consumer_op_names:
         Names of every op in the group that must have this dep's buffer
         name patched (via _NameSwapHandler) to load from copy_name instead.
@@ -174,6 +177,7 @@ class ReadCopyEntry:
     dep: "MemoryDep"
     insert_before_op_name: str
     sizing_op_name: str
+    sizing_read_index: int
     consumer_op_names: tuple[str, ...]
 
 
@@ -268,6 +272,12 @@ class CoarseTileInfo:
         contribution as an extra term via ``tiling_expr_to_device_expr``
         rather than by substitution. Empty list means no such dims for this
         read (the common case).
+    predivision_unit_step_per_read:
+        One entry per read dependency and loop level. Each tuple records
+        ``(op_dim_index, host_stride, tile_extent)`` for a tiled dimension
+        whose final per-tile extent is one. Planning captures this while the
+        dimension still exists in the dependency index; transformation uses
+        it after range division squeezes that dimension away.
     squeezed_advance_output:
         The analogous per-level ``(host_stride, extent)`` list for this op's
         own write dependency, parallel to ``output_tiled_dims`` the same way
@@ -290,6 +300,9 @@ class CoarseTileInfo:
     squeezed_advance_per_read: list[list[list[tuple[sympy.Expr, sympy.Expr]]]] = field(
         default_factory=list
     )
+    predivision_unit_step_per_read: list[
+        list[list[tuple[int, sympy.Expr, sympy.Expr]]]
+    ] = field(default_factory=list)
     squeezed_advance_output: list[list[tuple[sympy.Expr, sympy.Expr]]] = field(
         default_factory=list
     )

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -306,6 +306,10 @@ def plan_coarse_tile_groups(
             tiled_dims_per_read = [
                 _tiled_dims_for_dep(dep, per_level_extents, op) for dep in read_deps
             ]
+            predivision_unit_step_per_read = [
+                _predivision_unit_steps_for_dep(dep, tiled_dims, per_level_extents, op)
+                for dep, tiled_dims in zip(read_deps, tiled_dims_per_read)
+            ]
             output_tiled_dims = (
                 _tiled_dims_for_dep(write_deps[0], per_level_extents, op)
                 if write_deps
@@ -322,6 +326,7 @@ def plan_coarse_tile_groups(
                 loop_tiled_dims=op_tiled_dims,
                 loop_tiled_reduction_dims=op_tiled_reduction_dims,
                 tiled_dims_per_read=tiled_dims_per_read,
+                predivision_unit_step_per_read=predivision_unit_step_per_read,
                 output_tiled_dims=output_tiled_dims,
             )
 
@@ -1051,6 +1056,86 @@ def _tiled_dims_for_dep(
     ]
 
 
+def _predivision_unit_steps_for_dep(
+    dep: MemoryDep,
+    tiled_dims_per_level: list[list[tuple[int, Expr]]],
+    per_level_extents: list[dict[int, Expr]],
+    ir_node: ComputedBuffer,
+) -> list[list[tuple[int, Expr, Expr]]]:
+    """Keep address steps for tiled dimensions that will be squeezed away.
+
+    At planning time the original dimension and its index coefficient still
+    exist. After division, a one-element expert tile has neither, so the
+    address step cannot be reconstructed reliably from the smaller view.
+    """
+    raw_to_squeezed = _raw_to_squeezed_pos(ir_node)
+    unit_dims = {
+        dim
+        for dim in {d for level in per_level_extents for d in level}
+        if any(
+            extent == 1
+            for level in per_level_extents
+            for d, extent in level.items()
+            if d == dim
+        )
+    }
+    result: list[list[tuple[int, Expr, Expr]]] = []
+    for level in tiled_dims_per_level:
+        steps: list[tuple[int, Expr, Expr]] = []
+        for dim, extent in level:
+            if dim not in unit_dims:
+                continue
+            squeezed_dim = raw_to_squeezed.get(dim)
+            if squeezed_dim is None:
+                continue
+            symbol = sympy_index_symbol(f"d{squeezed_dim}")
+            stride = dep.index.coeff(symbol)
+            if stride != 0:
+                steps.append((dim, stride, extent))
+        result.append(steps)
+    return result
+
+
+def _materialize_predivision_unit_steps(info: CoarseTileInfo) -> CoarseTileInfo:
+    """Move captured unit-tile steps into codegen's squeezed-step form."""
+    if not any(any(levels) for levels in info.predivision_unit_step_per_read):
+        return info
+
+    tiled_dims = [
+        [list(level) for level in per_read] for per_read in info.tiled_dims_per_read
+    ]
+    squeezed = [
+        [list(level) for level in per_read]
+        for per_read in info.squeezed_advance_per_read
+    ]
+    while len(squeezed) < len(tiled_dims):
+        squeezed.append([[] for _ in info.loop_count])
+
+    for dep_idx, per_level_steps in enumerate(info.predivision_unit_step_per_read):
+        while len(tiled_dims[dep_idx]) < len(info.loop_count):
+            tiled_dims[dep_idx].append([])
+        while len(squeezed[dep_idx]) < len(info.loop_count):
+            squeezed[dep_idx].append([])
+        for level_idx, steps in enumerate(per_level_steps):
+            if not steps:
+                continue
+            unit_dims = {dim for dim, _stride, _extent in steps}
+            tiled_dims[dep_idx][level_idx] = [
+                pair
+                for pair in tiled_dims[dep_idx][level_idx]
+                if pair[0] not in unit_dims
+            ]
+            squeezed[dep_idx][level_idx].extend(
+                (stride, extent) for _dim, stride, extent in steps
+            )
+
+    return dataclasses.replace(
+        info,
+        tiled_dims_per_read=tiled_dims,
+        squeezed_advance_per_read=squeezed,
+    )
+
+
 def _check_matmul_broadcast_batch_tiling(
     op: ComputedBuffer,
     read_deps: list[MemoryDep],
@@ -1619,7 +1704,8 @@ def _apply_plan(
                 _divide_reduction_ranges(op, count, rpos_list)
 
         op.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
-            info, loop_group_id=stamped_group_id
+            _materialize_predivision_unit_steps(info),
+            loop_group_id=stamped_group_id,
         )
 
         logger.debug(
@@ -2823,6 +2909,7 @@ def _rescale_index(
 def _insert_one_read_copy(
     sizing_op: ComputedBuffer,
     dep: MemoryDep,
+    sizing_read_index: int,
     copy_name: str,
     operations: list[Operation],
     insert_before_op: Operation,
@@ -3164,6 +3251,16 @@ def _insert_one_read_copy(
     # SpyreKernel._general_tile_advance's positional dep-index lookup —
     # a semantic mismatch, not merely a magnitude one.
     sizing_op_info = sizing_op.loop_info  # type: ignore[attr-defined]
+    dep_idx = sizing_read_index
+    planned_unit_dims = (
+        {
+            dim
+            for level in sizing_op_info.predivision_unit_step_per_read[dep_idx]
+            for dim, _stride, _extent in level
+        }
+        if dep_idx < len(sizing_op_info.predivision_unit_step_per_read)
+        else set()
+    )
     copy_ranges = list(copy_data.ranges)
     # sizing_op_info.loop_tiled_dims's dim keys are raw positional indices
     # into sizing_op.data.ranges (see CoarseTileInfo's docstring), which
@@ -3185,10 +3282,16 @@ def _insert_one_read_copy(
     read_level_extents: list[dict[int, Expr]] = [
         {} for _ in sizing_op_info.loop_tiled_dims
     ]
-    squeezed_advance: list[list[tuple[Expr, Expr]]] = [
-        [] for _ in sizing_op_info.loop_tiled_dims
-    ]
+    squeezed_advance: list[list[tuple[Expr, Expr]]] = (
+        [list(level) for level in sizing_op_info.squeezed_advance_per_read[dep_idx]]
+        if dep_idx < len(sizing_op_info.squeezed_advance_per_read)
+        else [[] for _ in sizing_op_info.loop_tiled_dims]
+    )
     for d in {d for level in sizing_op_info.loop_tiled_dims for d in level}:
+        if d in planned_unit_dims:
+            # Planning captured this source step before division squeezed the
+            # dimension away; it is already present in squeezed_advance.
+            continue
         levels_tiling_d = [
             i for i, dims in enumerate(sizing_op_info.loop_tiled_dims) if d in dims
         ]
@@ -3449,7 +3552,8 @@ def _patch_consumer_to_read_copy(
     # read must be zeroed (dim omitted, see _fixed_level_extents).
     new_loop_info = new_op.loop_info  # type: ignore[attr-defined]
     new_reads = [r for r in new_op.get_read_writes().reads if isinstance(r, MemoryDep)]
-    if new_loop_info.tiled_dims_per_read:
+    new_tiled_dims_per_read = new_loop_info.tiled_dims_per_read
+    if new_tiled_dims_per_read:
         assert len(new_reads) == len(new_loop_info.tiled_dims_per_read), (
             f"_patch_consumer_to_read_copy: positional mismatch between "
             f"new_op.get_read_writes().reads ({len(new_reads)} entries) and "
@@ -3467,9 +3571,29 @@ def _patch_consumer_to_read_copy(
             )
             for read_dep, per_level in zip(new_reads, new_loop_info.tiled_dims_per_read)
         ]
-        new_op.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
-            new_loop_info, tiled_dims_per_read=new_tiled_dims_per_read
+
+    new_squeezed_advance_per_read = new_loop_info.squeezed_advance_per_read
+    if new_squeezed_advance_per_read:
+        assert len(new_reads) == len(new_squeezed_advance_per_read), (
+            "_patch_consumer_to_read_copy: positional mismatch between "
+            f"new_op.get_read_writes().reads ({len(new_reads)} entries) and "
+            "new_loop_info.squeezed_advance_per_read "
+            f"({len(new_squeezed_advance_per_read)} entries)"
         )
+        new_squeezed_advance_per_read = [
+            (
+                [[] for _ in new_loop_info.loop_count]
+                if read_dep.name == copy_name
+                else per_level
+            )
+            for read_dep, per_level in zip(new_reads, new_squeezed_advance_per_read)
+        ]
+
+    new_op.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
+        new_loop_info,
+        tiled_dims_per_read=new_tiled_dims_per_read,
+        squeezed_advance_per_read=new_squeezed_advance_per_read,
+    )
 
 
 def _plan_read_copies(
@@ -3569,6 +3693,11 @@ def _plan_read_copies(
                     dep=sizing_dep,
                     insert_before_op_name=sizing_op.get_operation_name(),
                     sizing_op_name=sizing_op.get_operation_name(),
+                    sizing_read_index=[
+                        read
+                        for read in sizing_op.get_read_writes().reads
+                        if isinstance(read, MemoryDep)
+                    ].index(sizing_dep),
                     consumer_op_names=tuple(
                         op.get_operation_name() for op, _dep in op_deps
                     ),
@@ -3606,6 +3735,7 @@ def _insert_all_read_copy_ops(
             new_copy_name = _insert_one_read_copy(
                 sizing_op,
                 entry.dep,
+                entry.sizing_read_index,
                 entry.copy_name,
                 operations,
                 insert_before_op=insert_before_op,


### PR DESCRIPTION
Closed duplicate. Superseded by #4040.

Do not review or use this PR as part of the MoE stack. The active address-step implementation, validation, and dependency record are maintained in #4040.

This PR reused the same head branch, so some GitHub Actions runs for later pushes may still display this closed PR number. The authoritative code head and review are #4040.
