### PR TITLE
Spyre-cli: Add direct launcher for spyrecode

### DIFF
--- a/docs/source/runtime/index.md
+++ b/docs/source/runtime/index.md
@@ -230,6 +230,28 @@ cover every operation a launch needs:
 `flex::RuntimeStream`. FIFO ordering on the stream is what makes the step
 sequence safe: each step completes before the next one starts.
 
+### Inspecting a JobPlan from Python
+
+`torch_spyre._C.JobPlan` exposes a read-only view of a prepared plan, useful
+for tests and for debugging a bundle before launching it:
+
+| Method | Returns |
+|---|---|
+| `num_steps()` | Number of steps in the plan |
+| `get_step_type(idx)` | `"H2D"`, `"D2H"`, `"Compute"`, or `"HostCompute"` |
+| `get_step_name(idx)` | Profiler-visible name of a compute step, else `None` |
+| `get_step_pipeline_barrier(idx)` | Pipeline-barrier flag for the step |
+| `job_allocation_size()` | Total size of the owning job allocation |
+| `num_expected_inputs()` | Number of recorded compiled input shapes |
+| `expected_input_shapes()` | Compiled tile dimensions, one list per input |
+| `get_expected_input_shape(idx)` | Compiled tile dimensions for one input |
+
+`expected_input_shapes()` returns an empty list for pure-DMA JobPlans. It is
+also empty for compute JobPlans today: `JobPlanBuilder::translateJobExecPlan`
+leaves the field unset because SpyreCode does not yet carry input shape
+metadata. Callers must therefore treat an empty result as "unknown", not as
+"zero inputs".
+
 ### Program correction
 
 Compiled binaries arrive with symbolic placeholders for tensor addresses that

--- a/extensions/spyre-cli/.gitignore
+++ b/extensions/spyre-cli/.gitignore
@@ -1,0 +1,10 @@
+# Python-generated files
+__pycache__/
+*.py[oc]
+build/
+dist/
+wheels/
+*.egg-info
+
+# Virtual environments
+.venv

--- a/extensions/spyre-cli/README.md
+++ b/extensions/spyre-cli/README.md
@@ -1,0 +1,37 @@
+# spyre-cli
+
+## Install
+
+Needs a pod with entire Spyre stack setup.
+
+```
+git clone ...
+uv pip install .
+```
+
+## CLI
+
+```
+spyre launch --path <folder with spyreCode> <path to io file>
+```
+
+## SDK
+
+Example, in a folder with the "spyreCode" for a torch.add operation:
+
+```
+import torch
+import spyre_cli
+
+a = torch.ones([512, 1024], device="spyre", dtype=torch.float16)
+b = torch.ones([512, 1024], device="spyre", dtype=torch.float16)
+c = torch.empty([512, 1024], device="spyre", dtype=torch.float16)
+
+spyre_cli.launch(a, b, c)
+
+print(c)
+```
+
+However, you have the following constraints:
+1. You need to pass the right input and output list.
+2. If the shapes don't match, there is no error - the code will silently work.

--- a/extensions/spyre-cli/README.md
+++ b/extensions/spyre-cli/README.md
@@ -2,7 +2,7 @@
 
 ## Install
 
-Needs a pod with entire Spyre stack setup.
+Needs a working Spyre stack environment.
 
 ```
 git clone ...

--- a/extensions/spyre-cli/pyproject.toml
+++ b/extensions/spyre-cli/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "spyre-cli"
 version = "0.1.0"
-description = "Add your description here"
+description = "A direct launcher for spyreCode"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [

--- a/extensions/spyre-cli/pyproject.toml
+++ b/extensions/spyre-cli/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "spyre-cli"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "click>=8.4.2",
+    "pydantic>=2.13.4",
+]
+
+[project.scripts]
+spyre = "spyre_cli.cli:main"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.1.1",
+]
+
+
+

--- a/extensions/spyre-cli/spyre_cli/__init__.py
+++ b/extensions/spyre-cli/spyre_cli/__init__.py
@@ -1,0 +1,3 @@
+from .core import launch
+
+__all__ = [launch]

--- a/extensions/spyre-cli/spyre_cli/__init__.py
+++ b/extensions/spyre-cli/spyre_cli/__init__.py
@@ -1,3 +1,3 @@
 from .core import launch
 
-__all__ = [launch]
+__all__ = ["launch"]

--- a/extensions/spyre-cli/spyre_cli/__init__.py
+++ b/extensions/spyre-cli/spyre_cli/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .core import launch
 
 __all__ = ["launch"]

--- a/extensions/spyre-cli/spyre_cli/cli.py
+++ b/extensions/spyre-cli/spyre_cli/cli.py
@@ -1,0 +1,19 @@
+import click
+from .core import launch_from_iofile
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+@click.option("--path", default=".", help="Path to folder with SpyreCode")
+@click.argument("iofile")
+def launch(path, iofile):
+    """Launch Spyrecode."""
+    launch_from_iofile(path, iofile)
+
+
+def main():
+    cli()

--- a/extensions/spyre-cli/spyre_cli/cli.py
+++ b/extensions/spyre-cli/spyre_cli/cli.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import click
 from .core import launch_from_iofile
 

--- a/extensions/spyre-cli/spyre_cli/core.py
+++ b/extensions/spyre-cli/spyre_cli/core.py
@@ -38,8 +38,7 @@ def launch_from_iofile(path=".", iofile="io.json"):
     try:
         spec = parse_json_file(iofile)
     except Exception as e:
-        print(e)
-        exit(1)
+        raise RuntimeError(f"Failed to parse IO Spec file '{iofile}': {e}") from e
 
     import torch
 

--- a/extensions/spyre-cli/spyre_cli/core.py
+++ b/extensions/spyre-cli/spyre_cli/core.py
@@ -64,6 +64,11 @@ def launch_from_iofile(path=".", iofile="io.json"):
 
     _launch(path, tensors)
 
+    # TODO: deal with the cases when we have multiple outputs
+    # which ops would those be?
+    if len(spec.outputs) > 1:
+        print("WARNING: multiple outputs found, but only last one printed!")
+
     print(tensors[-1])
 
 

--- a/extensions/spyre-cli/spyre_cli/core.py
+++ b/extensions/spyre-cli/spyre_cli/core.py
@@ -30,6 +30,8 @@ def _launch(path, tensors):
     # this is the magic line
     # should have already compiled at this point
     jobplan = torch.spyre.prepare_kernel(str(spyrecode_dir))
+
+    print(jobplan.expected_input_shapes())
     torch.spyre.launch_jobplan(jobplan, tensors)
 
 

--- a/extensions/spyre-cli/spyre_cli/core.py
+++ b/extensions/spyre-cli/spyre_cli/core.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+from spyre_cli.iospec.iospec import parse_json_file
+
+
+def _launch(path, tensors):
+    # delayed import, for easy testing
+    import torch
+
+    spyrecode_dir = path / "spyreCodeDir"
+    if not spyrecode_dir.exists():
+        raise FileNotFoundError(
+            f"spyreCodeDir not found at '{spyrecode_dir}'. "
+            "Ensure the model has been compiled before launching."
+        )
+
+    # this is the magic line
+    # should have already compiled at this point
+    jobplan = torch.spyre.prepare_kernel(str(spyrecode_dir))
+    torch.spyre.launch_jobplan(jobplan, tensors)
+
+
+def launch_from_iofile(path=".", iofile="io.json"):
+    path = Path(path)
+    try:
+        spec = parse_json_file(iofile)
+    except Exception as e:
+        print(e)
+        exit(1)
+
+    import torch
+
+    tensors = []
+    for tensor_spec in spec.inputs + spec.outputs:
+        dtype = getattr(torch, tensor_spec.dtype.value)
+        tensor = torch.ones(
+            tensor_spec.dimensions,
+            dtype=dtype,
+            device="spyre",
+        )
+        tensors.append(tensor)
+
+    _launch(path, tensors)
+
+    print(tensors[-1])
+
+
+def launch(*args, **kwargs):
+    path = Path(kwargs.get("path", "."))
+
+    _launch(path, args)

--- a/extensions/spyre-cli/spyre_cli/core.py
+++ b/extensions/spyre-cli/spyre_cli/core.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from pathlib import Path
 from spyre_cli.iospec.iospec import parse_json_file
 

--- a/extensions/spyre-cli/spyre_cli/core.py
+++ b/extensions/spyre-cli/spyre_cli/core.py
@@ -30,9 +30,19 @@ def launch_from_iofile(path=".", iofile="io.json"):
     import torch
 
     tensors = []
-    for tensor_spec in spec.inputs + spec.outputs:
+    for tensor_spec in spec.inputs:
         dtype = getattr(torch, tensor_spec.dtype.value)
         tensor = torch.ones(
+            tensor_spec.dimensions,
+            dtype=dtype,
+            device="spyre",
+        )
+        tensors.append(tensor)
+
+    # Use `torch.empty` for output tensors
+    for tensor_spec in spec.outputs:
+        dtype = getattr(torch, tensor_spec.dtype.value)
+        tensor = torch.empty(
             tensor_spec.dimensions,
             dtype=dtype,
             device="spyre",

--- a/extensions/spyre-cli/spyre_cli/iospec/e_incorrect.json
+++ b/extensions/spyre-cli/spyre_cli/iospec/e_incorrect.json
@@ -1,13 +1,11 @@
 {
   "inputs": [
     {
-      "ndims": 2,
       "dtype": "float16"
     },
   ],
   "outputs": [
     {
-      "ndims": 2,
       "dimensions": [512, 1024],
       "dtype": "float32"
     }

--- a/extensions/spyre-cli/spyre_cli/iospec/e_incorrect.json
+++ b/extensions/spyre-cli/spyre_cli/iospec/e_incorrect.json
@@ -1,0 +1,15 @@
+{
+  "inputs": [
+    {
+      "ndims": 2,
+      "dtype": "float16"
+    },
+  ],
+  "outputs": [
+    {
+      "ndims": 2,
+      "dimensions": [512, 1024],
+      "dtype": "float32"
+    }
+  ]
+}

--- a/extensions/spyre-cli/spyre_cli/iospec/example.json
+++ b/extensions/spyre-cli/spyre_cli/iospec/example.json
@@ -1,0 +1,21 @@
+{
+  "inputs": [
+    {
+      "ndims": 2,
+      "dimensions": [10, 1024],
+      "dtype": "float16"
+    },
+    {
+      "ndims": 2,
+      "dimensions": [10, 1024],
+      "dtype": "float16"
+    }
+  ],
+  "outputs": [
+    {
+      "ndims": 2,
+      "dimensions": [512, 1024],
+      "dtype": "float32"
+    }
+  ]
+}

--- a/extensions/spyre-cli/spyre_cli/iospec/example.json
+++ b/extensions/spyre-cli/spyre_cli/iospec/example.json
@@ -1,19 +1,16 @@
 {
   "inputs": [
     {
-      "ndims": 2,
       "dimensions": [10, 1024],
       "dtype": "float16"
     },
     {
-      "ndims": 2,
       "dimensions": [10, 1024],
       "dtype": "float16"
     }
   ],
   "outputs": [
     {
-      "ndims": 2,
       "dimensions": [512, 1024],
       "dtype": "float32"
     }

--- a/extensions/spyre-cli/spyre_cli/iospec/iospec.py
+++ b/extensions/spyre-cli/spyre_cli/iospec/iospec.py
@@ -55,4 +55,7 @@ def parse_json_file(iofile):
     except ValidationError as e:
         raise ValueError(f"IO Spec validation failed: {e}") from e
 
+    if len(spec.outputs) == 0:
+        raise ValueError(f"No output found in IO Spec. One or more output is expected.")
+
     return spec

--- a/extensions/spyre-cli/spyre_cli/iospec/iospec.py
+++ b/extensions/spyre-cli/spyre_cli/iospec/iospec.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from pathlib import Path
 import json
 

--- a/extensions/spyre-cli/spyre_cli/iospec/iospec.py
+++ b/extensions/spyre-cli/spyre_cli/iospec/iospec.py
@@ -26,7 +26,6 @@ class Dtype(str, Enum):
 
 
 class TensorSpec(BaseModel):
-    ndims: int
     dimensions: List[int]  # has to be opened-up for symbolic
     dtype: Dtype
 

--- a/extensions/spyre-cli/spyre_cli/iospec/iospec.py
+++ b/extensions/spyre-cli/spyre_cli/iospec/iospec.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import json
+
+from enum import Enum
+from pydantic import BaseModel, ValidationError
+from typing import List
+
+
+class Dtype(str, Enum):
+    FLOAT16 = "float16"
+    FLOAT32 = "float32"
+
+
+class TensorSpec(BaseModel):
+    ndims: int
+    dimensions: List[int]  # has to be opened-up for symbolic
+    dtype: Dtype
+
+
+class IOSpec(BaseModel):
+    inputs: List[TensorSpec]
+    outputs: List[TensorSpec]
+
+
+def parse_json_file(iofile):
+    iospec = Path(iofile)
+    if not iospec.exists():
+        raise FileNotFoundError(f"No file found: {iospec}")
+
+    if not iospec.suffix == ".json":
+        raise ValueError(f"IO Spec file is not a json: {iospec}")
+
+    try:
+        with open(iospec, "r") as f:
+            iospec_data = json.load(f)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON in IO Spec file: {e}") from e
+
+    try:
+        spec = IOSpec(**iospec_data)
+    except ValidationError as e:
+        raise ValueError(f"IO Spec validation failed: {e}") from e
+
+    return spec

--- a/extensions/spyre-cli/tests/test_iospec.py
+++ b/extensions/spyre-cli/tests/test_iospec.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 import pytest
 from pathlib import Path

--- a/extensions/spyre-cli/tests/test_iospec.py
+++ b/extensions/spyre-cli/tests/test_iospec.py
@@ -1,0 +1,44 @@
+import json
+import pytest
+from pathlib import Path
+
+from spyre_cli.iospec.iospec import Dtype, TensorSpec, IOSpec, parse_json_file
+
+
+def test_tensor_spec_from_string_dtype():
+    spec = TensorSpec(ndims=3, dimensions=[1, 2, 3], dtype="float32")
+    assert spec.dtype == Dtype.FLOAT32
+
+
+def test_parse_json_file_valid(tmp_path: Path):
+    iofile = tmp_path / "io.json"
+    data = {
+        "inputs": [{"ndims": 2, "dimensions": [10, 1024], "dtype": "float16"}],
+        "outputs": [{"ndims": 2, "dimensions": [512, 1024], "dtype": "float32"}],
+    }
+    iofile.write_text(json.dumps(data))
+
+    spec = parse_json_file(str(iofile))
+    assert isinstance(spec, IOSpec)
+    assert spec.inputs[0].dimensions == [10, 1024]
+    assert spec.outputs[0].dtype == Dtype.FLOAT32
+
+
+def test_parse_json_file_missing_file(tmp_path: Path):
+    iofile = tmp_path / "missing.json"
+    with pytest.raises(Exception):
+        parse_json_file(str(iofile))
+
+
+def test_parse_json_file_not_json(tmp_path: Path):
+    iofile = tmp_path / "io.txt"
+    iofile.write_text("not json")
+    with pytest.raises(Exception):
+        parse_json_file(str(iofile))
+
+
+def test_parse_json_file_invalid_data(tmp_path: Path):
+    iofile = tmp_path / "io.json"
+    iofile.write_text(json.dumps({"inputs": "bad", "outputs": []}))
+    with pytest.raises(Exception):
+        parse_json_file(str(iofile))

--- a/extensions/spyre-cli/tests/test_iospec.py
+++ b/extensions/spyre-cli/tests/test_iospec.py
@@ -58,6 +58,18 @@ def test_parse_json_file_invalid_data(tmp_path: Path):
         parse_json_file(str(iofile))
 
 
+def test_parse_json_file_no_outputs(tmp_path: Path):
+    iofile = tmp_path / "io.json"
+    data = {
+        "inputs": [{"ndims": 2, "dimensions": [10, 1024], "dtype": "float16"}],
+        "outputs": [],
+    }
+    iofile.write_text(json.dumps(data))
+
+    with pytest.raises(ValueError, match="No output found in IO Spec"):
+        parse_json_file(str(iofile))
+
+
 def test_parse_json_file_e_incorrect():
     iofile = Path(__file__).parent.parent / "spyre_cli" / "iospec" / "e_incorrect.json"
     with pytest.raises(ValueError, match="Invalid JSON"):

--- a/extensions/spyre-cli/tests/test_iospec.py
+++ b/extensions/spyre-cli/tests/test_iospec.py
@@ -56,3 +56,9 @@ def test_parse_json_file_invalid_data(tmp_path: Path):
     iofile.write_text(json.dumps({"inputs": "bad", "outputs": []}))
     with pytest.raises(Exception):
         parse_json_file(str(iofile))
+
+
+def test_parse_json_file_e_incorrect():
+    iofile = Path(__file__).parent.parent / "spyre_cli" / "iospec" / "e_incorrect.json"
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        parse_json_file(str(iofile))

--- a/extensions/spyre-cli/tests/test_iospec.py
+++ b/extensions/spyre-cli/tests/test_iospec.py
@@ -20,15 +20,15 @@ from spyre_cli.iospec.iospec import Dtype, TensorSpec, IOSpec, parse_json_file
 
 
 def test_tensor_spec_from_string_dtype():
-    spec = TensorSpec(ndims=3, dimensions=[1, 2, 3], dtype="float32")
+    spec = TensorSpec(dimensions=[1, 2, 3], dtype="float32")
     assert spec.dtype == Dtype.FLOAT32
 
 
 def test_parse_json_file_valid(tmp_path: Path):
     iofile = tmp_path / "io.json"
     data = {
-        "inputs": [{"ndims": 2, "dimensions": [10, 1024], "dtype": "float16"}],
-        "outputs": [{"ndims": 2, "dimensions": [512, 1024], "dtype": "float32"}],
+        "inputs": [{"dimensions": [10, 1024], "dtype": "float16"}],
+        "outputs": [{"dimensions": [512, 1024], "dtype": "float32"}],
     }
     iofile.write_text(json.dumps(data))
 
@@ -61,7 +61,7 @@ def test_parse_json_file_invalid_data(tmp_path: Path):
 def test_parse_json_file_no_outputs(tmp_path: Path):
     iofile = tmp_path / "io.json"
     data = {
-        "inputs": [{"ndims": 2, "dimensions": [10, 1024], "dtype": "float16"}],
+        "inputs": [{"dimensions": [10, 1024], "dtype": "float16"}],
         "outputs": [],
     }
     iofile.write_text(json.dumps(data))

--- a/extensions/spyre-cli/uv.lock
+++ b/extensions/spyre-cli/uv.lock
@@ -1,0 +1,222 @@
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427 },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "platform_system == 'Windows'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243 },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262 },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158 },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724 },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742 },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418 },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274 },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940 },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516 },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854 },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306 },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044 },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133 },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464 },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823 },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919 },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604 },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306 },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906 },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802 },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446 },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757 },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275 },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467 },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417 },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782 },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782 },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334 },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986 },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693 },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819 },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411 },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079 },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179 },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926 },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785 },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733 },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534 },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732 },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627 },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141 },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325 },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990 },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978 },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354 },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238 },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251 },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593 },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226 },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605 },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777 },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641 },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404 },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219 },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594 },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542 },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146 },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309 },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736 },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575 },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624 },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325 },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589 },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552 },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984 },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417 },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527 },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024 },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696 },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590 },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147 },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536 },
+]
+
+[[package]]
+name = "spyre-cli"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "click" },
+    { name = "pydantic" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "click", specifier = ">=8.4.2" },
+    { name = "pydantic", specifier = ">=2.13.4" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.1.1" }]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571 },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750 },
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ package-dir = { torch_spyre = "torch_spyre" }
 package-data = { torch_spyre = ["*.dll", "*.dylib", "*.so"] }
 
 [tool.setuptools.packages.find]
-exclude = ["tests"]  # exclude packages matching these glob patterns (empty by default)
+exclude = ["tests", "extensions"]  # exclude packages matching these glob patterns (empty by default)
 
 [tool.setuptools.dynamic]
 version = {attr = "torch_spyre.version.__version__"}  # any module attribute compatible with ast.literal_eval

--- a/tests/test_prepare_kernel.py
+++ b/tests/test_prepare_kernel.py
@@ -210,6 +210,37 @@ class TestPrepareKernel:
             # Should match the allocated size (1024 bytes)
             assert job_plan.job_allocation_size() == 1024
 
+    def test_job_plan_expected_input_shapes(self):
+        """Test JobPlan.expected_input_shapes() and num_expected_inputs().
+
+        SpyreCode does not carry input shape metadata yet (see the TODO in
+        JobPlanBuilder::translateJobExecPlan), so a prepared JobPlan reports
+        zero expected inputs. This test pins the accessor contract: a list is
+        returned, it is consistent with num_expected_inputs(), and it does not
+        raise. Update the expectation once deeptools emits the shapes.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            spyrecode_dir = self.create_mock_spyrecode(tmpdir)
+            job_plan = torch_spyre._C.prepare_kernel(spyrecode_dir)
+
+            shapes = job_plan.expected_input_shapes()
+            assert isinstance(shapes, list)
+            assert all(isinstance(shape, list) for shape in shapes)
+            assert all(isinstance(dim, int) for shape in shapes for dim in shape)
+            assert len(shapes) == job_plan.num_expected_inputs()
+
+            # Not yet populated from SpyreCode.
+            assert shapes == []
+
+    def test_job_plan_get_expected_input_shape_out_of_range(self):
+        """get_expected_input_shape must raise for an out-of-range index."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            spyrecode_dir = self.create_mock_spyrecode(tmpdir)
+            job_plan = torch_spyre._C.prepare_kernel(spyrecode_dir)
+
+            with pytest.raises(RuntimeError, match="Input shape index out of range"):
+                job_plan.get_expected_input_shape(0)
+
     def test_job_plan_step_type(self):
         """Test JobPlan.get_step_type() method."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/torch_spyre/_C.pyi
+++ b/torch_spyre/_C.pyi
@@ -399,6 +399,23 @@ class JobPlan:
         """Get the size of the job allocation"""
         ...
 
+    def num_expected_inputs(self) -> int:
+        """Get the number of compiled input shapes recorded in the JobPlan"""
+        ...
+
+    def expected_input_shapes(self) -> list[list[int]]:
+        """Get the compiled tile dimensions, one list per kernel input.
+
+        Returns an empty list for pure-DMA JobPlans (e.g. tensor .to(device))
+        and for JobPlans whose SpyreCode does not yet carry input shape
+        metadata.
+        """
+        ...
+
+    def get_expected_input_shape(self, idx: int) -> list[int]:
+        """Get the compiled tile dimensions for the input at the given index"""
+        ...
+
     def get_step_type(self, idx: int) -> str:
         """Get the type of step at the given index (H2D, D2H, Compute, or HostCompute)"""
         ...

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -467,6 +467,28 @@ PYBIND11_MODULE(_C, m) {
           },
           "Get the size of the job allocation")
       .def(
+          "num_expected_inputs",
+          [](const spyre::JobPlan& plan) {
+            return plan.expected_input_shapes.size();
+          },
+          "Get the number of compiled input shapes recorded in the JobPlan")
+      .def(
+          "expected_input_shapes",
+          [](const spyre::JobPlan& plan) { return plan.expected_input_shapes; },
+          "Get the compiled tile dimensions, one list per kernel input.\n\n"
+          "Returns an empty list for pure-DMA JobPlans (e.g. tensor "
+          ".to(device)) and for JobPlans whose SpyreCode does not yet carry "
+          "input shape metadata.")
+      .def(
+          "get_expected_input_shape",
+          [](const spyre::JobPlan& plan, size_t idx) {
+            TORCH_CHECK(idx < plan.expected_input_shapes.size(),
+                        "Input shape index out of range");
+            return plan.expected_input_shapes[idx];
+          },
+          py::arg("idx"),
+          "Get the compiled tile dimensions for the input at the given index")
+      .def(
           "get_step_type",
           [](const spyre::JobPlan& plan, size_t idx) {
             TORCH_CHECK(idx < plan.steps.size(), "Step index out of range");


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [X] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Provides a new tool which allows to directly run pre-compiled spyreCodeDir on real Spyre hardware relying on torch-spyre for the Runtime software only (no compile time pathway of torch-spyre is used here).

Initial version, with a few more planned features pending. This version is tested to work with spyreCode created from SDSC files (ie the current torch-spyre pathway), but not yet tested with KTIR etc.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
