### PR TITLE
Hoist loop-invariant coarse-tile read copies

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -41,6 +41,7 @@ ORIGINAL TESTS (below the boundary marker)
     Original class-based tests preserved for coverage and reference, to be cleaned up in future.
 """
 
+import ast
 import dataclasses
 import math
 import os
@@ -6906,7 +6907,7 @@ class TestCoarseTileMoEBroadcastMatmulE2E(InductorTestCase):
         )
 
     def test_unsqueeze_broadcast_matmul_emits_expert_weight_step(self):
-        """The read of packed weights advances once per expert loop trip."""
+        """Activation stays fixed while weights advance by one expert slab."""
         from torch_spyre._inductor import spyre_hint
 
         E, T, H, F = 3, 64, 64, 64
@@ -6930,15 +6931,46 @@ class TestCoarseTileMoEBroadcastMatmulE2E(InductorTestCase):
         ):
             _, source_codes = run_and_get_code(torch.compile(fn), x, w)
 
-        src = source_codes[0]
-        weight_copy = re.search(
-            r"op='identity'.*?arg_index=1.*?"
-            r"device_tile_advance_expr=sympify\('([^']+)'\)",
-            src,
-            flags=re.DOTALL,
-        )
-        self.assertIsNotNone(weight_copy)
-        self.assertIn("_tile_adv_coarse_tile_read_copy", weight_copy.group(1))
+        tensor_args = []
+        for node in ast.walk(ast.parse(source_codes[0])):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "TensorArg"
+            ):
+                continue
+            keywords = {kw.arg: kw.value for kw in node.keywords}
+            size_node = keywords.get("device_size")
+            if not isinstance(size_node, ast.List):
+                continue
+            size = [ast.literal_eval(elt) for elt in size_node.elts]
+            advance_node = keywords.get("device_tile_advance_expr")
+            advance = (
+                ast.literal_eval(advance_node.args[0])
+                if isinstance(advance_node, ast.Call) and advance_node.args
+                else None
+            )
+            tensor_args.append((ast.literal_eval(keywords["is_input"]), size, advance))
+
+        activation_reads = [
+            advance
+            for is_input, size, advance in tensor_args
+            if is_input and size == [1, T, H]
+        ]
+        self.assertEqual(activation_reads, [None])
+
+        weight_reads = [
+            advance
+            for is_input, size, advance in tensor_args
+            if is_input and size == [1, H, E, F]
+        ]
+        self.assertEqual(len(weight_reads), 1)
+        self.assertIsInstance(weight_reads[0], str)
+        weight_step = re.fullmatch(r"floor\((\d+)\*[^)]+\)", weight_reads[0])
+        self.assertIsNotNone(weight_step)
+        # TensorArg addresses are in df16 sticks.  64 sticks * 64 elements
+        # per stick is one H*F = 4096-element expert slab.
+        self.assertEqual(int(weight_step.group(1)) * 64, H * F)
 
     def test_unsqueeze_broadcast_matmul_tile_E_poisoned_correct(self):
         """Same pattern as test_unsqueeze_broadcast_matmul_tile_E_correct,

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -5439,18 +5439,26 @@ class TestPlanReadCopies(unittest.TestCase):
         """
         from torch_spyre._inductor.wsr.coarse_tile import (
             _ReadCopyHoistDecision,
+            _ReadCopySourceInfo,
+            _ReadCopySourceKind,
             _plan_read_copies,
             _read_copy_hoist_decision,
         )
 
         tiled_op, _full_deps, operations = _make_cross_group_producer_read_fixture()
+        # Isolate source classification: complete fixed-address metadata lets
+        # the test reach CROSS_GROUP_SOURCE rather than declining earlier.
         tiled_op.loop_info.tiled_dims_per_read = [[[]]]
 
         plans = _plan_read_copies(operations, [((0,), [tiled_op], {})])
 
         self.assertFalse(plans[(0,)].entries[0].loop_invariant)
         self.assertIs(
-            _read_copy_hoist_decision(tiled_op.loop_info, 0, (1,)),
+            _read_copy_hoist_decision(
+                tiled_op.loop_info,
+                0,
+                _ReadCopySourceInfo(_ReadCopySourceKind.LOOP_PRODUCED, (1,)),
+            ),
             _ReadCopyHoistDecision.CROSS_GROUP_SOURCE,
         )
 
@@ -5458,6 +5466,8 @@ class TestPlanReadCopies(unittest.TestCase):
         """Missing metadata cannot authorize moving a read before the loop."""
         from torch_spyre._inductor.wsr.coarse_tile import (
             _ReadCopyHoistDecision,
+            _ReadCopySourceInfo,
+            _ReadCopySourceKind,
             _plan_read_copies,
             _read_copy_hoist_decision,
         )
@@ -5469,13 +5479,19 @@ class TestPlanReadCopies(unittest.TestCase):
 
         self.assertFalse(plans[(0,)].entries[0].loop_invariant)
         self.assertIs(
-            _read_copy_hoist_decision(tiled_op.loop_info, 0, None),
+            _read_copy_hoist_decision(
+                tiled_op.loop_info,
+                0,
+                _ReadCopySourceInfo(_ReadCopySourceKind.KNOWN_EXTERNAL),
+            ),
             _ReadCopyHoistDecision.MISSING_STEP_METADATA,
         )
 
     def test_same_group_loop_source_is_not_loop_invariant(self):
         from torch_spyre._inductor.wsr.coarse_tile import (
             _ReadCopyHoistDecision,
+            _ReadCopySourceInfo,
+            _ReadCopySourceKind,
             _read_copy_hoist_decision,
         )
 
@@ -5483,13 +5499,88 @@ class TestPlanReadCopies(unittest.TestCase):
         tiled_op.loop_info.tiled_dims_per_read = [[[]]]
 
         self.assertIs(
-            _read_copy_hoist_decision(tiled_op.loop_info, 0, (0,)),
+            _read_copy_hoist_decision(
+                tiled_op.loop_info,
+                0,
+                _ReadCopySourceInfo(_ReadCopySourceKind.LOOP_PRODUCED, (0,)),
+            ),
             _ReadCopyHoistDecision.LOOP_PRODUCED_SOURCE,
+        )
+
+    def test_loop_written_storage_is_not_loop_invariant(self):
+        """A fixed allocation is not stable while a loop mutates it."""
+        from torch._inductor.ir import (
+            ComputedBuffer,
+            MutationLayoutSHOULDREMOVE,
+            StorageBox,
+            TensorBox,
+        )
+
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _ReadCopyHoistDecision,
+            _ReadCopySourceKind,
+            _loop_written_buffer_names,
+            _plan_read_copies,
+            _read_copy_hoist_decision,
+            _read_copy_source_info,
+        )
+
+        tiled_op, _full_deps, operations = _make_full_buffer_read_fixture()
+        tiled_op.loop_info.tiled_dims_per_read = [[[]]]
+        full_buf = operations[0]
+        writer = ComputedBuffer(
+            name="loop_writer",
+            layout=MutationLayoutSHOULDREMOVE(TensorBox(StorageBox(full_buf))),
+            data=tiled_op.data,
+        )
+        writer.operation_name = "loop_writer"
+        writer.origins = OrderedSet()
+        writer.loop_info = CoarseTileInfo(
+            loop_group_id=(0,),
+            loop_count=[Integer(8)],
+            loop_tiled_dims=[[0]],
+        )
+        operations.append(writer)
+
+        plans = _plan_read_copies(operations, [((0,), [tiled_op], {})])
+        source_info = _read_copy_source_info(
+            full_buf.get_name(),
+            {op.get_name(): op for op in operations},
+            _loop_written_buffer_names(operations),
+        )
+
+        self.assertFalse(plans[(0,)].entries[0].loop_invariant)
+        self.assertIs(source_info.kind, _ReadCopySourceKind.IN_LOOP_WRITTEN)
+        self.assertIs(
+            _read_copy_hoist_decision(tiled_op.loop_info, 0, source_info),
+            _ReadCopyHoistDecision.IN_LOOP_WRITTEN_SOURCE,
+        )
+
+    def test_unknown_source_is_not_loop_invariant(self):
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _ReadCopyHoistDecision,
+            _ReadCopySourceInfo,
+            _ReadCopySourceKind,
+            _read_copy_hoist_decision,
+        )
+
+        tiled_op, _full_deps, _operations = _make_full_buffer_read_fixture()
+        tiled_op.loop_info.tiled_dims_per_read = [[[]]]
+
+        self.assertIs(
+            _read_copy_hoist_decision(
+                tiled_op.loop_info,
+                0,
+                _ReadCopySourceInfo(_ReadCopySourceKind.UNKNOWN),
+            ),
+            _ReadCopyHoistDecision.UNKNOWN_SOURCE,
         )
 
     def test_advancing_external_read_is_not_loop_invariant(self):
         from torch_spyre._inductor.wsr.coarse_tile import (
             _ReadCopyHoistDecision,
+            _ReadCopySourceInfo,
+            _ReadCopySourceKind,
             _read_copy_hoist_decision,
         )
 
@@ -5497,13 +5588,19 @@ class TestPlanReadCopies(unittest.TestCase):
         tiled_op.loop_info.tiled_dims_per_read = [[[(0, Integer(8))]]]
 
         self.assertIs(
-            _read_copy_hoist_decision(tiled_op.loop_info, 0, None),
+            _read_copy_hoist_decision(
+                tiled_op.loop_info,
+                0,
+                _ReadCopySourceInfo(_ReadCopySourceKind.KNOWN_EXTERNAL),
+            ),
             _ReadCopyHoistDecision.ADVANCING_READ,
         )
 
     def test_fixed_external_read_is_loop_invariant(self):
         from torch_spyre._inductor.wsr.coarse_tile import (
             _ReadCopyHoistDecision,
+            _ReadCopySourceInfo,
+            _ReadCopySourceKind,
             _read_copy_hoist_decision,
         )
 
@@ -5511,7 +5608,11 @@ class TestPlanReadCopies(unittest.TestCase):
         tiled_op.loop_info.tiled_dims_per_read = [[[]]]
 
         self.assertIs(
-            _read_copy_hoist_decision(tiled_op.loop_info, 0, None),
+            _read_copy_hoist_decision(
+                tiled_op.loop_info,
+                0,
+                _ReadCopySourceInfo(_ReadCopySourceKind.KNOWN_EXTERNAL),
+            ),
             _ReadCopyHoistDecision.ELIGIBLE,
         )
 

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -5158,7 +5158,10 @@ def _make_cross_group_producer_read_fixture():
     tiled_op.operation_name = "tiled_op0"
     tiled_op.origins = OrderedSet()
     tiled_op.loop_info = CoarseTileInfo(
-        loop_group_id=(0,), loop_count=[Integer(8)], loop_tiled_dims=[[0]]
+        loop_group_id=(0,),
+        loop_count=[Integer(8)],
+        loop_tiled_dims=[[0]],
+        tiled_dims_per_read=[[[]]],
     )
     V.graph.name_to_buffer["tiled_op0"] = tiled_op
 
@@ -5353,7 +5356,10 @@ def _make_two_op_shared_read_fixture():
         op.operation_name = name
         op.origins = OrderedSet()
         op.loop_info = CoarseTileInfo(
-            loop_group_id=(0,), loop_count=[Integer(8)], loop_tiled_dims=[[0]]
+            loop_group_id=(0,),
+            loop_count=[Integer(8)],
+            loop_tiled_dims=[[0]],
+            tiled_dims_per_read=[[[]]],
         )
         V.graph.name_to_buffer[name] = op
         return op
@@ -5399,6 +5405,91 @@ class TestPlanReadCopies(unittest.TestCase):
         self.assertEqual(
             entry.predivision_unit_steps,
             (((0, Integer(128), Integer(1)),),),
+        )
+
+    def test_cross_group_source_is_not_loop_invariant(self):
+        """A fixed-address producer scratch is rewritten each trip.
+
+        Even after propagation clears the consumer's address step, a read
+        from another counted-loop group must remain inside the consumer's
+        loop so Pass 3 can redirect it to the advancing full buffer.
+        """
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _ReadCopyHoistDecision,
+            _plan_read_copies,
+            _read_copy_hoist_decision,
+        )
+
+        tiled_op, _full_deps, operations = _make_cross_group_producer_read_fixture()
+        tiled_op.loop_info.tiled_dims_per_read = [[[]]]
+
+        plans = _plan_read_copies(operations, [((0,), [tiled_op], {})])
+
+        self.assertFalse(plans[(0,)].entries[0].loop_invariant)
+        self.assertIs(
+            _read_copy_hoist_decision(tiled_op.loop_info, 0, (1,)),
+            _ReadCopyHoistDecision.CROSS_GROUP_SOURCE,
+        )
+
+    def test_missing_read_step_metadata_is_not_loop_invariant(self):
+        """Missing metadata cannot authorize moving a read before the loop."""
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _ReadCopyHoistDecision,
+            _plan_read_copies,
+            _read_copy_hoist_decision,
+        )
+
+        tiled_op, _full_deps, operations = _make_full_buffer_read_fixture()
+        self.assertEqual(tiled_op.loop_info.tiled_dims_per_read, [])
+
+        plans = _plan_read_copies(operations, [((0,), [tiled_op], {})])
+
+        self.assertFalse(plans[(0,)].entries[0].loop_invariant)
+        self.assertIs(
+            _read_copy_hoist_decision(tiled_op.loop_info, 0, None),
+            _ReadCopyHoistDecision.MISSING_STEP_METADATA,
+        )
+
+    def test_same_group_loop_source_is_not_loop_invariant(self):
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _ReadCopyHoistDecision,
+            _read_copy_hoist_decision,
+        )
+
+        tiled_op, _full_deps, _operations = _make_full_buffer_read_fixture()
+        tiled_op.loop_info.tiled_dims_per_read = [[[]]]
+
+        self.assertIs(
+            _read_copy_hoist_decision(tiled_op.loop_info, 0, (0,)),
+            _ReadCopyHoistDecision.LOOP_PRODUCED_SOURCE,
+        )
+
+    def test_advancing_external_read_is_not_loop_invariant(self):
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _ReadCopyHoistDecision,
+            _read_copy_hoist_decision,
+        )
+
+        tiled_op, _full_deps, _operations = _make_full_buffer_read_fixture()
+        tiled_op.loop_info.tiled_dims_per_read = [[[(0, Integer(8))]]]
+
+        self.assertIs(
+            _read_copy_hoist_decision(tiled_op.loop_info, 0, None),
+            _ReadCopyHoistDecision.ADVANCING_READ,
+        )
+
+    def test_fixed_external_read_is_loop_invariant(self):
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _ReadCopyHoistDecision,
+            _read_copy_hoist_decision,
+        )
+
+        tiled_op, _full_deps, _operations = _make_full_buffer_read_fixture()
+        tiled_op.loop_info.tiled_dims_per_read = [[[]]]
+
+        self.assertIs(
+            _read_copy_hoist_decision(tiled_op.loop_info, 0, None),
+            _ReadCopyHoistDecision.ELIGIBLE,
         )
 
     def test_same_op_two_reads_same_index_collapse_to_one_entry(self):
@@ -5734,6 +5825,7 @@ class TestInsertAllReadCopyOps(unittest.TestCase):
             loop_group_id=(0,),
             loop_count=[Integer(8)],
             loop_tiled_dims=[[0]],
+            tiled_dims_per_read=[[[]]],
         )
         V.graph.name_to_buffer[tiled_op.get_name()] = tiled_op
 

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -5552,10 +5552,12 @@ class TestReadCopyPlanDataclasses(unittest.TestCase):
             sizing_op_name="op0",
             sizing_read_index=0,
             consumer_op_names=("op0", "op1"),
+            loop_invariant=True,
         )
         self.assertEqual(entry.copy_name, "coarse_tile_read_copy_group0_a_0")
         self.assertEqual(entry.consumer_op_names, ("op0", "op1"))
         self.assertEqual(entry.predivision_unit_steps, ())
+        self.assertTrue(entry.loop_invariant)
         with self.assertRaises(Exception):
             entry.copy_name = "other"  # frozen -> raises FrozenInstanceError
 
@@ -5595,6 +5597,8 @@ class TestInsertAllReadCopyOps(unittest.TestCase):
         copy_buf = operations[1]
         self.assertIsInstance(copy_buf, ComputedBuffer)
         self.assertIs(operations[0], full_buf)
+        self.assertFalse(hasattr(copy_buf, "loop_info"))
+        self.assertFalse(hasattr(copy_buf, "work_div_loop_info"))
 
         # Both consumers were repointed at the SAME copy buffer name, not
         # two independent copies.
@@ -5658,6 +5662,95 @@ class TestInsertAllReadCopyOps(unittest.TestCase):
         ]
         self.assertEqual(len(generated), 1)
         self.assertFalse(hasattr(generated[0], "work_div_loop_info"))
+
+    def test_advancing_read_copy_stays_inside_loop(self):
+        """Only fixed reads move to the preheader; advancing reads retain
+        their counted-loop metadata and existing per-trip behavior."""
+        from torch._inductor.ir import ComputedBuffer
+
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _insert_all_read_copy_ops,
+            _plan_read_copies,
+        )
+
+        tiled_op, full_deps, operations = _make_full_buffer_read_fixture()
+        tiled_op.loop_info.tiled_dims_per_read = [[[(0, Integer(8))]]]
+        plans = _plan_read_copies(operations, [((0,), [tiled_op], {})])
+
+        entry = plans[(0,)].entries[0]
+        self.assertFalse(entry.loop_invariant)
+        _insert_all_read_copy_ops(operations, plans)
+
+        copy_buf = next(
+            op
+            for op in operations
+            if isinstance(op, ComputedBuffer) and op.get_name() == entry.copy_name
+        )
+        self.assertTrue(hasattr(copy_buf, "loop_info"))
+        self.assertEqual(full_deps[0].name, entry.dep.name)
+
+    def test_invariant_broadcast_copy_drops_absent_loop_dim(self):
+        """A fixed [H] input read by an [E,H] loop is staged as [H], not
+        materialized as the expanded [E,H] view."""
+        from torch._inductor.ir import (
+            ComputedBuffer,
+            FixedLayout,
+            Pointwise,
+            StorageBox,
+            TensorBox,
+        )
+
+        from torch_spyre._inductor.ir import SpyreEmptyFallback
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _insert_all_read_copy_ops,
+            _plan_read_copies,
+        )
+
+        device = torch.device("cpu")
+        dtype = torch.float32
+        full_buf = SpyreEmptyFallback(
+            torch.ops.spyre.empty.default, [128], device, dtype
+        )
+        full_buf.layout = FixedLayout(device, dtype, [128], [1])
+        full_box = TensorBox(StorageBox(full_buf))
+
+        def inner_fn(index):
+            return full_box.make_loader()([index[1]])
+
+        pw = Pointwise.create(
+            device=device,
+            dtype=dtype,
+            inner_fn=inner_fn,
+            ranges=[Integer(8), Integer(128)],
+        )
+        tiled_op = ComputedBuffer(
+            name="tiled_broadcast",
+            layout=FixedLayout(device, dtype, [8, 128], None),
+            data=pw.data.data,
+        )
+        tiled_op.operation_name = "tiled_broadcast"
+        tiled_op.origins = OrderedSet()
+        tiled_op.loop_info = CoarseTileInfo(
+            loop_group_id=(0,),
+            loop_count=[Integer(8)],
+            loop_tiled_dims=[[0]],
+        )
+        V.graph.name_to_buffer[tiled_op.get_name()] = tiled_op
+
+        operations = [full_buf, tiled_op]
+        plans = _plan_read_copies(operations, [((0,), [tiled_op], {})])
+        entry = plans[(0,)].entries[0]
+        self.assertTrue(entry.loop_invariant)
+
+        _insert_all_read_copy_ops(operations, plans)
+        copy_buf = next(
+            op
+            for op in operations
+            if isinstance(op, ComputedBuffer) and op.get_name() == entry.copy_name
+        )
+        self.assertEqual(list(copy_buf.get_size()), [Integer(128)])
+        self.assertEqual(list(copy_buf.layout.stride), [Integer(1)])
+        self.assertFalse(hasattr(copy_buf, "loop_info"))
 
     def test_transposed_read_gets_its_own_copy(self):
         """a+b+a.t()-style: two reads of the same buffer with different

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -2593,6 +2593,29 @@ class TestBuildLoopSchedulerNodes(unittest.TestCase):
         self.assertIs(result[2], after)
         self.assertEqual(created[0].loop_count, Integer(2))
 
+    def test_dependency_of_later_group_member_precedes_whole_group(self):
+        """A preheader copy inserted before a later consumer stays outside.
+
+        Coarse tiling may place a loop-invariant copy between two flat loop
+        members when only the later member reads it. Scheduler regrouping must
+        move that dependency before the counted-loop unit, not split the unit.
+        """
+        sched = _make_scheduler()
+        first = _make_snode(sched, _make_ir_op((0,), Integer(4)), "first")
+        copy = _make_snode(sched, _make_ir_op(), "copy")
+        consumer = _make_snode(sched, _make_ir_op((0,), Integer(4)), "consumer")
+
+        for node, name in ((first, "first"), (copy, "copy"), (consumer, "consumer")):
+            node.get_buffer_names.return_value = {name}
+        consumer.unmet_dependencies = OrderedSet(
+            [inductor_deps.MemoryDep("copy", Integer(0), (), ())]
+        )
+
+        result, created = self._run([first, copy, consumer])
+
+        self.assertEqual(result, [copy, created[0]])
+        self.assertEqual(created[0].snodes, [first, consumer])
+
     def test_two_separate_groups(self):
         sched = _make_scheduler()
         g0a = _make_snode(sched, _make_ir_op((0,), Integer(4)), "g0a")

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -247,9 +247,11 @@ class CoarseTileInfo:
         level's extent equals the final (innermost) extent times the
         product of every more-inner level's own count that also tiles that
         dim.
-        An empty per-level list means the dep is loop-invariant at that
-        level. This is a tiling *decision*, not a substituted index
-        expression -- deferred substitution into the dependency's actual
+        An empty per-level list means this read's address does not advance at
+        that level. It does not by itself prove value invariance: a producer
+        may rewrite fixed-address scratch on every trip. This is a tiling
+        *decision*, not a substituted index expression -- deferred
+        substitution into the dependency's actual
         (possibly later-rewritten) index expression happens in
         spyre_kernel.py at OpSpec/TensorArg construction time, when the
         index is guaranteed final.

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -285,8 +285,10 @@ class CoarseTileInfo:
         ``test_flash_tile_B``). Independent of ``dep.index`` entirely, so
         ``SpyreKernel._general_tile_advance`` can add its device-address
         contribution as an extra term via ``tiling_expr_to_device_expr``
-        rather than by substitution. Empty list means no such dims for this
-        read (the common case).
+        rather than by substitution. An empty per-read list means that read
+        has no such dims. The outer list may also be empty when no read in the
+        operation needs squeezed-dimension metadata; that is complete "none
+        needed" metadata, not a missing entry for every read.
     squeezed_advance_output:
         The analogous per-level ``(host_stride, extent)`` list for this op's
         own write dependency, parallel to ``output_tiled_dims`` the same way

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -176,6 +176,10 @@ class ReadCopyEntry:
         captured before division squeezes a size-one tiled dimension away.
         ``_plan_read_copies`` attaches the selected sizing read's facts here;
         this entry is their authority during copy construction.
+    loop_invariant:
+        True only when every consumer reads the same source slice on every
+        trip of the surrounding counted loop.  Such a copy is a preheader
+        operation, not part of the loop body.
     """
 
     copy_name: str
@@ -187,6 +191,7 @@ class ReadCopyEntry:
     predivision_unit_steps: tuple[
         tuple[tuple[int, sympy.Expr, sympy.Expr], ...], ...
     ] = ()
+    loop_invariant: bool = False
 
 
 @dataclass(frozen=True)

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -4052,7 +4052,9 @@ def _plan_read_copies(
     holds before _apply_plan runs for that op's group.
     """
     op_position = {op.get_operation_name(): i for i, op in enumerate(operations)}
-    operations_by_name = {op.get_name(): op for op in operations}
+    operations_by_name = {
+        op.get_name(): op for op in operations if isinstance(op, ComputedBuffer)
+    }
     loop_written_names = _loop_written_buffer_names(operations)
     predivision_unit_steps_by_op = predivision_unit_steps_by_op or {}
     plans: dict[tuple[int, ...], ReadCopyPlan] = {}

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -132,14 +132,30 @@ class _ReadCopyHoistDecision(enum.Enum):
     ELIGIBLE = enum.auto()
     CROSS_GROUP_SOURCE = enum.auto()
     LOOP_PRODUCED_SOURCE = enum.auto()
+    IN_LOOP_WRITTEN_SOURCE = enum.auto()
+    UNKNOWN_SOURCE = enum.auto()
     MISSING_STEP_METADATA = enum.auto()
     ADVANCING_READ = enum.auto()
+
+
+class _ReadCopySourceKind(enum.Enum):
+    """What planning has positively established about a staged-read source."""
+
+    KNOWN_EXTERNAL = enum.auto()
+    LOOP_PRODUCED = enum.auto()
+    IN_LOOP_WRITTEN = enum.auto()
+    UNKNOWN = enum.auto()
+
+
+class _ReadCopySourceInfo(NamedTuple):
+    kind: _ReadCopySourceKind
+    loop_group_id: tuple[int, ...] | None = None
 
 
 def _read_copy_hoist_decision(
     consumer_info: CoarseTileInfo,
     dep_idx: int,
-    producer_loop_group_id: tuple[int, ...] | None,
+    source_info: _ReadCopySourceInfo,
 ) -> _ReadCopyHoistDecision:
     """Classify whether a read sees the same source slice on every trip.
 
@@ -148,14 +164,25 @@ def _read_copy_hoist_decision(
     scratch address can be rewritten by another counted loop every trip.
     Hoisting is sound only when the source is loop-external and complete
     read-step metadata proves that the consumer's window does not advance.
+    Reads synthesized after Pass 1 are outside this classifier's scope and
+    must be validated by the pass that creates them.
     """
-    if producer_loop_group_id is not None:
-        if producer_loop_group_id != consumer_info.loop_group_id:
+    if source_info.kind is _ReadCopySourceKind.LOOP_PRODUCED:
+        if source_info.loop_group_id != consumer_info.loop_group_id:
             # Keep this distinct from the general loop-produced rejection:
             # cross-group scratch caused the correctness bug this guard fixes.
             return _ReadCopyHoistDecision.CROSS_GROUP_SOURCE
         return _ReadCopyHoistDecision.LOOP_PRODUCED_SOURCE
+    if source_info.kind is _ReadCopySourceKind.IN_LOOP_WRITTEN:
+        return _ReadCopyHoistDecision.IN_LOOP_WRITTEN_SOURCE
+    if source_info.kind is _ReadCopySourceKind.UNKNOWN:
+        return _ReadCopyHoistDecision.UNKNOWN_SOURCE
+    if source_info.kind is not _ReadCopySourceKind.KNOWN_EXTERNAL:
+        raise AssertionError(f"unexpected read-copy source kind {source_info.kind}")
 
+    # tiled_dims_per_read is dense: planning records one entry for every read,
+    # so a missing entry is missing evidence. squeezed_advance_per_read is
+    # sparse by design: an empty outer list is complete "none needed" evidence.
     if dep_idx >= len(consumer_info.tiled_dims_per_read):
         return _ReadCopyHoistDecision.MISSING_STEP_METADATA
     if consumer_info.squeezed_advance_per_read and dep_idx >= len(
@@ -172,6 +199,54 @@ def _read_copy_hoist_decision(
     if any(per_level_dims) or any(per_level_squeezed):
         return _ReadCopyHoistDecision.ADVANCING_READ
     return _ReadCopyHoistDecision.ELIGIBLE
+
+
+def _loop_written_buffer_names(operations: list[Operation]) -> set[str]:
+    """Return storage names mutated by an operation inside a counted loop."""
+    written: set[str] = set()
+    for op in operations:
+        if hasattr(op, "loop_info"):
+            # get_mutation_names is Inductor's authoritative record of storage
+            # written by this op beyond its ordinary produced value.
+            written.update(op.get_mutation_names())
+    return written
+
+
+def _read_copy_source_info(
+    source_name: str,
+    operations_by_name: dict[str, Operation],
+    loop_written_names: set[str],
+) -> _ReadCopySourceInfo:
+    """Classify one source using positive producer and writer evidence."""
+    if source_name in loop_written_names:
+        return _ReadCopySourceInfo(_ReadCopySourceKind.IN_LOOP_WRITTEN)
+
+    source = operations_by_name.get(source_name)
+    if source is None:
+        source = V.graph.try_get_buffer(source_name)
+        if source is None:
+            return _ReadCopySourceInfo(_ReadCopySourceKind.UNKNOWN)
+
+    while isinstance(source, (TensorBox, StorageBox)):
+        source = source.data
+
+    if isinstance(source, ComputedBuffer):
+        producer_info = getattr(source, "loop_info", None)
+        if producer_info is not None:
+            return _ReadCopySourceInfo(
+                _ReadCopySourceKind.LOOP_PRODUCED,
+                producer_info.loop_group_id,
+            )
+        return _ReadCopySourceInfo(_ReadCopySourceKind.KNOWN_EXTERNAL)
+
+    # Imported lazily for the same circular-import reason as
+    # _full_buffer_read_deps. A SpyreEmptyFallback is only external when the
+    # writer scan above proved no counted-loop operation mutates it.
+    from ..ir import SpyreEmptyFallback
+
+    if isinstance(source, (InputBuffer, SpyreEmptyFallback)):
+        return _ReadCopySourceInfo(_ReadCopySourceKind.KNOWN_EXTERNAL)
+    return _ReadCopySourceInfo(_ReadCopySourceKind.UNKNOWN)
 
 
 class _LogicalIterationSymbol(NamedTuple):
@@ -3270,6 +3345,7 @@ def _insert_one_read_copy(
     # A broadcast input that is fixed for the whole counted loop needs one
     # compact staging copy of its real tensor dimensions.  Keeping the absent
     # loop dimension would materialize the expanded [E, ...] view in HBM.
+    # A fully-broadcast scalar has no real dimensions to compact.
     compact_invariant = loop_invariant and bool(active_idx)
     tile_ranges = (
         [dep.size[i] for i in active_idx] if compact_invariant else list(dep.size)
@@ -3818,7 +3894,7 @@ def _patch_consumer_to_read_copy(
     # Keep the dependency-coordinate positions separate from buffer-layout
     # strides appended below.  The latter make _rescale_index complete, but
     # they are not dimensions of a compact invariant copy.
-    dep_full_strides = list(full_strides)
+    pre_extension_strides = list(full_strides)
     # dep is sizing_op's own (upstream-Inductor-squeezed) MemoryDep for this
     # read, so dep.var_names only covers host dims sizing_op's tile-extent
     # keeps distinct -- a host dim tiled down to extent 1 (e.g. a B-tiled
@@ -3850,12 +3926,12 @@ def _patch_consumer_to_read_copy(
         if isinstance(op, ComputedBuffer) and op.get_name() == copy_name
     )
     copy_strides = list(copy_buf.layout.stride)
-    active_idx = [i for i, stride in enumerate(dep_full_strides) if stride != 0]
+    active_idx = [i for i, stride in enumerate(pre_extension_strides) if stride != 0]
     if loop_invariant and len(copy_strides) == len(active_idx):
         # Expand a compact invariant copy's real strides back into the
         # consumer's iteration-space positions.  Broadcast loop dimensions
         # remain fixed at zero instead of shifting the real tensor strides.
-        tile_strides = [sympy.Integer(0)] * len(dep_full_strides)
+        tile_strides = [sympy.Integer(0)] * len(pre_extension_strides)
         for pos, stride in zip(active_idx, copy_strides):
             tile_strides[pos] = stride
     else:
@@ -3976,11 +4052,8 @@ def _plan_read_copies(
     holds before _apply_plan runs for that op's group.
     """
     op_position = {op.get_operation_name(): i for i, op in enumerate(operations)}
-    producer_loop_groups = {
-        op.get_name(): op.loop_info.loop_group_id  # type: ignore[attr-defined]
-        for op in operations
-        if isinstance(op, ComputedBuffer) and hasattr(op, "loop_info")
-    }
+    operations_by_name = {op.get_name(): op for op in operations}
+    loop_written_names = _loop_written_buffer_names(operations)
     predivision_unit_steps_by_op = predivision_unit_steps_by_op or {}
     plans: dict[tuple[int, ...], ReadCopyPlan] = {}
 
@@ -4035,7 +4108,11 @@ def _plan_read_copies(
                 decision = _read_copy_hoist_decision(
                     candidate_info,
                     dep_idx,
-                    producer_loop_groups.get(candidate_dep.name),
+                    _read_copy_source_info(
+                        candidate_dep.name,
+                        operations_by_name,
+                        loop_written_names,
+                    ),
                 )
                 hoist_decisions.append(decision)
                 logger.debug(

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -61,6 +61,7 @@ from __future__ import annotations
 
 import collections
 import dataclasses
+import enum
 import logging
 from typing import NamedTuple
 
@@ -123,6 +124,54 @@ class _RetiledBufferInfo(NamedTuple):
     old_stride: tuple[Expr, ...]
     new_stride: tuple[Expr, ...]
     old_size: tuple[Expr, ...]
+
+
+class _ReadCopyHoistDecision(enum.Enum):
+    """Why a staged read may or may not move before its counted loop."""
+
+    ELIGIBLE = enum.auto()
+    CROSS_GROUP_SOURCE = enum.auto()
+    LOOP_PRODUCED_SOURCE = enum.auto()
+    MISSING_STEP_METADATA = enum.auto()
+    ADVANCING_READ = enum.auto()
+
+
+def _read_copy_hoist_decision(
+    consumer_info: CoarseTileInfo,
+    dep_idx: int,
+    producer_loop_group_id: tuple[int, ...] | None,
+) -> _ReadCopyHoistDecision:
+    """Classify whether a read sees the same source slice on every trip.
+
+    Source stability and address stability are independent requirements. A
+    graph input can still be read through an advancing window, while a fixed
+    scratch address can be rewritten by another counted loop every trip.
+    Hoisting is sound only when the source is loop-external and complete
+    read-step metadata proves that the consumer's window does not advance.
+    """
+    if producer_loop_group_id is not None:
+        if producer_loop_group_id != consumer_info.loop_group_id:
+            # Keep this distinct from the general loop-produced rejection:
+            # cross-group scratch caused the correctness bug this guard fixes.
+            return _ReadCopyHoistDecision.CROSS_GROUP_SOURCE
+        return _ReadCopyHoistDecision.LOOP_PRODUCED_SOURCE
+
+    if dep_idx >= len(consumer_info.tiled_dims_per_read):
+        return _ReadCopyHoistDecision.MISSING_STEP_METADATA
+    if consumer_info.squeezed_advance_per_read and dep_idx >= len(
+        consumer_info.squeezed_advance_per_read
+    ):
+        return _ReadCopyHoistDecision.MISSING_STEP_METADATA
+
+    per_level_dims = consumer_info.tiled_dims_per_read[dep_idx]
+    per_level_squeezed = (
+        consumer_info.squeezed_advance_per_read[dep_idx]
+        if consumer_info.squeezed_advance_per_read
+        else []
+    )
+    if any(per_level_dims) or any(per_level_squeezed):
+        return _ReadCopyHoistDecision.ADVANCING_READ
+    return _ReadCopyHoistDecision.ELIGIBLE
 
 
 class _LogicalIterationSymbol(NamedTuple):
@@ -777,6 +826,10 @@ def _zero_reads_of_fixed_buffers_planned(
         reads = [d for d in op.get_read_writes().reads if isinstance(d, MemoryDep)]
         for i, dep in enumerate(reads):
             if dep.name in fixed_names and info.tiled_dims_per_read[i]:
+                # This makes the read address stationary while it names the
+                # producer's per-tile scratch.  It does not make the value
+                # invariant: that scratch is rewritten every trip, and an
+                # outside consumer may later be redirected to a full buffer.
                 info.tiled_dims_per_read[i] = []
 
 
@@ -3924,6 +3977,11 @@ def _plan_read_copies(
     holds before _apply_plan runs for that op's group.
     """
     op_position = {op.get_operation_name(): i for i, op in enumerate(operations)}
+    producer_loop_groups = {
+        op.get_name(): op.loop_info.loop_group_id  # type: ignore[attr-defined]
+        for op in operations
+        if isinstance(op, ComputedBuffer) and hasattr(op, "loop_info")
+    }
     predivision_unit_steps_by_op = predivision_unit_steps_by_op or {}
     plans: dict[tuple[int, ...], ReadCopyPlan] = {}
 
@@ -3963,7 +4021,7 @@ def _plan_read_copies(
             op_deps.sort(key=lambda pair: op_position[pair[0].get_operation_name()])
             sizing_op, sizing_dep = op_deps[0]
             sizing_info = sizing_op.loop_info  # type: ignore[attr-defined]
-            invariant_by_consumer: list[bool] = []
+            hoist_decisions: list[_ReadCopyHoistDecision] = []
             for candidate_op, candidate_dep in op_deps:
                 candidate_info = candidate_op.loop_info  # type: ignore[attr-defined]
                 candidate_reads = [
@@ -3972,18 +4030,18 @@ def _plan_read_copies(
                     if isinstance(read, MemoryDep)
                 ]
                 dep_idx = candidate_reads.index(candidate_dep)
-                per_level_dims = (
-                    candidate_info.tiled_dims_per_read[dep_idx]
-                    if dep_idx < len(candidate_info.tiled_dims_per_read)
-                    else []
+                decision = _read_copy_hoist_decision(
+                    candidate_info,
+                    dep_idx,
+                    producer_loop_groups.get(candidate_dep.name),
                 )
-                per_level_squeezed = (
-                    candidate_info.squeezed_advance_per_read[dep_idx]
-                    if dep_idx < len(candidate_info.squeezed_advance_per_read)
-                    else []
-                )
-                invariant_by_consumer.append(
-                    not any(per_level_dims) and not any(per_level_squeezed)
+                hoist_decisions.append(decision)
+                logger.debug(
+                    "coarse_tile: read-copy hoist decision consumer=%s "
+                    "source=%s decision=%s",
+                    candidate_op.get_operation_name(),
+                    candidate_dep.name,
+                    decision.name,
                 )
             for other_op, _dep in op_deps[1:]:
                 other_info = other_op.loop_info  # type: ignore[attr-defined]
@@ -4038,7 +4096,14 @@ def _plan_read_copies(
                         op.get_operation_name() for op, _dep in op_deps
                     ),
                     predivision_unit_steps=predivision_unit_steps,
-                    loop_invariant=all(invariant_by_consumer),
+                    # This one decision controls both preheader placement and
+                    # compact staging in _insert_one_read_copy. They require
+                    # the same proof: every consumer sees the same source
+                    # slice on every counted-loop trip.
+                    loop_invariant=all(
+                        decision is _ReadCopyHoistDecision.ELIGIBLE
+                        for decision in hoist_decisions
+                    ),
                 )
             )
         if entries:

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -3136,6 +3136,7 @@ def _insert_one_read_copy(
     insert_before_op: Operation,
     *,
     predivision_unit_steps: tuple[tuple[tuple[int, Expr, Expr], ...], ...] = (),
+    loop_invariant: bool = False,
 ) -> str:
     """Build and insert one tile-sized copy op for a single full-buffer read.
 
@@ -3188,7 +3189,6 @@ def _insert_one_read_copy(
     if isinstance(full_buf, StorageBox):
         full_buf = full_buf.data
 
-    tile_ranges = list(dep.size)
     # Derive copy buffer strides using compute_tile_stride.
     # dep.size is the full loop iteration space (output + reduction dims) and
     # may have higher rank than the tensor (e.g. for a Reduction reading
@@ -3214,6 +3214,13 @@ def _insert_one_read_copy(
     # Positions with non-zero coeff are active tensor dims; zero coeff means
     # broadcast/absent (e.g. the N dim in a Reduction reading a[M,K]).
     active_idx = [i for i, c in enumerate(full_coeff) if c != 0]
+    # A broadcast input that is fixed for the whole counted loop needs one
+    # compact staging copy of its real tensor dimensions.  Keeping the absent
+    # loop dimension would materialize the expanded [E, ...] view in HBM.
+    compact_invariant = loop_invariant and bool(active_idx)
+    tile_ranges = (
+        [dep.size[i] for i in active_idx] if compact_invariant else list(dep.size)
+    )
 
     tile_strides: list[Expr]
     if not active_idx:
@@ -3246,19 +3253,34 @@ def _insert_one_read_copy(
                 if next_stride is None
                 else next_stride // active_full_strides[k]
             )
-        active_tile_ranges = [tile_ranges[i] for i in active_idx]
+        active_tile_ranges = [dep.size[i] for i in active_idx]
         active_tile_strides = compute_tile_stride(
             active_full_sizes, active_full_strides, active_tile_ranges
         )
         # active_tile_strides[i] corresponds to active_idx[i]: both are indexed
         # by position in the compressed active-dims space, so zip pairs each
         # full dep.var_names position with its computed tile stride correctly.
-        tile_strides = [sympy.Integer(0)] * len(tile_ranges)
-        for pos, ts in zip(active_idx, active_tile_strides):
-            tile_strides[pos] = ts
+        if compact_invariant:
+            tile_strides = active_tile_strides
+        else:
+            tile_strides = [sympy.Integer(0)] * len(tile_ranges)
+            for pos, ts in zip(active_idx, active_tile_strides):
+                tile_strides[pos] = ts
 
-    def _copy_inner_fn(idx, _dep=dep, _full_name=full_buf.get_name()):
-        subs = dict(zip(_dep.var_names, idx))
+    def _copy_inner_fn(
+        idx,
+        _dep=dep,
+        _full_name=full_buf.get_name(),
+        _active_idx=active_idx,
+        _compact=compact_invariant,
+    ):
+        if _compact:
+            full_idx = [sympy.Integer(0)] * len(_dep.var_names)
+            for pos, value in zip(_active_idx, idx):
+                full_idx[pos] = value
+        else:
+            full_idx = idx
+        subs = dict(zip(_dep.var_names, full_idx))
         flat_index = sympy_subs(_dep.index, subs)
         return V.ops.load(_full_name, flat_index)
 
@@ -3457,6 +3479,21 @@ def _insert_one_read_copy(
     # let work-division planning choose from the copy's actual dimensions.
     if hasattr(copy_buf, "work_div_loop_info"):
         del copy_buf.work_div_loop_info  # type: ignore[attr-defined]
+
+    if loop_invariant:
+        # No loop metadata means codegen emits this copy once before the first
+        # loop-body consumer.  The copy has its own iteration symbols, so the
+        # consumer's named work-division request must not be reused on it.
+        if hasattr(copy_buf, "loop_info"):
+            del copy_buf.loop_info  # type: ignore[attr-defined]
+        if hasattr(copy_buf, "work_div_loop_info"):
+            del copy_buf.work_div_loop_info  # type: ignore[attr-defined]
+        V.graph.name_to_buffer[copy_name] = copy_buf
+        operations.insert(insert_idx, copy_buf)
+        logger.debug(
+            "coarse_tile: invariant read copy-in %s -> %s", dep.name, copy_name
+        )
+        return copy_buf.get_name()
 
     # Fresh per-level tiled-dim decisions for copy_buf's own read/write —
     # mirroring _insert_copy_op's read/write split (see its comment), but
@@ -3708,6 +3745,8 @@ def _patch_consumer_to_read_copy(
     dep: MemoryDep,
     copy_name: str,
     operations: list[Operation],
+    *,
+    loop_invariant: bool = False,
 ) -> None:
     """Patch consumer's inner_fn to read copy_name instead of dep.name.
 
@@ -3724,6 +3763,10 @@ def _patch_consumer_to_read_copy(
     one) via replace_computed_buffer_body, exactly as today.
     """
     full_strides = [dep.index.coeff(v) for v in dep.var_names]
+    # Keep the dependency-coordinate positions separate from buffer-layout
+    # strides appended below.  The latter make _rescale_index complete, but
+    # they are not dimensions of a compact invariant copy.
+    dep_full_strides = list(full_strides)
     # dep is sizing_op's own (upstream-Inductor-squeezed) MemoryDep for this
     # read, so dep.var_names only covers host dims sizing_op's tile-extent
     # keeps distinct -- a host dim tiled down to extent 1 (e.g. a B-tiled
@@ -3754,7 +3797,17 @@ def _patch_consumer_to_read_copy(
         for op in operations
         if isinstance(op, ComputedBuffer) and op.get_name() == copy_name
     )
-    tile_strides = list(copy_buf.layout.stride)
+    copy_strides = list(copy_buf.layout.stride)
+    active_idx = [i for i, stride in enumerate(dep_full_strides) if stride != 0]
+    if loop_invariant and len(copy_strides) == len(active_idx):
+        # Expand a compact invariant copy's real strides back into the
+        # consumer's iteration-space positions.  Broadcast loop dimensions
+        # remain fixed at zero instead of shifting the real tensor strides.
+        tile_strides = [sympy.Integer(0)] * len(dep_full_strides)
+        for pos, stride in zip(active_idx, copy_strides):
+            tile_strides[pos] = stride
+    else:
+        tile_strides = copy_strides
     tile_strides.extend(
         sympy.Integer(0) for _ in range(len(full_strides) - len(tile_strides))
     )
@@ -3910,6 +3963,28 @@ def _plan_read_copies(
             op_deps.sort(key=lambda pair: op_position[pair[0].get_operation_name()])
             sizing_op, sizing_dep = op_deps[0]
             sizing_info = sizing_op.loop_info  # type: ignore[attr-defined]
+            invariant_by_consumer: list[bool] = []
+            for candidate_op, candidate_dep in op_deps:
+                candidate_info = candidate_op.loop_info  # type: ignore[attr-defined]
+                candidate_reads = [
+                    read
+                    for read in candidate_op.get_read_writes().reads
+                    if isinstance(read, MemoryDep)
+                ]
+                dep_idx = candidate_reads.index(candidate_dep)
+                per_level_dims = (
+                    candidate_info.tiled_dims_per_read[dep_idx]
+                    if dep_idx < len(candidate_info.tiled_dims_per_read)
+                    else []
+                )
+                per_level_squeezed = (
+                    candidate_info.squeezed_advance_per_read[dep_idx]
+                    if dep_idx < len(candidate_info.squeezed_advance_per_read)
+                    else []
+                )
+                invariant_by_consumer.append(
+                    not any(per_level_dims) and not any(per_level_squeezed)
+                )
             for other_op, _dep in op_deps[1:]:
                 other_info = other_op.loop_info  # type: ignore[attr-defined]
                 # Only loop_count (the per-level trip counts) is a genuine
@@ -3963,6 +4038,7 @@ def _plan_read_copies(
                         op.get_operation_name() for op, _dep in op_deps
                     ),
                     predivision_unit_steps=predivision_unit_steps,
+                    loop_invariant=all(invariant_by_consumer),
                 )
             )
         if entries:
@@ -4002,11 +4078,16 @@ def _insert_all_read_copy_ops(
                 operations,
                 insert_before_op=insert_before_op,
                 predivision_unit_steps=entry.predivision_unit_steps,
+                loop_invariant=entry.loop_invariant,
             )
             for consumer_name in entry.consumer_op_names:
                 consumer = name_to_op[consumer_name]
                 _patch_consumer_to_read_copy(
-                    consumer, entry.dep, new_copy_name, operations
+                    consumer,
+                    entry.dep,
+                    new_copy_name,
+                    operations,
+                    loop_invariant=entry.loop_invariant,
                 )
 
 

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -3536,11 +3536,10 @@ def _insert_one_read_copy(
     if loop_invariant:
         # No loop metadata means codegen emits this copy once before the first
         # loop-body consumer.  The copy has its own iteration symbols, so the
-        # consumer's named work-division request must not be reused on it.
+        # consumer's named work-division request must not be reused on it
+        # (it was removed unconditionally above).
         if hasattr(copy_buf, "loop_info"):
             del copy_buf.loop_info  # type: ignore[attr-defined]
-        if hasattr(copy_buf, "work_div_loop_info"):
-            del copy_buf.work_div_loop_info  # type: ignore[attr-defined]
         V.graph.name_to_buffer[copy_name] = copy_buf
         operations.insert(insert_idx, copy_buf)
         logger.debug(
@@ -4029,6 +4028,9 @@ def _plan_read_copies(
                     for read in candidate_op.get_read_writes().reads
                     if isinstance(read, MemoryDep)
                 ]
+                # reads is an OrderedSet: identical MemoryDeps collapse to one
+                # equality class, so index() cannot select a different copy of
+                # the same dependency with different movement metadata.
                 dep_idx = candidate_reads.index(candidate_dep)
                 decision = _read_copy_hoist_decision(
                     candidate_info,


### PR DESCRIPTION
Tracking: #3565
Split from #3928
Prerequisites #4040 and #4096 have merged into `main`.

## Campaign status

Merged. The full dense expert-loop compiler implementation and acceptance are complete in `main` through #4042 (`3358f39e`). Structural, numerical-correctness, and same-stack device-performance gates have passed.

## This PR owns

This PR moves a staged read before a counted loop only when every consumer reads the same data slice on every loop trip. That requires two independent facts:

1. The source is stable: it is positively classified as external to all counted loops and no in-loop operation writes its storage. Sources produced by the same loop or another loop group, sources written inside any counted loop, and sources that cannot be classified are rejected.
2. The address is stable: complete per-read movement metadata proves that the consumer's window does not advance at any loop level. Missing metadata and advancing reads are rejected.

One classification controls both preheader placement and compact staging, so the two decisions cannot drift apart. Rejections carry named reasons for cross-group sources, other loop-produced sources, in-loop-written sources, unknown sources, missing movement metadata, and advancing reads.

For the dense-expert case, `x[T,H]` is staged once and reused by every expert iteration. The absent expert dimension is not materialized as an expanded `[E,T,H]` buffer.

## Why both facts are required

A graph input can be unchanged while the consumer reads a different window from it on each iteration. Conversely, a scratch address can stay fixed while another counted loop overwrites the value stored there on every iteration. A zero address step therefore proves only a fixed address, not an invariant value.

This distinction fixes the chained-group failure where a consumer read fixed-address producer scratch that was rewritten every producer trip. The old logic treated the empty address step as value invariance and incorrectly hoisted the read.

## This PR does not own

- recovering the step for size-one tiled dimensions (#4040, merged);
- removing advancing weight copies (#4041);
- named work-division lineage through size-one tiling (#4096, merged);
- work division, LX placement, or the running sum (#4042).

Advancing reads retain their original per-trip copy and loop metadata.

## Validation

- Current base/head: `main@0db532b3 → ef8b33de`.
- Current PR diff: production +251/-15; tests +353/-12 across four files.
- All five commits are DCO-signed and GPG-signed.
- Rebase range-diff: all five commits are patch-equivalent to the previously reviewed/tested versions.
- Full coarse-tiling unit file: 345 passed, 1 skipped on the pre-refresh tree; the focused source-classification class passes 10/10 after the latest hardening.
- Coarse-tiling end-to-end file, excluding three inherited `outside_consumer_copy_then_read` failures: 190 passed, 42 skipped, 3 deselected, 1 expected failure.
- Focused chained-group regression passes.
- Scheduler-ordering regression proves a hoisted dependency of a later loop member is scheduled before the complete counted-loop unit.
- Structural address test checks meaning rather than generated names: the activation read is non-advancing, while the weight read advances by one 4096-element expert slab.
- Focused mypy, Ruff check, Ruff format check, `py_compile`, and `git diff --check` pass for the changed files.
- Fresh GitHub CI is running on the current-main refresh.

The recurring unhinted `keep_by_index_4d_dim3` failure cannot engage this counted-loop path and previously passed in a matched Python/native/cache environment. Device-startup failures are classified separately from compiler-test failures.

## Integration contract

The final program must contain one preheader copy of `x[T,H]`, no expert-expanded activation allocation, and unchanged advancing copies until #4041 proves they can be removed.

