### PR TITLE
feat(ci): drop per-failure retry loop; keep only the stall-triggered xdist retry since _test_matrix.yaml now retries failed suites on a fresh pod

### DIFF
--- a/.github/actions/run-test-suite/action.yml
+++ b/.github/actions/run-test-suite/action.yml
@@ -1,8 +1,10 @@
-name: Run test suite (with retry + stall watcher)
+name: Run test suite (single attempt + stall-triggered xdist retry)
 description: >
-  Runs a single run_test.sh config with up to MAX_ATTEMPTS retries,
-  a stall watchdog, DTLOG_LEVEL=Info on retry attempts, and -n1
-  (pytest-xdist worker isolation) on the attempt following a stall.
+  Runs a single run_test.sh config once. A stall (no stdout for
+  stall_timeout_secs) kills the attempt and retries it once, in the same
+  pod, with -n1 (pytest-xdist worker isolation). Any other failure is left
+  for pod-level retry (_test_matrix.yaml's test_retry/test_multi_spyre_retry
+  jobs) instead of retrying here.
 
 inputs:
   torch_spyre_dir:
@@ -30,10 +32,6 @@ inputs:
     description: Extra flags forwarded to run_test.sh (e.g. "-v")
     required: false
     default: ''
-  max_attempts:
-    description: Total number of attempts before giving up
-    required: false
-    default: '3'
   stall_timeout_secs:
     description: Seconds of no stdout before the test is killed as hung
     required: false
@@ -44,10 +42,10 @@ inputs:
     default: '30'
   card_release_timeout_secs:
     description: >-
-      Grace period before retrying an attempt that failed because the AIU card
-      was still held (VFIO device busy). Longer than the plain retry backoff:
-      the holder is a leftover process from the previous attempt in this pod,
-      and the pod's VFIO devices are fixed at admission.
+      Grace period before the stall-triggered retry, waiting for the AIU
+      card VFIO fd held by the killed attempt to release: a killed holder
+      does not drop its fd synchronously, and the pod's VFIO devices are
+      fixed at admission, so retrying while still held is guaranteed to fail.
     required: false
     default: '60'
   junit_xml_path:
@@ -75,7 +73,6 @@ runs:
       env:
         TORCH_SPYRE_DIR: ${{ inputs.torch_spyre_dir }}
         VENV_PATH: ${{ inputs.venv_path }}
-        MAX_ATTEMPTS: ${{ inputs.max_attempts }}
         STALL_TIMEOUT_SECS: ${{ inputs.stall_timeout_secs }}
         STALL_CHECK_INTERVAL: ${{ inputs.stall_check_interval }}
         CARD_RELEASE_TIMEOUT_SECS: ${{ inputs.card_release_timeout_secs }}
@@ -83,8 +80,8 @@ runs:
         set +e
         set +o pipefail
         # Job control: each `&` background job gets its own process group, so
-        # the stall watcher can kill TEST_PID's entire descendant tree (incl.
-        # xdist workers) via its PGID instead of only direct children.
+        # the stall watcher can kill the test PID's entire descendant tree
+        # (incl. xdist workers) via its PGID instead of only direct children.
         set -m
 
         source "$HOME/.bashrc"
@@ -125,14 +122,6 @@ runs:
           _SLOW_FLAG="--skip-slow"
         fi
 
-        attempt=0
-        # Set by stall_watcher when it kills a hung attempt; read after `wait`
-        # to make the next attempt add -n1 (pytest-xdist worker isolation).
-        _STALLED_LAST_ATTEMPT=0
-        # Previous attempt's TEST_PID (also its PGID, via `set -m`); empty
-        # until the first attempt has run.
-        TEST_PID=""
-
         # PIDs holding a /dev/vfio device, excluding this shell's own tree.
         # Reads /proc directly: lsof/fuser are not guaranteed on the runner
         # image, and this must never fail the job when it cannot tell.
@@ -150,47 +139,25 @@ runs:
           done
           printf '%s' "$found"
         }
-        while [[ $attempt -lt $MAX_ATTEMPTS ]]; do
-          attempt=$(( attempt + 1 ))
-          echo "=== Attempt ${attempt}/${MAX_ATTEMPTS}: ${{ inputs.suite_name }} ==="
 
-          # Clean up the previous attempt's leader PID or its process group, whichever is still alive.
-          if [[ -n "$TEST_PID" ]] && { kill -0 -- "$TEST_PID" 2>/dev/null || kill -0 -- "-$TEST_PID" 2>/dev/null; }; then
-            echo "Previous attempt's process (PID/PGID ${TEST_PID}) still alive — cleaning up"
-            kill -STOP -- "$TEST_PID" "-$TEST_PID" 2>/dev/null || true
-            kill -KILL -- "$TEST_PID" "-$TEST_PID" 2>/dev/null || true
+        # Runs one attempt of run_test.sh with a stall watchdog. Sets globals
+        # TEST_EXIT and _STALLED. $1 (optional): extra xdist flag, e.g. -n1.
+        run_attempt() {
+          local xdist_flag="$1"
+          local log_file stall_flag fifo tee_pid watcher_pid test_pid
+
+          # Run any per-attempt setup (e.g. topology reset for multi-Spyre)
+          if [[ -n '${{ inputs.pre_run }}' ]]; then
+            eval '${{ inputs.pre_run }}'
           fi
 
-          # A killed holder does not drop its VFIO fd synchronously: torchrun's
-          # per-rank children can outlive the PGID kill above, and a process
-          # blocked in a VFIO ioctl stays in D state until the driver returns.
-          # The pod's cards are fixed at admission, so retrying while one is
-          # still held is guaranteed to fail with RAS::VFIO::DeviceOpenFail.
-          # Wait for the fds to actually close before starting the next attempt.
-          if [[ $attempt -gt 1 ]]; then
-            _waited=0
-            while [[ $_waited -lt $CARD_RELEASE_TIMEOUT_SECS ]]; do
-              _holders="$(_vfio_holder_pids)"
-              [[ -z "$_holders" ]] && break
-              [[ $_waited -eq 0 ]] && echo "Waiting for AIU card release; still held by PID(s): ${_holders}"
-              sleep 2
-              _waited=$(( _waited + 2 ))
-            done
-            _holders="$(_vfio_holder_pids)"
-            if [[ -n "$_holders" ]]; then
-              echo "::warning::AIU card still held by PID(s) ${_holders} after ${CARD_RELEASE_TIMEOUT_SECS}s — attempt ${attempt} may fail to open the device"
-            elif [[ $_waited -gt 0 ]]; then
-              echo "AIU card released after ${_waited}s"
-            fi
-          fi
-
-          LOG_FILE="$(mktemp /tmp/test_output_XXXXXX.log)"
-          STALL_FLAG="$(mktemp /tmp/stall_flag_XXXXXX.tmp)"
+          log_file="$(mktemp /tmp/test_output_XXXXXX.log)"
+          stall_flag="$(mktemp /tmp/stall_flag_XXXXXX.tmp)"
 
           stall_watcher() {
             local elapsed_stall=0
             local prev_lines=0
-            while [[ ! -f "${STALL_FLAG}.done" ]]; do
+            while [[ ! -f "${stall_flag}.done" ]]; do
               sleep "$STALL_CHECK_INTERVAL"
               # Once pytest has printed its terminal summary line the suite has
               # finished executing; any silence after that is teardown, not a
@@ -198,29 +165,29 @@ runs:
               # elastic agent can linger silently after every rank passed, and
               # counting that window as a stall kills a run that already passed
               # (spurious exit 147). Stop watching as soon as a terminal summary
-              # appears; the parent's `wait "$TEST_PID"` (plus the bounded
+              # appears; the parent's `wait "$test_pid"` (plus the bounded
               # torchrun teardown in run_test.sh) collects the real exit code.
-              if grep -qE '^=+ (.*[0-9]+ (passed|failed|error|skipped|xfailed|xpassed|deselected)|no tests ran)' "$LOG_FILE" 2>/dev/null; then
+              if grep -qE '^=+ (.*[0-9]+ (passed|failed|error|skipped|xfailed|xpassed|deselected)|no tests ran)' "$log_file" 2>/dev/null; then
                 echo "[stall-watcher] pytest summary seen — teardown may be quiet, stopping stall watch"
                 return
               fi
-              current_lines=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
+              current_lines=$(wc -l < "$log_file" 2>/dev/null || echo 0)
               if [[ "$current_lines" -eq "$prev_lines" ]]; then
                 elapsed_stall=$(( elapsed_stall + STALL_CHECK_INTERVAL ))
                 echo "[stall-watcher] No new output for ${elapsed_stall}s (lines=${current_lines})"
                 if [[ $elapsed_stall -ge $STALL_TIMEOUT_SECS ]]; then
                   echo "[stall-watcher] STALL DETECTED — killing test child processes"
-                  # Marks this attempt as stalled for the parent shell to read after `wait`.
-                  touch "${STALL_FLAG}.stalled"
-                  # Kill TEST_PID's whole process group (set -m gives it its own
-                  # PGID == TEST_PID): `pkill -P` alone only hits direct children,
+                  # Marks this attempt as stalled for the caller to read after `wait`.
+                  touch "${stall_flag}.stalled"
+                  # Kill test_pid's whole process group (set -m gives it its own
+                  # PGID == test_pid): `pkill -P` alone only hits direct children,
                   # missing deeper descendants in run_test.sh -> subshell -> python3
                   # -m pytest -> xdist worker, which can survive and keep the Spyre
-                  # device open, causing "device busy" on retry.
+                  # device open, causing "device busy" on the stall retry.
                   # 1. Freeze the group so it cannot spawn anything further
-                  kill -STOP -- "-$TEST_PID" || true
+                  kill -STOP -- "-$test_pid" || true
                   # 2. Kill the whole frozen group
-                  kill -KILL -- "-$TEST_PID" || true
+                  kill -KILL -- "-$test_pid" || true
                   return
                 fi
               else
@@ -230,23 +197,15 @@ runs:
             done
           }
 
-          # Run any per-attempt setup (e.g. topology reset for multi-Spyre)
-          if [[ -n '${{ inputs.pre_run }}' ]]; then
-            eval '${{ inputs.pre_run }}'
-          fi
-
           echo "Running ${{ inputs.suite_name }} tests..."
           echo "  Host Platform : ${_ARCH}"
           echo "  Slow flag     : ${_SLOW_FLAG:-none (all tests will run)}"
           echo "  Extra flags   : ${{ inputs.extra_test_flags }}"
 
-          # From the first retry onward, enable verbose DT logging for
-          # diagnostics. A retry means something already went wrong (stall,
-          # hardware RAS, etc.), so every attempt after the first should be
-          # at least as diagnostic as attempt 1 — not just the final one.
+          # Stall retry: enable verbose DT logging for diagnostics.
           _DTLOG_PREFIX=""
-          if [[ $attempt -gt 1 ]]; then
-            echo "  DTLOG_LEVEL   : Info (retry attempt — verbose logging enabled)"
+          if [[ -n "$xdist_flag" ]]; then
+            echo "  DTLOG_LEVEL   : Info (stall retry — verbose logging enabled)"
             _DTLOG_PREFIX="DTLOG_LEVEL=Info"
           fi
 
@@ -255,20 +214,17 @@ runs:
             _JUNIT_FLAG="--junit-xml=${{ inputs.junit_xml_path }}"
           fi
 
-          # Previous attempt stalled: isolate each test in its own xdist worker subprocess.
-          _XDIST_FLAG=""
-          if [[ $_STALLED_LAST_ATTEMPT -eq 1 ]]; then
-            echo "  xdist         : -n1 (previous attempt stalled)"
-            _XDIST_FLAG="-n1"
+          if [[ -n "$xdist_flag" ]]; then
+            echo "  xdist         : ${xdist_flag} (previous attempt stalled)"
           fi
 
-          FIFO="$(mktemp -u /tmp/test_fifo_XXXXXX)"
-          mkfifo "$FIFO"
+          fifo="$(mktemp -u /tmp/test_fifo_XXXXXX)"
+          mkfifo "$fifo"
 
-          tee "$LOG_FILE" < "$FIFO" &
-          TEE_PID=$!
+          tee "$log_file" < "$fifo" &
+          tee_pid=$!
 
-          exec {FIFO_FD}>"$FIFO"
+          exec {FIFO_FD}>"$fifo"
 
           _PARALLEL_FLAG=""
           if [[ "${{ inputs.parallel }}" != "false" ]]; then
@@ -284,59 +240,80 @@ runs:
           # do in the invocation below, so the printed and run word lists match.
           printf '  command       :'
           printf ' %q' env ${_DTLOG_PREFIX} bash tests/run_test.sh "$CONFIG" \
-            ${_PARALLEL_FLAG} ${{ inputs.extra_test_flags }} ${_SLOW_FLAG} ${_JUNIT_FLAG} ${_XDIST_FLAG}
+            ${_PARALLEL_FLAG} ${{ inputs.extra_test_flags }} ${_SLOW_FLAG} ${_JUNIT_FLAG} ${xdist_flag}
           printf '\n'
 
-          env ${_DTLOG_PREFIX} bash tests/run_test.sh "$CONFIG" ${_PARALLEL_FLAG} ${{ inputs.extra_test_flags }} ${_SLOW_FLAG} ${_JUNIT_FLAG} ${_XDIST_FLAG} \
+          env ${_DTLOG_PREFIX} bash tests/run_test.sh "$CONFIG" ${_PARALLEL_FLAG} ${{ inputs.extra_test_flags }} ${_SLOW_FLAG} ${_JUNIT_FLAG} ${xdist_flag} \
             >&"$FIFO_FD" 2>&1 &
-          TEST_PID=$!
+          test_pid=$!
 
           exec {FIFO_FD}>&-
 
           stall_watcher &
-          WATCHER_PID=$!
+          watcher_pid=$!
 
-          wait "$TEST_PID"
+          wait "$test_pid"
           TEST_EXIT=$?
 
-          touch "${STALL_FLAG}.done"
-          kill "$WATCHER_PID" 2>/dev/null || true
-          wait "$WATCHER_PID" 2>/dev/null || true
+          touch "${stall_flag}.done"
+          kill "$watcher_pid" 2>/dev/null || true
+          wait "$watcher_pid" 2>/dev/null || true
 
-          kill "$TEE_PID" 2>/dev/null || true
-          wait "$TEE_PID" 2>/dev/null || true
-          rm -f "$FIFO"
+          kill "$tee_pid" 2>/dev/null || true
+          wait "$tee_pid" 2>/dev/null || true
+          rm -f "$fifo"
 
-          _STALLED_LAST_ATTEMPT=0
-          [[ -f "${STALL_FLAG}.stalled" ]] && _STALLED_LAST_ATTEMPT=1
+          _STALLED=0
+          [[ -f "${stall_flag}.stalled" ]] && _STALLED=1
+          rm -f "$log_file" "$stall_flag" "${stall_flag}.done" "${stall_flag}.stalled"
+        }
 
-          if [[ $TEST_EXIT -eq 0 ]]; then
-            echo "=== Attempt ${attempt} PASSED ==="
-            echo "${{ inputs.suite_name }} tests done"
-            rm -f "$LOG_FILE" "$STALL_FLAG" "${STALL_FLAG}.done" "${STALL_FLAG}.stalled"
-            exit 0
-          fi
+        echo "=== Attempt 1/2: ${{ inputs.suite_name }} ==="
+        run_attempt ""
 
-          echo "=== Attempt ${attempt} FAILED (exit=${TEST_EXIT}) ==="
-          # Backoff before the next attempt. Card contention needs longer than a
-          # plain rerun: the holder is a leftover process of the *previous*
-          # attempt inside this same pod, and the VFIO devices are fixed at pod
-          # admission, so there is no second card to fall back to.
-          _RETRY_SLEEP=10
-          if grep -qE "ResponseTimeout|Exceeded max iterations|Fatal Python error: Aborted|LX logout" "$LOG_FILE"; then
-            echo "    --> Hardware RAS timeout detected — will retry"
-          elif grep -qE 'RAS::VFIO::DeviceOpenFail|"code":"0x332b"|Device or resource busy' "$LOG_FILE"; then
-            echo "    --> Card still held (VFIO device busy) — will retry after ${CARD_RELEASE_TIMEOUT_SECS}s grace"
-            _RETRY_SLEEP=$CARD_RELEASE_TIMEOUT_SECS
-          elif [[ $_STALLED_LAST_ATTEMPT -eq 1 ]]; then
-            echo "    --> Stall detected — will retry with -n1 (xdist worker isolation)"
-          else
-            echo "    --> Non-hardware failure — will retry (up to ${MAX_ATTEMPTS} total)"
-          fi
+        if [[ $TEST_EXIT -eq 0 ]]; then
+          echo "=== Attempt 1 PASSED ==="
+          echo "${{ inputs.suite_name }} tests done"
+          exit 0
+        fi
 
-          rm -f "$LOG_FILE" "$STALL_FLAG" "${STALL_FLAG}.done" "${STALL_FLAG}.stalled"
-          [[ $attempt -lt $MAX_ATTEMPTS ]] && sleep "$_RETRY_SLEEP"
+        echo "=== Attempt 1 FAILED (exit=${TEST_EXIT}) ==="
+
+        if [[ $_STALLED -ne 1 ]]; then
+          echo "    --> Non-stall failure — leaving retry to the pod-level retry (test_retry/test_multi_spyre_retry)"
+          exit 1
+        fi
+
+        # A killed holder does not drop its VFIO fd synchronously: torchrun's
+        # per-rank children can outlive the PGID kill above, and a process
+        # blocked in a VFIO ioctl stays in D state until the driver returns.
+        # This pod's cards are fixed at admission, so retrying now while one is
+        # still held is guaranteed to fail with RAS::VFIO::DeviceOpenFail.
+        # Wait for the fds to actually close before starting the stall retry.
+        echo "    --> Stall detected — retrying once with -n1 (xdist worker isolation)"
+        _waited=0
+        while [[ $_waited -lt $CARD_RELEASE_TIMEOUT_SECS ]]; do
+          _holders="$(_vfio_holder_pids)"
+          [[ -z "$_holders" ]] && break
+          [[ $_waited -eq 0 ]] && echo "Waiting for AIU card release; still held by PID(s): ${_holders}"
+          sleep 2
+          _waited=$(( _waited + 2 ))
         done
+        _holders="$(_vfio_holder_pids)"
+        if [[ -n "$_holders" ]]; then
+          echo "::warning::AIU card still held by PID(s) ${_holders} after ${CARD_RELEASE_TIMEOUT_SECS}s — stall retry may fail to open the device"
+        elif [[ $_waited -gt 0 ]]; then
+          echo "AIU card released after ${_waited}s"
+        fi
 
-        echo "=== All ${MAX_ATTEMPTS} attempts failed for ${{ inputs.suite_name }} ==="
+        echo "=== Attempt 2/2 (stall retry): ${{ inputs.suite_name }} ==="
+        run_attempt "-n1"
+
+        if [[ $TEST_EXIT -eq 0 ]]; then
+          echo "=== Attempt 2 PASSED ==="
+          echo "${{ inputs.suite_name }} tests done"
+          exit 0
+        fi
+
+        echo "=== Attempt 2 FAILED (exit=${TEST_EXIT}) — leaving further retry to the pod-level retry"
         exit 1

--- a/.github/workflows/retry-failed-tests.yaml
+++ b/.github/workflows/retry-failed-tests.yaml
@@ -1,6 +1,6 @@
 name: retry-failed-tests
 
-# On failure of "tests"/"tests-nightly", reruns the failed jobs via `gh run rerun --failed` so ARC gives them a fresh pod/card (unlike run-test-suite's same-pod in-suite retry).
+# On failure of "tests"/"tests-nightly", reruns the failed jobs via `gh run rerun --failed` so ARC gives them a fresh pod/card (run-test-suite itself only retries a same-pod stall, once, with -n1).
 # Separate workflow_run workflow, like push-to-clickhouse.yaml (gh run rerun needs a completed run; workflow_run keeps base-repo perms for fork PRs); only picks up changes from the default branch.
 on:
   workflow_run:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

- Removed in-pod retry-on-any-failure loop (`MAX_ATTEMPTS`, RAS/VFIO-busy detection, backoff)
- Kept stall-only retry: hang for 5 min → kill → retry once with `-n1` xdist isolation
- Retry now waits for AIU card VFIO release before the stall retry, same as before
- Removed unused `max_attempts` input from `run-test-suite` action
- Relies on `_test_matrix.yaml`'s pod-level retry for all other failures
- Updated stale comment in `retry-failed-tests.yaml` to match new behavior
