### PR TITLE
feat(model_utils): add MoE DMA layout helpers

### DIFF
--- a/tests/tensor/test_model_utils.py
+++ b/tests/tensor/test_model_utils.py
@@ -26,6 +26,8 @@ from torch.testing._internal.common_utils import (
 from torch_spyre.model_utils import (
     _dma_to_spyre_dim_order_swapped,
     _dma_to_spyre_indirect_access,
+    dma_moe_expert_weight_to_spyre,
+    dma_moe_per_expert_scale_to_spyre,
     load_model_to_spyre,
     patch_module_to_for_spyre,
 )
@@ -107,6 +109,29 @@ class TestLoadModelToSpyre(TestCase):
         """The indirect-access helper only accepts 2D tables."""
         with self.assertRaises(AssertionError):
             _dma_to_spyre_indirect_access(torch.randn(4, dtype=torch.float16))
+
+    def test_moe_expert_weight_layout(self):
+        from torch_spyre._C import get_spyre_tensor_layout
+
+        weight = torch.randn(3, 64, 128, dtype=torch.float16)
+        device_weight = dma_moe_expert_weight_to_spyre(weight)
+
+        layout = get_spyre_tensor_layout(device_weight)
+        self.assertEqual(list(layout.device_size), [3, 64, 2, 64])
+        torch.testing.assert_close(
+            device_weight.cpu(), weight, rtol=DLFLOAT16_RTOL, atol=DLFLOAT16_ATOL
+        )
+
+    def test_moe_per_expert_scale_layout(self):
+        from torch_spyre._C import get_spyre_tensor_layout
+
+        scale = torch.arange(3, dtype=torch.float16)
+        device_scale = dma_moe_per_expert_scale_to_spyre(scale)
+
+        self.assertEqual(device_scale.shape, (3, 64))
+        layout = get_spyre_tensor_layout(device_scale)
+        self.assertEqual(list(layout.device_size), [3, 1, 64])
+        torch.testing.assert_close(device_scale.cpu(), scale[:, None].expand(-1, 64))
 
     def test_load_model_routes_embedding_through_indirect_access(self):
         """An nn.Embedding table lands on Spyre with the indirect-access layout

--- a/torch_spyre/model_utils.py
+++ b/torch_spyre/model_utils.py
@@ -199,6 +199,72 @@ def _dma_to_spyre_indirect_access(
     return dst
 
 
+def dma_moe_expert_weight_to_spyre(
+    weight: torch.Tensor,
+    target_dtype: torch.dtype | None = None,
+) -> torch.Tensor | None:
+    """Transfer ``[E, C, F]`` weights in a gather- and matmul-friendly layout.
+
+    The device layout is ``[E, C, F // eps, eps]``. Returns ``None`` when
+    ``F`` does not span complete sticks.
+    """
+    assert weight.ndim == 3, "MoE expert-weight path is for rank-3 [E,C,F] only"
+
+    if not weight.is_contiguous():
+        weight = weight.contiguous()
+    dev_dtype = target_dtype if target_dtype is not None else weight.dtype
+
+    experts, contract, free = weight.shape
+    eps = SpyreTensorLayout(list(weight.shape), dev_dtype).elems_per_stick()
+    if free % eps != 0:
+        warnings.warn(
+            f"MoE expert-weight free dim {free} is not a multiple of the Spyre "
+            f"stick size {eps} for dtype {dev_dtype}; falling back to the "
+            "default layout (no shared-layout optimization) for this weight.",
+            stacklevel=2,
+        )
+        return None
+
+    layout = SpyreTensorLayout(
+        [experts, contract, free // eps, eps],
+        [contract * free, free, eps, 1],
+        get_device_dtype(dev_dtype),
+    )
+    dst = spyre_empty_with_layout(weight.size(), weight.stride(), dev_dtype, layout)
+    copy_tensor(weight, dst, non_blocking=False)
+    return dst
+
+
+def dma_moe_per_expert_scale_to_spyre(
+    scale: torch.Tensor,
+    target_dtype: torch.dtype | None = None,
+) -> torch.Tensor | None:
+    """Transfer ``[E]`` scales as a gather-ready ``[E, eps]`` tensor.
+
+    Each scale fills one stick. Widening on the host avoids an unsupported
+    in-graph rank expansion.
+    """
+    assert scale.ndim == 1, "per-expert-scale path is for 1D [E] tensors only"
+
+    if not scale.is_contiguous():
+        scale = scale.contiguous()
+    dev_dtype = target_dtype if target_dtype is not None else scale.dtype
+
+    experts = scale.shape[0]
+    eps = SpyreTensorLayout([experts, 1], dev_dtype).elems_per_stick()
+
+    widened = scale[:, None].expand(-1, eps).contiguous()
+
+    layout = SpyreTensorLayout(
+        [experts, 1, eps],
+        [eps, eps, 1],
+        get_device_dtype(dev_dtype),
+    )
+    dst = spyre_empty_with_layout(widened.size(), widened.stride(), dev_dtype, layout)
+    copy_tensor(widened, dst, non_blocking=False)
+    return dst
+
+
 # --- Model loading ---------------------------------------------------
 
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds two reusable model-loading helpers for MoE tensors:

- `dma_moe_expert_weight_to_spyre` transfers `[experts, contract, free]` weights with the expert dimension outermost for gather and the free dimension sticked for matmul. It derives the stick size from `SpyreTensorLayout` and returns `None` with a warning when the free dimension cannot be tiled.
- `dma_moe_per_expert_scale_to_spyre` widens `[experts]` scales to one replicated stick per expert on the host, then transfers them in a gather-ready layout.

The helpers are independent of the Gemma 4 adapter and can be reused by other MoE model integrations.

#### Which issue(s) this PR is related to:

None. Extracted from the Gemma 4 MoE enablement work so the DMA layout support can merge independently.

#### Special notes for your reviewer:

The branch is one commit on current `main`; it does not include the routing or memory-planning changes from the larger Gemma 4 development branch.

Validation:

- `pre-commit run --files torch_spyre/model_utils.py tests/tensor/test_model_utils.py`
- `pytest -vv tests/tensor/test_model_utils.py -k moe` (`2 passed`)

#### Does this PR introduce a user-facing change?

Yes. It adds two public helpers to `torch_spyre.model_utils` for loading MoE expert weights and per-expert scales with suitable device layouts.

#### Additional note:

The implementation queries the dtype-specific elements-per-stick value rather than hard-coding it.