### PR TITLE
Move core mapping out of sdsc generation

### DIFF
--- a/tests/inductor/indirect_access_common.py
+++ b/tests/inductor/indirect_access_common.py
@@ -607,12 +607,10 @@ class IndirectAccessTestCase(InductorTestCase):
         value-table / destination data dim (c1). The entry dim is the index
         tensor's stick dim, so it splits in whole 32-entry sticks: the split is
         the planner's ``core_split`` -- the largest divisor of the stick count
-        ``ceil(index_size / 32)`` that does not exceed SENCORES (so it always
-        divides evenly, and a non-power-of-two core count like 6 rounds down to
-        the nearest divisor, e.g. 8 sticks over 6 cores -> 4). The ceiling
-        handles a NON-stick-aligned count, whose partial last stick is padded up
-        to a whole stick (enforce_indirect_access_layout) so the dim still
-        splits, e.g. 40 -> 2 sticks. c1 always stays 1. Skips at sencores=1.
+        that does not exceed SENCORES (so it always divides evenly, and a
+        non-power-of-two core count like 6 rounds down to the nearest divisor,
+        e.g. 8 sticks over 6 cores -> 4). c1 always stays 1. Skips at
+        sencores=1. Partial-stick entry counts use ``assert_entry_dim_unsplit``.
 
         For power-of-two stick counts and core counts (the historical sweep)
         ``core_split`` equals ``min(sencores, sticks)`` -- this generalises it to
@@ -639,35 +637,30 @@ class IndirectAccessTestCase(InductorTestCase):
             "splitting a shared table/destination dim silently corrupts results",
         )
 
-    def assert_entry_dim_unsplit(self, code, index_size):
+    def assert_entry_dim_unsplit(self, code, index_size, data_size=None):
         """Assert the index/entry dim is NOT core-split at the current SENCORES.
 
-        The correct outcome when a stick-aligned split is forbidden and cannot be
-        made safe by padding -- e.g. a partial-last-stick SCATTER, whose in-place
-        destination cannot be grown to a whole stick the way a gather output can
-        (enforce_indirect_access_layout). If the dim were splittable it would
-        split by ``core_split(ceil(index_size/32), sencores)``; assert that split
-        is absent, so the guard kept the op on a single core rather than letting
-        an even slice straddle the index stick boundary. Skips at sencores=1, and
-        is a no-op when the count could not split anyway (would-be split of 1).
+        A partial last stick is padded by restickify. That padded dimension must
+        stay on one core: older code enforced this only inside SuperDSC, after
+        wrapper emission, so the wrapper could advertise a split the device did
+        not execute. Planning now blocks that split before wrapper emission.
         """
         from torch_spyre._inductor import config
 
         n = config.sencores
         if n == 1:
             self.skipTest("no work division at sencores=1")
-        sticks = -(-index_size // self.INDEX_ELEMS_PER_STICK)  # ceil division
-        would_be = max(divisor for divisor in range(1, n + 1) if sticks % divisor == 0)
-        if would_be <= 1:
-            return  # nothing could split even if allowed; nothing to assert
-        self.assertNotIn(
-            f"sympify('c0'): (sympify('{index_size}'), {would_be})",
+        self.assertIn(
+            f"sympify('c0'): (sympify('{index_size}'), 1)",
             code,
-            f"partial-stick entry dim {index_size} must NOT be core-split "
-            f"(would be {would_be} at {n} cores if allowed); its in-place scatter "
-            "destination can't be padded to a whole stick, so the guard must keep "
-            "it single-core rather than straddle the index stick boundary",
+            f"partial-stick entry dim {index_size} must stay unsplit at {n} cores",
         )
+        if data_size is not None:
+            self.assertIn(
+                f"sympify('c1'): (sympify('{data_size}'), 1)",
+                code,
+                f"data dim {data_size} must stay unsplit at {n} cores",
+            )
 
     # -- Dimension naming helpers ----------------------------------------
     def name_dims(self, tensor, dims: dict):

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -71,6 +71,7 @@ from torch_spyre._inductor.constants import (
     SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY,
     SHARED_WEIGHT_UNIT_BMM_INFO_KEY,
 )
+from torch_spyre._inductor.core_mapping import derive_operation_mapping
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.loop_info import CoarseTileInfo, copy_op_metadata
 from torch_spyre._inductor.pass_utils import coeff_through_floor
@@ -633,10 +634,12 @@ def _make_tiled_op_spec() -> OpSpec:
         allocation={"hbm": 0x2000},
         device_tile_advance_expr=tile_advance_expr,
     )
+    iteration_space = {c0: (Integer(128), 1)}
     return OpSpec(
         op="abs",
         is_reduction=False,
-        iteration_space={c0: (Integer(128), 1)},
+        iteration_space=iteration_space,
+        core_id_to_work_slice=derive_operation_mapping(iteration_space),
         args=[tensor_in, tensor_out],
         op_info={},
         tiled_symbols=[[c0]],
@@ -3082,14 +3085,16 @@ class TestCompileOpSpecTwoTiledSymbols(unittest.TestCase):
             allocation={"hbm": 0x2000},
             device_tile_advance_expr=tile_advance_expr,
         )
+        iteration_space = {
+            c0: (Integer(2), 1),
+            c1: (Integer(4), 1),
+            c2: (Integer(64), 1),
+        }
         return OpSpec(
             op="add",
             is_reduction=False,
-            iteration_space={
-                c0: (Integer(2), 1),
-                c1: (Integer(4), 1),
-                c2: (Integer(64), 1),
-            },
+            iteration_space=iteration_space,
+            core_id_to_work_slice=derive_operation_mapping(iteration_space),
             args=[tensor_in, tensor_out],
             op_info={},
             tiled_symbols=[[c0, c1]],
@@ -3576,6 +3581,7 @@ class TestSharedWeightUnitBmmLayout(unittest.TestCase):
                 op="batchmatmul",
                 is_reduction=True,
                 iteration_space=iteration_space,
+                core_id_to_work_slice=derive_operation_mapping(iteration_space),
                 args=args,
                 op_info=op_info,
             )
@@ -4045,10 +4051,12 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
             allocation={"hbm": 0x3000},
             device_tile_advance_expr=64 * out,
         )
+        iteration_space = {c0: (Integer(128), 1)}
         op = OpSpec(
             op="add",
             is_reduction=False,
-            iteration_space={c0: (Integer(128), 1)},
+            iteration_space=iteration_space,
+            core_id_to_work_slice=derive_operation_mapping(iteration_space),
             args=[tensor_in0, tensor_in1, tensor_out],
             op_info={},
             tiled_symbols=[[c0]],

--- a/tests/inductor/test_codegen.py
+++ b/tests/inductor/test_codegen.py
@@ -39,6 +39,7 @@ from torch_spyre._inductor.codegen.superdsc import (
     _resolve_sdsc_size,
     compile_op_spec,
 )
+from torch_spyre._inductor.core_mapping import derive_operation_mapping
 from torch_spyre._inductor.op_spec import OpSpec, TensorArg
 from torch_spyre._inductor.work_division import (
     _collect_symbol_metadata,
@@ -446,13 +447,15 @@ class TestSdscJsonSymbolicDimSmoke(InductorTestCase):
                 allocation={"hbm": hbm_base},
             )
 
+        iteration_space = {
+            c_row: (s0, 1),
+            c_col: (sympy.Integer(256), 1),
+        }
         return OpSpec(
             op="add",
             is_reduction=False,
-            iteration_space={
-                c_row: (s0, 1),
-                c_col: (sympy.Integer(256), 1),
-            },
+            iteration_space=iteration_space,
+            core_id_to_work_slice=derive_operation_mapping(iteration_space),
             args=[
                 _tensor_arg(True, 0, self._HBM_BASE),
                 _tensor_arg(True, 1, self._HBM_BASE + 0x1000),
@@ -664,13 +667,15 @@ class TestGenerateSdscSymbolicPerCoreAddresses(InductorTestCase):
                 allocation={"hbm": hbm_base},
             )
 
+        iteration_space = {
+            c_row: (s0, self._NUM_CORES),
+            c_col: (sympy.Integer(256), 1),
+        }
         return OpSpec(
             op="add",
             is_reduction=False,
-            iteration_space={
-                c_row: (s0, self._NUM_CORES),
-                c_col: (sympy.Integer(256), 1),
-            },
+            iteration_space=iteration_space,
+            core_id_to_work_slice=derive_operation_mapping(iteration_space),
             args=[
                 _tensor_arg(True, 0, self._HBM_BASE),
                 _tensor_arg(True, 1, self._HBM_BASE + 0x1000),

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -33,8 +33,9 @@ from torch_spyre._inductor.core_mapping import (
     derive_core_mapping,
     derive_operation_mapping,
     derive_partition_mapping,
+    finalize_tensor_work_divisions,
 )
-from torch_spyre._inductor.op_spec import OpSpec, TensorArg
+from torch_spyre._inductor.op_spec import OpSpec, TensorArg, TensorWorkDivision
 from torch_spyre._inductor.spyre_kernel import simplify_op_spec
 from torch_spyre._inductor.views import (
     align_tensors,
@@ -175,6 +176,111 @@ def test_late_mapping_rejects_geometry_that_does_not_fill_groups():
             (4, 8),
             32,
             grouped_splits={h: 2},
+        )
+
+
+def test_final_tensor_ownership_is_derived_from_aligned_buffer_geometry():
+    extra, shared = sympy.symbols("extra shared")
+    core_id = sympy.Symbol("core_id")
+    division = TensorWorkDivision(
+        {shared: 2},
+        # Planning-time placement is working data, not the final assignment.
+        {shared: sympy.Mod(core_id, 2)},
+        num_cores=4,
+    )
+
+    (finalized,) = finalize_tensor_work_divisions(
+        {extra: (8, 2), shared: (8, 2)},
+        [division],
+    )
+
+    assert finalized == TensorWorkDivision(
+        {shared: 2},
+        {shared: sympy.Mod(sympy.floor(core_id / 2), 2)},
+        num_cores=4,
+    )
+
+
+def test_shared_lx_buffer_keeps_owners_across_different_operation_dims():
+    producer_extra, producer_shared = sympy.symbols("producer_extra producer_shared")
+    consumer_shared, consumer_extra = sympy.symbols("consumer_shared consumer_extra")
+    core_id = sympy.Symbol("core_id")
+    owners = sympy.Mod(core_id, 2)
+    producer_division = finalize_tensor_work_divisions(
+        {producer_extra: (8, 2), producer_shared: (8, 2)},
+        [
+            TensorWorkDivision(
+                {producer_shared: 2},
+                {producer_shared: owners},
+                num_cores=4,
+            )
+        ],
+    )[0]
+    consumer_division = finalize_tensor_work_divisions(
+        {consumer_shared: (8, 2), consumer_extra: (8, 2)},
+        [
+            TensorWorkDivision(
+                {consumer_shared: 2},
+                {consumer_shared: owners},
+                num_cores=4,
+            )
+        ],
+    )[0]
+    assert producer_division is not None
+    assert consumer_division is not None
+
+    producer = derive_operation_mapping(
+        {producer_extra: (8, 2), producer_shared: (8, 2)},
+        [producer_division],
+    )
+    consumer = derive_operation_mapping(
+        {consumer_shared: (8, 2), consumer_extra: (8, 2)},
+        [consumer_division],
+    )
+
+    assert core_mappings_equal(
+        {producer_shared: producer[producer_shared]},
+        {producer_shared: consumer[consumer_shared]},
+        4,
+    )
+
+
+def test_final_tensor_ownership_requires_a_buffer_core_domain():
+    shared = sympy.Symbol("shared")
+    core_id = sympy.Symbol("core_id")
+
+    with pytest.raises(ValueError, match="physical core domain"):
+        finalize_tensor_work_divisions(
+            {shared: (8, 2)},
+            [
+                TensorWorkDivision(
+                    {shared: 2},
+                    {shared: sympy.Mod(core_id, 2)},
+                )
+            ],
+        )
+
+
+def test_operation_mapping_rejects_conflicting_lx_tensor_owners():
+    shared, extra = sympy.symbols("shared extra")
+    core_id = sympy.Symbol("core_id")
+    divisions = [
+        TensorWorkDivision(
+            {shared: 2},
+            {shared: sympy.Mod(core_id, 2)},
+            num_cores=4,
+        ),
+        TensorWorkDivision(
+            {shared: 2},
+            {shared: sympy.floor(core_id / 2)},
+            num_cores=4,
+        ),
+    ]
+
+    with pytest.raises(ValueError, match="disagree on core ownership"):
+        derive_operation_mapping(
+            {shared: (8, 2), extra: (8, 2)},
+            divisions,
         )
 
 

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -29,6 +29,7 @@ from torch_spyre._inductor.core_mapping import (
     core_mappings_equal,
     core_to_slice_mapping,
     derive_core_mapping,
+    derive_operation_mapping,
     derive_partition_mapping,
 )
 from torch_spyre._inductor.op_spec import OpSpec, TensorArg
@@ -293,6 +294,10 @@ def test_planner_and_sdsc_use_the_same_mapping(monkeypatch, op, reduction_contig
         prep, splits, {dims[2]: 4}
     )
 
+    op_spec.core_id_to_work_slice = derive_operation_mapping(
+        op_spec.iteration_space,
+        contiguous_dim=dims[-1] if reduction_contiguous else None,
+    )
     sdsc_spec, renamed = parse_op_spec(op_spec)
     sdsc_output_mapping = {
         device_dim: sdsc_spec.core_id_to_work_slice[renamed[dim]]

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import math
+from types import SimpleNamespace
 
 import pytest
 import sympy
@@ -34,7 +36,10 @@ from torch_spyre._inductor.core_mapping import (
 )
 from torch_spyre._inductor.op_spec import OpSpec, TensorArg
 from torch_spyre._inductor.spyre_kernel import simplify_op_spec
-from torch_spyre._inductor.views import align_tensors
+from torch_spyre._inductor.views import (
+    align_tensors,
+    align_tensors_pure,
+)
 
 
 def _coordinates(splits, num_cores, **kwargs):
@@ -199,6 +204,46 @@ def test_alignment_preview_is_repeatable_and_does_not_consume_repeat_info():
 
     assert repeat_info == original
     assert preview == codegen
+
+
+def test_captured_alignment_inputs_leave_codegen_unchanged(monkeypatch):
+    dim = sympy.Symbol("dim")
+    op_spec = OpSpec(
+        "identity",
+        False,
+        {dim: (sympy.Integer(4), 2)},
+        [
+            TensorArg(
+                True,
+                0,
+                DataFormats.SEN169_FP16,
+                [2, 64],
+                [sympy.floor(dim / 2), dim],
+                {"hbm": 0},
+            )
+        ],
+        {},
+    )
+    monkeypatch.setattr(
+        pass_utils_module,
+        "alignment_coordinates",
+        lambda *args, **kwargs: [sympy.floor(dim / 2), dim],
+    )
+    captured = pass_utils_module.build_operation_alignment_inputs(
+        {dim: sympy.Integer(4)},
+        [pass_utils_module.AlignmentAccess(SimpleNamespace(device_size=[2, 64]), dim)],
+        aligned_iteration_space=op_spec.iteration_space,
+    )
+    # A preceding validation preview must neither consume nor change the input
+    # subsequently used by codegen.
+    align_tensors_pure(captured)
+
+    captured_path = copy.deepcopy(op_spec)
+    ordinary_path = copy.deepcopy(op_spec)
+    simplify_op_spec(captured_path, alignment_inputs=captured)
+    simplify_op_spec(ordinary_path)
+
+    assert captured_path == ordinary_path
 
 
 def _bmm_op_spec(op: str) -> OpSpec:

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -25,8 +25,15 @@ from torch_spyre._inductor.constants import (
     BATCH_MATMUL_FP8_OP,
     BATCH_MATMUL_OP,
 )
-from torch_spyre._inductor.core_mapping import core_to_slice_mapping
+from torch_spyre._inductor.core_mapping import (
+    core_mappings_equal,
+    core_to_slice_mapping,
+    derive_core_mapping,
+    derive_partition_mapping,
+)
 from torch_spyre._inductor.op_spec import OpSpec, TensorArg
+from torch_spyre._inductor.spyre_kernel import simplify_op_spec
+from torch_spyre._inductor.views import align_tensors
 
 
 def _coordinates(splits, num_cores, **kwargs):
@@ -62,6 +69,135 @@ def test_selected_dim_varies_first(contiguous_dim):
         for dim in range(len(splits))
         if dim != contiguous_dim
     )
+
+
+def _mapping_coordinates(mapping, dims, num_cores):
+    core_id = sympy.Symbol("core_id")
+    return [
+        tuple(int(mapping[dim].subs(core_id, core)) for dim in dims)
+        for core in range(num_cores)
+    ]
+
+
+def test_late_mapping_derives_contiguous_gather_groups():
+    h, lq = sympy.symbols("h lq")
+    mapping = derive_core_mapping(
+        (h, lq),
+        (4, 8),
+        32,
+        grouped_splits={h: 4},
+    )
+    coordinates = _mapping_coordinates(mapping, (h, lq), 32)
+    assert coordinates == [(core // 8, core % 8) for core in range(32)]
+
+
+def test_late_mapping_preserves_selected_contiguous_dimension():
+    batch, output, reduction = sympy.symbols("batch output reduction")
+    mapping = derive_core_mapping(
+        (batch, output, reduction),
+        (2, 4, 4),
+        32,
+        contiguous_dim=reduction,
+    )
+    coordinates = _mapping_coordinates(mapping, (batch, output, reduction), 32)
+    assert [coordinate[2] for coordinate in coordinates[:4]] == [0, 1, 2, 3]
+    assert all(coordinate[:2] == (0, 0) for coordinate in coordinates[:4])
+
+
+def test_late_mapping_derives_contiguous_broadcast_groups():
+    h, query = sympy.symbols("h query")
+    mapping = derive_core_mapping(
+        (query, h),
+        (16, 2),
+        32,
+        grouped_splits={h: 2},
+    )
+    coordinates = _mapping_coordinates(mapping, (query, h), 32)
+    assert coordinates == [(core % 16, core // 16) for core in range(32)]
+
+
+def test_late_partition_mapping_repeats_contiguous_owners():
+    head = sympy.Symbol("head")
+    mapping = derive_partition_mapping((head,), (4,), 32)
+    assert _mapping_coordinates(mapping, (head,), 32) == [
+        (core // 8,) for core in range(32)
+    ]
+
+
+def test_late_mapping_keeps_shared_destination_after_one_consumer_factors():
+    h, query, inner = sympy.symbols("h query inner")
+    original = derive_core_mapping(
+        (h, query),
+        (4, 8),
+        32,
+        grouped_splits={h: 4},
+    )
+    factored = derive_core_mapping(
+        (h, inner, query),
+        (4, 2, 4),
+        32,
+        grouped_splits={h: 4},
+    )
+    assert core_mappings_equal({h: original[h]}, {h: factored[h]}, 32)
+
+
+def test_group_topology_does_not_follow_final_loop_reordering():
+    head, kv, query = sympy.symbols("head kv query")
+    grouped_splits = {head: 2, kv: 2}
+    original = derive_core_mapping(
+        (head, kv, query),
+        (2, 2, 8),
+        32,
+        grouped_splits=grouped_splits,
+    )
+    reordered = derive_core_mapping(
+        (query, kv, head),
+        (8, 2, 2),
+        32,
+        grouped_splits=grouped_splits,
+    )
+    assert _mapping_coordinates(original, (head, kv), 32) == _mapping_coordinates(
+        reordered, (head, kv), 32
+    )
+
+
+def test_late_mapping_rejects_geometry_that_does_not_fill_groups():
+    h, query = sympy.symbols("h query")
+    with pytest.raises(ValueError, match="does not match operation split"):
+        derive_core_mapping(
+            (h, query),
+            (4, 8),
+            32,
+            grouped_splits={h: 2},
+        )
+
+
+def test_scalar_op_has_a_complete_empty_mapping():
+    op_spec = OpSpec("identity", False, {}, [], {})
+    simplify_op_spec(op_spec)
+    assert op_spec.core_id_to_work_slice == {}
+
+
+def test_alignment_preview_is_repeatable_and_does_not_consume_repeat_info():
+    dim = sympy.Symbol("dim")
+    repeat_info = {
+        dim: {
+            "modulus": sympy.Integer(2),
+            "node": sympy.Mod(dim, 2),
+            "kind": "mod",
+        }
+    }
+    original = {symbol: dict(info) for symbol, info in repeat_info.items()}
+    args = (
+        {dim: (sympy.Integer(4), 2)},
+        [{"size": [2, 64], "coordinates": [sympy.floor(dim / 2), dim]}],
+    )
+
+    preview = align_tensors(*args, repeat_info=repeat_info)
+    codegen = align_tensors(*args, repeat_info=repeat_info)
+
+    assert repeat_info == original
+    assert preview == codegen
 
 
 def _bmm_op_spec(op: str) -> OpSpec:

--- a/tests/inductor/test_indirect_access_gather.py
+++ b/tests/inductor/test_indirect_access_gather.py
@@ -1113,15 +1113,14 @@ class _GatherMulticoreScenarios:
     # (c1 = K) -- splitting K makes every core read address 0 of the shared
     # table, silently returning wrong results. Shapes are chosen so the planner
     # *would* prefer K (its largest output-coordinate dim) if the guard were
-    # absent. assert_indexed_dim_split() reads the current SENCORES and expects
-    # c0 to split by min(SENCORES, index_size // 32) with c1 pinned at 1.
+    # absent. Aligned c0 sizes split in whole sticks; partial-stick c0 sizes stay
+    # unsplit because restickify must pad them. c1 always stays unsplit.
     #
-    # After the split-map check each scenario runs through the shared
+    # After the work-division check each scenario runs through the shared
     # _stage_and_e2e path (fresh inputs, since run_and_get_code has already
     # executed the split-map compile) -- the same capture-path stage checks +
-    # e2e leg every other gather scenario uses -- so the multicore split is also
-    # exercised end-to-end. (Skipped at sencores=1 by assert_indexed_dim_split
-    # -- nothing to divide.)
+    # e2e leg every other gather scenario uses -- so the selected mapping is
+    # exercised end-to-end. (Skipped at sencores=1 -- nothing to divide.)
 
     @staticmethod
     def _gather_fn(table, idx):
@@ -1173,15 +1172,11 @@ class _GatherMulticoreScenarios:
         self._stage_and_e2e(fn, *make(), expect=GATHER_OP_SPEC)
 
     # -- stick-aligned vs partial-last-stick index-entry counts -----------
-    # The index-entry dim is the index tensor's stick dim, so work division
-    # splits it in whole 32-entry sticks. A STICK-ALIGNED count (a multiple of
-    # 32) has always split cleanly. A NON-aligned count (a partial last stick)
-    # used to be forced onto one core, because an even per-core slice straddles
-    # the index stick boundary and the backend cannot step a sticked dim across it;
-    # the fix pads the gather output's entry dim up to the next whole stick
-    # (enforce_indirect_access_layout) so the split lands stick-aligned. Both
-    # kinds are swept across every SENCORES; the expected split for either is
-    # min(SENCORES, ceil(count / 32)) with the K data dim always pinned at 1.
+    # The index-entry dim is the index tensor's stick dim, so an aligned count
+    # can split in whole 32-entry sticks. A partial last stick is padded during
+    # restickify and must stay unsplit. SuperDSC historically forced that split
+    # to one only after wrapper emission; the planning constraint now makes the
+    # wrapper and the executed mapping agree.
 
     def test_work_division_index_split_aligned_six_sticks(self):
         """Stick-aligned index with exactly 6 sticks (P=192): a non-power-of-two
@@ -1202,9 +1197,7 @@ class _GatherMulticoreScenarios:
 
     def test_work_division_index_split_partial_stick(self):
         """Non-stick-aligned index (P=40 = one full stick + a partial second):
-        the entry dim is padded up to ceil(40/32)=2 whole sticks so the split
-        lands stick-aligned (2 across any SENCORES>=2) instead of an even slice
-        that would straddle the index stick boundary and miscompile."""
+        restickify pads the entry dim, so planning keeps it on one core."""
 
         def make():
             x = torch.rand(128, 64, 256, dtype=torch.float16).to("spyre")
@@ -1213,14 +1206,11 @@ class _GatherMulticoreScenarios:
 
         fn = self._gather_fn
         _, source_codes = run_and_get_code(torch.compile(fn, dynamic=False), *make())
-        self.assert_indexed_dim_split(source_codes[0], index_size=40, data_size=64)
+        self.assert_entry_dim_unsplit(source_codes[0], index_size=40, data_size=64)
         self._stage_and_e2e(fn, *make(), expect=GATHER_OP_SPEC)
 
     def test_work_division_index_split_partial_stick_mid(self):
-        """Non-stick-aligned index spanning several sticks (P=250, ceil=8 sticks):
-        the padded split scales past a single partial stick -- the non-aligned
-        counterpart of the aligned 8-stick test_work_division_index_split_capped,
-        splitting by the same largest divisor of 8 that fits the core count."""
+        """A larger partial-stick index (P=250) also stays unsplit."""
 
         def make():
             x = torch.rand(128, 64, 256, dtype=torch.float16).to("spyre")
@@ -1229,14 +1219,11 @@ class _GatherMulticoreScenarios:
 
         fn = self._gather_fn
         _, source_codes = run_and_get_code(torch.compile(fn, dynamic=False), *make())
-        self.assert_indexed_dim_split(source_codes[0], index_size=250, data_size=64)
+        self.assert_entry_dim_unsplit(source_codes[0], index_size=250, data_size=64)
         self._stage_and_e2e(fn, *make(), expect=GATHER_OP_SPEC)
 
     def test_work_division_index_split_partial_stick_full(self):
-        """Non-stick-aligned index at 32-stick scale (P=1000, ceil=32): the padded
-        split would reach a full 32-way division, but the indirect uint32 address
-        cap holds it to 16-way at SENCORES=32 -- the partial-stick counterpart of
-        test_work_division_index_split_full."""
+        """A full-scale partial-stick index (P=1000) also stays unsplit."""
 
         def make():
             x = torch.rand(128, 64, 256, dtype=torch.float16).to("spyre")
@@ -1245,7 +1232,7 @@ class _GatherMulticoreScenarios:
 
         fn = self._gather_fn
         _, source_codes = run_and_get_code(torch.compile(fn, dynamic=False), *make())
-        self.assert_indexed_dim_split(source_codes[0], index_size=1000, data_size=64)
+        self.assert_entry_dim_unsplit(source_codes[0], index_size=1000, data_size=64)
         self._stage_and_e2e(fn, *make(), expect=GATHER_OP_SPEC)
 
     # -- shared value table: cross-core read correctness ------------------

--- a/tests/inductor/test_kernel_provenance.py
+++ b/tests/inductor/test_kernel_provenance.py
@@ -243,6 +243,23 @@ class TestKernelProvenanceDescriptor:
             work_division=TensorWorkDivision({c0: 2}, {c0: Symbol("core_id")}),
         )
         changed_owner = dataclasses.replace(first, args=[owned_arg])
+        changed_owner_cores = dataclasses.replace(
+            first,
+            args=[
+                dataclasses.replace(
+                    arg,
+                    work_division=TensorWorkDivision(
+                        {c0: 2}, {c0: Symbol("core_id")}, num_cores=4
+                    ),
+                )
+            ],
+        )
+        changed_core_mapping = dataclasses.replace(
+            first, core_id_to_work_slice={c0: Integer(1)}
+        )
+        canonical_core_mapping = dataclasses.replace(
+            first, core_id_to_work_slice={c0: Integer(0)}
+        )
 
         first_descriptor = build_kernel_provenance_descriptor([first])
         reordered_descriptor = build_kernel_provenance_descriptor([reordered_metadata])
@@ -251,6 +268,15 @@ class TestKernelProvenanceDescriptor:
             [changed_arrangement]
         )
         changed_owner_descriptor = build_kernel_provenance_descriptor([changed_owner])
+        changed_owner_cores_descriptor = build_kernel_provenance_descriptor(
+            [changed_owner_cores]
+        )
+        changed_core_mapping_descriptor = build_kernel_provenance_descriptor(
+            [changed_core_mapping]
+        )
+        canonical_core_mapping_descriptor = build_kernel_provenance_descriptor(
+            [canonical_core_mapping]
+        )
 
         assert first_descriptor is not None
         assert reordered_descriptor is not None
@@ -261,6 +287,9 @@ class TestKernelProvenanceDescriptor:
         assert changed_descriptor.key != first_descriptor.key
         assert changed_arrangement_descriptor.key != first_descriptor.key
         assert changed_owner_descriptor.key != first_descriptor.key
+        assert changed_owner_cores_descriptor.key != changed_owner_descriptor.key
+        assert changed_core_mapping_descriptor.key != first_descriptor.key
+        assert canonical_core_mapping_descriptor.key == first_descriptor.key
 
     def test_pins_rich_canonical_bundle_key(self):
         c0 = Symbol("c0")

--- a/tests/inductor/test_log_op_specs.py
+++ b/tests/inductor/test_log_op_specs.py
@@ -195,6 +195,22 @@ class TestFormatOpSpecList:
 # ---------------------------------------------------------------------------
 
 
+def _make_test_kernel():
+    from torch_spyre._inductor.spyre_kernel import SpyreKernel
+
+    kernel = SpyreKernel.__new__(SpyreKernel)
+    kernel.op_specs = [_make_add_op()]
+    kernel.indirect_vars = None
+    kernel.indirect_sizes = {}
+    kernel.args = MagicMock()
+    kernel.args.python_argdefs.return_value = (None, [])
+    kernel.spyre_kernel_args = []
+    kernel._alignment_repeat_info = {}
+    kernel._alignment_repeat_info_by_spec = {}
+    kernel.pool_size = 0
+    return kernel
+
+
 class TestSpyreKernelLogging:
     """Tests for logger.info calls in SpyreKernel.codegen_kernel."""
 
@@ -206,16 +222,7 @@ class TestSpyreKernelLogging:
                     "torch_spyre._inductor.spyre_kernel.format_op_spec_list",
                     return_value="<formatted>",
                 ) as mock_fmt:
-                    from torch_spyre._inductor.spyre_kernel import SpyreKernel
-
-                    kernel = SpyreKernel.__new__(SpyreKernel)
-                    kernel.op_specs = [_make_add_op()]
-                    kernel.indirect_vars = None
-                    kernel.indirect_sizes = {}
-                    kernel.args = MagicMock()
-                    kernel.args.python_argdefs.return_value = (None, [])
-                    kernel.spyre_kernel_args = []
-                    kernel.pool_size = 0
+                    kernel = _make_test_kernel()
 
                     with patch("torch_spyre._inductor.spyre_kernel.simplify_op_spec"):
                         kernel.codegen_kernel()
@@ -232,16 +239,7 @@ class TestSpyreKernelLogging:
             with patch(
                 "torch_spyre._inductor.spyre_kernel.format_op_spec_list"
             ) as mock_fmt:
-                from torch_spyre._inductor.spyre_kernel import SpyreKernel
-
-                kernel = SpyreKernel.__new__(SpyreKernel)
-                kernel.op_specs = [_make_add_op()]
-                kernel.indirect_vars = None
-                kernel.indirect_sizes = {}
-                kernel.args = MagicMock()
-                kernel.args.python_argdefs.return_value = (None, [])
-                kernel.spyre_kernel_args = []
-                kernel.pool_size = 0
+                kernel = _make_test_kernel()
 
                 with patch("torch_spyre._inductor.spyre_kernel.simplify_op_spec"):
                     kernel.codegen_kernel()

--- a/tests/inductor/test_log_op_specs.py
+++ b/tests/inductor/test_log_op_specs.py
@@ -207,6 +207,8 @@ def _make_test_kernel():
     kernel.spyre_kernel_args = []
     kernel._alignment_repeat_info = {}
     kernel._alignment_repeat_info_by_spec = {}
+    kernel._alignment_access_by_tensor_arg = {}
+    kernel._alignment_inputs_by_spec = {}
     kernel.pool_size = 0
     return kernel
 

--- a/tests/inductor/test_provenance.py
+++ b/tests/inductor/test_provenance.py
@@ -31,6 +31,7 @@ from torch._inductor.utils import IndentedBuffer
 from torch_spyre._C import DataFormats
 from torch_spyre._inductor.codegen.compute_ops import generate_sdsc
 from torch_spyre._inductor.codegen.superdsc import SDSCSpec, parse_op_spec
+from torch_spyre._inductor.core_mapping import derive_operation_mapping
 from torch_spyre._inductor.op_spec import (
     DebugHandle,
     OpSpec,
@@ -445,10 +446,12 @@ def _threadable_op_spec(debug_handle=None):
         device_coordinates=[Integer(0), c0],
         allocation={"hbm": 0x2000},
     )
+    iteration_space = {c0: (Integer(128), 1)}
     return OpSpec(
         op="add",
         is_reduction=False,
-        iteration_space={c0: (Integer(128), 1)},
+        iteration_space=iteration_space,
+        core_id_to_work_slice=derive_operation_mapping(iteration_space),
         args=[tin, tout],
         op_info={},
         tiled_symbols=[[c0]],

--- a/tests/inductor/test_work_division.py
+++ b/tests/inductor/test_work_division.py
@@ -31,6 +31,11 @@ from torch._inductor.ir import (
 from torch_spyre._C import ElementArrangement, SpyreTensorLayout
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.ir import FixedTiledLayout
+from torch_spyre._inductor.constants import (
+    AVGPOOL2D_OP,
+    CONV2D_FWD_OP,
+    DEPTHWISE_CONV2D_OP,
+)
 from torch_spyre._inductor.pass_utils import SchedNodeArg
 from torch_spyre._inductor.scratchpad.allocator import (
     CoOptimizingAllocator,
@@ -56,8 +61,10 @@ from torch_spyre._inductor.work_division_constraints import (
     keep_by_index_k_split_constraint,
     keep_by_index_pinned_search_space_vars,
     qfp8wt_matmul_k_split_domains,
-    topk_split_domains,
     qfp8wt_split_domains,
+    reduction_window_blocked_vars,
+    restickify_padding_blocked_vars,
+    topk_split_domains,
 )
 
 
@@ -618,6 +625,140 @@ class TestConvSpatialBlockedVars(unittest.TestCase):
         self.assertNotIn(j, output_dims)
         self.assertEqual(splits[i], 1)
         self.assertEqual(splits[j], 1)
+
+
+class TestFinalMappingConstraints(unittest.TestCase):
+    _PLACEHOLDER_TD = _tensor_dep("mapping_placeholder", (128,), (_isym("_mapping"),))
+
+    def test_pool_window_dims_are_unsplit(self):
+        ki, kj = (_isym(name) for name in ("ki", "kj"))
+        op = _computed_buffer(
+            (8,),
+            name="pool",
+            reduction_type=AVGPOOL2D_OP,
+            reduction_ranges=(3, 3),
+        )
+        result = reduction_window_blocked_vars(
+            _make_context(
+                op,
+                self._PLACEHOLDER_TD,
+                reduction_vars=[ki, kj],
+            )
+        )
+
+        self.assertEqual(result.blocked, {ki, kj})
+
+    def test_conv_only_blocks_nontrivial_kernel_dims(self):
+        channel, ki, kj = (_isym(name) for name in ("channel", "ki", "kj"))
+        op = _computed_buffer(
+            (8,),
+            name="conv",
+            reduction_type=CONV2D_FWD_OP,
+            reduction_ranges=(64, 3, 1),
+        )
+        op.data.op_info = {"conv_params": {"kernel_h": 3, "kernel_w": 1}}
+        result = reduction_window_blocked_vars(
+            _make_context(
+                op,
+                self._PLACEHOLDER_TD,
+                reduction_vars=[channel, ki],
+            )
+        )
+
+        self.assertEqual(result.blocked, {ki})
+
+    def test_depthwise_conv_does_not_block_trailing_group_dim(self):
+        kh, kw, group = (_isym(name) for name in ("kh", "kw", "group"))
+        op = _computed_buffer(
+            (8,),
+            name="depthwise_conv",
+            reduction_type=DEPTHWISE_CONV2D_OP,
+            reduction_ranges=(3, 3, 4),
+        )
+        result = reduction_window_blocked_vars(
+            _make_context(
+                op,
+                self._PLACEHOLDER_TD,
+                reduction_vars=[kh, kw, group],
+            )
+        )
+
+        self.assertEqual(result.blocked, {kh, kw})
+
+    def test_conv_spatial_and_window_blocks_compose(self):
+        mb, out, i, j, channel, ki = (
+            _isym(name) for name in ("mb", "out", "i", "j", "channel", "ki")
+        )
+        op = _computed_buffer(
+            (2, 3, 8, 16),
+            name="strided_windowed_conv",
+            reduction_type=CONV2D_FWD_OP,
+            reduction_ranges=(64, 3),
+        )
+        op.data.op_info = {
+            "conv_params": {
+                "stride_i": 2,
+                "stride_j": 1,
+                "kernel_h": 3,
+                "kernel_w": 1,
+            }
+        }
+        ctx = _make_context(
+            op,
+            self._PLACEHOLDER_TD,
+            it_space={mb: 2, out: 3, i: 8, j: 16, channel: 64, ki: 3},
+            reduction_vars=[channel, ki],
+        )
+        rw = MagicMock()
+        rw.writes = [MagicMock(ranges=(mb, out, i, j))]
+
+        with patch(TestConvSpatialBlockedVars._PATCH_TARGET, return_value=rw):
+            result = collect_work_division_constraints(ctx)
+
+        self.assertEqual(result.blocked, {i, j, ki})
+
+    def test_window_block_conflicting_with_span_commit_raises_unsupported(self):
+        ki, kj = (_isym(name) for name in ("ki", "kj"))
+        op = _computed_buffer(
+            (8,),
+            name="pool_with_forced_window_split",
+            reduction_type=AVGPOOL2D_OP,
+            reduction_ranges=(3, 3),
+        )
+        ctx = _make_context(
+            op,
+            self._PLACEHOLDER_TD,
+            reduction_vars=[ki, kj],
+            committed_splits={ki: 2},
+        )
+
+        with self.assertRaisesRegex(Unsupported, "reduction_window_blocked_vars"):
+            collect_work_division_constraints(ctx)
+
+    def test_unaligned_restickify_stick_dim_is_unsplit(self):
+        old_stick, new_stick = (_isym(name) for name in ("old_stick", "new_stick"))
+        op = _computed_buffer((96,), name="restickify")
+        input_td = MagicMock()
+        input_td.device_coords = [
+            sympy.floor(old_stick / 64),
+            sympy.Mod(old_stick, 64),
+        ]
+        output_td = MagicMock()
+        output_td.device_coords = [
+            sympy.floor(new_stick / 64),
+            sympy.Mod(new_stick, 64),
+        ]
+        result = restickify_padding_blocked_vars(
+            _make_context(
+                op,
+                output_td,
+                input_tds=[input_td],
+                it_space={old_stick: 96, new_stick: 128},
+                stick_vars={old_stick: 64, new_stick: 64},
+            )
+        )
+
+        self.assertEqual(result.blocked, {old_stick})
 
 
 class TestQfp8wtConstraints(unittest.TestCase):

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -52,7 +52,8 @@ from torch_spyre._inductor.pass_utils import PerCoreView
 from torch_spyre._inductor.scratchpad.allocator import ScratchpadAllocator
 from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
 from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
-from torch_spyre._inductor.spyre_kernel import _remap_work_division, simplify_op_spec
+from torch_spyre._inductor.core_mapping import remap_work_division
+from torch_spyre._inductor.spyre_kernel import simplify_op_spec
 
 _LAUNCH_JOBPLAN = "torch_spyre.execution.kernel_runner.launch_jobplan"
 _PREPARE_KERNEL = "torch_spyre.execution.kernel_runner.prepare_kernel"
@@ -701,8 +702,8 @@ def test_lx_relayout_normalizes_ownership_and_lowers_only_in_superdsc():
     ]
     assert root["numWkSlicesPerDim_"] == {"mb": 1, "x": 8, "out": 1}
     maps = [node["coordinates_"]["coreIdToWkSlice_"] for node in allocations]
-    assert [maps[0][str(i)]["x"] for i in range(8)] == [i // 2 for i in range(8)]
-    assert [maps[0][str(i)]["out"] for i in range(8)] == [i % 2 for i in range(8)]
+    assert [maps[0][str(i)]["x"] for i in range(8)] == [i % 4 for i in range(8)]
+    assert [maps[0][str(i)]["out"] for i in range(8)] == [i // 4 for i in range(8)]
     assert [maps[1][str(i)]["x"] for i in range(8)] == [i % 2 for i in range(8)]
     assert [maps[1][str(i)]["out"] for i in range(8)] == [i // 2 for i in range(8)]
     coord_info = [node["coordinates_"]["coordInfo"] for node in allocations]
@@ -726,8 +727,10 @@ def test_lx_relayout_normalizes_ownership_and_lowers_only_in_superdsc():
         base,
         work_division=TensorWorkDivision({old: 16}, {old: Mod(_CORE_ID, 16)}),
     )
-    _remap_work_division(remapped, {old: ((inner, 2), (outer, 8))})
     assert remapped.work_division is not None
+    remapped.work_division = remap_work_division(
+        remapped.work_division, {old: ((inner, 2), (outer, 8))}
+    )
     core_three = {
         dim: int(slot.subs(_CORE_ID, 3))
         for dim, slot in remapped.work_division.core_id_to_work_slice.items()

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -556,9 +556,11 @@ class TestNamedWorkDivisionHint(InductorTestCase):
 
 _CORE_ID = Symbol("core_id")
 _SOURCE_VIEW = PerCoreView(
-    ((0, 4), (1, 2)), ((0, floor(_CORE_ID / 2)), (1, Mod(_CORE_ID, 2)))
+    ((0, 4), (1, 2)),
+    ((0, floor(_CORE_ID / 2)), (1, Mod(_CORE_ID, 2))),
+    num_cores=8,
 )
-_DESTINATION_VIEW = PerCoreView(((0, 8),), ((0, _CORE_ID),))
+_DESTINATION_VIEW = PerCoreView(((0, 8),), ((0, _CORE_ID),), num_cores=8)
 
 
 def _relayout_plan(source="source", consumers="consumer"):
@@ -591,10 +593,12 @@ def test_lx_relayout_planner_rejects_equal_projected_ownership():
     source_view = PerCoreView(
         ((1, 32),),
         ((1, Mod(_CORE_ID, 32)),),
+        num_cores=32,
     )
     destination_view = PerCoreView(
         ((0, 32),),
         ((0, Mod(_CORE_ID, 32)),),
+        num_cores=32,
     )
     coordinates = [m, m]
     source_work_division = work_division_from_view(source_view, coordinates, (m,))
@@ -668,10 +672,12 @@ def test_lx_relayout_normalizes_ownership_and_lowers_only_in_superdsc():
     source_view = PerCoreView(
         ((1, 4), (2, 2)),
         ((1, floor(_CORE_ID / 2)), (2, Mod(_CORE_ID, 2))),
+        num_cores=8,
     )
     destination_view = PerCoreView(
         ((1, 2), (2, 4)),
         ((1, Mod(_CORE_ID, 2)), (2, floor(_CORE_ID / 2))),
+        num_cores=8,
     )
     coordinates = [Mod(n, 32), floor(n / 32), Mod(m, 64)]
     base = TensorArg(

--- a/tests/op_specs/test_op_spec_lab.py
+++ b/tests/op_specs/test_op_spec_lab.py
@@ -34,6 +34,7 @@ import torch
 
 from torch_spyre._C import DataFormats, ElementArrangement
 from torch_spyre._inductor import config as spyre_config
+from torch_spyre._inductor.core_mapping import derive_operation_mapping
 from torch_spyre._inductor.op_spec import (
     DebugHandle,
     LoopSpec,
@@ -53,13 +54,15 @@ import runner  # noqa: E402
 
 def _add_op(debug_handle=None):
     """A 128x256 fp16 elementwise add -- the shape verified on hardware."""
+    iteration_space = {
+        sympify("c0"): (sympify("128"), 32),
+        sympify("c1"): (sympify("256"), 1),
+    }
     return OpSpec(
         op="add",
         is_reduction=False,
-        iteration_space={
-            sympify("c0"): (sympify("128"), 32),
-            sympify("c1"): (sympify("256"), 1),
-        },
+        iteration_space=iteration_space,
+        core_id_to_work_slice=derive_operation_mapping(iteration_space),
         op_info={},
         debug_handle=debug_handle,
         args=[

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -687,6 +687,7 @@ def generate_sdsc(
     operation_work_division = TensorWorkDivision(
         {dim: int(split) for dim, split in sdsc_spec.work_slices.items()},
         {dim: sdsc_spec.core_id_to_work_slice[dim] for dim in sdsc_spec.work_slices},
+        num_cores=sdsc_spec.num_cores,
     )
     for tensor in sdsc_spec.args:
         if tensor.work_division is None:
@@ -1548,7 +1549,8 @@ def generate_sdsc(
                                         ),
                                         "coreIdToWkSlice_": (
                                             tensor.work_division.to_core_slices(
-                                                sdsc_spec.num_cores
+                                                tensor.work_division.num_cores
+                                                or sdsc_spec.num_cores
                                             )
                                             if sdsc_spec.opfunc == "shuffle"
                                             and tensor.work_division is not None

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -2080,9 +2080,10 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
                 if dev_dim_size < padded_it_size:
                     sdsc_arg.backGap[dim_sym] = padded_it_size - dev_dim_size
         for dim in padding:
-            dim_splits[dim] = 1
-            work_slices[dim] = 1
-        num_cores = math.prod(dim_splits.values())
+            if dim_splits[dim] != 1:
+                raise ValueError(
+                    f"restickify padding dimension {dim} must be unsplit before codegen"
+                )
 
     conv_params = (
         dict(op_spec.op_info.get("conv_params", {})) if op_spec.op_info else {}
@@ -2124,10 +2125,10 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
         # The pool hardware accumulates the full kernel window on each core.
         # Splitting ki/kj across cores produces partial sums, giving wrong results.
         for _k_sym in (Symbol("ki"), Symbol("kj")):
-            if _k_sym in dim_splits:
-                dim_splits[_k_sym] = 1
-                work_slices[_k_sym] = 1
-        num_cores = math.prod(dim_splits.values())
+            if dim_splits.get(_k_sym, 1) != 1:
+                raise ValueError(
+                    f"pool kernel dimension {_k_sym} must be unsplit before codegen"
+                )
 
     if is_conv:
         # Both conv paths accumulate the full kernel window per core; splitting
@@ -2135,9 +2136,10 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
         # reduction MAY be core-split (matmul K via psum), so it is left to the
         # default work division.
         for _k_sym in (Symbol("ki"), Symbol("kj")):
-            if _k_sym in dim_splits:
-                dim_splits[_k_sym] = 1
-                work_slices[_k_sym] = 1
+            if dim_splits.get(_k_sym, 1) != 1:
+                raise ValueError(
+                    f"convolution kernel dimension {_k_sym} must be unsplit before codegen"
+                )
 
         if _spyre_config.disable_conv2d_spatial_split:
             # Strided convs cannot split the output spatial dims (i/j): a strided
@@ -2163,8 +2165,6 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
                             f"ways; expected work division to block it unless the "
                             f"memory-span limit required the split."
                         )
-        num_cores = math.prod(dim_splits.values())
-
     # Pool-specific SDSC field values (#3510).  Empty for non-pool ops.
     pool_sdsc_fields = (
         _avgpool_sdsc_fields(sdsc_iteration_space, pool_params_out) if is_pool else {}

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -45,7 +45,6 @@ from torch_spyre._inductor.constants import (
     TOPK_OPS,
     KEEP_BY_INDEX_OP,
 )
-from torch_spyre._inductor.core_mapping import core_to_slice_mapping
 from torch_spyre._inductor.dtype_ops import DtypeOpTable
 from torch_spyre._inductor.indirect_access import (
     compute_indirect_max_dim_sizes,
@@ -1684,6 +1683,7 @@ def _finalize_tensor_work_divisions(
     operation_work_division = TensorWorkDivision(
         {dim: work_slices[dim] for dim in mapping_dims},
         {dim: core_map[dim] for dim in mapping_dims},
+        num_cores=num_cores,
     )
     assert is_lx_relayout or all(arg.work_division is None for arg in args), (
         "per-tensor ownership is supported only for LX relayout identities"
@@ -1701,11 +1701,20 @@ def _finalize_tensor_work_divisions(
                     dim: override.core_id_to_work_slice.get(dim, Integer(0))
                     for dim in mapping_dims
                 },
+                num_cores=override.num_cores or num_cores,
             )
         )
-        if math.prod(effective.work_slices.values()) != num_cores:
+        tensor_cores = effective.num_cores or num_cores
+        tensor_owners = math.prod(effective.work_slices.values())
+        valid = (
+            tensor_cores == num_cores == tensor_owners
+            if not is_lx_relayout
+            else num_cores % tensor_cores == 0 and tensor_cores % tensor_owners == 0
+        )
+        if not valid:
             raise ValueError(
-                f"tensor ownership uses {effective.work_slices}, expected {num_cores} cores"
+                f"tensor ownership uses {tensor_owners} slices across "
+                f"{tensor_cores} of {num_cores} operation cores"
             )
         arg.work_division = effective
 
@@ -1809,6 +1818,12 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
     work_slices = {
         symbol_mapping[sym]: wk_slice
         for sym, (_, wk_slice) in op_spec.iteration_space.items()
+    }
+    if op_spec.core_id_to_work_slice is None:
+        raise ValueError("OpSpec is missing its finalized core mapping")
+    core_id_to_work_slice = {
+        symbol_mapping[sym]: expression
+        for sym, expression in op_spec.core_id_to_work_slice.items()
     }
 
     # Inject implicit kernel dimensions for conv2d when kernel_size=1. This is
@@ -2166,24 +2181,20 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
     else:
         window_sdsc_fields = {}
 
-    # Project dim_splits into final SDSC iteration-space order; normalization
-    # can add unit axes to either mapping independently.
+    # Unit dimensions may be injected while translating the completed OpSpec
+    # into backend labels. They are unsplit and therefore owned at slice zero.
+    # Every non-unit dimension must already have a final assignment.
     mapping_dims = tuple(sdsc_iteration_space)
-    mapping_splits = tuple(int(dim_splits[dim]) for dim in mapping_dims)
-    # Generic reductions do not yet define the same physical cohort contract as
-    # matmul partial sums.
-    contiguous_dim = (
-        len(mapping_splits) - 1
-        if is_matmul and _spyre_config.core_id_k_fast_emission
-        else None
-    )
-    # TODO: Choose the mapping before LX planning and pass it through to codegen.
-    core_id_to_work_slice = core_to_slice_mapping(
-        mapping_dims,
-        mapping_splits,
-        num_cores,
-        contiguous_dim=contiguous_dim,
-    )
+    if is_relayout:
+        num_cores = max(
+            num_cores,
+            *(arg.work_division.num_cores or 1 for arg in args if arg.work_division),
+        )
+    for dim in mapping_dims:
+        if dim not in core_id_to_work_slice:
+            if int(dim_splits[dim]) != 1:
+                raise ValueError(f"final core mapping is missing split dimension {dim}")
+            core_id_to_work_slice[dim] = Integer(0)
     _finalize_tensor_work_divisions(
         args,
         mapping_dims,

--- a/torch_spyre/_inductor/core_mapping.py
+++ b/torch_spyre/_inductor/core_mapping.py
@@ -17,9 +17,11 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 from sympy import Expr, Integer, Mod, Symbol, floor
+
+from .op_spec import TensorWorkDivision
 
 
 def core_to_slice_mapping(
@@ -66,3 +68,252 @@ def core_to_slice_mapping(
         result[dims[dim]] = coordinate
         stride *= split
     return result
+
+
+def derive_core_mapping(
+    dims: Sequence[Symbol],
+    dim_splits: Sequence[int],
+    num_cores: int,
+    *,
+    contiguous_dim: Symbol | None = None,
+    grouped_splits: Mapping[Symbol, int] | None = None,
+) -> dict[Symbol, Expr]:
+    """Derive one complete mapping from final dimensions and group geometry.
+
+    ``grouped_splits`` describes logical owners that must occupy contiguous,
+    equal-size core groups. Its device-dimension order defines the group
+    topology; final loop order does not. Dimensions outside that mapping divide
+    work within each group. No planning-time core assignment is consumed.
+    """
+
+    dims = tuple(dims)
+    splits = tuple(int(split) for split in dim_splits)
+    if len(dims) != len(splits):
+        raise ValueError(f"dimension/split count differs: {len(dims)} != {len(splits)}")
+    split_by_dim = dict(zip(dims, splits))
+    if math.prod(splits) != num_cores:
+        raise ValueError(
+            f"operation split product must equal num_cores: {math.prod(splits)} != {num_cores}"
+        )
+
+    grouped_splits = dict(grouped_splits or {})
+    unknown_dims = grouped_splits.keys() - split_by_dim.keys()
+    if unknown_dims:
+        raise ValueError(f"grouped dimensions are not in the operation: {unknown_dims}")
+    for dim, split in grouped_splits.items():
+        if int(split) != split_by_dim[dim]:
+            raise ValueError(
+                f"grouped split {dim}={split} does not match operation split "
+                f"{split_by_dim[dim]}"
+            )
+
+    if not grouped_splits:
+        contiguous_index = (
+            dims.index(contiguous_dim) if contiguous_dim in dims else None
+        )
+        return core_to_slice_mapping(
+            dims,
+            splits,
+            num_cores,
+            contiguous_dim=contiguous_index,
+        )
+
+    grouped_dims = tuple(grouped_splits)
+    local_dims = tuple(dim for dim in dims if dim not in grouped_splits)
+    owner_count = math.prod(grouped_splits[dim] for dim in grouped_dims)
+    if owner_count <= 0 or num_cores % owner_count:
+        raise ValueError("grouped ownership does not divide the operation")
+    group_size = num_cores // owner_count
+    if math.prod(split_by_dim[dim] for dim in local_dims) != group_size:
+        raise ValueError("operation splits do not fill each owner group")
+
+    core_id = Symbol("core_id")
+    group_id = floor(core_id / group_size)
+    local_core_id = Mod(core_id, group_size)
+    owner_mapping = core_to_slice_mapping(
+        grouped_dims,
+        tuple(grouped_splits[dim] for dim in grouped_dims),
+        owner_count,
+    )
+    local_contiguous = (
+        local_dims.index(contiguous_dim) if contiguous_dim in local_dims else None
+    )
+    local_mapping = core_to_slice_mapping(
+        local_dims,
+        tuple(split_by_dim[dim] for dim in local_dims),
+        group_size,
+        contiguous_dim=local_contiguous,
+    )
+    return {
+        **{
+            dim: expression.subs(core_id, group_id)
+            for dim, expression in owner_mapping.items()
+        },
+        **{
+            dim: expression.subs(core_id, local_core_id)
+            for dim, expression in local_mapping.items()
+        },
+    }
+
+
+def derive_partition_mapping(
+    dims: Sequence[Symbol],
+    dim_splits: Sequence[int],
+    num_cores: int,
+) -> dict[Symbol, Expr]:
+    """Derive tensor owners from final partition geometry.
+
+    A partition may have fewer logical owners than physical cores. In that
+    case each owner occupies one contiguous, equal-size core group.
+    """
+
+    dims = tuple(dims)
+    splits = tuple(int(split) for split in dim_splits)
+    owner_count = math.prod(splits)
+    if owner_count <= 0 or num_cores % owner_count:
+        raise ValueError(
+            f"partition owner count must divide num_cores: {owner_count}, {num_cores}"
+        )
+    group_size = num_cores // owner_count
+    core_id = Symbol("core_id")
+    group_id = floor(core_id / group_size)
+    mapping = core_to_slice_mapping(dims, splits, owner_count)
+    return {
+        dim: expression.subs(core_id, group_id) for dim, expression in mapping.items()
+    }
+
+
+def remap_work_division(
+    division: TensorWorkDivision,
+    dimension_remap: Mapping[Symbol, Sequence[tuple[Symbol, int]]],
+) -> TensorWorkDivision:
+    """Express tensor ownership in an aligned iteration space.
+
+    ``align_tensors`` may split one loop dimension into several dimensions. The
+    physical partition does not change; only the symbols used to describe it do.
+    """
+
+    new_splits: dict[Symbol, int] = {}
+    new_core_map: dict[Symbol, Expr] = {}
+    for old_dim, split in division.work_slices.items():
+        new_dims = dimension_remap[old_dim]
+        remaining_split = int(split)
+        split_factors: list[tuple[Symbol, int]] = []
+        if len(new_dims) == 1:
+            split_factors = [(new_dims[0][0], remaining_split)]
+            remaining_split = 1
+        else:
+            for new_dim, basis in reversed(new_dims):
+                factor = math.gcd(remaining_split, int(basis))
+                split_factors.append((new_dim, factor))
+                remaining_split //= factor
+            split_factors.reverse()
+        if remaining_split != 1:
+            raise ValueError(f"cannot normalize {split}-way split on {old_dim}")
+
+        slot = division.core_id_to_work_slice[old_dim]
+        slot_stride = 1
+        for new_dim, factor in split_factors:
+            if factor == 1:
+                continue
+            new_slot = Mod(floor(slot / slot_stride), factor)
+            previous = (new_splits.get(new_dim), new_core_map.get(new_dim))
+            if previous[0] is not None and previous != (factor, new_slot):
+                raise ValueError(f"conflicting normalized ownership on {new_dim}")
+            new_splits[new_dim] = factor
+            new_core_map[new_dim] = new_slot
+            slot_stride *= factor
+    return TensorWorkDivision(
+        new_splits,
+        new_core_map,
+        num_cores=division.num_cores,
+    )
+
+
+def finalize_tensor_work_divisions(
+    iteration_space: Mapping[Symbol, tuple[Expr, int]],
+    divisions: Sequence[TensorWorkDivision | None],
+) -> tuple[TensorWorkDivision | None, ...]:
+    """Derive every tensor's final owners from aligned split geometry."""
+
+    operation_cores = math.prod(int(split) for _, split in iteration_space.values())
+    owner_counts = [
+        math.prod(int(split) for split in division.work_slices.values())
+        for division in divisions
+        if division is not None
+    ]
+    default_num_cores = max([operation_cores, *owner_counts])
+    result: list[TensorWorkDivision | None] = []
+    for division in divisions:
+        if division is None:
+            result.append(None)
+            continue
+        work_slices = {
+            dim: int(split)
+            for dim, split in division.work_slices.items()
+            if int(split) > 1
+        }
+        num_cores = division.num_cores or default_num_cores
+        owner_count = math.prod(work_slices.values())
+        if num_cores % owner_count:
+            raise ValueError(
+                f"tensor ownership uses {owner_count} slices across {num_cores} cores"
+            )
+        result.append(
+            TensorWorkDivision(
+                work_slices,
+                derive_partition_mapping(
+                    tuple(work_slices),
+                    tuple(work_slices.values()),
+                    num_cores,
+                ),
+                num_cores=num_cores,
+            )
+        )
+    return tuple(result)
+
+
+def derive_operation_mapping(
+    iteration_space: Mapping[Symbol, tuple[Expr, int]],
+    tensor_divisions: Sequence[TensorWorkDivision | None] = (),
+    *,
+    contiguous_dim: Symbol | None = None,
+) -> dict[Symbol, Expr]:
+    """Derive one operation mapping from final dimensions and LX constraints."""
+
+    dims = tuple(iteration_space)
+    splits = tuple(int(iteration_space[dim][1]) for dim in dims)
+    grouped_splits: dict[Symbol, int] = {}
+    for division in tensor_divisions:
+        if division is None:
+            continue
+        for dim, split in division.work_slices.items():
+            previous = grouped_splits.setdefault(dim, int(split))
+            if previous != int(split):
+                raise ValueError(
+                    f"LX tensors disagree on the split for {dim}: {previous} != {split}"
+                )
+    return derive_core_mapping(
+        dims,
+        splits,
+        math.prod(splits),
+        contiguous_dim=contiguous_dim,
+        grouped_splits=grouped_splits,
+    )
+
+
+def core_mappings_equal(
+    left: Mapping[Symbol, Expr],
+    right: Mapping[Symbol, Expr],
+    num_cores: int,
+) -> bool:
+    """Return whether two symbolic mappings assign every core identically."""
+
+    if left.keys() != right.keys():
+        return False
+    core_id = Symbol("core_id")
+    return all(
+        int(left[dim].subs(core_id, core)) == int(right[dim].subs(core_id, core))
+        for dim in left
+        for core in range(num_cores)
+    )

--- a/torch_spyre/_inductor/core_mapping.py
+++ b/torch_spyre/_inductor/core_mapping.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Mapping, Sequence
+from itertools import permutations
 
 from sympy import Expr, Integer, Mod, Symbol, floor
 
@@ -234,15 +235,8 @@ def finalize_tensor_work_divisions(
     iteration_space: Mapping[Symbol, tuple[Expr, int]],
     divisions: Sequence[TensorWorkDivision | None],
 ) -> tuple[TensorWorkDivision | None, ...]:
-    """Derive every tensor's final owners from aligned split geometry."""
+    """Derive each tensor's owners from its final aligned partition."""
 
-    operation_cores = math.prod(int(split) for _, split in iteration_space.values())
-    owner_counts = [
-        math.prod(int(split) for split in division.work_slices.values())
-        for division in divisions
-        if division is not None
-    ]
-    default_num_cores = max([operation_cores, *owner_counts])
     result: list[TensorWorkDivision | None] = []
     for division in divisions:
         if division is None:
@@ -253,11 +247,15 @@ def finalize_tensor_work_divisions(
             for dim, split in division.work_slices.items()
             if int(split) > 1
         }
-        num_cores = division.num_cores or default_num_cores
-        owner_count = math.prod(work_slices.values())
-        if num_cores % owner_count:
+        unknown_dims = work_slices.keys() - iteration_space.keys()
+        if unknown_dims:
             raise ValueError(
-                f"tensor ownership uses {owner_count} slices across {num_cores} cores"
+                f"tensor ownership dimensions are not aligned: {unknown_dims}"
+            )
+
+        if division.num_cores is None:
+            raise ValueError(
+                "tensor ownership must carry its physical core domain before alignment"
             )
         result.append(
             TensorWorkDivision(
@@ -265,9 +263,9 @@ def finalize_tensor_work_divisions(
                 derive_partition_mapping(
                     tuple(work_slices),
                     tuple(work_slices.values()),
-                    num_cores,
+                    division.num_cores,
                 ),
-                num_cores=num_cores,
+                num_cores=division.num_cores,
             )
         )
     return tuple(result)
@@ -279,27 +277,59 @@ def derive_operation_mapping(
     *,
     contiguous_dim: Symbol | None = None,
 ) -> dict[Symbol, Expr]:
-    """Derive one operation mapping from final dimensions and LX constraints."""
+    """Derive one operation mapping that satisfies every LX tensor owner."""
 
     dims = tuple(iteration_space)
     splits = tuple(int(iteration_space[dim][1]) for dim in dims)
-    grouped_splits: dict[Symbol, int] = {}
+    num_cores = math.prod(splits)
+    split_by_dim = dict(zip(dims, splits))
+    constrained: dict[Symbol, Expr] = {}
     for division in tensor_divisions:
         if division is None:
             continue
+        if division.work_slices and division.num_cores not in (None, num_cores):
+            raise ValueError(
+                "LX tensor ownership and operation use different core domains: "
+                f"{division.num_cores} != {num_cores}"
+            )
         for dim, split in division.work_slices.items():
-            previous = grouped_splits.setdefault(dim, int(split))
-            if previous != int(split):
+            if dim not in split_by_dim:
+                raise ValueError(f"LX tensor dimension {dim} is not in the operation")
+            if split_by_dim[dim] != int(split):
                 raise ValueError(
-                    f"LX tensors disagree on the split for {dim}: {previous} != {split}"
+                    f"LX tensor split for {dim} does not match the operation: "
+                    f"{split} != {split_by_dim[dim]}"
                 )
-    return derive_core_mapping(
-        dims,
-        splits,
-        math.prod(splits),
-        contiguous_dim=contiguous_dim,
-        grouped_splits=grouped_splits,
-    )
+            expression = division.core_id_to_work_slice[dim]
+            previous = constrained.setdefault(dim, expression)
+            if not core_mappings_equal({dim: previous}, {dim: expression}, num_cores):
+                raise ValueError(f"LX tensors disagree on core ownership for {dim}")
+
+    if not constrained:
+        return derive_core_mapping(
+            dims,
+            splits,
+            num_cores,
+            contiguous_dim=contiguous_dim,
+        )
+
+    # Tensor-owned dimensions occupy the outer, contiguous groups. At most five
+    # dimensions can be split on 32 cores, so trying their radix orders is small.
+    for order in permutations(constrained):
+        candidate = derive_core_mapping(
+            dims,
+            splits,
+            num_cores,
+            contiguous_dim=contiguous_dim,
+            grouped_splits={dim: split_by_dim[dim] for dim in order},
+        )
+        if all(
+            core_mappings_equal({dim: candidate[dim]}, {dim: expression}, num_cores)
+            for dim, expression in constrained.items()
+        ):
+            return candidate
+
+    raise ValueError("no operation core mapping satisfies every LX tensor owner")
 
 
 def core_mappings_equal(

--- a/torch_spyre/_inductor/kernel_provenance.py
+++ b/torch_spyre/_inductor/kernel_provenance.py
@@ -32,10 +32,16 @@ import base64
 import dataclasses
 import hashlib
 import json
+import math
 from collections.abc import Iterator, Mapping, Sequence
 
 import sympy
 
+from torch_spyre._inductor.constants import MATMUL_REDUCTION_OPS
+from torch_spyre._inductor.core_mapping import (
+    core_mappings_equal,
+    derive_core_mapping,
+)
 from torch_spyre._inductor.op_spec import (
     DebugHandle,
     LoopSpec,
@@ -60,6 +66,7 @@ _EXPECTED_OP_SPEC_SCHEMA = {
     "args": "Sequence[TensorArg]",
     "op_info": "dict[str, Any]",
     "tiled_symbols": "list[list[Symbol]]",
+    "core_id_to_work_slice": "dict[Symbol, Expr] | None",
     "tiled_symbol_trip_counts": "dict[Symbol, int]",
     "symbolic_dim_bounds": "dict[str, tuple[int, int]]",
     "node_output_ranges": "tuple[Expr, ...] | None",
@@ -80,6 +87,7 @@ _EXPECTED_TENSOR_ARG_SCHEMA = {
 _EXPECTED_TENSOR_WORK_DIVISION_SCHEMA = {
     "work_slices": "dict[Symbol, int]",
     "core_id_to_work_slice": "dict[Symbol, Expr]",
+    "num_cores": "int | None",
 }
 _EXPECTED_LOOP_SPEC_SCHEMA = {
     "count": "Expr",
@@ -232,7 +240,7 @@ def _validate_finalized_schema() -> None:
 
 def _canonical_spec(spec: object) -> object:
     if isinstance(spec, OpSpec):
-        return {
+        result = {
             "kind": "op",
             "op": spec.op,
             "is_reduction": spec.is_reduction,
@@ -260,6 +268,16 @@ def _canonical_spec(spec: object) -> object:
                 str(spec.debug_handle.id) if spec.debug_handle is not None else None
             ),
         }
+        # Preserve existing v1 identities when the explicit mapping is exactly
+        # the mapping older codegen would have derived. Only a non-canonical
+        # assignment adds information to the bundle identity.
+        if spec.core_id_to_work_slice is not None and not _is_canonical_core_mapping(
+            spec
+        ):
+            result["core_id_to_work_slice"] = _canonical_value(
+                spec.core_id_to_work_slice
+            )
+        return result
     if isinstance(spec, LoopSpec):
         return {
             "kind": "loop",
@@ -267,6 +285,21 @@ def _canonical_spec(spec: object) -> object:
             "body": [_canonical_spec(child) for child in spec.body],
         }
     raise TypeError(f"Unsupported finalized kernel spec: {type(spec).__qualname__}")
+
+
+def _is_canonical_core_mapping(spec: OpSpec) -> bool:
+    dims = tuple(spec.iteration_space)
+    splits = tuple(int(spec.iteration_space[dim][1]) for dim in dims)
+    contiguous_dim = dims[-1] if dims and spec.op in MATMUL_REDUCTION_OPS else None
+    expected = derive_core_mapping(
+        dims,
+        splits,
+        math.prod(splits),
+        contiguous_dim=contiguous_dim,
+    )
+    return core_mappings_equal(
+        spec.core_id_to_work_slice or {}, expected, math.prod(splits)
+    )
 
 
 def _canonical_tensor_arg(arg: TensorArg) -> object:
@@ -289,6 +322,7 @@ def _canonical_tensor_arg(arg: TensorArg) -> object:
             "core_id_to_work_slice": _canonical_value(
                 arg.work_division.core_id_to_work_slice
             ),
+            "num_cores": arg.work_division.num_cores,
         }
     return result
 

--- a/torch_spyre/_inductor/op_spec.py
+++ b/torch_spyre/_inductor/op_spec.py
@@ -145,11 +145,13 @@ class TensorWorkDivision:
 
     Both mappings have the same symbol keys. ``work_slices`` gives each loop's
     split count and ``core_id_to_work_slice`` maps the free symbol ``core_id``
-    to that loop's owned slice.
+    to that loop's owned slice. ``num_cores`` is the physical domain of that
+    mapping; it can exceed the logical slice count for replicated ownership.
     """
 
     work_slices: dict[Symbol, int]
     core_id_to_work_slice: dict[Symbol, Expr]
+    num_cores: int | None = None
 
     def remap_symbols(self, symbol_mapping: dict[Symbol, Symbol]) -> TensorWorkDivision:
         """Return this ownership expressed in remapped loop symbols."""
@@ -163,6 +165,7 @@ class TensorWorkDivision:
                 symbol_mapping.get(dim, dim): sympify(slot).xreplace(symbol_mapping)
                 for dim, slot in self.core_id_to_work_slice.items()
             },
+            num_cores=self.num_cores,
         )
 
     def to_core_slices(self, num_cores: int) -> dict[str, dict[str, int]]:
@@ -257,6 +260,9 @@ class OpSpec:
         op: The name of the operation.
         is_reduction: Is the operation a reduction?
         iteration_space: The iteration space of the operation. The values are tuples of (range, work_division).
+        core_id_to_work_slice: The final core assignment derived from the
+            aligned iteration space. Codegen serializes this mapping but does
+            not choose or reconstruct it.
         args: The input and output arguments to the operation.
         op_info: A dictionary of auxiliary information whose content is operation-specific.
         tiled_symbols: Per-loop-level iteration-space symbols, innermost first.
@@ -291,6 +297,7 @@ class OpSpec:
     args: Sequence[TensorArg]
     op_info: dict[str, Any]
     tiled_symbols: list[list[Symbol]] = dataclasses.field(default_factory=list)
+    core_id_to_work_slice: dict[Symbol, Expr] | None = None
     tiled_symbol_trip_counts: dict[Symbol, int] = dataclasses.field(
         default_factory=dict
     )

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -16,7 +16,7 @@ import io
 import math
 import warnings
 from dataclasses import dataclass
-from typing import Any, Callable, NamedTuple, Optional, TypeVar, Union
+from typing import Any, Callable, NamedTuple, Optional, Sequence, TypeVar, Union
 
 import regex
 import torch
@@ -53,7 +53,12 @@ from .ir import FixedTiledLayout, SpyreConstantFallback
 from .logging_utils import get_inductor_logger
 from .loop_info import copy_op_metadata
 from .provenance import preserve_provenance
-from .views import compute_coordinates, matching_dim
+from .views import (
+    AlignmentInputs,
+    build_alignment_inputs,
+    compute_coordinates,
+    matching_dim,
+)
 
 # PyTorch's default lower bound for size symbols (sizes 0/1 are specialised).
 _SHAPE_ENV_DEFAULT_LOWER = 2
@@ -63,6 +68,14 @@ logger = get_inductor_logger("pass_utils")
 class SchedNodeArg(NamedTuple):
     dep: MemoryDep
     layout: "FixedTiledLayout"
+
+
+@dataclass(frozen=True)
+class AlignmentAccess:
+    """One tensor access before its coordinates are normalized for codegen."""
+
+    device_layout: Any
+    index: sympy.Expr
 
 
 def _fixed_read_layout(buf) -> "FixedTiledLayout":
@@ -1092,6 +1105,71 @@ def alignment_coordinates(
         repeat_info_out=repeat_info_out,
     )
     return coords
+
+
+def build_operation_alignment_inputs(
+    raw_iteration_space: dict[sympy.Symbol, sympy.Expr],
+    accesses: Sequence[AlignmentAccess],
+    *,
+    indirect_sizes: "dict[sympy.Symbol, int] | None" = None,
+    repeat_info: "dict[sympy.Symbol, dict] | None" = None,
+    op: ComputedBuffer | None = None,
+    read_writes: ReadWrites | None = None,
+    aligned_iteration_space: (dict[sympy.Symbol, tuple[sympy.Expr, int]] | None) = None,
+) -> AlignmentInputs:
+    """Build the complete, immutable input to tensor alignment.
+
+    Codegen may supply its already-finalized iteration space when an operation
+    has an op-specific extension.  Scheduler preview supplies ``op`` and
+    ``read_writes`` and gets the standard split-aware space.  Coordinate and
+    indirect-symbol preparation are shared in both cases.
+    """
+
+    if aligned_iteration_space is None:
+        if op is None or read_writes is None:
+            raise ValueError(
+                "alignment input construction requires either a finalized "
+                "iteration space or an operation and its dependencies"
+            )
+        aligned_iteration_space = iteration_space_with_splits(
+            op, read_writes, raw_iteration_space
+        )
+
+    if indirect_sizes is None and op is not None:
+        indirect_sizes = indirect_sizes_from_op(op)
+    resolved_indirect_sizes = dict(indirect_sizes or {})
+    if resolved_indirect_sizes:
+        # Dependency extraction can recreate an equivalent Symbol with
+        # different assumptions.  Bind the Symbol present in the real index to
+        # the recovered range so preview and codegen normalize the same input.
+        size_by_name = {str(dim): size for dim, size in resolved_indirect_sizes.items()}
+        for access in accesses:
+            for dim in access.index.free_symbols - raw_iteration_space.keys():
+                if dim not in resolved_indirect_sizes and str(dim) in size_by_name:
+                    resolved_indirect_sizes[dim] = size_by_name[str(dim)]
+
+    repeat_snapshot = {
+        symbol: dict(info) for symbol, info in (repeat_info or {}).items()
+    }
+    tensors = [
+        {
+            "size": list(access.device_layout.device_size),
+            "coordinates": alignment_coordinates(
+                access.device_layout,
+                access.index,
+                raw_iteration_space,
+                resolved_indirect_sizes,
+                repeat_info_out=repeat_snapshot,
+            ),
+        }
+        for access in accesses
+    ]
+    return build_alignment_inputs(
+        aligned_iteration_space,
+        tensors,
+        resolved_indirect_sizes,
+        repeat_snapshot,
+    )
 
 
 def try_device_coordinates(

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1550,6 +1550,7 @@ def make_iteration_space_ownership(
             math.prod(dim_splits),
             contiguous_dim=contiguous_dim,
         ),
+        num_cores=math.prod(dim_splits),
     )
 
 
@@ -2277,10 +2278,12 @@ class PerCoreView:
       split dim.
     - core_to_slot: (device-dim index, slice-index expression in core_id)
       pairs giving each core's position along that split dim.
+    - num_cores: physical cores over which ``core_to_slot`` is defined. This
+      can exceed the number of logical slices when data is replicated.
 
-    Both fields are keyed by the buffer's device-dim index — not by op-
-    local iter symbols — so the value depends only on the buffer's
-    physical slicing.
+    The first two fields are keyed by the buffer's device-dim index — not by
+    op-local iter symbols — so the value depends only on the buffer's physical
+    slicing.
 
     Example: a 2D buffer split 4-ways on dim 0 across 4 cores has
         work_slice_dims = ((0, 4),)
@@ -2290,6 +2293,7 @@ class PerCoreView:
 
     work_slice_dims: tuple[tuple[int, int], ...]
     core_to_slot: tuple[tuple[int, Expr], ...]
+    num_cores: int | None = None
 
 
 def _is_matmul_op(op: Operation) -> bool:
@@ -2462,17 +2466,30 @@ def _per_core_view_from_prep(
     reduction_splits: Optional[dict[sympy.Symbol, int]] = None,
 ) -> tuple[PerCoreView, bool, bool]:
     """Evaluate a precomputed view for symbol splits or scheduler transport."""
+    num_cores = math.prod(
+        value
+        for group in (splits if isinstance(splits, tuple) else (splits,))
+        for value in group.values()
+    )
     # 3-tuple: (view, has_partial_reduction, representable). ``representable`` is
     # False only on the give-up returns below (a split that slices this buffer
     # can't be placed on a device dim); cross-op view comparisons must treat it
     # as "no match", since its empty view means "couldn't tell", not "whole".
-    unrepresentable = (PerCoreView(work_slice_dims=(), core_to_slot=()), False, False)
+    unrepresentable = (
+        PerCoreView(work_slice_dims=(), core_to_slot=(), num_cores=num_cores),
+        False,
+        False,
+    )
 
     # No real split -> whole-buffer view, representable regardless of layout. Must
     # precede the ``prep is None`` guard to match the original ordering.
     if isinstance(splits, tuple):
         if not any(n > 1 for d in splits for n in d.values()):
-            return (PerCoreView(work_slice_dims=(), core_to_slot=()), False, True)
+            return (
+                PerCoreView(work_slice_dims=(), core_to_slot=(), num_cores=num_cores),
+                False,
+                True,
+            )
         if prep is None:
             return unrepresentable
         per_sym = apply_splits_from_index_coeff(
@@ -2481,7 +2498,11 @@ def _per_core_view_from_prep(
         has_partial_reduction = any(n > 1 for n in splits[1].values())
     else:
         if not any(n > 1 for n in splits.values()):
-            return (PerCoreView(work_slice_dims=(), core_to_slot=()), False, True)
+            return (
+                PerCoreView(work_slice_dims=(), core_to_slot=(), num_cores=num_cores),
+                False,
+                True,
+            )
         if prep is None:
             return unrepresentable
         per_sym = {sym: int(splits.get(sym, 1)) for sym in prep.iter_space}
@@ -2625,6 +2646,7 @@ def _per_core_view_from_prep(
     view = PerCoreView(
         work_slice_dims=tuple(sorted(work_slice_dims.items())),
         core_to_slot=tuple(pruned_core_to_slot),
+        num_cores=num_cores,
     )
     return (view, has_partial_reduction, True)
 
@@ -2667,7 +2689,12 @@ def _per_core_view_on_buf(
             return hit
 
     if not any(n > 1 for n in splits.values()):
-        result = (PerCoreView(work_slice_dims=(), core_to_slot=()), False, True)
+        num_cores = ownership.num_cores if ownership is not None else 1
+        result = (
+            PerCoreView(work_slice_dims=(), core_to_slot=(), num_cores=num_cores),
+            False,
+            True,
+        )
         if cache is not None:
             cache[key] = result
         return result
@@ -2699,14 +2726,25 @@ def per_core_view_scheduled(
     coeff_splits: tuple[dict, dict] = getattr(op, "op_it_space_splits", ({}, {}))
     if not any(n > 1 for d in coeff_splits for n in d.values()):
         # No real split -> whole-buffer view; every core holds all of it.
-        return (PerCoreView(work_slice_dims=(), core_to_slot=()), False, True)
+        return (
+            PerCoreView(work_slice_dims=(), core_to_slot=(), num_cores=1),
+            False,
+            True,
+        )
 
     rw = node.read_writes
     write_dep = next((d for d in rw.writes if isinstance(d, MemoryDep)), None)
     if write_dep is None:
         # StarDep-only writer: no index to reason about, so treat as
         # unrepresentable rather than guessing.
-        return (PerCoreView(work_slice_dims=(), core_to_slot=()), False, False)
+        num_cores = math.prod(
+            value for group in coeff_splits for value in group.values()
+        )
+        return (
+            PerCoreView(work_slice_dims=(), core_to_slot=(), num_cores=num_cores),
+            False,
+            False,
+        )
     read_index = next(
         (d.index for d in rw.reads if isinstance(d, MemoryDep)), write_dep.index
     )

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1060,17 +1060,37 @@ def device_coordinates(
         One coordinate expression per device dimension; the last element is
         the stick expression.
     """
+    coords = alignment_coordinates(stl, dep.index, dep.ranges, indirect_sizes)
+    _check_stick_expr_supported(coords[-1], stl.elems_per_stick())
+    return coords
+
+
+def alignment_coordinates(
+    stl: SpyreTensorLayout,
+    index: sympy.Expr,
+    it_space: dict[sympy.Symbol, sympy.Expr],
+    indirect_sizes: "dict[sympy.Symbol, int] | None",
+    *,
+    repeat_info_out: "dict[sympy.Symbol, dict] | None" = None,
+) -> list[sympy.Expr]:
+    """Build the coordinates consumed by tensor alignment.
+
+    Scheduler validation and codegen must prepare identical inputs for
+    ``align_tensors``.  Keep index concretization and coordinate construction in
+    this one helper so the validation preview cannot drift from real codegen.
+    """
+
     # device_size and stride_map come from the C++ SpyreTensorLayout and are
     # already concrete, so no concretization is needed here.
-    index = concretize_index(dep.index, set(dep.ranges.keys()))
+    index = concretize_index(index, set(it_space))
     coords = compute_coordinates(
         stl.device_size,
         stl.stride_map,
-        dep.ranges,
+        it_space,
         index,
         indirect_sizes,
+        repeat_info_out=repeat_info_out,
     )
-    _check_stick_expr_supported(coords[-1], stl.elems_per_stick())
     return coords
 
 
@@ -1669,6 +1689,24 @@ def apply_splits_from_index_coeff(
             if rc != 0 and rc in reduction_coeff_splits:
                 result[sym] = reduction_coeff_splits[rc]
     return result
+
+
+def iteration_space_with_splits(
+    op: Operation,
+    rw: ReadWrites,
+    it_space: dict[sympy.Symbol, sympy.Expr],
+) -> dict[sympy.Symbol, tuple[sympy.Expr, int]]:
+    """Attach the operation's committed work-division splits to loop symbols."""
+
+    splits: dict[sympy.Symbol, int] = {}
+    if hasattr(op, "op_it_space_splits"):
+        write_index, read_index = select_work_division_transport_indexes(
+            op, rw, it_space
+        )
+        splits = apply_splits_from_index_coeff(
+            op.op_it_space_splits, write_index, read_index, it_space
+        )
+    return {dim: (extent, int(splits.get(dim, 1))) for dim, extent in it_space.items()}
 
 
 # The following restickify helpers are used only by the restickify

--- a/torch_spyre/_inductor/scratchpad/lx_relayout.py
+++ b/torch_spyre/_inductor/scratchpad/lx_relayout.py
@@ -93,7 +93,7 @@ def work_division_from_view(
             raise ValueError(f"conflicting ownership for loop {dim}")
         splits[dim] = split
         core_map[dim] = slot
-    return TensorWorkDivision(splits, core_map)
+    return TensorWorkDivision(splits, core_map, num_cores=view.num_cores)
 
 
 def materialized_lx_relayouts(

--- a/torch_spyre/_inductor/scratchpad/lx_relayout.py
+++ b/torch_spyre/_inductor/scratchpad/lx_relayout.py
@@ -77,6 +77,8 @@ def work_division_from_view(
 
     if view is None:
         return None
+    if view.num_cores is None:
+        raise ValueError("LX ownership must carry its physical core domain")
     loop_symbols = set(iteration_symbols)
     splits: dict[sympy.Symbol, int] = {}
     core_map: dict[sympy.Symbol, sympy.Expr] = {}

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -53,16 +53,15 @@ from .ir import FixedTiledLayout
 from .scratchpad.lx_relayout import work_division_from_view
 from .pass_utils import (
     concretize_expr,
-    concretize_index,
     compute_symbolic_bounds,
     finite_upper_or_none,
-    apply_splits_from_index_coeff,
     iteration_space,
-    select_work_division_transport_indexes,
     indirect_access_subs_from_kernel,
     is_restickify_coords,
+    alignment_coordinates,
+    iteration_space_with_splits,
 )
-from .views import compute_coordinates, align_tensors, tiling_expr_to_device_expr
+from .views import align_tensors, tiling_expr_to_device_expr
 from .logging_utils import get_inductor_logger
 from .op_spec import (
     IndirectAccess,
@@ -795,8 +794,6 @@ class SpyreKernel(Kernel[CSEVariable]):
         # (e.g. x0*s1+x1).  Concretize size symbols so normalize_coordinates
         # can correctly isolate each loop variable's contribution.
 
-        index = concretize_index(tensor.index, set(it_space.keys()))
-
         # insert_post_mutation_restickify may override the input layout for this input tensor.
         # Restore it here because the tensor data was uploaded as orig_stl.
         if is_input:
@@ -804,11 +801,10 @@ class SpyreKernel(Kernel[CSEVariable]):
             if (layout := overrides.get(name)) is not None:
                 tensor.layout = layout
 
-        device_coords = compute_coordinates(
-            tensor.layout.device_layout.device_size,
-            tensor.layout.device_layout.stride_map,
+        device_coords = alignment_coordinates(
+            tensor.layout.device_layout,
+            tensor.index,
             it_space,
-            index,
             self.indirect_sizes,
         )
         work_division = work_division_from_view(
@@ -866,18 +862,9 @@ class SpyreKernel(Kernel[CSEVariable]):
         it_space = iteration_space(self.current_node)
 
         ir_node = self.current_node.node  # ComputedBuffer
-        work_division: dict[sympy.Symbol, int] = {}
-        if hasattr(ir_node, "op_it_space_splits"):
-            write_index, read_index = select_work_division_transport_indexes(
-                ir_node, self.current_node.read_writes, it_space
-            )
-            work_division = apply_splits_from_index_coeff(
-                ir_node.op_it_space_splits, write_index, read_index, it_space
-            )
-
-        it_space_extended = {
-            k: (v, work_division.get(k, 1)) for k, v in it_space.items()
-        }
+        it_space_extended = iteration_space_with_splits(
+            ir_node, self.current_node.read_writes, it_space
+        )
         it_space_extended = _preserve_shared_weight_unit_bmm_dim(
             op, it_space_extended, args, op_info
         )

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from dataclasses import dataclass, field
-import math
 from typing import Any, Callable, Self, Sequence, Tuple, Union
 from abc import ABC
 import itertools
@@ -41,6 +40,7 @@ from .constants import (
     CONV_OPS,
     DEPTHWISE_CONV_REDUCTION_OPS,
     IDENTITY_OP,
+    MATMUL_REDUCTION_OPS,
     POOL_OPS,
     RESTICKIFY_OP,
     SEGMENT_OFFSETS,
@@ -48,6 +48,11 @@ from .constants import (
     SHARED_WEIGHT_UNIT_BMM_INFO_KEY,
 )
 from . import config as _spyre_config
+from .core_mapping import (
+    derive_operation_mapping,
+    finalize_tensor_work_divisions,
+    remap_work_division,
+)
 from .errors import Unsupported
 from .ir import FixedTiledLayout
 from .scratchpad.lx_relayout import work_division_from_view
@@ -68,7 +73,6 @@ from .op_spec import (
     LoopSpec,
     OpSpec,
     TensorArg,
-    TensorWorkDivision,
     UnimplementedOp as OpSpecUnimplementedOp,
     format_op_spec_list,
     is_lx_relayout_identity,
@@ -558,6 +562,10 @@ class SpyreKernel(Kernel[CSEVariable]):
         self._indirect_var_count: int = 0
         self._general_tile_advance_seen: dict[str, int] = {}
         self._tile_advance_symbols: dict[int, sympy.Symbol] = {}
+        self._alignment_repeat_info: dict[sympy.Symbol, dict[str, Any]] = {}
+        self._alignment_repeat_info_by_spec: dict[
+            int, dict[sympy.Symbol, dict[str, Any]]
+        ] = {}
         self.pool_size: int = pool_size
 
     def indirect_var_names(self) -> "frozenset[str] | None":
@@ -806,6 +814,7 @@ class SpyreKernel(Kernel[CSEVariable]):
             tensor.index,
             it_space,
             self.indirect_sizes,
+            repeat_info_out=self._alignment_repeat_info,
         )
         work_division = work_division_from_view(
             tensor.layout.lx_view if "lx" in tensor.layout.allocation else None,
@@ -959,11 +968,7 @@ class SpyreKernel(Kernel[CSEVariable]):
             and hasattr(ir_node.data, "ranges")
             else None
         )
-        if not is_lx_relayout_identity(op, args):
-            for arg in args:
-                arg.work_division = None
-
-        return OpSpec(
+        op_spec = OpSpec(
             op,
             is_reduction,
             it_space_extended,
@@ -975,6 +980,10 @@ class SpyreKernel(Kernel[CSEVariable]):
             node_output_ranges=node_output_ranges,
             debug_handle=debug_handle,
         )
+        self._alignment_repeat_info_by_spec[id(op_spec)] = {
+            symbol: dict(info) for symbol, info in self._alignment_repeat_info.items()
+        }
+        return op_spec
 
     def remove_kernel_local_buffers(self) -> None:
         """Remove buffers that have a scratchpad or temporary allocation from the kernel's arg list."""
@@ -1018,6 +1027,7 @@ class SpyreKernel(Kernel[CSEVariable]):
     ) -> None:
         self._general_tile_advance_seen = {}
         self._tile_advance_symbols = {}
+        self._alignment_repeat_info = {}
         # mutation_real_name maps mutation aliases to their real destination buffer. Resolve that here,
         # and mark the buf name as removed so the wrapper does not allocate it separately.
         real_dst_name = V.graph.scheduler.mutation_real_name.get(name, name)
@@ -1146,6 +1156,7 @@ class SpyreKernel(Kernel[CSEVariable]):
         """Convert an RValue"""
         self._general_tile_advance_seen = {}
         self._tile_advance_symbols = {}
+        self._alignment_repeat_info = {}
         buf = V.graph.get_buffer(name)
         layout = buf.get_layout()
         if not isinstance(layout, FixedTiledLayout):
@@ -1246,7 +1257,12 @@ class SpyreKernel(Kernel[CSEVariable]):
             )
 
         for op_spec in _iter_op_specs(self.op_specs):
-            simplify_op_spec(op_spec, self.indirect_sizes, indirect_access_subs)
+            simplify_op_spec(
+                op_spec,
+                self.indirect_sizes,
+                indirect_access_subs,
+                repeat_info=self._alignment_repeat_info_by_spec.get(id(op_spec)),
+            )
 
         if _spyre_config.validate_op_specs:
             validate_op_specs(self.op_specs, stage="after_simplification")
@@ -1451,6 +1467,12 @@ def _codegen_op_spec_list(specs, buf: IndentedBuffer, sympy_str) -> None:
                         for sym, count in op_spec.tiled_symbol_trip_counts.items()
                     )
                     buf.writeline(f"tiled_symbol_trip_counts={{{trip_counts_str}}},")
+                if op_spec.core_id_to_work_slice is not None:
+                    core_map = ", ".join(
+                        f"{sympy_str(dim)}: {sympy_str(slot)}"
+                        for dim, slot in op_spec.core_id_to_work_slice.items()
+                    )
+                    buf.writeline(f"core_id_to_work_slice={{{core_map}}},")
                 buf.writeline(
                     f"symbolic_dim_bounds={_serialize_value(op_spec.symbolic_dim_bounds)},"
                 )
@@ -1512,51 +1534,17 @@ def _codegen_op_spec_list(specs, buf: IndentedBuffer, sympy_str) -> None:
                                 buf.writeline(
                                     "work_division=TensorWorkDivision("
                                     f"work_slices={{{splits}}}, "
-                                    f"core_id_to_work_slice={{{core_map}}}),"
+                                    f"core_id_to_work_slice={{{core_map}}}"
+                                    + (
+                                        f", num_cores={arg.work_division.num_cores}"
+                                        if arg.work_division.num_cores is not None
+                                        else ""
+                                    )
+                                    + "),"
                                 )
                         buf.writeline("),")
                 buf.writeline("]")
             buf.writeline("),")
-
-
-def _remap_work_division(arg: TensorArg, work_division_remap) -> None:
-    """Carry tensor ownership through iteration-space normalization."""
-
-    if arg.work_division is None:
-        return
-    new_splits: dict[sympy.Symbol, int] = {}
-    new_core_map: dict[sympy.Symbol, sympy.Expr] = {}
-    for old_dim, split in arg.work_division.work_slices.items():
-        new_dims = work_division_remap[old_dim]
-        remaining_split = int(split)
-        split_factors = []
-        if len(new_dims) == 1:
-            split_factors = [(new_dims[0][0], remaining_split)]
-            remaining_split = 1
-        else:
-            for new_dim, basis in reversed(new_dims):
-                factor = math.gcd(remaining_split, basis)
-                split_factors.append((new_dim, factor))
-                remaining_split //= factor
-            split_factors.reverse()
-        if remaining_split != 1:
-            raise ValueError(f"cannot normalize {split}-way split on {old_dim}")
-
-        slot = arg.work_division.core_id_to_work_slice[old_dim]
-        slot_stride = 1
-        for new_dim, factor in split_factors:
-            if factor == 1:
-                continue
-            new_slot = sympy.Mod(sympy.floor(slot / slot_stride), factor)
-            if new_dim in new_splits and (
-                new_splits[new_dim],
-                new_core_map[new_dim],
-            ) != (factor, new_slot):
-                raise ValueError(f"conflicting normalized ownership on {new_dim}")
-            new_splits[new_dim] = factor
-            new_core_map[new_dim] = new_slot
-            slot_stride *= factor
-    arg.work_division = TensorWorkDivision(new_splits, new_core_map)
 
 
 def _restickify_restore_elided_dim(op_spec) -> None:
@@ -1656,7 +1644,13 @@ def _restickify_restore_elided_dim(op_spec) -> None:
         _restore(new_sym, out_arg, in_arg)
 
 
-def simplify_op_spec(op_spec, indirect_sizes=None, indirect_access_subs=None):
+def simplify_op_spec(
+    op_spec,
+    indirect_sizes=None,
+    indirect_access_subs=None,
+    *,
+    repeat_info=None,
+):
     # Both parameters must be provided together for gather kernels — indirect_sizes
     # decomposes symbols in align_tensors; indirect_access_subs replaces them with IndirectAccess.
 
@@ -1673,11 +1667,15 @@ def simplify_op_spec(op_spec, indirect_sizes=None, indirect_access_subs=None):
             for arg in op_spec.args
         ],
         indirect_sizes,
+        repeat_info=repeat_info,
     )
     op_spec.iteration_space = new_op_space_splits
 
     for arg, t in zip(op_spec.args, new_tensors):
-        _remap_work_division(arg, work_division_remap)
+        if arg.work_division is not None:
+            arg.work_division = remap_work_division(
+                arg.work_division, work_division_remap
+            )
         arg.device_size = t["size"]
         arg.device_coordinates = t["coordinates"]
 
@@ -1687,3 +1685,43 @@ def simplify_op_spec(op_spec, indirect_sizes=None, indirect_access_subs=None):
             arg.device_coordinates = [
                 c.xreplace(indirect_access_subs) for c in arg.device_coordinates
             ]
+
+    _finalize_tensor_work_divisions(op_spec)
+    is_relayout = is_lx_relayout_identity(op_spec.op, op_spec.args)
+    if is_relayout:
+        destination = op_spec.args[-1].work_division
+        assert destination is not None
+        op_spec.core_id_to_work_slice = dict(destination.core_id_to_work_slice)
+    else:
+        _finalize_core_mapping(op_spec, use_tensor_constraints=True)
+        for arg in op_spec.args:
+            arg.work_division = None
+
+
+def _finalize_tensor_work_divisions(op_spec: OpSpec) -> None:
+    """Derive tensor owners from final symbols, never planning-time formulas."""
+    finalized = finalize_tensor_work_divisions(
+        op_spec.iteration_space,
+        [arg.work_division for arg in op_spec.args],
+    )
+    for arg, division in zip(op_spec.args, finalized):
+        arg.work_division = division
+
+
+def _finalize_core_mapping(
+    op_spec: OpSpec, *, use_tensor_constraints: bool = False
+) -> None:
+    """Assign physical cores from an OpSpec's final aligned dimensions."""
+
+    contiguous_dim = (
+        next(reversed(op_spec.iteration_space))
+        if op_spec.iteration_space
+        and op_spec.op in MATMUL_REDUCTION_OPS
+        and _spyre_config.core_id_k_fast_emission
+        else None
+    )
+    op_spec.core_id_to_work_slice = derive_operation_mapping(
+        op_spec.iteration_space,
+        [arg.work_division for arg in op_spec.args] if use_tensor_constraints else (),
+        contiguous_dim=contiguous_dim,
+    )

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -563,6 +563,8 @@ class SpyreKernel(Kernel[CSEVariable]):
         self._general_tile_advance_seen: dict[str, int] = {}
         self._tile_advance_symbols: dict[int, sympy.Symbol] = {}
         self._alignment_repeat_info: dict[sympy.Symbol, dict[str, Any]] = {}
+        # Specs stay in self.op_specs until codegen, and capture precedes lookup,
+        # so id(op_spec) remains stable for this side table's lifetime.
         self._alignment_repeat_info_by_spec: dict[
             int, dict[sympy.Symbol, dict[str, Any]]
         ] = {}

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -57,6 +57,7 @@ from .errors import Unsupported
 from .ir import FixedTiledLayout
 from .scratchpad.lx_relayout import work_division_from_view
 from .pass_utils import (
+    AlignmentAccess,
     concretize_expr,
     compute_symbolic_bounds,
     finite_upper_or_none,
@@ -64,9 +65,15 @@ from .pass_utils import (
     indirect_access_subs_from_kernel,
     is_restickify_coords,
     alignment_coordinates,
+    build_operation_alignment_inputs,
     iteration_space_with_splits,
 )
-from .views import align_tensors, tiling_expr_to_device_expr
+from .views import (
+    AlignmentInputs,
+    align_tensors,
+    align_tensors_pure,
+    tiling_expr_to_device_expr,
+)
 from .logging_utils import get_inductor_logger
 from .op_spec import (
     IndirectAccess,
@@ -568,6 +575,8 @@ class SpyreKernel(Kernel[CSEVariable]):
         self._alignment_repeat_info_by_spec: dict[
             int, dict[sympy.Symbol, dict[str, Any]]
         ] = {}
+        self._alignment_access_by_tensor_arg: dict[int, AlignmentAccess] = {}
+        self._alignment_inputs_by_spec: dict[int, AlignmentInputs] = {}
         self.pool_size: int = pool_size
 
     def indirect_var_names(self) -> "frozenset[str] | None":
@@ -836,6 +845,9 @@ class SpyreKernel(Kernel[CSEVariable]):
             device_tile_advance_expr=device_tile_advance_expr,
             work_division=work_division,
         )
+        self._alignment_access_by_tensor_arg[id(tensor_arg)] = AlignmentAccess(
+            tensor.layout.device_layout, tensor.index
+        )
         if (
             "lx" not in tensor.layout.allocation
             and "hbm_pool" not in tensor.layout.allocation
@@ -879,6 +891,18 @@ class SpyreKernel(Kernel[CSEVariable]):
         it_space_extended = _preserve_shared_weight_unit_bmm_dim(
             op, it_space_extended, args, op_info
         )
+        alignment_inputs = build_operation_alignment_inputs(
+            it_space,
+            [self._alignment_access_by_tensor_arg[id(arg)] for arg in args],
+            indirect_sizes=self.indirect_sizes,
+            repeat_info=self._alignment_repeat_info,
+            aligned_iteration_space=it_space_extended,
+        )
+        for arg, tensor in zip(args, alignment_inputs.tensors):
+            if list(arg.device_coordinates) != tensor["coordinates"]:
+                raise RuntimeError(
+                    "alignment input collection disagrees with tensor codegen"
+                )
 
         # Build per-level tiled_symbols (innermost first) for this op.
         # loop_tiled_dims / loop_tiled_reduction_dims are lists of per-level
@@ -985,6 +1009,8 @@ class SpyreKernel(Kernel[CSEVariable]):
         self._alignment_repeat_info_by_spec[id(op_spec)] = {
             symbol: dict(info) for symbol, info in self._alignment_repeat_info.items()
         }
+        if op != RESTICKIFY_OP:
+            self._alignment_inputs_by_spec[id(op_spec)] = alignment_inputs
         return op_spec
 
     def remove_kernel_local_buffers(self) -> None:
@@ -1264,6 +1290,7 @@ class SpyreKernel(Kernel[CSEVariable]):
                 self.indirect_sizes,
                 indirect_access_subs,
                 repeat_info=self._alignment_repeat_info_by_spec.get(id(op_spec)),
+                alignment_inputs=self._alignment_inputs_by_spec.get(id(op_spec)),
             )
 
         if _spyre_config.validate_op_specs:
@@ -1652,6 +1679,7 @@ def simplify_op_spec(
     indirect_access_subs=None,
     *,
     repeat_info=None,
+    alignment_inputs: AlignmentInputs | None = None,
 ):
     # Both parameters must be provided together for gather kernels — indirect_sizes
     # decomposes symbols in align_tensors; indirect_access_subs replaces them with IndirectAccess.
@@ -1662,15 +1690,24 @@ def simplify_op_spec(
         _restickify_restore_elided_dim(op_spec)
 
     it_space = op_spec.iteration_space
-    new_op_space_splits, new_tensors, work_division_remap = align_tensors(
-        it_space,
-        [
-            {"size": arg.device_size, "coordinates": arg.device_coordinates}
-            for arg in op_spec.args
-        ],
-        indirect_sizes,
-        repeat_info=repeat_info,
-    )
+    if alignment_inputs is None:
+        new_op_space_splits, new_tensors, work_division_remap = align_tensors(
+            it_space,
+            [
+                {"size": arg.device_size, "coordinates": arg.device_coordinates}
+                for arg in op_spec.args
+            ],
+            indirect_sizes,
+            repeat_info=repeat_info,
+        )
+    else:
+        if alignment_inputs.iteration_space != it_space:
+            raise RuntimeError(
+                "captured alignment iteration space changed before codegen"
+            )
+        new_op_space_splits, new_tensors, work_division_remap = align_tensors_pure(
+            alignment_inputs
+        )
     op_spec.iteration_space = new_op_space_splits
 
     for arg, t in zip(op_spec.args, new_tensors):

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -184,6 +184,7 @@ def compute_coordinates(
     var_ranges: dict[sympy.Symbol, sympy.Expr],
     index: sympy.Expr,
     indirect_sizes: "dict[sympy.Symbol, int] | None" = None,
+    repeat_info_out: "dict[sympy.Symbol, dict] | None" = None,
 ) -> list[sympy.Expr]:
     """
     Compute an array of coordinate expressions from an index expression.
@@ -211,10 +212,8 @@ def compute_coordinates(
     # Convert ModularIndexing expressions to sympy.Mod before processing
     index = convert_modular_indexing(index)
     repeat_info = find_repeat_vars([index], var_ranges)
-    if not hasattr(V.graph, "_repeat_info"):
-        V.graph._repeat_info = dict(repeat_info)
-    else:
-        V.graph._repeat_info.update(repeat_info)
+    if repeat_info_out is not None:
+        repeat_info_out.update(repeat_info)
 
     # find stride immediately strictly larger that dim stride
     n = len(size)
@@ -426,6 +425,7 @@ def normalize_coordinates(
     coordinates: Sequence[sympy.Expr],
     synthetic_var_fn: Callable[[], sympy.Symbol],
     indirect_sizes: "dict[sympy.Symbol, int] | None" = None,
+    compare_value: Callable[[sympy.Expr], int | float] = _concretize_for_cmp,
 ) -> list[Term]:
     """
     Normalize coordinate expressions obtained from compute_coordinates.
@@ -516,8 +516,8 @@ def normalize_coordinates(
         # when num is equal
         dim_terms.sort(
             key=lambda t: (
-                _concretize_for_cmp(t.num),
-                _concretize_for_cmp(t.mod),
+                compare_value(t.num),
+                compare_value(t.mod),
             )
         )
 
@@ -615,17 +615,79 @@ def normalize_coordinates(
     return fused_terms
 
 
-def align_tensors(
+@dataclass(frozen=True)
+class AlignmentInputs:
+    """Everything tensor alignment needs, captured without hidden graph state."""
+
+    iteration_space: dict[sympy.Symbol, tuple[sympy.Expr, int]]
+    tensors: list[dict[str, list[sympy.Expr]]]
+    indirect_sizes: dict[sympy.Symbol, int] | None
+    repeat_info: dict[sympy.Symbol, dict]
+    concrete_ranges: dict[sympy.Symbol, int | float]
+    restored_ranges: dict[sympy.Symbol, sympy.Expr | int | float]
+
+
+def build_alignment_inputs(
     iteration_space: Dict[sympy.Symbol, Tuple[sympy.Expr, int]],
     tensors: list[Dict[str, list[sympy.Expr]]],
     indirect_sizes: "dict[sympy.Symbol, int] | None" = None,
+    repeat_info: "dict[sympy.Symbol, dict] | None" = None,
+) -> AlignmentInputs:
+    """Snapshot explicit inputs for a repeatable, side-effect-free alignment."""
+
+    from .pass_utils import finite_upper_or_none
+
+    concrete_ranges = {
+        var: _concretize_for_cmp(value) for var, (value, _) in iteration_space.items()
+    }
+    restored_ranges: dict[sympy.Symbol, sympy.Expr | int | float] = {}
+    for var, (value, _) in iteration_space.items():
+        if (
+            hasattr(value, "free_symbols")
+            and value.free_symbols
+            and finite_upper_or_none(value) is None
+        ):
+            restored_ranges[var] = concrete_ranges[var]
+        else:
+            restored_ranges[var] = value
+
+    return AlignmentInputs(
+        iteration_space=dict(iteration_space),
+        tensors=[
+            {
+                "size": list(tensor["size"]),
+                "coordinates": list(tensor["coordinates"]),
+            }
+            for tensor in tensors
+        ],
+        indirect_sizes=dict(indirect_sizes) if indirect_sizes is not None else None,
+        repeat_info={
+            symbol: dict(info) for symbol, info in (repeat_info or {}).items()
+        },
+        concrete_ranges=concrete_ranges,
+        restored_ranges=restored_ranges,
+    )
+
+
+def _concrete_alignment_value(expr: sympy.Expr) -> int | float:
+    if hasattr(expr, "free_symbols") and expr.free_symbols:
+        raise Unsupported(f"alignment input is not concrete: {expr}")
+    if expr == sympy.oo:
+        return math.inf
+    if expr == -sympy.oo:
+        return -math.inf
+    return int(expr)
+
+
+def align_tensors_pure(
+    inputs: AlignmentInputs,
 ) -> tuple[
     dict[sympy.Symbol, tuple[sympy.Expr, int]],
     list[dict[str, list]],
     dict[sympy.Symbol, tuple[tuple[sympy.Symbol, int], ...]],
 ]:
     """
-    Transform op iteration space and tensor arguments to satisfy codegen requirements.
+    Transform tensor coordinates using only the supplied immutable snapshot.
     """
 
     # Concretize range values for the algorithm: align_tensors performs
@@ -633,33 +695,11 @@ def align_tensors(
     # Coordinate *expressions* remain symbolic (they reference loop variable
     # Symbols, not range values).
 
-    # Save original (possibly symbolic) range expressions before concretizing.
-    # The algorithm below requires concrete ints for sorting and integer division,
-    # but we must propagate symbolic expressions forward so downstream passes
-    # (work_division, SDSC codegen) see the symbols to extract fields, not hints.
-    orig_ranges = {var: val[0] for var, val in iteration_space.items()}
-    # local import: pass_utils imports compute_coordinates/matching_dim from
-    # this module, so importing at module scope would create a cycle.
-    from .pass_utils import finite_upper_or_none
-
-    def _bounded_or_hint(expr, hint):
-        """Return ``expr`` unless it's an unbounded symbolic expression.
-
-        Auto-dynamic symbols (Dynamo promoting an int on retrace, with no
-        finite max and are not symbolic dims ) carry no bound downstream passes
-        (work_division, SDSC codegen) can size buffers/loops with. Fall back to
-        the concretized ``hint`` instead of propagating an unbounded symbol.
-        """
-        if hasattr(expr, "free_symbols") and expr.free_symbols:
-            if finite_upper_or_none(expr) is None:
-                return hint
-        return expr
-
-    repeat_info: dict = getattr(V.graph, "_repeat_info", {})
-
-    var_ranges = {
-        var: _concretize_for_cmp(val[0]) for var, val in iteration_space.items()
-    }
+    iteration_space = inputs.iteration_space
+    tensors = inputs.tensors
+    indirect_sizes = inputs.indirect_sizes
+    repeat_info = inputs.repeat_info
+    var_ranges = dict(inputs.concrete_ranges)
 
     # work division for each variable
     op_it_space_splits = {var: val[1] for var, val in iteration_space.items()}
@@ -691,6 +731,7 @@ def align_tensors(
             tensor["coordinates"],
             synthetic_var,
             indirect_sizes,
+            _concrete_alignment_value,
         )
         stick_dim.append(terms[-1].var)
         stick_size.append(terms[-1].dim_size)
@@ -726,9 +767,6 @@ def align_tensors(
                 ):
                     # add mod to splits unless stick dim and stick size
                     splits[var].add(mod)
-
-    if hasattr(V.graph, "_repeat_info"):
-        V.graph._repeat_info.clear()
 
     # Insert restored size-1 dimensions with offset/gap to the other tensors
     for var in new_vars:
@@ -783,9 +821,7 @@ def align_tensors(
             # Synthetic vars (z0, z1, …) are introduced by normalize_coordinates
             # for restored size-1 dims and are not in orig_ranges; fall back to
             # the concretized value (always 1) for those.
-            new_var_ranges[var] = _bounded_or_hint(
-                orig_ranges.get(var, var_ranges[var]), var_ranges[var]
-            )
+            new_var_ranges[var] = inputs.restored_ranges.get(var, var_ranges[var])
             # var can be a loop var or an indirect symbol
             if var in var_ranges:
                 new_var_ranges[var] = var_ranges[var]
@@ -903,10 +939,10 @@ def align_tensors(
     # bound, so fall back to the concretized size-hint instead of
     # propagating an unbounded symbol. See work_division.py's symbol_meta
     # for the same distinction.
-    for var, orig_expr in orig_ranges.items():
+    for var, restored_expr in inputs.restored_ranges.items():
         if var not in new_var_ranges or new_var_ranges[var] != var_ranges[var]:
             continue
-        new_var_ranges[var] = _bounded_or_hint(orig_expr, var_ranges[var])
+        new_var_ranges[var] = restored_expr
 
     # Iteration space should only contain loop variables, not indirect symbols.
     # Filter out any indirect symbols that were added during normalization.
@@ -918,6 +954,23 @@ def align_tensors(
     }
 
     return new_iteration_space, new_tensors, work_division_remap
+
+
+def align_tensors(
+    iteration_space: Dict[sympy.Symbol, Tuple[sympy.Expr, int]],
+    tensors: list[Dict[str, list[sympy.Expr]]],
+    indirect_sizes: "dict[sympy.Symbol, int] | None" = None,
+    repeat_info: "dict[sympy.Symbol, dict] | None" = None,
+) -> tuple[
+    dict[sympy.Symbol, tuple[sympy.Expr, int]],
+    list[dict[str, list]],
+    dict[sympy.Symbol, tuple[tuple[sympy.Symbol, int], ...]],
+]:
+    """Build explicit alignment inputs, then run the pure implementation."""
+
+    return align_tensors_pure(
+        build_alignment_inputs(iteration_space, tensors, indirect_sizes, repeat_info)
+    )
 
 
 def tiling_expr_to_device_expr(

--- a/torch_spyre/_inductor/work_division_constraints.py
+++ b/torch_spyre/_inductor/work_division_constraints.py
@@ -30,14 +30,17 @@ import dataclasses
 import typing
 from sympy import Expr, Symbol, divisors
 
-from torch._inductor.ir import ComputedBuffer, Reduction
 from torch._inductor.dependencies import MemoryDep
+from torch._inductor.ir import ComputedBuffer, Pointwise, Reduction
 from torch_spyre._C import ElementArrangement
 
 from .constants import (
     BATCH_MATMUL_OP,
     BATCH_MATMUL_FP8_OP,
+    CONV2D_FWD_OP,
+    DEPTHWISE_CONV2D_OP,
     KEEP_BY_INDEX_OP,
+    POOL_OPS,
     _MAX_K_PER_CORE,
     TOPK_MAX_K_PER_CORE,
     TOPK_OPS,
@@ -46,6 +49,7 @@ from .errors import Unsupported
 from .pass_utils import (
     concretize_expr,
     indirect_forbidden_split_syms,
+    is_restickify_coords,
     op_read_writes,
 )
 from .logging_utils import get_inductor_logger
@@ -101,6 +105,8 @@ def collect_work_division_constraints(
     for constraint in (
         coordinate_mask_blocked_vars,
         conv_spatial_blocked_vars,
+        reduction_window_blocked_vars,
+        restickify_padding_blocked_vars,
         qfp8wt_split_domains,
         qfp8wt_matmul_k_split_domains,
         topk_split_domains,
@@ -196,6 +202,55 @@ def conv_spatial_blocked_vars(ctx: WorkDivConstraintContext) -> ConstraintResult
         and concretize_expr(ctx.it_space[sym]) > 1
     }
     return ConstraintResult(blocked=blocked)
+
+
+def reduction_window_blocked_vars(ctx: WorkDivConstraintContext) -> ConstraintResult:
+    """Keep pooling and convolution kernel windows local to each core."""
+
+    if not isinstance(ctx.op.data, Reduction):
+        return ConstraintResult()
+    op = ctx.op.data.reduction_type
+    if op in POOL_OPS:
+        window_dims = ctx.reduction_vars
+    elif op == CONV2D_FWD_OP:
+        op_info = getattr(ctx.op.data, "op_info", None)
+        conv_params = (
+            op_info.get("conv_params", {}) if isinstance(op_info, dict) else {}
+        )
+        kernel_dims = sum(
+            int(conv_params.get(name, 1)) > 1 for name in ("kernel_h", "kernel_w")
+        )
+        window_dims = ctx.reduction_vars[-kernel_dims:] if kernel_dims else []
+    elif op == DEPTHWISE_CONV2D_OP:
+        # Depthwise reduction order is kh, kw, then optional group. Unlike the
+        # forward-conv path, a group dimension may therefore follow the window.
+        window_dims = ctx.reduction_vars[:2]
+    else:
+        return ConstraintResult()
+
+    return ConstraintResult(blocked=set(window_dims))
+
+
+def restickify_padding_blocked_vars(
+    ctx: WorkDivConstraintContext,
+) -> ConstraintResult:
+    """Keep an unaligned restickify stick dimension on one core."""
+
+    if (
+        not isinstance(ctx.op.data, Pointwise)
+        or len(ctx.input_tds) != 1
+        or not is_restickify_coords(
+            ctx.input_tds[0].device_coords, ctx.output_td.device_coords
+        )
+    ):
+        return ConstraintResult()
+
+    padded = {
+        dim
+        for dim, stick_size in ctx.stick_vars.items()
+        if concretize_expr(ctx.it_space[dim]) % stick_size
+    }
+    return ConstraintResult(blocked=padded)
 
 
 def has_qfp8wt_tensor(tds: "list[TensorDep]") -> bool:


### PR DESCRIPTION
Supersedes #3346 and is built on the now-merged #4062.

## Stack order

1. #4062 — merged foundation for symbol-keyed work division and LX planning.
2. #4090 — this PR; derives the final core assignment after alignment.
3. #3440 — grouped gather plus the graph-wide relayout validation gate.
4. #4061 — grouped broadcast extension.
5. #3955 — completed-reduction handoff extension.

Each later PR depends on the previous PR. Review starts here.

## Summary

- Derive final core assignment after tensor alignment, using final iteration symbols.
- Use one generic mapping implementation and store the complete result in `OpSpec`.
- Share one pure alignment-input path between Scheduler validation and codegen.
- Keep SuperDSC serialization-only.

The pre-scheduler mapping is temporary planning data. Final ownership is derived after alignment.

This carries forward the functionality introduced in #3346 by @avery-blanchard and design by @cyang49.

## Validation

- 617 focused tests pass, with 1 skip and 3 expected xfails.
- Alignment preview leaves graph state unchanged and produces identical codegen inputs.
- Ruff, formatting, scoped mypy, DCO, and commit signatures pass.
