### PR TITLE
fix(inductor): give every OpSpec a unique sdsc file for the bundler

### DIFF
--- a/tests/inductor/test_symbolic_dim_bundle.py
+++ b/tests/inductor/test_symbolic_dim_bundle.py
@@ -19,10 +19,13 @@ compile_op_spec is mocked throughout so no Spyre hardware is required.
 
 import os
 import tempfile
+
+import regex as re
 from unittest.mock import patch
 
 from torch._inductor.test_case import TestCase as InductorTestCase
 
+from torch_spyre._inductor import config
 from torch_spyre._inductor.codegen.bundle import (
     _extract_symbol_ids,
     generate_bundle,
@@ -406,3 +409,79 @@ class TestGenerateBundleDimensionSymbols(InductorTestCase):
             f"%pool = sdscbundle.device_mem_allocate {MAX_POOL_SIZE_BYTES} bytes : index",
             bundle,
         )
+
+
+class TestSdscCacheUniqueFilenames(InductorTestCase):
+    """The sdsc_cache must never make two sdsc_execute ops share a filename.
+
+    The backend's SDSC-loading pass registers each sdsc_filename exactly once
+    and assumes it appears in a single sdsc_execute (the SBF bundler enforces
+    this with a uniqueSdscMap_ that rejects a repeated filename outright). HBM
+    pool planning routinely executes one structurally-identical kernel across
+    several pool regions -- the pool address is an sdsc_execute operand, not
+    part of the SDSC json -- which the cache would otherwise collapse onto a
+    single reused file, emitting several sdsc_execute ops that share one
+    filename and crashing the bundler. Every OpSpec must get its own file.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.output_dir = self._tmpdir.name
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+        super().tearDown()
+
+    def _run_identical_ops(self, n: int) -> str:
+        """Bundle n structurally-identical ops with the cache on; return mlir.
+
+        The real compile_op_spec bakes its idx argument into the SDSC json's
+        top-level key. The cache-key probe always passes idx=0, so identical
+        ops collide on the cache key (hits after the first); the real call
+        passes the freshly-allocated sdsc idx, so each op's json -- and hence
+        its sdsc file -- must be distinct.
+        """
+
+        def fake_compile(idx, entry, symbols, offset):
+            return (
+                _make_sdsc_json(sdsc_idx=idx, hbm_sym_ids_per_core={"[0, 0, 0]": -1}),
+                [0],
+                [],
+                [SymbolKind.kernel(arg_index=0)],
+            )
+
+        op_specs = [_minimal_op_spec() for _ in range(n)]
+        with (
+            config.patch({"sdsc_cache": True}),
+            patch(
+                "torch_spyre._inductor.codegen.bundle.compile_op_spec",
+                side_effect=fake_compile,
+            ),
+        ):
+            generate_bundle("test", self.output_dir, op_specs, pool_size=0)
+        with open(os.path.join(self.output_dir, "bundle.mlir")) as f:
+            return f.read()
+
+    def test_identical_ops_get_distinct_sdsc_filenames(self):
+        """Three identical ops -> three sdsc_execute ops, three distinct files.
+
+        Regression: with the old file-reuse behavior the cache hits collapsed
+        all three onto sdsc_0.json, producing duplicate sdsc_filename refs.
+        """
+        bundle = self._run_identical_ops(3)
+
+        filenames = re.findall(r'sdsc_filename="([^"]+)"', bundle)
+        self.assertEqual(len(filenames), 3, f"expected 3 sdsc_execute, got {filenames}")
+        self.assertEqual(
+            len(set(filenames)),
+            3,
+            f"duplicate sdsc_filename(s) violate the backend 1:1 invariant: {filenames}",
+        )
+
+        written = sorted(
+            f
+            for f in os.listdir(self.output_dir)
+            if f.startswith("sdsc_") and f.endswith(".json")
+        )
+        self.assertEqual(set(filenames), set(written))

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -138,7 +138,8 @@ def generate_bundle(
     if sdsc_cache_counts is not None:
         hits, misses = sdsc_cache_counts
         logger.info(
-            "sdsc_cache: %d/%d ops reused an existing sdsc file (%d unique)",
+            "sdsc_cache: %d/%d ops were structurally identical to an earlier "
+            "op (%d unique; each still emitted as its own sdsc file)",
             hits,
             hits + misses,
             misses,
@@ -497,15 +498,15 @@ def _compile_specs(
                     arg_indices
                 )
                 cached = sdsc_cache.get(cache_key)
-            if cached is None:
-                idx = sdsc_counter[0]
-                sdsc_counter[0] += 1
-                if _sdsc_cache_counts is not None:
-                    _sdsc_cache_counts[1] += 1
-            else:
-                idx, cached_json = cached
-                if _sdsc_cache_counts is not None:
-                    _sdsc_cache_counts[0] += 1
+            # The SBF bundler's uniqueSdscMap_ requires each sdsc_filename in
+            # exactly one sdsc_execute, so every OpSpec gets its own file even
+            # on a cache hit -- reuse would emit duplicate filenames and abort
+            # the bundler. Pool planning makes reuse routine (one kernel across
+            # many pool regions). The cache lookup now only tallies duplicates.
+            idx = sdsc_counter[0]
+            sdsc_counter[0] += 1
+            if _sdsc_cache_counts is not None:
+                _sdsc_cache_counts[0 if cached is not None else 1] += 1
             sdsc_json, local_sym_values, affine_strides, local_symbol_kinds = (
                 compile_op_spec(
                     idx,
@@ -516,13 +517,12 @@ def _compile_specs(
             )
             symbol_id_offset_counter[0] += len(local_sym_values)
             file_name = f"sdsc_{idx}.json"
-            if cached is None:
-                cached_json = sdsc_json
-                if sdsc_cache is not None:
-                    sdsc_cache[cache_key] = (idx, cached_json)
-                with open(os.path.join(output_dir, file_name), "w") as f:
-                    logger.info(f"Generating {f.name}")
-                    json.dump(sdsc_json, f, indent=2)
+            cached_json = sdsc_json
+            if sdsc_cache is not None and cached is None:
+                sdsc_cache[cache_key] = (idx, cached_json)
+            with open(os.path.join(output_dir, file_name), "w") as f:
+                logger.info(f"Generating {f.name}")
+                json.dump(sdsc_json, f, indent=2)
             compiled.append(
                 (
                     sdsc_json,


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

`sdsc_cache` (#3868) deduplicated structurally-identical ops onto one `sdsc_N.json`, so several `sdsc_execute` ops shared a filename. The SBF bundler's `uniqueSdscMap_` requires each `sdsc_filename` in exactly one `sdsc_execute` and aborts (`dxp_standalone` exit 1) on a repeat. HBM pool planning runs one kernel across many pool regions (the pool address is an `sdsc_execute` operand, not in the json), making the collision routine — so compiled attention fails to bundle with the planner on.

Give each `OpSpec` its own `sdsc` file even on a cache hit; the emitted bundle now matches `SPYRE_INDUCTOR_SDSC_CACHE=0`. The cache lookup is kept only to tally structural duplicates.

This gets the attention tests passing again on spyre-inference: https://github.com/torch-spyre/spyre-inference/pull/665

#### Which issue(s) this PR is related to:

Fixes: #4094 

Related: #3868 (introduced the cache), #3707 (pool_base_addr codegen).

#### Special notes for your reviewer:

File-level dedup is incompatible with the one-filename-per-`sdsc_execute` invariant; a follow-up could drop the now-bookkeeping-only cache.

#### Does this PR introduce a user-facing change?

No API change; bundles that previously aborted under pool planning now build.

#### Additional note:

Test plan:
- `pytest tests/inductor/test_symbolic_dim_bundle.py` → 18 passed (adds `TestSdscCacheUniqueFilenames`).
- Reverting the fix collapses the new test to one reused filename (assert fires).
