### PR TITLE
inductor: lower BF16 torch.full natively

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -6872,6 +6872,29 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
 
         self.compare_with_cpu(fn, needs_device=True, cpu_compile=False)
 
+    def test_full_bfloat16_cpu(self):
+        """Compiled BF16 ``full`` stays in native Spyre lowering."""
+
+        def fn():
+            return torch.full(
+                (4, 64), 1.5, dtype=torch.bfloat16, device=utils_inductor.DEVICE
+            )
+
+        with fresh_inductor_cache():
+            actual, source_codes = run_and_get_code(torch.compile(fn, dynamic=False))
+        self.assertEqual(actual.dtype, torch.bfloat16)
+        torch.testing.assert_close(
+            actual.cpu(), torch.full((4, 64), 1.5, dtype=torch.bfloat16)
+        )
+        generated = "\n".join(source_codes)
+        self.assertIn("async_compile.sdsc(", generated)
+        self.assertFalse(
+            any(
+                " = torch.ops.aten.full.default(" in line
+                for line in generated.splitlines()
+            )
+        )
+
     def test_dim_op_cpu(self, op, dim, *args):
         def fn(*args):
             return op(dim, *args)

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -1430,7 +1430,7 @@ def lower_full(size, fill_value, dtype=None, layout=None, device=None, pin_memor
     assert not pin_memory, f"doesn't support pin_memory={pin_memory}"
     if dtype is None:
         dtype = torch.get_default_dtype()
-    if dtype not in (torch.float16, torch.float32):
+    if dtype not in (torch.float16, torch.bfloat16, torch.float32):
         return ir.TensorBox.create(
             ir.FallbackKernel.create(
                 torch.ops.aten.full.default,


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does

> **Draft / discussion PR.** This is the BF16 torch.full fix extracted from #3981 so it can be reviewed and merged independently.

[lower_full](https://github.com/torch-spyre/torch-spyre/blob/a7c6c18a7683f254aa9a1e156900e14dfd034749/torch_spyre/_inductor/lowering.py#L1428) natively lowered FP16 and FP32 fills, but sent BF16 fills through ir.FallbackKernel.create. Granite attention initializes its online-softmax denominator with BF16 torch.zeros / torch.full. The generic fallback becomes an opaque scheduler barrier, which can split one hinted recurrence into two coarse-tile groups and make compilation reject the repeated hint scope.

The source change at [lowering.py L1433](https://github.com/torch-spyre/torch-spyre/blob/a7c6c18a7683f254aa9a1e156900e14dfd034749/torch_spyre/_inductor/lowering.py#L1433) adds torch.bfloat16 to the existing native floating-point dtype set. BF16 fills then follow the same SpyreConstantFallback scalar plus Pointwise.create broadcast path as FP16 and FP32; unsupported dtypes still use the generic aten.full fallback.

**Before:** generated wrapper code directly called torch.ops.aten.full.default for a BF16 fill.

**After:** generated wrapper code creates a BF16 Spyre scalar and launches an SDSC identity/broadcast kernel, so the fill remains schedulable and fusible with surrounding Spyre work.

#### Test

[TestOps.test_full_bfloat16_cpu](https://github.com/torch-spyre/torch-spyre/blob/a7c6c18a7683f254aa9a1e156900e14dfd034749/tests/inductor/test_inductor_ops.py#L6875) compiles a BF16 torch.full on Spyre, checks its dtype and values, and verifies generated code contains an SDSC kernel rather than a direct torch.ops.aten.full.default fallback.

    source /mnt/home/spyre/torch-spyre-docs/scripts/dev-env.sh
    /mnt/home/spyre/.venv/bin/pytest -q tests/inductor/test_inductor_ops.py -k full_bfloat16_cpu
    1 passed, 2379 deselected

#### Relationship to #3981

The lowering change and Granite-specific BF16 regression were removed from #3981. That PR still exercises BF16 Granite attention, so it should be validated with this PR merged or applied first.

The combined #3981 + #4102 integration tree passed the Granite 3.3 8B CPU-vs-Spyre E2E comparison from a fresh compiler cache: prefill plus four decode steps matched top-1 5/5 with no NaNs.