### PR TITLE
fix(tests): give single-card and multi-card legs distinct junit-xml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,21 @@ ifeq ($(TEST_TYPE),perf)
 	@test -f "$(RESULTS_DIR)/report.xml" || \
 		{ echo "ERROR: spyre-perf-suite did not emit $(RESULTS_DIR)/report.xml" >&2; \
 		  exit 1; }
+# The single-card and multi-card legs run as two separate run_test.sh
+# invocations, and run_test.sh writes the caller's --junit-xml destination with
+# a truncating merge once per invocation. If both legs share one
+# --junit-xml=FILE the second leg overwrites the first, so only one leg's
+# results survive. Give each leg its own file when the caller asked for a
+# report: the single-card leg keeps the requested path (so existing consumers
+# see the same name), and the multi-card leg writes a "<stem>-multi-card.xml"
+# sibling. CI ingesters glob *.xml, so both files are collected. With no
+# --junit-xml the sed is a no-op and both legs run with PYTEST_ARGS unchanged.
 else ifneq ($(wildcard $(TEST_CONFIGS)/.),)
 	@rc=0; \
-	$(MAKE) tests-single-card TEST_TYPE="$(TEST_TYPE)" TEST_CONFIGS="$(TEST_CONFIGS)" PYTEST_ARGS="$(PYTEST_ARGS)" || rc=1; \
-	$(MAKE) tests-multi-card TEST_TYPE="$(TEST_TYPE)" PYTEST_ARGS="$(PYTEST_ARGS)" || rc=1; \
+	_single_args='$(PYTEST_ARGS)'; \
+	_multi_args="$$(printf '%s' '$(PYTEST_ARGS)' | sed -E 's#(--junit-xml[= ]+[^ ]*)\.xml#\1-multi-card.xml#')"; \
+	$(MAKE) tests-single-card TEST_TYPE="$(TEST_TYPE)" TEST_CONFIGS="$(TEST_CONFIGS)" PYTEST_ARGS="$$_single_args" || rc=1; \
+	$(MAKE) tests-multi-card TEST_TYPE="$(TEST_TYPE)" PYTEST_ARGS="$$_multi_args" || rc=1; \
 	exit $$rc
 else
 	@if [ ! -f "$(TEST_CONFIGS)" ]; then \


### PR DESCRIPTION
## What

`make tests` fans out into two `run_test.sh` invocations, `tests-single-card`
then `tests-multi-card`, and passes both the same `PYTEST_ARGS`. When
`PYTEST_ARGS` carries `--junit-xml=FILE`, both legs write the same `FILE`, and
the second leg erases the first. This gives each leg its own report file.

## The defect

`run_test.sh` writes the caller's `--junit-xml` destination once per invocation
with a truncating merge (it merges its own shard files into that path and
overwrites whatever was there). The `tests:` target runs it twice with one
shared `--junit-xml`:

```make
$(MAKE) tests-single-card ... PYTEST_ARGS="$(PYTEST_ARGS)"
$(MAKE) tests-multi-card  ... PYTEST_ARGS="$(PYTEST_ARGS)"
```

So `make tests TEST_TYPE=trunk PYTEST_ARGS="... --junit-xml=trunk.xml"` runs the
single-card leg (writes `trunk.xml`), then the multi-card leg (writes
`trunk.xml` again, truncating). Only the multi-card results survive in the
report. If the multi-card leg produces an empty report, the single-card results
are lost and the final XML shows 0 tests even though the single-card leg passed.

This only affects the `make tests` composite path. The GHA test matrix is not
affected because it calls `run_test.sh` directly, once per matrix job, each with
its own `junit_xml_path`.

## Fix

`Makefile`, `tests:` fan-out only. Rewrite `PYTEST_ARGS` per leg when the caller
passed `--junit-xml=FILE`:

- single-card leg keeps `FILE` (existing consumers see the same name),
- multi-card leg writes a `<stem>-multi-card.xml` sibling.

```make
_single_args='$(PYTEST_ARGS)'; \
_multi_args="$$(printf '%s' '$(PYTEST_ARGS)' | sed -E 's#(--junit-xml[= ]+[^ ]*)\.xml#\1-multi-card.xml#')"; \
```

CI ingesters already glob `*.xml` (the `TEST_TYPE=perf` comment in this same
target notes `ingest_xml.py globs *.xml non-recursively`), so both files are
collected as separate rows with no ingester or schema change. This matches the
approach in #3843, which preserves per-attempt reports as additional `*.xml`
files rather than a single fixed path.

## Verified

`make -n` parses; the `sed` transform was checked directly across forms:

| input | output |
|---|---|
| `-v --skip-slow --junit-xml=/x/trunk.xml` | `... --junit-xml=/x/trunk-multi-card.xml` |
| `--junit-xml /tmp/trunk.xml --more` | `--junit-xml /tmp/trunk-multi-card.xml --more` |
| `-v --skip-slow` (no junit) | unchanged |
| `--junit-xml=/tmp/report` (no .xml) | unchanged |

The transform touches only the junit path, so multi-word pytest args (for
example a `-m` marker expression) pass through untouched.

## Scope / notes

- This touches shared test infrastructure that every `make tests` caller uses;
  please review rather than self-merge.
- Related and complementary: #4105 fixes a separate defect in
  `tests/distributed/split_output.sh` (an unquoted `$@` that word-split the
  `-m` marker so distributed shards collected 0 tests). Both are needed for a
  correct `make tests TEST_TYPE=trunk` report on a two-card host: #4105 makes
  the distributed leg actually collect tests, and this PR keeps its results
  from clobbering the single-card leg's report.
