### PR TITLE
fix(inductor): reject interleaved LX ownership views

### DIFF
--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -431,6 +431,7 @@ def test_planner_and_sdsc_use_the_same_mapping(monkeypatch, op, reduction_contig
         write_index=dims[0],
         read_index=dims[-1],
         dep_coeff={dims[0]: 1, dims[1]: 2, dims[2]: 0},
+        dep_device_coordinates=(dims[0], dims[1]),
         device_size=[2, 4],
         stride_map=[1, 2],
         elems_per_stick=64,
@@ -465,6 +466,15 @@ def test_flattened_iteration_span_is_not_a_single_axis_view():
         write_index=512 * heads + flat,
         read_index=512 * heads + flat,
         dep_coeff={heads: 512, flat: 1},
+        dep_device_coordinates=(
+            sympy.floor(flat / 256),
+            sympy.S.Zero,
+            sympy.S.Zero,
+            sympy.S.Zero,
+            sympy.floor(sympy.Mod(flat, 256) / 64),
+            heads,
+            sympy.Mod(flat, 64),
+        ),
         device_size=[2, 1, 1, 1, 4, 16, 64],
         stride_map=[256, -1, -1, -1, 64, 512, 1],
         elems_per_stick=64,
@@ -483,3 +493,86 @@ def test_flattened_iteration_span_is_not_a_single_axis_view():
     assert not representable
     assert not partial
     assert not view.work_slice_dims
+
+
+def test_reshape_changes_per_core_ownership_within_one_device_axis():
+    """A split of an inner term is not a contiguous split of the containing axis.
+
+    This is the Gemma 4 decode geometry: the producer splits a flattened
+    512-element dimension into two contiguous 256-element halves, while its
+    consumer views that dimension as ``[2, 256]`` and splits the inner 256.
+    The latter owns alternating pairs of sticks, not contiguous groups of four.
+    """
+    producer_head, producer_flat = sympy.symbols("producer_head producer_flat")
+    producer_prep = pass_utils_module._ViewPrep(
+        iter_space={producer_head: 16, producer_flat: 512},
+        write_index=512 * producer_head + producer_flat,
+        read_index=512 * producer_head + producer_flat,
+        dep_coeff={producer_head: 512, producer_flat: 1},
+        dep_device_coordinates=(
+            sympy.S.Zero,
+            sympy.S.Zero,
+            sympy.floor(producer_flat / 64),
+            producer_head,
+            sympy.Mod(producer_flat, 64),
+        ),
+        device_size=[1, 1, 8, 16, 64],
+        stride_map=[-1, -1, 64, 512, 1],
+        elems_per_stick=64,
+        device_stride_to_dim={64: 2, 512: 3, 1: 4},
+        stick_host_stride=1,
+        num_stick_dim=2,
+        num_stick=8,
+        num_stick_stride=64,
+        is_matmul=False,
+    )
+    producer_view, _, producer_representable = (
+        pass_utils_module._per_core_view_from_prep(
+            producer_prep,
+            {producer_head: 16, producer_flat: 2},
+        )
+    )
+
+    consumer_head, consumer_outer, consumer_inner = sympy.symbols(
+        "consumer_head consumer_outer consumer_inner"
+    )
+    consumer_prep = pass_utils_module._ViewPrep(
+        iter_space={consumer_head: 16, consumer_outer: 2, consumer_inner: 256},
+        write_index=512 * consumer_head + 256 * consumer_outer + consumer_inner,
+        read_index=512 * consumer_head + 256 * consumer_outer + consumer_inner,
+        dep_coeff={consumer_head: 512, consumer_outer: 256, consumer_inner: 1},
+        dep_device_coordinates=(
+            sympy.S.Zero,
+            sympy.S.Zero,
+            4 * consumer_outer + sympy.floor(consumer_inner / 64),
+            consumer_head,
+            sympy.Mod(consumer_inner, 64),
+        ),
+        device_size=[1, 1, 8, 16, 64],
+        stride_map=[-1, -1, 64, 512, 1],
+        elems_per_stick=64,
+        device_stride_to_dim={64: 2, 512: 3, 1: 4},
+        stick_host_stride=1,
+        num_stick_dim=2,
+        num_stick=8,
+        num_stick_stride=64,
+        is_matmul=False,
+    )
+    consumer_view, _, consumer_representable = (
+        pass_utils_module._per_core_view_from_prep(
+            consumer_prep,
+            {consumer_head: 16, consumer_outer: 1, consumer_inner: 2},
+        )
+    )
+
+    assert producer_representable
+    assert not consumer_representable
+    assert producer_view != consumer_view
+
+    # Splitting the outer term of the same compound coordinate is contiguous:
+    # each core group owns one four-stick half of the physical axis.
+    _, _, outer_split_representable = pass_utils_module._per_core_view_from_prep(
+        consumer_prep,
+        {consumer_head: 16, consumer_outer: 2, consumer_inner: 1},
+    )
+    assert outer_split_representable

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -21,7 +21,7 @@ import sympy
 
 import torch_spyre._inductor.codegen.superdsc as superdsc_module
 import torch_spyre._inductor.pass_utils as pass_utils_module
-from torch_spyre._C import DataFormats
+from torch_spyre._C import DataFormats, ElementArrangement
 from torch_spyre._inductor.codegen.superdsc import parse_op_spec
 from torch_spyre._inductor.constants import (
     BATCH_MATMUL_FP8_OP,
@@ -495,6 +495,57 @@ def test_flattened_iteration_span_is_not_a_single_axis_view():
     assert not view.work_slice_dims
 
 
+def _prepare_compound_axis_view(iter_space, index, repeat_info=None):
+    device_layout = pass_utils_module.SpyreTensorLayout(
+        [1, 1, 8, 16, 64],
+        [-1, -1, 64, 512, 1],
+        DataFormats.SEN169_FP16,
+        ElementArrangement.STANDARD,
+    )
+    layout = pass_utils_module.FixedTiledLayout(
+        "spyre:0",
+        pass_utils_module.torch.float16,
+        [16, 512],
+        [512, 1],
+        device_layout,
+    )
+    dep = pass_utils_module.MemoryDep(
+        "buf",
+        index,
+        tuple(iter_space),
+        tuple(iter_space.values()),
+    )
+    graph = SimpleNamespace(
+        _repeat_info={} if repeat_info is None else repeat_info,
+        get_buffer=lambda name: SimpleNamespace(layout=layout),
+    )
+    with pass_utils_module.V.set_graph_handler(graph):
+        prep = pass_utils_module._prepare_per_core_view(
+            object(),
+            dep,
+            "buf",
+            parts=(iter_space, index, index),
+        )
+    assert prep is not None
+    return prep, graph
+
+
+def test_prepare_per_core_view_does_not_record_repeat_info():
+    head, flat = sympy.symbols("head flat", integer=True, nonnegative=True)
+    prior = sympy.Symbol("prior")
+    existing = {prior: {"kind": "mod", "modulus": 2}}
+    before = dict(existing)
+
+    _, graph = _prepare_compound_axis_view(
+        {head: 16, flat: 512},
+        512 * head + sympy.Mod(flat, 256),
+        existing,
+    )
+
+    assert graph._repeat_info is existing
+    assert graph._repeat_info == before
+
+
 def test_reshape_changes_per_core_ownership_within_one_device_axis():
     """A split of an inner term is not a contiguous split of the containing axis.
 
@@ -503,28 +554,12 @@ def test_reshape_changes_per_core_ownership_within_one_device_axis():
     consumer views that dimension as ``[2, 256]`` and splits the inner 256.
     The latter owns alternating pairs of sticks, not contiguous groups of four.
     """
-    producer_head, producer_flat = sympy.symbols("producer_head producer_flat")
-    producer_prep = pass_utils_module._ViewPrep(
-        iter_space={producer_head: 16, producer_flat: 512},
-        write_index=512 * producer_head + producer_flat,
-        read_index=512 * producer_head + producer_flat,
-        dep_coeff={producer_head: 512, producer_flat: 1},
-        dep_device_coordinates=(
-            sympy.S.Zero,
-            sympy.S.Zero,
-            sympy.floor(producer_flat / 64),
-            producer_head,
-            sympy.Mod(producer_flat, 64),
-        ),
-        device_size=[1, 1, 8, 16, 64],
-        stride_map=[-1, -1, 64, 512, 1],
-        elems_per_stick=64,
-        device_stride_to_dim={64: 2, 512: 3, 1: 4},
-        stick_host_stride=1,
-        num_stick_dim=2,
-        num_stick=8,
-        num_stick_stride=64,
-        is_matmul=False,
+    producer_head, producer_flat = sympy.symbols(
+        "producer_head producer_flat", integer=True, nonnegative=True
+    )
+    producer_prep, _ = _prepare_compound_axis_view(
+        {producer_head: 16, producer_flat: 512},
+        512 * producer_head + producer_flat,
     )
     producer_view, _, producer_representable = (
         pass_utils_module._per_core_view_from_prep(
@@ -534,29 +569,14 @@ def test_reshape_changes_per_core_ownership_within_one_device_axis():
     )
 
     consumer_head, consumer_outer, consumer_inner = sympy.symbols(
-        "consumer_head consumer_outer consumer_inner"
+        "consumer_head consumer_outer consumer_inner",
+        integer=True,
+        nonnegative=True,
     )
-    consumer_prep = pass_utils_module._ViewPrep(
-        iter_space={consumer_head: 16, consumer_outer: 2, consumer_inner: 256},
-        write_index=512 * consumer_head + 256 * consumer_outer + consumer_inner,
-        read_index=512 * consumer_head + 256 * consumer_outer + consumer_inner,
-        dep_coeff={consumer_head: 512, consumer_outer: 256, consumer_inner: 1},
-        dep_device_coordinates=(
-            sympy.S.Zero,
-            sympy.S.Zero,
-            4 * consumer_outer + sympy.floor(consumer_inner / 64),
-            consumer_head,
-            sympy.Mod(consumer_inner, 64),
-        ),
-        device_size=[1, 1, 8, 16, 64],
-        stride_map=[-1, -1, 64, 512, 1],
-        elems_per_stick=64,
-        device_stride_to_dim={64: 2, 512: 3, 1: 4},
-        stick_host_stride=1,
-        num_stick_dim=2,
-        num_stick=8,
-        num_stick_stride=64,
-        is_matmul=False,
+    consumer_index = 512 * consumer_head + 256 * consumer_outer + consumer_inner
+    consumer_prep, _ = _prepare_compound_axis_view(
+        {consumer_head: 16, consumer_outer: 2, consumer_inner: 256},
+        consumer_index,
     )
     consumer_view, _, consumer_representable = (
         pass_utils_module._per_core_view_from_prep(

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -2444,6 +2444,11 @@ class _ViewPrep(NamedTuple):
     # concretize_expr(dep.index.coeff(sym)) over the *full* iteration space, so
     # the per-candidate path does a dict lookup instead of a sympy .coeff() call.
     dep_coeff: dict
+    # The target dependency projected into the buffer's physical device
+    # coordinates.  A single physical axis can contain multiple logical loop
+    # symbols after a reshape; their relative host strides determine whether a
+    # split owns one contiguous slice or several interleaved slices.
+    dep_device_coordinates: tuple["sympy.Expr", ...]
     device_size: Any
     stride_map: Any
     elems_per_stick: int
@@ -2520,12 +2525,17 @@ def _prepare_per_core_view(
     # iteration-space symbols, so precomputing the coeff for every iter symbol
     # covers every symbol the per-candidate path can ask for.
     dep_coeff = {sym: concretize_expr(dep.index.coeff(sym)) for sym in iter_space}
+    coordinates = try_device_coordinates(dev_layout, dep, None)
+    if coordinates is None:
+        return None
+    dep_device_coordinates = tuple(coordinates)
 
     return _ViewPrep(
         iter_space=iter_space,
         write_index=write_index,
         read_index=read_index,
         dep_coeff=dep_coeff,
+        dep_device_coordinates=dep_device_coordinates,
         device_size=device_size,
         stride_map=stride_map,
         elems_per_stick=elems_per_stick,
@@ -2665,6 +2675,31 @@ def _per_core_view_from_prep(
             if split * k == num_stick:
                 dev_dim = num_stick_dim
                 split *= k
+
+        # A reshape can place more than one logical loop symbol on one physical
+        # device axis.  Splitting an inner symbol while an unsplit outer symbol
+        # also contributes to that axis gives each core several interleaved
+        # regions, which PerCoreView's single ``(axis, slice)`` cannot express.
+        #
+        # For example, ``4 * outer + floor(inner / 64)`` over an 8-stick axis,
+        # with ``inner`` split in two, gives the two core groups ownership of
+        # {0, 1, 4, 5} and {2, 3, 6, 7}; it is not the contiguous 2-way split
+        # represented by ``work_slice_dims=(axis, 2)``.  Host-index coefficient
+        # order identifies those outer contributors without depending on the
+        # iteration order of SymPy's ``free_symbols`` set.
+        if dev_dim is not None:
+            axis_symbols = prep.dep_device_coordinates[dev_dim].free_symbols
+            if any(
+                other != sym
+                and per_sym.get(other, 1) <= 1
+                and prep.dep_coeff.get(other, 0) > h
+                for other in axis_symbols
+            ):
+                logger.debug(
+                    f"split iteration {sym} is interleaved by an outer loop "
+                    f"on device dim {dev_dim}; returning empty_view"
+                )
+                return unrepresentable
         # TODO: two known unhandled failure modes fall through to the
         # empty_view fallback (cases catalogued in
         # per_core_view_failing_cases.md):


### PR DESCRIPTION
## Summary

- Detect logical loop symbols that are interleaved within one physical device axis.
- Reject inner-symbol splits that `PerCoreView` cannot represent as a single contiguous per-core slice.
- Keep those values in HBM instead of allowing an invalid per-core LX placement.
- Add the exact Gemma 4 reshape geometry as a regression, plus a representable outer-split control.

## Root cause

Gemma 4 decode produces a buffer whose physical stick-axis coordinate is:

```text
4 * outer + floor(inner / 64)
```

For `outer=2` and `inner=256`, splitting `inner` in two gives these physical-axis ownership sets:

```text
core group 0: {0, 1, 4, 5}
core group 1: {2, 3, 6, 7}
```

The producer's flattened 512-element loop instead owns contiguous halves:

```text
core group 0: {0, 1, 2, 3}
core group 1: {4, 5, 6, 7}
```

`PerCoreView` previously represented both as the same two-way split of the physical axis. That let the LX planner treat the producer and consumer as ownership-compatible even though the consumer reads interleaved regions from storage written in contiguous regions.

The fix records the dependency's physical device coordinates while preparing a view. When a split logical symbol is nested inside an unsplit outer symbol on the same physical axis, the view is marked unrepresentable. The existing conservative fallback then keeps the value in HBM. Splitting the outer term remains representable.

## Relationship to #4027

This is a follow-up to #4027, which fixed the first Gemma 4 `PerCoreView` bug: a single flattened loop spanning beyond the capacity of the physical stickified axis.

No later merged PR reintroduced this failure. Controlled fresh-cache tests ruled out the initially suspected #3800 and #4062 boundaries: the merged #4027 revision itself can produce either 5/5 or 1/5 Gemma token agreement. #4027 did not cover this second, compound-axis ownership shape.

The apparent regression was nondeterministic because the existing back-gap eligibility check selects one element from `coord_expr.free_symbols`. Depending on symbol/set ordering, it sometimes rejected the affected value from LX and masked this ownership bug; other orderings admitted it and corrupted decode. This change fixes the ownership representation directly rather than broadening that unrelated back-gap heuristic.

## Validation

- New focused regression fails on unmodified `main` and passes with this change.
- Gemma 4 12B fresh-cache token comparison: 5/5 for `PYTHONHASHSEED=0`, `1`, and `3`.
- Core mapping, scratchpad use, and work-division hint suites: 169 passed, 2 expected xfails, 8 subtests passed.
- Scratchpad pattern/solver and work-division suites: 296 passed, 11 expected xfails, 6 subtests passed.
- `pre-commit run --all-files`: passed.
