### PR TITLE
Fix versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,9 @@ os.environ.setdefault(
 
 import glob
 
+import regex as re
 from setuptools import Command, setup
+from setuptools.command.build_py import build_py as _build_py
 
 PATH_NAME = "torch_spyre"
 PACKAGE_NAME = "torch_spyre"
@@ -35,13 +37,23 @@ DISTRIBUTED_PACKAGE_NAME = "spyre_ccl"
 
 
 def get_torch_spyre_version() -> str:
-    version_ns: dict[str, object] = {}
-    with open(f"{PATH_NAME}/version.py") as f:
+    # Not ROOT_DIR: that is defined further down, after this runs.
+    version_path = Path(__file__).absolute().parent / PATH_NAME / "version.py"
+    # Seed __file__ so version.py can locate the repo root and resolve the git
+    # commit; a bare exec() namespace has no __file__ and it would fall back to
+    # the cwd. version.py tolerates either, but being explicit keeps the result
+    # independent of where the build was invoked from.
+    version_ns: dict[str, object] = {"__file__": str(version_path)}
+    with open(version_path) as f:
         exec(f.read(), version_ns)
         version = cast(str, version_ns["__version__"])
     return version
 
 
+# Resolved version, e.g. "0.0.1+gabc1234" in a git checkout. Consumed by
+# BuildPyWithVersion to stamp the wheel's copy of version.py; the project version
+# in metadata comes separately from pyproject.toml's attr: pointer, which reads
+# the static literal instead.
 version = get_torch_spyre_version()
 
 
@@ -208,6 +220,57 @@ class clean(Command):
                 shutil.rmtree(str(path), ignore_errors=True)
 
 
+# Matches the single top-level `__version__ = "..."` literal in version.py.
+# A regex, not str.replace of the exact literal: on an incremental build the
+# staged copy may already carry a stale `0.0.1+gOLD`, which a literal replace
+# would silently fail to update (shipping the wrong commit). This re-stamps
+# whatever is there.
+_VERSION_LITERAL_RE = re.compile(r'^__version__ = "[^"]*"$', re.MULTILINE)
+
+
+class BuildPyWithVersion(_build_py):
+    """Bake the resolved version into the ``build_lib`` copy of ``version.py``.
+
+    An installed wheel has no ``.git`` beside it, so ``version.py``'s import-time
+    git lookup cannot fire once installed. Rewriting the *staged* copy gives
+    wheels a literal ``__version__ = "0.0.1+gabc1234"``.
+
+    The tracked source file is never touched: builds run inside the checkout
+    (every CI build passes ``--no-build-isolation``), so mutating it would dirty
+    the working tree and could trip the pre-commit hooks.
+    """
+
+    def build_module(self, module, module_file, package):
+        result = super().build_module(module, module_file, package)
+        pkg = package if isinstance(package, str) else ".".join(package)
+        if module == "version" and pkg == PACKAGE_NAME:
+            outfile = self.get_module_outfile(self.build_lib, pkg.split("."), module)
+            self._stamp_version(outfile)
+        return result
+
+    def _stamp_version(self, outfile):
+        if "+" not in version:
+            # No git metadata available at build time (exported tarball, no git
+            # binary, ...). Leave the copy pristine so the wheel reports the
+            # plain base version rather than a bogus one.
+            print(f"build_py: no git metadata; keeping version {version}")
+            return
+        original = Path(outfile).read_text()
+        stamped, count = _VERSION_LITERAL_RE.subn(
+            f'__version__ = "{version}"', original, count=1
+        )
+        if count != 1:
+            # The literal was moved, reformatted or re-quoted. Fail loudly:
+            # silently shipping a stale version is the exact bug this fixes.
+            raise RuntimeError(
+                f"could not find a top-level '__version__ = \"...\"' literal in "
+                f"{outfile}; {PATH_NAME}/version.py and setup.py's "
+                f"BuildPyWithVersion have drifted."
+            )
+        Path(outfile).write_text(stamped)
+        print(f"build_py: baked __version__ = {version!r} into {outfile}")
+
+
 if __name__ == "__main__":
     import sys
 
@@ -299,6 +362,7 @@ if __name__ == "__main__":
             ext_modules=ext_modules,
             cmdclass={
                 "build_ext": PermanentBuildExtension,
+                "build_py": BuildPyWithVersion,
                 "clean": clean,
             },
             entry_points={

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ os.environ.setdefault(
 
 
 import glob
+import re
 
-import regex as re
 from setuptools import Command, setup
 from setuptools.command.build_py import build_py as _build_py
 
@@ -255,7 +255,7 @@ class BuildPyWithVersion(_build_py):
             # plain base version rather than a bogus one.
             print(f"build_py: no git metadata; keeping version {version}")
             return
-        original = Path(outfile).read_text()
+        original = Path(outfile).read_text(encoding="utf-8")
         stamped, count = _VERSION_LITERAL_RE.subn(
             f'__version__ = "{version}"', original, count=1
         )
@@ -267,7 +267,7 @@ class BuildPyWithVersion(_build_py):
                 f"{outfile}; {PATH_NAME}/version.py and setup.py's "
                 f"BuildPyWithVersion have drifted."
             )
-        Path(outfile).write_text(stamped)
+        Path(outfile).write_text(stamped, encoding="utf-8")
         print(f"build_py: baked __version__ = {version!r} into {outfile}")
 
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ os.environ.setdefault(
 
 
 import glob
-import re
+import regex as re
 
 from setuptools import Command, setup
 from setuptools.command.build_py import build_py as _build_py

--- a/tests/configs/torch_spyre_tests/test_version_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_version_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [unit, regression, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/test_version.py
+      unlisted_test_mode: mandatory_success

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Torch-Spyre Authors.
+# Copyright 2026 The Torch-Spyre Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -32,9 +32,30 @@ from pathlib import Path
 import pytest
 
 
+def _repo_root() -> Path:
+    """Locate the repo root without assuming this file's path depth.
+
+    The CI harness runs pytest from its own working directory with the test file
+    passed by basename.
+    """
+    env_root = os.environ.get("TORCH_DEVICE_ROOT")
+    if env_root and (Path(env_root) / "torch_spyre" / "version.py").is_file():
+        return Path(env_root).resolve()
+
+    here = Path(__file__).resolve()
+    for candidate in (here.parent, *here.parents):
+        if (candidate / "torch_spyre" / "version.py").is_file():
+            return candidate
+
+    raise RuntimeError(
+        "cannot locate the torch-spyre repo root: no torch_spyre/version.py found "
+        f"above {here} and TORCH_DEVICE_ROOT={env_root!r} does not contain it"
+    )
+
+
 def _load_version_module():
     """Import torch_spyre.version without importing the torch_spyre package."""
-    module_path = Path(__file__).resolve().parent.parent / "torch_spyre" / "version.py"
+    module_path = _repo_root() / "torch_spyre" / "version.py"
     spec = importlib.util.spec_from_file_location("torch_spyre_version", module_path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
@@ -57,11 +78,10 @@ def _in_source_checkout() -> bool:
     """True when the live git lookup is expected to have fired.
 
     Evaluated at decoration time by ``skipif``, so it cannot use the fixture and
-    resolves the repo root from this file's location instead.
+    resolves the repo root itself.
     """
-    repo_root = Path(__file__).resolve().parent.parent
     return (
-        (repo_root / ".git").is_dir()
+        (_repo_root() / ".git").is_dir()
         and shutil.which("git") is not None
         and os.environ.get("TORCH_SPYRE_VERSION_NO_GIT") != "1"
     )

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,144 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for torch_spyre.version.
+
+``__version__`` is environment-dependent -- a source checkout yields
+``0.0.1+g<sha>``, a wheel built without git yields a plain ``0.0.1`` -- so these
+assert invariants and shape, never a hardcoded value.
+
+``torch_spyre.version`` is imported directly rather than via ``import
+torch_spyre`` so these run without a built ``_C`` extension.
+"""
+
+import ast
+import importlib.util
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _load_version_module():
+    """Import torch_spyre.version without importing the torch_spyre package."""
+    module_path = Path(__file__).resolve().parent.parent / "torch_spyre" / "version.py"
+    spec = importlib.util.spec_from_file_location("torch_spyre_version", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+version_mod = _load_version_module()
+
+
+def _in_source_checkout() -> bool:
+    """True when the live git lookup is expected to have fired."""
+    return (
+        (Path(version_mod._REPO_ROOT) / ".git").is_dir()
+        and shutil.which("git") is not None
+        and os.environ.get("TORCH_SPYRE_VERSION_NO_GIT") != "1"
+    )
+
+
+def test_version_is_valid_pep440():
+    """__version__ must parse as a PEP 440 version, local segment included."""
+    packaging_version = pytest.importorskip("packaging.version")
+    packaging_version.Version(version_mod.__version__)
+
+
+def test_base_version_is_the_public_prefix():
+    """__version__ is either the bare base version or base + a local segment."""
+    base = version_mod._BASE_VERSION
+    assert version_mod.__version__ == base or version_mod.__version__.startswith(
+        base + "+"
+    )
+
+
+def test_local_segment_shape_when_present():
+    """A local segment must be 'g' followed by a plausible short sha."""
+    if "+" not in version_mod.__version__:
+        pytest.skip("no local segment (wheel built without git metadata)")
+    local = version_mod.__version__.split("+", 1)[1]
+    assert local.startswith("g"), f"local segment should start with 'g': {local!r}"
+    sha = local[1:]
+    assert sha.isalnum(), f"sha should be alphanumeric: {sha!r}"
+    assert len(sha) >= 4, f"sha suspiciously short: {sha!r}"
+
+
+def test_version_module_is_statically_readable():
+    """The first top-level __version__ binding must be an ast.literal_eval-able str.
+
+    pyproject.toml resolves the project version with
+    ``version = {attr = "torch_spyre.version.__version__"}``, which setuptools
+    reads via ``ast.literal_eval`` over top-level assignments WITHOUT importing
+    the module (setuptools.config.expand.StaticModule). A computed first binding
+    -- including a bare name such as ``_BASE_VERSION`` -- breaks every build.
+
+    This replicates that reader so the constraint cannot regress silently.
+    """
+    source = Path(version_mod.__file__).read_bytes()
+    module = ast.parse(source)
+
+    values = [
+        statement.value
+        for statement in module.body
+        if isinstance(statement, ast.Assign)
+        for target in statement.targets
+        if isinstance(target, ast.Name) and target.id == "__version__"
+    ]
+    assert values, "no top-level __version__ assignment found"
+
+    # literal_eval raises ValueError on a non-literal; that failure IS the point.
+    statically_read = ast.literal_eval(values[0])
+    assert isinstance(statically_read, str)
+    assert statically_read == version_mod._BASE_VERSION
+
+
+@pytest.mark.skipif(
+    not _in_source_checkout(), reason="not a git source checkout with git available"
+)
+def test_checkout_version_matches_head():
+    """In a checkout the local segment must be the real HEAD short sha."""
+    sha = subprocess.run(
+        ["git", "-C", str(version_mod._REPO_ROOT), "rev-parse", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=True,
+    ).stdout.strip()
+    expected = f"{version_mod._BASE_VERSION}+g{sha}"
+    assert version_mod.__version__ == expected
+
+
+def test_git_short_sha_returns_none_for_non_repo(tmp_path):
+    """A path that is not a git repository must yield None, not raise."""
+    # A nonexistent path, not tmp_path itself: `git -C` walks UP looking for a
+    # repository, and the temp dir could sit under one on some machines.
+    assert version_mod._git_short_sha(tmp_path / "definitely-not-a-repo") is None
+
+
+def test_no_git_env_var_suppresses_lookup(monkeypatch):
+    """TORCH_SPYRE_VERSION_NO_GIT=1 must yield the bare base version."""
+    monkeypatch.setenv("TORCH_SPYRE_VERSION_NO_GIT", "1")
+    reloaded = _load_version_module()
+    assert reloaded.__version__ == reloaded._BASE_VERSION
+    assert "+" not in reloaded.__version__
+
+
+def test_module_exports_only_version():
+    """__all__ stays limited to __version__; helpers are private."""
+    assert version_mod.__all__ == ["__version__"]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -42,25 +42,38 @@ def _load_version_module():
     return module
 
 
-version_mod = _load_version_module()
+@pytest.fixture(scope="module")
+def version_mod():
+    """torch_spyre.version, imported once per module.
+
+    A fixture rather than a module-level call: an import failure here surfaces as
+    an error on the individual tests instead of breaking collection of the whole
+    file with a bare traceback.
+    """
+    return _load_version_module()
 
 
 def _in_source_checkout() -> bool:
-    """True when the live git lookup is expected to have fired."""
+    """True when the live git lookup is expected to have fired.
+
+    Evaluated at decoration time by ``skipif``, so it cannot use the fixture and
+    resolves the repo root from this file's location instead.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
     return (
-        (Path(version_mod._REPO_ROOT) / ".git").is_dir()
+        (repo_root / ".git").is_dir()
         and shutil.which("git") is not None
         and os.environ.get("TORCH_SPYRE_VERSION_NO_GIT") != "1"
     )
 
 
-def test_version_is_valid_pep440():
+def test_version_is_valid_pep440(version_mod):
     """__version__ must parse as a PEP 440 version, local segment included."""
     packaging_version = pytest.importorskip("packaging.version")
     packaging_version.Version(version_mod.__version__)
 
 
-def test_base_version_is_the_public_prefix():
+def test_base_version_is_the_public_prefix(version_mod):
     """__version__ is either the bare base version or base + a local segment."""
     base = version_mod._BASE_VERSION
     assert version_mod.__version__ == base or version_mod.__version__.startswith(
@@ -68,7 +81,7 @@ def test_base_version_is_the_public_prefix():
     )
 
 
-def test_local_segment_shape_when_present():
+def test_local_segment_shape_when_present(version_mod):
     """A local segment must be 'g' followed by a plausible short sha."""
     if "+" not in version_mod.__version__:
         pytest.skip("no local segment (wheel built without git metadata)")
@@ -79,7 +92,7 @@ def test_local_segment_shape_when_present():
     assert len(sha) >= 4, f"sha suspiciously short: {sha!r}"
 
 
-def test_version_module_is_statically_readable():
+def test_version_module_is_statically_readable(version_mod):
     """The first top-level __version__ binding must be an ast.literal_eval-able str.
 
     pyproject.toml resolves the project version with
@@ -111,7 +124,7 @@ def test_version_module_is_statically_readable():
 @pytest.mark.skipif(
     not _in_source_checkout(), reason="not a git source checkout with git available"
 )
-def test_checkout_version_matches_head():
+def test_checkout_version_matches_head(version_mod):
     """In a checkout the local segment must be the real HEAD short sha."""
     sha = subprocess.run(
         ["git", "-C", str(version_mod._REPO_ROOT), "rev-parse", "--short", "HEAD"],
@@ -124,7 +137,7 @@ def test_checkout_version_matches_head():
     assert version_mod.__version__ == expected
 
 
-def test_git_short_sha_returns_none_for_non_repo(tmp_path):
+def test_git_short_sha_returns_none_for_non_repo(version_mod, tmp_path):
     """A path that is not a git repository must yield None, not raise."""
     # A nonexistent path, not tmp_path itself: `git -C` walks UP looking for a
     # repository, and the temp dir could sit under one on some machines.
@@ -139,6 +152,6 @@ def test_no_git_env_var_suppresses_lookup(monkeypatch):
     assert "+" not in reloaded.__version__
 
 
-def test_module_exports_only_version():
+def test_module_exports_only_version(version_mod):
     """__all__ stays limited to __version__; helpers are private."""
     assert version_mod.__all__ == ["__version__"]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -23,6 +23,7 @@ torch_spyre`` so these run without a built ``_C`` extension.
 """
 
 import ast
+import importlib.metadata
 import importlib.util
 import os
 import shutil
@@ -32,30 +33,70 @@ from pathlib import Path
 import pytest
 
 
-def _repo_root() -> Path:
-    """Locate the repo root without assuming this file's path depth.
+def _find_version_file() -> Path:
+    """Locate the version.py that is actually in effect, without importing it.
 
-    The CI harness runs pytest from its own working directory with the test file
-    passed by basename.
+    Two layouts must both work:
+
+    * **Source checkout** -- ``torch_spyre/version.py`` sits next to ``tests/``.
+    * **CI wheel flow** -- ``.github/actions/install-prebuilt-torch-spyre`` installs
+      the prebuilt wheel and then deletes the checked-out ``torch_spyre/`` package
+      so it cannot shadow it, leaving ``tests/`` with no sibling source package.
+      The installed wheel is authoritative there, and is the copy whose stamped
+      version we actually want to assert on.
+
+    The installed distribution is therefore consulted first, via its recorded file
+    list -- ``import torch_spyre`` is avoided throughout because importing the
+    package triggers the PyTorch backend autoload (and needs a compiled ``_C``).
     """
-    env_root = os.environ.get("TORCH_DEVICE_ROOT")
-    if env_root and (Path(env_root) / "torch_spyre" / "version.py").is_file():
-        return Path(env_root).resolve()
+    try:
+        dist = importlib.metadata.distribution("torch_spyre")
+    except importlib.metadata.PackageNotFoundError:
+        dist = None
 
-    here = Path(__file__).resolve()
-    for candidate in (here.parent, *here.parents):
-        if (candidate / "torch_spyre" / "version.py").is_file():
-            return candidate
+    if dist is not None:
+        for recorded in dist.files or ():
+            if recorded.parts[-2:] == ("torch_spyre", "version.py"):
+                located = Path(str(dist.locate_file(recorded))).resolve()
+                if located.is_file():
+                    return located
+
+    # Source checkout: walk up for the sentinel rather than assuming this file's
+    # depth, since the CI harness may run pytest from a different directory.
+    for candidate in Path(__file__).resolve().parents:
+        source_copy = candidate / "torch_spyre" / "version.py"
+        if source_copy.is_file():
+            return source_copy
 
     raise RuntimeError(
-        "cannot locate the torch-spyre repo root: no torch_spyre/version.py found "
-        f"above {here} and TORCH_DEVICE_ROOT={env_root!r} does not contain it"
+        "cannot locate torch_spyre/version.py: it is neither recorded in an "
+        "installed torch_spyre distribution nor present in a parent directory of "
+        f"{Path(__file__).resolve()}"
     )
+
+
+def _read_static_version() -> str:
+    """The ``__version__`` literal as it sits on disk, before any git override.
+
+    Read statically rather than imported, so it reflects what the file ships with
+    -- a wheel stamped at build time carries a local segment here, a source
+    checkout carries the bare base version.
+    """
+    module = ast.parse(_find_version_file().read_bytes())
+    for statement in module.body:
+        if not isinstance(statement, ast.Assign):
+            continue
+        for target in statement.targets:
+            if isinstance(target, ast.Name) and target.id == "__version__":
+                literal = ast.literal_eval(statement.value)
+                assert isinstance(literal, str)
+                return literal
+    raise AssertionError("no top-level __version__ assignment found")
 
 
 def _load_version_module():
     """Import torch_spyre.version without importing the torch_spyre package."""
-    module_path = _repo_root() / "torch_spyre" / "version.py"
+    module_path = _find_version_file()
     spec = importlib.util.spec_from_file_location("torch_spyre_version", module_path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
@@ -77,11 +118,13 @@ def version_mod():
 def _in_source_checkout() -> bool:
     """True when the live git lookup is expected to have fired.
 
-    Evaluated at decoration time by ``skipif``, so it cannot use the fixture and
-    resolves the repo root itself.
+    Only a source checkout has a ``.git`` beside the package; the CI wheel flow
+    installs into site-packages, where the lookup never fires. Evaluated at
+    decoration time by ``skipif``, so it cannot use the fixture -- the directory
+    tested here mirrors version.py's own ``_REPO_ROOT`` (its ``parent.parent``).
     """
     return (
-        (_repo_root() / ".git").is_dir()
+        (_find_version_file().parent.parent / ".git").is_dir()
         and shutil.which("git") is not None
         and os.environ.get("TORCH_SPYRE_VERSION_NO_GIT") != "1"
     )
@@ -165,11 +208,24 @@ def test_git_short_sha_returns_none_for_non_repo(version_mod, tmp_path):
 
 
 def test_no_git_env_var_suppresses_lookup(monkeypatch):
-    """TORCH_SPYRE_VERSION_NO_GIT=1 must yield the bare base version."""
+    """TORCH_SPYRE_VERSION_NO_GIT=1 must suppress the live git lookup.
+
+    Only the lookup is suppressed, never an already-baked local segment: the
+    guarded block is deliberately inert when ``__version__`` already carries a
+    ``+`` so an unpacked wheel cannot be re-stamped from an unrelated checkout.
+    So a stamped copy (the CI wheel flow) legitimately keeps its segment, and
+    only an unstamped source copy collapses to the bare base version.
+    """
     monkeypatch.setenv("TORCH_SPYRE_VERSION_NO_GIT", "1")
+    baked = "+" in _read_static_version()
+
     reloaded = _load_version_module()
-    assert reloaded.__version__ == reloaded._BASE_VERSION
-    assert "+" not in reloaded.__version__
+
+    if baked:
+        assert reloaded.__version__ == _read_static_version()
+    else:
+        assert reloaded.__version__ == reloaded._BASE_VERSION
+        assert "+" not in reloaded.__version__
 
 
 def test_module_exports_only_version(version_mod):

--- a/torch_spyre/version.py
+++ b/torch_spyre/version.py
@@ -14,36 +14,22 @@
 """Package version.
 
 ``__version__`` is a PEP 440 local version (``0.0.1+g<short-sha>``) whenever the
-commit can be determined.  This project has no tagged releases, so without the
-local segment every build of every commit would report the same ``0.0.1`` --
-useless for anything keyed on the version, such as diagnostics provenance or a
-compile cache that must invalidate when the code changes.
+commit can be determined: this project has no tags, so a plain ``0.0.1`` would be
+identical for every build. Wheels get the suffix baked in by ``setup.py``'s
+``BuildPyWithVersion``; source checkouts, where ``build_py`` never runs, resolve
+it live at import (see the block at the bottom of this file).
 
-Two independent mechanisms produce the suffix:
+.. warning::
+   The first statement binding ``__version__`` MUST stay a plain string literal.
+   ``pyproject.toml`` resolves the project version through an ``attr:`` pointer to
+   it, which setuptools reads with ``ast.literal_eval`` over top-level statements
+   without importing the module -- so a computed expression, even a bare name,
+   breaks every build. Hence ``_BASE_VERSION`` derives *from* ``__version__``, and
+   the override is nested inside an ``if``. Locked in by
+   ``tests/test_version.py::test_version_module_is_statically_readable``.
 
-* **Wheel builds.**  ``setup.py``'s ``BuildPyWithVersion`` rewrites this file
-  inside ``build_lib``, baking a literal ``__version__ = "0.0.1+gabc1234"`` into
-  the wheel.  Nothing is resolved at import time there -- an installed wheel has
-  no ``.git`` beside it.
-* **Source checkouts** (``pip install -e .``, ``uv sync``, running from the repo).
-  ``build_py`` never runs for an editable install, so a baked literal would go
-  stale on the next commit.  The block at the bottom detects a checkout and
-  resolves the commit live at import time.
-
-The first statement binding ``__version__`` MUST stay a plain string literal.
-``pyproject.toml`` resolves the project version via
-``[tool.setuptools.dynamic] version = {attr = "torch_spyre.version.__version__"}``,
-and setuptools reads that with ``ast.literal_eval`` over the module's top-level
-assignments (``setuptools.config.expand.StaticModule``) without importing it.  A
-computed expression there -- including a bare name such as ``_BASE_VERSION`` --
-raises ``ValueError`` and breaks every build.  ``_BASE_VERSION`` is therefore
-derived *from* ``__version__`` rather than the reverse, and the override below is
-nested inside an ``if`` so the static reader (which walks only top-level
-statements, and takes the first binding) never sees it.
-``tests/test_version.py::test_version_module_is_statically_readable`` locks this in.
-
-A dirty working tree is reported as its ``HEAD`` commit with no marker, so
-uncommitted edits are NOT reflected in the version.
+A dirty working tree reports its ``HEAD`` commit with no marker, so uncommitted
+edits are not reflected in the version.
 """
 
 import os
@@ -58,23 +44,19 @@ __all__ = [
 # Keep this a bare string literal -- see the module docstring.
 __version__ = "0.0.1"
 
-# Version without any local segment, i.e. what a tagged release would carry.
-# Derived from __version__, never the reverse: a bare name on the right-hand side
-# of the __version__ assignment is not ast.literal_eval-able and would break
-# pyproject.toml's attr: resolution.
+# What a tagged release would carry, i.e. no local segment. Derived from
+# __version__, never the reverse -- see the docstring warning.
 _BASE_VERSION = __version__
 
 # Escape hatch for reproducible builds and for bisecting version-keyed problems.
 _NO_GIT = os.environ.get("TORCH_SPYRE_VERSION_NO_GIT") == "1"
 
-# A `.git` directory at the parent of the package directory is the
-# source-checkout signal; an installed wheel has none.
+# A `.git` directory beside the package directory is the source-checkout signal;
+# an installed wheel has none.
 #
-# `__file__` is looked up defensively rather than referenced directly. This module
-# is also read with `exec(f.read(), ns)` by setup.py's get_torch_spyre_version(),
-# and a bare `__file__` raises NameError in an exec() namespace that lacks it --
-# which would break the build. setup.py seeds `__file__` for exactly that reason,
-# so the cwd fallback below is only a safety net for other exec()-style readers.
+# `__file__` is looked up defensively because setup.py also reads this module with
+# `exec(f.read(), ns)`, and a bare `__file__` would raise NameError in a namespace
+# that lacks it. setup.py seeds it, so the cwd fallback is only a safety net.
 _MODULE_PATH = globals().get("__file__")
 if _MODULE_PATH is not None:
     _REPO_ROOT = Path(_MODULE_PATH).resolve().parent.parent
@@ -85,9 +67,8 @@ else:
 def _git_short_sha(repo_root: Path) -> str | None:
     """Return the short ``HEAD`` sha for ``repo_root``, or ``None``.
 
-    Swallows every failure: a missing or broken ``git``, a shallow or corrupt
-    repository, a repository with no commits, a hung filesystem.  The version
-    string is never important enough to raise from a module import.
+    Swallows every failure -- missing ``git``, corrupt or empty repository, hung
+    filesystem: the version string is not worth raising from a module import.
     """
     try:
         result = subprocess.run(
@@ -102,21 +83,21 @@ def _git_short_sha(repo_root: Path) -> str | None:
     if result.returncode != 0:
         return None
     sha = result.stdout.strip()
-    # Only accept something that keeps the result a valid PEP 440 local segment.
-    # git yields lowercase hex; anything else means we misread the output.
+    # Keep the result a valid PEP 440 local segment; git yields lowercase hex, so
+    # anything else means we misread the output.
     if not sha or not sha.isalnum():
         return None
     return sha
 
 
-# Live resolution, source checkouts only.  `rev-parse --short HEAD` is used
-# rather than `git describe --tags` on purpose: this repo has zero tags and CI
-# checks out shallow without fetch-tags, so `describe` fails outright.
+# Live resolution, source checkouts only. `rev-parse` rather than
+# `git describe --tags` because this repo has zero tags and CI checks out shallow
+# without fetch-tags, so `describe` fails outright.
 #
-# The `.is_dir()` test comes last so an installed wheel spawns no subprocess at
-# all.  The `"+" not in __version__` test makes this block idempotent and leaves
-# an already-stamped wheel file inert, so a wheel unpacked next to an unrelated
-# checkout cannot silently claim that repository's commit.
+# `.is_dir()` comes last so an installed wheel spawns no subprocess at all. The
+# `"+" not in __version__` test makes the block idempotent and leaves an
+# already-stamped wheel inert, so a wheel unpacked next to an unrelated checkout
+# cannot claim that repository's commit.
 if not _NO_GIT and "+" not in __version__ and (_REPO_ROOT / ".git").is_dir():
     _sha = _git_short_sha(_REPO_ROOT)
     if _sha is not None:

--- a/torch_spyre/version.py
+++ b/torch_spyre/version.py
@@ -11,8 +11,114 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Package version.
+
+``__version__`` is a PEP 440 local version (``0.0.1+g<short-sha>``) whenever the
+commit can be determined.  This project has no tagged releases, so without the
+local segment every build of every commit would report the same ``0.0.1`` --
+useless for anything keyed on the version, such as diagnostics provenance or a
+compile cache that must invalidate when the code changes.
+
+Two independent mechanisms produce the suffix:
+
+* **Wheel builds.**  ``setup.py``'s ``BuildPyWithVersion`` rewrites this file
+  inside ``build_lib``, baking a literal ``__version__ = "0.0.1+gabc1234"`` into
+  the wheel.  Nothing is resolved at import time there -- an installed wheel has
+  no ``.git`` beside it.
+* **Source checkouts** (``pip install -e .``, ``uv sync``, running from the repo).
+  ``build_py`` never runs for an editable install, so a baked literal would go
+  stale on the next commit.  The block at the bottom detects a checkout and
+  resolves the commit live at import time.
+
+The first statement binding ``__version__`` MUST stay a plain string literal.
+``pyproject.toml`` resolves the project version via
+``[tool.setuptools.dynamic] version = {attr = "torch_spyre.version.__version__"}``,
+and setuptools reads that with ``ast.literal_eval`` over the module's top-level
+assignments (``setuptools.config.expand.StaticModule``) without importing it.  A
+computed expression there -- including a bare name such as ``_BASE_VERSION`` --
+raises ``ValueError`` and breaks every build.  ``_BASE_VERSION`` is therefore
+derived *from* ``__version__`` rather than the reverse, and the override below is
+nested inside an ``if`` so the static reader (which walks only top-level
+statements, and takes the first binding) never sees it.
+``tests/test_version.py::test_version_module_is_statically_readable`` locks this in.
+
+A dirty working tree is reported as its ``HEAD`` commit with no marker, so
+uncommitted edits are NOT reflected in the version.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
 
 __all__ = [
     "__version__",
 ]
+
+# Keep this a bare string literal -- see the module docstring.
 __version__ = "0.0.1"
+
+# Version without any local segment, i.e. what a tagged release would carry.
+# Derived from __version__, never the reverse: a bare name on the right-hand side
+# of the __version__ assignment is not ast.literal_eval-able and would break
+# pyproject.toml's attr: resolution.
+_BASE_VERSION = __version__
+
+# Escape hatch for reproducible builds and for bisecting version-keyed problems.
+_NO_GIT = os.environ.get("TORCH_SPYRE_VERSION_NO_GIT") == "1"
+
+# A `.git` directory at the parent of the package directory is the
+# source-checkout signal; an installed wheel has none.
+#
+# `__file__` is looked up defensively rather than referenced directly. This module
+# is also read with `exec(f.read(), ns)` by setup.py's get_torch_spyre_version(),
+# and a bare `__file__` raises NameError in an exec() namespace that lacks it --
+# which would break the build. setup.py seeds `__file__` for exactly that reason,
+# so the cwd fallback below is only a safety net for other exec()-style readers.
+_MODULE_PATH = globals().get("__file__")
+if _MODULE_PATH is not None:
+    _REPO_ROOT = Path(_MODULE_PATH).resolve().parent.parent
+else:
+    _REPO_ROOT = Path.cwd()
+
+
+def _git_short_sha(repo_root: Path) -> str | None:
+    """Return the short ``HEAD`` sha for ``repo_root``, or ``None``.
+
+    Swallows every failure: a missing or broken ``git``, a shallow or corrupt
+    repository, a repository with no commits, a hung filesystem.  The version
+    string is never important enough to raise from a module import.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    sha = result.stdout.strip()
+    # Only accept something that keeps the result a valid PEP 440 local segment.
+    # git yields lowercase hex; anything else means we misread the output.
+    if not sha or not sha.isalnum():
+        return None
+    return sha
+
+
+# Live resolution, source checkouts only.  `rev-parse --short HEAD` is used
+# rather than `git describe --tags` on purpose: this repo has zero tags and CI
+# checks out shallow without fetch-tags, so `describe` fails outright.
+#
+# The `.is_dir()` test comes last so an installed wheel spawns no subprocess at
+# all.  The `"+" not in __version__` test makes this block idempotent and leaves
+# an already-stamped wheel file inert, so a wheel unpacked next to an unrelated
+# checkout cannot silently claim that repository's commit.
+if not _NO_GIT and "+" not in __version__ and (_REPO_ROOT / ".git").is_dir():
+    _sha = _git_short_sha(_REPO_ROOT)
+    if _sha is not None:
+        __version__ = f"{_BASE_VERSION}+g{_sha}"
+    del _sha


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Makes `torch_spyre.__version__` commit-qualified: `0.0.1+g8068434` instead of a permanent `0.0.1`. Today `version.py` is a static literal with no `setuptools_scm`, so every build of every commit reports the same version and anything keyed on it has nothing to work with.

Source checkouts resolve the commit live at import (`pip install -e .` never runs `build_py`, so a build-time-only fix would go stale in the dev workflow). Wheels get it baked in by a new `build_py` subclass that rewrites the staged copy under `build_lib` — never the tracked source, since builds run inside the checkout and would dirty the tree.

`rev-parse --short HEAD` rather than `git describe --tags`: this repo has zero tags and CI checks out shallow, so `describe` fails outright.

#### Which issue(s) this PR is related to:

Closes #4146

#### Special notes for your reviewer:

**The first top-level `__version__` binding must stay a bare string literal.** `pyproject.toml` resolves the version via `attr:`, which setuptools reads with `ast.literal_eval` without importing — a bare name like `_BASE_VERSION` there raises `ValueError` and breaks every build. So `_BASE_VERSION` derives *from* `__version__`, and the git override is nested in an `if` where the static reader never looks. `test_version_module_is_statically_readable` replicates that reader so it can't regress silently.

**Wheel METADATA `Version:` and the filename stay `0.0.1`** — setuptools resolves `dynamic` statically, before `build_py` runs. Only the runtime `__version__` inside the wheel carries the commit, which is enough for the goal; matching the metadata would mean dropping the `attr:` pointer, out of scope here.

**Stamping uses a regex, not `str.replace`.** `build_py` skips copying when the destination is newer, so a stale `+gOLD` can survive in `build_lib`; the regex re-stamps it where a literal replace would silently no-op and ship the wrong commit. Verified with an empty commit between builds. A non-match raises rather than warns.

Installed wheels spawn no subprocess (`.is_dir()` tested last), and `_git_short_sha` swallows every failure rather than raising from a module import.

#### Does this PR introduce a user-facing change?

Yes. `__version__` becomes `0.0.1+g<short-sha>`, staying `0.0.1` when git metadata is unavailable or `TORCH_SPYRE_VERSION_NO_GIT=1`. No test asserts on the version and the only consumers are `_ffdc.py` (format-agnostic) and `ffdc_trigger.py` (prints it).

FFDC diagnostics now identify the build — `torch_spyre_version` was always `0.0.1` and told you nothing about which code produced a dump. No code change needed there:

```console
$ python -c "from torch_spyre.profiler._ffdc import _safe_torch_spyre_version as f; print(f())"
0.0.1+g4bca291
```

#### Additional note:

`rev-parse HEAD` ignores the working tree, so uncommitted edits aren't reflected — a dirty tree reports its `HEAD` commit with no marker. Matches today's behavior, documented in the docstring; a `.dirty` marker is an easy follow-up if the dev-iteration pain proves real.

Not implemented, in case you want it here: an assertion after `uv build` in CI that the wheel's `version.py` contains `+g`, so a silent revert to `0.0.1` becomes a red build.
