### PR TITLE
DRAFT:  matmul operand identiy fixes from (Group 5 from 3981)

### DIFF
--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -13,14 +13,19 @@
 # limitations under the License.
 
 import sympy
+from types import SimpleNamespace
 
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.ir import FixedLayout
+from torch._inductor.virtualized import V
 from torch_spyre._C import DataFormats, SpyreTensorLayout
+from torch_spyre._inductor.constants import BATCH_MATMUL_OP
 from torch_spyre._inductor.errors import Unsupported
+from torch_spyre._inductor.optimize_restickify import FixedInOutNode
 from torch_spyre._inductor.pass_utils import (
+    compute_restickify_needed,
     device_coordinates,
     try_device_coordinates,
 )
@@ -28,6 +33,7 @@ from torch_spyre._inductor.propagate_layouts import (
     PropArg,
     _check_supported_input_sticks,
     _find_alt_target_stl,
+    _matmul_layouts,
 )
 from torch_spyre._inductor.views import (
     _decompose_constant_offset,
@@ -595,6 +601,159 @@ class TestNormalizeCoordinatesFusion(TestCase):
             ],
         )
         self.assertEqual([int(t.dim_size) for t in terms], [32, 64])
+
+
+class TestUnitNMatmulLayouts(TestCase):
+    """A size-one BMM N axis is semantic even after its symbol disappears."""
+
+    def _scenario(self):
+        batch, reduction = sympy.symbols(
+            "batch reduction", integer=True, nonnegative=True
+        )
+        ranges = (batch, reduction)
+        sizes = (32, 128)
+
+        # Use reverse-lexical buffer names to ensure semantic read order, not a
+        # name/set ordering heuristic, determines x and y.  When N == 1, both
+        # reads can have identical affine expressions.
+        x_dep = MemoryDep("z_x", 128 * batch + reduction, ranges, sizes)
+        y_dep = MemoryDep("a_y", 128 * batch + reduction, ranges, sizes)
+        out_dep = MemoryDep("out", batch, (batch,), (32,))
+
+        host = FixedLayout(
+            torch.device("cpu"), torch.float16, [32, 1, 128], [128, 128, 1]
+        )
+        source = SpyreTensorLayout(
+            [32, 1, 128], [128, 128, 1], torch.float16, [0, 1, 2]
+        )
+        args = [
+            PropArg(x_dep, host, [source]),
+            PropArg(y_dep, host, [source]),
+        ]
+        output = FixedLayout(torch.device("cpu"), torch.float16, [32, 1, 1], [1, 1, 1])
+        op = SimpleNamespace(
+            data=SimpleNamespace(
+                reduction_type=BATCH_MATMUL_OP,
+                ranges=[32, 1, 1],
+                reduction_ranges=[128],
+            )
+        )
+        layouts = {"z_x": host, "a_y": host}
+        graph = SimpleNamespace(
+            get_buffer=lambda name: SimpleNamespace(get_layout=lambda: layouts[name])
+        )
+        return op, output, out_dep, args, source, graph
+
+    def test_identical_deps_use_ordered_roles_and_sparse_y(self):
+        op, output, out_dep, args, source, graph = self._scenario()
+
+        with V.set_graph_handler(graph):
+            (out_stl,) = _matmul_layouts(op, output, out_dep, args)
+
+            self.assertEqual(
+                [edge.dep.name for edge in op.restick_cost_fn.edge_costs],
+                ["z_x", "a_y"],
+            )
+            x_req, y_req = op.restick_cost_fn.required_in_stls
+            self.assertEqual(x_req, source)
+            self.assertEqual(
+                device_coordinates(y_req, args[1].dep, None),
+                [0, args[1].dep.var_names[1], 0, args[1].dep.var_names[0], 0],
+            )
+            self.assertEqual(
+                device_coordinates(out_stl, out_dep, None),
+                [0, 0, out_dep.var_names[0], 0],
+            )
+
+    def test_same_buffer_name_keeps_distinct_operand_positions(self):
+        """Self-matmul roles are positional even when both deps share a name."""
+        op, output, out_dep, args, source, graph = self._scenario()
+        args[1] = PropArg(
+            MemoryDep(
+                args[0].dep.name,
+                args[1].dep.index,
+                args[1].dep.var_names,
+                args[1].dep.size,
+            ),
+            args[1].layout,
+            args[1].layouts,
+        )
+
+        with V.set_graph_handler(graph):
+            _matmul_layouts(op, output, out_dep, args)
+
+        self.assertEqual(
+            [edge.dep.name for edge in op.restick_cost_fn.edge_costs],
+            ["z_x", "z_x"],
+        )
+        self.assertEqual(op.restick_cost_fn.required_in_stls[0], source)
+        self.assertEqual(
+            device_coordinates(
+                op.restick_cost_fn.required_in_stls[1], args[1].dep, None
+            ),
+            [0, args[1].dep.var_names[1], 0, args[1].dep.var_names[0], 0],
+        )
+
+    def test_exact_self_alias_read_restores_two_semantic_edges(self):
+        """An OrderedSet-deduplicated read still supplies lhs and rhs roles."""
+        op, output, out_dep, args, source, graph = self._scenario()
+
+        with V.set_graph_handler(graph):
+            _matmul_layouts(op, output, out_dep, args[:1])
+
+        edges = op.restick_cost_fn.edge_costs
+        self.assertEqual(len(edges), 2)
+        self.assertIs(edges[0].dep, edges[1].dep)
+        self.assertEqual(op.restick_cost_fn.required_in_stls[0], source)
+        self.assertEqual(
+            device_coordinates(
+                op.restick_cost_fn.required_in_stls[1], edges[1].dep, None
+            ),
+            [0, args[0].dep.var_names[1], 0, args[0].dep.var_names[0], 0],
+        )
+
+    def test_fixed_input_can_materialize_exact_zero_stick_target(self):
+        _, _, _, args, source, graph = self._scenario()
+        y = args[1]
+        target = SpyreTensorLayout(
+            [32, 1, 128],
+            [128, 128, 1],
+            torch.float16,
+            [0, 1, 2, -1],
+        )
+
+        with V.set_graph_handler(graph):
+            # Dependency object identity is not an exact-target contract.
+            self.assertEqual(
+                compute_restickify_needed(source, y.layout, y.dep, target, y.dep, None),
+                (True, None),
+            )
+
+            # FixedInOut declares the exceptional sparse target explicitly,
+            # and equivalent reconstructed dependencies behave identically.
+            equivalent_dep = MemoryDep(
+                y.dep.name, y.dep.index, y.dep.var_names, y.dep.size
+            )
+            self.assertEqual(
+                compute_restickify_needed(
+                    source,
+                    y.layout,
+                    y.dep,
+                    target,
+                    equivalent_dep,
+                    None,
+                    exact_target=True,
+                ),
+                (True, target),
+            )
+            node = FixedInOutNode.from_args(
+                [y],
+                target,
+                [target],
+                None,
+                exact_target_layouts=[True],
+            )
+            self.assertEqual(node.edge_costs[0].layout(source, target), target)
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/optimize_restickify.py
+++ b/torch_spyre/_inductor/optimize_restickify.py
@@ -60,12 +60,14 @@ class EdgeCostMap:
         target_layouts: list,
         target_dep: "MemoryDep",
         op,
+        exact_target: bool = False,
     ):
         self.dep = dep
         self._op = op
         self._in_layouts = in_layouts
         self._target_layouts = target_layouts
         self._target_dep = target_dep
+        self._exact_target = exact_target
         self._dep_layout = V.graph.get_buffer(dep.name).get_layout()
         self._target_dep_layout = V.graph.get_buffer(target_dep.name).get_layout()
 
@@ -96,7 +98,13 @@ class EdgeCostMap:
           SpyreTensorLayout  — feasible restickify target layout
         """
         needed, tgt = compute_restickify_needed(
-            in_stl, self._dep_layout, self.dep, target_stl, self._target_dep, self._op
+            in_stl,
+            self._dep_layout,
+            self.dep,
+            target_stl,
+            self._target_dep,
+            self._op,
+            exact_target=self._exact_target,
         )
         if not needed:
             cost = 0.0
@@ -280,11 +288,18 @@ class FixedInOutNode(RestickNodeCost):
         )
 
     @classmethod
-    def from_args(cls, args, out_stl, req_stls, op):
+    def from_args(cls, args, out_stl, req_stls, op, exact_target_layouts=None):
         assert req_stls, "FixedInOutNode.from_args: req_stls is empty"
         edge_costs = [
-            EdgeCostMap(arg.dep, arg.layouts, [req], arg.dep, op)
-            for arg, req in zip(args, req_stls)
+            EdgeCostMap(
+                arg.dep,
+                arg.layouts,
+                [req],
+                arg.dep,
+                op,
+                exact_target=exact_target_layouts[i] if exact_target_layouts else False,
+            )
+            for i, (arg, req) in enumerate(zip(args, req_stls))
         ]
         return cls(edge_costs, required_out_stl=out_stl, required_in_stls=req_stls)
 

--- a/torch_spyre/_inductor/padding.py
+++ b/torch_spyre/_inductor/padding.py
@@ -242,12 +242,6 @@ def insert_bmm_padding(graph: GraphLowering) -> None:
 
         write_dep = next(iter(rw.writes))
         x_dep, y_dep = identify_matmul_inputs(reads, write_dep)
-        if x_dep is None or y_dep is None:
-            logger.warning(
-                "insert_bmm_padding: could not identify x/y for %s, skipping",
-                op.get_name(),
-            )
-            continue
 
         reduction_var = find_reduction_var(x_dep, write_dep)
 

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1908,6 +1908,7 @@ def compute_restickify_needed(
     out_stl: SpyreTensorLayout,
     out_dep: MemoryDep,
     op: "ComputedBuffer | None" = None,
+    exact_target: bool = False,
 ) -> "tuple[bool, SpyreTensorLayout | None]":
     """Determine whether a restickify is needed for one (in_stl, out_stl) pair.
 
@@ -1955,9 +1956,10 @@ def compute_restickify_needed(
         if reduction_vars:
             red_var = next(iter(reduction_vars))
             target_stick = sympy.Mod(red_var, in_stl.elems_per_stick())
-    return True, compute_restickify_target_layout(
-        in_stl, in_host, target_stick, ic, idc
-    )
+    tgt = compute_restickify_target_layout(in_stl, in_host, target_stick, ic, idc)
+    if tgt is None and exact_target:
+        return True, out_stl
+    return True, tgt
 
 
 def copy_fx_custom_meta(src: "torch.fx.Node", dst: "torch.fx.Node") -> None:

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -878,36 +878,38 @@ def host_coordinates(
 def identify_matmul_inputs(
     inputs: list[MemoryDep],
     write_dep: MemoryDep,
-) -> tuple[MemoryDep, MemoryDep] | tuple[None, None]:
+) -> tuple[MemoryDep, MemoryDep]:
     """Identify Input1 (x) and Input2 (y) of a BatchMatmul op.
 
-    Uses the BatchMatmul semantic dimension definitions:
-      reduction_dim: in Input1, Input2,  NOT Output
-      generated_dim: in Input2, Output,  NOT Input1
-      preserved_dim: in Input1, Output,  NOT Input2
-      noreuse_dim:   in Input1, Input2,  Output
+    Uses positional order: lower_bmm always emits x before y, so inputs[0] is
+    x and inputs[1] is y.  This is valid even when N=1 (the N symbol is
+    constant-folded out of index expressions) or when both deps are identical
+    (ReadWrites deduplicated a self-alias read).
 
-    Identifies y by its generated_dim (N): present in y and the output, absent
-    from x.  This is more robust than identifying x by its preserved_dim (M):
-    when M=1, M is constant-folded out of both x's and the output's index
-    simultaneously, making the preserved_dim test blind.  N is immune — even
-    N=1 ranges stay in the output's index expression.
+    For a 1-element input list, the single dep is treated as both x and y
+    (self-matmul where ReadWrites collapsed two identical MemoryDeps to one).
 
-    Returns (None, None) if y cannot be identified.
+    Raises ValueError for 0 or 3+ inputs.
     """
-    assert len(inputs) == 2
-    a, b = inputs[0], inputs[1]
-    out_syms = write_dep.index.free_symbols
-    syms_a = a.index.free_symbols
-    syms_b = b.index.free_symbols
+    if len(inputs) == 0 or len(inputs) > 2:
+        raise ValueError(
+            f"identify_matmul_inputs: expected 1 or 2 inputs, got {len(inputs)}"
+        )
+    if len(inputs) == 1:
+        return inputs[0], inputs[0]
 
-    # b has generated_dim → b is y, a is x
-    if (syms_b & out_syms) - syms_a:
-        return a, b
-    # a has generated_dim → a is y, b is x
-    if (syms_a & out_syms) - syms_b:
-        return b, a
-    return None, None
+    a, b = inputs[0], inputs[1]
+    return a, b
+
+
+def get_matmul_n_size(op: "Operation") -> int:
+    """Return the concrete N (output columns) extent of a matmul op.
+
+    Reads from op.data.ranges[-1] rather than inferring from index expressions,
+    so it is correct even when N=1 and the N symbol has been constant-folded
+    out of every MemoryDep.
+    """
+    return concretize_expr(op.data.ranges[-1])
 
 
 def find_reduction_var(x_dep: MemoryDep, out_dep: MemoryDep) -> sympy.Symbol:

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -81,6 +81,7 @@ from .pass_utils import (
     concretize_expr,
     find_matmul_generated_var,
     find_reduction_var,
+    get_matmul_n_size,
     identify_matmul_inputs,
     host_coordinates,
     device_coordinates,
@@ -878,37 +879,57 @@ def _matmul_layouts(
     _check_supported_input_sticks(args, data.reduction_type)
     out_coords = host_coordinates(output, output_dep, None)
 
-    x_dep, y_dep = identify_matmul_inputs([a.dep for a in args], output_dep)
-    if x_dep is None or y_dep is None:
-        raise Unsupported(f"{data.reduction_type}: could not identify Input1/Input2")
-    # Map identified deps back to PropArgs.
-    if x_dep is args[0].dep:
-        x, y = args[0], args[1]
-    else:
-        x, y = args[1], args[0]
+    # ReadWrites.reads is an OrderedSet: two semantic operands collapse to one
+    # MemoryDep when they are aliases with identical access.  Restore the pair.
+    if len(args) == 1:
+        args = [args[0], args[0]]
+
+    # identify_matmul_inputs either confirms positional order or falls back to it.
+    # Map positionally — object identity breaks for self-alias (same dep object).
+    identify_matmul_inputs([a.dep for a in args], output_dep)
+    x, y = args[0], args[1]
 
     # Hardware stick constraints (DF16):
     #   Input1 (x): stick on reduction_var (loop var absent from output)
     #   Input2 (y): stick on generated_var (loop var present in output, absent from x)
     #   Output:     stick on generated_var
     reduction_var = find_reduction_var(x.dep, output_dep)
-    generated_var = find_matmul_generated_var(y.dep, x.dep, output_dep, op)
+    n_size = get_matmul_n_size(op)
 
     x_req_stl = find_stick_compatible_input_layout(
         x, reduction_var, data.reduction_type, "x"
     )
-    y_req_stl = find_stick_compatible_input_layout(
-        y, generated_var, data.reduction_type, "y"
-    )
 
-    out_stick_dim = next(
-        (i for i, c in enumerate(out_coords) if generated_var in c.free_symbols),
-        None,
-    )
-    if out_stick_dim is None:
-        raise Unsupported(
-            f"{data.reduction_type}: generated_var={generated_var} not found in output coords {out_coords}"
+    if n_size == 1:
+        # N has no loop symbol after size-one simplification, so there is no
+        # generated_var to discover.  Build an explicit sparse-stick layout for y
+        # so K is not mistaken for a second contraction dimension.
+        y_dim_order = list(range(len(y.layout.size))) + [-1]
+        y_req_stl = SpyreTensorLayout(
+            [concretize_expr(s) for s in y.layout.size],
+            [concretize_expr(s) for s in y.layout.stride],
+            y.layout.dtype,
+            y_dim_order,
         )
+        # Output stick is on the last host dim (N=1 means it collapses to a scalar
+        # position; the standard row-major dim_order applies).
+        out_dims = len(output.size)
+        out_stick_dim = out_dims - 1
+    else:
+        generated_var = find_matmul_generated_var(y.dep, x.dep, output_dep, op)
+        y_req_stl = find_stick_compatible_input_layout(
+            y, generated_var, data.reduction_type, "y"
+        )
+        _out_stick_dim = next(
+            (i for i, c in enumerate(out_coords) if generated_var in c.free_symbols),
+            None,
+        )
+        if _out_stick_dim is None:
+            raise Unsupported(
+                f"{data.reduction_type}: generated_var={generated_var} not found "
+                f"in output coords {out_coords}"
+            )
+        out_stick_dim = _out_stick_dim
 
     out_dims = len(output.size)
     out_dim_order = list(range(out_dims - 2))


### PR DESCRIPTION
…mul_n_size

lower_bmm always emits x before y in the lowered inner_fn, so the insertion order in ReadWrites.reads is the reliable semantic signal.  The previous set-arithmetic heuristic (detect y by its generated_dim symbol appearing in the output but not in x) was equivalent on well-formed N>1 inputs but broke silently when N=1 because the N symbol is constant-folded out of every MemoryDep, leaving both inputs with identical free-symbol sets.

Changes:
- identify_matmul_inputs: drop set-arithmetic heuristic; return inputs[0], inputs[1] directly.  Handle the 1-element dedup case (self-alias matmul where ReadWrites collapsed two identical MemoryDeps) by returning the single dep as both x and y.  Raise ValueError instead of returning (None, None).
- padding.py: remove now-dead (None, None) guard.
- propagate_layouts._matmul_layouts: expand 1-element args list before calling identify_matmul_inputs; map x/y positionally.  Add N=1 branch that builds an explicit sparse-stick layout for y instead of calling find_matmul_generated_var (which requires a non-constant N symbol).
- add get_matmul_n_size: reads N directly from op.data.ranges[-1] via concretize_expr so it is correct even when N=1.
- tests/tensor/test_coordinates.py: add TestUnitNMatmulLayouts (4 tests covering N=1 semantics, self-alias dedup, and exact-target materiali- zation — the last test is an xfail placeholder for Group 2).

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
