### PR TITLE
docs: document FRONTEND_POOL_ALLOCATION env var

### DIFF
--- a/docs/source/api/torch_spyre.rst
+++ b/docs/source/api/torch_spyre.rst
@@ -679,6 +679,11 @@ Environment Variables
    * - ``HBM_POOL_PLANNING``
      - Enable HBM-pool planning for intermediates not in LX
        (default ``1``)
+   * - ``FRONTEND_POOL_ALLOCATION``
+     - Allocate each SDSC bundle's HBM pool as a front-end PyTorch tensor
+       passed in as ``%pool_base_addr``, instead of the backend
+       self-allocating via ``sdscbundle.device_mem_allocate``
+       (default ``0``)
    * - ``GLOBAL_STICK_OPTIMIZER``
      - Enable the global stick-dimension optimizer (default ``1``)
    * - ``SPYRE_CORE_ID_K_FAST_EMISSION``


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ x ] documentation
- [ ] cleanup

#### What this PR does:

Add the new FRONTEND_POOL_ALLOCATION row to the env-var table in docs/source/api/torch_spyre.rst, next to HBM_POOL_PLANNING.   

Split out from the main PR #4118 to expedite merging the primary PR since we lack sufficient inductor approvers who are also docs approvers.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
