### PR TITLE
grouped LX regroup for the GQA page (cross-dim relayout)

### DIFF
--- a/tests/inductor/indirect_access_common.py
+++ b/tests/inductor/indirect_access_common.py
@@ -607,12 +607,10 @@ class IndirectAccessTestCase(InductorTestCase):
         value-table / destination data dim (c1). The entry dim is the index
         tensor's stick dim, so it splits in whole 32-entry sticks: the split is
         the planner's ``core_split`` -- the largest divisor of the stick count
-        ``ceil(index_size / 32)`` that does not exceed SENCORES (so it always
-        divides evenly, and a non-power-of-two core count like 6 rounds down to
-        the nearest divisor, e.g. 8 sticks over 6 cores -> 4). The ceiling
-        handles a NON-stick-aligned count, whose partial last stick is padded up
-        to a whole stick (enforce_indirect_access_layout) so the dim still
-        splits, e.g. 40 -> 2 sticks. c1 always stays 1. Skips at sencores=1.
+        that does not exceed SENCORES (so it always divides evenly, and a
+        non-power-of-two core count like 6 rounds down to the nearest divisor,
+        e.g. 8 sticks over 6 cores -> 4). c1 always stays 1. Skips at
+        sencores=1. Partial-stick entry counts use ``assert_entry_dim_unsplit``.
 
         For power-of-two stick counts and core counts (the historical sweep)
         ``core_split`` equals ``min(sencores, sticks)`` -- this generalises it to
@@ -639,35 +637,30 @@ class IndirectAccessTestCase(InductorTestCase):
             "splitting a shared table/destination dim silently corrupts results",
         )
 
-    def assert_entry_dim_unsplit(self, code, index_size):
+    def assert_entry_dim_unsplit(self, code, index_size, data_size=None):
         """Assert the index/entry dim is NOT core-split at the current SENCORES.
 
-        The correct outcome when a stick-aligned split is forbidden and cannot be
-        made safe by padding -- e.g. a partial-last-stick SCATTER, whose in-place
-        destination cannot be grown to a whole stick the way a gather output can
-        (enforce_indirect_access_layout). If the dim were splittable it would
-        split by ``core_split(ceil(index_size/32), sencores)``; assert that split
-        is absent, so the guard kept the op on a single core rather than letting
-        an even slice straddle the index stick boundary. Skips at sencores=1, and
-        is a no-op when the count could not split anyway (would-be split of 1).
+        A partial last stick is padded by restickify. That padded dimension must
+        stay on one core: older code enforced this only inside SuperDSC, after
+        wrapper emission, so the wrapper could advertise a split the device did
+        not execute. Planning now blocks that split before wrapper emission.
         """
         from torch_spyre._inductor import config
 
         n = config.sencores
         if n == 1:
             self.skipTest("no work division at sencores=1")
-        sticks = -(-index_size // self.INDEX_ELEMS_PER_STICK)  # ceil division
-        would_be = max(divisor for divisor in range(1, n + 1) if sticks % divisor == 0)
-        if would_be <= 1:
-            return  # nothing could split even if allowed; nothing to assert
-        self.assertNotIn(
-            f"sympify('c0'): (sympify('{index_size}'), {would_be})",
+        self.assertIn(
+            f"sympify('c0'): (sympify('{index_size}'), 1)",
             code,
-            f"partial-stick entry dim {index_size} must NOT be core-split "
-            f"(would be {would_be} at {n} cores if allowed); its in-place scatter "
-            "destination can't be padded to a whole stick, so the guard must keep "
-            "it single-core rather than straddle the index stick boundary",
+            f"partial-stick entry dim {index_size} must stay unsplit at {n} cores",
         )
+        if data_size is not None:
+            self.assertIn(
+                f"sympify('c1'): (sympify('{data_size}'), 1)",
+                code,
+                f"data dim {data_size} must stay unsplit at {n} cores",
+            )
 
     # -- Dimension naming helpers ----------------------------------------
     def name_dims(self, tensor, dims: dict):

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -71,6 +71,7 @@ from torch_spyre._inductor.constants import (
     SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY,
     SHARED_WEIGHT_UNIT_BMM_INFO_KEY,
 )
+from torch_spyre._inductor.core_mapping import derive_operation_mapping
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.loop_info import CoarseTileInfo, copy_op_metadata
 from torch_spyre._inductor.pass_utils import coeff_through_floor
@@ -633,10 +634,12 @@ def _make_tiled_op_spec() -> OpSpec:
         allocation={"hbm": 0x2000},
         device_tile_advance_expr=tile_advance_expr,
     )
+    iteration_space = {c0: (Integer(128), 1)}
     return OpSpec(
         op="abs",
         is_reduction=False,
-        iteration_space={c0: (Integer(128), 1)},
+        iteration_space=iteration_space,
+        core_id_to_work_slice=derive_operation_mapping(iteration_space),
         args=[tensor_in, tensor_out],
         op_info={},
         tiled_symbols=[[c0]],
@@ -3082,14 +3085,16 @@ class TestCompileOpSpecTwoTiledSymbols(unittest.TestCase):
             allocation={"hbm": 0x2000},
             device_tile_advance_expr=tile_advance_expr,
         )
+        iteration_space = {
+            c0: (Integer(2), 1),
+            c1: (Integer(4), 1),
+            c2: (Integer(64), 1),
+        }
         return OpSpec(
             op="add",
             is_reduction=False,
-            iteration_space={
-                c0: (Integer(2), 1),
-                c1: (Integer(4), 1),
-                c2: (Integer(64), 1),
-            },
+            iteration_space=iteration_space,
+            core_id_to_work_slice=derive_operation_mapping(iteration_space),
             args=[tensor_in, tensor_out],
             op_info={},
             tiled_symbols=[[c0, c1]],
@@ -3576,6 +3581,7 @@ class TestSharedWeightUnitBmmLayout(unittest.TestCase):
                 op="batchmatmul",
                 is_reduction=True,
                 iteration_space=iteration_space,
+                core_id_to_work_slice=derive_operation_mapping(iteration_space),
                 args=args,
                 op_info=op_info,
             )
@@ -4045,10 +4051,12 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
             allocation={"hbm": 0x3000},
             device_tile_advance_expr=64 * out,
         )
+        iteration_space = {c0: (Integer(128), 1)}
         op = OpSpec(
             op="add",
             is_reduction=False,
-            iteration_space={c0: (Integer(128), 1)},
+            iteration_space=iteration_space,
+            core_id_to_work_slice=derive_operation_mapping(iteration_space),
             args=[tensor_in0, tensor_in1, tensor_out],
             op_info={},
             tiled_symbols=[[c0]],

--- a/tests/inductor/test_codegen.py
+++ b/tests/inductor/test_codegen.py
@@ -39,6 +39,7 @@ from torch_spyre._inductor.codegen.superdsc import (
     _resolve_sdsc_size,
     compile_op_spec,
 )
+from torch_spyre._inductor.core_mapping import derive_operation_mapping
 from torch_spyre._inductor.op_spec import OpSpec, TensorArg
 from torch_spyre._inductor.work_division import (
     _collect_symbol_metadata,
@@ -446,13 +447,15 @@ class TestSdscJsonSymbolicDimSmoke(InductorTestCase):
                 allocation={"hbm": hbm_base},
             )
 
+        iteration_space = {
+            c_row: (s0, 1),
+            c_col: (sympy.Integer(256), 1),
+        }
         return OpSpec(
             op="add",
             is_reduction=False,
-            iteration_space={
-                c_row: (s0, 1),
-                c_col: (sympy.Integer(256), 1),
-            },
+            iteration_space=iteration_space,
+            core_id_to_work_slice=derive_operation_mapping(iteration_space),
             args=[
                 _tensor_arg(True, 0, self._HBM_BASE),
                 _tensor_arg(True, 1, self._HBM_BASE + 0x1000),
@@ -664,13 +667,15 @@ class TestGenerateSdscSymbolicPerCoreAddresses(InductorTestCase):
                 allocation={"hbm": hbm_base},
             )
 
+        iteration_space = {
+            c_row: (s0, self._NUM_CORES),
+            c_col: (sympy.Integer(256), 1),
+        }
         return OpSpec(
             op="add",
             is_reduction=False,
-            iteration_space={
-                c_row: (s0, self._NUM_CORES),
-                c_col: (sympy.Integer(256), 1),
-            },
+            iteration_space=iteration_space,
+            core_id_to_work_slice=derive_operation_mapping(iteration_space),
             args=[
                 _tensor_arg(True, 0, self._HBM_BASE),
                 _tensor_arg(True, 1, self._HBM_BASE + 0x1000),

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -33,8 +33,9 @@ from torch_spyre._inductor.core_mapping import (
     derive_core_mapping,
     derive_operation_mapping,
     derive_partition_mapping,
+    finalize_tensor_work_divisions,
 )
-from torch_spyre._inductor.op_spec import OpSpec, TensorArg
+from torch_spyre._inductor.op_spec import OpSpec, TensorArg, TensorWorkDivision
 from torch_spyre._inductor.spyre_kernel import simplify_op_spec
 from torch_spyre._inductor.views import (
     align_tensors,
@@ -175,6 +176,111 @@ def test_late_mapping_rejects_geometry_that_does_not_fill_groups():
             (4, 8),
             32,
             grouped_splits={h: 2},
+        )
+
+
+def test_final_tensor_ownership_is_derived_from_aligned_buffer_geometry():
+    extra, shared = sympy.symbols("extra shared")
+    core_id = sympy.Symbol("core_id")
+    division = TensorWorkDivision(
+        {shared: 2},
+        # Planning-time placement is working data, not the final assignment.
+        {shared: sympy.Mod(core_id, 2)},
+        num_cores=4,
+    )
+
+    (finalized,) = finalize_tensor_work_divisions(
+        {extra: (8, 2), shared: (8, 2)},
+        [division],
+    )
+
+    assert finalized == TensorWorkDivision(
+        {shared: 2},
+        {shared: sympy.Mod(sympy.floor(core_id / 2), 2)},
+        num_cores=4,
+    )
+
+
+def test_shared_lx_buffer_keeps_owners_across_different_operation_dims():
+    producer_extra, producer_shared = sympy.symbols("producer_extra producer_shared")
+    consumer_shared, consumer_extra = sympy.symbols("consumer_shared consumer_extra")
+    core_id = sympy.Symbol("core_id")
+    owners = sympy.Mod(core_id, 2)
+    producer_division = finalize_tensor_work_divisions(
+        {producer_extra: (8, 2), producer_shared: (8, 2)},
+        [
+            TensorWorkDivision(
+                {producer_shared: 2},
+                {producer_shared: owners},
+                num_cores=4,
+            )
+        ],
+    )[0]
+    consumer_division = finalize_tensor_work_divisions(
+        {consumer_shared: (8, 2), consumer_extra: (8, 2)},
+        [
+            TensorWorkDivision(
+                {consumer_shared: 2},
+                {consumer_shared: owners},
+                num_cores=4,
+            )
+        ],
+    )[0]
+    assert producer_division is not None
+    assert consumer_division is not None
+
+    producer = derive_operation_mapping(
+        {producer_extra: (8, 2), producer_shared: (8, 2)},
+        [producer_division],
+    )
+    consumer = derive_operation_mapping(
+        {consumer_shared: (8, 2), consumer_extra: (8, 2)},
+        [consumer_division],
+    )
+
+    assert core_mappings_equal(
+        {producer_shared: producer[producer_shared]},
+        {producer_shared: consumer[consumer_shared]},
+        4,
+    )
+
+
+def test_final_tensor_ownership_requires_a_buffer_core_domain():
+    shared = sympy.Symbol("shared")
+    core_id = sympy.Symbol("core_id")
+
+    with pytest.raises(ValueError, match="physical core domain"):
+        finalize_tensor_work_divisions(
+            {shared: (8, 2)},
+            [
+                TensorWorkDivision(
+                    {shared: 2},
+                    {shared: sympy.Mod(core_id, 2)},
+                )
+            ],
+        )
+
+
+def test_operation_mapping_rejects_conflicting_lx_tensor_owners():
+    shared, extra = sympy.symbols("shared extra")
+    core_id = sympy.Symbol("core_id")
+    divisions = [
+        TensorWorkDivision(
+            {shared: 2},
+            {shared: sympy.Mod(core_id, 2)},
+            num_cores=4,
+        ),
+        TensorWorkDivision(
+            {shared: 2},
+            {shared: sympy.floor(core_id / 2)},
+            num_cores=4,
+        ),
+    ]
+
+    with pytest.raises(ValueError, match="disagree on core ownership"):
+        derive_operation_mapping(
+            {shared: (8, 2), extra: (8, 2)},
+            divisions,
         )
 
 

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -29,6 +29,7 @@ from torch_spyre._inductor.core_mapping import (
     core_mappings_equal,
     core_to_slice_mapping,
     derive_core_mapping,
+    derive_operation_mapping,
     derive_partition_mapping,
 )
 from torch_spyre._inductor.op_spec import OpSpec, TensorArg
@@ -293,6 +294,10 @@ def test_planner_and_sdsc_use_the_same_mapping(monkeypatch, op, reduction_contig
         prep, splits, {dims[2]: 4}
     )
 
+    op_spec.core_id_to_work_slice = derive_operation_mapping(
+        op_spec.iteration_space,
+        contiguous_dim=dims[-1] if reduction_contiguous else None,
+    )
     sdsc_spec, renamed = parse_op_spec(op_spec)
     sdsc_output_mapping = {
         device_dim: sdsc_spec.core_id_to_work_slice[renamed[dim]]

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import math
+from types import SimpleNamespace
 
 import pytest
 import sympy
@@ -34,7 +36,10 @@ from torch_spyre._inductor.core_mapping import (
 )
 from torch_spyre._inductor.op_spec import OpSpec, TensorArg
 from torch_spyre._inductor.spyre_kernel import simplify_op_spec
-from torch_spyre._inductor.views import align_tensors
+from torch_spyre._inductor.views import (
+    align_tensors,
+    align_tensors_pure,
+)
 
 
 def _coordinates(splits, num_cores, **kwargs):
@@ -199,6 +204,46 @@ def test_alignment_preview_is_repeatable_and_does_not_consume_repeat_info():
 
     assert repeat_info == original
     assert preview == codegen
+
+
+def test_captured_alignment_inputs_leave_codegen_unchanged(monkeypatch):
+    dim = sympy.Symbol("dim")
+    op_spec = OpSpec(
+        "identity",
+        False,
+        {dim: (sympy.Integer(4), 2)},
+        [
+            TensorArg(
+                True,
+                0,
+                DataFormats.SEN169_FP16,
+                [2, 64],
+                [sympy.floor(dim / 2), dim],
+                {"hbm": 0},
+            )
+        ],
+        {},
+    )
+    monkeypatch.setattr(
+        pass_utils_module,
+        "alignment_coordinates",
+        lambda *args, **kwargs: [sympy.floor(dim / 2), dim],
+    )
+    captured = pass_utils_module.build_operation_alignment_inputs(
+        {dim: sympy.Integer(4)},
+        [pass_utils_module.AlignmentAccess(SimpleNamespace(device_size=[2, 64]), dim)],
+        aligned_iteration_space=op_spec.iteration_space,
+    )
+    # A preceding validation preview must neither consume nor change the input
+    # subsequently used by codegen.
+    align_tensors_pure(captured)
+
+    captured_path = copy.deepcopy(op_spec)
+    ordinary_path = copy.deepcopy(op_spec)
+    simplify_op_spec(captured_path, alignment_inputs=captured)
+    simplify_op_spec(ordinary_path)
+
+    assert captured_path == ordinary_path
 
 
 def _bmm_op_spec(op: str) -> OpSpec:

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -25,8 +25,15 @@ from torch_spyre._inductor.constants import (
     BATCH_MATMUL_FP8_OP,
     BATCH_MATMUL_OP,
 )
-from torch_spyre._inductor.core_mapping import core_to_slice_mapping
+from torch_spyre._inductor.core_mapping import (
+    core_mappings_equal,
+    core_to_slice_mapping,
+    derive_core_mapping,
+    derive_partition_mapping,
+)
 from torch_spyre._inductor.op_spec import OpSpec, TensorArg
+from torch_spyre._inductor.spyre_kernel import simplify_op_spec
+from torch_spyre._inductor.views import align_tensors
 
 
 def _coordinates(splits, num_cores, **kwargs):
@@ -62,6 +69,135 @@ def test_selected_dim_varies_first(contiguous_dim):
         for dim in range(len(splits))
         if dim != contiguous_dim
     )
+
+
+def _mapping_coordinates(mapping, dims, num_cores):
+    core_id = sympy.Symbol("core_id")
+    return [
+        tuple(int(mapping[dim].subs(core_id, core)) for dim in dims)
+        for core in range(num_cores)
+    ]
+
+
+def test_late_mapping_derives_contiguous_gather_groups():
+    h, lq = sympy.symbols("h lq")
+    mapping = derive_core_mapping(
+        (h, lq),
+        (4, 8),
+        32,
+        grouped_splits={h: 4},
+    )
+    coordinates = _mapping_coordinates(mapping, (h, lq), 32)
+    assert coordinates == [(core // 8, core % 8) for core in range(32)]
+
+
+def test_late_mapping_preserves_selected_contiguous_dimension():
+    batch, output, reduction = sympy.symbols("batch output reduction")
+    mapping = derive_core_mapping(
+        (batch, output, reduction),
+        (2, 4, 4),
+        32,
+        contiguous_dim=reduction,
+    )
+    coordinates = _mapping_coordinates(mapping, (batch, output, reduction), 32)
+    assert [coordinate[2] for coordinate in coordinates[:4]] == [0, 1, 2, 3]
+    assert all(coordinate[:2] == (0, 0) for coordinate in coordinates[:4])
+
+
+def test_late_mapping_derives_contiguous_broadcast_groups():
+    h, query = sympy.symbols("h query")
+    mapping = derive_core_mapping(
+        (query, h),
+        (16, 2),
+        32,
+        grouped_splits={h: 2},
+    )
+    coordinates = _mapping_coordinates(mapping, (query, h), 32)
+    assert coordinates == [(core % 16, core // 16) for core in range(32)]
+
+
+def test_late_partition_mapping_repeats_contiguous_owners():
+    head = sympy.Symbol("head")
+    mapping = derive_partition_mapping((head,), (4,), 32)
+    assert _mapping_coordinates(mapping, (head,), 32) == [
+        (core // 8,) for core in range(32)
+    ]
+
+
+def test_late_mapping_keeps_shared_destination_after_one_consumer_factors():
+    h, query, inner = sympy.symbols("h query inner")
+    original = derive_core_mapping(
+        (h, query),
+        (4, 8),
+        32,
+        grouped_splits={h: 4},
+    )
+    factored = derive_core_mapping(
+        (h, inner, query),
+        (4, 2, 4),
+        32,
+        grouped_splits={h: 4},
+    )
+    assert core_mappings_equal({h: original[h]}, {h: factored[h]}, 32)
+
+
+def test_group_topology_does_not_follow_final_loop_reordering():
+    head, kv, query = sympy.symbols("head kv query")
+    grouped_splits = {head: 2, kv: 2}
+    original = derive_core_mapping(
+        (head, kv, query),
+        (2, 2, 8),
+        32,
+        grouped_splits=grouped_splits,
+    )
+    reordered = derive_core_mapping(
+        (query, kv, head),
+        (8, 2, 2),
+        32,
+        grouped_splits=grouped_splits,
+    )
+    assert _mapping_coordinates(original, (head, kv), 32) == _mapping_coordinates(
+        reordered, (head, kv), 32
+    )
+
+
+def test_late_mapping_rejects_geometry_that_does_not_fill_groups():
+    h, query = sympy.symbols("h query")
+    with pytest.raises(ValueError, match="does not match operation split"):
+        derive_core_mapping(
+            (h, query),
+            (4, 8),
+            32,
+            grouped_splits={h: 2},
+        )
+
+
+def test_scalar_op_has_a_complete_empty_mapping():
+    op_spec = OpSpec("identity", False, {}, [], {})
+    simplify_op_spec(op_spec)
+    assert op_spec.core_id_to_work_slice == {}
+
+
+def test_alignment_preview_is_repeatable_and_does_not_consume_repeat_info():
+    dim = sympy.Symbol("dim")
+    repeat_info = {
+        dim: {
+            "modulus": sympy.Integer(2),
+            "node": sympy.Mod(dim, 2),
+            "kind": "mod",
+        }
+    }
+    original = {symbol: dict(info) for symbol, info in repeat_info.items()}
+    args = (
+        {dim: (sympy.Integer(4), 2)},
+        [{"size": [2, 64], "coordinates": [sympy.floor(dim / 2), dim]}],
+    )
+
+    preview = align_tensors(*args, repeat_info=repeat_info)
+    codegen = align_tensors(*args, repeat_info=repeat_info)
+
+    assert repeat_info == original
+    assert preview == codegen
 
 
 def _bmm_op_spec(op: str) -> OpSpec:

--- a/tests/inductor/test_indirect_access_gather.py
+++ b/tests/inductor/test_indirect_access_gather.py
@@ -1113,15 +1113,14 @@ class _GatherMulticoreScenarios:
     # (c1 = K) -- splitting K makes every core read address 0 of the shared
     # table, silently returning wrong results. Shapes are chosen so the planner
     # *would* prefer K (its largest output-coordinate dim) if the guard were
-    # absent. assert_indexed_dim_split() reads the current SENCORES and expects
-    # c0 to split by min(SENCORES, index_size // 32) with c1 pinned at 1.
+    # absent. Aligned c0 sizes split in whole sticks; partial-stick c0 sizes stay
+    # unsplit because restickify must pad them. c1 always stays unsplit.
     #
-    # After the split-map check each scenario runs through the shared
+    # After the work-division check each scenario runs through the shared
     # _stage_and_e2e path (fresh inputs, since run_and_get_code has already
     # executed the split-map compile) -- the same capture-path stage checks +
-    # e2e leg every other gather scenario uses -- so the multicore split is also
-    # exercised end-to-end. (Skipped at sencores=1 by assert_indexed_dim_split
-    # -- nothing to divide.)
+    # e2e leg every other gather scenario uses -- so the selected mapping is
+    # exercised end-to-end. (Skipped at sencores=1 -- nothing to divide.)
 
     @staticmethod
     def _gather_fn(table, idx):
@@ -1173,15 +1172,11 @@ class _GatherMulticoreScenarios:
         self._stage_and_e2e(fn, *make(), expect=GATHER_OP_SPEC)
 
     # -- stick-aligned vs partial-last-stick index-entry counts -----------
-    # The index-entry dim is the index tensor's stick dim, so work division
-    # splits it in whole 32-entry sticks. A STICK-ALIGNED count (a multiple of
-    # 32) has always split cleanly. A NON-aligned count (a partial last stick)
-    # used to be forced onto one core, because an even per-core slice straddles
-    # the index stick boundary and the backend cannot step a sticked dim across it;
-    # the fix pads the gather output's entry dim up to the next whole stick
-    # (enforce_indirect_access_layout) so the split lands stick-aligned. Both
-    # kinds are swept across every SENCORES; the expected split for either is
-    # min(SENCORES, ceil(count / 32)) with the K data dim always pinned at 1.
+    # The index-entry dim is the index tensor's stick dim, so an aligned count
+    # can split in whole 32-entry sticks. A partial last stick is padded during
+    # restickify and must stay unsplit. SuperDSC historically forced that split
+    # to one only after wrapper emission; the planning constraint now makes the
+    # wrapper and the executed mapping agree.
 
     def test_work_division_index_split_aligned_six_sticks(self):
         """Stick-aligned index with exactly 6 sticks (P=192): a non-power-of-two
@@ -1202,9 +1197,7 @@ class _GatherMulticoreScenarios:
 
     def test_work_division_index_split_partial_stick(self):
         """Non-stick-aligned index (P=40 = one full stick + a partial second):
-        the entry dim is padded up to ceil(40/32)=2 whole sticks so the split
-        lands stick-aligned (2 across any SENCORES>=2) instead of an even slice
-        that would straddle the index stick boundary and miscompile."""
+        restickify pads the entry dim, so planning keeps it on one core."""
 
         def make():
             x = torch.rand(128, 64, 256, dtype=torch.float16).to("spyre")
@@ -1213,14 +1206,11 @@ class _GatherMulticoreScenarios:
 
         fn = self._gather_fn
         _, source_codes = run_and_get_code(torch.compile(fn, dynamic=False), *make())
-        self.assert_indexed_dim_split(source_codes[0], index_size=40, data_size=64)
+        self.assert_entry_dim_unsplit(source_codes[0], index_size=40, data_size=64)
         self._stage_and_e2e(fn, *make(), expect=GATHER_OP_SPEC)
 
     def test_work_division_index_split_partial_stick_mid(self):
-        """Non-stick-aligned index spanning several sticks (P=250, ceil=8 sticks):
-        the padded split scales past a single partial stick -- the non-aligned
-        counterpart of the aligned 8-stick test_work_division_index_split_capped,
-        splitting by the same largest divisor of 8 that fits the core count."""
+        """A larger partial-stick index (P=250) also stays unsplit."""
 
         def make():
             x = torch.rand(128, 64, 256, dtype=torch.float16).to("spyre")
@@ -1229,14 +1219,11 @@ class _GatherMulticoreScenarios:
 
         fn = self._gather_fn
         _, source_codes = run_and_get_code(torch.compile(fn, dynamic=False), *make())
-        self.assert_indexed_dim_split(source_codes[0], index_size=250, data_size=64)
+        self.assert_entry_dim_unsplit(source_codes[0], index_size=250, data_size=64)
         self._stage_and_e2e(fn, *make(), expect=GATHER_OP_SPEC)
 
     def test_work_division_index_split_partial_stick_full(self):
-        """Non-stick-aligned index at 32-stick scale (P=1000, ceil=32): the padded
-        split would reach a full 32-way division, but the indirect uint32 address
-        cap holds it to 16-way at SENCORES=32 -- the partial-stick counterpart of
-        test_work_division_index_split_full."""
+        """A full-scale partial-stick index (P=1000) also stays unsplit."""
 
         def make():
             x = torch.rand(128, 64, 256, dtype=torch.float16).to("spyre")
@@ -1245,7 +1232,7 @@ class _GatherMulticoreScenarios:
 
         fn = self._gather_fn
         _, source_codes = run_and_get_code(torch.compile(fn, dynamic=False), *make())
-        self.assert_indexed_dim_split(source_codes[0], index_size=1000, data_size=64)
+        self.assert_entry_dim_unsplit(source_codes[0], index_size=1000, data_size=64)
         self._stage_and_e2e(fn, *make(), expect=GATHER_OP_SPEC)
 
     # -- shared value table: cross-core read correctness ------------------

--- a/tests/inductor/test_kernel_provenance.py
+++ b/tests/inductor/test_kernel_provenance.py
@@ -243,6 +243,23 @@ class TestKernelProvenanceDescriptor:
             work_division=TensorWorkDivision({c0: 2}, {c0: Symbol("core_id")}),
         )
         changed_owner = dataclasses.replace(first, args=[owned_arg])
+        changed_owner_cores = dataclasses.replace(
+            first,
+            args=[
+                dataclasses.replace(
+                    arg,
+                    work_division=TensorWorkDivision(
+                        {c0: 2}, {c0: Symbol("core_id")}, num_cores=4
+                    ),
+                )
+            ],
+        )
+        changed_core_mapping = dataclasses.replace(
+            first, core_id_to_work_slice={c0: Integer(1)}
+        )
+        canonical_core_mapping = dataclasses.replace(
+            first, core_id_to_work_slice={c0: Integer(0)}
+        )
 
         first_descriptor = build_kernel_provenance_descriptor([first])
         reordered_descriptor = build_kernel_provenance_descriptor([reordered_metadata])
@@ -251,6 +268,15 @@ class TestKernelProvenanceDescriptor:
             [changed_arrangement]
         )
         changed_owner_descriptor = build_kernel_provenance_descriptor([changed_owner])
+        changed_owner_cores_descriptor = build_kernel_provenance_descriptor(
+            [changed_owner_cores]
+        )
+        changed_core_mapping_descriptor = build_kernel_provenance_descriptor(
+            [changed_core_mapping]
+        )
+        canonical_core_mapping_descriptor = build_kernel_provenance_descriptor(
+            [canonical_core_mapping]
+        )
 
         assert first_descriptor is not None
         assert reordered_descriptor is not None
@@ -261,6 +287,9 @@ class TestKernelProvenanceDescriptor:
         assert changed_descriptor.key != first_descriptor.key
         assert changed_arrangement_descriptor.key != first_descriptor.key
         assert changed_owner_descriptor.key != first_descriptor.key
+        assert changed_owner_cores_descriptor.key != changed_owner_descriptor.key
+        assert changed_core_mapping_descriptor.key != first_descriptor.key
+        assert canonical_core_mapping_descriptor.key == first_descriptor.key
 
     def test_pins_rich_canonical_bundle_key(self):
         c0 = Symbol("c0")

--- a/tests/inductor/test_log_op_specs.py
+++ b/tests/inductor/test_log_op_specs.py
@@ -195,6 +195,22 @@ class TestFormatOpSpecList:
 # ---------------------------------------------------------------------------
 
 
+def _make_test_kernel():
+    from torch_spyre._inductor.spyre_kernel import SpyreKernel
+
+    kernel = SpyreKernel.__new__(SpyreKernel)
+    kernel.op_specs = [_make_add_op()]
+    kernel.indirect_vars = None
+    kernel.indirect_sizes = {}
+    kernel.args = MagicMock()
+    kernel.args.python_argdefs.return_value = (None, [])
+    kernel.spyre_kernel_args = []
+    kernel._alignment_repeat_info = {}
+    kernel._alignment_repeat_info_by_spec = {}
+    kernel.pool_size = 0
+    return kernel
+
+
 class TestSpyreKernelLogging:
     """Tests for logger.info calls in SpyreKernel.codegen_kernel."""
 
@@ -206,16 +222,7 @@ class TestSpyreKernelLogging:
                     "torch_spyre._inductor.spyre_kernel.format_op_spec_list",
                     return_value="<formatted>",
                 ) as mock_fmt:
-                    from torch_spyre._inductor.spyre_kernel import SpyreKernel
-
-                    kernel = SpyreKernel.__new__(SpyreKernel)
-                    kernel.op_specs = [_make_add_op()]
-                    kernel.indirect_vars = None
-                    kernel.indirect_sizes = {}
-                    kernel.args = MagicMock()
-                    kernel.args.python_argdefs.return_value = (None, [])
-                    kernel.spyre_kernel_args = []
-                    kernel.pool_size = 0
+                    kernel = _make_test_kernel()
 
                     with patch("torch_spyre._inductor.spyre_kernel.simplify_op_spec"):
                         kernel.codegen_kernel()
@@ -232,16 +239,7 @@ class TestSpyreKernelLogging:
             with patch(
                 "torch_spyre._inductor.spyre_kernel.format_op_spec_list"
             ) as mock_fmt:
-                from torch_spyre._inductor.spyre_kernel import SpyreKernel
-
-                kernel = SpyreKernel.__new__(SpyreKernel)
-                kernel.op_specs = [_make_add_op()]
-                kernel.indirect_vars = None
-                kernel.indirect_sizes = {}
-                kernel.args = MagicMock()
-                kernel.args.python_argdefs.return_value = (None, [])
-                kernel.spyre_kernel_args = []
-                kernel.pool_size = 0
+                kernel = _make_test_kernel()
 
                 with patch("torch_spyre._inductor.spyre_kernel.simplify_op_spec"):
                     kernel.codegen_kernel()

--- a/tests/inductor/test_log_op_specs.py
+++ b/tests/inductor/test_log_op_specs.py
@@ -207,6 +207,8 @@ def _make_test_kernel():
     kernel.spyre_kernel_args = []
     kernel._alignment_repeat_info = {}
     kernel._alignment_repeat_info_by_spec = {}
+    kernel._alignment_access_by_tensor_arg = {}
+    kernel._alignment_inputs_by_spec = {}
     kernel.pool_size = 0
     return kernel
 

--- a/tests/inductor/test_provenance.py
+++ b/tests/inductor/test_provenance.py
@@ -31,6 +31,7 @@ from torch._inductor.utils import IndentedBuffer
 from torch_spyre._C import DataFormats
 from torch_spyre._inductor.codegen.compute_ops import generate_sdsc
 from torch_spyre._inductor.codegen.superdsc import SDSCSpec, parse_op_spec
+from torch_spyre._inductor.core_mapping import derive_operation_mapping
 from torch_spyre._inductor.op_spec import (
     DebugHandle,
     OpSpec,
@@ -445,10 +446,12 @@ def _threadable_op_spec(debug_handle=None):
         device_coordinates=[Integer(0), c0],
         allocation={"hbm": 0x2000},
     )
+    iteration_space = {c0: (Integer(128), 1)}
     return OpSpec(
         op="add",
         is_reduction=False,
-        iteration_space={c0: (Integer(128), 1)},
+        iteration_space=iteration_space,
+        core_id_to_work_slice=derive_operation_mapping(iteration_space),
         args=[tin, tout],
         op_info={},
         tiled_symbols=[[c0]],

--- a/tests/inductor/test_work_division.py
+++ b/tests/inductor/test_work_division.py
@@ -31,6 +31,11 @@ from torch._inductor.ir import (
 from torch_spyre._C import ElementArrangement, SpyreTensorLayout
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.ir import FixedTiledLayout
+from torch_spyre._inductor.constants import (
+    AVGPOOL2D_OP,
+    CONV2D_FWD_OP,
+    DEPTHWISE_CONV2D_OP,
+)
 from torch_spyre._inductor.pass_utils import SchedNodeArg
 from torch_spyre._inductor.scratchpad.allocator import (
     CoOptimizingAllocator,
@@ -56,8 +61,10 @@ from torch_spyre._inductor.work_division_constraints import (
     keep_by_index_k_split_constraint,
     keep_by_index_pinned_search_space_vars,
     qfp8wt_matmul_k_split_domains,
-    topk_split_domains,
     qfp8wt_split_domains,
+    reduction_window_blocked_vars,
+    restickify_padding_blocked_vars,
+    topk_split_domains,
 )
 
 
@@ -618,6 +625,140 @@ class TestConvSpatialBlockedVars(unittest.TestCase):
         self.assertNotIn(j, output_dims)
         self.assertEqual(splits[i], 1)
         self.assertEqual(splits[j], 1)
+
+
+class TestFinalMappingConstraints(unittest.TestCase):
+    _PLACEHOLDER_TD = _tensor_dep("mapping_placeholder", (128,), (_isym("_mapping"),))
+
+    def test_pool_window_dims_are_unsplit(self):
+        ki, kj = (_isym(name) for name in ("ki", "kj"))
+        op = _computed_buffer(
+            (8,),
+            name="pool",
+            reduction_type=AVGPOOL2D_OP,
+            reduction_ranges=(3, 3),
+        )
+        result = reduction_window_blocked_vars(
+            _make_context(
+                op,
+                self._PLACEHOLDER_TD,
+                reduction_vars=[ki, kj],
+            )
+        )
+
+        self.assertEqual(result.blocked, {ki, kj})
+
+    def test_conv_only_blocks_nontrivial_kernel_dims(self):
+        channel, ki, kj = (_isym(name) for name in ("channel", "ki", "kj"))
+        op = _computed_buffer(
+            (8,),
+            name="conv",
+            reduction_type=CONV2D_FWD_OP,
+            reduction_ranges=(64, 3, 1),
+        )
+        op.data.op_info = {"conv_params": {"kernel_h": 3, "kernel_w": 1}}
+        result = reduction_window_blocked_vars(
+            _make_context(
+                op,
+                self._PLACEHOLDER_TD,
+                reduction_vars=[channel, ki],
+            )
+        )
+
+        self.assertEqual(result.blocked, {ki})
+
+    def test_depthwise_conv_does_not_block_trailing_group_dim(self):
+        kh, kw, group = (_isym(name) for name in ("kh", "kw", "group"))
+        op = _computed_buffer(
+            (8,),
+            name="depthwise_conv",
+            reduction_type=DEPTHWISE_CONV2D_OP,
+            reduction_ranges=(3, 3, 4),
+        )
+        result = reduction_window_blocked_vars(
+            _make_context(
+                op,
+                self._PLACEHOLDER_TD,
+                reduction_vars=[kh, kw, group],
+            )
+        )
+
+        self.assertEqual(result.blocked, {kh, kw})
+
+    def test_conv_spatial_and_window_blocks_compose(self):
+        mb, out, i, j, channel, ki = (
+            _isym(name) for name in ("mb", "out", "i", "j", "channel", "ki")
+        )
+        op = _computed_buffer(
+            (2, 3, 8, 16),
+            name="strided_windowed_conv",
+            reduction_type=CONV2D_FWD_OP,
+            reduction_ranges=(64, 3),
+        )
+        op.data.op_info = {
+            "conv_params": {
+                "stride_i": 2,
+                "stride_j": 1,
+                "kernel_h": 3,
+                "kernel_w": 1,
+            }
+        }
+        ctx = _make_context(
+            op,
+            self._PLACEHOLDER_TD,
+            it_space={mb: 2, out: 3, i: 8, j: 16, channel: 64, ki: 3},
+            reduction_vars=[channel, ki],
+        )
+        rw = MagicMock()
+        rw.writes = [MagicMock(ranges=(mb, out, i, j))]
+
+        with patch(TestConvSpatialBlockedVars._PATCH_TARGET, return_value=rw):
+            result = collect_work_division_constraints(ctx)
+
+        self.assertEqual(result.blocked, {i, j, ki})
+
+    def test_window_block_conflicting_with_span_commit_raises_unsupported(self):
+        ki, kj = (_isym(name) for name in ("ki", "kj"))
+        op = _computed_buffer(
+            (8,),
+            name="pool_with_forced_window_split",
+            reduction_type=AVGPOOL2D_OP,
+            reduction_ranges=(3, 3),
+        )
+        ctx = _make_context(
+            op,
+            self._PLACEHOLDER_TD,
+            reduction_vars=[ki, kj],
+            committed_splits={ki: 2},
+        )
+
+        with self.assertRaisesRegex(Unsupported, "reduction_window_blocked_vars"):
+            collect_work_division_constraints(ctx)
+
+    def test_unaligned_restickify_stick_dim_is_unsplit(self):
+        old_stick, new_stick = (_isym(name) for name in ("old_stick", "new_stick"))
+        op = _computed_buffer((96,), name="restickify")
+        input_td = MagicMock()
+        input_td.device_coords = [
+            sympy.floor(old_stick / 64),
+            sympy.Mod(old_stick, 64),
+        ]
+        output_td = MagicMock()
+        output_td.device_coords = [
+            sympy.floor(new_stick / 64),
+            sympy.Mod(new_stick, 64),
+        ]
+        result = restickify_padding_blocked_vars(
+            _make_context(
+                op,
+                output_td,
+                input_tds=[input_td],
+                it_space={old_stick: 96, new_stick: 128},
+                stick_vars={old_stick: 64, new_stick: 64},
+            )
+        )
+
+        self.assertEqual(result.blocked, {old_stick})
 
 
 class TestQfp8wtConstraints(unittest.TestCase):

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -569,6 +569,101 @@ def _relayout_plan(source="source", consumers="consumer"):
     return LXRelayoutPlan(source, consumers, _SOURCE_VIEW, _DESTINATION_VIEW, 8)
 
 
+def test_grouped_gather_records_geometry_without_persisting_new_placement():
+    source = PerCoreView(
+        ((0, 4), (1, 8)),
+        ((0, Mod(_CORE_ID, 4)), (1, Mod(floor(_CORE_ID / 4), 8))),
+    )
+    destination = PerCoreView(((0, 4),), ((0, Mod(_CORE_ID, 4)),))
+
+    grouped = lx_relayout_module._grouped_gather_geometry(source, destination, 32)
+    assert grouped is not None
+    grouped_source, grouped_destination, geometry = grouped
+    assert lx_relayout_module._compatible_partitions(
+        grouped_source, grouped_destination, 32
+    )
+    assert [(item.source_split, item.destination_split) for item in geometry] == [
+        (4, 4),
+        (8, 1),
+    ]
+    owners = lx_relayout_module._core_slices(grouped_destination, 32)
+    assert all(
+        len({tuple(owners[core].items()) for core in range(start, start + 8)}) == 1
+        for start in range(0, 32, 8)
+    )
+
+
+def test_partition_footprint_counts_strided_span_not_elements():
+    assert (
+        lx_relayout_module.partition_physical_span_bytes(
+            (5, 5, 64),
+            (320, 64, 1),
+            64,
+            {0: 2, 1: 2},
+        )
+        == 13 * 128
+    )
+    assert (
+        lx_relayout_module.partition_physical_span_bytes(
+            (5, 5, 64),
+            (512, 64, 1),
+            64,
+            {0: 2, 1: 2},
+        )
+        == 19 * 128
+    )
+
+
+def test_grouped_gather_mapping_is_derived_after_alignment():
+    h, local = Symbol("h"), Symbol("local")
+    source = TensorWorkDivision(
+        {h: 4, local: 8},
+        {h: Mod(floor(_CORE_ID / 8), 4), local: Mod(_CORE_ID, 8)},
+    )
+    destination = TensorWorkDivision({h: 4}, {h: Mod(_CORE_ID, 4)})
+    args = [
+        TensorArg(
+            True,
+            -1,
+            DataFormats.SEN169_FP16,
+            [4, 8, 64],
+            [h, local, Integer(0)],
+            {"lx": 0},
+            work_division=source,
+        ),
+        TensorArg(
+            False,
+            -1,
+            DataFormats.SEN169_FP16,
+            [4, 8, 64],
+            [h, local, Integer(0)],
+            {"lx": 1024},
+            work_division=destination,
+        ),
+    ]
+    spec = OpSpec(
+        IDENTITY_OP,
+        False,
+        {h: (Integer(4), 4), local: (Integer(8), 8)},
+        args,
+        {},
+    )
+
+    simplify_op_spec(spec)
+    source_owner, destination_owner = [arg.work_division for arg in spec.args]
+    assert source_owner is not None and destination_owner is not None
+    assert source_owner.core_id_to_work_slice != source.core_id_to_work_slice
+    destination_dim = next(iter(destination_owner.core_id_to_work_slice))
+    assert [
+        int(
+            destination_owner.core_id_to_work_slice[destination_dim].subs(
+                _CORE_ID, core
+            )
+        )
+        for core in range(32)
+    ] == [owner for owner in range(4) for _ in range(8)]
+
+
 def test_lx_relayout_activation_policy_is_source_wide():
     dep = SimpleNamespace(name="input")
     producer = SimpleNamespace()
@@ -828,6 +923,57 @@ def test_lx_relayout_consumers_share_destination_view(second_consumer):
     if not shares_destination:
         expected_destinations.add("sympify('c0'): 8")
     assert {pair[1] for pair in divisions} == expected_destinations
+
+
+@config.patch(
+    {
+        "sencores": 32,
+        "lx_planning": True,
+        "allow_all_ops_in_lx_planning": True,
+        "lx_planner_relayout": True,
+        "layout_solver": "greedy",
+    }
+)
+@pytest.mark.parametrize(
+    ("num_heads", "key_length", "query_length", "key_split"),
+    ((4, 128, 8, 8), (8, 64, 4, 4)),
+)
+def test_grouped_lx_gather_device(num_heads, key_length, query_length, key_split):
+    torch.manual_seed(0)
+    value = torch.randn(num_heads, key_length, 64, dtype=torch.float16)
+    attention = torch.randn(num_heads, query_length, key_length, dtype=torch.float16)
+    for name, size in (
+        ("H", num_heads),
+        ("Lk", key_length),
+        ("Lq", query_length),
+        ("D", 64),
+    ):
+        _declare_tensor_dim(name, size)
+
+    def fn(value, attention):
+        with spyre_hint(work_div={"H": num_heads, "Lk": key_split}):
+            hidden = torch.neg(value)
+        with spyre_hint(work_div={"H": num_heads, "Lq": query_length}):
+            return torch.bmm(attention, hidden)
+
+    device_args = (
+        _name_tensor_dims(value.to("spyre"), ["H", "Lk", "D"]),
+        _name_tensor_dims(attention.to("spyre"), ["H", "Lq", "Lk"]),
+    )
+    torch._inductor.codecache.FxGraphCache.clear()
+    actual, code = run_and_get_code(
+        torch.compile(fn, dynamic=False, options={"epilogue_fusion": False}),
+        *device_args,
+    )
+    torch.testing.assert_close(actual.cpu(), fn(value, attention), rtol=2e-2, atol=1e-1)
+    identities = [
+        block
+        for block in "\n".join(code).split("OpSpec(")
+        if "op='identity'" in block[:100]
+    ]
+    assert len(identities) == 1
+    assert identities[0].count("allocation={'lx':") == 2
+    assert identities[0].count("TensorWorkDivision(") == 2
 
 
 def test_lx_relayout_allocation_is_atomic_in_one_greedy_solve(caplog):

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -927,6 +927,60 @@ def test_grouped_gather_mapping_is_derived_after_alignment():
     ] == [owner for owner in range(4) for _ in range(8)]
 
 
+@config.patch({"sencores": 32})
+def test_grouped_broadcast_derives_distinct_physical_core_domains():
+    h = Symbol("h")
+    source_view = PerCoreView(((0, 2),), ((0, Mod(_CORE_ID, 2)),), num_cores=2)
+    destination_view = PerCoreView(
+        ((0, 2),), ((0, floor(_CORE_ID / 16)),), num_cores=32
+    )
+    grouped = lx_relayout_module._grouped_broadcast_geometry(
+        source_view, destination_view, 2, 32
+    )
+    assert grouped is not None
+    source_view, destination_view, geometry = grouped
+    assert [(item.source_split, item.destination_split) for item in geometry] == [
+        (2, 2)
+    ]
+
+    coordinates = [h, Integer(0)]
+    args = [
+        TensorArg(
+            True,
+            -1,
+            DataFormats.SEN169_FP16,
+            [2, 64],
+            coordinates,
+            {"lx": 0},
+            work_division=work_division_from_view(source_view, coordinates, (h,)),
+        ),
+        TensorArg(
+            False,
+            -1,
+            DataFormats.SEN169_FP16,
+            [2, 64],
+            coordinates,
+            {"lx": 1024},
+            work_division=work_division_from_view(destination_view, coordinates, (h,)),
+        ),
+    ]
+    root, allocations = _compile_spec(
+        OpSpec(IDENTITY_OP, False, {h: (Integer(2), 2)}, args, {})
+    )
+    assert set(root["dscs_"][0]) == {"shuffle"}
+    assert root["numCoresUsed_"] == 32
+    source_map, destination_map = [
+        node["coordinates_"]["coreIdToWkSlice_"] for node in allocations
+    ]
+    assert set(source_map) == {"0", "1"}
+    source_owners = [tuple(source_map[str(core)].values()) for core in range(2)]
+    destination_owners = [
+        tuple(destination_map[str(core)].values()) for core in range(32)
+    ]
+    assert source_owners[0] != source_owners[1]
+    assert destination_owners == [owner for owner in source_owners for _ in range(16)]
+
+
 def test_lx_relayout_activation_policy_is_source_wide():
     dep = SimpleNamespace(name="input")
     producer = SimpleNamespace()
@@ -1263,6 +1317,52 @@ def test_grouped_lx_gather_device(
         assert identities[0].count("allocation={'lx':") == 2
         assert identities[0].count("TensorWorkDivision(") == 2
         _assert_lx_only_relayout_payload(output_dirs)
+
+
+@config.patch(
+    {
+        "sencores": 32,
+        "lx_planning": True,
+        "allow_all_ops_in_lx_planning": True,
+        "lx_planner_relayout": True,
+        "layout_solver": "greedy",
+    }
+)
+def test_grouped_lx_broadcast_device():
+    torch.manual_seed(0)
+    probs = torch.randn(1, 8, 512, 128, dtype=torch.float16)
+    value_pages = torch.randn(2, 8, 128, 128, dtype=torch.float16)
+    page_table = torch.zeros(2, 32, dtype=torch.int32)
+
+    def fn(probs, value_pages, page_table):
+        page = value_pages.index_select(0, page_table[0, :1])
+        return torch.matmul(probs, page)
+
+    device_args = tuple(arg.to("spyre") for arg in (probs, value_pages, page_table))
+    torch._inductor.codecache.FxGraphCache.clear()
+    with _capture_backend_output_dirs() as output_dirs:
+        actual, code = run_and_get_code(
+            torch.compile(fn, dynamic=False, options={"epilogue_fusion": False}),
+            *device_args,
+        )
+    torch.testing.assert_close(
+        actual.cpu(), fn(probs, value_pages, page_table), rtol=2e-2, atol=2e-1
+    )
+    identities = [
+        block
+        for block in "\n".join(code).split("OpSpec(")
+        if "op='identity'" in block[:100]
+    ]
+    relayouts = [
+        block
+        for block in identities
+        if block.count("allocation={'lx':") == 2
+        and block.count("TensorWorkDivision(") == 2
+    ]
+    assert len(relayouts) == 1
+    assert "num_cores=1" in relayouts[0]
+    assert "num_cores=32" in relayouts[0]
+    _assert_lx_only_relayout_payload(output_dirs)
 
 
 def test_lx_relayout_allocation_is_atomic_in_one_greedy_solve(caplog):

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -769,6 +769,15 @@ def test_final_view_validation_requires_one_shared_physical_view():
             )
             is None
         )
+        assert "source users derived 0 final views" in (
+            lx_relayout_module.validate_final_views(
+                graph,
+                plan,
+                {},
+                destination_name="destination",
+            )
+            or ""
+        )
         views[("consumer", "destination")] = replace(
             destination,
             slice_shape=(2, 4, 64),
@@ -868,8 +877,13 @@ def test_grouped_gather_mapping_is_derived_after_alignment():
     source = TensorWorkDivision(
         {h: 4, local: 8},
         {h: Mod(floor(_CORE_ID / 8), 4), local: Mod(_CORE_ID, 8)},
+        num_cores=32,
     )
-    destination = TensorWorkDivision({h: 4}, {h: Mod(_CORE_ID, 4)})
+    destination = TensorWorkDivision(
+        {h: 4},
+        {h: Mod(_CORE_ID, 4)},
+        num_cores=32,
+    )
     args = [
         TensorArg(
             True,
@@ -1493,13 +1507,16 @@ def test_lx_relayout_scheduler_demotes_groups_but_not_ordinary_unary():
             128,
         )
 
-        def preview(node, *, relayout_copy):
+        def preview(node, *, relayout_copy, tracked_buffers):
             del relayout_copy
+            if drift == "mapping" and node.name == "consumer":
+                raise ValueError("no operation core mapping satisfies LX ownership")
             return (
                 {
                     (node.name, dep.name): final_view
                     for dep in (*node.read_writes.reads, *node.read_writes.writes)
-                    if dep.name in buffers
+                    if dep.name in tracked_buffers
+                    and dep.name in buffers
                     and "lx" in buffers[dep.name].get_layout().allocation
                 },
                 False,
@@ -1548,11 +1565,12 @@ def test_lx_relayout_scheduler_demotes_groups_but_not_ordinary_unary():
     run_registered("source")
     run_registered("consumer")
     run_registered("projection")
+    run_registered("mapping")
     run_registered("missing")
     run_registered("missing_buffer")
 
 
-def test_final_view_gate_demotes_ordinary_buffer_without_a_preview_view():
+def test_final_view_gate_leaves_ordinary_lx_to_existing_validation():
     dep = SimpleNamespace(name="ordinary")
     layout = _relayout_layout(0, _SOURCE_VIEW)
     nodes = [
@@ -1583,13 +1601,13 @@ def test_final_view_gate_demotes_ordinary_buffer_without_a_preview_view():
         mock_patch.object(
             scheduler_module,
             "_preview_final_lx_views",
-            return_value=({}, False),
+            side_effect=AssertionError("ordinary LX must not enter the relayout gate"),
         ),
         config.patch({"lx_planning": True}),
     ):
         scheduler_module.demote_incoherent_lx_buffers(nodes)
 
-    assert "lx" not in layout.allocation
+    assert "lx" in layout.allocation
 
 
 def aot_backend(gm: GraphModule, example_inputs: Sequence[InputType]):

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -658,6 +658,29 @@ def test_grouped_gather_records_geometry_without_persisting_new_placement():
     )
 
 
+def test_grouped_regroup_classifies_cross_dim_transfer():
+    # GQA paged-attention page: source partitioned on dim 1 across all cores,
+    # consumer owns it on a DISJOINT dim 2 with fewer owners (a transpose of the
+    # owned axis). The same-dim gather classifier rejects this; the regroup
+    # classifier accepts it and _compatible_regroup certifies the transfer.
+    source = PerCoreView(((1, 32),), ((1, Mod(_CORE_ID, 32)),), num_cores=32)
+    destination = PerCoreView(((2, 2),), ((2, floor(_CORE_ID / 16)),), num_cores=32)
+
+    assert lx_relayout_module._grouped_gather_geometry(source, destination, 32) is None
+    grouped = lx_relayout_module._grouped_regroup_geometry(source, destination, 32)
+    assert grouped is not None
+    assert lx_relayout_module._compatible_regroup(source, destination, 32)
+
+
+def test_grouped_regroup_rejects_shared_split_axis():
+    # A same-axis contraction is a gather, not a regroup: the regroup classifier
+    # must decline when source and destination split overlapping dims.
+    source = PerCoreView(((0, 32),), ((0, Mod(_CORE_ID, 32)),), num_cores=32)
+    destination = PerCoreView(((0, 2),), ((0, floor(_CORE_ID / 16)),), num_cores=32)
+
+    assert lx_relayout_module._grouped_regroup_geometry(source, destination, 32) is None
+
+
 def test_partition_footprint_counts_strided_span_not_elements():
     assert (
         lx_relayout_module.partition_physical_span_bytes(

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -37,6 +37,7 @@ from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code, InputType
 
 from torch_spyre._inductor import config, spyre_hint
+import torch_spyre._inductor.scratchpad.allocator as allocator_module
 import torch_spyre._inductor.scratchpad.lx_relayout as lx_relayout_module
 import torch_spyre._inductor.scheduler as scheduler_module
 import torch_spyre._inductor.work_division as _wd
@@ -44,6 +45,7 @@ import torch_spyre._inductor.wsr.propagate_named_dims as _pnd
 from torch_spyre._C import DataFormats
 from torch_spyre._inductor.codegen.superdsc import compile_op_spec, parse_op_spec
 from torch_spyre._inductor.constants import IDENTITY_OP
+from torch_spyre._inductor.core_mapping import remap_work_division
 from torch_spyre._inductor.scratchpad.lx_relayout import (
     FinalLXView,
     LXRelayoutPlan,
@@ -54,7 +56,6 @@ from torch_spyre._inductor.pass_utils import PerCoreView
 from torch_spyre._inductor.scratchpad.allocator import ScratchpadAllocator
 from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
 from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
-from torch_spyre._inductor.core_mapping import remap_work_division
 from torch_spyre._inductor.spyre_kernel import simplify_op_spec
 
 _LAUNCH_JOBPLAN = "torch_spyre.execution.kernel_runner.launch_jobplan"
@@ -614,6 +615,24 @@ def test_partition_footprint_counts_strided_span_not_elements():
         )
         == 19 * 128
     )
+
+
+def test_partition_footprints_skip_buffers_without_concrete_layout():
+    dep = SimpleNamespace(name="multi_output")
+
+    def unavailable_layout():
+        raise NotImplementedError("MultiOutputLayout")
+
+    graph = SimpleNamespace(
+        operations=[SimpleNamespace()],
+        try_get_buffer=lambda _name: SimpleNamespace(get_layout=unavailable_layout),
+    )
+    read_writes = SimpleNamespace(reads=[], writes=[dep])
+    with (
+        mock_patch.object(allocator_module, "MemoryDep", SimpleNamespace),
+        mock_patch.object(allocator_module, "op_read_writes", return_value=read_writes),
+    ):
+        assert ScratchpadAllocator._partition_footprints(graph, {dep.name: 1}) == {}
 
 
 def test_final_view_maps_stick_split_to_outer_device_dimension():

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections.abc import Sequence
+from contextlib import nullcontext
 from dataclasses import replace
 import logging
 import logging.handlers
@@ -638,12 +639,14 @@ def test_final_view_ignores_alignment_only_singleton_dimensions():
         [8, 64],
         [c, Mod(c, 64)],
         {c: (8, 1)},
+        physical_span_bytes=512,
     )
     expanded = lx_relayout_module.final_view_from_work_division(
         division,
         [1, 1, 8, 64],
         [0, 0, c, Mod(c, 64)],
         {c: (8, 1)},
+        physical_span_bytes=512,
     )
     assert expanded == compact
 
@@ -690,6 +693,85 @@ def test_final_view_validation_requires_one_shared_physical_view():
             slice_shape=(2, 4, 64),
         )
         assert "destination users derived 2 final views" in (
+            lx_relayout_module.validate_final_views(
+                graph,
+                plan,
+                views,
+                destination_name="destination",
+            )
+            or ""
+        )
+        views[("consumer", "destination")] = destination
+        oversized_source = replace(
+            source,
+            physical_span_bytes=2048,
+        )
+        views[("producer", "source")] = oversized_source
+        views[("copy", "source")] = oversized_source
+        assert "physical span 2048 exceeds planned 1024" in (
+            lx_relayout_module.validate_final_views(
+                graph,
+                plan,
+                views,
+                destination_name="destination",
+            )
+            or ""
+        )
+
+
+def test_final_view_validation_rejects_padded_span_above_plan():
+    source_view = PerCoreView(
+        ((0, 2), (1, 2)),
+        ((0, floor(_CORE_ID / 2)), (1, Mod(_CORE_ID, 2))),
+        num_cores=4,
+    )
+    destination_view = PerCoreView(
+        ((0, 2), (1, 2)),
+        ((0, Mod(_CORE_ID, 2)), (1, floor(_CORE_ID / 2))),
+        num_cores=4,
+    )
+    element_count_bound = 3 * 3 * 128
+    physical_span = lx_relayout_module.partition_physical_span_bytes(
+        (5, 5, 64),
+        (512, 64, 1),
+        64,
+        {0: 2, 1: 2},
+    )
+    assert physical_span == 19 * 128 > element_count_bound
+
+    plan = LXRelayoutPlan(
+        "source",
+        ("consumer",),
+        source_view,
+        destination_view,
+        4,
+        max_footprint_bytes=element_count_bound,
+        source_address=0,
+        destination_address=4096,
+    )
+    source = FinalLXView(
+        source_view,
+        (5, 5, 64),
+        (3, 3, 64),
+        physical_span,
+    )
+    destination = replace(source, ownership=destination_view)
+    views = {
+        ("producer", "source"): source,
+        ("copy", "source"): source,
+        ("copy", "destination"): destination,
+        ("consumer", "destination"): destination,
+    }
+    layout = SimpleNamespace(device_layout=SimpleNamespace(device_size=(5, 5, 64)))
+    graph = SimpleNamespace(
+        try_get_buffer=lambda name: (
+            SimpleNamespace(get_layout=lambda: layout)
+            if name in {"source", "destination"}
+            else None
+        )
+    )
+    with mock_patch.object(lx_relayout_module, "FixedTiledLayout", SimpleNamespace):
+        assert "physical span 2432 exceeds planned 1152" in (
             lx_relayout_module.validate_final_views(
                 graph,
                 plan,
@@ -1021,10 +1103,12 @@ def test_lx_relayout_consumers_share_destination_view(second_consumer):
     }
 )
 @pytest.mark.parametrize(
-    ("num_heads", "key_length", "query_length", "key_split"),
-    ((4, 128, 8, 8), (8, 64, 4, 4)),
+    ("num_heads", "key_length", "query_length", "key_split", "force_fallback"),
+    ((4, 128, 8, 8, False), (8, 64, 4, 4, False), (4, 128, 8, 8, True)),
 )
-def test_grouped_lx_gather_device(num_heads, key_length, query_length, key_split):
+def test_grouped_lx_gather_device(
+    num_heads, key_length, query_length, key_split, force_fallback
+):
     torch.manual_seed(0)
     value = torch.randn(num_heads, key_length, 64, dtype=torch.float16)
     attention = torch.randn(num_heads, query_length, key_length, dtype=torch.float16)
@@ -1047,10 +1131,23 @@ def test_grouped_lx_gather_device(num_heads, key_length, query_length, key_split
         _name_tensor_dims(attention.to("spyre"), ["H", "Lq", "Lk"]),
     )
     torch._inductor.codecache.FxGraphCache.clear()
-    actual, code = run_and_get_code(
-        torch.compile(fn, dynamic=False, options={"epilogue_fusion": False}),
-        *device_args,
+    clone_counter = scheduler_module.counters["torch_spyre"][
+        "lx_relayout_gate_demoted_with_hbm_clone"
+    ]
+    preview = (
+        mock_patch.object(
+            scheduler_module,
+            "_preview_final_lx_views",
+            side_effect=ValueError("forced fallback"),
+        )
+        if force_fallback
+        else nullcontext()
     )
+    with preview:
+        actual, code = run_and_get_code(
+            torch.compile(fn, dynamic=False, options={"epilogue_fusion": False}),
+            *device_args,
+        )
     torch.testing.assert_close(actual.cpu(), fn(value, attention), rtol=2e-2, atol=1e-1)
     identities = [
         block
@@ -1058,8 +1155,17 @@ def test_grouped_lx_gather_device(num_heads, key_length, query_length, key_split
         if "op='identity'" in block[:100]
     ]
     assert len(identities) == 1
-    assert identities[0].count("allocation={'lx':") == 2
-    assert identities[0].count("TensorWorkDivision(") == 2
+    if force_fallback:
+        assert "allocation={'lx':" not in identities[0]
+        assert (
+            scheduler_module.counters["torch_spyre"][
+                "lx_relayout_gate_demoted_with_hbm_clone"
+            ]
+            > clone_counter
+        )
+    else:
+        assert identities[0].count("allocation={'lx':") == 2
+        assert identities[0].count("TensorWorkDivision(") == 2
 
 
 def test_lx_relayout_allocation_is_atomic_in_one_greedy_solve(caplog):
@@ -1297,6 +1403,29 @@ def test_lx_relayout_scheduler_demotes_groups_but_not_ordinary_unary():
                 True,
             )
 
+        final_view = FinalLXView(
+            PerCoreView((), (), num_cores=1),
+            (64,),
+            (64,),
+            128,
+        )
+
+        def preview(node, *, relayout_copy):
+            del relayout_copy
+            return (
+                {
+                    (node.name, dep.name): final_view
+                    for dep in (*node.read_writes.reads, *node.read_writes.writes)
+                    if dep.name in buffers
+                    and "lx" in buffers[dep.name].get_layout().allocation
+                },
+                False,
+            )
+
+        clone_counter = scheduler_module.counters["torch_spyre"][
+            "lx_relayout_gate_demoted_with_hbm_clone"
+        ]
+
         with (
             mock_patch.object(scheduler_module, "SchedulerNode", _RelayoutNode),
             mock_patch.object(scheduler_module, "MemoryDep", SimpleNamespace),
@@ -1307,7 +1436,7 @@ def test_lx_relayout_scheduler_demotes_groups_but_not_ordinary_unary():
             mock_patch.object(
                 scheduler_module,
                 "_preview_final_lx_views",
-                return_value=({}, False),
+                side_effect=preview,
             ),
             mock_patch.object(
                 scheduler_module,
@@ -1319,6 +1448,12 @@ def test_lx_relayout_scheduler_demotes_groups_but_not_ordinary_unary():
             config.patch({"lx_planning": True}),
         ):
             scheduler_module.demote_incoherent_lx_buffers(nodes)
+        assert (
+            scheduler_module.counters["torch_spyre"][
+                "lx_relayout_gate_demoted_with_hbm_clone"
+            ]
+            == clone_counter + 1
+        )
         assert graph._spyre_lx_relayout_copies == {}
         assert "lx" not in layouts["source"].allocation
         if drift != "missing_buffer":
@@ -1332,6 +1467,46 @@ def test_lx_relayout_scheduler_demotes_groups_but_not_ordinary_unary():
     run_registered("projection")
     run_registered("missing")
     run_registered("missing_buffer")
+
+
+def test_final_view_gate_demotes_ordinary_buffer_without_a_preview_view():
+    dep = SimpleNamespace(name="ordinary")
+    layout = _relayout_layout(0, _SOURCE_VIEW)
+    nodes = [
+        _RelayoutNode("producer", writes=(dep,), layout=layout),
+        _RelayoutNode("consumer", reads=(dep,)),
+    ]
+    buffer = SimpleNamespace(get_layout=lambda: layout)
+    graph = SimpleNamespace(
+        _spyre_lx_relayout_copies={},
+        try_get_buffer=lambda name: buffer if name == "ordinary" else None,
+        get_buffer=lambda name: buffer,
+    )
+    with (
+        mock_patch.object(scheduler_module, "SchedulerNode", _RelayoutNode),
+        mock_patch.object(scheduler_module, "MemoryDep", SimpleNamespace),
+        mock_patch.object(scheduler_module, "FixedTiledLayout", SimpleNamespace),
+        mock_patch.object(scheduler_module, "V", SimpleNamespace(graph=graph)),
+        mock_patch.object(
+            scheduler_module,
+            "per_core_view_scheduled",
+            return_value=(_SOURCE_VIEW, False, True),
+        ),
+        mock_patch.object(
+            scheduler_module,
+            "_ownership_projectable",
+            return_value=True,
+        ),
+        mock_patch.object(
+            scheduler_module,
+            "_preview_final_lx_views",
+            return_value=({}, False),
+        ),
+        config.patch({"lx_planning": True}),
+    ):
+        scheduler_module.demote_incoherent_lx_buffers(nodes)
+
+    assert "lx" not in layout.allocation
 
 
 def aot_backend(gm: GraphModule, example_inputs: Sequence[InputType]):

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -44,6 +44,7 @@ from torch_spyre._C import DataFormats
 from torch_spyre._inductor.codegen.superdsc import compile_op_spec, parse_op_spec
 from torch_spyre._inductor.constants import IDENTITY_OP
 from torch_spyre._inductor.scratchpad.lx_relayout import (
+    FinalLXView,
     LXRelayoutPlan,
     work_division_from_view,
 )
@@ -612,6 +613,91 @@ def test_partition_footprint_counts_strided_span_not_elements():
         )
         == 19 * 128
     )
+
+
+def test_final_view_maps_stick_split_to_outer_device_dimension():
+    c = Symbol("c")
+    division = TensorWorkDivision(
+        {c: 2},
+        {c: Mod(_CORE_ID, 2)},
+        num_cores=2,
+    )
+    view = lx_relayout_module.view_from_work_division(
+        division,
+        [floor(c / 64), Mod(c, 64)],
+        {c: (128, 2)},
+    )
+    assert view.work_slice_dims == ((0, 2),)
+
+
+def test_final_view_ignores_alignment_only_singleton_dimensions():
+    c = Symbol("c")
+    division = TensorWorkDivision({}, {}, num_cores=1)
+    compact = lx_relayout_module.final_view_from_work_division(
+        division,
+        [8, 64],
+        [c, Mod(c, 64)],
+        {c: (8, 1)},
+    )
+    expanded = lx_relayout_module.final_view_from_work_division(
+        division,
+        [1, 1, 8, 64],
+        [0, 0, c, Mod(c, 64)],
+        {c: (8, 1)},
+    )
+    assert expanded == compact
+
+
+def test_final_view_validation_requires_one_shared_physical_view():
+    plan = replace(
+        _relayout_plan(),
+        max_footprint_bytes=1024,
+        source_address=0,
+        destination_address=2048,
+    )
+    layout = SimpleNamespace(device_layout=SimpleNamespace(device_size=(8, 4, 64)))
+    graph = SimpleNamespace(
+        try_get_buffer=lambda name: (
+            SimpleNamespace(get_layout=lambda: layout)
+            if name in {"source", "destination"}
+            else None
+        )
+    )
+    source = FinalLXView(
+        replace(_SOURCE_VIEW, num_cores=8), (8, 4, 64), (2, 2, 64), 512
+    )
+    destination = FinalLXView(
+        replace(_DESTINATION_VIEW, num_cores=8), (8, 4, 64), (1, 4, 64), 512
+    )
+    views = {
+        ("producer", "source"): source,
+        ("copy", "source"): source,
+        ("copy", "destination"): destination,
+        ("consumer", "destination"): destination,
+    }
+    with mock_patch.object(lx_relayout_module, "FixedTiledLayout", SimpleNamespace):
+        assert (
+            lx_relayout_module.validate_final_views(
+                graph,
+                plan,
+                views,
+                destination_name="destination",
+            )
+            is None
+        )
+        views[("consumer", "destination")] = replace(
+            destination,
+            slice_shape=(2, 4, 64),
+        )
+        assert "destination users derived 2 final views" in (
+            lx_relayout_module.validate_final_views(
+                graph,
+                plan,
+                views,
+                destination_name="destination",
+            )
+            or ""
+        )
 
 
 def test_grouped_gather_mapping_is_derived_after_alignment():
@@ -1218,6 +1304,11 @@ def test_lx_relayout_scheduler_demotes_groups_but_not_ordinary_unary():
             mock_patch.object(lx_relayout_module, "FixedTiledLayout", SimpleNamespace),
             mock_patch.object(scheduler_module, "V", SimpleNamespace(graph=graph)),
             mock_patch.object(scheduler_module, "per_core_view_scheduled", view),
+            mock_patch.object(
+                scheduler_module,
+                "_preview_final_lx_views",
+                return_value=({}, False),
+            ),
             mock_patch.object(
                 scheduler_module,
                 "_ownership_projectable",

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -13,11 +13,15 @@
 # limitations under the License.
 
 from collections.abc import Sequence
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from dataclasses import replace
+import json
 import logging
 import logging.handlers
+import os
+from pathlib import Path
 import regex as re
+import subprocess
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch as mock_patch
@@ -42,6 +46,7 @@ import torch_spyre._inductor.scratchpad.lx_relayout as lx_relayout_module
 import torch_spyre._inductor.scheduler as scheduler_module
 import torch_spyre._inductor.work_division as _wd
 import torch_spyre._inductor.wsr.propagate_named_dims as _pnd
+import torch_spyre.execution.async_compile as async_compile_module
 from torch_spyre._C import DataFormats
 from torch_spyre._inductor.codegen.superdsc import compile_op_spec, parse_op_spec
 from torch_spyre._inductor.constants import IDENTITY_OP
@@ -64,6 +69,63 @@ _PREPARE_KERNEL = "torch_spyre.execution.kernel_runner.prepare_kernel"
 
 _declare_tensor_dim = _pnd.declare_tensor_dim
 _name_tensor_dims = _pnd.name_tensor_dims
+
+
+@contextmanager
+def _capture_backend_output_dirs():
+    output_dirs = []
+    get_output_dir = async_compile_module.get_output_dir
+
+    def capture(kernel_name):
+        output_dir = get_output_dir(kernel_name)
+        output_dirs.append(Path(output_dir))
+        return output_dir
+
+    with mock_patch.object(async_compile_module, "get_output_dir", side_effect=capture):
+        yield output_dirs
+
+
+def _assert_lx_only_relayout_payload(output_dirs):
+    for output_dir in output_dirs:
+        subprocess.run(
+            ["dxp_standalone", "-d", output_dir, "--use-dxp"],
+            check=True,
+            env={**os.environ, "DXP_DEBUG": "1"},
+        )
+    payloads = [
+        json.loads(path.read_text())
+        for output_dir in output_dirs
+        for path in output_dir.glob("debug/sdsc_*/*.out.out.out.json")
+    ]
+    assert payloads, "DeepTools emitted no debug SDSC payloads"
+
+    op_names = []
+    lx_ops = []
+
+    def visit(value):
+        if isinstance(value, dict):
+            op = value.get("op")
+            if isinstance(op, dict) and op.get("name") == "STCDPOpLx":
+                lx_ops.append(value)
+            for key, child in value.items():
+                if key == "name" and isinstance(child, str):
+                    op_names.append(child)
+                visit(child)
+        elif isinstance(value, list):
+            for child in value:
+                visit(child)
+
+    for payload in payloads:
+        visit(payload)
+
+    assert len(lx_ops) == 1
+    assert not any(
+        token in name.lower()
+        for name in op_names
+        for token in ("dma", "restickify", "stcdpophbm")
+    )
+    labeled_ds = lx_ops[0]["labeledDs_"]
+    assert labeled_ds and all(ds["hbmSize_"] == 0 for ds in labeled_ds)
 
 
 class TestNamedWorkDivisionHint(InductorTestCase):
@@ -1162,7 +1224,8 @@ def test_grouped_lx_gather_device(
         if force_fallback
         else nullcontext()
     )
-    with preview:
+    backend = nullcontext([]) if force_fallback else _capture_backend_output_dirs()
+    with preview, backend as output_dirs:
         actual, code = run_and_get_code(
             torch.compile(fn, dynamic=False, options={"epilogue_fusion": False}),
             *device_args,
@@ -1185,6 +1248,7 @@ def test_grouped_lx_gather_device(
     else:
         assert identities[0].count("allocation={'lx':") == 2
         assert identities[0].count("TensorWorkDivision(") == 2
+        _assert_lx_only_relayout_payload(output_dirs)
 
 
 def test_lx_relayout_allocation_is_atomic_in_one_greedy_solve(caplog):

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -52,7 +52,8 @@ from torch_spyre._inductor.pass_utils import PerCoreView
 from torch_spyre._inductor.scratchpad.allocator import ScratchpadAllocator
 from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
 from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
-from torch_spyre._inductor.spyre_kernel import _remap_work_division, simplify_op_spec
+from torch_spyre._inductor.core_mapping import remap_work_division
+from torch_spyre._inductor.spyre_kernel import simplify_op_spec
 
 _LAUNCH_JOBPLAN = "torch_spyre.execution.kernel_runner.launch_jobplan"
 _PREPARE_KERNEL = "torch_spyre.execution.kernel_runner.prepare_kernel"
@@ -701,8 +702,8 @@ def test_lx_relayout_normalizes_ownership_and_lowers_only_in_superdsc():
     ]
     assert root["numWkSlicesPerDim_"] == {"mb": 1, "x": 8, "out": 1}
     maps = [node["coordinates_"]["coreIdToWkSlice_"] for node in allocations]
-    assert [maps[0][str(i)]["x"] for i in range(8)] == [i // 2 for i in range(8)]
-    assert [maps[0][str(i)]["out"] for i in range(8)] == [i % 2 for i in range(8)]
+    assert [maps[0][str(i)]["x"] for i in range(8)] == [i % 4 for i in range(8)]
+    assert [maps[0][str(i)]["out"] for i in range(8)] == [i // 4 for i in range(8)]
     assert [maps[1][str(i)]["x"] for i in range(8)] == [i % 2 for i in range(8)]
     assert [maps[1][str(i)]["out"] for i in range(8)] == [i // 2 for i in range(8)]
     coord_info = [node["coordinates_"]["coordInfo"] for node in allocations]
@@ -726,8 +727,10 @@ def test_lx_relayout_normalizes_ownership_and_lowers_only_in_superdsc():
         base,
         work_division=TensorWorkDivision({old: 16}, {old: Mod(_CORE_ID, 16)}),
     )
-    _remap_work_division(remapped, {old: ((inner, 2), (outer, 8))})
     assert remapped.work_division is not None
+    remapped.work_division = remap_work_division(
+        remapped.work_division, {old: ((inner, 2), (outer, 8))}
+    )
     core_three = {
         dim: int(slot.subs(_CORE_ID, 3))
         for dim, slot in remapped.work_division.core_id_to_work_slice.items()

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -556,9 +556,11 @@ class TestNamedWorkDivisionHint(InductorTestCase):
 
 _CORE_ID = Symbol("core_id")
 _SOURCE_VIEW = PerCoreView(
-    ((0, 4), (1, 2)), ((0, floor(_CORE_ID / 2)), (1, Mod(_CORE_ID, 2)))
+    ((0, 4), (1, 2)),
+    ((0, floor(_CORE_ID / 2)), (1, Mod(_CORE_ID, 2))),
+    num_cores=8,
 )
-_DESTINATION_VIEW = PerCoreView(((0, 8),), ((0, _CORE_ID),))
+_DESTINATION_VIEW = PerCoreView(((0, 8),), ((0, _CORE_ID),), num_cores=8)
 
 
 def _relayout_plan(source="source", consumers="consumer"):
@@ -591,10 +593,12 @@ def test_lx_relayout_planner_rejects_equal_projected_ownership():
     source_view = PerCoreView(
         ((1, 32),),
         ((1, Mod(_CORE_ID, 32)),),
+        num_cores=32,
     )
     destination_view = PerCoreView(
         ((0, 32),),
         ((0, Mod(_CORE_ID, 32)),),
+        num_cores=32,
     )
     coordinates = [m, m]
     source_work_division = work_division_from_view(source_view, coordinates, (m,))
@@ -668,10 +672,12 @@ def test_lx_relayout_normalizes_ownership_and_lowers_only_in_superdsc():
     source_view = PerCoreView(
         ((1, 4), (2, 2)),
         ((1, floor(_CORE_ID / 2)), (2, Mod(_CORE_ID, 2))),
+        num_cores=8,
     )
     destination_view = PerCoreView(
         ((1, 2), (2, 4)),
         ((1, Mod(_CORE_ID, 2)), (2, floor(_CORE_ID / 2))),
+        num_cores=8,
     )
     coordinates = [Mod(n, 32), floor(n / 32), Mod(m, 64)]
     base = TensorArg(

--- a/tests/op_specs/test_op_spec_lab.py
+++ b/tests/op_specs/test_op_spec_lab.py
@@ -34,6 +34,7 @@ import torch
 
 from torch_spyre._C import DataFormats, ElementArrangement
 from torch_spyre._inductor import config as spyre_config
+from torch_spyre._inductor.core_mapping import derive_operation_mapping
 from torch_spyre._inductor.op_spec import (
     DebugHandle,
     LoopSpec,
@@ -53,13 +54,15 @@ import runner  # noqa: E402
 
 def _add_op(debug_handle=None):
     """A 128x256 fp16 elementwise add -- the shape verified on hardware."""
+    iteration_space = {
+        sympify("c0"): (sympify("128"), 32),
+        sympify("c1"): (sympify("256"), 1),
+    }
     return OpSpec(
         op="add",
         is_reduction=False,
-        iteration_space={
-            sympify("c0"): (sympify("128"), 32),
-            sympify("c1"): (sympify("256"), 1),
-        },
+        iteration_space=iteration_space,
+        core_id_to_work_slice=derive_operation_mapping(iteration_space),
         op_info={},
         debug_handle=debug_handle,
         args=[

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -687,6 +687,7 @@ def generate_sdsc(
     operation_work_division = TensorWorkDivision(
         {dim: int(split) for dim, split in sdsc_spec.work_slices.items()},
         {dim: sdsc_spec.core_id_to_work_slice[dim] for dim in sdsc_spec.work_slices},
+        num_cores=sdsc_spec.num_cores,
     )
     for tensor in sdsc_spec.args:
         if tensor.work_division is None:
@@ -1548,7 +1549,8 @@ def generate_sdsc(
                                         ),
                                         "coreIdToWkSlice_": (
                                             tensor.work_division.to_core_slices(
-                                                sdsc_spec.num_cores
+                                                tensor.work_division.num_cores
+                                                or sdsc_spec.num_cores
                                             )
                                             if sdsc_spec.opfunc == "shuffle"
                                             and tensor.work_division is not None

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -2080,9 +2080,10 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
                 if dev_dim_size < padded_it_size:
                     sdsc_arg.backGap[dim_sym] = padded_it_size - dev_dim_size
         for dim in padding:
-            dim_splits[dim] = 1
-            work_slices[dim] = 1
-        num_cores = math.prod(dim_splits.values())
+            if dim_splits[dim] != 1:
+                raise ValueError(
+                    f"restickify padding dimension {dim} must be unsplit before codegen"
+                )
 
     conv_params = (
         dict(op_spec.op_info.get("conv_params", {})) if op_spec.op_info else {}
@@ -2124,10 +2125,10 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
         # The pool hardware accumulates the full kernel window on each core.
         # Splitting ki/kj across cores produces partial sums, giving wrong results.
         for _k_sym in (Symbol("ki"), Symbol("kj")):
-            if _k_sym in dim_splits:
-                dim_splits[_k_sym] = 1
-                work_slices[_k_sym] = 1
-        num_cores = math.prod(dim_splits.values())
+            if dim_splits.get(_k_sym, 1) != 1:
+                raise ValueError(
+                    f"pool kernel dimension {_k_sym} must be unsplit before codegen"
+                )
 
     if is_conv:
         # Both conv paths accumulate the full kernel window per core; splitting
@@ -2135,9 +2136,10 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
         # reduction MAY be core-split (matmul K via psum), so it is left to the
         # default work division.
         for _k_sym in (Symbol("ki"), Symbol("kj")):
-            if _k_sym in dim_splits:
-                dim_splits[_k_sym] = 1
-                work_slices[_k_sym] = 1
+            if dim_splits.get(_k_sym, 1) != 1:
+                raise ValueError(
+                    f"convolution kernel dimension {_k_sym} must be unsplit before codegen"
+                )
 
         if _spyre_config.disable_conv2d_spatial_split:
             # Strided convs cannot split the output spatial dims (i/j): a strided
@@ -2163,8 +2165,6 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
                             f"ways; expected work division to block it unless the "
                             f"memory-span limit required the split."
                         )
-        num_cores = math.prod(dim_splits.values())
-
     # Pool-specific SDSC field values (#3510).  Empty for non-pool ops.
     pool_sdsc_fields = (
         _avgpool_sdsc_fields(sdsc_iteration_space, pool_params_out) if is_pool else {}

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -45,7 +45,6 @@ from torch_spyre._inductor.constants import (
     TOPK_OPS,
     KEEP_BY_INDEX_OP,
 )
-from torch_spyre._inductor.core_mapping import core_to_slice_mapping
 from torch_spyre._inductor.dtype_ops import DtypeOpTable
 from torch_spyre._inductor.indirect_access import (
     compute_indirect_max_dim_sizes,
@@ -1684,6 +1683,7 @@ def _finalize_tensor_work_divisions(
     operation_work_division = TensorWorkDivision(
         {dim: work_slices[dim] for dim in mapping_dims},
         {dim: core_map[dim] for dim in mapping_dims},
+        num_cores=num_cores,
     )
     assert is_lx_relayout or all(arg.work_division is None for arg in args), (
         "per-tensor ownership is supported only for LX relayout identities"
@@ -1701,11 +1701,20 @@ def _finalize_tensor_work_divisions(
                     dim: override.core_id_to_work_slice.get(dim, Integer(0))
                     for dim in mapping_dims
                 },
+                num_cores=override.num_cores or num_cores,
             )
         )
-        if math.prod(effective.work_slices.values()) != num_cores:
+        tensor_cores = effective.num_cores or num_cores
+        tensor_owners = math.prod(effective.work_slices.values())
+        valid = (
+            tensor_cores == num_cores == tensor_owners
+            if not is_lx_relayout
+            else num_cores % tensor_cores == 0 and tensor_cores % tensor_owners == 0
+        )
+        if not valid:
             raise ValueError(
-                f"tensor ownership uses {effective.work_slices}, expected {num_cores} cores"
+                f"tensor ownership uses {tensor_owners} slices across "
+                f"{tensor_cores} of {num_cores} operation cores"
             )
         arg.work_division = effective
 
@@ -1809,6 +1818,12 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
     work_slices = {
         symbol_mapping[sym]: wk_slice
         for sym, (_, wk_slice) in op_spec.iteration_space.items()
+    }
+    if op_spec.core_id_to_work_slice is None:
+        raise ValueError("OpSpec is missing its finalized core mapping")
+    core_id_to_work_slice = {
+        symbol_mapping[sym]: expression
+        for sym, expression in op_spec.core_id_to_work_slice.items()
     }
 
     # Inject implicit kernel dimensions for conv2d when kernel_size=1. This is
@@ -2166,24 +2181,20 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
     else:
         window_sdsc_fields = {}
 
-    # Project dim_splits into final SDSC iteration-space order; normalization
-    # can add unit axes to either mapping independently.
+    # Unit dimensions may be injected while translating the completed OpSpec
+    # into backend labels. They are unsplit and therefore owned at slice zero.
+    # Every non-unit dimension must already have a final assignment.
     mapping_dims = tuple(sdsc_iteration_space)
-    mapping_splits = tuple(int(dim_splits[dim]) for dim in mapping_dims)
-    # Generic reductions do not yet define the same physical cohort contract as
-    # matmul partial sums.
-    contiguous_dim = (
-        len(mapping_splits) - 1
-        if is_matmul and _spyre_config.core_id_k_fast_emission
-        else None
-    )
-    # TODO: Choose the mapping before LX planning and pass it through to codegen.
-    core_id_to_work_slice = core_to_slice_mapping(
-        mapping_dims,
-        mapping_splits,
-        num_cores,
-        contiguous_dim=contiguous_dim,
-    )
+    if is_relayout:
+        num_cores = max(
+            num_cores,
+            *(arg.work_division.num_cores or 1 for arg in args if arg.work_division),
+        )
+    for dim in mapping_dims:
+        if dim not in core_id_to_work_slice:
+            if int(dim_splits[dim]) != 1:
+                raise ValueError(f"final core mapping is missing split dimension {dim}")
+            core_id_to_work_slice[dim] = Integer(0)
     _finalize_tensor_work_divisions(
         args,
         mapping_dims,

--- a/torch_spyre/_inductor/core_mapping.py
+++ b/torch_spyre/_inductor/core_mapping.py
@@ -347,6 +347,8 @@ def core_mappings_equal(
         for dim in left
         for core in range(num_cores)
     )
+
+
 def partition_physical_span_bytes(
     device_size: Sequence[int],
     stride_map: Sequence[int],

--- a/torch_spyre/_inductor/core_mapping.py
+++ b/torch_spyre/_inductor/core_mapping.py
@@ -347,3 +347,32 @@ def core_mappings_equal(
         for dim in left
         for core in range(num_cores)
     )
+def partition_physical_span_bytes(
+    device_size: Sequence[int],
+    stride_map: Sequence[int],
+    elems_per_stick: int,
+    split_by_device_dim: Mapping[int, int],
+) -> int:
+    """Return the largest per-core physical span for a partition.
+
+    A slice is a rectangle cut from the original strided tensor. Its storage
+    span can exceed its element count because rows may retain padding between
+    them. The final device dimension is one 128-byte stick and is never split.
+    """
+
+    if len(device_size) != len(stride_map) or not device_size:
+        raise ValueError("device size and stride map must have the same rank")
+    if elems_per_stick <= 0:
+        raise ValueError("elems_per_stick must be positive")
+
+    max_offset_elems = 0
+    for dim, (extent, stride) in enumerate(zip(device_size[:-1], stride_map[:-1])):
+        split = int(split_by_device_dim.get(dim, 1))
+        if split <= 0:
+            raise ValueError(f"invalid split {split} on device dimension {dim}")
+        slice_extent = math.ceil(int(extent) / split)
+        if int(stride) > 0:
+            max_offset_elems += (slice_extent - 1) * int(stride)
+
+    sticks = math.ceil((max_offset_elems + elems_per_stick) / elems_per_stick)
+    return sticks * 128

--- a/torch_spyre/_inductor/core_mapping.py
+++ b/torch_spyre/_inductor/core_mapping.py
@@ -17,9 +17,11 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 from sympy import Expr, Integer, Mod, Symbol, floor
+
+from .op_spec import TensorWorkDivision
 
 
 def core_to_slice_mapping(
@@ -66,3 +68,252 @@ def core_to_slice_mapping(
         result[dims[dim]] = coordinate
         stride *= split
     return result
+
+
+def derive_core_mapping(
+    dims: Sequence[Symbol],
+    dim_splits: Sequence[int],
+    num_cores: int,
+    *,
+    contiguous_dim: Symbol | None = None,
+    grouped_splits: Mapping[Symbol, int] | None = None,
+) -> dict[Symbol, Expr]:
+    """Derive one complete mapping from final dimensions and group geometry.
+
+    ``grouped_splits`` describes logical owners that must occupy contiguous,
+    equal-size core groups. Its device-dimension order defines the group
+    topology; final loop order does not. Dimensions outside that mapping divide
+    work within each group. No planning-time core assignment is consumed.
+    """
+
+    dims = tuple(dims)
+    splits = tuple(int(split) for split in dim_splits)
+    if len(dims) != len(splits):
+        raise ValueError(f"dimension/split count differs: {len(dims)} != {len(splits)}")
+    split_by_dim = dict(zip(dims, splits))
+    if math.prod(splits) != num_cores:
+        raise ValueError(
+            f"operation split product must equal num_cores: {math.prod(splits)} != {num_cores}"
+        )
+
+    grouped_splits = dict(grouped_splits or {})
+    unknown_dims = grouped_splits.keys() - split_by_dim.keys()
+    if unknown_dims:
+        raise ValueError(f"grouped dimensions are not in the operation: {unknown_dims}")
+    for dim, split in grouped_splits.items():
+        if int(split) != split_by_dim[dim]:
+            raise ValueError(
+                f"grouped split {dim}={split} does not match operation split "
+                f"{split_by_dim[dim]}"
+            )
+
+    if not grouped_splits:
+        contiguous_index = (
+            dims.index(contiguous_dim) if contiguous_dim in dims else None
+        )
+        return core_to_slice_mapping(
+            dims,
+            splits,
+            num_cores,
+            contiguous_dim=contiguous_index,
+        )
+
+    grouped_dims = tuple(grouped_splits)
+    local_dims = tuple(dim for dim in dims if dim not in grouped_splits)
+    owner_count = math.prod(grouped_splits[dim] for dim in grouped_dims)
+    if owner_count <= 0 or num_cores % owner_count:
+        raise ValueError("grouped ownership does not divide the operation")
+    group_size = num_cores // owner_count
+    if math.prod(split_by_dim[dim] for dim in local_dims) != group_size:
+        raise ValueError("operation splits do not fill each owner group")
+
+    core_id = Symbol("core_id")
+    group_id = floor(core_id / group_size)
+    local_core_id = Mod(core_id, group_size)
+    owner_mapping = core_to_slice_mapping(
+        grouped_dims,
+        tuple(grouped_splits[dim] for dim in grouped_dims),
+        owner_count,
+    )
+    local_contiguous = (
+        local_dims.index(contiguous_dim) if contiguous_dim in local_dims else None
+    )
+    local_mapping = core_to_slice_mapping(
+        local_dims,
+        tuple(split_by_dim[dim] for dim in local_dims),
+        group_size,
+        contiguous_dim=local_contiguous,
+    )
+    return {
+        **{
+            dim: expression.subs(core_id, group_id)
+            for dim, expression in owner_mapping.items()
+        },
+        **{
+            dim: expression.subs(core_id, local_core_id)
+            for dim, expression in local_mapping.items()
+        },
+    }
+
+
+def derive_partition_mapping(
+    dims: Sequence[Symbol],
+    dim_splits: Sequence[int],
+    num_cores: int,
+) -> dict[Symbol, Expr]:
+    """Derive tensor owners from final partition geometry.
+
+    A partition may have fewer logical owners than physical cores. In that
+    case each owner occupies one contiguous, equal-size core group.
+    """
+
+    dims = tuple(dims)
+    splits = tuple(int(split) for split in dim_splits)
+    owner_count = math.prod(splits)
+    if owner_count <= 0 or num_cores % owner_count:
+        raise ValueError(
+            f"partition owner count must divide num_cores: {owner_count}, {num_cores}"
+        )
+    group_size = num_cores // owner_count
+    core_id = Symbol("core_id")
+    group_id = floor(core_id / group_size)
+    mapping = core_to_slice_mapping(dims, splits, owner_count)
+    return {
+        dim: expression.subs(core_id, group_id) for dim, expression in mapping.items()
+    }
+
+
+def remap_work_division(
+    division: TensorWorkDivision,
+    dimension_remap: Mapping[Symbol, Sequence[tuple[Symbol, int]]],
+) -> TensorWorkDivision:
+    """Express tensor ownership in an aligned iteration space.
+
+    ``align_tensors`` may split one loop dimension into several dimensions. The
+    physical partition does not change; only the symbols used to describe it do.
+    """
+
+    new_splits: dict[Symbol, int] = {}
+    new_core_map: dict[Symbol, Expr] = {}
+    for old_dim, split in division.work_slices.items():
+        new_dims = dimension_remap[old_dim]
+        remaining_split = int(split)
+        split_factors: list[tuple[Symbol, int]] = []
+        if len(new_dims) == 1:
+            split_factors = [(new_dims[0][0], remaining_split)]
+            remaining_split = 1
+        else:
+            for new_dim, basis in reversed(new_dims):
+                factor = math.gcd(remaining_split, int(basis))
+                split_factors.append((new_dim, factor))
+                remaining_split //= factor
+            split_factors.reverse()
+        if remaining_split != 1:
+            raise ValueError(f"cannot normalize {split}-way split on {old_dim}")
+
+        slot = division.core_id_to_work_slice[old_dim]
+        slot_stride = 1
+        for new_dim, factor in split_factors:
+            if factor == 1:
+                continue
+            new_slot = Mod(floor(slot / slot_stride), factor)
+            previous = (new_splits.get(new_dim), new_core_map.get(new_dim))
+            if previous[0] is not None and previous != (factor, new_slot):
+                raise ValueError(f"conflicting normalized ownership on {new_dim}")
+            new_splits[new_dim] = factor
+            new_core_map[new_dim] = new_slot
+            slot_stride *= factor
+    return TensorWorkDivision(
+        new_splits,
+        new_core_map,
+        num_cores=division.num_cores,
+    )
+
+
+def finalize_tensor_work_divisions(
+    iteration_space: Mapping[Symbol, tuple[Expr, int]],
+    divisions: Sequence[TensorWorkDivision | None],
+) -> tuple[TensorWorkDivision | None, ...]:
+    """Derive every tensor's final owners from aligned split geometry."""
+
+    operation_cores = math.prod(int(split) for _, split in iteration_space.values())
+    owner_counts = [
+        math.prod(int(split) for split in division.work_slices.values())
+        for division in divisions
+        if division is not None
+    ]
+    default_num_cores = max([operation_cores, *owner_counts])
+    result: list[TensorWorkDivision | None] = []
+    for division in divisions:
+        if division is None:
+            result.append(None)
+            continue
+        work_slices = {
+            dim: int(split)
+            for dim, split in division.work_slices.items()
+            if int(split) > 1
+        }
+        num_cores = division.num_cores or default_num_cores
+        owner_count = math.prod(work_slices.values())
+        if num_cores % owner_count:
+            raise ValueError(
+                f"tensor ownership uses {owner_count} slices across {num_cores} cores"
+            )
+        result.append(
+            TensorWorkDivision(
+                work_slices,
+                derive_partition_mapping(
+                    tuple(work_slices),
+                    tuple(work_slices.values()),
+                    num_cores,
+                ),
+                num_cores=num_cores,
+            )
+        )
+    return tuple(result)
+
+
+def derive_operation_mapping(
+    iteration_space: Mapping[Symbol, tuple[Expr, int]],
+    tensor_divisions: Sequence[TensorWorkDivision | None] = (),
+    *,
+    contiguous_dim: Symbol | None = None,
+) -> dict[Symbol, Expr]:
+    """Derive one operation mapping from final dimensions and LX constraints."""
+
+    dims = tuple(iteration_space)
+    splits = tuple(int(iteration_space[dim][1]) for dim in dims)
+    grouped_splits: dict[Symbol, int] = {}
+    for division in tensor_divisions:
+        if division is None:
+            continue
+        for dim, split in division.work_slices.items():
+            previous = grouped_splits.setdefault(dim, int(split))
+            if previous != int(split):
+                raise ValueError(
+                    f"LX tensors disagree on the split for {dim}: {previous} != {split}"
+                )
+    return derive_core_mapping(
+        dims,
+        splits,
+        math.prod(splits),
+        contiguous_dim=contiguous_dim,
+        grouped_splits=grouped_splits,
+    )
+
+
+def core_mappings_equal(
+    left: Mapping[Symbol, Expr],
+    right: Mapping[Symbol, Expr],
+    num_cores: int,
+) -> bool:
+    """Return whether two symbolic mappings assign every core identically."""
+
+    if left.keys() != right.keys():
+        return False
+    core_id = Symbol("core_id")
+    return all(
+        int(left[dim].subs(core_id, core)) == int(right[dim].subs(core_id, core))
+        for dim in left
+        for core in range(num_cores)
+    )

--- a/torch_spyre/_inductor/core_mapping.py
+++ b/torch_spyre/_inductor/core_mapping.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Mapping, Sequence
+from itertools import permutations
 
 from sympy import Expr, Integer, Mod, Symbol, floor
 
@@ -234,15 +235,8 @@ def finalize_tensor_work_divisions(
     iteration_space: Mapping[Symbol, tuple[Expr, int]],
     divisions: Sequence[TensorWorkDivision | None],
 ) -> tuple[TensorWorkDivision | None, ...]:
-    """Derive every tensor's final owners from aligned split geometry."""
+    """Derive each tensor's owners from its final aligned partition."""
 
-    operation_cores = math.prod(int(split) for _, split in iteration_space.values())
-    owner_counts = [
-        math.prod(int(split) for split in division.work_slices.values())
-        for division in divisions
-        if division is not None
-    ]
-    default_num_cores = max([operation_cores, *owner_counts])
     result: list[TensorWorkDivision | None] = []
     for division in divisions:
         if division is None:
@@ -253,11 +247,15 @@ def finalize_tensor_work_divisions(
             for dim, split in division.work_slices.items()
             if int(split) > 1
         }
-        num_cores = division.num_cores or default_num_cores
-        owner_count = math.prod(work_slices.values())
-        if num_cores % owner_count:
+        unknown_dims = work_slices.keys() - iteration_space.keys()
+        if unknown_dims:
             raise ValueError(
-                f"tensor ownership uses {owner_count} slices across {num_cores} cores"
+                f"tensor ownership dimensions are not aligned: {unknown_dims}"
+            )
+
+        if division.num_cores is None:
+            raise ValueError(
+                "tensor ownership must carry its physical core domain before alignment"
             )
         result.append(
             TensorWorkDivision(
@@ -265,9 +263,9 @@ def finalize_tensor_work_divisions(
                 derive_partition_mapping(
                     tuple(work_slices),
                     tuple(work_slices.values()),
-                    num_cores,
+                    division.num_cores,
                 ),
-                num_cores=num_cores,
+                num_cores=division.num_cores,
             )
         )
     return tuple(result)
@@ -279,27 +277,59 @@ def derive_operation_mapping(
     *,
     contiguous_dim: Symbol | None = None,
 ) -> dict[Symbol, Expr]:
-    """Derive one operation mapping from final dimensions and LX constraints."""
+    """Derive one operation mapping that satisfies every LX tensor owner."""
 
     dims = tuple(iteration_space)
     splits = tuple(int(iteration_space[dim][1]) for dim in dims)
-    grouped_splits: dict[Symbol, int] = {}
+    num_cores = math.prod(splits)
+    split_by_dim = dict(zip(dims, splits))
+    constrained: dict[Symbol, Expr] = {}
     for division in tensor_divisions:
         if division is None:
             continue
+        if division.work_slices and division.num_cores not in (None, num_cores):
+            raise ValueError(
+                "LX tensor ownership and operation use different core domains: "
+                f"{division.num_cores} != {num_cores}"
+            )
         for dim, split in division.work_slices.items():
-            previous = grouped_splits.setdefault(dim, int(split))
-            if previous != int(split):
+            if dim not in split_by_dim:
+                raise ValueError(f"LX tensor dimension {dim} is not in the operation")
+            if split_by_dim[dim] != int(split):
                 raise ValueError(
-                    f"LX tensors disagree on the split for {dim}: {previous} != {split}"
+                    f"LX tensor split for {dim} does not match the operation: "
+                    f"{split} != {split_by_dim[dim]}"
                 )
-    return derive_core_mapping(
-        dims,
-        splits,
-        math.prod(splits),
-        contiguous_dim=contiguous_dim,
-        grouped_splits=grouped_splits,
-    )
+            expression = division.core_id_to_work_slice[dim]
+            previous = constrained.setdefault(dim, expression)
+            if not core_mappings_equal({dim: previous}, {dim: expression}, num_cores):
+                raise ValueError(f"LX tensors disagree on core ownership for {dim}")
+
+    if not constrained:
+        return derive_core_mapping(
+            dims,
+            splits,
+            num_cores,
+            contiguous_dim=contiguous_dim,
+        )
+
+    # Tensor-owned dimensions occupy the outer, contiguous groups. At most five
+    # dimensions can be split on 32 cores, so trying their radix orders is small.
+    for order in permutations(constrained):
+        candidate = derive_core_mapping(
+            dims,
+            splits,
+            num_cores,
+            contiguous_dim=contiguous_dim,
+            grouped_splits={dim: split_by_dim[dim] for dim in order},
+        )
+        if all(
+            core_mappings_equal({dim: candidate[dim]}, {dim: expression}, num_cores)
+            for dim, expression in constrained.items()
+        ):
+            return candidate
+
+    raise ValueError("no operation core mapping satisfies every LX tensor owner")
 
 
 def core_mappings_equal(

--- a/torch_spyre/_inductor/kernel_provenance.py
+++ b/torch_spyre/_inductor/kernel_provenance.py
@@ -32,10 +32,16 @@ import base64
 import dataclasses
 import hashlib
 import json
+import math
 from collections.abc import Iterator, Mapping, Sequence
 
 import sympy
 
+from torch_spyre._inductor.constants import MATMUL_REDUCTION_OPS
+from torch_spyre._inductor.core_mapping import (
+    core_mappings_equal,
+    derive_core_mapping,
+)
 from torch_spyre._inductor.op_spec import (
     DebugHandle,
     LoopSpec,
@@ -60,6 +66,7 @@ _EXPECTED_OP_SPEC_SCHEMA = {
     "args": "Sequence[TensorArg]",
     "op_info": "dict[str, Any]",
     "tiled_symbols": "list[list[Symbol]]",
+    "core_id_to_work_slice": "dict[Symbol, Expr] | None",
     "tiled_symbol_trip_counts": "dict[Symbol, int]",
     "symbolic_dim_bounds": "dict[str, tuple[int, int]]",
     "node_output_ranges": "tuple[Expr, ...] | None",
@@ -80,6 +87,7 @@ _EXPECTED_TENSOR_ARG_SCHEMA = {
 _EXPECTED_TENSOR_WORK_DIVISION_SCHEMA = {
     "work_slices": "dict[Symbol, int]",
     "core_id_to_work_slice": "dict[Symbol, Expr]",
+    "num_cores": "int | None",
 }
 _EXPECTED_LOOP_SPEC_SCHEMA = {
     "count": "Expr",
@@ -232,7 +240,7 @@ def _validate_finalized_schema() -> None:
 
 def _canonical_spec(spec: object) -> object:
     if isinstance(spec, OpSpec):
-        return {
+        result = {
             "kind": "op",
             "op": spec.op,
             "is_reduction": spec.is_reduction,
@@ -260,6 +268,16 @@ def _canonical_spec(spec: object) -> object:
                 str(spec.debug_handle.id) if spec.debug_handle is not None else None
             ),
         }
+        # Preserve existing v1 identities when the explicit mapping is exactly
+        # the mapping older codegen would have derived. Only a non-canonical
+        # assignment adds information to the bundle identity.
+        if spec.core_id_to_work_slice is not None and not _is_canonical_core_mapping(
+            spec
+        ):
+            result["core_id_to_work_slice"] = _canonical_value(
+                spec.core_id_to_work_slice
+            )
+        return result
     if isinstance(spec, LoopSpec):
         return {
             "kind": "loop",
@@ -267,6 +285,21 @@ def _canonical_spec(spec: object) -> object:
             "body": [_canonical_spec(child) for child in spec.body],
         }
     raise TypeError(f"Unsupported finalized kernel spec: {type(spec).__qualname__}")
+
+
+def _is_canonical_core_mapping(spec: OpSpec) -> bool:
+    dims = tuple(spec.iteration_space)
+    splits = tuple(int(spec.iteration_space[dim][1]) for dim in dims)
+    contiguous_dim = dims[-1] if dims and spec.op in MATMUL_REDUCTION_OPS else None
+    expected = derive_core_mapping(
+        dims,
+        splits,
+        math.prod(splits),
+        contiguous_dim=contiguous_dim,
+    )
+    return core_mappings_equal(
+        spec.core_id_to_work_slice or {}, expected, math.prod(splits)
+    )
 
 
 def _canonical_tensor_arg(arg: TensorArg) -> object:
@@ -289,6 +322,7 @@ def _canonical_tensor_arg(arg: TensorArg) -> object:
             "core_id_to_work_slice": _canonical_value(
                 arg.work_division.core_id_to_work_slice
             ),
+            "num_cores": arg.work_division.num_cores,
         }
     return result
 

--- a/torch_spyre/_inductor/op_spec.py
+++ b/torch_spyre/_inductor/op_spec.py
@@ -145,11 +145,13 @@ class TensorWorkDivision:
 
     Both mappings have the same symbol keys. ``work_slices`` gives each loop's
     split count and ``core_id_to_work_slice`` maps the free symbol ``core_id``
-    to that loop's owned slice.
+    to that loop's owned slice. ``num_cores`` is the physical domain of that
+    mapping; it can exceed the logical slice count for replicated ownership.
     """
 
     work_slices: dict[Symbol, int]
     core_id_to_work_slice: dict[Symbol, Expr]
+    num_cores: int | None = None
 
     def remap_symbols(self, symbol_mapping: dict[Symbol, Symbol]) -> TensorWorkDivision:
         """Return this ownership expressed in remapped loop symbols."""
@@ -163,6 +165,7 @@ class TensorWorkDivision:
                 symbol_mapping.get(dim, dim): sympify(slot).xreplace(symbol_mapping)
                 for dim, slot in self.core_id_to_work_slice.items()
             },
+            num_cores=self.num_cores,
         )
 
     def to_core_slices(self, num_cores: int) -> dict[str, dict[str, int]]:
@@ -257,6 +260,9 @@ class OpSpec:
         op: The name of the operation.
         is_reduction: Is the operation a reduction?
         iteration_space: The iteration space of the operation. The values are tuples of (range, work_division).
+        core_id_to_work_slice: The final core assignment derived from the
+            aligned iteration space. Codegen serializes this mapping but does
+            not choose or reconstruct it.
         args: The input and output arguments to the operation.
         op_info: A dictionary of auxiliary information whose content is operation-specific.
         tiled_symbols: Per-loop-level iteration-space symbols, innermost first.
@@ -291,6 +297,7 @@ class OpSpec:
     args: Sequence[TensorArg]
     op_info: dict[str, Any]
     tiled_symbols: list[list[Symbol]] = dataclasses.field(default_factory=list)
+    core_id_to_work_slice: dict[Symbol, Expr] | None = None
     tiled_symbol_trip_counts: dict[Symbol, int] = dataclasses.field(
         default_factory=dict
     )

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -16,7 +16,7 @@ import io
 import math
 import warnings
 from dataclasses import dataclass
-from typing import Any, Callable, NamedTuple, Optional, TypeVar, Union
+from typing import Any, Callable, NamedTuple, Optional, Sequence, TypeVar, Union
 
 import regex
 import torch
@@ -53,7 +53,12 @@ from .ir import FixedTiledLayout, SpyreConstantFallback
 from .logging_utils import get_inductor_logger
 from .loop_info import copy_op_metadata
 from .provenance import preserve_provenance
-from .views import compute_coordinates, matching_dim
+from .views import (
+    AlignmentInputs,
+    build_alignment_inputs,
+    compute_coordinates,
+    matching_dim,
+)
 
 # PyTorch's default lower bound for size symbols (sizes 0/1 are specialised).
 _SHAPE_ENV_DEFAULT_LOWER = 2
@@ -63,6 +68,14 @@ logger = get_inductor_logger("pass_utils")
 class SchedNodeArg(NamedTuple):
     dep: MemoryDep
     layout: "FixedTiledLayout"
+
+
+@dataclass(frozen=True)
+class AlignmentAccess:
+    """One tensor access before its coordinates are normalized for codegen."""
+
+    device_layout: Any
+    index: sympy.Expr
 
 
 def _fixed_read_layout(buf) -> "FixedTiledLayout":
@@ -1092,6 +1105,71 @@ def alignment_coordinates(
         repeat_info_out=repeat_info_out,
     )
     return coords
+
+
+def build_operation_alignment_inputs(
+    raw_iteration_space: dict[sympy.Symbol, sympy.Expr],
+    accesses: Sequence[AlignmentAccess],
+    *,
+    indirect_sizes: "dict[sympy.Symbol, int] | None" = None,
+    repeat_info: "dict[sympy.Symbol, dict] | None" = None,
+    op: ComputedBuffer | None = None,
+    read_writes: ReadWrites | None = None,
+    aligned_iteration_space: (dict[sympy.Symbol, tuple[sympy.Expr, int]] | None) = None,
+) -> AlignmentInputs:
+    """Build the complete, immutable input to tensor alignment.
+
+    Codegen may supply its already-finalized iteration space when an operation
+    has an op-specific extension.  Scheduler preview supplies ``op`` and
+    ``read_writes`` and gets the standard split-aware space.  Coordinate and
+    indirect-symbol preparation are shared in both cases.
+    """
+
+    if aligned_iteration_space is None:
+        if op is None or read_writes is None:
+            raise ValueError(
+                "alignment input construction requires either a finalized "
+                "iteration space or an operation and its dependencies"
+            )
+        aligned_iteration_space = iteration_space_with_splits(
+            op, read_writes, raw_iteration_space
+        )
+
+    if indirect_sizes is None and op is not None:
+        indirect_sizes = indirect_sizes_from_op(op)
+    resolved_indirect_sizes = dict(indirect_sizes or {})
+    if resolved_indirect_sizes:
+        # Dependency extraction can recreate an equivalent Symbol with
+        # different assumptions.  Bind the Symbol present in the real index to
+        # the recovered range so preview and codegen normalize the same input.
+        size_by_name = {str(dim): size for dim, size in resolved_indirect_sizes.items()}
+        for access in accesses:
+            for dim in access.index.free_symbols - raw_iteration_space.keys():
+                if dim not in resolved_indirect_sizes and str(dim) in size_by_name:
+                    resolved_indirect_sizes[dim] = size_by_name[str(dim)]
+
+    repeat_snapshot = {
+        symbol: dict(info) for symbol, info in (repeat_info or {}).items()
+    }
+    tensors = [
+        {
+            "size": list(access.device_layout.device_size),
+            "coordinates": alignment_coordinates(
+                access.device_layout,
+                access.index,
+                raw_iteration_space,
+                resolved_indirect_sizes,
+                repeat_info_out=repeat_snapshot,
+            ),
+        }
+        for access in accesses
+    ]
+    return build_alignment_inputs(
+        aligned_iteration_space,
+        tensors,
+        resolved_indirect_sizes,
+        repeat_snapshot,
+    )
 
 
 def try_device_coordinates(

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1550,6 +1550,7 @@ def make_iteration_space_ownership(
             math.prod(dim_splits),
             contiguous_dim=contiguous_dim,
         ),
+        num_cores=math.prod(dim_splits),
     )
 
 
@@ -2277,10 +2278,12 @@ class PerCoreView:
       split dim.
     - core_to_slot: (device-dim index, slice-index expression in core_id)
       pairs giving each core's position along that split dim.
+    - num_cores: physical cores over which ``core_to_slot`` is defined. This
+      can exceed the number of logical slices when data is replicated.
 
-    Both fields are keyed by the buffer's device-dim index — not by op-
-    local iter symbols — so the value depends only on the buffer's
-    physical slicing.
+    The first two fields are keyed by the buffer's device-dim index — not by
+    op-local iter symbols — so the value depends only on the buffer's physical
+    slicing.
 
     Example: a 2D buffer split 4-ways on dim 0 across 4 cores has
         work_slice_dims = ((0, 4),)
@@ -2290,6 +2293,7 @@ class PerCoreView:
 
     work_slice_dims: tuple[tuple[int, int], ...]
     core_to_slot: tuple[tuple[int, Expr], ...]
+    num_cores: int | None = None
 
 
 def _is_matmul_op(op: Operation) -> bool:
@@ -2462,17 +2466,30 @@ def _per_core_view_from_prep(
     reduction_splits: Optional[dict[sympy.Symbol, int]] = None,
 ) -> tuple[PerCoreView, bool, bool]:
     """Evaluate a precomputed view for symbol splits or scheduler transport."""
+    num_cores = math.prod(
+        value
+        for group in (splits if isinstance(splits, tuple) else (splits,))
+        for value in group.values()
+    )
     # 3-tuple: (view, has_partial_reduction, representable). ``representable`` is
     # False only on the give-up returns below (a split that slices this buffer
     # can't be placed on a device dim); cross-op view comparisons must treat it
     # as "no match", since its empty view means "couldn't tell", not "whole".
-    unrepresentable = (PerCoreView(work_slice_dims=(), core_to_slot=()), False, False)
+    unrepresentable = (
+        PerCoreView(work_slice_dims=(), core_to_slot=(), num_cores=num_cores),
+        False,
+        False,
+    )
 
     # No real split -> whole-buffer view, representable regardless of layout. Must
     # precede the ``prep is None`` guard to match the original ordering.
     if isinstance(splits, tuple):
         if not any(n > 1 for d in splits for n in d.values()):
-            return (PerCoreView(work_slice_dims=(), core_to_slot=()), False, True)
+            return (
+                PerCoreView(work_slice_dims=(), core_to_slot=(), num_cores=num_cores),
+                False,
+                True,
+            )
         if prep is None:
             return unrepresentable
         per_sym = apply_splits_from_index_coeff(
@@ -2481,7 +2498,11 @@ def _per_core_view_from_prep(
         has_partial_reduction = any(n > 1 for n in splits[1].values())
     else:
         if not any(n > 1 for n in splits.values()):
-            return (PerCoreView(work_slice_dims=(), core_to_slot=()), False, True)
+            return (
+                PerCoreView(work_slice_dims=(), core_to_slot=(), num_cores=num_cores),
+                False,
+                True,
+            )
         if prep is None:
             return unrepresentable
         per_sym = {sym: int(splits.get(sym, 1)) for sym in prep.iter_space}
@@ -2625,6 +2646,7 @@ def _per_core_view_from_prep(
     view = PerCoreView(
         work_slice_dims=tuple(sorted(work_slice_dims.items())),
         core_to_slot=tuple(pruned_core_to_slot),
+        num_cores=num_cores,
     )
     return (view, has_partial_reduction, True)
 
@@ -2667,7 +2689,12 @@ def _per_core_view_on_buf(
             return hit
 
     if not any(n > 1 for n in splits.values()):
-        result = (PerCoreView(work_slice_dims=(), core_to_slot=()), False, True)
+        num_cores = ownership.num_cores if ownership is not None else 1
+        result = (
+            PerCoreView(work_slice_dims=(), core_to_slot=(), num_cores=num_cores),
+            False,
+            True,
+        )
         if cache is not None:
             cache[key] = result
         return result
@@ -2699,14 +2726,25 @@ def per_core_view_scheduled(
     coeff_splits: tuple[dict, dict] = getattr(op, "op_it_space_splits", ({}, {}))
     if not any(n > 1 for d in coeff_splits for n in d.values()):
         # No real split -> whole-buffer view; every core holds all of it.
-        return (PerCoreView(work_slice_dims=(), core_to_slot=()), False, True)
+        return (
+            PerCoreView(work_slice_dims=(), core_to_slot=(), num_cores=1),
+            False,
+            True,
+        )
 
     rw = node.read_writes
     write_dep = next((d for d in rw.writes if isinstance(d, MemoryDep)), None)
     if write_dep is None:
         # StarDep-only writer: no index to reason about, so treat as
         # unrepresentable rather than guessing.
-        return (PerCoreView(work_slice_dims=(), core_to_slot=()), False, False)
+        num_cores = math.prod(
+            value for group in coeff_splits for value in group.values()
+        )
+        return (
+            PerCoreView(work_slice_dims=(), core_to_slot=(), num_cores=num_cores),
+            False,
+            False,
+        )
     read_index = next(
         (d.index for d in rw.reads if isinstance(d, MemoryDep)), write_dep.index
     )

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1060,17 +1060,37 @@ def device_coordinates(
         One coordinate expression per device dimension; the last element is
         the stick expression.
     """
+    coords = alignment_coordinates(stl, dep.index, dep.ranges, indirect_sizes)
+    _check_stick_expr_supported(coords[-1], stl.elems_per_stick())
+    return coords
+
+
+def alignment_coordinates(
+    stl: SpyreTensorLayout,
+    index: sympy.Expr,
+    it_space: dict[sympy.Symbol, sympy.Expr],
+    indirect_sizes: "dict[sympy.Symbol, int] | None",
+    *,
+    repeat_info_out: "dict[sympy.Symbol, dict] | None" = None,
+) -> list[sympy.Expr]:
+    """Build the coordinates consumed by tensor alignment.
+
+    Scheduler validation and codegen must prepare identical inputs for
+    ``align_tensors``.  Keep index concretization and coordinate construction in
+    this one helper so the validation preview cannot drift from real codegen.
+    """
+
     # device_size and stride_map come from the C++ SpyreTensorLayout and are
     # already concrete, so no concretization is needed here.
-    index = concretize_index(dep.index, set(dep.ranges.keys()))
+    index = concretize_index(index, set(it_space))
     coords = compute_coordinates(
         stl.device_size,
         stl.stride_map,
-        dep.ranges,
+        it_space,
         index,
         indirect_sizes,
+        repeat_info_out=repeat_info_out,
     )
-    _check_stick_expr_supported(coords[-1], stl.elems_per_stick())
     return coords
 
 
@@ -1669,6 +1689,24 @@ def apply_splits_from_index_coeff(
             if rc != 0 and rc in reduction_coeff_splits:
                 result[sym] = reduction_coeff_splits[rc]
     return result
+
+
+def iteration_space_with_splits(
+    op: Operation,
+    rw: ReadWrites,
+    it_space: dict[sympy.Symbol, sympy.Expr],
+) -> dict[sympy.Symbol, tuple[sympy.Expr, int]]:
+    """Attach the operation's committed work-division splits to loop symbols."""
+
+    splits: dict[sympy.Symbol, int] = {}
+    if hasattr(op, "op_it_space_splits"):
+        write_index, read_index = select_work_division_transport_indexes(
+            op, rw, it_space
+        )
+        splits = apply_splits_from_index_coeff(
+            op.op_it_space_splits, write_index, read_index, it_space
+        )
+    return {dim: (extent, int(splits.get(dim, 1))) for dim, extent in it_space.items()}
 
 
 # The following restickify helpers are used only by the restickify

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -47,10 +47,33 @@ from .scratchpad.lx_relayout import (
     materialized_lx_relayouts,
     work_division_from_view,
 )
-from .op_spec import LoopSpec
+from .op_spec import LoopSpec, TensorWorkDivision
 from . import config as _spyre_config
 
 logger = get_inductor_logger("scheduler")
+
+
+def _scheduled_work_division(
+    node: SchedulerNode,
+    dep: MemoryDep,
+    name: str,
+    view: PerCoreView,
+) -> TensorWorkDivision | None:
+    """Project a physical partition into final scheduled loop symbols."""
+
+    buffer = V.graph.try_get_buffer(name)
+    if buffer is None:
+        return None
+    layout = buffer.get_layout()
+    if not isinstance(layout, FixedTiledLayout):
+        return None
+    coordinates = try_device_coordinates(layout.device_layout, dep, None)
+    if coordinates is None:
+        return None
+    try:
+        return work_division_from_view(view, coordinates, tuple(iteration_space(node)))
+    except ValueError:
+        return None
 
 
 def _ownership_projectable(
@@ -59,22 +82,7 @@ def _ownership_projectable(
     name: str,
     view: PerCoreView,
 ) -> bool:
-    """Whether final scheduled coordinates can carry ``view`` into codegen."""
-
-    buffer = V.graph.try_get_buffer(name)
-    if buffer is None:
-        return False
-    layout = buffer.get_layout()
-    if not isinstance(layout, FixedTiledLayout):
-        return False
-    coordinates = try_device_coordinates(layout.device_layout, dep, None)
-    if coordinates is None:
-        return False
-    try:
-        work_division_from_view(view, coordinates, tuple(iteration_space(node)))
-    except ValueError:
-        return False
-    return True
+    return _scheduled_work_division(node, dep, name, view) is not None
 
 
 class CountedLoopSchedulerNode(FusedSchedulerNode):
@@ -360,7 +368,10 @@ def _lx_view(name: str):
     buffer = V.graph.try_get_buffer(name)
     if buffer is None:
         return None
-    layout = buffer.get_layout()
+    try:
+        layout = buffer.get_layout()
+    except NotImplementedError:
+        return None
     if not isinstance(layout, FixedTiledLayout):
         return None
     if "lx" not in layout.allocation:
@@ -450,32 +461,13 @@ def align_lx_producer_loop_order(
 def demote_incoherent_lx_buffers(
     nodes: list[BaseSchedulerNode],
 ) -> list[BaseSchedulerNode]:
-    """Post-fusion pass: drop an LX buffer whose users disagree on core->slice.
+    """Reject LX groups that final scheduled loops cannot represent safely.
 
-    LX planning runs before the Scheduler exists, so it reasons about each op's
-    *pre*-scheduler ranges. ``core_to_slice_mapping`` is positional -- it hands
-    ``core_id`` strides out in iteration-space order -- and Inductor's
-    ``loop_ordering_after_fusion`` may permute a fused op's ranges after planning
-    has already committed. When it permutes one user of an LX buffer and not
-    another, the two disagree about which core owns which slice: each core writes
-    one slice and reads back a different one. LX is per-core scratchpad with no
-    other copy, so the read is silently wrong (#2062).
-
-    Planning cannot see that permutation, so re-check here, where the ranges are
-    final, and demote any buffer whose users no longer agree. Clearing ``"lx"``
-    is all that is needed: this runs before ``hbm_pool_planning``, which claims
-    exactly the intermediates LX did not, so a demoted buffer lands in the HBM
-    intermediates segment on its way through.
-
-    Deliberately verification-only -- it never *adds* residency and never
-    rewrites a loop order, so it cannot perturb a graph whose users already
-    agree.
-
-    Complements :func:`align_lx_producer_loop_order`, which runs pre-fusion and
-    rewrites a producer's loop order to match its consumers'. That pass fixes the
-    incoherence it can reach; this one is the backstop for what it cannot -- a
-    disagreement introduced after it ran, or a view too irregular to represent --
-    where the only safe answer is to give up LX residency.
+    The planner preserves physical partition geometry, not a final core map.
+    After fusion this pass checks that every producer, copy, and consumer can
+    still project that geometry into its scheduled loops. The final mapping is
+    derived later from those loops. A failed check demotes the complete source
+    group before HBM-pool planning, so no partial relayout survives.
     """
     if not _spyre_config.lx_planning:
         return nodes
@@ -499,6 +491,7 @@ def demote_incoherent_lx_buffers(
     relayout_sources = set(source_by_copy.values())
 
     copy_reads = set()
+    valid_copy_nodes = set()
     invalid_sources = {}
     seen_copies = set()
     for node in scheduled:
@@ -533,6 +526,7 @@ def demote_incoherent_lx_buffers(
             ):
                 invalid_sources[plan.source_name] = f"invalid relayout copy {dep.name}"
             else:
+                valid_copy_nodes.add(node.get_name())
                 copy_reads.add((node.get_name(), plan.source_name))
     for copy_name, plan in plans_by_copy.items():
         if copy_name not in seen_copies:
@@ -574,8 +568,11 @@ def demote_incoherent_lx_buffers(
                 culprit = f"{node.get_name()} view unrepresentable"
                 break
             if expected is not None:
-                if view != expected:
-                    culprit = f"{node.get_name()} view {view} != {expected}"
+                if view.work_slice_dims != expected.work_slice_dims:
+                    culprit = (
+                        f"{node.get_name()} split geometry "
+                        f"{view.work_slice_dims} != {expected.work_slice_dims}"
+                    )
                     break
                 if not _ownership_projectable(node, dep, name, expected):
                     culprit = f"{node.get_name()} ownership unprojectable"
@@ -589,6 +586,37 @@ def demote_incoherent_lx_buffers(
         if culprit is None:
             continue
         demote(source_by_copy.get(name, name), culprit)
+
+    # An ordinary operation has one execution mapping. Accepted LX tensors may
+    # constrain it, but they cannot demand different split counts for one loop.
+    for node in scheduled:
+        accesses = [
+            dep
+            for dep in (*node.read_writes.reads, *node.read_writes.writes)
+            if isinstance(dep, MemoryDep) and _lx_view(dep.name) is not None
+        ]
+        if len(accesses) < 2 or node.get_name() in valid_copy_nodes:
+            continue
+        merged_splits = {}
+        conflict = False
+        for dep in accesses:
+            view = _lx_view(dep.name)
+            assert view is not None
+            division = _scheduled_work_division(node, dep, dep.name, view)
+            if division is None:
+                continue
+            for dim, split in division.work_slices.items():
+                previous = merged_splits.setdefault(dim, int(split))
+                if previous != int(split):
+                    conflict = True
+                    break
+            if conflict:
+                break
+        if not conflict:
+            continue
+        reason = f"{node.get_name()} has incompatible LX split geometry"
+        for dep in accesses:
+            demote(source_by_copy.get(dep.name, dep.name), reason)
 
     return nodes
 

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -42,12 +42,11 @@ from .ir import FixedTiledLayout
 from .pass_utils import (
     PerCoreView,
     _is_matmul_op,
-    apply_splits_from_index_coeff,
-    concretize_index,
+    alignment_coordinates,
     indirect_sizes_from_op,
     iteration_space,
+    iteration_space_with_splits,
     per_core_view_scheduled,
-    select_work_division_transport_indexes,
     try_device_coordinates,
 )
 from .core_mapping import (
@@ -64,10 +63,11 @@ from .scratchpad.lx_relayout import (
     set_final_lx_views,
     validate_final_views,
     final_view_from_work_division,
+    partition_footprint,
     work_division_from_view,
 )
 from .op_spec import LoopSpec, TensorWorkDivision
-from .views import align_tensors, compute_coordinates
+from .views import align_tensors
 from . import config as _spyre_config
 
 logger = get_inductor_logger("scheduler")
@@ -499,19 +499,7 @@ def _preview_final_lx_views(
         raise ValueError(f"{node.get_name()} has no computed operation")
 
     raw_iteration_space = iteration_space(node)
-    write_index, read_index = select_work_division_transport_indexes(
-        op, rw, raw_iteration_space
-    )
-    split_by_dim = apply_splits_from_index_coeff(
-        getattr(op, "op_it_space_splits", ({}, {})),
-        write_index,
-        read_index,
-        raw_iteration_space,
-    )
-    aligned_input_space = {
-        dim: (extent, int(split_by_dim.get(dim, 1)))
-        for dim, extent in raw_iteration_space.items()
-    }
+    aligned_input_space = iteration_space_with_splits(op, rw, raw_iteration_space)
     indirect_sizes = indirect_sizes_from_op(op)
     if indirect_sizes:
         # Re-executing the op to recover indirect ranges can create equivalent
@@ -534,12 +522,10 @@ def _preview_final_lx_views(
             continue
         if not isinstance(layout, FixedTiledLayout):
             continue
-        index = concretize_index(dep.index, set(raw_iteration_space))
-        coordinates = compute_coordinates(
-            layout.device_layout.device_size,
-            layout.device_layout.stride_map,
+        coordinates = alignment_coordinates(
+            layout.device_layout,
+            dep.index,
             raw_iteration_space,
-            index,
             indirect_sizes,
             repeat_info_out=repeat_info,
         )
@@ -604,11 +590,17 @@ def _preview_final_lx_views(
         effective = division if relayout_copy else operation_division
         if effective is None:
             raise ValueError(f"{node.get_name()} has no final ownership for {name}")
+        physical_span_bytes = (
+            partition_footprint(layout, layout.lx_view)
+            if layout.lx_view is not None
+            else None
+        )
         view = final_view_from_work_division(
             effective,
             tensor["size"],
             tensor["coordinates"],
             final_space,
+            physical_span_bytes=physical_span_bytes,
         )
         key = (node.get_name(), name)
         previous = result.setdefault(key, view)
@@ -700,6 +692,7 @@ def demote_incoherent_lx_buffers(
         if source_name in relayout_sources:
             # Scheduling supplies the final ownership verdict; the relayout
             # layer owns atomic group fallback and registry cleanup.
+            counters["torch_spyre"]["lx_relayout_gate_demoted_with_hbm_clone"] += 1
             demote_lx_relayout_group(V.graph, source_name, reason)
             return
         buffer = V.graph.try_get_buffer(source_name)
@@ -829,7 +822,7 @@ def demote_incoherent_lx_buffers(
             for (_, buffer_name), view in preview_views.items()
             if buffer_name == name
         }
-        if len(buffer_views) > 1:
+        if len(buffer_views) != 1:
             counters["torch_spyre"]["lx_relayout_gate_ordinary_mismatch"] += 1
             demote(
                 name,

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -14,6 +14,8 @@
 
 from typing import Sequence, Union
 
+import math
+
 import sympy
 
 from torch._inductor.utils import IndentedBuffer
@@ -23,6 +25,7 @@ from torch._inductor.utils import (
     sympy_product,
 )
 from torch._inductor.dependencies import MemoryDep
+from torch._inductor.ir import ComputedBuffer
 from torch._inductor.scheduler import (
     BaseScheduling,
     BaseSchedulerNode,
@@ -31,23 +34,40 @@ from torch._inductor.scheduler import (
 )
 from torch._inductor.virtualized import V
 from torch._inductor.codecache import code_hash
+from torch._dynamo.utils import counters
 from torch.utils._ordered_set import OrderedSet
 
 from .spyre_kernel import SpyreKernel
 from .ir import FixedTiledLayout
 from .pass_utils import (
     PerCoreView,
+    _is_matmul_op,
+    apply_splits_from_index_coeff,
+    concretize_index,
+    indirect_sizes_from_op,
     iteration_space,
     per_core_view_scheduled,
+    select_work_division_transport_indexes,
     try_device_coordinates,
 )
+from .core_mapping import (
+    derive_operation_mapping,
+    finalize_tensor_work_divisions,
+    remap_work_division,
+)
+from .errors import Unsupported
 from .logging_utils import get_inductor_logger
 from .scratchpad.lx_relayout import (
+    FinalLXView,
     demote_lx_relayout_group,
     materialized_lx_relayouts,
+    set_final_lx_views,
+    validate_final_views,
+    final_view_from_work_division,
     work_division_from_view,
 )
 from .op_spec import LoopSpec, TensorWorkDivision
+from .views import align_tensors, compute_coordinates
 from . import config as _spyre_config
 
 logger = get_inductor_logger("scheduler")
@@ -458,6 +478,145 @@ def align_lx_producer_loop_order(
     return nodes
 
 
+def _preview_final_lx_views(
+    node: SchedulerNode,
+    *,
+    relayout_copy: bool,
+) -> tuple[dict[tuple[str, str], FinalLXView], bool]:
+    """Run codegen's pure alignment and derive this op's final physical views.
+
+    The preview is read-only. It consumes scheduler-final ranges and tensor
+    coordinates, then uses the same alignment and mapping helpers as codegen.
+    """
+
+    rw = node.read_writes
+    reads = [dep for dep in rw.reads if isinstance(dep, MemoryDep)]
+    writes = [dep for dep in rw.writes if isinstance(dep, MemoryDep)]
+    if not writes:
+        raise ValueError(f"{node.get_name()} has no concrete output dependency")
+    op = node.node
+    if not isinstance(op, ComputedBuffer):
+        raise ValueError(f"{node.get_name()} has no computed operation")
+
+    raw_iteration_space = iteration_space(node)
+    write_index, read_index = select_work_division_transport_indexes(
+        op, rw, raw_iteration_space
+    )
+    split_by_dim = apply_splits_from_index_coeff(
+        getattr(op, "op_it_space_splits", ({}, {})),
+        write_index,
+        read_index,
+        raw_iteration_space,
+    )
+    aligned_input_space = {
+        dim: (extent, int(split_by_dim.get(dim, 1)))
+        for dim, extent in raw_iteration_space.items()
+    }
+    indirect_sizes = indirect_sizes_from_op(op)
+    if indirect_sizes:
+        # Re-executing the op to recover indirect ranges can create equivalent
+        # SymPy symbols with different assumptions. Bind the scheduler's actual
+        # index symbol to the recovered range, just as codegen does directly.
+        size_by_name = {str(dim): size for dim, size in indirect_sizes.items()}
+        for dep in (*reads, *writes):
+            for dim in dep.index.free_symbols - raw_iteration_space.keys():
+                if dim not in indirect_sizes and str(dim) in size_by_name:
+                    indirect_sizes[dim] = size_by_name[str(dim)]
+    repeat_info: dict[sympy.Symbol, dict] = {}
+    entries = []
+    for dep in (*reads, *writes):
+        buffer = V.graph.try_get_buffer(dep.name)
+        if buffer is None:
+            continue
+        try:
+            layout = buffer.get_layout()
+        except NotImplementedError:
+            continue
+        if not isinstance(layout, FixedTiledLayout):
+            continue
+        index = concretize_index(dep.index, set(raw_iteration_space))
+        coordinates = compute_coordinates(
+            layout.device_layout.device_size,
+            layout.device_layout.stride_map,
+            raw_iteration_space,
+            index,
+            indirect_sizes,
+            repeat_info_out=repeat_info,
+        )
+        division = work_division_from_view(
+            layout.lx_view if "lx" in layout.allocation else None,
+            coordinates,
+            tuple(raw_iteration_space),
+        )
+        entries.append((dep.name, layout, coordinates, division))
+
+    final_space, final_tensors, dimension_remap = align_tensors(
+        aligned_input_space,
+        [
+            {
+                "size": list(layout.device_layout.device_size),
+                "coordinates": coordinates,
+            }
+            for _, layout, coordinates, _ in entries
+        ],
+        indirect_sizes,
+        repeat_info=repeat_info,
+    )
+    changed = any(
+        len(new_dims) != 1 or new_dims[0][0] != old_dim
+        for old_dim, new_dims in dimension_remap.items()
+    )
+    remapped = [
+        remap_work_division(division, dimension_remap) if division is not None else None
+        for *_, division in entries
+    ]
+    finalized = finalize_tensor_work_divisions(final_space, remapped)
+
+    operation_division = None
+    if not relayout_copy:
+        contiguous_dim = (
+            next(reversed(final_space))
+            if final_space
+            and _is_matmul_op(op)
+            and _spyre_config.core_id_k_fast_emission
+            else None
+        )
+        mapping = derive_operation_mapping(
+            final_space,
+            finalized,
+            contiguous_dim=contiguous_dim,
+        )
+        work_slices = {
+            dim: int(split) for dim, (_, split) in final_space.items() if int(split) > 1
+        }
+        operation_division = TensorWorkDivision(
+            work_slices,
+            {dim: mapping[dim] for dim in work_slices},
+            num_cores=math.prod(int(split) for _, split in final_space.values()),
+        )
+
+    result: dict[tuple[str, str], FinalLXView] = {}
+    for (name, layout, _, _), tensor, division in zip(
+        entries, final_tensors, finalized
+    ):
+        if "lx" not in layout.allocation:
+            continue
+        effective = division if relayout_copy else operation_division
+        if effective is None:
+            raise ValueError(f"{node.get_name()} has no final ownership for {name}")
+        view = final_view_from_work_division(
+            effective,
+            tensor["size"],
+            tensor["coordinates"],
+            final_space,
+        )
+        key = (node.get_name(), name)
+        previous = result.setdefault(key, view)
+        if previous != view:
+            raise ValueError(f"{node.get_name()} accesses {name} with two final views")
+    return result, changed
+
+
 def demote_incoherent_lx_buffers(
     nodes: list[BaseSchedulerNode],
 ) -> list[BaseSchedulerNode]:
@@ -597,7 +756,7 @@ def demote_incoherent_lx_buffers(
         ]
         if len(accesses) < 2 or node.get_name() in valid_copy_nodes:
             continue
-        merged_splits = {}
+        merged_splits: dict[sympy.Symbol, int] = {}
         conflict = False
         for dep in accesses:
             view = _lx_view(dep.name)
@@ -617,6 +776,101 @@ def demote_incoherent_lx_buffers(
         reason = f"{node.get_name()} has incompatible LX split geometry"
         for dep in accesses:
             demote(source_by_copy.get(dep.name, dep.name), reason)
+
+    # Preview the same alignment calculation codegen will run, while atomic
+    # fallback is still possible. This is the graph-wide proof point: all
+    # producer, copy, and consumer views coexist here.
+    source_by_buffer = {
+        plan.source_name: plan.source_name for plan in plans_by_copy.values()
+    }
+    source_by_buffer.update(source_by_copy)
+    preview_views: dict[tuple[str, str], FinalLXView] = {}
+    changed_ops = 0
+    previewed_ops = 0
+    for node in scheduled:
+        lx_buffers = {
+            dep.name
+            for dep in (*node.read_writes.reads, *node.read_writes.writes)
+            if isinstance(dep, MemoryDep)
+            and (
+                (buffer := V.graph.try_get_buffer(dep.name)) is not None
+                and isinstance((layout := buffer.get_layout()), FixedTiledLayout)
+                and "lx" in layout.allocation
+            )
+        }
+        if not lx_buffers:
+            continue
+        try:
+            views, changed = _preview_final_lx_views(
+                node,
+                relayout_copy=node.get_name() in valid_copy_nodes,
+            )
+        except (Unsupported, ValueError) as exc:
+            reason = f"{node.get_name()} alignment preview failed: {exc}"
+            counters["torch_spyre"]["lx_relayout_gate_preview_failures"] += 1
+            for name in lx_buffers:
+                demote(source_by_buffer.get(name, name), reason)
+            continue
+        previewed_ops += 1
+        changed_ops += int(changed)
+        preview_views.update(views)
+
+    counters["torch_spyre"]["lx_relayout_gate_previewed_ops"] += previewed_ops
+    counters["torch_spyre"]["lx_relayout_gate_alignment_changed_ops"] += changed_ops
+
+    relayout_buffers = {
+        name
+        for copy_name, plan in plans_by_copy.items()
+        for name in (plan.source_name, copy_name)
+    }
+    for name in lx_names - relayout_buffers:
+        buffer_views = {
+            view
+            for (_, buffer_name), view in preview_views.items()
+            if buffer_name == name
+        }
+        if len(buffer_views) > 1:
+            counters["torch_spyre"]["lx_relayout_gate_ordinary_mismatch"] += 1
+            demote(
+                name,
+                f"ordinary LX handoff derived {len(buffer_views)} final views",
+            )
+
+    checked_groups = 0
+    for copy_name, plan in list(materialized_lx_relayouts(V.graph).values()):
+        if plan.source_name in demoted:
+            continue
+        checked_groups += 1
+        if validation_reason := validate_final_views(
+            V.graph,
+            plan,
+            preview_views,
+            destination_name=copy_name,
+        ):
+            counters["torch_spyre"]["lx_relayout_gate_group_mismatch"] += 1
+            demote(plan.source_name, validation_reason)
+    counters["torch_spyre"]["lx_relayout_gate_checked_groups"] += checked_groups
+    counters["torch_spyre"]["lx_relayout_gate_demoted_groups"] += len(
+        demoted & relayout_sources
+    )
+
+    accepted_views: dict[tuple[str, str], FinalLXView] = {}
+    for key, view in preview_views.items():
+        buffer = V.graph.try_get_buffer(key[1])
+        if buffer is None:
+            continue
+        layout = buffer.get_layout()
+        if isinstance(layout, FixedTiledLayout) and "lx" in layout.allocation:
+            accepted_views[key] = view
+    set_final_lx_views(V.graph, accepted_views)
+    logger.debug(
+        "LX final-view gate: previewed_ops=%d alignment_changed_ops=%d "
+        "checked_groups=%d demoted_groups=%d",
+        previewed_ops,
+        changed_ops,
+        checked_groups,
+        len(demoted & relayout_sources),
+    )
 
     return nodes
 

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -40,12 +40,11 @@ from torch.utils._ordered_set import OrderedSet
 from .spyre_kernel import SpyreKernel
 from .ir import FixedTiledLayout
 from .pass_utils import (
+    AlignmentAccess,
     PerCoreView,
     _is_matmul_op,
-    alignment_coordinates,
-    indirect_sizes_from_op,
+    build_operation_alignment_inputs,
     iteration_space,
-    iteration_space_with_splits,
     per_core_view_scheduled,
     try_device_coordinates,
 )
@@ -67,7 +66,7 @@ from .scratchpad.lx_relayout import (
     work_division_from_view,
 )
 from .op_spec import LoopSpec, TensorWorkDivision
-from .views import align_tensors
+from .views import align_tensors_pure
 from . import config as _spyre_config
 
 logger = get_inductor_logger("scheduler")
@@ -484,6 +483,7 @@ def _preview_final_lx_views(
     node: SchedulerNode,
     *,
     relayout_copy: bool,
+    tracked_buffers: set[str],
 ) -> tuple[dict[tuple[str, str], FinalLXView], bool]:
     """Run codegen's pure alignment and derive this op's final physical views.
 
@@ -501,18 +501,6 @@ def _preview_final_lx_views(
         raise ValueError(f"{node.get_name()} has no computed operation")
 
     raw_iteration_space = iteration_space(node)
-    aligned_input_space = iteration_space_with_splits(op, rw, raw_iteration_space)
-    indirect_sizes = indirect_sizes_from_op(op)
-    if indirect_sizes:
-        # Re-executing the op to recover indirect ranges can create equivalent
-        # SymPy symbols with different assumptions. Bind the scheduler's actual
-        # index symbol to the recovered range, just as codegen does directly.
-        size_by_name = {str(dim): size for dim, size in indirect_sizes.items()}
-        for dep in (*reads, *writes):
-            for dim in dep.index.free_symbols - raw_iteration_space.keys():
-                if dim not in indirect_sizes and str(dim) in size_by_name:
-                    indirect_sizes[dim] = size_by_name[str(dim)]
-    repeat_info: dict[sympy.Symbol, dict] = {}
     entries = []
     for dep in (*reads, *writes):
         buffer = V.graph.try_get_buffer(dep.name)
@@ -524,39 +512,32 @@ def _preview_final_lx_views(
             continue
         if not isinstance(layout, FixedTiledLayout):
             continue
-        coordinates = alignment_coordinates(
-            layout.device_layout,
-            dep.index,
-            raw_iteration_space,
-            indirect_sizes,
-            repeat_info_out=repeat_info,
-        )
+        entries.append((dep.name, layout, dep.index))
+
+    alignment_inputs = build_operation_alignment_inputs(
+        raw_iteration_space,
+        [AlignmentAccess(layout.device_layout, index) for _, layout, index in entries],
+        op=op,
+        read_writes=rw,
+    )
+    divisions = []
+    for (_, layout, _), tensor in zip(entries, alignment_inputs.tensors):
+        coordinates = tensor["coordinates"]
         division = work_division_from_view(
             layout.lx_view if "lx" in layout.allocation else None,
             coordinates,
             tuple(raw_iteration_space),
         )
-        entries.append((dep.name, layout, coordinates, division))
+        divisions.append(division)
 
-    final_space, final_tensors, dimension_remap = align_tensors(
-        aligned_input_space,
-        [
-            {
-                "size": list(layout.device_layout.device_size),
-                "coordinates": coordinates,
-            }
-            for _, layout, coordinates, _ in entries
-        ],
-        indirect_sizes,
-        repeat_info=repeat_info,
-    )
+    final_space, final_tensors, dimension_remap = align_tensors_pure(alignment_inputs)
     changed = any(
         len(new_dims) != 1 or new_dims[0][0] != old_dim
         for old_dim, new_dims in dimension_remap.items()
     )
     remapped = [
         remap_work_division(division, dimension_remap) if division is not None else None
-        for *_, division in entries
+        for division in divisions
     ]
     finalized = finalize_tensor_work_divisions(final_space, remapped)
 
@@ -584,10 +565,8 @@ def _preview_final_lx_views(
         )
 
     result: dict[tuple[str, str], FinalLXView] = {}
-    for (name, layout, _, _), tensor, division in zip(
-        entries, final_tensors, finalized
-    ):
-        if "lx" not in layout.allocation:
+    for (name, layout, _), tensor, division in zip(entries, final_tensors, finalized):
+        if "lx" not in layout.allocation or name not in tracked_buffers:
             continue
         effective = division if relayout_copy else operation_division
         if effective is None:
@@ -642,6 +621,11 @@ def demote_incoherent_lx_buffers(
         copy_name: plan.source_name for copy_name, plan in plans_by_copy.items()
     }
     relayout_sources = set(source_by_copy.values())
+    relayout_buffers = {
+        name
+        for copy_name, plan in plans_by_copy.items()
+        for name in (plan.source_name, copy_name)
+    }
 
     copy_reads = set()
     valid_copy_nodes = set()
@@ -685,6 +669,24 @@ def demote_incoherent_lx_buffers(
         if copy_name not in seen_copies:
             invalid_sources[plan.source_name] = f"missing relayout copy {copy_name}"
 
+    # Validation coverage is partitioned by the plan registry. Ordinary LX
+    # buffers retain the scheduler's established view-equality validation;
+    # registered non-canonical handoffs use the graph-wide C4 gate below.
+    # Future non-canonical residency must first register its buffers here.
+    resident_relayout_buffers = {
+        name
+        for name in relayout_buffers
+        if (layout := _fixed_tiled_layout(name)) is not None
+        and "lx" in layout.allocation
+    }
+    resident_lx_buffers = set(lx_names) | resident_relayout_buffers
+    registered_lx_buffers = resident_lx_buffers & relayout_buffers
+    ordinary_lx_buffers = OrderedSet(
+        name for name in lx_names if name not in relayout_buffers
+    )
+    assert registered_lx_buffers.isdisjoint(set(ordinary_lx_buffers))
+    assert registered_lx_buffers | set(ordinary_lx_buffers) == resident_lx_buffers
+
     demoted = set()
 
     def demote(source_name: str, reason: str) -> None:
@@ -706,7 +708,7 @@ def demote_incoherent_lx_buffers(
     for source_name, reason in invalid_sources.items():
         demote(source_name, reason)
 
-    for name in lx_names:
+    for name in ordinary_lx_buffers:
         ref = None
         culprit = None
         expected = _lx_view(name)
@@ -770,9 +772,13 @@ def demote_incoherent_lx_buffers(
         for dep in accesses:
             demote(source_by_copy.get(dep.name, dep.name), reason)
 
+    if not relayout_buffers:
+        set_final_lx_views(V.graph, {})
+        return nodes
+
     # Preview the same alignment calculation codegen will run, while atomic
     # fallback is still possible. This is the graph-wide proof point: all
-    # producer, copy, and consumer views coexist here.
+    # producer, copy, and consumer views for each relayout coexist here.
     source_by_buffer = {
         plan.source_name: plan.source_name for plan in plans_by_copy.values()
     }
@@ -790,15 +796,19 @@ def demote_incoherent_lx_buffers(
         }
         if not lx_buffers:
             continue
+        tracked_buffers = lx_buffers & relayout_buffers
+        if not tracked_buffers:
+            continue
         try:
             views, changed = _preview_final_lx_views(
                 node,
                 relayout_copy=node.get_name() in valid_copy_nodes,
+                tracked_buffers=tracked_buffers,
             )
         except (Unsupported, ValueError) as exc:
             reason = f"{node.get_name()} alignment preview failed: {exc}"
             counters["torch_spyre"]["lx_relayout_gate_preview_failures"] += 1
-            for name in lx_buffers:
+            for name in tracked_buffers:
                 demote(source_by_buffer.get(name, name), reason)
             continue
         previewed_ops += 1
@@ -807,24 +817,6 @@ def demote_incoherent_lx_buffers(
 
     counters["torch_spyre"]["lx_relayout_gate_previewed_ops"] += previewed_ops
     counters["torch_spyre"]["lx_relayout_gate_alignment_changed_ops"] += changed_ops
-
-    relayout_buffers = {
-        name
-        for copy_name, plan in plans_by_copy.items()
-        for name in (plan.source_name, copy_name)
-    }
-    for name in lx_names - relayout_buffers:
-        buffer_views = {
-            view
-            for (_, buffer_name), view in preview_views.items()
-            if buffer_name == name
-        }
-        if len(buffer_views) != 1:
-            counters["torch_spyre"]["lx_relayout_gate_ordinary_mismatch"] += 1
-            demote(
-                name,
-                f"ordinary LX handoff derived {len(buffer_views)} final views",
-            )
 
     checked_groups = 0
     for copy_name, plan in list(materialized_lx_relayouts(V.graph).values()):
@@ -847,7 +839,11 @@ def demote_incoherent_lx_buffers(
     accepted_views: dict[tuple[str, str], FinalLXView] = {}
     for key, final_view in preview_views.items():
         layout = _fixed_tiled_layout(key[1])
-        if layout is not None and "lx" in layout.allocation:
+        if (
+            key[1] in relayout_buffers
+            and layout is not None
+            and "lx" in layout.allocation
+        ):
             accepted_views[key] = final_view
     set_final_lx_views(V.graph, accepted_views)
     logger.debug(

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -73,6 +73,17 @@ from . import config as _spyre_config
 logger = get_inductor_logger("scheduler")
 
 
+def _fixed_tiled_layout(name: str) -> FixedTiledLayout | None:
+    buffer = V.graph.try_get_buffer(name)
+    if buffer is None:
+        return None
+    try:
+        layout = buffer.get_layout()
+    except NotImplementedError:
+        return None
+    return layout if isinstance(layout, FixedTiledLayout) else None
+
+
 def _scheduled_work_division(
     node: SchedulerNode,
     dep: MemoryDep,
@@ -81,11 +92,8 @@ def _scheduled_work_division(
 ) -> TensorWorkDivision | None:
     """Project a physical partition into final scheduled loop symbols."""
 
-    buffer = V.graph.try_get_buffer(name)
-    if buffer is None:
-        return None
-    layout = buffer.get_layout()
-    if not isinstance(layout, FixedTiledLayout):
+    layout = _fixed_tiled_layout(name)
+    if layout is None:
         return None
     coordinates = try_device_coordinates(layout.device_layout, dep, None)
     if coordinates is None:
@@ -385,14 +393,8 @@ def _lx_resident(node: SchedulerNode) -> bool:
 
 
 def _lx_view(name: str):
-    buffer = V.graph.try_get_buffer(name)
-    if buffer is None:
-        return None
-    try:
-        layout = buffer.get_layout()
-    except NotImplementedError:
-        return None
-    if not isinstance(layout, FixedTiledLayout):
+    layout = _fixed_tiled_layout(name)
+    if layout is None:
         return None
     if "lx" not in layout.allocation:
         return None
@@ -695,12 +697,10 @@ def demote_incoherent_lx_buffers(
             counters["torch_spyre"]["lx_relayout_gate_demoted_with_hbm_clone"] += 1
             demote_lx_relayout_group(V.graph, source_name, reason)
             return
-        buffer = V.graph.try_get_buffer(source_name)
-        if buffer is not None:
-            layout = buffer.get_layout()
-            if isinstance(layout, FixedTiledLayout):
-                layout.allocation.pop("lx", None)
-                layout.lx_view = None
+        layout = _fixed_tiled_layout(source_name)
+        if layout is not None:
+            layout.allocation.pop("lx", None)
+            layout.lx_view = None
         logger.info("demoted %s out of LX: %s", source_name, reason)
 
     for source_name, reason in invalid_sources.items():
@@ -785,11 +785,8 @@ def demote_incoherent_lx_buffers(
             dep.name
             for dep in (*node.read_writes.reads, *node.read_writes.writes)
             if isinstance(dep, MemoryDep)
-            and (
-                (buffer := V.graph.try_get_buffer(dep.name)) is not None
-                and isinstance((layout := buffer.get_layout()), FixedTiledLayout)
-                and "lx" in layout.allocation
-            )
+            and (layout := _fixed_tiled_layout(dep.name)) is not None
+            and "lx" in layout.allocation
         }
         if not lx_buffers:
             continue
@@ -849,11 +846,8 @@ def demote_incoherent_lx_buffers(
 
     accepted_views: dict[tuple[str, str], FinalLXView] = {}
     for key, final_view in preview_views.items():
-        buffer = V.graph.try_get_buffer(key[1])
-        if buffer is None:
-            continue
-        layout = buffer.get_layout()
-        if isinstance(layout, FixedTiledLayout) and "lx" in layout.allocation:
+        layout = _fixed_tiled_layout(key[1])
+        if layout is not None and "lx" in layout.allocation:
             accepted_views[key] = final_view
     set_final_lx_views(V.graph, accepted_views)
     logger.debug(

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -855,13 +855,13 @@ def demote_incoherent_lx_buffers(
     )
 
     accepted_views: dict[tuple[str, str], FinalLXView] = {}
-    for key, view in preview_views.items():
+    for key, final_view in preview_views.items():
         buffer = V.graph.try_get_buffer(key[1])
         if buffer is None:
             continue
         layout = buffer.get_layout()
         if isinstance(layout, FixedTiledLayout) and "lx" in layout.allocation:
-            accepted_views[key] = view
+            accepted_views[key] = final_view
     set_final_lx_views(V.graph, accepted_views)
     logger.debug(
         "LX final-view gate: previewed_ops=%d alignment_changed_ops=%d "

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -900,7 +900,8 @@ class ScratchpadAllocator:
                 ncores[name] = plan.num_cores
                 ncores_reasons.pop(name, None)
                 mem_usage[name]["size_per_core"] = (
-                    mem_usage[name]["size"] // plan.num_cores
+                    plan.max_footprint_bytes
+                    or mem_usage[name]["size"] // plan.num_cores
                 )
                 mem_usage[name]["core_div_mismatch"] = False
         t2 = time.perf_counter()
@@ -998,7 +999,8 @@ class ScratchpadAllocator:
                 destination = LifetimeBoundBuffer(
                     plan.destination_name,
                     round_up_to_alignment(
-                        source.size, _LX_ALLOCATION_GRANULARITY_BYTES
+                        plan.max_footprint_bytes or source.size,
+                        _LX_ALLOCATION_GRANULARITY_BYTES,
                     ),
                     [transfer_tick, *consumer_ticks],
                     lifetime_end_override=destination_end,

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -955,19 +955,26 @@ class ScratchpadAllocator:
             if name in partition_footprints:
                 info["size_per_core"] = partition_footprints[name]
         for plan in lx_relayout_plans:
-            name = plan.source_name
-            if name not in mem_usage:
-                continue
-            ncores[name] = plan.num_cores
-            ncores_reasons.pop(name, None)
-            footprint = plan.max_footprint_bytes or partition_footprints.get(name, 0)
-            # One source may feed differently shaped destinations. Its shared
-            # allocation must satisfy the largest member of the atomic group,
-            # independent of plan iteration order.
-            mem_usage[name]["size_per_core"] = max(
-                mem_usage[name]["size_per_core"], footprint
-            )
-            mem_usage[name]["core_div_mismatch"] = False
+            core_counts = {
+                plan.source_name: plan.source_view.num_cores or plan.num_cores,
+                plan.destination_name: plan.destination_view.num_cores
+                or plan.num_cores,
+            }
+            for name, num_cores in core_counts.items():
+                if name not in mem_usage:
+                    continue
+                ncores[name] = num_cores
+                ncores_reasons.pop(name, None)
+                footprint = plan.max_footprint_bytes or partition_footprints.get(
+                    name, 0
+                )
+                # One source may feed differently shaped destinations. Its
+                # shared allocation must satisfy the largest member of the
+                # atomic group, independent of plan iteration order.
+                mem_usage[name]["size_per_core"] = max(
+                    mem_usage[name]["size_per_core"], footprint
+                )
+                mem_usage[name]["core_div_mismatch"] = False
         t2 = time.perf_counter()
         if timings is not None:
             timings["residency"] += t1 - t0

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -44,9 +44,11 @@ from torch_spyre._inductor.pass_utils import (
     op_read_writes,
     _prepare_per_core_view,
     _per_core_view_from_prep,
+    _per_core_view_on_buf,
     _is_matmul_op,
     op_short_name,
 )
+from torch_spyre._inductor.core_mapping import partition_physical_span_bytes
 from torch_spyre._inductor.work_division import (
     enumerate_work_division_candidates,
     work_division_splits_are_legal,
@@ -644,6 +646,7 @@ class ScratchpadAllocator:
         lifetimes: dict[str, list[int]],
         ncores: dict[str, int],
         ncores_reasons: dict[str, str],
+        partition_footprints: dict[str, int],
         lifetime_end_overrides: Optional[dict[str, int]] = None,
     ) -> list[LifetimeBoundBuffer]:
         """Build one :class:`LifetimeBoundBuffer` per buffer, barred or not.
@@ -705,7 +708,7 @@ class ScratchpadAllocator:
                 ncores_reasons=ncores_reasons,
                 division_is_fixed=True,
             )
-            clone_size = self._input_footprint(graph, input_name, ncores)
+            clone_size = partition_footprints.get(input_name, 0)
             buffers.append(
                 LifetimeBoundBuffer(
                     input_name,
@@ -812,18 +815,66 @@ class ScratchpadAllocator:
         )
 
     @staticmethod
-    def _input_footprint(
-        graph: GraphLowering, name: str, ncores: dict[str, int]
-    ) -> int:
-        """Per-core LX footprint of a cloned graph input, or 0 when it has no
-        computable one (in which case ``input_residency_reason`` has already
-        barred it, so the value is never used)."""
-        layout = getattr(graph.get_buffer(name), "layout", None)
-        dev_layout = getattr(layout, "device_layout", None)
-        num_cores = ncores.get(name, -1)
-        if dev_layout is None or num_cores < 1:
-            return 0
-        return math.prod(dev_layout.device_size[:-1]) * 128 // num_cores
+    def _partition_footprints(
+        graph: GraphLowering, ncores: dict[str, int]
+    ) -> dict[str, int]:
+        """Largest physical per-core span for every committed partition."""
+
+        footprints: dict[str, int] = {}
+        cache: dict = {}
+        for op in graph.operations:
+            for dep in (*op_read_writes(op).writes, *op_read_writes(op).reads):
+                if not isinstance(dep, MemoryDep):
+                    continue
+                num_cores = ncores.get(dep.name, -1)
+                if num_cores < 1:
+                    continue
+                buffer = graph.try_get_buffer(dep.name)
+                if buffer is None:
+                    continue
+                layout = buffer.get_layout()
+                if not isinstance(layout, FixedTiledLayout):
+                    continue
+                view, partial, representable = _per_core_view_on_buf(
+                    op, dep, dep.name, cache
+                )
+                if not representable or partial or view.num_cores != num_cores:
+                    continue
+                device_layout = layout.device_layout
+                footprint = partition_physical_span_bytes(
+                    tuple(int(size) for size in device_layout.device_size),
+                    tuple(int(stride) for stride in device_layout.stride_map),
+                    int(device_layout.elems_per_stick()),
+                    dict(view.work_slice_dims),
+                )
+                # The physical span is the ragged/padded-layout bound.  Keep
+                # the historical equal-share size as a lower bound so this
+                # refinement can never shrink an ordinary LX allocation.
+                full_size = math.prod(device_layout.device_size[:-1]) * 128
+                equal_share = math.ceil(full_size / num_cores / 128) * 128
+                footprint = max(footprint, equal_share)
+                footprints[dep.name] = max(footprints.get(dep.name, 0), footprint)
+
+        # The residency gate bars partitions with no valid view. Keep a padded,
+        # full-buffer span as a conservative value so they cannot look cheap if
+        # a future caller reaches allocation before that verdict.
+        for name, num_cores in ncores.items():
+            if num_cores < 1 or name in footprints:
+                continue
+            buffer = graph.try_get_buffer(name)
+            if buffer is None:
+                continue
+            layout = buffer.get_layout()
+            if not isinstance(layout, FixedTiledLayout):
+                continue
+            device_layout = layout.device_layout
+            footprints[name] = partition_physical_span_bytes(
+                tuple(int(size) for size in device_layout.device_size),
+                tuple(int(stride) for stride in device_layout.stride_map),
+                int(device_layout.elems_per_stick()),
+                {},
+            )
+        return footprints
 
     def _determine_in_place(
         self,
@@ -893,17 +944,24 @@ class ScratchpadAllocator:
         ncores, ncores_reasons = get_ncores_for_buffers(graph)
         t1 = time.perf_counter()
         mem_usage = mem_usage_by_buf(graph, cache)
+        partition_footprints = self._partition_footprints(graph, ncores)
+        for name, info in mem_usage.items():
+            if name in partition_footprints:
+                info["size_per_core"] = partition_footprints[name]
         for plan in lx_relayout_plans:
-            for name in (plan.source_name, plan.destination_name):
-                if name not in mem_usage:
-                    continue
-                ncores[name] = plan.num_cores
-                ncores_reasons.pop(name, None)
-                mem_usage[name]["size_per_core"] = (
-                    plan.max_footprint_bytes
-                    or mem_usage[name]["size"] // plan.num_cores
-                )
-                mem_usage[name]["core_div_mismatch"] = False
+            name = plan.source_name
+            if name not in mem_usage:
+                continue
+            ncores[name] = plan.num_cores
+            ncores_reasons.pop(name, None)
+            footprint = plan.max_footprint_bytes or partition_footprints.get(name, 0)
+            # One source may feed differently shaped destinations. Its shared
+            # allocation must satisfy the largest member of the atomic group,
+            # independent of plan iteration order.
+            mem_usage[name]["size_per_core"] = max(
+                mem_usage[name]["size_per_core"], footprint
+            )
+            mem_usage[name]["core_div_mismatch"] = False
         t2 = time.perf_counter()
         if timings is not None:
             timings["residency"] += t1 - t0
@@ -930,6 +988,7 @@ class ScratchpadAllocator:
             lifetimes=lifetimes,
             ncores=ncores,
             ncores_reasons=ncores_reasons,
+            partition_footprints=partition_footprints,
             lifetime_end_overrides=lifetime_end_overrides,
         )
         if lx_relayout_plans:

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -832,7 +832,10 @@ class ScratchpadAllocator:
                 buffer = graph.try_get_buffer(dep.name)
                 if buffer is None:
                     continue
-                layout = buffer.get_layout()
+                try:
+                    layout = buffer.get_layout()
+                except NotImplementedError:
+                    continue
                 if not isinstance(layout, FixedTiledLayout):
                     continue
                 view, partial, representable = _per_core_view_on_buf(
@@ -864,7 +867,10 @@ class ScratchpadAllocator:
             buffer = graph.try_get_buffer(name)
             if buffer is None:
                 continue
-            layout = buffer.get_layout()
+            try:
+                layout = buffer.get_layout()
+            except NotImplementedError:
+                continue
             if not isinstance(layout, FixedTiledLayout):
                 continue
             device_layout = layout.device_layout

--- a/torch_spyre/_inductor/scratchpad/lx_relayout.py
+++ b/torch_spyre/_inductor/scratchpad/lx_relayout.py
@@ -71,7 +71,7 @@ class LXRelayoutPlan:
     source_view: PerCoreView
     destination_view: PerCoreView
     num_cores: int
-    kind: Literal["shuffle", "gather"] = "shuffle"
+    kind: Literal["shuffle", "gather", "broadcast"] = "shuffle"
     group_geometry: tuple[RelayoutDimension, ...] = ()
     max_footprint_bytes: int = 0
     source_address: int | None = None
@@ -371,6 +371,52 @@ def _grouped_gather_geometry(
     return grouped_source, grouped_destination, tuple(geometry)
 
 
+def _grouped_broadcast_geometry(
+    source: PerCoreView,
+    destination: PerCoreView,
+    source_num_cores: int,
+    destination_num_cores: int,
+) -> tuple[PerCoreView, PerCoreView, tuple[RelayoutDimension, ...]] | None:
+    """Classify a complete source partition spread over more physical cores."""
+
+    source_splits = dict(source.work_slice_dims)
+    destination_splits = dict(destination.work_slice_dims)
+    if (
+        source_num_cores >= destination_num_cores
+        or math.prod(source_splits.values()) != source_num_cores
+        or destination_num_cores % math.prod(destination_splits.values())
+    ):
+        return None
+
+    geometry = []
+    for dim in dict.fromkeys((*source_splits, *destination_splits)):
+        source_split = source_splits.get(dim, 1)
+        destination_split = destination_splits.get(dim, 1)
+        if destination_split < source_split or destination_split % source_split:
+            return None
+        geometry.append(
+            RelayoutDimension(
+                device_dim=dim,
+                source_split=source_split,
+                destination_split=destination_split,
+                group_count=source_split,
+                group_size=destination_split // source_split,
+                multiplicity=destination_split // source_split,
+                ordering_tag="contiguous_groups",
+            )
+        )
+    grouped_source = _view_from_splits(source_splits, source_num_cores)
+    grouped_destination = _view_from_splits(destination_splits, destination_num_cores)
+    if not _compatible_partitions(
+        grouped_source,
+        grouped_destination,
+        source_num_cores,
+        destination_num_cores,
+    ):
+        return None
+    return grouped_source, grouped_destination, tuple(geometry)
+
+
 def partition_footprint(layout: FixedTiledLayout, view: PerCoreView) -> int:
     device_layout = layout.device_layout
     return partition_physical_span_bytes(
@@ -410,12 +456,16 @@ def _overlap(a: int, an: int, b: int, bn: int) -> bool:
 
 
 def _compatible_partitions(
-    source: PerCoreView, destination: PerCoreView, num_cores: int
+    source: PerCoreView,
+    destination: PerCoreView,
+    source_num_cores: int,
+    destination_num_cores: int | None = None,
 ) -> bool:
     """Whether every destination receives a uniform, complete partition."""
 
-    source_map = _core_slices(source, num_cores)
-    destination_map = _core_slices(destination, num_cores)
+    destination_num_cores = destination_num_cores or source_num_cores
+    source_map = _core_slices(source, source_num_cores)
+    destination_map = _core_slices(destination, destination_num_cores)
     source_splits = dict(source.work_slice_dims)
     destination_splits = dict(destination.work_slice_dims)
     dims = set(source_splits) | set(destination_splits)
@@ -433,20 +483,30 @@ def _compatible_partitions(
             for dim in dims
         )
     }
-    fanout = [sum(src == core for src, _ in edges) for core in range(num_cores)]
-    fanin = [sum(dst == core for _, dst in edges) for core in range(num_cores)]
+    fanout = [sum(src == core for src, _ in edges) for core in range(source_num_cores)]
+    fanin = [
+        sum(dst == core for _, dst in edges) for core in range(destination_num_cores)
+    ]
     if not edges or len(set(fanout)) != 1 or len(set(fanin)) != 1:
         return False
     source_owners = len({tuple(sorted(row.items())) for row in source_map.values()})
     destination_owners = len(
         {tuple(sorted(row.items())) for row in destination_map.values()}
     )
-    if source_owners != num_cores or math.prod(source_splits.values()) != num_cores:
+    if (
+        source_owners != source_num_cores
+        or math.prod(source_splits.values()) != source_num_cores
+    ):
         return False
     destination_slices = math.prod(destination_splits.values())
-    if destination_owners != destination_slices or num_cores % destination_slices:
+    if (
+        destination_owners != destination_slices
+        or destination_num_cores % destination_slices
+    ):
         return False
-    multiplicity = num_cores // destination_slices
+    if source_num_cores != destination_num_cores:
+        return fanout[0] == destination_num_cores // source_num_cores and fanin[0] == 1
+    multiplicity = source_num_cores // destination_slices
     return multiplicity == 1 or (fanout[0] == multiplicity and fanin[0] == multiplicity)
 
 
@@ -477,15 +537,20 @@ def validate_final_views(
     source = next(iter(source_views))
     destination = next(iter(destination_views))
 
+    source_num_cores = plan.source_view.num_cores or plan.num_cores
+    destination_num_cores = plan.destination_view.num_cores or plan.num_cores
     if (
-        source.ownership.num_cores != plan.num_cores
-        or destination.ownership.num_cores != plan.num_cores
+        source.ownership.num_cores != source_num_cores
+        or destination.ownership.num_cores != destination_num_cores
     ):
         return "final view physical core count changed"
     if source == destination:
         return "final source and destination views no longer require a relayout"
     if not _compatible_partitions(
-        source.ownership, destination.ownership, plan.num_cores
+        source.ownership,
+        destination.ownership,
+        source_num_cores,
+        destination_num_cores,
     ):
         return "final source and destination partitions are not a complete transfer"
 
@@ -493,13 +558,25 @@ def validate_final_views(
         classified = _grouped_gather_geometry(
             source.ownership,
             destination.ownership,
-            plan.num_cores,
+            source_num_cores,
         )
         if classified is None:
             return "final views are not a grouped gather"
         geometry = classified[2]
         if _geometry_topology(geometry) != _geometry_topology(plan.group_geometry):
             return f"final grouped-gather geometry changed: {geometry}"
+    elif plan.kind == "broadcast":
+        classified = _grouped_broadcast_geometry(
+            source.ownership,
+            destination.ownership,
+            source_num_cores,
+            destination_num_cores,
+        )
+        if classified is None:
+            return "final views are not a grouped broadcast"
+        geometry = classified[2]
+        if _geometry_topology(geometry) != _geometry_topology(plan.group_geometry):
+            return f"final grouped-broadcast geometry changed: {geometry}"
     elif plan.kind != "shuffle":
         return f"unsupported relayout kind {plan.kind}"
 
@@ -613,7 +690,7 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
         source_view, partial, representable = _per_core_view_on_buf(
             producer, write, source_name, cache
         )
-        num_cores = _op_num_cores(producer)
+        source_num_cores = _op_num_cores(producer)
         if source_view is None or partial or not representable:
             continue
 
@@ -648,16 +725,21 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
             view, consumer_partial, representable = _per_core_view_on_buf(
                 consumer, dep, source_name, cache
             )
+            consumer_num_cores = _op_num_cores(consumer)
+            if view is None or consumer_partial or not representable:
+                rejection_reason = "consumer ownership is partial or unrepresentable"
+                break
+            if consumer_num_cores < source_num_cores:
+                rejection_reason = "consumer uses fewer physical cores than producer"
+                break
+            if consumer_num_cores > source_num_cores and not _is_matmul_op(consumer):
+                rejection_reason = "grouped broadcast requires a matmul consumer"
+                break
             if (
-                view is None
-                or consumer_partial
-                or not representable
-                or _op_num_cores(consumer) != num_cores
+                consumer_num_cores > source_num_cores
+                and consumer_num_cores != config.sencores
             ):
-                rejection_reason = (
-                    "consumer ownership is partial, unrepresentable, or uses a "
-                    "different core count"
-                )
+                rejection_reason = "grouped broadcast must target all compute cores"
                 break
             consumer_coordinates = try_device_coordinates(
                 producer.layout.device_layout, dep, None
@@ -674,21 +756,57 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                     view,
                     consumer_coordinates,
                     consumer_symbols,
+                    consumer_num_cores,
                 )
             )
 
         grouped_source = None
         grouped_destinations = {}
         grouped_geometry = {}
+        grouped_kinds = {}
         if rejection_reason is None:
-            for consumer_name, consumer, _, view, _, _ in consumer_views:
+            for (
+                consumer_name,
+                consumer,
+                _,
+                view,
+                _,
+                _,
+                consumer_num_cores,
+            ) in consumer_views:
+                if consumer_num_cores > source_num_cores:
+                    grouped = _grouped_broadcast_geometry(
+                        source_view,
+                        view,
+                        source_num_cores,
+                        consumer_num_cores,
+                    )
+                    if grouped is None:
+                        rejection_reason = (
+                            "grouped destination does not evenly replicate the source"
+                        )
+                        break
+                    candidate_source, destination, geometry = grouped
+                    if (
+                        grouped_source is not None
+                        and candidate_source != grouped_source
+                    ):
+                        rejection_reason = (
+                            "consumers require different grouped source geometry"
+                        )
+                        break
+                    grouped_source = candidate_source
+                    grouped_destinations[consumer_name] = destination
+                    grouped_geometry[consumer_name] = geometry
+                    grouped_kinds[consumer_name] = "broadcast"
+                    continue
                 destination_owners = math.prod(dict(view.work_slice_dims).values())
-                if destination_owners >= num_cores:
+                if destination_owners >= source_num_cores:
                     continue
                 if not _is_matmul_op(consumer):
                     rejection_reason = "grouped gather requires a matmul consumer"
                     break
-                grouped = _grouped_gather_geometry(source_view, view, num_cores)
+                grouped = _grouped_gather_geometry(source_view, view, source_num_cores)
                 if grouped is None:
                     rejection_reason = (
                         "grouped destination does not evenly contract the source"
@@ -703,6 +821,7 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                 grouped_source = candidate_source
                 grouped_destinations[consumer_name] = destination
                 grouped_geometry[consumer_name] = geometry
+                grouped_kinds[consumer_name] = "gather"
 
         source_view = grouped_source or source_view
         producer_coordinates = try_device_coordinates(
@@ -733,9 +852,13 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                 raw_view,
                 consumer_coordinates,
                 consumer_symbols,
+                consumer_num_cores,
             ) in consumer_views:
                 destination_view = grouped_destinations.get(consumer_name, raw_view)
-                if raw_view.work_slice_dims == source_geometry:
+                if (
+                    raw_view.work_slice_dims == source_geometry
+                    and consumer_num_cores == source_num_cores
+                ):
                     destination_view = source_view
                 try:
                     source_work_division = work_division_from_view(
@@ -756,7 +879,12 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                 if not is_matmul and not isinstance(consumer.data, Pointwise):
                     rejection_reason = "consumer is neither pointwise nor matmul"
                     break
-                if not _compatible_partitions(source_view, destination_view, num_cores):
+                if not _compatible_partitions(
+                    source_view,
+                    destination_view,
+                    source_num_cores,
+                    consumer_num_cores,
+                ):
                     rejection_reason = (
                         "source and destination partitions are incompatible"
                     )
@@ -776,7 +904,7 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                 ):
                     rejection_reason = reason
                     break
-                kind = "gather" if consumer_name in grouped_geometry else "shuffle"
+                kind = grouped_kinds.get(consumer_name, "shuffle")
                 geometry = grouped_geometry.get(consumer_name, ())
                 footprint = max(
                     partition_footprint(producer.layout, source_view),
@@ -792,7 +920,7 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                     consumer_names=tuple(consumer_names),
                     source_view=source_view,
                     destination_view=destination_view,
-                    num_cores=num_cores,
+                    num_cores=source_num_cores,
                     kind=kind,
                     group_geometry=geometry,
                     max_footprint_bytes=footprint,

--- a/torch_spyre/_inductor/scratchpad/lx_relayout.py
+++ b/torch_spyre/_inductor/scratchpad/lx_relayout.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import dataclasses
 import math
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Literal, cast
 
 import sympy
@@ -48,6 +48,7 @@ from .utils import _op_num_cores
 logger = get_inductor_logger("lx_relayout")
 _DESTINATION_PREFIX = "__spyre_lx_relayout__"
 _REGISTRY = "_spyre_lx_relayout_copies"
+_FINAL_VIEWS = "_spyre_lx_final_views"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -57,6 +58,9 @@ class RelayoutDimension:
     device_dim: int
     source_split: int
     destination_split: int
+    group_count: int
+    group_size: int
+    multiplicity: int
     ordering_tag: Literal["contiguous_groups"]
 
 
@@ -80,6 +84,16 @@ class LXRelayoutPlan:
     @property
     def edge(self) -> tuple[str, str]:
         return self.source_name, self.destination_name
+
+
+@dataclasses.dataclass(frozen=True)
+class FinalLXView:
+    """One tensor's final emitted physical shape and ownership."""
+
+    ownership: PerCoreView
+    device_size: tuple[int, ...]
+    slice_shape: tuple[int, ...]
+    minimum_footprint_bytes: int
 
 
 def work_division_from_view(
@@ -118,6 +132,18 @@ def materialized_lx_relayouts(
     return getattr(graph, _REGISTRY, {})
 
 
+def final_lx_views(graph: GraphLowering) -> dict[tuple[str, str], FinalLXView]:
+    """Final post-alignment physical views accepted by the graph-wide gate."""
+
+    return getattr(graph, _FINAL_VIEWS, {})
+
+
+def set_final_lx_views(
+    graph: GraphLowering, views: dict[tuple[str, str], FinalLXView]
+) -> None:
+    setattr(graph, _FINAL_VIEWS, views)
+
+
 def _discard_lx_relayout_group(graph: GraphLowering, source_name: str) -> set[str]:
     copies = materialized_lx_relayouts(graph)
     removed = set()
@@ -125,6 +151,10 @@ def _discard_lx_relayout_group(graph: GraphLowering, source_name: str) -> set[st
         if edge[0] == source_name:
             removed.add(copy_name)
             del copies[edge]
+    cached = final_lx_views(graph)
+    for key in list(cached):
+        if key[1] == source_name or key[1] in removed:
+            del cached[key]
     return removed
 
 
@@ -166,6 +196,103 @@ def _core_slices(view: PerCoreView, num_cores: int) -> dict[int, dict[int, int]]
             row[dim] = slot
         result[core] = row
     return result
+
+
+def view_from_work_division(
+    division: TensorWorkDivision,
+    device_coordinates: Sequence[sympy.Expr],
+    iteration_space: Mapping[sympy.Symbol, tuple[sympy.Expr, int]],
+) -> PerCoreView:
+    """Convert final loop-symbol ownership back to a physical device view."""
+
+    split_by_device_dim: dict[int, int] = {}
+    slot_by_device_dim: dict[int, sympy.Expr] = {}
+    for loop_dim, split in division.work_slices.items():
+        matches = [
+            device_dim
+            for device_dim, coordinate in enumerate(device_coordinates)
+            if loop_dim in coordinate.free_symbols
+        ]
+        # An operation may split a loop that this tensor broadcasts across
+        # (for example the query dimension of a BMM input). That loop chooses
+        # execution cores, but it does not further partition this tensor.
+        if not matches:
+            continue
+        if len(matches) > 1:
+            extent = int(iteration_space[loop_dim][0])
+            slice_extent = math.ceil(extent / int(split))
+            physical_matches = []
+            for device_dim in matches:
+                coordinate = device_coordinates[device_dim]
+                other_dims = coordinate.free_symbols - {loop_dim}
+                coordinate = coordinate.xreplace({dim: 0 for dim in other_dims})
+                values = []
+                for slot in range(int(split)):
+                    start = slot * slice_extent
+                    end = min(extent, start + slice_extent) - 1
+                    if start >= extent:
+                        break
+                    first = sympy.simplify(coordinate.xreplace({loop_dim: start}))
+                    last = sympy.simplify(coordinate.xreplace({loop_dim: end}))
+                    if first != last:
+                        break
+                    values.append(first)
+                if len(values) == int(split) and len(set(values)) == int(split):
+                    physical_matches.append(device_dim)
+            matches = physical_matches
+        if len(matches) != 1:
+            raise ValueError(
+                f"cannot map final loop {loop_dim} to one device dimension"
+            )
+        device_dim = matches[0]
+        slot = sympy.sympify(division.core_id_to_work_slice[loop_dim])
+        previous = (
+            split_by_device_dim.get(device_dim),
+            slot_by_device_dim.get(device_dim),
+        )
+        if previous[0] is not None and previous != (int(split), slot):
+            raise ValueError(
+                f"conflicting final ownership on device dimension {device_dim}"
+            )
+        split_by_device_dim[device_dim] = int(split)
+        slot_by_device_dim[device_dim] = slot
+    return PerCoreView(
+        tuple(sorted(split_by_device_dim.items())),
+        tuple(sorted(slot_by_device_dim.items())),
+        num_cores=division.num_cores,
+    )
+
+
+def final_view_from_work_division(
+    division: TensorWorkDivision,
+    device_size: Sequence[int],
+    device_coordinates: Sequence[sympy.Expr],
+    iteration_space: Mapping[sympy.Symbol, tuple[sympy.Expr, int]],
+) -> FinalLXView:
+    """Build the physical view described by a finalized tensor argument."""
+
+    size = tuple(int(extent) for extent in device_size)
+    ownership = view_from_work_division(division, device_coordinates, iteration_space)
+    kept_dims = [dim for dim, extent in enumerate(size) if extent != 1]
+    canonical_dim = {dim: index for index, dim in enumerate(kept_dims)}
+    ownership = PerCoreView(
+        tuple((canonical_dim[dim], split) for dim, split in ownership.work_slice_dims),
+        tuple((canonical_dim[dim], slot) for dim, slot in ownership.core_to_slot),
+        num_cores=ownership.num_cores,
+    )
+    canonical_size = tuple(size[dim] for dim in kept_dims)
+    splits = dict(ownership.work_slice_dims)
+    extents = tuple(
+        math.ceil(extent / int(splits.get(dim, 1)))
+        for dim, extent in enumerate(canonical_size)
+    )
+    slice_shape = tuple(sorted(extents[:-1])) + (extents[-1],)
+    return FinalLXView(
+        ownership=ownership,
+        device_size=canonical_size,
+        slice_shape=slice_shape,
+        minimum_footprint_bytes=math.prod(extents[:-1]) * 128,
+    )
 
 
 def _view_from_splits(
@@ -216,6 +343,9 @@ def _grouped_gather_geometry(
                 device_dim=dim,
                 source_split=source_split,
                 destination_split=destination_split,
+                group_count=destination_split,
+                group_size=source_split // destination_split,
+                multiplicity=source_split // destination_split,
                 ordering_tag="contiguous_groups",
             )
         )
@@ -240,6 +370,30 @@ def _partition_footprint(layout: FixedTiledLayout, view: PerCoreView) -> int:
         tuple(int(stride) for stride in device_layout.stride_map),
         int(device_layout.elems_per_stick()),
         dict(view.work_slice_dims),
+    )
+
+
+def _geometry_topology(
+    geometry: Sequence[RelayoutDimension],
+) -> tuple[tuple[int, int, int, int, int, str], ...]:
+    """Return the layout-normalization-invariant collective geometry.
+
+    Device-dimension numbers may change when a tensor layout is normalized.
+    The split contraction and grouping structure must not.
+    """
+
+    return tuple(
+        sorted(
+            (
+                item.source_split,
+                item.destination_split,
+                item.group_count,
+                item.group_size,
+                item.multiplicity,
+                item.ordering_tag,
+            )
+            for item in geometry
+        )
     )
 
 
@@ -286,6 +440,100 @@ def _compatible_partitions(
         return False
     multiplicity = num_cores // destination_slices
     return multiplicity == 1 or (fanout[0] == multiplicity and fanin[0] == multiplicity)
+
+
+def validate_final_views(
+    graph: GraphLowering,
+    plan: LXRelayoutPlan,
+    views: dict[tuple[str, str], FinalLXView],
+    *,
+    destination_name: str | None = None,
+) -> str | None:
+    """Validate one complete relayout group after scheduler alignment preview."""
+
+    destination_name = destination_name or plan.destination_name
+    source_views = {
+        view
+        for (_, buffer_name), view in views.items()
+        if buffer_name == plan.source_name
+    }
+    destination_views = {
+        view
+        for (_, buffer_name), view in views.items()
+        if buffer_name == destination_name
+    }
+    if len(source_views) != 1:
+        return f"source users derived {len(source_views)} final views"
+    if len(destination_views) != 1:
+        return f"destination users derived {len(destination_views)} final views"
+    source = next(iter(source_views))
+    destination = next(iter(destination_views))
+
+    if (
+        source.ownership.num_cores != plan.num_cores
+        or destination.ownership.num_cores != plan.num_cores
+    ):
+        return "final view physical core count changed"
+    if source == destination:
+        return "final source and destination views no longer require a relayout"
+    if not _compatible_partitions(
+        source.ownership, destination.ownership, plan.num_cores
+    ):
+        return "final source and destination partitions are not a complete transfer"
+
+    if plan.kind == "gather":
+        classified = _grouped_gather_geometry(
+            source.ownership,
+            destination.ownership,
+            plan.num_cores,
+        )
+        if classified is None:
+            return "final views are not a grouped gather"
+        geometry = classified[2]
+        if _geometry_topology(geometry) != _geometry_topology(plan.group_geometry):
+            return f"final grouped-gather geometry changed: {geometry}"
+    elif plan.kind != "shuffle":
+        return f"unsupported relayout kind {plan.kind}"
+
+    for name, view in (
+        (plan.source_name, source),
+        (destination_name, destination),
+    ):
+        buffer = graph.try_get_buffer(name)
+        if buffer is None:
+            return f"missing final buffer {name}"
+        layout = buffer.get_layout()
+        if not isinstance(layout, FixedTiledLayout):
+            return f"final buffer {name} has no fixed tiled layout"
+        planned_view = (
+            plan.source_view if name == plan.source_name else plan.destination_view
+        )
+        planned_size = tuple(int(extent) for extent in layout.device_layout.device_size)
+        planned_splits = dict(planned_view.work_slice_dims)
+        planned_extents = tuple(
+            math.ceil(extent / int(planned_splits.get(dim, 1)))
+            for dim, extent in enumerate(planned_size)
+            if extent != 1
+        )
+        planned_shape = tuple(sorted(planned_extents[:-1])) + (planned_extents[-1],)
+        if view.slice_shape != planned_shape:
+            return (
+                f"final {name} slice shape {view.slice_shape} differs from planned "
+                f"{planned_shape}"
+            )
+        if view.minimum_footprint_bytes > plan.max_footprint_bytes:
+            return (
+                f"final {name} minimum footprint {view.minimum_footprint_bytes} "
+                f"exceeds planned "
+                f"{plan.max_footprint_bytes}"
+            )
+
+    if plan.source_address is None or plan.destination_address is None:
+        return "relayout group has no committed LX addresses"
+    # The allocator validates disjointness using each concrete buffer size.
+    # Repeating that check with this edge's maximum bound is incorrect for a
+    # source shared by differently sized destinations.
+    return None
 
 
 def _single_write(op: ComputedBuffer, name: str) -> MemoryDep | None:
@@ -465,7 +713,7 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                         "source ownership cannot be projected to producer"
                     )
 
-        plans_by_destination = {}
+        plans_by_destination: dict[tuple, list[str]] = {}
         if rejection_reason is None:
             source_geometry = source_view.work_slice_dims
             for (

--- a/torch_spyre/_inductor/scratchpad/lx_relayout.py
+++ b/torch_spyre/_inductor/scratchpad/lx_relayout.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import dataclasses
 import math
 from collections.abc import Sequence
-from typing import cast
+from typing import Literal, cast
 
 import sympy
 from torch._inductor.dependencies import MemoryDep
@@ -30,6 +30,7 @@ from torch._inductor.ir import (
 )
 
 from .. import config
+from ..core_mapping import derive_partition_mapping, partition_physical_span_bytes
 from ..ir import FixedTiledLayout
 from ..logging_utils import get_inductor_logger
 from ..op_spec import TensorWorkDivision
@@ -50,12 +51,25 @@ _REGISTRY = "_spyre_lx_relayout_copies"
 
 
 @dataclasses.dataclass(frozen=True)
+class RelayoutDimension:
+    """One device dimension's source-to-destination partition geometry."""
+
+    device_dim: int
+    source_split: int
+    destination_split: int
+    ordering_tag: Literal["contiguous_groups"]
+
+
+@dataclasses.dataclass(frozen=True)
 class LXRelayoutPlan:
     source_name: str
     consumer_names: tuple[str, ...]
     source_view: PerCoreView
     destination_view: PerCoreView
     num_cores: int
+    kind: Literal["shuffle", "gather"] = "shuffle"
+    group_geometry: tuple[RelayoutDimension, ...] = ()
+    max_footprint_bytes: int = 0
     source_address: int | None = None
     destination_address: int | None = None
 
@@ -154,6 +168,81 @@ def _core_slices(view: PerCoreView, num_cores: int) -> dict[int, dict[int, int]]
     return result
 
 
+def _view_from_splits(
+    split_by_device_dim: dict[int, int], num_cores: int
+) -> PerCoreView:
+    """Build v1 planning ownership with the shared late-mapping formula."""
+
+    dims = tuple(sympy.Symbol(f"device_dim_{dim}") for dim in split_by_device_dim)
+    mapping = derive_partition_mapping(
+        dims,
+        tuple(split_by_device_dim.values()),
+        num_cores,
+    )
+    device_dim_by_symbol = dict(zip(dims, split_by_device_dim))
+    return PerCoreView(
+        tuple(split_by_device_dim.items()),
+        tuple(
+            (device_dim_by_symbol[dim], expression)
+            for dim, expression in mapping.items()
+            if split_by_device_dim[device_dim_by_symbol[dim]] > 1
+        ),
+        num_cores=num_cores,
+    )
+
+
+def _grouped_gather_geometry(
+    source: PerCoreView, destination: PerCoreView, num_cores: int
+) -> tuple[PerCoreView, PerCoreView, tuple[RelayoutDimension, ...]] | None:
+    """Classify a full source partition contracting into repeated owners."""
+
+    source_splits = dict(source.work_slice_dims)
+    destination_splits = dict(destination.work_slice_dims)
+    if math.prod(source_splits.values()) != num_cores:
+        return None
+    destination_owners = math.prod(destination_splits.values())
+    if not 0 < destination_owners < num_cores:
+        return None
+
+    dimensions = tuple(dict.fromkeys((*source_splits, *destination_splits)))
+    geometry = []
+    for dim in dimensions:
+        source_split = source_splits.get(dim, 1)
+        destination_split = destination_splits.get(dim, 1)
+        if source_split < destination_split or source_split % destination_split:
+            return None
+        geometry.append(
+            RelayoutDimension(
+                device_dim=dim,
+                source_split=source_split,
+                destination_split=destination_split,
+                ordering_tag="contiguous_groups",
+            )
+        )
+
+    if (
+        destination_owners
+        * math.prod(item.source_split // item.destination_split for item in geometry)
+        != num_cores
+    ):
+        return None
+    grouped_source = _view_from_splits(source_splits, num_cores)
+    grouped_destination = _view_from_splits(destination_splits, num_cores)
+    if not _compatible_partitions(grouped_source, grouped_destination, num_cores):
+        return None
+    return grouped_source, grouped_destination, tuple(geometry)
+
+
+def _partition_footprint(layout: FixedTiledLayout, view: PerCoreView) -> int:
+    device_layout = layout.device_layout
+    return partition_physical_span_bytes(
+        tuple(int(size) for size in device_layout.device_size),
+        tuple(int(stride) for stride in device_layout.stride_map),
+        int(device_layout.elems_per_stick()),
+        dict(view.work_slice_dims),
+    )
+
+
 def _overlap(a: int, an: int, b: int, bn: int) -> bool:
     return a * bn < (b + 1) * an and b * an < (a + 1) * bn
 
@@ -161,6 +250,8 @@ def _overlap(a: int, an: int, b: int, bn: int) -> bool:
 def _compatible_partitions(
     source: PerCoreView, destination: PerCoreView, num_cores: int
 ) -> bool:
+    """Whether every destination receives a uniform, complete partition."""
+
     source_map = _core_slices(source, num_cores)
     destination_map = _core_slices(destination, num_cores)
     source_splits = dict(source.work_slice_dims)
@@ -182,18 +273,19 @@ def _compatible_partitions(
     }
     fanout = [sum(src == core for src, _ in edges) for core in range(num_cores)]
     fanin = [sum(dst == core for _, dst in edges) for core in range(num_cores)]
-    return bool(edges) and all(
-        (
-            len(set(fanout)) == 1,
-            len(set(fanin)) == 1,
-            len({tuple(sorted(row.items())) for row in source_map.values()})
-            == num_cores,
-            len({tuple(sorted(row.items())) for row in destination_map.values()})
-            == num_cores,
-            math.prod(source_splits.values()) == num_cores,
-            math.prod(destination_splits.values()) == num_cores,
-        )
+    if not edges or len(set(fanout)) != 1 or len(set(fanin)) != 1:
+        return False
+    source_owners = len({tuple(sorted(row.items())) for row in source_map.values()})
+    destination_owners = len(
+        {tuple(sorted(row.items())) for row in destination_map.values()}
     )
+    if source_owners != num_cores or math.prod(source_splits.values()) != num_cores:
+        return False
+    destination_slices = math.prod(destination_splits.values())
+    if destination_owners != destination_slices or num_cores % destination_slices:
+        return False
+    multiplicity = num_cores // destination_slices
+    return multiplicity == 1 or (fanout[0] == multiplicity and fanin[0] == multiplicity)
 
 
 def _single_write(op: ComputedBuffer, name: str) -> MemoryDep | None:
@@ -272,24 +364,10 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
         if not _is_activation_source(operations, producer):
             continue
 
-        producer_coordinates = try_device_coordinates(
-            producer.layout.device_layout, write, None
-        )
-        if producer_coordinates is None:
-            continue
-        try:
-            work_division_from_view(
-                source_view,
-                producer_coordinates,
-                tuple(iteration_space_from_op(producer)),
-            )
-        except ValueError:
-            continue
-
         # Relayout copies sharing one source are allocated and materialized as
         # one atomic group. Any unsupported consumer therefore rejects the
         # group; supported consumers keep using the original buffer instead.
-        consumers_by_view: dict[PerCoreView, list[str]] = {}
+        consumer_views = []
         seen_consumers = set()
         rejection_reason = None
         for consumer, dep in consumer_reads:
@@ -330,52 +408,143 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                 rejection_reason = "consumer coordinates are unavailable"
                 break
             consumer_symbols = tuple(iteration_space_from_op(consumer))
-            try:
-                source_work_division = work_division_from_view(
-                    source_view, consumer_coordinates, consumer_symbols
+            consumer_views.append(
+                (
+                    consumer_name,
+                    consumer,
+                    deps,
+                    view,
+                    consumer_coordinates,
+                    consumer_symbols,
                 )
-            except ValueError:
-                rejection_reason = "source ownership cannot be projected to consumer"
-                break
-            assert source_work_division is not None
-            if view == source_view:
-                continue
-            is_matmul = _is_matmul_op(consumer)
-            if is_matmul and len(deps) != 2:
-                rejection_reason = "matmul consumer does not have two inputs"
-                break
-            if not is_matmul and not isinstance(consumer.data, Pointwise):
-                rejection_reason = "consumer is neither pointwise nor matmul"
-                break
-            if not _compatible_partitions(source_view, view, num_cores):
-                rejection_reason = "source and destination partitions are incompatible"
-                break
-            try:
-                destination_work_division = work_division_from_view(
-                    view, consumer_coordinates, consumer_symbols
+            )
+
+        grouped_source = None
+        grouped_destinations = {}
+        grouped_geometry = {}
+        if rejection_reason is None:
+            for consumer_name, consumer, _, view, _, _ in consumer_views:
+                destination_owners = math.prod(dict(view.work_slice_dims).values())
+                if destination_owners >= num_cores:
+                    continue
+                if not _is_matmul_op(consumer):
+                    rejection_reason = "grouped gather requires a matmul consumer"
+                    break
+                grouped = _grouped_gather_geometry(source_view, view, num_cores)
+                if grouped is None:
+                    rejection_reason = (
+                        "grouped destination does not evenly contract the source"
+                    )
+                    break
+                candidate_source, destination, geometry = grouped
+                if grouped_source is not None and candidate_source != grouped_source:
+                    rejection_reason = (
+                        "consumers require different grouped source geometry"
+                    )
+                    break
+                grouped_source = candidate_source
+                grouped_destinations[consumer_name] = destination
+                grouped_geometry[consumer_name] = geometry
+
+        source_view = grouped_source or source_view
+        producer_coordinates = try_device_coordinates(
+            producer.layout.device_layout, write, None
+        )
+        if rejection_reason is None:
+            if producer_coordinates is None:
+                rejection_reason = "producer coordinates are unavailable"
+            else:
+                try:
+                    work_division_from_view(
+                        source_view,
+                        producer_coordinates,
+                        tuple(iteration_space_from_op(producer)),
+                    )
+                except ValueError:
+                    rejection_reason = (
+                        "source ownership cannot be projected to producer"
+                    )
+
+        plans_by_destination = {}
+        if rejection_reason is None:
+            source_geometry = source_view.work_slice_dims
+            for (
+                consumer_name,
+                consumer,
+                deps,
+                raw_view,
+                consumer_coordinates,
+                consumer_symbols,
+            ) in consumer_views:
+                destination_view = grouped_destinations.get(consumer_name, raw_view)
+                if raw_view.work_slice_dims == source_geometry:
+                    destination_view = source_view
+                try:
+                    source_work_division = work_division_from_view(
+                        source_view, consumer_coordinates, consumer_symbols
+                    )
+                except ValueError:
+                    rejection_reason = (
+                        "source ownership cannot be projected to consumer"
+                    )
+                    break
+                assert source_work_division is not None
+                if destination_view == source_view:
+                    continue
+                is_matmul = _is_matmul_op(consumer)
+                if is_matmul and len(deps) != 2:
+                    rejection_reason = "matmul consumer does not have two inputs"
+                    break
+                if not is_matmul and not isinstance(consumer.data, Pointwise):
+                    rejection_reason = "consumer is neither pointwise nor matmul"
+                    break
+                if not _compatible_partitions(source_view, destination_view, num_cores):
+                    rejection_reason = (
+                        "source and destination partitions are incompatible"
+                    )
+                    break
+                try:
+                    destination_work_division = work_division_from_view(
+                        destination_view, consumer_coordinates, consumer_symbols
+                    )
+                except ValueError:
+                    rejection_reason = (
+                        "destination ownership cannot be projected to consumer"
+                    )
+                    break
+                assert destination_work_division is not None
+                if reason := _unsupported_relayout_transition_reason(
+                    source_work_division, destination_work_division
+                ):
+                    rejection_reason = reason
+                    break
+                kind = "gather" if consumer_name in grouped_geometry else "shuffle"
+                geometry = grouped_geometry.get(consumer_name, ())
+                footprint = max(
+                    _partition_footprint(producer.layout, source_view),
+                    _partition_footprint(producer.layout, destination_view),
                 )
-            except ValueError:
-                rejection_reason = (
-                    "destination ownership cannot be projected to consumer"
-                )
-                break
-            assert destination_work_division is not None
-            if reason := _unsupported_relayout_transition_reason(
-                source_work_division, destination_work_division
-            ):
-                rejection_reason = reason
-                break
-            consumers_by_view.setdefault(view, []).append(consumer_name)
-        else:
+                key = (destination_view, kind, geometry, footprint)
+                plans_by_destination.setdefault(key, []).append(consumer_name)
+
+        if rejection_reason is None:
             result.extend(
                 LXRelayoutPlan(
-                    source_name,
-                    tuple(consumer_names),
-                    source_view,
-                    destination_view,
-                    num_cores,
+                    source_name=source_name,
+                    consumer_names=tuple(consumer_names),
+                    source_view=source_view,
+                    destination_view=destination_view,
+                    num_cores=num_cores,
+                    kind=kind,
+                    group_geometry=geometry,
+                    max_footprint_bytes=footprint,
                 )
-                for destination_view, consumer_names in consumers_by_view.items()
+                for (
+                    destination_view,
+                    kind,
+                    geometry,
+                    footprint,
+                ), consumer_names in plans_by_destination.items()
             )
         if rejection_reason is not None:
             logger.debug(

--- a/torch_spyre/_inductor/scratchpad/lx_relayout.py
+++ b/torch_spyre/_inductor/scratchpad/lx_relayout.py
@@ -93,7 +93,7 @@ class FinalLXView:
     ownership: PerCoreView
     device_size: tuple[int, ...]
     slice_shape: tuple[int, ...]
-    minimum_footprint_bytes: int
+    physical_span_bytes: int | None
 
 
 def work_division_from_view(
@@ -268,8 +268,16 @@ def final_view_from_work_division(
     device_size: Sequence[int],
     device_coordinates: Sequence[sympy.Expr],
     iteration_space: Mapping[sympy.Symbol, tuple[sympy.Expr, int]],
+    *,
+    physical_span_bytes: int | None,
 ) -> FinalLXView:
-    """Build the physical view described by a finalized tensor argument."""
+    """Build the view described by a finalized tensor argument.
+
+    Alignment may factor or insert descriptor dimensions, so its ``device_size``
+    cannot be combined with the original layout strides.  The exact physical
+    span is therefore carried from the committed physical partition while the
+    final ownership and slice shape are derived from the aligned descriptor.
+    """
 
     size = tuple(int(extent) for extent in device_size)
     ownership = view_from_work_division(division, device_coordinates, iteration_space)
@@ -291,7 +299,7 @@ def final_view_from_work_division(
         ownership=ownership,
         device_size=canonical_size,
         slice_shape=slice_shape,
-        minimum_footprint_bytes=math.prod(extents[:-1]) * 128,
+        physical_span_bytes=physical_span_bytes,
     )
 
 
@@ -363,7 +371,7 @@ def _grouped_gather_geometry(
     return grouped_source, grouped_destination, tuple(geometry)
 
 
-def _partition_footprint(layout: FixedTiledLayout, view: PerCoreView) -> int:
+def partition_footprint(layout: FixedTiledLayout, view: PerCoreView) -> int:
     device_layout = layout.device_layout
     return partition_physical_span_bytes(
         tuple(int(size) for size in device_layout.device_size),
@@ -521,9 +529,11 @@ def validate_final_views(
                 f"final {name} slice shape {view.slice_shape} differs from planned "
                 f"{planned_shape}"
             )
-        if view.minimum_footprint_bytes > plan.max_footprint_bytes:
+        if view.physical_span_bytes is None:
+            return f"final {name} has no committed physical span"
+        if view.physical_span_bytes > plan.max_footprint_bytes:
             return (
-                f"final {name} minimum footprint {view.minimum_footprint_bytes} "
+                f"final {name} physical span {view.physical_span_bytes} "
                 f"exceeds planned "
                 f"{plan.max_footprint_bytes}"
             )
@@ -769,8 +779,8 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                 kind = "gather" if consumer_name in grouped_geometry else "shuffle"
                 geometry = grouped_geometry.get(consumer_name, ())
                 footprint = max(
-                    _partition_footprint(producer.layout, source_view),
-                    _partition_footprint(producer.layout, destination_view),
+                    partition_footprint(producer.layout, source_view),
+                    partition_footprint(producer.layout, destination_view),
                 )
                 key = (destination_view, kind, geometry, footprint)
                 plans_by_destination.setdefault(key, []).append(consumer_name)

--- a/torch_spyre/_inductor/scratchpad/lx_relayout.py
+++ b/torch_spyre/_inductor/scratchpad/lx_relayout.py
@@ -71,7 +71,7 @@ class LXRelayoutPlan:
     source_view: PerCoreView
     destination_view: PerCoreView
     num_cores: int
-    kind: Literal["shuffle", "gather", "broadcast"] = "shuffle"
+    kind: Literal["shuffle", "gather", "broadcast", "regroup"] = "shuffle"
     group_geometry: tuple[RelayoutDimension, ...] = ()
     max_footprint_bytes: int = 0
     source_address: int | None = None
@@ -326,6 +326,81 @@ def _view_from_splits(
     )
 
 
+def _compatible_regroup(
+    source: PerCoreView, destination: PerCoreView, num_cores: int
+) -> bool:
+    """Whether a cross-dim regroup is a complete, uniform transfer.
+
+    ``_compatible_partitions`` assumes source and destination split the SAME
+    device dims (it intersects per-dim slice coordinates via ``_overlap``). A
+    regroup partitions DIFFERENT dims (source on dims X, destination on disjoint
+    dims Y), so per-dim overlap is meaningless. Here every source core owns a
+    distinct 1/num_cores slice and every destination owner replicates one of
+    ``destination_owners`` slices to an equal-size contiguous core group; the
+    transfer is complete iff the counts line up.
+    """
+
+    source_splits = dict(source.work_slice_dims)
+    destination_splits = dict(destination.work_slice_dims)
+    if set(source_splits) & set(destination_splits):
+        return False
+    if math.prod(source_splits.values()) != num_cores:
+        return False
+    destination_owners = math.prod(destination_splits.values())
+    if not 0 < destination_owners < num_cores or num_cores % destination_owners:
+        return False
+    source_map = _core_slices(source, num_cores)
+    destination_map = _core_slices(destination, num_cores)
+    if len({tuple(sorted(r.items())) for r in source_map.values()}) != num_cores:
+        return False
+    if (
+        len({tuple(sorted(r.items())) for r in destination_map.values()})
+        != destination_owners
+    ):
+        return False
+    # Each destination owner group must be an equal-size contiguous core block.
+    group_size = num_cores // destination_owners
+    for core in range(num_cores):
+        if destination_map[core] != destination_map[(core // group_size) * group_size]:
+            return False
+    return True
+
+
+def _grouped_regroup_geometry(
+    source: PerCoreView, destination: PerCoreView, num_cores: int
+) -> tuple[PerCoreView, PerCoreView, tuple[RelayoutDimension, ...]] | None:
+    """Classify a cross-dim regroup: a source partitioned on dims X re-expressed
+    as a destination partitioned on disjoint dims Y (a transpose of the owned
+    axis).
+
+    This is the GQA paged-attention V/K page: the page is split across all cores
+    on its kv-head axis, but the matmul owns it on the head-group axis. Emitted as
+    a generic ``shuffle`` (validated only by ``_compatible_regroup``) because the
+    structured gather/broadcast geometry both assume a shared split axis.
+    """
+
+    if not _compatible_regroup(source, destination, num_cores):
+        return None
+    source_splits = dict(source.work_slice_dims)
+    destination_splits = dict(destination.work_slice_dims)
+    destination_owners = math.prod(destination_splits.values())
+    geometry = tuple(
+        RelayoutDimension(
+            device_dim=dim,
+            source_split=source_splits.get(dim, 1),
+            destination_split=destination_splits.get(dim, 1),
+            group_count=destination_splits.get(dim, 1),
+            group_size=num_cores // destination_owners,
+            multiplicity=num_cores // destination_owners,
+            ordering_tag="contiguous_groups",
+        )
+        for dim in dict.fromkeys((*source_splits, *destination_splits))
+    )
+    grouped_source = _view_from_splits(source_splits, num_cores)
+    grouped_destination = _view_from_splits(destination_splits, num_cores)
+    return grouped_source, grouped_destination, geometry
+
+
 def _grouped_gather_geometry(
     source: PerCoreView, destination: PerCoreView, num_cores: int
 ) -> tuple[PerCoreView, PerCoreView, tuple[RelayoutDimension, ...]] | None:
@@ -577,6 +652,17 @@ def validate_final_views(
         geometry = classified[2]
         if _geometry_topology(geometry) != _geometry_topology(plan.group_geometry):
             return f"final grouped-broadcast geometry changed: {geometry}"
+    elif plan.kind == "regroup":
+        classified = _grouped_regroup_geometry(
+            source.ownership,
+            destination.ownership,
+            source_num_cores,
+        )
+        if classified is None:
+            return "final views are not a grouped regroup"
+        geometry = classified[2]
+        if _geometry_topology(geometry) != _geometry_topology(plan.group_geometry):
+            return f"final grouped-regroup geometry changed: {geometry}"
     elif plan.kind != "shuffle":
         return f"unsupported relayout kind {plan.kind}"
 
@@ -807,6 +893,12 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                     rejection_reason = "grouped gather requires a matmul consumer"
                     break
                 grouped = _grouped_gather_geometry(source_view, view, source_num_cores)
+                grouped_kind = "gather"
+                if grouped is None:
+                    grouped = _grouped_regroup_geometry(
+                        source_view, view, source_num_cores
+                    )
+                    grouped_kind = "regroup"
                 if grouped is None:
                     rejection_reason = (
                         "grouped destination does not evenly contract the source"
@@ -821,7 +913,7 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                 grouped_source = candidate_source
                 grouped_destinations[consumer_name] = destination
                 grouped_geometry[consumer_name] = geometry
-                grouped_kinds[consumer_name] = "gather"
+                grouped_kinds[consumer_name] = grouped_kind
 
         source_view = grouped_source or source_view
         producer_coordinates = try_device_coordinates(
@@ -884,6 +976,11 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                     destination_view,
                     source_num_cores,
                     consumer_num_cores,
+                ) and not (
+                    grouped_kinds.get(consumer_name) == "regroup"
+                    and _compatible_regroup(
+                        source_view, destination_view, source_num_cores
+                    )
                 ):
                     rejection_reason = (
                         "source and destination partitions are incompatible"

--- a/torch_spyre/_inductor/scratchpad/lx_relayout.py
+++ b/torch_spyre/_inductor/scratchpad/lx_relayout.py
@@ -93,7 +93,7 @@ def work_division_from_view(
             raise ValueError(f"conflicting ownership for loop {dim}")
         splits[dim] = split
         core_map[dim] = slot
-    return TensorWorkDivision(splits, core_map)
+    return TensorWorkDivision(splits, core_map, num_cores=view.num_cores)
 
 
 def materialized_lx_relayouts(

--- a/torch_spyre/_inductor/scratchpad/lx_relayout.py
+++ b/torch_spyre/_inductor/scratchpad/lx_relayout.py
@@ -77,6 +77,8 @@ def work_division_from_view(
 
     if view is None:
         return None
+    if view.num_cores is None:
+        raise ValueError("LX ownership must carry its physical core domain")
     loop_symbols = set(iteration_symbols)
     splits: dict[sympy.Symbol, int] = {}
     core_map: dict[sympy.Symbol, sympy.Expr] = {}

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass, field
+import math
 from typing import Any, Callable, Self, Sequence, Tuple, Union
 from abc import ABC
 import itertools
@@ -55,7 +56,12 @@ from .core_mapping import (
 )
 from .errors import Unsupported
 from .ir import FixedTiledLayout
-from .scratchpad.lx_relayout import work_division_from_view
+from .scratchpad.lx_relayout import (
+    final_view_from_work_division,
+    final_lx_views,
+    partition_footprint,
+    work_division_from_view,
+)
 from .pass_utils import (
     AlignmentAccess,
     concretize_expr,
@@ -80,6 +86,7 @@ from .op_spec import (
     LoopSpec,
     OpSpec,
     TensorArg,
+    TensorWorkDivision,
     UnimplementedOp as OpSpecUnimplementedOp,
     format_op_spec_list,
     is_lx_relayout_identity,
@@ -577,6 +584,8 @@ class SpyreKernel(Kernel[CSEVariable]):
         ] = {}
         self._alignment_access_by_tensor_arg: dict[int, AlignmentAccess] = {}
         self._alignment_inputs_by_spec: dict[int, AlignmentInputs] = {}
+        self._buffer_name_by_tensor_arg: dict[int, str] = {}
+        self._node_name_by_spec: dict[int, str] = {}
         self.pool_size: int = pool_size
 
     def indirect_var_names(self) -> "frozenset[str] | None":
@@ -848,6 +857,7 @@ class SpyreKernel(Kernel[CSEVariable]):
         self._alignment_access_by_tensor_arg[id(tensor_arg)] = AlignmentAccess(
             tensor.layout.device_layout, tensor.index
         )
+        self._buffer_name_by_tensor_arg[id(tensor_arg)] = name
         if (
             "lx" not in tensor.layout.allocation
             and "hbm_pool" not in tensor.layout.allocation
@@ -1011,7 +1021,61 @@ class SpyreKernel(Kernel[CSEVariable]):
         }
         if op != RESTICKIFY_OP:
             self._alignment_inputs_by_spec[id(op_spec)] = alignment_inputs
+        assert self.current_node is not None
+        self._node_name_by_spec[id(op_spec)] = self.current_node.get_name()
         return op_spec
+
+    def _validate_final_lx_views(self, op_spec: OpSpec) -> None:
+        """Assert codegen reproduced the graph-wide gate's accepted views."""
+
+        cached = final_lx_views(V.graph)
+        if not cached:
+            return
+        node_name = self._node_name_by_spec.get(id(op_spec))
+        if node_name is None:
+            return
+        is_relayout = is_lx_relayout_identity(op_spec.op, op_spec.args)
+        operation_division = None
+        if not is_relayout:
+            assert op_spec.core_id_to_work_slice is not None
+            work_slices = {
+                dim: int(split)
+                for dim, (_, split) in op_spec.iteration_space.items()
+                if int(split) > 1
+            }
+            operation_division = TensorWorkDivision(
+                work_slices,
+                {dim: op_spec.core_id_to_work_slice[dim] for dim in work_slices},
+                num_cores=math.prod(
+                    int(split) for _, split in op_spec.iteration_space.values()
+                ),
+            )
+
+        for arg in op_spec.args:
+            if "lx" not in arg.allocation:
+                continue
+            name = self._buffer_name_by_tensor_arg.get(id(arg))
+            if name is None:
+                raise RuntimeError("LX tensor is missing its codegen buffer identity")
+            expected = cached.get((node_name, name))
+            if expected is None:
+                raise RuntimeError(
+                    f"LX final-view gate has no result for {node_name} reading {name}"
+                )
+            division = arg.work_division if is_relayout else operation_division
+            if division is None:
+                raise RuntimeError(f"LX tensor {name} has no final work division")
+            actual = final_view_from_work_division(
+                division,
+                arg.device_size,
+                arg.device_coordinates,
+                op_spec.iteration_space,
+            )
+            if actual != expected:
+                raise RuntimeError(
+                    f"LX final view changed after the graph-wide gate for "
+                    f"{node_name}:{name}: {actual} != {expected}"
+                )
 
     def remove_kernel_local_buffers(self) -> None:
         """Remove buffers that have a scratchpad or temporary allocation from the kernel's arg list."""
@@ -1292,6 +1356,7 @@ class SpyreKernel(Kernel[CSEVariable]):
                 repeat_info=self._alignment_repeat_info_by_spec.get(id(op_spec)),
                 alignment_inputs=self._alignment_inputs_by_spec.get(id(op_spec)),
             )
+            self._validate_final_lx_views(op_spec)
 
         if _spyre_config.validate_op_specs:
             validate_op_specs(self.op_specs, stage="after_simplification")

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -1059,9 +1059,9 @@ class SpyreKernel(Kernel[CSEVariable]):
                 raise RuntimeError("LX tensor is missing its codegen buffer identity")
             expected = cached.get((node_name, name))
             if expected is None:
-                raise RuntimeError(
-                    f"LX final-view gate has no result for {node_name} reading {name}"
-                )
+                # The graph-wide cache proves relayout handoffs. Ordinary LX
+                # residency keeps using the scheduler's existing validation.
+                continue
             division = arg.work_division if is_relayout else operation_division
             if division is None:
                 raise RuntimeError(f"LX tensor {name} has no final work division")

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -1065,11 +1065,21 @@ class SpyreKernel(Kernel[CSEVariable]):
             division = arg.work_division if is_relayout else operation_division
             if division is None:
                 raise RuntimeError(f"LX tensor {name} has no final work division")
+            buffer = V.graph.try_get_buffer(name)
+            if buffer is None or not isinstance(
+                (layout := buffer.get_layout()), FixedTiledLayout
+            ):
+                raise RuntimeError(f"LX tensor {name} has no fixed tiled layout")
             actual = final_view_from_work_division(
                 division,
                 arg.device_size,
                 arg.device_coordinates,
                 op_spec.iteration_space,
+                physical_span_bytes=(
+                    partition_footprint(layout, layout.lx_view)
+                    if layout.lx_view is not None
+                    else None
+                ),
             )
             if actual != expected:
                 raise RuntimeError(

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -53,16 +53,15 @@ from .ir import FixedTiledLayout
 from .scratchpad.lx_relayout import work_division_from_view
 from .pass_utils import (
     concretize_expr,
-    concretize_index,
     compute_symbolic_bounds,
     finite_upper_or_none,
-    apply_splits_from_index_coeff,
     iteration_space,
-    select_work_division_transport_indexes,
     indirect_access_subs_from_kernel,
     is_restickify_coords,
+    alignment_coordinates,
+    iteration_space_with_splits,
 )
-from .views import compute_coordinates, align_tensors, tiling_expr_to_device_expr
+from .views import align_tensors, tiling_expr_to_device_expr
 from .logging_utils import get_inductor_logger
 from .op_spec import (
     IndirectAccess,
@@ -795,8 +794,6 @@ class SpyreKernel(Kernel[CSEVariable]):
         # (e.g. x0*s1+x1).  Concretize size symbols so normalize_coordinates
         # can correctly isolate each loop variable's contribution.
 
-        index = concretize_index(tensor.index, set(it_space.keys()))
-
         # insert_post_mutation_restickify may override the input layout for this input tensor.
         # Restore it here because the tensor data was uploaded as orig_stl.
         if is_input:
@@ -804,11 +801,10 @@ class SpyreKernel(Kernel[CSEVariable]):
             if (layout := overrides.get(name)) is not None:
                 tensor.layout = layout
 
-        device_coords = compute_coordinates(
-            tensor.layout.device_layout.device_size,
-            tensor.layout.device_layout.stride_map,
+        device_coords = alignment_coordinates(
+            tensor.layout.device_layout,
+            tensor.index,
             it_space,
-            index,
             self.indirect_sizes,
         )
         work_division = work_division_from_view(
@@ -866,18 +862,9 @@ class SpyreKernel(Kernel[CSEVariable]):
         it_space = iteration_space(self.current_node)
 
         ir_node = self.current_node.node  # ComputedBuffer
-        work_division: dict[sympy.Symbol, int] = {}
-        if hasattr(ir_node, "op_it_space_splits"):
-            write_index, read_index = select_work_division_transport_indexes(
-                ir_node, self.current_node.read_writes, it_space
-            )
-            work_division = apply_splits_from_index_coeff(
-                ir_node.op_it_space_splits, write_index, read_index, it_space
-            )
-
-        it_space_extended = {
-            k: (v, work_division.get(k, 1)) for k, v in it_space.items()
-        }
+        it_space_extended = iteration_space_with_splits(
+            ir_node, self.current_node.read_writes, it_space
+        )
         it_space_extended = _preserve_shared_weight_unit_bmm_dim(
             op, it_space_extended, args, op_info
         )

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from dataclasses import dataclass, field
-import math
 from typing import Any, Callable, Self, Sequence, Tuple, Union
 from abc import ABC
 import itertools
@@ -41,6 +40,7 @@ from .constants import (
     CONV_OPS,
     DEPTHWISE_CONV_REDUCTION_OPS,
     IDENTITY_OP,
+    MATMUL_REDUCTION_OPS,
     POOL_OPS,
     RESTICKIFY_OP,
     SEGMENT_OFFSETS,
@@ -48,6 +48,11 @@ from .constants import (
     SHARED_WEIGHT_UNIT_BMM_INFO_KEY,
 )
 from . import config as _spyre_config
+from .core_mapping import (
+    derive_operation_mapping,
+    finalize_tensor_work_divisions,
+    remap_work_division,
+)
 from .errors import Unsupported
 from .ir import FixedTiledLayout
 from .scratchpad.lx_relayout import work_division_from_view
@@ -68,7 +73,6 @@ from .op_spec import (
     LoopSpec,
     OpSpec,
     TensorArg,
-    TensorWorkDivision,
     UnimplementedOp as OpSpecUnimplementedOp,
     format_op_spec_list,
     is_lx_relayout_identity,
@@ -558,6 +562,10 @@ class SpyreKernel(Kernel[CSEVariable]):
         self._indirect_var_count: int = 0
         self._general_tile_advance_seen: dict[str, int] = {}
         self._tile_advance_symbols: dict[int, sympy.Symbol] = {}
+        self._alignment_repeat_info: dict[sympy.Symbol, dict[str, Any]] = {}
+        self._alignment_repeat_info_by_spec: dict[
+            int, dict[sympy.Symbol, dict[str, Any]]
+        ] = {}
         self.pool_size: int = pool_size
 
     def indirect_var_names(self) -> "frozenset[str] | None":
@@ -806,6 +814,7 @@ class SpyreKernel(Kernel[CSEVariable]):
             tensor.index,
             it_space,
             self.indirect_sizes,
+            repeat_info_out=self._alignment_repeat_info,
         )
         work_division = work_division_from_view(
             tensor.layout.lx_view if "lx" in tensor.layout.allocation else None,
@@ -959,11 +968,7 @@ class SpyreKernel(Kernel[CSEVariable]):
             and hasattr(ir_node.data, "ranges")
             else None
         )
-        if not is_lx_relayout_identity(op, args):
-            for arg in args:
-                arg.work_division = None
-
-        return OpSpec(
+        op_spec = OpSpec(
             op,
             is_reduction,
             it_space_extended,
@@ -975,6 +980,10 @@ class SpyreKernel(Kernel[CSEVariable]):
             node_output_ranges=node_output_ranges,
             debug_handle=debug_handle,
         )
+        self._alignment_repeat_info_by_spec[id(op_spec)] = {
+            symbol: dict(info) for symbol, info in self._alignment_repeat_info.items()
+        }
+        return op_spec
 
     def remove_kernel_local_buffers(self) -> None:
         """Remove buffers that have a scratchpad or temporary allocation from the kernel's arg list."""
@@ -1018,6 +1027,7 @@ class SpyreKernel(Kernel[CSEVariable]):
     ) -> None:
         self._general_tile_advance_seen = {}
         self._tile_advance_symbols = {}
+        self._alignment_repeat_info = {}
         # mutation_real_name maps mutation aliases to their real destination buffer. Resolve that here,
         # and mark the buf name as removed so the wrapper does not allocate it separately.
         real_dst_name = V.graph.scheduler.mutation_real_name.get(name, name)
@@ -1146,6 +1156,7 @@ class SpyreKernel(Kernel[CSEVariable]):
         """Convert an RValue"""
         self._general_tile_advance_seen = {}
         self._tile_advance_symbols = {}
+        self._alignment_repeat_info = {}
         buf = V.graph.get_buffer(name)
         layout = buf.get_layout()
         if not isinstance(layout, FixedTiledLayout):
@@ -1246,7 +1257,12 @@ class SpyreKernel(Kernel[CSEVariable]):
             )
 
         for op_spec in _iter_op_specs(self.op_specs):
-            simplify_op_spec(op_spec, self.indirect_sizes, indirect_access_subs)
+            simplify_op_spec(
+                op_spec,
+                self.indirect_sizes,
+                indirect_access_subs,
+                repeat_info=self._alignment_repeat_info_by_spec.get(id(op_spec)),
+            )
 
         if _spyre_config.validate_op_specs:
             validate_op_specs(self.op_specs, stage="after_simplification")
@@ -1451,6 +1467,12 @@ def _codegen_op_spec_list(specs, buf: IndentedBuffer, sympy_str) -> None:
                         for sym, count in op_spec.tiled_symbol_trip_counts.items()
                     )
                     buf.writeline(f"tiled_symbol_trip_counts={{{trip_counts_str}}},")
+                if op_spec.core_id_to_work_slice is not None:
+                    core_map = ", ".join(
+                        f"{sympy_str(dim)}: {sympy_str(slot)}"
+                        for dim, slot in op_spec.core_id_to_work_slice.items()
+                    )
+                    buf.writeline(f"core_id_to_work_slice={{{core_map}}},")
                 buf.writeline(
                     f"symbolic_dim_bounds={_serialize_value(op_spec.symbolic_dim_bounds)},"
                 )
@@ -1512,51 +1534,17 @@ def _codegen_op_spec_list(specs, buf: IndentedBuffer, sympy_str) -> None:
                                 buf.writeline(
                                     "work_division=TensorWorkDivision("
                                     f"work_slices={{{splits}}}, "
-                                    f"core_id_to_work_slice={{{core_map}}}),"
+                                    f"core_id_to_work_slice={{{core_map}}}"
+                                    + (
+                                        f", num_cores={arg.work_division.num_cores}"
+                                        if arg.work_division.num_cores is not None
+                                        else ""
+                                    )
+                                    + "),"
                                 )
                         buf.writeline("),")
                 buf.writeline("]")
             buf.writeline("),")
-
-
-def _remap_work_division(arg: TensorArg, work_division_remap) -> None:
-    """Carry tensor ownership through iteration-space normalization."""
-
-    if arg.work_division is None:
-        return
-    new_splits: dict[sympy.Symbol, int] = {}
-    new_core_map: dict[sympy.Symbol, sympy.Expr] = {}
-    for old_dim, split in arg.work_division.work_slices.items():
-        new_dims = work_division_remap[old_dim]
-        remaining_split = int(split)
-        split_factors = []
-        if len(new_dims) == 1:
-            split_factors = [(new_dims[0][0], remaining_split)]
-            remaining_split = 1
-        else:
-            for new_dim, basis in reversed(new_dims):
-                factor = math.gcd(remaining_split, basis)
-                split_factors.append((new_dim, factor))
-                remaining_split //= factor
-            split_factors.reverse()
-        if remaining_split != 1:
-            raise ValueError(f"cannot normalize {split}-way split on {old_dim}")
-
-        slot = arg.work_division.core_id_to_work_slice[old_dim]
-        slot_stride = 1
-        for new_dim, factor in split_factors:
-            if factor == 1:
-                continue
-            new_slot = sympy.Mod(sympy.floor(slot / slot_stride), factor)
-            if new_dim in new_splits and (
-                new_splits[new_dim],
-                new_core_map[new_dim],
-            ) != (factor, new_slot):
-                raise ValueError(f"conflicting normalized ownership on {new_dim}")
-            new_splits[new_dim] = factor
-            new_core_map[new_dim] = new_slot
-            slot_stride *= factor
-    arg.work_division = TensorWorkDivision(new_splits, new_core_map)
 
 
 def _restickify_restore_elided_dim(op_spec) -> None:
@@ -1656,7 +1644,13 @@ def _restickify_restore_elided_dim(op_spec) -> None:
         _restore(new_sym, out_arg, in_arg)
 
 
-def simplify_op_spec(op_spec, indirect_sizes=None, indirect_access_subs=None):
+def simplify_op_spec(
+    op_spec,
+    indirect_sizes=None,
+    indirect_access_subs=None,
+    *,
+    repeat_info=None,
+):
     # Both parameters must be provided together for gather kernels — indirect_sizes
     # decomposes symbols in align_tensors; indirect_access_subs replaces them with IndirectAccess.
 
@@ -1673,11 +1667,15 @@ def simplify_op_spec(op_spec, indirect_sizes=None, indirect_access_subs=None):
             for arg in op_spec.args
         ],
         indirect_sizes,
+        repeat_info=repeat_info,
     )
     op_spec.iteration_space = new_op_space_splits
 
     for arg, t in zip(op_spec.args, new_tensors):
-        _remap_work_division(arg, work_division_remap)
+        if arg.work_division is not None:
+            arg.work_division = remap_work_division(
+                arg.work_division, work_division_remap
+            )
         arg.device_size = t["size"]
         arg.device_coordinates = t["coordinates"]
 
@@ -1687,3 +1685,43 @@ def simplify_op_spec(op_spec, indirect_sizes=None, indirect_access_subs=None):
             arg.device_coordinates = [
                 c.xreplace(indirect_access_subs) for c in arg.device_coordinates
             ]
+
+    _finalize_tensor_work_divisions(op_spec)
+    is_relayout = is_lx_relayout_identity(op_spec.op, op_spec.args)
+    if is_relayout:
+        destination = op_spec.args[-1].work_division
+        assert destination is not None
+        op_spec.core_id_to_work_slice = dict(destination.core_id_to_work_slice)
+    else:
+        _finalize_core_mapping(op_spec, use_tensor_constraints=True)
+        for arg in op_spec.args:
+            arg.work_division = None
+
+
+def _finalize_tensor_work_divisions(op_spec: OpSpec) -> None:
+    """Derive tensor owners from final symbols, never planning-time formulas."""
+    finalized = finalize_tensor_work_divisions(
+        op_spec.iteration_space,
+        [arg.work_division for arg in op_spec.args],
+    )
+    for arg, division in zip(op_spec.args, finalized):
+        arg.work_division = division
+
+
+def _finalize_core_mapping(
+    op_spec: OpSpec, *, use_tensor_constraints: bool = False
+) -> None:
+    """Assign physical cores from an OpSpec's final aligned dimensions."""
+
+    contiguous_dim = (
+        next(reversed(op_spec.iteration_space))
+        if op_spec.iteration_space
+        and op_spec.op in MATMUL_REDUCTION_OPS
+        and _spyre_config.core_id_k_fast_emission
+        else None
+    )
+    op_spec.core_id_to_work_slice = derive_operation_mapping(
+        op_spec.iteration_space,
+        [arg.work_division for arg in op_spec.args] if use_tensor_constraints else (),
+        contiguous_dim=contiguous_dim,
+    )

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -563,6 +563,8 @@ class SpyreKernel(Kernel[CSEVariable]):
         self._general_tile_advance_seen: dict[str, int] = {}
         self._tile_advance_symbols: dict[int, sympy.Symbol] = {}
         self._alignment_repeat_info: dict[sympy.Symbol, dict[str, Any]] = {}
+        # Specs stay in self.op_specs until codegen, and capture precedes lookup,
+        # so id(op_spec) remains stable for this side table's lifetime.
         self._alignment_repeat_info_by_spec: dict[
             int, dict[sympy.Symbol, dict[str, Any]]
         ] = {}

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -57,6 +57,7 @@ from .errors import Unsupported
 from .ir import FixedTiledLayout
 from .scratchpad.lx_relayout import work_division_from_view
 from .pass_utils import (
+    AlignmentAccess,
     concretize_expr,
     compute_symbolic_bounds,
     finite_upper_or_none,
@@ -64,9 +65,15 @@ from .pass_utils import (
     indirect_access_subs_from_kernel,
     is_restickify_coords,
     alignment_coordinates,
+    build_operation_alignment_inputs,
     iteration_space_with_splits,
 )
-from .views import align_tensors, tiling_expr_to_device_expr
+from .views import (
+    AlignmentInputs,
+    align_tensors,
+    align_tensors_pure,
+    tiling_expr_to_device_expr,
+)
 from .logging_utils import get_inductor_logger
 from .op_spec import (
     IndirectAccess,
@@ -568,6 +575,8 @@ class SpyreKernel(Kernel[CSEVariable]):
         self._alignment_repeat_info_by_spec: dict[
             int, dict[sympy.Symbol, dict[str, Any]]
         ] = {}
+        self._alignment_access_by_tensor_arg: dict[int, AlignmentAccess] = {}
+        self._alignment_inputs_by_spec: dict[int, AlignmentInputs] = {}
         self.pool_size: int = pool_size
 
     def indirect_var_names(self) -> "frozenset[str] | None":
@@ -836,6 +845,9 @@ class SpyreKernel(Kernel[CSEVariable]):
             device_tile_advance_expr=device_tile_advance_expr,
             work_division=work_division,
         )
+        self._alignment_access_by_tensor_arg[id(tensor_arg)] = AlignmentAccess(
+            tensor.layout.device_layout, tensor.index
+        )
         if (
             "lx" not in tensor.layout.allocation
             and "hbm_pool" not in tensor.layout.allocation
@@ -879,6 +891,18 @@ class SpyreKernel(Kernel[CSEVariable]):
         it_space_extended = _preserve_shared_weight_unit_bmm_dim(
             op, it_space_extended, args, op_info
         )
+        alignment_inputs = build_operation_alignment_inputs(
+            it_space,
+            [self._alignment_access_by_tensor_arg[id(arg)] for arg in args],
+            indirect_sizes=self.indirect_sizes,
+            repeat_info=self._alignment_repeat_info,
+            aligned_iteration_space=it_space_extended,
+        )
+        for arg, tensor in zip(args, alignment_inputs.tensors):
+            if list(arg.device_coordinates) != tensor["coordinates"]:
+                raise RuntimeError(
+                    "alignment input collection disagrees with tensor codegen"
+                )
 
         # Build per-level tiled_symbols (innermost first) for this op.
         # loop_tiled_dims / loop_tiled_reduction_dims are lists of per-level
@@ -985,6 +1009,8 @@ class SpyreKernel(Kernel[CSEVariable]):
         self._alignment_repeat_info_by_spec[id(op_spec)] = {
             symbol: dict(info) for symbol, info in self._alignment_repeat_info.items()
         }
+        if op != RESTICKIFY_OP:
+            self._alignment_inputs_by_spec[id(op_spec)] = alignment_inputs
         return op_spec
 
     def remove_kernel_local_buffers(self) -> None:
@@ -1264,6 +1290,7 @@ class SpyreKernel(Kernel[CSEVariable]):
                 self.indirect_sizes,
                 indirect_access_subs,
                 repeat_info=self._alignment_repeat_info_by_spec.get(id(op_spec)),
+                alignment_inputs=self._alignment_inputs_by_spec.get(id(op_spec)),
             )
 
         if _spyre_config.validate_op_specs:
@@ -1652,6 +1679,7 @@ def simplify_op_spec(
     indirect_access_subs=None,
     *,
     repeat_info=None,
+    alignment_inputs: AlignmentInputs | None = None,
 ):
     # Both parameters must be provided together for gather kernels — indirect_sizes
     # decomposes symbols in align_tensors; indirect_access_subs replaces them with IndirectAccess.
@@ -1662,15 +1690,24 @@ def simplify_op_spec(
         _restickify_restore_elided_dim(op_spec)
 
     it_space = op_spec.iteration_space
-    new_op_space_splits, new_tensors, work_division_remap = align_tensors(
-        it_space,
-        [
-            {"size": arg.device_size, "coordinates": arg.device_coordinates}
-            for arg in op_spec.args
-        ],
-        indirect_sizes,
-        repeat_info=repeat_info,
-    )
+    if alignment_inputs is None:
+        new_op_space_splits, new_tensors, work_division_remap = align_tensors(
+            it_space,
+            [
+                {"size": arg.device_size, "coordinates": arg.device_coordinates}
+                for arg in op_spec.args
+            ],
+            indirect_sizes,
+            repeat_info=repeat_info,
+        )
+    else:
+        if alignment_inputs.iteration_space != it_space:
+            raise RuntimeError(
+                "captured alignment iteration space changed before codegen"
+            )
+        new_op_space_splits, new_tensors, work_division_remap = align_tensors_pure(
+            alignment_inputs
+        )
     op_spec.iteration_space = new_op_space_splits
 
     for arg, t in zip(op_spec.args, new_tensors):

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -184,6 +184,7 @@ def compute_coordinates(
     var_ranges: dict[sympy.Symbol, sympy.Expr],
     index: sympy.Expr,
     indirect_sizes: "dict[sympy.Symbol, int] | None" = None,
+    repeat_info_out: "dict[sympy.Symbol, dict] | None" = None,
 ) -> list[sympy.Expr]:
     """
     Compute an array of coordinate expressions from an index expression.
@@ -211,10 +212,8 @@ def compute_coordinates(
     # Convert ModularIndexing expressions to sympy.Mod before processing
     index = convert_modular_indexing(index)
     repeat_info = find_repeat_vars([index], var_ranges)
-    if not hasattr(V.graph, "_repeat_info"):
-        V.graph._repeat_info = dict(repeat_info)
-    else:
-        V.graph._repeat_info.update(repeat_info)
+    if repeat_info_out is not None:
+        repeat_info_out.update(repeat_info)
 
     # find stride immediately strictly larger that dim stride
     n = len(size)
@@ -426,6 +425,7 @@ def normalize_coordinates(
     coordinates: Sequence[sympy.Expr],
     synthetic_var_fn: Callable[[], sympy.Symbol],
     indirect_sizes: "dict[sympy.Symbol, int] | None" = None,
+    compare_value: Callable[[sympy.Expr], int | float] = _concretize_for_cmp,
 ) -> list[Term]:
     """
     Normalize coordinate expressions obtained from compute_coordinates.
@@ -516,8 +516,8 @@ def normalize_coordinates(
         # when num is equal
         dim_terms.sort(
             key=lambda t: (
-                _concretize_for_cmp(t.num),
-                _concretize_for_cmp(t.mod),
+                compare_value(t.num),
+                compare_value(t.mod),
             )
         )
 
@@ -615,17 +615,79 @@ def normalize_coordinates(
     return fused_terms
 
 
-def align_tensors(
+@dataclass(frozen=True)
+class AlignmentInputs:
+    """Everything tensor alignment needs, captured without hidden graph state."""
+
+    iteration_space: dict[sympy.Symbol, tuple[sympy.Expr, int]]
+    tensors: list[dict[str, list[sympy.Expr]]]
+    indirect_sizes: dict[sympy.Symbol, int] | None
+    repeat_info: dict[sympy.Symbol, dict]
+    concrete_ranges: dict[sympy.Symbol, int | float]
+    restored_ranges: dict[sympy.Symbol, sympy.Expr | int | float]
+
+
+def build_alignment_inputs(
     iteration_space: Dict[sympy.Symbol, Tuple[sympy.Expr, int]],
     tensors: list[Dict[str, list[sympy.Expr]]],
     indirect_sizes: "dict[sympy.Symbol, int] | None" = None,
+    repeat_info: "dict[sympy.Symbol, dict] | None" = None,
+) -> AlignmentInputs:
+    """Snapshot explicit inputs for a repeatable, side-effect-free alignment."""
+
+    from .pass_utils import finite_upper_or_none
+
+    concrete_ranges = {
+        var: _concretize_for_cmp(value) for var, (value, _) in iteration_space.items()
+    }
+    restored_ranges: dict[sympy.Symbol, sympy.Expr | int | float] = {}
+    for var, (value, _) in iteration_space.items():
+        if (
+            hasattr(value, "free_symbols")
+            and value.free_symbols
+            and finite_upper_or_none(value) is None
+        ):
+            restored_ranges[var] = concrete_ranges[var]
+        else:
+            restored_ranges[var] = value
+
+    return AlignmentInputs(
+        iteration_space=dict(iteration_space),
+        tensors=[
+            {
+                "size": list(tensor["size"]),
+                "coordinates": list(tensor["coordinates"]),
+            }
+            for tensor in tensors
+        ],
+        indirect_sizes=dict(indirect_sizes) if indirect_sizes is not None else None,
+        repeat_info={
+            symbol: dict(info) for symbol, info in (repeat_info or {}).items()
+        },
+        concrete_ranges=concrete_ranges,
+        restored_ranges=restored_ranges,
+    )
+
+
+def _concrete_alignment_value(expr: sympy.Expr) -> int | float:
+    if hasattr(expr, "free_symbols") and expr.free_symbols:
+        raise Unsupported(f"alignment input is not concrete: {expr}")
+    if expr == sympy.oo:
+        return math.inf
+    if expr == -sympy.oo:
+        return -math.inf
+    return int(expr)
+
+
+def align_tensors_pure(
+    inputs: AlignmentInputs,
 ) -> tuple[
     dict[sympy.Symbol, tuple[sympy.Expr, int]],
     list[dict[str, list]],
     dict[sympy.Symbol, tuple[tuple[sympy.Symbol, int], ...]],
 ]:
     """
-    Transform op iteration space and tensor arguments to satisfy codegen requirements.
+    Transform tensor coordinates using only the supplied immutable snapshot.
     """
 
     # Concretize range values for the algorithm: align_tensors performs
@@ -633,33 +695,11 @@ def align_tensors(
     # Coordinate *expressions* remain symbolic (they reference loop variable
     # Symbols, not range values).
 
-    # Save original (possibly symbolic) range expressions before concretizing.
-    # The algorithm below requires concrete ints for sorting and integer division,
-    # but we must propagate symbolic expressions forward so downstream passes
-    # (work_division, SDSC codegen) see the symbols to extract fields, not hints.
-    orig_ranges = {var: val[0] for var, val in iteration_space.items()}
-    # local import: pass_utils imports compute_coordinates/matching_dim from
-    # this module, so importing at module scope would create a cycle.
-    from .pass_utils import finite_upper_or_none
-
-    def _bounded_or_hint(expr, hint):
-        """Return ``expr`` unless it's an unbounded symbolic expression.
-
-        Auto-dynamic symbols (Dynamo promoting an int on retrace, with no
-        finite max and are not symbolic dims ) carry no bound downstream passes
-        (work_division, SDSC codegen) can size buffers/loops with. Fall back to
-        the concretized ``hint`` instead of propagating an unbounded symbol.
-        """
-        if hasattr(expr, "free_symbols") and expr.free_symbols:
-            if finite_upper_or_none(expr) is None:
-                return hint
-        return expr
-
-    repeat_info: dict = getattr(V.graph, "_repeat_info", {})
-
-    var_ranges = {
-        var: _concretize_for_cmp(val[0]) for var, val in iteration_space.items()
-    }
+    iteration_space = inputs.iteration_space
+    tensors = inputs.tensors
+    indirect_sizes = inputs.indirect_sizes
+    repeat_info = inputs.repeat_info
+    var_ranges = dict(inputs.concrete_ranges)
 
     # work division for each variable
     op_it_space_splits = {var: val[1] for var, val in iteration_space.items()}
@@ -691,6 +731,7 @@ def align_tensors(
             tensor["coordinates"],
             synthetic_var,
             indirect_sizes,
+            _concrete_alignment_value,
         )
         stick_dim.append(terms[-1].var)
         stick_size.append(terms[-1].dim_size)
@@ -726,9 +767,6 @@ def align_tensors(
                 ):
                     # add mod to splits unless stick dim and stick size
                     splits[var].add(mod)
-
-    if hasattr(V.graph, "_repeat_info"):
-        V.graph._repeat_info.clear()
 
     # Insert restored size-1 dimensions with offset/gap to the other tensors
     for var in new_vars:
@@ -783,9 +821,7 @@ def align_tensors(
             # Synthetic vars (z0, z1, …) are introduced by normalize_coordinates
             # for restored size-1 dims and are not in orig_ranges; fall back to
             # the concretized value (always 1) for those.
-            new_var_ranges[var] = _bounded_or_hint(
-                orig_ranges.get(var, var_ranges[var]), var_ranges[var]
-            )
+            new_var_ranges[var] = inputs.restored_ranges.get(var, var_ranges[var])
             # var can be a loop var or an indirect symbol
             if var in var_ranges:
                 new_var_ranges[var] = var_ranges[var]
@@ -903,10 +939,10 @@ def align_tensors(
     # bound, so fall back to the concretized size-hint instead of
     # propagating an unbounded symbol. See work_division.py's symbol_meta
     # for the same distinction.
-    for var, orig_expr in orig_ranges.items():
+    for var, restored_expr in inputs.restored_ranges.items():
         if var not in new_var_ranges or new_var_ranges[var] != var_ranges[var]:
             continue
-        new_var_ranges[var] = _bounded_or_hint(orig_expr, var_ranges[var])
+        new_var_ranges[var] = restored_expr
 
     # Iteration space should only contain loop variables, not indirect symbols.
     # Filter out any indirect symbols that were added during normalization.
@@ -918,6 +954,23 @@ def align_tensors(
     }
 
     return new_iteration_space, new_tensors, work_division_remap
+
+
+def align_tensors(
+    iteration_space: Dict[sympy.Symbol, Tuple[sympy.Expr, int]],
+    tensors: list[Dict[str, list[sympy.Expr]]],
+    indirect_sizes: "dict[sympy.Symbol, int] | None" = None,
+    repeat_info: "dict[sympy.Symbol, dict] | None" = None,
+) -> tuple[
+    dict[sympy.Symbol, tuple[sympy.Expr, int]],
+    list[dict[str, list]],
+    dict[sympy.Symbol, tuple[tuple[sympy.Symbol, int], ...]],
+]:
+    """Build explicit alignment inputs, then run the pure implementation."""
+
+    return align_tensors_pure(
+        build_alignment_inputs(iteration_space, tensors, indirect_sizes, repeat_info)
+    )
 
 
 def tiling_expr_to_device_expr(

--- a/torch_spyre/_inductor/work_division_constraints.py
+++ b/torch_spyre/_inductor/work_division_constraints.py
@@ -30,14 +30,17 @@ import dataclasses
 import typing
 from sympy import Expr, Symbol, divisors
 
-from torch._inductor.ir import ComputedBuffer, Reduction
 from torch._inductor.dependencies import MemoryDep
+from torch._inductor.ir import ComputedBuffer, Pointwise, Reduction
 from torch_spyre._C import ElementArrangement
 
 from .constants import (
     BATCH_MATMUL_OP,
     BATCH_MATMUL_FP8_OP,
+    CONV2D_FWD_OP,
+    DEPTHWISE_CONV2D_OP,
     KEEP_BY_INDEX_OP,
+    POOL_OPS,
     _MAX_K_PER_CORE,
     TOPK_MAX_K_PER_CORE,
     TOPK_OPS,
@@ -46,6 +49,7 @@ from .errors import Unsupported
 from .pass_utils import (
     concretize_expr,
     indirect_forbidden_split_syms,
+    is_restickify_coords,
     op_read_writes,
 )
 from .logging_utils import get_inductor_logger
@@ -101,6 +105,8 @@ def collect_work_division_constraints(
     for constraint in (
         coordinate_mask_blocked_vars,
         conv_spatial_blocked_vars,
+        reduction_window_blocked_vars,
+        restickify_padding_blocked_vars,
         qfp8wt_split_domains,
         qfp8wt_matmul_k_split_domains,
         topk_split_domains,
@@ -196,6 +202,55 @@ def conv_spatial_blocked_vars(ctx: WorkDivConstraintContext) -> ConstraintResult
         and concretize_expr(ctx.it_space[sym]) > 1
     }
     return ConstraintResult(blocked=blocked)
+
+
+def reduction_window_blocked_vars(ctx: WorkDivConstraintContext) -> ConstraintResult:
+    """Keep pooling and convolution kernel windows local to each core."""
+
+    if not isinstance(ctx.op.data, Reduction):
+        return ConstraintResult()
+    op = ctx.op.data.reduction_type
+    if op in POOL_OPS:
+        window_dims = ctx.reduction_vars
+    elif op == CONV2D_FWD_OP:
+        op_info = getattr(ctx.op.data, "op_info", None)
+        conv_params = (
+            op_info.get("conv_params", {}) if isinstance(op_info, dict) else {}
+        )
+        kernel_dims = sum(
+            int(conv_params.get(name, 1)) > 1 for name in ("kernel_h", "kernel_w")
+        )
+        window_dims = ctx.reduction_vars[-kernel_dims:] if kernel_dims else []
+    elif op == DEPTHWISE_CONV2D_OP:
+        # Depthwise reduction order is kh, kw, then optional group. Unlike the
+        # forward-conv path, a group dimension may therefore follow the window.
+        window_dims = ctx.reduction_vars[:2]
+    else:
+        return ConstraintResult()
+
+    return ConstraintResult(blocked=set(window_dims))
+
+
+def restickify_padding_blocked_vars(
+    ctx: WorkDivConstraintContext,
+) -> ConstraintResult:
+    """Keep an unaligned restickify stick dimension on one core."""
+
+    if (
+        not isinstance(ctx.op.data, Pointwise)
+        or len(ctx.input_tds) != 1
+        or not is_restickify_coords(
+            ctx.input_tds[0].device_coords, ctx.output_td.device_coords
+        )
+    ):
+        return ConstraintResult()
+
+    padded = {
+        dim
+        for dim, stick_size in ctx.stick_vars.items()
+        if concretize_expr(ctx.it_space[dim]) % stick_size
+    }
+    return ConstraintResult(blocked=padded)
 
 
 def has_qfp8wt_tensor(tds: "list[TensorDep]") -> bool:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Add support for lx-lx broadcast of the GQA dimension of V tensors within paged attention. 

#### Which issue(s) this PR is related to:


Attempt to solve https://github.com/torch-spyre/torch-spyre/issues/4123, based on https://github.com/torch-spyre/torch-spyre/pull/4061


<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
