### PR TITLE
[KTIR Emitter] The `spyreop` intrinsics, their int32 arms, and per-format recipes

### DIFF
--- a/tests/inductor/test_ktir_emitter.py
+++ b/tests/inductor/test_ktir_emitter.py
@@ -579,5 +579,151 @@ module {
         self.assertEqual(emitted, self.EXPECTED_TILED_ADD_KTIR)
 
 
+@unittest.skipUnless(
+    _mlir_ktdp_available(),
+    "mlir_ktdp with the func/arith/linalg/scf/tensor dialect bindings is not installed",
+)
+class TestIntrinsicPayloadEmission(unittest.TestCase):
+    """A ``spyreop`` intrinsic (``sqrt``) over the whole [16, 512, 64] tile.
+
+    A PAYLOAD recipe is a *scalar* builder, so it reaches ``Surface.GENERIC``: an
+    all-parallel ``linalg.generic`` stating the identity maps, whose body is the
+    one ``spyreop`` op and a ``linalg.yield``.  The intrinsic takes the tile's own
+    f16 and owns its f16->f32->approx->f16 internally, so there is no fp32
+    precision bracket around it (dataflow-scheduler#36).
+
+    No new emission shape: ``_emit_generic`` is the same method the on-stick
+    reduction uses, reached here with no reduced dim, so the ``outs`` block
+    argument is dropped rather than folded into.  The dataflow either side of the
+    compute -- view, tile, load, store -- is exactly the pointwise form, which is
+    why only the compute lines differ from ``EXPECTED_ADD_KTIR``.
+    """
+
+    EXPECTED_SQRT_KTIR = """\
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#set = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 15 >= 0, d1 >= 0, -d1 + 511 >= 0, d2 >= 0, -d2 + 63 >= 0)>
+module {
+  func.func @ktir_fused_sqrt_0(%arg0: index, %arg1: index) attributes {grid = [1]} {
+    %c0 = arith.constant 0 : index
+    %0 = ktdp.construct_memory_view %arg0, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.memory_space<global>} : memref<16x512x64xf16>
+    %1 = ktdp.construct_memory_view %arg1, sizes: [16, 512, 64], strides: [32768, 64, 1] {coordinate_set = #set, memory_space = #ktdp.memory_space<global>} : memref<16x512x64xf16>
+    %2 = ktdp.construct_access_tile %0[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    %3 = ktdp.load %2 : <16x512x64xindex> -> tensor<16x512x64xf16>
+    %4 = tensor.empty() : tensor<16x512x64xf16>
+    %5 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%3 : tensor<16x512x64xf16>) outs(%4 : tensor<16x512x64xf16>) {
+    ^bb0(%in: f16, %out: f16):
+      %7 = spyreop.sqrt %in : f16
+      linalg.yield %7 : f16
+    } -> tensor<16x512x64xf16>
+    %6 = ktdp.construct_access_tile %1[%c0, %c0, %c0] {access_tile_order = #map, access_tile_set = #set} : memref<16x512x64xf16> -> !ktdp.access_tile<16x512x64xindex>
+    ktdp.store %5, %6 : tensor<16x512x64xf16>, <16x512x64xindex>
+    return
+  }
+}
+"""
+
+    def test_sqrt_golden(self):
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        emitted = generate_ktir("ktir_fused_sqrt_0", [make_op_spec("sqrt", inputs=1)])
+        self.assertEqual(emitted, self.EXPECTED_SQRT_KTIR)
+
+    def test_the_generic_body_is_a_single_spyreop(self):
+        """One op in the region and no cast pair: the generic walks all-parallel,
+        the intrinsic takes and yields the tile's own f16, and no ``arith.extf`` /
+        ``arith.truncf`` widen or narrow appears."""
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        emitted = generate_ktir("ktir_fused_sqrt_0", [make_op_spec("sqrt", inputs=1)])
+        self.assertIn('iterator_types = ["parallel", "parallel", "parallel"]', emitted)
+        self.assertIn("spyreop.sqrt %in : f16", emitted)
+        self.assertIn("linalg.yield", emitted)
+        # No fp32 precision bracket: the intrinsic owns its own precision.
+        self.assertNotIn("arith.extf", emitted)
+        self.assertNotIn("arith.truncf", emitted)
+
+    def test_the_out_block_argument_is_dropped_not_read(self):
+        """A parallel body computes from its inputs, so ``%out`` is unused.
+
+        The same block ``_emit_generic`` gives a reducing nest, where ``%out`` *is*
+        the accumulator -- which is why this is worth pinning: the arity works out
+        either way, so reading the wrong argument would still verify.
+        """
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        emitted = generate_ktir("ktir_fused_sqrt_0", [make_op_spec("sqrt", inputs=1)])
+        [body] = [line for line in emitted.splitlines() if "spyreop.sqrt" in line]
+        self.assertNotIn("%out", body)
+
+    def test_each_intrinsic_reaches_its_own_binding(self):
+        """A second intrinsic costs one recipe and no emitter change: same generic
+        shape, different ``spyreop`` op.  Asserted as a delta against the ``sqrt``
+        golden, so what it claims is that nothing but the op name moved."""
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        for op, printed in (
+            ("exp", "spyreop.exp"),
+            ("sigmoid", "spyreop.sigmoid"),
+            ("reciprocal", "spyreop.reciprocal"),
+            # The one pair where the handler name and the op differ.
+            ("gelufwd", "spyreop.gelu"),
+            ("layernormscale", "spyreop.layernormscale"),
+        ):
+            with self.subTest(op=op):
+                emitted = generate_ktir(
+                    f"ktir_fused_{op}_0", [make_op_spec(op, inputs=1)]
+                )
+                self.assertIn(f"{printed} %in : f16", emitted)
+                self.assertNotIn("spyreop.sqrt", emitted)
+                self.assertEqual(
+                    emitted.replace(printed, "spyreop.sqrt").replace(
+                        f"@ktir_fused_{op}_0", "@ktir_fused_sqrt_0"
+                    ),
+                    self.EXPECTED_SQRT_KTIR,
+                )
+
+    def test_softplus_carries_its_beta_and_threshold(self):
+        """An intrinsic with scalar arguments: softplus's ``beta``/``threshold``
+        are read from ``op_info["constants"]`` onto the step and printed on the op,
+        the generic scaffold otherwise identical to the argument-free case."""
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        spec = make_op_spec(
+            "softplus",
+            inputs=1,
+            op_info={"constants": {"softplusBeta": 1.0, "softplusThresh": 20.0}},
+        )
+        emitted = generate_ktir("ktir_fused_softplus_0", [spec])
+        self.assertIn(
+            "spyreop.softplus %in beta 1.000000e+00 threshold 2.000000e+01 : f16",
+            emitted,
+        )
+        # Same scaffold as the argument-free intrinsics: only the op line differs.
+        self.assertEqual(
+            emitted.replace(
+                "spyreop.softplus %in beta 1.000000e+00 threshold 2.000000e+01 : f16",
+                "spyreop.sqrt %in : f16",
+            ).replace("@ktir_fused_softplus_0", "@ktir_fused_sqrt_0"),
+            self.EXPECTED_SQRT_KTIR,
+        )
+
+    def test_the_attributes_are_the_specs_and_not_defaults(self):
+        """A second set of constants reaches the op, so the values are read rather
+        than baked: the beta/threshold of the golden are not the only pair that
+        can print."""
+        from torch_spyre._inductor.codegen.ktir import generate_ktir
+
+        spec = make_op_spec(
+            "softplus",
+            inputs=1,
+            op_info={"constants": {"softplusBeta": 2.5, "softplusThresh": 10.0}},
+        )
+        emitted = generate_ktir("ktir_fused_softplus_0", [spec])
+        self.assertIn(
+            "spyreop.softplus %in beta 2.500000e+00 threshold 1.000000e+01 : f16",
+            emitted,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_ktir_validate.py
+++ b/tests/inductor/test_ktir_validate.py
@@ -572,18 +572,28 @@ class TestRecipes(unittest.TestCase):
         for op, recipe in ktir.KtirBuilder.RECIPES.items():
             with self.subTest(op=op):
                 self.assertGreaterEqual(recipe.arity, 1)
-                self.assertIsInstance(recipe.kind, ktir.BindingKind)
-                # A thunk, not the builder itself: resolving it here would need
-                # the dialect, which this module deliberately does not require.
-                self.assertTrue(callable(recipe.binding))
+                self.assertTrue(recipe.arms)
                 # A reader, not the values: resolving one needs an ``op_info``.
                 self.assertTrue(recipe.attrs is None or callable(recipe.attrs))
+                for index, arm in enumerate(recipe.arms):
+                    with self.subTest(arm=index):
+                        self.assertIsInstance(arm.kind, ktir.BindingKind)
+                        # A thunk, not the builder itself: resolving it here would
+                        # need the dialect, which this module deliberately does
+                        # not require.
+                        self.assertTrue(callable(arm.binding))
+                # A one-armed op has to be reachable at every format, so that arm
+                # cannot list any: a lone arm claiming a format would make
+                # ``Recipe.arm`` refuse every other one.
+                if len(recipe.arms) == 1:
+                    self.assertEqual(recipe.arms[0].dtypes, ())
 
-        # Every kind is now registered by some recipe, so the mirror assertion is
+        # Every kind is now registered by some arm, so the mirror assertion is
         # worth making: PAYLOAD stopped being a hook nothing reaches when the
         # ``spyreop`` intrinsics landed on it.
         self.assertEqual(
-            {r.kind for r in ktir.KtirBuilder.RECIPES.values()}, set(ktir.BindingKind)
+            {arm.kind for r in ktir.KtirBuilder.RECIPES.values() for arm in r.arms},
+            set(ktir.BindingKind),
         )
 
         # Which surface a step gets is the plan's choice, not a recipe's, so
@@ -615,7 +625,122 @@ class TestRecipes(unittest.TestCase):
     def test_recipe_rejects_a_nonsense_arity(self):
         """A duplicate op name is ruff F601; arity is checked at construction."""
         with self.assertRaises(ValueError):
-            ktir.Recipe(arity=0, kind=ktir.BindingKind.NAMED, binding=lambda: None)
+            ktir.Recipe(arity=0, arms=self._arm())
+
+    def test_a_lone_arm_is_promoted_to_a_tuple(self):
+        """``arms=Arm(...)`` and ``arms=(Arm(...),)`` are the same recipe.
+
+        Asserted because the shorthand would otherwise be a second representation
+        of the field: anything reading ``recipe.arms`` directly must see a tuple
+        however the entry was written, or it iterates an ``Arm``'s attributes.
+        """
+        arm = self._arm()
+        self.assertEqual(ktir.Recipe(arity=1, arms=arm).arms, (arm,))
+        self.assertEqual(ktir.Recipe(arity=1, arms=(arm,)).arms, (arm,))
+        # And every registered entry has been normalised, whichever form it used.
+        for op, recipe in ktir.KtirBuilder.RECIPES.items():
+            with self.subTest(op=op):
+                self.assertIsInstance(recipe.arms, tuple)
+
+    @staticmethod
+    def _arm(*dtypes):
+        return ktir.Arm(
+            kind=ktir.BindingKind.NAMED, binding=lambda: None, dtypes=tuple(dtypes)
+        )
+
+    def test_recipe_rejects_an_ambiguous_arm_set(self):
+        """The two ways a format could resolve to more than one arm.
+
+        Both are refused where the table is written rather than at the lookup,
+        because a table that can be read two ways is wrong however it is read --
+        and ``Recipe.arm`` returning the first match would make which arm wins a
+        fact about declaration order.
+        """
+        with self.assertRaises(ValueError):
+            ktir.Recipe(arity=1, arms=())
+        with self.assertRaises(ValueError):
+            # Two arms claiming every unlisted format.
+            ktir.Recipe(arity=1, arms=(self._arm(), self._arm()))
+        with self.assertRaises(ValueError):
+            # Two arms claiming the same format.
+            ktir.Recipe(
+                arity=1,
+                arms=(
+                    self._arm(DataFormats.IEEE_INT32),
+                    self._arm(DataFormats.IEEE_INT32),
+                ),
+            )
+
+    def test_an_op_with_two_spellings_resolves_on_the_format(self):
+        """``add`` is a named linalg op at floats and a spyreop payload at int32.
+
+        The point of the arms: one entry per op, and the format picks the spelling.
+        Asserted on the recipe rather than through a plan so it holds without a
+        dialect build -- the bindings stay unresolved thunks.
+        """
+        recipe = ktir.KtirBuilder.RECIPES["add"]
+        self.assertIs(recipe.arm(DataFormats.SEN169_FP16).kind, ktir.BindingKind.NAMED)
+        self.assertIs(recipe.arm(DataFormats.IEEE_INT32).kind, ktir.BindingKind.PAYLOAD)
+        # Arity is the op's, not the arm's, so both spellings agree on it by
+        # construction rather than by two entries happening to match.
+        self.assertEqual(recipe.arity, 2)
+
+    def test_an_op_with_one_spelling_reaches_it_at_every_format(self):
+        """``sub`` has no integer intrinsic, so its one arm takes every format."""
+        recipe = ktir.KtirBuilder.RECIPES["sub"]
+        for dtype in (DataFormats.SEN169_FP16, DataFormats.IEEE_INT32, None):
+            with self.subTest(dtype=dtype):
+                self.assertIs(recipe.arm(dtype).kind, ktir.BindingKind.NAMED)
+
+    def test_the_format_reaches_the_step_and_picks_the_surface(self):
+        """An int32 ``add`` plans as a generic, and the step carries the format.
+
+        The whole path in one assertion: the spec's format picks the payload arm,
+        the payload arm picks ``Surface.GENERIC`` (a scalar builder needs a region),
+        and the format lands on the step so emission resolves the same arm without
+        seeing the spec.
+        """
+        spec = make_op_spec("add", dtype=DataFormats.IEEE_INT32)
+        [step] = ktir.build_kernel_plan([spec]).steps
+        self.assertIs(step.dtype, DataFormats.IEEE_INT32)
+        self.assertIs(step.surface, ktir.Surface.GENERIC)
+        # The same op at fp16 is the named linalg op, which states its own
+        # indexing and so needs no record.
+        [float_step] = ktir.build_kernel_plan([make_op_spec("add")]).steps
+        self.assertIs(float_step.surface, ktir.Surface.BARE)
+        self.assertIsNone(float_step.indexing)
+
+    def test_a_spec_that_mixes_formats_is_refused_by_the_plan(self):
+        """No arm resolves a mixed request, so the plan refuses to guess one.
+
+        Taking any single operand's format would emit an intrinsic for the wrong
+        type on the others, and the old ``any(... == INT32)`` rule did exactly that
+        for one int32 operand among floats.
+        """
+        spec = make_op_spec("add")
+        mixed = dataclasses.replace(
+            spec,
+            args=[
+                dataclasses.replace(spec.args[0], device_dtype=DataFormats.IEEE_INT32),
+                *spec.args[1:],
+            ],
+        )
+        with self.assertRaises(NotImplementedError) as ctx:
+            ktir.build_kernel_plan([mixed])
+        self.assertIn("mixes device formats", str(ctx.exception))
+
+    def test_a_format_no_arm_takes_is_refused(self):
+        """An op with only a claimed arm does not exist at any other format.
+
+        The membership question the two-table arrangement got wrong: an op is
+        supported at a format or it is not, and there is no second table to fall
+        back out of.
+        """
+        recipe = ktir.Recipe(arity=1, arms=(self._arm(DataFormats.IEEE_INT32),))
+        self.assertIs(recipe.arm(DataFormats.IEEE_INT32).kind, ktir.BindingKind.NAMED)
+        with self.assertRaises(NotImplementedError) as ctx:
+            recipe.arm(DataFormats.SEN169_FP16)
+        self.assertIn("no arm for", str(ctx.exception))
 
     def test_a_reduction_asked_for_elementwise_is_rejected(self):
         """The other direction of the agreement check, and the dangerous one.
@@ -794,7 +919,8 @@ class TestAPayloadWithNoNamedOpGetsAGeneric(unittest.TestCase):
         ):
             with self.subTest(op=op):
                 recipe = ktir.KtirBuilder.RECIPES[op]
-                self.assertIs(recipe.kind, ktir.BindingKind.PAYLOAD)
+                [arm] = recipe.arms
+                self.assertIs(arm.kind, ktir.BindingKind.PAYLOAD)
                 self.assertEqual(recipe.arity, 1)
 
     def test_the_identity_maps_are_stated_rather_than_implied(self):
@@ -830,7 +956,12 @@ class TestAPayloadWithNoNamedOpGetsAGeneric(unittest.TestCase):
         for op, recipe in ktir.KtirBuilder.RECIPES.items():
             # A reduction wants coordinates that actually reduce, which its own
             # fixtures own; the claim here is about the pointwise ops.
-            if recipe.attrs is not None or recipe.kind is ktir.BindingKind.COMBINER:
+            # ``arm(None)`` is the arm an unlisted format reaches, which is the one
+            # ``make_op_spec``'s fp16 args resolve to.
+            if (
+                recipe.attrs is not None
+                or recipe.arm(None).kind is ktir.BindingKind.COMBINER
+            ):
                 continue
             with self.subTest(op=op):
                 spec = make_op_spec(op, inputs=recipe.arity)

--- a/tests/inductor/test_ktir_validate.py
+++ b/tests/inductor/test_ktir_validate.py
@@ -82,6 +82,7 @@ def make_op_spec(
     tiled: list | None = None,
     trips: dict | None = None,
     first_arg_index: int = 0,
+    op_info: dict | None = None,
 ) -> OpSpec:
     """A finished ``OpSpec``, defaulting to ``a + b`` at [16, 512, 64] fp16.
 
@@ -104,6 +105,9 @@ def make_op_spec(
       ``space`` replaces the iteration space outright (``{}`` for a tiled op).
     * ``tiled`` / ``trips`` are the loop-level symbols and trip counts, and
       ``first_arg_index`` continues the numbering for a second op in one kernel.
+    * ``op_info`` is the op's auxiliary dict, which the recipes that take scalar
+      arguments read (softplus's beta/threshold live in ``op_info["constants"]``);
+      it defaults to empty, which every other op wants.
     """
     if allocations and baked:
         raise ValueError("make_op_spec: pass allocations= or baked=, not both")
@@ -156,7 +160,7 @@ def make_op_spec(
         is_reduction=is_reduction,
         iteration_space=space,
         args=args,
-        op_info={},
+        op_info=op_info or {},
         tiled_symbols=tiled or [],
         tiled_symbol_trip_counts=trips or {},
     )
@@ -572,14 +576,21 @@ class TestRecipes(unittest.TestCase):
                 # A thunk, not the builder itself: resolving it here would need
                 # the dialect, which this module deliberately does not require.
                 self.assertTrue(callable(recipe.binding))
+                # A reader, not the values: resolving one needs an ``op_info``.
+                self.assertTrue(recipe.attrs is None or callable(recipe.attrs))
+
+        # Every kind is now registered by some recipe, so the mirror assertion is
+        # worth making: PAYLOAD stopped being a hook nothing reaches when the
+        # ``spyreop`` intrinsics landed on it.
+        self.assertEqual(
+            {r.kind for r in ktir.KtirBuilder.RECIPES.values()}, set(ktir.BindingKind)
+        )
 
         # Which surface a step gets is the plan's choice, not a recipe's, so
         # completeness on this side is about ``compute`` rather than about any one
         # op: every ``Surface`` must appear as a ``case`` pattern.  Read off the
         # AST because ``case _:`` alone turns a missing arm into a runtime
-        # discovery, at which point a module is already half built.  Deliberately
-        # *not* the mirror assertion that every ``BindingKind`` is used by some
-        # recipe -- PAYLOAD is the registered-nowhere hook for ``spyreop``.
+        # discovery, at which point a module is already half built.
         tree = ast.parse(inspect.getsource(ktir))
         builder = next(
             node
@@ -759,38 +770,35 @@ class TestAnOutputLaneIsNotATranspose(unittest.TestCase):
 class TestAPayloadWithNoNamedOpGetsAGeneric(unittest.TestCase):
     """An elementwise op the dialect has no named op for, and how it is spelled.
 
-    Nothing in ``RECIPES`` is a ``PAYLOAD`` yet -- registering the intrinsics that
-    will be is one line each and no emitter change -- so the arm that serves them
-    is exercised here with a recipe registered for the length of the test.  Its
-    binding is never called: what is under test is the plan's choice, which is
-    made before any dialect is reached.
+    ``sqrt`` is one: its binding is ``spyreop.sqrt``, a *scalar* builder, so there
+    is nothing to call it but a region and the step has to state the identity maps
+    itself.  Everything here is the plan's choice, made before any dialect is
+    reached, which is why these run without a dialect build.
     """
 
-    @staticmethod
-    @contextlib.contextmanager
-    def _registered(op, recipe):
-        """``recipe`` in ``RECIPES`` under ``op``, for the body of the ``with``."""
-        ktir.KtirBuilder.RECIPES[op] = recipe
-        try:
-            yield
-        finally:
-            del ktir.KtirBuilder.RECIPES[op]
+    def test_every_spyreop_intrinsic_is_a_payload(self):
+        """The kind is what puts them on the generic, so it is asserted per op.
 
-    def test_no_recipe_registers_a_payload_binding(self):
-        """The state this test compensates for, asserted so it stays true.
-
-        The moment an intrinsic is registered, this fails and the synthetic recipe
-        below has a real counterpart to be replaced by.
+        Registered as PAYLOAD and not NAMED: a ``spyreop`` op is not a ``linalg``
+        named op, and calling one as if it were would hand a scalar builder tensor
+        operands inside emission.
         """
-        kinds = {r.kind for r in ktir.KtirBuilder.RECIPES.values()}
-        self.assertNotIn(ktir.BindingKind.PAYLOAD, kinds)
+        for op in (
+            "exp",
+            "sqrt",
+            "sigmoid",
+            "reciprocal",
+            "gelufwd",
+            "layernormscale",
+            "softplus",
+        ):
+            with self.subTest(op=op):
+                recipe = ktir.KtirBuilder.RECIPES[op]
+                self.assertIs(recipe.kind, ktir.BindingKind.PAYLOAD)
+                self.assertEqual(recipe.arity, 1)
 
     def test_the_identity_maps_are_stated_rather_than_implied(self):
-        recipe = ktir.Recipe(
-            arity=1, kind=ktir.BindingKind.PAYLOAD, binding=lambda: None
-        )
-        with self._registered("probe", recipe):
-            plan = ktir.build_kernel_plan([make_op_spec("probe", inputs=1)])
+        plan = ktir.build_kernel_plan([make_op_spec("sqrt", inputs=1)])
         [step] = plan.steps
         self.assertIs(step.surface, ktir.Surface.GENERIC)
         self.assertEqual(step.reduce_dims, ())
@@ -798,6 +806,45 @@ class TestAPayloadWithNoNamedOpGetsAGeneric(unittest.TestCase):
         # destination are read one element at a time in the same order.
         self.assertEqual(step.indexing.iters, ("parallel",) * 3)
         self.assertEqual(step.indexing.maps, ((0, 1, 2), (0, 1, 2)))
+
+    def test_a_scalar_argument_is_read_at_plan_time(self):
+        """softplus's two scalars land on the step, so emission derives nothing.
+
+        The values are on the record and the reader is not: what ``op_info`` looks
+        like is a fact about the request, and the step is what emission sees.
+        """
+        spec = make_op_spec(
+            "softplus",
+            inputs=1,
+            op_info={"constants": {"softplusBeta": 1.0, "softplusThresh": 20.0}},
+        )
+        [step] = ktir.build_kernel_plan([spec]).steps
+        self.assertEqual(step.attrs, (("beta", 1.0), ("threshold", 20.0)))
+
+    def test_an_op_with_no_scalar_arguments_carries_none(self):
+        """``attrs`` is empty for every op that is a function of its operands.
+
+        Asserted over every registered recipe rather than one, so an ``attrs``
+        reader added to an op that does not want one shows up here.
+        """
+        for op, recipe in ktir.KtirBuilder.RECIPES.items():
+            # A reduction wants coordinates that actually reduce, which its own
+            # fixtures own; the claim here is about the pointwise ops.
+            if recipe.attrs is not None or recipe.kind is ktir.BindingKind.COMBINER:
+                continue
+            with self.subTest(op=op):
+                spec = make_op_spec(op, inputs=recipe.arity)
+                [step] = ktir.build_kernel_plan([spec]).steps
+                self.assertEqual(step.attrs, ())
+
+    def test_a_missing_scalar_argument_is_the_plans_problem(self):
+        """An ``op_info`` without the constants fails in the plan, not in emission.
+
+        This is what reading the scalars at plan time buys: the failure arrives
+        before ``KtirBuilder.create``, so there is no half-built module in hand.
+        """
+        with self.assertRaises(KeyError):
+            ktir.build_kernel_plan([make_op_spec("softplus", inputs=1)])
 
 
 class TestStepFieldsAgreeWithTheSurface(unittest.TestCase):
@@ -847,6 +894,19 @@ class TestStepFieldsAgreeWithTheSurface(unittest.TestCase):
                 )
             ],
             "onstick_reduction": make_onstick_sum_specs(),
+            # A pointwise op whose payload is a ``spyreop`` intrinsic: the other
+            # way onto ``Surface.GENERIC``, and the one that reaches it with no
+            # reduced dim, which is the combination the two claims below split on.
+            "intrinsic": [make_op_spec("sqrt", inputs=1)],
+            "intrinsic_with_attrs": [
+                make_op_spec(
+                    "softplus",
+                    inputs=1,
+                    op_info={
+                        "constants": {"softplusBeta": 1.0, "softplusThresh": 20.0}
+                    },
+                )
+            ],
         }
 
     @staticmethod

--- a/torch_spyre/_inductor/codegen/ktir.py
+++ b/torch_spyre/_inductor/codegen/ktir.py
@@ -167,9 +167,11 @@ class ElemTypes:
     ``storage`` types the memref (the view), ``value`` types the tensor a load
     produces or a store consumes.  KTDP compares neither against the other --
     ``LoadOp``/``StoreOp`` verify shapes only -- so they are two fields rather
-    than one, and today's derivation returns them equal.  Held as the *names* of
-    the ``mlir_ktdp.ir`` type builders, so the record stays dialect-free; the
-    builder's ``named_type`` is what resolves a name against the imported ``ir``.
+    than one, and today's derivation returns them equal.  Held as MLIR type
+    *spellings* (``f16``, ``i32``), so the record stays dialect-free; the
+    builder's ``named_type`` is what resolves a spelling against the imported
+    ``ir``.  Spellings rather than builder names so that every element type is
+    written the same way, whether or not its builder takes a width.
 
     ``NAMES`` is the supported-dtype table, and ``of`` the only way to get an
     ``ElemTypes`` from a device dtype -- so the names this record can hold, the
@@ -179,10 +181,11 @@ class ElemTypes:
     """
 
     NAMES: ClassVar[dict[DataFormats, str]] = {
-        DataFormats.IEEE_FP16: "F16Type",
-        DataFormats.SEN169_FP16: "F16Type",
-        DataFormats.IEEE_FP32: "F32Type",
-        DataFormats.BFLOAT16: "BF16Type",
+        DataFormats.IEEE_FP16: "f16",
+        DataFormats.SEN169_FP16: "f16",
+        DataFormats.IEEE_FP32: "f32",
+        DataFormats.BFLOAT16: "bf16",
+        DataFormats.IEEE_INT32: "i32",
     }
 
     storage: str
@@ -388,6 +391,26 @@ class ComputeStep:
     reduce_dims: tuple[int, ...] = ()
     indexing: Indexing | None = None
     attrs: tuple[tuple[str, float], ...] = ()
+    # Which of the two recipe tables the op name was resolved against.  Carried
+    # rather than re-derived at emit time, where the dtypes are no longer in
+    # reach: a step reads no spec.
+    i32: bool = False
+
+
+def is_i32(args: Sequence[TensorArg]) -> bool:
+    """Whether \\p args ask for the int32 arm of their op.
+
+    The one rule the four recipe lookups share: an op name alone cannot tell an
+    integer request from a float one -- both say ``add`` -- so the dtype does.
+    """
+    return any(arg.device_dtype == DataFormats.IEEE_INT32 for arg in args)
+
+
+def recipe_for(op: str, i32: bool) -> Recipe:
+    """The recipe \\p op resolves to, against the int32 table when \\p i32."""
+    if i32 and op in KtirBuilder.RECIPES_I32:
+        return KtirBuilder.RECIPES_I32[op]
+    return KtirBuilder.RECIPES[op]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1058,12 +1081,15 @@ class KernelPlan:
                 raise NotImplementedError(
                     f"OpSpec->KTIR: unexpected spec entry {type(entry).__name__}"
                 )
+            # An op whose integer form names a different intrinsic is looked up in
+            # the int32 table first; every other op, and every other dtype, comes
+            # from RECIPES.
             if entry.op not in KtirBuilder.RECIPES:
                 raise NotImplementedError(
                     f"OpSpec->KTIR: op {entry.op!r} is not supported yet "
                     f"(registered: {sorted(KtirBuilder.RECIPES)})"
                 )
-            recipe = KtirBuilder.RECIPES[entry.op]
+            recipe = recipe_for(entry.op, is_i32(entry.args))
             if (recipe.kind is BindingKind.COMBINER) != bool(entry.is_reduction):
                 # Two independent statements of one bit -- what the recipe's
                 # binding accumulates, and what the frontend labelled the request
@@ -1091,7 +1117,7 @@ class KernelPlan:
         """
         out, inputs = validated_roles(spec)
         out_extents = [int(s) for s in out.device_size]
-        recipe = KtirBuilder.RECIPES[spec.op]
+        recipe = recipe_for(spec.op, is_i32(spec.args))
         for arg in inputs:
             # In-place (input buffer aliases the output) is not supported yet.
             if buf_id(arg) == buf_id(out):
@@ -1187,6 +1213,7 @@ class KernelPlan:
             reduce_dims=reduce_dims,
             indexing=indexing,
             attrs=attrs,
+            i32=is_i32(spec.args),
             # An internal buffer never reaches memory: it is threaded as a value,
             # so it gets no store, no func parameter, no view and no address.
             store=not is_internal(out),
@@ -1277,7 +1304,7 @@ def validated_roles(spec: OpSpec) -> tuple[TensorArg, list[TensorArg]]:
         raise NotImplementedError(
             f"OpSpec->KTIR: expected exactly one output, got {len(outputs)}"
         )
-    arity = KtirBuilder.RECIPES[spec.op].arity
+    arity = recipe_for(spec.op, is_i32(spec.args)).arity
     if len(inputs) != arity:
         raise NotImplementedError(
             f"OpSpec->KTIR: {spec.op!r} expects {arity} inputs, got {len(inputs)}"
@@ -1454,8 +1481,15 @@ class KtirBuilder:
 
     @staticmethod
     def named_type(name: str):
-        """The ``ir`` type for one ``ElemTypes`` entry (a type-builder name)."""
-        return getattr(ir, name).get()
+        """The ``ir`` type for one ``ElemTypes`` entry (an MLIR type spelling).
+
+        Parsed rather than dispatched to a builder so that one spelling works for
+        every element type this emitter supports: the float builders take no
+        argument while ``IntegerType`` takes a width, so naming builders would
+        make the integer entries a second kind of name to be told apart by
+        inspecting the string.
+        """
+        return ir.Type.parse(name)
 
     def icst_index(self, value: int):
         """A fresh ``arith.constant <value> : index``."""
@@ -1609,7 +1643,7 @@ class KtirBuilder:
         (a method and an arm), and a test parses this ``match`` to catch the
         second one being forgotten.
         """
-        recipe = self.RECIPES[step.op]
+        recipe = recipe_for(step.op, step.i32)
         ins = [self.operand(buf_id, access) for buf_id, access in step.ins]
         match step.surface:
             case Surface.BARE:
@@ -1798,6 +1832,21 @@ class KtirBuilder:
         ),
         "realdiv": Recipe(
             arity=2, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.realdiv
+        ),
+    }
+
+    # The int32 arms of ops that also have a float one.  ``add`` and ``mul`` name
+    # a different intrinsic at four-byte integers than the ``linalg`` op they
+    # reach at floats, and the op name alone cannot tell the two apart -- the
+    # request says ``add`` either way -- so the dtype picks the table.  Only ops
+    # whose integer form differs belong here; anything absent falls back to
+    # ``RECIPES``.
+    RECIPES_I32: ClassVar[dict[str, Recipe]] = {
+        "add": Recipe(
+            arity=2, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.addi32toi32
+        ),
+        "mul": Recipe(
+            arity=2, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.muli32toi32
         ),
     }
 

--- a/torch_spyre/_inductor/codegen/ktir.py
+++ b/torch_spyre/_inductor/codegen/ktir.py
@@ -1750,6 +1750,7 @@ class KtirBuilder:
     RECIPES: ClassVar[dict[str, Recipe]] = {
         "add": Recipe(arity=2, kind=BindingKind.NAMED, binding=lambda: linalg.add),
         "mul": Recipe(arity=2, kind=BindingKind.NAMED, binding=lambda: linalg.mul),
+        "sub": Recipe(arity=2, kind=BindingKind.NAMED, binding=lambda: linalg.sub),
         "sum": Recipe(arity=1, kind=BindingKind.COMBINER, binding=lambda: arith.addf),
         # The unary float ops whose payload is one ``spyreop`` scalar intrinsic.
         # There is no named linalg op behind any of them, so they are PAYLOADs and
@@ -1765,11 +1766,9 @@ class KtirBuilder:
         # ``softplus`` is the one that takes more than its operand: ``attrs`` says
         # where in ``op_info`` its two scalars live.
         #
-        # Not here: ``spyreop.realdiv`` and the integer/address intrinsics
-        # (addi32toi32, addi64toi64, muli32toi32, idx32toaddr), which are not unary
-        # float ops and want operand rules of their own; and the pointwise ops the
-        # dialect has no intrinsic for at all (log, rsqrt, tanh, erf, silu,
-        # relufwd), which this path does not support.
+        # Not here: the integer/address intrinsics (addi32toi32, addi64toi64,
+        # muli32toi32, idx32toaddr) and other pointwise ops the device has no
+        # intrinsic for (log, tanh, erf, relufwd).
         "exp": Recipe(arity=1, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.exp),
         "sqrt": Recipe(arity=1, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.sqrt),
         "sigmoid": Recipe(
@@ -1792,6 +1791,13 @@ class KtirBuilder:
                 "beta": float(info["constants"]["softplusBeta"]),
                 "threshold": float(info["constants"]["softplusThresh"]),
             },
+        ),
+        "silu": Recipe(arity=1, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.silu),
+        "rsqrt": Recipe(
+            arity=1, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.rsqrt
+        ),
+        "realdiv": Recipe(
+            arity=2, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.realdiv
         ),
     }
 

--- a/torch_spyre/_inductor/codegen/ktir.py
+++ b/torch_spyre/_inductor/codegen/ktir.py
@@ -81,14 +81,14 @@ from torch_spyre._inductor.pass_utils import coeff_through_floor
 # this module requires no dialect build.
 if TYPE_CHECKING:
     from mlir_ktdp import ir
-    from mlir_ktdp.dialects import arith, func, ktdp, linalg, scf, tensor
+    from mlir_ktdp.dialects import arith, func, ktdp, linalg, scf, spyreop, tensor
 else:
-    ir = arith = func = ktdp = linalg = scf = tensor = None
+    ir = arith = func = ktdp = linalg = scf = spyreop = tensor = None
 
 
 def _load_dialects() -> None:
     """Bind the dialect handles into this module, once.  The only import site."""
-    global ir, arith, func, ktdp, linalg, scf, tensor
+    global ir, arith, func, ktdp, linalg, scf, spyreop, tensor
     if ir is not None:
         return
     from mlir_ktdp import ir as _ir
@@ -97,15 +97,17 @@ def _load_dialects() -> None:
     from mlir_ktdp.dialects import ktdp as _ktdp
     from mlir_ktdp.dialects import linalg as _linalg
     from mlir_ktdp.dialects import scf as _scf
+    from mlir_ktdp.dialects import spyreop as _spyreop
     from mlir_ktdp.dialects import tensor as _tensor
 
-    ir, arith, func, ktdp, linalg, scf, tensor = (
+    ir, arith, func, ktdp, linalg, scf, spyreop, tensor = (
         _ir,
         _arith,
         _func,
         _ktdp,
         _linalg,
         _scf,
+        _spyreop,
         _tensor,
     )
 
@@ -369,6 +371,12 @@ class ComputeStep:
     read by one surface: a named op defines its own indexing and ``linalg.reduce``
     derives its maps from ``dimensions=``, so a per-operand map record on every
     step would be built three times and read once.
+
+    ``attrs`` are the scalar arguments the payload builder takes beyond its
+    operands -- softplus's ``beta``/``threshold`` -- as ``(name, value)`` pairs in
+    the order the builder is called with them.  A tuple rather than a dict so the
+    record stays hashable and frozen like every other field, and empty for every
+    op that is a pure function of its operands, which is almost all of them.
     """
 
     op: str  # a KtirBuilder.RECIPES key
@@ -379,6 +387,7 @@ class ComputeStep:
     store: bool
     reduce_dims: tuple[int, ...] = ()
     indexing: Indexing | None = None
+    attrs: tuple[tuple[str, float], ...] = ()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -739,8 +748,8 @@ def _parallel_surface(
     ``NAMED`` builder is an op the dialect already has, which says its own
     indexing and needs no record, while anything else has to state the identity
     maps and the all-parallel iterators itself -- which only a generic can do.
-    That second arm is where a ``spyreop`` intrinsic hooks in; no recipe selects
-    it yet.
+    That second arm is where a ``spyreop`` intrinsic lands: it is a scalar builder,
+    so there is nothing to call it but a region.
     """
     if recipe.kind is BindingKind.NAMED:
         return Surface.BARE, None
@@ -1161,6 +1170,14 @@ class KernelPlan:
                     "same elements; dividing the within-stick axis or a reduced "
                     "axis (which needs a cross-core combine) reads like this"
                 )
+        # The scalar arguments the payload builder takes beyond its operands are
+        # read here, once, from the spec's ``op_info`` -- the same place-and-time
+        # discipline as ``reduce_dims`` and ``indexing`` -- so emission has nothing
+        # left to derive and a malformed ``op_info`` is refused by the plan rather
+        # than by a KeyError with a half-built module in hand.
+        attrs: tuple[tuple[str, float], ...] = ()
+        if recipe.attrs is not None:
+            attrs = tuple(recipe.attrs(spec.op_info).items())
         return ComputeStep(
             op=spec.op,
             surface=surface,
@@ -1169,6 +1186,7 @@ class KernelPlan:
             out_buf_id=buf_id(out),
             reduce_dims=reduce_dims,
             indexing=indexing,
+            attrs=attrs,
             # An internal buffer never reaches memory: it is threaded as a value,
             # so it gets no store, no func parameter, no view and no address.
             store=not is_internal(out),
@@ -1310,6 +1328,12 @@ class Recipe:
     arity: int
     kind: BindingKind
     binding: Callable[[], Any]
+    # How to read the op's scalar arguments out of a spec's ``op_info``, for the
+    # few ops whose builder takes more than operands (softplus).  ``None`` when
+    # the op is a pure function of its operands, which is almost all of them.
+    # A reader rather than the values themselves, because where they live in
+    # ``op_info`` is the op's own business and the plan should not have to know.
+    attrs: Callable[[dict[str, Any]], dict[str, float]] | None = None
 
     def __post_init__(self) -> None:
         if self.arity < 1:
@@ -1727,6 +1751,48 @@ class KtirBuilder:
         "add": Recipe(arity=2, kind=BindingKind.NAMED, binding=lambda: linalg.add),
         "mul": Recipe(arity=2, kind=BindingKind.NAMED, binding=lambda: linalg.mul),
         "sum": Recipe(arity=1, kind=BindingKind.COMBINER, binding=lambda: arith.addf),
+        # The unary float ops whose payload is one ``spyreop`` scalar intrinsic.
+        # There is no named linalg op behind any of them, so they are PAYLOADs and
+        # land on ``Surface.GENERIC``: the recipe contributes the intrinsic and the
+        # generic states the identity maps and the all-parallel iterators for it.
+        #
+        # The key is the pointwise-handler name the frontend already uses and the
+        # binding is the ``spyreop`` op, which is why they differ for ``gelufwd``
+        # -> ``spyreop.gelu``.  The intrinsic takes the tile's own f16 and owns its
+        # f16->f32->approx->f16 internally, so the body is the one op with no
+        # precision bracket around it (dataflow-scheduler#36).
+        #
+        # ``softplus`` is the one that takes more than its operand: ``attrs`` says
+        # where in ``op_info`` its two scalars live.
+        #
+        # Not here: ``spyreop.realdiv`` and the integer/address intrinsics
+        # (addi32toi32, addi64toi64, muli32toi32, idx32toaddr), which are not unary
+        # float ops and want operand rules of their own; and the pointwise ops the
+        # dialect has no intrinsic for at all (log, rsqrt, tanh, erf, silu,
+        # relufwd), which this path does not support.
+        "exp": Recipe(arity=1, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.exp),
+        "sqrt": Recipe(arity=1, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.sqrt),
+        "sigmoid": Recipe(
+            arity=1, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.sigmoid
+        ),
+        "reciprocal": Recipe(
+            arity=1, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.reciprocal
+        ),
+        "gelufwd": Recipe(
+            arity=1, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.gelu
+        ),
+        "layernormscale": Recipe(
+            arity=1, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.layernormscale
+        ),
+        "softplus": Recipe(
+            arity=1,
+            kind=BindingKind.PAYLOAD,
+            binding=lambda: spyreop.softplus,
+            attrs=lambda info: {
+                "beta": float(info["constants"]["softplusBeta"]),
+                "threshold": float(info["constants"]["softplusThresh"]),
+            },
+        ),
     }
 
     # -- emission surfaces -------------------------------------------------
@@ -1816,6 +1882,10 @@ class KtirBuilder:
         from its ``outs`` operand rather than being stated, and unlike
         ``_emit_reduce`` the region's block argument types are appended by the
         builder off the operand element types, so there is no annotation to set.
+
+        ``step.attrs`` are the payload's non-operand scalars, passed as keyword
+        arguments.  They were read from the spec's ``op_info`` when the step was
+        planned, so nothing here knows what an op's attributes mean.
         """
         indexing = step.indexing
         # Every GENERIC step carries one (the plan's field invariant); reaching
@@ -1824,9 +1894,10 @@ class KtirBuilder:
         _extents, _elt_t, dest = self._destination(step)
         rank = len(indexing.iters)
         reducing = bool(step.reduce_dims)
+        attrs = dict(step.attrs)
 
         def body(*args):
-            return payload(*(args if reducing else args[:-1]))
+            return payload(*(args if reducing else args[:-1]), **attrs)
 
         return linalg.generic(
             inputs=list(ins),

--- a/torch_spyre/_inductor/codegen/ktir.py
+++ b/torch_spyre/_inductor/codegen/ktir.py
@@ -45,8 +45,10 @@ Structure
    spec and derives nothing, so emission cannot refuse a request the plan
    accepted.
 
-Adding an op is one ``RECIPES`` entry; adding an emission *shape* is one method
-on ``KtirBuilder`` plus one ``Surface`` arm in ``compute``.
+Adding an op is one ``RECIPES`` entry; giving an op it already has a second
+spelling at some element format is one ``Arm`` inside that entry; adding an
+emission *shape* is one method on ``KtirBuilder`` plus one ``Surface`` arm in
+``compute``.
 """
 
 from __future__ import annotations
@@ -182,7 +184,7 @@ class ElemTypes:
 
     NAMES: ClassVar[dict[DataFormats, str]] = {
         DataFormats.IEEE_FP16: "f16",
-        DataFormats.SEN169_FP16: "f16",
+        DataFormats.SEN169_FP16: "f16",  # for now treating dl169 as cosmetic
         DataFormats.IEEE_FP32: "f32",
         DataFormats.BFLOAT16: "bf16",
         DataFormats.IEEE_INT32: "i32",
@@ -391,26 +393,30 @@ class ComputeStep:
     reduce_dims: tuple[int, ...] = ()
     indexing: Indexing | None = None
     attrs: tuple[tuple[str, float], ...] = ()
-    # Which of the two recipe tables the op name was resolved against.  Carried
-    # rather than re-derived at emit time, where the dtypes are no longer in
-    # reach: a step reads no spec.
-    i32: bool = False
+    # Which format's arm of the op this step wants.  Carried rather than
+    # re-derived at emit time, where the args are no longer in reach: a step reads
+    # no spec.  The format rather than the arm itself, because an arm holds a
+    # deferred dialect reference and a step stays dialect-free.
+    dtype: DataFormats | None = None
 
 
-def is_i32(args: Sequence[TensorArg]) -> bool:
-    """Whether \\p args ask for the int32 arm of their op.
+def dtype_of(spec: OpSpec) -> DataFormats:
+    """The one device format \\p spec is asked for, or raise.
 
-    The one rule the four recipe lookups share: an op name alone cannot tell an
-    integer request from a float one -- both say ``add`` -- so the dtype does.
+    An op name alone cannot tell an integer request from a float one -- both say
+    ``add`` -- so the format is what picks the arm, and it has to be a single
+    format: a mixed request has no arm to resolve to, and guessing one (taking the
+    first, or any integer operand) would emit an intrinsic for the wrong type on
+    the rest.  Mixed formats are refused here, in the plan, rather than being
+    carried into emission where the choice is no longer visible.
     """
-    return any(arg.device_dtype == DataFormats.IEEE_INT32 for arg in args)
-
-
-def recipe_for(op: str, i32: bool) -> Recipe:
-    """The recipe \\p op resolves to, against the int32 table when \\p i32."""
-    if i32 and op in KtirBuilder.RECIPES_I32:
-        return KtirBuilder.RECIPES_I32[op]
-    return KtirBuilder.RECIPES[op]
+    formats = {arg.device_dtype for arg in spec.args}
+    if len(formats) != 1:
+        raise NotImplementedError(
+            f"OpSpec->KTIR: {spec.op!r} mixes device formats "
+            f"{sorted(f.name for f in formats)}; one op is one format"
+        )
+    return formats.pop()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -754,7 +760,7 @@ def _reduce_surface(
 
 
 def _parallel_surface(
-    recipe: Recipe, operands: int, rank: int
+    arm: Arm, operands: int, rank: int
 ) -> tuple[Surface, Indexing | None]:
     """Which shape carries a non-reducing payload, and what it has to state.
 
@@ -774,7 +780,7 @@ def _parallel_surface(
     That second arm is where a ``spyreop`` intrinsic lands: it is a scalar builder,
     so there is nothing to call it but a region.
     """
-    if recipe.kind is BindingKind.NAMED:
+    if arm.kind is BindingKind.NAMED:
         return Surface.BARE, None
     identity = tuple(range(rank))
     return Surface.GENERIC, Indexing(
@@ -1081,16 +1087,16 @@ class KernelPlan:
                 raise NotImplementedError(
                     f"OpSpec->KTIR: unexpected spec entry {type(entry).__name__}"
                 )
-            # An op whose integer form names a different intrinsic is looked up in
-            # the int32 table first; every other op, and every other dtype, comes
-            # from RECIPES.
             if entry.op not in KtirBuilder.RECIPES:
                 raise NotImplementedError(
                     f"OpSpec->KTIR: op {entry.op!r} is not supported yet "
                     f"(registered: {sorted(KtirBuilder.RECIPES)})"
                 )
-            recipe = recipe_for(entry.op, is_i32(entry.args))
-            if (recipe.kind is BindingKind.COMBINER) != bool(entry.is_reduction):
+            # One question about the op name, then one about its format: whether
+            # the op exists at all is the table's business, and which of its
+            # spellings this request reaches is the recipe's.
+            arm = KtirBuilder.RECIPES[entry.op].arm(dtype_of(entry))
+            if (arm.kind is BindingKind.COMBINER) != bool(entry.is_reduction):
                 # Two independent statements of one bit -- what the recipe's
                 # binding accumulates, and what the frontend labelled the request
                 # -- and both directions are silent if unchecked.  An 'add' asked
@@ -1101,7 +1107,7 @@ class KernelPlan:
                 # one thing the plan/emission split exists to rule out.
                 raise NotImplementedError(
                     f"OpSpec->KTIR: op {entry.op!r} is registered as "
-                    f"{recipe.kind.name} but this spec asks for "
+                    f"{arm.kind.name} but this spec asks for "
                     f"{'a reduction' if entry.is_reduction else 'an elementwise op'}"
                 )
             steps.append(self._compute_step(entry, loops))
@@ -1117,7 +1123,9 @@ class KernelPlan:
         """
         out, inputs = validated_roles(spec)
         out_extents = [int(s) for s in out.device_size]
-        recipe = recipe_for(spec.op, is_i32(spec.args))
+        dtype = dtype_of(spec)
+        recipe = KtirBuilder.RECIPES[spec.op]
+        arm = recipe.arm(dtype)
         for arg in inputs:
             # In-place (input buffer aliases the output) is not supported yet.
             if buf_id(arg) == buf_id(out):
@@ -1163,7 +1171,7 @@ class KernelPlan:
                 # the lane axis is reduced on the way in and kept on the way out.
                 indexing = Indexing(iters=iters, maps=(in_map, out_map))
         else:
-            surface, indexing = _parallel_surface(recipe, len(inputs), len(out_extents))
+            surface, indexing = _parallel_surface(arm, len(inputs), len(out_extents))
             for arg in inputs:
                 # Reject broadcast / transpose operands: only operands whose
                 # device axes already match the output tile exactly are supported.
@@ -1213,7 +1221,7 @@ class KernelPlan:
             reduce_dims=reduce_dims,
             indexing=indexing,
             attrs=attrs,
-            i32=is_i32(spec.args),
+            dtype=dtype,
             # An internal buffer never reaches memory: it is threaded as a value,
             # so it gets no store, no func parameter, no view and no address.
             store=not is_internal(out),
@@ -1304,7 +1312,9 @@ def validated_roles(spec: OpSpec) -> tuple[TensorArg, list[TensorArg]]:
         raise NotImplementedError(
             f"OpSpec->KTIR: expected exactly one output, got {len(outputs)}"
         )
-    arity = recipe_for(spec.op, is_i32(spec.args)).arity
+    # Arity is a property of the op, not of the format it is asked for, so this
+    # needs no arm and cannot be wrong about which spelling the request reaches.
+    arity = KtirBuilder.RECIPES[spec.op].arity
     if len(inputs) != arity:
         raise NotImplementedError(
             f"OpSpec->KTIR: {spec.op!r} expects {arity} inputs, got {len(inputs)}"
@@ -1326,7 +1336,7 @@ def validated_roles(spec: OpSpec) -> tuple[TensorArg, list[TensorArg]]:
 
 
 class BindingKind(enum.Enum):
-    """What ``Recipe.binding()`` returns, which is what decides how it is used.
+    """What ``Arm.binding()`` returns, which is what decides how it is used.
 
     Three kinds, and the surface follows from the kind plus (for a ``COMBINER``)
     the shape of the reduction:
@@ -1340,9 +1350,9 @@ class BindingKind(enum.Enum):
 
     No separate ``reduces`` flag: reducing *is* ``kind is COMBINER``, because a
     named linalg op is elementwise and a parallel-body payload does not
-    accumulate.  Nor is ``binding`` split per kind -- no op in scope wants two
-    spellings of itself, and the day one does (``add`` as a named op *and* as a
-    payload under a broadcast operand) is the day it earns a second field.
+    accumulate.  The kind belongs to the ``Arm`` and not to the ``Recipe``
+    because it varies with the format: ``add`` is a named ``linalg`` op at floats
+    and a ``spyreop`` payload at four-byte integers.
     """
 
     NAMED = enum.auto()
@@ -1351,10 +1361,53 @@ class BindingKind(enum.Enum):
 
 
 @dataclasses.dataclass(frozen=True)
-class Recipe:
-    arity: int
+class Arm:
+    """One format's spelling of an op: its builder, how it is used, and its trigger.
+
+    ``dtypes`` are the formats that reach this arm.  Empty claims every format no
+    sibling arm claims, which is what all but a handful of arms want -- an op with
+    one spelling is one arm with an empty ``dtypes``, and the float arm of an op
+    that also has an integer one does not have to enumerate every float format to
+    say "not that one".
+
+    The trigger travels with the binding deliberately.  The alternative -- a
+    second table keyed on op name, consulted first and fallen back out of -- makes
+    the two spellings unequal: one table answers "is this op supported at all" and
+    the other silently overrides it, so an op registered only in the second is
+    reported unsupported while holding a perfectly good recipe.
+    """
+
     kind: BindingKind
     binding: Callable[[], Any]
+    dtypes: tuple[DataFormats, ...] = ()
+
+
+def _arms(arms: Arm | tuple[Arm, ...]) -> tuple[Arm, ...]:
+    """\\p arms as a tuple, whether it was written as one arm or several.
+
+    Idempotent, so it is safe to call on an already-normalised field: it is what
+    ``Recipe.__post_init__`` normalises *with* and what every reader goes through,
+    which keeps the one-arm shorthand from being a second representation that some
+    code path forgets to handle.
+    """
+    return (arms,) if isinstance(arms, Arm) else arms
+
+
+@dataclasses.dataclass(frozen=True)
+class Recipe:
+    # Both ``arity`` and ``attrs`` are properties of the *op*, invariant across
+    # formats, which is why they sit here and not on an arm: 'add' takes two
+    # operands and reads no scalars from ``op_info`` whatever its element type is.
+    # Stating them once is also what keeps two spellings of one op from drifting
+    # apart on arity.
+    arity: int
+    # One ``Arm`` or a tuple of them; ``__post_init__`` promotes the bare one, so
+    # the field is a tuple by the time anything reads it.  Written this way because
+    # an op with a single spelling is the overwhelming majority and ``arms=Arm(...)``
+    # is what that op means -- the ``(...,)`` around it would be noise on eleven of
+    # the thirteen entries, and a stray missing comma turns a tuple into an ``Arm``
+    # silently.
+    arms: Arm | tuple[Arm, ...]
     # How to read the op's scalar arguments out of a spec's ``op_info``, for the
     # few ops whose builder takes more than operands (softplus).  ``None`` when
     # the op is a pure function of its operands, which is almost all of them.
@@ -1365,6 +1418,38 @@ class Recipe:
     def __post_init__(self) -> None:
         if self.arity < 1:
             raise ValueError(f"OpSpec->KTIR: arity must be >= 1, got {self.arity}")
+        arms = _arms(self.arms)
+        if not arms:
+            raise ValueError("OpSpec->KTIR: a recipe needs at least one arm")
+        if sum(1 for arm in arms if not arm.dtypes) > 1:
+            raise ValueError(
+                "OpSpec->KTIR: at most one arm may claim the unlisted formats"
+            )
+        claimed = [dtype for arm in arms for dtype in arm.dtypes]
+        if len(claimed) != len(set(claimed)):
+            raise ValueError(
+                "OpSpec->KTIR: two arms claim the same format: "
+                f"{sorted({d.name for d in claimed if claimed.count(d) > 1})}"
+            )
+        object.__setattr__(self, "arms", arms)
+
+    def arm(self, dtype: DataFormats | None) -> Arm:
+        """The arm \\p dtype reaches, or raise.
+
+        A format nothing claims falls to the arm with an empty ``dtypes``; if no
+        arm takes the unlisted formats either, the op does not exist at this one.
+        """
+        arms = _arms(self.arms)
+        for candidate in arms:
+            if dtype is not None and dtype in candidate.dtypes:
+                return candidate
+        for candidate in arms:
+            if not candidate.dtypes:
+                return candidate
+        raise NotImplementedError(
+            f"OpSpec->KTIR: no arm for {dtype.name if dtype else 'an unknown format'} "
+            f"(registered: {sorted(d.name for a in arms for d in a.dtypes)})"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1643,15 +1728,15 @@ class KtirBuilder:
         (a method and an arm), and a test parses this ``match`` to catch the
         second one being forgotten.
         """
-        recipe = recipe_for(step.op, step.i32)
+        arm = self.RECIPES[step.op].arm(step.dtype)
         ins = [self.operand(buf_id, access) for buf_id, access in step.ins]
         match step.surface:
             case Surface.BARE:
-                value = self._emit_bare(recipe.binding(), ins, step)
+                value = self._emit_bare(arm.binding(), ins, step)
             case Surface.REDUCE:
-                value = self._emit_reduce(recipe.binding(), ins, step)
+                value = self._emit_reduce(arm.binding(), ins, step)
             case Surface.GENERIC:
-                value = self._emit_generic(recipe.binding(), ins, step)
+                value = self._emit_generic(arm.binding(), ins, step)
             case _:
                 raise AssertionError(f"unplanned surface {step.surface} of {step.op!r}")
         self.result(step.out_buf_id, step.out if step.store else None, value)
@@ -1782,10 +1867,39 @@ class KtirBuilder:
     #
     # A repeated key here is ruff F601, so an op cannot be declared twice.
     RECIPES: ClassVar[dict[str, Recipe]] = {
-        "add": Recipe(arity=2, kind=BindingKind.NAMED, binding=lambda: linalg.add),
-        "mul": Recipe(arity=2, kind=BindingKind.NAMED, binding=lambda: linalg.mul),
-        "sub": Recipe(arity=2, kind=BindingKind.NAMED, binding=lambda: linalg.sub),
-        "sum": Recipe(arity=1, kind=BindingKind.COMBINER, binding=lambda: arith.addf),
+        # ``add`` and ``mul`` are the two ops with more than one spelling: a named
+        # linalg op at floats, and a ``spyreop`` intrinsic at four-byte integers
+        # that splits its operands into halves and finds the carry with a pair of
+        # scale factors.  The float arm lists no formats, so it takes every format
+        # the integer arm does not claim.
+        "add": Recipe(
+            arity=2,
+            arms=(
+                Arm(kind=BindingKind.NAMED, binding=lambda: linalg.add),
+                Arm(
+                    kind=BindingKind.PAYLOAD,
+                    binding=lambda: spyreop.addi32toi32,
+                    dtypes=(DataFormats.IEEE_INT32,),
+                ),
+            ),
+        ),
+        "mul": Recipe(
+            arity=2,
+            arms=(
+                Arm(kind=BindingKind.NAMED, binding=lambda: linalg.mul),
+                Arm(
+                    kind=BindingKind.PAYLOAD,
+                    binding=lambda: spyreop.muli32toi32,
+                    dtypes=(DataFormats.IEEE_INT32,),
+                ),
+            ),
+        ),
+        "sub": Recipe(
+            arity=2, arms=Arm(kind=BindingKind.NAMED, binding=lambda: linalg.sub)
+        ),
+        "sum": Recipe(
+            arity=1, arms=Arm(kind=BindingKind.COMBINER, binding=lambda: arith.addf)
+        ),
         # The unary float ops whose payload is one ``spyreop`` scalar intrinsic.
         # There is no named linalg op behind any of them, so they are PAYLOADs and
         # land on ``Surface.GENERIC``: the recipe contributes the intrinsic and the
@@ -1800,53 +1914,48 @@ class KtirBuilder:
         # ``softplus`` is the one that takes more than its operand: ``attrs`` says
         # where in ``op_info`` its two scalars live.
         #
-        # Not here: the integer/address intrinsics (addi32toi32, addi64toi64,
-        # muli32toi32, idx32toaddr) and other pointwise ops the device has no
-        # intrinsic for (log, tanh, erf, relufwd).
-        "exp": Recipe(arity=1, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.exp),
-        "sqrt": Recipe(arity=1, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.sqrt),
+        # Not here: the remaining integer/address intrinsics (addi64toi64,
+        # idx32toaddr) and other pointwise ops the device has no intrinsic for
+        # (log, tanh, erf, relufwd).
+        "exp": Recipe(
+            arity=1, arms=Arm(kind=BindingKind.PAYLOAD, binding=lambda: spyreop.exp)
+        ),
+        "sqrt": Recipe(
+            arity=1, arms=Arm(kind=BindingKind.PAYLOAD, binding=lambda: spyreop.sqrt)
+        ),
         "sigmoid": Recipe(
-            arity=1, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.sigmoid
+            arity=1,
+            arms=Arm(kind=BindingKind.PAYLOAD, binding=lambda: spyreop.sigmoid),
         ),
         "reciprocal": Recipe(
-            arity=1, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.reciprocal
+            arity=1,
+            arms=Arm(kind=BindingKind.PAYLOAD, binding=lambda: spyreop.reciprocal),
         ),
         "gelufwd": Recipe(
-            arity=1, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.gelu
+            arity=1, arms=Arm(kind=BindingKind.PAYLOAD, binding=lambda: spyreop.gelu)
         ),
         "layernormscale": Recipe(
-            arity=1, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.layernormscale
+            arity=1,
+            arms=Arm(kind=BindingKind.PAYLOAD, binding=lambda: spyreop.layernormscale),
         ),
         "softplus": Recipe(
             arity=1,
-            kind=BindingKind.PAYLOAD,
-            binding=lambda: spyreop.softplus,
+            arms=Arm(kind=BindingKind.PAYLOAD, binding=lambda: spyreop.softplus),
             attrs=lambda info: {
                 "beta": float(info["constants"]["softplusBeta"]),
                 "threshold": float(info["constants"]["softplusThresh"]),
             },
         ),
-        "silu": Recipe(arity=1, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.silu),
+        "silu": Recipe(
+            arity=1, arms=Arm(kind=BindingKind.PAYLOAD, binding=lambda: spyreop.silu)
+        ),
         "rsqrt": Recipe(
-            arity=1, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.rsqrt
+            arity=1,
+            arms=Arm(kind=BindingKind.PAYLOAD, binding=lambda: spyreop.rsqrt),
         ),
         "realdiv": Recipe(
-            arity=2, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.realdiv
-        ),
-    }
-
-    # The int32 arms of ops that also have a float one.  ``add`` and ``mul`` name
-    # a different intrinsic at four-byte integers than the ``linalg`` op they
-    # reach at floats, and the op name alone cannot tell the two apart -- the
-    # request says ``add`` either way -- so the dtype picks the table.  Only ops
-    # whose integer form differs belong here; anything absent falls back to
-    # ``RECIPES``.
-    RECIPES_I32: ClassVar[dict[str, Recipe]] = {
-        "add": Recipe(
-            arity=2, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.addi32toi32
-        ),
-        "mul": Recipe(
-            arity=2, kind=BindingKind.PAYLOAD, binding=lambda: spyreop.muli32toi32
+            arity=2,
+            arms=Arm(kind=BindingKind.PAYLOAD, binding=lambda: spyreop.realdiv),
         ),
     }
 

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -156,6 +156,7 @@ SPYRE_FP32_OPS = [
     "neg",
     "exp",
     "sigmoid",
+    "silu",
     "exx2",
     "layernormnorm",
     "identity",
@@ -174,6 +175,16 @@ SPYRE_FP32_OPS = [
     "equal",
     "notequal",
     "prod",
+]
+
+# Operations the device has a 32-bit integer intrinsic for: `spyreop.addi32toi32`
+# and `spyreop.muli32toi32`, each splitting its operands into halves and finding
+# the carry with a pair of scale factors.  Separate from SPYRE_FP32_OPS because
+# the two are different templates reached by the same op name, and only the KTIR
+# path can spell them -- SDSC still relabels IEEE_INT32 as SENUINT32 for indices.
+SPYRE_INT32_OPS = [
+    "add",
+    "mul",
 ]
 
 # FP8 E4M3 numeric limits

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -35,6 +35,7 @@ from torch._inductor.virtualized import V
 
 from .constants import (
     SPYRE_FP32_OPS,
+    SPYRE_INT32_OPS,
     BATCH_MATMUL_OP,
     BATCH_MATMUL_FP8_OP,
     CONV_OPS,
@@ -882,6 +883,9 @@ class SpyreKernel(Kernel[CSEVariable]):
                 op == IDENTITY_OP
                 or DtypeOpTable.is_dtype_op(op)
                 or (op in SPYRE_FP32_OPS and arg.device_dtype == DataFormats.IEEE_FP32)
+                or (
+                    op in SPYRE_INT32_OPS and arg.device_dtype == DataFormats.IEEE_INT32
+                )
                 or arg.device_dtype == DataFormats.SEN169_FP16
                 or (
                     op in SPYRE_FP8_OPS


### PR DESCRIPTION
cc: @tnakaike 

Branch `ktir-surface-spyreop`, based on `ktir-surface-rebase`,
so this is stacked on that branch rather than on `main`.

Diff: `ktir.py`, `constants.py`, `spyre_kernel.py`, tests 

## What is implemented

A `spyreop` intrinsic is a **scalar** builder, so no `linalg` named op wraps it.
Each is registered as a `PAYLOAD` recipe and emitted as an all-parallel
`linalg.generic` whose body is that one intrinsic and nothing else — no fp32 cast
bracket, because the intrinsic owns its `f16->f32->approx->f16` internally
(dataflow-scheduler#36).

`add` and `mul` at four-byte integers name a *different* intrinsic
(`spyreop.addi32toi32` / `muli32toi32`, each splitting its operands into halves
and finding the carry with a pair of scale factors) than the `linalg` op they
reach at floats. The op name alone cannot tell those apart — the request says
`add` either way — which is what motivated the recipe change below.

## Device results

Run on device against a nightly backend build (Aug 28 2026), one core,
`(256, 64)` unless noted. Compared with `atol=1e-2, rtol=2e-2`; a reduction
accumulates in a different order from eager, so error scales with the sum rather
than with one ulp.

**These are transcribed from earlier notes, not from a fresh run for this PR.**

### fp16 arm (`SEN169_FP16`, 64 lanes to a stick)

| op | intrinsic | result |
|---|---|---|
| `gelufwd` | `spyreop.gelu` | PASS |
| `exp` | `spyreop.exp` | PASS, max abs diff 5.9e-3 |
| `sigmoid` | `spyreop.sigmoid` | PASS |
| `reciprocal` | `spyreop.reciprocal` | PASS (inputs away from zero) |
| `silu` | `spyreop.silu` | PASS |
| `rsqrt` | `spyreop.rsqrt` | PASS (inputs in `[0.1, 1)`, so rsqrt stays in `(1, 3.2]`) |
| `realdiv` | `spyreop.realdiv` | PASS  |
| `sqrt` | `spyreop.sqrt` (expands to `rsqrt` + `mulf`) | needs re-confirmation |


### fp32 arm (`IEEE_FP32`, 32 lanes to a stick)

| op | surface | result |
|---|---|---|
| `exp` | GENERIC payload | PASS, max abs diff 2.5e-3 |
| `sigmoid` | GENERIC payload | PASS |
| `silu` | GENERIC payload | PASS |
| `reciprocal` | GENERIC payload | PASS |
| `rsqrt` | GENERIC payload | PASS |
| `sqrt` | GENERIC payload | PASS, exact to 1.8e-7 |
| `realdiv` | GENERIC payload | PASS |
| `add` | BARE `linalg.add` | PASS |
| `mul` | BARE `linalg.mul` | PASS |
| `sum` | REDUCE `linalg.reduce`, `(256, 128)` | PASS |

The fp32 arms come back correct to about 1e-7 — three orders better than the fp16
arms, which is the clearest sign the compute really is four bytes wide and not a
downcast. `add`/`mul`/`sum` are here because every other fp32 case is a payload:
they reach BARE and REDUCE instead, so they say whether four-byte support is a
property of the opaque path or of the emitter's tiling.

fp32 `silu` was refused before any KTIR was emitted — not by the device, which has
an fp32 `silu` pattern, but by `SPYRE_FP32_OPS` in `constants.py`, which listed
`sigmoid` and not `silu`. Adding it there is all it needed.

### int32 arm (`IEEE_INT32`)

| op | intrinsic | result |
|---|---|---|
| `add` | `spyreop.addi32toi32` | PASS, exact |
| `mul` | `spyreop.muli32toi32` | PASS, exact |

The int32 `mul` answering exactly at 991008 is past 2^16, so the carry really is
being done rather than the low half being returned.

## The recipe change

The int32 ops first landed as a parallel `RECIPES_I32` table, consulted first and
fallen back out of. That made the two spellings of one op unequal three ways:

- Support was decided by `RECIPES` membership alone, so an op registered only in
  the integer table would be reported "not supported yet" while listing a set it
  is deliberately not in — latent only because `add` and `mul` are in both.
- `arity` was stated twice per op with nothing tying the statements together,
  though it cannot differ between an op's formats.
- "Adding an op is one `RECIPES` entry" stopped being true.

What actually varies with the format is the *kind* — `add` is a named `linalg` op
at floats and a `spyreop` payload at int32 — so `kind` and `binding` move into an
`Arm`, and the arm carries the formats that reach it:

```python
"add": Recipe(arity=2, arms=(
    Arm(kind=BindingKind.NAMED,   binding=lambda: linalg.add),
    Arm(kind=BindingKind.PAYLOAD, binding=lambda: spyreop.addi32toi32,
        dtypes=(DataFormats.IEEE_INT32,)),
)),
"sub": Recipe(arity=2, arms=Arm(kind=BindingKind.NAMED, binding=lambda: linalg.sub)),
```

A `Recipe` is then the op's format-invariant facts (`arity`, `attrs`) plus its
arms. One table answers "does this op exist"; `Recipe.arm(dtype)` answers "which
spelling does this request get". This is what the `BindingKind` docstring already
prescribed for the day an op wanted two spellings — it asked for a second field,
not a second table.

An arm with no `dtypes` takes every format its siblings do not claim, so a
one-spelling op stays one line and `add`'s float arm does not enumerate every
float format to say "not that one". `arms` also accepts a bare `Arm`, promoted in
`__post_init__`: twelve of the fourteen entries have a single spelling, where the
wrapping `(...,)` is noise and a dropped comma silently turns the tuple back into
an `Arm`. Readers go through an idempotent `_arms`, so the shorthand cannot become
a second representation some path forgets to normalise. Ambiguity is refused where
the table is written rather than at the lookup — two unclaiming arms, or two arms
claiming one format, would make which arm wins a fact about declaration order.

### One op is one format

Resolving an arm needs a single format, so `dtype_of` assumes the operands and the
result of one op agree on theirs and refuses the spec otherwise. Nothing in scope
produces a mixed-format op, and there is no arm for one to resolve to, so the
assumption is stated in the plan rather than guessed at emit time.

The step carries that format in place of the old `i32` bool — still not the arm
itself, since an arm holds a deferred dialect reference and a step stays
dialect-free.

## Tests

`tests/inductor/test_ktir_validate.py` and `test_ktir_emitter.py`:
**103 passed, 100 subtests**. `ktir.py` stays mypy-clean; `ruff check` and
`ruff format --check` clean.

New coverage: arm resolution at both formats, the lone-arm promotion, the
ambiguity and empty-arms rejections, a format no arm takes, the format reaching
the step and picking the surface, and the mixed-format refusal. Golden MLIR
snapshots for the payload generics (body is a single `spyreop`, the `outs` block
argument is dropped rather than read).

The unit tests assert arm *resolution* — bindings stay unresolved thunks so the
file needs no dialect build — not that `addi32toi32` computes correctly; that is
what the device table above is for.
