### PR TITLE
chore(clickhouse ingest): write GHA/Jenkins run id to runner_run_id instead of gha_run_id

### DIFF
--- a/.github/scripts/ingest_xml.py
+++ b/.github/scripts/ingest_xml.py
@@ -766,7 +766,7 @@ def insert_run(client, run_id: str, run: dict, args):
             "branch",
             "commit_sha",
             "pr_number",
-            "gha_run_id",
+            "runner_run_id",
             "triggered_at",
             "total_tests",
             "passed",
@@ -1064,8 +1064,11 @@ def main():
                 # to keep that path idempotent.
                 existing = client.query(
                     "SELECT count() FROM test_runs WHERE "
-                    "gha_run_id = {gha_run_id:UInt64} AND filename = {filename:String}",
-                    parameters={"gha_run_id": gha_run_id, "filename": run["filename"]},
+                    "runner_run_id = {runner_run_id:UInt64} AND filename = {filename:String}",
+                    parameters={
+                        "runner_run_id": gha_run_id,
+                        "filename": run["filename"],
+                    },
                 )
             if existing.result_rows[0][0] > 0:
                 print(f"  Already ingested — skipping {run['filename']}")


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup