### PR TITLE
fix(ingest_xml): populate runner_run_id with the leg's own uuid (or GHA run id), not just GHA

### DIFF
--- a/.github/scripts/ingest_xml.py
+++ b/.github/scripts/ingest_xml.py
@@ -744,7 +744,7 @@ def insert_run(client, run_id: str, run: dict, args):
                 args.branch,
                 (args.sha or "").ljust(40)[:40],
                 int(args.pr_number) if args.pr_number.strip() else 0,
-                _gha_run_id(args),
+                _runner_run_id(args, run_id),
                 run["triggered_at"].replace(tzinfo=None),
                 run["total_tests"],
                 run["passed"],
@@ -858,17 +858,16 @@ def insert_properties(client, run_id: str, cases: list[dict]):
 # ---------------------------------------------------------------------------
 
 
-def _gha_run_id(args) -> int:
-    """The numeric GitHub Actions run id for the gha_run_id column / dedup key.
-
-    Kept strictly separate from --run-id, which carries a UUID: a non-numeric value here
-    must degrade to 0 rather than abort the whole ingest.
-    """
+def _runner_run_id(args, run_id: str) -> str:
+    """This leg's own run id: --gha-run-id when GHA-dispatched, else the same uuid as run_id."""
     raw = (getattr(args, "gha_run_id", "") or "").strip()
-    try:
-        return int(raw)
-    except (ValueError, TypeError):
-        return 0
+    if raw:
+        try:
+            int(raw)
+            return raw
+        except (ValueError, TypeError):
+            pass
+    return run_id
 
 
 def _threaded_run_id(args) -> str:
@@ -1051,22 +1050,25 @@ def main():
             run_id = _threaded_run_id(args) or str(uuid.uuid4())
 
             # Dedup on (run_id, filename): re-ingesting the SAME test run must be idempotent,
-            # but two distinct runs must never collapse. gha_run_id alone cannot do this --
-            # it is 0 on Jenkins legs, which carry a uuid instead.
-            gha_run_id = _gha_run_id(args)
+            # but two distinct runs must never collapse. runner_run_id mirrors run_id for a Jenkins/standalone leg, so it's only an independent signal for a GHA numeric id.
+            runner_run_id = _runner_run_id(args, run_id)
             existing = client.query(
                 "SELECT count() FROM test_runs "
                 "WHERE run_id = {run_id:String} AND filename = {filename:String}",
                 parameters={"run_id": run_id, "filename": run["filename"]},
             )
-            if existing.result_rows[0][0] == 0 and gha_run_id:
+            if (
+                existing.result_rows[0][0] == 0
+                and runner_run_id
+                and runner_run_id != run_id
+            ):
                 # A GHA re-ingest mints a fresh uuid4, so fall back to the numeric run id
                 # to keep that path idempotent.
                 existing = client.query(
                     "SELECT count() FROM test_runs WHERE "
-                    "runner_run_id = {runner_run_id:UInt64} AND filename = {filename:String}",
+                    "runner_run_id = {runner_run_id:String} AND filename = {filename:String}",
                     parameters={
-                        "runner_run_id": gha_run_id,
+                        "runner_run_id": runner_run_id,
                         "filename": run["filename"],
                     },
                 )


### PR DESCRIPTION
### Summary

-  Stop `runner_run_id` from always landing as 0 on Jenkins-dispatched test legs.

 ### Problem
 
 - `runner_run_id` was only ever populated from `--gha-run-id`, which GHA legs supply and Jenkins legs never do, so every Jenkins-run row recorded 0.
 
### Fix:
-  `_runner_run_id()` now returns the real GHA run id when `--gha-run-id` is present, otherwise the same uuid already written to `run_id` (threaded from the orchestrator, or self-minted) — a uniform run identifier regardless of dispatcher, instead of a GHA-only field. Requires `ALTER TABLE ... MODIFY COLUMN runner_run_id String` on ClickHouse first (was `UInt64`, can't hold a uuid).