### PR TITLE
coarse_tile: fixes for flash when tiling both B and H dimensions

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -2909,9 +2909,11 @@ def test_flash_tile_Lk():
 
 
 @pytest.mark.skip(
-    reason="copy_forced/mutation_write_back drop is fixed (issue #4126) -- no"
-    " more inf, but a distinct B+H tiling correctness bug remains (70%"
-    " mismatch, finite values); B tiling itself compiles and runs correctly"
+    reason="numerically incorrect results when both B and H are tiled -- root"
+    " cause not yet diagnosed; not issue #4126 (v1 uses plain Python"
+    " rebinding for M/denominator/output, no copy_forced, so there is no"
+    " auto_functionalized_v2 node for AOTAutograd to drop); B tiling alone"
+    " compiles and runs correctly"
 )
 def test_flash_tile_B_H():
     """Flash v1: tile B÷2 H÷4. B=2."""

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -2908,13 +2908,6 @@ def test_flash_tile_Lk():
         )
 
 
-@pytest.mark.skip(
-    reason="numerically incorrect results when both B and H are tiled -- root"
-    " cause not yet diagnosed; not issue #4126 (v1 uses plain Python"
-    " rebinding for M/denominator/output, no copy_forced, so there is no"
-    " auto_functionalized_v2 node for AOTAutograd to drop); B tiling alone"
-    " compiles and runs correctly"
-)
 def test_flash_tile_B_H():
     """Flash v1: tile B÷2 H÷4. B=2."""
     run_coarse_tile_test(

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -2846,19 +2846,18 @@ def test_flash_tile_H():
     )
 
 
-@pytest.mark.skip(
-    reason=(
-        "Intermittent numerical mismatch against CPU reference (~22.7% "
-        "elements wrong), unrelated to coarse-tiling changes in "
-        "#3888/#3927 -- confirmed via git-stash A/B, reproduces identically "
-        "with those changes reverted. Mismatch pattern (scattered, large "
-        "abs+rel error) suggests an uninitialized-memory read similar to "
-        "the MoE E-tiling bug fixed in 133a3afb; not yet root-caused with "
-        "the poisoned-memory harness. See issue #3937."
-    )
-)
 def test_flash_tile_B():
-    """Flash v1: tile B÷2 only. B=2."""
+    """Flash v1: tile B÷2 only. B=2.
+
+    Previously skipped for an intermittent ~22.7% numerical mismatch
+    suspected to be an uninitialized-memory read (issue #3937). No longer
+    reproduces -- confirmed passing across 5 isolated runs (fresh fxgraph
+    cache each time) plus the full flash test cluster, at a point in
+    history with ~20 candidate fixes to cross-group/reduction-consumer
+    read redirection landed since the issue was filed. Not worth
+    bisecting to a single fixing commit; un-skipped on verified current
+    behavior.
+    """
     run_coarse_tile_test(
         lambda q, k, v: _flash_v1_fn(
             q, k, v, B=2, H=8, Lq=256, Lk=256, D=64, b_tiles=2
@@ -3102,7 +3101,8 @@ def _flash_v2_fn(
 
 
 @pytest.mark.skip(
-    reason="finalize_layouts: restickify infeasible for copy ops across loop groups"
+    reason="copy_forced(running_max, real_max) write-back is dropped -- real_max"
+    " never carries across H tiles, producing inf (issue #4126)"
 )
 def test_flash_v2_tile_H():
     """Flash v2: tile H÷4 only."""
@@ -3134,7 +3134,8 @@ def test_flash_v2_tile_B():
 
 
 @pytest.mark.skip(
-    reason="finalize_layouts: restickify infeasible for copy ops across loop groups"
+    reason="copy_forced(running_max, real_max) write-back is dropped -- real_max"
+    " never carries across tiles, producing inf (issue #4126)"
 )
 def test_flash_v2_tile_Lq():
     """Flash v2: tile Lq÷2 only."""

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -933,12 +933,36 @@ class SpyreKernel(Kernel[CSEVariable]):
         raw_tiled_red_dims: list[list[int]] = (
             li.loop_tiled_reduction_dims if li is not None else []
         )
+        # A dim tiled down to a per-tile extent of 1 is squeezed out of the
+        # op's own iteration space entirely (no d{i} symbol survives), so it
+        # is invisible to loop_tiled_dims/loop_tiled_reduction_dims and can
+        # only advance via squeezed_advance_per_read/squeezed_advance_output
+        # (see coarse_tile.py's _insert_all_read_copy_ops, the "d not in
+        # squeeze_pos" branch). _general_tile_advance already mints/uses a
+        # level symbol from squeezed_advance_per_level regardless of
+        # loop_tiled_dims, so has_any_tiled_dim must check the same fields —
+        # otherwise the minted symbol shows up in device_tile_advance_expr
+        # but never in OpSpec.tiled_symbols, and superdsc.py's affine-stride
+        # extraction (which only walks tiled_symbols) silently drops the
+        # advance, leaving the tensor's address pinned across that level's
+        # iterations instead of stepping through it.
+        raw_squeezed_advance_reads: list[list[list[tuple]]] = (
+            li.squeezed_advance_per_read if li is not None else []
+        )
+        raw_squeezed_advance_output: list[list[tuple]] = (
+            li.squeezed_advance_output if li is not None else []
+        )
         # CoarseTileInfo always constructs loop_tiled_dims and
         # loop_tiled_reduction_dims with the same length (one sublist per
         # nesting level), so max() is just a safety net; in practice both
         # lists have the same length and the per-level loop below never
         # silently drops an entry from the shorter one.
-        n_levels = max(len(raw_tiled_dims), len(raw_tiled_red_dims))
+        n_levels = max(
+            len(raw_tiled_dims),
+            len(raw_tiled_red_dims),
+            max((len(levels) for levels in raw_squeezed_advance_reads), default=0),
+            len(raw_squeezed_advance_output),
+        )
 
         tiled_symbol_trip_counts: dict = {}
         tiled_syms: list[list] = []
@@ -950,8 +974,17 @@ class SpyreKernel(Kernel[CSEVariable]):
             for lvl in range(n_levels):
                 level_syms: list = []
                 has_any_tiled_dim = (
-                    lvl < len(raw_tiled_dims) and raw_tiled_dims[lvl]
-                ) or (lvl < len(raw_tiled_red_dims) and raw_tiled_red_dims[lvl])
+                    (lvl < len(raw_tiled_dims) and raw_tiled_dims[lvl])
+                    or (lvl < len(raw_tiled_red_dims) and raw_tiled_red_dims[lvl])
+                    or any(
+                        lvl < len(levels) and levels[lvl]
+                        for levels in raw_squeezed_advance_reads
+                    )
+                    or (
+                        lvl < len(raw_squeezed_advance_output)
+                        and raw_squeezed_advance_output[lvl]
+                    )
+                )
                 if has_any_tiled_dim:
                     level_syms.append(self._get_or_mint_level_symbol(lvl, op_name))
                 tiled_syms_per_level_outermost.append(level_syms)

--- a/torch_spyre/_inductor/work_division_constraints.py
+++ b/torch_spyre/_inductor/work_division_constraints.py
@@ -32,6 +32,7 @@ from sympy import Expr, Symbol, divisors
 
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.ir import ComputedBuffer, Pointwise, Reduction
+from torch._inductor.utils import sympy_index_symbol
 from torch_spyre._C import ElementArrangement
 
 from .constants import (
@@ -53,6 +54,7 @@ from .pass_utils import (
     op_read_writes,
 )
 from .logging_utils import get_inductor_logger
+from .wsr.coarse_tile import _raw_to_squeezed_pos
 from . import config
 
 if typing.TYPE_CHECKING:
@@ -107,6 +109,8 @@ def collect_work_division_constraints(
         coordinate_mask_blocked_vars,
         conv_spatial_blocked_vars,
         reduction_window_blocked_vars,
+        coarse_tile_local_dim_split_domains,
+        plain_reduction_k_split_domains,
         restickify_padding_blocked_vars,
         qfp8wt_split_domains,
         qfp8wt_matmul_k_split_domains,
@@ -257,6 +261,217 @@ def reduction_window_blocked_vars(ctx: WorkDivConstraintContext) -> ConstraintRe
         return ConstraintResult()
 
     return ConstraintResult(blocked=set(window_dims))
+
+
+_K_SPLIT_COMBINE_SUPPORTED = {
+    BATCH_MATMUL_OP,
+    BATCH_MATMUL_FP8_OP,
+    "topkvalue",
+    "topkindex",
+    KEEP_BY_INDEX_OP,
+    *POOL_OPS,
+    CONV2D_FWD_OP,
+    DEPTHWISE_CONV2D_OP,
+}
+
+# Generated scratch-copy ops (coarse_tile.py's _insert_all_read_copy_ops /
+# _insert_reduce_copy_op) inherit their tiled dims from the sizing op they
+# copy for, but their own write is per-tile scratch reused in place and
+# never advances (see PropagationPlan(kind="loop_internal")) -- no sibling op
+# in the fused loop body depends on which cores a copy op's OWN internal
+# work is split across the way it depends on a self-planning op's shared
+# coarse-tile-local loop variable. A copy op's read, by contrast, is often
+# into the full, un-tiled source tensor, so splitting its tile-local dims
+# across cores is exactly what lets the normal per-core span-limit search
+# (raise_if_per_core_overflow) shrink that read's footprint -- pinning them
+# to 1 forecloses that and can make an otherwise-legal plan look
+# Unsupported (confirmed: test_copy_running_max_4d_H4_Lq4 fails with
+# "per-core tensor span ... exceeds hardware limit" once its read-copy op's
+# H/Lq dims are pinned, and passes once they aren't).
+_GENERATED_COPY_OP_PREFIXES = ("coarse_tile_read_copy_", "coarse_tile_reduce_copy_")
+
+
+def coarse_tile_local_dim_split_domains(
+    ctx: WorkDivConstraintContext,
+) -> ConstraintResult:
+    """Pin every coarse-tile-local dim's work-division split to 1, on every op.
+
+    ``allowed_splits`` values are core-partition *counts* (legal divisors of
+    a dim's extent), not the extent itself -- ``multi_dim_iteration_space_split``
+    (work_division.py) initializes every dim's split to 1 by default, meaning
+    "one partition covers the dim's full extent, walked serially inside the
+    op's own loop" (see ``TensorWorkDivision.work_slices``'s docstring in
+    ``op_spec.py``). A coarse-tile-local dim's extent is already the correct
+    per-tile size decided by coarse_tile.py's own loop nest; work_division
+    must never fragment it further across cores, or two ops in the same
+    fused loop body could disagree about which core owns which slice of that
+    dim (``committed_splits``/ownership is keyed by split count, so a split
+    other than the deliberate, uniform value of 1 breaks that agreement).
+    ``work_distribution``/``span_reduction`` divide each op in the graph
+    independently, so without this pin an op's own greedy, size-priority core
+    search (``_default_split`` -> ``multi_dim_iteration_space_split``) could
+    otherwise choose a split > 1 for a dim that must stay whole -- confirmed
+    by a minimal B+H coarse-tiled matmul repro producing stale cross-tile
+    data when that happened.
+
+    Skips generated scratch-copy ops entirely (see
+    ``_GENERATED_COPY_OP_PREFIXES``): a copy op's own tile-local dims are not
+    shared, cross-op, ownership the way a self-planning op's loop variable
+    is, and pinning them can defeat the per-core span-limit search on a copy
+    whose read spans the full, un-tiled source tensor.
+
+    ``coarse_tile.py`` stamps ``op.loop_info`` (a ``CoarseTileInfo``) on every
+    op it tiles. ``loop_tiled_dims``/``loop_tiled_reduction_dims`` name tiled
+    dims by *raw position into ``op.data.ranges``/``reduction_ranges``*.
+    Historically this raw numbering was only self-consistent for an op that
+    planned its own tiling: a generated read-copy op
+    (``_insert_all_read_copy_ops``, coarse_tile.py) used to inherit
+    ``loop_tiled_dims``/``loop_tiled_reduction_dims`` verbatim from the
+    *sizing op* it copies for, still numbered in the sizing op's ranges,
+    which can disagree with the copy's own ``data.ranges``
+    position-for-position (issue: a minimal B+H coarse-tiled matmul repro
+    produced ``Unsupported: Cannot satisfy mandatory split 64 for d1 within
+    32 cores``, tracing to exactly this: the copy's own D axis at position 1
+    misread as the sizing op's H axis). ``coarse_tile.py`` now recomputes
+    ``loop_tiled_dims``/``loop_tiled_reduction_dims`` for a generated copy in
+    the copy's own raw-position space too (from the same ``read_level_extents``
+    data used for ``tiled_dims_per_read``), so ``loop_tiled_dims`` is now sound
+    to read directly for every op, self-planning or copy.
+
+    ``loop_tiled_dims`` must be the primary source (not
+    ``tiled_dims_per_read``/``output_tiled_dims``): for a self-planning op
+    whose only read is of a generated copy buffer,
+    ``tiled_dims_per_read``'s entry for that read is *deliberately* zeroed
+    by ``_insert_all_read_copy_ops`` (the copy is per-tile scratch reused in
+    place every iteration and "must not advance" -- the same
+    ``_fixed_level_extents`` convention used for a copy's own
+    ``output_tiled_dims``). That zeroing is correct for its own purpose
+    (building the copy-read's ``device_tile_advance_expr``) but leaves
+    ``tiled_dims_per_read``/``output_tiled_dims`` carrying no "is this op's
+    own dim tiled" signal at all for such an op -- confirmed by a direct
+    trace: ``buf0`` (reads only a generated copy) showed
+    ``tiled_dims_per_read=[[[], []]]``, ``output_tiled_dims=[]``, so this
+    constraint pinned nothing for ``buf0``'s own H/B dims, leaving them
+    exposed to the greedy search's independent, unpinned choice.
+    ``loop_tiled_dims`` has no such caveat: it is recomputed fresh from
+    ``ctx.op``'s own ranges at whichever point (self-planning or copy
+    construction) last stamped ``loop_info``, so it always reflects the
+    current op's own tiling.
+
+    Each raw position is translated to an ``ctx.it_space`` symbol via
+    ``ctx.op``'s own raw->squeezed table (mirroring
+    ``_raw_to_squeezed_pos``'s convention -- squeezed index ``i`` names
+    symbol ``d{i}``), the same bridge ``_tiled_dims_for_dep`` itself uses,
+    rather than an independent survivor-count walk that silently assumes
+    the raw numbering already matches ``ctx.op.data.ranges`` (that
+    assumption is what this function's docstring above documents as
+    trustworthy now, but the translation step itself must still go through
+    the table rather than being conflated with squeezed indices directly).
+
+    The symbol built from ``d{i}`` MUST use ``sympy_index_symbol`` (the same
+    constructor ``coarse_tile.py`` uses everywhere it builds a ``d{i}``
+    iteration symbol, e.g. its ``sizing_symbol``/``symbol`` locals), not a
+    plain ``sympy.Symbol`` -- ``sympy_index_symbol`` stamps extra assumptions
+    (``integer=True`` etc.) that make its symbols compare unequal to a
+    plain ``Symbol`` of the same name despite printing identically. Every
+    key in ``ctx.it_space`` is a ``sympy_index_symbol``, so a plain
+    ``Symbol(f"d{squeezed}")`` here silently fails every ``sym not in
+    ctx.it_space`` check and ``pin()`` never sets anything -- confirmed by
+    direct trace: for ``buf0``, ``sym`` printed as ``d0`` and
+    ``ctx.it_space`` printed as ``{d0: 2, ...}``, yet ``sym not in
+    ctx.it_space`` was ``True``. This was the actual reason this
+    constraint never forced any split, for any op, since it was written --
+    the coordinate-space/copy-op issues above are real but were never the
+    thing silently defeating this function; a mismatched ``Symbol``
+    constructor was.
+
+    ``loop_tiled_reduction_dims`` can be non-empty on an op whose own
+    ``data`` is a ``Pointwise`` with no ``reduction_ranges`` at all: a
+    reduction combine op (``_insert_combine_op``, coarse_tile.py)
+    deliberately inherits ``loop_tiled_reduction_dims`` verbatim from the
+    ``Reduction`` op it combines into, purely so the scheduler places it in
+    the same ``CountedLoopSchedulerNode`` -- the reduction dim has already
+    been reduced away and does not exist in the combine op's own iteration
+    space, so there is nothing of that dim left to pin here. Guard on
+    ``ctx.op.data`` actually exposing ``reduction_ranges`` before indexing
+    into it, rather than assuming a non-empty ``loop_tiled_reduction_dims``
+    implies one exists.
+    """
+    loop_info = getattr(ctx.op, "loop_info", None)
+    if loop_info is None:
+        return ConstraintResult()
+
+    if ctx.op.get_name().startswith(_GENERATED_COPY_OP_PREFIXES):
+        return ConstraintResult()
+
+    raw_to_squeezed = _raw_to_squeezed_pos(ctx.op)
+
+    def pin(pos: int, extent: Expr) -> None:
+        squeezed = raw_to_squeezed.get(pos)
+        if squeezed is None:
+            return
+        sym = sympy_index_symbol(f"d{squeezed}")
+        if sym not in ctx.it_space:
+            return
+        assert concretize_expr(extent) == concretize_expr(ctx.it_space[sym]), (
+            f"{ctx.op.get_name()}: tiled-dim extent {extent} for {sym} "
+            f"disagrees with its iteration-space extent {ctx.it_space[sym]}."
+        )
+        # allowed_splits values are core-partition COUNTS (divisors of the
+        # dim's extent), not the extent itself -- work_division.py's
+        # splits[var] defaults to 1 for every dim, meaning "one partition
+        # covers the dim's full extent, walked serially inside the op's own
+        # loop" (see TensorWorkDivision.work_slices' docstring). Pinning to
+        # {1} is what forces work_division to leave this coarse-tile-local
+        # dim whole rather than fragmenting it across cores -- every sibling
+        # constraint in this file (qfp8wt_split_domains,
+        # qfp8wt_matmul_k_split_domains, topk_split_domains,
+        # indirect_access_split_domains) uses the same frozenset({1}) idiom.
+        # Pinning to the extent itself (the old code here) asks
+        # work_division for a split count equal to the dim's size, which
+        # fails outright once that exceeds max_cores.
+        allowed_splits[sym] = frozenset({1})
+
+    allowed_splits: dict[Symbol, frozenset[int]] = {}
+    output_ranges = ctx.op.data.ranges
+    for level_dims in loop_info.loop_tiled_dims:
+        for pos in level_dims:
+            pin(pos, output_ranges[pos])
+
+    n_output_dims = len(output_ranges)
+    reduction_ranges = getattr(ctx.op.data, "reduction_ranges", None)
+    if reduction_ranges is not None:
+        for level_dims in loop_info.loop_tiled_reduction_dims:
+            for pos in level_dims:
+                pin(n_output_dims + pos, reduction_ranges[pos])
+
+    return ConstraintResult(allowed_splits=allowed_splits)
+
+
+def plain_reduction_k_split_domains(
+    ctx: WorkDivConstraintContext,
+) -> ConstraintResult:
+    """Forbid K-splits for reductions with no cross-core combine step.
+
+    Splitting a reduction dim across cores leaves each core holding a partial
+    result (e.g. a partial max over its own slice of the reduction range).
+    Matmul has PSUM hardware to combine those partial sums, and topk/
+    keep_by_index/pool/conv have their own dedicated combine or blocking
+    rules above. Every other reduction type (max, min, sum, prod, mean,
+    absmax, ...) has no combine step wired up anywhere in codegen: the
+    partial result is written out and never reduced further, silently
+    producing a wrong answer (issue: B+H coarse-tiled flash-attention amax,
+    where freeing up core budget let the generic work-division search reach
+    for a K-split on a plain `max` reduction). Restrict those to split=1
+    until a real combine mechanism exists for them.
+    """
+    if not isinstance(ctx.op.data, Reduction):
+        return ConstraintResult()
+    if ctx.op.data.reduction_type in _K_SPLIT_COMBINE_SUPPORTED:
+        return ConstraintResult()
+    return ConstraintResult(
+        allowed_splits={v: frozenset({1}) for v in ctx.reduction_vars}
+    )
 
 
 def restickify_padding_blocked_vars(

--- a/torch_spyre/_inductor/work_division_constraints.py
+++ b/torch_spyre/_inductor/work_division_constraints.py
@@ -54,6 +54,7 @@ from .pass_utils import (
     op_read_writes,
 )
 from .logging_utils import get_inductor_logger
+from .propagate_hints import get_op_hints
 from .wsr.coarse_tile import _raw_to_squeezed_pos
 from . import config
 
@@ -291,6 +292,34 @@ _K_SPLIT_COMBINE_SUPPORTED = {
 _GENERATED_COPY_OP_PREFIXES = ("coarse_tile_read_copy_", "coarse_tile_reduce_copy_")
 
 
+def _hinted_work_div_syms(ctx: WorkDivConstraintContext) -> set[Symbol]:
+    """Symbols in ``ctx.it_space`` that carry an explicit user ``work_div`` hint.
+
+    Mirrors ``_resolve_work_div_hint``'s name->symbol resolution
+    (work_division.py) so a dim the user explicitly asked to split can be
+    recognized here too, without importing work_division.py itself (it
+    imports this module, so importing back would be circular). Kept as a
+    plain set of symbols, not a split-count dict: this function only needs
+    to know which symbols to leave unpinned -- the actual requested split
+    value is validated and applied later, by work_division.py's own
+    ``_apply_user_hint``.
+    """
+    dim_to_split: dict[str, int] = {}
+    for _, hint_dict in sorted(get_op_hints(ctx.op).items()):
+        dim_to_split.update(hint_dict.get("work_div") or {})
+    if not dim_to_split:
+        return set()
+
+    loop_var_dims = getattr(ctx.op, "work_div_loop_info", {})
+    hinted: set[Symbol] = set()
+    for name in dim_to_split:
+        for sym in ctx.it_space:
+            if name in loop_var_dims.get(sym, []):
+                hinted.add(sym)
+                break
+    return hinted
+
+
 def coarse_tile_local_dim_split_domains(
     ctx: WorkDivConstraintContext,
 ) -> ConstraintResult:
@@ -405,6 +434,7 @@ def coarse_tile_local_dim_split_domains(
         return ConstraintResult()
 
     raw_to_squeezed = _raw_to_squeezed_pos(ctx.op)
+    hinted_syms = _hinted_work_div_syms(ctx)
 
     def pin(pos: int, extent: Expr) -> None:
         squeezed = raw_to_squeezed.get(pos)
@@ -412,6 +442,16 @@ def coarse_tile_local_dim_split_domains(
             return
         sym = sympy_index_symbol(f"d{squeezed}")
         if sym not in ctx.it_space:
+            return
+        if sym in hinted_syms:
+            # The user explicitly asked (via spyre_hint(work_div=...)) to
+            # split this coarse-tile-local dim. Leave it unpinned here and
+            # let work_division.py's _apply_user_hint validate and apply the
+            # requested split -- it already checks divisibility, core
+            # budget, and consistency with every OTHER constraint's
+            # allowed_splits/blocked, so deferring to it does not reopen the
+            # unhinted-greedy-search hazard this function otherwise guards
+            # against for the remaining, un-hinted coarse-tile-local dims.
             return
         assert concretize_expr(extent) == concretize_expr(ctx.it_space[sym]), (
             f"{ctx.op.get_name()}: tiled-dim extent {extent} for {sym} "

--- a/torch_spyre/_inductor/work_division_constraints.py
+++ b/torch_spyre/_inductor/work_division_constraints.py
@@ -264,6 +264,13 @@ def reduction_window_blocked_vars(ctx: WorkDivConstraintContext) -> ConstraintRe
     return ConstraintResult(blocked=set(window_dims))
 
 
+# These ops have dedicated cross-core hardware/codegen combine support
+# (matmul: PSUM accumulation; topk/keep_by_index/pool/conv: dedicated
+# combine codegen), so a K-split across cores is safe. Plain elementwise
+# reductions like sum/max/min/xor_sum/any are deliberately absent: they use
+# coarse_tile.py's own outer-loop accumulate path (_insert_combine_op)
+# instead, which is a different mechanism and does not enable a cross-core
+# K-split -- their absence here is not an oversight to "fix" by adding them.
 _K_SPLIT_COMBINE_SUPPORTED = {
     BATCH_MATMUL_OP,
     BATCH_MATMUL_FP8_OP,
@@ -289,6 +296,12 @@ _K_SPLIT_COMBINE_SUPPORTED = {
 # Unsupported (confirmed: test_copy_running_max_4d_H4_Lq4 fails with
 # "per-core tensor span ... exceeds hardware limit" once its read-copy op's
 # H/Lq dims are pinned, and passes once they aren't).
+#
+# These prefixes are matched cross-module against names coarse_tile.py
+# constructs via V.graph.qualify_name: "coarse_tile_read_copy_..." in
+# _insert_all_read_copy_ops, and "coarse_tile_reduce_copy_..." in
+# _insert_reduce_copy_op and its _insert_combine_op/reduction-drain
+# call sites. If either naming site changes, update this tuple to match.
 _GENERATED_COPY_OP_PREFIXES = ("coarse_tile_read_copy_", "coarse_tile_reduce_copy_")
 
 

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -4097,6 +4097,14 @@ def _insert_one_read_copy(
     # by its correct raw position in copy_buf's own data.ranges -- reuse
     # those keys instead of sizing_op_info's.
     copy_loop_tiled_dims = [sorted(level) for level in read_level_extents]
+    # Always empty, unconditionally: a generated copy_buf's own data is
+    # always a Pointwise passthrough (a plain per-tile scratch read or
+    # write-back), never a Reduction, so it has no reduction_ranges of its
+    # own to tile regardless of whether the sizing op it copies for reduces
+    # over a dim. work_division_constraints.coarse_tile_local_dim_split_
+    # domains relies on this: it only indexes reduction_ranges when
+    # ctx.op.data exposes it, so an empty list here is correct, not a
+    # placeholder to fill in later.
     copy_loop_tiled_reduction_dims: list[list[int]] = [
         [] for _ in sizing_op_info.loop_count
     ]

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -3181,16 +3181,27 @@ def _insert_copy_op(
             # Tiled down to extent 1 in copy_buf's own write -- no d{i}
             # symbol survives squeeze for _host_dim_to_index_symbol to find.
             # full_buf's own canonical (squeezed-space) index coefficient
-            # for this raw dim -- product of copy_buf's *own* data.ranges
-            # sizes strictly to its right, matching the units
-            # dep.index's surviving d{i} symbols already carry (Inductor
-            # mints those coefficients over the *unsqueezed* data.ranges,
-            # then squeeze only renumbers/drops symbols, never rescales
-            # them) -- not full_buf.layout.stride, which is a raw PyTorch
-            # memory stride in a different unit system that
-            # tiling_expr_to_device_expr's stride_map-based dimension
-            # selection cannot be compared against.
-            host_stride = sympy.prod(copy_ranges[d + 1 :])
+            # for this raw dim -- product of the sizes strictly to its
+            # right, matching the units dep.index's surviving d{i} symbols
+            # already carry (Inductor mints those coefficients over the
+            # *unsqueezed* data.ranges, then squeeze only renumbers/drops
+            # symbols, never rescales them) -- not full_buf.layout.stride,
+            # which is a raw PyTorch memory stride in a different unit
+            # system that tiling_expr_to_device_expr's stride_map-based
+            # dimension selection cannot be compared against.
+            #
+            # Must use full_buf's own (pre-division) sizes here, NOT
+            # copy_ranges (== copy_buf's already-divided data.ranges): a
+            # dim strictly to the right of d that is ITSELF tiled by
+            # another loop level has already been divided down in
+            # copy_ranges, undercounting host_stride by that dim's
+            # division factor. full_buf.get_size() is allocated directly
+            # from full_ranges (see _allocate_full_buffer) in this same
+            # raw dim order and is never divided, so it gives the correct
+            # full extent for both tiled and untiled dims to the right of
+            # d (a no-op substitution for the untiled ones).
+            full_sizes = list(full_buf.get_size())
+            host_stride = sympy.prod(full_sizes[d + 1 :])
             running = sympy.Integer(1)
             for level_idx in reversed(levels_tiling_d):
                 squeezed_advance[level_idx].append((host_stride, running))
@@ -4068,8 +4079,31 @@ def _insert_one_read_copy(
     # a "reduction"-kind plan leak onto this Pointwise passthrough buffer,
     # causing Pass 2 (_insert_all_reduction_ops) to misdispatch it into
     # _propagate_tiled_reduction_op.
+    #
+    # loop_tiled_dims/loop_tiled_reduction_dims must ALSO be recomputed in
+    # copy_buf's own raw-position space here, for the same reason
+    # tiled_dims_per_read/output_tiled_dims are: sizing_op_info's raw
+    # positions name dims in sizing_op's data.ranges, which can (and, for
+    # any sizing_op whose read/write dims don't line up 1:1 with copy_buf's
+    # own -- e.g. a transpose/reshape between them -- generally does) point
+    # at a different dim of copy_buf's own data.ranges at the same raw
+    # index. Downstream consumers of copy_buf.loop_info (e.g.
+    # work_division_constraints.coarse_tile_local_dim_split_domains) read
+    # loop_tiled_dims against copy_buf's own ranges/raw-squeeze table, so a
+    # verbatim carry-over here silently mis-names which dim is tiled at
+    # each level (confirmed by a minimal B+H coarse-tiled matmul repro
+    # misreading the copy's own D axis as sizing_op's H axis). read_level_
+    # extents/write_level_extents (built above) already key each tiled dim
+    # by its correct raw position in copy_buf's own data.ranges -- reuse
+    # those keys instead of sizing_op_info's.
+    copy_loop_tiled_dims = [sorted(level) for level in read_level_extents]
+    copy_loop_tiled_reduction_dims: list[list[int]] = [
+        [] for _ in sizing_op_info.loop_count
+    ]
     copy_buf.loop_info = dataclasses.replace(  # type: ignore[attr-defined]
         sizing_op_info,
+        loop_tiled_dims=copy_loop_tiled_dims,
+        loop_tiled_reduction_dims=copy_loop_tiled_reduction_dims,
         tiled_dims_per_read=tiled_dims_per_read,
         output_tiled_dims=output_tiled_dims,
         squeezed_advance_per_read=[squeezed_advance] if copy_reads else [],


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/mai
n/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes silent wrong-answers when coarse-tiling **both** B and H dimensions
together in one fused loop group (e.g. flash-attention with B and H both
tiled). Tiling either dimension alone worked correctly; tiling them
together produced numerically wrong results (~70% of elements mismatched
in `test_flash_tile_B_H`, confirmed down to a minimal plain-matmul repro).

Five distinct, independently-necessary root causes were found and fixed,
all latent in the single-dim-tiling case and only exposed once two
coarse-tile-local loop variables gave the per-op work-division search
enough extra freedom to go wrong:

1. **`spyre_kernel.py`**: a dim squeezed to a per-tile extent of 1 minted
   no `d{i}` symbol, so `has_any_tiled_dim` missed it even though
   `_general_tile_advance` still emitted an advance expression for it. The
   level symbol ended up in `device_tile_advance_expr` but not
   `OpSpec.tiled_symbols`, so `superdsc.py`'s affine-stride extraction
   silently dropped the advance, leaving the tensor's address pinned
   across that level's iterations instead of stepping through it. Fixed
   by also checking `squeezed_advance_per_read`/`squeezed_advance_output`.

2. **`coarse_tile.py` (`_insert_copy_op`)**: `host_stride` was computed
   from `copy_buf`'s own already-divided `data.ranges` instead of
   `full_buf`'s undivided sizes, undercounting the stride for any dim to
   the right that is itself tiled by another loop level. Fixed by using
   `full_buf.get_size()`.

3. **`coarse_tile.py` (`_insert_one_read_copy`)**: a generated read-copy
   op's `loop_tiled_dims`/`loop_tiled_reduction_dims` were inherited
   verbatim from the sizing op's own raw-position coordinate space, which
   can (and did) disagree with the copy's own `data.ranges`
   position-for-position — e.g. the copy's own D axis at position 1 was
   misread as the sizing op's H axis. Fixed by recomputing both fields in
   the copy's own coordinate space from `read_level_extents`.

4. **`work_division_constraints.py`**: added a new constraint,
   `coarse_tile_local_dim_split_domains`, that pins every coarse-tile-local
   dim's work-division split to 1 on every op, so one op's independent
   greedy per-core search can't fragment a dim that must stay whole for
   cross-op agreement within the fused loop body. Building this constraint
   surfaced two further bugs: using a plain `sympy.Symbol` instead of
   `sympy_index_symbol` (compares unequal to `ctx.it_space` keys despite
   printing identically, silently defeating every pin), and an
   `AttributeError` on `Pointwise` combine ops that deliberately inherit a
   non-empty `loop_tiled_reduction_dims` from the `Reduction` op they
   combine into purely for scheduler-grouping purposes and have no
   `reduction_ranges` of their own.

5. **`work_division_constraints.py`**: exempted generated scratch-copy ops
   (`coarse_tile_read_copy_*` / `coarse_tile_reduce_copy_*`) from the
   fix-4 pin entirely. A copy op's own tile-local dims aren't shared,
   cross-op state the way a self-planning op's loop variable is, and
   pinning them defeated the per-core span-limit search
   (`raise_if_per_core_overflow`) on a copy whose read spans the full,
   un-tiled source tensor — producing spurious "per-core tensor span
   exceeds hardware limit" failures on otherwise-legal plans.

Also adds `plain_reduction_k_split_domains`, forbidding K-splits for
reduction types with no cross-core combine step (only
matmul/topk/keep_by_index/pool/conv have one wired up). Freeing up core
budget from fix 4 let the generic work-division search reach for an
unsupported K-split on flash-attention's plain `max`/amax reduction.

Two smaller, related test-hygiene commits are included:

- Un-skips `test_flash_tile_B` — its intermittent ~22.7% mismatch (issue
  #3937) no longer reproduces after a recent wave of cross-group/
  reduction-consumer read-redirection fixes; verified passing across
  multiple isolated runs and the full flash cluster.
- Corrects stale/inaccurate skip reasons on the remaining flash v2/v3
  skips to cite the actual root cause (issue #4126: `copy_forced`'s
  write-back is dropped by AOTAutograd DCE when there's no downstream
  same-trace read) instead of a vague or unrelated prior description, and
  clarifies that `test_flash_tile_B_H`'s failure was a distinct,
  not-yet-diagnosed issue at the time (now resolved by this PR).

`test_flash_tile_B_H` itself is un-skipped and passing.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

Part of #206 

#### Special notes for your reviewer:

- Root-caused via systematic debugging: each of the five bugs was isolated
  with its own minimal reproduction before being fixed, rather than
  bundling speculative fixes.
- Bug 4's `_GENERATED_COPY_OP_PREFIXES` name-prefix approach for
  distinguishing "generated scratch-copy op" from "self-planning op" was
  chosen over threading a new `CoarseTileInfo` field through
  `loop_info.py`/`coarse_tile.py`, because `PropagationPlan.kind ==
  "loop_internal"` is *not* a reliable discriminator — it's also used for
  genuine self-planning ops with no outside consumers. There is existing
  precedent for name-prefix matching in the same codebase
  (`allowed_reader_prefixes` in `coarse_tile.py`).
- Full local regression, all clean:
  - `tests/inductor/test_coarse_tile_e2e.py`: 203 passed, 32 skipped,
    1 xfailed, 0 failed
  - `tests/inductor/test_coarse_tiling.py`: 337 passed, 1 skipped
  - `tests/inductor/test_building_blocks.py`: 20 passed
  - `pre-commit run --all-files`: clean

#### Does this PR introduce a user-facing change?

No public API change. Coarse-tiling two dimensions together in a fused
loop group (a previously silently-incorrect configuration) now produces
correct results instead of wrong ones; some previously-passing
configurations that relied on the (buggy, unpinned) work-division search
finding a lucky-but-fragile split may now be constrained more
conservatively via the new `coarse_tile_local_dim_split_domains` and
`plain_reduction_k_split_domains` constraints.

#### Additional note: