### PR TITLE
Add two additional paths to inductor codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,6 +16,7 @@
 
 # Inductor / compiler backend
 /torch_spyre/_inductor/  @dgrove-oss @avery-blanchard @cyang49 @marnold-ibm @tardieu
+/torch_spyre/inductor/  @dgrove-oss @avery-blanchard @cyang49 @marnold-ibm @tardieu
 
 # Device, execution, memory, and C++ runtime
 /torch_spyre/device/     @JRosenkranz @thoangtrvn @ani300
@@ -55,3 +56,6 @@
 # against is a fact about /torch_spyre/_inductor/.
 /tools/ktir-mlir-frontend.pin  @dgrove-oss @avery-blanchard @tardieu
 /tools/install-ktir.sh         @dgrove-oss @avery-blanchard @tardieu
+
+# tools used to tune/refresh the cost model used in inductor
+/tools/cost_model/  @dgrove-oss @avery-blanchard @cyang49 @marnold-ibm @tardieu


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Two recently added paths (/torch_spyre/inductor and tools/cost_model) should be managed by the inductor code approvers.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
