### PR TITLE
restore MAX_SPAN_BYTES to the correct value of 256MB

### DIFF
--- a/docs/source/architecture/dataflow_architecture.md
+++ b/docs/source/architecture/dataflow_architecture.md
@@ -156,7 +156,7 @@ The IBM Spyre Accelerator chip (left) and IBM Telum II processor (right). *Image
 | Cores | 32 AI accelerator cores |
 | Technology | 5 nm |
 | LX scratchpad | 2 MB per core (SRAM, shared between corelets) |
-| Per-core memory span | 255.996 MiB addressable contiguous device memory |
+| Per-core memory span | 256 MB addressable contiguous device memory |
 | Memory per card | Up to 128 GB LPDDR5 |
 | Peak performance | >300 TOPS per card |
 | Supported data types | int4, int8, fp8, fp16 |

--- a/docs/source/architecture/spyre_accelerator.md
+++ b/docs/source/architecture/spyre_accelerator.md
@@ -27,7 +27,7 @@ Some of the key features of the Spyre device are listed below:
 * It delivers exceptional AI compute, exceeding 300 TOPS per card, while consuming just 75W.
 * PCIe gen5 x16 host interface (PCIe form factor card).
 * Each core has a 2 MB LX scratchpad (SRAM), shared between the two corelets within the core.
-* Each core has a 255.996 MiB limit on the contiguous device-memory span it can address. This is a hardware constraint on the addressable range, distinct from the 2 MB LX scratchpad capacity.
+* Each core has a 256 MB limit on the contiguous device-memory span it can address. This is a hardware constraint on the addressable range, distinct from the 2 MB LX scratchpad capacity.
 
 ### Core microarchitecture
 

--- a/docs/source/compiler/scratchpad_planning.md
+++ b/docs/source/compiler/scratchpad_planning.md
@@ -62,7 +62,7 @@ The compiler picks which buffers live where.
 | Usable LX per core | ~1.55 MB | `round_up_128(int(((2<<20) - (64<<10)) * (1 - frac_avail)))` |
 | Alignment | 128-byte (stick) | implicit |
 | Cores | 1 to 32 | `SENCORES` |
-| Per-core HBM span limit | (255.996 MiB) | hardware, separate from LX |
+| Per-core HBM span limit | (256 MB) | hardware, separate from LX |
 | Inter-core data ring | yes | not yet used by compiler |
 | Inter-core reduce-sum ring | yes | not yet used by compiler |
 
@@ -150,7 +150,7 @@ insert_post_mutation_restickify
 insert_bmm_padding
 dedup_and_promote_constants
 _maybe_coarse_tile_span_overflow      # span-overflow coarse tiling (post-stickification)
-span_reduction                        # work-division: enforce 255.996 MiB span
+span_reduction                        # work-division: enforce 256 MB span
 cost_model_matmul_division            # work-division: matmul cost model
 work_distribution                     # work-division: default distributor
 _maybe_scratchpad_planning            # ← THIS PASS, gated by config.lx_planning

--- a/docs/source/compiler/span_overflow_hint_analysis.md
+++ b/docs/source/compiler/span_overflow_hint_analysis.md
@@ -3,7 +3,7 @@
 ## Background
 
 Spyre kernels must keep each core's memory-address span within the hardware
-limit (`MAX_SPAN_BYTES`, (255.996 MiB)).  Normal `work_division` splits work
+limit (`MAX_SPAN_BYTES`, (256 MB)).  Normal `work_division` splits work
 across cores, but some physical layouts still expose a span that is too large
 for one core.  When that happens, backend compilation can fail with Work
 Division warnings, deeptools mutable-address failures, or immediate/EAR boundary
@@ -51,6 +51,7 @@ Example operation:
 ```python
 def fn(x, y):
     return x + y
+
 
 x.shape == y.shape == (1, 8195, 256, 64)
 ```
@@ -114,6 +115,7 @@ Example operation:
 def fn(x):
     return x.sum(dim=-1)
 
+
 x.shape == (1, 8195, 256, 64)
 out.shape == (1, 8195, 256)
 ```
@@ -142,7 +144,8 @@ Example operation:
 def fn(x):
     return x.sum(dim=0)
 
-x.shape   == (2, 20, 16, 64)
+
+x.shape == (2, 20, 16, 64)
 out.shape == (20, 16, 64)
 ```
 
@@ -181,9 +184,10 @@ Example operation:
 def lm_head(x, weight):
     return torch.nn.functional.linear(x, weight)
 
-x.shape      == (2, 64)
+
+x.shape == (2, 64)
 weight.shape == (1024, 64)
-out.shape    == (2, 1024)
+out.shape == (2, 1024)
 ```
 
 Lowering can represent this as a restickify producer followed by a
@@ -611,9 +615,7 @@ For a physical device coordinate at `device_dim`, span is computed as:
 
 ```python
 per_core_span = (
-    coord_span_elems
-    * math.prod(device_size[device_dim + 1:])
-    * dtype.itemsize
+    coord_span_elems * math.prod(device_size[device_dim + 1 :]) * dtype.itemsize
 )
 ```
 

--- a/docs/source/compiler/work_division_planning.md
+++ b/docs/source/compiler/work_division_planning.md
@@ -19,13 +19,13 @@ scratchpad planning) consume that plan.
 ## Three-pass planner overview
 
 The planner has three responsibilities, one per pass: **Pass 1
-enforces the 255.996 MiB per-core span limit, Pass 2 selects matmul splits
+enforces the 256 MB per-core span limit, Pass 2 selects matmul splits
 from a cost model, and Pass 3 selects a default split for every other
 eligible op.**
 
 For each eligible op the planner runs three passes in order:
 
-1. **Pass 1, span reduction**, enforces the 255.996 MiB per-core span limit.
+1. **Pass 1, span reduction**, enforces the 256 MB per-core span limit.
    When a tensor's per-core span exceeds the limit, this pass commits
    the minimum splits needed to bring the span back under. When no
    tensor violates the limit, the pass leaves the op untouched.
@@ -123,9 +123,9 @@ element counts to stick counts so core splits always align to stick
 boundaries. When tensors of different dtypes share a stick variable,
 the conversion uses the largest `elems_per_stick` across those tensors.
 
-### Per-core memory span (255.996 MiB)
+### Per-core memory span (256 MB)
 
-Each Spyre core has a 255.996 MiB limit on the memory span it can address.
+Each Spyre core has a 256 MB limit on the memory span it can address.
 The per-core span for a tensor is the contiguous range of device memory
 (in bytes) that a single core must read or write under a particular
 split assignment. The outermost device dimension a core touches sets
@@ -161,7 +161,7 @@ A card has 32 cores connected by a bi-directional ring.
 |---|---|---|
 | Cores per card | 32 (configurable down to 1 via `SENCORES`) | Total core budget Pass 3 distributes |
 | PT rows per corelet | 8 | Pass 2's compute term and M tie-break |
-| Per-core memory span | 255.996 MiB | Pass 1's correctness constraint |
+| Per-core memory span | 256 MB | Pass 1's correctness constraint |
 | Stick size | 128 B (`BYTES_IN_STICK`); element count from `device_dtype.elems_per_stick()` | Stick-aligned splits across all passes |
 
 For the full hardware overview see
@@ -170,7 +170,7 @@ For the full hardware overview see
 :::{admonition} Common misconceptions
 :class: warning
 
-- **The 255.996 MiB span is not the 2 MB LX.** The span limit is a per-core
+- **The 256 MB span is not the 2 MB LX.** The span limit is a per-core
   *addressable device memory* range. The 2 MB LX scratchpad is a
   separate on-core SRAM whose placement is decided by
   [scratchpad planning](scratchpad_planning.md), not work division.
@@ -189,11 +189,11 @@ For the full hardware overview see
 This pass is mandatory and runs first over every eligible op.
 
 For each operation, `span_reduction_pass` computes the minimum splits
-required to keep every tensor's per-core memory span within 255.996 MiB
+required to keep every tensor's per-core memory span within 256 MB
 (`must_split_vars`).
 
 `must_split_vars` processes tensors one at a time. For each tensor whose
-per-core span exceeds 255.996 MiB, it iterates over device dimensions outer
+per-core span exceeds 256 MB, it iterates over device dimensions outer
 to inner and searches for the best split combination (Cartesian product
 of valid divisors for the variables contributing to that dimension)
 that satisfies the hardware limit. The search applies a two-tier
@@ -217,15 +217,15 @@ A: [8192, 32768] fp16, total 512 MB
 
 Unsplit                          Split K by 2
 ┌───────────────────────────┐    ┌──────────────┬──────────────┐
-│       512 MB per core     │    │ 255.996 MiB / core│ 255.996 MiB / core│
-│   (violates 255.996 MiB limit) │    │     core 0   │     core 1   │
+│       512 MB per core     │    │ 256 MB / core│ 256 MB / core│
+│   (violates 256 MB limit) │    │     core 0   │     core 1   │
 └───────────────────────────┘    └──────────────┴──────────────┘
               ✗                                  ✓
 ```
 
 The arithmetic generalises:
 `per_core_span = (dim_size / split) × outer_stride × dtype_bytes`. Pass 1
-picks the smallest `split` that brings the span under 255.996 MiB on the
+picks the smallest `split` that brings the span under 256 MB on the
 outermost dimension that violates it.
 
 ## Pass 2 — Cost-Model Matmul Division (`cost_model_matmul_division`)
@@ -429,7 +429,7 @@ Two op-kind constraints apply on top of the algorithm above. For
 pointwise ops there is no reduction dimension, so the ranking step
 considers only output dimensions. For reductions, span-required splits
 may include at most one reduction variable. If more than one reduction
-variable would have to be split to satisfy the 255.996 MiB span limit, the
+variable would have to be split to satisfy the 256 MB span limit, the
 compiler raises an error.
 
 (topk-work-division)=
@@ -479,7 +479,7 @@ dim `K`.
 | Tensor | Unsplit per-core span | Violating dim | Pass 1 commit | After Pass 3 | Cores reading it |
 |---|---|---|---|---|---|
 | A `[8192, 32768]` fp16 | 512 MB | K (outermost) | K minimum = 2 | M = 16, K = 2 | each core reads (512 rows) × (16384 K) = 16 MB |
-| W `[32768, 4096]` fp16 | 255.996 MiB | none (at limit) | — | M = 16, K = 2 | each core reads (16384 K) × (4096 N) = 128 MB |
+| W `[32768, 4096]` fp16 | 256 MB | none (at limit) | — | M = 16, K = 2 | each core reads (16384 K) × (4096 N) = 128 MB |
 | O `[8192, 4096]` fp16 | 64 MB | none | — | M = 16, K = 2 | each core writes (512 rows) × 4096 = 4 MB |
 
 Pass 2 detects that Pass 1 already committed a split (`K = 2`). The
@@ -600,6 +600,7 @@ declare_tensor_dim("N", N)
 name_tensor_dims(x, ["M", "K"])
 name_tensor_dims(y, ["K", "N"])
 
+
 def fn(x, y):
     with spyre_hint(work_div={"M": 2, "K": 4}):
         return x @ y
@@ -624,7 +625,7 @@ the accepted split decision. Validation checks that:
 - at most one accepted reduction dimension is split
 
 User work-division hints are intentionally authoritative. If Pass 1
-(`span_reduction`) already committed minimum splits for the 255.996 MiB span limit,
+(`span_reduction`) already committed minimum splits for the 256 MB span limit,
 and the user hint asks for fewer splits, the compiler logs a warning and applies
 the strict user hint. `raise_if_per_core_overflow` then raises `Unsupported` if
 the resulting per-core span exceeds the hardware limit.

--- a/docs/source/getting_started/key_concepts.md
+++ b/docs/source/getting_started/key_concepts.md
@@ -174,10 +174,10 @@ that the Deeptools backend turns into a device binary.
 import torch
 import torch_spyre  # registers the device
 
-model = ...                     # any nn.Module
+model = ...  # any nn.Module
 model = model.to("spyre")
 compiled = torch.compile(model)  # routed to the Spyre backend by device
-out = compiled(x.to("spyre"))   # this is the fast path
+out = compiled(x.to("spyre"))  # this is the fast path
 ```
 
 If you only want to *test that something runs*, the eager path is fine.
@@ -315,6 +315,7 @@ implementations. Granite 3.3 8B runs in production this way:
 
 ```python
 from fms.models import get_model
+
 model = get_model("granite", "3.3-8b-instruct", device_type="spyre")
 compiled = torch.compile(model)
 ```
@@ -343,7 +344,7 @@ Constraints that show up as compile-time errors or unexpected behavior:
 | **No HW scalar immediates** | Scalar constants in the FX graph are rewritten to size-1 tensors via `spyre::constant`. |
 | **Indivisible reduction dims** | Some reduction dimensions cannot be split across cores; work distribution honors this. |
 | **Static shapes** | Dynamic shapes are work-in-progress. Shape-polymorphic models may recompile per shape. |
-| **Per-core memory span (255.996 MiB)** | Each core's contiguous device-memory footprint must fit within 255.996 MiB of addressable range. Separate from the 2 MB LX scratchpad capacity. |
+| **Per-core memory span (256 MB)** | Each core's contiguous device-memory footprint must fit within 256 MB of addressable range. Separate from the 2 MB LX scratchpad capacity. |
 | **fp16 default** | int64 is down-cast to int32 with a warning. Set `TORCH_SPYRE_DOWNCAST_WARN=0` to suppress. |
 | **`SENCORES=32`** | Default core count; lowering it for debugging changes work-division decisions. |
 

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1020,9 +1020,9 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                     cached_randn((3, 11, 2880)),
                     cached_xavier((2880, 2880)),
                 ),
-                "4d_B2_H2_M2048_K2048_N65472": (
+                "4d_B2_H2_M2048_K2048_N65536": (
                     cached_randn((2, 2, 2048, 2048)),
-                    cached_xavier((2, 2, 2048, 65472)),
+                    cached_xavier((2, 2, 2048, 65536)),
                 ),
             },
         },

--- a/tests/inductor/test_span_overflow_hint_analysis.py
+++ b/tests/inductor/test_span_overflow_hint_analysis.py
@@ -4377,7 +4377,7 @@ class TestSpanOverflowAdditionalPlannerCases(InductorTestCase):
         outside the initial candidate set.  With tiled ranges, the selected
         split validates against the same domain the real tiled kernel executes.
         """
-        op = _pointwise_op((4096, 4032, 4032, 64))
+        op = _pointwise_op((4096, 4096, 4096, 64))
 
         with patch.object(soha, "MAX_SPAN_BYTES", MAX_SPAN_BYTES):
             plan = plan_span_overflow_tile(op, max_cores=1)

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -71,12 +71,8 @@ from .work_division_constraints import (
 
 logger = get_inductor_logger("work_division")
 
-# Maximum memory-access span per core.
-#
-# MVLOC supports a maximum value of 65535, with each entry representing
-# 4096 bytes. Therefore, the maximum addressable offset is:
-# 65535 * 4096 = 268431360 bytes (255.996 MiB).
-MAX_SPAN_BYTES = 65535 * 4096
+# Maximum memory-access span per core: 256MB hardware limit
+MAX_SPAN_BYTES = 256 * 1024 * 1024
 
 
 @dataclasses.dataclass

--- a/torch_spyre/_inductor/wsr/span_overflow_hint_analysis.py
+++ b/torch_spyre/_inductor/wsr/span_overflow_hint_analysis.py
@@ -1180,7 +1180,7 @@ def _candidate_required_split_count(candidate: SpanOverflowCandidate) -> int:
     """Return the minimum split needed if this candidate's dim tiled alone.
 
     This is ``ceil(per_core_span / MAX_SPAN_BYTES)``: if a dim creates a
-    384 MB span and the limit is 255.996 MB it needs at least split ``2`` when
+    384 MB span and the limit is 256 MB it needs at least split ``2`` when
     considered by itself.
 
     The combined search can still choose a different legal divisor or combine


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [x] documentation
- [ ] cleanup

#### What this PR does:

A backend compiler bug (#4135) was misinterpreted as implying that MAX_SPAN_BYTES was 4k less than the actual 256MB hardware limit. This PR restores the correct value while keeping the other cleanups of PR #3162 intact.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
