### PR TITLE
inductor: certified greedy seed for placement-only CP-SAT

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_cpsat_certified_greedy_seed_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_cpsat_certified_greedy_seed_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [unit, regression, integration, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_cpsat_certified_greedy_seed.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_cpsat_certified_greedy_seed.py
+++ b/tests/inductor/test_cpsat_certified_greedy_seed.py
@@ -1,0 +1,465 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the certified greedy fast path inside
+``CpSatLayoutSolver.plan_layout()``.
+
+Placement-only ``plan_layout`` optimizes only level 1 of the CP-SAT
+lex-solve:
+
+    minimize sum(spill_cost(b) * (1 - in_buffer(b)))
+
+Every ``spill_cost(b) >= 0``, and ``_add_core_division`` pins every
+buffer returned by ``record_exclusions()`` to ``in_buffer = 0``. So
+the objective is bounded below by
+
+    L = sum(spill_cost(b) for b in buffers if b.name in record_exclusions())
+
+and any plan reaching ``L`` is globally optimal. The fast path runs
+greedy on a solver-local copy, evaluates that objective in CP-SAT's
+alignment-unit domain, checks representability against CP-SAT's
+domain (``_capacity_units``, alignment-aligned offsets, top-of-buffer
+within ``_capacity_units * alignment``), and either commits greedy's
+placement or falls through to the full CP-SAT solve.
+
+These tests do not measure wall clock. They check:
+"""
+
+import copy
+import unittest
+from unittest.mock import patch
+
+# torch first so torch_spyre's PrivateUse1 backend autoload sees a
+# fully-initialised module.
+import torch  # noqa: F401
+
+try:
+    from ortools.sat.python import cp_model  # noqa: F401
+
+    _HAS_ORTOOLS = True
+except ImportError:
+    _HAS_ORTOOLS = False
+
+from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
+from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
+
+
+LARGE_SIZE = 1 << 20  # 1 MiB, always enough for the tiny fixtures below
+ALIGNMENT = 1
+
+
+def _mk(name, size, uses, **kwargs):
+    return LifetimeBoundBuffer(name, size, uses, **kwargs)
+
+
+def _placed(buffers):
+    return {b.name for b in buffers if b.address is not None}
+
+
+def _greedy(buffers, size=LARGE_SIZE, alignment=ALIGNMENT):
+    return GreedyLayoutSolver(
+        copy.deepcopy(list(buffers)), size, alignment
+    ).plan_layout()
+
+
+def _cpsat_only(buffers, size=LARGE_SIZE, alignment=ALIGNMENT):
+    """Standalone CP-SAT: bypasses the seed by driving
+    ``_plan_layout_generic`` directly, so the objective is what CP-SAT
+    alone would have produced on the same input.
+    """
+    from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+        CpSatLayoutSolver,
+    )
+
+    solver = CpSatLayoutSolver(copy.deepcopy(list(buffers)), size, alignment)
+    return list(solver._plan_layout_generic())
+
+
+def _hybrid(buffers, size=LARGE_SIZE, alignment=ALIGNMENT):
+    """The full public path: seed first, CP-SAT fallback.
+
+    Deep-copies so the caller's buffers stay unaddressed and can also be
+    passed to :func:`_cpsat_only` (which asserts unplanned inputs)."""
+    from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+        CpSatLayoutSolver,
+    )
+
+    return CpSatLayoutSolver(
+        copy.deepcopy(list(buffers)), size, alignment
+    ).plan_layout()
+
+
+def _obj_units(buffers, alignment):
+    """Evaluate the placement-only CP-SAT objective on a plan, in
+    alignment units (the units CP-SAT actually optimises)."""
+    from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+        _hbm_spill_cost,
+    )
+    from torch_spyre._inductor.scratchpad.plan_solver import ceil_div
+    from dataclasses import replace as _replace
+
+    return sum(
+        _hbm_spill_cost(_replace(b, size=ceil_div(b.size, alignment)))
+        for b in buffers
+        if b.address is None
+    )
+
+
+@unittest.skipUnless(_HAS_ORTOOLS, "certified greedy seed is a CP-SAT feature")
+class TestCertifiedGreedySeed(unittest.TestCase):
+    """The certified greedy fast path inside ``CpSatLayoutSolver.plan_layout``."""
+
+    # -- 1. greedy at exact CP-SAT lower bound skips Solve() --
+    def test_lower_bound_greedy_plan_skips_cpsat_solve(self):
+        """Three buffers, plenty of capacity, no forced exclusion: greedy
+        places all three (objective = 0 = lower bound). ``CpSolver.Solve``
+        must never run."""
+        buffers = [
+            _mk("a", 10, [0, 3]),
+            _mk("b", 20, [0, 3]),
+            _mk("c", 30, [0, 3]),
+        ]
+        with patch.object(
+            cp_model.CpSolver,
+            "Solve",
+            side_effect=AssertionError(
+                "CP-SAT Solve should not run when greedy certifies"
+            ),
+        ):
+            result = _hybrid(buffers, LARGE_SIZE, ALIGNMENT)
+        self.assertEqual(_placed(result), {"a", "b", "c"})
+        self.assertEqual(_obj_units(result, ALIGNMENT), 0)
+
+    # -- 2. nonzero greedy objective invokes CP-SAT --
+    def test_nonzero_objective_falls_through_to_cpsat(self):
+        """The classic ``test_largest_buffer_evicted_when_full`` shape:
+        capacity 50 forces exactly one spill; greedy spills the largest
+        (obj 60), CP-SAT spills the smallest (obj 20). Seed rejects and
+        the returned placement is CP-SAT's optimum."""
+        buffers = [
+            _mk("a", 10, [0, 3]),
+            _mk("b", 20, [0, 3]),
+            _mk("c", 30, [0, 3]),
+        ]
+        capacity = 50
+        greedy_only = _greedy(buffers, capacity, ALIGNMENT)
+        self.assertEqual(_obj_units(greedy_only, ALIGNMENT), 60)
+        hybrid = _hybrid(buffers, capacity, ALIGNMENT)
+        cpsat_only = _cpsat_only(buffers, capacity, ALIGNMENT)
+        # The invariant that matters: hybrid == standalone CP-SAT.
+        self.assertEqual(
+            _obj_units(hybrid, ALIGNMENT),
+            _obj_units(cpsat_only, ALIGNMENT),
+        )
+        self.assertEqual(_obj_units(hybrid, ALIGNMENT), 20)
+
+    # -- 3. forced exclusion via residency_reason contributes to L --
+    def test_residency_reason_contributes_to_lower_bound(self):
+        """A buffer with ``residency_reason`` is in ``record_exclusions``
+        and its full spill_cost contributes to L. Greedy places the
+        others; hybrid certifies."""
+        buffers = [
+            _mk("barred", 40, [0, 1], residency_reason="not eligible"),
+            _mk("free", 40, [0, 1]),
+        ]
+        result = _hybrid(buffers, LARGE_SIZE, ALIGNMENT)
+        self.assertEqual(_placed(result), {"free"})
+        # Both hybrid and standalone cpsat return the same objective.
+        cpsat_only = _cpsat_only(buffers, LARGE_SIZE, ALIGNMENT)
+        self.assertEqual(
+            _obj_units(result, ALIGNMENT),
+            _obj_units(cpsat_only, ALIGNMENT),
+        )
+        # Nonzero: barred spill_cost has to appear somewhere.
+        self.assertGreater(_obj_units(result, ALIGNMENT), 0)
+
+    # -- 4. forced exclusion via min_footprint > limit contributes to L --
+    def test_min_footprint_over_limit_contributes_to_lower_bound(self):
+        """A buffer whose ``min_footprint > limit`` is pinned non-resident
+        by ``record_exclusions`` even without ``residency_reason``.
+        ``min_footprint`` defaults to ``size``, so a buffer bigger than
+        the capacity is the natural fixture."""
+        big = _mk("big", 200, [0, 3])
+        small = _mk("small", 10, [0, 3])
+        capacity = 100  # big.min_footprint = 200 > 100
+        result = _hybrid([big, small], capacity, ALIGNMENT)
+        cpsat_only = _cpsat_only([big, small], capacity, ALIGNMENT)
+        self.assertEqual(_placed(result), {"small"})
+        self.assertEqual(
+            _obj_units(result, ALIGNMENT),
+            _obj_units(cpsat_only, ALIGNMENT),
+        )
+
+    # -- 5. zero-spill-cost buffer semantics --
+    def test_zero_spill_cost_buffer(self):
+        """A single-use graph input has ``read_count = 1``,
+        ``first_use_is_read = True`` so ``reads_served = 0`` and
+        ``is_intermediate = 0``: ``spill_cost = 0``. Its presence or
+        absence in the placed set does not change the objective; the seed
+        must still certify when the objective already at the floor."""
+        buffers = [
+            _mk("live_input", 10, [0], first_use_is_read=True),
+            _mk("useful", 20, [0, 3]),
+        ]
+        result = _hybrid(buffers, LARGE_SIZE, ALIGNMENT)
+        cpsat_only = _cpsat_only(buffers, LARGE_SIZE, ALIGNMENT)
+        self.assertEqual(
+            _obj_units(result, ALIGNMENT),
+            _obj_units(cpsat_only, ALIGNMENT),
+        )
+
+    # -- 6. graph-input spill-cost semantics --
+    def test_graph_input_spill_cost_semantics(self):
+        """A multi-use graph input's spill_cost is
+        ``(read_count - 1) * size`` (drop the clone-in read pinning cannot
+        avoid). Certificate arithmetic must match CP-SAT's."""
+        from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+            _hbm_spill_cost,
+        )
+
+        b = _mk("input", 8, [0, 2, 4, 6], first_use_is_read=True)
+        # read_count = 4, first_use_is_read discounts 1 => reads_served=3.
+        # is_intermediate = not first_use_is_read = False => 0.
+        # spill_cost = (3 + 0) * 8 = 24.
+        self.assertEqual(_hbm_spill_cost(b), 24)
+
+    # -- 7. intermediate spill-cost semantics --
+    def test_intermediate_spill_cost_semantics(self):
+        """A computed intermediate's first use is the producing write, so
+        ``read_count`` already excludes it and ``is_intermediate = 1``:
+        ``spill_cost = (read_count + 1) * size``."""
+        from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+            _hbm_spill_cost,
+        )
+
+        b = _mk("intermediate", 8, [0, 2, 4], first_use_is_read=False)
+        # read_count = len(uses)-1 = 2, reads_served = 2, is_intermediate=1
+        # spill_cost = (2 + 1) * 8 = 24.
+        self.assertEqual(_hbm_spill_cost(b), 24)
+
+    # -- 8. non-aligned buffer sizes use the same objective as CP-SAT --
+    def test_non_aligned_buffer_sizes_match_cpsat_objective(self):
+        """CP-SAT wraps every buffer with ``ceil_div(size, alignment)``.
+        Certificate must use the same scaling, else the seed can accept a
+        plan whose greedy objective differs from what CP-SAT would compute."""
+        # size 129, alignment 128 -> ceil_div = 2 unit-sized in CP-SAT.
+        buffers = [_mk("odd", 129, [0, 1])]
+        alignment = 128
+        # Capacity plenty; both solvers place it.
+        capacity = 4096
+        hybrid = _hybrid(buffers, capacity, alignment)
+        cpsat_only = _cpsat_only(buffers, capacity, alignment)
+        self.assertEqual(_placed(hybrid), _placed(cpsat_only))
+        # Both objectives equal 0 here (only buffer placed). More
+        # interesting: force a spill and verify the unit-domain matches.
+        buffers2 = [_mk("odd", 129, [0, 1]) for _ in range(3)]
+        for i, b in enumerate(buffers2):
+            b.name = f"odd_{i}"
+        # 3 buffers of 2 units each, capacity 2 units => spill 2.
+        capacity_units_2 = 2 * alignment
+        h2 = _hybrid(buffers2, capacity_units_2, alignment)
+        c2 = _cpsat_only(buffers2, capacity_units_2, alignment)
+        self.assertEqual(_obj_units(h2, alignment), _obj_units(c2, alignment))
+
+    # -- 9. non-aligned capacity cannot certify unrepresentable layouts --
+    def test_limit_below_alignment_never_certifies(self):
+        """When ``_capacity_units = limit // alignment == 0``, CP-SAT has
+        no addressable slots; the seed must not certify anything (greedy
+        might place a small buffer with byte capacity, but CP-SAT's model
+        would place none). Falls through to CP-SAT."""
+        buffers = [_mk("a", 3, [0, 1]), _mk("b", 3, [0, 1])]
+        limit = 10  # < alignment=128 -> _capacity_units = 0
+        alignment = 128
+        result = _hybrid(buffers, limit, alignment)
+        cpsat_only = _cpsat_only(buffers, limit, alignment)
+        # Whatever cpsat does on its own, hybrid must match it.
+        self.assertEqual(_placed(result), _placed(cpsat_only))
+        self.assertEqual(
+            _obj_units(result, alignment),
+            _obj_units(cpsat_only, alignment),
+        )
+
+    def test_limit_not_divisible_by_alignment_uses_cpsat_top(self):
+        """``_capacity_units = limit // alignment`` rounds down, so if
+        greedy places a buffer whose top-of-buffer exceeds
+        ``_capacity_units * alignment`` the seed must reject."""
+        # limit=200, alignment=128 -> _capacity_units = 1, cpsat_top = 128
+        # Greedy on byte capacity 200 might place a 130-byte buffer at 0
+        # (top=130 > 128), which CP-SAT can't represent.
+        buffers = [_mk("a", 130, [0, 1])]
+        limit = 200
+        alignment = 128
+        result = _hybrid(buffers, limit, alignment)
+        cpsat_only = _cpsat_only(buffers, limit, alignment)
+        self.assertEqual(
+            _obj_units(result, alignment),
+            _obj_units(cpsat_only, alignment),
+        )
+
+    # -- 10. in-place reuse remains legal --
+    def test_in_place_reuse_still_certifies(self):
+        """In-place reuse: parent and child at the same LX offset for the
+        handoff tick. Certificate must accept and CP-SAT must be skipped
+        when greedy already places both."""
+        buffers = [
+            _mk("parent", 40, [0, 1]),
+            _mk("child", 20, [1, 3], in_place_parents=["parent"]),
+            _mk("stranger", 10, [2]),
+        ]
+        with patch.object(
+            cp_model.CpSolver,
+            "Solve",
+            side_effect=AssertionError("Solve must not run"),
+        ):
+            result = _hybrid(buffers, LARGE_SIZE, ALIGNMENT)
+        self.assertEqual(_placed(result), {"parent", "child", "stranger"})
+        # child shares parent's address on the handoff.
+        by_name = {b.name: b for b in result}
+        self.assertEqual(by_name["parent"].address, by_name["child"].address)
+
+    # -- 11. rejected greedy probe leaves originals untouched --
+    def test_rejected_seed_leaves_originals_untouched_before_cpsat(self):
+        """``_plan_layout_generic`` asserts every ``b.address is None`` on
+        entry. Snapshot the caller's list right before that assertion; it
+        must be all-None even after greedy ran its probe."""
+        from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+            CpSatLayoutSolver,
+        )
+
+        buffers = [_mk("a", 10, [0, 3]), _mk("b", 20, [0, 3]), _mk("c", 30, [0, 3])]
+        solver = CpSatLayoutSolver(buffers, 50, ALIGNMENT)
+        orig = solver._plan_layout_generic
+        seen: dict = {}
+
+        def _spy(*a, **k):
+            seen["before_cpsat"] = [b.address for b in buffers]
+            return orig(*a, **k)
+
+        solver._plan_layout_generic = _spy  # type: ignore[method-assign]
+        solver.plan_layout()
+        self.assertEqual(seen["before_cpsat"], [None, None, None])
+
+    # -- 12. accepted seed commits only the placement state expected --
+    def test_accepted_seed_commits_addresses_only(self):
+        """A certified seed writes ``address`` on the caller's buffers and
+        sets ``spill_reasons`` in the same shape ``_plan_layout_generic``
+        would; nothing else is mutated."""
+        from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+            CpSatLayoutSolver,
+        )
+
+        buffers = [_mk("a", 10, [0, 1]), _mk("b", 10, [0, 1])]
+        # Preserve identity + starting fields we don't expect to be touched.
+        pre_names = [b.name for b in buffers]
+        pre_uses = [list(b.uses) for b in buffers]
+        pre_sizes = [b.size for b in buffers]
+        solver = CpSatLayoutSolver(buffers, LARGE_SIZE, ALIGNMENT)
+        result = solver.plan_layout()
+        # Same identity, same list.
+        self.assertIs(result[0], buffers[0])
+        self.assertIs(result[1], buffers[1])
+        # Addresses populated.
+        for b in buffers:
+            self.assertIsNotNone(b.address)
+        # Other fields untouched.
+        self.assertEqual([b.name for b in buffers], pre_names)
+        self.assertEqual([list(b.uses) for b in buffers], pre_uses)
+        self.assertEqual([b.size for b in buffers], pre_sizes)
+        # spill_reasons matches the shape _plan_layout_generic would emit.
+        self.assertIsInstance(solver.spill_reasons, dict)
+        # No buffer was excluded, so no spill reasons expected here.
+        self.assertEqual(solver.spill_reasons, {})
+
+    # -- 13. spill_reasons match allocator expectations --
+    def test_spill_reasons_use_forced_reason_for_excluded_buffer(self):
+        """A buffer forced non-resident by ``residency_reason`` must show
+        up in ``spill_reasons`` with that same reason after a certified
+        seed, matching what CP-SAT's own tail would emit."""
+        from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+            CpSatLayoutSolver,
+        )
+
+        buffers = [
+            _mk("barred", 40, [0, 1], residency_reason="unit-test barred"),
+            _mk("free", 40, [0, 1]),
+        ]
+        solver = CpSatLayoutSolver(buffers, LARGE_SIZE, ALIGNMENT)
+        solver.plan_layout()
+        self.assertEqual(solver.spill_reasons.get("barred"), "unit-test barred")
+
+    # -- 14. joint plan_layout_and_core_divisions never uses the seed --
+    def test_joint_path_does_not_use_seed_behavioral(self):
+        """Behavioral test: patch ``_try_certified_greedy_seed`` to raise
+        if called, then invoke ``plan_layout_and_core_divisions`` on a
+        minimal ``CoreDivisionBuffer`` fixture. The joint entry must not
+        touch the seed, so the call succeeds without hitting the patched
+        raise.
+
+        Uses the same ``_whole()`` single-division fixture pattern
+        ``TestCpSatJointDivision`` uses in ``test_scratchpad_solver`` so
+        the joint model has valid ``core_divisions`` to select from.
+        """
+        from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+            CpSatLayoutSolver,
+        )
+        from torch_spyre._inductor.scratchpad.plan_solver import (
+            CoreDivision,
+            CoreDivisionBuffer,
+        )
+
+        whole = [CoreDivision()]
+        # A single computed buffer with the whole-only division; keeps
+        # the joint model well-formed without needing edge structure.
+        buffers = [CoreDivisionBuffer("a", 8, [0, 1], core_divisions=whole)]
+        with patch.object(
+            CpSatLayoutSolver,
+            "_try_certified_greedy_seed",
+            side_effect=AssertionError("certified seed must not run on the joint path"),
+        ):
+            solver = CpSatLayoutSolver(buffers, LARGE_SIZE, alignment=128)
+            solver.plan_layout_and_core_divisions()
+
+    # -- 15. explicit LAYOUT_SOLVER=greedy behavior unchanged --
+    def test_explicit_greedy_solver_unchanged(self):
+        """``LAYOUT_SOLVER=greedy`` calls ``GreedyLayoutSolver`` directly;
+        the fast path only lives in ``CpSatLayoutSolver`` so nothing about
+        this call goes through the seed."""
+        buffers = [_mk("a", 10, [0, 3]), _mk("b", 20, [0, 3]), _mk("c", 30, [0, 3])]
+        greedy = _greedy(buffers, 50, ALIGNMENT)
+        # Deterministic: greedy at capacity 50 spills c (largest last).
+        self.assertEqual(_placed(greedy), {"a", "b"})
+        self.assertEqual(_obj_units(greedy, ALIGNMENT), 60)
+
+
+@unittest.skipUnless(_HAS_ORTOOLS, "seed helper is a CP-SAT feature")
+class TestSharedSpillCostFormula(unittest.TestCase):
+    """Both the CP-SAT wrapper and the certified seed call the same
+    :func:`_hbm_spill_cost`. Verify the wrapper method delegates."""
+
+    def test_wrapper_spill_cost_delegates_to_shared_helper(self):
+        from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+            _LifetimeBufferWithCpVars,
+            _hbm_spill_cost,
+        )
+
+        buf = _mk("b", 8, [0, 1, 2], first_use_is_read=False)
+        model = cp_model.CpModel()
+        wrapper = _LifetimeBufferWithCpVars(
+            buffer=buf, capacity_units=1024, model=model
+        )
+        self.assertEqual(wrapper.spill_cost(), _hbm_spill_cost(buf))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/inductor/test_cpsat_certified_greedy_seed.py
+++ b/tests/inductor/test_cpsat_certified_greedy_seed.py
@@ -219,6 +219,78 @@ class TestCertifiedGreedySeed(unittest.TestCase):
             _obj_units(cpsat_only, ALIGNMENT),
         )
 
+    # -- 5b. zero-cost non-excluded buffer may remain spilled --
+    def test_zero_cost_non_excluded_buffer_may_remain_spilled(self):
+        """The certificate bounds the *objective*, not the placement set.
+        A non-excluded buffer whose ``spill_cost == 0`` can legally be
+        left spilled on a certified plan: it neither raises the sum
+        above the forced-spill floor nor lowers it. Regression test
+        against the incorrect claim "reaching the floor is equivalent
+        to placing every non-excluded buffer" -- a claim that assumes
+        strictly positive spill costs.
+
+        Fixture. ``hot`` has ``spill_cost = 40`` (a nonzero-cost
+        intermediate with two reads) and lives across [0, 5). ``zero``
+        is a single-use graph input (``read_count=1``,
+        ``first_use_is_read=True`` => ``spill_cost = 0``) that arrives
+        at t=1 while ``hot`` still occupies the entire capacity.
+        Greedy places ``hot`` first and cannot fit ``zero``, so
+        ``zero`` remains spilled. ``zero`` is not in
+        ``record_exclusions()`` (its ``residency_reason`` is unset and
+        ``min_footprint == size <= limit``), yet the plan is still
+        certifiable: the residency objective evaluates to 0 -- the
+        forced-spill floor for this input.
+        """
+        from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+            CpSatLayoutSolver,
+        )
+
+        capacity = 10
+        buffers = [
+            _mk("hot", 10, [0, 2, 4]),
+            _mk("zero", 10, [1], first_use_is_read=True),
+        ]
+
+        # Verify the fixture predicts what we're asserting: zero has
+        # spill_cost == 0, hot has spill_cost > 0.
+        from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+            _hbm_spill_cost,
+        )
+
+        self.assertEqual(_hbm_spill_cost(buffers[1]), 0)
+        self.assertGreater(_hbm_spill_cost(buffers[0]), 0)
+
+        # Hybrid certifies and returns hot placed, zero spilled.
+        result = _hybrid(buffers, capacity, ALIGNMENT)
+        placed = _placed(result)
+        self.assertEqual(placed, {"hot"})
+        # Certificate was valid: objective matches standalone CP-SAT.
+        cpsat_only = _cpsat_only(buffers, capacity, ALIGNMENT)
+        self.assertEqual(
+            _obj_units(result, ALIGNMENT),
+            _obj_units(cpsat_only, ALIGNMENT),
+        )
+        # zero was spilled but was NOT in the forced-spill set: it had
+        # no ``residency_reason`` and its ``min_footprint <= limit``.
+        # The seed still committed a plan with zero as address=None, so
+        # ``spill_reasons`` must fall back to the solver-chose-spill
+        # sentinel for zero.
+        solver = CpSatLayoutSolver(
+            copy.deepcopy(buffers),
+            capacity,
+            ALIGNMENT,
+        )
+        solver.plan_layout()
+        self.assertIn("zero", solver.spill_reasons)
+        forced = dict(
+            CpSatLayoutSolver(
+                copy.deepcopy(buffers),
+                capacity,
+                ALIGNMENT,
+            ).record_exclusions()
+        )
+        self.assertNotIn("zero", forced)
+
     # -- 6. graph-input spill-cost semantics --
     def test_graph_input_spill_cost_semantics(self):
         """A multi-use graph input's spill_cost is

--- a/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
+++ b/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
@@ -731,7 +731,13 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
         over exactly the buffers CP-SAT is forced to keep non-resident:
         the set :meth:`record_exclusions` returns, which
         ``_add_core_division`` pins to ``in_buffer = 0``. Reaching that
-        floor is equivalent to placing every non-excluded buffer.
+        floor proves global optimality of the placement-only residency
+        objective: no feasible CP-SAT solution can have a strictly
+        lower objective value than the forced-spill sum. Any
+        additionally spilled non-excluded buffers on such a plan must
+        have ``spill_cost == 0`` (else they would raise the sum above
+        the floor), and zero-cost terms neither help nor hurt the
+        objective.
 
         The certificate compares CP-SAT-domain quantities. Buffer sizes
         are wrapped with ``ceil_div(size, alignment)`` -- exactly what
@@ -845,10 +851,10 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
             b.address = greedy_by_name[b.name].address
         # ``spill_reasons`` matches the CP-SAT tail: pre-solve forced
         # reason when we have one, else the solver-chose-spill sentinel.
-        # Every spilled buffer here is in ``forced_reasons`` by the
-        # certificate (greedy placed every non-excluded buffer, so no
-        # buffer outside ``forced_reasons`` is spilled), but keep the
-        # fallback for symmetry with the CP-SAT tail.
+        # The certificate only bounds the *objective*, not the placement
+        # set: a non-excluded buffer with ``spill_cost == 0`` may
+        # remain spilled without lifting the sum above the floor, so
+        # the sentinel branch is a real code path, not just symmetry.
         self.spill_reasons = {
             b.name: forced_reasons.get(b.name, _SOLVER_CHOSE_SPILL)
             for b in buffers

--- a/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
+++ b/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
@@ -83,6 +83,7 @@ below are written once against whichever wrapper ``_wrap`` chose.
 
 from __future__ import annotations
 
+import copy
 import logging
 import math
 import os
@@ -103,6 +104,7 @@ else:
     except ImportError:  # pragma: no cover - exercised only when ortools is absent
         cp_model = None
 
+from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
 from torch_spyre._inductor.scratchpad.plan_solver import (
     CoreDivisionBuffer,
     ceil_div,
@@ -123,6 +125,29 @@ logger = logging.getLogger(__name__)
 # there was no room once higher-value buffers were placed. Shared so the DEBUG
 # log and the reasons surfaced to the allocator agree.
 _SOLVER_CHOSE_SPILL = "spilled by solver (no residency benefit / no room)"
+
+
+def _hbm_spill_cost(buffer: LifetimeBoundBuffer) -> int:
+    """Differential HBM traffic a spill of ``buffer`` adds over residency.
+
+    See :meth:`_LifetimeBufferWithCpVars.spill_cost` for the derivation. This
+    helper is the single source of truth: both the CP-SAT residency objective
+    (``sum(spill_cost * (1 - in_buffer))``) and the certified-greedy-seed
+    lower-bound / plan-objective evaluators call it against a buffer whose
+    ``size`` field is in whatever unit the caller has already normalised to
+    (bytes for a raw ``LifetimeBoundBuffer``; alignment-units after
+    :func:`_wrap` has replaced ``size`` with ``ceil_div(size, alignment)``).
+    Reads and boundary attributes do not depend on the unit.
+    """
+    boundary = getattr(buffer, "boundary", None)
+    is_intermediate = (
+        boundary == BufferType.Intermediate
+        if boundary is not None
+        else not buffer.first_use_is_read
+    )
+    reads_served = buffer.read_count - (1 if buffer.first_use_is_read else 0)
+    return (reads_served + (1 if is_intermediate else 0)) * buffer.size
+
 
 # Buffer type the wrapper carries: the base placement wrapper holds any
 # LifetimeBoundBuffer; the joint subclass binds this to CoreDivisionBuffer.
@@ -236,16 +261,13 @@ class _LifetimeBufferWithCpVars(Generic[_BufT]):
         not one of the reads residency serves and is discounted from
         ``read_count`` (which counts the buffer's reads, not the savings). For a
         computed buffer the first use is the write and ``read_count`` already
-        excludes it, hence the discount is keyed on ``first_use_is_read``."""
-        b = self.buffer
-        boundary = getattr(b, "boundary", None)
-        is_intermediate = (
-            boundary == BufferType.Intermediate
-            if boundary is not None
-            else not b.first_use_is_read
-        )
-        reads_served = b.read_count - (1 if b.first_use_is_read else 0)
-        return (reads_served + (1 if is_intermediate else 0)) * b.size
+        excludes it, hence the discount is keyed on ``first_use_is_read``.
+
+        The arithmetic is factored out into :func:`_hbm_spill_cost` so the
+        certified-greedy seed inside :meth:`CpSatLayoutSolver.plan_layout`
+        evaluates the exact same formula on the exact same
+        alignment-unit-scaled ``buffer.size`` this wrapper carries."""
+        return _hbm_spill_cost(self.buffer)
 
     def constrain_residency(self, model, kids, bufs) -> None:
         """Placement-only: any buffer may reside, so there is no slicing gate."""
@@ -659,14 +681,190 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
     def plan_layout(self, log_lx_usage: bool = False) -> list[LifetimeBoundBuffer]:
         """Place buffers on their already-fixed core divisions (placement-only).
 
-        Same model as :meth:`plan_layout_and_core_divisions` minus the joint
-        division choice: each buffer's footprint is its ``size``, so there is no
-        slicing gate on residency and no parallelism step -- the solve reduces
-        to minimising HBM traffic under the 2D no-overlap with in-place reuse.
-        Dispatch is per buffer and keys on whether it carries candidate
-        divisions, not on its class, so a :class:`CoreDivisionBuffer` with an
-        empty candidate list is placed here rather than divided."""
+        First runs a cheap **certified greedy seed** on a solver-local copy
+        (:meth:`_try_certified_greedy_seed`): if that plan is feasible under
+        CP-SAT's placement contract and attains the exact forced-spill lower
+        bound of CP-SAT's own residency objective, it is already globally
+        optimal for that objective and the CP-SAT solve is skipped. Otherwise
+        the full CP-SAT solve runs as before via :meth:`_plan_layout_generic`
+        on the untouched caller buffers.
+
+        The joint entry (:meth:`plan_layout_and_core_divisions`) does not
+        use this seed: greedy cannot pick core divisions, and the joint
+        model's objective (residency, then parallelism, then balance, or a
+        caller-supplied ``cost_expr``) is not a scalar residency floor.
+
+        Otherwise the model is unchanged: same as
+        :meth:`plan_layout_and_core_divisions` minus the joint division
+        choice -- each buffer's footprint is its ``size``, so there is no
+        slicing gate on residency and no parallelism step. Dispatch is per
+        buffer and keys on whether it carries candidate divisions, not on
+        its class, so a :class:`CoreDivisionBuffer` with an empty candidate
+        list is placed here rather than divided."""
+        seed = self._try_certified_greedy_seed(log_lx_usage=log_lx_usage)
+        if seed is not None:
+            return seed
         return cast("list[LifetimeBoundBuffer]", list(self._plan_layout_generic()))
+
+    def _try_certified_greedy_seed(
+        self, log_lx_usage: bool = False
+    ) -> Optional[list[LifetimeBoundBuffer]]:
+        """Run greedy on a solver-local copy; commit its placement onto the
+        caller's buffers and return them iff the plan is representable in
+        the CP-SAT placement domain **and** its objective attains CP-SAT's
+        forced-spill lower bound. Return ``None`` otherwise; the caller
+        then runs the normal ``_plan_layout_generic`` path unchanged.
+
+        The certificate. Placement-only ``plan_layout`` runs only level 1
+        of the lex-solve inside :meth:`_run`: minimize
+        ``sum(spill_cost(b) * (1 - in_buffer(b)))`` over CP-SAT's
+        alignment-unit-scaled buffer copies. Levels 2 and 3 are gated on
+        ``core_terms`` being non-empty, which requires at least one
+        buffer to be a :class:`CoreDivisionBuffer` with non-empty
+        ``core_divisions`` -- absent on the placement-only path. The
+        :meth:`_run` ``cost_expr`` branch is not reachable from
+        :meth:`plan_layout` either (only
+        :meth:`plan_layout_and_core_divisions` accepts ``cost_expr``).
+
+        Every ``spill_cost(b) >= 0`` and ``(1 - in_buffer) in {0, 1}``, so
+        the objective is a nonnegative sum. Its lower bound is the sum
+        over exactly the buffers CP-SAT is forced to keep non-resident:
+        the set :meth:`record_exclusions` returns, which
+        ``_add_core_division`` pins to ``in_buffer = 0``. Reaching that
+        floor is equivalent to placing every non-excluded buffer.
+
+        The certificate compares CP-SAT-domain quantities. Buffer sizes
+        are wrapped with ``ceil_div(size, alignment)`` -- exactly what
+        :meth:`_wrap` does before the objective is built -- so
+        :func:`_hbm_spill_cost` (which
+        :meth:`_LifetimeBufferWithCpVars.spill_cost` also calls) evaluates
+        the exact same numerical objective CP-SAT would optimize.
+
+        Representability precondition. CP-SAT works in
+        ``_capacity_units = self.limit // self.alignment`` alignment-unit
+        slots and can only express offsets in ``[0, _capacity_units)``. If
+        ``_capacity_units == 0`` no plan the model can build places any
+        buffer, so greedy is not allowed to seed it; likewise a greedy
+        placement whose top-of-buffer exceeds ``_capacity_units *
+        alignment`` or whose address is not alignment-aligned is a plan
+        the model could not represent. Both cases fall through to
+        :meth:`_plan_layout_generic`.
+
+        Never mutates the caller's buffers unless it commits.
+        """
+        buffers = self.buffers
+        if not buffers:
+            return list(buffers)
+        # Representability: CP-SAT has zero addressable slots when
+        # capacity < alignment, so it cannot express any placement.
+        if self._capacity_units <= 0:
+            logger.debug(
+                "[CP-SAT layout solver] greedy seed skipped: "
+                "_capacity_units=%d has no placement domain",
+                self._capacity_units,
+            )
+            return None
+        # The forced-spill floor, in CP-SAT's alignment units. Match the
+        # exact set CP-SAT pins non-resident (residency_reason plus
+        # ``min_footprint > limit`` -- both covered by record_exclusions).
+        forced_reasons = dict(self.record_exclusions())
+        lower_bound_units = sum(
+            _hbm_spill_cost(replace(b, size=ceil_div(b.size, self.alignment)))
+            for b in buffers
+            if b.name in forced_reasons
+        )
+        try:
+            probe_buffers = copy.deepcopy(buffers)
+            greedy_plan = GreedyLayoutSolver(
+                probe_buffers,
+                self.limit,
+                self.alignment,
+            ).plan_layout(log_lx_usage=log_lx_usage)
+        except Exception as e:
+            # Greedy failed on this input -- surface via the CP-SAT path,
+            # which either handles the input or raises its own error.
+            logger.debug(
+                "[CP-SAT layout solver] greedy seed failed: %s; "
+                "falling through to full CP-SAT solve",
+                e,
+            )
+            return None
+        # Representability check on greedy's plan: each placed buffer
+        # must fit within ``[0, _capacity_units * alignment)`` and its
+        # address must be alignment-aligned. Greedy already aligns
+        # addresses to ``self.alignment`` in ``_find_free_block`` and
+        # already refuses to place a buffer above ``self.limit``, but
+        # ``self.limit`` isn't necessarily a multiple of alignment while
+        # CP-SAT's domain ceiling ``_capacity_units * alignment`` is.
+        cpsat_top = self._capacity_units * self.alignment
+        for b in greedy_plan:
+            if b.address is None:
+                continue
+            if b.address < 0 or b.address % self.alignment != 0:
+                logger.debug(
+                    "[CP-SAT layout solver] greedy seed unrepresentable: "
+                    "buffer %s at address=%d violates alignment=%d",
+                    b.name,
+                    b.address,
+                    self.alignment,
+                )
+                return None
+            if b.address + b.size > cpsat_top:
+                logger.debug(
+                    "[CP-SAT layout solver] greedy seed unrepresentable: "
+                    "buffer %s at address=%d size=%d exceeds CP-SAT top=%d",
+                    b.name,
+                    b.address,
+                    b.size,
+                    cpsat_top,
+                )
+                return None
+        # Evaluate greedy's objective in the same alignment-unit domain
+        # CP-SAT is optimizing.
+        greedy_objective_units = sum(
+            _hbm_spill_cost(replace(b, size=ceil_div(b.size, self.alignment)))
+            for b in greedy_plan
+            if b.address is None
+        )
+        if greedy_objective_units != lower_bound_units:
+            logger.debug(
+                "[CP-SAT layout solver] greedy seed left %d units of "
+                "residency objective on the table (lower bound %d, "
+                "greedy %d); running full CP-SAT solve",
+                greedy_objective_units - lower_bound_units,
+                lower_bound_units,
+                greedy_objective_units,
+            )
+            return None
+        # Certified. Commit greedy's addresses onto the caller's own
+        # ``LifetimeBoundBuffer`` instances, matching what
+        # :meth:`_plan_layout_generic` does at the tail of a normal CP-SAT
+        # solve. Match by name so the seed's own copies stay solver-local.
+        greedy_by_name = {b.name: b for b in greedy_plan}
+        for b in buffers:
+            b.address = greedy_by_name[b.name].address
+        # ``spill_reasons`` matches the CP-SAT tail: pre-solve forced
+        # reason when we have one, else the solver-chose-spill sentinel.
+        # Every spilled buffer here is in ``forced_reasons`` by the
+        # certificate (greedy placed every non-excluded buffer, so no
+        # buffer outside ``forced_reasons`` is spilled), but keep the
+        # fallback for symmetry with the CP-SAT tail.
+        self.spill_reasons = {
+            b.name: forced_reasons.get(b.name, _SOLVER_CHOSE_SPILL)
+            for b in buffers
+            if b.address is None
+        }
+        if logger.isEnabledFor(logging.DEBUG):
+            n_placed = sum(1 for b in buffers if b.address is not None)
+            logger.debug(
+                "[CP-SAT layout solver] greedy seed certified: "
+                "buffers=%d resident=%d hbm_traffic=%d (lower bound in "
+                "alignment units); CP-SAT solve skipped",
+                len(buffers),
+                n_placed,
+                lower_bound_units,
+            )
+        return list(buffers)
 
     def plan_layout_and_core_divisions(
         self, cost_expr: sympy.Expr | None = None


### PR DESCRIPTION
# inductor: certified greedy seed for placement-only CP-SAT

> Placement-only CP-SAT first runs greedy on a solver-local copy. If
> that placement is representable under CP-SAT's placement domain and
> attains the exact forced-spill lower bound of CP-SAT's own residency
> objective, then no feasible CP-SAT solution can have a lower
> objective value, so the greedy placement is accepted. Otherwise
> normal CP-SAT runs unchanged. The certificate bounds the objective,
> not the placement set: a non-excluded buffer whose `spill_cost == 0`
> may legally remain spilled on a certified plan.

Ready for technical review by the scratchpad / CP-SAT owners.
Reviewers should evaluate the certificate implementation, API
assumptions, and whether any additional DXP/on-device validation is
wanted before merge — objective equivalence is formally certified
on accepted plans and preserved by the standalone CP-SAT fallback
on rejected ones, but the final rebased end-to-end pass intercepted
DXP before its subprocess (see caveat below).

Refs #4117, #3978, #3932, #2062.

**Architecture note (Aug. 31):** maintainers indicated joint CP-SAT
co-optimization of scratchpad allocation and work division is
expected to become the default imminently. This PR intentionally
does not apply to that joint path; the certificate is a
forced-spill lower bound on the placement-only residency objective
only, not on the joint objective (which adds parallelism, balance,
and #3810's optional `cost_expr` axes). Merge value therefore
depends on whether placement-only CP-SAT remains a meaningful
supported configuration; that maintainer decision is pending in
the discussion below.

The final implementation was rebased on August 31 onto then-current
upstream `main` (which includes #3810 "Integrate cost model with
ILP solver"). #3810 adds a `cost_expr` parameter reachable only
through `plan_layout_and_core_divisions`; the placement-only entry
`plan_layout` never passes `cost_expr`, so its `_run` branch is
unchanged. The seed is on `plan_layout` only —
`plan_layout_and_core_divisions` is untouched.

## Certificate

Under `co_optimizing_lx_planning=False` (the current default at the
time of writing; the joint-CP-SAT default switch flagged in the
architecture note above is still pending),
`plan_layout` runs only level 1 of the lexicographic solve inside
`_plan_layout_generic._run`: minimize
`sum(spill_cost(b) * (1 - in_buffer(b)))` over CP-SAT's
alignment-unit-scaled buffer copies. Levels 2 (parallelism) and 3
(balance) are gated on `core_terms` being non-empty, which requires a
non-`None` `.cores` on a wrapped buffer;
`_LifetimeBufferWithCpVars.__post_init__` sets `cores = None`, so
those levels never fire on the placement-only path. The `cost_expr`
branch is also unreachable here.

Every `spill_cost(b) ≥ 0` and `(1 - in_buffer) ∈ {0, 1}`, so the
objective is a nonnegative sum. Its absolute lower bound is the sum
over the buffers CP-SAT pins non-resident before it optimizes anything:
`MemoryPlanSolver.record_exclusions()`, which is the union of

- buffers whose allocator-declared `residency_reason` is not `None`,
- buffers whose `min_footprint > limit` (size-only forced exclusion),

matches the exact set `_add_core_division` pins to `in_buffer = 0`.
Reaching the forced-spill lower bound proves global optimality of the
placement-only residency objective. Any additionally spilled
non-excluded buffers must have `spill_cost == 0` and therefore cannot
improve or worsen that objective (test #5b covers this case). The
certificate bounds the objective, not the placement set.

The certificate compares CP-SAT-domain quantities. CP-SAT works over
alignment-unit-scaled sizes (`ceil_div(size, alignment)` in `_wrap`)
and can only express addresses in `[0, _capacity_units × alignment)`
where `_capacity_units = self.limit // self.alignment`. The seed
therefore:

1. **Guards representability.** If `_capacity_units ≤ 0` the model
   has no addressable slot; the seed cannot be evaluated in that
   domain and returns `None` immediately (fallback to CP-SAT).
2. **Runs greedy on a solver-local deep copy** at `self.limit`, so the
   caller's buffers are never mutated by the probe.
3. **Rejects any unrepresentable greedy plan.** Each placed buffer
   must have `address % alignment == 0` and
   `address + size ≤ _capacity_units × alignment`, so
   `self.limit` not being a multiple of alignment does not fool the
   certificate into accepting a plan CP-SAT could not encode.
4. **Evaluates greedy's objective in the same alignment-unit domain**
   the CP-SAT objective is built in, via a single module-level helper
   `_hbm_spill_cost(buffer)` that `_LifetimeBufferWithCpVars.spill_cost`
   also delegates to (one source of truth — no hand-duplicated
   formula).
5. **Accepts iff** `greedy_objective_units == lower_bound_units`;
   otherwise falls through to `_plan_layout_generic` on the untouched
   originals.

On acceptance, greedy's addresses are committed onto the caller's
buffers by name, and `spill_reasons` is populated with each excluded
buffer's reason from `record_exclusions()` — matching what the
`_plan_layout_generic` tail would have produced.

## Evidence

**Differential corpus** — 28 non-SKIP scenarios captured from
`BaseLayoutSolverTests`, with the harness's lower-bound function using
the exact `record_exclusions()` semantics:

| hybrid choice        | count |
|----------------------|------:|
| greedy-certified     |    20 |
| cpsat-fallback       |     8 |
| SKIP (no solve call) |     7 |
| **INVARIANT_VIOLATION** | **0** |

Invariants that hold on every valid case:

- `hybrid_objective == standalone_cpsat_objective` (via
  `_plan_layout_generic` directly to bypass the seed)
- `hybrid_chosen == "greedy-certified" ⇒ hybrid_objective == lb ==
  greedy_objective`

**Capacity-pressure sweep on captured planner-buffer sets** (flash
512x{1024,2048,4096,8192}, MLP L∈{96,192,384}, sdpa
S∈{512,1024,2048}, each at 100/75/50/25% of the shipped LX
capacity — 40 workload-scale points):

| hybrid choice   | count |
|-----------------|------:|
| greedy-certified |    39 |
| cpsat-fallback   |     1 |

Invariant `hybrid_objective == standalone_cpsat_objective` holds on
every 40 points (0 mismatches).

The single fallback is flash-512x8192 at 25% capacity — the exact
capacity-pressure case where CP-SAT genuinely picks a better placement
(greedy_obj = 74,039,296; cpsat_obj = 73,711,616). The seed correctly
rejects and the hybrid returns CP-SAT's optimum.

Compared with the previous sweep summary in `certified-greedy-seed.md`
(which was written against a harness lower-bound function that only
counted `residency_reason`-forced buffers), 9 sdpa/edge-case points
that used to appear as fallback now correctly certify: they attain
the true `record_exclusions`-based floor.

Selected wall times:

| workload         | scale | g_obj    | c_obj    | chosen           | g_ms  | c_ms      | h_ms   |
|------------------|------:|---------:|---------:|------------------|------:|----------:|-------:|
| flash-512x1024   |  1.00 |  3.75M   |  3.75M   | greedy-certified |   4.9 |     333.1 |    9.1 |
| flash-512x2048   |  1.00 |  9.03M   |  9.03M   | greedy-certified |  19.6 |    1627.0 |   23.3 |
| flash-512x4096   |  1.00 | 24.30M   | 24.30M   | greedy-certified |  57.0 |    8938.5 |   73.6 |
| flash-512x8192   |  1.00 | 73.71M   | 73.71M   | greedy-certified | 229.1 |   50456.4 |  265.7 |
| **flash-512x8192**  | **0.25** | **74.04M** | **73.71M** | **cpsat-fallback** | **236.9** | **65316.5** | **45476.2** |
| mlp-L96          |  1.00 |   128    |   128    | greedy-certified |   9.5 |     196.4 |   19.9 |
| mlp-L192         |  1.00 |   128    |   128    | greedy-certified |  38.0 |     621.6 |   53.1 |
| mlp-L384         |  1.00 |   128    |   128    | greedy-certified | 151.7 |    1488.4 |  182.7 |
| sdpa-S512        |  1.00 |  459K    |  459K    | greedy-certified |   0.2 |      23.6 |    0.8 |
| sdpa-S1024       |  1.00 |  1.44M   |  1.44M   | greedy-certified |   0.2 |      23.5 |    0.8 |
| sdpa-S2048       |  1.00 | 22.02M   | 22.02M   | greedy-certified |   0.2 |      17.1 |    1.0 |

**Wall-time framing on the fallback row.** On a fallback, the hybrid
necessarily pays the greedy probe overhead before running CP-SAT.
In the measured 2056-buffer flash-512x8192 case the greedy probe
itself was about 237 ms. End-to-end CP-SAT solve wall varied
substantially between runs (a separate rebased-branch run on the
same captured buffers reported 45.3 s standalone vs 64.9 s hybrid;
this table reports 65.3 s vs 45.5 s from a different run), so the
fallback measurements are NOT used to claim a wall-time improvement
or regression. The deterministic conclusions are objective identity
and the per-run greedy-probe overhead.

**Unit tests** — `tests/inductor/test_cpsat_certified_greedy_seed.py`,
18 tests:

1. lower-bound greedy plan skips CP-SAT solve
2. non-zero greedy objective falls through to CP-SAT
3. `residency_reason` contributes to lower bound
4. `min_footprint > limit` contributes to lower bound (size-only
   forced exclusion)
5. zero-spill-cost buffer semantics
5b. zero-cost non-excluded buffer may remain spilled on a certified
    plan (proves the certificate bounds the objective, not the
    placement set — a `spill_cost == 0` term neither raises nor
    lowers the residency sum)
6. graph-input spill-cost semantics
7. intermediate spill-cost semantics
8. non-aligned buffer sizes match CP-SAT objective in unit domain
9. `limit < alignment` never certifies (`_capacity_units == 0`
   representability guard)
10. `limit` not divisible by `alignment` uses CP-SAT top for
    representability
11. in-place reuse still certifies
12. rejected seed leaves originals untouched before CP-SAT
13. accepted seed commits addresses only (no other field mutated)
14. `spill_reasons` use forced reason for excluded buffer
15. joint `plan_layout_and_core_divisions` never uses the seed
    (behavioral: patch `_try_certified_greedy_seed` to raise;
    joint path succeeds without hitting the raise)
16. explicit greedy solver arm (`LAYOUT_SOLVER=greedy`) unchanged
17. `_LifetimeBufferWithCpVars.spill_cost` delegates to shared
    `_hbm_spill_cost` helper

Also verified: the 250 existing scratchpad-solver tests all pass with
the seed enabled.

## What's in this PR

`torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py`:
- Module-level `_hbm_spill_cost(buffer)` helper: the one source of
  truth for the placement-only spill-cost formula.
- `_LifetimeBufferWithCpVars.spill_cost` delegates to
  `_hbm_spill_cost` (no duplicated formula).
- `CpSatLayoutSolver._try_certified_greedy_seed()` implements the
  certificate: representability guard, solver-local greedy probe,
  address/top-of-buffer representability check per placed buffer,
  unit-domain objective evaluation, exact
  `record_exclusions()`-based lower bound, address commit on
  acceptance, `None` return on rejection.
- `CpSatLayoutSolver.plan_layout()` calls
  `_try_certified_greedy_seed()` first and falls through to
  `_plan_layout_generic()` on `None`.
- `plan_layout_and_core_divisions()` is untouched (the `cost_expr`
  branch added by #3810 is not on the placement-only path).

`tests/inductor/test_cpsat_certified_greedy_seed.py`: 18 tests
described above (the labelled `5b` addition brings the visually 1–17
list to 18 actual test cases).

## What is NOT in this PR

- No config knob. No `adaptive_solver_threshold_ops`, no workload
  classifier. The certificate is derived from CP-SAT's own objective.
- No default change to `layout_solver`.
- No change to the joint (`co_optimizing_lx_planning=True`) path.
- No change to `demote_incoherent_lx_buffers` (#3378) or the
  correctness path from #2062.
- No mutation of caller buffers when the seed rejects; on
  acceptance, only `address` (and `spill_reasons`) are written.

## Post-#3810 end-to-end validation on the rebased branch

`harness/seed_endtoend_probe.py` instruments the shipped
`plan_layout` on the rebased branch and records every real
invocation as `torch.compile` drives the front end. The DXP
subprocess is intercepted before its call so wall time stays
bounded; the seed decision fires inside the scratchpad allocator,
which runs before DXP.

| workload   | sample | chosen           | n_buf | placed | lb_u | hybrid_obj | std_obj | seed_ms | std_cpsat_ms |
|------------|-------:|------------------|------:|-------:|-----:|-----------:|--------:|--------:|-------------:|
| flash-512x4096 | 0/1/2 | greedy-certified | 13 | 6 | 16 | 16 | 16 | 0.4–0.5 | 10–15 |
| flash-512x8192 | 0/1/2 | greedy-certified | 13 | 6 | 16 | 16 | 16 | 0.4–0.5 | 10–16 |
| mlp (N_in=1024, N_hidden=4096, 4L) | 0 | greedy-certified | 21 | 8 | 2 | 2 | 2 | 0.73 | 17.3 |
| sdpa (S=512, D=128, H=8, B=1) | 0 | greedy-certified | 31 | 18 | 1152 | 1152 | 1152 | 1.42 | 35.1 |

8 real seed invocations, all certified, 0 objective mismatches vs
standalone CP-SAT.

Fallback validation on the captured 2056-buffer flash-512x8192
planner set at 25% of shipped LX capacity, driven through the
rebased solver:

- greedy alone: 578432 units (2560 units above the floor)
- forced-spill floor: 575872 units
- seed returned `None` (certificate rejects — greedy > floor)
- standalone CP-SAT: 575872 units
- hybrid public path: 575872 units
- **objectives match**

Data: `data/e2e_validation/*.json`.

## Caveats

- **The certificate proves objective optimality, not placement
  identity.** On an accepted plan the returned buffer list is
  objective-equivalent to what CP-SAT would produce; the placement
  set may differ, and a non-excluded buffer whose `spill_cost == 0`
  can legally remain spilled (test 5b guards this). `spill_reasons`
  falls back to `_SOLVER_CHOSE_SPILL` in that branch.
- **Zero-cost non-excluded buffers may remain spilled.** Single-use
  graph inputs (`read_count == 1`, `first_use_is_read == True`) have
  `reads_served == 0` and `is_intermediate == 0`, so `spill_cost ==
  0`; the residency objective is invariant to their placement, so
  the certificate is valid even when they are unplaced.
- **Greedy probe adds overhead on CP-SAT fallback cases.** ~0.2 ms
  on tiny graphs, ~237 ms on the 2056-buffer flash-512x8192
  capacity-pressure case. On fallback the hybrid necessarily pays
  this on top of the CP-SAT solve; the CP-SAT solve wall itself
  varies substantially between runs, so the measurements here are
  not used to claim a fallback wall-time improvement or regression.
- **The current-main post-#3810 front-end validation intercepted
  DXP before its subprocess.** The e2e harness records the seed
  decision, buffer counts, objectives, and the standalone-CP-SAT
  cross-check on the rebased branch, but the DXP compile itself was
  short-circuited to keep wall time bounded (the seed fires inside
  the scratchpad allocator, which runs before DXP). Earlier study
  data on the parent #4117 branch contains actual DXP / on-device
  bitwise-equality evidence; this final rebased validation did not
  repeat device execution.
- **Joint `plan_layout_and_core_divisions(cost_expr=...)` is
  untouched.** #3810's `cost_expr` branch is reachable only through
  that joint entry and never through `plan_layout`; the seed is on
  `plan_layout` only. Test 15 exercises this behaviorally by
  patching the seed to raise and confirming the joint path
  completes without hitting the raise.
- Bundle-generation nondeterminism from the #4117 study stands as a
  separate follow-up; the regression gates for this PR are the
  structural placement-objective identity, not `bundle.mlir` bytes.

## Study links

- Certified greedy seed writeup:
  `toddllm/compiler-timing/analyses/2026-08-pr4117-pre-dxp/notes/certified-greedy-seed.md`
- Differential corpus (with hybrid arm):
  `.../data/hybrid_certified_corpus_v2/summary.json`
- Capacity pressure sweep:
  `.../data/capacity_pressure_sweep_v2/summary.json`
- End-to-end validation on the rebased branch:
  `.../data/e2e_validation/*.json`
- Hardening report:
  `.../notes/pr4139-hardening-report.md`
- Captured planner-buffer sets:
  `.../data/captured_buffers/*.pkl`

Signed-off-by: Todd Deshane <todd.deshane@ibm.com>
