### PR TITLE
Fix copy_forced silent drop and mutation-target consumer routing (#4126)

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1742,7 +1742,7 @@ def test_copy_into_preallocated_512x256_A4():
             c = torch.ones(a.shape, device=a.device, dtype=a.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(expected_named_dims=["A", "B"]):
-                copy_forced(a + c, c)
+                c = copy_forced(a + c, c)
         return c
 
     run_coarse_tile_test(fn, inputs, loopspec=None)
@@ -1760,7 +1760,7 @@ def test_copy_into_preallocated_512x256_B4():
             c = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
         with spyre_hint(num_tiles_per_dim={"B": 4}):
             with spyre_hint(expected_named_dims=["A", "B"]):
-                copy_forced(a + b, c)
+                c = copy_forced(a + b, c)
         return c
 
     run_coarse_tile_test(fn, inputs)
@@ -1779,7 +1779,7 @@ def test_copy_into_preallocated_512x256_A4_B4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
-                    copy_forced(a + b, c)
+                    c = copy_forced(a + b, c)
         return c
 
     run_coarse_tile_test(fn, inputs)
@@ -1798,7 +1798,7 @@ def test_copy_inplace_accum_512x256_A4():
     def fn(acc, x):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(expected_named_dims=["A", "B"]):
-                copy_forced(acc + x, acc)
+                acc = copy_forced(acc + x, acc)
         return acc
 
     run_coarse_tile_test(fn, inputs)
@@ -1814,7 +1814,7 @@ def test_copy_inplace_accum_512x256_B4():
     def fn(acc, x):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
             with spyre_hint(expected_named_dims=["A", "B"]):
-                copy_forced(acc + x, acc)
+                acc = copy_forced(acc + x, acc)
         return acc
 
     run_coarse_tile_test(fn, inputs)
@@ -1831,7 +1831,7 @@ def test_copy_inplace_accum_512x256_A4_B4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
-                    copy_forced(acc + x, acc)
+                    acc = copy_forced(acc + x, acc)
         return acc
 
     run_coarse_tile_test(fn, inputs)
@@ -1852,7 +1852,7 @@ def test_copy_rmw_correction_512x256_A4():
     def fn(acc, scale, y):
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(expected_named_dims=["A", "B"]):
-                copy_forced(acc * scale + y, acc)
+                acc = copy_forced(acc * scale + y, acc)
         return acc
 
     run_coarse_tile_test(fn, inputs)
@@ -1869,7 +1869,7 @@ def test_copy_rmw_correction_512x256_B4():
     def fn(acc, scale, y):
         with spyre_hint(num_tiles_per_dim={"B": 4}):
             with spyre_hint(expected_named_dims=["A", "B"]):
-                copy_forced(acc * scale + y, acc)
+                acc = copy_forced(acc * scale + y, acc)
         return acc
 
     run_coarse_tile_test(fn, inputs)
@@ -1887,7 +1887,7 @@ def test_copy_rmw_correction_512x256_A4_B4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
-                    copy_forced(acc * scale + y, acc)
+                    acc = copy_forced(acc * scale + y, acc)
         return acc
 
     run_coarse_tile_test(fn, inputs)
@@ -1903,7 +1903,7 @@ def test_copy_forced_untiled():
 
     def fn(x):
         out = torch.zeros(256, device=x.device, dtype=x.dtype)
-        copy_forced(x.amin(dim=0), out)
+        out = copy_forced(x.amin(dim=0), out)
         return out
 
     run_coarse_tile_test(fn, inputs, loopspec=None)
@@ -1924,7 +1924,7 @@ def test_copy_not_deleted():
         out = torch.zeros(256, device=x.device, dtype=x.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
-                copy_forced(x.amin(dim=0), out)
+                out = copy_forced(x.amin(dim=0), out)
         return out
 
     with pytest.raises(InductorError, match="validate_named_dims"):
@@ -1940,7 +1940,7 @@ def test_copy_after_reduction_512x256_A4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
                 temp = x.amin(dim=0)
-            copy_forced(temp, out)
+            out = copy_forced(temp, out)
         return out
 
     _run_coarse_tile_test_raises(
@@ -1961,7 +1961,7 @@ def test_copy_after_reduction_512x256_B4():
             with spyre_hint(expected_named_dims=["B"], expected_reduction_dims=["A"]):
                 temp = x.amin(dim=0)
             with spyre_hint(expected_named_dims=["B"]):
-                copy_forced(temp, out)
+                out = copy_forced(temp, out)
         return out
 
     run_coarse_tile_test(fn, inputs)
@@ -1979,7 +1979,7 @@ def test_copy_after_reduction_512x256_A4_B4():
                     expected_named_dims=["B"], expected_reduction_dims=["A"]
                 ):
                     temp = x.amin(dim=0)
-                copy_forced(temp, out)
+                out = copy_forced(temp, out)
         return out
 
     _run_coarse_tile_test_raises(
@@ -2013,7 +2013,7 @@ def test_copy_running_max_4d_H4_Lq4():
                     block_max = torch.amax(scores, dim=-2)
                 with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                     running_max = torch.maximum(real_max, block_max)
-                copy_forced(running_max, real_max)
+                real_max = copy_forced(running_max, real_max)
         return real_max
 
     run_coarse_tile_test(fn, inputs)
@@ -2035,7 +2035,7 @@ def test_copy_restickify_512x256_A4():
             c = torch.zeros(b.shape, device=b.device, dtype=b.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(expected_named_dims=["A", "B"]):
-                copy_forced(a.t() + b, c)
+                c = copy_forced(a.t() + b, c)
         return c
 
     run_coarse_tile_test(fn, inputs)
@@ -2053,7 +2053,7 @@ def test_copy_restickify_512x256_B4():
             c = torch.zeros(b.shape, device=b.device, dtype=b.dtype)
         with spyre_hint(num_tiles_per_dim={"B": 4}):
             with spyre_hint(expected_named_dims=["A", "B"]):
-                copy_forced(a.t() + b, c)
+                c = copy_forced(a.t() + b, c)
         return c
 
     run_coarse_tile_test(fn, inputs)
@@ -2072,7 +2072,7 @@ def test_copy_restickify_512x256_A4_B4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
-                    copy_forced(a.t() + b, c)
+                    c = copy_forced(a.t() + b, c)
         return c
 
     run_coarse_tile_test(fn, inputs)
@@ -2095,7 +2095,7 @@ def test_copy_accum_with_reduction_512x256_A4():
             with spyre_hint(expected_named_dims=["A"], expected_reduction_dims=["B"]):
                 r = x.amin(dim=1, keepdim=True)
             with spyre_hint(expected_named_dims=["A", "B"]):
-                copy_forced(acc * scale + r, acc)
+                acc = copy_forced(acc * scale + r, acc)
         return acc
 
     run_coarse_tile_test(fn, inputs)
@@ -2125,7 +2125,7 @@ def test_copy_accum_with_reduction_512x256_B4():
             with spyre_hint(expected_named_dims=["A"], expected_reduction_dims=["B"]):
                 r = x.amin(dim=1, keepdim=True)
             with spyre_hint(expected_named_dims=["A", "B"]):
-                copy_forced(acc * scale + r, acc)
+                acc = copy_forced(acc * scale + r, acc)
         return acc
 
     _run_coarse_tile_test_raises(
@@ -2159,7 +2159,7 @@ def test_copy_accum_with_reduction_512x256_A4_B4():
                 ):
                     r = x.amin(dim=1, keepdim=True)
                 with spyre_hint(expected_named_dims=["A", "B"]):
-                    copy_forced(acc * scale + r, acc)
+                    acc = copy_forced(acc * scale + r, acc)
         return acc
 
     run_coarse_tile_test(fn, inputs)
@@ -2181,9 +2181,9 @@ def test_copy_two_copies_same_scope_512x256_A4():
             c2 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(expected_named_dims=["A", "B"]):
-                copy_forced(a + b, c1)
+                c1 = copy_forced(a + b, c1)
             with spyre_hint(expected_named_dims=["A", "B"]):
-                copy_forced(a * b, c2)
+                c2 = copy_forced(a * b, c2)
         return c1, c2
 
     run_coarse_tile_test(fn, inputs)
@@ -2202,9 +2202,9 @@ def test_copy_two_copies_same_scope_512x256_B4():
             c2 = torch.zeros(a.shape, device=a.device, dtype=a.dtype)
         with spyre_hint(num_tiles_per_dim={"B": 4}):
             with spyre_hint(expected_named_dims=["A", "B"]):
-                copy_forced(a + b, c1)
+                c1 = copy_forced(a + b, c1)
             with spyre_hint(expected_named_dims=["A", "B"]):
-                copy_forced(a * b, c2)
+                c2 = copy_forced(a * b, c2)
         return c1, c2
 
     run_coarse_tile_test(fn, inputs)
@@ -2224,9 +2224,9 @@ def test_copy_two_copies_same_scope_512x256_A4_B4():
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
                 with spyre_hint(expected_named_dims=["A", "B"]):
-                    copy_forced(a + b, c1)
+                    c1 = copy_forced(a + b, c1)
                 with spyre_hint(expected_named_dims=["A", "B"]):
-                    copy_forced(a * b, c2)
+                    c2 = copy_forced(a * b, c2)
         return c1, c2
 
     run_coarse_tile_test(fn, inputs)
@@ -2309,7 +2309,7 @@ def test_outside_consumer_copy_then_read_512x256_A4():
         with spyre_hint(named_dims=["A", "B"]):
             out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            copy_forced(x + y, out)
+            out = copy_forced(x + y, out)
         return out / (torch.abs(norm) + 1.0)
 
     run_coarse_tile_test(fn, inputs)
@@ -2327,7 +2327,7 @@ def test_outside_consumer_copy_then_read_512x256_B4():
         with spyre_hint(named_dims=["A", "B"]):
             out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            copy_forced(x + y, out)
+            out = copy_forced(x + y, out)
         return out / (torch.abs(norm) + 1.0)
 
     run_coarse_tile_test(fn, inputs)
@@ -2346,7 +2346,7 @@ def test_outside_consumer_copy_then_read_512x256_A4_B4():
             out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                copy_forced(x + y, out)
+                out = copy_forced(x + y, out)
         return out / (torch.abs(norm) + 1.0)
 
     run_coarse_tile_test(fn, inputs)
@@ -2371,8 +2371,8 @@ def test_outside_consumer_two_accum_512x256_A4():
         with spyre_hint(named_dims=["A"]):
             denom = torch.zeros(x.shape[0], device=x.device, dtype=x.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
-            copy_forced(out * scale + x, out)
-            copy_forced(denom + x.amin(dim=0), denom)
+            out = copy_forced(out * scale + x, out)
+            denom = copy_forced(denom + x.amin(dim=0), denom)
         return out / denom.unsqueeze(1)
 
     _run_coarse_tile_test_raises(
@@ -2393,8 +2393,8 @@ def test_outside_consumer_two_accum_512x256_B4():
         out = torch.zeros(x.shape, device=x.device, dtype=x.dtype)
         denom = torch.zeros(x.shape[0], device=x.device, dtype=x.dtype)
         with spyre_hint(num_tiles_per_dim={"B": 4}):
-            copy_forced(out * scale + x, out)
-            copy_forced(denom + x.amin(dim=1), denom)
+            out = copy_forced(out * scale + x, out)
+            denom = copy_forced(denom + x.amin(dim=1), denom)
         return out / denom.unsqueeze(1)
 
     _run_coarse_tile_test_raises(
@@ -2419,8 +2419,8 @@ def test_outside_consumer_two_accum_512x256_A4_B4():
         denom = torch.zeros(x.shape[0], device=x.device, dtype=x.dtype)
         with spyre_hint(num_tiles_per_dim={"A": 4}):
             with spyre_hint(num_tiles_per_dim={"B": 4}):
-                copy_forced(out * scale + x, out)
-                copy_forced(denom + x.sum(dim=1), denom)
+                out = copy_forced(out * scale + x, out)
+                denom = copy_forced(denom + x.sum(dim=1), denom)
         return out / denom.unsqueeze(1)
 
     run_coarse_tile_test(fn, inputs)
@@ -2910,8 +2910,9 @@ def test_flash_tile_Lk():
 
 
 @pytest.mark.skip(
-    reason="running-max/copy_forced accumulator bug produces inf (see"
-    " test_flash_v2_tile_H); B tiling itself compiles and runs correctly"
+    reason="copy_forced/mutation_write_back drop is fixed (issue #4126) -- no"
+    " more inf, but a distinct B+H tiling correctness bug remains (70%"
+    " mismatch, finite values); B tiling itself compiles and runs correctly"
 )
 def test_flash_tile_B_H():
     """Flash v1: tile B÷2 H÷4. B=2."""
@@ -3087,7 +3088,7 @@ def _flash_v2_fn(
                         denom_corrected = denominator * correction
                     with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                         new_denom = denom_corrected + sum_scores
-                    copy_forced(new_denom, denominator)
+                    denominator = copy_forced(new_denom, denominator)
                     with spyre_hint(named_dims=["B", "H", "Lq", "D"]):
                         matmul_out = torch.matmul(exp_scores, values)
                     # correction.unsqueeze(-1) is [B,H,Lq,1] — size-1 dim can't carry "D"
@@ -3095,8 +3096,8 @@ def _flash_v2_fn(
                     output_corrected = output * corr_expanded
                     with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
                         new_output = output_corrected + matmul_out
-                    copy_forced(new_output, output)
-                    copy_forced(running_max, real_max)
+                    output = copy_forced(new_output, output)
+                    real_max = copy_forced(running_max, real_max)
     return output / denominator.unsqueeze(-1)
 
 
@@ -3117,8 +3118,9 @@ def test_flash_v2_tile_H():
 
 
 @pytest.mark.skip(
-    reason="running-max/copy_forced accumulator bug produces inf (see"
-    " test_flash_v2_tile_H); B tiling itself compiles and runs correctly"
+    reason="B-tiling still produces inf after the copy_forced/"
+    "mutation_write_back drop fix (issue #4126) -- distinct, still-open"
+    " B-tiling bug, not the copy_forced accumulator drop"
 )
 def test_flash_v2_tile_B():
     """Flash v2: tile B÷2 only. B=2."""
@@ -3161,8 +3163,9 @@ def test_flash_v2_tile_Lk():
 
 
 @pytest.mark.skip(
-    reason="running-max/copy_forced accumulator bug produces inf (see"
-    " test_flash_v2_tile_H); B tiling itself compiles and runs correctly"
+    reason="B-tiling still produces inf after the copy_forced/"
+    "mutation_write_back drop fix (issue #4126) -- distinct, still-open"
+    " B-tiling bug, not the copy_forced accumulator drop"
 )
 def test_flash_v2_tile_B_H():
     """Flash v2: tile B÷2 H÷4. B=2."""
@@ -3320,17 +3323,17 @@ def _flash_v3_fn(
                     with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                         correction = torch.exp(real_max_diff)
 
-                    copy_forced(
+                    denominator = copy_forced(
                         denominator * correction + exp_scores.sum(dim=-2),
                         denominator,
                     )  # B, H, Lq sparse
-                    copy_forced(
+                    output = copy_forced(
                         output * correction.unsqueeze(-1)
                         + torch.matmul(exp_scores.transpose(-1, -2), values),
                         output,
                     )  # B, H, Lq, D
 
-                    copy_forced(running_max, real_max)  # B, H, Lq sparse
+                    real_max = copy_forced(running_max, real_max)  # B, H, Lq sparse
 
     return output / denominator.unsqueeze(-1)
 
@@ -3352,8 +3355,9 @@ def test_flash_v3_tile_H():
 
 
 @pytest.mark.skip(
-    reason="running-max/copy_forced accumulator bug produces inf (see"
-    " test_flash_v2_tile_H); B tiling itself compiles and runs correctly"
+    reason="B-tiling still produces inf after the copy_forced/"
+    "mutation_write_back drop fix (issue #4126) -- distinct, still-open"
+    " B-tiling bug, not the copy_forced accumulator drop"
 )
 def test_flash_v3_tile_B():
     """Flash v3: tile B÷2 only. B=2."""
@@ -3401,8 +3405,9 @@ def test_flash_v3_tile_Lk():
 
 
 @pytest.mark.skip(
-    reason="running-max/copy_forced accumulator bug produces inf (see"
-    " test_flash_v2_tile_H); B tiling itself compiles and runs correctly"
+    reason="B-tiling still produces inf after the copy_forced/"
+    "mutation_write_back drop fix (issue #4126) -- distinct, still-open"
+    " B-tiling bug, not the copy_forced accumulator drop"
 )
 def test_flash_v3_tile_B_H():
     """Flash v3: tile B÷2 H÷4. B=2."""
@@ -3550,7 +3555,7 @@ def _flash_v4_fn(q, k, v, *, B, S, H, D, b_tiles=1, h_tiles=1, lq_tiles=1, lk_ti
                         denom_corrected = denominator * correction
                     with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                         new_denom = denom_corrected + sum_scores
-                    copy_forced(new_denom, denominator)
+                    denominator = copy_forced(new_denom, denominator)
                     with spyre_hint(expected_named_dims=["B", "H", "Lq", "Lk"]):
                         exp_scores_T = exp_scores.transpose(-1, -2).contiguous()
                     with spyre_hint(named_dims=["B", "H", "Lq", "D"]):
@@ -3559,9 +3564,9 @@ def _flash_v4_fn(q, k, v, *, B, S, H, D, b_tiles=1, h_tiles=1, lq_tiles=1, lk_ti
                     output_corrected = output * correction.unsqueeze(-1)
                     with spyre_hint(expected_named_dims=["B", "H", "Lq", "D"]):
                         new_output = output_corrected + matmul_out
-                    copy_forced(new_output, output)
-                    copy_forced(running_max, real_max)
-    copy_forced(output / denominator.unsqueeze(-1), output)
+                    output = copy_forced(new_output, output)
+                    real_max = copy_forced(running_max, real_max)
+    output = copy_forced(output / denominator.unsqueeze(-1), output)
     return output.transpose(1, 2).reshape(B, S, H * D)
 
 
@@ -4460,17 +4465,17 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                             real_max - running_max
                         )  # B, H, Lq sparse
 
-                        copy_forced(
+                        denominator = copy_forced(
                             denominator * correction + exp_scores.sum(dim=-1),
                             denominator,
                         )  # B, H, Lq sparse
-                        copy_forced(
+                        output = copy_forced(
                             output * correction.unsqueeze(-1)
                             + torch.matmul(exp_scores, values),
                             output,
                         )  # B, H, Lq, D
 
-                        copy_forced(running_max, real_max)  # B, H, Lq sparse
+                        real_max = copy_forced(running_max, real_max)  # B, H, Lq sparse
 
             return output / denominator.unsqueeze(-1)
 
@@ -4562,15 +4567,15 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                     exp_scores = torch.exp(scores - running_max.unsqueeze(-1))
                     correction = torch.exp(real_max - running_max)
 
-                    copy_forced(
+                    denominator = copy_forced(
                         denominator * correction + exp_scores.sum(dim=-1), denominator
                     )
-                    copy_forced(
+                    output = copy_forced(
                         output * correction.unsqueeze(-1)
                         + torch.matmul(exp_scores, values),
                         output,
                     )
-                    copy_forced(running_max, real_max)
+                    real_max = copy_forced(running_max, real_max)
 
                     # The one difference from test_hint_flash_attention_v2.
                     result = output / denominator.unsqueeze(-1)
@@ -4674,17 +4679,19 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                                 real_max - running_max
                             )  # B, H, Lq sparse
 
-                            copy_forced(
+                            denominator = copy_forced(
                                 denominator * correction + exp_scores.sum(dim=-2),
                                 denominator,
                             )  # B, H, Lq sparse
-                            copy_forced(
+                            output = copy_forced(
                                 output * correction.unsqueeze(-1)
                                 + torch.matmul(exp_scores.transpose(-1, -2), values),
                                 output,
                             )  # B, H, Lq, D
 
-                            copy_forced(running_max, real_max)  # B, H, Lq sparse
+                            real_max = copy_forced(
+                                running_max, real_max
+                            )  # B, H, Lq sparse
             return output / denominator.unsqueeze(-1)
 
         queries_t_spyre = queries_t.to(device="spyre")
@@ -4779,17 +4786,19 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                                 real_max - running_max
                             )  # B, H, Lq sparse
 
-                            copy_forced(
+                            denominator = copy_forced(
                                 denominator * correction + exp_scores.sum(dim=-2),
                                 denominator,
                             )  # B, H, Lq sparse
-                            copy_forced(
+                            output = copy_forced(
                                 output * correction.unsqueeze(-1)
                                 + torch.matmul(exp_scores.transpose(-1, -2), values),
                                 output,
                             )  # B, H, Lq, D
 
-                            copy_forced(running_max, real_max)  # B, H, Lq sparse
+                            real_max = copy_forced(
+                                running_max, real_max
+                            )  # B, H, Lq sparse
             return output / denominator.unsqueeze(-1)
 
         queries_t_spyre = queries_t.to(device="spyre")
@@ -4857,7 +4866,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                         block_max = torch.amax(scores, dim=-2)  # [B, H, Lq]
                     with spyre_hint(expected_named_dims=["B", "H", "Lq"]):
                         running_max = torch.maximum(real_max, block_max)
-                    copy_forced(running_max, real_max)
+                    real_max = copy_forced(running_max, real_max)
             return real_max
 
         ref = fn(scores)
@@ -4934,18 +4943,18 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                             running_max = torch.maximum(real_max, block_max)
                             exp_scores = torch.exp(scores - running_max.unsqueeze(-2))
                             correction = torch.exp(real_max - running_max)
-                            copy_forced(
+                            denominator = copy_forced(
                                 denominator * correction + exp_scores.sum(dim=-2),
                                 denominator,
                             )
-                            copy_forced(
+                            output = copy_forced(
                                 output * correction.unsqueeze(-1)
                                 + torch.matmul(exp_scores.transpose(-1, -2), v),
                                 output,
                             )
-                            copy_forced(running_max, real_max)
+                            real_max = copy_forced(running_max, real_max)
 
-            copy_forced(output / denominator.unsqueeze(-1), output)
+            output = copy_forced(output / denominator.unsqueeze(-1), output)
             return output.transpose(1, 2).reshape(B, S, H * D)
 
         ref = block(queries_t, keys_t, values_t)
@@ -5321,17 +5330,17 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                             real_max - running_max
                         )  # B, H, Lq sparse
 
-                        copy_forced(
+                        denominator = copy_forced(
                             denominator * correction + exp_scores.sum(dim=-1),
                             denominator,
                         )  # B, H, Lq sparse
-                        copy_forced(
+                        output = copy_forced(
                             output * correction.unsqueeze(-1)
                             + torch.matmul(exp_scores, values),
                             output,
                         )  # B, H, Lq, D
 
-                        copy_forced(running_max, real_max)  # B, H, Lq sparse
+                        real_max = copy_forced(running_max, real_max)  # B, H, Lq sparse
             return output / denominator.unsqueeze(-1)
 
         cfn = torch.compile(flash)
@@ -5864,7 +5873,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             c = torch.full((Lq, D), 0, device=a.device, dtype=torch.float16)
             with spyre_hint(num_tiles_per_dim={"Lq": 2}):
                 with spyre_hint(num_tiles_per_dim={"D": 2}):
-                    copy_forced(a + b, c)
+                    c = copy_forced(a + b, c)
             return c
 
         compare_with_cpu(fn, a, b, run_compile=True, run_eager=False)
@@ -5917,7 +5926,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             c = torch.full((B, Lq, D), 0, device=a.device, dtype=torch.float16)
             with spyre_hint(num_tiles_per_dim={"Lq": 2}):
                 with spyre_hint(num_tiles_per_dim={"B": 2}):
-                    copy_forced(a + b, c)
+                    c = copy_forced(a + b, c)
             return c
 
         spyre_result = torch.compile(fn)(a_dev, b_dev).cpu()
@@ -5949,7 +5958,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             c = torch.full([Lq * D], 0, device=a.device, dtype=torch.float16)
             with spyre_hint(num_tiles_per_dim={"Lq": 2}):
                 with spyre_hint(num_tiles_per_dim={"D": 2}):
-                    copy_forced(a + b, c)
+                    c = copy_forced(a + b, c)
             return c
 
         compare_with_cpu(fn, a, b, run_compile=True, run_eager=False)
@@ -7720,7 +7729,7 @@ def test_tiled_in_place_accumulator():
         with spyre_hint(num_tiles_per_dim={"H": 4}):
             with spyre_hint(num_tiles_per_dim={"Lq": lq_slices}):
                 block_max = torch.amax(x, dim=-1, keepdim=True)
-                copy_forced(acc + block_max * scale, acc)
+                acc = copy_forced(acc + block_max * scale, acc)
         return acc
 
     ref = fn(x_t, scale_t, acc_t.clone())

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -616,7 +616,7 @@ def test_mutation_target_multi_candidate_layout():
 
     def fn(a, b, d):
         c = a + b
-        torch.ops.spyre.copy_forced(d, c)
+        c = torch.ops.spyre.copy_forced(d, c)
         return c
 
     _compare(fn, a, b, d)
@@ -634,7 +634,7 @@ def test_mutation_target_restick_on_src_not_target():
 
     def fn(a, b, d):
         c = a + b
-        torch.ops.spyre.copy_forced(d.t(), c)
+        c = torch.ops.spyre.copy_forced(d.t(), c)
         return c
 
     _compare(fn, a, b, d, optimal_cost=M * N)
@@ -650,8 +650,8 @@ def test_two_mutations_same_target_copy_f():
 
     def fn(a, b):
         acc = torch.ops.spyre.empty([M, N], device=a.device, dtype=a.dtype)
-        torch.ops.spyre.copy_forced(a.t() + a.t(), acc)
-        torch.ops.spyre.copy_forced(b + b, acc)
+        acc = torch.ops.spyre.copy_forced(a.t() + a.t(), acc)
+        acc = torch.ops.spyre.copy_forced(b + b, acc)
         return acc
 
     result = _compile_and_run(fn, (a.to(DEVICE), b.to(DEVICE)), DEVICE).cpu()
@@ -687,9 +687,9 @@ def test_two_mutations_read_between_writes_minimal_copy_f():
 
     def fn(a, b):
         acc = torch.ops.spyre.empty([M, N], device=a.device, dtype=a.dtype)
-        torch.ops.spyre.copy_forced(a.t(), acc)  # write 1: col-stick
+        acc = torch.ops.spyre.copy_forced(a.t(), acc)  # write 1: col-stick
         snapshot = acc * b  # READ acc
-        torch.ops.spyre.copy_forced(b, acc)  # write 2: row-stick
+        acc = torch.ops.spyre.copy_forced(b, acc)  # write 2: row-stick
         return snapshot
 
     result = _compile_and_run(fn, (a.to(DEVICE), b.to(DEVICE)), DEVICE).cpu()
@@ -732,9 +732,9 @@ def test_two_mutations_read_between_writes_v2_copy_f():
 
     def fn(a, b):
         acc = torch.ops.spyre.empty([M, N], device=a.device, dtype=a.dtype)
-        torch.ops.spyre.copy_forced(a.t() + a.t(), acc)  # write 1: col-stick
+        acc = torch.ops.spyre.copy_forced(a.t() + a.t(), acc)  # write 1: col-stick
         snapshot = acc * b  # READ acc
-        torch.ops.spyre.copy_forced(b + b, acc)  # write 2: row-stick
+        acc = torch.ops.spyre.copy_forced(b + b, acc)  # write 2: row-stick
         return snapshot * acc
 
     result = _compile_and_run(fn, (a.to(DEVICE), b.to(DEVICE)), DEVICE).cpu()

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -15,6 +15,7 @@
 from typing import Optional, Sequence
 import torch
 import torch._dynamo
+import torch._higher_order_ops.effects
 from torch._inductor.fx_passes.reinplace import inplaceable_ops, InplaceableOp
 from torch_spyre.ops.eager import compile_once
 from torch_spyre.ops.fallbacks import warn_fallback
@@ -336,48 +337,62 @@ def _(
     pass
 
 
-# Copy src into dst in-place, guaranteed to survive Inductor's
-# remove_noop_ops pass (unlike aten.copy_, this op is not in
-# noop_registry). Use this to guarantee a copy survives to the coarse
-# tile validator.
-@torch.library.custom_op(
-    "spyre::copy_forced", mutates_args=("dst",), device_types="spyre"
-)
-def copy_forced(src: torch.Tensor, dst: torch.Tensor) -> None:
-    dst.copy_(src)
+# Copy src into dst, guaranteed to survive both Inductor's remove_noop_ops
+# pass (unlike aten.copy_, this op is not in noop_registry) and
+# AOTAutograd's dead-code elimination when dst is never read again in the
+# same trace (issue #4126). Use this to guarantee a copy survives to the
+# coarse tile validator.
+#
+# mutates_args=() (not ("dst",)) so the schema carries no alias_info. This
+# is required for two independent reasons that turn out to be the same
+# underlying constraint:
+#   1. It lets this op be called from inside a decomposition traced by
+#      torch.compile (e.g. spyre__sdpa_overrideable) without tripping
+#      aot_autograd's assert_functional_graph, which rejects any node
+#      whose OpOverload schema is_mutable.
+#   2. It is a precondition for effects registration below: has_effects()
+#      unconditionally returns False for any op with an aliasing schema,
+#      so a mutates_args=("dst",) op can never be made DCE-safe this way.
+#
+# CALLERS MUST REASSIGN THE RETURN VALUE: dst = copy_forced(src, dst).
+# Because this op has no alias_info, AOTAutograd never threads its
+# mutation into the caller's own dataflow -- unlike the old
+# mutates_args=("dst",) design, whose auto_functionalized_v2 getitem was
+# spliced back into every later read of dst automatically. Here, a
+# discarded return value means later reads of the old `dst` Python
+# variable see the *pre-copy* value; only the reassigned variable sees
+# the write. A void call (`copy_forced(src, dst)` with no reassignment)
+# is only correct when dst is never read again in the same trace.
+#
+# _register_effectful_op below wraps every call in
+# torch.ops.higher_order.with_effects at trace time, threading a token
+# through it. That keeps the call node alive through ordinary FX DCE
+# regardless of whether the caller's dst is read again -- unlike a
+# mutates_args-based op, whose auto_functionalized_v2 getitem is silently
+# removed when unread (see issue #4126). Inductor's own generic
+# with_effects lowering delegates straight to lower_spyre_copy_forced
+# below and marks the resulting scheduler op has_side_effects=True, so it
+# is additionally protected from the scheduler's own DCE (see
+# _spyre_scheduler_node_has_side_effects in patches.py).
+@torch.library.custom_op("spyre::copy_forced", mutates_args=(), device_types="spyre")
+def copy_forced(src: torch.Tensor, dst: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(dst).copy_(src)
 
 
 @copy_forced.register_fake
-def _(src: torch.Tensor, dst: torch.Tensor) -> None:
-    pass
+def _(src: torch.Tensor, dst: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(dst)
 
 
 @torch.library.register_kernel("spyre::copy_forced", ["cpu"])
-def copy_forced_cpu(src: torch.Tensor, dst: torch.Tensor) -> None:
-    dst.copy_(src)
+def copy_forced_cpu(src: torch.Tensor, dst: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(dst).copy_(src)
 
 
-# Purely functional at trace time (mutates_args=()) so aot_autograd's
-# assert_functional_graph never sees a mutation. The real write into acc is
-# introduced later by lower_spyre_opaque_copy_ at Inductor lowering time,
-# which builds a MutationLayoutSHOULDREMOVE(acc) buffer identical to the one
-# copy_forced's lowering builds. Callers must reassign:
-# acc = opaque_copy_(value, acc). Use this instead of copy_forced where
-# AOTAutograd functionalization would otherwise reject the mutation (e.g.
-# inside a decomposition traced by torch.compile).
-@torch.library.custom_op("spyre::opaque_copy_", mutates_args=(), device_types="spyre")
-def opaque_copy_(value: torch.Tensor, acc: torch.Tensor) -> torch.Tensor:
-    return value.clone()
-
-
-@opaque_copy_.register_fake
-def _(value: torch.Tensor, acc: torch.Tensor) -> torch.Tensor:
-    return torch.empty_like(value)
-
-
-@torch.library.register_kernel("spyre::opaque_copy_", ["cpu"])
-def opaque_copy__cpu(value: torch.Tensor, acc: torch.Tensor) -> torch.Tensor:
-    return value.clone()
+torch._higher_order_ops.effects._register_effectful_op(
+    torch.ops.spyre.copy_forced.default,
+    torch._higher_order_ops.effects._EffectType.ORDERED,
+)
 
 
 # Copy input into output starting at offsets along dimensions dims and

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -504,22 +504,22 @@ def spyre__sdpa_overrideable(
                             M - max_running
                         )  # batch_size, num_heads, max_seqlen_q sparse
 
-                        denominator = torch.ops.spyre.opaque_copy_(
+                        denominator = torch.ops.spyre.copy_forced(
                             denominator * correction + exp_scores.sum(dim=-1),
                             denominator,
                         )  # batch_size, num_heads, max_seqlen_q sparse
-                        output = torch.ops.spyre.opaque_copy_(
+                        output = torch.ops.spyre.copy_forced(
                             output * correction.unsqueeze(-1)
                             + torch.matmul(exp_scores, value),
                             output,
                         )  # batch_size, num_heads, max_seqlen_q, head_dim
 
-                        M = torch.ops.spyre.opaque_copy_(
+                        M = torch.ops.spyre.copy_forced(
                             max_running,
                             M,
                         )  # batch_size, num_heads, max_seqlen_q sparse
 
-    output = torch.ops.spyre.opaque_copy_(output / denominator.unsqueeze(-1), output)
+    output = torch.ops.spyre.copy_forced(output / denominator.unsqueeze(-1), output)
     # The reference meta kernel for this op
     # (torch._meta_registrations.meta__scaled_dot_product_fused_attention_
     # overrideable -> alloc_with_matching_layout) declares the output layout to

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -155,6 +155,16 @@ class PropagationPlan:
         ``copy_forced(src, c)`` where ``c`` is a locally-created buffer that is
         also the function's return value). ``None`` otherwise, meaning the
         op's own name should be used to patch ``V.graph.graph_outputs``.
+    consumer_lookup_name:
+        Only set (and only differs from the op's own name) when this op is
+        a ``MutationLayoutSHOULDREMOVE`` write whose mutation *target* --
+        not the op's own buffer -- is what outside ops actually read (e.g.
+        ``copy_forced(src, c)`` where ``c`` is a locally-created buffer read
+        later by another op). Transform-time consumer re-resolution
+        (``_propagate_tiled_op``) and the read-redirect it performs
+        (``_patch_consumers``) must search for reads of this name instead of
+        the op's own name. ``None`` otherwise, meaning the op's own name
+        should be used, as for ordinary (non-mutation) copy-out ops.
     """
 
     kind: Literal["loop_internal", "copy_out", "reduction", "mutation_write_back"]
@@ -164,6 +174,7 @@ class PropagationPlan:
     outside_consumer_names: tuple[str, ...] = ()
     is_graph_output: bool = False
     graph_output_name: str | None = None
+    consumer_lookup_name: str | None = None
 
 
 @dataclass(frozen=True)

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -1342,18 +1342,6 @@ def lower_spyre_copy_forced(src, dst):
     return _build_mutation_lowering(src, dst)
 
 
-@register_spyre_lowering(torch.ops.spyre.opaque_copy_)
-def lower_spyre_opaque_copy_(value, acc):
-    # opaque_copy_ is functional at the FX/AOTAutograd level (see customops.py)
-    # so that assert_functional_graph never sees a mutation. The real
-    # mutating write into acc is introduced here, at lowering time, via the
-    # same MutationLayoutSHOULDREMOVE(acc) buffer that lower_spyre_copy_forced
-    # builds for copy_forced. Everything downstream that keys off
-    # MutationLayoutSHOULDREMOVE (e.g. wsr/coarse_tile.py) treats this
-    # identically to a copy_forced write.
-    return _build_mutation_lowering(value, acc)
-
-
 @register_spyre_lowering(torch.ops.spyre.overwrite)
 def lower_overwrite(input, output, dims, offsets):
     depr_msg = """torch.ops.spyre.overwrite is deprecated. Use standard PyTorch operations like \

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -939,15 +939,18 @@ def _plan_tiling_propagation(
                         mut_target = op.layout.get_buffer()
                         mut_target_name = mut_target.get_name()
                         target_is_graph_input = mut_target_name in V.graph.graph_inputs
-                        _, target_is_output = _find_outside_consumers_planned(
-                            mut_target_name,
-                            info.loop_group_id,
-                            operations,
-                            name_to_group_outer_key,
+                        target_consumer_names, target_is_output = (
+                            _find_outside_consumers_planned(
+                                mut_target_name,
+                                info.loop_group_id,
+                                operations,
+                                name_to_group_outer_key,
+                            )
                         )
                     except (AttributeError, TypeError):
                         target_is_graph_input = False
                         target_is_output = False
+                        target_consumer_names = []
                         mut_target = None
                     if (
                         target_is_graph_input
@@ -963,20 +966,28 @@ def _plan_tiling_propagation(
                         )
                         continue
                     # Locally-created mutation target that IS the graph
-                    # output (not a graph input): per the comment above,
-                    # this must still go through the normal copy_out path,
-                    # patching graph_outputs by the *target's* name (buf_name
-                    # itself never appears there -- see
-                    # PropagationPlan.graph_output_name).
-                    if target_is_output and mut_target is not None:
+                    # output, and/or is read by other ops outside this loop
+                    # group (e.g. copy_forced(src, acc) where acc is a local
+                    # buffer later read by another op, or is the function's
+                    # return value, or both): must go through the normal
+                    # copy_out path, keyed on the *target's* name -- not
+                    # buf_name, which is the mutation op's own (irrelevant)
+                    # buffer name -- for both consumer redirection
+                    # (PropagationPlan.consumer_lookup_name) and, if
+                    # applicable, graph-output patching
+                    # (PropagationPlan.graph_output_name).
+                    if (
+                        target_is_output or target_consumer_names
+                    ) and mut_target is not None:
                         full_ranges = _compute_full_ranges_planned(op, info)
                         info.propagation = PropagationPlan(
                             kind="copy_out",
                             full_ranges=full_ranges,
                             full_strides=tuple(op.layout.stride),
-                            outside_consumer_names=(),
-                            is_graph_output=True,
+                            outside_consumer_names=tuple(target_consumer_names),
+                            is_graph_output=target_is_output,
                             graph_output_name=mut_target_name,
+                            consumer_lookup_name=mut_target_name,
                         )
                         continue
                 info.propagation = PropagationPlan(kind="loop_internal")
@@ -2703,27 +2714,33 @@ def _propagate_tiled_op(
     loop_info = op.loop_info
     loop_group_id = loop_info.loop_group_id
     buf_name = op.get_name()
+    # A MutationLayoutSHOULDREMOVE op whose mutation target (not the op's
+    # own buffer) is what outside ops actually read -- e.g.
+    # copy_forced(src, c) where c is read later -- must have its consumers
+    # re-resolved against the target's name; see PropagationPlan's
+    # consumer_lookup_name docstring.
+    read_lookup_name = propagation.consumer_lookup_name or buf_name
 
     # Resolve consumers at TRANSFORM time, by actual reads rather than by
     # the planning-time name list. Pass 1/2 may have spliced replacements
     # into `operations` under the same names since planning ran (see
     # PropagationPlan's docstring on name stability) -- and Pass 1 may have
     # rewired a planned consumer in another tiled group through a read-copy
-    # staging op, which then performs the group's actual read of buf_name.
-    # Patching only the planned names would miss that staging op, leaving
-    # it draining this op's per-tile scratch while the full buffer goes
-    # unread (issue #4008: 94.6% wrong on two chained hint groups). Any
-    # current reader outside this op's outermost loop group needs the
-    # redirect; the in-group copy-out drain reads buf_name by design and is
-    # excluded by the group test exactly like the planning-time analog
-    # (_find_outside_consumers_planned).
+    # staging op, which then performs the group's actual read of
+    # read_lookup_name. Patching only the planned names would miss that
+    # staging op, leaving it draining this op's per-tile scratch while the
+    # full buffer goes unread (issue #4008: 94.6% wrong on two chained hint
+    # groups). Any current reader outside this op's outermost loop group
+    # needs the redirect; the in-group copy-out drain reads read_lookup_name
+    # by design and is excluded by the group test exactly like the
+    # planning-time analog (_find_outside_consumers_planned).
     own_outer_key = loop_group_id[0]
     planned_names = set(propagation.outside_consumer_names)
     outside_consumers = []
     for o in operations:
         if not isinstance(o, ComputedBuffer) or o is op:
             continue
-        if not _reads_buffer(o, buf_name):
+        if not _reads_buffer(o, read_lookup_name):
             continue
         o_outer = getattr(getattr(o, "loop_info", None), "loop_group_id", (None,))[0]
         # Union of both consumer notions: a planned name that still reads
@@ -2790,7 +2807,9 @@ def _propagate_tiled_op(
     retile_info = _RetiledBufferInfo(
         old_stride, tuple(full_buf.layout.stride), old_size
     )
-    _patch_consumers(outside_consumers, buf_name, full_name, operations, retile_info)
+    _patch_consumers(
+        outside_consumers, read_lookup_name, full_name, operations, retile_info
+    )
     if is_graph_output:
         _patch_graph_outputs(propagation.graph_output_name or buf_name, full_buf)
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/mai
n/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes the `copy_forced` silent-drop bug from #4126, plus a related
mutation-target routing bug in coarse tiling uncovered while verifying
the fix.

**`copy_forced` DCE drop.** `copy_forced` was registered with
`mutates_args=("dst",)`, so AOTAutograd represents each call via
`auto_functionalized_v2`. When nothing in the same trace reads `dst`
again after the call (e.g. `_flash_v2_fn`'s `real_max` carry), ordinary
FX dead-code elimination removed the whole node before
`decompose_auto_functionalized` or Inductor lowering ever ran — silently
dropping the copy with no compile-time signal.

Fix: unify `copy_forced` with the now-redundant `opaque_copy_` into a
single op with `mutates_args=()` (no alias_info) plus
`torch._higher_order_ops.effects._register_effectful_op(...,
EffectType.ORDERED)`. This wraps every call in
`torch.ops.higher_order.with_effects`, which survives FX DCE
unconditionally via its token thread, regardless of whether the result is
read again. `opaque_copy_` is deleted (its lowering was already
byte-for-byte identical to `copy_forced`'s). Callers must now reassign
the return value (`dst = copy_forced(src, dst)`); the SDPA decomposition
and test call sites are updated accordingly.

**Mutation-target consumer routing.** While verifying the above fix
against `test_coarse_tile_e2e.py`, found that `_plan_tiling_propagation`
(`wsr/coarse_tile.py`) discarded the outside-consumer names for a
`MutationLayoutSHOULDREMOVE` op's mutation target, keeping only whether
the target was a graph-output buffer. Any mutation target with genuine
outside consumers that wasn't itself a graph output fell through to
`loop_internal`, leaving `output_tiled_dims` empty — so the write never
advanced across loop iterations, and only the last tile's data survived
in the buffer (silent, large-magnitude wrong answers).

Fix: added `PropagationPlan.consumer_lookup_name`, generalizing the
existing `graph_output_name` redirect pattern so transform-time consumer
re-resolution (`_propagate_tiled_op`) and its read-redirect
(`_patch_consumers`) key off the mutation target's name instead of the
op's own (irrelevant) buffer name.

**Scope.** Per the issue, this PR targets only the `copy_forced` drop
mechanism and the mutation-routing bug it exposed. Full end-to-end
flash-attention numerical correctness is out of scope — a separate,
still-open B-tiling `inf` bug was found in `test_flash_v2_tile_B`,
`test_flash_v2_tile_B_H`, `test_flash_v3_tile_B`, and
`test_flash_v3_tile_B_H` (unrelated to `copy_forced`; likely PR #4133
territory). Their skip reasons are updated to describe the new,
narrower failure precisely rather than leaving stale text. We're holding
off on filing a new issue for it until this branch can be combined with
other in-flight fixes and the overall scope reassessed.

#### Which issue(s) this PR is related to:

Fixes #4126

#### Special notes for your reviewer:

- `copy_forced` callers must now reassign the return value
  (`dst = copy_forced(src, dst)`); a discarded return value is only
  correct when `dst` is never read again in the same trace. This is
  documented at length in the op's docstring in `customops.py`.
- `opaque_copy_` is removed entirely — `copy_forced` now covers both use
  cases (ordinary in-place copy, and copies inside a traced decomposition
  where `assert_functional_graph` would otherwise reject a mutation).
- The `MutationLayoutSHOULDREMOVE` scheduler-level protection in
  `patches.py` is unaffected by either fix and remains a second line of
  defense.
- `test_flash_tile_B_H`'s skip reason changed from the old copy_forced
  bug to a distinct, still-open 70% mismatch (finite values, no more
  `inf`) — confirming the copy_forced/mutation-routing fix is doing its
  job even though this particular test still needs further work.

#### Does this PR introduce a user-facing change?

No public API change. `torch.ops.spyre.opaque_copy_` (an internal op, not
part of any public surface) is removed; internal callers are updated in
this PR.

#### Additional note:

Full local regression run (`tests/inductor/test_coarse_tile_e2e.py`,
`tests/inductor/test_coarse_tiling.py`, `tests/inductor/
test_building_blocks.py`, `tests/inductor/test_restickify.py`) passes
with only pre-existing skips/xfails. `pre-commit run --all-files` is
clean.