### PR TITLE
inductor: lazily load OR-Tools for CP-SAT fallback

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_cpsat_certified_greedy_seed_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_cpsat_certified_greedy_seed_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [unit, regression, integration, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_cpsat_certified_greedy_seed.py
+      unlisted_test_mode: mandatory_success

--- a/tests/configs/torch_spyre_tests/inductor/test_cpsat_lazy_ortools_load_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_cpsat_lazy_ortools_load_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [unit, regression, integration, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_cpsat_lazy_ortools_load.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_cpsat_certified_greedy_seed.py
+++ b/tests/inductor/test_cpsat_certified_greedy_seed.py
@@ -1,0 +1,465 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the certified greedy fast path inside
+``CpSatLayoutSolver.plan_layout()``.
+
+Placement-only ``plan_layout`` optimizes only level 1 of the CP-SAT
+lex-solve:
+
+    minimize sum(spill_cost(b) * (1 - in_buffer(b)))
+
+Every ``spill_cost(b) >= 0``, and ``_add_core_division`` pins every
+buffer returned by ``record_exclusions()`` to ``in_buffer = 0``. So
+the objective is bounded below by
+
+    L = sum(spill_cost(b) for b in buffers if b.name in record_exclusions())
+
+and any plan reaching ``L`` is globally optimal. The fast path runs
+greedy on a solver-local copy, evaluates that objective in CP-SAT's
+alignment-unit domain, checks representability against CP-SAT's
+domain (``_capacity_units``, alignment-aligned offsets, top-of-buffer
+within ``_capacity_units * alignment``), and either commits greedy's
+placement or falls through to the full CP-SAT solve.
+
+These tests do not measure wall clock. They check:
+"""
+
+import copy
+import unittest
+from unittest.mock import patch
+
+# torch first so torch_spyre's PrivateUse1 backend autoload sees a
+# fully-initialised module.
+import torch  # noqa: F401
+
+try:
+    from ortools.sat.python import cp_model  # noqa: F401
+
+    _HAS_ORTOOLS = True
+except ImportError:
+    _HAS_ORTOOLS = False
+
+from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
+from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
+
+
+LARGE_SIZE = 1 << 20  # 1 MiB, always enough for the tiny fixtures below
+ALIGNMENT = 1
+
+
+def _mk(name, size, uses, **kwargs):
+    return LifetimeBoundBuffer(name, size, uses, **kwargs)
+
+
+def _placed(buffers):
+    return {b.name for b in buffers if b.address is not None}
+
+
+def _greedy(buffers, size=LARGE_SIZE, alignment=ALIGNMENT):
+    return GreedyLayoutSolver(
+        copy.deepcopy(list(buffers)), size, alignment
+    ).plan_layout()
+
+
+def _cpsat_only(buffers, size=LARGE_SIZE, alignment=ALIGNMENT):
+    """Standalone CP-SAT: bypasses the seed by driving
+    ``_plan_layout_generic`` directly, so the objective is what CP-SAT
+    alone would have produced on the same input.
+    """
+    from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+        CpSatLayoutSolver,
+    )
+
+    solver = CpSatLayoutSolver(copy.deepcopy(list(buffers)), size, alignment)
+    return list(solver._plan_layout_generic())
+
+
+def _hybrid(buffers, size=LARGE_SIZE, alignment=ALIGNMENT):
+    """The full public path: seed first, CP-SAT fallback.
+
+    Deep-copies so the caller's buffers stay unaddressed and can also be
+    passed to :func:`_cpsat_only` (which asserts unplanned inputs)."""
+    from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+        CpSatLayoutSolver,
+    )
+
+    return CpSatLayoutSolver(
+        copy.deepcopy(list(buffers)), size, alignment
+    ).plan_layout()
+
+
+def _obj_units(buffers, alignment):
+    """Evaluate the placement-only CP-SAT objective on a plan, in
+    alignment units (the units CP-SAT actually optimises)."""
+    from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+        _hbm_spill_cost,
+    )
+    from torch_spyre._inductor.scratchpad.plan_solver import ceil_div
+    from dataclasses import replace as _replace
+
+    return sum(
+        _hbm_spill_cost(_replace(b, size=ceil_div(b.size, alignment)))
+        for b in buffers
+        if b.address is None
+    )
+
+
+@unittest.skipUnless(_HAS_ORTOOLS, "certified greedy seed is a CP-SAT feature")
+class TestCertifiedGreedySeed(unittest.TestCase):
+    """The certified greedy fast path inside ``CpSatLayoutSolver.plan_layout``."""
+
+    # -- 1. greedy at exact CP-SAT lower bound skips Solve() --
+    def test_lower_bound_greedy_plan_skips_cpsat_solve(self):
+        """Three buffers, plenty of capacity, no forced exclusion: greedy
+        places all three (objective = 0 = lower bound). ``CpSolver.Solve``
+        must never run."""
+        buffers = [
+            _mk("a", 10, [0, 3]),
+            _mk("b", 20, [0, 3]),
+            _mk("c", 30, [0, 3]),
+        ]
+        with patch.object(
+            cp_model.CpSolver,
+            "Solve",
+            side_effect=AssertionError(
+                "CP-SAT Solve should not run when greedy certifies"
+            ),
+        ):
+            result = _hybrid(buffers, LARGE_SIZE, ALIGNMENT)
+        self.assertEqual(_placed(result), {"a", "b", "c"})
+        self.assertEqual(_obj_units(result, ALIGNMENT), 0)
+
+    # -- 2. nonzero greedy objective invokes CP-SAT --
+    def test_nonzero_objective_falls_through_to_cpsat(self):
+        """The classic ``test_largest_buffer_evicted_when_full`` shape:
+        capacity 50 forces exactly one spill; greedy spills the largest
+        (obj 60), CP-SAT spills the smallest (obj 20). Seed rejects and
+        the returned placement is CP-SAT's optimum."""
+        buffers = [
+            _mk("a", 10, [0, 3]),
+            _mk("b", 20, [0, 3]),
+            _mk("c", 30, [0, 3]),
+        ]
+        capacity = 50
+        greedy_only = _greedy(buffers, capacity, ALIGNMENT)
+        self.assertEqual(_obj_units(greedy_only, ALIGNMENT), 60)
+        hybrid = _hybrid(buffers, capacity, ALIGNMENT)
+        cpsat_only = _cpsat_only(buffers, capacity, ALIGNMENT)
+        # The invariant that matters: hybrid == standalone CP-SAT.
+        self.assertEqual(
+            _obj_units(hybrid, ALIGNMENT),
+            _obj_units(cpsat_only, ALIGNMENT),
+        )
+        self.assertEqual(_obj_units(hybrid, ALIGNMENT), 20)
+
+    # -- 3. forced exclusion via residency_reason contributes to L --
+    def test_residency_reason_contributes_to_lower_bound(self):
+        """A buffer with ``residency_reason`` is in ``record_exclusions``
+        and its full spill_cost contributes to L. Greedy places the
+        others; hybrid certifies."""
+        buffers = [
+            _mk("barred", 40, [0, 1], residency_reason="not eligible"),
+            _mk("free", 40, [0, 1]),
+        ]
+        result = _hybrid(buffers, LARGE_SIZE, ALIGNMENT)
+        self.assertEqual(_placed(result), {"free"})
+        # Both hybrid and standalone cpsat return the same objective.
+        cpsat_only = _cpsat_only(buffers, LARGE_SIZE, ALIGNMENT)
+        self.assertEqual(
+            _obj_units(result, ALIGNMENT),
+            _obj_units(cpsat_only, ALIGNMENT),
+        )
+        # Nonzero: barred spill_cost has to appear somewhere.
+        self.assertGreater(_obj_units(result, ALIGNMENT), 0)
+
+    # -- 4. forced exclusion via min_footprint > limit contributes to L --
+    def test_min_footprint_over_limit_contributes_to_lower_bound(self):
+        """A buffer whose ``min_footprint > limit`` is pinned non-resident
+        by ``record_exclusions`` even without ``residency_reason``.
+        ``min_footprint`` defaults to ``size``, so a buffer bigger than
+        the capacity is the natural fixture."""
+        big = _mk("big", 200, [0, 3])
+        small = _mk("small", 10, [0, 3])
+        capacity = 100  # big.min_footprint = 200 > 100
+        result = _hybrid([big, small], capacity, ALIGNMENT)
+        cpsat_only = _cpsat_only([big, small], capacity, ALIGNMENT)
+        self.assertEqual(_placed(result), {"small"})
+        self.assertEqual(
+            _obj_units(result, ALIGNMENT),
+            _obj_units(cpsat_only, ALIGNMENT),
+        )
+
+    # -- 5. zero-spill-cost buffer semantics --
+    def test_zero_spill_cost_buffer(self):
+        """A single-use graph input has ``read_count = 1``,
+        ``first_use_is_read = True`` so ``reads_served = 0`` and
+        ``is_intermediate = 0``: ``spill_cost = 0``. Its presence or
+        absence in the placed set does not change the objective; the seed
+        must still certify when the objective already at the floor."""
+        buffers = [
+            _mk("live_input", 10, [0], first_use_is_read=True),
+            _mk("useful", 20, [0, 3]),
+        ]
+        result = _hybrid(buffers, LARGE_SIZE, ALIGNMENT)
+        cpsat_only = _cpsat_only(buffers, LARGE_SIZE, ALIGNMENT)
+        self.assertEqual(
+            _obj_units(result, ALIGNMENT),
+            _obj_units(cpsat_only, ALIGNMENT),
+        )
+
+    # -- 6. graph-input spill-cost semantics --
+    def test_graph_input_spill_cost_semantics(self):
+        """A multi-use graph input's spill_cost is
+        ``(read_count - 1) * size`` (drop the clone-in read pinning cannot
+        avoid). Certificate arithmetic must match CP-SAT's."""
+        from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+            _hbm_spill_cost,
+        )
+
+        b = _mk("input", 8, [0, 2, 4, 6], first_use_is_read=True)
+        # read_count = 4, first_use_is_read discounts 1 => reads_served=3.
+        # is_intermediate = not first_use_is_read = False => 0.
+        # spill_cost = (3 + 0) * 8 = 24.
+        self.assertEqual(_hbm_spill_cost(b), 24)
+
+    # -- 7. intermediate spill-cost semantics --
+    def test_intermediate_spill_cost_semantics(self):
+        """A computed intermediate's first use is the producing write, so
+        ``read_count`` already excludes it and ``is_intermediate = 1``:
+        ``spill_cost = (read_count + 1) * size``."""
+        from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+            _hbm_spill_cost,
+        )
+
+        b = _mk("intermediate", 8, [0, 2, 4], first_use_is_read=False)
+        # read_count = len(uses)-1 = 2, reads_served = 2, is_intermediate=1
+        # spill_cost = (2 + 1) * 8 = 24.
+        self.assertEqual(_hbm_spill_cost(b), 24)
+
+    # -- 8. non-aligned buffer sizes use the same objective as CP-SAT --
+    def test_non_aligned_buffer_sizes_match_cpsat_objective(self):
+        """CP-SAT wraps every buffer with ``ceil_div(size, alignment)``.
+        Certificate must use the same scaling, else the seed can accept a
+        plan whose greedy objective differs from what CP-SAT would compute."""
+        # size 129, alignment 128 -> ceil_div = 2 unit-sized in CP-SAT.
+        buffers = [_mk("odd", 129, [0, 1])]
+        alignment = 128
+        # Capacity plenty; both solvers place it.
+        capacity = 4096
+        hybrid = _hybrid(buffers, capacity, alignment)
+        cpsat_only = _cpsat_only(buffers, capacity, alignment)
+        self.assertEqual(_placed(hybrid), _placed(cpsat_only))
+        # Both objectives equal 0 here (only buffer placed). More
+        # interesting: force a spill and verify the unit-domain matches.
+        buffers2 = [_mk("odd", 129, [0, 1]) for _ in range(3)]
+        for i, b in enumerate(buffers2):
+            b.name = f"odd_{i}"
+        # 3 buffers of 2 units each, capacity 2 units => spill 2.
+        capacity_units_2 = 2 * alignment
+        h2 = _hybrid(buffers2, capacity_units_2, alignment)
+        c2 = _cpsat_only(buffers2, capacity_units_2, alignment)
+        self.assertEqual(_obj_units(h2, alignment), _obj_units(c2, alignment))
+
+    # -- 9. non-aligned capacity cannot certify unrepresentable layouts --
+    def test_limit_below_alignment_never_certifies(self):
+        """When ``_capacity_units = limit // alignment == 0``, CP-SAT has
+        no addressable slots; the seed must not certify anything (greedy
+        might place a small buffer with byte capacity, but CP-SAT's model
+        would place none). Falls through to CP-SAT."""
+        buffers = [_mk("a", 3, [0, 1]), _mk("b", 3, [0, 1])]
+        limit = 10  # < alignment=128 -> _capacity_units = 0
+        alignment = 128
+        result = _hybrid(buffers, limit, alignment)
+        cpsat_only = _cpsat_only(buffers, limit, alignment)
+        # Whatever cpsat does on its own, hybrid must match it.
+        self.assertEqual(_placed(result), _placed(cpsat_only))
+        self.assertEqual(
+            _obj_units(result, alignment),
+            _obj_units(cpsat_only, alignment),
+        )
+
+    def test_limit_not_divisible_by_alignment_uses_cpsat_top(self):
+        """``_capacity_units = limit // alignment`` rounds down, so if
+        greedy places a buffer whose top-of-buffer exceeds
+        ``_capacity_units * alignment`` the seed must reject."""
+        # limit=200, alignment=128 -> _capacity_units = 1, cpsat_top = 128
+        # Greedy on byte capacity 200 might place a 130-byte buffer at 0
+        # (top=130 > 128), which CP-SAT can't represent.
+        buffers = [_mk("a", 130, [0, 1])]
+        limit = 200
+        alignment = 128
+        result = _hybrid(buffers, limit, alignment)
+        cpsat_only = _cpsat_only(buffers, limit, alignment)
+        self.assertEqual(
+            _obj_units(result, alignment),
+            _obj_units(cpsat_only, alignment),
+        )
+
+    # -- 10. in-place reuse remains legal --
+    def test_in_place_reuse_still_certifies(self):
+        """In-place reuse: parent and child at the same LX offset for the
+        handoff tick. Certificate must accept and CP-SAT must be skipped
+        when greedy already places both."""
+        buffers = [
+            _mk("parent", 40, [0, 1]),
+            _mk("child", 20, [1, 3], in_place_parents=["parent"]),
+            _mk("stranger", 10, [2]),
+        ]
+        with patch.object(
+            cp_model.CpSolver,
+            "Solve",
+            side_effect=AssertionError("Solve must not run"),
+        ):
+            result = _hybrid(buffers, LARGE_SIZE, ALIGNMENT)
+        self.assertEqual(_placed(result), {"parent", "child", "stranger"})
+        # child shares parent's address on the handoff.
+        by_name = {b.name: b for b in result}
+        self.assertEqual(by_name["parent"].address, by_name["child"].address)
+
+    # -- 11. rejected greedy probe leaves originals untouched --
+    def test_rejected_seed_leaves_originals_untouched_before_cpsat(self):
+        """``_plan_layout_generic`` asserts every ``b.address is None`` on
+        entry. Snapshot the caller's list right before that assertion; it
+        must be all-None even after greedy ran its probe."""
+        from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+            CpSatLayoutSolver,
+        )
+
+        buffers = [_mk("a", 10, [0, 3]), _mk("b", 20, [0, 3]), _mk("c", 30, [0, 3])]
+        solver = CpSatLayoutSolver(buffers, 50, ALIGNMENT)
+        orig = solver._plan_layout_generic
+        seen: dict = {}
+
+        def _spy(*a, **k):
+            seen["before_cpsat"] = [b.address for b in buffers]
+            return orig(*a, **k)
+
+        solver._plan_layout_generic = _spy  # type: ignore[method-assign]
+        solver.plan_layout()
+        self.assertEqual(seen["before_cpsat"], [None, None, None])
+
+    # -- 12. accepted seed commits only the placement state expected --
+    def test_accepted_seed_commits_addresses_only(self):
+        """A certified seed writes ``address`` on the caller's buffers and
+        sets ``spill_reasons`` in the same shape ``_plan_layout_generic``
+        would; nothing else is mutated."""
+        from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+            CpSatLayoutSolver,
+        )
+
+        buffers = [_mk("a", 10, [0, 1]), _mk("b", 10, [0, 1])]
+        # Preserve identity + starting fields we don't expect to be touched.
+        pre_names = [b.name for b in buffers]
+        pre_uses = [list(b.uses) for b in buffers]
+        pre_sizes = [b.size for b in buffers]
+        solver = CpSatLayoutSolver(buffers, LARGE_SIZE, ALIGNMENT)
+        result = solver.plan_layout()
+        # Same identity, same list.
+        self.assertIs(result[0], buffers[0])
+        self.assertIs(result[1], buffers[1])
+        # Addresses populated.
+        for b in buffers:
+            self.assertIsNotNone(b.address)
+        # Other fields untouched.
+        self.assertEqual([b.name for b in buffers], pre_names)
+        self.assertEqual([list(b.uses) for b in buffers], pre_uses)
+        self.assertEqual([b.size for b in buffers], pre_sizes)
+        # spill_reasons matches the shape _plan_layout_generic would emit.
+        self.assertIsInstance(solver.spill_reasons, dict)
+        # No buffer was excluded, so no spill reasons expected here.
+        self.assertEqual(solver.spill_reasons, {})
+
+    # -- 13. spill_reasons match allocator expectations --
+    def test_spill_reasons_use_forced_reason_for_excluded_buffer(self):
+        """A buffer forced non-resident by ``residency_reason`` must show
+        up in ``spill_reasons`` with that same reason after a certified
+        seed, matching what CP-SAT's own tail would emit."""
+        from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+            CpSatLayoutSolver,
+        )
+
+        buffers = [
+            _mk("barred", 40, [0, 1], residency_reason="unit-test barred"),
+            _mk("free", 40, [0, 1]),
+        ]
+        solver = CpSatLayoutSolver(buffers, LARGE_SIZE, ALIGNMENT)
+        solver.plan_layout()
+        self.assertEqual(solver.spill_reasons.get("barred"), "unit-test barred")
+
+    # -- 14. joint plan_layout_and_core_divisions never uses the seed --
+    def test_joint_path_does_not_use_seed_behavioral(self):
+        """Behavioral test: patch ``_try_certified_greedy_seed`` to raise
+        if called, then invoke ``plan_layout_and_core_divisions`` on a
+        minimal ``CoreDivisionBuffer`` fixture. The joint entry must not
+        touch the seed, so the call succeeds without hitting the patched
+        raise.
+
+        Uses the same ``_whole()`` single-division fixture pattern
+        ``TestCpSatJointDivision`` uses in ``test_scratchpad_solver`` so
+        the joint model has valid ``core_divisions`` to select from.
+        """
+        from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+            CpSatLayoutSolver,
+        )
+        from torch_spyre._inductor.scratchpad.plan_solver import (
+            CoreDivision,
+            CoreDivisionBuffer,
+        )
+
+        whole = [CoreDivision()]
+        # A single computed buffer with the whole-only division; keeps
+        # the joint model well-formed without needing edge structure.
+        buffers = [CoreDivisionBuffer("a", 8, [0, 1], core_divisions=whole)]
+        with patch.object(
+            CpSatLayoutSolver,
+            "_try_certified_greedy_seed",
+            side_effect=AssertionError("certified seed must not run on the joint path"),
+        ):
+            solver = CpSatLayoutSolver(buffers, LARGE_SIZE, alignment=128)
+            solver.plan_layout_and_core_divisions()
+
+    # -- 15. explicit LAYOUT_SOLVER=greedy behavior unchanged --
+    def test_explicit_greedy_solver_unchanged(self):
+        """``LAYOUT_SOLVER=greedy`` calls ``GreedyLayoutSolver`` directly;
+        the fast path only lives in ``CpSatLayoutSolver`` so nothing about
+        this call goes through the seed."""
+        buffers = [_mk("a", 10, [0, 3]), _mk("b", 20, [0, 3]), _mk("c", 30, [0, 3])]
+        greedy = _greedy(buffers, 50, ALIGNMENT)
+        # Deterministic: greedy at capacity 50 spills c (largest last).
+        self.assertEqual(_placed(greedy), {"a", "b"})
+        self.assertEqual(_obj_units(greedy, ALIGNMENT), 60)
+
+
+@unittest.skipUnless(_HAS_ORTOOLS, "seed helper is a CP-SAT feature")
+class TestSharedSpillCostFormula(unittest.TestCase):
+    """Both the CP-SAT wrapper and the certified seed call the same
+    :func:`_hbm_spill_cost`. Verify the wrapper method delegates."""
+
+    def test_wrapper_spill_cost_delegates_to_shared_helper(self):
+        from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+            _LifetimeBufferWithCpVars,
+            _hbm_spill_cost,
+        )
+
+        buf = _mk("b", 8, [0, 1, 2], first_use_is_read=False)
+        model = cp_model.CpModel()
+        wrapper = _LifetimeBufferWithCpVars(
+            buffer=buf, capacity_units=1024, model=model
+        )
+        self.assertEqual(wrapper.spill_cost(), _hbm_spill_cost(buf))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/inductor/test_cpsat_certified_greedy_seed.py
+++ b/tests/inductor/test_cpsat_certified_greedy_seed.py
@@ -219,6 +219,78 @@ class TestCertifiedGreedySeed(unittest.TestCase):
             _obj_units(cpsat_only, ALIGNMENT),
         )
 
+    # -- 5b. zero-cost non-excluded buffer may remain spilled --
+    def test_zero_cost_non_excluded_buffer_may_remain_spilled(self):
+        """The certificate bounds the *objective*, not the placement set.
+        A non-excluded buffer whose ``spill_cost == 0`` can legally be
+        left spilled on a certified plan: it neither raises the sum
+        above the forced-spill floor nor lowers it. Regression test
+        against the incorrect claim "reaching the floor is equivalent
+        to placing every non-excluded buffer" -- a claim that assumes
+        strictly positive spill costs.
+
+        Fixture. ``hot`` has ``spill_cost = 40`` (a nonzero-cost
+        intermediate with two reads) and lives across [0, 5). ``zero``
+        is a single-use graph input (``read_count=1``,
+        ``first_use_is_read=True`` => ``spill_cost = 0``) that arrives
+        at t=1 while ``hot`` still occupies the entire capacity.
+        Greedy places ``hot`` first and cannot fit ``zero``, so
+        ``zero`` remains spilled. ``zero`` is not in
+        ``record_exclusions()`` (its ``residency_reason`` is unset and
+        ``min_footprint == size <= limit``), yet the plan is still
+        certifiable: the residency objective evaluates to 0 -- the
+        forced-spill floor for this input.
+        """
+        from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+            CpSatLayoutSolver,
+        )
+
+        capacity = 10
+        buffers = [
+            _mk("hot", 10, [0, 2, 4]),
+            _mk("zero", 10, [1], first_use_is_read=True),
+        ]
+
+        # Verify the fixture predicts what we're asserting: zero has
+        # spill_cost == 0, hot has spill_cost > 0.
+        from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+            _hbm_spill_cost,
+        )
+
+        self.assertEqual(_hbm_spill_cost(buffers[1]), 0)
+        self.assertGreater(_hbm_spill_cost(buffers[0]), 0)
+
+        # Hybrid certifies and returns hot placed, zero spilled.
+        result = _hybrid(buffers, capacity, ALIGNMENT)
+        placed = _placed(result)
+        self.assertEqual(placed, {"hot"})
+        # Certificate was valid: objective matches standalone CP-SAT.
+        cpsat_only = _cpsat_only(buffers, capacity, ALIGNMENT)
+        self.assertEqual(
+            _obj_units(result, ALIGNMENT),
+            _obj_units(cpsat_only, ALIGNMENT),
+        )
+        # zero was spilled but was NOT in the forced-spill set: it had
+        # no ``residency_reason`` and its ``min_footprint <= limit``.
+        # The seed still committed a plan with zero as address=None, so
+        # ``spill_reasons`` must fall back to the solver-chose-spill
+        # sentinel for zero.
+        solver = CpSatLayoutSolver(
+            copy.deepcopy(buffers),
+            capacity,
+            ALIGNMENT,
+        )
+        solver.plan_layout()
+        self.assertIn("zero", solver.spill_reasons)
+        forced = dict(
+            CpSatLayoutSolver(
+                copy.deepcopy(buffers),
+                capacity,
+                ALIGNMENT,
+            ).record_exclusions()
+        )
+        self.assertNotIn("zero", forced)
+
     # -- 6. graph-input spill-cost semantics --
     def test_graph_input_spill_cost_semantics(self):
         """A multi-use graph input's spill_cost is

--- a/tests/inductor/test_cpsat_lazy_ortools_load.py
+++ b/tests/inductor/test_cpsat_lazy_ortools_load.py
@@ -15,21 +15,33 @@
 """Unit tests for the lazy OR-Tools load in
 ``ilp_solver_ortools``.
 
-Design (PR #4139 already merged the certified-greedy fast path; this
-test file guards the follow-up that makes OR-Tools genuinely lazy):
+This test file stacks on the certified-greedy fast path introduced in
+PR #4139 (``CpSatLayoutSolver.plan_layout`` runs a greedy probe first
+and skips CP-SAT entirely when its plan attains the forced-spill
+lower bound of the residency objective). It guards the follow-up
+change that makes OR-Tools genuinely lazy so certified compiles do
+not trigger the ~1.4 s SWIG bootstrap at all.
+
+Guarantees:
 
 - Importing ``ilp_solver_ortools`` does NOT pull in the SWIG-heavy
   ``ortools.sat.python.cp_model`` module.
 - Constructing ``CpSatLayoutSolver`` does NOT import it either.
 - A certified-greedy ``plan_layout`` (the common case) returns a
   plan without ever importing it.
-- A fallback ``plan_layout`` (seed rejects, CP-SAT runs) lazily
+- A fallback ``plan_layout`` (seed rejects; CP-SAT runs) lazily
   imports it and returns the CP-SAT-optimal objective.
-- Joint ``plan_layout_and_core_divisions`` lazily imports it.
-- Repeated CP-SAT solves reuse the already-loaded module.
+- Joint ``plan_layout_and_core_divisions`` lazily imports it, on both
+  the default residency-lex-solve path and the #3810 ``cost_expr``
+  branch.
+- Repeated CP-SAT solves reuse the already-loaded module (patch-based
+  proof that ``_load_ortools`` does at most one real import).
+- Availability check is robust to ``ModuleNotFoundError`` /
+  ``ImportError`` / ``ValueError`` from ``find_spec``.
+- The first-load critical section is protected by a lock.
 
-Uses subprocess isolation for the sys.modules-membership assertions
-so pytest's own imports do not pollute the check.
+Uses subprocess isolation for the ``sys.modules``-membership
+assertions so pytest's own imports do not pollute the check.
 """
 
 import json
@@ -45,8 +57,10 @@ _PYTHON = sys.executable
 
 def _run(script: str) -> dict:
     """Run a small python program in a subprocess and return its
-    parsed JSON stdout. Returns the raw stdout under ``_raw`` on
-    parse failure to make diagnosis clearer."""
+    parsed JSON stdout (the last non-empty stdout line). Raises with
+    the full transcript on parse or subprocess failure so a broken
+    test is diagnosable at a glance.
+    """
     env = os.environ.copy()
     # Suppress the PrivateUse1 autoload so subprocess start is fast:
     # nothing in these tests needs the Spyre device backend.
@@ -161,15 +175,22 @@ print(json.dumps(result))
 
     def test_fallback_plan_layout_lazily_imports_cp_model(self):
         """When the seed rejects, ``_plan_layout_generic`` calls
-        ``_load_ortools`` which imports ``cp_model`` /
+        ``_load_ortools`` which imports ``cp_model`` and
         ``cp_model_helper`` on demand.
 
-        Uses the classic constrained-spill fixture from
-        ``test_cpsat_certified_greedy_seed.test_nonzero_objective_falls_through_to_cpsat``:
-        three buffers (10, 20, 30) with a 50-capacity limit. Greedy
-        evicts the largest and reaches objective 60, but CP-SAT's
-        forced-spill lower bound for this fixture is 0 (nothing is in
-        ``record_exclusions``), so the seed rejects and CP-SAT runs.
+        Fixture: the classic constrained-spill case reused from
+        ``test_cpsat_certified_greedy_seed``. Three computed
+        intermediates a=10, b=20, c=30, all live across [0, 3),
+        alignment=1, capacity=50. Combined live footprint 60 > 50,
+        so at least one buffer must be spilled. Each buffer's
+        ``spill_cost`` = ``(read_count + is_intermediate) * size``
+        = ``(1 + 1) * size`` = ``2 * size``. Greedy spills the
+        largest (c) reaching objective ``2 * 30 = 60``; CP-SAT's
+        forced-spill lower bound is 0 (nothing pinned by
+        ``record_exclusions``), so ``60 > 0`` and the seed rejects.
+        CP-SAT then finds the true optimum: spill ``a`` alone
+        (``2 * 10 = 20``), which fits ``b`` (20) and ``c`` (30) in
+        the 50-byte capacity.
         """
         program = (
             _SETUP
@@ -204,17 +225,9 @@ print(json.dumps(result))
 """
         )
         r = _run(program)
-        # cp_model must have been imported by the fallback path.
         self.assertTrue(r["cp_model"], r)
         self.assertTrue(r["cp_model_helper"], r)
-        # CP-SAT reaches the classic optimum on this fixture: place
-        # a (10) + b (20) = 30 <= 50, spill c (30). Objective for c
-        # is (0 reads_served + 1 is_intermediate) * 30 = 30 -- wait,
-        # reads_served = 1 for uses=[0,3] with first_use_is_read=False,
-        # so spill_cost(c) = (1+1)*30 = 60... but CP-SAT finds
-        # optimum 20 by placing c (30) instead, spilling a and b
-        # whose combined cost = (1+1)*10 + (1+1)*20 = 60. Actually
-        # optimum here is spill a alone -> obj = (1+1)*10 = 20.
+        # CP-SAT reaches objective 20 (spill a; place b and c).
         self.assertEqual(r["objective_units"], 20, r)
 
     def test_joint_path_lazily_imports_cp_model(self):
@@ -246,39 +259,155 @@ print(json.dumps(result))
         self.assertTrue(r["cp_model"], r)
         self.assertEqual(r["n_ops"], 3)
 
-    def test_repeated_cpsat_solves_do_not_reimport(self):
-        """Second CP-SAT solve in the same process must not reimport
-        anything: the module-level ``cp_model`` is populated on the
-        first call and reused thereafter. Checks that
-        ``_load_ortools`` is genuinely idempotent (its cheap
-        ``if cp_model is not None: return`` short-circuit fires)."""
+    def test_joint_path_with_cost_expr_lazily_imports_and_runs(self):
+        """#3810's ``cost_expr`` branch: pass a small nonconstant
+        sympy expression to ``plan_layout_and_core_divisions``,
+        prove that OR-Tools was not loaded before the call, that
+        the call triggers the lazy load, and that the returned plan
+        respects the cost_expr's preference.
+
+        The cost expression is ``-(sym_is_lx_a + sym_is_lx_b + sym_is_lx_c)``
+        -- ``_minimize_cost_expr`` maps each buffer's
+        ``sym_is_lx.name`` to its CP-SAT ``in_buffer`` bool var, so
+        minimizing the negation is equivalent to maximizing the
+        residency count. Capacity is generous, so the optimum is
+        every buffer resident; that is behaviorally testable
+        without depending on solver arithmetic beyond "resident is
+        preferred over spilled."
+        """
         program = (
             _SETUP
             + """
+import sympy
+from torch_spyre._inductor.scratchpad.plan_solver import (
+    CoreDivision, CoreDivisionBuffer,
+)
 from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
     CpSatLayoutSolver,
 )
+
+whole = [CoreDivision()]
+bufs = [
+    CoreDivisionBuffer(f"c{i}", 100, [i, i+2], core_divisions=whole)
+    for i in range(3)
+]
+
+# Before the joint call: ortools must not be loaded yet.
+before = snap()
+
+# Build the cost_expr against the buffers' sym_is_lx symbols.
+# ``_minimize_cost_expr`` in ilp_solver_ortools.py resolves
+# ``buffer.sym_is_lx.name`` to the CP-SAT ``in_buffer`` var. A
+# negated sum maximizes residency.
+cost_expr = -sum(b.sym_is_lx for b in bufs)
+plan = CpSatLayoutSolver(
+    bufs, 100_000,
+).plan_layout_and_core_divisions(cost_expr=cost_expr)
+
+# After: cp_model must be loaded.
+after = snap()
+
+result = {
+    "before": before,
+    "after": after,
+    "n_ops": len(plan),
+    "n_resident": sum(1 for b in plan if b.address is not None),
+    "n_spilled": sum(1 for b in plan if b.address is None),
+}
+print(json.dumps(result))
+"""
+        )
+        r = _run(program)
+        self.assertFalse(
+            r["before"]["cp_model"], "cp_model must not be loaded before joint call"
+        )
+        self.assertFalse(
+            r["before"]["cp_model_helper"],
+            "cp_model_helper must not be loaded before joint call",
+        )
+        self.assertTrue(
+            r["after"]["cp_model"], "joint call must have triggered the lazy load"
+        )
+        self.assertTrue(r["after"]["cp_model_helper"])
+        self.assertEqual(r["n_ops"], 3)
+        # cost_expr said "prefer residency" and capacity was generous,
+        # so every buffer should be resident.
+        self.assertEqual(r["n_resident"], 3, r)
+        self.assertEqual(r["n_spilled"], 0, r)
+
+    def test_repeated_cpsat_solves_load_exactly_once(self):
+        """A second CP-SAT solve in the same process must not re-run
+        the real ortools import. Instrumented by patching
+        ``ortools.sat.python``'s attribute lookup via
+        ``sys.modules``-observation: after the first load
+        ``cp_model`` and ``cp_model_helper`` are set, and the
+        idempotent short-circuit in ``_load_ortools`` returns
+        immediately without touching the import machinery.
+
+        Patches the ``from ortools.sat.python import cp_model,
+        cp_model_helper`` statement's target to track invocation:
+        counts how many times ``_load_ortools`` actually reached
+        the ``from ortools.sat.python import`` line.
+        """
+        # We can't easily intercept `from X import Y` from outside
+        # so instead we verify by module identity: after two solves,
+        # the module objects must be the same instance and cp_model
+        # must be non-None throughout. Combined with the observation
+        # that the second call to _load_ortools takes < 1 ms while
+        # the first takes hundreds of ms, module identity is a
+        # sufficient proxy for "no reimport happened."
+        program = (
+            _SETUP
+            + """
+import time
+from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+    CpSatLayoutSolver,
+)
+from torch_spyre._inductor.scratchpad import ilp_solver_ortools as m
 from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
 
 def force_fallback():
     bufs = [
-        LifetimeBoundBuffer("a", 60, [0, 5]),
-        LifetimeBoundBuffer("b", 60, [0, 5]),
+        LifetimeBoundBuffer("a", 10, [0, 3]),
+        LifetimeBoundBuffer("b", 20, [0, 3]),
+        LifetimeBoundBuffer("c", 30, [0, 3]),
     ]
-    CpSatLayoutSolver(bufs, 100).plan_layout()
+    return CpSatLayoutSolver(bufs, 50, alignment=1).plan_layout()
 
+t0 = time.perf_counter()
 force_fallback()
-after_first = snap()
+t_first = time.perf_counter() - t0
+first_cp = m.cp_model
+first_cph = m.cp_model_helper
+
+t0 = time.perf_counter()
 force_fallback()
-after_second = snap()
-print(json.dumps({"first": after_first, "second": after_second}))
+t_second = time.perf_counter() - t0
+second_cp = m.cp_model
+second_cph = m.cp_model_helper
+
+print(json.dumps({
+    "same_cp_model": first_cp is second_cp,
+    "same_cp_model_helper": first_cph is second_cph,
+    "first_wall_s": t_first,
+    "second_wall_s": t_second,
+    "cp_model_present": snap()["cp_model"],
+}))
 """
         )
         r = _run(program)
-        # Both snapshots must show cp_model present. The point of
-        # the test is that the second call doesn't raise or refetch.
-        self.assertTrue(r["first"]["cp_model"])
-        self.assertTrue(r["second"]["cp_model"])
+        self.assertTrue(r["same_cp_model"], r)
+        self.assertTrue(r["same_cp_model_helper"], r)
+        self.assertTrue(r["cp_model_present"])
+        # Not a wall-clock assertion in the strict sense: the second
+        # solve reuses the loaded module and the fixture is tiny, so
+        # it completes in <100 ms. A regression that reimports would
+        # add ~1400 ms. Assert an order-of-magnitude ceiling only.
+        self.assertLess(
+            r["second_wall_s"],
+            1.0,
+            "second solve took >1s -- likely a reimport happened",
+        )
 
 
 class TestAvailabilityContractPreserved(unittest.TestCase):
@@ -286,11 +415,8 @@ class TestAvailabilityContractPreserved(unittest.TestCase):
     :func:`allocator._make_cpsat_solver` catches to fall back to the
     greedy allocator when ortools is not installed on this arch.
 
-    We can't actually uninstall ortools inside a test, but we can
-    verify the check helper's shape: when
-    ``_ortools_available()`` returns False, ``CpSatLayoutSolver`` must
-    raise ``ImportError`` at construction with the same message shape
-    the outer factory expects."""
+    We can't actually uninstall ortools inside a test, so we test the
+    helpers' behavior on a variety of ``find_spec`` returns."""
 
     def test_availability_helper_matches_find_spec(self):
         from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
@@ -304,8 +430,8 @@ class TestAvailabilityContractPreserved(unittest.TestCase):
 
     def test_availability_helper_is_cached(self):
         """The cheap ``find_spec`` runs once; subsequent calls hit the
-        module-level cache. Verified by patching the underlying
-        ``find_spec`` to raise if called."""
+        module-level cache. Verified by patching ``find_spec`` to
+        raise if called after the cache is primed."""
         from unittest.mock import patch
 
         from torch_spyre._inductor.scratchpad import ilp_solver_ortools as m
@@ -323,9 +449,63 @@ class TestAvailabilityContractPreserved(unittest.TestCase):
             self.assertEqual(m._ortools_available(), first)
             self.assertEqual(m._ortools_available(), first)
 
+    def test_availability_helper_absent_returns_false(self):
+        """When ``find_spec`` returns ``None`` (package genuinely
+        absent), ``_ortools_available`` returns False and caches
+        that."""
+        from unittest.mock import patch
+
+        from torch_spyre._inductor.scratchpad import ilp_solver_ortools as m
+
+        # Reset the cache to force the probe to run again.
+        with (
+            patch.object(m, "_ORTOOLS_AVAILABLE", None),
+            patch(
+                "importlib.util.find_spec",
+                return_value=None,
+            ),
+        ):
+            self.assertIs(m._ortools_available(), False)
+
+    def test_availability_helper_module_not_found_returns_false(self):
+        """When a parent package on the dotted lookup is missing,
+        ``find_spec`` raises ``ModuleNotFoundError``. The helper must
+        translate that into a False result rather than let it
+        escape."""
+        from unittest.mock import patch
+
+        from torch_spyre._inductor.scratchpad import ilp_solver_ortools as m
+
+        with (
+            patch.object(m, "_ORTOOLS_AVAILABLE", None),
+            patch(
+                "importlib.util.find_spec",
+                side_effect=ModuleNotFoundError("No module named 'ortools'"),
+            ),
+        ):
+            self.assertIs(m._ortools_available(), False)
+
+    def test_availability_helper_value_error_returns_false(self):
+        """Some frozen distributions can produce ``ValueError`` from
+        ``find_spec`` when a parent package's ``__spec__`` is
+        ``None``. Treated the same as absent."""
+        from unittest.mock import patch
+
+        from torch_spyre._inductor.scratchpad import ilp_solver_ortools as m
+
+        with (
+            patch.object(m, "_ORTOOLS_AVAILABLE", None),
+            patch(
+                "importlib.util.find_spec",
+                side_effect=ValueError("__spec__ is None"),
+            ),
+        ):
+            self.assertIs(m._ortools_available(), False)
+
     def test_load_ortools_is_idempotent(self):
         """``_load_ortools`` populates the module globals on first
-        call; repeated calls return immediately without re-importing."""
+        call; repeated calls return immediately without re-importing.
+        """
         from torch_spyre._inductor.scratchpad import ilp_solver_ortools as m
 
         m._load_ortools()
@@ -335,6 +515,70 @@ class TestAvailabilityContractPreserved(unittest.TestCase):
         # Same object identity: the module was not re-fetched.
         self.assertIs(m.cp_model, first_cp)
         self.assertIs(m.cp_model_helper, first_cph)
+
+    def test_load_ortools_publishes_both_globals(self):
+        """After ``_load_ortools`` returns successfully, both
+        ``cp_model`` and ``cp_model_helper`` must be non-None -- no
+        caller may observe a half-initialized state."""
+        from torch_spyre._inductor.scratchpad import ilp_solver_ortools as m
+
+        m._load_ortools()
+        self.assertIsNotNone(m.cp_model)
+        self.assertIsNotNone(m.cp_model_helper)
+
+
+class TestConcurrentFirstLoad(unittest.TestCase):
+    """The first-load critical section is protected by a
+    ``threading.Lock`` with a double-check. Two threads that race
+    into ``_load_ortools`` before the module is loaded must produce
+    the same ``cp_model`` and ``cp_model_helper`` object identities
+    and must not corrupt each other."""
+
+    def test_two_threads_race_to_first_load(self):
+        """Fresh subprocess so the module globals start unset, then
+        two threads both call ``_load_ortools`` in a barrier-
+        synchronized way. Both must complete without exception and
+        must see identical module objects afterward."""
+        program = (
+            _SETUP
+            + """
+import threading
+
+from torch_spyre._inductor.scratchpad import ilp_solver_ortools as m
+
+barrier = threading.Barrier(2)
+results = [None, None]
+errors = [None, None]
+
+
+def worker(idx):
+    try:
+        barrier.wait()  # synchronize the start
+        m._load_ortools()
+        results[idx] = (id(m.cp_model), id(m.cp_model_helper))
+    except Exception as exc:  # noqa: BLE001
+        errors[idx] = f"{type(exc).__name__}: {exc}"
+
+
+threads = [threading.Thread(target=worker, args=(i,)) for i in range(2)]
+for t in threads:
+    t.start()
+for t in threads:
+    t.join()
+
+print(json.dumps({
+    "results": results,
+    "errors": errors,
+    "identity_agree": results[0] == results[1],
+    "cp_model_present": snap()["cp_model"],
+}))
+"""
+        )
+        r = _run(program)
+        self.assertIsNone(r["errors"][0], r)
+        self.assertIsNone(r["errors"][1], r)
+        self.assertTrue(r["identity_agree"], r)
+        self.assertTrue(r["cp_model_present"])
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_cpsat_lazy_ortools_load.py
+++ b/tests/inductor/test_cpsat_lazy_ortools_load.py
@@ -1,0 +1,341 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the lazy OR-Tools load in
+``ilp_solver_ortools``.
+
+Design (PR #4139 already merged the certified-greedy fast path; this
+test file guards the follow-up that makes OR-Tools genuinely lazy):
+
+- Importing ``ilp_solver_ortools`` does NOT pull in the SWIG-heavy
+  ``ortools.sat.python.cp_model`` module.
+- Constructing ``CpSatLayoutSolver`` does NOT import it either.
+- A certified-greedy ``plan_layout`` (the common case) returns a
+  plan without ever importing it.
+- A fallback ``plan_layout`` (seed rejects, CP-SAT runs) lazily
+  imports it and returns the CP-SAT-optimal objective.
+- Joint ``plan_layout_and_core_divisions`` lazily imports it.
+- Repeated CP-SAT solves reuse the already-loaded module.
+
+Uses subprocess isolation for the sys.modules-membership assertions
+so pytest's own imports do not pollute the check.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+
+# Path to the current Python; matches the venv the test runner uses.
+_PYTHON = sys.executable
+
+
+def _run(script: str) -> dict:
+    """Run a small python program in a subprocess and return its
+    parsed JSON stdout. Returns the raw stdout under ``_raw`` on
+    parse failure to make diagnosis clearer."""
+    env = os.environ.copy()
+    # Suppress the PrivateUse1 autoload so subprocess start is fast:
+    # nothing in these tests needs the Spyre device backend.
+    env.setdefault("TORCH_DEVICE_BACKEND_AUTOLOAD", "0")
+    result = subprocess.run(
+        [_PYTHON, "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"subprocess exited {result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    try:
+        return json.loads(result.stdout.strip().splitlines()[-1])
+    except Exception as exc:
+        raise AssertionError(
+            f"could not parse subprocess stdout as JSON:\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        ) from exc
+
+
+# Small helper program templates. Each dumps a single JSON dict at
+# the end.
+_SETUP = """
+import json
+import sys
+import torch  # noqa
+import torch_spyre  # noqa
+
+
+def _has(name):
+    return name in sys.modules
+
+
+def snap():
+    return {
+        "ortools": _has("ortools"),
+        "cp_model": _has("ortools.sat.python.cp_model"),
+        "cp_model_helper": _has("ortools.sat.python.cp_model_helper"),
+    }
+"""
+
+
+class TestLazyOrtoolsLoad(unittest.TestCase):
+    def test_import_ilp_solver_ortools_does_not_import_cp_model(self):
+        """Just importing the scratchpad ilp solver module must not
+        trigger the SWIG ``cp_model`` import. It is safe for
+        ``importlib.util.find_spec`` to walk the ``ortools`` /
+        ``ortools.sat`` / ``ortools.sat.python`` package tree (those
+        packages are cheap ``__init__.py`` files); ``cp_model`` itself
+        is where the ~1.4 s cost lives."""
+        program = (
+            _SETUP
+            + """
+from torch_spyre._inductor.scratchpad import ilp_solver_ortools  # noqa
+print(json.dumps(snap()))
+"""
+        )
+        r = _run(program)
+        self.assertFalse(r["cp_model"], r)
+        self.assertFalse(r["cp_model_helper"], r)
+
+    def test_constructing_solver_does_not_import_cp_model(self):
+        """Building a ``CpSatLayoutSolver`` instance runs the
+        availability check but not the load."""
+        program = (
+            _SETUP
+            + """
+from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+    CpSatLayoutSolver,
+)
+from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
+
+bufs = [LifetimeBoundBuffer(f"b{i}", 100, [i, i+2]) for i in range(4)]
+_ = CpSatLayoutSolver(bufs, 100_000)
+print(json.dumps(snap()))
+"""
+        )
+        r = _run(program)
+        self.assertFalse(r["cp_model"], r)
+        self.assertFalse(r["cp_model_helper"], r)
+
+    def test_certified_plan_layout_does_not_import_cp_model(self):
+        """The common case: capacity is generous, the certified
+        greedy seed accepts, and CP-SAT is skipped entirely. No
+        OR-Tools SWIG import is triggered."""
+        program = (
+            _SETUP
+            + """
+from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+    CpSatLayoutSolver,
+)
+from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
+
+bufs = [LifetimeBoundBuffer(f"b{i}", 100, [i, i+2]) for i in range(4)]
+plan = CpSatLayoutSolver(bufs, 100_000).plan_layout()
+# Sanity: every buffer placed (capacity dwarfs live footprint).
+placed = sum(1 for b in plan if b.address is not None)
+result = snap()
+result["n_placed"] = placed
+print(json.dumps(result))
+"""
+        )
+        r = _run(program)
+        self.assertFalse(r["cp_model"], r)
+        self.assertFalse(r["cp_model_helper"], r)
+        self.assertEqual(r["n_placed"], 4)
+
+    def test_fallback_plan_layout_lazily_imports_cp_model(self):
+        """When the seed rejects, ``_plan_layout_generic`` calls
+        ``_load_ortools`` which imports ``cp_model`` /
+        ``cp_model_helper`` on demand.
+
+        Uses the classic constrained-spill fixture from
+        ``test_cpsat_certified_greedy_seed.test_nonzero_objective_falls_through_to_cpsat``:
+        three buffers (10, 20, 30) with a 50-capacity limit. Greedy
+        evicts the largest and reaches objective 60, but CP-SAT's
+        forced-spill lower bound for this fixture is 0 (nothing is in
+        ``record_exclusions``), so the seed rejects and CP-SAT runs.
+        """
+        program = (
+            _SETUP
+            + """
+from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+    CpSatLayoutSolver, _hbm_spill_cost,
+)
+from dataclasses import replace
+from torch_spyre._inductor.scratchpad.plan_solver import (
+    LifetimeBoundBuffer, ceil_div,
+)
+
+bufs = [
+    LifetimeBoundBuffer("a", 10, [0, 3]),
+    LifetimeBoundBuffer("b", 20, [0, 3]),
+    LifetimeBoundBuffer("c", 30, [0, 3]),
+]
+alignment = 1
+plan = CpSatLayoutSolver(bufs, 50, alignment=alignment).plan_layout()
+obj = sum(
+    _hbm_spill_cost(replace(b, size=ceil_div(b.size, alignment)))
+    for b in plan
+    if b.address is None
+)
+result = snap()
+result["objective_units"] = obj
+result["n_placed"] = sum(1 for b in plan if b.address is not None)
+result["placed_names"] = sorted(
+    b.name for b in plan if b.address is not None
+)
+print(json.dumps(result))
+"""
+        )
+        r = _run(program)
+        # cp_model must have been imported by the fallback path.
+        self.assertTrue(r["cp_model"], r)
+        self.assertTrue(r["cp_model_helper"], r)
+        # CP-SAT reaches the classic optimum on this fixture: place
+        # a (10) + b (20) = 30 <= 50, spill c (30). Objective for c
+        # is (0 reads_served + 1 is_intermediate) * 30 = 30 -- wait,
+        # reads_served = 1 for uses=[0,3] with first_use_is_read=False,
+        # so spill_cost(c) = (1+1)*30 = 60... but CP-SAT finds
+        # optimum 20 by placing c (30) instead, spilling a and b
+        # whose combined cost = (1+1)*10 + (1+1)*20 = 60. Actually
+        # optimum here is spill a alone -> obj = (1+1)*10 = 20.
+        self.assertEqual(r["objective_units"], 20, r)
+
+    def test_joint_path_lazily_imports_cp_model(self):
+        """``plan_layout_and_core_divisions`` unconditionally reaches
+        ``_plan_layout_generic`` and therefore lazily loads
+        OR-Tools."""
+        program = (
+            _SETUP
+            + """
+from torch_spyre._inductor.scratchpad.plan_solver import (
+    CoreDivision, CoreDivisionBuffer,
+)
+from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+    CpSatLayoutSolver,
+)
+
+whole = [CoreDivision()]
+bufs = [
+    CoreDivisionBuffer(f"c{i}", 100, [i, i+2], core_divisions=whole)
+    for i in range(3)
+]
+plan = CpSatLayoutSolver(bufs, 100_000).plan_layout_and_core_divisions()
+result = snap()
+result["n_ops"] = len(plan)
+print(json.dumps(result))
+"""
+        )
+        r = _run(program)
+        self.assertTrue(r["cp_model"], r)
+        self.assertEqual(r["n_ops"], 3)
+
+    def test_repeated_cpsat_solves_do_not_reimport(self):
+        """Second CP-SAT solve in the same process must not reimport
+        anything: the module-level ``cp_model`` is populated on the
+        first call and reused thereafter. Checks that
+        ``_load_ortools`` is genuinely idempotent (its cheap
+        ``if cp_model is not None: return`` short-circuit fires)."""
+        program = (
+            _SETUP
+            + """
+from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+    CpSatLayoutSolver,
+)
+from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
+
+def force_fallback():
+    bufs = [
+        LifetimeBoundBuffer("a", 60, [0, 5]),
+        LifetimeBoundBuffer("b", 60, [0, 5]),
+    ]
+    CpSatLayoutSolver(bufs, 100).plan_layout()
+
+force_fallback()
+after_first = snap()
+force_fallback()
+after_second = snap()
+print(json.dumps({"first": after_first, "second": after_second}))
+"""
+        )
+        r = _run(program)
+        # Both snapshots must show cp_model present. The point of
+        # the test is that the second call doesn't raise or refetch.
+        self.assertTrue(r["first"]["cp_model"])
+        self.assertTrue(r["second"]["cp_model"])
+
+
+class TestAvailabilityContractPreserved(unittest.TestCase):
+    """Preserve the existing ``ImportError`` contract that
+    :func:`allocator._make_cpsat_solver` catches to fall back to the
+    greedy allocator when ortools is not installed on this arch.
+
+    We can't actually uninstall ortools inside a test, but we can
+    verify the check helper's shape: when
+    ``_ortools_available()`` returns False, ``CpSatLayoutSolver`` must
+    raise ``ImportError`` at construction with the same message shape
+    the outer factory expects."""
+
+    def test_availability_helper_matches_find_spec(self):
+        from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
+            _ortools_available,
+        )
+        import importlib.util
+
+        # Fresh call has to line up with find_spec's answer.
+        expected = importlib.util.find_spec("ortools.sat.python.cp_model") is not None
+        self.assertEqual(_ortools_available(), expected)
+
+    def test_availability_helper_is_cached(self):
+        """The cheap ``find_spec`` runs once; subsequent calls hit the
+        module-level cache. Verified by patching the underlying
+        ``find_spec`` to raise if called."""
+        from unittest.mock import patch
+
+        from torch_spyre._inductor.scratchpad import ilp_solver_ortools as m
+
+        # Prime the cache once.
+        first = m._ortools_available()
+
+        # Now any call would hit the cache -- find_spec must not run.
+        def _boom(*args, **kwargs):
+            raise AssertionError(
+                "find_spec must not run again after the first cache hit"
+            )
+
+        with patch("importlib.util.find_spec", side_effect=_boom):
+            self.assertEqual(m._ortools_available(), first)
+            self.assertEqual(m._ortools_available(), first)
+
+    def test_load_ortools_is_idempotent(self):
+        """``_load_ortools`` populates the module globals on first
+        call; repeated calls return immediately without re-importing."""
+        from torch_spyre._inductor.scratchpad import ilp_solver_ortools as m
+
+        m._load_ortools()
+        first_cp = m.cp_model
+        first_cph = m.cp_model_helper
+        m._load_ortools()
+        # Same object identity: the module was not re-fetched.
+        self.assertIs(m.cp_model, first_cp)
+        self.assertIs(m.cp_model_helper, first_cph)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/inductor/test_cpsat_lazy_ortools_load.py
+++ b/tests/inductor/test_cpsat_lazy_ortools_load.py
@@ -34,8 +34,9 @@ Guarantees:
 - Joint ``plan_layout_and_core_divisions`` lazily imports it, on both
   the default residency-lex-solve path and the #3810 ``cost_expr``
   branch.
-- Repeated CP-SAT solves reuse the already-loaded module (patch-based
-  proof that ``_load_ortools`` does at most one real import).
+- Repeated CP-SAT solves reuse the already-loaded module; the real
+  import (``_do_ortools_import``) runs exactly once across both
+  serial repeat calls and concurrent contention.
 - Availability check is robust to ``ModuleNotFoundError`` /
   ``ImportError`` / ``ValueError`` from ``find_spec``.
 - The first-load critical section is protected by a lock.
@@ -336,35 +337,40 @@ print(json.dumps(result))
         self.assertEqual(r["n_spilled"], 0, r)
 
     def test_repeated_cpsat_solves_load_exactly_once(self):
-        """A second CP-SAT solve in the same process must not re-run
-        the real ortools import. Instrumented by patching
-        ``ortools.sat.python``'s attribute lookup via
-        ``sys.modules``-observation: after the first load
-        ``cp_model`` and ``cp_model_helper`` are set, and the
-        idempotent short-circuit in ``_load_ortools`` returns
-        immediately without touching the import machinery.
+        """Two CP-SAT solves in one process must trigger the real
+        OR-Tools import exactly once. Proved deterministically by
+        patching ``_do_ortools_import`` (the tiny helper that owns
+        the actual ``from ortools.sat.python import ...`` statement)
+        with a counter wrapper: after two solves, the counter must
+        read 1.
 
-        Patches the ``from ortools.sat.python import cp_model,
-        cp_model_helper`` statement's target to track invocation:
-        counts how many times ``_load_ortools`` actually reached
-        the ``from ortools.sat.python import`` line.
+        No wall-clock assertion. Module-identity is checked as a
+        supporting invariant but is not the primary proof.
         """
-        # We can't easily intercept `from X import Y` from outside
-        # so instead we verify by module identity: after two solves,
-        # the module objects must be the same instance and cp_model
-        # must be non-None throughout. Combined with the observation
-        # that the second call to _load_ortools takes < 1 ms while
-        # the first takes hundreds of ms, module identity is a
-        # sufficient proxy for "no reimport happened."
         program = (
             _SETUP
             + """
-import time
 from torch_spyre._inductor.scratchpad.ilp_solver_ortools import (
     CpSatLayoutSolver,
 )
 from torch_spyre._inductor.scratchpad import ilp_solver_ortools as m
 from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
+
+# Install a counter around _do_ortools_import BEFORE anything else
+# runs. The lazy loader has not been called yet on this process, so
+# cp_model / cp_model_helper are still None: the first solve will
+# unavoidably reach _do_ortools_import, and the second must NOT.
+call_count = {"n": 0}
+_real_import = m._do_ortools_import
+
+
+def counted_import():
+    call_count["n"] += 1
+    return _real_import()
+
+
+m._do_ortools_import = counted_import
+
 
 def force_fallback():
     bufs = [
@@ -374,40 +380,40 @@ def force_fallback():
     ]
     return CpSatLayoutSolver(bufs, 50, alignment=1).plan_layout()
 
-t0 = time.perf_counter()
 force_fallback()
-t_first = time.perf_counter() - t0
 first_cp = m.cp_model
 first_cph = m.cp_model_helper
+count_after_first = call_count["n"]
 
-t0 = time.perf_counter()
 force_fallback()
-t_second = time.perf_counter() - t0
 second_cp = m.cp_model
 second_cph = m.cp_model_helper
+count_after_second = call_count["n"]
 
 print(json.dumps({
+    "count_after_first": count_after_first,
+    "count_after_second": count_after_second,
     "same_cp_model": first_cp is second_cp,
     "same_cp_model_helper": first_cph is second_cph,
-    "first_wall_s": t_first,
-    "second_wall_s": t_second,
     "cp_model_present": snap()["cp_model"],
+    "cp_model_helper_present": snap()["cp_model_helper"],
 }))
 """
         )
         r = _run(program)
+        self.assertEqual(
+            r["count_after_first"],
+            1,
+            "first solve must trigger exactly one real import",
+        )
+        self.assertEqual(
+            r["count_after_second"], 1, "second solve must not trigger any real import"
+        )
+        # Supporting invariants.
         self.assertTrue(r["same_cp_model"], r)
         self.assertTrue(r["same_cp_model_helper"], r)
         self.assertTrue(r["cp_model_present"])
-        # Not a wall-clock assertion in the strict sense: the second
-        # solve reuses the loaded module and the fixture is tiny, so
-        # it completes in <100 ms. A regression that reimports would
-        # add ~1400 ms. Assert an order-of-magnitude ceiling only.
-        self.assertLess(
-            r["second_wall_s"],
-            1.0,
-            "second solve took >1s -- likely a reimport happened",
-        )
+        self.assertTrue(r["cp_model_helper_present"])
 
 
 class TestAvailabilityContractPreserved(unittest.TestCase):
@@ -529,56 +535,122 @@ class TestAvailabilityContractPreserved(unittest.TestCase):
 
 class TestConcurrentFirstLoad(unittest.TestCase):
     """The first-load critical section is protected by a
-    ``threading.Lock`` with a double-check. Two threads that race
-    into ``_load_ortools`` before the module is loaded must produce
-    the same ``cp_model`` and ``cp_model_helper`` object identities
-    and must not corrupt each other."""
+    ``threading.Lock``. Every thread that returns from
+    ``_load_ortools`` must observe both ``cp_model`` and
+    ``cp_model_helper`` bound; no successful caller may see a half-
+    published pair.
 
-    def test_two_threads_race_to_first_load(self):
-        """Fresh subprocess so the module globals start unset, then
-        two threads both call ``_load_ortools`` in a barrier-
-        synchronized way. Both must complete without exception and
-        must see identical module objects afterward."""
+    Guarding the actual invariant, not just "two threads finish".
+    Uses a slow inner import to enlarge the race window, then
+    stress-tests with many threads and asserts each one saw both
+    globals non-None immediately after its own ``_load_ortools``
+    returned. The number of real imports done under contention must
+    still be exactly one (the same guarantee
+    :meth:`test_repeated_cpsat_solves_load_exactly_once` checks in
+    the serial case).
+    """
+
+    def test_concurrent_first_load_publishes_atomically(self):
+        """Widened race window: patch ``_do_ortools_import`` to
+        sleep briefly before returning, then race N threads through
+        ``_load_ortools`` and assert:
+
+        * every worker saw ``cp_model is not None`` AND
+          ``cp_model_helper is not None`` right after its own
+          ``_load_ortools`` returned;
+        * every worker saw identical object identities for both
+          globals;
+        * ``_do_ortools_import`` was invoked exactly once total
+          (proves the lock actually serialised, not that all threads
+          happened to skip the import section).
+        """
         program = (
             _SETUP
             + """
 import threading
+import time
 
 from torch_spyre._inductor.scratchpad import ilp_solver_ortools as m
 
-barrier = threading.Barrier(2)
-results = [None, None]
-errors = [None, None]
+# Widen the race window by slowing the actual import. A concurrent
+# caller entering the lock after the slow import completes must see
+# both globals bound in one visit -- an outer fast-path check would
+# let it see the first assignment before the second.
+_real_import = m._do_ortools_import
+call_count = {"n": 0}
+count_lock = threading.Lock()
+
+
+def slow_import():
+    with count_lock:
+        call_count["n"] += 1
+    result = _real_import()
+    time.sleep(0.10)  # 100 ms of extra window
+    return result
+
+
+m._do_ortools_import = slow_import
+
+N = 8
+barrier = threading.Barrier(N)
+results = [None] * N
+errors = [None] * N
 
 
 def worker(idx):
     try:
         barrier.wait()  # synchronize the start
         m._load_ortools()
-        results[idx] = (id(m.cp_model), id(m.cp_model_helper))
+        # Read both globals immediately in the worker so its
+        # observation is captured atomically with respect to this
+        # worker's own return.
+        cp = m.cp_model
+        cph = m.cp_model_helper
+        results[idx] = {
+            "cp_is_none": cp is None,
+            "cph_is_none": cph is None,
+            "cp_id": id(cp) if cp is not None else None,
+            "cph_id": id(cph) if cph is not None else None,
+        }
     except Exception as exc:  # noqa: BLE001
         errors[idx] = f"{type(exc).__name__}: {exc}"
 
 
-threads = [threading.Thread(target=worker, args=(i,)) for i in range(2)]
+threads = [threading.Thread(target=worker, args=(i,)) for i in range(N)]
 for t in threads:
     t.start()
 for t in threads:
     t.join()
 
+cp_ids = sorted({r["cp_id"] for r in results if r})
+cph_ids = sorted({r["cph_id"] for r in results if r})
+any_saw_half = any(
+    r and (r["cp_is_none"] or r["cph_is_none"])
+    for r in results
+)
 print(json.dumps({
     "results": results,
     "errors": errors,
-    "identity_agree": results[0] == results[1],
-    "cp_model_present": snap()["cp_model"],
+    "call_count": call_count["n"],
+    "unique_cp_ids": cp_ids,
+    "unique_cph_ids": cph_ids,
+    "any_saw_half_published": any_saw_half,
+    "n_workers": N,
 }))
 """
         )
         r = _run(program)
-        self.assertIsNone(r["errors"][0], r)
-        self.assertIsNone(r["errors"][1], r)
-        self.assertTrue(r["identity_agree"], r)
-        self.assertTrue(r["cp_model_present"])
+        # No worker raised.
+        for err in r["errors"]:
+            self.assertIsNone(err, r)
+        # No worker observed a half-published pair.
+        self.assertFalse(r["any_saw_half_published"], r)
+        # All workers agreed on the identities of both globals.
+        self.assertEqual(len(r["unique_cp_ids"]), 1, r)
+        self.assertEqual(len(r["unique_cph_ids"]), 1, r)
+        # The lock actually serialised: exactly one real import ran
+        # under contention.
+        self.assertEqual(r["call_count"], 1, r)
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
+++ b/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
@@ -98,11 +98,19 @@ import torch
 if TYPE_CHECKING:
     from ortools.sat.python import cp_model, cp_model_helper
 else:
-    try:
-        from ortools.sat.python import cp_model, cp_model_helper
-
-    except ImportError:  # pragma: no cover - exercised only when ortools is absent
-        cp_model = None
+    # OR-Tools loading is deferred. The certified-greedy fast path in
+    # :meth:`CpSatLayoutSolver.plan_layout` never needs a CP-SAT solve, so
+    # importing OR-Tools (a SWIG-wrapped C++ extension whose first import
+    # costs ~1.4 s in a fresh process) up front is pure startup tax on the
+    # certified-compile common case. These globals are populated by
+    # :func:`_load_ortools` the first time a CP-SAT-solve code path
+    # actually runs. Availability is probed cheaply and cached by
+    # :func:`_ortools_available`, preserving today's "cpsat with no
+    # ortools -> ImportError caught by _make_cpsat_solver -> greedy
+    # fallback" contract without paying the import cost on certified
+    # compiles.
+    cp_model = None
+    cp_model_helper = None
 
 from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
 from torch_spyre._inductor.scratchpad.plan_solver import (
@@ -119,6 +127,57 @@ from torch_spyre._inductor import config
 __all__ = ["CpSatLayoutSolver"]
 
 logger = logging.getLogger(__name__)
+
+_ORTOOLS_AVAILABLE: Optional[bool] = None
+
+
+def _ortools_available() -> bool:
+    """Cheap idempotent 'is ortools installable?' check.
+
+    Uses :func:`importlib.util.find_spec` once and caches the answer.
+    First call is ~10 ms; subsequent calls are effectively free
+    (dictionary lookup). Never triggers the full ~1.4 s OR-Tools SWIG
+    import; that only happens inside :func:`_load_ortools`, which the
+    CP-SAT-solve code paths call and the certified greedy seed does
+    not.
+    """
+    global _ORTOOLS_AVAILABLE
+    if _ORTOOLS_AVAILABLE is None:
+        import importlib.util
+
+        _ORTOOLS_AVAILABLE = (
+            importlib.util.find_spec("ortools.sat.python.cp_model") is not None
+        )
+    return _ORTOOLS_AVAILABLE
+
+
+def _load_ortools() -> None:
+    """Import OR-Tools and populate the module-global ``cp_model`` and
+    ``cp_model_helper`` names. Idempotent; safe to call in every
+    method that touches a CP-SAT model. Raises :exc:`ImportError` with
+    the same message as the previous eager import path when ortools is
+    not installed (matched by :func:`_make_cpsat_solver` in
+    ``allocator.py`` to fall back to greedy).
+    """
+    global cp_model, cp_model_helper
+    if cp_model is not None:
+        return
+    try:
+        from ortools.sat.python import (
+            cp_model as _cp,
+            cp_model_helper as _cph,
+        )
+    except (
+        ImportError
+    ) as exc:  # pragma: no cover - exercised only when ortools is absent
+        raise ImportError(
+            "The 'cpsat' layout solver requires the 'ortools' package, "
+            "which is not installed. Install it with 'pip install ortools' "
+            "or select a different layout_solver (e.g. 'greedy')."
+        ) from exc
+    cp_model = _cp
+    cp_model_helper = _cph
+
 
 # Drop cause for a buffer the solver chose to spill (rather than one pinned out
 # up front by _add_core_division): it fit but residency gave no benefit, or
@@ -665,7 +724,17 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
         time_limit_seconds: float = 600.0,
         bottom_justify: bool = True,
     ) -> None:
-        if cp_model is None:
+        # Availability check preserves the pre-existing contract that
+        # constructing ``CpSatLayoutSolver`` on an arch without ortools
+        # raises ``ImportError`` at construction, which
+        # :func:`~torch_spyre._inductor.scratchpad.allocator._make_cpsat_solver`
+        # catches to fall back to the greedy allocator. Uses
+        # :func:`importlib.util.find_spec` (~10 ms once, cached
+        # thereafter) rather than an eager import, so the ~1.4 s SWIG
+        # bootstrap is deferred to :func:`_load_ortools`, which the
+        # CP-SAT-solve paths call and the certified greedy seed does
+        # not.
+        if not _ortools_available():
             raise ImportError(
                 "The 'cpsat' layout solver requires the 'ortools' package, "
                 "which is not installed. Install it with 'pip install ortools' "
@@ -918,6 +987,14 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
         log_lx_usage: bool = False,
         cost_expr: sympy.Expr | None = None,
     ) -> list[LifetimeBoundBuffer | CoreDivisionBuffer]:
+        # Deferred until we actually need to build a CP-SAT model.
+        # :meth:`plan_layout` reaches this only when the certified greedy
+        # seed rejects; :meth:`plan_layout_and_core_divisions` always
+        # reaches it. In both cases the ~1.4 s SWIG import is fair to pay
+        # here (a full CP-SAT solve costs seconds or more), but paying it
+        # on every certified fast-path compile was pure startup tax.
+        _load_ortools()
+
         buffers = self.buffers
         if not buffers:
             return []

--- a/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
+++ b/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
@@ -87,6 +87,7 @@ import copy
 import logging
 import math
 import os
+import threading
 from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Generic, Optional, TypeVar, cast
@@ -99,16 +100,13 @@ if TYPE_CHECKING:
     from ortools.sat.python import cp_model, cp_model_helper
 else:
     # OR-Tools loading is deferred. The certified-greedy fast path in
-    # :meth:`CpSatLayoutSolver.plan_layout` never needs a CP-SAT solve, so
-    # importing OR-Tools (a SWIG-wrapped C++ extension whose first import
-    # costs ~1.4 s in a fresh process) up front is pure startup tax on the
-    # certified-compile common case. These globals are populated by
-    # :func:`_load_ortools` the first time a CP-SAT-solve code path
-    # actually runs. Availability is probed cheaply and cached by
-    # :func:`_ortools_available`, preserving today's "cpsat with no
-    # ortools -> ImportError caught by _make_cpsat_solver -> greedy
-    # fallback" contract without paying the import cost on certified
-    # compiles.
+    # :meth:`CpSatLayoutSolver.plan_layout` (PR #4139) never needs a CP-SAT
+    # solve, so importing OR-Tools (a SWIG-wrapped C++ extension whose
+    # first import costs ~1.4 s in a fresh process) up front is pure
+    # startup tax on the certified-compile common case. These globals are
+    # populated by :func:`_load_ortools` the first time a CP-SAT-solve
+    # code path actually runs; availability is probed cheaply and cached
+    # by :func:`_ortools_available`.
     cp_model = None
     cp_model_helper = None
 
@@ -128,55 +126,114 @@ __all__ = ["CpSatLayoutSolver"]
 
 logger = logging.getLogger(__name__)
 
+# Cached True/False; ``None`` means "not probed yet". Populated by
+# :func:`_ortools_available`.
 _ORTOOLS_AVAILABLE: Optional[bool] = None
+
+# Serializes the first-load critical section in :func:`_load_ortools` so
+# two threads that hit an uncertified compile simultaneously do not both
+# attempt the SWIG import.
+_ORTOOLS_LOAD_LOCK = threading.Lock()
 
 
 def _ortools_available() -> bool:
-    """Cheap idempotent 'is ortools installable?' check.
+    """Cheap idempotent "is OR-Tools importable?" check.
 
     Uses :func:`importlib.util.find_spec` once and caches the answer.
-    First call is ~10 ms; subsequent calls are effectively free
-    (dictionary lookup). Never triggers the full ~1.4 s OR-Tools SWIG
+    First call is ~10 ms on x86_64 with OR-Tools installed; subsequent
+    calls hit the cached ``_ORTOOLS_AVAILABLE`` global and are
+    effectively free. Never triggers the full ~1.4 s OR-Tools SWIG
     import; that only happens inside :func:`_load_ortools`, which the
     CP-SAT-solve code paths call and the certified greedy seed does
     not.
+
+    Contract: returns True iff ``ortools.sat.python.cp_model`` is
+    importable in principle, False if any part of the dotted path is
+    missing. ``find_spec`` raises :exc:`ModuleNotFoundError` /
+    :exc:`ImportError` when a parent package on a dotted-module lookup
+    is absent -- treated as "not available" here rather than allowed to
+    leak out. Any other exception (a genuinely misconfigured
+    ``sys.path``, say) is also treated as unavailable so the
+    ``_make_cpsat_solver`` factory in ``allocator.py`` can fall back to
+    greedy uniformly.
     """
     global _ORTOOLS_AVAILABLE
     if _ORTOOLS_AVAILABLE is None:
         import importlib.util
 
-        _ORTOOLS_AVAILABLE = (
-            importlib.util.find_spec("ortools.sat.python.cp_model") is not None
-        )
+        try:
+            spec = importlib.util.find_spec("ortools.sat.python.cp_model")
+        except (ImportError, ValueError):
+            # ModuleNotFoundError is an ImportError. ValueError shows up
+            # when a parent package's ``__spec__`` is None (edge case,
+            # observed on some frozen distributions).
+            spec = None
+        _ORTOOLS_AVAILABLE = spec is not None
     return _ORTOOLS_AVAILABLE
 
 
 def _load_ortools() -> None:
     """Import OR-Tools and populate the module-global ``cp_model`` and
-    ``cp_model_helper`` names. Idempotent; safe to call in every
-    method that touches a CP-SAT model. Raises :exc:`ImportError` with
-    the same message as the previous eager import path when ortools is
-    not installed (matched by :func:`_make_cpsat_solver` in
-    ``allocator.py`` to fall back to greedy).
+    ``cp_model_helper`` names. Idempotent, thread-safe, safe to call in
+    every method that touches a CP-SAT model.
+
+    Failure modes and observable semantics:
+
+    * **OR-Tools not installed at all** (typical s390x/ppc64le, or an
+      unusual x86_64 install missing the wheel):
+      :func:`_ortools_available` returns False, so
+      :meth:`CpSatLayoutSolver.__init__` raises :exc:`ImportError`
+      before ``_make_cpsat_solver`` in ``allocator.py`` returns; that
+      :exc:`ImportError` is caught there and the allocator falls back
+      to greedy with a warning. ``_load_ortools`` is never called in
+      that case. This matches pre-#4141 observable behavior exactly.
+
+    * **OR-Tools present-but-broken** (spec resolvable, but importing
+      ``cp_model`` fails for a native-dep or install-corruption reason):
+      :func:`_ortools_available` returns True, ``__init__`` succeeds,
+      the certified seed runs on ``plan_layout``. If the seed rejects,
+      :meth:`_plan_layout_generic` calls ``_load_ortools`` and the
+      genuine :exc:`ImportError` propagates. That is a *narrowing* of
+      the pre-#4141 fallback contract: pre-#4141 the same failure would
+      have surfaced during ``_make_cpsat_solver``'s outer catch and
+      fallen back to greedy. Post-#4141, on a certified compile the
+      broken install is invisible; on a fallback compile the
+      :exc:`ImportError` surfaces at solve time. We treat this as
+      acceptable because (a) an OR-Tools install that ``find_spec``
+      resolves but that raises at import time is a corrupted
+      environment problem the user needs to see; and (b) the certified
+      case -- the vast majority of measured compiles -- silently gets
+      an objective-equivalent result instead of a silent greedy
+      fallback. See the PR body for the explicit narrowing statement.
     """
     global cp_model, cp_model_helper
+    # First check outside the lock keeps the fast path lock-free after
+    # the module is loaded. Double-check inside the lock guards against
+    # two threads racing to be the first to load.
     if cp_model is not None:
         return
-    try:
-        from ortools.sat.python import (
-            cp_model as _cp,
-            cp_model_helper as _cph,
-        )
-    except (
-        ImportError
-    ) as exc:  # pragma: no cover - exercised only when ortools is absent
-        raise ImportError(
-            "The 'cpsat' layout solver requires the 'ortools' package, "
-            "which is not installed. Install it with 'pip install ortools' "
-            "or select a different layout_solver (e.g. 'greedy')."
-        ) from exc
-    cp_model = _cp
-    cp_model_helper = _cph
+    with _ORTOOLS_LOAD_LOCK:
+        if cp_model is not None:
+            return
+        try:
+            from ortools.sat.python import (
+                cp_model as _cp,
+                cp_model_helper as _cph,
+            )
+        except (
+            ImportError
+        ) as exc:  # pragma: no cover - exercised only when ortools is broken
+            raise ImportError(
+                "The 'cpsat' layout solver requires the 'ortools' package, "
+                "which is not installed or is broken. Install it with "
+                "'pip install ortools' or select a different layout_solver "
+                "(e.g. 'greedy')."
+            ) from exc
+        # Publish both globals in one step: any successful call to
+        # ``_load_ortools`` leaves both names bound; a concurrent second
+        # caller that arrives after this block sees both, not one.
+        cp_model = _cp
+        cp_model_helper = _cph
 
 
 # Drop cause for a buffer the solver chose to spill (rather than one pinned out
@@ -990,9 +1047,10 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
         # Deferred until we actually need to build a CP-SAT model.
         # :meth:`plan_layout` reaches this only when the certified greedy
         # seed rejects; :meth:`plan_layout_and_core_divisions` always
-        # reaches it. In both cases the ~1.4 s SWIG import is fair to pay
-        # here (a full CP-SAT solve costs seconds or more), but paying it
-        # on every certified fast-path compile was pure startup tax.
+        # reaches it. When CP-SAT is actually required, paying its
+        # one-time OR-Tools import is unavoidable; subsequent solves in
+        # the same process reuse the loaded module. Certified compiles
+        # pay nothing.
         _load_ortools()
 
         buffers = self.buffers

--- a/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
+++ b/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
@@ -731,7 +731,13 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
         over exactly the buffers CP-SAT is forced to keep non-resident:
         the set :meth:`record_exclusions` returns, which
         ``_add_core_division`` pins to ``in_buffer = 0``. Reaching that
-        floor is equivalent to placing every non-excluded buffer.
+        floor proves global optimality of the placement-only residency
+        objective: no feasible CP-SAT solution can have a strictly
+        lower objective value than the forced-spill sum. Any
+        additionally spilled non-excluded buffers on such a plan must
+        have ``spill_cost == 0`` (else they would raise the sum above
+        the floor), and zero-cost terms neither help nor hurt the
+        objective.
 
         The certificate compares CP-SAT-domain quantities. Buffer sizes
         are wrapped with ``ceil_div(size, alignment)`` -- exactly what
@@ -845,10 +851,10 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
             b.address = greedy_by_name[b.name].address
         # ``spill_reasons`` matches the CP-SAT tail: pre-solve forced
         # reason when we have one, else the solver-chose-spill sentinel.
-        # Every spilled buffer here is in ``forced_reasons`` by the
-        # certificate (greedy placed every non-excluded buffer, so no
-        # buffer outside ``forced_reasons`` is spilled), but keep the
-        # fallback for symmetry with the CP-SAT tail.
+        # The certificate only bounds the *objective*, not the placement
+        # set: a non-excluded buffer with ``spill_cost == 0`` may
+        # remain spilled without lifting the sum above the floor, so
+        # the sentinel branch is a real code path, not just symmetry.
         self.spill_reasons = {
             b.name: forced_reasons.get(b.name, _SOLVER_CHOSE_SPILL)
             for b in buffers

--- a/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
+++ b/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
@@ -83,6 +83,7 @@ below are written once against whichever wrapper ``_wrap`` chose.
 
 from __future__ import annotations
 
+import copy
 import logging
 import math
 import os
@@ -103,6 +104,7 @@ else:
     except ImportError:  # pragma: no cover - exercised only when ortools is absent
         cp_model = None
 
+from torch_spyre._inductor.scratchpad.greedy_solver import GreedyLayoutSolver
 from torch_spyre._inductor.scratchpad.plan_solver import (
     CoreDivisionBuffer,
     ceil_div,
@@ -123,6 +125,29 @@ logger = logging.getLogger(__name__)
 # there was no room once higher-value buffers were placed. Shared so the DEBUG
 # log and the reasons surfaced to the allocator agree.
 _SOLVER_CHOSE_SPILL = "spilled by solver (no residency benefit / no room)"
+
+
+def _hbm_spill_cost(buffer: LifetimeBoundBuffer) -> int:
+    """Differential HBM traffic a spill of ``buffer`` adds over residency.
+
+    See :meth:`_LifetimeBufferWithCpVars.spill_cost` for the derivation. This
+    helper is the single source of truth: both the CP-SAT residency objective
+    (``sum(spill_cost * (1 - in_buffer))``) and the certified-greedy-seed
+    lower-bound / plan-objective evaluators call it against a buffer whose
+    ``size`` field is in whatever unit the caller has already normalised to
+    (bytes for a raw ``LifetimeBoundBuffer``; alignment-units after
+    :func:`_wrap` has replaced ``size`` with ``ceil_div(size, alignment)``).
+    Reads and boundary attributes do not depend on the unit.
+    """
+    boundary = getattr(buffer, "boundary", None)
+    is_intermediate = (
+        boundary == BufferType.Intermediate
+        if boundary is not None
+        else not buffer.first_use_is_read
+    )
+    reads_served = buffer.read_count - (1 if buffer.first_use_is_read else 0)
+    return (reads_served + (1 if is_intermediate else 0)) * buffer.size
+
 
 # Buffer type the wrapper carries: the base placement wrapper holds any
 # LifetimeBoundBuffer; the joint subclass binds this to CoreDivisionBuffer.
@@ -236,16 +261,13 @@ class _LifetimeBufferWithCpVars(Generic[_BufT]):
         not one of the reads residency serves and is discounted from
         ``read_count`` (which counts the buffer's reads, not the savings). For a
         computed buffer the first use is the write and ``read_count`` already
-        excludes it, hence the discount is keyed on ``first_use_is_read``."""
-        b = self.buffer
-        boundary = getattr(b, "boundary", None)
-        is_intermediate = (
-            boundary == BufferType.Intermediate
-            if boundary is not None
-            else not b.first_use_is_read
-        )
-        reads_served = b.read_count - (1 if b.first_use_is_read else 0)
-        return (reads_served + (1 if is_intermediate else 0)) * b.size
+        excludes it, hence the discount is keyed on ``first_use_is_read``.
+
+        The arithmetic is factored out into :func:`_hbm_spill_cost` so the
+        certified-greedy seed inside :meth:`CpSatLayoutSolver.plan_layout`
+        evaluates the exact same formula on the exact same
+        alignment-unit-scaled ``buffer.size`` this wrapper carries."""
+        return _hbm_spill_cost(self.buffer)
 
     def constrain_residency(self, model, kids, bufs) -> None:
         """Placement-only: any buffer may reside, so there is no slicing gate."""
@@ -659,14 +681,190 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
     def plan_layout(self, log_lx_usage: bool = False) -> list[LifetimeBoundBuffer]:
         """Place buffers on their already-fixed core divisions (placement-only).
 
-        Same model as :meth:`plan_layout_and_core_divisions` minus the joint
-        division choice: each buffer's footprint is its ``size``, so there is no
-        slicing gate on residency and no parallelism step -- the solve reduces
-        to minimising HBM traffic under the 2D no-overlap with in-place reuse.
-        Dispatch is per buffer and keys on whether it carries candidate
-        divisions, not on its class, so a :class:`CoreDivisionBuffer` with an
-        empty candidate list is placed here rather than divided."""
+        First runs a cheap **certified greedy seed** on a solver-local copy
+        (:meth:`_try_certified_greedy_seed`): if that plan is feasible under
+        CP-SAT's placement contract and attains the exact forced-spill lower
+        bound of CP-SAT's own residency objective, it is already globally
+        optimal for that objective and the CP-SAT solve is skipped. Otherwise
+        the full CP-SAT solve runs as before via :meth:`_plan_layout_generic`
+        on the untouched caller buffers.
+
+        The joint entry (:meth:`plan_layout_and_core_divisions`) does not
+        use this seed: greedy cannot pick core divisions, and the joint
+        model's objective (residency, then parallelism, then balance, or a
+        caller-supplied ``cost_expr``) is not a scalar residency floor.
+
+        Otherwise the model is unchanged: same as
+        :meth:`plan_layout_and_core_divisions` minus the joint division
+        choice -- each buffer's footprint is its ``size``, so there is no
+        slicing gate on residency and no parallelism step. Dispatch is per
+        buffer and keys on whether it carries candidate divisions, not on
+        its class, so a :class:`CoreDivisionBuffer` with an empty candidate
+        list is placed here rather than divided."""
+        seed = self._try_certified_greedy_seed(log_lx_usage=log_lx_usage)
+        if seed is not None:
+            return seed
         return cast("list[LifetimeBoundBuffer]", list(self._plan_layout_generic()))
+
+    def _try_certified_greedy_seed(
+        self, log_lx_usage: bool = False
+    ) -> Optional[list[LifetimeBoundBuffer]]:
+        """Run greedy on a solver-local copy; commit its placement onto the
+        caller's buffers and return them iff the plan is representable in
+        the CP-SAT placement domain **and** its objective attains CP-SAT's
+        forced-spill lower bound. Return ``None`` otherwise; the caller
+        then runs the normal ``_plan_layout_generic`` path unchanged.
+
+        The certificate. Placement-only ``plan_layout`` runs only level 1
+        of the lex-solve inside :meth:`_run`: minimize
+        ``sum(spill_cost(b) * (1 - in_buffer(b)))`` over CP-SAT's
+        alignment-unit-scaled buffer copies. Levels 2 and 3 are gated on
+        ``core_terms`` being non-empty, which requires at least one
+        buffer to be a :class:`CoreDivisionBuffer` with non-empty
+        ``core_divisions`` -- absent on the placement-only path. The
+        :meth:`_run` ``cost_expr`` branch is not reachable from
+        :meth:`plan_layout` either (only
+        :meth:`plan_layout_and_core_divisions` accepts ``cost_expr``).
+
+        Every ``spill_cost(b) >= 0`` and ``(1 - in_buffer) in {0, 1}``, so
+        the objective is a nonnegative sum. Its lower bound is the sum
+        over exactly the buffers CP-SAT is forced to keep non-resident:
+        the set :meth:`record_exclusions` returns, which
+        ``_add_core_division`` pins to ``in_buffer = 0``. Reaching that
+        floor is equivalent to placing every non-excluded buffer.
+
+        The certificate compares CP-SAT-domain quantities. Buffer sizes
+        are wrapped with ``ceil_div(size, alignment)`` -- exactly what
+        :meth:`_wrap` does before the objective is built -- so
+        :func:`_hbm_spill_cost` (which
+        :meth:`_LifetimeBufferWithCpVars.spill_cost` also calls) evaluates
+        the exact same numerical objective CP-SAT would optimize.
+
+        Representability precondition. CP-SAT works in
+        ``_capacity_units = self.limit // self.alignment`` alignment-unit
+        slots and can only express offsets in ``[0, _capacity_units)``. If
+        ``_capacity_units == 0`` no plan the model can build places any
+        buffer, so greedy is not allowed to seed it; likewise a greedy
+        placement whose top-of-buffer exceeds ``_capacity_units *
+        alignment`` or whose address is not alignment-aligned is a plan
+        the model could not represent. Both cases fall through to
+        :meth:`_plan_layout_generic`.
+
+        Never mutates the caller's buffers unless it commits.
+        """
+        buffers = self.buffers
+        if not buffers:
+            return list(buffers)
+        # Representability: CP-SAT has zero addressable slots when
+        # capacity < alignment, so it cannot express any placement.
+        if self._capacity_units <= 0:
+            logger.debug(
+                "[CP-SAT layout solver] greedy seed skipped: "
+                "_capacity_units=%d has no placement domain",
+                self._capacity_units,
+            )
+            return None
+        # The forced-spill floor, in CP-SAT's alignment units. Match the
+        # exact set CP-SAT pins non-resident (residency_reason plus
+        # ``min_footprint > limit`` -- both covered by record_exclusions).
+        forced_reasons = dict(self.record_exclusions())
+        lower_bound_units = sum(
+            _hbm_spill_cost(replace(b, size=ceil_div(b.size, self.alignment)))
+            for b in buffers
+            if b.name in forced_reasons
+        )
+        try:
+            probe_buffers = copy.deepcopy(buffers)
+            greedy_plan = GreedyLayoutSolver(
+                probe_buffers,
+                self.limit,
+                self.alignment,
+            ).plan_layout(log_lx_usage=log_lx_usage)
+        except Exception as e:
+            # Greedy failed on this input -- surface via the CP-SAT path,
+            # which either handles the input or raises its own error.
+            logger.debug(
+                "[CP-SAT layout solver] greedy seed failed: %s; "
+                "falling through to full CP-SAT solve",
+                e,
+            )
+            return None
+        # Representability check on greedy's plan: each placed buffer
+        # must fit within ``[0, _capacity_units * alignment)`` and its
+        # address must be alignment-aligned. Greedy already aligns
+        # addresses to ``self.alignment`` in ``_find_free_block`` and
+        # already refuses to place a buffer above ``self.limit``, but
+        # ``self.limit`` isn't necessarily a multiple of alignment while
+        # CP-SAT's domain ceiling ``_capacity_units * alignment`` is.
+        cpsat_top = self._capacity_units * self.alignment
+        for b in greedy_plan:
+            if b.address is None:
+                continue
+            if b.address < 0 or b.address % self.alignment != 0:
+                logger.debug(
+                    "[CP-SAT layout solver] greedy seed unrepresentable: "
+                    "buffer %s at address=%d violates alignment=%d",
+                    b.name,
+                    b.address,
+                    self.alignment,
+                )
+                return None
+            if b.address + b.size > cpsat_top:
+                logger.debug(
+                    "[CP-SAT layout solver] greedy seed unrepresentable: "
+                    "buffer %s at address=%d size=%d exceeds CP-SAT top=%d",
+                    b.name,
+                    b.address,
+                    b.size,
+                    cpsat_top,
+                )
+                return None
+        # Evaluate greedy's objective in the same alignment-unit domain
+        # CP-SAT is optimizing.
+        greedy_objective_units = sum(
+            _hbm_spill_cost(replace(b, size=ceil_div(b.size, self.alignment)))
+            for b in greedy_plan
+            if b.address is None
+        )
+        if greedy_objective_units != lower_bound_units:
+            logger.debug(
+                "[CP-SAT layout solver] greedy seed left %d units of "
+                "residency objective on the table (lower bound %d, "
+                "greedy %d); running full CP-SAT solve",
+                greedy_objective_units - lower_bound_units,
+                lower_bound_units,
+                greedy_objective_units,
+            )
+            return None
+        # Certified. Commit greedy's addresses onto the caller's own
+        # ``LifetimeBoundBuffer`` instances, matching what
+        # :meth:`_plan_layout_generic` does at the tail of a normal CP-SAT
+        # solve. Match by name so the seed's own copies stay solver-local.
+        greedy_by_name = {b.name: b for b in greedy_plan}
+        for b in buffers:
+            b.address = greedy_by_name[b.name].address
+        # ``spill_reasons`` matches the CP-SAT tail: pre-solve forced
+        # reason when we have one, else the solver-chose-spill sentinel.
+        # Every spilled buffer here is in ``forced_reasons`` by the
+        # certificate (greedy placed every non-excluded buffer, so no
+        # buffer outside ``forced_reasons`` is spilled), but keep the
+        # fallback for symmetry with the CP-SAT tail.
+        self.spill_reasons = {
+            b.name: forced_reasons.get(b.name, _SOLVER_CHOSE_SPILL)
+            for b in buffers
+            if b.address is None
+        }
+        if logger.isEnabledFor(logging.DEBUG):
+            n_placed = sum(1 for b in buffers if b.address is not None)
+            logger.debug(
+                "[CP-SAT layout solver] greedy seed certified: "
+                "buffers=%d resident=%d hbm_traffic=%d (lower bound in "
+                "alignment units); CP-SAT solve skipped",
+                len(buffers),
+                n_placed,
+                lower_bound_units,
+            )
+        return list(buffers)
 
     def plan_layout_and_core_divisions(
         self, cost_expr: sympy.Expr | None = None

--- a/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
+++ b/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
@@ -149,13 +149,13 @@ def _ortools_available() -> bool:
 
     Contract: returns True iff ``ortools.sat.python.cp_model`` is
     importable in principle, False if any part of the dotted path is
-    missing. ``find_spec`` raises :exc:`ModuleNotFoundError` /
-    :exc:`ImportError` when a parent package on a dotted-module lookup
-    is absent -- treated as "not available" here rather than allowed to
-    leak out. Any other exception (a genuinely misconfigured
-    ``sys.path``, say) is also treated as unavailable so the
-    ``_make_cpsat_solver`` factory in ``allocator.py`` can fall back to
-    greedy uniformly.
+    missing. ``find_spec`` raises :exc:`ModuleNotFoundError` (an
+    :exc:`ImportError` subclass) when a parent package on a dotted-
+    module lookup is absent, and :exc:`ValueError` when a parent
+    package's ``__spec__`` is None (observed on some frozen
+    distributions). Both are caught here and translated into False.
+    Every other exception is left to propagate; unknown states are
+    the caller's problem, not silently masked.
     """
     global _ORTOOLS_AVAILABLE
     if _ORTOOLS_AVAILABLE is None:
@@ -164,74 +164,116 @@ def _ortools_available() -> bool:
         try:
             spec = importlib.util.find_spec("ortools.sat.python.cp_model")
         except (ImportError, ValueError):
-            # ModuleNotFoundError is an ImportError. ValueError shows up
-            # when a parent package's ``__spec__`` is None (edge case,
-            # observed on some frozen distributions).
             spec = None
         _ORTOOLS_AVAILABLE = spec is not None
     return _ORTOOLS_AVAILABLE
 
 
+def _do_ortools_import() -> tuple[object, object]:
+    """Perform the real OR-Tools SWIG import and return
+    ``(cp_model, cp_model_helper)``.
+
+    Broken out from :func:`_load_ortools` for two reasons:
+
+    1. Deterministic testing: unit tests count "did we actually
+       import" by patching this helper rather than by comparing
+       wall-clock durations.
+    2. The ``ImportError`` translation logic stays isolated from the
+       lock and publication logic in :func:`_load_ortools`.
+
+    Raises :exc:`ImportError` with the standard message when the
+    actual import fails.
+    """
+    try:
+        from ortools.sat.python import (
+            cp_model as _cp,
+            cp_model_helper as _cph,
+        )
+    except (
+        ImportError
+    ) as exc:  # pragma: no cover - exercised only when ortools is broken
+        raise ImportError(
+            "The 'cpsat' layout solver requires the 'ortools' package, "
+            "which is not installed or is broken. Install it with "
+            "'pip install ortools' or select a different layout_solver "
+            "(e.g. 'greedy')."
+        ) from exc
+    return _cp, _cph
+
+
 def _load_ortools() -> None:
-    """Import OR-Tools and populate the module-global ``cp_model`` and
-    ``cp_model_helper`` names. Idempotent, thread-safe, safe to call in
-    every method that touches a CP-SAT model.
+    """Import OR-Tools and publish the module-global ``cp_model`` and
+    ``cp_model_helper`` names atomically. Idempotent, thread-safe,
+    safe to call in every method that touches a CP-SAT model.
+
+    Contract on successful return:
+
+    * ``cp_model is not None``
+    * ``cp_model_helper is not None``
+
+    No caller may observe one bound and the other still ``None``.
+    The whole check-and-publish happens under
+    ``_ORTOOLS_LOAD_LOCK``: a concurrent caller entering the
+    critical section after publication sees both globals bound in
+    the same visit and returns without re-importing.
+
+    We do NOT do an outer fast-path ``if cp_model is not None:
+    return`` before acquiring the lock. Skipping the lock would
+    allow this race: publisher thread P assigns ``cp_model = _cp``,
+    reader thread R sees the non-None ``cp_model`` in the outer
+    check and returns before P has published ``cp_model_helper``.
+    Uncontended lock acquisition is cheap in Python (a few hundred
+    nanoseconds) and only happens on CP-SAT-solve paths, which
+    already cost milliseconds to seconds. The certified fast path
+    never calls :func:`_load_ortools`, so it is not paying the lock
+    either way.
 
     Failure modes and observable semantics:
 
-    * **OR-Tools not installed at all** (typical s390x/ppc64le, or an
-      unusual x86_64 install missing the wheel):
+    * **OR-Tools not installed at all** (typical s390x/ppc64le, or
+      an unusual x86_64 install missing the wheel):
       :func:`_ortools_available` returns False, so
       :meth:`CpSatLayoutSolver.__init__` raises :exc:`ImportError`
-      before ``_make_cpsat_solver`` in ``allocator.py`` returns; that
-      :exc:`ImportError` is caught there and the allocator falls back
-      to greedy with a warning. ``_load_ortools`` is never called in
-      that case. This matches pre-#4141 observable behavior exactly.
+      before ``_make_cpsat_solver`` in ``allocator.py`` returns;
+      that :exc:`ImportError` is caught there and the allocator
+      falls back to greedy with a warning. ``_load_ortools`` is
+      never called in that case. This matches pre-#4141 observable
+      behavior exactly.
 
-    * **OR-Tools present-but-broken** (spec resolvable, but importing
-      ``cp_model`` fails for a native-dep or install-corruption reason):
-      :func:`_ortools_available` returns True, ``__init__`` succeeds,
-      the certified seed runs on ``plan_layout``. If the seed rejects,
+    * **OR-Tools present-but-broken** (spec resolvable, but
+      importing ``cp_model`` fails for a native-dep or install-
+      corruption reason): :func:`_ortools_available` returns True,
+      ``__init__`` succeeds, the certified seed runs on
+      ``plan_layout``. If the seed rejects,
       :meth:`_plan_layout_generic` calls ``_load_ortools`` and the
-      genuine :exc:`ImportError` propagates. That is a *narrowing* of
-      the pre-#4141 fallback contract: pre-#4141 the same failure would
-      have surfaced during ``_make_cpsat_solver``'s outer catch and
-      fallen back to greedy. Post-#4141, on a certified compile the
-      broken install is invisible; on a fallback compile the
-      :exc:`ImportError` surfaces at solve time. We treat this as
-      acceptable because (a) an OR-Tools install that ``find_spec``
-      resolves but that raises at import time is a corrupted
-      environment problem the user needs to see; and (b) the certified
-      case -- the vast majority of measured compiles -- silently gets
-      an objective-equivalent result instead of a silent greedy
-      fallback. See the PR body for the explicit narrowing statement.
+      genuine :exc:`ImportError` propagates. That is a *narrowing*
+      of the pre-#4141 fallback contract: pre-#4141 the same
+      failure would have surfaced during ``_make_cpsat_solver``'s
+      outer catch and fallen back to greedy. Post-#4141, on a
+      certified compile the broken install is invisible; on a
+      fallback compile the :exc:`ImportError` surfaces at solve
+      time. We treat this as acceptable because (a) an OR-Tools
+      install that ``find_spec`` resolves but that raises at import
+      time is a corrupted environment problem the user needs to
+      see; and (b) the certified case -- the vast majority of
+      measured compiles -- silently gets an objective-equivalent
+      result instead of a silent greedy fallback. See the PR body
+      for the explicit narrowing statement.
     """
     global cp_model, cp_model_helper
-    # First check outside the lock keeps the fast path lock-free after
-    # the module is loaded. Double-check inside the lock guards against
-    # two threads racing to be the first to load.
-    if cp_model is not None:
-        return
     with _ORTOOLS_LOAD_LOCK:
         if cp_model is not None:
+            # A previous call published both globals under this same
+            # lock. Assert the pair is intact so any future refactor
+            # that breaks atomicity fails loudly rather than in a
+            # subtle way at a downstream ``cp_model_helper`` access.
+            assert cp_model_helper is not None
             return
-        try:
-            from ortools.sat.python import (
-                cp_model as _cp,
-                cp_model_helper as _cph,
-            )
-        except (
-            ImportError
-        ) as exc:  # pragma: no cover - exercised only when ortools is broken
-            raise ImportError(
-                "The 'cpsat' layout solver requires the 'ortools' package, "
-                "which is not installed or is broken. Install it with "
-                "'pip install ortools' or select a different layout_solver "
-                "(e.g. 'greedy')."
-            ) from exc
-        # Publish both globals in one step: any successful call to
-        # ``_load_ortools`` leaves both names bound; a concurrent second
-        # caller that arrives after this block sees both, not one.
+        _cp, _cph = _do_ortools_import()
+        # Assign both under the lock in one visible step. Any
+        # concurrent caller that arrives after this block enters the
+        # lock, sees ``cp_model is not None``, verifies the
+        # invariant, and returns.
         cp_model = _cp
         cp_model_helper = _cph
 


### PR DESCRIPTION
Stacks on #4139 (certified greedy seed for placement-only CP-SAT) but touches an orthogonal concern: module loading, not the certificate.

Refs #4117.

**Architecture note (Aug. 31):** the measured 1–2 s startup benefit in this PR is for certified placement-only compiles stacked on #4139, where CP-SAT can be skipped entirely. If joint CP-SAT co-optimization becomes the default (see #4139 discussion), OR-Tools is needed on the first default compile and this headline startup elimination no longer applies. Residual value of lazy loading (module-loading hygiene, thread-safe first-load, preserved absent-package fallback) survives regardless, but the primary compile-latency win is coupled to the maintainer decision on #4139.

## Motivation

PR #4139's certified greedy seed lets `CpSatLayoutSolver.plan_layout` return the CP-SAT-optimal placement without a CP-SAT solve when greedy already reaches the forced-spill lower bound of the residency objective. On the production-shaped compile probes used to demonstrate the startup win in this PR — 8/8 real `torch.compile` invocations on the rebased branch — the seed accepts on the certified path.

The broader #4139 evidence, which set expectations for how often the fast path fires but is *not* what this PR's win rests on:
- Differential corpus: 20 greedy-certified, 8 CP-SAT-fallback (of 28 non-SKIP cases).
- Capacity-pressure sweep on captured planner-buffer sets: 39 greedy-certified, 1 CP-SAT-fallback (flash-512x8192 at 25% of shipped LX capacity — the known case where CP-SAT strictly wins).

Yet every first compile in a fresh process was still paying ~1.4 s for the SWIG bootstrap of `ortools.sat.python.cp_model`, because that module was imported eagerly at `ilp_solver_ortools` import time — before the seed had a chance to prove CP-SAT unnecessary. The reconnaissance harness (commit `a0ec30a` in `toddllm/compiler-timing`, `notes/frontend-roadmap-handoff.md` Card 1) traced the exact import chain.

This PR makes the OR-Tools import happen only when a CP-SAT solve actually needs to run. Known-fallback cases (capacity-pressure workloads that hit the 1-of-40 sweep point, or the joint `plan_layout_and_core_divisions` path) still trigger the load on demand — that cost is unchanged for them.

## Design

- Replace module-top `from ortools.sat.python import cp_model, cp_model_helper` with `cp_model = None; cp_model_helper = None` in the runtime branch. Type annotations already use `TYPE_CHECKING` + `from __future__ import annotations`, so class definitions and method signatures don't need `cp_model` alive at import time.

- New `_ortools_available()`: cheap idempotent availability probe via `importlib.util.find_spec("ortools.sat.python.cp_model")`. First call is on the order of tens of milliseconds (measured 10-27 ms across the sessions we sampled); the answer is cached in `_ORTOOLS_AVAILABLE`; subsequent calls are microseconds. Catches `ImportError` (which subsumes `ModuleNotFoundError`) and `ValueError` (some frozen distributions emit this when a parent package's `__spec__` is None). Any other exception is left to propagate — unknown states are the caller's problem, not silently masked.

- New `_do_ortools_import()`: a tiny helper that owns the actual `from ortools.sat.python import cp_model, cp_model_helper` statement and the `ImportError` translation. Split out so unit tests can patch it to count real imports deterministically, and so the lock-and-publish logic in `_load_ortools` stays isolated from import-error translation.

- New `_load_ortools()`: idempotent, thread-safe full import that publishes the module globals `cp_model` and `cp_model_helper` while holding `_ORTOOLS_LOAD_LOCK`, so callers cannot return from `_load_ortools` with a half-initialized pair. The Python-level assignments to the two globals are not literally atomic; the synchronization contract is that only a lock-holding caller ever reads or writes them, and every publish-then-return happens under the lock. **`_load_ortools` always acquires the lock — there is no lock-free outer `cp_model is not None` short-circuit.** An earlier draft did have that outer check, which allowed this race: publisher P assigns `cp_model = _cp`; reader R sees non-None `cp_model` in the outer check and returns before P has published `cp_model_helper`; a downstream reader observes a half-published pair. The fix is to always take the lock and check inside. Uncontended lock cost is a few hundred nanoseconds; `_load_ortools` runs only on CP-SAT-solve paths, which already cost milliseconds to seconds. The certified fast path never calls `_load_ortools`.
  - Inside the lock: if `cp_model is not None`, `assert cp_model_helper is not None` guards the invariant, and return.
  - Otherwise: `_do_ortools_import()`, then assign `cp_model = _cp; cp_model_helper = _cph` before releasing the lock. Any concurrent second caller that arrives after this block enters the lock, sees both globals bound, and returns.

- `CpSatLayoutSolver.__init__` swaps the old `if cp_model is None: raise ImportError` for `_ortools_available()`. On x86_64 with ortools installed, the tens-of-milliseconds probe runs once per process; the cached answer serves every subsequent solver instance. On s390x/ppc64le, the probe returns False and `ImportError` fires exactly as today (caught by `_make_cpsat_solver` → greedy fallback).

- `CpSatLayoutSolver._plan_layout_generic` calls `_load_ortools()` on entry. This is the single choke point every CP-SAT code path flows through: the certificate-rejection fallback from `plan_layout` and the joint entry `plan_layout_and_core_divisions` (including the `cost_expr` branch added by #3810). A source audit of all 15 non-string runtime `cp_model` / `cp_model_helper` accesses in `ilp_solver_ortools.py` confirmed every one is inside methods reachable only through `_plan_layout_generic`.

## Observable-semantics reassessment

An earlier draft of this PR claimed "user-visible behavior unchanged." That claim is too strong. Two failure modes to distinguish:

**Package absent** (typical s390x/ppc64le, or any x86_64 install missing the wheel):
`_ortools_available()` returns False. `CpSatLayoutSolver.__init__` raises `ImportError` at construction. `_make_cpsat_solver` catches it and returns the greedy allocator with the same warning message. **Behavior identical to pre-#4141.**

**Package present-but-broken** (spec resolvable, but `import ortools.sat.python.cp_model` fails at runtime — a corrupted install, missing native dependency, etc.):
- Pre-#4141: the eager module-level `from ortools.sat.python import cp_model` inside `ilp_solver_ortools` fires as part of `_make_cpsat_solver`'s lazy import of the module; its `ImportError` is caught there and translated into the greedy fallback with a warning. The broken install is invisible to the user.
- Post-#4141 on a certified compile: `_ortools_available()` returns True; `__init__` succeeds; the seed accepts; no `_load_ortools()` call; **the broken install is silently invisible on the certified path**.
- Post-#4141 on a fallback compile: `_plan_layout_generic` calls `_load_ortools()`, which raises `ImportError`. That error propagates past `scratchpad_planning`'s `except SolveError` (it is not a `SolveError`) and past `_make_cpsat_solver`'s already-completed catch, so the compile fails with a genuine import error.

Verdict: this is a **narrowing** of the pre-#4141 fallback contract for the present-but-broken case. We accept the narrowing intentionally because (a) an ortools install that resolves via `find_spec` but raises at import time is a corrupted environment problem the user should see, not paper over silently; and (b) certified compiles — the majority in the measured placement-only corpus — silently succeed with an objective-equivalent result (whether that remains "the vast majority" of shipped compiles depends on whether the placement-only path remains the default; see architecture note above). The `_load_ortools` docstring documents this narrowing explicitly.

## Measured impact

Two fresh-process A/B sessions on the same pod, 5 samples per arm, trivial `torch.relu(x)` compile:

| session | BASELINE first_call median (min, max) | LAZY first_call median (min, max) | delta |
|---|---:|---:|---:|
| initial (pre-hardening) | 3.04 s (2.59, 5.00) | 1.93 s (1.59, 2.22) | -1.11 s (-36%) |
| hardened (higher pod contention) | 5.12 s (3.70, 15.82) | 3.06 s (2.40, 5.40) | -2.06 s (-40%) |

Two fresh-process A/B sessions independently show roughly **1–2 seconds removed from first useful certified-compile latency**. Absolute wall values are noisy — pod contention shifted the BASELINE median from 3.04 s to 5.12 s between sessions — so the exact "-2.06 s" figure is not promoted as the canonical universal win; the cleaner initial session's -1.11 s is a more conservative representative value.

Across the four stand-alone workloads from the frontend reconnaissance (flash 512x4096, flash 512x8192, MLP L=8, sdpa S=512), `_maybe_scratchpad_planning` falls off the top-8 pass list entirely (was 500-1200 ms; now < 60 ms), and `graphlowering.compile_to_module` drops ~600 ms consistently on every workload.

Second-call cache hit is unchanged (54 ms LAZY vs 68 ms BASELINE, within noise). `_ortools_available()` overhead: tens of milliseconds on first call (10-27 ms across the sessions we sampled), sub-microsecond on subsequent cached calls.

## Tests

`tests/inductor/test_cpsat_lazy_ortools_load.py` — 15 tests wired into GHA CI. There are no wall-clock assertions; every "how many times did we actually load OR-Tools" claim is proved deterministically by patching `_do_ortools_import`.

1. Importing `ilp_solver_ortools` does not import `cp_model`.
2. Constructing `CpSatLayoutSolver` does not import `cp_model`.
3. Certified greedy `plan_layout` does not import `cp_model`.
4. Fallback `plan_layout` (classic 10/20/30 with capacity 50) lazily imports `cp_model` and returns the CP-SAT optimum (objective 20).
5. Joint `plan_layout_and_core_divisions` (default residency-lex-solve path) lazily imports `cp_model`.
6. Joint `plan_layout_and_core_divisions(cost_expr=…)` behavioral test: pass a small nonconstant sympy expression (`-sum(sym_is_lx for b in bufs)`); assert `cp_model` unloaded before the call, loaded after, and the plan respects the `cost_expr`'s residency preference.
7. **Repeated CP-SAT solves load exactly once.** Patches `_do_ortools_import` with a counter wrapper before either solve runs; after two serial CP-SAT solves, the counter must read 1. Module identity is checked as a supporting invariant. No wall-clock assertion.
8. `_ortools_available()` matches `find_spec`.
9. `_ortools_available()` is cached (patching `find_spec` to raise).
10. `_ortools_available()` returns False when `find_spec` returns None.
11. `_ortools_available()` returns False when `find_spec` raises `ModuleNotFoundError`.
12. `_ortools_available()` returns False when `find_spec` raises `ValueError` (frozen-dist edge).
13. `_load_ortools()` is idempotent (module identity preserved on repeat calls).
14. `_load_ortools()` never returns with a half-published pair: both globals are non-None on every successful return.
15. **Concurrent first-load: no half-published state is observable.** Patches `_do_ortools_import` to sleep 100 ms after the real import to widen the race window; N=8 workers under a `threading.Barrier(N)` all call `_load_ortools`. Each worker reads both globals into its own record immediately after its own `_load_ortools` returns. Assertions: no worker raised; every worker's record shows both `cp_model` and `cp_model_helper` non-None; all workers agreed on both module identities; `_do_ortools_import` was invoked exactly once under contention.

Subprocess isolation for the `sys.modules`-membership assertions so pytest's own imports do not pollute the state under test.

All 15 lazy-load tests pass on the rebased branch. Focused validation: 390 tests pass (15 lazy-load + 18 certified-greedy-seed + 250 scratchpad-solver + 35 scratchpad-patterns + cost_objective + cooptimization_types + sa_cooptimizer; 1 skip, 11 unrelated expected failures).

## Not touched (reserved for follow-on owners)

- `optimize_restickify_locations` / restickify pipeline (Will's lane).
- SDSC per-spec / bundle-generation optimization.
- Shared cross-pass analysis context.
- Scheduler init/codegen or wrapper generation.
- Spyre device / runtime initialization.
- Broad `torch`/`torch_spyre` import restructuring.

The frontend roadmap for these lives at `toddllm/compiler-timing` `analyses/2026-08-pr4117-pre-dxp/notes/frontend-roadmap-handoff.md`.

Signed-off-by: Todd Deshane <todd.deshane@ibm.com>
