### PR TITLE
fix(ci): test_cases/run_properties dedup dropping cases when multiple XML files share one run_id

### DIFF
--- a/.github/scripts/ingest_xml.py
+++ b/.github/scripts/ingest_xml.py
@@ -1083,23 +1083,9 @@ def main():
 
             insert_run(client, run_id, run, args)
 
-            # run_id is this run's own key, so the join through test_runs is unnecessary.
-            existing_cases = client.query(
-                "SELECT count() FROM test_cases WHERE run_id = {run_id:String}",
-                parameters={"run_id": run_id},
-            )
-            if existing_cases.result_rows[0][0] > 0:
-                print("  Cases already exist — skipping case+property inserts")
-            else:
-                insert_cases(client, run_id, cases, workflow=args.workflow)
-                existing_props = client.query(
-                    "SELECT count() FROM run_properties WHERE run_id = {run_id:String}",
-                    parameters={"run_id": run_id},
-                )
-                if existing_props.result_rows[0][0] > 0:
-                    print("  Properties already exist — skipping property insert")
-                else:
-                    insert_properties(client, run_id, cases)
+            # The (run_id, filename) dedup above already covers this file; a run_id-only recheck here would skip a second file sharing the same run_id.
+            insert_cases(client, run_id, cases, workflow=args.workflow)
+            insert_properties(client, run_id, cases)
 
             total_cases += len(cases)
             print(


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

## Summary
Fixes `test_cases`/`run_properties` rows being silently dropped for trunk runs whose single-card and multi-card XML files share one `run_id`.

## Problem
The dedup check queried `test_cases` by `run_id` alone, so once the multi-card file's cases were inserted, the single-card file's ~20k cases (same `run_id`) were skipped as "already ingested".

## Fix
Removed the redundant `run_id`-only recheck — the `(run_id, filename)` check already above it makes each file's ingestion idempotent — so cases/properties are now always inserted per file.

```python
-            # run_id is this run's own key, so the join through test_runs is unnecessary.
-            existing_cases = client.query(
-                "SELECT count() FROM test_cases WHERE run_id = {run_id:String}",
-                parameters={"run_id": run_id},
-            )
-            if existing_cases.result_rows[0][0] > 0:
-                print("  Cases already exist — skipping case+property inserts")
-            else:
-                insert_cases(client, run_id, cases, workflow=args.workflow)
-                existing_props = client.query(
-                    "SELECT count() FROM run_properties WHERE run_id = {run_id:String}",
-                    parameters={"run_id": run_id},
-                )
-                if existing_props.result_rows[0][0] > 0:
-                    print("  Properties already exist — skipping property insert")
-                else:
-                    insert_properties(client, run_id, cases)
+            # The (run_id, filename) dedup above already covers this file; a run_id-only recheck here would skip a second file sharing the same run_id.
+            insert_cases(client, run_id, cases, workflow=args.workflow)
+            insert_properties(client, run_id, cases)
