### PR TITLE
fix(ingest): gate test_cases inserts on (run_id, filename), crash-safe (follow-up to #4144)

### DIFF
--- a/.github/scripts/ingest_xml.py
+++ b/.github/scripts/ingest_xml.py
@@ -781,7 +781,9 @@ def insert_run(client, run_id: str, run: dict, args):
     )
 
 
-def insert_cases(client, run_id: str, cases: list[dict], workflow: str = ""):
+def insert_cases(
+    client, run_id: str, cases: list[dict], workflow: str = "", filename: str = ""
+):
     if not cases:
         return
     client.insert(
@@ -799,6 +801,7 @@ def insert_cases(client, run_id: str, cases: list[dict], workflow: str = ""):
                 c["fail_message"][:8192],
                 c["triggered_at"].replace(tzinfo=None),
                 workflow,
+                filename,
             ]
             for c in cases
         ],
@@ -814,6 +817,7 @@ def insert_cases(client, run_id: str, cases: list[dict], workflow: str = ""):
             "fail_message",
             "triggered_at",
             "workflow",
+            "filename",
         ],
     )
 
@@ -935,6 +939,14 @@ def main():
     client.command(
         "ALTER TABLE benchmark_runs ADD COLUMN IF NOT EXISTS platform String DEFAULT ''"
     )
+    # test_cases carries the source filename so the case-insert idempotency gate
+    # below can ask "were THIS file's cases already written", the same
+    # (run_id, filename) key test_runs dedups on. Without it a crash between the
+    # run insert and the case insert would leave that file's cases missing on a
+    # retry, and two legs that share one threaded run_id could not be told apart.
+    client.command(
+        "ALTER TABLE test_cases ADD COLUMN IF NOT EXISTS filename String DEFAULT ''"
+    )
 
     total_cases = 0
     total_benchmarks = 0
@@ -1049,21 +1061,25 @@ def main():
             # Resolved BEFORE dedup, which keys on it.
             run_id = _threaded_run_id(args) or str(uuid.uuid4())
 
-            # Dedup on (run_id, filename): re-ingesting the SAME test run must be idempotent,
-            # but two distinct runs must never collapse. runner_run_id mirrors run_id for a Jenkins/standalone leg, so it's only an independent signal for a GHA numeric id.
+            # Dedup on (run_id, filename): re-ingesting the SAME test run must
+            # be idempotent, but two distinct runs must never collapse.
+            # runner_run_id mirrors run_id for a Jenkins/standalone leg, so it is
+            # an independent signal only for a GHA numeric id.
             runner_run_id = _runner_run_id(args, run_id)
             existing = client.query(
                 "SELECT count() FROM test_runs "
                 "WHERE run_id = {run_id:String} AND filename = {filename:String}",
                 parameters={"run_id": run_id, "filename": run["filename"]},
             )
-            if (
-                existing.result_rows[0][0] == 0
-                and runner_run_id
-                and runner_run_id != run_id
-            ):
-                # A GHA re-ingest mints a fresh uuid4, so fall back to the numeric run id
-                # to keep that path idempotent.
+            # Did THIS file's run row already exist under the SAME run_id we are
+            # about to insert under? Only then can the case gate below find its
+            # cases by (run_id, filename), so only then is the crash-heal
+            # fall-through safe. A match on the runner_run_id fallback is a
+            # different run_id, so it must not fall through (see below).
+            matched_same_run_id = existing.result_rows[0][0] > 0
+            if not matched_same_run_id and runner_run_id and runner_run_id != run_id:
+                # A GHA re-ingest mints a fresh uuid4, so fall back to the
+                # numeric run id to keep that path idempotent.
                 existing = client.query(
                     "SELECT count() FROM test_runs WHERE "
                     "runner_run_id = {runner_run_id:String} AND filename = {filename:String}",
@@ -1072,26 +1088,58 @@ def main():
                         "filename": run["filename"],
                     },
                 )
-            if existing.result_rows[0][0] > 0:
-                print(f"  Already ingested — skipping {run['filename']}")
-                continue
             print(
                 f"  run_id={run_id}  tests={run['total_tests']}  "
                 f"passed={run['passed']}  failed={run['failed']}  "
                 f"xpass={run['xpass']}  xfail={run['xfail']}  skipped={run['skipped']}"
             )
 
-            insert_run(client, run_id, run, args)
+            if existing.result_rows[0][0] > 0:
+                # This file's run row is already present. If it matched only via
+                # the runner_run_id fallback (a GHA re-ingest under a fresh
+                # uuid4), the cases live under the OLD run_id, so the (run_id,
+                # filename) case gate below could not see them and would insert
+                # duplicates. Keep #4144's behavior there: skip the whole file.
+                if not matched_same_run_id:
+                    print(f"  Already ingested — skipping {run['filename']}")
+                    continue
+                # Matched under the SAME run_id: a prior ingest of THIS file may
+                # have written the run row but crashed before its cases (network
+                # drop / OOM between the two inserts). Skip only the run insert
+                # and fall through to the case gate, which re-inserts the missing
+                # cases. A fully-ingested file still finds its cases and skips.
+                print(f"  Run row already present — {run['filename']}")
+            else:
+                insert_run(client, run_id, run, args)
 
-            # The (run_id, filename) dedup above already covers this file; a run_id-only recheck here would skip a second file sharing the same run_id.
-            insert_cases(client, run_id, cases, workflow=args.workflow)
-            insert_properties(client, run_id, cases)
-
-            total_cases += len(cases)
-            print(
-                f"  Inserted {len(cases)} test cases + "
-                f"{sum(len(c['properties']) for c in cases)} properties"
+            # Gate the case + property inserts on THIS file's cases, keyed on the
+            # same (run_id, filename) as the test_runs dedup above. A run_id-only
+            # recheck was wrong: two legs share one threaded run_id, so the second
+            # file processed would see the first's cases and skip its own. Keying
+            # on filename also self-heals the crash case above: the run row exists
+            # but the cases do not, so the retry re-inserts them instead of
+            # skipping this file forever.
+            existing_cases = client.query(
+                "SELECT count() FROM test_cases "
+                "WHERE run_id = {run_id:String} AND filename = {filename:String}",
+                parameters={"run_id": run_id, "filename": run["filename"]},
             )
+            if existing_cases.result_rows[0][0] > 0:
+                print(f"  Cases already exist — skipping {run['filename']}")
+            else:
+                insert_cases(
+                    client,
+                    run_id,
+                    cases,
+                    workflow=args.workflow,
+                    filename=run["filename"],
+                )
+                insert_properties(client, run_id, cases)
+                total_cases += len(cases)
+                print(
+                    f"  Inserted {len(cases)} test cases + "
+                    f"{sum(len(c['properties']) for c in cases)} properties"
+                )
 
     print(f"\nDone. {len(xml_files)} file(s) processed.")
     print(f"  Test cases ingested:  {total_cases}")


### PR DESCRIPTION
## What this does

Follow-up to #4144 (now merged). It adds a `filename` column to `test_cases`
and keys the case-insert idempotency check on `(run_id, filename)`, the same key
`test_runs` already dedups on, instead of `run_id` alone.

## Why

#4144 fixed the reported bug (two per-leg XMLs that share one threaded `run_id`
dropped the second file's cases) by removing the `run_id`-only recheck and
relying on the `test_runs` `(run_id, filename)` guard. That is correct for the
normal single-pass path.

One edge stayed open after #4144, flagged in the #4144 review: idempotency then
depends on the `test_runs` row existing. If a prior ingest wrote the `test_runs`
row but crashed before its cases (a network drop or OOM between the two
inserts), a retry hit the `(run_id, filename)` `test_runs` guard, `continue`d,
and that file's cases stayed missing forever.

It is rare (once ClickHouse connects, the two inserts are seconds apart), so
this is a small belt-and-suspenders on top of #4144, not a rewrite.

## How

- `ALTER TABLE test_cases ADD COLUMN IF NOT EXISTS filename String DEFAULT ''`
  at startup, matching the existing `benchmark_runs` column adds. The live PROD
  table self-migrates on the next ingest; no manual step.
- `insert_cases` writes the source filename.
- The case gate now checks `test_cases` for THIS `(run_id, filename)` and
  inserts only when its cases are absent.
- The `test_runs` row-exists path falls through to the case gate ONLY when the
  run row matched under the SAME `run_id` this ingest uses. It then skips just
  the run insert, so a crash between the run insert and the case insert
  self-heals on retry: the run row is present, the cases are not, so the retry
  re-inserts them. A fully re-ingested file still finds its cases and skips.
- The one path that must NOT fall through is a GHA re-ingest, which mints a
  fresh `uuid4` each time and finds the prior row only through the
  `runner_run_id` fallback. There the cases live under the old `run_id`, so a
  `(run_id, filename)` case gate could not see them and would insert duplicates.
  That path keeps #4144's behavior and skips the whole file. Only a same-`run_id`
  match (the Jenkins threaded-`run_id` and standalone paths) takes the crash-heal
  fall-through.

No ClickHouse engine change (`test_cases` stays a plain `MergeTree`); no row
update or mutation.

## Companion change

A fresh database gets the column from the `spyre-dashboard` schema-of-record. A
matching addition to the `test_cases` DDL, `_alter_statements()`, and a numbered
migration there keeps a from-scratch bootstrap consistent with the live table
this PR migrates. It is tracked separately because it lives in another repo.

## Test

No local Groovy or ClickHouse instance validates the ingest path end to end.
The change is a Python edit to `ingest_xml.py`; it compiles and the added lines
stay within the 88-character limit. The reported defect and the fix are
documented with live PROD ClickHouse evidence (run IDs, per-leg counts, and the
exact code path) in the investigation that led here.
