### PR TITLE
fix(inductor): coarse-tile persistent loop fixes for MoE

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -6818,8 +6818,8 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
             rtol=0.05,
         )
 
-    def test_carried_sum_requires_terminal_reduction(self):
-        """A sum with a consumer retains the existing unsupported result."""
+    def test_carried_sum_allows_outside_pointwise_consumer(self):
+        """An outside consumer reads the completed post-loop drain."""
 
         E, T, H = 4, 64, 64
         values = torch.randn(E, T, H, dtype=torch.float16) * 0.1
@@ -6830,16 +6830,25 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
         def fn(values):
             _name_tensor_dims(values, ["E", "T", "H"])
             with spyre_hint(
-                num_tiles_per_dim={"E": 2},
+                num_tiles_per_dim={"E": E},
                 work_div={"T": 32},
             ):
                 reduced = values.sum(dim=0)
-                return reduced + 1
+            return reduced + 1
 
-        with self.assertRaisesRegex(
-            Exception, "partial reduction result consumed before accumulation"
-        ):
-            _compile_and_run(fn, (values,), "spyre")
+        def check_source(source):
+            self.assertIn("coarse_tile_reduction_drain", source)
+
+        with config.patch({"sencores": 32, "lx_planning": True}):
+            compare_with_cpu(
+                fn,
+                values,
+                run_compile=True,
+                run_eager=False,
+                source_check=check_source,
+                atol=0.05,
+                rtol=0.05,
+            )
 
     def test_carried_sum_rejects_reduction_dim_work_div(self):
         """The hint must name an output row, not the reduced expert dim."""

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -6844,16 +6844,15 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
         def check_source(source):
             self.assertIn("coarse_tile_reduction_drain", source)
 
-        with config.patch({"sencores": 32, "lx_planning": True}):
-            compare_with_cpu(
-                fn,
-                values,
-                run_compile=True,
-                run_eager=False,
-                source_check=check_source,
-                atol=0.05,
-                rtol=0.05,
-            )
+        compare_with_cpu(
+            fn,
+            values,
+            run_compile=True,
+            run_eager=False,
+            source_check=check_source,
+            atol=0.05,
+            rtol=0.05,
+        )
 
     def test_carried_sum_rejects_reduction_dim_work_div(self):
         """The hint must name an output row, not the reduced expert dim."""

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1500,6 +1500,64 @@ class TestDivideRanges(unittest.TestCase):
             [["T"]],
         )
 
+    def test_fused_symbol_fallback_invalidates_and_preserves_stable_symbols(self):
+        from torch_spyre._inductor.pass_utils import iteration_space_from_op
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _apply_work_div_symbol_remap,
+        )
+
+        op = self._make_named_pointwise([Integer(128), Integer(64)], ["T", "H"])
+        symbols = tuple(iteration_space_from_op(op))
+        before_space = dict(zip(symbols, (Integer(128), Integer(64))))
+        after_space = dict(zip(symbols, (Integer(64), Integer(64))))
+
+        with (
+            patch(
+                "torch_spyre._inductor.wsr.coarse_tile._capture_logical_iteration_symbols",
+                side_effect=Unsupported("fused dimensions"),
+            ),
+            patch(
+                "torch_spyre._inductor.wsr.coarse_tile.iteration_space_from_op",
+                side_effect=(before_space, after_space),
+            ),
+            patch(
+                "torch_spyre._inductor.wsr.coarse_tile.invalidate_op_read_writes"
+            ) as invalidate,
+        ):
+            result = _divide_ranges(op, Integer(2), tiled_dims=[0])
+
+        invalidate.assert_called_once_with(op)
+        _apply_work_div_symbol_remap(op, result.symbol_remap)
+        self.assertEqual(
+            op.work_div_loop_info,  # type: ignore[attr-defined]
+            {symbols[0]: ["T"], symbols[1]: ["H"]},
+        )
+
+    def test_fused_symbol_fallback_rejects_output_rank_change(self):
+        from torch_spyre._inductor.pass_utils import iteration_space_from_op
+
+        op = self._make_named_pointwise([Integer(2), Integer(64)], ["E", "H"])
+        before_symbols = tuple(iteration_space_from_op(op))
+        after_symbols = before_symbols[:1]
+
+        with (
+            patch(
+                "torch_spyre._inductor.wsr.coarse_tile._capture_logical_iteration_symbols",
+                side_effect=Unsupported("fused dimensions"),
+            ),
+            patch(
+                "torch_spyre._inductor.wsr.coarse_tile.iteration_space_from_op",
+                side_effect=(
+                    dict(zip(before_symbols, (Integer(2), Integer(64)))),
+                    {after_symbols[0]: Integer(64)},
+                ),
+            ),
+            self.assertRaisesRegex(
+                Unsupported, "cannot safely preserve fused work-division symbols"
+            ),
+        ):
+            _divide_ranges(op, Integer(2), tiled_dims=[0])
+
     def test_non_monotone_symbol_mapping_fails_visibly(self):
         from torch_spyre._inductor.wsr.coarse_tile import (
             _LogicalIterationSymbol,
@@ -7351,6 +7409,48 @@ class TestDivideReductionRanges(unittest.TestCase):
         self.assertEqual(
             op.work_div_loop_info,  # type: ignore[attr-defined]
             {Symbol("d0"): ["T"], Symbol("d1"): ["F"]},
+        )
+
+    def test_fused_output_dims_allow_trailing_reduction_symbol_squeeze(self):
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _apply_work_div_symbol_remap,
+            _divide_reduction_ranges,
+        )
+
+        output_sym = Symbol("d0")
+        reduction_sym = Symbol("r0")
+        op = self._make_reduction_op(
+            ranges=[Integer(512), Integer(704)],
+            reduction_ranges=[Integer(128)],
+        )
+        op.work_div_loop_info = {  # type: ignore[attr-defined]
+            output_sym: ["T", "H"],
+            reduction_sym: ["E"],
+        }
+
+        with (
+            patch(
+                "torch_spyre._inductor.wsr.coarse_tile._capture_logical_iteration_symbols",
+                side_effect=Unsupported("fused output dimensions"),
+            ),
+            patch(
+                "torch_spyre._inductor.wsr.coarse_tile.iteration_space_from_op",
+                side_effect=(
+                    {output_sym: Integer(512 * 704), reduction_sym: Integer(128)},
+                    {output_sym: Integer(512 * 704)},
+                ),
+            ),
+            patch(
+                "torch_spyre._inductor.wsr.coarse_tile.invalidate_op_read_writes"
+            ) as invalidate,
+        ):
+            remap = _divide_reduction_ranges(op, Integer(128), [0])
+
+        invalidate.assert_called_once_with(op)
+        _apply_work_div_symbol_remap(op, remap)
+        self.assertEqual(
+            op.work_div_loop_info,  # type: ignore[attr-defined]
+            {output_sym: ["T", "H"]},
         )
 
 

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -1898,6 +1898,42 @@ def _order_preserving_symbol_remap(
     )
 
 
+def _fused_iteration_symbol_remap(
+    op: ComputedBuffer,
+    before_symbols: tuple[sympy.Symbol, ...],
+    *,
+    max_trailing_removals: int,
+) -> _IterationSymbolRemap:
+    """Preserve names when fused-loop symbols demonstrably retain their identity.
+
+    ``_capture_logical_iteration_symbols`` cannot describe a many-logical-dims to
+    one-loop-symbol fusion.  For that case, accept only the narrower invariant we
+    can still prove: the post-rewrite symbols are an unchanged prefix of the old
+    symbols.  Reduction variables are appended to the iteration space, so a
+    reduction-range rewrite may additionally remove a known number of trailing
+    symbols.  Output-range rewrites pass zero and therefore cannot silently
+    reinterpret a renumbered surviving dimension.
+    """
+
+    after_symbols = tuple(iteration_space_from_op(op))
+    removed = len(before_symbols) - len(after_symbols)
+    if (
+        removed < 0
+        or removed > max_trailing_removals
+        or before_symbols[: len(after_symbols)] != after_symbols
+    ):
+        raise Unsupported(
+            f"coarse_tile: cannot safely preserve fused work-division symbols "
+            f"for {op.get_name()!r}: before={tuple(map(str, before_symbols))}, "
+            f"after={tuple(map(str, after_symbols))}"
+        )
+
+    return _IterationSymbolRemap(
+        before_symbols=before_symbols,
+        pairs=tuple((symbol, symbol) for symbol in after_symbols),
+    )
+
+
 def _apply_work_div_symbol_remap(
     op: ComputedBuffer, remap: _IterationSymbolRemap | None
 ) -> None:
@@ -1952,11 +1988,12 @@ def _divide_ranges(
         return _DivideRangesResult(None, None)
 
     before_symbols = None
+    fused_before_symbols = None
     if tiled_dims and hasattr(op, "work_div_loop_info"):
         try:
             before_symbols = _capture_logical_iteration_symbols(op)
         except Unsupported:
-            pass
+            fused_before_symbols = tuple(iteration_space_from_op(op))
 
     for i in tiled_dims:
         assert 0 <= i < len(ranges), (
@@ -1992,11 +2029,20 @@ def _divide_ranges(
     _clear_cache(op, _COMPUTED_BUF_FREE_SYMS_KEY)
 
     symbol_remap = None
-    if before_symbols is not None:
+    if before_symbols is not None or fused_before_symbols is not None:
+        # Both capture paths call the memoized iteration-space helper before
+        # ranges are rewritten.  Always invalidate it before observing the new
+        # iteration space, including the fused-dimension fallback.
         invalidate_op_read_writes(op)
-        symbol_remap = _order_preserving_symbol_remap(
-            op, before_symbols, _capture_logical_iteration_symbols(op)
-        )
+        if before_symbols is not None:
+            symbol_remap = _order_preserving_symbol_remap(
+                op, before_symbols, _capture_logical_iteration_symbols(op)
+            )
+        else:
+            assert fused_before_symbols is not None
+            symbol_remap = _fused_iteration_symbol_remap(
+                op, fused_before_symbols, max_trailing_removals=0
+            )
 
     # Sync layout.size, layout.stride, and layout.device_layout with the new ranges.
     layout = getattr(op, "layout", None)
@@ -2062,12 +2108,14 @@ def _divide_reduction_ranges(
     if not tiled_dims:
         return None
     before_symbols = None
+    fused_before_symbols = None
     if hasattr(op, "work_div_loop_info"):
         try:
             before_symbols = _capture_logical_iteration_symbols(op)
         except Unsupported:
-            pass
-    reduction_ranges = list(data.reduction_ranges)
+            fused_before_symbols = tuple(iteration_space_from_op(op))
+    original_reduction_ranges = tuple(data.reduction_ranges)
+    reduction_ranges = list(original_reduction_ranges)
     for i in tiled_dims:
         assert 0 <= i < len(reduction_ranges), (
             f"coarse_tile: op {op.get_name()!r} tiled reduction dim {i} out of bounds "
@@ -2088,12 +2136,29 @@ def _divide_reduction_ranges(
             reduction_ranges[i] = sympy.sympify(r) / sympy.sympify(loop_count)
     # Reduction is a frozen dataclass; use object.__setattr__ to mutate it.
     object.__setattr__(data, "reduction_ranges", reduction_ranges)
-    if before_symbols is None:
+    if before_symbols is None and fused_before_symbols is None:
         return None
 
     invalidate_op_read_writes(op)
-    return _order_preserving_symbol_remap(
-        op, before_symbols, _capture_logical_iteration_symbols(op)
+    if before_symbols is not None:
+        return _order_preserving_symbol_remap(
+            op, before_symbols, _capture_logical_iteration_symbols(op)
+        )
+
+    active_before = [
+        i
+        for i, extent in enumerate(original_reduction_ranges)
+        if sympy.sympify(extent) != 1
+    ]
+    removed = [i for i in active_before if sympy.sympify(data.reduction_ranges[i]) == 1]
+    # Only reduction symbols at the end of the iteration space may disappear
+    # without renumbering a survivor. Anything else remains ambiguous.
+    trailing_removals = (
+        len(removed) if removed and removed == active_before[-len(removed) :] else 0
+    )
+    assert fused_before_symbols is not None
+    return _fused_iteration_symbol_remap(
+        op, fused_before_symbols, max_trailing_removals=trailing_removals
     )
 
 

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -1950,11 +1950,12 @@ def _divide_ranges(
     if not ranges:
         return _DivideRangesResult(None, None)
 
-    before_symbols = (
-        _capture_logical_iteration_symbols(op)
-        if tiled_dims and hasattr(op, "work_div_loop_info")
-        else None
-    )
+    before_symbols = None
+    if tiled_dims and hasattr(op, "work_div_loop_info"):
+        try:
+            before_symbols = _capture_logical_iteration_symbols(op)
+        except Unsupported:
+            pass
 
     for i in tiled_dims:
         assert 0 <= i < len(ranges), (
@@ -2059,11 +2060,12 @@ def _divide_reduction_ranges(
     assert isinstance(data, Reduction)
     if not tiled_dims:
         return None
-    before_symbols = (
-        _capture_logical_iteration_symbols(op)
-        if hasattr(op, "work_div_loop_info")
-        else None
-    )
+    before_symbols = None
+    if hasattr(op, "work_div_loop_info"):
+        try:
+            before_symbols = _capture_logical_iteration_symbols(op)
+        except Unsupported:
+            pass
     reduction_ranges = list(data.reduction_ranges)
     for i in tiled_dims:
         assert 0 <= i < len(reduction_ranges), (

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -298,13 +298,14 @@ def _plan_carried_sum(
     """
 
     data = op.data
+    has_work_div = bool(getattr(op, "work_div_loop_info", None))
     if not (
         isinstance(data, Reduction)
         and data.reduction_type == "sum"
         and getattr(data, "src_dtype", object()) == getattr(data, "dtype", None)
         and not is_nested
-        and is_graph_output
-        and not outside_consumer_names
+        and (is_graph_output or has_work_div)
+        and (not outside_consumer_names or has_work_div)
         and len(info.loop_count) == 1
         and all(not dims for dims in info.loop_tiled_dims)
         and info.loop_tiled_reduction_dims == [[0]]


### PR DESCRIPTION
## Summary

Two fixes for the coarse-tile persistent expert loop path used by MoE models (Gemma 4 26B) where `num_tiles_per_dim` tiles the expert reduction and `work_div` divides output rows across cores:

- **Skip symbol capture when fused dims prevent mapping**: when the Inductor scheduler fuses output dimensions, the logical dimension count can exceed the iteration symbol count. Wrap `_capture_logical_iteration_symbols` in try/except so reductions with fused dims can still tile without aborting.
- **Allow carried sums with work-div outside consumers**: when a reduction has an explicit `work_div` hint, relax the `is_graph_output` and no-outside-consumers requirements for carried sum planning. The `work_div` annotation provides an explicit ownership contract that makes the carried accumulator safe even when downstream pointwise consumers (e.g. a dtype cast) exist in the graph.

## Test plan

- [ ] Existing `test_coarse_tiling.py` and `test_coarse_tile_e2e.py` pass
- [ ] Gemma 4 26B MoE prefill compiles and produces correct tokens (tested via hf-adapters `test_e2e_token_compare_spyre`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)