### PR TITLE
fix(inductor): preserve staggered RMSNorm layout

### DIFF
--- a/tests/inductor/test_building_blocks.py
+++ b/tests/inductor/test_building_blocks.py
@@ -201,6 +201,38 @@ class TestBuildingBlocks(unittest.TestCase):
             run_eager=False,
         )
 
+    def test_chained_rms_norm_fp32_upcast(self):
+        B, S, H = 1, 64, 2816
+        eps = 1e-6
+        residual = torch.randn(B, S, H, dtype=torch.float16) / 4
+        dense = torch.randn(B, S, H, dtype=torch.float16) / 4
+        moe = torch.randn(S, H, dtype=torch.float16) / 4
+        weight1 = torch.randn(H, dtype=torch.float16) / 4
+        weight2 = torch.randn(H, dtype=torch.float16) / 4
+        scale = torch.tensor([0.5], dtype=torch.float16)
+
+        def rms_norm(x, weight):
+            x32 = x.to(torch.float32)
+            var = x32.pow(2).mean(-1, keepdim=True)
+            return (x32 * torch.rsqrt(var + eps)).to(x.dtype) * weight
+
+        def chained_rms_norm(residual, dense, moe, weight1, weight2, scale):
+            moe_out = rms_norm(moe, weight1).reshape_as(dense)
+            ffn_out = rms_norm(dense + moe_out, weight2)
+            return (residual + ffn_out) * scale
+
+        compare_with_cpu(
+            chained_rms_norm,
+            residual,
+            dense,
+            moe,
+            weight1,
+            weight2,
+            scale,
+            cpu_compile=False,
+            run_eager=False,
+        )
+
     def test_mixed_ea_staggered_broadcaster_fp16(self):
         # Case 3.2 of the mixed-EA rule: the *staggered* operand is the
         # size-1-stick broadcaster (fp16 produced by an fp32->fp16 downcast,

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -1059,15 +1059,12 @@ def _multi_arg_pointwise_layouts(
     #   2a. >1 distinct staggered EA                -> unsupported (raise)
     #   2b. one staggered EA, no STANDARD operands  -> staggered output (via 3.1)
     #   3.  one staggered EA mixed with STANDARD operands:
-    #       3.2 every staggered operand can broadcast  -> STANDARD output
     #       3.1 every STANDARD operand can broadcast   -> staggered output
+    #       3.2 every staggered operand can broadcast  -> STANDARD output
     #       3.3 otherwise (a STANDARD and a staggered full operand coexist)
     #                                                  -> unsupported (raise)
-    # 3.2 is checked BEFORE 3.1: when every staggered operand is a size-1-stick
-    # broadcaster it carries no ordering, so the op is representable as an
-    # all-STANDARD broadcast, and a STANDARD output is preferred even when the
-    # STANDARD operands are also broadcastable (the overlap) -- it avoids a
-    # downstream back-conversion and the staggered operands are degenerate anyway.
+    # Prefer 3.1 in the overlap because propagation does not yet know which
+    # candidate layout the optimizer will commit for the staggered producer.
     # A future extension may admit 2a/3.3 by inserting an explicit EA conversion
     # at extra cost.
     staggered_inputs = input_eas & STAGGERED_EAS
@@ -1116,11 +1113,17 @@ def _multi_arg_pointwise_layouts(
             if arg.layouts and arg.layouts[0].element_arrangement == staggered_ea
         ]
 
-        if stag_split and all(broadcast for _, broadcast, _ in stag_split):
-            # Case 3.2 (checked before 3.1): every staggered operand is a size-1-
-            # stick broadcaster, so none carries a real ordering. Treat the op as
-            # an all-STANDARD broadcast (STANDARD output), preferred even in the
-            # overlap where the STANDARD operands also broadcast.
+        if all(broadcast for _, broadcast, _ in std_split):
+            # Case 3.1 (and case 2b with no STANDARD operands): preserve the
+            # staggered arrangement and keep only broadcast-compatible STANDARD
+            # candidates.
+            output_ea = staggered_ea
+            for arg, broadcast, non_broadcast in std_split:
+                if non_broadcast:
+                    arg.layouts[:] = broadcast
+        elif stag_split and all(broadcast for _, broadcast, _ in stag_split):
+            # Case 3.2: every staggered operand has a broadcast candidate, so
+            # the operation can use STANDARD ordering.
             #
             # Safety: device coordinates depend only on device_size/stride_map,
             # not the EA label (see device_coordinates), and `_is_supported_layout`
@@ -1163,16 +1166,6 @@ def _multi_arg_pointwise_layouts(
                 if non_broadcast:
                     arg.layouts[:] = broadcast
             staggered_inputs = set()
-        elif all(broadcast for _, broadcast, _ in std_split):
-            # Case 3.1 (and, vacuously, case 2b when there are no STANDARD
-            # operands): a genuine (full) staggered operand dictates the
-            # arrangement and every STANDARD operand broadcasts against it. Keep
-            # the staggered candidates and prune each STANDARD operand to its
-            # broadcast candidates; the output stays staggered.
-            output_ea = staggered_ea
-            for arg, broadcast, non_broadcast in std_split:
-                if non_broadcast:
-                    arg.layouts[:] = broadcast
         else:
             # Case 3.3: a STANDARD operand and a staggered operand are both
             # non-broadcast full tensors — a genuine mixed-order op we cannot


### PR DESCRIPTION
## Summary

- prefer the staggered-output mixed-EA rule when both broadcast rules are possible
- keep the existing STANDARD-output rule when the STANDARD operands cannot broadcast
- add a Gemma-shaped regression test with chained fp32-upcast RMSNorms

## Why this is separate

This is a follow-up to #4110. Case 3.2 checks whether a staggered operand has a broadcast candidate, but that per-consumer candidate does not prove the producer will commit a broadcast layout. Choosing STANDARD in the overlap can therefore relabel full DL16_TO_FP32 data without a conversion.

The bug is independent of #4157 coarse tiling and #4158 mixed-dtype reduction handling. This change applies and its focused tests pass directly on current main without either PR.

## Validation

- Before the fix, the tokenizer-updated Gemma 4 26B E2E test fails compiling the first prefill MoE FFN at buf73 with the mixed-EA geometry error for buf68.
- With the fix on the full MoE stack, Gemma 4 26B passes 5/5 token comparisons; prefill max/mean logit error is 0.50/0.131.
- Focused building-block tests: 3 passed.
- Pre-commit hooks pass.