### PR TITLE
Delete greedy restickify optimizer 

### DIFF
--- a/docs/source/api/torch_spyre.rst
+++ b/docs/source/api/torch_spyre.rst
@@ -684,8 +684,6 @@ Environment Variables
        passed in as ``%pool_base_addr``, instead of the backend
        self-allocating via ``sdscbundle.device_mem_allocate``
        (default ``0``)
-   * - ``GLOBAL_STICK_OPTIMIZER``
-     - Enable the global stick-dimension optimizer (default ``1``)
    * - ``SPYRE_CORE_ID_K_FAST_EMISSION``
      - Permute physical core IDs at SDSC emission so K-collaborator cores
        sit on adjacent ring positions, reducing PSUM chain hops (default

--- a/tests/inductor/test_copy_back_elision.py
+++ b/tests/inductor/test_copy_back_elision.py
@@ -43,8 +43,7 @@ def _assert_copy_back_preserved(source: str) -> None:
     assert any("copy_" in line for line in source.splitlines() if "sdsc_fused_" in line)
 
 
-@pytest.mark.parametrize("global_stick_optimizer", [True, False])
-def test_mm_out_copy_back_into_input_is_elided(global_stick_optimizer):
+def test_mm_out_copy_back_into_input_is_elided():
     torch.manual_seed(0xAFFE)
     x = torch.randn(SIZE, SIZE, dtype=torch.float16)
     y = torch.randn(SIZE, SIZE, dtype=torch.float16)
@@ -57,10 +56,7 @@ def test_mm_out_copy_back_into_input_is_elided(global_stick_optimizer):
 
     expected_z = z.clone()
     expected = fn(x, y, expected_z, w)
-    with patch.object(
-        inductor_config, "global_stick_optimizer", global_stick_optimizer
-    ):
-        actual, source, device_args = _compile_and_source(fn, x, y, z, w)
+    actual, source, device_args = _compile_and_source(fn, x, y, z, w)
 
     torch.testing.assert_close(actual.cpu(), expected, atol=0.1, rtol=0.1)
     torch.testing.assert_close(device_args[2].cpu(), expected_z, atol=0.1, rtol=0.1)

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -32,8 +32,6 @@ hbm_pool_planning: bool = _get_env_bool("HBM_POOL_PLANNING", True)
 # spyre_empty_with_layout) and pass its address in as %pool_base_addr.
 frontend_pool_allocation: bool = _get_env_bool("FRONTEND_POOL_ALLOCATION", False)
 
-global_stick_optimizer: bool = os.environ.get("GLOBAL_STICK_OPTIMIZER", "1") == "1"
-
 # Emit a native conv2d SDSC (opFuncName="conv2d" on the "pt" unit) instead of
 # the im2col+matmul decomposition (conv2d_via_bmm_decomp). Off by default: the
 # decomposition remains the default path and the fallback for cases the direct

--- a/torch_spyre/_inductor/optimize_restickify.py
+++ b/torch_spyre/_inductor/optimize_restickify.py
@@ -22,7 +22,6 @@ from typing import Any
 
 import sympy
 
-from . import config
 from .logging_utils import get_inductor_logger
 
 from torch._inductor.dependencies import MemoryDep
@@ -420,66 +419,6 @@ def _no_feasible_layout_error(op) -> NotImplementedError:
     return NotImplementedError("\n".join(lines))
 
 
-def greedy_local_min_cost(operations: list) -> None:
-    """Greedy layout selection: process ops in topological order, picking the output layout with minimum local restick cost.
-
-    On cost ties, the first candidate layout (leftmost arg's stick) is chosen. Each op's chosen
-    layout is committed immediately so downstream ops can read it.
-    """
-
-    # Process graph inputs first so all upstreams have committed_stl.
-    # For now inputs are always a set of size 1, since we use it as it
-    # was transferred to device
-    for name in V.graph.graph_input_names:
-        tb = V.graph.graph_inputs[name]
-        if (
-            isinstance(tb, TensorBox)
-            and isinstance(tb.data, StorageBox)
-            and isinstance(tb.data.data, InputBuffer)
-            and hasattr(tb, "layouts")
-        ):
-            if not tb.layouts:
-                raise AssertionError(f"graph input {name} has empty layouts set")
-            stl = next(iter(tb.layouts))
-            tb.data.data.committed_stl = stl
-            tb.committed_stl = stl
-
-    for op in operations:
-        if not hasattr(op, "layouts"):
-            continue  # FallbackKernel and other unhandled op types
-
-        assert hasattr(op, "restick_cost_fn"), (
-            f"op {op.get_name()} has layouts but no restick_cost_fn"
-        )
-        cost_fn = op.restick_cost_fn
-
-        # Collect each input arg's committed layout (finalized by earlier topo iterations).
-        in_layouts = []
-        for ec in cost_fn.edge_costs:
-            buf = V.graph.get_buffer(ec.dep.name)
-            assert hasattr(buf, "committed_stl"), (
-                f"buffer {ec.dep.name} has no committed_stl — "
-                "topological order violated or input not committed"
-            )
-            in_layouts.append(buf.committed_stl)
-
-        assert op.layouts, (
-            f"op {op.get_name()} has restick_cost_fn but no candidate output layouts"
-        )
-        out_stl = None
-        best_cost = float("inf")
-        for candidate_stl in op.layouts:
-            out_layout_cost = cost_fn.cost(in_layouts, candidate_stl)
-            if out_layout_cost < best_cost:
-                best_cost = out_layout_cost
-                out_stl = candidate_stl
-
-        if out_stl is None:
-            raise _no_feasible_layout_error(op)
-
-        op.committed_stl = out_stl
-
-
 # Global Stick Optimizer
 #
 # The global optimizer is a simple forward-propagation algorithm that tracks a frontier of possible
@@ -858,9 +797,5 @@ def beam_global_min_cost(operations: list) -> None:
 def optimize_restickify_locations(graph: GraphLowering) -> None:
     """Select restickify locations for all ops, minimizing total restickify cost."""
     operations = graph.operations
-    if config.global_stick_optimizer:
-        logger.info("optimizer: beam (global)")
-        beam_global_min_cost(operations)
-    else:
-        logger.info("optimizer: greedy (local)")
-        greedy_local_min_cost(operations)
+    logger.info("optimizer: beam (global)")
+    beam_global_min_cost(operations)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

The greedy (local) restickify optimizer has been dead code since the beam search global optimizer becoame the unconditional default. Remove it along with the GLOBAL_STICK_OPTIMIZER env-var flag that once toggled between the two paths.

- Delete `greedy_local_min_cost` from `optimize_restickify.py`
- Simplify `optimize_restickify_locations` to always call `beam_global_min_cost`
- Remove `global_stick_optimizer` config flag and `GLOBAL_STICK_OPTIMIZER` env var
- Drop the now-unused `from . import config` import
- Collapse the parametrized `test_mm_out_copy_back_into_input_is_elided` test (which exercised both optimizer paths) into a single non-parametrized test

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
