### PR TITLE
Keep sympy numbers out of the cost-model report

### DIFF
--- a/tests/inductor/test_cost_model_pass.py
+++ b/tests/inductor/test_cost_model_pass.py
@@ -451,6 +451,30 @@ def test_sympy_feature_sizes_do_not_reach_the_report(monkeypatch):
     assert shares == [float, float]
 
 
+def test_relayout_share_sheds_sympy_too(monkeypatch):
+    """``relayout_ns`` is called a second time in ``_price``, outside ``predict_ops``,
+    to attribute an LX relayout op its own share (see the comment above ``rel_us`` in
+    ``_price``). That call needs its own ``float()``: it is not covered by coercing
+    ``predict_ops``'s return, and ``test_sympy_feature_sizes_do_not_reach_the_report``
+    never sets ``is_lx_relayout``, so ``relayout_ns`` always short-circuited to a plain
+    ``0.0`` there and left this path unexercised.
+    """
+    ops = _ops([_feats("a")], monkeypatch)
+    f = ops[0]
+    f.is_lx_relayout = True
+    f.relayout_split = 4
+    f.out_elems = sympy.Integer(f.out_elems)
+    f.relayout_run_elems = sympy.Integer(4096)
+    for a in f.args:
+        a.elems = sympy.Integer(a.elems)
+
+    report = cmp.build_report(ops)
+
+    json.dumps(dataclasses.asdict(report))  # raises if any field is still sympy
+    assert type(report.total_us) is float
+    assert all(type(o.predicted_us) is float for g in report.groups for o in g.ops)
+
+
 def test_empty_report_formats_without_dividing_by_zero():
     assert "predicted total" in cmp.CostReport(total_us=0.0, groups=[]).format()
 

--- a/tests/inductor/test_cost_model_pass.py
+++ b/tests/inductor/test_cost_model_pass.py
@@ -31,9 +31,11 @@ No Spyre device or backend compiler is required -- ops are injected directly.
 """
 
 import dataclasses
+import json
 import threading
 
 import pytest
+import sympy
 
 import torch_spyre._inductor.cost_model_pass as cmp
 from torch_spyre._inductor import config
@@ -420,6 +422,33 @@ def test_report_formats_without_error(monkeypatch):
     assert "HBM" in text and "-" in text
     assert "LX" in text
     assert "attribution" in text
+
+
+def test_sympy_feature_sizes_do_not_reach_the_report(monkeypatch):
+    """Inductor buffer sizes are sympy Integers; no report field may end up sympy.
+
+    This broke the dump outright: an op with no HBM traffic gets a share of
+    ``predicted_us * 0``, sympy ``Zero``, and ``format(Zero, ">13.1f")`` raises, so
+    ``SPYRE_DUMP_COST=1`` logged a warning and printed nothing. Report fields are also
+    JSON-serialized by out-of-tree consumers, which no sympy number survives either.
+    """
+    ops = _ops(
+        [_feats("a"), _feats("b", write_mb=0, lx_mb=2, shared_input=False)],
+        monkeypatch,
+    )
+    for f in ops:
+        f.out_elems = sympy.Integer(f.out_elems)
+        for a in f.args:
+            a.elems = sympy.Integer(a.elems)
+
+    report = cmp.build_report(ops)
+
+    assert "predicted total" in report.format()
+    json.dumps(dataclasses.asdict(report))  # raises if any field is still sympy
+    assert type(report.total_us) is float
+    # "b" is the zero-HBM op, the one whose share was Zero.
+    shares = [type(o.predicted_us) for g in report.groups for o in g.ops]
+    assert shares == [float, float]
 
 
 def test_empty_report_formats_without_dividing_by_zero():

--- a/torch_spyre/_inductor/cost_model_pass.py
+++ b/torch_spyre/_inductor/cost_model_pass.py
@@ -356,7 +356,7 @@ def _price(feats, index, params) -> GroupCost | None:
         # real time as 0.0 (exactly the misleading display that motivated the
         # term). Attribute each op its own relayout cost, and split only the
         # remainder by HBM share; parts still sum to the kernel total.
-        rel_us = [relayout_ns(f, params) / 1000.0 for f in feats]
+        rel_us = [float(relayout_ns(f, params)) / 1000.0 for f in feats]
         base_us = predicted_us - sum(rel_us)
         for f, w, r in zip(feats, weights, rel_us):
             ops.append(

--- a/torch_spyre/_inductor/cost_model_pass.py
+++ b/torch_spyre/_inductor/cost_model_pass.py
@@ -151,6 +151,10 @@ class CostReport:
 
     ``total_us`` is the headline: the sum over kernels. It is the number another
     component should compare between two candidate plans.
+
+    Every number here is a plain Python one, coerced where it is built: the model itself
+    computes in sympy, and a sympy number survives neither ``format()``'s aligned specs
+    nor ``json``.
     """
 
     total_us: float
@@ -310,7 +314,7 @@ def _per_iteration(f) -> dict:
     trip = max(1, int(getattr(f, "loop_trip", 1) or 1))
     return {
         "trip": trip,
-        "hbm_per_iter": max(0, f.hbm_bytes()) // trip,
+        "hbm_per_iter": max(0, int(f.hbm_bytes())) // trip,
         "reread_bytes": int(_loop_reread_bytes([f])),
     }
 
@@ -318,7 +322,14 @@ def _per_iteration(f) -> dict:
 def _price(feats, index, params) -> GroupCost | None:
     """Price one kernel. Returns None if the model cannot price it."""
     try:
-        predicted_us = predict_ops(feats, params) / 1000.0
+        # float(): Inductor buffer sizes are sympy Integers, so the model propagates
+        # sympy numbers out of them. Those neither format against the aligned specs
+        # format() uses (`Zero.__format__` rejects ">13.1f") nor serialize to JSON, so
+        # no sympy may reach a report field. A genuinely SYMBOLIC price does not
+        # convert -- the co-optimizing allocator builds symbolic features on purpose,
+        # this path does not -- and raising here drops the kernel like any other one
+        # the model cannot price.
+        predicted_us = float(predict_ops(feats, params)) / 1000.0
     except Exception:  # noqa: BLE001 - a bad group must not lose the whole report
         logger.warning("cost model could not price kernel %d; skipping", index)
         return None
@@ -334,7 +345,10 @@ def _price(feats, index, params) -> GroupCost | None:
     # here costs the breakdown for this kernel and nothing else.
     ops = []
     try:
-        weights = [max(0, f.hbm_bytes()) for f in feats]
+        # int() for the same reason as the price above, and because OpCost declares
+        # these int: a share weighted by a sympy byte count comes back sympy, and a
+        # zero-HBM op's share comes back sympy Zero -- the value format() choked on.
+        weights = [max(0, int(f.hbm_bytes())) for f in feats]
         total = sum(weights)
         # An LX relayout op's cost is ADDITIVE and PER-OP (its own term in
         # predict_ops), not part of the bundle's HBM price -- and it moves no HBM
@@ -350,7 +364,7 @@ def _price(feats, index, params) -> GroupCost | None:
                     name=f.name,
                     loop_group_id=getattr(f, "_loop_group_id", None),
                     hbm_bytes=w,
-                    lx_bytes=max(0, f.lx_bytes()),
+                    lx_bytes=max(0, int(f.lx_bytes())),
                     predicted_us=r
                     + base_us * (w / total if total > 0 else 1.0 / max(1, len(feats))),
                     **_per_iteration(f),
@@ -368,7 +382,7 @@ def _price(feats, index, params) -> GroupCost | None:
         index=index,
         op_names=[f.name for f in feats],
         loop_group_ids=gids,
-        loop_trip=max((getattr(f, "loop_trip", 1) or 1) for f in feats),
+        loop_trip=int(max((getattr(f, "loop_trip", 1) or 1) for f in feats)),
         predicted_us=predicted_us,
         ops=ops,
     )
@@ -411,7 +425,9 @@ def build_report(operations: list, params: CostParams | None = None) -> CostRepo
         runs.append(current)
 
     groups = [g for i, r in enumerate(runs) if (g := _price(r, i, params)) is not None]
-    return CostReport(total_us=sum(g.predicted_us for g in groups), groups=groups)
+    return CostReport(
+        total_us=float(sum(g.predicted_us for g in groups)), groups=groups
+    )
 
 
 def cost_model_pass(graph) -> CostReport | None:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Makes the cost-model report print again. Every compile with `SPYRE_DUMP_COST=1` logged

```
[WARNING] [spyre.inductor.cost_model_pass] cost model report could not be emitted:
    TypeError('unsupported format string passed to Zero.__format__')
```

and printed nothing — four warnings per run on the model I was measuring. The report has been silently unavailable on every run observed; reproduced on `84a625a5`.

**Mechanism.** Inductor buffer sizes are sympy `Integer`s, so the cost model's arithmetic propagates sympy numbers out into the report's fields. A sympy `Float` formats fine, but `Zero`/`Integer`/`Rational` reject any spec carrying an **alignment** character — which is what `CostReport.format()` uses throughout:

```python
>>> format(sympy.S.Zero, '>13.1f')
TypeError: unsupported format string passed to Zero.__format__
>>> format(sympy.S.Zero, '10.1f')    # width, no alignment -> fine
'       0.0'
```

The group total is a `Float` (it is divided by `1000.0`), so the value that is actually `Zero` is an op's **share** of its kernel total: `predicted_us * (w / total)`, where `w` is that op's sympy HBM byte count. An op whose output stays in LX has `w == 0`, so its share collapses to `Zero`. The same values are not JSON-serializable either (`TypeError: Object of type Float is not JSON serializable`), which is how this was found.

**Fix.** Coerce where the report's fields are built — the price, the attribution weights, the byte counts, `loop_trip`, and the total — and record the invariant on `CostReport`: every number in the report is a plain Python one.

#### Which issue(s) this PR is related to:

None filed; found while A/B-ing scratchpad-planner arms.

#### Special notes for your reviewer:

Two decisions worth a look:

- **Why the coercion is at the report boundary, not at feature extraction.** Coercing in `extract_op_features` would be more honest about where sympy enters, but that function is shared with the co-optimizing allocator (`scratchpad/allocator.py`, `scratchpad/sa_cooptimizer.py`), which builds symbolic features on purpose. Breaking that path to tidy the report would be the wrong trade.
- **A genuinely symbolic price.** It cannot be converted, so `float()` raises inside the existing guard in `_price`, dropping that kernel exactly as any other one the model cannot price. Verified on a co-optimizing arm that no kernel is actually dropped today.

Testing:

- `tests/inductor/test_cost_model_pass.py`: 52 passed. New `test_sympy_feature_sizes_do_not_reach_the_report` builds features with sympy `Integer` sizes including a zero-HBM op, and asserts `format()`, `json.dumps(dataclasses.asdict(report))`, and float-typed shares. Confirmed it fails with the original weights line (same sympy `TypeError`) and passes with the fix.
- End to end on a granite block with `SPYRE_DUMP_COST=1`, on both a placement-only arm and a co-optimizing arm: zero "could not be emitted" warnings (was 4 per run), the report prints, and no new "could not price" lines.

#### Does this PR introduce a user-facing change?

Yes: `SPYRE_DUMP_COST=1` now prints the predicted-runtime report instead of a warning. `CostReport.total_us` and the per-op fields are now plain Python numbers, so a consumer holding the report can format and JSON-serialize them.

#### Additional note:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LQyQDijgH18eDWVQDGUf1
