### PR TITLE
skip alignment check for unit-BMM-rewritten tensor args

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -3654,7 +3654,7 @@ class TestSharedWeightUnitBmmLayout(unittest.TestCase):
         args = [input_arg, kernel_arg, output_arg]
         op_info = {SHARED_WEIGHT_UNIT_BMM_INFO_KEY: {"batch_dim": 0}}
 
-        iteration_space = _preserve_shared_weight_unit_bmm_dim(
+        iteration_space, _ = _preserve_shared_weight_unit_bmm_dim(
             "batchmatmul", iteration_space, args, op_info
         )
         sdsc_spec, _ = parse_op_spec(
@@ -3725,7 +3725,7 @@ class TestSharedWeightUnitBmmLayout(unittest.TestCase):
         }
         op_info = {SHARED_WEIGHT_UNIT_BMM_INFO_KEY: {"batch_dim": 0}}
 
-        new_iteration_space = _preserve_shared_weight_unit_bmm_dim(
+        new_iteration_space, modified_ids = _preserve_shared_weight_unit_bmm_dim(
             "batchmatmul",
             iteration_space,
             [input_arg, kernel_arg, output_arg],
@@ -3733,6 +3733,7 @@ class TestSharedWeightUnitBmmLayout(unittest.TestCase):
         )
 
         self.assertIs(new_iteration_space, iteration_space)
+        self.assertEqual(modified_ids, set())
         self.assertNotIn("_spyre_bmm_unit", {str(dim) for dim in iteration_space})
         self.assertEqual(input_arg.device_size, [512, 32, 2, 1, 64])
         self.assertEqual(

--- a/tests/inductor/test_inductor_matmul.py
+++ b/tests/inductor/test_inductor_matmul.py
@@ -93,3 +93,18 @@ class TestMatmulOps:
         _compare_modes(
             execution_mode, fn, *(eye, a) if left else (a, eye), atol=atol, rtol=rtol
         )
+
+    @pytest.mark.parametrize(
+        "N,K,M",
+        [
+            (16, 64, 64),
+            (16, 128, 192),
+        ],
+        ids=["square", "fused_qkv"],
+    )
+    def test_unit_batch_matmul(self, execution_mode, N, K, M):
+        torch.manual_seed(0)
+        x = torch.randn(1, N, K, dtype=torch.float16)
+        w = torch.randn(K, M, dtype=torch.float16)
+        atol, rtol = _tol(torch.float16)
+        _compare_modes(execution_mode, torch.matmul, x, w, atol=0.1, rtol=0.1)

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -110,18 +110,20 @@ def _preserve_shared_weight_unit_bmm_dim(
     it_space: dict[sympy.Symbol, tuple[sympy.Expr, int]],
     args: Sequence[TensorArg],
     op_info: dict[str, Any],
-) -> dict[sympy.Symbol, tuple[sympy.Expr, int]]:
+) -> tuple[dict[sympy.Symbol, tuple[sympy.Expr, int]], set[int]]:
     # TensorArg layout is normalized in-place below to match the surrounding
     # OpSpec construction helpers.
+    # Returns (iteration_space, modified_arg_ids) where modified_arg_ids is the
+    # set of id(arg) for args whose device_coordinates were rewritten.
     if SHARED_WEIGHT_UNIT_BMM_INFO_KEY not in op_info:
-        return it_space
+        return it_space, set()
     if op not in [BATCH_MATMUL_OP, BATCH_MATMUL_FP8_OP]:
-        return it_space
+        return it_space, set()
     if len(it_space) != 3 or len(args) < 3:
-        return it_space
+        return it_space, set()
     info = op_info.get(SHARED_WEIGHT_UNIT_BMM_INFO_KEY)
     if not isinstance(info, dict) or info.get("batch_dim") != 0:
-        return it_space
+        return it_space, set()
 
     unit_sym = sympy.Symbol("_spyre_bmm_unit")
     suffix = 0
@@ -144,20 +146,20 @@ def _preserve_shared_weight_unit_bmm_dim(
     # as attention heads from SDPA, rewriting one axis into the BMM iteration
     # space can produce an illegal SDSC layout.
     if any(len(arg.device_size) > 4 for arg in target_args):
-        return it_space
+        return it_space, set()
     unit_idxs_by_arg = [_unit_indices(arg) for arg in target_args]
 
     if all(len(unit_idxs) == 0 for unit_idxs in unit_idxs_by_arg):
         for arg in target_args:
             if len(arg.device_size) < 2:
-                return it_space
+                return it_space, set()
             insert_at = len(arg.device_size) - 1
             arg.device_size.insert(insert_at, 1)
             arg.device_coordinates.insert(insert_at, sympy.S.Zero)
         unit_idxs_by_arg = [_unit_indices(arg) for arg in target_args]
 
     if not all(len(unit_idxs) == 1 for unit_idxs in unit_idxs_by_arg):
-        return it_space
+        return it_space, set()
 
     rewrite_targets = [
         (arg, unit_idxs[0]) for arg, unit_idxs in zip(target_args, unit_idxs_by_arg)
@@ -172,7 +174,8 @@ def _preserve_shared_weight_unit_bmm_dim(
         arg.device_coordinates[:] = [arg.device_coordinates[i] for i in order]
 
     logger.info("Preserving shared-weight unit BMM dim %s", unit_sym)
-    return {unit_sym: (sympy.S.One, 1), **it_space}
+    modified_ids = {id(arg) for arg, _ in rewrite_targets}
+    return {unit_sym: (sympy.S.One, 1), **it_space}, modified_ids
 
 
 @dataclass
@@ -901,7 +904,7 @@ class SpyreKernel(Kernel[CSEVariable]):
         it_space_extended = iteration_space_with_splits(
             ir_node, self.current_node.read_writes, it_space
         )
-        it_space_extended = _preserve_shared_weight_unit_bmm_dim(
+        it_space_extended, bmm_modified_arg_ids = _preserve_shared_weight_unit_bmm_dim(
             op, it_space_extended, args, op_info
         )
         alignment_inputs = build_operation_alignment_inputs(
@@ -912,6 +915,8 @@ class SpyreKernel(Kernel[CSEVariable]):
             aligned_iteration_space=it_space_extended,
         )
         for arg, tensor in zip(args, alignment_inputs.tensors):
+            if id(arg) in bmm_modified_arg_ids:
+                continue
             if list(arg.device_coordinates) != tensor["coordinates"]:
                 raise RuntimeError(
                     "alignment input collection disagrees with tensor codegen"


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
`_preserve_shared_weight_unit_bmm_dim` rewrites `device_coordinates` of input/output tensor args in place for unit-batch BMMs, but the alignment validation check  recomputes coordinates from the original `AlignmentAccess` layout — which doesn't include those rewrites. The comparison always fails for 3D matmuls with `batch_dim=0, size=1`.
This is triggered by vLLM's transformers modeling backend, which adds a `[1, seq, hidden]` batch dimension causing linear layers to lower as batch matmuls instead of 2D matmuls.
#### Which issue(s) this PR is related to:

Fixes #4178 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
