### PR TITLE
coarse tiling: fix 3 bugs to enable the `real_max` SDPA accumulation pattern

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -3075,11 +3075,6 @@ def _flash_v2_fn(
     return output / denominator.unsqueeze(-1)
 
 
-@pytest.mark.skip(
-    reason="H-tiling produces a large finite mismatch (~88% of elements,"
-    " max abs diff ~4) -- distinct, still-open H-tiling bug, not"
-    " accumulator inf"
-)
 def test_flash_v2_tile_H():
     """Flash v2: tile H÷4 only."""
     run_coarse_tile_test(
@@ -3093,11 +3088,6 @@ def test_flash_v2_tile_H():
     )
 
 
-@pytest.mark.skip(
-    reason="B-tiling produces a large finite mismatch (~48% of elements,"
-    " max abs diff ~3.5) -- distinct, still-open B-tiling bug, not"
-    " accumulator inf"
-)
 def test_flash_v2_tile_B():
     """Flash v2: tile B÷2 only. B=2."""
     run_coarse_tile_test(
@@ -3135,11 +3125,6 @@ def test_flash_v2_tile_Lk():
         )
 
 
-@pytest.mark.skip(
-    reason="B/H-tiling produces a large finite mismatch (~46% of elements,"
-    " max abs diff ~3.8) -- distinct, still-open B-tiling bug, not"
-    " accumulator inf"
-)
 def test_flash_v2_tile_B_H():
     """Flash v2: tile B÷2 H÷4. B=2."""
     run_coarse_tile_test(
@@ -3308,11 +3293,6 @@ def _flash_v3_fn(
     return output / denominator.unsqueeze(-1)
 
 
-@pytest.mark.skip(
-    reason="flash v3 H-tiling still mismatches after mutation_write_back copy_out "
-    "fix (49% mismatch) -- distinct/deeper bug, not the locally-created-buffer "
-    "copy_out routing issue"
-)
 def test_flash_v3_tile_H():
     """Flash v3: tile H÷4 only."""
     run_coarse_tile_test(
@@ -3324,11 +3304,6 @@ def test_flash_v3_tile_H():
     )
 
 
-@pytest.mark.skip(
-    reason="B-tiling produces a large finite mismatch (~48% of elements,"
-    " max abs diff ~3.5) -- distinct, still-open B-tiling bug, not"
-    " accumulator inf"
-)
 def test_flash_v3_tile_B():
     """Flash v3: tile B÷2 only. B=2."""
     run_coarse_tile_test(

--- a/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
+++ b/torch_spyre/_inductor/scratchpad/ilp_solver_ortools.py
@@ -640,7 +640,7 @@ class CpSatLayoutSolver(CoreDivisionLayoutSolver):
         buffers: Sequence[LifetimeBoundBuffer],
         size: int,
         alignment: int = 128,
-        time_limit_seconds: float = 600.0,
+        time_limit_seconds: float = 120.0,
         bottom_justify: bool = True,
     ) -> None:
         if cp_model is None:

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -135,6 +135,7 @@ def counted_loop_lifetime_end_overrides(graph: GraphLowering) -> dict[str, int]:
             last_access[dep.name] = index
 
     overrides: dict[str, int] = {}
+    crossed_loops: set[tuple[int, ...]] = set()
     for index, op in enumerate(graph.operations):
         consumer_path = group_path(op)
         if not consumer_path:
@@ -154,6 +155,28 @@ def counted_loop_lifetime_end_overrides(graph: GraphLowering) -> dict[str, int]:
             end = loop_end[enclosing_loop] + 1
             if end > last_access.get(dep.name, index) + 1:
                 overrides[dep.name] = max(overrides.get(dep.name, 0), end)
+                crossed_loops.add(enclosing_loop)
+
+    # A value that crosses `enclosing_loop`'s boundary (above) must stay valid
+    # across every runtime iteration of that loop. But the graph holds only one
+    # textual copy of the loop body, so any OTHER value that is born and fully
+    # consumed entirely inside that same loop looks, under plain liveness, like
+    # it occupies a short, disjoint tick range that never overlaps the
+    # crossing value's -- even though that loop-local value is actually
+    # rewritten fresh on every iteration, including iterations after the one
+    # the crossing value's own reads happen to fall in. Sharing an LX address
+    # between the two is therefore unsafe: a later iteration's rewrite of the
+    # loop-local value can land between two of the crossing value's reads and
+    # clobber it. Extending the loop-local value's own end_time to also cover
+    # the whole loop forces `overlaps_in_time` to see the conflict for every
+    # solver, instead of leaving it to placement-order luck.
+    if crossed_loops:
+        for name, path in birth_group.items():
+            for loop in crossed_loops:
+                if path[: len(loop)] == loop:
+                    end = loop_end[loop] + 1
+                    if end > last_access.get(name, 0) + 1:
+                        overrides[name] = max(overrides.get(name, 0), end)
     return overrides
 
 
@@ -285,6 +308,17 @@ def _is_tiled_advancing(op: Operation) -> bool:
     all. A loop-internal buffer (e.g. drained by a copy op every iteration)
     can be tiled yet have its own write pinned at a fixed address; such a
     buffer is LX-eligible.
+
+    Also checks ``squeezed_advance_output``: a dim tiled down to per-tile
+    extent 1 (e.g. a coarse-tiled batch dim with one tile per iteration) is
+    squeezed out of the write's own index entirely, so it never appears in
+    ``output_tiled_dims`` even though the write's device address genuinely
+    advances every iteration (see ``loop_info.py``'s
+    ``squeezed_advance_output`` docstring). Missing this let a
+    mutation_write_back accumulator (e.g. flash attention's running max/
+    denominator carry) reside in LX, where the advance later crashed --
+    or, if the crash path were ever bypassed, silently pinned every
+    iteration to the same address.
     """
     layout = getattr(op, "layout", None)
     if not isinstance(layout, FixedTiledLayout):
@@ -292,7 +326,10 @@ def _is_tiled_advancing(op: Operation) -> bool:
     loop_info = getattr(op, "loop_info", None)
     if loop_info is None:
         return False
-    return any(dims for dims in loop_info.output_tiled_dims)
+    if any(dims for dims in loop_info.output_tiled_dims):
+        return True
+    squeezed_advance_output = getattr(loop_info, "squeezed_advance_output", None) or []
+    return any(level for level in squeezed_advance_output)
 
 
 def _is_read_advancing_anywhere(
@@ -339,6 +376,19 @@ def _is_read_advancing_anywhere(
         # continue` never contributes a term for such a level, so the
         # resulting device_tile_advance_expr is None, not merely small.
         if any(loop_info.tiled_dims_per_read[dep_idx]):
+            return True
+        # Mirror _is_tiled_advancing's squeezed_advance_output check on the
+        # read side: a dim tiled down to per-tile extent 1 is squeezed out
+        # of this read's own index, so it never appears in
+        # tiled_dims_per_read even though the read's device address
+        # genuinely advances every iteration (see loop_info.py's
+        # squeezed_advance_per_read docstring).
+        squeezed_advance_per_read = (
+            getattr(loop_info, "squeezed_advance_per_read", None) or []
+        )
+        if dep_idx < len(squeezed_advance_per_read) and any(
+            squeezed_advance_per_read[dep_idx]
+        ):
             return True
     return False
 

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -121,6 +121,7 @@ def counted_loop_lifetime_end_overrides(graph: GraphLowering) -> dict[str, int]:
         name: () for name in graph.graph_input_names
     }
     last_access: dict[str, int] = {}
+    last_read: dict[str, int] = {}
 
     for index, op in enumerate(graph.operations):
         path = group_path(op)
@@ -133,6 +134,7 @@ def counted_loop_lifetime_end_overrides(graph: GraphLowering) -> dict[str, int]:
         for dep in rw.reads:
             birth_group.setdefault(dep.name, ())
             last_access[dep.name] = index
+            last_read[dep.name] = index
 
     overrides: dict[str, int] = {}
     crossed_loops: set[tuple[int, ...]] = set()
@@ -169,13 +171,19 @@ def counted_loop_lifetime_end_overrides(graph: GraphLowering) -> dict[str, int]:
     # loop-local value can land between two of the crossing value's reads and
     # clobber it. Extending the loop-local value's own end_time to also cover
     # the whole loop forces `overlaps_in_time` to see the conflict for every
-    # solver, instead of leaving it to placement-order luck.
+    # solver, instead of leaving it to placement-order luck. A value that is
+    # never read again by anything (write-only) cannot be clobbered before its
+    # next read -- it has none -- so only values with at least one recorded
+    # read are candidates here; `last_read`, not `last_access`, decides
+    # whether that read already falls before the loop's end.
     if crossed_loops:
         for name, path in birth_group.items():
+            if name not in last_read:
+                continue
             for loop in crossed_loops:
                 if path[: len(loop)] == loop:
                     end = loop_end[loop] + 1
-                    if end > last_access.get(name, 0) + 1:
+                    if end > last_read[name] + 1:
                         overrides[name] = max(overrides.get(name, 0), end)
     return overrides
 

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -720,7 +720,25 @@ class SpyreKernel(Kernel[CSEVariable]):
                 for dep in ir_node.get_read_writes().reads
                 if isinstance(dep, MemoryDep)
             ]
-            matching_idx = [i for i, dep in enumerate(read_deps) if dep.name == name]
+            # `name` has already been resolved through mutation_real_name by
+            # load() (e.g. coarse_tile_copy_buf19's dep is named "buf19" --
+            # tiled_op's own output identity -- but load() passes in "buf2",
+            # buf19's MutationLayoutSHOULDREMOVE target, since that's the
+            # actual underlying buffer). dep.name is the pre-resolution
+            # identity, so it must go through the same resolution before
+            # comparing, or a dep on a mutation alias never matches its own
+            # resolved name and this falls through to "no advance" every
+            # time (issue: flash-v2's B-tiled denominator/output copy-out
+            # reads silently pinned to tile 0).
+            scheduler = getattr(V.graph, "scheduler", None)
+            mutation_real_name = (
+                scheduler.mutation_real_name if scheduler is not None else {}
+            )
+            matching_idx = [
+                i
+                for i, dep in enumerate(read_deps)
+                if mutation_real_name.get(dep.name, dep.name) == name
+            ]
             if not matching_idx:
                 return None
             # Positional tie-break: if this buffer is read more than once,

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -84,6 +84,7 @@ from torch._inductor.ir import (
     Operation,
     Pointwise,
     Reduction,
+    ReinterpretView,
     StorageBox,
     TensorBox,
 )
@@ -991,6 +992,39 @@ def _plan_tiling_propagation(
                             consumer_lookup_name=mut_target_name,
                         )
                         continue
+                    # Locally-created mutation target with NO outside
+                    # consumer and NOT a graph output, but still read by
+                    # another op inside this SAME loop group (e.g. flash
+                    # attention's real_max: copy_forced(running_max,
+                    # real_max) writes real_max, and the *next* tile
+                    # iteration's `torch.maximum(real_max, block_max)` reads
+                    # it back -- a pure intra-loop carry with no reader at
+                    # all outside the loop). Such a target still needs its
+                    # write to land at a fresh per-tile address each
+                    # iteration -- otherwise every iteration after the first
+                    # reads back the wrong (stale/aliased) tile's value.
+                    # There is no separate copy-out to insert (nothing
+                    # outside reads it), so mutation_write_back is the right
+                    # shape: it sets output_tiled_dims on the op's own write
+                    # directly, with no full-buffer allocation.
+                    if mut_target is not None:
+                        in_loop_carry = any(
+                            isinstance(candidate, ComputedBuffer)
+                            and candidate is not op
+                            and _reads_buffer(candidate, mut_target_name)
+                            and name_to_group_outer_key.get(candidate.get_name())
+                            == info.loop_group_id[0]
+                            for candidate in group_ops
+                        )
+                        if in_loop_carry:
+                            full_ranges = _compute_full_ranges_planned(op, info)
+                            info.propagation = PropagationPlan(
+                                kind="mutation_write_back",
+                                full_ranges=full_ranges,
+                                full_strides=tuple(mut_target.layout.stride),
+                                is_graph_output=False,
+                            )
+                            continue
                 info.propagation = PropagationPlan(kind="loop_internal")
                 continue
 
@@ -1029,6 +1063,18 @@ def _zero_reads_of_fixed_buffers_planned(
     there is no reader-before-producer ordering hazard to work around --
     this always sees the complete, final fixed set on its one and only
     pass.
+
+    "mutation_write_back" is deliberately excluded: that kind means the
+    op's own write genuinely advances per iteration (its target -- e.g. a
+    flash-attention running max/denominator carry -- is read back by name
+    on a later iteration, see the in_loop_carry check above), just via the
+    squeezed_advance_output side channel rather than output_tiled_dims
+    when the advancing dim divides to per-tile extent 1. Treating such an
+    op as "fixed" here would zero its own output_tiled_dims (when that
+    happens to be nonempty pre-squeeze) and any sibling's
+    tiled_dims_per_read of it, erasing the only signal
+    _propagate_mutation_write_back and the scratchpad allocator have for
+    routing it away from LX -- see issue #4126.
     """
     fixed_names = {
         op.get_name()
@@ -1036,6 +1082,7 @@ def _zero_reads_of_fixed_buffers_planned(
         if isinstance(op, ComputedBuffer)
         and (info := plan.get(id(op))) is not None
         and info.propagation is not None
+        and info.propagation.kind != "mutation_write_back"
         and any(dims for dims in info.loop_tiled_dims)
     }
     if not fixed_names:
@@ -2743,14 +2790,47 @@ def _propagate_mutation_write_back(
     """
     loop_info = op.loop_info  # type: ignore[attr-defined]
     op_ranges = list(op.data.ranges)  # already divided by _apply_plan
+    mut_target = op.layout.get_buffer()  # type: ignore[attr-defined]
+    full_sizes = list(mut_target.get_size())
+
+    # A raw dim tiled to per-tile extent 1 is squeezed out of op_ranges
+    # entirely -- index_vars_squeeze mints no d{i} symbol for it, so
+    # _tiled_dims_for_dep's dep_dims membership test always drops it no
+    # matter what extent we compute below (issue #4126's real_max/
+    # denominator carries hit exactly this: their B-tile dim divides to
+    # extent 1). Mirror _insert_copy_op's squeezed_advance_output
+    # construction here: for each such dim, record (host_stride, extent)
+    # pairs per tiling level, independent of dep.index's free symbols, so
+    # SpyreKernel._general_tile_advance can add the device-address
+    # contribution as an extra term instead of by substitution.
+    squeeze_pos: dict[int, int] = {}
+    it_idx = 0
+    for host_idx, r in enumerate(op_ranges):
+        if int(r) != 1:
+            squeeze_pos[host_idx] = it_idx
+            it_idx += 1
 
     write_level_extents: list[dict[int, sympy.Expr]] = [
         {} for _ in loop_info.loop_tiled_dims
+    ]
+    squeezed_advance: list[list[tuple[sympy.Expr, sympy.Expr]]] = [
+        [] for _ in loop_info.loop_tiled_dims
     ]
     for d in {d for level in loop_info.loop_tiled_dims for d in level}:
         levels_tiling_d = [
             i for i, dims in enumerate(loop_info.loop_tiled_dims) if d in dims
         ]
+        if d not in squeeze_pos:
+            # Squeezed out of op's own write -- use mut_target's own
+            # (undivided) sizes for the host_stride, not op_ranges (a dim
+            # to the right that is itself tiled has already been divided
+            # down in op_ranges, which would undercount the stride).
+            host_stride = sympy.prod(full_sizes[d + 1 :])
+            running = sympy.Integer(1)
+            for level_idx in reversed(levels_tiling_d):
+                squeezed_advance[level_idx].append((host_stride, running))
+                running = running * loop_info.loop_count[level_idx]
+            continue
         running = sympy.sympify(op_ranges[d])
         for level_idx in reversed(levels_tiling_d):
             write_level_extents[level_idx][d] = running
@@ -2765,11 +2845,14 @@ def _propagate_mutation_write_back(
         else []
     )
     loop_info.output_tiled_dims = output_tiled_dims
+    loop_info.squeezed_advance_output = squeezed_advance if write_deps else []
 
     logger.debug(
-        "coarse_tile: mutation_write_back %s output_tiled_dims=%s",
+        "coarse_tile: mutation_write_back %s output_tiled_dims=%s "
+        "squeezed_advance_output=%s",
         op.get_name(),
         output_tiled_dims,
+        loop_info.squeezed_advance_output,
     )
 
 
@@ -2864,11 +2947,78 @@ def _propagate_tiled_op(
     # reconciling the op's *input* layouts, and there is no compatibility
     # check analogous to finalize_layouts's is_elided/is_carry_into_accum
     # guard on that path.
-    _insert_copy_op(op, full_buf, operations)
-    # The tiled op's own buffer is always loop-internal scratch here: it is
-    # fully drained by the copy op inserted above before the next iteration
-    # overwrites it, so its own write must not advance at any level.
-    loop_info.output_tiled_dims = []
+    _insert_copy_op(
+        op,
+        full_buf,
+        operations,
+        tiled_op_write_advances=propagation.consumer_lookup_name is not None,
+    )
+    if propagation.consumer_lookup_name is not None:
+        # op.layout is MutationLayoutSHOULDREMOVE targeting a pre-existing,
+        # locally-created buffer (e.g. copy_forced(src, acc) where acc is a
+        # loop-carried accumulator also read later, by name, inside the SAME
+        # loop group -- flash-attention's real_max/denominator/output). That
+        # in-loop read already advances per tile (it goes through the normal
+        # read-copy machinery keyed on the mutation target's name), so the
+        # direct write into the target must ALSO advance per tile to stay
+        # consistent with it -- leaving it at [] silently pins every tile's
+        # write to the same address, so tile 1+ never actually lands and the
+        # next iteration's read of the "accumulator" reads back tile 0's
+        # value every time. Use the same write_level_extents math
+        # _propagate_mutation_write_back uses for its own direct write.
+        write_deps = [
+            dep for dep in op.get_read_writes().writes if isinstance(dep, MemoryDep)
+        ]
+        if write_deps:
+            op_ranges = list(op.data.ranges)
+            # A raw dim tiled to per-tile extent 1 (e.g. flash attention's
+            # B-tile dim on real_max/denominator/output) is squeezed out of
+            # op_ranges entirely -- no d{i} symbol survives for it, so
+            # _tiled_dims_for_dep always drops it below no matter what
+            # extent write_level_extents carries. Mirror
+            # _propagate_mutation_write_back's squeezed_advance_output
+            # construction: use full_ranges (op's own undivided sizes, same
+            # raw dim order) for the host_stride of such dims, independent
+            # of dep.index's free symbols.
+            squeeze_pos: dict[int, int] = {}
+            it_idx = 0
+            for host_idx, r in enumerate(op_ranges):
+                if int(r) != 1:
+                    squeeze_pos[host_idx] = it_idx
+                    it_idx += 1
+            write_level_extents: list[dict[int, Expr]] = [
+                {} for _ in loop_info.loop_tiled_dims
+            ]
+            squeezed_advance: list[list[tuple[Expr, Expr]]] = [
+                [] for _ in loop_info.loop_tiled_dims
+            ]
+            for d in {d for level in loop_info.loop_tiled_dims for d in level}:
+                levels_tiling_d = [
+                    i for i, dims in enumerate(loop_info.loop_tiled_dims) if d in dims
+                ]
+                if d not in squeeze_pos:
+                    host_stride = sympy.prod(list(full_ranges)[d + 1 :])
+                    running = sympy.Integer(1)
+                    for level_idx in reversed(levels_tiling_d):
+                        squeezed_advance[level_idx].append((host_stride, running))
+                        running = running * loop_info.loop_count[level_idx]
+                    continue
+                running = sympy.sympify(op_ranges[d])
+                for level_idx in reversed(levels_tiling_d):
+                    write_level_extents[level_idx][d] = running
+                    running = running * loop_info.loop_count[level_idx]
+            loop_info.output_tiled_dims = _tiled_dims_for_dep(
+                write_deps[0], write_level_extents, op
+            )
+            loop_info.squeezed_advance_output = squeezed_advance
+        else:
+            loop_info.output_tiled_dims = []
+    else:
+        # The tiled op's own buffer is loop-internal scratch here: it is
+        # fully drained by the copy op inserted above before the next
+        # iteration overwrites it, so its own write must not advance at any
+        # level.
+        loop_info.output_tiled_dims = []
 
     # Patch outside consumers and graph outputs to read full_buf.
     full_name = full_buf.get_name()
@@ -3153,6 +3303,7 @@ def _insert_copy_op(
     tiled_op: ComputedBuffer,
     full_buf: ComputedBuffer,
     operations: list[Operation],
+    tiled_op_write_advances: bool = False,
 ) -> None:
     """Insert a copy op after tiled_op that writes each tile into full_buf.
 
@@ -3164,6 +3315,17 @@ def _insert_copy_op(
     into full_buf; loop_tiled_dims being set makes SpyreKernel stamp
     tiled_symbols on the OpSpec and bundle.mlir emit affine.apply for the
     per-iteration output address.
+
+    tiled_op_write_advances must be True when the caller has routed
+    tiled_op's OWN write through a per-tile-advancing target instead of
+    loop-internal scratch -- the `propagation.consumer_lookup_name is not
+    None` case in _propagate_tiled_op, where tiled_op's write lands in a
+    real accumulator buffer (e.g. flash attention's real_max/denominator/
+    output) that a later loop iteration reads back by name and that must
+    therefore actually move each iteration. This copy op's READ side reads
+    that same buffer, so it must advance too, or every iteration reads back
+    tile 0's slice regardless of which tile is current (issue: flash-v2's
+    B-tiled denominator/output collapsing every batch to batch 0's values).
     """
     copy_data = Pointwise(
         device=tiled_op.get_device(),
@@ -3185,13 +3347,61 @@ def _insert_copy_op(
     # (positionally different from tiled_op's).  The read and write sides need
     # DIFFERENT extents, because they address differently sized buffers:
     #
-    # READS re-read tiled_op's already-divided per-tile buffer, which is
-    # scratch reused in place every iteration -- it does not move, so it
-    # must not advance at any level (the copy op is not itself re-divided).
-    # See _fixed_level_extents for why "not advance" means omitting the
-    # dim, not giving it extent 1.
+    # READS normally re-read tiled_op's already-divided per-tile buffer,
+    # which is scratch reused in place every iteration -- it does not move,
+    # so it must not advance at any level (the copy op is not itself
+    # re-divided). See _fixed_level_extents for why "not advance" means
+    # omitting the dim, not giving it extent 1.
+    #
+    # tiled_op_write_advances=True overrides this: the caller has routed
+    # tiled_op's own write into a real per-tile-advancing accumulator
+    # buffer instead of scratch (propagation.consumer_lookup_name is not
+    # None in _propagate_tiled_op -- flash attention's real_max/
+    # denominator/output carried across loop iterations). This copy op
+    # reads that same buffer, so its read must advance in lockstep with
+    # tiled_op's write, using the identical squeeze-aware extents
+    # construction _propagate_tiled_op uses there (a raw dim tiled to
+    # per-tile extent 1, e.g. the B-tile dim, is squeezed out of
+    # tiled_op.data.ranges entirely and must go through squeezed_advance
+    # instead of read_level_extents -- see squeezed_advance_output's
+    # docstring). Leaving this at _fixed_level_extents here silently pins
+    # every iteration's read to tile 0's address: the next iteration's
+    # "fresh" tile read is actually tile 0's stale value every time
+    # (confirmed via test_flash_v2_tile_B: spyre batch 1's entire output
+    # was a verbatim copy of batch 0's).
     tiled_op_info = tiled_op.loop_info  # type: ignore[attr-defined]
-    read_level_extents = _fixed_level_extents(tiled_op_info.loop_tiled_dims)
+    read_squeezed_advance: list[list[tuple[Expr, Expr]]] = [
+        [] for _ in tiled_op_info.loop_tiled_dims
+    ]
+    if tiled_op_write_advances:
+        tiled_op_ranges = list(tiled_op.data.ranges)
+        tiled_op_squeeze_pos: dict[int, int] = {}
+        it_idx = 0
+        for host_idx, r in enumerate(tiled_op_ranges):
+            if int(r) != 1:
+                tiled_op_squeeze_pos[host_idx] = it_idx
+                it_idx += 1
+        read_level_extents: list[dict[int, Expr]] = [
+            {} for _ in tiled_op_info.loop_tiled_dims
+        ]
+        full_sizes_for_read = list(full_buf.get_size())
+        for d in {d for level in tiled_op_info.loop_tiled_dims for d in level}:
+            levels_tiling_d = [
+                i for i, dims in enumerate(tiled_op_info.loop_tiled_dims) if d in dims
+            ]
+            if d not in tiled_op_squeeze_pos:
+                host_stride = sympy.prod(full_sizes_for_read[d + 1 :])
+                running = sympy.Integer(1)
+                for level_idx in reversed(levels_tiling_d):
+                    read_squeezed_advance[level_idx].append((host_stride, running))
+                    running = running * tiled_op_info.loop_count[level_idx]
+                continue
+            running = sympy.sympify(tiled_op_ranges[d])
+            for level_idx in reversed(levels_tiling_d):
+                read_level_extents[level_idx][d] = running
+                running = running * tiled_op_info.loop_count[level_idx]
+    else:
+        read_level_extents = _fixed_level_extents(tiled_op_info.loop_tiled_dims)
     # The WRITE targets full_buf, which is NOT divided, so its store base must
     # advance a whole tile per iteration -- the same real per-level extents
     # plan_coarse_tile_groups derives for an op's own reads/write via
@@ -3311,6 +3521,11 @@ def _insert_copy_op(
         tiled_dims_per_read=tiled_dims_per_read,
         output_tiled_dims=output_tiled_dims,
         squeezed_advance_output=squeezed_advance if copy_writes else [],
+        squeezed_advance_per_read=(
+            [read_squeezed_advance] * len(copy_reads)
+            if tiled_op_write_advances and copy_reads
+            else []
+        ),
     )
 
     V.graph.name_to_buffer[copy_name] = copy_buf
@@ -4183,6 +4398,14 @@ def _insert_one_read_copy(
         tiled_dims_per_read=tiled_dims_per_read,
         output_tiled_dims=output_tiled_dims,
         squeezed_advance_per_read=[squeezed_advance] if copy_reads else [],
+        # copy_buf's own write is always scratch reused in place every
+        # iteration (never advancing) -- unlike squeezed_advance_per_read
+        # above, there is no fresh per-write computation here to override
+        # sizing_op_info.squeezed_advance_output with, so it must be forced
+        # to [] explicitly or it silently carries over sizing_op's own
+        # (unrelated) output advance via this dataclasses.replace, wrongly
+        # marking this LX write as advancing.
+        squeezed_advance_output=[],
         propagation=PropagationPlan(kind="loop_internal"),
     )
 
@@ -5852,7 +6075,19 @@ def _patch_retiled_load_indexes(
 
 
 def _patch_graph_outputs(old_name: str, new_buf: ComputedBuffer) -> None:
-    """Replace references to old_name in V.graph.graph_outputs with new_buf."""
+    """Replace references to old_name in V.graph.graph_outputs with new_buf.
+
+    A graph output is often not the tiled op's ComputedBuffer directly, but a
+    ReinterpretView over it (e.g. from a trailing unsqueeze/view the caller
+    applied to the reduction's result) wrapping a StorageBox wrapping the
+    ComputedBuffer. That ReinterpretView's own layout is computed from the
+    op's true (pre-coarse-tiling) shape, so it already describes the correct
+    full-sized addressing -- only its underlying storage still points at the
+    tile-local scratch buffer. Unwrap through StorageBox *and*
+    ReinterpretView, and when a ReinterpretView is found, repoint its own
+    `.data` in place (preserving its layout) rather than substituting a bare
+    TensorBox that would discard the view's reshape/stride.
+    """
     try:
         outputs = V.graph.graph_outputs
     except Exception:
@@ -5860,10 +6095,21 @@ def _patch_graph_outputs(old_name: str, new_buf: ComputedBuffer) -> None:
 
     new_tb = TensorBox(StorageBox(new_buf))
     for i, out in enumerate(outputs):
-        # Unwrap StorageBox layers to reach ComputedBuffer without going into
-        # the ComputedBuffer's inner data (Pointwise / Reduction).
+        # Unwrap StorageBox/ReinterpretView layers to reach ComputedBuffer
+        # without going into the ComputedBuffer's inner data (Pointwise /
+        # Reduction). Track the last ReinterpretView seen so we can patch its
+        # storage in place instead of discarding its view metadata.
         candidate = out
-        while isinstance(candidate, StorageBox):
+        last_reinterpret_view = None
+        while isinstance(candidate, (StorageBox, ReinterpretView)):
+            if isinstance(candidate, ReinterpretView):
+                last_reinterpret_view = candidate
             candidate = candidate.data
-        if isinstance(candidate, ComputedBuffer) and candidate.get_name() == old_name:
+        if not (
+            isinstance(candidate, ComputedBuffer) and candidate.get_name() == old_name
+        ):
+            continue
+        if last_reinterpret_view is not None:
+            object.__setattr__(last_reinterpret_view, "data", StorageBox(new_buf))
+        else:
             outputs[i] = new_tb


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://g
ithub.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes three distinct compiler bugs that caused flash-attention's
running-max/denominator/output accumulator pattern (`real_max =
copy_forced(running_max, real_max)`, mirroring the real SDPA
decomposition's sparse-tensor-via-reduction initialization) to either
crash, produce `inf`, or silently produce wrong finite results when
compiled inside a coarse-tiling loop, and fixes a compile-time
regression introduced by the third of those fixes:

1. **`spyre_kernel.py`** -- `SpyreKernel`'s per-read tile-advance lookup
   compared a `MemoryDep`'s name directly against the caller-supplied
   buffer name, but `load()` passes in a mutation target's name resolved
   through `scheduler.mutation_real_name`, not the dep's own
   pre-resolution identity. A dep on a mutation alias never matched,
   silently falling through to "no advance" and pinning every loop
   iteration's read to the same address (e.g. flash-v2's B-tiled
   denominator/output copy-out reads were pinned to tile 0 regardless of
   the current iteration).

2. **`wsr/coarse_tile.py`** -- Two related gaps:
   - A locally-created mutation target with no outside consumer and no
     graph-output status, but read back by name on a later iteration of
     the *same* loop group (flash attention's `real_max`/`denominator`/
     `output` carries), was treated as ordinary loop-internal scratch, so
     its write pinned to the same address every iteration instead of
     advancing per tile. Detected this in-loop-carry shape and routed such
     targets through `mutation_write_back`-style advancing writes,
     threading `squeezed_advance_output` through for dims that tile down
     to per-tile extent 1 (squeezed out of the op's own ranges entirely).
   - `_patch_graph_outputs` only unwrapped `StorageBox` layers when
     redirecting a graph output from a tile-local scratch buffer to the
     correctly-tiled full accumulator buffer. A graph output is often a
     `ReinterpretView` over the `ComputedBuffer` instead (e.g. from a
     trailing `unsqueeze`), whose storage still pointed at the stale
     scratch buffer. Now unwraps through `ReinterpretView` too and
     repoints its `.data` in place rather than discarding the view.

   Together these two fixes are what make the flash-attention v2/v3
   accumulator pattern compile and produce finite, non-`inf` results
   under coarse-tiling at all (issue #4126).

3. **`scratchpad/utils.py`** -- Even once (1) and (2) made the pattern
   produce finite results, B/H-tiled flash-attention still produced
   silently-wrong finite numbers. Root cause:
   `counted_loop_lifetime_end_overrides` correctly extends a
   loop-invariant buffer's (e.g. a causal mask read every iteration)
   lifetime to cover a whole counted loop, but had no mechanism to
   protect that buffer's LX storage from a *different* buffer that is
   born and fully consumed inside a single textual copy of the same loop
   body (e.g. per-iteration scaled key/query scratch copies). Since the
   graph holds only one textual copy of a loop's body, such a
   loop-body-local buffer's nominal tick range looked lifetime-disjoint
   from the loop-invariant buffer's under plain liveness, so every
   placement solver (greedy/firstfit/bestfit/cpsat -- this is upstream of
   any solver-specific code) could legally alias them to the same LX
   address. At runtime the loop-body-local buffer is rewritten fresh on
   every iteration, so whenever a solver picked the colliding address, a
   later iteration's rewrite clobbered the loop-invariant buffer's data
   before its next read. This also explains previously-unexplained
   flakiness: `cpsat`'s search is not fully deterministic in which of
   several equally-legal-per-the-incomplete-model addresses it picks, so
   some runs happened to avoid the collision by luck. Fixed by extending
   every loop-body-local buffer's own effective lifetime to also span the
   whole loop whenever any other buffer's lifetime already crosses that
   loop's boundary, so the shared `overlaps_in_time` check (used by every
   solver) correctly forbids the collision for everyone. This extension
   only applies to buffers that are actually read again by something:
   last-write and last-read indices are tracked separately, and a
   loop-body-local buffer with no read at all (write-only scratch) is
   never extended, since a write with no subsequent read can never be
   clobbered before "its next read" -- there isn't one.

4. **`scratchpad/ilp_solver_ortools.py`** -- Fix (3) is correct but
   uncovered a compile-time regression: for
   `test_hint_flash_attention_kv_chunked_prefill_8k` (H/Lq WSR-tiled, 4
   KV chunks, `Lk=8192`), the crossing-loop extension in (3) correctly
   extends 76 of the graph's 96 candidate buffers to span one wide,
   mutually-overlapping time window (every same-loop buffer is a genuine
   aliasing hazard once any value crosses that loop's boundary, not just
   carry-across-iteration buffers -- narrowing the *set* of protected
   buffers or the *amount* by which they are extended would be unsound).
   This turns `cpsat`'s residency phase from an easy, mostly-disjoint
   interval-scheduling instance into a dense 2D bin-packing instance it
   cannot prove optimal within the solver's time budget, regressing this
   test's compile time from 42s to 649s and tripping CI's 300s
   silent-output kill. Confirmed by direct instrumentation: the residency
   `solver.Solve(model)` call itself accounts for the entire stall,
   returning `CpSolverStatus.FEASIBLE` (a valid, just unproven-optimal
   plan) only after exhausting its time limit -- not an error, just an
   expensive proof of optimality the compile doesn't need. Since a timed-
   out solve already yields a valid feasible plan rather than failing,
   bounding `CpSatLayoutSolver`'s default `time_limit_seconds` from
   600.0 to 120.0 trades a small amount of possible LX-residency
   optimality for compile time: this test now completes in 166.76s, well
   under CI's 300s ceiling, and still passes.

Un-skipped the flash-attention tests that were blocked by these bugs:
`test_flash_v2_tile_B`, `test_flash_v2_tile_H`, `test_flash_v2_tile_B_H`,
`test_flash_v3_tile_B`, `test_flash_v3_tile_H`. Each was verified passing
across multiple repeated clean-cache runs, given the solver
nondeterminism described above -- a single passing run was not
sufficient evidence on its own.

The test file itself was not modified beyond removing `@pytest.mark.skip`
decorators: the sparse-tensor-via-reduction accumulator pattern under
test is the real production SDPA decomposition shape
(`torch_spyre/_inductor/decompositions.py`), so the fix is entirely at
the compiler/pass level.

#### Which issue(s) this PR is related to:

Fixes #4126

#### Special notes for your reviewer:

- These are four bugs fixed in dependency order (mutation-alias
  resolution → advancing-write routing → LX lifetime/placement →
  CP-SAT compile-time regression uncovered by that fix), committed as
  four separate commits, each reviewable and bisectable on its own.
- The `scratchpad/utils.py` fix (commit 3) is the most subtle: it is a
  placement *soundness* gap shared by every LX layout solver (not a
  `cpsat`-specific bug), which happened to manifest as visible wrong
  output only under `cpsat` in this repro because the other solvers'
  heuristics incidentally avoided the colliding address. Any future
  change touching `counted_loop_lifetime_end_overrides` or the LX
  solvers should re-run the flash-v2/v3 B/H-tiling tests across multiple
  clean-cache runs, not just once.
- The `ilp_solver_ortools.py` fix (commit 4) only lowers a time-budget
  default; it does not change the correctness of commit 3's lifetime
  extension. It was validated by direct `py-spy`/timing instrumentation
  identifying `solver.Solve(model)` in the residency phase as the entire
  cost of the regression (confirmed FEASIBLE-but-unproven-optimal at
  timeout, not a solver failure), and by re-running
  `test_hint_flash_attention_kv_chunked_prefill_8k` and the full
  `test_coarse_tiling.py` + `test_building_blocks.py` suite after the
  change.
- Full local regression run clean: `tests/inductor/test_coarse_tile_e2e.py`
  + `tests/inductor/test_building_blocks.py` (275 tests): 256 passed, 18
  skipped, 1 xfailed, 0 failed -- all skips/xfail pre-existing and
  unrelated to this change. Separately, after commit 4:
  `test_coarse_tiling.py` + `test_building_blocks.py` (385 tests): 384
  passed, 1 skipped -- pre-existing skip, unrelated.
- Review-driven correction included in this PR: the initial
  `crossed_loops` extension pass in `scratchpad/utils.py` guarded on a
  buffer's last *any* access (read or write combined), which incorrectly
  extended write-only loop-local buffers that are never read again and so
  can never actually be clobbered by this hazard. Fixed by tracking
  last-read separately from last-write and gating the extension on
  last-read, with a buffer that has no read at all excluded outright.
  `test_post_stickify_loop_extends_crossing_lifetime` (the regression
  this caught) now passes with the expected `{"crossing": 4, "arg1": 4}`
  mapping; the flash-v2/v3 B/H-tiling tests were re-verified across
  another 3 clean-cache runs to confirm the narrower guard still catches
  the original hazard.
- Remaining flash-attention tiling combinations still skipped
  (`tile_H_Lq`, `tile_H_Lq_Lk`, `tile_Lk`, v4 variants, etc.) fail for
  separate, already-tracked reasons (Lk reduction-dim carry propagation,
  v4 view+transpose layout-coordinate issues) unrelated to this fix.

#### Does this PR introduce a user-facing change?

No public API change. Previously-silent wrong-answer and crash/`inf`
bugs are fixed for coarse-tiled flash-attention (B-tiling, H-tiling, and
B+H-tiling combinations); several previously-skipped tests now pass.
`CpSatLayoutSolver`'s default LX layout solve time budget is lowered
from 600s to 120s, which may very rarely leave a harder graph's LX
residency plan slightly less optimal (never incorrect) than before, in
exchange for bounding compile time.

#### Additional note: