### PR TITLE
Allow setting of per_cores when m/n are non-zero

### DIFF
--- a/torch_spyre/_inductor/dump_cost_model.py
+++ b/torch_spyre/_inductor/dump_cost_model.py
@@ -381,9 +381,9 @@ def _matmul_features(
                 n_size = _int(it_space[n_sym], 1) if n_sym is not None else 1
                 m_split = max(1, readable.get(m_sym, 1))
                 n_split = max(1, readable.get(n_sym, 1)) if n_sym is not None else 1
-                if m_size > 1:
+                if m_size:
                     rows_per_core = m_size / m_split
-                if n_size > 1:
+                if n_size:
                     cols_per_core = n_size / n_split
                 a_bytes = m_size * k_size * dtype_bytes
                 b_bytes = k_size * n_size * dtype_bytes


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [X] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR resolves a latent bug where column and row vectors are not correctly handled when generating op features. No test has been added because co-optimization exposes this bug and an extra test wouldn't make us more sensitive to regressions.

#### Which issue(s) this PR is related to:
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
No

#### Additional note:
None