### PR TITLE
 fix(inductor): reject HBM pool candidates whose allocation is read by another bundle

### DIFF
--- a/tests/inductor/test_hbm_pool_planning.py
+++ b/tests/inductor/test_hbm_pool_planning.py
@@ -889,6 +889,45 @@ class TestHbmPoolPlanningE2E(InductorTestCase):
         self.assertIn("async_compile.sdsc(", src)
         self.assertNotIn("pool_size", src)
 
+    @config.patch({"lx_planning": False})
+    @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
+    def test_alias_read_in_another_bundle_blocks_pool_eligibility(self):
+        """A co-allocated sibling read by another bundle must keep the whole
+        allocation off the pool.
+
+        copy_forced's lowering builds a MutationLayoutSHOULDREMOVE buffer, so
+        several buffer names share one layout.allocation dict. Assigning a
+        pool offset writes into that shared dict, relocating EVERY name on it
+        -- including names that were never pool candidates and so were never
+        passed to _is_cross_bundle. When such a sibling is read by a later
+        bundle, that bundle addresses it pool-relative while owning no pool
+        of its own, and generate_bundle's `pool_size=0 out of range ... for a
+        bundle with a pool symbol present` assertion fires.
+
+        torch.sin is a CPU fallback and forces the bundle boundary; the
+        multiply after it is compiled, so the read of `acc` lands in a second
+        compiled bundle rather than in fallback_read.
+        """
+
+        def fn(x, y):
+            acc = torch.zeros_like(x)
+            acc = torch.ops.spyre.copy_forced(x + y, acc)
+            s = torch.sin(x)  # CPU fallback -- forces a bundle boundary
+            return acc * 2 + s  # second compiled bundle reads `acc`
+
+        x = torch.randn(64, 64, dtype=torch.float16, device="spyre")
+        y = torch.randn(64, 64, dtype=torch.float16, device="spyre")
+
+        with (
+            mock_patch(_LAUNCH_JOBPLAN),
+            mock_patch(_PREPARE_KERNEL),
+            mock_patch("subprocess.run"),
+            pytest.warns(UserWarning),
+        ):
+            # Without the alias-read guard this raises InductorError from
+            # generate_bundle's pool_size assertion.
+            torch.compile(fn)(x, y)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_hbm_pool_planning.py
+++ b/tests/inductor/test_hbm_pool_planning.py
@@ -890,30 +890,37 @@ class TestHbmPoolPlanningE2E(InductorTestCase):
         self.assertNotIn("pool_size", src)
 
     @config.patch({"lx_planning": False})
-    @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_alias_read_in_another_bundle_blocks_pool_eligibility(self):
         """A co-allocated sibling read by another bundle must keep the whole
         allocation off the pool.
 
         copy_forced's lowering builds a MutationLayoutSHOULDREMOVE buffer, so
-        several buffer names share one layout.allocation dict. Assigning a
-        pool offset writes into that shared dict, relocating EVERY name on it
-        -- including names that were never pool candidates and so were never
-        passed to _is_cross_bundle. When such a sibling is read by a later
-        bundle, that bundle addresses it pool-relative while owning no pool
-        of its own, and generate_bundle's `pool_size=0 out of range ... for a
-        bundle with a pool symbol present` assertion fires.
+        several names share one layout.allocation dict. Assigning a pool offset
+        writes into that shared dict, relocating EVERY name on it -- including
+        names that were never pool candidates and so were never passed to
+        _is_cross_bundle. When such a sibling is read by another bundle, that
+        bundle addresses it pool-relative while owning no pool, and
+        generate_bundle asserts `pool_size=0 out of range ... for a bundle with
+        a pool symbol present`.
 
-        torch.sin is a CPU fallback and forces the bundle boundary; the
-        multiply after it is compiled, so the read of `acc` lands in a second
-        compiled bundle rather than in fallback_read.
+        Three names on one allocation are required, which is why `acc` is
+        written by TWO copy_forced calls: the zeros buffer and the first copy's
+        result are written and read entirely inside the first bundle, so both
+        are candidates; the second copy's result is read by the cat bundle, so
+        it is correctly rejected -- and then dragged into the pool anyway by
+        the two that were accepted. This mirrors sliding-window attention,
+        where `output` is the dst of both the accumulator update and the final
+        divide, and the per-block results are read by torch.cat.
         """
 
         def fn(x, y):
-            acc = torch.zeros_like(x)
-            acc = torch.ops.spyre.copy_forced(x + y, acc)
-            s = torch.sin(x)  # CPU fallback -- forces a bundle boundary
-            return acc * 2 + s  # second compiled bundle reads `acc`
+            outs = []
+            for i in range(2):
+                acc = torch.zeros_like(x)
+                acc = torch.ops.spyre.copy_forced(x * (i + 1) + y, acc)
+                acc = torch.ops.spyre.copy_forced(acc * 2, acc)
+                outs.append(acc)
+            return torch.cat(outs, dim=0)
 
         x = torch.randn(64, 64, dtype=torch.float16, device="spyre")
         y = torch.randn(64, 64, dtype=torch.float16, device="spyre")
@@ -922,7 +929,6 @@ class TestHbmPoolPlanningE2E(InductorTestCase):
             mock_patch(_LAUNCH_JOBPLAN),
             mock_patch(_PREPARE_KERNEL),
             mock_patch("subprocess.run"),
-            pytest.warns(UserWarning),
         ):
             # Without the alias-read guard this raises InductorError from
             # generate_bundle's pool_size assertion.

--- a/torch_spyre/_inductor/hbm_pool_planning.py
+++ b/torch_spyre/_inductor/hbm_pool_planning.py
@@ -320,17 +320,27 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
     # aliased names (see _alloc_id) are attributed to the same underlying
     # storage even though they share no name-based dependency edge.
     #
-    # Deliberately write-keyed only: the sole Inductor mechanism that makes
-    # two distinct buffer names share the literal id(layout.allocation)
-    # object is MutationLayoutSHOULDREMOVE, which always attaches to a
-    # write (set via `src.data.layout = MutationLayoutSHOULDREMOVE(dst)` in
-    # Inductor's realize_into/mark_buffer_mutated) -- so walking .writes
-    # alone is provably complete. Inductor's read-only aliasing mechanism
-    # (NonOwningLayout, used for views) builds a new Layout object rather
-    # than sharing one, and such buffers are excluded from pool eligibility
-    # entirely by the isinstance(layout, FixedTiledLayout) checks in
-    # _is_intermediate/_alloc_id, independent of bundle analysis.
+    # The sole Inductor mechanism that makes two distinct buffer names
+    # share the literal id(layout.allocation) object is
+    # MutationLayoutSHOULDREMOVE, which always attaches to a write (set via
+    # `src.data.layout = MutationLayoutSHOULDREMOVE(dst)` in Inductor's
+    # realize_into/mark_buffer_mutated). Inductor's read-only aliasing
+    # mechanism (NonOwningLayout, used for views) builds a new Layout object
+    # rather than sharing one, and such buffers are excluded from pool
+    # eligibility entirely by the isinstance(layout, FixedTiledLayout) checks
+    # in _is_intermediate/_alloc_id, independent of bundle analysis.
     alloc_id_bundles: dict[int, set[str]] = {}
+    # id(layout.allocation) -> every bundle that READ a name resolving to
+    # that allocation dict.  Required, not merely symmetric with the writer
+    # map above: assigning a pool offset writes into the shared allocation
+    # dict (`layout.allocation["hbm_pool"] = offset` below), which relocates
+    # EVERY name resolving to it -- including names that were never pool
+    # candidates and so were never passed to _is_cross_bundle. A co-allocated
+    # sibling read by another bundle would then be addressed pool-relative in
+    # a bundle that owns no pool, tripping generate_bundle's pool_size
+    # assertion. Keying reads by allocation lets _is_cross_bundle reject the
+    # whole allocation when any name on it is read outside its writer.
+    alloc_id_reader_bundles: dict[int, set[str]] = {}
 
     for bundle in nodes:
         bundle_name = bundle.get_name()
@@ -348,6 +358,10 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
             for dep in node.read_writes.reads:
                 if dep.name not in graph_inputs:
                     buffer_reader_bundles.setdefault(dep.name, set()).add(bundle_name)
+                    if (alloc_id := _alloc_id(dep.name)) is not None:
+                        alloc_id_reader_bundles.setdefault(alloc_id, set()).add(
+                            bundle_name
+                        )
         # SpyreEmptyFallback nodes allocate a buffer but emit no dep-tracked
         # write, so they never appear via the dep walk above.  Collect them
         # explicitly, using the underlying buffer's name (node.node.get_name())
@@ -389,8 +403,25 @@ def hbm_pool_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
                 sorted(alloc_id_bundles[alloc_id]),
             )
             return True
-        readers = buffer_reader_bundles.get(name, set())
         writer = buffer_writer_bundle.get(name)
+        if alloc_id is not None:
+            # Allocation-scoped, not name-scoped: pooling this name writes
+            # the offset into the allocation dict every co-allocated name
+            # shares, so a read of ANY of those names from another bundle
+            # makes the whole allocation ineligible -- the sibling is not
+            # itself a candidate and would never be checked on its own.
+            alias_readers = alloc_id_reader_bundles.get(alloc_id, set())
+            alias_writers = alloc_id_bundles.get(alloc_id, {writer})
+            if alias_readers - alias_writers:
+                logger.debug(
+                    "hbm_pool_planning: %s shares its allocation with a "
+                    "buffer read in another bundle %s -- excluding from "
+                    "pool eligibility",
+                    name,
+                    sorted(alias_readers - alias_writers),
+                )
+                return True
+        readers = buffer_reader_bundles.get(name, set())
         return bool(readers - {writer})
 
     all_candidates = {


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

A bundle that owns no HBM pool can be handed a pool-resident tensor:

```
generate_bundle: pool_size=0 out of range (0, 15032385536] for a bundle with a
pool symbol present
```

**Root cause: pool membership is allocation-scoped, eligibility is name-scoped.**
`copy_forced` builds a `MutationLayoutSHOULDREMOVE` buffer, so several names share one
`layout.allocation` dict. `_is_cross_bundle` (`:387`) checks candidates per name, but
`layout.allocation["hbm_pool"] = offset` (`:521`) relocates *every* name on that
allocation — including names that were never candidates. Such a name loses its
`arg_index` (`spyre_kernel.py:855-865`, `ir.py:425-428`), so `compute_ops.py:1015`
emits a pool symbol for it in whichever bundle reads it, and that bundle's `pool_size`
is 0.

The three existing guards all miss it: the candidate has one writer, only one bundle
*writes* the allocation, and the candidate's own readers are in-bundle. The escaping
read is on a sibling name.


#### Which issue(s) this PR is related to:

Found via #3405, which stays red until this lands (`HBM_POOL_PLANNING` defaults on).

#### Special notes for your reviewer:

Red/green, same tree, only `hbm_pool_planning.py` differing: `-k alias_read` fails on
`main`, passes here. No regressions: `test_hbm_pool_planning.py` 26 passed,
`test_coarse_tile_e2e.py` 223 passed / 23 skipped / 1 xfailed. On #3405 the SWA suite
goes 14 failed / 12 passed → 26 passed.

**The test writes `acc` twice on purpose.** With two names the escaping name is also the
only candidate, so `_is_cross_bundle` rejects it, nothing is pooled, and the test passes
without the fix — I checked. Three names are needed: two pooled in-bundle, dragging in a
third that another bundle reads. Same shape as SWA, where `output` is the dst of both
the accumulator update and the final divide.

**Cost:** allocations that escape their bundle stay on standalone HBM — four 64 KB
entries in the SWA case.

#### Does this PR introduce a user-facing change?

No API change. Graphs that pool a buffer sharing storage with a name read by another
bundle now compile instead of failing the assertion.
