### PR TITLE
fix(inductor): fix a gap in making LX planning independent of PYTHONHASHSEED

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_scratchpad_utils_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_scratchpad_utils_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [unit, regression, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_scratchpad_utils.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_scratchpad_utils.py
+++ b/tests/inductor/test_scratchpad_utils.py
@@ -1,0 +1,145 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers in ``scratchpad/utils.py`` that decide LX residency.
+
+``_would_produce_lx_back_gap`` asks whether a device dimension is *fully
+covered* by the iteration symbols that walk it: a backGap fires when
+``device_size[d]`` exceeds the extent the coordinate actually reaches, and the
+backend supports that for HBM but not for LX.
+
+The covered extent is a property of the whole coordinate expression, not of any
+one symbol in it. These tests pin that, because the two obvious cheaper
+approximations are both wrong and were both live:
+
+* Substituting *one* symbol's iteration range (what this did before) breaks as
+  soon as a coordinate folds two symbols into one axis, in both directions --
+  see ``test_multi_symbol_*`` for a spurious gap and ``test_stickified_*`` for a
+  missed one. It was also read out of the unordered ``free_symbols`` set, so
+  which symbol you got moved with ``PYTHONHASHSEED``; that made LX plans, and
+  hence core-division plans, differ between processes on identical input.
+* Substituting *every* symbol's maximum is right only for a monotone
+  coordinate. ``test_mod_coordinate_uses_a_real_bound`` is the counter-example.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest import TestCase, mock
+
+import sympy
+from torch._inductor.dependencies import MemoryDep
+
+from torch_spyre._inductor.scratchpad.utils import _would_produce_lx_back_gap
+
+_COORDS = "torch_spyre._inductor.scratchpad.utils.device_coordinates"
+
+_BUF = "buf0"
+
+# Iteration symbols, named as the pre-scheduler names them.
+d0, d1, d2, d3 = sympy.symbols("d0 d1 d2 d3", integer=True, nonnegative=True)
+
+# The trailing device coordinate is the within-stick lane, which the check skips
+# (a stick is atomic, so it cannot carry a gap). Every fixture here has exactly
+# one non-stick device dim, so ``device_size[0]`` is the dim under test.
+_STICK_COORD = sympy.Mod(d0, 64)
+_STICK_SIZE = 64
+
+
+def _graph(extent, ranges):
+    """A one-op graph whose only read of ``_BUF`` carries ``ranges``.
+
+    ``extent`` is ``device_size[0]``, the non-stick device dim under test.
+    ``ranges`` maps each iteration symbol to its size, which is what
+    ``MemoryDep`` exposes as ``dep.ranges``.
+    """
+    symbols = tuple(ranges)
+    dep = MemoryDep(
+        _BUF,
+        # The index is unused here: the coordinate under test is supplied by the
+        # patched ``device_coordinates``. Kept plausible rather than empty.
+        sum(symbols, sympy.Integer(0)),
+        symbols,
+        tuple(ranges[sym] for sym in symbols),
+    )
+    op = SimpleNamespace(
+        get_read_writes=lambda: SimpleNamespace(reads={dep}, writes=set())
+    )
+    buf = SimpleNamespace(
+        layout=SimpleNamespace(
+            device_layout=SimpleNamespace(device_size=[extent, _STICK_SIZE])
+        )
+    )
+    return SimpleNamespace(operations=[op], get_buffer=lambda _name: buf)
+
+
+def _back_gap(coord, extent, ranges):
+    graph = _graph(extent, ranges)
+    with mock.patch(_COORDS, return_value=[coord, _STICK_COORD]):
+        return _would_produce_lx_back_gap(graph, _BUF, [0])
+
+
+class BackGapTest(TestCase):
+    def test_multi_symbol_coordinate_that_covers_its_dim_has_no_gap(self):
+        """``2*d1 + d3`` over ``d1 in [0,40)``, ``d3 in [0,2)`` reaches 0..79.
+
+        The dim is 80 wide, so it is exactly covered and there is no gap. Note
+        that *neither* single symbol's range answers this: 80 > 40 and 80 > 2 are
+        both true, so picking either one reports a gap that is not there. This
+        case fails on any hash seed, which is what makes it a regression test.
+        """
+        self.assertFalse(_back_gap(2 * d1 + d3, 80, {d1: 40, d3: 2}))
+
+    def test_multi_symbol_stickified_coordinate_has_no_gap(self):
+        """``2*d0 + floor(d2/64)`` over ``d0 in [0,8)``, ``d2 in [0,128)``.
+
+        The shape observed on a granite-4.0-micro decoder block, where this
+        decided one buffer's LX residency and, through it, the whole
+        core-division plan. Reaches 0..15 on a dim 16 wide: no gap. Here the two
+        symbols disagree (``d0`` says gap, ``d2`` says none), which is how the
+        verdict came to depend on the hash seed.
+        """
+        self.assertFalse(_back_gap(2 * d0 + sympy.floor(d2 / 64), 16, {d0: 8, d2: 128}))
+
+    def test_uncovered_dim_has_a_gap(self):
+        """``d0`` over ``[0,8)`` reaches 0..7, which leaves a dim 16 wide short.
+
+        The positive case: without it the tests above would pass against a
+        function that always returned False.
+        """
+        self.assertTrue(_back_gap(d0, 16, {d0: 8}))
+
+    def test_stickified_coordinate_gap_is_not_hidden_by_the_element_range(self):
+        """``floor(d1/64)`` over ``d1 in [0,1024)`` reaches 0..15, not 0..1023.
+
+        A stick-count coordinate covers ``range/64``, so a dim 32 wide really
+        does have a gap. Reading ``d1``'s raw *element* range instead (1024)
+        overstates coverage by 64x and hides it -- the dangerous direction, since
+        LX has no backGap support, so a missed gap is a codegen hazard rather
+        than a lost optimization.
+        """
+        self.assertTrue(_back_gap(sympy.floor(d1 / 64), 32, {d1: 1024}))
+
+    def test_mod_coordinate_uses_a_real_bound(self):
+        """``Mod(d0, 5)`` over ``d0 in [0,8)`` reaches 0..4, so a dim 4 wide is
+        covered.
+
+        Non-monotone, so substituting the symbol's maximum is not its bound:
+        ``Mod(7, 5)`` is 2, which would understate the extent as 3 and report a
+        gap. This is why the check needs real range analysis and not ``subs``.
+        """
+        self.assertFalse(_back_gap(sympy.Mod(d0, 5), 4, {d0: 8}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -327,7 +327,7 @@ def _get_device_dim_order(
         expr = coord.subs(symbol_mapping)
         if expr == 0 and stick_dim is not None and stick_dim not in dim_order:
             dim_order.append(stick_dim)
-        for sym in expr.free_symbols:
+        for sym in sorted(expr.free_symbols, key=str):
             # For kernel tensors in conv ops, exclude size-1 output-spatial dimensions.
             # Kernels don't depend on output spatial position, so i and j (when size-1)
             # are synthetic placeholders that shouldn't affect kernel layout.
@@ -1541,8 +1541,14 @@ def _resolve_sdsc_size(expr: Expr, symbolic_dim_bounds: dict) -> int:
     file) so this works during the reload phase when ShapeEnv is gone.
     Falls back to _concretize_for_sdsc for concrete expressions.
     """
-    if hasattr(expr, "free_symbols") and expr.free_symbols:
-        sym_name = str(next(iter(expr.free_symbols)))
+    # ``symbolic_dim_bounds`` is keyed by a single symbol name, so it can only
+    # answer for a single-symbol expression; a multi-symbol one falls through to
+    # ``_concretize_for_sdsc``, which resolves the whole expression. Reading one
+    # arbitrary symbol's bound out of the ``free_symbols`` set both answered the
+    # wrong question and made the answer depend on PYTHONHASHSEED.
+    syms = getattr(expr, "free_symbols", None)
+    if syms and len(syms) == 1:
+        sym_name = str(next(iter(syms)))
         if sym_name in symbolic_dim_bounds:
             return symbolic_dim_bounds[sym_name][0]  # max
     return _concretize_for_sdsc(expr)
@@ -1614,7 +1620,7 @@ def _extend_matmul_k_to_padded(
             out_syms,
         )
         return
-    k_sym = next(iter(k_candidates))
+    k_sym = min(k_candidates, key=str)
 
     if k_sym not in sdsc_iteration_space:
         logger.warning(

--- a/torch_spyre/_inductor/enforce_indirect_access_layout.py
+++ b/torch_spyre/_inductor/enforce_indirect_access_layout.py
@@ -667,7 +667,7 @@ def enforce_indirect_access_layout(graph: GraphLowering) -> None:
                 for sym in access_subs.values()
                 if isinstance(sym, IndirectAccess)
             }
-            index_name = next(iter(index_names & dep_names), None)
+            index_name = min(index_names & dep_names, default=None)
             if index_name is None:
                 continue
             index_dep = next(

--- a/torch_spyre/_inductor/op_spec_validation.py
+++ b/torch_spyre/_inductor/op_spec_validation.py
@@ -586,7 +586,7 @@ def _check_stick_all_same(op_spec: OpSpec, stage: str) -> None:
             continue
         syms = _arg_stick_syms(arg)
         if syms:
-            stick_vars.add(next(iter(syms)))
+            stick_vars.add(min(syms, key=str))
 
     if len(stick_vars) > 1:
         coords_str = ", ".join(
@@ -608,7 +608,7 @@ def _check_stick_restickify(op_spec: OpSpec, stage: str) -> None:
     for arg in op_spec.args:
         syms = _arg_stick_syms(arg)
         if syms:
-            stick_vars.add(next(iter(syms)))
+            stick_vars.add(min(syms, key=str))
 
     if len(stick_vars) < 2:
         coords_str = ", ".join(
@@ -761,7 +761,7 @@ def _check_stick_matmul(op_spec: OpSpec, stage: str) -> None:
             on_y_stick = gen_from_b & _arg_stick_syms(y_arg)
             if len(on_y_stick) == 1:
                 gen_from_b = on_y_stick
-        generated_sym = next(iter(gen_from_b))
+        generated_sym = min(gen_from_b, key=str)
     else:
         # No generated_sym found — N=1 collapsed or symmetric. Vacuously valid.
         return
@@ -770,7 +770,7 @@ def _check_stick_matmul(op_spec: OpSpec, stage: str) -> None:
     # If reduction sym is missing (K=1 or constant-folded), skip.
     if not reduction_syms:
         return
-    reduction_sym = next(iter(reduction_syms))
+    reduction_sym = min(reduction_syms, key=str)
 
     out_stick: set[sympy.Symbol] = set()
     for arg in outputs:

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1498,7 +1498,7 @@ def iter_var_id(stick_expr) -> int:
     NOTE: this is the loop variable index (suffix of dN), NOT a tensor dimension index."""
     if stick_expr == sympy.S.Zero or not stick_expr.free_symbols:
         return -1
-    sym = next(iter(stick_expr.free_symbols))
+    sym = min(stick_expr.free_symbols, key=str)
     name = str(sym)
     i = len(name) - 1
     while i >= 0 and name[i].isdigit():
@@ -2026,7 +2026,7 @@ def compute_restickify_needed(
         # restickify removes the offset.
         reduction_vars = in_dep.index.free_symbols - out_dep.index.free_symbols
         if reduction_vars:
-            red_var = next(iter(reduction_vars))
+            red_var = min(reduction_vars, key=str)
             target_stick = sympy.Mod(red_var, in_stl.elems_per_stick())
     return True, compute_restickify_target_layout(
         in_stl, in_host, target_stick, ic, idc

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -802,7 +802,7 @@ def _find_layout_avoiding_var_on_stick(
         raise Unsupported(
             f"{label}: no surviving coordinates after removing {avoid_var}"
         )
-    surviving_var = next(iter(surviving_vars))
+    surviving_var = min(surviving_vars, key=str)
 
     for stl in arg.layouts:
         dev_coords = device_coordinates(stl, arg.dep, None)
@@ -1028,7 +1028,7 @@ def _conv_reduction_var(x: PropArg, reduction_candidates: set) -> sympy.Symbol |
         stick_syms = device_coordinates(stl, x.dep, None)[-1].free_symbols
         hit = reduction_candidates & stick_syms
         if hit:
-            return next(iter(hit))
+            return min(hit, key=str)
     return None
 
 
@@ -1545,7 +1545,7 @@ def _keep_by_index_layouts(
         # Check if this coordinate appears in indices
         found_in_indices = any(v_coord.equals(i_coord) for i_coord in indices_coords)
         if not found_in_indices:
-            search_var = next(iter(v_coord.free_symbols))
+            search_var = min(v_coord.free_symbols, key=str)
             break
 
     if search_var is None:
@@ -1562,7 +1562,7 @@ def _keep_by_index_layouts(
             continue
         found_in_values = any(i_coord.equals(v_coord) for v_coord in values_coords)
         if not found_in_values:
-            reduction_var = next(iter(i_coord.free_symbols))
+            reduction_var = min(i_coord.free_symbols, key=str)
             break
 
     if reduction_var is None:

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -1364,7 +1364,7 @@ def _matmul_axis_parse(op: Operation) -> dict[str, tuple[sympy.Symbol, int, int]
     for role, stride in zip(("N", "M", "B"), sorted(out_syms)):
         sym = out_syms[stride]
         roles[role] = (sym, sizes[stride], seed[sym])
-    k_sym = next(iter(k_syms))
+    k_sym = min(k_syms, key=str)
     roles["K"] = (
         k_sym,
         concretize_expr(iteration_space_from_op(op)[k_sym]),

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -24,6 +24,7 @@ from torch._inductor.ir import (
 )
 from torch._inductor.virtualized import V
 from torch._inductor.ops_handler import WrapperHandler
+from torch.utils._sympy.value_ranges import ValueRanges, bound_sympy
 
 import sympy
 
@@ -682,9 +683,26 @@ def _would_produce_lx_back_gap(
                     if device_size[d] > 1:
                         return True
                     continue
-                sym = next(iter(syms))
-                it_dim_size = int(dep.ranges[sym])
-                if device_size[d] > it_dim_size:
+                if any(sym not in dep.ranges for sym in syms):
+                    continue
+                # A device coordinate may be walked by several iteration symbols
+                # (``2*d0 + floor(d2/64)``), so the covered extent is the
+                # expression's upper bound over their ranges, not one symbol's
+                # range. Picking one out of the ``free_symbols`` *set* also made
+                # the verdict depend on PYTHONHASHSEED.
+                covered = (
+                    int(
+                        bound_sympy(
+                            coord_expr,
+                            {
+                                sym: ValueRanges(0, int(dep.ranges[sym]) - 1)
+                                for sym in syms
+                            },
+                        ).upper
+                    )
+                    + 1
+                )
+                if device_size[d] > covered:
                     return True
     return False
 

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -5758,7 +5758,7 @@ def _index_var_prefix(free_symbols: "OrderedSet[Expr] | set[Expr]") -> str:
     from any sibling symbol already present in the index instead of
     assuming one.
     """
-    for sym in free_symbols:
+    for sym in sorted(free_symbols, key=str):
         name = sym.name
         i = len(name)
         while i > 0 and name[i - 1].isdigit():

--- a/torch_spyre/_inductor/wsr/span_overflow_hint_analysis.py
+++ b/torch_spyre/_inductor/wsr/span_overflow_hint_analysis.py
@@ -664,10 +664,9 @@ def _input_span_infos_controlled_by_output_dims(
             if not coord.free_symbols:
                 continue
 
-            output_syms = [sym for sym in coord.free_symbols if sym in symbol_to_dim]
-            reduction_syms = [
-                sym for sym in coord.free_symbols if sym not in symbol_to_dim
-            ]
+            coord_syms = sorted(coord.free_symbols, key=str)
+            output_syms = [sym for sym in coord_syms if sym in symbol_to_dim]
+            reduction_syms = [sym for sym in coord_syms if sym not in symbol_to_dim]
             if reduction_syms and not (
                 k_symbol is not None and set(reduction_syms) == {k_symbol}
             ):
@@ -1007,7 +1006,9 @@ def _output_span_candidates_from_op(
     for device_dim, coord in enumerate(device_coords[:-1]):
         if not coord.free_symbols:
             continue
-        output_syms = [sym for sym in coord.free_symbols if sym in symbol_to_dim]
+        output_syms = sorted(
+            [sym for sym in coord.free_symbols if sym in symbol_to_dim], key=str
+        )
         # A coordinate can be jointly controlled by more than one output
         # symbol, for example two interleaved dims sharing one physical
         # stride -- ``floor(d1 / 64)`` maps cleanly to the output dim for


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Compilation is not reproducible across processes. Same tree, same input, same `_SEED`, same step budget — two different LX plans and two different core-division vectors, differing in 36 of 63 buffers. On granite-4.0-micro (1 layer, seq 64) the two plans measure 2546 us and 2609 us, a 2.5% spread, well outside device noise (sd 25–70 us). That makes any core-division or scratchpad A/B untrustworthy, and lets a compiled-artifact cache return a plan built under a different residency decision.

The cause is `next(iter(...))` on a plain `set`. sympy's `Symbol.__hash__` derives from the name string, so a `free_symbols` set's iteration order moves with `PYTHONHASHSEED`:

```console
$ for h in 0 1 2 3 4 5; do PYTHONHASHSEED=$h python3 -c "
import sympy; d0, d2 = sympy.symbols('d0 d2')
print(next(iter((2*d0 + sympy.floor(d2/64)).free_symbols)))"; done
d0 d2 d0 d2 d2 d0
```

**Commit 1 — the bug.** `_would_produce_lx_back_gap` picked one symbol out of `coord_expr.free_symbols` and compared `device_size[d]` against *that symbol's* iteration range. On the probe graph `buf31` has `coord = 2*d0 + floor(d2/64)`, `device_size[1] = 16`, `d0 → 8`, `d2 → 128`: picking `d2` gives `16 > 128` false and the buffer stays LX-resident, picking `d0` gives `16 > 8` true and it spills. That flip drops `buf32`'s `cd_parent_matches[buf31]` edge, which changes the co-optimizer's eligibility set, hence its trajectory, hence the division vector.

Neither pick is the intended semantics: a symbol's raw range is not the coordinate's covered extent. For a stickified coordinate (`floor(d1/64)`, range 1024, extent 16) it overstates coverage 64x and **misses** back gaps — the dangerous direction, since LX has no backGap support — and for a strided multi-symbol coordinate it understates coverage and invents gaps. The fix bounds the expression over every symbol's range with `bound_sympy`, which handles the `floor` and `Mod` coordinates here (substituting each symbol's maximum would be wrong for `Mod`).

Dumping the true extent for every `(buffer, use, device dim)` shows the probe graph has no back gaps at all, and the old code manufactured two or three:

| buffer | coordinate | ranges | covered | `device_size` | before | after |
|---|---|---|---|---|---|---|
| `buf31` | `2*d0 + floor(d2/64)` | d0→8, d2→128 | 16 | 16 | `None` **or** `lx back gap` | `None` |
| `buf13` | `2*d1 + d3` | d1→8, d3→2 | 16 | 16 | `lx back gap` | `None` |
| `buf9` | `2*d1 + d3` | d1→40, d3→2 | 80 | 80 | `lx back gap` | `None` |

For `buf9`/`buf13` *both* picks are wrong (`2 < 80` and `40 < 80`), which is why they never flipped — they were consistently, deterministically wrong.

`tests/inductor/test_scratchpad_utils.py` (new, wired into CI by `tests/configs/torch_spyre_tests/inductor/test_scratchpad_utils_config.yaml` with labels `unit, regression, trunk`) pins the semantics, with cases chosen so the old code fails at *every* hash seed rather than half of them: `2*d1 + d3` on a dim 80 wide is wrong on both picks; `floor(d1/64)` over `[0,1024)` on a dim 32 wide covers the missed-gap direction; a `Mod` case pins why this needs range analysis and not `subs`; a positive case keeps the rest honest. Against the unpatched function, 3 of 5 fail at seed 0 and 2 of 5 at seed 1 — the difference is the `buf31` case flipping with the seed.

**Commit 2 — the audit.** All 99 `next(iter(...))` sites in `torch_spyre/_inductor`, classified by container type and guard:

| | sites |
|---|---|
| ordered container — no issue | 53 |
| plain set, guarded to exactly one element | 32 |
| plain set, **unguarded** | 14 (1 is commit 1; 13 fixed here) |

Container types settled 53 at once: `ReadWrites.reads`/`.writes` and `IRNode.origins` are `OrderedSet`, `PropArg.layouts` is a `list`, and dicts are insertion-ordered.

12 of the 13 become `min(X, key=str)` — identical to the old code whenever the set holds one element (the invariant every one of these sites assumes) and reproducible when it does not. Each is already guarded against an empty set, so none changes which exception it can raise. They decide a matmul's K axis, stick/generated/reduction symbols in `op_spec_validation`, `iter_var_id`'s loop var, the reduction var promoted to the stick dim, a conv's contraction var, `keep_by_index`'s search and reduction vars, and which index tensor drives a device-layout rotation.

The 13th, `superdsc._resolve_sdsc_size`, gets a real fix: `symbolic_dim_bounds` is keyed by a *single* symbol name, so it can only answer for a single-symbol expression. Returning one arbitrary symbol's bound as a multi-symbol expression's size answered the wrong question; that case now falls through to `_concretize_for_sdsc`, which resolves the whole expression. This sits on what the surrounding comment calls a "correctness-critical boundary".

Four further sites build a list, or return on the first element, while iterating a `free_symbols` set — so hash order sets the *order*, not the pick. That order is the SDSC device dim order in `superdsc`, the order candidates are registered in `span_overflow_hint_analysis`, and a symbol name prefix in `coarse_tile`. Those iterate `sorted(...)`.

#### Which issue(s) this PR is related to:

Related to #858 (Environment & Reproducibility — its "Non-Determinism Detection & Reporting" story).

Adjacent to #2346, which is about multi-variable *stick* expressions hitting an explicit `Unsupported` in a different code path. This PR touches the non-stick coordinates (`coords[:-1]`) and does not change it — see the `-k unfold` result below.

#### Special notes for your reviewer:

**Why the existing hashseed test did not catch this.** `CrossProcessDeterminismTest.test_pythonhashseed_independent` (#3513) does the right thing in principle and passes on `main` regardless of this bug: `_SOLVE_SNIPPET` builds `SaCoOptimizingSolver` directly from pre-built buffers, so `residency_reason` and `cd_parent_matches` arrive already baked and the allocator stage never runs. The test starts *downstream* of where the nondeterminism enters. Extending it to drive residency pinning on a graph with a multi-symbol non-stick coordinate is the obvious follow-up; it needs a new fixture rather than a new case, so I would rather agree the shape first than bundle it here.

**How live are commit 2's sites?** Every fixed site was instrumented to log whenever its set actually held more than one element. Across 1466 tests the two classes differ: the 13 `next(iter(...))` sites were **never** reached with an ambiguous set (three were reached at all, always with one symbol, so `min` returned exactly what `next(iter(...))` did), while the list-order sites are **live** — `span_overflow_hint_analysis`'s output scan fired 37 times with two symbols, its input scan twice, and `coarse_tile`'s prefix scan once. No asserted outcome changes either way: `test_span_overflow_hint_analysis.py` gives the same 149 passed / 4 xfailed with the `sorted()` present or absent, across hash seeds. Read that as "no evidence of impact", not "proven harmless" — the suite may simply not assert on candidate order.

**Why `min(..., key=str)` and not a hard `raise`?** It costs nothing, cannot regress a corpus where the sets are singletons, and removes the failure mode rather than converting it into a crash on the first graph that trips it. Note `key=str` sorts `d10` before `d2`; the goal is a *stable* representative, not a numerically meaningful one. If you would rather these fail loudly so the wrong-answer cases surface, that is a reasonable alternative and an easy change — I picked the conservative option deliberately.

**Counts changed on rebase.** The audit above was taken at `622681fe`, where there were 100 `next(iter(...))` sites and 15 unguarded ones. Since then #4206 rewrote `_validate_matmul_stick_syms` in `op_spec_validation.py`: it dropped the `elif gen_from_a:` branch and added a broadcast-batch disambiguation step (`on_y_stick`) ahead of the `gen_from_b` pick. One of the sites this PR fixed therefore no longer exists, so every count is one lower than originally written — 99 audited, 14 unguarded, 13 fixed in commit 2, 12 of them via `min(X, key=str)`. Verified by counting `next(iter(` under `torch_spyre/_inductor`: 99 at the base, 98 after commit 1, 85 after commit 2. The surviving `gen_from_b` pick keeps `min(..., key=str)` as the tiebreak for the case #4206's disambiguation cannot narrow to one symbol; commit 2's message carries the same note.

**Validation**, on this branch. The full sweep below ran against `main` @ `622681fe`. The branch has since been rebased twice, now onto `b20b790a`; that base touches 6 of the 11 files here (`superdsc.py`, `op_spec_validation.py`, `pass_utils.py`, `propagate_layouts.py`, `scratchpad/utils.py`, `wsr/coarse_tile.py`), and only `op_spec_validation.py` conflicted — resolved as described above. Smoke re-run on the new base, last bullet.

- Determinism: `coopt_probe.py --arms coopt-sa`, granite-4.0-micro, 1 layer, seq 64 — 3/3 identical division vectors. On `main`, 2 distinct in 5 runs.
- 1216 passed / 2 skipped / 19 xfailed / **0 failed** across the op-spec-validation, opspec-utils/tiling, padding, restickify, work-division, propagate-named-dims, span-overflow, symbolic-dim-bundle, sa-cooptimizer, scratchpad solver/patterns/use, cooptimization-types, hbm-pool, lx-clobber, lx-inplace and new scratchpad-utils suites.
- An evenly-spaced 258-case sample of `test_inductor_ops`, `test_indirect_access_gather`, `test_indirect_access_scatter`, `test_inductor_matmul`, `test_coarse_tiling`: 246 passed, 9 xfailed, 2 failed — `test_cmp_le_fp32_1d` and `test_cmp_lt_fp32_3d`, which fail identically on unpatched `main`.
- `test_inductor_ops_lx_planning.py` (~4900 cases) was **not** run beyond what the above covers — worth a full CI pass before merge. Its `-k unfold` subset gives an identical 36 failed / 4 passed on this branch and on `main`.
- Smoke re-run on the new base `b20b790a`, 10 suites (scratchpad utils/solver/patterns/use, sa-cooptimizer, cooptimization-types, span-overflow, op-spec-validation, opspec-utils/tiling): **728 passed / 1 skipped / 15 xfailed / 3 failed** in 6m01s. All 3 failures are `test_op_spec_validation.py::TestMatmulStick::test_input1_wrong_stick_raises`, `test_input2_wrong_stick_raises` and `test_output_wrong_stick_raises`, and they are **pre-existing on the new base, not caused by this branch**: reverting this PR's two changed lines in `_validate_matmul_stick_syms` to trunk's exact code reproduces all 3, stable across `PYTHONHASHSEED` 0-3. #4206's `on_y_stick` rewrite appears to have made those three negative cases stop raising. This supersedes the "0 failed across op-spec-validation" figure two bullets up, which was measured at `622681fe`.
- `pre-commit run --files` on all 11 touched files: ruff, ruff format, yamlfmt, mypy and the import-regex hook pass. `tests/scripts/check_test_coverage.sh` reports 110/110 covered, and `bash tests/run_test.sh tests/configs/torch_spyre_tests/inductor/test_scratchpad_utils_config.yaml` drives the new file end-to-end (5 passed).

**Plan aggregates are not plan equality**, worth knowing for anyone benchmarking: the two `main` division vectors give *identical* LX/HBM/pred aggregates (both `63 buf / 30 LX / 11.30 MiB / 11.16 MiB / 1499.5 us`) while differing in 36 of 63 buffers. Compare the per-buffer vector, and repeat within a tree before comparing across trees.

**Outstanding**, not in this PR: an exhaustive sweep for list order derived from a set (the four here surfaced while reading the `next(iter(...))` neighbourhoods; the class was not audited systematically); the same audit outside `_inductor`; four sites in `padding.py` guarded only by `assert`, so they degrade under `python -O`; and the `spyre-cost-model-experiments` skill's claim that "the same config gives byte-identical LX/HBM/division figures across runs", which was false for the division vector.

#### Does this PR introduce a user-facing change?

No API change, but compiled plans do change: LX residency decisions that were hash-order-dependent are now fixed, and three buffers on the probe graph that were spuriously spilled become LX-resident. Predicted runtime there moves from 1499.5 us to 1501.8 us — within model noise, and the point is that it is now the same number every run.

#### Additional note:

Two commits, deliberately split: commit 1 is the behaviour change and carries the measured evidence and the new test; commit 2 is 17 edits across 8 files, 16 mechanical and one (`_resolve_sdsc_size`) a real semantic fix worth a closer look. Please read them separately rather than as a squashed diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HESYdF7SHpQPaN6MUn72X


