### PR TITLE
Extract compute_coordinates and normalize_coordinates fixes from #4108

### DIFF
--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+
 import sympy
 
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.ir import FixedLayout
+from torch._inductor.virtualized import V
 from torch_spyre._C import DataFormats, SpyreTensorLayout
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.pass_utils import (
@@ -31,11 +34,12 @@ from torch_spyre._inductor.propagate_layouts import (
 )
 from torch_spyre._inductor.views import (
     _decompose_constant_offset,
+    align_tensors,
     compute_coordinates,
     normalize_coordinates,
     tiling_expr_to_device_expr,
 )
-from torch.utils._sympy.functions import ModularIndexing
+from torch.utils._sympy.functions import FloorDiv, ModularIndexing
 
 p0, p1, p2, p3, p4, p5 = sympy.symbols("p0 p1 p2 p3 p4 p5", integer=True)
 
@@ -153,6 +157,68 @@ class TestCoordinates(TestCase):
         )
         # offset 1855 = 3*600 + 1*30 + 25*1
         self.assertEqual(cx, [p0 + 3, p1 + 1, p2 + 25])
+
+    def test_compute_coordinates_mixed_radix_flattened_dim(self):
+        """A flattened H*D loop maps back to separate H and D coordinates."""
+        lq, hd = sympy.symbols("lq hd", integer=True, nonnegative=True)
+        with V.set_graph_handler(SimpleNamespace()):
+            repeat_info: dict = {}
+            cx = compute_coordinates(
+                [1, 32, 64, 128],
+                [262144, 8192, 128, 1],
+                {lq: 64, hd: 4096},
+                128 * lq
+                + 8192 * ModularIndexing(hd, 128, 32)
+                + ModularIndexing(hd, 1, 128),
+                repeat_info_out=repeat_info,
+            )
+            self.assertEqual(
+                cx,
+                [0, sympy.Mod(FloorDiv(hd, 128), 32), lq, sympy.Mod(hd, 128)],
+            )
+
+            terms = normalize_coordinates(
+                {lq: 64, hd: 4096},
+                [1, 32, 64, 128],
+                cx,
+                lambda: sympy.Symbol("z0"),
+            )
+            high_digit = next(
+                term for term in terms if term.var == hd and term.dim_size == 32
+            )
+            self.assertEqual(high_digit.den, 128)
+            self.assertEqual(high_digit.mod, 4096)
+
+            iteration_space, tensors, remap = align_tensors(
+                {lq: (64, 1), hd: (4096, 1)},
+                [{"size": [1, 32, 64, 128], "coordinates": cx}],
+                repeat_info=repeat_info,
+            )
+            self.assertEqual(iteration_space[hd][0], 128)
+            self.assertEqual(remap[hd][0], (hd, 1))
+            high_var = remap[hd][1][0]
+            self.assertEqual(iteration_space[high_var][0], 32)
+            self.assertTrue(all(size > 0 for size in tensors[0]["size"]))
+
+    def test_compute_coordinates_rejects_overlapping_moduli(self):
+        """Multiple Mods remain unsupported unless they form one digit chain."""
+        with self.assertRaisesRegex(Unsupported, "multiple Mod"):
+            compute_coordinates(
+                [4, 6],
+                [6, 1],
+                {p0: 24},
+                6 * (p0 % 4) + p0 % 6,
+            )
+
+    def test_compute_coordinates_rejects_fractional_mixed_radix_coefficient(self):
+        """An unsupported digit scale is rejected before normalization."""
+        with self.assertRaisesRegex(Unsupported, "multiple Mod"):
+            compute_coordinates(
+                [4, 6],
+                [6, 1],
+                {p0: 24},
+                sympy.Rational(3, 2) * (p0 % 4) + 6 * sympy.Mod(FloorDiv(p0, 4), 6),
+            )
 
     def test_compute_device_coordinates(self):
         # B, S, E -> B, E/H, S, H

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -25,6 +25,71 @@ from torch._inductor.virtualized import V
 from .errors import Unsupported
 
 
+def _mixed_radix_digits(expr, var, var_range, mods):
+    """Describe an exact quotient/remainder digit chain for ``var``.
+
+    A flattened loop variable commonly reaches a pre-flatten view as adjacent
+    mixed-radix digits, for example ``Mod(hd, 128)`` and
+    ``Mod(FloorDiv(hd, 128), 32)`` for a flattened ``H*D`` axis. Multiple Mods
+    are safe in that case: each digit addresses a distinct tensor dimension.
+
+    Return the digits in low-to-high order, or ``None`` when the expressions
+    overlap, leave a gap, or do not cover the variable's full range. Keeping
+    this recognition deliberately strict preserves rejection of ambiguous
+    combinations such as ``Mod(x, 4) + Mod(x, 6)``.
+    """
+    term = expr.xreplace({s: 0 for s in expr.free_symbols - {var}})
+    var_terms = [addend for addend in sympy.Add.make_args(term) if addend.has(var)]
+    if len(var_terms) != len(mods):
+        return None
+
+    digits = []
+    for node in mods:
+        containing = [addend for addend in var_terms if addend.has(node)]
+        if len(containing) != 1:
+            return None
+        addend = containing[0]
+        if len([m for m in addend.atoms(sympy.Mod) if m.has(var)]) != 1:
+            return None
+
+        base, modulus = node.args
+        if base == var:
+            divisor = sympy.S.One
+        elif isinstance(base, FloorDiv) and base.args[0] == var:
+            divisor = base.args[1]
+        else:
+            return None
+
+        coeff = sympy.simplify(addend / node)
+        if (
+            coeff.has(var)
+            or coeff.is_Rational is not True
+            or coeff <= 0
+            or (coeff.numerator != 1 and coeff.denominator != 1)
+        ):
+            return None
+        if any(not value.is_Integer or value <= 0 for value in (divisor, modulus)):
+            return None
+        digits.append(
+            {
+                "node": node,
+                "modulus": modulus,
+                "divisor": divisor,
+                "coeff": coeff,
+            }
+        )
+
+    digits.sort(key=lambda digit: int(digit["divisor"]))
+    if digits[0]["divisor"] != 1:
+        return None
+    for low, high in zip(digits, digits[1:]):
+        if sympy.simplify(low["divisor"] * low["modulus"] - high["divisor"]) != 0:
+            return None
+    if sympy.simplify(digits[-1]["divisor"] * digits[-1]["modulus"] - var_range) != 0:
+        return None
+    return digits
+
+
 def find_repeat_vars(index_exprs, var_ranges):
     repeat_info = {}
     for var, var_range in var_ranges.items():
@@ -34,12 +99,16 @@ def find_repeat_vars(index_exprs, var_ranges):
             for m in all_mods:
                 if m.has(var):
                     mods.append(m)
-            if len(mods) != 1:
-                if len(mods) > 1:
+            if len(mods) > 1:
+                digits = _mixed_radix_digits(expr, var, var_range, mods)
+                if digits is None:
                     raise Unsupported(
                         f"variable {var} (range {var_range}) appears in multiple Mod "
                         f"expressions {mods} and cannot be mapped to coordinates."
                     )
+                repeat_info[var] = {"kind": "mixed_radix", "digits": digits}
+                break
+            if len(mods) == 0:
                 continue
             node = mods[0]
             base, modulus = node.args
@@ -330,6 +399,13 @@ def compute_coordinates(
             elif info["kind"] == "mul_mod":
                 coeff = info["coeff"]
                 add_term(var=info["node"], step=coeff, limit=coeff * info["modulus"])
+            elif info["kind"] == "mixed_radix":
+                for digit in info["digits"]:
+                    add_term(
+                        var=digit["node"],
+                        step=digit["coeff"],
+                        limit=digit["coeff"] * digit["modulus"],
+                    )
             continue
 
         # compute index({var=1}) and index({var=var_ranges[var]})
@@ -442,6 +518,53 @@ def normalize_coordinates(
     device dims with a constant zero coordinate are dropped, and do not stop
     the dims on either side of them from fusing.
     """
+
+    def normalize_var_expr(term, var, var_range, dim_size):
+        """Convert one single-variable coordinate term to ``Term``.
+
+        ``Mod(FloorDiv(var, divisor), radix)`` is one digit of a
+        mixed-radix decomposition. Its equivalent normalized form is
+        ``(var % (divisor * radix)) // divisor``; retaining both bounds is
+        essential when ``align_tensors`` splits the original loop variable.
+        """
+        coeff = sympy.S.One
+        body = term
+        if term.func == sympy.Mul and term.args[0].is_rational:
+            coeff, body = term.args
+            # TODO: handle non-unit fractions
+            # https://github.com/torch-spyre/torch-spyre/issues/1353
+            assert coeff.numerator == 1 or coeff.denominator == 1, (
+                f"Unsupported coordinate expression {term}"
+            )
+
+        divisor = sympy.S.One
+        modulus = var_range
+        if body == var:
+            pass
+        elif isinstance(body, FloorDiv) and body.args[0] == var:
+            divisor = body.args[1]
+        elif body.func == sympy.Mod:
+            base, radix = body.args
+            if base == var:
+                modulus = radix
+            elif isinstance(base, FloorDiv) and base.args[0] == var:
+                divisor = base.args[1]
+                modulus = divisor * radix
+            else:
+                raise Unsupported(
+                    f"Unsupported modular coordinate expression {body} for {var}"
+                )
+        else:
+            raise Unsupported(f"Unsupported coordinate expression {term}")
+
+        return Term(
+            coeff.numerator,
+            coeff.denominator * divisor,
+            var,
+            modulus,
+            dim_size,
+        )
+
     # terms in non-increasing stride order
     terms = []
 
@@ -489,28 +612,7 @@ def normalize_coordinates(
 
             # extract term for each var
             term = expr.xreplace({v: 0 for v in vars - {var}}) - offset
-            # pattern match expression tree, there is small number of possibilities
-            if term.is_symbol:
-                dim_terms.append(
-                    Term(sympy.S.One, sympy.S.One, var, var_range, dim_size)
-                )
-            elif term.func == sympy.Mod:
-                dim_terms.append(
-                    Term(sympy.S.One, sympy.S.One, var, term.args[1], dim_size)
-                )
-            elif term.func == sympy.Mul and term.args[0].is_rational:
-                expr0, expr1 = term.args
-                mod = expr1.args[1] if expr1.func == sympy.Mod else var_range
-                # TODO: handle non-unit fractions
-                # https://github.com/torch-spyre/torch-spyre/issues/1353
-                assert expr0.numerator == 1 or expr0.denominator == 1, (
-                    f"Unsupported coordinate expression {expr}"
-                )
-                dim_terms.append(
-                    Term(expr0.numerator, expr0.denominator, var, mod, dim_size)
-                )
-            else:
-                assert False, f"Unsupported coordinate expression {expr}"
+            dim_terms.append(normalize_var_expr(term, var, var_range, dim_size))
         # sort dim_terms in increasing (num, mod) order so that z + offset
         # vars (num=1, mod=1) always sort before real iteration vars (num=1, mod=N)
         # when num is equal


### PR DESCRIPTION
#### What type of PR is this?

- [X] bug

#### What this PR does:

This PR extracts the `compute_coordinates` and` normalize_coordinates` fixes from #4108 and the relevant tests. See #4108 for context. The approach to layout propagation and restickification adopted in #4108 conflicts with other pending changes and are not included here.

This code is intended to fix the computation of coordinates when the range of an iteration variable is split across multiple terms. It validates that the terms properly divide the range but it does not enforce any "contiguous dimensions" property as this code is used both for host and device coordinates. The requirement that these terms have to recombine once considering device coordinates belongs to the remainder of #4108.
