### PR TITLE
fix(hw diagnostics): track pod-level-retry outcomes distinctly in ClickHouse hw diagnostics ingest

### DIFF
--- a/.github/scripts/ingest_hw_diagnostics.py
+++ b/.github/scripts/ingest_hw_diagnostics.py
@@ -99,6 +99,7 @@ def build_row(rec: dict, args) -> list:
         _str(rec.get("suite_name")),
         _int(rec.get("attempt"), 1),
         _int(rec.get("total_attempts"), 1),
+        _int(rec.get("pod_level_retry"), 0),
         _parse_ts(rec.get("ingested_at"))
         or datetime.now(timezone.utc).replace(tzinfo=None),
         # ── Outcome ───────────────────────────────────────────────────────
@@ -153,6 +154,7 @@ COLUMN_NAMES = [
     "suite_name",
     "attempt",
     "total_attempts",
+    "pod_level_retry",
     "ingested_at",
     # Outcome
     "outcome",
@@ -233,6 +235,8 @@ def ensure_extra_columns(client) -> None:
         ("ras_severity", "LowCardinality(String) DEFAULT ''"),
         ("ras_message", "String DEFAULT ''"),
         ("ras_events_json", "String DEFAULT '[]'"),
+        # True when this row came from a _test_matrix.yaml pod-level-retry job (a fresh-pod re-run), not the original job.
+        ("pod_level_retry", "Bool DEFAULT false"),
     ]
     for col_name, col_type in extras:
         try:

--- a/.github/scripts/parse_hw_failures.py
+++ b/.github/scripts/parse_hw_failures.py
@@ -68,6 +68,9 @@ RE_HW_RETRY_BANNER = re.compile(r"Hardware RAS timeout detected", re.IGNORECASE)
 RE_STALL_LINE = re.compile(r"\[stall-watcher\] No new output for (?P<secs>\d+)s")
 RE_SIGNAL_EXIT = re.compile(r"SIGNAL EXIT", re.IGNORECASE)
 
+# Matches the "(pod-level retry)" job-name suffix _test_matrix.yaml's test_retry / test_multi_spyre_retry jobs stamp on a suite re-run on a fresh pod; tolerates the parens already being stripped by the upstream sanitizer.
+RE_POD_LEVEL_RETRY_SUFFIX = re.compile(r"\(?\s*pod-level retry\s*\)?\s*$", re.IGNORECASE)
+
 # Process crash / signal patterns
 # Matches: "Signal Received: 6 (Aborted)" or "Signal Received: 11 (Segmentation fault)"
 RE_SIGNAL_RECEIVED = re.compile(
@@ -392,10 +395,23 @@ def _extract_all_ras_events(chunk_lines: list[str]) -> list[dict]:
 # --------------------------------
 
 
-def parse_log(text: str, run_id: str, suite_hint: str = "") -> list[dict[str, Any]]:
+def parse_log(
+    text: str,
+    run_id: str,
+    suite_hint: str = "",
+    is_pod_level_retry: bool = False,
+) -> list[dict[str, Any]]:
     """
     Parse a (potentially multi-attempt) log blob.
     Returns one record per (suite, attempt).
+
+    is_pod_level_retry identifies the whole log as coming from a
+    _test_matrix.yaml test_retry / test_multi_spyre_retry job (a suite
+    re-run on a fresh pod after exhausting its in-job attempts) -- distinct
+    from the in-log "=== Attempt N/M ===" banners, which track same-pod
+    retries within a single job and know nothing about pod-level retry. It
+    is stamped onto every record from this log, not derived from log
+    content.
     """
     lines = text.splitlines()
     records: list[dict[str, Any]] = []
@@ -435,6 +451,7 @@ def parse_log(text: str, run_id: str, suite_hint: str = "") -> list[dict[str, An
             "suite_name": suite_name,
             "attempt": attempt_num,
             "total_attempts": total_attempts,
+            "pod_level_retry": is_pod_level_retry,
             "ingested_at": datetime.now(timezone.utc).isoformat(),
             # Outcome
             "outcome": "unknown",
@@ -681,24 +698,32 @@ _SKIP_JOB_NAMES = re.compile(
 )
 
 
-def _suite_from_filename(filename: str) -> str | None:
+def _suite_from_filename(filename: str) -> tuple[str, bool] | None:
     """
     Extract a clean suite name from a GHA log filename.
 
-    Returns None if the file should be skipped (meta/gate job or unrecognised).
+    Returns (suite_name, is_pod_level_retry), or None if the file should be
+    skipped (meta/gate job or unrecognised).
 
     Examples
     --------
-    "24_run-tests _ Inductor Ops Reductions Scalar.txt"  → "Inductor Ops Reductions Scalar"
-    "run-tests _ Tensor Layout"                          → "Tensor Layout"
+    "24_run-tests _ Inductor Ops Reductions Scalar.txt"  → ("Inductor Ops Reductions Scalar", False)
+    "run-tests _ Tensor Layout"                          → ("Tensor Layout", False)
     "53_Detect changed files.txt"                        → None  (skipped)
     "0_Run Spyre unit tests.txt"                         → None  (skipped)
+    "12_run-tests _ Inductor Ops Misc Shape C pod-level retry.txt"
+                                                          → ("Inductor Ops Misc Shape C", True)
     """
     # Strip .txt extension (case-insensitive)
     stem = re.sub(r"\.txt$", "", filename, flags=re.IGNORECASE)
     # Strip leading numeric prefix  e.g. "24_"
     stem = re.sub(r"^\d+_", "", stem)
     stem = stem.strip()
+
+    # Detect + strip the pod-level-retry suffix first, before the prefix cleanup below.
+    is_pod_level_retry = bool(RE_POD_LEVEL_RETRY_SUFFIX.search(stem))
+    if is_pod_level_retry:
+        stem = RE_POD_LEVEL_RETRY_SUFFIX.sub("", stem).strip()
 
     # Skip meta/gate jobs
     if _SKIP_JOB_NAMES.match(stem):
@@ -707,7 +732,7 @@ def _suite_from_filename(filename: str) -> str | None:
     # Strip "run-tests _ " prefix (the GHA job name format)
     m = re.match(r"^run-tests\s*_\s*(.+)$", stem, re.IGNORECASE)
     if m:
-        return m.group(1).strip()
+        return m.group(1).strip(), is_pod_level_retry
 
     # Extension-less files without a "run-tests _ " prefix are almost always
     # the unnumbered GHA duplicate of a .txt file (same content) OR a stray
@@ -715,21 +740,24 @@ def _suite_from_filename(filename: str) -> str | None:
     # and a capital letter, matching the "Suite Name" pattern).
     # This prevents oddities like bare filenames without spaces from slipping in.
     if re.search(r"[A-Z]", stem) and " " in stem:
-        return stem
+        return stem, is_pod_level_retry
     return None
 
 
-def _pick_files_from_dir(log_dir: Path) -> list[tuple[Path, str]]:
+def _pick_files_from_dir(log_dir: Path) -> list[tuple[Path, str, bool]]:
     """
-    Scan log_dir and return (path, suite_name) pairs for every file that
-    represents a test suite.
+    Scan log_dir and return (path, suite_name, is_pod_level_retry) triples
+    for every file that represents a test suite.
 
     Deduplication: GHA downloads often produce both a numbered .txt file
     ("24_run-tests _ Foo.txt") AND an unnumbered no-extension copy
     ("run-tests _ Foo").  We prefer the .txt variant and skip the duplicate.
+    A suite's pod-level-retry log (job "Foo (pod-level retry)") is kept as
+    its own entry, not deduplicated against the original job's log -- they
+    are two distinct job runs and both outcomes matter.
     """
     # Collect all candidates
-    candidates: list[tuple[Path, str]] = []
+    candidates: list[tuple[Path, str, bool]] = []
     for fpath in sorted(log_dir.iterdir()):
         if not fpath.is_file():
             continue
@@ -739,22 +767,27 @@ def _pick_files_from_dir(log_dir: Path) -> list[tuple[Path, str]]:
         # Accept .txt and .log files, plus extension-less files (GHA produces both)
         if fpath.suffix not in (".txt", ".log", ""):
             continue
-        suite = _suite_from_filename(fpath.name)
-        if suite is None:
+        result = _suite_from_filename(fpath.name)
+        if result is None:
             continue
-        candidates.append((fpath, suite))
+        suite, is_pod_level_retry = result
+        candidates.append((fpath, suite, is_pod_level_retry))
 
-    # Deduplicate by suite name — keep the .txt (or .log) over extension-less
-    seen: dict[str, Path] = {}
-    for fpath, suite in candidates:
-        if suite not in seen:
-            seen[suite] = fpath
+    # Deduplicate by (suite name, is_pod_level_retry) — keep the .txt (or .log) over extension-less
+    seen: dict[tuple[str, bool], Path] = {}
+    for fpath, suite, is_pod_level_retry in candidates:
+        key = (suite, is_pod_level_retry)
+        if key not in seen:
+            seen[key] = fpath
         else:
             # Prefer files with an extension over extension-less duplicates
-            if fpath.suffix in (".txt", ".log") and seen[suite].suffix == "":
-                seen[suite] = fpath
+            if fpath.suffix in (".txt", ".log") and seen[key].suffix == "":
+                seen[key] = fpath
 
-    return [(path, suite) for suite, path in sorted(seen.items())]
+    return [
+        (path, suite, is_pod_level_retry)
+        for (suite, is_pod_level_retry), path in sorted(seen.items())
+    ]
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -833,9 +866,14 @@ def main() -> None:
             file=sys.stderr,
         )
 
-        for fpath, suite_name in file_suite_pairs:
+        for fpath, suite_name, is_pod_level_retry in file_suite_pairs:
             text = fpath.read_text(errors="replace")
-            recs = parse_log(text, run_id=args.run_id, suite_hint=suite_name)
+            recs = parse_log(
+                text,
+                run_id=args.run_id,
+                suite_hint=suite_name,
+                is_pod_level_retry=is_pod_level_retry,
+            )
             all_records.extend(recs)
             outcomes = [r["outcome"] for r in recs]
             reasons = [
@@ -846,7 +884,8 @@ def main() -> None:
                 file=sys.stderr,
             )
             print(
-                f"         suite={suite_name!r}  attempts={len(recs)}"
+                f"         suite={suite_name!r}  pod_level_retry={is_pod_level_retry}"
+                f"  attempts={len(recs)}"
                 f"  outcomes={outcomes}  reasons={reasons or ['(none)']!r}",
                 file=sys.stderr,
             )

--- a/.github/scripts/parse_hw_failures.py
+++ b/.github/scripts/parse_hw_failures.py
@@ -69,7 +69,9 @@ RE_STALL_LINE = re.compile(r"\[stall-watcher\] No new output for (?P<secs>\d+)s"
 RE_SIGNAL_EXIT = re.compile(r"SIGNAL EXIT", re.IGNORECASE)
 
 # Matches the "(pod-level retry)" job-name suffix _test_matrix.yaml's test_retry / test_multi_spyre_retry jobs stamp on a suite re-run on a fresh pod; tolerates the parens already being stripped by the upstream sanitizer.
-RE_POD_LEVEL_RETRY_SUFFIX = re.compile(r"\(?\s*pod-level retry\s*\)?\s*$", re.IGNORECASE)
+RE_POD_LEVEL_RETRY_SUFFIX = re.compile(
+    r"\(?\s*pod-level retry\s*\)?\s*$", re.IGNORECASE
+)
 
 # Process crash / signal patterns
 # Matches: "Signal Received: 6 (Aborted)" or "Signal Received: 11 (Segmentation fault)"


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

## Summary
- `parse_hw_failures.py`: detects the `(pod-level retry)` suffix on GHA job log filenames and tags every parsed record with a new `pod_level_retry` flag, instead of losing that info during suite-name cleanup.
- `ingest_hw_diagnostics.py`: writes the new `pod_level_retry` column to ClickHouse and auto-adds it to the table on the next ingest run (also self-applies via `ALTER TABLE spyre.hw_failure_diagnostics ADD COLUMN IF NOT EXISTS pod_level_retry Bool DEFAULT false;` if run manually first).
