### PR TITLE
fix(inductor): pad coarse-tile read-copy buffers with no FX node

### DIFF
--- a/tests/inductor/test_padding.py
+++ b/tests/inductor/test_padding.py
@@ -35,9 +35,14 @@ from torch._inductor.graph import GraphLowering
 from torch_spyre._C import get_elem_in_stick
 from torch_spyre._inductor import config as ts_inductor_config
 from torch_spyre._inductor import passes
+from torch_spyre._inductor import spyre_hint
 from torch_spyre._inductor.constants import BATCH_MATMUL_OP
 from torch_spyre._inductor.ir import FixedTiledLayout, SpyreConstantFallback
 from torch_spyre._inductor.passes import CustomPreSchedulingPasses
+from torch_spyre._inductor.wsr.propagate_named_dims import (
+    declare_tensor_dim,
+    name_tensor_dims,
+)
 from torch_spyre._inductor.scratchpad import allocator
 from torch_spyre._inductor.scratchpad import utils as scratchpad_utils
 
@@ -701,6 +706,50 @@ class TestInsertPaddingIR(unittest.TestCase):
         # padding sequence for y, so _assert_constant_pad_nd_ops (which expects
         # exactly 4 ops) cannot be used here.  Correctness is verified by assert_close.
         torch.testing.assert_close(fn(x_cpu, y_cpu), result.cpu(), atol=0.1, rtol=0.1)
+
+    def test_bmm_read_copy_y_unaligned_k_pads(self) -> None:
+        """y is a coarse-tile read-copy buffer AND has unaligned K.
+
+        x is [E, M, K] tiled over E via spyre_hint; w (y in BatchMatmul terms)
+        is [K, N], loop-invariant across the E tiles, so coarse tiling inserts
+        a read-copy ComputedBuffer for it (see coarse_tile.py's
+        _insert_one_read_copy) -- that copy has no FX node of its own.  K=67 is
+        not stick-aligned, so insert_bmm_padding must pad the read-copy buffer,
+        not any FX-graph node.  Regression test for issue where
+        _find_arg_fx_node raised "no FX node found" for such a buffer.
+        """
+        dtype = torch.float16
+        stick_size = get_elem_in_stick(dtype)
+        E, M, K, N = 3, 64, 67, 128
+        assert K % stick_size != 0
+
+        x_cpu = torch.randn(E, M, K, dtype=dtype)
+        w_cpu = torch.randn(K, N, dtype=dtype)
+        x = x_cpu.to(device="spyre")
+        w = w_cpu.to(device="spyre")
+
+        declare_tensor_dim("E", E)
+        declare_tensor_dim("M", M)
+        declare_tensor_dim("K", K)
+        declare_tensor_dim("N", N)
+        name_tensor_dims(x, ["E", "M", "K"])
+        name_tensor_dims(w, ["K", "N"])
+
+        def fn(x, w):
+            with spyre_hint(num_tiles_per_dim={"E": E}):
+                return torch.matmul(x, w)
+
+        ops, result = self.compile_and_run(fn, (x, w))
+        matmuls = self._matmul_ops(ops)
+        self.assertEqual(len(matmuls), 1, "Expected exactly one batched matmul op")
+        mm = matmuls[0]
+
+        # reduction_ranges stays at K.
+        reduction = mm.data
+        assert isinstance(reduction, Reduction)
+        self.assertEqual(int(reduction.reduction_ranges[0]), K)
+
+        torch.testing.assert_close(fn(x_cpu, w_cpu), result.cpu(), atol=0.1, rtol=0.1)
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -1574,7 +1574,19 @@ def lower_cat(inputs, dim=0):
 @register_spyre_lowering(
     torch.ops.aten.constant_pad_nd.default, type_promotion_kind=None
 )
-def lower_constant_pad_nd(input, pad, value=0, align_to_stick=False):
+def lower_constant_pad_nd(
+    input, pad, value=0, align_to_stick=False, output_stride=None
+):
+    # output_stride, when given, is the host stride the *output* buffer must
+    # be allocated with (e.g. to match a non-row-major source buffer's
+    # physical layout -- see pass_utils.py's lower_pad_sequence).  It must be
+    # applied at allocation time via lowering.empty_strided, not patched onto
+    # output.layout afterward: ir.SliceView.create's fast path (taken because
+    # a freshly-allocated ComputedBuffer is_storage_and_layout) snapshots
+    # old_layout.stride into a brand-new, independent FixedLayout on the
+    # ReinterpretView it returns, with no back-reference to output.layout --
+    # every fill_padding/copy slice built below would keep using the stale
+    # stride regardless of any later reassignment of output.layout.
     # pad is in reverse dim order: (left_last, right_last, left_2nd_last, right_2nd_last, ...)
     bounds = list(reversed(list(zip(pad[::2], pad[1::2]))))
     sizes = input.get_size()
@@ -1614,7 +1626,12 @@ def lower_constant_pad_nd(input, pad, value=0, align_to_stick=False):
 
     dtype = input.get_dtype()
     device = input.get_device()
-    output = lowering.empty(output_size, dtype=dtype, device=device)
+    if output_stride is not None:
+        output = lowering.empty_strided(
+            output_size, output_stride, dtype=dtype, device=device
+        )
+    else:
+        output = lowering.empty(output_size, dtype=dtype, device=device)
     pad_constant = lower_constant(value, dtype, device)
 
     # Fill padding regions. If align_to_stick is enabled, use stick-aligned offsets.

--- a/torch_spyre/_inductor/padding.py
+++ b/torch_spyre/_inductor/padding.py
@@ -43,6 +43,8 @@ present in the output but absent from x (N).  This handles M==K==N and
 M=1 (decode phase) correctly.
 """
 
+from typing import Optional
+
 import torch
 from sympy import Expr
 from torch._inductor.graph import GraphLowering
@@ -117,7 +119,7 @@ def _move_ops_before(
         operations.insert(idx + i, o)
 
 
-def _find_arg_fx_node(arg_name: str) -> torch.fx.Node:
+def _find_arg_fx_node(arg_name: str) -> Optional[torch.fx.Node]:
     """Return the FX node whose lowered TensorBox has the given buffer name.
 
     Buffer names are unique, but a single buffer can be reached through
@@ -127,8 +129,11 @@ def _find_arg_fx_node(arg_name: str) -> torch.fx.Node:
     [M, K].  Both FX nodes lower to a TensorBox whose get_name() returns
     the same buffer name, but with different get_size() results.
 
-    Returns the first candidate (the base buffer, with no view applied).
-    Raises RuntimeError if no candidate exists.
+    Returns the first candidate (the base buffer, with no view applied), or
+    None if no candidate exists -- e.g. a coarse_tile read-copy buffer (see
+    coarse_tile.py's _insert_one_read_copy), which is synthesized purely at
+    the IR level after FX lowering completed and so has no FX-graph
+    counterpart at all.
     """
     graph_lowering = V.graph
     _patch_env(graph_lowering)
@@ -139,14 +144,13 @@ def _find_arg_fx_node(arg_name: str) -> torch.fx.Node:
         and isinstance(tb, TensorBox)
         and tb.get_name() == arg_name
     ]
-    if not candidates:
-        raise RuntimeError(f"no FX node found for buffer {arg_name!r}")
-    return candidates[0]
+    return candidates[0] if candidates else None
 
 
 def _rebuild_matmul(
     op: ComputedBuffer,
     y_padded_buf: Buffer,
+    y_k_dim: int,
     operations: list[Operation],
 ) -> ComputedBuffer:
     """Rebuild the matmul ComputedBuffer so y's loader reads from the padded buffer.
@@ -155,6 +159,13 @@ def _rebuild_matmul(
     loader with one that reads from the padded buffer.  reduction_ranges stays
     at K; the K→K_padded extension happens at SDSC codegen time via
     _extend_matmul_k_to_padded in superdsc.py.
+
+    y's non-batch dims are [K, N] in the common case, but need not be --
+    e.g. a coarse-tile read-copy buffer for a loop-invariant y can be
+    transposed ([N, K]), see test_bmm_read_copy_y_unaligned_k_pads.
+    ``y_k_dim`` (the same host dim insert_bmm_padding padded) says which
+    non-batch position K actually occupies in y_padded_buf; N takes
+    whichever position is left.
     """
     reduction = op.data
     assert isinstance(reduction, Reduction)
@@ -163,6 +174,13 @@ def _rebuild_matmul(
     y_padded_loader = y_padded_buf.make_loader()
     y_ndim = len(y_padded_buf.get_size())
     y_batch_ndim = y_ndim - 2
+    # y_k_dim is a host-dim index into the whole buffer; translate to a
+    # position within the two non-batch dims (0 or 1).
+    y_k_local = y_k_dim - y_batch_ndim
+    assert y_k_local in (0, 1), (
+        f"_rebuild_matmul: y_k_dim={y_k_dim} not in y's non-batch dims "
+        f"(y_batch_ndim={y_batch_ndim})"
+    )
 
     def new_inner_fn(
         index,
@@ -170,10 +188,14 @@ def _rebuild_matmul(
         _orig_inner_fn=orig_inner_fn,
         _y_loader=y_padded_loader,
         _y_batch_ndim=y_batch_ndim,
+        _y_k_local=y_k_local,
     ):
         # x_val comes from the original inner_fn; discard its y and replace below.
         x_val, _ = _orig_inner_fn(index, reduction_index)
-        y_index = list(index[:_y_batch_ndim]) + list(reduction_index) + [index[-1]]
+        non_batch = [None, None]
+        non_batch[_y_k_local] = reduction_index[0]
+        non_batch[1 - _y_k_local] = index[-1]
+        y_index = list(index[:_y_batch_ndim]) + non_batch
         y_val = _y_loader(y_index)
         return (x_val, y_val)
 
@@ -318,6 +340,7 @@ def insert_bmm_padding(graph: GraphLowering) -> None:
             dim=y_k_dim,
             insert_before=matmul_fx_node,
             orig_stl=y_orig_stl,
+            arg_buf=y_buf if y_fx_node is None else None,
         )
 
         # --- Relocate new ops before the matmul ---
@@ -335,7 +358,7 @@ def insert_bmm_padding(graph: GraphLowering) -> None:
         # --- Rebuild matmul inner_fn to load y from the padded buffer ---
         # x is left entirely untouched: the original inner_fn's x loader is
         # preserved as-is.  Only y's loader is replaced with the padded buffer.
-        _rebuild_matmul(op, y_padded_buf, operations)
+        _rebuild_matmul(op, y_padded_buf, y_k_dim, operations)
 
 
 # --------------------------------------------------------------------------- #
@@ -747,8 +770,11 @@ def _pad_restickify_input(op: Operation, graph: GraphLowering) -> None:
         device = in_buf.get_device()
         if device is None:
             return
+        in_fx_node = _find_arg_fx_node(in_dep.name)
+        if in_fx_node is None:
+            raise RuntimeError(f"no FX node found for buffer {in_dep.name!r}")
         clone_buf, new_ops = lower_identity_clone(
-            _find_arg_fx_node(in_dep.name),
+            in_fx_node,
             host_size=[concretize_expr(s) for s in in_layout.size],
             host_stride=[concretize_expr(s) for s in in_layout.stride],
             device=device,

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -26,17 +26,21 @@ from torch._inductor.ir import (
     Buffer,
     ComputedBuffer,
     FixedLayout,
+    IRNode,
     Loops,
     MutationLayoutSHOULDREMOVE,
     Operation,
     Pointwise,
     Reduction,
+    StorageBox,
+    TensorBox,
 )
 from torch._inductor.ops_handler import WrapperHandler
 from torch._inductor.scheduler import SchedulerNode
 from torch._inductor.graph import GraphLowering
 from torch._inductor.dependencies import MemoryDep, ReadWrites, StarDep, is_indirect
 from torch._inductor.virtualized import V
+from torch.utils._ordered_set import OrderedSet
 from torch_spyre._C import SpyreTensorLayout, get_elem_in_stick
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.op_spec import IndirectAccess, TensorWorkDivision
@@ -2148,7 +2152,7 @@ def redirect_computed_buffer_reads(
 
 
 def lower_pad_sequence(
-    arg_fx_node: torch.fx.Node,
+    arg_fx_node: Optional[torch.fx.Node],
     padded_size: list[int],
     device: torch.device,
     dtype: torch.dtype,
@@ -2156,6 +2160,7 @@ def lower_pad_sequence(
     insert_before: torch.fx.Node,
     orig_stl: SpyreTensorLayout,
     fill_value: float = 0.0,
+    arg_buf: Optional[Buffer] = None,
 ) -> tuple[Buffer, list[Operation]]:
     """Lower an IR-level pad sequence that extends a buffer along one dimension.
 
@@ -2178,12 +2183,28 @@ def lower_pad_sequence(
     dimension.  Raises ``RuntimeError`` if the within-stick dimension cannot be
     determined from ``orig_stl``.
 
+    ``arg_fx_node`` is None for a buffer with no FX-graph counterpart -- e.g. a
+    coarse_tile read-copy (see coarse_tile.py's _insert_one_read_copy), which is
+    synthesized purely at the IR level after FX lowering completed.  In that
+    case ``arg_buf`` (the buffer itself) must be given instead, and the pad is
+    lowered by calling the constant_pad_nd lowering function directly against a
+    manually-built TensorBox rather than splicing a new FX node -- mirroring
+    insert_restickify.py's handling of the same kind of buffer.  Exactly one of
+    ``arg_fx_node``/``arg_buf`` must be given.  Either way, the same buffer (as
+    ``arg_buf``, or the buffer named by ``arg_fx_node``) is also used, when it is
+    a ``ComputedBuffer``, to recover the within-stick host dim from coordinate
+    identity via ``_stick_host_dim`` -- see the device-layout-construction
+    section below.
+
     Deduplication of identical constants across multiple pad calls happens later
     at the IR level via dedup_and_promote_constants.
 
     Returns ``(padded_buf, new_ops)`` where ``padded_buf`` is the allocated buffer
     and ``new_ops`` is the list of new IR operations in topological order.
     """
+    assert (arg_fx_node is None) != (arg_buf is None), (
+        "lower_pad_sequence: exactly one of arg_fx_node/arg_buf must be given"
+    )
 
     graph_lowering = V.graph
     fx_graph = graph_lowering.graph
@@ -2191,7 +2212,13 @@ def lower_pad_sequence(
     # Count operations before lowering so we can identify newly added ones.
     ops_before = len(graph_lowering.operations)
 
-    original_shape = list(arg_fx_node.meta["val"].shape)
+    if arg_fx_node is not None:
+        original_shape = list(arg_fx_node.meta["val"].shape)
+        original_stride = list(arg_fx_node.meta["val"].stride())
+    else:
+        assert arg_buf is not None
+        original_shape = [concretize_expr(s) for s in arg_buf.get_size()]
+        original_stride = [concretize_expr(s) for s in arg_buf.get_stride()]
     assert len(padded_size) == len(original_shape), (
         f"lower_pad_sequence: padded_size rank {len(padded_size)} != "
         f"original rank {len(original_shape)}"
@@ -2220,21 +2247,169 @@ def lower_pad_sequence(
         else:
             pad_tuple.extend([0, 0])
 
-    with fx_graph.inserting_before(insert_before):
-        # Single constant_pad_nd call (lowers to 4 IR operations)
-        pad_fx = fx_graph.create_node(
-            "call_function",
-            torch.ops.aten.constant_pad_nd.default,
-            args=(arg_fx_node, pad_tuple, fill_value),
-            kwargs={"align_to_stick": True},
-        )
-        pad_fx.meta["val"] = torch.empty(padded_size, dtype=dtype, device=device)
+    # --- Compute the padded buffer's host stride up front. ---
+    #
+    # This must happen BEFORE lower_constant_pad_nd runs, not after: that
+    # lowering internally slices its freshly-allocated output buffer via
+    # ir.SliceView.create (once per fill_padding region, plus once for the
+    # final input copy).  SliceView.create's fast path snapshots the
+    # buffer's *current* layout.stride into a brand-new, independent
+    # FixedLayout on the ReinterpretView it returns, with no back-reference
+    # to the original buffer's .layout -- so patching padded_buf.layout
+    # afterward cannot retroactively fix strides already baked into those
+    # slices.  We therefore compute the correct stride first and pass it in
+    # via output_stride, so lower_constant_pad_nd allocates the output
+    # buffer with the right stride from the start (lowering.empty_strided),
+    # before any slicing occurs.
+    #
+    # See the "Build the device layout" section below for why this
+    # computation looks the way it does (phantom dims, within-stick dim
+    # recovery, non-row-major source buffers).
 
-    # Lower the constant_pad_nd node, assigning FixedTiledLayouts immediately.
-    # propagate_spyre_tensor_layouts already ran, so the new op keep FlexibleLayout
-    # unless we assign here.
-    pad_tb = graph_lowering.run_node(pad_fx)
-    graph_lowering.env[pad_fx] = pad_tb
+    # Step 1 — strip phantom batch dims to get the core host shape.
+    orig_host_ndim = len(list(orig_stl.stride_map)) - 1
+    n_phantom = len(padded_size) - orig_host_ndim
+    padded_core = padded_size[n_phantom:]
+
+    # Step 2 — identify the within-stick host dim (in core-shape space).
+    #
+    # Prefer coordinate-identity recovery (_stick_host_dim, same mechanism
+    # coarse_tile.py's other _resize_device_layout call sites use): the source
+    # buffer's own write-dep unambiguously names its stick host dim, even when
+    # two host dims share a size.  This works whenever the source buffer is a
+    # ComputedBuffer with its own write-dep -- true both for graph inputs read
+    # through an earlier op's output and for coarse-tile read-copy buffers,
+    # which is exactly the case that has no FX node at all.
+    #
+    # Fall back to matching orig_stl.stride_map[-1] (the within-stick element
+    # stride, always 1 for contiguous layouts) against the source buffer's own
+    # host strides -- e.g. for a graph-input Buffer with no write-dep to walk.
+    if arg_buf is not None:
+        source_buf = arg_buf
+    else:
+        assert arg_fx_node is not None
+        source_buf = V.graph.get_buffer(arg_fx_node.name)
+    # Both recovery mechanisms below resolve an index in "view space" (source_
+    # buf's own raw dims, i.e. original_shape's space, which may include
+    # phantom leading dims) -- translate to core space once at the end by
+    # subtracting n_phantom, mirroring Step 1's stripping of padded_size.
+    within_stick_dim_view: Optional[int] = None
+    if isinstance(source_buf, ComputedBuffer):
+        from .wsr.coarse_tile import _stick_host_dim
+
+        within_stick_dim_view = _stick_host_dim(source_buf, orig_stl)
+
+    if within_stick_dim_view is None:
+        sm_last = int(list(orig_stl.stride_map)[-1])
+        orig_host_stride = original_stride
+        within_stick_dim_view = next(
+            (i for i, s in enumerate(orig_host_stride) if int(s) == sm_last), None
+        )
+        if within_stick_dim_view is None:
+            if arg_fx_node is not None:
+                buf_name = arg_fx_node.name
+            else:
+                assert arg_buf is not None
+                buf_name = arg_buf.get_name()
+            raise RuntimeError(
+                f"lower_pad_sequence: cannot determine within-stick host "
+                f"dimension for buffer {buf_name!r}: neither coordinate "
+                f"identity nor orig_stl.stride_map[-1]={sm_last} (in view "
+                f"strides {orig_host_stride}) resolved it.  "
+                f"orig_stl={list(orig_stl.device_size)} "
+                f"stride_map={list(orig_stl.stride_map)}, padded_size={padded_size}"
+            )
+
+    # Translate the within-stick dim index from view space to core space
+    # (subtract the number of phantom dims stripped in Step 1).
+    within_stick_dim_core = within_stick_dim_view - n_phantom
+
+    # Step 4 — build dim_order for SpyreTensorLayout: all non-stick dims in their
+    # natural order, followed by the within-stick dim last.  This tells the STL
+    # constructor which host dim maps to the innermost device (within-stick) axis.
+    dim_order_core = [
+        i for i in range(len(padded_core)) if i != within_stick_dim_core
+    ] + [within_stick_dim_core]
+
+    # Step 5 — compute strides for the padded core shape, preserving the
+    # *relative* dim ordering (fastest- to slowest-varying) of the source
+    # buffer's own host strides.  original_core's storage need not be
+    # row-major -- a coarse-tile read-copy buffer can be transposed/
+    # column-major (e.g. shape [N, K] with stride [1, N], N contiguous) -- so
+    # a fixed row-major assumption over padded_core's given index order
+    # silently produces a layout with the wrong contiguous dim whenever
+    # source_buf isn't row-major.  Rank dims by their original host stride
+    # (ascending: smallest stride = fastest-varying = innermost) and assign
+    # padded strides in that same relative order, using padded_core's sizes.
+    # These are host strides, not device strides; SpyreTensorLayout derives
+    # the device layout (sticks, rows, …) from the host shape + dim_order.
+    original_stride_core = original_stride[n_phantom:]
+    order_fastest_first = sorted(
+        range(len(padded_core)), key=lambda i: original_stride_core[i]
+    )
+    core_stride = [0] * len(padded_core)
+    running = 1
+    for i in order_fastest_first:
+        core_stride[i] = running
+        running *= padded_core[i]
+
+    padded_stl = SpyreTensorLayout(padded_core, core_stride, dtype, dim_order_core)
+
+    # Phantom leading batch dims (size 1) never contribute to addressing, so
+    # any stride value works for them; use row-major defaults for these
+    # positions to match SpyreTensorLayout's own convention.
+    phantom_stride = [1] * n_phantom
+    running = 1
+    for i in range(n_phantom - 1, -1, -1):
+        phantom_stride[i] = running
+        running *= padded_size[i]
+    padded_stride = phantom_stride + core_stride
+
+    if arg_fx_node is not None:
+        with fx_graph.inserting_before(insert_before):
+            # Single constant_pad_nd call (lowers to 4 IR operations)
+            pad_fx = fx_graph.create_node(
+                "call_function",
+                torch.ops.aten.constant_pad_nd.default,
+                args=(arg_fx_node, pad_tuple, fill_value),
+                kwargs={"align_to_stick": True, "output_stride": padded_stride},
+            )
+            pad_fx.meta["val"] = torch.empty(padded_size, dtype=dtype, device=device)
+
+        # Lower the constant_pad_nd node, assigning FixedTiledLayouts immediately.
+        # propagate_spyre_tensor_layouts already ran, so the new op keep FlexibleLayout
+        # unless we assign here.
+        pad_tb = graph_lowering.run_node(pad_fx)
+        graph_lowering.env[pad_fx] = pad_tb
+    else:
+        # arg_buf has no FX node: call the constant_pad_nd lowering directly
+        # against a manually-built TensorBox, as insert_restickify.py does for
+        # this same kind of FX-node-free buffer.  pad_fx is a synthetic node
+        # with no args, created only so origins/env bookkeeping below has
+        # something to key off of -- it is never spliced into the FX graph as
+        # an actual operand.
+        from .lowering import lower_constant_pad_nd
+
+        arg_tb = TensorBox(StorageBox(arg_buf))
+        with fx_graph.inserting_before(insert_before):
+            pad_fx = fx_graph.create_node(
+                "call_function",
+                torch.ops.aten.constant_pad_nd.default,
+                args=(),
+            )
+        with (
+            IRNode.current_origins(OrderedSet([pad_fx])),
+            V.set_current_node(pad_fx),
+            graph_lowering.set_current_node(pad_fx),
+        ):
+            pad_tb = lower_constant_pad_nd(
+                arg_tb,
+                pad_tuple,
+                fill_value,
+                align_to_stick=True,
+                output_stride=padded_stride,
+            )
+        graph_lowering.env[pad_fx] = pad_tb
     padded_buf = pad_tb.data.data  # TensorBox -> StorageBox -> Buffer
 
     # Collect all newly added operations (appended at the end of graph.operations).
@@ -2259,76 +2434,20 @@ def lower_pad_sequence(
         and isinstance(new_ops[3].get_layout(), MutationLayoutSHOULDREMOVE)
     )
 
-    # --- Build the device layout (SpyreTensorLayout) for the padded buffer. ---
+    # --- Attach the device layout (SpyreTensorLayout) to the padded buffer. ---
     #
-    # We need to know two things to construct the padded STL:
-    #   1. The "core" host shape — the dimensions that orig_stl was actually
-    #      built from.  mm_to_bmm_pass sometimes adds a leading batch=1 dim to
-    #      padded_size (the view the matmul inner_fn uses) while leaving the
-    #      underlying buffer 2D.  Passing that phantom dim to SpyreTensorLayout
-    #      would produce a degenerate 4D device layout with a -1 sentinel stride
-    #      for the size-1 device dim, which causes compute_coordinates to emit a
-    #      constant nonzero stick offset and normalize_coordinates to assert.
-    #      We strip phantom dims by comparing padded_size rank against the host
-    #      rank implied by orig_stl: stride_map has one entry per device dim, and
-    #      device dims = host dims + 1 (the extra entry is the within-stick dim),
-    #      so orig_host_ndim = len(stride_map) - 1.
-    #   2. Which host dimension is the within-stick dimension.  SpyreTensorLayout
-    #      takes an explicit dim_order whose last element names the within-stick
-    #      host dim; we must carry this over from the original buffer so that the
-    #      padded buffer's device coordinates use the same stick dimension.  We
-    #      identify it by matching orig_stl.stride_map[-1] (the within-stick
-    #      element stride, always 1 for contiguous layouts) against the original
-    #      buffer's host strides.
-
-    # Step 1 — strip phantom batch dims to get the core host shape.
-    orig_host_ndim = len(list(orig_stl.stride_map)) - 1
-    n_phantom = len(padded_size) - orig_host_ndim
-    padded_core = padded_size[n_phantom:]
-
-    # Step 2 — identify the within-stick host dim in the view (which may include
-    # phantom leading dims) by matching the within-stick element stride.
-    # TODO: replace this sm_last heuristic with _resize_device_layout from
-    # coarse_tile.py (device-native reconstruction that handles transposed and
-    # non-contiguous layouts without guessing from stride_map[-1]).
-    sm_last = int(list(orig_stl.stride_map)[-1])
-    orig_host_stride = list(arg_fx_node.meta["val"].stride())
-    within_stick_dim_view = next(
-        (i for i, s in enumerate(orig_host_stride) if int(s) == sm_last), None
-    )
-    if within_stick_dim_view is None:
-        raise RuntimeError(
-            f"lower_pad_sequence: cannot determine within-stick host dimension for "
-            f"buffer {arg_fx_node.name!r}: orig_stl.stride_map[-1]={sm_last} not found "
-            f"in view strides {orig_host_stride}.  orig_stl={list(orig_stl.device_size)} "
-            f"stride_map={list(orig_stl.stride_map)}, padded_size={padded_size}"
-        )
-
-    # Step 3 — translate the within-stick dim index from view space to core space
-    # (subtract the number of phantom dims that were stripped in step 1).
-    within_stick_dim_core = within_stick_dim_view - n_phantom
-
-    # Step 4 — build dim_order for SpyreTensorLayout: all non-stick dims in their
-    # natural order, followed by the within-stick dim last.  This tells the STL
-    # constructor which host dim maps to the innermost device (within-stick) axis.
-    dim_order_core = [
-        i for i in range(len(padded_core)) if i != within_stick_dim_core
-    ] + [within_stick_dim_core]
-
-    # Step 5 — compute row-major strides for the padded core shape.  These are
-    # host strides, not device strides; SpyreTensorLayout derives the device
-    # layout (sticks, rows, …) from the host shape + dim_order.
-    core_stride = [1] * len(padded_core)
-    for i in range(len(padded_core) - 2, -1, -1):
-        core_stride[i] = core_stride[i + 1] * padded_core[i + 1]
-
-    padded_stl = SpyreTensorLayout(padded_core, core_stride, dtype, dim_order_core)
+    # padded_stl/padded_stride were already computed above (before the
+    # lower_constant_pad_nd/FX-splice call, per the note there) and used to
+    # allocate padded_buf.layout with the correct stride from the start.
+    # We still need to replace that layout with a FixedTiledLayout carrying
+    # padded_stl as its device_layout -- lowering.empty_strided has no notion
+    # of SpyreTensorLayout, so this attachment step still has to happen here.
     host_layout = padded_buf.layout
     padded_buf.layout = FixedTiledLayout(
         host_layout.device,
         host_layout.dtype,
         host_layout.size,
-        host_layout.stride,
+        padded_stride,
         padded_stl,
     )
 

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -2288,7 +2288,15 @@ def lower_pad_sequence(
         source_buf = arg_buf
     else:
         assert arg_fx_node is not None
-        source_buf = V.graph.get_buffer(arg_fx_node.name)
+        # arg_fx_node.name is the FX node's own identifier, not necessarily
+        # the lowered buffer's name (see _find_arg_fx_node's docstring: a
+        # single buffer can be reached through multiple FX nodes presenting
+        # it at different sizes, e.g. mm_to_bmm_pass's unsqueeze/reshape, or
+        # conv2d's im2col unfold node).  Recover the buffer via the node's
+        # own TensorBox in graph_lowering.env instead of re-deriving a name.
+        arg_tb = graph_lowering.env[arg_fx_node]
+        assert isinstance(arg_tb, TensorBox)
+        source_buf = arg_tb.data.data
     # Both recovery mechanisms below resolve an index in "view space" (source_
     # buf's own raw dims, i.e. original_shape's space, which may include
     # phantom leading dims) -- translate to core space once at the end by


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

`insert_bmm_padding`'s `_find_arg_fx_node` raised a `RuntimeError` whenever
the buffer needing K-padding was a coarse-tile "read-copy" buffer (see
`coarse_tile.py`'s `_insert_one_read_copy`) -- these are synthesized purely
at the IR level after FX lowering completes, so they have no FX-graph
counterpart to look up. This PR routes that case through a new `arg_buf`
path in `lower_pad_sequence` that calls the `constant_pad_nd` lowering
directly against a manually-built `TensorBox`, mirroring how
`insert_restickify.py` already handles the same kind of buffer.

Two further bugs surfaced once compilation started succeeding on this path
instead of raising early, both needed together to get correct results:

- `_rebuild_matmul` hardcoded `y`'s non-batch dim order as `[K, N]`, which
  is wrong for a transposed read-copy buffer whose logical order is
  `[N, K]` (for a `BATCH_MATMUL_OP`'s `y` operand, the stick dim is `N`,
  not `K`). Parameterized it with `y_k_dim` so the load index places `K`
  and `N` according to the buffer's actual layout instead of a fixed order.

- `lower_constant_pad_nd` allocated its output buffer via `lowering.empty`
  (always row-major) and relied on patching `padded_buf.layout` afterward
  to fix the stride. That patch can't retroactively fix already-created
  slices: `ir.SliceView.create`'s fast path snapshots the buffer's
  *current* stride into a brand-new, independent `FixedLayout` on the
  `ReinterpretView` it returns, with no back-reference to the original
  buffer's `.layout`. Every fill/copy slice built inside
  `lower_constant_pad_nd` therefore kept using the stale row-major stride
  regardless of any later reassignment. Added an `output_stride` parameter
  so `lower_pad_sequence` computes the correct stride up front and
  `lower_constant_pad_nd` allocates via `lowering.empty_strided` before any
  slicing occurs. This is the same class of bug as CLAUDE.md's "wrap,
  never reconstruct" rule for `ComputedBuffer.inner_fn` warns about, just
  manifesting through `SliceView.create` instead of a rebuilt `inner_fn`.

New regression test `test_bmm_read_copy_y_unaligned_k_pads` covers a
batched matmul with a loop-invariant, transposed read-copy `y` buffer whose
K dimension is not stick-aligned.

A fourth bug surfaced from CI, not local testing: the coordinate-identity
recovery added above looked up the source buffer via
`V.graph.get_buffer(arg_fx_node.name)`, but an FX node's own name is not
necessarily the name of the buffer it lowers to (`_find_arg_fx_node`'s
docstring already documents this -- e.g. `mm_to_bmm_pass`'s
unsqueeze/reshape). Every `conv2d` test hit this: its im2col FX node is
named `"unfold"`, and no buffer is ever named that, so the lookup always
raised `RuntimeError: Failed to find buffer matching name unfold`. Fixed
by recovering the buffer from the FX node's own `TensorBox` in
`graph_lowering.env` instead of re-deriving a name.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

- Root cause of the stale-stride bug was tracked down via the
  `ir.SliceView.create` fast path (`ir.py`, `is_storage_and_layout(x)`
  branch) -- worth reading that code alongside the diff in
  `lowering.py`/`pass_utils.py` if reviewing the `output_stride` plumbing.
- Verified no regressions: `tests/inductor/test_padding.py` (13/13),
  `tests/inductor/test_building_blocks.py` (28/28),
  `tests/inductor/test_coarse_tiling.py` +
  `tests/inductor/test_coarse_tile_e2e.py` (605 items: 580 passed / 24
  skipped / 1 pre-existing xfail, unchanged from main).
- The `arg_fx_node.name` buffer-lookup fix was validated against CI's
  actual failure: all 7 previously-failing `test_conv2d_*` cases now pass,
  plus a full rerun of `test_coarse_tiling.py` + `test_building_blocks.py`
  (384 passed / 1 pre-existing skip) and `test_padding.py` +
  `test_dedup_constants.py` (31 passed).

#### Does this PR introduce a user-facing change?

No. This fixes a compilation failure (and, for the transposed-`y` case, a
silent-wrong-answer risk) in an internal padding pass; no public API
changes.

#### Additional note:

None.

