### PR TITLE
fix(ci): dedupe job-log downloads to stop double-counted rows in ClickHouse hw diagnostics

### DIFF
--- a/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
+++ b/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
@@ -112,9 +112,14 @@ jobs:
         run: |
           mkdir -p raw_logs
 
+          # filter=latest is the API's own default, but pin it explicitly: jobs from a
+          # prior attempt of this run (a runner-infra retry, not just a user re-run
+          # click) leaking into the list would download and parse every one of them
+          # twice, doubling every row this run produces in hw_failure_diagnostics.
           gh api \
             "/repos/${{ github.repository }}/actions/runs/${TRIGGERING_RUN_ID}/jobs" \
             --paginate \
+            -f filter=latest \
             --jq '.jobs[] | {id: .id, name: .name}' \
           > /tmp/jobs.jsonl
 
@@ -123,6 +128,19 @@ jobs:
 
           repo = os.environ["GITHUB_REPOSITORY"]
           jobs = [json.loads(l) for l in open("/tmp/jobs.jsonl") if l.strip()]
+
+          # Defensive: dedupe by job id even with filter=latest pinned above, so a
+          # duplicate entry in the API response downloads and parses each job once,
+          # not once per repeated listing.
+          seen_ids = set()
+          deduped = []
+          for j in jobs:
+              if j["id"] not in seen_ids:
+                  seen_ids.add(j["id"])
+                  deduped.append(j)
+          if len(deduped) != len(jobs):
+              print(f"[warn] jobs list had {len(jobs) - len(deduped)} duplicate id(s), deduped")
+          jobs = deduped
 
           # gh 2.97.0 started refusing to emit a response body that contains
           # terminal escape sequences unless --allow-escape-sequences is passed,


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

## Summary
Dedupe job-log downloads in the ClickHouse hw-diagnostics ingest to stop every row from being counted twice.

## Problem
The Download Job Logs step listed jobs via `gh api .../runs/{id}/jobs --paginate` with no explicit `filter` param; if a job from a prior attempt of the run leaked into that paginated response, its log got downloaded and parsed a second time, so a suite that only ran once could still land two rows in `hw_failure_diagnostics` — e.g. `Inductor / Test Coarse Tile E2e` showed up twice per run, once as `passed` and once as `failed` for the same `attempt=1`, which silently corrupts any pass/fail count or trend built on this table (including the pod-level-retry recovery metrics from the earlier PR).

## Fix
Pin `filter=latest` explicitly on the jobs-list API call, and add a defensive dedupe-by-`id` pass before downloading, so each job is fetched and parsed exactly once.
