### PR TITLE
fix(hw_diagnostics): pin gh api to GET so filter=latest doesn't 404 hw-diagnostics job-log listing

### DIFF
--- a/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
+++ b/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
@@ -116,12 +116,28 @@ jobs:
           # prior attempt of this run (a runner-infra retry, not just a user re-run
           # click) leaking into the list would download and parse every one of them
           # twice, doubling every row this run produces in hw_failure_diagnostics.
-          gh api \
-            "/repos/${{ github.repository }}/actions/runs/${TRIGGERING_RUN_ID}/jobs" \
-            --paginate \
-            -f filter=latest \
-            --jq '.jobs[] | {id: .id, name: .name}' \
-          > /tmp/jobs.jsonl
+          # Retry: the Jobs API can briefly 404 right after workflow_run "completed"
+          # fires (GitHub's own eventual consistency), so retry before failing loudly.
+          repo="${{ github.repository }}"
+          max_attempts=5
+          attempt=1
+          until gh api \
+              "/repos/${repo}/actions/runs/${TRIGGERING_RUN_ID}/jobs" \
+              --paginate \
+              -f filter=latest \
+              --jq '.jobs[] | {id: .id, name: .name}' \
+            > /tmp/jobs.jsonl 2>/tmp/jobs_list_err.txt
+          do
+            err="$(cat /tmp/jobs_list_err.txt)"
+            if [ "${attempt}" -ge "${max_attempts}" ]; then
+              echo "::error::failed to list jobs for run ${TRIGGERING_RUN_ID} in ${repo} after ${max_attempts} attempts: ${err}"
+              exit 1
+            fi
+            backoff=$((attempt * 5))
+            echo "[warn] attempt ${attempt}/${max_attempts} listing jobs for run ${TRIGGERING_RUN_ID} in ${repo} failed: ${err}; retrying in ${backoff}s"
+            sleep "${backoff}"
+            attempt=$((attempt + 1))
+          done
 
           python3 - << 'PYEOF'
           import json, os, re, subprocess, sys

--- a/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
+++ b/.github/workflows/push-hw-diagnostics-to-clickhouse.yaml
@@ -116,28 +116,15 @@ jobs:
           # prior attempt of this run (a runner-infra retry, not just a user re-run
           # click) leaking into the list would download and parse every one of them
           # twice, doubling every row this run produces in hw_failure_diagnostics.
-          # Retry: the Jobs API can briefly 404 right after workflow_run "completed"
-          # fires (GitHub's own eventual consistency), so retry before failing loudly.
-          repo="${{ github.repository }}"
-          max_attempts=5
-          attempt=1
-          until gh api \
-              "/repos/${repo}/actions/runs/${TRIGGERING_RUN_ID}/jobs" \
-              --paginate \
-              -f filter=latest \
-              --jq '.jobs[] | {id: .id, name: .name}' \
-            > /tmp/jobs.jsonl 2>/tmp/jobs_list_err.txt
-          do
-            err="$(cat /tmp/jobs_list_err.txt)"
-            if [ "${attempt}" -ge "${max_attempts}" ]; then
-              echo "::error::failed to list jobs for run ${TRIGGERING_RUN_ID} in ${repo} after ${max_attempts} attempts: ${err}"
-              exit 1
-            fi
-            backoff=$((attempt * 5))
-            echo "[warn] attempt ${attempt}/${max_attempts} listing jobs for run ${TRIGGERING_RUN_ID} in ${repo} failed: ${err}; retrying in ${backoff}s"
-            sleep "${backoff}"
-            attempt=$((attempt + 1))
-          done
+          # --method GET is required: gh api infers POST as soon as any -f/-F field is
+          # given, and this endpoint has no POST route, so filter=latest alone 404s.
+          gh api \
+            --method GET \
+            "/repos/${{ github.repository }}/actions/runs/${TRIGGERING_RUN_ID}/jobs" \
+            --paginate \
+            -f filter=latest \
+            --jq '.jobs[] | {id: .id, name: .name}' \
+          > /tmp/jobs.jsonl
 
           python3 - << 'PYEOF'
           import json, os, re, subprocess, sys


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

## Summary
Fix `gh api` sending a POST (and 404ing) instead of GET when listing job logs for the ClickHouse hw-diagnostics ingest.

## Problem
Adding `-f filter=latest` in #4214 silently switched `gh api`'s inferred HTTP method from GET to POST, and that endpoint has no POST route, so every run 404'd.

## Fix
Pass `--method GET` explicitly so `filter=latest` is sent as a query parameter instead of a POST body.
