### PR TITLE
fix(inductor): use finite fp16 extremes for padding/reduction masks

### DIFF
--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -234,16 +234,39 @@ class SDSCSpec:
 # (set at DMA-in and at buffer allocation), which would let the compiler pick the
 # right neutral value per consumer and elide pad/zero copies — tracked in #3290.
 # Retire this dict once that lands.
+#
+# NOTE: the mask value is a large finite negative, not -inf. encode_constant()
+# (module.cpp -> deeptools::FloatToFp16Bin) mis-encodes IEEE +-inf as a NaN bit
+# pattern instead of the fp16 infinity encoding (confirmed empirically: -inf
+# round-trips to NaN, not 0xFC00), so exp(-inf) never reaches the runtime as
+# exp(-inf) -- it reaches it as exp(NaN), which poisons the output instead of
+# masking it to 0. -1e4 is finite (encodes correctly) and still underflows
+# exp() to exactly 0 in fp16 (fp16's smallest positive value is ~6e-8; anything
+# below about -12 already underflows), so it produces the same masking effect
+# without going through the broken infinity path.
+#
+# The max/min reduction identities below have the same encode_constant bug:
+# _get_mask_value("max") fed float("-inf") through the same broken path, so a
+# max-reduction's padded lanes were seeded with NaN instead of -inf. Unlike
+# exp's poisoned-but-locally-contained NaN, max(x, NaN) == NaN -- the identity
+# failure propagates through the whole reduction result, not just the padded
+# lanes, which would poison any block_max = torch.amax(scores, dim=-1) whose
+# padded lanes get reduced over. _FP16_MAX/_FP16_MIN are the most extreme
+# finite fp16 values, so they lose (max)/win (min) against any real fp16 score
+# while still encoding correctly.
+_FP16_MAX = 65504.0
+_FP16_MIN = -65504.0
+
 _POINTWISE_PADDING_MASK_VALUE: dict[str, float] = {
-    "exp": float("-inf"),  # exp(-inf) == 0
+    "exp": -1e4,  # exp(-1e4) underflows to 0 in fp16; see NOTE above.
 }
 
 
 def _get_mask_value(op: str) -> float:
     if op == "max":
-        return float("-inf")
+        return _FP16_MIN
     if op == "min":
-        return float("inf")
+        return _FP16_MAX
     if op in _POINTWISE_PADDING_MASK_VALUE:
         return _POINTWISE_PADDING_MASK_VALUE[op]
     return 0


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

`encode_constant()` (`module.cpp` -> `deeptools::FloatToFp16Bin`) mis-encodes
IEEE +-inf as a NaN bit pattern instead of the fp16 infinity encoding
(confirmed empirically: -inf round-trips to NaN, not `0xFC00`). Every mask
value in `superdsc.py` that relied on +-inf therefore poisoned its output
with NaN instead of neutralizing it:

- The `exp()` padding mask used `-inf`, expecting `exp(-inf) == 0`, but got
  `exp(NaN)` instead. Switched to `-1e4`: finite, so it encodes correctly,
  and still far enough negative that `exp()` underflows to exactly 0 in
  fp16.
- `_get_mask_value("max"/"min")` used `-inf`/`inf` as reduction identities.
  `max(x, NaN) == NaN`, so a max-reduction's padded lanes came back NaN and
  poisoned the entire reduction result, not just the padded lanes. Switched
  to the most extreme finite fp16 values (`+-65504.0`), which lose/win
  against any real fp16 score while encoding correctly.

Both fixes address the same root cause and are combined into a single
commit.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

No. This is a correctness fix for internal Inductor codegen (padding and
reduction mask values); no public API changes.

#### Additional note: