### PR TITLE
fix(inductor): pull hinted ops across unhinted opaque blockers in coarse-tile runs

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -7485,11 +7485,22 @@ class TestReorderUnhintedInterlopers(unittest.TestCase):
         b = _make_rui_op("b", hint_ids=(0,))
         self.assertEqual(self._run([a, extern, b]), ["a", "extern", "b"])
 
-    def test_differently_hinted_breaks_run(self):
-        # An op with a different hint_id is not a candidate for reordering.
+    def test_differently_hinted_pulled_across_when_safe(self):
+        # An op with a different hint_id is not a candidate for reordering
+        # itself, but the later same-key op is pulled before it when doing
+        # so is dependency-safe, making the hint-0 run contiguous.
         a = _make_rui_op("a", hint_ids=(0,))
         c = _make_rui_op("c", hint_ids=(1,))
         b = _make_rui_op("b", hint_ids=(0,))
+        self.assertEqual(self._run([a, c, b]), ["a", "b", "c"])
+
+    def test_differently_hinted_breaks_run_when_pull_unsafe(self):
+        # b reads c's output, so pulling b before c would violate that
+        # read dependency; the pull is skipped and the run stays broken
+        # (left for validate_coarse_tile_groups to report).
+        a = _make_rui_op("a", hint_ids=(0,))
+        c = _make_rui_op("c", hint_ids=(1,))
+        b = _make_rui_op("b", hint_ids=(0,), reads=("c",))
         self.assertEqual(self._run([a, c, b]), ["a", "c", "b"])
 
     def test_multiple_interlopers_all_moveable_before(self):

--- a/torch_spyre/_inductor/wsr/coarse_tile_hints.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile_hints.py
@@ -85,20 +85,47 @@ def _hint_key(op: Operation) -> frozenset | None:
     return frozenset(h.hint_id for h in hints) if hints else None
 
 
-def _is_movable_interloper(op: Operation) -> bool:
-    """True if op is eligible to be relocated by reorder_unhinted_interlopers.
+def _is_tensor_input_free_fallback(op: Operation) -> bool:
+    """True if op is a FallbackKernel/MultiOutput with no tensor-typed input.
 
-    Either an unhinted ComputedBuffer, or a seed-allocator fallback
+    FallbackKernel.inputs holds only its tensor-typed arguments (scalars,
+    dtypes, and devices are recorded separately as constant_args); a
+    FallbackKernel with an empty inputs list — e.g. spyre::causal_mask,
+    which takes only ints/dtype/device and derives its output solely from
+    those constants — therefore cannot read or mutate any buffer the
+    scheduler tracks. That structural guarantee (not get_read_names()/
+    get_mutation_names(), which a FallbackKernel may not populate
+    completely) is what makes it safe to relocate, unlike a general
+    FallbackKernel with real tensor operands. MultiOutput is included so
+    the paired output-unwrapper of such a kernel is equally movable: it
+    only reads its own FallbackKernel's output, which travels with it.
+    """
+    from torch._inductor.ir import FallbackKernel, MultiOutput
+
+    if isinstance(op, FallbackKernel):
+        return len(op.inputs) == 0
+    if isinstance(op, MultiOutput):
+        return len(op.inputs) == 1 and _is_tensor_input_free_fallback(op.inputs[0])
+    return False
+
+
+def _is_movable_interloper(op: Operation) -> bool:
+    """True if an op is safe for dependency-checked relocation.
+
+    A ComputedBuffer, a seed-allocator fallback
     (SpyreConstantFallback/SpyreEmptyFallback) — a one-time scalar/buffer
-    materialization with no per-iteration significance. A general
-    FallbackKernel is deliberately excluded: it may carry real data-flow
-    side effects (see reorder_unhinted_interlopers's docstring), so it is
-    not safe to relocate on the strength of get_read_names()/
-    get_mutation_names() alone.
+    materialization with no per-iteration significance — or a
+    FallbackKernel/MultiOutput pair with no tensor-typed input (see
+    _is_tensor_input_free_fallback). A general FallbackKernel with real
+    tensor operands is deliberately excluded: it may carry real data-flow
+    side effects not represented by get_read_names()/get_mutation_names()
+    alone, so it is not safe to relocate on the strength of those accessors.
     """
     from ..ir import SpyreEmptyFallback  # deferred: avoids circular import
 
-    return isinstance(op, (ComputedBuffer, SpyreConstantFallback, SpyreEmptyFallback))
+    return isinstance(
+        op, (ComputedBuffer, SpyreConstantFallback, SpyreEmptyFallback)
+    ) or _is_tensor_input_free_fallback(op)
 
 
 def _written_names(op: Operation) -> set[str]:
@@ -121,11 +148,30 @@ def _no_dep_conflict(op: Operation, others: list[Operation]) -> bool:
     op_written = _written_names(op)
     op_needs = op.get_read_names() | set(op.get_mutation_names())
     for other in others:
-        if not isinstance(other, ComputedBuffer):
-            continue
-        if op_written & other.get_read_names():
+        if not _is_movable_interloper(other):
+            hints_logger.debug(
+                "cannot move %s across opaque op %s",
+                op.get_name(),
+                other.get_name(),
+            )
             return False
-        if _written_names(other) & op_needs:
+        later_reads = op_written & other.get_read_names()
+        if later_reads:
+            hints_logger.debug(
+                "cannot move %s across %s: crossed op reads %s",
+                op.get_name(),
+                other.get_name(),
+                sorted(later_reads),
+            )
+            return False
+        earlier_writes = _written_names(other) & op_needs
+        if earlier_writes:
+            hints_logger.debug(
+                "cannot move %s across %s: candidate reads/mutates %s",
+                op.get_name(),
+                other.get_name(),
+                sorted(earlier_writes),
+            )
             return False
     return True
 
@@ -163,13 +209,54 @@ def _can_move_after(
     return _no_dep_conflict(op, ops[start + 1 : end])
 
 
-def reorder_unhinted_interlopers(graph: GraphLowering) -> None:
-    """Move unhinted ComputedBuffer ops that interrupt hint-group runs.
+def _unhinted_predecessor_closure(
+    op: Operation,
+    ops: list[Operation],
+    start: int,
+    end: int,
+) -> list[Operation] | None:
+    """Return movable unhinted producers that ``op`` needs in ``ops[start:end]``.
 
-    ``hints_to_coarse_tile_groups`` treats unhinted ops as run-breakers.
-    This pass attempts to move each such op either just before the run it
-    splits or just after the last same-key op in the remainder, so the run
-    becomes contiguous.
+    The returned operations are in their original order.  ``None`` means the
+    dependency closure reaches another hint scope or an opaque operation and
+    therefore cannot be hoisted safely by this pass.
+    """
+    needed = op.get_read_names() | set(op.get_mutation_names())
+    predecessors: list[Operation] = []
+    for candidate in reversed(ops[start:end]):
+        written = _written_names(candidate)
+        if not written & needed:
+            continue
+        if _hint_key(candidate) is not None or not _is_movable_interloper(candidate):
+            return None
+        predecessors.append(candidate)
+        needed.update(candidate.get_read_names())
+        needed.update(candidate.get_mutation_names())
+    predecessors.reverse()
+    return predecessors
+
+
+def _index_by_identity(ops: list[Operation], target: Operation) -> int:
+    return next(i for i, op in enumerate(ops) if op is target)
+
+
+def reorder_unhinted_interlopers(graph: GraphLowering) -> None:
+    """Make each hint-scope run contiguous when dependencies permit.
+
+    ``hints_to_coarse_tile_groups`` treats both unhinted ops and a different
+    hint key as run-breakers.  For a *movable* unhinted interloper (an
+    unhinted ComputedBuffer, or a seed-allocator fallback), this pass
+    attempts to move the interloper before or after the run.  For a
+    different hint key, or an unhinted-but-opaque op (e.g. a general
+    FallbackKernel, which may carry real data-flow side effects and so is
+    never itself relocated), it instead pulls later ops from the current
+    run left across that op when doing so is dependency-safe.  The latter
+    matters for two distinct shapes:  branched recurrences, where Inductor
+    may schedule all main branches first and their independent denominator
+    branches later, fragmenting every otherwise-valid hint scope; and
+    provably side-effect-free opaque ops (e.g. a mask precomputed once
+    from constants), which never need to move themselves — only the hinted
+    ops on either side of them do.
 
     Algorithm — two-cursor scan over ops:
 
@@ -179,14 +266,15 @@ def reorder_unhinted_interlopers(graph: GraphLowering) -> None:
     Inner cursor j: walks forward from i+1 building the run.  For each
     op at ops[j]:
       - Same hint key → absorb into run; j += 1.
-      - Unhinted ComputedBuffer, or a seed-allocator fallback
-        (SpyreConstantFallback/SpyreEmptyFallback — one-time scalar/buffer
-        materialization with no per-iteration significance, e.g. the
-        torch.zeros(...) that seeds an online-softmax recurrence) →
-        interloper; try to relocate (see below).
-      - Any other non-ComputedBuffer op (e.g. a general FallbackKernel,
-        which may carry real data-flow side effects) or differently-hinted
-        op → hard stop; break.
+      - Movable unhinted interloper (an unhinted ComputedBuffer, or a
+        seed-allocator fallback — SpyreConstantFallback/SpyreEmptyFallback,
+        a one-time scalar/buffer materialization with no per-iteration
+        significance, e.g. the torch.zeros(...) that seeds an online-softmax
+        recurrence) → interloper; try to relocate (see below).
+      - Differently-hinted op, or an unhinted-but-opaque op (e.g. a general
+        FallbackKernel) → find the next op with the current key and pull it
+        before the blocking op(s) when dependency-safe.  Otherwise stop and
+        let ``validate_coarse_tile_groups`` report the fragmentation.
       - Interloper → one of three outcomes:
           (a) Move before: insert at run_start, run_start += 1, j stays
               (the rotate shifts subsequent ops left so ops[j] is fresh).
@@ -231,10 +319,75 @@ def reorder_unhinted_interlopers(graph: GraphLowering) -> None:
             if ckey == key:
                 j += 1
                 continue
-            if not _is_movable_interloper(candidate) or ckey is not None:
+            if ckey is not None or not _is_movable_interloper(candidate):
+                next_same_key = next(
+                    (k for k in range(j + 1, len(ops)) if _hint_key(ops[k]) == key),
+                    None,
+                )
+                if next_same_key is None:
+                    break
+                if any(
+                    not _is_movable_interloper(crossed)
+                    for crossed in ops[j:next_same_key]
+                    if crossed is not candidate
+                ):
+                    # Never reorder around an opaque fallback or another
+                    # operation whose effects are not represented completely
+                    # by get_read_names()/get_mutation_names(). candidate
+                    # itself is exempt from this check here: it is not being
+                    # relocated, only crossed by a later same-key op, and
+                    # that op's own dependency check (_can_move_before /
+                    # _unhinted_predecessor_closure below) already verifies
+                    # it has no data-flow hazard with candidate specifically.
+                    break
+                same_key_op = ops[next_same_key]
+                if _can_move_before(same_key_op, ops, j, next_same_key):
+                    ops.insert(j, ops.pop(next_same_key))
+                    j += 1
+                    continue
+
+                # The hinted op may only be blocked by an independently
+                # scheduled unhinted seed chain.  Hoist that chain before the
+                # current run, then retry the same pull.  This is the shape of
+                # online softmax after Inductor schedules denominator=zeros
+                # just before the deferred denominator-update branch.
+                predecessors = _unhinted_predecessor_closure(
+                    same_key_op, ops, j, next_same_key
+                )
+                if predecessors:
+                    trial_ops = list(ops)
+                    trial_run_start = run_start
+                    can_hoist = True
+                    for predecessor in predecessors:
+                        predecessor_idx = _index_by_identity(trial_ops, predecessor)
+                        if not _can_move_before(
+                            predecessor,
+                            trial_ops,
+                            trial_run_start,
+                            predecessor_idx,
+                        ):
+                            can_hoist = False
+                            break
+                        trial_ops.insert(
+                            trial_run_start, trial_ops.pop(predecessor_idx)
+                        )
+                        trial_run_start += 1
+                    if can_hoist:
+                        ops[:] = trial_ops
+                        run_start = trial_run_start
+                        j = _index_by_identity(ops, candidate)
+                        continue
+                hints_logger.debug(
+                    "cannot pull hinted op %s into scope %s across [%s]",
+                    same_key_op.get_name(),
+                    sorted(key),
+                    ", ".join(op.get_name() for op in ops[j:next_same_key]),
+                )
                 break
             # candidate is an unhinted ComputedBuffer, or a seed-allocator
-            # fallback, interrupting the run.
+            # fallback, interrupting the run: _is_movable_interloper(candidate)
+            # is guaranteed True here (the branch above already handled and
+            # continued/broke every case where it's False).
             # Scan backward for the last same-key op; run_end is one past it.
             # O(n) per interloper → O(n²) overall; acceptable for small graphs.
             run_end = None


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Ports the general "pull op backward across a blocking span" strategy from PR #3981's reorder_unhinted_interlopers, generalized to also trigger on an unhinted-but-opaque blocker (not just a differently-hinted one) -- the case a data-independent FallbackKernel like spyre::causal_mask produces.

Also extends _is_movable_interloper to recognize a FallbackKernel/ MultiOutput pair with no tensor-typed input as safe to relocate: such an op (e.g. causal_mask, which takes only ints/dtype/device) cannot read or mutate any tracked buffer, so it carries none of the hidden-side-effect risk that excludes a general FallbackKernel from relocation.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

Part of #206 
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
