### PR TITLE
fix(inductor): align padded matmul batch index from the right, not left

### DIFF
--- a/torch_spyre/_inductor/padding.py
+++ b/torch_spyre/_inductor/padding.py
@@ -195,7 +195,18 @@ def _rebuild_matmul(
         non_batch = [None, None]
         non_batch[_y_k_local] = reduction_index[0]
         non_batch[1 - _y_k_local] = index[-1]
-        y_index = list(index[:_y_batch_ndim]) + non_batch
+        # index's batch prefix can be longer than y_padded_buf's: e.g. a
+        # leading batch=1 dim that op's own output layout carries (from the
+        # un-squeezed [B, H, ...] tensor) but that y_padded_buf never had
+        # (y is built from a per-block V slice that dropped/never carried a
+        # batch axis). Aligning index[:y_batch_ndim] from the LEFT then
+        # silently drops the real trailing batch coordinates (e.g. the
+        # coarse-tiled head-tile index) and replaces them with a
+        # leading placeholder like the constant batch index.
+        # Align from the RIGHT instead, immediately before the N-dim
+        # (index[-1]), so the batch coordinates actually used are the ones
+        # nearest to y's own dims.
+        y_index = list(index[-1 - _y_batch_ndim : -1]) + non_batch
         y_val = _y_loader(y_index)
         return (x_val, y_val)
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ x ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

_rebuild_matmul() built the padded-operand load index by slicing the consuming matmul's own index tuple from the left: index[:y_batch_ndim]. This assumes op's own index tuple and y_padded_buf's leading dims line up positionally from the start, which breaks once coarse-tiling adds a head-tile axis: op's index tuple gains a leading constant (a squeezed batch=1 placeholder) that y_padded_buf never carries, since y is built from a per-KV-block V slice with no batch axis of its own.

The left-aligned slice grabbed that constant 0 and assigned it to y_padded_buf's head-tile dim -- vanishing the head-tile stride term from the generated index entirely -- while the real head-tile loop variable landed on the wrong axis. Every head-tile iteration ended up reading the same slice of V, corrupting the P@V matmul whenever a KV block needed K-padding (sequence length not a multiple of the 64-elem stick) combined with head-tiling.

Slice from the right instead, anchored immediately before the N-dim slot (index[-1]), so the batch coordinates used are the ones adjacent to y's own dims rather than the leftmost ones in op's index tuple.

Fixes test_causal_sdpa_unpadded_kv_no_inf for S=13/63 (S=64 was already correct, being exactly one stick with no K-padding).

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
