### PR TITLE
fix(inductor): unblock fp32 RMSNorm for Gemma 4

### DIFF
--- a/tests/inductor/test_building_blocks.py
+++ b/tests/inductor/test_building_blocks.py
@@ -16,12 +16,14 @@ import dataclasses
 import math
 import unittest
 from unittest import mock
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
 import torch_spyre._inductor.wsr.propagate_named_dims as _pnd
 from torch._inductor.utils import run_and_get_code
+from torch_spyre._C import SpyreTensorLayout
 from torch_spyre._inductor import spyre_hint  # noqa: F401
 from torch_spyre._inductor import config
 
@@ -200,6 +202,39 @@ class TestBuildingBlocks(unittest.TestCase):
             cpu_compile=False,
             run_eager=False,
         )
+
+    def test_rms_norm_fp32_upcast_non_normalized_input_stick(self):
+        # Gemma 4's embedding output can enter a compiled decoder block with
+        # the sequence dimension as its device stick. RMSNorm must restick the
+        # input before its fp16-to-fp32 upcast: the reduction result is STANDARD
+        # and has to broadcast along the normalized axis against the staggered
+        # upcast tensor.
+        B, S, H = 1, 64, 1536
+        eps = 1e-6
+        for dtype in (torch.float16, torch.bfloat16):
+            with self.subTest(dtype=dtype):
+                hidden = torch.randn(B, S, H, dtype=dtype)
+                weight = torch.randn(H, dtype=dtype)
+
+                def rms_norm(hidden, weight):
+                    x = hidden.to(torch.float32)
+                    var = x.pow(2).mean(-1, keepdim=True)
+                    normed = x * torch.rsqrt(var + eps)
+                    return weight * normed.to(dtype)
+
+                expected = rms_norm(hidden, weight)
+                hidden_layout = SpyreTensorLayout(
+                    hidden.size(), hidden.stride(), hidden.dtype, [0, 2, 1]
+                )
+                hidden_device = hidden.to(device_layout=hidden_layout)
+                weight_device = weight.to(DEVICE)
+                actual = torch.compile(rms_norm)(hidden_device, weight_device).cpu()
+                torch.testing.assert_close(
+                    actual,
+                    expected,
+                    atol=0.1,
+                    rtol=0.1,
+                )
 
     def test_chained_rms_norm_fp32_upcast(self):
         B, S, H = 1, 64, 2816

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -7462,21 +7462,21 @@ class TestReorderUnhintedInterlopers(unittest.TestCase):
         self.assertEqual(self._run([a, x, b]), ["a", "b", "x"])
 
     def test_interloper_move_after_blocked_by_hinted_reader(self):
-        # x reads a (blocks move-before) AND b reads x (blocks move-after) → error.
+        # x reads a (blocks move-before) AND b reads x (blocks move-after).
+        # Keep x in place and split the hinted ops into separate runs.
         a = _make_rui_op("a", hint_ids=(0,))
         x = _make_rui_op("x", reads=("a",))
         b = _make_rui_op("b", reads=("x",), hint_ids=(0,))
         c = _make_rui_op("c", hint_ids=(0,))
-        with self.assertRaises(RuntimeError):
-            self._run([a, x, b, c])
+        self.assertEqual(self._run([a, x, b, c]), ["a", "x", "b", "c"])
 
     def test_interloper_blocked_both_directions(self):
-        # x reads a (blocks move-before) AND b reads x (blocks move-after) → error.
+        # x reads a (blocks move-before) AND b reads x (blocks move-after).
+        # The original topological order is already valid and is preserved.
         a = _make_rui_op("a", hint_ids=(0,))
         x = _make_rui_op("x_out", reads=("a",))
         b = _make_rui_op("b", reads=("x_out",), hint_ids=(0,))
-        with self.assertRaises(RuntimeError):
-            self._run([a, x, b])
+        self.assertEqual(self._run([a, x, b]), ["a", "x_out", "b"])
 
     def test_non_computed_buffer_breaks_run(self):
         # A non-ComputedBuffer between two hinted ops cannot be reordered.
@@ -7602,13 +7602,12 @@ class TestReorderUnhintedInterlopers(unittest.TestCase):
     def test_mutating_interloper_blocked(self):
         # x mutates buffer 'a' produced by a hinted op; x cannot legally move
         # before the run (would run before 'a' is produced) and b reads x so
-        # x cannot move after — should raise RuntimeError.
+        # x cannot move after. Keep it in place as the run boundary.
         a = _make_rui_op("a", hint_ids=(0,))
         x = _make_rui_op("x", mutates=("a",))  # mutation dep on a
         b = _make_rui_op("b", reads=("x",), hint_ids=(0,))
         c = _make_rui_op("c", hint_ids=(0,))
-        with self.assertRaises(RuntimeError):
-            self._run([a, x, b, c])
+        self.assertEqual(self._run([a, x, b, c]), ["a", "x", "b", "c"])
 
 
 # ===========================================================================

--- a/tests/inductor/test_ea_bidirectional_conversion.py
+++ b/tests/inductor/test_ea_bidirectional_conversion.py
@@ -128,10 +128,7 @@ def test_fp32_to_fp16_standard_input(device, mode, fp16):
     result = _run(fn, x, mode=mode)
 
     # Verify output EA
-    expected_ea = ElementArrangement.STANDARD
-    if mode == "compile":
-        expected_ea = ElementArrangement.FP32_TO_DL16
-    assert_ea(result, expected_ea)
+    assert_ea(result, ElementArrangement.FP32_TO_DL16)
 
     # Note: Cannot compare tensors with non-STANDARD EA directly with CPU
     # The result has FP32_TO_DL16 EA which differs from CPU's STANDARD EA
@@ -359,12 +356,17 @@ EAGER_TO_TEST_CASES, EAGER_TO_TEST_IDS = _build_eager_ea_tests()
 )
 def test_eager_ea(src_dev, dst_dev, fp16, eager_to):
     """Verify eager mode EA across device transfer combinations."""
+    same_spyre_device = src_dev == dst_dev == DEVICE_NAME
+
     # FP16 -> FP32 casting flow
     x16 = torch.randn(4, 128, device=src_dev, dtype=fp16)
     assert_ea(x16, ea_of(src_dev))
 
     y32 = eager_to(x16, dst_dev, torch.float32)
-    assert_ea(y32, ea_of(dst_dev))
+    assert_ea(
+        y32,
+        ElementArrangement.DL16_TO_FP32 if same_spyre_device else ea_of(dst_dev),
+    )
 
     z16 = eager_to(y32, src_dev, fp16)
     assert_ea(z16, ea_of(src_dev))
@@ -374,7 +376,10 @@ def test_eager_ea(src_dev, dst_dev, fp16, eager_to):
     assert_ea(x32, ea_of(src_dev))
 
     y16 = eager_to(x32, dst_dev, fp16)
-    assert_ea(y16, ea_of(dst_dev))
+    assert_ea(
+        y16,
+        ElementArrangement.FP32_TO_DL16 if same_spyre_device else ea_of(dst_dev),
+    )
 
     z32 = eager_to(y16, src_dev, torch.float32)
     assert_ea(z32, ea_of(src_dev))

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -819,6 +819,70 @@ class TestSpyre(TestCase):
             with self.assertRaises(RuntimeError):
                 tensor.to("spyre", dtype=dst_dtype)
 
+    def test_d2d_dtype_conversion_overloads(self):
+        """Dtype-only ``Tensor.to`` overloads use the compiled D2D conversion.
+
+        In particular, ``x.to(torch.float32)`` must recognize its first
+        positional argument as a dtype rather than raw-copying bf16 bits into
+        an fp32 allocation. D2D conversions produce a staggered element
+        arrangement, so convert back to the source dtype before comparing on
+        CPU.
+        """
+        from torch_spyre._C import ElementArrangement, get_spyre_tensor_layout
+
+        pairs = (
+            (torch.float16, torch.float32),
+            (torch.bfloat16, torch.float32),
+            (torch.float32, torch.float16),
+            (torch.float32, torch.bfloat16),
+        )
+
+        for src_dtype, dst_dtype in pairs:
+            base_cpu = torch.linspace(-4, 4, 512, dtype=src_dtype).reshape(4, 128)
+            source_cpu = base_cpu[1:3]
+            source = base_cpu.to("spyre")[1:3]
+            self.assertEqual(source.storage_offset(), 128)
+            expected = source_cpu.to(dst_dtype).to(src_dtype)
+            other = torch.empty_like(source, dtype=dst_dtype)
+            expected_ea = (
+                ElementArrangement.DL16_TO_FP32
+                if dst_dtype == torch.float32
+                else ElementArrangement.FP32_TO_DL16
+            )
+
+            conversions = (
+                ("positional dtype", lambda: source.to(dst_dtype)),
+                ("keyword dtype", lambda: source.to(dtype=dst_dtype)),
+                ("device and dtype", lambda: source.to("spyre", dtype=dst_dtype)),
+                ("other tensor", lambda: source.to(other)),
+            )
+            for overload, convert in conversions:
+                with self.subTest(
+                    src_dtype=src_dtype,
+                    dst_dtype=dst_dtype,
+                    overload=overload,
+                ):
+                    actual = convert()
+                    self.assertEqual(actual.device.type, "spyre")
+                    self.assertEqual(actual.dtype, dst_dtype)
+                    self.assertEqual(
+                        get_spyre_tensor_layout(actual).element_arrangement,
+                        expected_ea,
+                    )
+                    restored = actual.to(src_dtype)
+                    self.assertEqual(
+                        get_spyre_tensor_layout(restored).element_arrangement,
+                        ElementArrangement.STANDARD,
+                    )
+                    atol, rtol = (
+                        (1e-2, 1.6e-2)
+                        if torch.bfloat16 in (src_dtype, dst_dtype)
+                        else (1e-3, 1e-3)
+                    )
+                    torch.testing.assert_close(
+                        restored.cpu(), expected, atol=atol, rtol=rtol
+                    )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -337,6 +337,30 @@ def _(
     pass
 
 
+@torch.library.custom_op("spyre::to_dtype_d2d", mutates_args=(), device_types="spyre")
+@compile_once("spyre.to_dtype_d2d", dynamic=False)
+def to_dtype_d2d(
+    src: torch.Tensor,
+    dtype: torch.dtype,
+    src_off: int,
+    compiled,
+) -> torch.Tensor:
+    """Run an eager same-device dtype conversion as a compiled Spyre op.
+
+    The explicit offset is required for the same reason as copy_from_d2d:
+    Inductor otherwise drops a graph input view's storage offset. Returning the
+    converted tensor (rather than mutating a preallocated destination) also lets
+    the compiled wrapper attach the conversion's staggered element arrangement.
+    """
+    with torch._dynamo.config.patch(specialize_int=True):
+        return compiled(src, dtype, src_off)
+
+
+@to_dtype_d2d.register_fake
+def _(src: torch.Tensor, dtype: torch.dtype, src_off: int) -> torch.Tensor:
+    return torch.empty_like(src, dtype=dtype)
+
+
 # Copy src into dst, guaranteed to survive both Inductor's remove_noop_ops
 # pass (unlike aten.copy_, this op is not in noop_registry) and
 # AOTAutograd's dead-code elimination when dst is never read again in the

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -1287,6 +1287,14 @@ def lower_spyre_from_d2d(src, dst, src_off, dst_off):
     lowering.mutate_to(dst, src)
 
 
+@register_spyre_lowering(torch.ops.spyre.to_dtype_d2d, type_promotion_kind=None)
+def lower_spyre_to_dtype_d2d(src, dtype, src_off):
+    # Like copy_from_d2d, preserve a sliced eager input's storage offset when it
+    # becomes a graph input to the standalone compiled conversion.
+    src = _reoffset(src, src_off)
+    return to_dtype(src, dtype)
+
+
 def _build_mutation_lowering(src, dst):
     # Builds an explicit MutationLayoutSHOULDREMOVE buffer so the mutation into dst
     # survives regardless of what the scheduler would otherwise decide.

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -42,10 +42,11 @@ from torch._inductor.dependencies import MemoryDep, ReadWrites, StarDep, is_indi
 from torch._inductor.virtualized import V
 from torch.utils._ordered_set import OrderedSet
 from torch_spyre._C import (
-    SpyreTensorLayout,
+    DataFormats,
     ElementArrangement,
-    get_elem_in_stick,
+    SpyreTensorLayout,
     get_device_dtype,
+    get_elem_in_stick,
 )
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.op_spec import IndirectAccess, TensorWorkDivision
@@ -2047,7 +2048,21 @@ def compute_restickify_needed(
         c for c in idc[:-1] if bool(c.free_symbols & stick_syms)
     ]
     is_factorized = bool(stick_syms) and len(outer_axes_with_stick_var) > 1
-    if is_factorized and in_stl != out_stl:
+    factorized_layout_mismatch = is_factorized and in_stl != out_stl
+    if not factorized_layout_mismatch and in_stick_offset_free and stick_compatible(
+        [idc, out_idc]
+    ):
+        return False, None
+
+    # ReStickifyOpHBM currently supports only the native FP16 device format.
+    # Do not advertise an edge as feasible when codegen cannot lower it: this
+    # is especially important for fp32-upcast graphs, where a later IEEE_FP32
+    # restick can otherwise tie with and displace the valid FP16 restick before
+    # the conversion.
+    if in_stl.device_dtype != DataFormats.SEN169_FP16:
+        return True, None
+
+    if factorized_layout_mismatch:
         # The input layout places the contraction variable on outer axes AND the
         # stick (factorized layout). The backend would see two contraction dims
         # even though the var is on the stick — stick_compatible would incorrectly
@@ -2057,8 +2072,6 @@ def compute_restickify_needed(
         # queries this function with that canonical result.
         assert in_stl.element_arrangement == ElementArrangement.STANDARD
         return True, out_stl
-    if in_stick_offset_free and stick_compatible([idc, out_idc]):
-        return False, None
     ic = host_coordinates(in_host, in_dep, ind_sizes)
     target_stick = out_idc[-1]
 

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -2049,8 +2049,10 @@ def compute_restickify_needed(
     ]
     is_factorized = bool(stick_syms) and len(outer_axes_with_stick_var) > 1
     factorized_layout_mismatch = is_factorized and in_stl != out_stl
-    if not factorized_layout_mismatch and in_stick_offset_free and stick_compatible(
-        [idc, out_idc]
+    if (
+        not factorized_layout_mismatch
+        and in_stick_offset_free
+        and stick_compatible([idc, out_idc])
     ):
         return False, None
 

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -480,7 +480,37 @@ def _single_arg_op_layout(
             #    Rebuild a clean dense layout from the output host size instead,
             #    as the general (non-EA) convert path does.
             if fmt in STAGGERED_EAS or input_ea in STAGGERED_EAS:
-                return [rescale_stl_for_dtype(stl, output.dtype, fmt)]
+                layouts = [rescale_stl_for_dtype(stl, output.dtype, fmt)]
+
+                # A conversion that creates a staggered EA must also expose
+                # outputs reachable by restickifying its STANDARD input first.
+                # Otherwise the conversion permanently inherits the input's
+                # stick and a downstream reduction-broadcast join has no way to
+                # request the normalized dimension as the stick. Gemma 4 hits
+                # this when an embedding output enters RMSNorm with its sequence
+                # dimension on the stick.
+                if fmt in STAGGERED_EAS and input_ea == ElementArrangement.STANDARD:
+                    in_coords = host_coordinates(in_layout, dep, None)
+                    source_device_coords = device_coordinates(stl, dep, None)
+                    for target_stick_expr in in_coords:
+                        if not target_stick_expr.free_symbols:
+                            continue
+                        target_stl = compute_restickify_target_layout(
+                            stl,
+                            in_layout,
+                            target_stick_expr,
+                            in_coords,
+                            source_device_coords,
+                        )
+                        if target_stl is None:
+                            continue
+                        candidate = rescale_stl_for_dtype(
+                            target_stl, output.dtype, fmt
+                        )
+                        if candidate not in layouts:
+                            layouts.append(candidate)
+
+                return layouts
 
             # Dense reconstruction from the output host size. When the input
             # stick dim is unaligned, force a full input-stick depth so stick

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -442,9 +442,12 @@ def _single_arg_op_layout(
     origin_node = next(iter(data.origins))
     aten_op = origin_node.target
     match aten_op:
-        case prims.convert_element_type.default | aten.copy.default if (
-            output.dtype != torch.bool
-            and stl.elems_per_stick() != get_elem_in_stick(output.dtype)
+        case (
+            prims.convert_element_type.default
+            | aten.copy.default
+            | torch.ops.spyre.to_dtype_d2d.default
+        ) if output.dtype != torch.bool and stl.elems_per_stick() != get_elem_in_stick(
+            output.dtype
         ):
             # Type conversion may require padding when input has padding due to stick
             # alignment. For example, 4x16 FP16 has 48 elements of padding (64 total),
@@ -504,9 +507,7 @@ def _single_arg_op_layout(
                         )
                         if target_stl is None:
                             continue
-                        candidate = rescale_stl_for_dtype(
-                            target_stl, output.dtype, fmt
-                        )
+                        candidate = rescale_stl_for_dtype(target_stl, output.dtype, fmt)
                         if candidate not in layouts:
                             layouts.append(candidate)
 

--- a/torch_spyre/_inductor/wsr/coarse_tile_hints.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile_hints.py
@@ -279,7 +279,7 @@ def reorder_unhinted_interlopers(graph: GraphLowering) -> None:
           (a) Move before: insert at run_start, run_start += 1, j stays
               (the rotate shifts subsequent ops left so ops[j] is fresh).
           (b) Move after: pop(j), insert at run_end-1, j stays.
-          (c) Neither legal → RuntimeError.
+          (c) Neither legal → leave it in place and end the current run.
         run_end is the index one past the *last* same-key op in ops[j+1:],
         found by scanning backward.  Using the last op (not just the next)
         ensures the move-after target span covers the full remaining run,
@@ -298,9 +298,10 @@ def reorder_unhinted_interlopers(graph: GraphLowering) -> None:
     When both directions are legal the op is moved before the run (closer
     to its original position).
 
-    Raises RuntimeError if an interloper cannot be moved in either
-    direction (data-flow dependencies anchor it between hinted ops that
-    share the same hint key).
+    If data-flow dependencies anchor an interloper between hinted ops with
+    the same key, it remains in place and splits them into separate runs.
+    This preserves the graph's topological order; the later grouping pass
+    already treats an unhinted op as a run boundary.
     """
     ops = graph.operations
     i = 0
@@ -409,13 +410,14 @@ def reorder_unhinted_interlopers(graph: GraphLowering) -> None:
                 # Insert at run_end-1 to land just after that last hinted op.
                 ops.insert(run_end - 1, ops.pop(j))
                 continue
-            run_ops = [ops[k].get_name() for k in range(run_start, j)]
-            raise RuntimeError(
-                f"Cannot reorder unhinted op '{candidate.get_name()}': "
-                f"data-flow deps prevent moving it before or after the "
-                f"hint-group run [{', '.join(run_ops)}] "
-                f"(hint_ids={sorted(key)})"
+            hints_logger.debug(
+                "Leaving dependency-anchored unhinted op '%s' in place; "
+                "it splits the hint-group run [%s] (hint_ids=%s)",
+                candidate.get_name(),
+                ", ".join(ops[k].get_name() for k in range(run_start, j)),
+                sorted(key),
             )
+            break
         i = j
 
 

--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -135,47 +135,51 @@ def _patch_tensor_for_spyre():
 
     def spyre_to(self, *args, device_layout=None, **kwargs):
         if device_layout is None:
-            # Support D2H and H2D dtype casting via DCI (DataConversionInfo) in spyre_mem.cpp.
-            # For D2D data casting, split it into a D2H copy and a H2D dtype conversion.
+            # During Dynamo tracing this wrapper is an allow_in_graph leaf: keep
+            # the operation device-local so Inductor sees and lowers the dtype
+            # conversion. The host-staged path below is only for real eager
+            # tensors; introducing CPU copies while tracing would put
+            # DeviceCopy nodes into the compiled graph.
+            if (
+                torch.compiler.is_compiling()
+                or isinstance(self, torch._subclasses.FakeTensor)
+                or torch._is_functional_tensor(self)
+            ):
+                return orig_to(self, *args, **kwargs)
+
+            # Support D2H and H2D dtype casting via DCI (DataConversionInfo) in
+            # spyre_mem.cpp. Same-device casting is lowered through the existing
+            # compiled D2D copy, whose mutate_to lowering performs the conversion
+            # on device.
             _device = kwargs.get("device", None)
-            if (
-                _device is None
-                and len(args) > 0
-                and isinstance(args[0], (str, torch.device))
-            ):
-                _device = args[0]
             _dtype = kwargs.get("dtype", None)
-            if _dtype is None:
-                if len(args) > 0 and isinstance(args[0], torch.dtype):
-                    _dtype = args[0]
-                elif len(args) > 1 and isinstance(args[1], torch.dtype):
-                    _dtype = args[1]
+            if args:
+                first = args[0]
+                if isinstance(first, torch.Tensor):
+                    # ``self.to(other)`` adopts both properties from ``other``.
+                    _device = first.device
+                    _dtype = first.dtype
+                elif isinstance(first, torch.dtype):
+                    # ``self.to(dtype)`` keeps the current device.
+                    _dtype = first
+                elif isinstance(first, (str, torch.device)):
+                    _device = first
+                    if len(args) > 1 and isinstance(args[1], torch.dtype):
+                        _dtype = args[1]
 
-            target_device_type = (
-                torch.device(_device).type if _device is not None else None
-            )
+            target_device = self.device if _device is None else torch.device(_device)
 
             if (
-                target_device_type == DEVICE_NAME
+                self.device.type == DEVICE_NAME
+                and target_device.type == DEVICE_NAME
                 and _dtype is not None
-                and self.device.type == DEVICE_NAME
+                and _dtype != self.dtype
             ):
-                import warnings
-
-                warnings.warn(
-                    "D2D dtype conversion on Spyre is not directly supported. "
-                    "Using CPU as an intermediate for the cast.",
-                    stacklevel=2,
-                )
-                # Step 1: plain D2H copy (no dtype change)
-                tmp = orig_to(self, "cpu")
-                # Step 2: cast dtype via H2D
-                return orig_to(tmp, _device, dtype=_dtype)
+                return torch.ops.spyre.to_dtype_d2d(self, _dtype, self.storage_offset())
 
             res = orig_to(self, *args, **kwargs)
             if res.device.type == DEVICE_NAME:
                 _add_ea(self, res)
-
             return res
         else:
             # Check if copy kwarg is explicitly set


### PR DESCRIPTION
## Summary

- expose valid restick-before-conversion layouts when fp16/bf16 inputs are upcast for fp32 RMSNorm, while rejecting unsupported fp32 restick edges
- preserve the hardware FP32_TO_DL16 element arrangement for fp32-to-bf16 conversions
- split coarse-tile hint runs at dependency-anchored unhinted ops instead of rejecting a valid schedule
- correctly parse dtype-only and to(other) eager Spyre conversions and run supported DL16/fp32 conversions through the compiled on-device path

Together these changes unblock fp32 RMSNorm for the full Gemma 4 family in torch-spyre/hf-adapters#366, including dense, PLE/KV-sharing E variants, and MoE.

## Validation

- pytest focused on RMSNorm layout propagation, bidirectional dtype conversion, coarse-tile run splitting, and eager Tensor.to overloads: 44 passed, 18 subtests passed
- pre-commit run --all-files: passed
- Gemma 4 CPU-vs-Spyre greedy token comparison (prefill + 4 decode steps):
  - google/gemma-4-E2B-it: 5/5
  - google/gemma-4-E4B: 5/5
  - google/gemma-4-12B-it: 5/5
  - google/gemma-4-26B-A4B-it: 5/5

All commits are signed off.
