### PR TITLE
tests/distributed: Improve invalid rank regex

### DIFF
--- a/tests/distributed/spyreccl_backend.py
+++ b/tests/distributed/spyreccl_backend.py
@@ -58,9 +58,17 @@ class TestSpyreCCLBackend(TestCase):
         proc = self._run_local_rank_script("invalid")
         output = f"{proc.stdout}\n{proc.stderr}"
         assert proc.returncode != 0, output
-        # - Torch Spyre will catch and throw with the message:
+        # - Spyre Comms will catch and throw with the message:
         #   LOCAL_RANK must be a valid integer (no digits found): 'invalid'
-        assert "LOCAL_RANK must be a valid integer" in output, output
+        # - Torch Spyre will catch and throw with the message:
+        #   LOCAL_RANK is not a valid integer: 'invalid'
+        assert any(
+            text in output
+            for text in (
+                "LOCAL_RANK must be a valid integer",
+                "LOCAL_RANK is not a valid integer",
+            )
+        ), output
 
     def test_parse_local_rank_negative_raises(self) -> None:
         proc = self._run_local_rank_script("-1")


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

The unit test `spyreccl_backend.py TestSpyreCCLBackend.test_parse_local_rank_invalid_text_raises` was tied to the Spyre Comms error message instead of either the Spyre Comms or the Torch Spyre error message. By accounting for both messages the test case is slightly more robust.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No

#### Additional note:
