### PR TITLE
perf(restickify): share one device_coordinates memo

### DIFF
--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -2593,7 +2593,10 @@ def test_coord_cache_detached_after_layout_selection():
     # The shared device_coordinates memo must not outlive layout selection: its
     # results depend on V.graph.sizevars optimization hints, whose
     # precomputed-replacement state keeps growing as compilation proceeds.
-    # Assert the detach reaches every edge rather than trusting the finally.
+    # Pins that the finally ran and that every edge the setter reaches is left
+    # at None. Coverage of "every edge" is tautological -- this walks the same
+    # structure the setter does -- so the vacuity guard below is what gives it
+    # teeth.
     #
     # Spies on the module-global helper, which optimize_restickify_locations
     # resolves at call time, rather than on the pass function itself -- the
@@ -2619,4 +2622,67 @@ def test_coord_cache_detached_after_layout_selection():
     assert all(c is None for c in observed), (
         f"{sum(c is not None for c in observed)} of {len(observed)} edge cost "
         "maps still hold a coordinate cache after layout selection"
+    )
+
+
+def test_memos_agree_with_fresh_computation_during_search():
+    # Both memos are filled during layout selection, not snapshotted when the
+    # edge maps are built, because propagate_spyre_tensor_layouts rebinds buffer
+    # layouts while it constructs them and get_read_writes reads input layouts
+    # through make_indexer. Comparing against a snapshot taken at construction
+    # would pass even if a later rebinding had invalidated it, so recompute both
+    # fresh mid-search and compare against what the caches are serving.
+    from torch_spyre._inductor import pass_utils as pu
+
+    checked = {"indirect": 0, "host": 0}
+    # Patch where it is CALLED from: optimize_restickify imports it by name, so
+    # patching pass_utils would not take.
+    real = _optimize_restickify.compute_restickify_needed
+
+    def _spy(
+        in_stl,
+        in_host,
+        in_dep,
+        out_stl,
+        out_dep,
+        op=None,
+        coord_cache=None,
+        host_coords=None,
+    ):
+        out = real(
+            in_stl, in_host, in_dep, out_stl, out_dep, op, coord_cache, host_coords
+        )
+        if coord_cache is not None:
+            key = ("indirect_info", op.get_name() if op is not None else None)
+            if key in coord_cache:
+                assert coord_cache[key] == pu.indirect_info_from_op(op), (
+                    f"memoized indirect info for {key[1]} disagrees with a fresh "
+                    "computation taken during the search"
+                )
+                checked["indirect"] += 1
+        if host_coords:
+            _, _, ind_sizes = pu.indirect_info_from_op(op)  # full tuple here
+            sizes_key = None if ind_sizes is None else frozenset(ind_sizes.items())
+            hk = (in_dep, sizes_key)
+            if hk in host_coords:
+                assert host_coords[hk] == pu.host_coordinates(
+                    in_host, in_dep, ind_sizes
+                ), "memoized host coordinates disagree with a fresh computation"
+                checked["host"] += 1
+        return out
+
+    # A transpose feeding an add whose other operand has the transposed shape:
+    # the two inputs disagree on layout, so candidate pairs are priced past the
+    # stick-compatible early-out and the host-coordinate memo is actually
+    # reached. A workload whose pairs all take that early-out leaves the host
+    # half of this test verifying nothing, which the guard below catches.
+    a = torch.randn((2, 256, 128), dtype=torch.float16)
+    x = torch.randn((2, 128, 256), dtype=torch.float16)
+    with patch.object(_optimize_restickify, "compute_restickify_needed", _spy):
+        _compare(lambda a, x: a.transpose(1, 2) + x, a, x)
+
+    assert checked["indirect"], "no memoized indirect info was reached"
+    assert checked["host"], (
+        "no memoized host coordinates were reached; that half of this test "
+        "would verify nothing"
     )

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -2587,3 +2587,36 @@ def test_round_up_to_stick_geometry():
     assert round_up_to_stick(70, torch.float16) == 128
     assert round_up_to_stick(128, torch.float16) == 128
     assert round_up_to_stick(129, torch.float16) == 192
+
+
+def test_coord_cache_detached_after_layout_selection():
+    # The shared device_coordinates memo must not outlive layout selection: its
+    # results depend on V.graph.sizevars optimization hints, whose
+    # precomputed-replacement state keeps growing as compilation proceeds.
+    # Assert the detach reaches every edge rather than trusting the finally.
+    #
+    # Spies on the module-global helper, which optimize_restickify_locations
+    # resolves at call time, rather than on the pass function itself -- the
+    # pass pipeline captures that by reference when it is built, so patching it
+    # would not take.
+    observed = []
+    real = _optimize_restickify._set_coord_cache
+
+    def _spy(operations, cache):
+        real(operations, cache)
+        if cache is None:
+            for op in operations:
+                cost_fn = getattr(op, "restick_cost_fn", None)
+                if cost_fn is None:
+                    continue
+                observed.extend(edge.coord_cache for edge in cost_fn.edge_costs)
+
+    x = _arange(3, 1, 5, 64, span=255)
+    with patch.object(_optimize_restickify, "_set_coord_cache", _spy):
+        _strict(lambda x: (x + x * 3.0).permute(0, 1, 3, 2).contiguous(), x)
+
+    assert observed, "no edge cost maps were reached; the assertion is vacuous"
+    assert all(c is None for c in observed), (
+        f"{sum(c is not None for c in observed)} of {len(observed)} edge cost "
+        "maps still hold a coordinate cache after layout selection"
+    )

--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -399,6 +399,42 @@ class TestUnrepresentableStickCandidates(TestCase):
         d2 = sympy.Symbol("d2", integer=True, nonnegative=True)
         self.assertEqual(device_coordinates(good, dep, None)[-1].free_symbols, {d2})
 
+    def test_cache_matches_uncached_and_copies(self):
+        # A wrong or incomplete cache key would show up as a silently different
+        # layout decision, so pin equality with and without a cache. The cache is
+        # the FOURTH argument: passing it third binds it to indirect_sizes and
+        # every assertion below then holds vacuously.
+        dep, bad, good = self._traced_scenario()
+        cache: dict = {}
+        for stl in (good, bad):
+            key = (stl, dep, None)
+            try:
+                expected = device_coordinates(stl, dep, None)
+            except Unsupported:
+                # Unsupported layouts raise before the store, so the raising
+                # path must be identical with a cache supplied and must leave no
+                # entry of its own -- asserted for this key, not globally, since
+                # the representable layout above has already stored one.
+                with self.assertRaises(Unsupported):
+                    device_coordinates(stl, dep, None, cache)
+                self.assertNotIn(key, cache)
+                continue
+            self.assertEqual(expected, device_coordinates(stl, dep, None, cache))
+            # Pins that the cache path was actually taken, so this cannot go
+            # quietly vacuous again.
+            self.assertIn(key, cache)
+            # Served from the cache on the second call and still agreeing ...
+            first = device_coordinates(stl, dep, None, cache)
+            second = device_coordinates(stl, dep, None, cache)
+            self.assertEqual(expected, second)
+            # ... while handing out a distinct list, so one caller mutating its
+            # result cannot corrupt another's.
+            self.assertIsNot(first, second)
+        self.assertEqual(
+            try_device_coordinates(good, dep, None),
+            try_device_coordinates(good, dep, None, cache),
+        )
+
     def test_reversed_dim_rejected(self):
         # prims.rev / Tensor.flip(0) on a (4, 64) tensor reads
         # x[64*(3 - p0) + p1], i.e. p0 carries a negative coefficient.  No

--- a/torch_spyre/_inductor/optimize_restickify.py
+++ b/torch_spyre/_inductor/optimize_restickify.py
@@ -68,6 +68,11 @@ class EdgeCostMap:
         self._dep_layout = V.graph.get_buffer(dep.name).get_layout()
         self._target_dep_layout = V.graph.get_buffer(target_dep.name).get_layout()
 
+        # Shared device_coordinates memo, installed for the duration of layout
+        # selection (see _set_coord_cache). None means "no sharing": each cost
+        # computation recomputes its coordinates.
+        self.coord_cache: "dict | None" = None
+
         # _cost and _layout are parallel maps.
         # _cost stores the cost for a given in/target layout pair
         # _layout stores the target STL for the restickify, or None if no restickify is needed
@@ -95,7 +100,13 @@ class EdgeCostMap:
           SpyreTensorLayout  — feasible restickify target layout
         """
         needed, tgt = compute_restickify_needed(
-            in_stl, self._dep_layout, self.dep, target_stl, self._target_dep, self._op
+            in_stl,
+            self._dep_layout,
+            self.dep,
+            target_stl,
+            self._target_dep,
+            self._op,
+            self.coord_cache,
         )
         if not needed:
             cost = 0.0
@@ -629,6 +640,32 @@ def _compute_last_use(operations: list, step_of: "dict[str, int]") -> "dict[str,
     return last_use
 
 
+def _set_coord_cache(operations: list, cache: "dict | None") -> None:
+    """Point every edge cost map at ``cache``, or at None to detach it.
+
+    EdgeCostMap memoizes compute_restickify_needed per (in_stl, target_stl),
+    but each map covers a single op-input edge, so the same (layout, access)
+    pair recomputes its device coordinates once per edge. Those pairs recur
+    across edges on tiled graphs, which is redundancy a per-edge cache cannot
+    see.
+
+    The lifetime is bounded because `device_coordinates` results are not a pure
+    function of their arguments: concretization consults
+    ``V.graph.sizevars`` optimization hints, whose precomputed-replacement
+    state grows as compilation proceeds. Its arguments are all immutable and
+    all in the key, so a committed layout cannot invalidate an entry -- what
+    bounds the cache is the graph, not this pass. Scoping it here rather than
+    sharing one memo with propagate_layouts, which issues the same queries
+    immediately before, keeps that bound close to the code that relies on it.
+    """
+    for op in operations:
+        cost_fn = getattr(op, "restick_cost_fn", None)
+        if cost_fn is None:
+            continue
+        for edge_cost in cost_fn.edge_costs:
+            edge_cost.coord_cache = cache
+
+
 def beam_global_min_cost(operations: list) -> None:
     """Global beam search layout selection.
 
@@ -798,4 +835,8 @@ def optimize_restickify_locations(graph: GraphLowering) -> None:
     """Select restickify locations for all ops, minimizing total restickify cost."""
     operations = graph.operations
     logger.info("optimizer: beam (global)")
-    beam_global_min_cost(operations)
+    _set_coord_cache(operations, {})
+    try:
+        beam_global_min_cost(operations)
+    finally:
+        _set_coord_cache(operations, None)

--- a/torch_spyre/_inductor/optimize_restickify.py
+++ b/torch_spyre/_inductor/optimize_restickify.py
@@ -73,6 +73,12 @@ class EdgeCostMap:
         # computation recomputes its coordinates.
         self.coord_cache: "dict | None" = None
 
+        # Host-side coordinates for THIS edge. Its inputs (_dep_layout, dep) are
+        # the snapshots above, so the result varies only with the indirect-access
+        # sizes; filled on first use, since an edge whose candidate pairs all
+        # take the stick-compatible early-out never needs it.
+        self._host_coords: dict = {}
+
         # _cost and _layout are parallel maps.
         # _cost stores the cost for a given in/target layout pair
         # _layout stores the target STL for the restickify, or None if no restickify is needed
@@ -107,6 +113,7 @@ class EdgeCostMap:
             self._target_dep,
             self._op,
             self.coord_cache,
+            self._host_coords,
         )
         if not needed:
             cost = 0.0

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1102,6 +1102,7 @@ def device_coordinates(
     stl: SpyreTensorLayout,
     dep: MemoryDep,
     indirect_sizes: "dict[sympy.Symbol, int] | None",
+    cache: "dict | None" = None,
 ) -> list[sympy.Expr]:
     """Compute device-space coordinate expressions for a tensor access.
 
@@ -1111,13 +1112,37 @@ def device_coordinates(
         indirect_sizes: {indirect_sym → size} from indirect_sizes_from_op(), or
             None for structural callers (stick-compatibility checks, layout
             matching) where indirect coordinates are irrelevant.
+        cache: optional memo keyed on (stl, dep, indirect_sizes), for a caller
+            that asks the same question repeatedly. The key covers every
+            argument: SpyreTensorLayout compares and hashes over all four of
+            its fields, and MemoryDep is frozen. The result is NOT a pure
+            function of them, though -- concretization consults
+            ``V.graph.sizevars`` optimization hints, whose
+            precomputed-replacement state grows as compilation proceeds -- so a
+            cache must not outlive the graph it was populated for. A fresh list
+            is returned each time, so no caller can mutate another's result
+            through it.
 
     Returns:
         One coordinate expression per device dimension; the last element is
         the stick expression.
     """
+    key = None
+    if cache is not None:
+        sizes_key = (
+            None if indirect_sizes is None else frozenset(indirect_sizes.items())
+        )
+        key = (stl, dep, sizes_key)
+        hit = cache.get(key)
+        if hit is not None:
+            return list(hit)
     coords = alignment_coordinates(stl, dep.index, dep.ranges, indirect_sizes)
+    # Unsupported stick expressions raise here, so they are never cached and
+    # the raising path stays identical whether or not a cache is supplied.
     _check_stick_expr_supported(coords[-1], stl.elems_per_stick())
+    if cache is not None:
+        cache[key] = coords
+        return list(coords)
     return coords
 
 
@@ -1219,6 +1244,7 @@ def try_device_coordinates(
     stl: SpyreTensorLayout,
     dep: MemoryDep,
     indirect_sizes: "dict[sympy.Symbol, int] | None",
+    cache: "dict | None" = None,
 ) -> list[sympy.Expr] | None:
     """Like ``device_coordinates`` but returns ``None`` instead of raising when
     the layout's stick expression is one the backend cannot represent.
@@ -1229,7 +1255,7 @@ def try_device_coordinates(
     when the stick dimension is size-1 in the current op's loop ranges).
     """
     try:
-        return device_coordinates(stl, dep, indirect_sizes)
+        return device_coordinates(stl, dep, indirect_sizes, cache)
     except Unsupported:
         return None
 
@@ -1949,6 +1975,7 @@ def compute_restickify_needed(
     out_stl: SpyreTensorLayout,
     out_dep: MemoryDep,
     op: "ComputedBuffer | None" = None,
+    coord_cache: "dict | None" = None,
 ) -> "tuple[bool, SpyreTensorLayout | None]":
     """Determine whether a restickify is needed for one (in_stl, out_stl) pair.
 
@@ -1958,6 +1985,9 @@ def compute_restickify_needed(
     op: when provided, index-role deps (gather indices) are never stick-constrained
     and always return (False, None).
 
+    coord_cache: optional memo forwarded to try_device_coordinates, shared by a
+    caller that evaluates many layout pairs over the same accesses.
+
     Returns:
       (False, None)   — stick-compatible: no restickify needed
       (True, stl)     — restickify needed, stl is the target STL for the restickified input
@@ -1966,8 +1996,8 @@ def compute_restickify_needed(
     ind_names, _, ind_sizes = indirect_info_from_op(op)
     if in_dep.name in ind_names:
         return False, None
-    idc = try_device_coordinates(in_stl, in_dep, ind_sizes)
-    out_idc = try_device_coordinates(out_stl, out_dep, ind_sizes)
+    idc = try_device_coordinates(in_stl, in_dep, ind_sizes, coord_cache)
+    out_idc = try_device_coordinates(out_stl, out_dep, ind_sizes, coord_cache)
     if idc is None or out_idc is None:
         # One of the layouts has a stick expression the backend cannot
         # represent (e.g. floor(var/N) from a cross-stick access). Such a

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -1968,6 +1968,69 @@ def stick_compatible(coords: "list[list[sympy.Expr]]") -> bool:
     return len(stick_vars) <= 1 and stick_vars.isdisjoint(nonstick_vars)
 
 
+def _indirect_info_memo(
+    op: "ComputedBuffer | None", cache: "dict | None"
+) -> "tuple[set[str], dict[sympy.Symbol, int] | None]":
+    """``indirect_info_from_op`` memoized per op for the lifetime of ``cache``.
+
+    A function of ``op`` alone, yet recomputed on every candidate pair by
+    :func:`compute_restickify_needed` -- and not cheap: it calls
+    ``ComputedBuffer.get_read_writes``, which carries no ``cache_on_self`` and so
+    re-extracts every dep and index expression, then re-runs ``inner_fn`` for ops
+    with indirect reads.
+
+    Computed on first use during layout selection rather than snapshotted when
+    the edge maps are built. ``get_read_writes`` reaches input buffer layouts
+    through ``make_indexer``, and ``propagate_spyre_tensor_layouts`` rebinds
+    buffer layouts while it constructs those maps, so a construction-time value
+    could predate a rebinding. Copies are handed out so no caller can mutate
+    another's.
+    """
+    if cache is None:
+        names, _, sizes = indirect_info_from_op(op)
+        return names, sizes
+    key = ("indirect_info", op.get_name() if op is not None else None)
+    hit = cache.get(key)
+    if hit is None:
+        hit = indirect_info_from_op(op)
+        cache[key] = hit
+    names, _, sizes = hit
+    return set(names), None if sizes is None else dict(sizes)
+
+
+def _host_coords_memo(
+    in_host: FixedLayout,
+    in_dep: MemoryDep,
+    ind_sizes: "dict[sympy.Symbol, int] | None",
+    cache: "dict | None",
+) -> "list[sympy.Expr]":
+    """``host_coordinates`` memoized per edge for the lifetime of ``cache``.
+
+    ``in_host`` and ``in_dep`` are an edge's construction-time snapshots, so the
+    result varies only with ``ind_sizes`` for a given edge. Keyed on
+    ``(in_dep, sizes)`` even though the owning EdgeCostMap makes the dep
+    redundant: this parameter sits beside ``coord_cache`` with the same type but
+    the opposite sharing contract, and a self-keyed entry means a dict passed
+    for both cannot silently serve another edge's coordinates. ``in_host`` stays
+    out of the key because it is fixed for a dep name across the search, the
+    invariant ``_dep_layout`` already leans on.
+
+    Filled on first use, so an edge whose candidate pairs all take the
+    stick-compatible early-out never pays for it. Like the coordinate memo this
+    is graph-bounded rather than pass-bounded, which holds because the owning
+    edge map is itself per-graph.
+    """
+    if cache is None:
+        return host_coordinates(in_host, in_dep, ind_sizes)
+    sizes_key = None if ind_sizes is None else frozenset(ind_sizes.items())
+    key = (in_dep, sizes_key)
+    hit = cache.get(key)
+    if hit is None:
+        hit = host_coordinates(in_host, in_dep, ind_sizes)
+        cache[key] = hit
+    return list(hit)
+
+
 def compute_restickify_needed(
     in_stl: SpyreTensorLayout,
     in_host: FixedLayout,
@@ -1976,6 +2039,7 @@ def compute_restickify_needed(
     out_dep: MemoryDep,
     op: "ComputedBuffer | None" = None,
     coord_cache: "dict | None" = None,
+    host_coords: "dict | None" = None,
 ) -> "tuple[bool, SpyreTensorLayout | None]":
     """Determine whether a restickify is needed for one (in_stl, out_stl) pair.
 
@@ -1985,15 +2049,19 @@ def compute_restickify_needed(
     op: when provided, index-role deps (gather indices) are never stick-constrained
     and always return (False, None).
 
-    coord_cache: optional memo forwarded to try_device_coordinates, shared by a
-    caller that evaluates many layout pairs over the same accesses.
+    coord_cache: optional memo forwarded to try_device_coordinates and used for
+    the per-op indirect-access info, shared by a caller that evaluates many
+    layout pairs over the same accesses.
+
+    host_coords: optional per-edge memo for the host-side coordinates, whose
+    inputs are fixed for one edge.
 
     Returns:
       (False, None)   — stick-compatible: no restickify needed
       (True, stl)     — restickify needed, stl is the target STL for the restickified input
       (True, None)    — restickify needed but infeasible
     """
-    ind_names, _, ind_sizes = indirect_info_from_op(op)
+    ind_names, ind_sizes = _indirect_info_memo(op, coord_cache)
     if in_dep.name in ind_names:
         return False, None
     idc = try_device_coordinates(in_stl, in_dep, ind_sizes, coord_cache)
@@ -2015,7 +2083,7 @@ def compute_restickify_needed(
     in_stick_offset_free = is_stick_expr_offset_free(idc[-1], in_stl.elems_per_stick())
     if in_stick_offset_free and stick_compatible([idc, out_idc]):
         return False, None
-    ic = host_coordinates(in_host, in_dep, ind_sizes)
+    ic = _host_coords_memo(in_host, in_dep, ind_sizes, host_coords)
     target_stick = out_idc[-1]
 
     if target_stick == sympy.S.Zero and in_stick_offset_free and _is_matmul_op(op):


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:
`optimize_restickify_locations` decides, for every operation, which tensor layout each input should have. To score a candidate it has to know whether the producer's layout and the consumer's layout are stick-compatible, and that question is answered by `device_coordinates(layout, access, indirect_sizes)`, which works out where each element physically lands on the device.

That function is pure symbolic algebra and costs roughly **0.8 ms per call** — expensive because it is sympy all the way down.

There is already a cache for the layer above it. `EdgeCostMap` memoizes `compute_restickify_needed` per `(in_stl, target_stl)`. But an `EdgeCostMap` covers **one op-input edge**, so the moment the search moves to the next edge
the cache is gone. On a tiled workload the graph is largely the same computation repeated per tile, so tile 3 and tile 7 ask about structurally identical layouts and accesses — different edge, different cache, full recompute.

This adds an optional `cache` argument to `device_coordinates` and `try_device_coordinates`, following the convention already used by `_per_core_view_on_buf(..., cache)` and `get_ncores_for_buffers(graph, cache)`. `compute_restickify_needed` forwards it. `optimize_restickify_locations` owns one dict, installs it on every edge cost map, and detaches it in a `finally`.

```python
key = (stl, dep, sizes_key)
hit = cache.get(key)
if hit is not None:
    return list(hit)
...
cache[key] = coords
return list(coords)
```

A second commit hoists two more per-edge invariants out of the same candidate loop: `indirect_info_from_op` (per op, into the same memo) and `host_coordinates` (per edge, into a lazy slot on EdgeCostMap).

Measured on tiled flash attention, Lq=512, cold compiles. Three arms on one isolated checkout of `ff23e62` with one `_C.so`, patches applied in turn, so each mechanism keeps its own number:

| point   | base | +memo | +memo+hoists |
|---------|-----:|------:|-------------:|
| Lk=2048 | 1991 | 1098 (**-44.9%**) | 583 (**-70.7%**) |
| Lk=8192 | 8771 | 4714 (**-46.2%**) | 2693 (**-69.3%**) |

The hoists contribute a further -46.9% / -42.9% on top of the memo.

## Three mechanisms, and why they sit where they do

`compute_restickify_needed` runs once per (in_stl, target_stl) pair per edge. Three things it recomputes on every call do not need to be:

| | varies with | home | reuse |
|---|---|---|---|
| `device_coordinates` | in_stl / out_stl | shared search-scoped memo | 4.6x |
| `indirect_info_from_op` | op only | same shared memo, keyed per op | 5.2x |
| `host_coordinates` | edge, plus indirect sizes | lazy slot on EdgeCostMap | 3.7x |

Only `device_coordinates` needs cross-edge sharing -- its key includes the candidate layouts, so no per-edge or per-op scope reaches that 4.6x. That is what the install/detach buys; the other two then ride on machinery that already exists.

`host_coordinates` derives only from `_dep_layout` and `dep`, already construction-time snapshots on EdgeCostMap, so a slot there adds no staleness surface the class does not already carry. It fills on first use, so an edge whose candidate pairs all take the stick-compatible early-out never pays for it.

`indirect_info_from_op` is per-op invariant during the search but is deliberately NOT snapshotted at construction. `get_read_writes` reaches input buffer layouts through `make_indexer`, and `propagate_spyre_tensor_layouts` --
the pass that builds these edge maps -- rebinds buffer layouts while it runs, interleaved with that construction, so a captured value could predate a rebinding. Computing it on first use during layout selection avoids the question entirely. It is also why it goes in the shared memo rather than in `from_args`.

#### Which issue(s) this PR is related to:

Contributes to investigation as part of #4117 

#### Special notes for your reviewer:
**Lifetime is the load-bearing design choice.** `finalize_layouts` runs in a later pass and calls `EdgeCostMap.cost()` again, by which point committed layouts have changed and cached coordinates would be stale. The memo is
therefore detached when layout selection ends rather than left reachable from the edge maps. Within the search, candidate layouts are only read. This follows a specific prior lesson: a naive global memo on a dependency-derived helper in the coarse-tile work broke correctness by outliving the mutations that invalidated it.

**Aliasing.** A fresh list is returned on every call, so no caller can mutate another's result through the cache. The lists hold one expression per device dimension, so the copy is a few elements against 0.8 ms of avoided sympy.

**The raising path is unchanged.** Unsupported stick expressions raise in `_check_stick_expr_supported` before the store, so they are never cached.

**With no cache supplied, behaviour is byte-identical.** Every other caller of these functions passes nothing and takes the same path plus one `is not None` check.

**What this does not do.** The search makes exactly the same decisions — in a runtime-shim prototype of the same change, `n_states_built`, `cost_calls` and `device_coordinates` call counts were identical between arms. It skips recomputation, it does not prune. So it does not change how the pass scales; that would mean reducing states per op, which is a search-quality question.

**Scope of the numbers.** The counter and profile results in the section above were taken on `7c1d5b6`; the A/B table and the reuse factors were re-taken on `ff23e62` after the rebase. `_maybe_scratchpad_planning` moves +3.1% / +10.9% between arms, which is CP-SAT's known run-to-run nondeterminism and not attributable to this change; every other pre-scheduling pass is flat to within a few ms.

#### Does this PR introduce a user-facing change?

No. Layout selection produces the same result; only the time to compute it changes.

#### Additional note:
