### PR TITLE
Fix broadcast pad stride

### DIFF
--- a/tests/inductor/test_padding.py
+++ b/tests/inductor/test_padding.py
@@ -24,13 +24,17 @@ import unittest
 from unittest.mock import patch
 
 import torch
+import torch.fx as fx
 from torch._inductor import config as t_inductor_config
 from torch._inductor.ir import (
     ComputedBuffer,
+    FixedLayout,
+    InputBuffer,
     Operation,
     Reduction,
 )
 from torch._inductor.graph import GraphLowering
+from torch._inductor.virtualized import V
 
 from torch_spyre._C import get_elem_in_stick
 from torch_spyre._inductor import config as ts_inductor_config
@@ -872,6 +876,86 @@ class TestInsertPaddingIR(unittest.TestCase):
         for op in ops:
             if isinstance(op, ComputedBuffer):
                 self.assertIs(self.captured_name_to_buffer[op.get_name()], op)
+
+
+class TestLowerPadSequenceBroadcastDim(unittest.TestCase):
+    """White-box tests for ``lower_pad_sequence``'s host-stride ranking.
+
+    A coarse-tile read-copy buffer can carry a broadcast dim -- stride 0,
+    size > 1 -- alongside a dim that needs stick-boundary padding (see
+    coarse_tile.py's ``_insert_one_read_copy``: an ``ADVANCING_READ`` source
+    keeps its full, uncompacted rank, with absent/broadcast dims left at
+    stride 0).  ``lower_pad_sequence`` ranks the padded buffer's host dims
+    by the source buffer's raw host stride to preserve fastest/slowest
+    ordering; ranking a stride-0 broadcast dim by that raw value put it
+    first (0 sorts smallest) and handed it a real nonzero stride, corrupting
+    addressing for a dimension that must stay stride 0.
+
+    These tests call ``lower_pad_sequence`` directly against a hand-built
+    ``InputBuffer`` (the pre-stickification path used by
+    ``insert_bmm_padding``, mirroring ``coarse_tile.py``'s own FX-node-free
+    ``arg_buf`` call convention), independent of any end-to-end
+    coarse-tiling or SDPA compilation -- exercising the bug's structural
+    precondition directly rather than reproducing it through a full
+    ``torch.compile`` call.
+    """
+
+    def setUp(self) -> None:
+        gm = fx.symbolic_trace(lambda: None)
+        self._graph_ctx = V.set_graph_handler(GraphLowering(gm))
+        self._graph_ctx.__enter__()
+
+    def tearDown(self) -> None:
+        self._graph_ctx.__exit__(None, None, None)
+
+    def test_broadcast_dim_kept_at_stride_zero_when_padding_adjacent_dim(
+        self,
+    ) -> None:
+        """A stride-0, size>1 dim must stay stride 0 in the padded buffer.
+
+        arg_buf mirrors a coarse-tile read-copy of V broadcast across 4 head
+        tiles (dim 0, stride 0, size 4), with a real row dim (dim 1, size
+        64, stride 32) and a K dim (dim 2, size 13, unaligned) padded to 32.
+        """
+        from torch_spyre._inductor.pass_utils import lower_pad_sequence
+
+        device = torch.device("cpu")
+        dtype = torch.float16
+
+        arg_buf = InputBuffer(
+            name="arg0",
+            layout=FixedLayout(device, dtype, [4, 64, 13], [0, 1, 32]),
+        )
+        V.graph.name_to_buffer["arg0"] = arg_buf
+        V.graph.graph_inputs["arg0"] = arg_buf
+        insert_before = next(iter(V.graph.graph.nodes))
+
+        padded_buf, _new_ops = lower_pad_sequence(
+            arg_fx_node=None,
+            padded_size=[4, 64, 32],
+            device=device,
+            dtype=dtype,
+            dim=2,
+            insert_before=insert_before,
+            orig_stl=None,
+            fill_value=0.0,
+            arg_buf=arg_buf,
+        )
+
+        size = [int(s) for s in padded_buf.get_size()]
+        stride = [int(s) for s in padded_buf.get_stride()]
+        self.assertEqual(size, [4, 64, 32])
+        self.assertEqual(
+            stride[0],
+            0,
+            f"broadcast dim (size 4) must stay stride 0; got padded stride {stride}",
+        )
+        # The two real dims must still be assigned distinct, non-overlapping
+        # strides consistent with their original relative order (dim 1 was
+        # fastest-varying at stride 1, dim 2 was next at stride 32).
+        self.assertLess(stride[1], stride[2])
+        self.assertNotEqual(stride[1], stride[0])
+        self.assertNotEqual(stride[2], stride[0])
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -2421,10 +2421,22 @@ def lower_pad_sequence(
     # padded strides in that same relative order, using padded_core's sizes.
     # These are host strides, not device strides; SpyreTensorLayout derives
     # the device layout (sticks, rows, …) from the host shape + dim_order.
+    #
+    # A broadcast dim (stride 0, size > 1 -- e.g. a coarse-tile read-copy
+    # buffer expanded across a tiled dim) has no real address contribution
+    # and must stay stride 0 in the padded output.  Ranking it by raw stride
+    # value would put it first (0 sorts as the smallest/fastest-varying),
+    # handing it a real nonzero stride and shifting every genuine dim's
+    # stride outward -- corrupting the padded buffer's addressing for a
+    # dimension that was never supposed to carry one.  Exclude broadcast
+    # dims from the ranking entirely and leave their padded stride at 0.
     original_stride_core = original_stride[n_phantom:]
-    order_fastest_first = sorted(
-        range(len(padded_core)), key=lambda i: original_stride_core[i]
-    )
+    real_dims = [
+        i
+        for i in range(len(padded_core))
+        if not (original_stride_core[i] == 0 and padded_core[i] > 1)
+    ]
+    order_fastest_first = sorted(real_dims, key=lambda i: original_stride_core[i])
     core_stride = [0] * len(padded_core)
     running = 1
     for i in order_fastest_first:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

Fixes a wrong-code bug in `lower_pad_sequence` (`torch_spyre/_inductor/pass_utils.py`),
the IR-level lowering used to pad a buffer up to a stick boundary before
stickification.

Step 5 of the function ranks a padded buffer's source dims "fastest to
slowest" via `sorted(range(n), key=lambda i: original_stride_core[i])` to
decide the padded output's host stride order. A genuine broadcast dim
(stride 0, size > 1 — e.g. a coarse-tile read-copy buffer expanded across a
tiled dim) sorts as *smallest* under a raw-stride key, so the algorithm was
assigning it a real nonzero stride in the padded output instead of leaving
it at 0. In a real coarse-tiled kernel this corrupted the broadcast dim's
addressing and, downstream, could collide with another dim's stick-radix
split, producing an invalid (non-injective) compound stick expression.

The fix excludes dims where `original_stride_core[i] == 0 and
padded_core[i] > 1` from the ranking, so a broadcast dim's padded stride
stays 0 as it should. `lower_pad_sequence` has exactly one caller
(`insert_bmm_padding` in `padding.py`), so the fix is contained.

This was originally found and fixed as part of the SDPA decomposition work
on `extract-decomp` (commit `c38316f8`, PR #4226 — a causal SDPA
`building_blocks` test at S=13 was failing in CI). This PR extracts just
the `lower_pad_sequence` fix onto its own branch off `main`, since the fix
itself has no dependency on that unmerged decomposition work.

**Regression test:** `main` doesn't yet have the SDPA decomposition chain
that made the original bug reachable end-to-end (and, separately,
coarse-tiling does not currently engage for causal SDPA on `main` at all —
a pre-existing, unrelated gap). Rather than carry a test that depends on
that unmerged work, or wait on an end-to-end repro, this PR adds a
white-box unit test
(`TestLowerPadSequenceBroadcastDim` in `tests/inductor/test_padding.py`)
that calls `lower_pad_sequence` directly against a hand-built buffer with a
stride-0 broadcast dim, using the same minimal
`V.set_graph_handler(GraphLowering(gm))` scaffolding already used elsewhere
in `tests/inductor/test_coarse_tiling.py`. Confirmed TDD-style: the test
fails against the pre-fix code (broadcast dim gets assigned stride 1
instead of staying at 0) and passes against the fix.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

Same underlying fix as landed in commit `c38316f8` on `extract-decomp` (PR #4226); this PR extracts it as a standalone change against `main`.

#### Special notes for your reviewer:

- The bug is in dim-ranking logic only; no change to the general
  padding/stride computation for non-broadcast dims.
- The new test is intentionally white-box (calls `lower_pad_sequence`
  directly) rather than an end-to-end `torch.compile` test — see the test
  class docstring for why an end-to-end repro wasn't available on `main`.
- Full `tests/inductor/test_padding.py` suite: 17 passed.
- `pre-commit run --files torch_spyre/_inductor/pass_utils.py
  tests/inductor/test_padding.py` is clean.

#### Does this PR introduce a user-facing change?

No. It fixes an internal compiler correctness bug (wrong-code, not a crash) that only manifests for coarse-tiled kernels with a broadcast dim adjacent to a padded dim; no public API chang
es.

#### Additional note:

None.