### PR TITLE
feat: Move to pytorch 2.14

### DIFF
--- a/.claude/skills/project-overview/SKILL.md
+++ b/.claude/skills/project-overview/SKILL.md
@@ -81,7 +81,7 @@ torch-spyre/
 │
 ├── examples/                    # Usage examples (softmax, gelu, mul, etc.)
 ├── setup.py                     # Build: C++ extension compilation
-├── pyproject.toml               # PEP 517/518 metadata, deps (torch~=2.13.0)
+├── pyproject.toml               # PEP 517/518 metadata, deps (torch~=2.14.0)
 └── tools/                       # Developer tooling (lint, format, mypy)
 ```
 
@@ -194,7 +194,7 @@ Two separate pybind11 modules:
    against `sendnn`, `flex`
 2. **Entry point**: `torch.backends` → `torch_spyre = torch_spyre:_autoload`
 
-Key external deps: `torch~=2.13.0`, `sendnn`, `flex`, `dxp_standalone`
+Key external deps: `torch~=2.14.0`, `sendnn`, `flex`, `dxp_standalone`
 
 ---
 

--- a/.github/actions/build-torch-spyre-local-pytorch/action.yml
+++ b/.github/actions/build-torch-spyre-local-pytorch/action.yml
@@ -44,12 +44,12 @@ runs:
         # the runner is ephemeral, but this keeps the checkout in the state a
         # human would expect if it were ever inspected mid-job.
         cp uv.lock uv.lock.bak
-        sed -i 's|^    "torch~=2.13.0",|#    "torch~=2.13.0",|' pyproject.toml
-        sed -i 's|^#    "torch>=2.13.0",|    "torch>=2.13.0",|' pyproject.toml
+        sed -i 's|^    "torch~=2.14.0",|#    "torch~=2.14.0",|' pyproject.toml
+        sed -i 's|^#    "torch>=2.14.0",|    "torch>=2.14.0",|' pyproject.toml
         sed -i 's|^#  { path = "\.\./pytorch", editable = true },|  { path = "../pytorch", editable = false },|' pyproject.toml
         sed -i '/^  { path = "\.\.\/pytorch", editable = false },/{n;s|^  { index = "pytorch-cpu" },|#  { index = "pytorch-cpu" },|}' pyproject.toml
-        trap 'sed -i "s|^#    \"torch~=2.13.0\",|    \"torch~=2.13.0\",|" pyproject.toml; \
-              sed -i "s|^    \"torch>=2.13.0\",|#    \"torch>=2.13.0\",|" pyproject.toml; \
+        trap 'sed -i "s|^#    \"torch~=2.14.0\",|    \"torch~=2.14.0\",|" pyproject.toml; \
+              sed -i "s|^    \"torch>=2.14.0\",|#    \"torch>=2.14.0\",|" pyproject.toml; \
               sed -i "/^  { path = \"\.\.\/pytorch\", editable = false },/{n;s|^#  { index = \"pytorch-cpu\" },|  { index = \"pytorch-cpu\" },|}" pyproject.toml; \
               sed -i "s|^  { path = \"\.\./pytorch\", editable = false },|#  { path = \"../pytorch\", editable = true },|" pyproject.toml; \
               mv uv.lock.bak uv.lock' EXIT

--- a/.github/workflows/push-pytorch-dispatch-to-clickhouse.yaml
+++ b/.github/workflows/push-pytorch-dispatch-to-clickhouse.yaml
@@ -255,10 +255,10 @@ jobs:
             exit 0
           fi
 
-          # torch-spyre's pinned PyTorch minor version (e.g. "2.13" from
-          # "torch~=2.13.0" in pyproject.toml) maps 1:1 onto the
+          # torch-spyre's pinned PyTorch minor version (e.g. "2.14" from
+          # "torch~=2.14.0" in pyproject.toml) maps 1:1 onto the
           # pytorch/pytorch release branch this repo currently tracks
-          # (e.g. "release/2.13"). Recomputed on every dispatch so this
+          # (e.g. "release/2.14"). Recomputed on every dispatch so this
           # keeps following whichever release branch pyproject.toml is
           # pinned to, without needing to touch this workflow on bump.
           PINNED_MINOR=$(grep -v '^#' pyproject.toml | grep -oE 'torch~=[0-9]+\.[0-9]+' | head -1 | grep -oE '[0-9]+\.[0-9]+')

--- a/docs/source/getting_started/installation.md
+++ b/docs/source/getting_started/installation.md
@@ -14,7 +14,7 @@ in early access.
 | Component | Version |
 |---|---|
 | Python | ≥ 3.11 |
-| PyTorch | ~= 2.13.0 |
+| PyTorch | ~= 2.14.0 |
 
 The exact pins live in [`pyproject.toml`](https://github.com/torch-spyre/torch-spyre/blob/main/pyproject.toml) and are resolved through [`requirements/run.txt`](https://github.com/torch-spyre/torch-spyre/blob/main/requirements/run.txt).
 

--- a/docs/source/user_guide/debugging/op_spec_lab.md
+++ b/docs/source/user_guide/debugging/op_spec_lab.md
@@ -83,7 +83,7 @@ torch-spyre installed. This is the header of
 #
 # Source program:  <your checkout>/tests/op_specs/programs/01_add.py
 # Kernel:          1 of 1 compiled from that program
-# Environment:     torch 2.13.0+cpu, SENCORES=32, bundle_symbolic_args=True
+# Environment:     torch 2.14.0+cpu, SENCORES=32, bundle_symbolic_args=True
 # Kernel args:     3 in the spec, 3 observed at .run()
 #
 # Run it:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ requires = [
     "pyyaml", # needed for codegen
     "regex",
     "setuptools>=77.0.3",  # match upstream torch dependency range
-    "torch~=2.13.0",
-#    "torch>=2.13.0",
+    "torch~=2.14.0",
+#    "torch>=2.14.0",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
@@ -25,8 +25,8 @@ description = "Torch-Spyre out of tree registration"
 dependencies = [
     "numpy",
     "regex",
-    "torch~=2.13.0",
-#    "torch>=2.13.0",
+    "torch~=2.14.0",
+#    "torch>=2.14.0",
     "psutil",
     # CP-SAT LX layout solver. `layout_solver` defaults to "cpsat" (see config.py),
     # so a base install needs ortools to actually get it -- without this, every
@@ -66,8 +66,8 @@ build = [ # no-isolation build
     "pyyaml", # needed for codegen
     "regex",
     "setuptools>=77.0.3",  # match upstream torch dependency range
-    "torch~=2.13.0",
-#    "torch>=2.13.0",
+    "torch~=2.14.0",
+#    "torch>=2.14.0",
     "wheel"
 ]
 test = [

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -97,9 +97,9 @@ six==1.17.0 ; platform_machine != 'ppc64le' and platform_machine != 's390x'
     # via python-dateutil
 sympy==1.14.0
     # via torch
-torch==2.13.0 ; python_full_version < '3.15' and sys_platform == 'darwin'
+torch==2.14.0 ; sys_platform == 'darwin'
     # via torch-spyre
-torch==2.13.0+cpu ; python_full_version >= '3.15' or sys_platform != 'darwin'
+torch==2.14.0+cpu ; sys_platform != 'darwin'
     # via torch-spyre
 types-pyyaml==6.0.12.20260724
     # via torch-spyre

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -120,9 +120,9 @@ six==1.17.0 ; platform_machine != 'ppc64le' and platform_machine != 's390x'
     # via python-dateutil
 sympy==1.14.0
     # via torch
-torch==2.13.0 ; python_full_version < '3.15' and sys_platform == 'darwin'
+torch==2.14.0 ; sys_platform == 'darwin'
     # via torch-spyre
-torch==2.13.0+cpu ; python_full_version >= '3.15' or sys_platform != 'darwin'
+torch==2.14.0+cpu ; sys_platform != 'darwin'
     # via torch-spyre
 types-pyyaml==6.0.12.20260724
     # via torch-spyre

--- a/requirements/run.txt
+++ b/requirements/run.txt
@@ -44,9 +44,9 @@ six==1.17.0 ; platform_machine != 'ppc64le' and platform_machine != 's390x'
     # via python-dateutil
 sympy==1.14.0
     # via torch
-torch==2.13.0 ; python_full_version < '3.15' and sys_platform == 'darwin'
+torch==2.14.0 ; sys_platform == 'darwin'
     # via torch-spyre
-torch==2.13.0+cpu ; python_full_version >= '3.15' or sys_platform != 'darwin'
+torch==2.14.0+cpu ; sys_platform != 'darwin'
     # via torch-spyre
 typing-extensions==4.16.0
     # via

--- a/uv.lock
+++ b/uv.lock
@@ -1205,39 +1205,41 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.13.0"
+version = "2.14.0"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin'",
     "python_full_version < '3.12' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "networkx", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "sympy", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:e76f9bcecc52b8ff711239a2f7547d5353df95878ab232f0773c1d95928b92f8", upload-time = "2026-07-08T12:26:13Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", upload-time = "2026-07-08T12:26:18Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:33449899ce5496c1b84b4853179d94fd102028ae1407314d9fb956bb79e70d09", upload-time = "2026-07-08T12:26:23Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d849b390e07d8d333ce8ecaf91b273c656c598379a19c9acf1318a883f6b391c", upload-time = "2026-07-08T12:26:28Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:c28def70706c2f9ecc752574766e8ae4da9b810ab6676b611166761a78a9f1e1", upload-time = "2026-07-08T12:26:33Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:1040f689e560ba6e02a0a147dfb9ec8dfdd3e4486ebec4b24dc8fdaa258fa9ba", upload-time = "2026-09-02T00:26:07Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:ab7e226c18d3cbc134dfa952d18ab1df202055dd33446837c8fd050ad449e6f5", upload-time = "2026-09-02T00:26:12Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:caf6359d64c0074bcb9f8641a169239118c8165a0a0fef79110c72bfd6474bec", upload-time = "2026-09-02T00:26:15Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d0f78744000a7863cc3f1eafaf511d4b9944f079f08277de6fefe4b01f4d41b9", upload-time = "2026-09-02T00:26:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:dd4c297f1af83ad44368ffdaa9ed0318984567ff952bbda3d90cc300afe1e8a0", upload-time = "2026-09-02T00:26:23Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0-cp315-cp315-macosx_14_0_arm64.whl", hash = "sha256:c65f7d7783e76272bbd53e4220aa029ac14e2dc346c6641691e041202a03b0e0", upload-time = "2026-09-02T00:26:27Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0-cp315-cp315t-macosx_14_0_arm64.whl", hash = "sha256:879140333148a3a5b1a14ab29a35b58c3c8db4d85c7130018a79178eb239008b", upload-time = "2026-09-02T00:26:30Z" },
 ]
 
 [[package]]
 name = "torch"
-version = "2.13.0+cpu"
+version = "2.14.0+cpu"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
@@ -1249,42 +1251,44 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
-    { name = "networkx", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
-    { name = "setuptools", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
-    { name = "sympy", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:6e9817dbdf5ea76789babd46e457eac5bf14ff566cf85f8addbfdff2d56601ce", upload-time = "2026-07-08T19:27:52Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:84453b69508ec79902f899c5ed9495acb9e2bbe9fda5f1d5d6f19e3c3842e1a7", upload-time = "2026-07-08T19:28:03Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:6746dbcbeb526eb61330b76b41ff1b4eb848951103a892eeb080dfa2b264667b", upload-time = "2026-07-08T19:28:16Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:10717d8b3b67c45a4788bf7ffc0bab1ea1e5ebbedd24466be6100102d141fac1", upload-time = "2026-07-08T19:28:27Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-win_arm64.whl", hash = "sha256:2b3d093abd919ad934c43d47e73ba63ceba7cbd7269fc2e9c1e4fc29e8fe45fa", upload-time = "2026-07-08T19:28:33Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:ffadde149901c8afa138daa38d898264003cfcf1a3336ca5cd964b5af227d867", upload-time = "2026-07-08T19:28:41Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f307c2c32d764ffc6ff6893b801fad6d4752f3e67966cb8abf1843427c02604", upload-time = "2026-07-08T19:28:51Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4ca4a9394b0c771238a4f73590fdbbc4debad85ed0fa63d026ae1b085da7d6e2", upload-time = "2026-07-08T19:29:03Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:a8b450c1e58e5800e5b4691dac412f8d2d65a1dc3298166f91596603a3531e6f", upload-time = "2026-07-08T19:29:15Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-win_arm64.whl", hash = "sha256:fa0762705b933624d59f6823db9ce7ec2e35b3e1e9c319c9db51fbeecfc3e319", upload-time = "2026-07-08T19:29:21Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:966d020354f465672dc7dd10d3a5c6cd17d7eb48620aa1d265b48a1f78f06898", upload-time = "2026-07-08T19:29:30Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:0b8f7d0423027ae8b90c7977c627f3379f325363a08224dffad9b4b2d684a83d", upload-time = "2026-07-08T19:29:40Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3fbf9c9d1f3c10c2d59d04aca426dee9ccc6ceb32d255c61e93acc3b4f75fae6", upload-time = "2026-07-08T19:29:54Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:a17ff48608634db245e17e8bb00a9558554a49aeb1e4f5fe6cd039af2a10515b", upload-time = "2026-07-08T19:30:05Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:ac7aaf322be4777765a53bed7264a214dd81b3a1d276b93150515a3c5f75e4b0", upload-time = "2026-07-08T19:30:12Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314-linux_s390x.whl", hash = "sha256:dec241fef3984c0d1edadd1f58708e218d4eae881ceef7bc10cf9964d41b68b9", upload-time = "2026-07-08T19:30:20Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:ca021f9eb2f8345c83fa03e3a04587308afb8df71bd472670b3ece00df58621c", upload-time = "2026-07-08T19:30:32Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d20fa53ee744502fa4c69818a720b05ca0d37abd055d4f6e66cae155114bc691", upload-time = "2026-07-08T19:30:45Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:e2e5134decf00e218da62318f3dc5df156231d367871918e91eba95ab0ad43ab", upload-time = "2026-07-08T19:30:58Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314t-linux_s390x.whl", hash = "sha256:991cc14b39e751122c01f017be6448533989868731cb5eecd1006893d26787c2", upload-time = "2026-07-08T19:31:09Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:7b8d26e29bceafbdaa8d63bfe7612f23875b5af2cc07e13f809c3ed890bbe1d8", upload-time = "2026-07-08T19:31:21Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b222c15a0fc2ce207d1c1a59700b46c8fa6748df1f447ad11e5c870dde0933d9", upload-time = "2026-07-08T19:31:35Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:a43376bd094124ef626bfdd3d4c2c62eacb0b5ddc99776f4a32d4fd16f1f3420", upload-time = "2026-07-08T19:31:48Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp315-cp315-manylinux_2_28_aarch64.whl", hash = "sha256:8eb5002ca81af00ae69b57540f615b58b8ae922b6d4848176b366a52bd2196e6", upload-time = "2026-07-08T19:32:00Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp315-cp315-manylinux_2_28_x86_64.whl", hash = "sha256:1a3a35229fdc13446b4eab50e7fcf9399ff941e89a3b761497786297a5d8dde5", upload-time = "2026-07-08T19:32:16Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp315-cp315t-manylinux_2_28_aarch64.whl", hash = "sha256:8e109528e6bab044815daebaf71770fbaace3a66ef1c816cb55c875350f78a60", upload-time = "2026-07-08T19:32:30Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp315-cp315t-manylinux_2_28_x86_64.whl", hash = "sha256:222a6681467cc7f6f05cd3068dfbc603def3a1e46d1d4620c1c8cdf6178bd563", upload-time = "2026-07-08T19:32:44Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:3fa39713d13f23563ad11636bfff76b677ab4addbc240c54e6b7e47622e8973d", upload-time = "2026-09-02T18:31:08Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:08894195f84541edcbd09072e6c53b791d4cdd09f650b05473f35718a848fd7b", upload-time = "2026-09-02T18:31:13Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:673dbf5c9bbadfffab7a386b6dd7a0c219f1408a328b7b4e86d0ae551cdafa42", upload-time = "2026-09-02T18:31:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:8e2c47c6556c7d5a85848634372bb2252907d411e9cad669c99406856d536eb5", upload-time = "2026-09-02T18:31:24Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp311-cp311-win_arm64.whl", hash = "sha256:38f0a0330267b36d76b988754878d94001c1519fe3743bd92f038ce5622bea5a", upload-time = "2026-09-02T18:31:28Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:07aefe1a437b6f1b41b0cba15e16583e2f43549ec9d062fcea8e7981a78e014a", upload-time = "2026-09-02T18:31:32Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:da8140c3d4a41500d29710e35bf8e66a4295ec31026487c69f54a3f583310f8d", upload-time = "2026-09-02T18:31:37Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a09987c95ec4cffdb6df798d3d641558110a334cfccce22f2f046d83142bc260", upload-time = "2026-09-02T18:31:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:738cd9237bf63443a5e5f9652e5115f7b0510b089636a43d4011e9fccede714f", upload-time = "2026-09-02T18:31:48Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp312-cp312-win_arm64.whl", hash = "sha256:420e7dbed969bbd045b34105fa90d1ccf3e5c09c4e9b0d0a5f9df25df9d02d2e", upload-time = "2026-09-02T18:31:52Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:d87cfff3af33c937b88c9bc6c0dfa17f2156e2599f63447c696f2345928b518a", upload-time = "2026-09-02T18:31:55Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:092d5c12938850dfbd90a654b3c8dac34c33e300f88eb19ee6f4ef93992c6347", upload-time = "2026-09-02T18:31:59Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:160e1bc46aeded3111d2801f8ae10dc9a1b946843a7e126b4dbf5e19c5706e95", upload-time = "2026-09-02T18:32:05Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:f2ffdacd95d7090a8bdfa8426f5d1557625874b19a96ba23a41f640d4a0c9c28", upload-time = "2026-09-02T18:32:10Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:4b1b78f8b9b1393576ef03cab0e6d941a6aa562b7539c45da12d80e86c09f9ed", upload-time = "2026-09-02T18:32:13Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp314-cp314-linux_s390x.whl", hash = "sha256:266a253980047f3c037191f45d7e7ecfa838d13102141ca57b86fcc892663004", upload-time = "2026-09-02T18:32:17Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:27b34640fea7268862961b734c723873e15b1c2657b1eb84bcfac053e5841527", upload-time = "2026-09-02T18:32:23Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:f152f41dc5dc462afe0de780e451ebb47ea8b4451f8f919f9537aa8e2cbe1d7e", upload-time = "2026-09-02T18:32:29Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:ca9b3c2c652587f7b26c86d30be3648f553bd07fb3cf9b3edb645e7eafe295a3", upload-time = "2026-09-02T18:32:35Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp314-cp314t-linux_s390x.whl", hash = "sha256:c1d81be03f715eca5b065fc767f73b2a26668a16d614e163a4378a3f38a5e471", upload-time = "2026-09-02T18:32:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a6ff46c0c0c4f5b9b399dff5e4856a98ce18e61ca14ad74b21790174c7cbde08", upload-time = "2026-09-02T18:32:43Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:2baf9cbaef964d821465df0c53a91cc01b2d0ea29ebd199e2f9c7d27a7fc70a4", upload-time = "2026-09-02T18:32:48Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:8fe5ff05cf3511daecdea986005f312f3b9cdbaf07ccf0bc42c68d01a4ae5d4d", upload-time = "2026-09-02T18:32:53Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp315-cp315-manylinux_2_28_aarch64.whl", hash = "sha256:07d50e40232d2757be323693e38f531e04ee654d40537bc0b04e787c1e73a27a", upload-time = "2026-09-02T18:32:57Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp315-cp315-manylinux_2_28_x86_64.whl", hash = "sha256:a8b2fa9a03d81bc083f279737fce1cd8d1ed2e267da92215260cd644dcfdd3fe", upload-time = "2026-09-02T18:33:02Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp315-cp315-win_amd64.whl", hash = "sha256:70a98493729cdd06f2735a7e4c4867e64e5d5b4eebbd6ffb841b7b034b16aff3", upload-time = "2026-09-02T18:33:07Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp315-cp315t-manylinux_2_28_aarch64.whl", hash = "sha256:e22ddf8a9fff9934fe2dd2440d45c437bb0539f2d6d24b57b26981d6dca4157c", upload-time = "2026-09-02T18:33:11Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp315-cp315t-manylinux_2_28_x86_64.whl", hash = "sha256:18b417c953e9b4d8b79294ca5184586790f0a609b3929e39258cea854b945870", upload-time = "2026-09-02T18:33:16Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp315-cp315t-win_amd64.whl", hash = "sha256:70b02d91b68ba0652b53294f51afbe774eea0f1f52b91a20207982298af294a2", upload-time = "2026-09-02T18:33:20Z" },
 ]
 
 [[package]]
@@ -1296,8 +1300,8 @@ dependencies = [
     { name = "ortools", marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'" },
     { name = "psutil" },
     { name = "regex" },
-    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
+    { name = "torch", version = "2.14.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.14.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
 ]
 
 [package.optional-dependencies]
@@ -1312,8 +1316,8 @@ build = [
     { name = "pyyaml" },
     { name = "regex" },
     { name = "setuptools" },
-    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
+    { name = "torch", version = "2.14.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.14.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "wheel" },
 ]
 cpsat = [
@@ -1352,8 +1356,8 @@ requires-dist = [
     { name = "regex" },
     { name = "regex", marker = "extra == 'build'" },
     { name = "setuptools", marker = "extra == 'build'", specifier = ">=77.0.3" },
-    { name = "torch", specifier = "~=2.13.0", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "torch", marker = "extra == 'build'", specifier = "~=2.13.0", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torch", specifier = "~=2.14.0", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torch", marker = "extra == 'build'", specifier = "~=2.14.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "types-pyyaml", marker = "extra == 'lint'", specifier = "~=6.0.12.20260518" },
     { name = "uv", marker = "extra == 'lint'", specifier = "~=0.11.15" },
     { name = "wheel", marker = "extra == 'build'" },


### PR DESCRIPTION
From CRCR  - https://github.com/torch-spyre/torch-spyre/actions/runs/33642026074


Total | Passed | Failed | Errors | Skipped | Xfailed | Xpassed
-- | -- | -- | -- | -- | -- | --
5248 | 4166 | 26 | 30 | 888 | 138 | 0


## (26) Failed


1. 2026-09-02T15:29:45.3372976Z FAILED test_restickify.py::test_fallback_with_restickify - torch._inductor.ex...
2. 2026-09-02T15:29:45.3373378Z FAILED test_restickify.py::test_arange_plus_xt - torch._inductor.exc.Inductor...
3. 2026-09-02T15:23:00.4238325Z FAILED [TAGS = platform__x86_64 testtype__regression testtype__trunk testtype__unit] test_overwrite__oot_wrapper.py::TestOverwriteFunctionalReinplacePRIVATEUSE1::test_overwrite_f_in_compiled_loop_spyre
4. 2026-09-02T15:22:52.5965698Z FAILED test_lx_extern_kernel_clobber.py::test_nested_launch_does_not_clobber_residual[1]
5. 2026-09-02T15:22:52.5966388Z FAILED test_lx_extern_kernel_clobber.py::test_nested_launch_does_not_clobber_residual[4]
6. 2026-09-02T15:23:54.8583119Z FAILED test_building_blocks__oot_wrapper.py::FrontendPoolAllocationTestBuildingBlocks::test_causal_sdpa_unpadded_kv_no_inf
7. 2026-09-02T15:23:54.8584935Z FAILED [TAGS = platform__x86_64 testtype__regression testtype__trunk testtype__unit] test_building_blocks__oot_wrapper.py::TestBuildingBlocksPRIVATEUSE1::test_causal_sdpa_unpadded_kv_no_inf_spyre
8. 2026-09-02T15:22:34.4645951Z FAILED [TAGS = platform__x86_64 testtype__regression testtype__trunk testtype__unit] test_inductor_decomp__oot_wrapper.py::TestOpsPRIVATEUSE1::test_decompositions_change_1d_spyre
9. 2026-09-02T15:23:06.2571604Z FAILED [TAGS = platform__x86_64 testtype__integration testtype__regression testtype__trunk testtype__unit] test_fallback_kernel__oot_wrapper.py::TestFallbackKernelPoolResidentArgPRIVATEUSE1::test_fresh_output_arg_keeps_dtype_spyre
10. 2026-09-02T15:23:06.2572126Z FAILED [TAGS = platform__x86_64 testtype__integration testtype__regression testtype__trunk testtype__unit] test_fallback_kernel__oot_wrapper.py::TestFallbackKernelShape1SinglePRIVATEUSE1::test_single_tensor_return_compiles_spyre
11. 2026-09-02T15:23:06.2572703Z FAILED [TAGS = platform__x86_64 testtype__integration testtype__regression testtype__trunk testtype__unit] test_fallback_kernel__oot_wrapper.py::TestFallbackResultNonCanonicalTilingPRIVATEUSE1::test_cat_disagrees_in_rank_without_size_one_dim_spyre
12. 2026-09-02T15:23:06.6857960Z FAILED [TAGS = platform__x86_64 testtype__integration testtype__regression testtype__trunk testtype__unit] test_fallback_kernel__oot_wrapper.py::TestFallbackResultNonCanonicalTilingPRIVATEUSE1::test_multi_token_gather_spyre
13. 2026-09-02T15:23:06.6859307Z FAILED [TAGS = platform__x86_64 testtype__integration testtype__regression testtype__trunk testtype__unit] test_fallback_kernel__oot_wrapper.py::TestFallbackResultNonCanonicalTilingPRIVATEUSE1::test_single_token_gather_spyre
14. 2026-09-02T15:23:06.6860723Z FAILED [TAGS = platform__x86_64 testtype__integration testtype__regression testtype__trunk testtype__unit] test_fallback_kernel__oot_wrapper.py::TestInGraphCpuComputedBuffersPRIVATEUSE1::test_cpu_pointwise_chain_compiles_co_optimizing_spyre
15. 2026-09-02T15:23:06.6862094Z FAILED [TAGS = platform__x86_64 testtype__integration testtype__regression testtype__trunk testtype__unit] test_fallback_kernel__oot_wrapper.py::TestInGraphCpuComputedBuffersPRIVATEUSE1::test_cpu_pointwise_chain_compiles_greedy_spyre
16. 2026-09-02T15:23:06.6863421Z FAILED [TAGS = platform__x86_64 testtype__integration testtype__regression testtype__trunk testtype__unit] test_fallback_kernel__oot_wrapper.py::TestLiftedCpuGraphInputPRIVATEUSE1::test_lifted_cpu_constant_matmul_compiles_spyre
17. 2026-09-02T15:23:06.6864777Z FAILED [TAGS = platform__x86_64 testtype__integration testtype__regression testtype__trunk testtype__unit] test_fallback_kernel__oot_wrapper.py::TestReinterpretTensorCpuBufferPRIVATEUSE1::test_cpu_slice_roundtrip_compiles_spyre
18. 2026-09-02T15:38:19.1440458Z FAILED [TAGS = platform__x86_64 testtype__integration testtype__regression testtype__trunk testtype__unit] test_coarse_tile_e2e__oot_wrapper.py::TestCoarseTileMoEBroadcastMatmulE2EPRIVATEUSE1::test_unsqueeze_broadcast_matmul_reads_expert_weights_directly_spyre
19. 2026-09-02T15:21:38.8153484Z FAILED [TAGS = platform__x86_64 testtype__regression testtype__trunk testtype__unit] test_hbm_pool_planning__oot_wrapper.py::TestHbmPoolPlanningE2EPRIVATEUSE1::test_no_python_side_pool_tensor_allocated_spyre
20. 2026-09-02T15:21:38.8154675Z FAILED [TAGS = platform__x86_64 testtype__regression testtype__trunk testtype__unit] test_hbm_pool_planning__oot_wrapper.py::TestHbmPoolPlanningE2EPRIVATEUSE1::test_pool_alloc_scoped_per_bundle_across_fallback_boundary_spyre
21. 2026-09-02T15:23:22.7219046Z FAILED test_indirect_access_scatter.py::TestScatter_cores32::test_masked_scatter_2d_row_broadcast
22. 2026-09-02T15:23:22.7219299Z FAILED test_indirect_access_scatter.py::TestScatter_cores32::test_masked_scatter_all_rows_selected
23. 2026-09-02T15:23:22.7219557Z FAILED test_indirect_access_scatter.py::TestScatter_cores32::test_masked_scatter_batched_row_broadcast
24. 2026-09-02T15:23:22.7219798Z FAILED test_indirect_access_scatter.py::TestScatter_cores32::test_masked_scatter_no_rows_selected
25. 2026-09-02T15:23:22.7220019Z FAILED test_indirect_access_scatter.py::TestScatter_cores32::test_masked_scatter_row_broadcast
26. 2026-09-02T15:23:22.7220283Z FAILED test_indirect_access_scatter.py::TestScatter_cores32::test_masked_scatter_unexpanded_row_broadcast


## (30) Errored

Logs can be found in the CRCR workflow  - https://github.com/torch-spyre/torch-spyre/actions/runs/33642026074

