### PR TITLE
fix(inductor): keep a strided stick-tile coordinate's footprint exact

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_shape_a_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_shape_a_config.yaml
@@ -32,6 +32,10 @@ test_suite_config:
             - TestOps::test_slice_scatter.*
             - TestOps::test_split.*
             - TestOps::test_storage_offset_placeholder.*
+            # views that split the stick dim into (heads, D) and then slice or
+            # stride D, incl. rotate_half on a transposed q/k (issue #4050)
+            - TestOps::test_view_split_stick_slice.*
+            - TestOps::test_rope_on_split_stick_view.*
           mode: mandatory_success
           tags:
             - ops__inductor_misc_shape

--- a/tests/inductor/test_copy_from_d2d_offsets.py
+++ b/tests/inductor/test_copy_from_d2d_offsets.py
@@ -39,15 +39,19 @@ surfaces this rejection early with an actionable message; see
 test_unaligned_offset_raises{,_select} and
 test_stick_multiple_offset_unaligned_inner_dim_ok.
 
-The one remaining silent-wrong-data case is an offset that falls INSIDE the
-stick dim (a column narrow) — see test_column_slice_inner_offset, a documented
-known limitation tracked for the follow-up PR.
+An offset that falls INSIDE the stick dim (a column narrow at a stick-aligned
+offset) used to be a silent-wrong-data case: the copy reads the source as a
+flat [sticks, 64] layout whose stick-tile coordinate is a strided term with a
+residual offset (2*c0 + 1), and tensor alignment inflated that dim and
+dropped the offset (issue #4050). It is covered by
+test_column_slice_inner_offset and now passes.
 
 The transpose / permute / strided cases below deliberately exercise
 NON-contiguous views (see TestCopyFromD2DStridedViews). permute / select at
-stick-aligned offsets are carried by the offset fix; transpose / stepped-slice
-fail in the restickify layout pass (a pre-existing backend limitation, not a
-regression from this fix).
+stick-aligned offsets are carried by the offset fix; a stepped slice is the
+same strided-coordinate shape as the column narrow above and passes since
+issue #4050; transpose still fails in the restickify layout pass (a
+pre-existing backend limitation, not a regression from this fix).
 """
 
 import unittest
@@ -99,20 +103,17 @@ class TestCopyFromD2DContiguousOffsets(unittest.TestCase):
         torch.testing.assert_close(out[1:2], torch.full((1, 64), -1.0, dtype=DTYPE))
         torch.testing.assert_close(out[3:4], torch.full((1, 64), -1.0, dtype=DTYPE))
 
-    @unittest.expectedFailure
     def test_column_slice_inner_offset(self):
         """Offset along the last (stick) dim: narrow columns at an offset.
 
-        KNOWN LIMITATION — the SOLE remaining silent-wrong-data case. Here the
-        offset (64) IS a stick multiple, so _validate_reoffset_supported accepts
-        it, but it falls inside the stick DIMENSION: superdsc decomposes per-dim
-        offsets against device_size and does not split a stick-dim offset
-        correctly, so the read is off by the stick-dim component (measured WRONG
-        in sweep_d2d_offsets.py: got 0.0, expected 64.0). The offset%eps guard
-        cannot catch this (the offset is aligned); detecting it needs the
-        base-storage layout, which is unavailable at lowering. Tracked for the
-        follow-up PR (stick-dim offset handling), distinct from the row-offset
-        bug fixed here."""
+        The offset (64) IS a stick multiple, so _validate_reoffset_supported
+        accepts it, but it falls inside the stick DIMENSION. The copy reads the
+        source as a flat [4 sticks, 64] layout whose stick-tile coordinate is
+        ``2*c0 + 1``: a strided term with a residual offset. Tensor alignment
+        used to count that dim in device units and then add a gap dim (16
+        sticks for 4) and to drop the ``+1``, so the read landed on sticks 0
+        and 2 (measured in sweep_d2d_offsets.py: got 0.0, expected 64.0).
+        Fixed with issue #4050 in normalize_coordinates."""
         x = torch.arange(2 * 128, dtype=DTYPE, device=DEVICE).reshape(2, 128)
         # columns [64:128) -> nonzero offset within a row
         out = x.narrow(1, 64, 64).clone()
@@ -175,8 +176,9 @@ class TestCopyFromD2DContiguousOffsets(unittest.TestCase):
 class TestCopyFromD2DStridedViews(unittest.TestCase):
     """Non-contiguous views: transpose / permute / step slices / select.
 
-    permute and select work (the offset fix carries them). transpose and
-    stepped-slice cases are marked expectedFailure: they fail in the Spyre
+    permute and select work (the offset fix carries them), and so does a
+    stepped slice since issue #4050 fixed strided stick-tile coordinates.
+    transpose cases are marked expectedFailure: they fail in the Spyre
     restickify layout pass ("no mechanism to resolve stick incompatibility" /
     "scatter elements from one stick to multiple sticks"), NOT in offset
     handling. Verified to fail identically on the pre-fix baseline (offset==0
@@ -217,9 +219,12 @@ class TestCopyFromD2DStridedViews(unittest.TestCase):
         out = x.select(0, 2).clone()  # row 2 as 1-D (64,), storage_offset=128
         torch.testing.assert_close(out.cpu(), x.cpu()[2])
 
-    @unittest.expectedFailure
     def test_stepped_slice_clone(self):
-        """Strided (step>1) slice — non-unit stride plus offset."""
+        """Strided (step>1) slice — non-unit stride plus offset.
+
+        Reads rows 1, 3, 5, 7 as stick-tile coordinate ``2*c0 + 1``; the
+        stride and the residual offset are realized as an inner gap dim
+        (issue #4050)."""
         x = torch.arange(8 * 64, dtype=DTYPE, device=DEVICE).reshape(8, 64)
         out = x[1::2].clone()  # rows 1,3,5,7 ; offset=64, stride[0]=128
         torch.testing.assert_close(out.cpu(), x.cpu()[1::2])

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -5653,6 +5653,70 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 "3d_to_4d_view_permute_mul": (cached_randn((2, 3, 4)),),
             },
         },
+        # A view that splits the stick dim into (heads, D) and then slices or
+        # strides D makes the read walk the stick-tile dim in steps (``2*d1``).
+        # That stride used to inflate the dim's footprint and double every
+        # outer stride, so output row l read input row 2*l (issue #4050).
+        ("test_view_split_stick_slice", "test_view_split_stick_slice_cpu"): {
+            "param_sets": {
+                "head_half_lo": (
+                    (1, 8, 4, 128),
+                    lambda t: t[..., :64],
+                    cached_randn((1, 8, 512), differentiation="vss_lo"),
+                ),
+                "head_half_hi_offset": (
+                    (1, 8, 4, 128),
+                    lambda t: t[..., 64:],
+                    cached_randn((1, 8, 512), differentiation="vss_hi"),
+                ),
+                "head_sub_stick": (
+                    (1, 8, 4, 128),
+                    lambda t: t[..., :32],
+                    cached_randn((1, 8, 512), differentiation="vss_sub"),
+                ),
+                "transposed_head_half_lo": (
+                    (1, 8, 4, 128),
+                    lambda t: t.transpose(1, 2)[..., :64],
+                    cached_randn((1, 8, 512), differentiation="vss_tlo"),
+                ),
+                "transposed_head_half_hi_offset": (
+                    (1, 8, 4, 128),
+                    lambda t: t.transpose(1, 2)[..., 64:],
+                    cached_randn((1, 8, 512), differentiation="vss_thi"),
+                ),
+                "batched_head_half_lo": (
+                    (4, 8, 4, 128),
+                    lambda t: t[..., :64],
+                    cached_randn((4, 8, 512), differentiation="vss_b4"),
+                ),
+                "quarter_of_4_stick_head": (
+                    (1, 8, 4, 256),
+                    lambda t: t[..., :64],
+                    cached_randn((1, 8, 1024), differentiation="vss_q"),
+                ),
+                "step2_over_sticks": (
+                    (1, 8, 8, 64),
+                    lambda t: t[:, :, ::2, :],
+                    cached_randn((1, 8, 512), differentiation="vss_s2"),
+                ),
+                "step2_over_sticks_offset": (
+                    (1, 8, 8, 64),
+                    lambda t: t[:, :, 1::2, :],
+                    cached_randn((1, 8, 512), differentiation="vss_s2o"),
+                ),
+            },
+        },
+        # rotate_half on q/k built by view + transpose of the projection output:
+        # the HF attention pattern issue #4050 was reported against.
+        ("test_rope_on_split_stick_view", "test_rope_on_split_stick_view_cpu"): {
+            "param_sets": {
+                "b1_l8_h4_d128": (
+                    cached_randn((1, 8, 512), differentiation="rope_h"),
+                    cached_randn((1, 8, 128), differentiation="rope_cos"),
+                    cached_randn((1, 8, 128), differentiation="rope_sin"),
+                ),
+            },
+        },
         ("test_transpose_patterns", "test_transpose_patterns_cpu"): {
             "param_sets": _pattern_param_sets(),
         },
@@ -7233,6 +7297,37 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             return x.view(*x.shape, 1).permute(0, 3, 1, 2).mul(5.0)
 
         self.compare_with_cpu(fn, x)
+
+    def test_view_split_stick_slice_cpu(self, view_shape, slicer, x):
+        """View the stick dim as (heads, D), then slice or stride D.
+
+        Compiled path only: the eager path materialises such views through
+        copy_from_d2d, which rejects sub-stick offsets for unrelated reasons.
+        """
+
+        def fn(x):
+            return slicer(x.view(*view_shape)) * 1.0
+
+        self.compare_with_cpu(fn, x, run_eager=False)
+
+    def test_rope_on_split_stick_view_cpu(self, hidden, cos, sin):
+        """rotate_half on q and k that are view + transpose of one buffer."""
+        B, L, H, D = 1, 8, 4, 128
+
+        def rotate_half(t):
+            half = t.shape[-1] // 2
+            return torch.cat((-t[..., half:], t[..., :half]), dim=-1)
+
+        def fn(hidden, cos, sin):
+            q = hidden.view(B, L, H, D).transpose(1, 2)
+            k = hidden.view(B, L, H, D).transpose(1, 2)
+            cos = cos.unsqueeze(1)
+            sin = sin.unsqueeze(1)
+            q = (q * cos) + (rotate_half(q) * sin)
+            k = (k * cos) + (rotate_half(k) * sin)
+            return q.contiguous(), k.contiguous()
+
+        self.compare_with_cpu(fn, hidden, cos, sin, run_eager=False)
 
     # --- Migrated from test_ops.py ---
 

--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -515,6 +515,67 @@ class TestCoordinates(TestCase):
             )
 
 
+class TestAlignTensorsStridedTerm(TestCase):
+    """A coordinate that steps over a device dim (``2*d1``) must keep the dim's
+    footprint exact (issue #4050).
+
+    ``h.view(B, L, H, D)[..., :64]`` on a ``[B, L, H*D]`` input reads the
+    stick-tile dim as ``2*d1``: one head is two sticks and the slice keeps one.
+    """
+
+    def _tensors(self, stick_coord):
+        d0, d1, d2 = sympy.symbols("d0 d1 d2", integer=True, nonnegative=True)
+        it_space = {d0: (sympy.Integer(8), 1), d1: (sympy.Integer(4), 1), d2: (64, 1)}
+        zero = sympy.S.Zero
+        inp = {"size": [8, 8, 1, 64], "coordinates": [d0, stick_coord(d1), zero, d2]}
+        out = {"size": [4, 1, 1, 8, 64], "coordinates": [d1, zero, zero, d0, d2]}
+        return (d0, d1, d2), it_space, inp, out
+
+    def test_stride_realized_as_gap_keeps_footprint(self):
+        (d0, d1, d2), it_space, inp, out = self._tensors(lambda d1: 2 * d1)
+        _, tensors, _ = align_tensors(it_space, [inp, out])
+        aligned_in = tensors[0]
+        # 8 rows x 8 sticks x 64: a stride-2 walk over 4 heads must not inflate
+        # the stick-tile dim to 8 iterations *and* add a gap of 2 (it did, and
+        # doubled the row stride so output row l read input row 2*l).
+        self.assertEqual(sympy.prod(aligned_in["size"]), 8 * 8 * 64)
+        sizes = [int(s) for s in aligned_in["size"]]
+        gap_idx = sizes.index(2)
+        self.assertEqual(sizes[gap_idx - 1], 4, "stick-tile dim counted in iterations")
+        self.assertEqual(aligned_in["coordinates"][gap_idx - 1], d1)
+        self.assertEqual(aligned_in["coordinates"][gap_idx], 0)
+
+    def test_stride_with_residual_offset_selects_gap_position(self):
+        """``2*d1 + 1`` (e.g. ``[..., 64:]`` or ``[:, 1::2]``) keeps the +1.
+
+        The residual is below the stride, so it cannot live on the variable's
+        own coordinate; it hangs off a synthetic size-1 variable in the gap dim,
+        the same way an elided dim with an offset is restored.
+        """
+        (d0, d1, d2), it_space, inp, out = self._tensors(lambda d1: 2 * d1 + 1)
+        new_it_space, tensors, _ = align_tensors(it_space, [inp, out])
+        aligned_in = tensors[0]
+        self.assertEqual(sympy.prod(aligned_in["size"]), 8 * 8 * 64)
+        sizes = [int(s) for s in aligned_in["size"]]
+        gap_coord = aligned_in["coordinates"][sizes.index(2)]
+        synthetic = gap_coord.free_symbols
+        self.assertEqual(len(synthetic), 1)
+        z = next(iter(synthetic))
+        self.assertEqual(gap_coord, z + 1)
+        self.assertEqual(new_it_space[z][0], 1)
+        # The other tensor gains a size-1 dim for the synthetic variable.
+        self.assertIn(z, {s for c in tensors[1]["coordinates"] for s in c.free_symbols})
+
+    def test_stride_not_dividing_dim_is_rejected(self):
+        d0, d1, d2 = sympy.symbols("d0 d1 d2", integer=True, nonnegative=True)
+        it_space = {d0: (8, 1), d1: (3, 1), d2: (64, 1)}
+        zero = sympy.S.Zero
+        inp = {"size": [8, 7, 1, 64], "coordinates": [d0, 2 * d1, zero, d2]}
+        out = {"size": [3, 1, 1, 8, 64], "coordinates": [d1, zero, zero, d0, d2]}
+        with self.assertRaisesRegex(Unsupported, "does not divide"):
+            align_tensors(it_space, [inp, out])
+
+
 class TestUnrepresentableStickCandidates(TestCase):
     """Cover the skip-unrepresentable-candidate behavior added for the
     ``floor(var/N)`` cross-stick crash (transpose feeding a matmul).

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -626,6 +626,9 @@ def normalize_coordinates(
         for dim_term in dim_terms[::-1]:
             dim_term.offset = offset // dim_term.num
             offset %= dim_term.num
+        # Whatever is left is smaller than the smallest stride; it is placed
+        # inside the gap dim realized for that term below.
+        residual_offset = offset
 
         # split dims with n>1 terms
         split_dim_terms = []
@@ -656,6 +659,59 @@ def normalize_coordinates(
 
         # accumulate terms in reverse order to ensure non-increasing device strides
         terms += reversed(split_dim_terms)
+
+        # The innermost term is the only one that can still carry num > 1 (the
+        # loop above resets num for every other term): its variable steps over
+        # ``num`` elements of the device dim per iteration, e.g. ``2*d1`` from a
+        # stick-aligned slice of a stick dim that a view split in two, or from
+        # ``x[..., ::2, :]``.  Realize that stride as an explicit inner gap dim
+        # of size ``num`` so the address arithmetic stays exact:
+        #
+        # - the term's own extent must then be counted in iterations of its
+        #   variable.  For a lone term ``dim_size`` is still in device units,
+        #   so divide it by ``num`` -- leaving it inflates the dim, and with it
+        #   every outer stride (issue #4050: output row l read input row 2*l).
+        #   With several terms the split loop already sized it in iterations.
+        # - a residual constant offset below the stride (``2*d1 + 1``) selects
+        #   the position inside the gap.  Like any other constant offset on a
+        #   non-stick dim it needs a variable to hang off, so mint a synthetic
+        #   size-1 variable the same way the elided-dimension case above does.
+        #
+        # The stick dim (last coordinate) is left alone: within-stick strides
+        # are not representable and are rejected downstream.
+        inner = split_dim_terms[0]
+        if inner.num > 1 and dim_idx != len(size) - 1:
+            stride = inner.num
+            inner.num = sympy.S.One
+            if len(split_dim_terms) == 1:
+                if inner.dim_size % stride != 0:
+                    raise Unsupported(
+                        f"strided coordinate {coordinate} walks a dim of size "
+                        f"{dim_size} in steps of {stride}, which does not divide it"
+                    )
+                inner.dim_size //= stride
+            if residual_offset == 0:
+                terms.append(Term(None, None, None, None, stride))
+            else:
+                var = synthetic_var_fn()
+                var_ranges[var] = 1
+                terms.append(
+                    Term(
+                        sympy.S.One,
+                        sympy.S.One,
+                        var,
+                        sympy.S.One,
+                        stride,
+                        residual_offset,
+                    )
+                )
+        elif residual_offset != 0:
+            # Only a within-stick stride can get here (``2*d + 1`` on the stick
+            # dim); there is no gap dim to place the residual in.
+            raise Unsupported(
+                f"coordinate {coordinate} on dim {dim_idx} has offset "
+                f"{residual_offset} below its stride, which cannot be addressed"
+            )
 
     # fuse contiguous dimensions when possible
     # never fuse last dimension = stick dimension!
@@ -1030,10 +1086,9 @@ def align_tensors_pure(
                 size[-1] //= den
                 (offset, term) = coordinates[-1].as_coeff_Add()
                 coordinates[-1] = term // den + offset
-            if num > 1:
-                # iteration skips over elements in dim, realize gap as new dimension
-                size.append(num)
-                coordinates.append(sympy.S.Zero)
+            # normalize_coordinates realizes any stride (num > 1) on a
+            # non-stick dim as an explicit gap term, so nothing is left here.
+            assert num == 1, f"unexpected stride {num} on non-stick term for {var}"
         # add stick dim
         num, den, var, mod, dim_size, offset = astuple(terms[-1])
         size.append(dim_size)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

A view that splits the stick dim into `(heads, D)` and then slices or strides `D` returned wrong values under `torch.compile`: `h.view(B, L, H, D)[..., :64]`, `rotate_half` on a transposed q/k built from a projection, `x[:, :, ::2, :]`. The HF attention block in #4050 was off by thousands. The smallest form is

```python
h = torch.randn(1, 8, 512, dtype=torch.float16)
fn = lambda h: h.view(1, 8, 4, 128)[..., :64] * 1.0   # output row l held input row 2*l
```

**Root cause (`views.py`).** The read coordinate on the stick-tile dim is `2*d1`: one head spans two sticks and the slice keeps one. For such a lone strided term `normalize_coordinates` left `num=2` with `dim_size` still in device units (8 sticks), and `align_tensors_pure` then appended a gap dim of size 2 inside it. The dim's footprint became 16 sticks instead of 8, doubling every outer stride. A sub-stride offset (`2*d1 + 1` from `[..., 64:]` or `[:, 1::2]`) was additionally discarded by `offset %= num`, so those slices read the even sticks. Native 4-D inputs are unaffected because their stick dim is never split; 2-D inputs hid the bug because their stick-tile dim is outermost, so nothing sits outside the inflated dim.

**Fix.** `normalize_coordinates` now realizes a stride on a non-stick dim as an explicit inner gap `Term` (size `num`, coordinate 0), counts a lone strided term's extent in iterations of its variable (raising `Unsupported` when the stride does not divide the dim), and carries a sub-stride offset on a synthetic size-1 variable as `z + offset`, the same convention the elided-dimension path already uses. The construction-time `if num > 1` gap branch in `align_tensors_pure` is removed; a leftover within-stick offset raises `Unsupported` instead of asserting.

**Tests.** Three `align_tensors` unit tests in `tests/tensor/test_coordinates.py` (footprint, residual offset, non-divisible stride) and ten end-to-end tests in `tests/inductor/test_inductor_ops.py` (nine view/slice/stride shapes plus a RoPE case). All ten end-to-end tests fail without the fix and pass with it.

**Also resolved.** Two documented limitations in `tests/inductor/test_copy_from_d2d_offsets.py` are the same defect: the D2D copy reads its source as a flat `[sticks, 64]` layout whose stick-tile coordinate is `2*c0 + 1`, so `x.narrow(1, 64, 64).clone()` (the file's "sole remaining silent-wrong-data case") and `x[1::2].clone()` now return correct data. Their `expectedFailure` markers are removed and the docstrings updated; the transpose cases stay expected failures (a restickify limitation, unrelated).

#### Which issue(s) this PR is related to:

Fixes #4050

The issue was closed today crediting #4200, but the reporter's script from the issue description still fails verbatim on `main` at `58b5a676` (which includes #4200) with the Inductor cache disabled; see the comment on the issue.

#### Special notes for your reviewer:

Verified on hardware with `TORCHINDUCTOR_FORCE_DISABLE_CACHES=1` (the Inductor cache does not key on torch-spyre sources, so a stale kernel can mask changes here):

| Check | Result |
|---|---|
| Reporter's script, verbatim, `main` without fix | 8 of 13 cases fail (transpose+RoPE max 9.5, RoPE+Q@K^T max 32005, full attention inf) |
| Reporter's script, verbatim, with fix | every layout-error case passes; remaining diffs are fp16 matmul precision, identical with/without the fix on the pure `linear` case |
| Full attention block vs fp32 reference, with fix | within 0.4% (logits reach ~2000; `atol=0.01` is tighter than fp16 allows there) |
| `tests/tensor/test_coordinates.py` | 29 passed |
| new end-to-end tests | 10 passed with fix, 10 failed without |
| `tests/inductor/test_inductor_ops.py -k "slice or view or offset or transpose or storage or cat or rope or unbind or split or permute or narrow"` | 511 passed, 12 xfailed |
| `tests/inductor/test_restickify.py` | 341 passed |
| `tests/inductor/test_coarse_tile_e2e.py` (full) | 230 passed, 18 skipped, 1 xfailed |
| `tests/inductor/test_building_blocks.py` (full) | 28 passed |
| `tests/inductor/test_padding.py` | 16 passed |
| `tests/inductor/test_copy_from_d2d_offsets.py` | 12 passed, 3 xfailed (was 10 passed, 5 xfailed) |

Interaction to be aware of: #3981 (@ani300) adds a synthetic-axis provenance check in `align_tensors_pure` that expects one synthetic variable per constant size>1 axis in the input coordinates. The sub-stride-offset case here mints a synthetic variable from a non-constant coordinate (`2*d1 + 1`), so whichever of the two lands second will need a small adjustment to that check.

#### Does this PR introduce a user-facing change?

Yes: compiled views that slice or stride a split stick dim (e.g. HF-style RoPE on `view(...).transpose(1, 2)` of a projection) now return correct values. No new flags.

#### Additional note:

Draft while CI runs.
