### PR TITLE
fix(scratchpad): let LX residency free the producing write in the SA cost objective

### DIFF
--- a/docs/source/compiler/sa_co_optimization.md
+++ b/docs/source/compiler/sa_co_optimization.md
@@ -71,6 +71,13 @@ The engine builds it itself from the ambient `V.graph`, because it has to: the o
 per-division `OpFeatures` and the bundle grouping, and the allocator's `CoreDivisionSolverFactory`
 passes only `(buffers, size, alignment)`.
 
+Residency frees a buffer's reads **and its producing write**, which is the same quantity the two
+memory-only objectives price as `spill_cost`'s `+1 if is_intermediate`. Only an intermediate's
+write is freed: the clone that pins a resident graph boundary buffer is inserted after the solve,
+so nothing in the featurized graph pays for its HBM write-out. The engine therefore passes the
+solver's `BufferType.Intermediate` set as `intermediates`. Matching an arg to the resident set is
+by name, so an op's output `ArgTraffic` is named after the *buffer* it writes, not the operation.
+
 **Memory-only** is the fallback, taken when there is no live graph — the normal case for anything
 driving serialized captures, including the tests. It counts the HBM traffic a spill adds over
 residency, converted once to fixed-point microseconds. Being *differential*, a resident buffer
@@ -112,7 +119,10 @@ opt-in via `SA_COOPT_LARGE_CAPTURES=1` because they are slow.
 The cost objective needs features as well, so it is driven from
 `cooptimization_captures_regen.json` paired with `cooptimization_op_features.json`. The two must
 come from the same compile: every Inductor graph names its buffers `buf0..`, so names collide
-across unrelated graphs without lining up. Scores are **not comparable** between the two corpora
+across unrelated graphs without lining up. The features fixture predates output args being named
+after their buffer, so the test module respells them on load
+(`_name_output_args_after_their_buffer`); drop that when the fixture is next regenerated. Scores
+are **not comparable** between the two corpora
 — they were captured from different pipeline revisions. Regenerating either requires a Spyre
 machine, since the feature extractor reads live Inductor IR.
 

--- a/tests/inductor/test_cost_objective.py
+++ b/tests/inductor/test_cost_objective.py
@@ -44,7 +44,26 @@ def _graph(name="simple_attn"):
         n: [None if f is None else op_from_dict(f) for f in b["features"]]
         for n, b in g["buffers"].items()
     }
+    _name_output_args_after_their_buffer(features)
     return names, features
+
+
+def _name_output_args_after_their_buffer(features):
+    """Respell each op's output arg with the buffer it writes.
+
+    The fixture predates ``extract_op_features`` naming that arg after the buffer
+    (it carries the old ``"op7"`` for a record whose buffer is ``"buf7"``), and
+    regenerating it needs a Spyre machine. Without this the fixture-driven tests
+    below never cross the seam the naming exists for -- a resident buffer's write
+    would silently stay charged, which is the bug the naming fixed.
+    """
+    for buf, menu in features.items():
+        for feat in menu:
+            if feat is None:
+                continue
+            for arg in feat.args:
+                if arg.role == "output":
+                    arg.name = buf
 
 
 def _objective(names, features, bundles=None):
@@ -121,6 +140,61 @@ class CacheAgreesWithFullRecomputeTest(TestCase):
         a = obj.score(chosen, frozenset(names[:2]))
         obj.score([1 if i == 0 else c for i, c in enumerate(chosen)], frozenset())
         self.assertEqual(obj.score(chosen, frozenset(names[:2])), a)
+
+
+class ResidencyFreesTheProducingWriteTest(TestCase):
+    """Residency frees an intermediate's write, not just its reads.
+
+    This is the seam the rest of the module does not touch: the resident set is
+    spelled the way the *solver* spells it -- buffer names -- and an op's output
+    arg has to be spelled the same way or its write stays charged. Both
+    memory-only objectives price that write (``spill_cost``'s
+    ``+1 if is_intermediate``), so the cost objective has to as well.
+    """
+
+    def test_freeing_the_write_lowers_the_score(self):
+        names, features = _graph("softmax")
+        chosen = [0] * len(names)
+        resident = frozenset(names)
+        reads_only = BundleCostObjective(
+            names, features, [names], intermediates=frozenset()
+        ).score_from_scratch(chosen, resident)
+        both = BundleCostObjective(
+            names, features, [names], intermediates=frozenset(names)
+        ).score_from_scratch(chosen, resident)
+        self.assertLess(both, reads_only)
+
+    def test_a_boundary_buffer_keeps_its_write(self):
+        # A graph output's write-out survives residency: the clone that pins it
+        # is inserted after the solve, so nothing in the featurized graph pays
+        # for it. Excluding one buffer from ``intermediates`` must therefore
+        # cost strictly more than including it.
+        names, features = _graph("softmax")
+        chosen = [0] * len(names)
+        resident = frozenset(names)
+        boundary = names[-1]
+        with_it = BundleCostObjective(
+            names, features, [names], intermediates=frozenset(names)
+        ).score_from_scratch(chosen, resident)
+        without = BundleCostObjective(
+            names, features, [names], intermediates=frozenset(names) - {boundary}
+        ).score_from_scratch(chosen, resident)
+        self.assertGreater(without, with_it)
+
+    def test_residency_of_a_write_only_buffer_dirties_its_bundle(self):
+        # The write side only reaches the incremental path if the dirty map
+        # routes a residency change to the bundle that WRITES the buffer, which
+        # it does through the output arg's name. One bundle per buffer makes the
+        # routing observable.
+        names, features = _graph("softmax")
+        obj = BundleCostObjective(
+            names, features, [[n] for n in names], intermediates=frozenset(names)
+        )
+        chosen = [0] * len(names)
+        base = obj.score(chosen, frozenset())
+        moved = obj.score(chosen, frozenset({names[0]}))
+        self.assertNotEqual(moved, base)
+        self.assertEqual(moved, obj.score_from_scratch(chosen, frozenset({names[0]})))
 
 
 class StructureTest(TestCase):

--- a/torch_spyre/_inductor/dump_cost_model.py
+++ b/torch_spyre/_inductor/dump_cost_model.py
@@ -652,10 +652,14 @@ def extract_op_features(
     in_factor = 1 if (tiles_out_dim or is_tiled_red) else loop_trip
 
     args: list = []
-    # Output arg (device-sized).
+    # Output arg (device-sized). Named after the BUFFER written, not the operation
+    # (``get_operation_name()`` -> "op7" vs ``get_name()`` -> "buf7"), so it is
+    # spelled the way the reads are and the way every caller that reasons about
+    # residency spells a buffer. Naming it after the op silently defeated
+    # ``with_residency``, which matches arg names against a set of buffer names.
     args.append(
         ArgTraffic(
-            name=op.get_operation_name(),
+            name=op.get_name(),
             role="output",
             is_lx=is_lx,
             elems=out_elems,

--- a/torch_spyre/_inductor/scratchpad/cost_objective.py
+++ b/torch_spyre/_inductor/scratchpad/cost_objective.py
@@ -63,18 +63,36 @@ from torch_spyre._inductor.scratchpad.allocator import _COST_PARAMS
 logger = get_inductor_logger("scratchpad.cost_objective")
 
 
-def with_residency(features: OpFeatures, lx_names: AbstractSet[str]) -> OpFeatures:
+def with_residency(
+    features: OpFeatures,
+    lx_names: AbstractSet[str],
+    write_lx_names: Optional[AbstractSet[str]] = None,
+) -> OpFeatures:
     """``features`` with each argument's ``mem`` set from ``lx_names``.
 
     The cost model charges an LX-resident argument no HBM traffic, so this is
     what turns a placement decision into a cost. Returns a new object; the input
     is left alone so one extracted menu can be scored against many candidate
     placements.
+
+    Residency frees an op's *output* arg too -- the producing write becomes an LX
+    write -- which is the ``+1 if is_intermediate`` term both memory-only
+    objectives price (``_LifetimeBufferWithCpVars.spill_cost``,
+    ``SaCoOptimizingSolver._spill_cost``). ``write_lx_names`` narrows the set that
+    applies to output args, since that saving is real only for an intermediate: a
+    resident graph output still gets written to HBM by the clone ``_apply_plan``
+    inserts *after* the solve, and no op in the featurized graph pays for it.
+    Defaults to ``lx_names``.
     """
+    writes = lx_names if write_lx_names is None else write_lx_names
     return dataclasses.replace(
         features,
         args=[
-            dataclasses.replace(a, is_lx=(a.name in lx_names)) for a in features.args
+            dataclasses.replace(
+                a,
+                is_lx=(a.name in (writes if a.role == "output" else lx_names)),
+            )
+            for a in features.args
         ],
     )
 
@@ -91,6 +109,10 @@ class BundleCostObjective:
         bundles: groups of buffer names, one per fused kernel (see
             ``fusion.estimate_bundles``). Names not in ``buffer_names`` are
             ignored, so a bundle may legitimately end up empty and is dropped.
+        intermediates: the buffers whose *producing write* residency frees --
+            the solver's ``BufferType.Intermediate`` ones. ``None`` (the
+            default) means every buffer's does; see :func:`with_residency` for
+            why a graph boundary buffer's does not.
     """
 
     def __init__(
@@ -98,10 +120,12 @@ class BundleCostObjective:
         buffer_names: Sequence[str],
         features: dict[str, list[Optional[OpFeatures]]],
         bundles: Sequence[Sequence[str]],
+        intermediates: Optional[AbstractSet[str]] = None,
     ) -> None:
         self._names = list(buffer_names)
         self._index = {name: i for i, name in enumerate(self._names)}
         self._features = features
+        self._intermediates = intermediates
         # Bundles as solver indices, dropping names this solver does not own
         # (graph inputs, constants) and any bundle left empty by that filter.
         self._bundles: list[tuple[int, ...]] = []
@@ -141,7 +165,11 @@ class BundleCostObjective:
     def _arg_names_of(self, b: int) -> set[str]:
         """Every argument name any op in bundle ``b`` touches, over all of its
         candidate divisions. Taken across the whole menu deliberately: the set
-        must not change as the search moves, or the dirty map would go stale."""
+        must not change as the search moves, or the dirty map would go stale.
+
+        This includes each member's own output buffer, so toggling a buffer's
+        residency dirties the bundle that *writes* it as well as those that read
+        it -- which is what makes the freed write visible to dirty tracking."""
         names: set[str] = set()
         for i in self._bundles[b]:
             for feat in self._features.get(self._name(i), ()) or ():
@@ -157,6 +185,9 @@ class BundleCostObjective:
     def _bundle_features(
         self, b: int, chosen: Sequence[int], resident: AbstractSet[str]
     ) -> list[OpFeatures]:
+        writes = (
+            resident if self._intermediates is None else resident & self._intermediates
+        )
         out = []
         for i in self._bundles[b]:
             menu = self._features.get(self._name(i))
@@ -164,7 +195,7 @@ class BundleCostObjective:
                 continue
             feat = menu[chosen[i]] if chosen[i] < len(menu) else None
             if feat is not None:
-                out.append(with_residency(feat, resident))
+                out.append(with_residency(feat, resident, writes))
         return out
 
     def _bundle_key(

--- a/torch_spyre/_inductor/scratchpad/sa_cooptimizer.py
+++ b/torch_spyre/_inductor/scratchpad/sa_cooptimizer.py
@@ -177,7 +177,14 @@ def _bundle_objective(
     bundles = [
         [op.get_name() for op in group] for group in estimate_bundles(graph.operations)
     ]
-    return BundleCostObjective([b.name for b in buffers], features, bundles)
+    # Only an intermediate's producing write is saved by residency; a graph
+    # boundary buffer's is not (see :func:`with_residency`).
+    intermediates = frozenset(
+        b.name for b in buffers if b.boundary == BufferType.Intermediate
+    )
+    return BundleCostObjective(
+        [b.name for b in buffers], features, bundles, intermediates
+    )
 
 
 class SaCoOptimizingSolver(CoreDivisionLayoutSolver):


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

`BundleCostObjective` prices LX residency by matching an `OpFeatures` argument's name against the solver's resident set, which holds **buffer** names. But `extract_op_features` named an op's output `ArgTraffic` after the **operation** (`op.get_operation_name()` -> `"op7"`) while its inputs carry the buffer read (`"buf7"`), so the output arg never matched: a resident buffer's reads were freed and its producing write stayed charged in full.

Two changes:

1. `dump_cost_model.py` names the output arg `op.get_name()` — the buffer it writes, spelled the way the reads are and the way every caller that reasons about residency spells a buffer. (`_lx_relayout_features` a hundred lines above already has to make exactly this distinction, with a comment saying so.)

2. `BundleCostObjective` takes an `intermediates` set and `with_residency` a `write_lx_names`, so only an intermediate's write is freed. A resident graph *boundary* buffer's write is not saved: the clone that pins it is inserted in `_apply_plan`, **after** the solve, so no op in the featurized graph pays for its HBM write-out. That is the same `boundary != Intermediate` cancellation both memory-only objectives already document.

The naming change also fixes dirty tracking for free — `_arg_names_of` now yields each bundle member's own output buffer, so toggling a buffer's residency dirties the bundle that *writes* it as well as those that read it.

A hand-checkable illustration of the accounting. `A` writes `buf1`, `B` reads it, one bundle, one fp16 tensor of 1024 device elements = 2048 B, nothing tiled or broadcast, so `_fused_hbm_bytes` is a plain sum:

| residency | read | write | total | saving |
|---|---|---|---|---|
| nothing resident | 4096 | 4096 | 8192 | 0 |
| `buf1` resident, write not freed (before) | 2048 | 4096 | 6144 | 2048 |
| `buf1` resident, write freed (after) | 2048 | 2048 | 4096 | 4096 |

`buf1`'s own traffic is one store plus one load = 4096 B, which is exactly what residency removes after the change. Before it, the 2048 B kept is `A`'s store of `buf1` to HBM in a plan where `B` loads that same buffer from LX — no placement does both.

Measured on the 10 scoreable graphs in `cooptimization_op_features.json` (card-free), the residency benefit the objective can see grows **1.5–2.4x**, and it changes decisions:

| graph | residency benefit | resident buffers |
|---|---|---|
| softmax | 69.0% -> 90.5% | 5 -> 5 |
| rms_norm | 57.7% -> 75.2% | 6 -> 6 |
| flash_big | 3.7% -> 5.6% | 46 -> **49** |
| flash_attention | 2.0% -> 3.0% | 18 -> **25** |
| block_x2 / x3 / x4 | 0.3% -> 0.5% | unchanged |
| sdpa / simple_attn / mlp | 0.2% -> 0.4% | unchanged |

137 division choices differ across the corpus.

#### Which issue(s) this PR is related to:

Refs #4233 — this is the second of the two in-tree defects that issue names as sitting on the critical path, the one that has to be fixed *before* the search is tuned against the residency signal rather than after. It does not close the issue.

#### Special notes for your reviewer:

**Opened as a draft for discussion.** A different change may remove the need for this one, so it is worth agreeing on the target semantics before polishing. The two halves are separable if that helps: change 1 (the naming) is the load-bearing one and is what every number above comes from; change 2 (the `intermediates` gate) is semantic parity with `spill_cost` and is measurably inert on the current corpus.

Why the gate is inert here, and it is structural rather than luck: every graph output in the captured corpus is *terminal*, so `_read_count(uses) == 0` bars it pre-solve with `'no consumer reads it from LX'` — all 11 graphs. The gate fires for a graph output that is *also* consumed in-graph, where `_read_count > 0`. It is not dead code either: `"clone"` is absent from `OP_OUTPUT_NOT_GOOD_FOR_LX_REUSE`, so `clone_at_graph_boundaries()` is unconditionally true.

Two related things deliberately **not** changed here, both worth a view:

- **The read-side mirror, which does bind today.** Pinning a graph input inserts a clone (also in `_apply_plan`, also after the solve) that reads the input from HBM once. That clone does not exist while the search runs, so the objective frees *every* load of the input and charges nobody for the one load the clone-in still performs. The error is exactly one HBM load of the input, independent of how the readers fuse. All four clone-eligible graph inputs in the corpus are resident in the fixed engine, so this is live: 1 MB over-credited on `softmax`, 512 KB on `flash_big`, 256 KB on `flash_attention`, 64 KB on `rms_norm`. `spill_cost` handles the same thing explicitly, via `reads_served = read_count - (1 if first_use_is_read else 0)`; the cost objective has no equivalent. Fixing it means leaving one reader's load charged, which a name set cannot express, so it wants its own discussion.

- **The CP-SAT symbolic path.** `allocator._extract_op_features` builds the output `ArgTraffic` with `is_lx = buf.sym_is_lx`, so that engine *already* frees the write — symbolically, and with no `Intermediate` gate, so it over-credits a resident non-terminal graph output by one full write-out. Left alone on purpose. Note for anyone who picks it up: the same `is_lx` local also feeds `tile_rows_per_core`, where it correctly means "is this an LX buffer already allocated per tile, or a full HBM buffer whose per-tile slice is `rows / loop_trip`" — so a fix has to gate the value handed to the output `ArgTraffic` alone, not the shared local.

On the test fixture. `cooptimization_op_features.json` predates the naming, so the fixture-driven tests would silently stop crossing the seam the naming exists for. Regenerating it needs a Spyre machine and would move every score in the corpus, so instead the test module respells output args on load (`_name_output_args_after_their_buffer`) with a comment saying to drop that at the next regeneration. Happy to regenerate instead if reviewers prefer that.

No test pinned the old behaviour, which is why this survived: `test_op_features.ResidencyTest` builds its resident set as `{a.name for a in op.args}`, so it never crosses the seam where buffer names meet operation-named output args. Three tests added for the seam itself, spelled the way the *solver* spells a resident set.

Verification: `test_cost_objective` + `test_op_features` (23), `test_sa_cooptimizer` + `test_cooptimization_types` (61), `test_cost_model_pass` (62), `test_scratchpad_solver` / `test_scratchpad_patterns` / `test_perm_layout_solver` / `test_cost_model_decode` (441) all pass. ruff, ruff format, PyMarkdown and mypy clean.

#### Does this PR introduce a user-facing change?

No API change. It does change the plans chosen under `LAYOUT_SOLVER=simulated_annealing` together with `co_optimizing_lx_planning`, which is the only route that reaches `BundleCostObjective`. Every score above is the cost model's own prediction; no device time has been measured for this change.

#### Additional note:

Audited for the naming change: nothing outside `cost_objective` resolves an output `ArgTraffic`'s name. `_fused_hbm_bytes`' external-input dedup keys on `role == "input" and name.startswith("arg")`; `read_bytes` / `write_bytes` / `lx_bytes` and `tools/cost_model/eval_model.py` key on `role` alone. Recorded datasets change only a label, and `op_from_dict` is schema-tolerant.
