### PR TITLE
fix(inductor): align scatter sources with index sticks

### DIFF
--- a/tests/inductor/test_building_blocks.py
+++ b/tests/inductor/test_building_blocks.py
@@ -209,32 +209,33 @@ class TestBuildingBlocks(unittest.TestCase):
         # input before its fp16-to-fp32 upcast: the reduction result is STANDARD
         # and has to broadcast along the normalized axis against the staggered
         # upcast tensor.
-        B, S, H = 1, 64, 1536
+        B, S = 1, 64
         eps = 1e-6
-        for dtype in (torch.float16, torch.bfloat16):
-            with self.subTest(dtype=dtype):
-                hidden = torch.randn(B, S, H, dtype=dtype)
-                weight = torch.randn(H, dtype=dtype)
+        for H in (1536, 3840):
+            for dtype in (torch.float16, torch.bfloat16):
+                with self.subTest(hidden_size=H, dtype=dtype):
+                    hidden = torch.randn(B, S, H, dtype=dtype)
+                    weight = torch.randn(H, dtype=dtype)
 
-                def rms_norm(hidden, weight):
-                    x = hidden.to(torch.float32)
-                    var = x.pow(2).mean(-1, keepdim=True)
-                    normed = x * torch.rsqrt(var + eps)
-                    return weight * normed.to(dtype)
+                    def rms_norm(hidden, weight):
+                        x = hidden.to(torch.float32)
+                        var = x.pow(2).mean(-1, keepdim=True)
+                        normed = x * torch.rsqrt(var + eps)
+                        return weight * normed.to(dtype)
 
-                expected = rms_norm(hidden, weight)
-                hidden_layout = SpyreTensorLayout(
-                    hidden.size(), hidden.stride(), hidden.dtype, [0, 2, 1]
-                )
-                hidden_device = hidden.to(device_layout=hidden_layout)
-                weight_device = weight.to(DEVICE)
-                actual = torch.compile(rms_norm)(hidden_device, weight_device).cpu()
-                torch.testing.assert_close(
-                    actual,
-                    expected,
-                    atol=0.1,
-                    rtol=0.1,
-                )
+                    expected = rms_norm(hidden, weight)
+                    hidden_layout = SpyreTensorLayout(
+                        hidden.size(), hidden.stride(), hidden.dtype, [0, 2, 1]
+                    )
+                    hidden_device = hidden.to(device_layout=hidden_layout)
+                    weight_device = weight.to(DEVICE)
+                    actual = torch.compile(rms_norm)(hidden_device, weight_device).cpu()
+                    torch.testing.assert_close(
+                        actual,
+                        expected,
+                        atol=0.1,
+                        rtol=0.1,
+                    )
 
     def test_chained_rms_norm_fp32_upcast(self):
         B, S, H = 1, 64, 2816

--- a/tests/inductor/test_ea_bidirectional_conversion.py
+++ b/tests/inductor/test_ea_bidirectional_conversion.py
@@ -127,7 +127,8 @@ def test_fp32_to_fp16_standard_input(device, mode, fp16):
     x = torch.randn(4, 128, device=device, dtype=torch.float32)
     result = _run(fn, x, mode=mode)
 
-    # Verify output EA
+    # Eager and compiled casts use the same compiled D2D conversion path, so
+    # both preserve the hardware conversion's staggered element arrangement.
     assert_ea(result, ElementArrangement.FP32_TO_DL16)
 
     # Note: Cannot compare tensors with non-STANDARD EA directly with CPU

--- a/tests/inductor/test_indirect_access_scatter.py
+++ b/tests/inductor/test_indirect_access_scatter.py
@@ -156,6 +156,68 @@ class _ScatterScenarios:
         ).to("cpu")
         torch.testing.assert_close(actual, expected)
 
+    def test_index_copy_transposed_source(self):
+        """Scatter a computed ``[B, L, H, D] -> [B, H, L, D]`` view.
+
+        RoPE produces K in this form before writing it into a pinned KV cache.
+        The scatter must honor the view's source layout without requiring an
+        explicit ``contiguous()`` materialization in the model.
+        """
+        Bn, H, L, D, M = 1, 8, 64, 256, 128
+        dtype = torch.bfloat16
+        src = torch.randn(Bn, L, H, D, dtype=dtype)
+        freqs = torch.randn(Bn, L, 2, 2, D // 2, dtype=dtype)
+        dst = torch.zeros(Bn, H, M, D, dtype=dtype)
+        cache_layout = SpyreTensorLayout(
+            device_size=[
+                M,
+                H,
+                D // get_elem_in_stick(dtype),
+                Bn,
+                get_elem_in_stick(dtype),
+            ],
+            stride_map=[D, M * D, get_elem_in_stick(dtype), H * M * D, 1],
+            device_dtype=get_device_dtype(dtype),
+        )
+
+        def apply_rope(src, freqs):
+            source = src.transpose(1, 2)
+            source = source.transpose(1, 2).reshape(Bn, L, H, 2, D // 2)
+            return (
+                freqs[:, :, None, :, :, :]
+                .mul(source.unsqueeze(-3))
+                .sum(4, keepdim=True)
+                .flatten(3)
+                .transpose(1, 2)
+            )
+
+        def kernel(dst, src, freqs, idx):
+            source = apply_rope(src, freqs)
+            dst.index_copy_(2, idx, source)
+            return dst
+
+        def kernel_with_contiguous_source(dst, src, freqs, idx):
+            source = apply_rope(src, freqs).contiguous()
+            dst.index_copy_(2, idx, source)
+            return dst
+
+        spyre_src = src.to("spyre")
+        spyre_freqs = freqs.to("spyre")
+        idx = torch.arange(L, dtype=torch.int64)
+        actual = torch.compile(kernel, dynamic=False)(
+            dst.to("spyre", device_layout=cache_layout),
+            spyre_src,
+            spyre_freqs,
+            idx.to("spyre"),
+        ).to("cpu")
+        expected = torch.compile(kernel_with_contiguous_source, dynamic=False)(
+            dst.to("spyre", device_layout=cache_layout),
+            spyre_src,
+            spyre_freqs,
+            idx.to("spyre"),
+        ).to("cpu")
+        torch.testing.assert_close(actual, expected)
+
     def test_index_put_p7(self):
         """y[idx] = src -- 1-D scatter with an odd (non-power-of-2) P=7."""
         M, N, P = 16, 1024, 7

--- a/tests/inductor/test_indirect_access_scatter.py
+++ b/tests/inductor/test_indirect_access_scatter.py
@@ -165,8 +165,9 @@ class _ScatterScenarios:
         """
         Bn, H, L, D, M = 1, 8, 64, 256, 128
         dtype = torch.bfloat16
-        src = torch.randn(Bn, L, H, D, dtype=dtype)
-        freqs = torch.randn(Bn, L, 2, 2, D // 2, dtype=dtype)
+        generator = torch.Generator().manual_seed(0)
+        src = torch.randn(Bn, L, H, D, dtype=dtype, generator=generator)
+        freqs = torch.randn(Bn, L, 2, 2, D // 2, dtype=dtype, generator=generator)
         dst = torch.zeros(Bn, H, M, D, dtype=dtype)
         cache_layout = SpyreTensorLayout(
             device_size=[
@@ -204,19 +205,23 @@ class _ScatterScenarios:
         spyre_src = src.to("spyre")
         spyre_freqs = freqs.to("spyre")
         idx = torch.arange(L, dtype=torch.int64)
+        expected = kernel(dst.clone(), src, freqs, idx)
         actual = torch.compile(kernel, dynamic=False)(
             dst.to("spyre", device_layout=cache_layout),
             spyre_src,
             spyre_freqs,
             idx.to("spyre"),
         ).to("cpu")
-        expected = torch.compile(kernel_with_contiguous_source, dynamic=False)(
+        contiguous_actual = torch.compile(kernel_with_contiguous_source, dynamic=False)(
             dst.to("spyre", device_layout=cache_layout),
             spyre_src,
             spyre_freqs,
             idx.to("spyre"),
         ).to("cpu")
-        torch.testing.assert_close(actual, expected)
+        torch.testing.assert_close(actual, contiguous_actual)
+        # CPU and Spyre may accumulate the two-term bf16 RoPE reduction in a
+        # different order; layout corruption is orders of magnitude larger.
+        torch.testing.assert_close(actual, expected, atol=0.03, rtol=0.02)
 
     def test_index_put_p7(self):
         """y[idx] = src -- 1-D scatter with an odd (non-power-of-2) P=7."""

--- a/tests/inductor/test_scatter_layout_helpers.py
+++ b/tests/inductor/test_scatter_layout_helpers.py
@@ -25,12 +25,15 @@ import unittest
 import sympy
 import torch
 
-from torch_spyre._C import SpyreTensorLayout, get_device_dtype
+from torch_spyre._C import ElementArrangement, SpyreTensorLayout, get_device_dtype
 from torch_spyre._inductor.enforce_indirect_access_layout import (
+    _dense_scatter_source_stl,
     _dim_order_is_compliant,
     _indirect_stride_idx,
     _build_required_stl,
 )
+from torch_spyre._inductor.errors import Unsupported
+from torch_spyre._inductor.ir import FixedTiledLayout
 from torch_spyre._inductor.op_spec import IndirectAccess
 
 
@@ -174,6 +177,55 @@ class TestBuildRequiredStl(unittest.TestCase):
         self.assertEqual(required_stl.device_size[1], 2)
         # Stick stays at end
         self.assertEqual(required_stl.device_size[3], 1)
+
+
+class TestDenseScatterSourceStl(unittest.TestCase):
+    def test_preserves_logical_dtype_and_element_arrangement(self):
+        host_size = [1, 64, 8, 2, 1, 128]
+        host_stride = [131072, 2048, 256, 128, 128, 1]
+        source_stl = SpyreTensorLayout(
+            [128, 8, 4, 1, 64],
+            [256, 32768, 64, 262144, 1],
+            get_device_dtype(torch.bfloat16),
+            ElementArrangement.FP32_TO_DL16,
+        )
+        layout = FixedTiledLayout(
+            torch.device("spyre"),
+            torch.bfloat16,
+            host_size,
+            host_stride,
+            source_stl,
+        )
+
+        dense = _dense_scatter_source_stl(layout)
+
+        self.assertEqual(dense.device_dtype, source_stl.device_dtype)
+        self.assertEqual(dense.element_arrangement, source_stl.element_arrangement)
+        self.assertEqual(
+            dense,
+            SpyreTensorLayout(
+                host_size,
+                host_stride,
+                torch.bfloat16,
+                list(range(len(host_size))),
+                source_stl.element_arrangement,
+            ),
+        )
+
+    def test_rejects_non_dl16_source(self):
+        host_size = [64, 32]
+        host_stride = [32, 1]
+        source_stl = SpyreTensorLayout(host_size, torch.float32)
+        layout = FixedTiledLayout(
+            torch.device("spyre"),
+            torch.float32,
+            host_size,
+            host_stride,
+            source_stl,
+        )
+
+        with self.assertRaisesRegex(Unsupported, "ReStickifyOpHBM does not support"):
+            _dense_scatter_source_stl(layout)
 
 
 if __name__ == "__main__":

--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -48,6 +48,7 @@ from torch_spyre._inductor.views import (
     compute_coordinates,
     normalize_coordinates,
     tiling_expr_to_device_expr,
+    UnalignedStickSplit,
 )
 from torch.utils._sympy.functions import FloorDiv, ModularIndexing
 
@@ -209,6 +210,139 @@ class TestCoordinates(TestCase):
             high_var = remap[hd][1][0]
             self.assertEqual(iteration_space[high_var][0], 32)
             self.assertTrue(all(size > 0 for size in tensors[0]["size"]))
+
+    def test_align_tensors_rejects_internal_boundary_inside_stick(self):
+        """A peer's factorization must not split an int32 physical stick."""
+        entry, head, width = sympy.symbols(
+            "entry head width", integer=True, nonnegative=True
+        )
+        indirect = sympy.Symbol("indirect", integer=True, nonnegative=True)
+        tensors = [
+            {
+                "size": [2, 32],
+                "coordinates": [
+                    sympy.floor(entry / 32),
+                    sympy.Mod(entry, 32),
+                ],
+            },
+            {
+                "size": [128, 8, 4, 1, 64],
+                "coordinates": [
+                    head + 8 * sympy.Mod(entry, 16),
+                    sympy.floor(entry / 16),
+                    sympy.floor(width / 64),
+                    sympy.S.Zero,
+                    sympy.Mod(width, 64),
+                ],
+            },
+            {
+                "size": [128, 8, 4, 1, 64],
+                "coordinates": [
+                    indirect,
+                    head,
+                    sympy.floor(width / 64),
+                    sympy.S.Zero,
+                    sympy.Mod(width, 64),
+                ],
+            },
+        ]
+
+        with self.assertRaisesRegex(
+            UnalignedStickSplit,
+            r"boundary 16 for entry cuts tensor 0.*stick of 32",
+        ):
+            align_tensors(
+                {entry: (64, 2), head: (8, 1), width: (256, 1)},
+                tensors,
+                {indirect: 128},
+            )
+
+    def test_align_tensors_rejects_nonzero_truncated_stick_split(self):
+        """Reject a sub-stick split even when integer division is nonzero."""
+        entry, head, width = sympy.symbols(
+            "entry head width", integer=True, nonnegative=True
+        )
+        tensors = [
+            {
+                "size": [3, 32],
+                "coordinates": [
+                    sympy.floor(entry / 32),
+                    sympy.Mod(entry, 32),
+                ],
+            },
+            {
+                "size": [384, 2, 4, 1, 64],
+                "coordinates": [
+                    head + 8 * sympy.Mod(entry, 48),
+                    sympy.floor(entry / 48),
+                    sympy.floor(width / 64),
+                    sympy.S.Zero,
+                    sympy.Mod(width, 64),
+                ],
+            },
+        ]
+
+        with self.assertRaisesRegex(
+            UnalignedStickSplit,
+            r"boundary 48 for entry cuts tensor 0.*stick of 32",
+        ):
+            align_tensors(
+                {entry: (96, 3), head: (8, 1), width: (256, 1)},
+                tensors,
+            )
+
+    def test_align_tensors_accepts_stick_aligned_source(self):
+        """A dense scatter source contributes no sub-stick index boundary."""
+        entry, head, width = sympy.symbols(
+            "entry head width", integer=True, nonnegative=True
+        )
+        tensors = [
+            {
+                "size": [2, 32],
+                "coordinates": [
+                    sympy.floor(entry / 32),
+                    sympy.Mod(entry, 32),
+                ],
+            },
+            {
+                "size": [64, 8, 4, 1, 64],
+                "coordinates": [
+                    entry,
+                    head,
+                    sympy.floor(width / 64),
+                    sympy.S.Zero,
+                    sympy.Mod(width, 64),
+                ],
+            },
+        ]
+
+        _, aligned, _ = align_tensors(
+            {entry: (64, 2), head: (8, 1), width: (256, 1)}, tensors
+        )
+
+        self.assertTrue(all(size > 0 for tensor in aligned for size in tensor["size"]))
+
+    def test_align_tensors_accepts_partial_stick_endpoint(self):
+        """A short final stick is legal because its endpoint is not a split."""
+        entry = sympy.Symbol("entry", integer=True, nonnegative=True)
+        _, aligned, _ = align_tensors(
+            {entry: (7, 1)},
+            [
+                {
+                    "size": [1, 32],
+                    "coordinates": [
+                        sympy.floor(entry / 32),
+                        sympy.Mod(entry, 32),
+                    ],
+                },
+                {
+                    "size": [7, 64],
+                    "coordinates": [entry, sympy.S.Zero],
+                },
+            ],
+        )
+
+        self.assertTrue(all(size > 0 for tensor in aligned for size in tensor["size"]))
 
     def test_compute_coordinates_rejects_overlapping_moduli(self):
         """Multiple Mods remain unsupported unless they form one digit chain."""

--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -291,6 +291,21 @@ class TestCoordinates(TestCase):
                 tensors,
             )
 
+    def test_align_tensors_accepts_noncanonical_stick_variable_split(self):
+        """A shared variable need not describe canonical outer-stick tiling."""
+        entry = sympy.Symbol("entry", integer=True, nonnegative=True)
+        _, aligned, _ = align_tensors(
+            {entry: (4, 2)},
+            [
+                {
+                    "size": [2, 64],
+                    "coordinates": [sympy.floor(entry / 2), entry],
+                }
+            ],
+        )
+
+        self.assertTrue(all(size > 0 for tensor in aligned for size in tensor["size"]))
+
     def test_align_tensors_accepts_stick_aligned_source(self):
         """A dense scatter source contributes no sub-stick index boundary."""
         entry, head, width = sympy.symbols(

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -883,6 +883,27 @@ class TestSpyre(TestCase):
                         restored.cpu(), expected, atol=atol, rtol=rtol
                     )
 
+    def test_unsupported_d2d_dtype_conversion_falls_back(self):
+        """Unsupported native D2D pairs retain the CPU fallback behavior."""
+        from torch_spyre._C import ElementArrangement, get_spyre_tensor_layout
+        from torch_spyre.ops.fallbacks import FallbackWarning
+
+        source_cpu = torch.arange(128, dtype=torch.int32).reshape(2, 64)
+        source = source_cpu.to("spyre")
+
+        with self.assertWarnsRegex(
+            FallbackWarning,
+            r"conversion from torch\.int32 to torch\.float16 is falling back to cpu",
+        ):
+            actual = source.to(torch.float16)
+
+        self.assertEqual(actual.dtype, torch.float16)
+        self.assertEqual(
+            get_spyre_tensor_layout(actual).element_arrangement,
+            ElementArrangement.STANDARD,
+        )
+        torch.testing.assert_close(actual.cpu(), source_cpu.to(torch.float16))
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -350,7 +350,8 @@ def to_dtype_d2d(
     The explicit offset is required for the same reason as copy_from_d2d:
     Inductor otherwise drops a graph input view's storage offset. Returning the
     converted tensor (rather than mutating a preallocated destination) also lets
-    the compiled wrapper attach the conversion's staggered element arrangement.
+    ``propagate_layouts`` attach the conversion's staggered element arrangement
+    to the compiled graph's output layout.
     """
     with torch._dynamo.config.patch(specialize_int=True):
         return compiled(src, dtype, src_off)

--- a/torch_spyre/_inductor/enforce_indirect_access_layout.py
+++ b/torch_spyre/_inductor/enforce_indirect_access_layout.py
@@ -368,6 +368,10 @@ def _materialize_unaligned_scatter_source(
     not representable and used to truncate the index's outer-stick extent to
     zero.  Materialize just the direct source in a canonical dense DL16 layout;
     the destination and index layouts remain unchanged.
+
+    PyTorch lowering represents every ``Scatter`` as a ``ComputedBuffer`` with
+    a ``MutationLayoutSHOULDREMOVE`` target, which is the invariant required by
+    ``_resolve_mutation_target`` below.
     """
     alignment_inputs = _scatter_alignment_inputs(graph, op)
     if alignment_inputs is None:
@@ -384,6 +388,9 @@ def _materialize_unaligned_scatter_source(
     # tensors recovered directly from the Scatter closure so they are never
     # mistaken for a source candidate.
     index_names = index_names | _find_scatter_index_buf_names(op)
+    # A fused Scatter retains no distinguished source edge.  Its remaining
+    # direct reads are therefore candidates, not assumptions: accept one only
+    # when substituting its dense layout makes the complete alignment valid.
     direct_deps = [
         dep
         for dep in op.get_read_writes().reads
@@ -395,23 +402,51 @@ def _materialize_unaligned_scatter_source(
         source_buf = graph.get_buffer(dep.name)
         source_layout = _real_layout(source_buf)
         if not isinstance(source_layout, FixedTiledLayout):
+            logger.debug(
+                "enforce_indirect_access_layout: scatter source candidate %s "
+                "has non-tiled layout %s",
+                dep.name,
+                type(source_layout).__name__,
+            )
             continue
         # ReStickify cannot materialize a non-DL16 source.  It may be an
         # unrelated direct operand, so keep looking for a feasible candidate;
         # if none resolves the split, preserve the original alignment error.
         if source_layout.device_layout.device_dtype != DataFormats.SEN169_FP16:
+            logger.debug(
+                "enforce_indirect_access_layout: scatter source candidate %s "
+                "uses unsupported ReStickify format %s",
+                dep.name,
+                source_layout.device_layout.device_dtype,
+            )
             continue
         dense_stl = _dense_scatter_source_stl(source_layout)
         if dense_stl == source_layout.device_layout:
+            logger.debug(
+                "enforce_indirect_access_layout: scatter source candidate %s "
+                "is already dense",
+                dep.name,
+            )
             continue
         candidate_inputs = _scatter_alignment_inputs(
             graph, op, layout_overrides={dep.name: dense_stl}
         )
         if candidate_inputs is None:
+            logger.debug(
+                "enforce_indirect_access_layout: could not reconstruct alignment "
+                "inputs for scatter source candidate %s",
+                dep.name,
+            )
             continue
         try:
             align_tensors_pure(candidate_inputs)
-        except UnalignedStickSplit:
+        except UnalignedStickSplit as candidate_error:
+            logger.debug(
+                "enforce_indirect_access_layout: dense scatter source candidate "
+                "%s leaves alignment invalid: %s",
+                dep.name,
+                candidate_error,
+            )
             continue
 
         logger.info(

--- a/torch_spyre/_inductor/enforce_indirect_access_layout.py
+++ b/torch_spyre/_inductor/enforce_indirect_access_layout.py
@@ -38,7 +38,7 @@ from torch._inductor.ir import (
     Scatter,
     StorageBox,
 )
-from torch_spyre._C import SpyreTensorLayout
+from torch_spyre._C import DataFormats, SpyreTensorLayout
 
 from .constants import ELIDED_COPY_BACK_ATTR
 from .errors import Unsupported
@@ -51,11 +51,17 @@ from .ir import FixedTiledLayout
 from .logging_utils import get_inductor_logger
 from .op_spec import IndirectAccess
 from .pass_utils import (
+    AlignmentAccess,
     _build_indirect_store_subs,
+    _find_scatter_index_buf_names,
+    build_operation_alignment_inputs,
+    concretize_expr,
     device_coordinates,
     indirect_info_from_op,
+    iteration_space_from_op,
     padded_entry_output_stl,
 )
+from .views import AlignmentInputs, UnalignedStickSplit, align_tensors_pure
 from . import config
 
 logger = get_inductor_logger("enforce_indirect_access_layout")
@@ -282,6 +288,146 @@ def _insert_relayout_copy(
         for o in operations
         if isinstance(o, ComputedBuffer) and o.get_name() == consumer_name
     )
+
+
+def _dense_scatter_source_stl(value_layout: FixedTiledLayout) -> SpyreTensorLayout:
+    """Build a dense layout for a direct scatter source.
+
+    ReStickifyOpHBM operates on the physical DL16 format, shared by logical
+    float16 and bfloat16 tensors.  Keep the source's logical dtype and element
+    arrangement while returning its host dimensions to their canonical order.
+    """
+    source_stl = value_layout.device_layout
+    if source_stl.device_dtype != DataFormats.SEN169_FP16:
+        raise Unsupported(
+            "scatter source alignment requires materialization, but "
+            f"ReStickifyOpHBM does not support {source_stl.device_dtype}"
+        )
+    size = [concretize_expr(value) for value in value_layout.size]
+    stride = [concretize_expr(value) for value in value_layout.stride]
+    return SpyreTensorLayout(
+        size,
+        stride,
+        value_layout.dtype,
+        list(range(len(size))),
+        source_stl.element_arrangement,
+    )
+
+
+def _scatter_alignment_inputs(
+    graph: GraphLowering,
+    op: ComputedBuffer,
+    *,
+    layout_overrides: dict[str, SpyreTensorLayout] | None = None,
+) -> AlignmentInputs | None:
+    """Reconstruct codegen's alignment input for a committed scatter op."""
+    overrides = layout_overrides or {}
+    read_writes = op.get_read_writes()
+    write_dep = next(
+        (dep for dep in read_writes.writes if isinstance(dep, MemoryDep)), None
+    )
+    if write_dep is None:
+        return None
+
+    output_layout = _output_real_layout(op)
+    if not isinstance(output_layout, FixedTiledLayout):
+        return None
+    _, indirect_sizes = _scatter_access_subs_and_sizes(op, output_layout, write_dep)
+
+    accesses: list[AlignmentAccess] = []
+    for dep in read_writes.reads:
+        if not isinstance(dep, MemoryDep):
+            continue
+        buf = graph.get_buffer(dep.name)
+        layout = _real_layout(buf)
+        if not isinstance(layout, FixedTiledLayout):
+            return None
+        accesses.append(
+            AlignmentAccess(overrides.get(dep.name, layout.device_layout), dep.index)
+        )
+    accesses.append(AlignmentAccess(output_layout.device_layout, write_dep.index))
+    return build_operation_alignment_inputs(
+        iteration_space_from_op(op),
+        accesses,
+        indirect_sizes=indirect_sizes,
+        op=op,
+        read_writes=read_writes,
+    )
+
+
+def _materialize_unaligned_scatter_source(
+    graph: GraphLowering,
+    op: ComputedBuffer,
+    index_names: set[str],
+) -> ComputedBuffer:
+    """Densify the direct source when it cuts through an index stick.
+
+    Tensor alignment merges factorization boundaries from every operand.  A
+    transposed direct source can contribute an internal boundary that falls
+    inside the int32 index tensor's 32-element physical stick.  Such a split is
+    not representable and used to truncate the index's outer-stick extent to
+    zero.  Materialize just the direct source in a canonical dense DL16 layout;
+    the destination and index layouts remain unchanged.
+    """
+    alignment_inputs = _scatter_alignment_inputs(graph, op)
+    if alignment_inputs is None:
+        return op
+    try:
+        align_tensors_pure(alignment_inputs)
+        return op
+    except UnalignedStickSplit as error:
+        alignment_error = error
+
+    target_name, _ = _resolve_mutation_target(op)
+    # ``indirect_info_from_op`` can expose placeholder names when it cannot
+    # pair a scatter symbol with its real index buffer.  Also exclude index
+    # tensors recovered directly from the Scatter closure so they are never
+    # mistaken for a source candidate.
+    index_names = index_names | _find_scatter_index_buf_names(op)
+    direct_deps = [
+        dep
+        for dep in op.get_read_writes().reads
+        if isinstance(dep, MemoryDep)
+        and dep.name not in index_names
+        and dep.name != target_name
+    ]
+    for dep in direct_deps:
+        source_buf = graph.get_buffer(dep.name)
+        source_layout = _real_layout(source_buf)
+        if not isinstance(source_layout, FixedTiledLayout):
+            continue
+        # ReStickify cannot materialize a non-DL16 source.  It may be an
+        # unrelated direct operand, so keep looking for a feasible candidate;
+        # if none resolves the split, preserve the original alignment error.
+        if source_layout.device_layout.device_dtype != DataFormats.SEN169_FP16:
+            continue
+        dense_stl = _dense_scatter_source_stl(source_layout)
+        if dense_stl == source_layout.device_layout:
+            continue
+        candidate_inputs = _scatter_alignment_inputs(
+            graph, op, layout_overrides={dep.name: dense_stl}
+        )
+        if candidate_inputs is None:
+            continue
+        try:
+            align_tensors_pure(candidate_inputs)
+        except UnalignedStickSplit:
+            continue
+
+        logger.info(
+            "enforce_indirect_access_layout: materializing scatter source %s "
+            "in a dense DL16 layout before %s",
+            dep.name,
+            op.get_name(),
+        )
+        return _insert_relayout_copy(
+            graph,
+            op,
+            source_buf,
+            _fixed_tiled(source_layout, dense_stl),
+        )
+
+    raise alignment_error
 
 
 def _value_bufs_for_op(
@@ -673,6 +819,12 @@ def enforce_indirect_access_layout(graph: GraphLowering) -> None:
         _pad_output_for_stick_aligned_split(original_op)
 
         op = original_op
+        if is_scatter:
+            op = _materialize_unaligned_scatter_source(graph, op, dep_names)
+            if op is not original_op:
+                requirement = _get_indirect_access_dim_order_requirements(op)
+                assert requirement is not None
+                dep_names, access_subs, sizes = requirement
         value_bufs = _value_bufs_for_op(graph, op, access_subs, sizes)
         for value_buf in value_bufs:
             value_layout = _real_layout(value_buf)
@@ -726,4 +878,4 @@ def enforce_indirect_access_layout(graph: GraphLowering) -> None:
 
         # For scatter ops, ensure scatter destination dimension 0 (scatter index) is outermost
         if is_scatter and is_mutation:
-            _enforce_scatter_destination_layout(graph, original_op, requirement)
+            _enforce_scatter_destination_layout(graph, op, requirement)

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -2056,11 +2056,13 @@ def compute_restickify_needed(
     ):
         return False, None
 
-    # ReStickifyOpHBM currently supports only the native FP16 device format.
+    # ReStickifyOpHBM currently supports only the native FP16 device format
+    # (both logical float16 and bfloat16 map to SEN169_FP16).
     # Do not advertise an edge as feasible when codegen cannot lower it: this
     # is especially important for fp32-upcast graphs, where a later IEEE_FP32
     # restick can otherwise tie with and displace the valid FP16 restick before
-    # the conversion.
+    # the conversion. This also deliberately precedes the factorized-layout
+    # target below: a concrete target is not actionable for a non-DL16 input.
     if in_stl.device_dtype != DataFormats.SEN169_FP16:
         return True, None
 

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -511,6 +511,10 @@ def _single_arg_op_layout(
                         if candidate not in layouts:
                             layouts.append(candidate)
 
+                # Under the current EA map, an already-staggered input is the
+                # reverse staggered-to-STANDARD restoration. It needs no
+                # expansion: preserve the stick selected before the upcast.
+
                 return layouts
 
             # Dense reconstruction from the output host size. When the input

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -729,6 +729,27 @@ class AlignmentInputs:
     restored_ranges: dict[sympy.Symbol, sympy.Expr | int | float]
 
 
+class UnalignedStickSplit(Unsupported):
+    """A global alignment boundary cuts through one tensor's physical stick."""
+
+    def __init__(
+        self,
+        tensor_index: int,
+        variable: sympy.Symbol,
+        boundary: int,
+        stick_size: int,
+    ) -> None:
+        self.tensor_index = tensor_index
+        self.variable = variable
+        self.boundary = boundary
+        self.stick_size = stick_size
+        super().__init__(
+            "tensor alignment boundary "
+            f"{boundary} for {variable} cuts tensor {tensor_index}'s "
+            f"physical stick of {stick_size} elements"
+        )
+
+
 def build_alignment_inputs(
     iteration_space: Dict[sympy.Symbol, Tuple[sympy.Expr, int]],
     tensors: list[Dict[str, list[sympy.Expr]]],
@@ -880,6 +901,28 @@ def align_tensors_pure(
 
     # sort splits
     splits = {var: sorted(val) for var, val in splits.items()}
+
+    # Every interior boundary for a tensor's stick variable must fall between
+    # physical sticks.  A boundary inside a stick cannot be represented as a
+    # device dimension: the outer-stick adjustment below would truncate it to
+    # zero (for example 16 // 32), silently producing a size-0 dimension and
+    # corrupting the access.  The final boundary is the logical range endpoint,
+    # so a partial last stick (for example 7 int32 elements in a 32-element
+    # stick) remains valid.
+    for tensor_index, (var, physical_stick_size) in enumerate(
+        zip(stick_dim, stick_size)
+    ):
+        if var is None:
+            continue
+        for boundary_expr in splits[var][1:-1]:
+            boundary = _concrete_alignment_value(boundary_expr)
+            if boundary % int(physical_stick_size) != 0:
+                raise UnalignedStickSplit(
+                    tensor_index,
+                    var,
+                    int(boundary),
+                    int(physical_stick_size),
+                )
 
     # create new vars, var ranges, and work division for each variable
     # with one var per segment (split[i], split[i+1])

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -916,6 +916,7 @@ def align_tensors_pure(
         zip(all_terms, stick_dim, stick_size)
     ):
         if var is None:
+            # A constant/broadcast innermost coordinate has no stick loop to split.
             continue
         has_outer_stick_coordinate = any(
             term.var == var and term.den == physical_stick_size for term in terms[:-1]

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -902,17 +902,25 @@ def align_tensors_pure(
     # sort splits
     splits = {var: sorted(val) for var, val in splits.items()}
 
-    # Every interior boundary for a tensor's stick variable must fall between
-    # physical sticks.  A boundary inside a stick cannot be represented as a
-    # device dimension: the outer-stick adjustment below would truncate it to
-    # zero (for example 16 // 32), silently producing a size-0 dimension and
-    # corrupting the access.  The final boundary is the logical range endpoint,
-    # so a partial last stick (for example 7 int32 elements in a 32-element
-    # stick) remains valid.
-    for tensor_index, (var, physical_stick_size) in enumerate(
-        zip(stick_dim, stick_size)
+    # When a tensor has the canonical pair of an outer-stick coordinate and an
+    # innermost stick coordinate for the same variable, every interior boundary
+    # must fall between physical sticks.  A boundary inside a stick cannot be
+    # represented as a device dimension: the outer-stick adjustment below would
+    # truncate it to zero (for example 16 // 32), or to an incorrect nonzero
+    # extent (for example 48 // 32).  Do not apply this restriction merely
+    # because the innermost coordinate uses the variable: arbitrary coordinate
+    # expressions in preceding dimensions can legally split it at other points.
+    # The final boundary is the logical range endpoint, so a partial last stick
+    # (for example 7 int32 elements in a 32-element stick) remains valid.
+    for tensor_index, (terms, var, physical_stick_size) in enumerate(
+        zip(all_terms, stick_dim, stick_size)
     ):
         if var is None:
+            continue
+        has_outer_stick_coordinate = any(
+            term.var == var and term.den == physical_stick_size for term in terms[:-1]
+        )
+        if not has_outer_stick_coordinate:
             continue
         for boundary_expr in splits[var][1:-1]:
             boundary = _concrete_alignment_value(boundary_expr)

--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -24,9 +24,10 @@ if TYPE_CHECKING:
 
 
 def _add_ea(src_tensor, res_tensor) -> None:
-    """Update ElementArrangement (EA) tag on output SpyreTensorLayout
+    """Update the EA tag after an eager transfer handled by ``orig_to``.
 
-    For to_dtype op in eager mode.
+    Same-device dtype-changing casts return through ``to_dtype_d2d`` before
+    this helper is reached; their EA is propagated by the compiled graph.
     """
     if res_tensor.dtype == src_tensor.dtype:
         return
@@ -45,7 +46,6 @@ def _add_ea(src_tensor, res_tensor) -> None:
         return
 
     from torch_spyre._C import (
-        ElementArrangement,
         get_spyre_tensor_layout,
         set_spyre_tensor_layout,
     )
@@ -62,13 +62,6 @@ def _add_ea(src_tensor, res_tensor) -> None:
 
     input_ea = src_layout.element_arrangement
     fmt = DtypeOpTable.ea_map(src_tensor.dtype, res_tensor.dtype, input_ea)
-
-    # FP32 -> FP16 runtime type conversion is not yet supported.
-    if (
-        src_tensor.dtype == torch.float32
-        and res_tensor.dtype in DtypeOpTable.fp16_types()
-    ):
-        fmt = ElementArrangement.STANDARD
 
     try:
         res_layout = get_spyre_tensor_layout(res_tensor)
@@ -148,9 +141,11 @@ def _patch_tensor_for_spyre():
                 return orig_to(self, *args, **kwargs)
 
             # Support D2H and H2D dtype casting via DCI (DataConversionInfo) in
-            # spyre_mem.cpp. Same-device casting is lowered through the existing
-            # compiled D2D copy, whose mutate_to lowering performs the conversion
-            # on device.
+            # spyre_mem.cpp. Same-device casting is routed through the standalone
+            # compiled to_dtype_d2d path, whose lowering converts on device.
+            # Unsupported conversion pairs are still accepted here: the compiled
+            # lowering checks DtypeOpTable and uses to_dtype_cpu, preserving the
+            # previous host-roundtrip fallback and warning.
             _device = kwargs.get("device", None)
             _dtype = kwargs.get("dtype", None)
             if args:
@@ -175,6 +170,8 @@ def _patch_tensor_for_spyre():
                 and _dtype is not None
                 and _dtype != self.dtype
             ):
+                # device_layout is necessarily None in this branch (guarded at
+                # function entry), so this dtype-only op drops no layout request.
                 return torch.ops.spyre.to_dtype_d2d(self, _dtype, self.storage_offset())
 
             res = orig_to(self, *args, **kwargs)


### PR DESCRIPTION
## Summary

- reject tensor alignment plans whose internal factor boundary cuts through another operand physical stick
- recover compatible Scatter operations by materializing only the direct DL16 source into a canonical dense layout
- cover the Gemma 4 RoPE-shaped `index_copy_` regression and preserve valid partial-stick cases
- include the review follow-ups from #4238

## Root cause

The failing Gemma 4 scatter aligned a 64-entry loop across an int32 index tensor with a 32-element physical stick and a factorized RoPE source with a boundary at 16. `align_tensors` propagated the source boundary into the index descriptor and produced a zero-sized dimension (`16 // 32 == 0`), corrupting roughly half the cache write.

The new invariant rejects internal boundaries that are not physical-stick aligned. Scatter layout enforcement previews alignment and, for this typed failure, inserts a targeted dense DL16 source copy. Endpoint boundaries remain legal, including partial final sticks such as seven int32 entries. ReStickify remains DL16-only.

## #4238 review follow-ups

- Unsupported D2D dtype pairs retain the prior warning plus CPU fallback through `to_dtype_cpu`; a regression test covers int32 to float16.
- The eager/compiled FP32-to-DL16 test now explains that both modes use the compiled D2D path and therefore receive the same staggered EA.
- `propagate_layouts` now documents why reverse staggered-to-STANDARD restoration needs no candidate expansion.
- `compute_restickify_needed` documents that its `SEN169_FP16` guard is about the physical format shared by logical fp16 and bf16, and why it precedes factorized-target construction.
- `to_dtype_d2d` documents that `propagate_layouts` attaches the staggered EA; there is no explicit wrapper-side EA stamp.
- `_add_ea` and the `spyre_to` call site no longer carry the stale D2D wording and document that `device_layout` is absent on this path.
- Existing #2305 and #2357 track first-class D2D dtype conversion; #4080 tracks the broader EA algebra.
- The advisory hf-adapters failure on #4238 tested hf-adapters `main`, not companion PR [#366](https://github.com/torch-spyre/hf-adapters/pull/366), so the missing Gemma 4 fp32 RMSNorm adapter there was expected.

## Validation

- `pytest -q tests/inductor/test_indirect_access_scatter.py`: 45 passed, 2 skipped, 20 xfailed
- `pytest -q tests/inductor/test_restickify.py`: 341 passed, 1 skipped
- scatter helpers plus coordinate tests: 41 passed, 9 subtests
- focused #4238 follow-up tests passed
- pre-commit passed

Test-With: https://github.com/torch-spyre/hf-adapters/pull/366