### PR TITLE
fix(inductor): preserve counted-loop locality and lifetimes

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_operation_scheduling_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_operation_scheduling_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [unit, regression, integration, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_operation_scheduling.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -2665,6 +2665,19 @@ class TestBuildLoopSchedulerNodes(unittest.TestCase):
         self.assertEqual(result, [copy, created[0]])
         self.assertEqual(created[0].snodes, [first, consumer])
 
+    def test_prescheduling_order_is_restored_after_inductor_toposort(self):
+        sched = _make_scheduler()
+        early_op = _make_ir_op((0,), Integer(4))
+        late_op = _make_ir_op((0,), Integer(4))
+        early_op._spyre_preschedule_order = 10
+        late_op._spyre_preschedule_order = 11
+        early = _make_snode(sched, early_op, "early")
+        late = _make_snode(sched, late_op, "late")
+
+        _result, created = self._run([late, early])
+
+        self.assertEqual(created[0].snodes, [early, late])
+
     def test_two_separate_groups(self):
         sched = _make_scheduler()
         g0a = _make_snode(sched, _make_ir_op((0,), Integer(4)), "g0a")
@@ -5643,6 +5656,7 @@ class TestReadCopyPlanDataclasses(unittest.TestCase):
         self.assertEqual(entry.consumer_op_names, ("op0", "op1"))
         self.assertEqual(entry.predivision_unit_steps, ())
         self.assertTrue(entry.loop_invariant)
+        self.assertIsNone(entry.hoist)
         with self.assertRaises(Exception):
             entry.copy_name = "other"  # frozen -> raises FrozenInstanceError
 
@@ -5650,6 +5664,40 @@ class TestReadCopyPlanDataclasses(unittest.TestCase):
         self.assertEqual(plan.entries, (entry,))
         with self.assertRaises(Exception):
             plan.entries = ()
+
+    def test_repeated_invariant_windows_are_sunk_into_the_loop(self):
+        from torch._inductor.dependencies import MemoryDep
+        from torch_spyre._inductor.loop_info import ReadCopyEntry
+        from torch_spyre._inductor.wsr.coarse_tile import (
+            _place_invariant_read_copies,
+        )
+
+        def entry(copy_name, source_name, offset=0, *, invariant=True):
+            return ReadCopyEntry(
+                copy_name=copy_name,
+                dep=MemoryDep(
+                    name=source_name,
+                    index=sympy.Integer(offset),
+                    var_names=(),
+                    size=(),
+                ),
+                insert_before_op_name="consumer",
+                sizing_op_name="consumer",
+                sizing_read_index=0,
+                consumer_op_names=("consumer",),
+                loop_invariant=invariant,
+            )
+
+        placed = _place_invariant_read_copies(
+            [
+                entry("mask0", "mask", 0),
+                entry("mask1", "mask", 256),
+                entry("weight", "weight"),
+                entry("advancing", "input", invariant=False),
+            ]
+        )
+
+        assert [item.hoist for item in placed] == [False, False, True, False]
 
 
 class TestReadCopyElisionProof(unittest.TestCase):

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -2003,6 +2003,7 @@ class TestCoarseTile(unittest.TestCase):
 
         from torch_spyre._inductor.scratchpad.utils import (
             counted_loop_lifetime_end_overrides,
+            counted_loop_lifetime_overrides,
         )
 
         _dep = namedtuple("_dep", ["name"])
@@ -2047,6 +2048,166 @@ class TestCoarseTile(unittest.TestCase):
         # and consumed inside the loop: no extension.  ``arg0`` is only read
         # outside the loop: no extension.
         self.assertEqual(overrides, {"crossing": 4, "arg1": 4})
+
+        starts, ends = counted_loop_lifetime_overrides(
+            SimpleNamespace(operations=operations, graph_input_names=["arg0", "arg1"])
+        )
+        self.assertEqual(starts, {"crossing": 0, "arg1": 1})
+        self.assertEqual(ends, overrides)
+
+    def test_counted_loop_crossing_uses_full_loop_bounds_only(self):
+        """Crossing values cover the loop without widening local temporaries.
+
+        In particular, an input first read in the middle of the textual body is
+        already live at loop entry on every runtime iteration after the first.
+        Giving that input a start override protects it from early temporaries;
+        leaving the temporaries' own bounds alone lets disjoint early/late
+        values reuse one LX address.
+        """
+        from collections import namedtuple
+
+        from torch_spyre._inductor.scratchpad.plan_solver import LifetimeBoundBuffer
+        from torch_spyre._inductor.scratchpad.utils import (
+            calculate_liveness,
+            counted_loop_lifetime_overrides,
+        )
+
+        _dep = namedtuple("_dep", ["name"])
+
+        def _stub_read_writes(op, reads, writes):
+            op.get_read_writes.return_value = SimpleNamespace(
+                reads={_dep(name) for name in reads},
+                writes={_dep(name) for name in writes},
+            )
+
+        crossing = _make_op(_make_pointwise([Integer(16)]), "crossing")
+        _stub_read_writes(crossing, reads=["arg0"], writes=["crossing"])
+        early_writer = _make_hinted_op(_make_pointwise([Integer(16)]), "early_writer")
+        _stub_read_writes(early_writer, reads=[], writes=["early"])
+        early_reader = _make_hinted_op(_make_pointwise([Integer(16)]), "early_reader")
+        _stub_read_writes(early_reader, reads=["early"], writes=["early_out"])
+        crossing_reader = _make_hinted_op(
+            _make_pointwise([Integer(16)]), "crossing_reader"
+        )
+        _stub_read_writes(
+            crossing_reader,
+            reads=["crossing", "arg1"],
+            writes=["crossing_out"],
+        )
+        late_writer = _make_hinted_op(_make_pointwise([Integer(16)]), "late_writer")
+        _stub_read_writes(late_writer, reads=[], writes=["late"])
+        late_reader = _make_hinted_op(_make_pointwise([Integer(16)]), "late_reader")
+        _stub_read_writes(late_reader, reads=["late"], writes=["late_out"])
+
+        operations = [
+            crossing,
+            early_writer,
+            early_reader,
+            crossing_reader,
+            late_writer,
+            late_reader,
+        ]
+        coarse_tile_post_stickify(
+            _graph(operations),
+            [
+                (
+                    [
+                        early_writer,
+                        early_reader,
+                        crossing_reader,
+                        late_writer,
+                        late_reader,
+                    ],
+                    [(0, Integer(4))],
+                )
+            ],
+        )
+        graph = SimpleNamespace(
+            operations=operations, graph_input_names=["arg0", "arg1"]
+        )
+        lifetimes = calculate_liveness(graph)
+        starts, ends = counted_loop_lifetime_overrides(graph)
+
+        self.assertEqual(starts, {"crossing": 0, "arg1": 1})
+        self.assertEqual(ends, {"crossing": 6, "arg1": 6})
+        self.assertNotIn("early", starts | ends)
+        self.assertNotIn("late", starts | ends)
+
+        def _bound(name, *, is_input=False):
+            return LifetimeBoundBuffer(
+                name,
+                128,
+                lifetimes[name],
+                first_use_is_read=is_input,
+                lifetime_start_override=starts.get(name),
+                lifetime_end_override=ends.get(name),
+            )
+
+        crossing_buf = _bound("crossing")
+        input_buf = _bound("arg1", is_input=True)
+        early_buf = _bound("early")
+        late_buf = _bound("late")
+        self.assertTrue(crossing_buf.overlaps_in_time(early_buf))
+        self.assertTrue(crossing_buf.overlaps_in_time(late_buf))
+        self.assertTrue(input_buf.overlaps_in_time(early_buf))
+        self.assertTrue(input_buf.overlaps_in_time(late_buf))
+        self.assertFalse(early_buf.overlaps_in_time(late_buf))
+
+    def test_counted_loop_nested_crossings_use_innermost_crossed_bounds(self):
+        """A value born in an outer loop spans only the nested loop it enters."""
+        from collections import namedtuple
+
+        from torch_spyre._inductor.scratchpad.utils import (
+            counted_loop_lifetime_overrides,
+        )
+
+        _dep = namedtuple("_dep", ["name"])
+
+        def _op(name, path, reads=(), writes=()):
+            op = _make_op(_make_pointwise([Integer(16)]), name)
+            op.loop_info = SimpleNamespace(loop_group_id=path)
+            op.get_read_writes.return_value = SimpleNamespace(
+                reads={_dep(dep) for dep in reads},
+                writes={_dep(dep) for dep in writes},
+            )
+            return op
+
+        operations = [
+            _op("outer_producer", (0,), writes=["outer_value"]),
+            _op("inner_early", (0, 1), writes=["inner_value"]),
+            _op(
+                "inner_reader",
+                (0, 1),
+                reads=["outer_value", "arg_inner"],
+                writes=["inner_out"],
+            ),
+            _op("inner_tail", (0, 1), reads=["inner_value"], writes=["tail_out"]),
+            _op("outer_tail", (0,), reads=["arg_outer"], writes=["outer_out"]),
+        ]
+
+        starts, ends = counted_loop_lifetime_overrides(
+            SimpleNamespace(
+                operations=operations,
+                graph_input_names=["arg_inner", "arg_outer"],
+            )
+        )
+
+        self.assertEqual(
+            starts,
+            {
+                "outer_value": 0,
+                "arg_inner": 0,
+                "arg_outer": 0,
+            },
+        )
+        self.assertEqual(
+            ends,
+            {
+                "outer_value": 4,
+                "arg_inner": 5,
+            },
+        )
+        self.assertNotIn("inner_value", starts | ends)
 
     def test_end_to_end_shares_one_copy_across_group(self):
         """Full coarse_tile() entry point: two hint-driven ops in one group

--- a/tests/inductor/test_operation_scheduling.py
+++ b/tests/inductor/test_operation_scheduling.py
@@ -1,0 +1,90 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import torch
+
+from torch_spyre._inductor.operation_scheduling import schedule_loop_body_for_liveness
+from torch_spyre._inductor.patches import enable_spyre_context
+
+
+class _FakeOperation:
+    def __init__(self, name, reads=(), size=1, loop_path=(0,)):
+        self.name = name
+        self._reads = set(reads)
+        self._size = [size]
+        self.loop_info = SimpleNamespace(loop_group_id=loop_path)
+
+    def get_name(self):
+        return self.name
+
+    def get_read_names(self):
+        return self._reads
+
+    def get_mutation_names(self):
+        return ()
+
+    def get_size(self):
+        return self._size
+
+    def get_dtype(self):
+        return torch.float16
+
+
+def test_loop_body_operation_order_is_preserved():
+    # Even independent recurrence branches must remain in their input order;
+    # scratchpad planning and the emitted LoopSpec use these same lifetimes.
+    ops = [
+        _FakeOperation("scores0", size=512),
+        _FakeOperation("max0", ("scores0",), size=8),
+        _FakeOperation("correction0", ("max0",), size=8),
+        _FakeOperation("weighted0", ("scores0",), size=128),
+        _FakeOperation("output0", ("weighted0", "correction0"), size=128),
+        _FakeOperation("denominator0", ("scores0", "correction0"), size=8),
+        _FakeOperation("scores1", ("max0",), size=512),
+        _FakeOperation("max1", ("scores1",), size=8),
+        _FakeOperation("correction1", ("max1",), size=8),
+        _FakeOperation("weighted1", ("scores1",), size=128),
+        _FakeOperation("output1", ("output0", "weighted1", "correction1"), size=128),
+        _FakeOperation(
+            "denominator1", ("denominator0", "scores1", "correction1"), size=8
+        ),
+    ]
+    graph = SimpleNamespace(operations=ops)
+
+    schedule_loop_body_for_liveness(graph)
+
+    assert graph.operations == ops
+    assert [op._spyre_preschedule_order for op in graph.operations] == list(
+        range(len(ops))
+    )
+
+
+def test_loop_preheader_is_moved_before_the_atomic_loop_unit():
+    first = _FakeOperation("first")
+    copy = _FakeOperation("copy", loop_path=())
+    consumer = _FakeOperation("consumer", ("copy",))
+    graph = SimpleNamespace(operations=[first, copy, consumer])
+
+    schedule_loop_body_for_liveness(graph)
+
+    assert [op.name for op in graph.operations] == ["copy", "first", "consumer"]
+
+
+def test_spyre_preserves_fx_program_order_before_loop_discovery():
+    original = torch._inductor.config.reorder_for_locality
+    with enable_spyre_context([]):
+        assert not torch._inductor.config.reorder_for_locality
+    assert torch._inductor.config.reorder_for_locality == original

--- a/tests/inductor/test_perm_layout_solver.py
+++ b/tests/inductor/test_perm_layout_solver.py
@@ -1476,22 +1476,25 @@ class NativeSolverDifferentialTests(TestCase):
         self._assert_equal(py_plan, cpp_plan, "pokethrough fast path")
         self._assert_equal(ref_plan, cpp_plan, "pokethrough fast path vs reference")
 
-    def test_native_solver_honors_lifetime_end_override(self):
+    def test_native_solver_honors_lifetime_bounds_overrides(self):
         persistent = LifetimeBoundBuffer(
             "persistent",
             64,
-            [0, 1],
+            [2, 3],
+            lifetime_start_override=0,
             lifetime_end_override=5,
         )
-        later = LifetimeBoundBuffer("later", 64, [2, 3])
-        buffers = [persistent, later]
-        permutation = [0, 1]
+        early = LifetimeBoundBuffer("early", 64, [0, 1])
+        later = LifetimeBoundBuffer("later", 64, [4])
+        buffers = [persistent, early, later]
+        permutation = [0, 1, 2]
 
         py_plan = PermutationBasedLayoutSolver(buffers, permutation, 10_000, 1)
         cpp_plan = NativePermutationLayoutSolver(buffers, permutation, 10_000, 1)
 
-        self._assert_equal(py_plan, cpp_plan, "lifetime end override")
+        self._assert_equal(py_plan, cpp_plan, "lifetime bounds overrides")
         self.assertNotEqual(cpp_plan.addresses[0], cpp_plan.addresses[1])
+        self.assertNotEqual(cpp_plan.addresses[0], cpp_plan.addresses[2])
 
     def test_random_mixed_sequences_match_python(self):
         seeds = 4000 if _STRESS else 800

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -895,7 +895,7 @@ def _assert_live_buffers_do_not_share_addresses(graph, buffers, limit):
             )
 
 
-def test_lx_relayout_copies_loop_lifetime_to_every_destination():
+def test_lx_relayout_keeps_crossing_source_live_and_destinations_ephemeral():
     plans = [
         _relayout_plan("source", ("consumer_a", "consumer_b")),
         LXRelayoutPlan(
@@ -912,15 +912,30 @@ def test_lx_relayout_copies_loop_lifetime_to_every_destination():
             for name in ("producer", "consumer_a", "consumer_b", "consumer_c")
         ]
     )
-    source = LifetimeBoundBuffer("source", 64, [0, 1, 2, 3], lifetime_end_override=6)
+    source = LifetimeBoundBuffer(
+        "source",
+        64,
+        [1, 2, 3],
+        first_use_is_read=True,
+        lifetime_start_override=0,
+        lifetime_end_override=6,
+    )
     source.lx_relayout_plans = list(plans)
     buffers = [source]
     ScratchpadAllocator(GreedyLayoutSolver, 256)._append_lx_relayout_destinations(
         graph, buffers
     )
 
-    assert source.lifetime_end_override is None
-    assert [buffer.lifetime_end_override for buffer in source.paired_with] == [12, 12]
+    assert source.lifetime_start_override == 0
+    assert source.lifetime_end_override == 12
+    assert [buffer.lifetime_start_override for buffer in source.paired_with] == [
+        None,
+        None,
+    ]
+    assert [buffer.lifetime_end_override for buffer in source.paired_with] == [
+        None,
+        None,
+    ]
     tail = LifetimeBoundBuffer("tail", 64, [8, 11])
     buffers.append(tail)
     _assert_live_buffers_do_not_share_addresses(graph, buffers, 384)
@@ -941,7 +956,7 @@ def test_lx_relayout_keeps_source_lifetime_for_later_original_reader():
     )
 
     assert source.lifetime_end_override == 8
-    assert source.paired_with[0].lifetime_end_override == 8
+    assert source.paired_with[0].lifetime_end_override is None
     tail = LifetimeBoundBuffer("tail", 64, [6, 7])
     buffers.append(tail)
     _assert_live_buffers_do_not_share_addresses(graph, buffers, 384)

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -210,8 +210,12 @@ class ReadCopyEntry:
         this entry is their authority during copy construction.
     loop_invariant:
         True only when every consumer reads the same source slice on every
-        trip of the surrounding counted loop.  Such a copy is a preheader
-        operation, not part of the loop body.
+        trip of the surrounding counted loop. This permits compact staging;
+        placement is controlled independently by ``hoist``.
+    hoist:
+        Whether to emit the copy in the counted-loop preheader. Repeated
+        invariant windows from one source may deliberately remain in the loop
+        so their LX lifetimes do not overlap.
     """
 
     copy_name: str
@@ -224,6 +228,7 @@ class ReadCopyEntry:
         tuple[tuple[int, sympy.Expr, sympy.Expr], ...], ...
     ] = ()
     loop_invariant: bool = False
+    hoist: bool | None = None
 
 
 @dataclass(frozen=True)

--- a/torch_spyre/_inductor/operation_scheduling.py
+++ b/torch_spyre/_inductor/operation_scheduling.py
@@ -1,0 +1,144 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Operation ordering used by LX planning and restored by the scheduler."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from torch._inductor.graph import GraphLowering
+from torch._inductor.ir import Operation
+
+
+def _loop_path(op: Operation) -> tuple[int, ...]:
+    info = getattr(op, "loop_info", None)
+    return tuple(getattr(info, "loop_group_id", ()) or ())
+
+
+def _dependency_predecessors(ops: list[Operation]) -> list[set[int]]:
+    """Build RAW/WAR/WAW edges while preserving the input order's semantics."""
+
+    predecessors: list[set[int]] = [set() for _ in ops]
+    last_writer: dict[str, int] = {}
+    readers_since_write: dict[str, set[int]] = defaultdict(set)
+
+    for index, op in enumerate(ops):
+        reads = set(op.get_read_names())
+        mutations = set(op.get_mutation_names())
+        writes = {op.get_name()} | mutations
+
+        for name in reads | mutations:
+            if name in last_writer:
+                predecessors[index].add(last_writer[name])
+        for name in writes:
+            if name in last_writer:
+                predecessors[index].add(last_writer[name])
+            predecessors[index].update(readers_since_write[name])
+
+        for name in reads:
+            readers_since_write[name].add(index)
+        for name in writes:
+            last_writer[name] = index
+            readers_since_write[name].clear()
+
+    return predecessors
+
+
+def _stable_topological_units(
+    operations: list[Operation],
+) -> list[list[Operation]]:
+    """Make every outer counted-loop group one dependency-ordered unit."""
+
+    predecessors = _dependency_predecessors(operations)
+    outer_units: dict[int, list[Operation]] = {}
+    units: list[list[Operation]] = []
+    unit_indices: dict[int, int] = {}
+    unit_index_by_op: dict[int, int] = {}
+
+    for op_index, op in enumerate(operations):
+        path = _loop_path(op)
+        if path:
+            unit = outer_units.get(path[0])
+            if unit is None:
+                unit = []
+                outer_units[path[0]] = unit
+                units.append(unit)
+                unit_indices[id(unit)] = len(units) - 1
+            unit.append(op)
+        else:
+            unit = [op]
+            units.append(unit)
+            unit_indices[id(unit)] = len(units) - 1
+        unit_index_by_op[op_index] = unit_indices[id(unit)]
+
+    unit_predecessors: list[set[int]] = [set() for _ in units]
+    for consumer, deps in enumerate(predecessors):
+        consumer_unit = unit_index_by_op[consumer]
+        for producer in deps:
+            producer_unit = unit_index_by_op[producer]
+            if producer_unit != consumer_unit:
+                unit_predecessors[consumer_unit].add(producer_unit)
+
+    ordered_units: list[list[Operation]] = []
+    seen: set[int] = set()
+    visiting: set[int] = set()
+
+    def visit(unit_index: int) -> None:
+        if unit_index in seen:
+            return
+        if unit_index in visiting:
+            # A dependency cycle between an outside op and a loop group means
+            # the group cannot be made atomic. Preserve the original order;
+            # downstream validation will report the malformed loop scope.
+            raise ValueError
+        visiting.add(unit_index)
+        for dependency in sorted(unit_predecessors[unit_index]):
+            visit(dependency)
+        visiting.remove(unit_index)
+        seen.add(unit_index)
+        ordered_units.append(units[unit_index])
+
+    try:
+        for unit_index in range(len(units)):
+            visit(unit_index)
+    except ValueError:
+        return [[op] for op in operations]
+    return ordered_units
+
+
+def schedule_loop_body_for_liveness(graph: GraphLowering) -> None:
+    """Preserve lowering's counted-loop order through LX planning and codegen.
+
+    This runs immediately before scratchpad planning, so ``graph.operations``
+    is both the allocator's liveness timeline and the order the scheduler must
+    later restore. Inductor's FX locality reorder is disabled for Spyre, so lazy
+    LoopIR lowering receives the decomposition's original block-major order.
+    Inductor's later scheduler is still free to follow one recurrence branch
+    across every unrolled KV block, extending every intervening LX lifetime, so
+    this pass records the lowering order for restoration at that boundary.
+
+    The only reordering here makes a counted-loop group atomic with respect to
+    its preheader operations. Within every LoopSpec, a dependency-respecting
+    order is left untouched.
+    """
+
+    operations = list(graph.operations)
+    ordered: list[Operation] = []
+    for unit in _stable_topological_units(operations):
+        ordered.extend(unit)
+
+    graph.operations[:] = ordered
+    for index, op in enumerate(graph.operations):
+        op._spyre_preschedule_order = index  # type: ignore[attr-defined]

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -100,6 +100,7 @@ from .dump_cost_model import dump_cost_model
 # ``from .cost_model_pass import LAST_REPORT`` would bind one thread's value forever.
 from . import cost_model_pass as cost_model_pass_module
 from .cost_model_pass import CostReport, cost_model_pass
+from .operation_scheduling import schedule_loop_body_for_liveness
 from .split_multi_ops import split_multi_ops, validate_ops
 
 
@@ -497,6 +498,10 @@ class CustomPreSchedulingPasses:
             # Core Division
             span_reduction,
             _distribute_work,
+            #
+            # Give scratchpad planning the same loop-body order codegen will
+            # restore after Inductor's own DFS topological sort.
+            schedule_loop_body_for_liveness,
             #
             # LX Planning
             _maybe_scratchpad_planning,

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -182,10 +182,9 @@ def _regroup_by_outer_loop_key(
     ordering purposes — its dependency set is the union of its members' real
     unmet_dependencies on buffers produced outside the group — and run a
     dependency-respecting DFS (mirroring topological_sort_schedule's own
-    shape) over {merged units, ungrouped nodes}. Each unit then expands back
-    into its original members in their original relative order, which is
-    always safe because that intra-group order is coarse_tile's deliberate
-    op sequence, not something this pass reorders.
+    shape) over {merged units, ungrouped nodes}. Each unit then expands in the
+    pre-scheduling order captured immediately before LX planning. This is the
+    same dependency-valid order in which coarse_tile built the loop body.
 
     The result is a valid topological order (edges are the real edges of the
     original graph) in which every outermost loop group is contiguous by
@@ -195,6 +194,17 @@ def _regroup_by_outer_loop_key(
     for node in nodes:
         for name in node.get_buffer_names():
             name_to_node[name] = node
+
+    original_node_order = {id(node): index for index, node in enumerate(nodes)}
+
+    def preschedule_order(node: BaseSchedulerNode) -> int:
+        orders = [
+            getattr(snode.node, "_spyre_preschedule_order", None)
+            for snode in node.get_nodes()
+            if isinstance(snode, SchedulerNode) and snode.node is not None
+        ]
+        known = [order for order in orders if isinstance(order, int)]
+        return min(known) if known else original_node_order[id(node)]
 
     outer_key_to_unit: dict[object, list[BaseSchedulerNode]] = {}
     units: list[Union[BaseSchedulerNode, list[BaseSchedulerNode]]] = []
@@ -214,6 +224,14 @@ def _regroup_by_outer_loop_key(
             units.append(unit)
         unit.append(node)
         unit_of_node[id(node)] = unit
+
+    # Scratchpad addresses were assigned against graph.operations immediately
+    # before Scheduler construction. Inductor subsequently performs a DFS
+    # topological sort that is free to reverse independent recurrence branches.
+    # Restore the allocator's explicit order inside each loop unit so codegen's
+    # real lifetimes match the ones used for LX placement.
+    for unit in outer_key_to_unit.values():
+        unit.sort(key=preschedule_order)
 
     def unit_key(unit) -> int:
         return id(unit)

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -89,7 +89,7 @@ from torch_spyre._inductor.scratchpad.utils import (
     _get_buffer_user_deps,
     _would_produce_lx_back_gap,
     OP_OUTPUT_NOT_GOOD_FOR_LX_REUSE,
-    counted_loop_lifetime_end_overrides,
+    counted_loop_lifetime_overrides,
 )
 from torch_spyre._inductor.scratchpad.graph_editor import GraphEditor
 from torch_spyre._inductor.ir import FixedTiledLayout, SpyreEmptyFallback
@@ -133,11 +133,11 @@ _LX_ALLOCATION_GRANULARITY_BYTES = 128
 
 
 def _safe_in_place_parents(
-    parents: Sequence[str], lifetime_end_overrides: dict[str, int]
+    parents: Sequence[str], lifetime_override_names: set[str]
 ) -> list[str]:
     """Drop handoffs from parents that remain live through a counted loop."""
 
-    return [parent for parent in parents if parent not in lifetime_end_overrides]
+    return [parent for parent in parents if parent not in lifetime_override_names]
 
 
 def _extern_kernel_in_live_range(graph: GraphLowering, uses: list[int]) -> bool:
@@ -686,6 +686,7 @@ class ScratchpadAllocator:
         lifetimes: dict[str, list[int]],
         ncores: dict[str, int],
         ncores_reasons: dict[str, str],
+        lifetime_start_overrides: Optional[dict[str, int]] = None,
         lifetime_end_overrides: Optional[dict[str, int]] = None,
     ) -> list[LifetimeBoundBuffer]:
         """Build one :class:`LifetimeBoundBuffer` per buffer, barred or not.
@@ -701,7 +702,11 @@ class ScratchpadAllocator:
         :meth:`_input_residency_reason` and their footprint is computed
         here rather than read off ``mem_usage`` (which covers ops only).
         """
+        lifetime_start_overrides = lifetime_start_overrides or {}
         lifetime_end_overrides = lifetime_end_overrides or {}
+        lifetime_override_names = set(lifetime_start_overrides) | set(
+            lifetime_end_overrides
+        )
         buffers: list[LifetimeBoundBuffer] = []
         for output_name, info in mem_usage.items():
             uses = lifetimes.get(output_name, [])
@@ -721,9 +726,10 @@ class ScratchpadAllocator:
                     # this list inside the shared ``in_place`` dict (matches the copy
                     # in ``_build_cd_bound_buffers``).
                     in_place_parents=_safe_in_place_parents(
-                        in_place.get(output_name, []), lifetime_end_overrides
+                        in_place.get(output_name, []), lifetime_override_names
                     ),
                     residency_reason=reasons.get(output_name),
+                    lifetime_start_override=lifetime_start_overrides.get(output_name),
                     lifetime_end_override=lifetime_end_overrides.get(output_name),
                 )
             )
@@ -756,6 +762,7 @@ class ScratchpadAllocator:
                     first_use_is_read=True,
                     in_place_parents=[],
                     residency_reason=reason,
+                    lifetime_start_override=lifetime_start_overrides.get(input_name),
                     lifetime_end_override=lifetime_end_overrides.get(input_name),
                 )
             )
@@ -769,7 +776,7 @@ class ScratchpadAllocator:
             # consumer is a built candidate with matching per-core size, device
             # layout, a pointwise producer, and no core-division mismatch is there
             # anything safe to merge.
-            if reason is not None or input_name in lifetime_end_overrides:
+            if reason is not None or input_name in lifetime_override_names:
                 continue
             last_use = uses[-1]
             consumer_op = graph.operations[last_use]
@@ -931,7 +938,9 @@ class ScratchpadAllocator:
         t0 = time.perf_counter()
         if lifetimes is None:
             lifetimes = calculate_liveness(graph)
-        lifetime_end_overrides = counted_loop_lifetime_end_overrides(graph)
+        lifetime_start_overrides, lifetime_end_overrides = (
+            counted_loop_lifetime_overrides(graph)
+        )
         ncores, ncores_reasons = get_ncores_for_buffers(graph)
         t1 = time.perf_counter()
         mem_usage = mem_usage_by_buf(graph, cache)
@@ -971,6 +980,7 @@ class ScratchpadAllocator:
             lifetimes=lifetimes,
             ncores=ncores,
             ncores_reasons=ncores_reasons,
+            lifetime_start_overrides=lifetime_start_overrides,
             lifetime_end_overrides=lifetime_end_overrides,
         )
         if lx_relayout_plans:
@@ -1007,6 +1017,8 @@ class ScratchpadAllocator:
             return
         for buffer in buffers:
             buffer.uses = [2 * use + 1 for use in buffer.uses]
+            if buffer.lifetime_start_override is not None:
+                buffer.lifetime_start_override *= 2
             if buffer.lifetime_end_override is not None:
                 buffer.lifetime_end_override *= 2
 
@@ -1020,22 +1032,12 @@ class ScratchpadAllocator:
 
         for source_entries in entries_by_source.values():
             source = source_entries[0][0]
-            original_end = source.lifetime_end_override
-            transfer_ticks = []
             for _, plan, original_ticks in source_entries:
                 consumer_ticks = [2 * tick + 1 for tick in original_ticks]
                 transfer_tick = consumer_ticks[0] - 1
-                transfer_ticks.append(transfer_tick)
                 source.uses = sorted(
                     {use for use in source.uses if use not in consumer_ticks}
                     | {transfer_tick}
-                )
-                nominal_destination_end = consumer_ticks[-1] + 1
-                destination_end = (
-                    original_end
-                    if original_end is not None
-                    and original_end > nominal_destination_end
-                    else None
                 )
                 destination = LifetimeBoundBuffer(
                     plan.destination_name,
@@ -1043,17 +1045,16 @@ class ScratchpadAllocator:
                         source.size, _LX_ALLOCATION_GRANULARITY_BYTES
                     ),
                     [transfer_tick, *consumer_ticks],
-                    lifetime_end_override=destination_end,
                 )
                 buffers.insert(buffers.index(source), destination)
                 source.paired_with.append(destination)
 
-            # Once relayout owns every later read, the extended lifetime moves
-            # from the source to its destinations. A same-view reader after the
-            # last transfer still needs the original source through the loop.
-            remaining_reads = source.uses[0 if source.first_use_is_read else 1 :]
-            if not any(use > max(transfer_ticks) for use in remaining_reads):
-                source.lifetime_end_override = None
+            # A counted-loop override describes the source value crossing an
+            # iteration boundary.  The relayout copy is materialized inside the
+            # LoopSpec and is recreated on every iteration, so it keeps its
+            # ordinary short lifetime.  The source itself must retain both
+            # overrides even when every textual consumer was redirected: the
+            # inserted copy reads it again on the next runtime iteration.
 
     def _allocated_lx_relayout_sources(
         self, allocation: Sequence[LifetimeBoundBuffer]
@@ -1835,7 +1836,12 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             op.name: self._op_inputs_good_for_lx_inplace(op) for op in graph.operations
         }
         lifetimes = calculate_liveness(graph)
-        lifetime_end_overrides = counted_loop_lifetime_end_overrides(graph)
+        lifetime_start_overrides, lifetime_end_overrides = (
+            counted_loop_lifetime_overrides(graph)
+        )
+        lifetime_override_names = set(lifetime_start_overrides) | set(
+            lifetime_end_overrides
+        )
         for buf_name, info in mem_usage.items():
             allow_inplace[buf_name] = []
             if not in_place_allowed[buf_name]:
@@ -1855,7 +1861,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                 # them). Skip them, matching the base allocator's guard.
                 if input_buf not in mem_usage or not lifetimes[input_buf]:
                     continue
-                if input_buf in lifetime_end_overrides:
+                if input_buf in lifetime_override_names:
                     continue
                 in_layout = graph.get_buffer(input_buf).layout
                 if not hasattr(in_layout, "device_layout"):
@@ -1917,7 +1923,12 @@ class CoOptimizingAllocator(ScratchpadAllocator):
         solver compares those total footprints.
         """
         lifetimes = calculate_liveness(graph)
-        lifetime_end_overrides = counted_loop_lifetime_end_overrides(graph)
+        lifetime_start_overrides, lifetime_end_overrides = (
+            counted_loop_lifetime_overrides(graph)
+        )
+        lifetime_override_names = set(lifetime_start_overrides) | set(
+            lifetime_end_overrides
+        )
         mem_usage = mem_usage_by_buf(graph)
         in_place = {} if in_place is None else in_place
         op_by_name = {op.name: op for op in graph.operations}
@@ -1968,6 +1979,9 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                         parents=[],
                         cd_parent_matches={},
                         residency_reason=None,
+                        lifetime_start_override=lifetime_start_overrides.get(
+                            input_name
+                        ),
                         lifetime_end_override=lifetime_end_overrides.get(input_name),
                         boundary=BufferType.Input,
                     )
@@ -1981,7 +1995,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
 
             buf_divisions = divisions[output_name]
             parents = _safe_in_place_parents(
-                in_place.get(output_name, []), lifetime_end_overrides
+                in_place.get(output_name, []), lifetime_override_names
             )
             size = info["size"]  # total footprint; solver divides per chosen cd
             parent_proj = info["op_inputs"].copy()
@@ -2011,7 +2025,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             # clone, so they are skipped.
             out_layout = graph.get_buffer(output_name).layout
             for clone_name in last_consumer_clones.get(output_name, []):
-                if clone_name in lifetime_end_overrides:
+                if clone_name in lifetime_override_names:
                     continue
                 if clone_name in parents:
                     continue
@@ -2047,6 +2061,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
                     parents=parent_proj,
                     cd_parent_matches=cd_parent_matches,
                     residency_reason=residency_reason,
+                    lifetime_start_override=lifetime_start_overrides.get(output_name),
                     lifetime_end_override=lifetime_end_overrides.get(output_name),
                     boundary=BufferType.Output
                     if output_name in graph_output_names

--- a/torch_spyre/_inductor/scratchpad/exhaustive_search.py
+++ b/torch_spyre/_inductor/scratchpad/exhaustive_search.py
@@ -150,6 +150,7 @@ class ExhaustiveSearchSolver(CoreDivisionLayoutSolver):
                     first_use_is_read=b.first_use_is_read,
                     in_place_parents=_valid_inplace_parents(b, chosen[b.name]),
                     residency_reason=_residency_reason(b, chosen[b.name]),
+                    lifetime_start_override=b.lifetime_start_override,
                     lifetime_end_override=b.lifetime_end_override,
                 )
                 for b in buffers_list

--- a/torch_spyre/_inductor/scratchpad/plan_solver.py
+++ b/torch_spyre/_inductor/scratchpad/plan_solver.py
@@ -71,7 +71,8 @@ class LifetimeBoundBuffer:
     would let such a buffer pass as an in-place parent.
 
     ``start_time`` and ``end_time`` are convenience properties derived from
-    ``uses``: ``uses[0]`` and ``uses[-1] + 1`` respectively.
+    ``uses`` and optional counted-loop overrides.  The overrides widen storage
+    liveness without adding fake accesses to ``uses``.
     """
 
     name: str
@@ -87,6 +88,10 @@ class LifetimeBoundBuffer:
     # Keep this separate from ``uses``: it changes address overlap, but must not
     # manufacture a read or inflate residency/spill benefit.
     lifetime_end_override: Optional[int] = None
+    # Optional inclusive lifetime start for storage reused by a counted loop.
+    # A loop-crossing value is live before its first textual read on every
+    # runtime iteration after the first.
+    lifetime_start_override: Optional[int] = None
     # Buffers that must be placed atomically with this one. Despite the name,
     # this is one-to-many: only the group root carries the complete partner list.
     paired_with: list["LifetimeBoundBuffer"] = field(
@@ -117,6 +122,12 @@ class LifetimeBoundBuffer:
                 f"{self.lifetime_end_override} before nominal exclusive end "
                 f"{self.uses[-1] + 1}"
             )
+        if self.lifetime_start_override is not None and self.uses:
+            assert self.lifetime_start_override <= self.uses[0], (
+                f"buffer {self.name} has lifetime_start_override="
+                f"{self.lifetime_start_override} after nominal start "
+                f"{self.uses[0]}"
+            )
 
     @property
     def read_count(self) -> int:
@@ -135,7 +146,9 @@ class LifetimeBoundBuffer:
 
     @property
     def start_time(self) -> int:
-        return self.uses[0]
+        nominal = self.uses[0]
+        override = self.lifetime_start_override
+        return min(nominal, override if override is not None else nominal)
 
     @property
     def end_time(self) -> int:

--- a/torch_spyre/_inductor/scratchpad/sa_cooptimizer.py
+++ b/torch_spyre/_inductor/scratchpad/sa_cooptimizer.py
@@ -433,6 +433,8 @@ class SaCoOptimizingSolver(CoreDivisionLayoutSolver):
                         p for p in b.in_place_parents if p in self._name_to_idx
                     ],
                     residency_reason=b.residency_reason,
+                    lifetime_start_override=b.lifetime_start_override,
+                    lifetime_end_override=b.lifetime_end_override,
                 )
             )
         return out

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -103,47 +103,69 @@ def calculate_liveness(graph: GraphLowering) -> dict[str, list[int]]:
     return liveness
 
 
-def counted_loop_lifetime_end_overrides(graph: GraphLowering) -> dict[str, int]:
-    """Return exclusive lifetime ends for values reused by counted loops.
+def counted_loop_lifetime_overrides(
+    graph: GraphLowering,
+) -> tuple[dict[str, int], dict[str, int]]:
+    """Return lifetime starts/ends for values reused by counted loops.
 
     The graph contains one textual copy of a loop body.  Ordinary liveness
-    therefore sees only the first runtime iteration and may reuse a value's LX
-    address later in that body, even though the next iteration reads it again.
-    A value born outside a loop and read inside it must stay alive through that
-    loop.  This records that storage fact without adding a fake read to
-    :func:`calculate_liveness`.
+    therefore sees only the first runtime iteration.  A value born outside a
+    loop and read inside it must occupy LX for the loop's *entire* textual body:
+    after the last textual read it remains live for the next iteration, and
+    before the first textual read a later iteration still carries the value
+    produced by the preceding iteration/preheader.
+
+    Model that circular lifetime by widening the crossing value itself to the
+    loop's start and exclusive end.  This makes it conflict with every
+    loop-local temporary without making those temporaries conflict with one
+    another.  Extending every loop-local value to the loop end is safe but much
+    too conservative for an unrolled attention body: independent K/V-block
+    temporaries then form one mutually-overlapping clique and cannot reuse LX.
+
+    The two returned dictionaries are ``(start_overrides, end_overrides)``.
+    Every crossing value appears in ``start_overrides`` even when its nominal
+    lifetime already starts before the loop; callers use that membership to
+    reject destructive in-place handoffs.  Keep the bounds separate from
+    :func:`calculate_liveness`: they affect address overlap, but must not
+    manufacture reads or inflate spill benefit.
     """
 
     def group_path(op: Operation) -> tuple[int, ...]:
         return tuple(getattr(getattr(op, "loop_info", None), "loop_group_id", ()) or ())
 
+    loop_start: dict[tuple[int, ...], int] = {}
     loop_end: dict[tuple[int, ...], int] = {}
     birth_group: dict[str, tuple[int, ...]] = {
         name: () for name in graph.graph_input_names
     }
+    first_access: dict[str, int] = {}
     last_access: dict[str, int] = {}
-    last_read: dict[str, int] = {}
+    read_writes = []
 
     for index, op in enumerate(graph.operations):
         path = group_path(op)
         for depth in range(1, len(path) + 1):
-            loop_end[path[:depth]] = index
+            loop = path[:depth]
+            loop_start.setdefault(loop, index)
+            loop_end[loop] = index
         rw = op_read_writes(op)
+        read_writes.append(rw)
         for dep in rw.writes:
             birth_group.setdefault(dep.name, path)
+            first_access.setdefault(dep.name, index)
             last_access[dep.name] = index
         for dep in rw.reads:
             birth_group.setdefault(dep.name, ())
+            first_access.setdefault(dep.name, index)
             last_access[dep.name] = index
-            last_read[dep.name] = index
 
-    overrides: dict[str, int] = {}
-    crossed_loops: set[tuple[int, ...]] = set()
-    for index, op in enumerate(graph.operations):
+    start_overrides: dict[str, int] = {}
+    end_overrides: dict[str, int] = {}
+    for index, (op, rw) in enumerate(zip(graph.operations, read_writes)):
         consumer_path = group_path(op)
         if not consumer_path:
             continue
-        for dep in op_read_writes(op).reads:
+        for dep in rw.reads:
             producer_path = birth_group.get(dep.name, ())
             common = 0
             while (
@@ -155,38 +177,25 @@ def counted_loop_lifetime_end_overrides(graph: GraphLowering) -> dict[str, int]:
             if common == len(consumer_path):
                 continue
             enclosing_loop = consumer_path[: common + 1]
+            start = loop_start[enclosing_loop]
             end = loop_end[enclosing_loop] + 1
+            nominal_start = first_access.get(dep.name, index)
+            # Record every crossing value even when its nominal interval
+            # already begins before this loop.  Allocators also use membership
+            # in this map to reject an in-place handoff that would overwrite
+            # the value before the next runtime iteration reads it.
+            start_overrides[dep.name] = min(
+                start_overrides.get(dep.name, nominal_start), nominal_start, start
+            )
             if end > last_access.get(dep.name, index) + 1:
-                overrides[dep.name] = max(overrides.get(dep.name, 0), end)
-                crossed_loops.add(enclosing_loop)
+                end_overrides[dep.name] = max(end_overrides.get(dep.name, 0), end)
+    return start_overrides, end_overrides
 
-    # A value that crosses `enclosing_loop`'s boundary (above) must stay valid
-    # across every runtime iteration of that loop. But the graph holds only one
-    # textual copy of the loop body, so any OTHER value that is born and fully
-    # consumed entirely inside that same loop looks, under plain liveness, like
-    # it occupies a short, disjoint tick range that never overlaps the
-    # crossing value's -- even though that loop-local value is actually
-    # rewritten fresh on every iteration, including iterations after the one
-    # the crossing value's own reads happen to fall in. Sharing an LX address
-    # between the two is therefore unsafe: a later iteration's rewrite of the
-    # loop-local value can land between two of the crossing value's reads and
-    # clobber it. Extending the loop-local value's own end_time to also cover
-    # the whole loop forces `overlaps_in_time` to see the conflict for every
-    # solver, instead of leaving it to placement-order luck. A value that is
-    # never read again by anything (write-only) cannot be clobbered before its
-    # next read -- it has none -- so only values with at least one recorded
-    # read are candidates here; `last_read`, not `last_access`, decides
-    # whether that read already falls before the loop's end.
-    if crossed_loops:
-        for name, path in birth_group.items():
-            if name not in last_read:
-                continue
-            for loop in crossed_loops:
-                if path[: len(loop)] == loop:
-                    end = loop_end[loop] + 1
-                    if end > last_read[name] + 1:
-                        overrides[name] = max(overrides.get(name, 0), end)
-    return overrides
+
+def counted_loop_lifetime_end_overrides(graph: GraphLowering) -> dict[str, int]:
+    """Compatibility view of counted-loop exclusive lifetime ends."""
+
+    return counted_loop_lifetime_overrides(graph)[1]
 
 
 def mem_usage_by_buf(

--- a/torch_spyre/_inductor/wsr/coarse_tile.py
+++ b/torch_spyre/_inductor/wsr/coarse_tile.py
@@ -3728,6 +3728,7 @@ def _insert_one_read_copy(
     *,
     predivision_unit_steps: tuple[tuple[tuple[int, Expr, Expr], ...], ...] = (),
     loop_invariant: bool = False,
+    hoist: bool | None = None,
 ) -> str:
     """Build and insert one tile-sized copy op for a single full-buffer read.
 
@@ -4073,7 +4074,8 @@ def _insert_one_read_copy(
     if hasattr(copy_buf, "work_div_loop_info"):
         del copy_buf.work_div_loop_info  # type: ignore[attr-defined]
 
-    if loop_invariant:
+    hoist = loop_invariant if hoist is None else hoist
+    if hoist:
         # No loop metadata means codegen emits this copy once before the first
         # loop-body consumer.  The copy has its own iteration symbols, so the
         # consumer's named work-division request must not be reused on it
@@ -4792,10 +4794,36 @@ def _plan_read_copies(
                     ),
                 )
             )
+        # Hoisting several different invariant windows from one source makes
+        # all of them live across the entire counted loop. This is disastrous
+        # for unrolled attention masks: N KV blocks consume N independent mask
+        # tiles. Keep each copy compact, but execute it in the loop next to its
+        # consumer so those tiles can reuse one LX address.
+        entries = _place_invariant_read_copies(entries)
         if entries:
             plans[stamped_group_id] = ReadCopyPlan(entries=tuple(entries))
 
     return plans
+
+
+def _place_invariant_read_copies(
+    entries: list[ReadCopyEntry],
+) -> list[ReadCopyEntry]:
+    """Hoist one invariant source window, but sink repeated source windows."""
+
+    invariant_windows_per_source = collections.Counter(
+        entry.dep.name for entry in entries if entry.loop_invariant
+    )
+    return [
+        dataclasses.replace(
+            entry,
+            hoist=(
+                entry.loop_invariant
+                and invariant_windows_per_source[entry.dep.name] == 1
+            ),
+        )
+        for entry in entries
+    ]
 
 
 def _insert_all_read_copy_ops(
@@ -4830,6 +4858,7 @@ def _insert_all_read_copy_ops(
                 insert_before_op=insert_before_op,
                 predivision_unit_steps=entry.predivision_unit_steps,
                 loop_invariant=entry.loop_invariant,
+                hoist=entry.hoist,
             )
             for consumer_name in entry.consumer_op_names:
                 consumer = name_to_op[consumer_name]


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

- Preserves dependency-correct lowering order for counted-loop bodies through scratchpad planning and scheduler construction.
- Keeps each outer counted-loop group atomic relative to its preheader operations.
- Models loop-carried values with circular lifetime start/end overrides while leaving loop-local temporaries ephemeral and reusable in LX.
- Propagates the lifetime bounds consistently through the native, exhaustive-search, and simulated-annealing allocators.

This is the locality/lifetime follow-up to the SDPA and M=1 work merged in #4259. Real GQA changes are intentionally excluded.

Validation:

- 550 passed, 5 skipped, 2 expected failures across test_operation_scheduling.py, test_coarse_tiling.py, test_perm_layout_solver.py, and test_work_division_hint.py
- all pre-commit hooks passed

#### Which issue(s) this PR is related to:

Follow-up to #4259.

#### Does this PR introduce a user-facing change?

No. This changes compiler scheduling and scratchpad lifetime accounting.