### PR TITLE
Enable/Test softmax

### DIFF
--- a/test_h2f.py
+++ b/test_h2f.py
@@ -1,0 +1,84 @@
+import torch
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "tests", "inductor"))
+from utils_inductor import cached_randn, _compile_and_run, DEVICE
+
+
+def dl16_to_fp32_restore_cpu(x_staggered: torch.Tensor) -> torch.Tensor:
+    FP16_STICK = 64
+    n = x_staggered.shape[-1]
+    assert n % FP16_STICK == 0, f"last dim {n} must be multiple of {FP16_STICK}"
+    P = torch.zeros(n, n, dtype=torch.float32)
+    for phys_j in range(n):
+        win_base = (phys_j // FP16_STICK) * FP16_STICK
+        local_phys = phys_j % FP16_STICK
+        local_logical = (
+            (local_phys // 32) * 4 + (local_phys % 4) + (local_phys % 32) // 4 * 8
+        )
+        P[win_base + local_logical, phys_j] = 1.0
+    orig_shape = x_staggered.shape
+    m = x_staggered.cpu().numel() // n
+    result = torch.mm(x_staggered.cpu().float().reshape(m, n), P.t())
+    return result.reshape(orig_shape)
+
+
+# h2f softmax cases: fp16 input → fp32 output
+# 4D non-aligned interior dims (e.g. (6,17,32,64) dim=2) are known unsupported
+# due to mixed-EA clash on non-stick reduction dims.
+CASES = [
+    # 2D
+    ("h2f 2D (24,128)     dim=0", 0, (24, 128)),
+    ("h2f 2D (24,128)     dim=1", 1, (24, 128)),
+    ("h2f 2D (512,1024)   dim=0", 0, (512, 1024)),
+    ("h2f 2D (512,1024)   dim=1", 1, (512, 1024)),
+    # 3D
+    ("h2f 3D (4,24,128)   dim=0", 0, (4, 24, 128)),
+    ("h2f 3D (4,24,128)   dim=1", 1, (4, 24, 128)),
+    ("h2f 3D (4,24,128)   dim=2", 2, (4, 24, 128)),
+    ("h2f 3D (256,64,128) dim=0", 0, (256, 64, 128)),
+    ("h2f 3D (256,64,128) dim=1", 1, (256, 64, 128)),
+    ("h2f 3D (256,64,128) dim=2", 2, (256, 64, 128)),
+    # 4D aligned (all dims multiples of fp32 stick=32)
+    ("h2f 4D (6,32,32,64) dim=0", 0, (6, 32, 32, 64)),
+    ("h2f 4D (6,32,32,64) dim=1", 1, (6, 32, 32, 64)),
+    ("h2f 4D (6,32,32,64) dim=2", 2, (6, 32, 32, 64)),
+    ("h2f 4D (6,32,32,64) dim=3", 3, (6, 32, 32, 64)),
+    # 4D non-aligned — known unsupported (mixed-EA on interior non-stick dim)
+    ("h2f 4D (6,17,32,64) dim=0", 0, (6, 17, 32, 64)),
+    ("h2f 4D (6,17,32,64) dim=1", 1, (6, 17, 32, 64)),
+    ("h2f 4D (6,17,32,64) dim=2", 2, (6, 17, 32, 64)),
+    ("h2f 4D (6,17,32,64) dim=3", 3, (6, 17, 32, 64)),
+]
+
+print("\n[h2f softmax: fp16 input → fp32 output]")
+print("=" * 80)
+print(f"  {'Test':<38s}  {'raw err':>10s}  {'restored':>10s}  Status")
+print("-" * 80)
+
+for label, dim, shape in CASES:
+    x = cached_randn(shape, dtype=torch.float16)
+    fn = lambda a, d=dim: torch.softmax(a, dim=d, dtype=torch.float32)
+    cpu_ref = fn(x)
+    try:
+        spyre_out = _compile_and_run(fn, [x], DEVICE, compile=True)
+        err_raw = torch.abs(spyre_out.float() - cpu_ref.float()).max().item()
+        last_dim = spyre_out.shape[-1]
+        if last_dim % 64 == 0:
+            restored = dl16_to_fp32_restore_cpu(spyre_out.float())
+            err_restored = torch.abs(restored - cpu_ref.float()).max().item()
+            ok = err_restored <= 0.1
+            print(
+                f"  {label:<38s}  {err_raw:>10.4e}  {err_restored:>10.4e}  {'PASS' if ok else 'FAIL'}"
+            )
+        else:
+            ok = err_raw <= 0.1
+            print(
+                f"  {label:<38s}  {err_raw:>10.4e}  {'n/a':>10s}  {'PASS' if ok else 'FAIL'}"
+            )
+    except Exception as e:
+        msg = str(e).split("\n")[0]
+        print(f"  {label:<38s}  {'FAILED':>10s}  {'':>10s}  {msg[:60]}")
+
+print("=" * 80)

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -435,6 +435,25 @@ def _single_arg_op_layout(
             data.reduction_type in REDUCTIONS_NON_STICK_DIM_ONLY
             and reduction_var in x_stick_expr.free_symbols
         ):
+            # When the input has a staggered EA and the reduction is along a
+            # non-stick dimension (reduction_var not in the stick expression),
+            # the stick dimension survives intact in the output.  Preserve the
+            # staggered EA by rescaling the input STL to the output dtype so
+            # that downstream pointwise ops (e.g. x_fp32 - amax) see matching
+            # EAs on both inputs.
+            # Only applicable when both dtypes share the same stick depth
+            # (same_device_size); cross-depth cases like fp16→fp32 where
+            # device_size dims may not be evenly divisible after rescaling are
+            # handled separately below.
+            input_ea = stl.element_arrangement
+            if (
+                input_ea in STAGGERED_EAS
+                and reduction_var is not None
+                and reduction_var not in x_stick_expr.free_symbols
+                and same_device_size(in_layout.dtype, out_dtype_for_layout)
+            ):
+                return [_rescale_stl_for_dtype(stl, out_dtype_for_layout, input_ea)]
+
             # Try to preserve input layout
             out_stl = _output_stl_from_stick_expr(
                 x_stick_expr, output, output_dep, c_size, c_stride, out_dtype_for_layout


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

will fixed #499 

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

<img width="1168" height="632" alt="Screenshot 2026-09-10 at 8 35 57 AM" src="https://github.com/user-attachments/assets/00ead9ca-1cf4-4182-a015-b2c54454792c" />


FP16 staggered to standard restore has been merged in #3571, below is the diagram of apply permutation matrix:
<img width="1513" height="1210" alt="Screenshot 2026-09-03 at 3 03 59 PM" src="https://github.com/user-attachments/assets/f1e7e355-0973-43b6-bdf2-d12fbb587fd6" />


Similarly, FP32 staggered to standard restore apply a permutation matrix as well. Now FP32 restickify has not yet enable in the backend, we restore FP32 staggered in CPU just for test: 
<img width="1533" height="1023" alt="Screenshot 2026-09-03 at 3 03 47 PM" src="https://github.com/user-attachments/assets/c99505bc-48fa-405a-aa63-d03bc3243abb" />


Below is result showing raw err and restored error:
<img width="1806" height="708" alt="image" src="https://github.com/user-attachments/assets/2fba9096-dc74-46b3-b1e8-a93f8fa86158" />


