### PR TITLE
fix(inductor): allow sparse staggered broadcasts

### DIFF
--- a/tests/inductor/test_building_blocks.py
+++ b/tests/inductor/test_building_blocks.py
@@ -273,8 +273,9 @@ class TestBuildingBlocks(unittest.TestCase):
         # Case 3.2 of the mixed-EA rule: the *staggered* operand is the
         # size-1-stick broadcaster (fp16 produced by an fp32->fp16 downcast,
         # FP32_TO_DL16) combined with a STANDARD full operand. A broadcastable
-        # staggered operand is physically identical to STANDARD of that shape, so
-        # the op is allowed (STANDARD output).
+        # staggered operand reads only element zero of each stick, so its
+        # within-stick ordering is unobservable and the op can produce a STANDARD
+        # output.
         x = torch.randn(4, 1, dtype=torch.float32)  # -> .to(f16): staggered bcast
         w = torch.randn(4, 64, dtype=torch.float16)  # STANDARD full
 
@@ -282,6 +283,23 @@ class TestBuildingBlocks(unittest.TestCase):
             return torch.add(x.to(torch.float16), w)
 
         compare_with_cpu(fn, x, w, cpu_compile=False, run_eager=False)
+
+    def test_mixed_ea_noncanonical_staggered_broadcaster_fp16(self):
+        # Gemma 4 vision RMSNorm produces its mean in fp32, then downcasts it
+        # before subtracting it from a full bf16 activation. The downcast keeps
+        # the reduction's noncanonical device geometry, but its stick is sparse;
+        # the FP32_TO_DL16 ordering is therefore unobservable to the broadcast.
+        x = torch.rand(1, 280, 6912, dtype=torch.bfloat16)
+
+        def fn(x):
+            xf = x.to(torch.float32)
+            mean = xf.mean(-1, keepdim=True)
+            centered = xf - mean
+            variance = (centered * centered).mean(-1, keepdim=True)
+            inv = torch.rsqrt(variance + 1e-6).to(x.dtype)
+            return (x - mean.to(x.dtype)) * inv
+
+        compare_with_cpu(fn, x, cpu_compile=False, run_eager=False)
 
     def test_mixed_ea_staggered_broadcaster_fp32(self):
         # Case 3.2 with an fp32-physical staggered broadcaster (DL16_TO_FP32).

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -1283,8 +1283,10 @@ def _multi_arg_pointwise_layouts(
     #       3.2 every staggered operand can broadcast  -> STANDARD output
     #       3.3 otherwise (a STANDARD and a staggered full operand coexist)
     #                                                  -> unsupported (raise)
-    # Prefer 3.1 in the overlap because propagation does not yet know which
-    # candidate layout the optimizer will commit for the staggered producer.
+    # In the overlap, prefer the direction whose broadcast condition holds for
+    # every candidate of the opposite-EA inputs. That choice remains valid no
+    # matter which producer layouts the optimizer can actually reach. If both
+    # directions are equally stable (or unstable), retain the 3.1 preference.
     # A future extension may admit 2a/3.3 by inserting an explicit EA conversion
     # at extra cost.
     staggered_inputs = input_eas & STAGGERED_EAS
@@ -1333,7 +1335,18 @@ def _multi_arg_pointwise_layouts(
             if arg.layouts and arg.layouts[0].element_arrangement == staggered_ea
         ]
 
-        if all(broadcast for _, broadcast, _ in std_split):
+        std_can_broadcast = all(broadcast for _, broadcast, _ in std_split)
+        stag_can_broadcast = bool(stag_split) and all(
+            broadcast for _, broadcast, _ in stag_split
+        )
+        std_always_broadcasts = all(
+            not non_broadcast for _, _, non_broadcast in std_split
+        )
+        stag_always_broadcasts = all(
+            not non_broadcast for _, _, non_broadcast in stag_split
+        )
+
+        if std_can_broadcast and (std_always_broadcasts or not stag_always_broadcasts):
             # Case 3.1 (and case 2b with no STANDARD operands): preserve the
             # staggered arrangement and keep only broadcast-compatible STANDARD
             # candidates.
@@ -1341,46 +1354,20 @@ def _multi_arg_pointwise_layouts(
             for arg, broadcast, non_broadcast in std_split:
                 if non_broadcast:
                     arg.layouts[:] = broadcast
-        elif stag_split and all(broadcast for _, broadcast, _ in stag_split):
+        elif stag_can_broadcast:
             # Case 3.2: every staggered operand has a broadcast candidate, so
             # the operation can use STANDARD ordering.
             #
-            # Safety: device coordinates depend only on device_size/stride_map,
-            # not the EA label (see device_coordinates), and `_is_supported_layout`
-            # rebuilds each operand from its host size/stride with the *output* EA
-            # (here STANDARD). Reinterpreting a broadcastable staggered operand as
-            # STANDARD is therefore sound only if its staggered device geometry is
-            # identical to the STANDARD layout of the same host shape. A size-1
-            # stick usually makes the staggering vacuous, but we do NOT assume it:
-            # verify per kept candidate and raise rather than silently emit wrong
-            # coordinates (e.g. under a non-identity dim_order or a shape whose
-            # staggering is not a genuine no-op).
-            for arg, broadcast, _ in stag_split:
-                c_in_size = [concretize_expr(s) for s in arg.layout.size]
-                c_in_stride = [concretize_expr(s) for s in arg.layout.stride]
-                std_geom = SpyreTensorLayout(
-                    c_in_size,
-                    c_in_stride,
-                    arg.layout.dtype,
-                    list(range(len(c_in_size))),
-                    ElementArrangement.STANDARD,
-                )
-                for cand in broadcast:
-                    if (
-                        cand.device_size != std_geom.device_size
-                        or cand.stride_map != std_geom.stride_map
-                    ):
-                        raise Unsupported(
-                            f"Multi-arg pointwise with mixed EA: staggered operand "
-                            f"{arg.dep.name} is broadcastable but its {staggered_ea} "
-                            f"device layout "
-                            f"({cand.device_size}/{cand.stride_map}) differs from the "
-                            f"STANDARD layout of the same shape "
-                            f"({std_geom.device_size}/{std_geom.stride_map}); "
-                            f"reinterpreting it as STANDARD would change its "
-                            f"coordinates. De-staggering via an explicit EA "
-                            f"conversion is not supported yet."
-                        )
+            # ElementArrangement changes only the order of elements *within* a
+            # stick. Every candidate retained here has a sparse stick
+            # (stride_map[-1] == -1), so all its logical loads address the same
+            # within-stick element and the stagger is unobservable. Its outer
+            # device geometry may still be noncanonical (dtype conversion keeps
+            # its producer's geometry); that geometry remains on the input and
+            # is handled independently by the coordinate compatibility solver.
+            # Comparing it with a freshly constructed canonical STANDARD layout
+            # would therefore reject valid broadcasts such as Gemma 4's fp32
+            # RMSNorm mean downcast.
             output_ea = ElementArrangement.STANDARD
             for arg, broadcast, non_broadcast in stag_split:
                 if non_broadcast:


### PR DESCRIPTION
## Summary

- allow a staggered broadcast operand to keep its noncanonical outer device geometry when its within-stick coordinate is sparse
- choose the mixed-EA propagation direction that remains valid for every producer candidate
- add a regression covering Gemma 4 vision LayerNorm

This fixes the compile failure blocking torch-spyre/hf-adapters#366 in the Gemma 4 12B VLM vision core.

## Validation

- `pytest -q -s tests/inductor/test_building_blocks.py::TestBuildingBlocks::test_mixed_ea_noncanonical_staggered_broadcaster_fp16`
- `pytest -q -s tests/inductor/test_building_blocks.py -k "mixed_ea or rms_norm"` (14 passed, 8 subtests passed)
- Gemma 4 12B VLM: 5/5 token agreement, cosine 0.998682-0.999811
- `pre-commit run --files torch_spyre/_inductor/propagate_layouts.py tests/inductor/test_building_blocks.py`