### PR TITLE
Enable coalesced collectives + reduce_scatter

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -770,6 +770,12 @@ jobs:
             config: distributed_tests/test_allgather_compiled.yaml
           - name: Test Multi-Spyre Allreduce Compiled
             config: distributed_tests/test_allreduce_compiled.yaml
+          - name: Test Multi-Spyre Allreduce Coalesced
+            config: distributed_tests/test_allreduce_coalesced.yaml
+          - name: Test Multi-Spyre Allgather Coalesced
+            config: distributed_tests/test_allgather_coalesced.yaml
+          - name: Test Multi-Spyre ReduceScatter Compiled
+            config: distributed_tests/test_reduce_scatter_compiled.yaml
 
     steps:
       # See the `test` job above: prebaked path symlinks the baked .github into

--- a/docs/source/user_guide/examples/distributed/compiled/all_gather_coalesced_demo_multirank.py
+++ b/docs/source/user_guide/examples/distributed/compiled/all_gather_coalesced_demo_multirank.py
@@ -1,0 +1,198 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compiled all_gather_into_tensor_coalesced demo.
+
+This example demonstrates how torch.compile lowers
+all_gather_into_tensor_coalesced into per-tensor allgather plan/run pairs
+via Spyre's compile-time collective ops.  The coalesced call takes a list
+of tensors and gathers each one independently:
+
+At graph load (compile-time, one plan per distinct shape):
+    plan_handle_0 = allgather_plan(num_elems, dtype, group_size, group)
+    plan_handle_1 = allgather_plan(num_elems, dtype, group_size, group)
+
+At every forward pass (runtime):
+    y0 = allgather_run(x0, plan_handle_0, group_size)
+    y1 = allgather_run(x1, plan_handle_1, group_size)
+    y0 = wait_work(y0)
+    y1 = wait_work(y1)
+
+Usage:
+    torchrun --nproc-per-node 2 all_gather_coalesced_demo_multirank.py
+"""
+
+import os
+
+import torch
+import torch.distributed as dist
+import torch.distributed.distributed_c10d as c10d
+
+import torch_spyre  # noqa: F401
+
+DEVICE = torch.device(f"spyre:{os.getenv('RANK', '0')}")
+C10D_BACKEND = "spyreccl"
+_GROUP_NAME = "default"
+
+
+def demo_basic_coalesced(comm_rank, comm_size):
+    """Basic coalesced allgather — two tensors gathered in one call."""
+    print(f"[Rank {comm_rank}] Demo 1: Basic coalesced allgather")
+
+    class CoalescedModule(torch.nn.Module):
+        def __init__(self, group_size):
+            super().__init__()
+            self._group_size = group_size
+
+        def forward(self, tensors):
+            results = torch.ops._c10d_functional.all_gather_into_tensor_coalesced(
+                tensors, self._group_size, _GROUP_NAME
+            )
+            return [torch.ops._c10d_functional.wait_tensor(r) for r in results]
+
+    a = torch.full((64,), float(comm_rank), dtype=torch.float16, device=DEVICE)
+    b = torch.full((64,), float(comm_rank + 10), dtype=torch.float16, device=DEVICE)
+    print(f"[Rank {comm_rank}] Input a: {comm_rank}.0, b: {comm_rank + 10}.0")
+
+    compiled_fn = torch.compile(CoalescedModule(comm_size))
+    r_a, r_b = compiled_fn([a, b])
+
+    r_a_cpu = r_a.to("cpu")
+    r_b_cpu = r_b.to("cpu")
+    print(f"[Rank {comm_rank}] Result a shape: {r_a.shape} (64 * {comm_size})")
+    print(f"[Rank {comm_rank}] Result b shape: {r_b.shape} (64 * {comm_size})")
+
+    for rank in range(comm_size):
+        chunk_a = r_a_cpu[rank * 64 : (rank + 1) * 64]
+        chunk_b = r_b_cpu[rank * 64 : (rank + 1) * 64]
+        expected_a = torch.full((64,), float(rank), dtype=torch.float16)
+        expected_b = torch.full((64,), float(rank + 10), dtype=torch.float16)
+        assert torch.allclose(chunk_a, expected_a), (
+            f"Rank {comm_rank}: tensor a, rank {rank} chunk FAILED"
+        )
+        assert torch.allclose(chunk_b, expected_b), (
+            f"Rank {comm_rank}: tensor b, rank {rank} chunk FAILED"
+        )
+    print(f"[Rank {comm_rank}] PASSED")
+
+
+def demo_mixed_shapes(comm_rank, comm_size):
+    """Coalesced allgather with tensors of different shapes.
+
+    Each tensor gets its own WSI plan.  The plan cache deduplicates by
+    (dtype, num_elems, group_size), so tensors with the same shape share
+    a plan.
+    """
+    print(f"[Rank {comm_rank}] Demo 2: Mixed-shape coalesced allgather")
+
+    class MixedShapeModule(torch.nn.Module):
+        def __init__(self, group_size):
+            super().__init__()
+            self._group_size = group_size
+
+        def forward(self, tensors):
+            results = torch.ops._c10d_functional.all_gather_into_tensor_coalesced(
+                tensors, self._group_size, _GROUP_NAME
+            )
+            return [torch.ops._c10d_functional.wait_tensor(r) for r in results]
+
+    a = torch.full((64,), float(comm_rank), dtype=torch.float16, device=DEVICE)
+    b = torch.full((128,), float(comm_rank), dtype=torch.float16, device=DEVICE)
+    print(f"[Rank {comm_rank}] Input: two tensors (64, 128), value={comm_rank}.0")
+
+    compiled_fn = torch.compile(MixedShapeModule(comm_size))
+    r_a, r_b = compiled_fn([a, b])
+
+    print(f"[Rank {comm_rank}] Result a shape: {r_a.shape}, b shape: {r_b.shape}")
+
+    r_a_cpu = r_a.to("cpu")
+    r_b_cpu = r_b.to("cpu")
+    for rank in range(comm_size):
+        chunk_a = r_a_cpu[rank * 64 : (rank + 1) * 64]
+        chunk_b = r_b_cpu[rank * 128 : (rank + 1) * 128]
+        expected = float(rank)
+        assert torch.allclose(
+            chunk_a, torch.full((64,), expected, dtype=torch.float16)
+        ), f"Rank {comm_rank}: tensor a, rank {rank} FAILED"
+        assert torch.allclose(
+            chunk_b, torch.full((128,), expected, dtype=torch.float16)
+        ), f"Rank {comm_rank}: tensor b, rank {rank} FAILED"
+    print(f"[Rank {comm_rank}] PASSED")
+
+
+def demo_coalesced_with_compute(comm_rank, comm_size):
+    """Compute interleaved with coalesced allgather."""
+    print(f"[Rank {comm_rank}] Demo 3: Coalesced allgather with compute")
+
+    class ComputeModule(torch.nn.Module):
+        def __init__(self, group_size):
+            super().__init__()
+            self._group_size = group_size
+
+        def forward(self, x, y):
+            x_scaled = x * 2.0
+            results = torch.ops._c10d_functional.all_gather_into_tensor_coalesced(
+                [x_scaled], self._group_size, _GROUP_NAME
+            )
+            z = y + 1.0
+            gathered = torch.ops._c10d_functional.wait_tensor(results[0])
+            return gathered + z
+
+    x = torch.full((64,), float(comm_rank + 1), dtype=torch.float16, device=DEVICE)
+    y = torch.ones((64 * comm_size,), dtype=torch.float16, device=DEVICE)
+    print(f"[Rank {comm_rank}] Input x: {comm_rank + 1}.0, y: 1.0")
+
+    compiled_fn = torch.compile(ComputeModule(comm_size))
+    result = compiled_fn(x, y)
+
+    result_cpu = result.to("cpu")
+    for rank in range(comm_size):
+        chunk = result_cpu[rank * 64 : (rank + 1) * 64]
+        # x_scaled = 2*(rank+1), gathered, + z where z = 2.0
+        expected_val = 2.0 * (rank + 1) + 2.0
+        print(
+            f"[Rank {comm_rank}] Chunk {rank}: "
+            f"{chunk[0].item()}, expected: {expected_val}"
+        )
+        assert torch.allclose(
+            chunk, torch.full((64,), expected_val, dtype=torch.float16)
+        ), f"Rank {comm_rank}: rank {rank} chunk FAILED"
+    print(f"[Rank {comm_rank}] PASSED")
+
+
+if __name__ == "__main__":
+    if not dist.distributed_c10d.is_backend_available(C10D_BACKEND):
+        raise RuntimeError(f"Error: Missing the C10 Backend {C10D_BACKEND}")
+    if C10D_BACKEND != dist.get_default_backend_for_device("spyre"):
+        raise RuntimeError(
+            f"Error: Missing a C10 Backend for 'spyre'! Expected {C10D_BACKEND}"
+        )
+
+    print("Initializing distributed process group...")
+    dist.init_process_group(f"cpu:gloo,spyre:{C10D_BACKEND}")
+
+    comm_size = dist.get_world_size()
+    comm_rank = dist.get_rank()
+
+    c10d._register_process_group(_GROUP_NAME, dist.group.WORLD)
+
+    print(f"[Rank {comm_rank}] World size: {comm_size}")
+    print(f"[Rank {comm_rank}] Device: {DEVICE}")
+
+    demo_basic_coalesced(comm_rank, comm_size)
+    demo_mixed_shapes(comm_rank, comm_size)
+    demo_coalesced_with_compute(comm_rank, comm_size)
+
+    print(f"\n[Rank {comm_rank}] All demos PASSED!")
+    dist.destroy_process_group()

--- a/docs/source/user_guide/examples/distributed/compiled/all_reduce_coalesced_demo_multirank.py
+++ b/docs/source/user_guide/examples/distributed/compiled/all_reduce_coalesced_demo_multirank.py
@@ -1,0 +1,190 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compiled all_reduce_coalesced demo.
+
+This example demonstrates how torch.compile lowers all_reduce_coalesced
+into per-tensor allreduce plan/run pairs via Spyre's compile-time
+collective ops.  The coalesced call takes a list of tensors and reduces
+each one independently:
+
+At graph load (compile-time, one plan per distinct shape):
+    plan_handle_0 = allreduce_plan(dtype, "sum", group)
+    plan_handle_1 = allreduce_plan(dtype, "sum", group)  # deduped if same shape
+
+At every forward pass (runtime):
+    y0 = allreduce_run(x0, plan_handle_0)
+    y1 = allreduce_run(x1, plan_handle_1)
+    y0 = wait_work(y0)
+    y1 = wait_work(y1)
+
+Usage:
+    torchrun --nproc-per-node 2 all_reduce_coalesced_demo_multirank.py
+"""
+
+import os
+
+import torch
+import torch.distributed as dist
+import torch.distributed.distributed_c10d as c10d
+
+import torch_spyre  # noqa: F401
+
+DEVICE = torch.device(f"spyre:{os.getenv('RANK', '0')}")
+C10D_BACKEND = "spyreccl"
+_GROUP_NAME = "default"
+
+
+def demo_basic_coalesced(comm_rank, comm_size):
+    """Basic coalesced allreduce — two tensors reduced in one call."""
+    print(f"[Rank {comm_rank}] Demo 1: Basic coalesced allreduce")
+
+    class CoalescedModule(torch.nn.Module):
+        def forward(self, tensors):
+            results = torch.ops._c10d_functional.all_reduce_coalesced(
+                tensors, "sum", _GROUP_NAME
+            )
+            return [torch.ops._c10d_functional.wait_tensor(r) for r in results]
+
+    a = torch.ones((128,), dtype=torch.float16, device=DEVICE)
+    b = torch.full((128,), 2.0, dtype=torch.float16, device=DEVICE)
+    print(f"[Rank {comm_rank}] Input a: all 1.0, b: all 2.0")
+
+    compiled_fn = torch.compile(CoalescedModule())
+    r_a, r_b = compiled_fn([a, b])
+
+    r_a_cpu = r_a.to("cpu")
+    r_b_cpu = r_b.to("cpu")
+    expected_a = float(comm_size)
+    expected_b = 2.0 * comm_size
+    print(
+        f"[Rank {comm_rank}] Result a[0]: {r_a_cpu[0].item()}, expected: {expected_a}"
+    )
+    print(
+        f"[Rank {comm_rank}] Result b[0]: {r_b_cpu[0].item()}, expected: {expected_b}"
+    )
+
+    assert torch.allclose(
+        r_a_cpu, torch.full((128,), expected_a, dtype=torch.float16)
+    ), f"Rank {comm_rank}: tensor a FAILED"
+    assert torch.allclose(
+        r_b_cpu, torch.full((128,), expected_b, dtype=torch.float16)
+    ), f"Rank {comm_rank}: tensor b FAILED"
+    print(f"[Rank {comm_rank}] PASSED")
+
+
+def demo_mixed_shapes(comm_rank, comm_size):
+    """Coalesced allreduce with tensors of different shapes.
+
+    Each tensor gets its own WSI plan. The plan cache deduplicates by
+    (dtype, num_elems), so tensors with the same shape share a plan.
+    """
+    print(f"[Rank {comm_rank}] Demo 2: Mixed-shape coalesced allreduce")
+
+    class MixedShapeModule(torch.nn.Module):
+        def forward(self, tensors):
+            results = torch.ops._c10d_functional.all_reduce_coalesced(
+                tensors, "sum", _GROUP_NAME
+            )
+            return [torch.ops._c10d_functional.wait_tensor(r) for r in results]
+
+    val = float(comm_rank + 1)
+    a = torch.full((64,), val, dtype=torch.float16, device=DEVICE)
+    b = torch.full((256,), val, dtype=torch.float16, device=DEVICE)
+    c = torch.full((128,), val, dtype=torch.float16, device=DEVICE)
+    print(f"[Rank {comm_rank}] Input: three tensors (64, 256, 128), value={val}")
+
+    compiled_fn = torch.compile(MixedShapeModule())
+    r_a, r_b, r_c = compiled_fn([a, b, c])
+
+    # sum of (rank+1) for all ranks = ws*(ws+1)/2
+    expected_val = comm_size * (comm_size + 1) / 2.0
+    print(f"[Rank {comm_rank}] Result a[0]: {r_a.to('cpu')[0].item()}")
+    print(f"[Rank {comm_rank}] Result b[0]: {r_b.to('cpu')[0].item()}")
+    print(f"[Rank {comm_rank}] Result c[0]: {r_c.to('cpu')[0].item()}")
+    print(f"[Rank {comm_rank}] Expected all: {expected_val}")
+
+    for name, result, size in [("a", r_a, 64), ("b", r_b, 256), ("c", r_c, 128)]:
+        assert torch.allclose(
+            result.to("cpu"),
+            torch.full((size,), expected_val, dtype=torch.float16),
+        ), f"Rank {comm_rank}: tensor {name} FAILED"
+    print(f"[Rank {comm_rank}] PASSED")
+
+
+def demo_coalesced_with_compute(comm_rank, comm_size):
+    """Compute interleaved with coalesced allreduce.
+
+    Demonstrates that independent compute can be placed around the
+    coalesced collective, just as with individual allreduce calls.
+    """
+    print(f"[Rank {comm_rank}] Demo 3: Coalesced allreduce with compute")
+
+    class ComputeModule(torch.nn.Module):
+        def forward(self, x, y):
+            x_scaled = x * 2.0
+            y_shifted = y + 1.0
+            results = torch.ops._c10d_functional.all_reduce_coalesced(
+                [x_scaled, y_shifted], "sum", _GROUP_NAME
+            )
+            r_x = torch.ops._c10d_functional.wait_tensor(results[0])
+            r_y = torch.ops._c10d_functional.wait_tensor(results[1])
+            return r_x + r_y
+
+    x = torch.ones((128,), dtype=torch.float16, device=DEVICE)
+    y = torch.ones((128,), dtype=torch.float16, device=DEVICE)
+    print(f"[Rank {comm_rank}] Input x: 1.0, y: 1.0")
+
+    compiled_fn = torch.compile(ComputeModule())
+    result = compiled_fn(x, y)
+
+    result_cpu = result.to("cpu")
+    # x_scaled = 2.0, allreduce -> 2.0 * ws
+    # y_shifted = 2.0, allreduce -> 2.0 * ws
+    # result = 2*ws + 2*ws = 4*ws
+    expected_val = 4.0 * comm_size
+    print(f"[Rank {comm_rank}] Result[0]: {result_cpu[0].item()}")
+    print(f"[Rank {comm_rank}] Expected: {expected_val}")
+
+    assert torch.allclose(
+        result_cpu, torch.full((128,), expected_val, dtype=torch.float16)
+    ), f"Rank {comm_rank}: FAILED"
+    print(f"[Rank {comm_rank}] PASSED")
+
+
+if __name__ == "__main__":
+    if not dist.distributed_c10d.is_backend_available(C10D_BACKEND):
+        raise RuntimeError(f"Error: Missing the C10 Backend {C10D_BACKEND}")
+    if C10D_BACKEND != dist.get_default_backend_for_device("spyre"):
+        raise RuntimeError(
+            f"Error: Missing a C10 Backend for 'spyre'! Expected {C10D_BACKEND}"
+        )
+
+    print("Initializing distributed process group...")
+    dist.init_process_group(f"cpu:gloo,spyre:{C10D_BACKEND}")
+
+    comm_size = dist.get_world_size()
+    comm_rank = dist.get_rank()
+
+    c10d._register_process_group(_GROUP_NAME, dist.group.WORLD)
+
+    print(f"[Rank {comm_rank}] World size: {comm_size}")
+    print(f"[Rank {comm_rank}] Device: {DEVICE}")
+
+    demo_basic_coalesced(comm_rank, comm_size)
+    demo_mixed_shapes(comm_rank, comm_size)
+    demo_coalesced_with_compute(comm_rank, comm_size)
+
+    print(f"\n[Rank {comm_rank}] All demos PASSED!")
+    dist.destroy_process_group()

--- a/docs/source/user_guide/examples/distributed/compiled/reduce_scatter_demo_multirank.py
+++ b/docs/source/user_guide/examples/distributed/compiled/reduce_scatter_demo_multirank.py
@@ -1,0 +1,179 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compiled reduce_scatter_tensor demo.
+
+This example demonstrates how torch.compile lowers reduce_scatter_tensor
+into reducescatter_plan/reducescatter_run pairs via Spyre's compile-time
+collective ops.  reduce_scatter is the inverse of allgather: each rank
+contributes its full input tensor, the tensors are reduced (summed),
+and each rank receives a disjoint slice of the result.
+
+At graph load (compile-time, one plan per distinct shape):
+    plan_handle = reducescatter_plan(num_elems, dtype, group_size, reduce_op, group)
+
+At every forward pass (runtime):
+    y = reducescatter_run(x, plan_handle, group_size)
+    y = wait_work(y)
+
+Usage:
+    torchrun --nproc-per-node 2 reduce_scatter_demo_multirank.py
+"""
+
+import os
+
+import torch
+import torch.distributed as dist
+import torch.distributed.distributed_c10d as c10d
+
+import torch_spyre  # noqa: F401
+
+DEVICE = torch.device(f"spyre:{os.getenv('RANK', '0')}")
+C10D_BACKEND = "spyreccl"
+_GROUP_NAME = "default"
+
+
+def demo_basic_reduce_scatter(comm_rank, comm_size):
+    """Basic reduce_scatter — each rank contributes a full tensor."""
+    print(f"[Rank {comm_rank}] Demo 1: Basic reduce_scatter")
+
+    class ReduceScatterModule(torch.nn.Module):
+        def __init__(self, group_size):
+            super().__init__()
+            self._group_size = group_size
+
+        def forward(self, x):
+            result = torch.ops._c10d_functional.reduce_scatter_tensor(
+                x, "sum", self._group_size, _GROUP_NAME
+            )
+            return torch.ops._c10d_functional.wait_tensor(result)
+
+    x = torch.full((128,), float(comm_rank + 1), dtype=torch.float16, device=DEVICE)
+    print(f"[Rank {comm_rank}] Input: {comm_rank + 1}.0 (128 elems)")
+
+    compiled_fn = torch.compile(ReduceScatterModule(comm_size))
+    result = compiled_fn(x)
+
+    result_cpu = result.to("cpu")
+    print(
+        f"[Rank {comm_rank}] Result shape: {result.shape} "
+        f"(128 / {comm_size} = {128 // comm_size})"
+    )
+
+    # sum of (rank+1) for all ranks = ws*(ws+1)/2
+    expected_val = comm_size * (comm_size + 1) / 2.0
+    expected = torch.full((128 // comm_size,), expected_val, dtype=torch.float16)
+    assert torch.allclose(result_cpu, expected), (
+        f"Rank {comm_rank}: expected {expected_val}, got {result_cpu[0].item()}"
+    )
+    print(f"[Rank {comm_rank}] PASSED (value={result_cpu[0].item()})")
+
+
+def demo_reduce_scatter_with_compute(comm_rank, comm_size):
+    """Compute interleaved with reduce_scatter."""
+    print(f"[Rank {comm_rank}] Demo 2: Reduce_scatter with compute")
+
+    class ComputeModule(torch.nn.Module):
+        def __init__(self, group_size):
+            super().__init__()
+            self._group_size = group_size
+
+        def forward(self, x, bias):
+            x_scaled = x * 2.0
+            result = torch.ops._c10d_functional.reduce_scatter_tensor(
+                x_scaled, "sum", self._group_size, _GROUP_NAME
+            )
+            scattered = torch.ops._c10d_functional.wait_tensor(result)
+            return scattered + bias
+
+    x = torch.full((128,), float(comm_rank + 1), dtype=torch.float16, device=DEVICE)
+    bias = torch.ones((128 // comm_size,), dtype=torch.float16, device=DEVICE)
+    print(f"[Rank {comm_rank}] Input x: {comm_rank + 1}.0, bias: 1.0, scale: 2.0")
+
+    compiled_fn = torch.compile(ComputeModule(comm_size))
+    result = compiled_fn(x, bias)
+
+    result_cpu = result.to("cpu")
+    # x_scaled = 2*(rank+1), reduce_scatter sum, + bias=1
+    rs_val = 2.0 * comm_size * (comm_size + 1) / 2.0
+    expected_val = rs_val + 1.0
+    expected = torch.full((128 // comm_size,), expected_val, dtype=torch.float16)
+    print(
+        f"[Rank {comm_rank}] Result: {result_cpu[0].item()}, expected: {expected_val}"
+    )
+    assert torch.allclose(result_cpu, expected), f"Rank {comm_rank}: FAILED"
+    print(f"[Rank {comm_rank}] PASSED")
+
+
+def demo_coalesced_reduce_scatter(comm_rank, comm_size):
+    """Coalesced reduce_scatter — multiple tensors in one call."""
+    print(f"[Rank {comm_rank}] Demo 3: Coalesced reduce_scatter")
+
+    class CoalescedModule(torch.nn.Module):
+        def __init__(self, group_size):
+            super().__init__()
+            self._group_size = group_size
+
+        def forward(self, tensors):
+            results = torch.ops._c10d_functional.reduce_scatter_tensor_coalesced(
+                tensors, "sum", self._group_size, _GROUP_NAME
+            )
+            return [torch.ops._c10d_functional.wait_tensor(r) for r in results]
+
+    a = torch.full((128,), float(comm_rank + 1), dtype=torch.float16, device=DEVICE)
+    b = torch.full((256,), float(comm_rank + 1), dtype=torch.float16, device=DEVICE)
+    print(f"[Rank {comm_rank}] Input: two tensors (128, 256), value={comm_rank + 1}.0")
+
+    compiled_fn = torch.compile(CoalescedModule(comm_size))
+    r_a, r_b = compiled_fn([a, b])
+
+    print(f"[Rank {comm_rank}] Result a shape: {r_a.shape}, b shape: {r_b.shape}")
+
+    expected_val = comm_size * (comm_size + 1) / 2.0
+    expected_a = torch.full((128 // comm_size,), expected_val, dtype=torch.float16)
+    expected_b = torch.full((256 // comm_size,), expected_val, dtype=torch.float16)
+    assert torch.allclose(r_a.to("cpu"), expected_a), (
+        f"Rank {comm_rank}: tensor a FAILED"
+    )
+    assert torch.allclose(r_b.to("cpu"), expected_b), (
+        f"Rank {comm_rank}: tensor b FAILED"
+    )
+    print(f"[Rank {comm_rank}] PASSED")
+
+
+if __name__ == "__main__":
+    if not dist.distributed_c10d.is_backend_available(C10D_BACKEND):
+        raise RuntimeError(f"Error: Missing the C10 Backend {C10D_BACKEND}")
+    if C10D_BACKEND != dist.get_default_backend_for_device("spyre"):
+        raise RuntimeError(
+            f"Error: Missing a C10 Backend for 'spyre'! Expected {C10D_BACKEND}"
+        )
+
+    print("Initializing distributed process group...")
+    dist.init_process_group(f"cpu:gloo,spyre:{C10D_BACKEND}")
+
+    comm_size = dist.get_world_size()
+    comm_rank = dist.get_rank()
+
+    c10d._register_process_group(_GROUP_NAME, dist.group.WORLD)
+
+    print(f"[Rank {comm_rank}] World size: {comm_size}")
+    print(f"[Rank {comm_rank}] Device: {DEVICE}")
+
+    demo_basic_reduce_scatter(comm_rank, comm_size)
+    demo_reduce_scatter_with_compute(comm_rank, comm_size)
+    demo_coalesced_reduce_scatter(comm_rank, comm_size)
+
+    print(f"\n[Rank {comm_rank}] All demos PASSED!")
+    dist.destroy_process_group()

--- a/tests/configs/distributed_tests/test_allgather_coalesced.yaml
+++ b/tests/configs/distributed_tests/test_allgather_coalesced.yaml
@@ -1,0 +1,23 @@
+# Configuration file for torch-spyre distributed compiled allgather tests
+# Tests the lowering of c10d all_gather operations to Spyre comms library
+#
+# Usage:
+#   cd torch-spyre/tests
+#   ./run_test.sh configs/distributed_tests/test_allgather_compiled.yaml
+#
+# The run_test.sh script automatically detects tests in the distributed/
+# directory and launches them with: torchrun --nproc-per-node $AIU_WORLD_SIZE
+
+test_suite_config:
+  labels: [regression, trunk, integration]
+  files:
+    # AllGather Compiled Tests - verify collectives lower correctly
+    - path: ${TORCH_DEVICE_ROOT}/tests/distributed/test_all_gather_coalesced_compiled.py
+      unlisted_test_mode: mandatory_success
+
+  global:
+    # Global configuration for compiled distributed tests
+    # These tests verify lowering of c10d ops to spyre_comms backend
+    supported_dtypes:
+      - name: float16
+      - name: float32

--- a/tests/configs/distributed_tests/test_allreduce_coalesced.yaml
+++ b/tests/configs/distributed_tests/test_allreduce_coalesced.yaml
@@ -1,0 +1,23 @@
+# Configuration file for torch-spyre distributed compiled allgather tests
+# Tests the lowering of c10d all_gather operations to Spyre comms library
+#
+# Usage:
+#   cd torch-spyre/tests
+#   ./run_test.sh configs/distributed_tests/test_allgather_compiled.yaml
+#
+# The run_test.sh script automatically detects tests in the distributed/
+# directory and launches them with: torchrun --nproc-per-node $AIU_WORLD_SIZE
+
+test_suite_config:
+  labels: [regression, trunk, integration]
+  files:
+    # AllGather Compiled Tests - verify collectives lower correctly
+    - path: ${TORCH_DEVICE_ROOT}/tests/distributed/test_all_reduce_coalesced_compiled.py
+      unlisted_test_mode: mandatory_success
+
+  global:
+    # Global configuration for compiled distributed tests
+    # These tests verify lowering of c10d ops to spyre_comms backend
+    supported_dtypes:
+      - name: float16
+      - name: float32

--- a/tests/configs/distributed_tests/test_reduce_scatter_compiled.yaml
+++ b/tests/configs/distributed_tests/test_reduce_scatter_compiled.yaml
@@ -1,0 +1,22 @@
+# Configuration file for torch-spyre distributed compiled reduce_scatter tests
+# Tests the lowering of c10d reduce_scatter operations to Spyre comms library
+#
+# Usage:
+#   cd torch-spyre/tests
+#   ./run_test.sh configs/distributed_tests/test_reduce_scatter_compiled.yaml
+#
+# The run_test.sh script automatically detects tests in the distributed/
+# directory and launches them with: torchrun --nproc-per-node $AIU_WORLD_SIZE
+
+test_suite_config:
+  labels: [regression, trunk, integration]
+  files:
+    # ReduceScatter Compiled Tests - verify collectives lower correctly
+    - path: ${TORCH_DEVICE_ROOT}/tests/distributed/test_reduce_scatter_compiled.py
+      unlisted_test_mode: mandatory_success
+
+  global:
+    # Global configuration for compiled distributed tests
+    # These tests verify lowering of c10d ops to spyre_comms backend
+    supported_dtypes:
+      - name: float16

--- a/tests/distributed/test_all_gather_coalesced_compiled.py
+++ b/tests/distributed/test_all_gather_coalesced_compiled.py
@@ -1,0 +1,265 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for compiled all_gather_into_tensor_coalesced.
+
+Verifies that _c10d_functional.all_gather_into_tensor_coalesced is decomposed
+into individual allgather_plan (compile-time) + allgather_run (runtime) calls
+and produces correct results for each tensor in the list.
+
+Usage:
+    torchrun --nproc-per-node 2 tests/distributed/test_all_gather_coalesced_compiled.py
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.distributed.distributed_c10d as c10d
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+import torch_spyre  # noqa: F401
+
+if "RANK" not in os.environ:
+    pytest.skip(
+        "RANK environment variable not defined, skipping distributed tests",
+        allow_module_level=True,
+    )
+
+if "WORLD_SIZE" not in os.environ:
+    pytest.skip(
+        "WORLD_SIZE environment variable not defined, skipping distributed tests",
+        allow_module_level=True,
+    )
+
+try:
+    world_size = int(os.environ.get("WORLD_SIZE", "0"))
+    if world_size < 2:
+        pytest.skip(
+            f"WORLD_SIZE is {world_size}, need at least 2 for distributed tests",
+            allow_module_level=True,
+        )
+except ValueError:
+    pytest.skip(
+        "WORLD_SIZE environment variable is not a valid integer, "
+        "skipping distributed tests",
+        allow_module_level=True,
+    )
+
+DEVICE = torch.device(f"spyre:{os.getenv('RANK', '0')}")
+C10D_BACKEND = "spyreccl"
+_GROUP_NAME = "default"
+
+
+class AllGatherCoalescedModule(torch.nn.Module):
+    """Module that performs coalesced allgather on a list of tensors."""
+
+    def __init__(self, group_size: int, group_name: str = _GROUP_NAME) -> None:
+        super().__init__()
+        self._group_size = group_size
+        self._group_name = group_name
+
+    def forward(self, tensors: list[torch.Tensor]) -> list[torch.Tensor]:
+        results = torch.ops._c10d_functional.all_gather_into_tensor_coalesced(
+            tensors, self._group_size, self._group_name
+        )
+        return [torch.ops._c10d_functional.wait_tensor(r) for r in results]
+
+
+class TestAllGatherCoalescedCompiled(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        torch.spyre._impl._lazy_init()
+
+        if not dist.distributed_c10d.is_backend_available(C10D_BACKEND):
+            raise RuntimeError(f"Error: Missing the C10 Backend {C10D_BACKEND}")
+        if C10D_BACKEND != dist.get_default_backend_for_device("spyre"):
+            raise RuntimeError(
+                f"Error: Missing a C10 Backend for 'spyre'! Expected {C10D_BACKEND}"
+            )
+
+        if not dist.is_initialized():
+            dist.init_process_group(f"cpu:gloo,spyre:{C10D_BACKEND}")
+
+        c10d._register_process_group(_GROUP_NAME, dist.group.WORLD)
+
+        cls.comm_size = dist.get_world_size()
+        cls.comm_rank = dist.get_rank()
+
+    @classmethod
+    def tearDownClass(cls):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def setUp(self):
+        super().setUp()
+        torch.compiler.reset()
+
+    def test_all_gather_coalesced_compiled_basic(self):
+        """Two same-shape tensors gathered correctly."""
+        a = torch.full((64,), float(self.comm_rank), dtype=torch.float16, device=DEVICE)
+        b = torch.full(
+            (64,), float(self.comm_rank + 10), dtype=torch.float16, device=DEVICE
+        )
+
+        module = AllGatherCoalescedModule(group_size=self.comm_size)
+        compiled_module = torch.compile(module)
+        r_a, r_b = compiled_module([a, b])
+
+        self.assertEqual(r_a.shape[0], 64 * self.comm_size)
+        self.assertEqual(r_b.shape[0], 64 * self.comm_size)
+
+        r_a_cpu = r_a.to("cpu")
+        r_b_cpu = r_b.to("cpu")
+        for rank in range(self.comm_size):
+            chunk_a = r_a_cpu[rank * 64 : (rank + 1) * 64]
+            expected_a = torch.full((64,), float(rank), dtype=torch.float16)
+            self.assertTrue(
+                torch.allclose(chunk_a, expected_a),
+                f"Rank {self.comm_rank}: tensor a chunk for rank {rank} incorrect",
+            )
+
+            chunk_b = r_b_cpu[rank * 64 : (rank + 1) * 64]
+            expected_b = torch.full((64,), float(rank + 10), dtype=torch.float16)
+            self.assertTrue(
+                torch.allclose(chunk_b, expected_b),
+                f"Rank {self.comm_rank}: tensor b chunk for rank {rank} incorrect",
+            )
+
+    def test_all_gather_coalesced_compiled_mixed_shapes(self):
+        """Tensors of different shapes in one coalesced call."""
+        a = torch.full((64,), float(self.comm_rank), dtype=torch.float16, device=DEVICE)
+        b = torch.full(
+            (128,), float(self.comm_rank), dtype=torch.float16, device=DEVICE
+        )
+
+        module = AllGatherCoalescedModule(group_size=self.comm_size)
+        compiled_module = torch.compile(module)
+        r_a, r_b = compiled_module([a, b])
+
+        self.assertEqual(r_a.shape[0], 64 * self.comm_size)
+        self.assertEqual(r_b.shape[0], 128 * self.comm_size)
+
+        r_a_cpu = r_a.to("cpu")
+        r_b_cpu = r_b.to("cpu")
+        for rank in range(self.comm_size):
+            chunk_a = r_a_cpu[rank * 64 : (rank + 1) * 64]
+            chunk_b = r_b_cpu[rank * 128 : (rank + 1) * 128]
+            expected = torch.full((1,), float(rank), dtype=torch.float16)
+            self.assertTrue(
+                torch.allclose(chunk_a, expected.expand(64)),
+                f"Rank {self.comm_rank}: mixed-shapes tensor a, "
+                f"rank {rank} chunk incorrect",
+            )
+            self.assertTrue(
+                torch.allclose(chunk_b, expected.expand(128)),
+                f"Rank {self.comm_rank}: mixed-shapes tensor b, "
+                f"rank {rank} chunk incorrect",
+            )
+
+    def test_all_gather_coalesced_compiled_fp16(self):
+        """Verify dtype and output shape preservation for fp16 inputs."""
+        a = torch.ones((64,), dtype=torch.float16, device=DEVICE)
+        b = torch.ones((128,), dtype=torch.float16, device=DEVICE)
+
+        module = AllGatherCoalescedModule(group_size=self.comm_size)
+        compiled_module = torch.compile(module)
+        r_a, r_b = compiled_module([a, b])
+
+        self.assertEqual(r_a.dtype, torch.float16)
+        self.assertEqual(r_b.dtype, torch.float16)
+        self.assertEqual(r_a.shape[0], 64 * self.comm_size)
+        self.assertEqual(r_b.shape[0], 128 * self.comm_size)
+
+    def test_all_gather_coalesced_compiled_with_compute(self):
+        """Compute interleaved around coalesced allgather."""
+
+        class CoalescedWithComputeModule(torch.nn.Module):
+            def __init__(self, group_size: int, group_name: str = _GROUP_NAME):
+                super().__init__()
+                self._group_size = group_size
+                self._group_name = group_name
+
+            def forward(self, x, y):
+                x_scaled = x * 2.0
+                results = torch.ops._c10d_functional.all_gather_into_tensor_coalesced(
+                    [x_scaled], self._group_size, self._group_name
+                )
+                z = y + 1.0
+                gathered = torch.ops._c10d_functional.wait_tensor(results[0])
+                return gathered + z
+
+        x = torch.full(
+            (64,), float(self.comm_rank + 1), dtype=torch.float16, device=DEVICE
+        )
+        y = torch.ones((64 * self.comm_size,), dtype=torch.float16, device=DEVICE)
+
+        module = CoalescedWithComputeModule(group_size=self.comm_size)
+        compiled_module = torch.compile(module)
+        result = compiled_module(x, y)
+
+        result_cpu = result.to("cpu")
+        for rank in range(self.comm_size):
+            chunk = result_cpu[rank * 64 : (rank + 1) * 64]
+            # x_scaled = 2*(rank+1), gathered, then + z where z = 2.0
+            expected_val = 2.0 * (rank + 1) + 2.0
+            expected = torch.full((64,), expected_val, dtype=torch.float16)
+            self.assertTrue(
+                torch.allclose(chunk, expected),
+                f"Rank {self.comm_rank}: coalesced allgather with compute, "
+                f"rank {rank} chunk incorrect. "
+                f"Expected {expected_val}, got {chunk[0].item()}",
+            )
+
+    def test_all_gather_coalesced_compiled_repeated_execution(self):
+        """WSI reuse: compiled coalesced allgather executed multiple times."""
+        module = AllGatherCoalescedModule(group_size=self.comm_size)
+        compiled_module = torch.compile(module)
+
+        for iteration in range(4):
+            a = torch.full(
+                (64,), float(self.comm_rank), dtype=torch.float16, device=DEVICE
+            )
+            b = torch.full(
+                (64,),
+                float(self.comm_rank + 10),
+                dtype=torch.float16,
+                device=DEVICE,
+            )
+            r_a, r_b = compiled_module([a, b])
+
+            self.assertEqual(r_a.shape[0], 64 * self.comm_size)
+            r_a_cpu = r_a.to("cpu")
+            r_b_cpu = r_b.to("cpu")
+            for rank in range(self.comm_size):
+                chunk_a = r_a_cpu[rank * 64 : (rank + 1) * 64]
+                expected_a = torch.full((64,), float(rank), dtype=torch.float16)
+                self.assertTrue(
+                    torch.allclose(chunk_a, expected_a),
+                    f"Rank {self.comm_rank}: iteration {iteration}, "
+                    f"tensor a chunk for rank {rank} incorrect",
+                )
+
+                chunk_b = r_b_cpu[rank * 64 : (rank + 1) * 64]
+                expected_b = torch.full((64,), float(rank + 10), dtype=torch.float16)
+                self.assertTrue(
+                    torch.allclose(chunk_b, expected_b),
+                    f"Rank {self.comm_rank}: iteration {iteration}, "
+                    f"tensor b chunk for rank {rank} incorrect",
+                )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/distributed/test_all_reduce_coalesced_compiled.py
+++ b/tests/distributed/test_all_reduce_coalesced_compiled.py
@@ -1,0 +1,235 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for compiled all_reduce_coalesced (decomposed into per-tensor allreduce).
+
+Verifies that _c10d_functional.all_reduce_coalesced is decomposed into
+individual allreduce_plan (compile-time) + allreduce_run (runtime) calls
+and produces correct results for each tensor in the list.
+
+Usage:
+    torchrun --nproc-per-node 2 tests/distributed/test_all_reduce_coalesced_compiled.py
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.distributed.distributed_c10d as c10d
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+import torch_spyre  # noqa: F401
+
+if "RANK" not in os.environ:
+    pytest.skip(
+        "RANK environment variable not defined, skipping distributed tests",
+        allow_module_level=True,
+    )
+
+if "WORLD_SIZE" not in os.environ:
+    pytest.skip(
+        "WORLD_SIZE environment variable not defined, skipping distributed tests",
+        allow_module_level=True,
+    )
+
+try:
+    world_size = int(os.environ.get("WORLD_SIZE", "0"))
+    if world_size < 2:
+        pytest.skip(
+            f"WORLD_SIZE is {world_size}, need at least 2 for distributed tests",
+            allow_module_level=True,
+        )
+except ValueError:
+    pytest.skip(
+        "WORLD_SIZE environment variable is not a valid integer, "
+        "skipping distributed tests",
+        allow_module_level=True,
+    )
+
+DEVICE = torch.device(f"spyre:{os.getenv('RANK', '0')}")
+C10D_BACKEND = "spyreccl"
+_GROUP_NAME = "default"
+
+
+class AllReduceCoalescedModule(torch.nn.Module):
+    """Module that performs coalesced allreduce on a list of tensors."""
+
+    def __init__(self, group_name: str = _GROUP_NAME) -> None:
+        super().__init__()
+        self._group_name = group_name
+
+    def forward(self, tensors: list[torch.Tensor]) -> list[torch.Tensor]:
+        results = torch.ops._c10d_functional.all_reduce_coalesced(
+            tensors, "sum", self._group_name
+        )
+        return [torch.ops._c10d_functional.wait_tensor(r) for r in results]
+
+
+class TestAllReduceCoalescedCompiled(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        torch.spyre._impl._lazy_init()
+
+        if not dist.distributed_c10d.is_backend_available(C10D_BACKEND):
+            raise RuntimeError(f"Error: Missing the C10 Backend {C10D_BACKEND}")
+        if C10D_BACKEND != dist.get_default_backend_for_device("spyre"):
+            raise RuntimeError(
+                f"Error: Missing a C10 Backend for 'spyre'! Expected {C10D_BACKEND}"
+            )
+
+        if not dist.is_initialized():
+            dist.init_process_group(f"cpu:gloo,spyre:{C10D_BACKEND}")
+
+        c10d._register_process_group(_GROUP_NAME, dist.group.WORLD)
+
+        cls.comm_size = dist.get_world_size()
+        cls.comm_rank = dist.get_rank()
+
+    @classmethod
+    def tearDownClass(cls):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def setUp(self):
+        super().setUp()
+        torch.compiler.reset()
+
+    def test_all_reduce_coalesced_compiled_basic(self):
+        """Two same-shape tensors reduced correctly."""
+        a = torch.ones((128,), dtype=torch.float16, device=DEVICE)
+        b = torch.full((128,), 2.0, dtype=torch.float16, device=DEVICE)
+
+        module = AllReduceCoalescedModule()
+        compiled_module = torch.compile(module)
+        r_a, r_b = compiled_module([a, b])
+
+        expected_a = torch.full((128,), float(self.comm_size), dtype=torch.float16)
+        expected_b = torch.full((128,), 2.0 * self.comm_size, dtype=torch.float16)
+        self.assertTrue(
+            torch.allclose(r_a.to("cpu"), expected_a),
+            f"Rank {self.comm_rank}: coalesced tensor 0 incorrect. "
+            f"Expected {expected_a[0].item()}, got {r_a[0].to('cpu').item()}",
+        )
+        self.assertTrue(
+            torch.allclose(r_b.to("cpu"), expected_b),
+            f"Rank {self.comm_rank}: coalesced tensor 1 incorrect. "
+            f"Expected {expected_b[0].item()}, got {r_b[0].to('cpu').item()}",
+        )
+
+    def test_all_reduce_coalesced_compiled_mixed_shapes(self):
+        """Tensors of different shapes in one coalesced call."""
+        a = torch.full(
+            (64,), float(self.comm_rank + 1), dtype=torch.float16, device=DEVICE
+        )
+        b = torch.full(
+            (256,), float(self.comm_rank + 1), dtype=torch.float16, device=DEVICE
+        )
+
+        module = AllReduceCoalescedModule()
+        compiled_module = torch.compile(module)
+        r_a, r_b = compiled_module([a, b])
+
+        # sum of (rank+1) for all ranks = ws*(ws+1)/2
+        expected_val = self.comm_size * (self.comm_size + 1) / 2.0
+        expected_a = torch.full((64,), expected_val, dtype=torch.float16)
+        expected_b = torch.full((256,), expected_val, dtype=torch.float16)
+        self.assertTrue(
+            torch.allclose(r_a.to("cpu"), expected_a),
+            f"Rank {self.comm_rank}: mixed-shapes tensor 0 (64,) incorrect. "
+            f"Expected {expected_val}, got {r_a[0].to('cpu').item()}",
+        )
+        self.assertTrue(
+            torch.allclose(r_b.to("cpu"), expected_b),
+            f"Rank {self.comm_rank}: mixed-shapes tensor 1 (256,) incorrect. "
+            f"Expected {expected_val}, got {r_b[0].to('cpu').item()}",
+        )
+
+    def test_all_reduce_coalesced_compiled_fp16(self):
+        """Verify dtype preservation for fp16 inputs."""
+        a = torch.ones((128,), dtype=torch.float16, device=DEVICE)
+        b = torch.ones((128,), dtype=torch.float16, device=DEVICE)
+
+        module = AllReduceCoalescedModule()
+        compiled_module = torch.compile(module)
+        r_a, r_b = compiled_module([a, b])
+
+        self.assertEqual(r_a.dtype, torch.float16)
+        self.assertEqual(r_b.dtype, torch.float16)
+
+    def test_all_reduce_coalesced_compiled_with_compute(self):
+        """Compute interleaved around coalesced allreduce."""
+
+        class CoalescedWithComputeModule(torch.nn.Module):
+            def __init__(self, group_name: str = _GROUP_NAME) -> None:
+                super().__init__()
+                self._group_name = group_name
+
+            def forward(self, x, y):
+                x_scaled = x * 2.0
+                y_shifted = y + 1.0
+                results = torch.ops._c10d_functional.all_reduce_coalesced(
+                    [x_scaled, y_shifted], "sum", self._group_name
+                )
+                r_x = torch.ops._c10d_functional.wait_tensor(results[0])
+                r_y = torch.ops._c10d_functional.wait_tensor(results[1])
+                return r_x + r_y
+
+        x = torch.ones((128,), dtype=torch.float16, device=DEVICE)
+        y = torch.ones((128,), dtype=torch.float16, device=DEVICE)
+
+        module = CoalescedWithComputeModule()
+        compiled_module = torch.compile(module)
+        result = compiled_module(x, y)
+
+        # x_scaled = 2.0, allreduce -> 2.0 * ws
+        # y_shifted = 2.0, allreduce -> 2.0 * ws
+        # result = 2*ws + 2*ws = 4*ws
+        expected_val = 4.0 * self.comm_size
+        expected = torch.full((128,), expected_val, dtype=torch.float16)
+        self.assertTrue(
+            torch.allclose(result.to("cpu"), expected),
+            f"Rank {self.comm_rank}: coalesced with compute incorrect. "
+            f"Expected {expected_val}, got {result[0].to('cpu').item()}",
+        )
+
+    def test_all_reduce_coalesced_compiled_repeated_execution(self):
+        """WSI reuse: compiled coalesced allreduce executed multiple times."""
+        module = AllReduceCoalescedModule()
+        compiled_module = torch.compile(module)
+
+        expected_a = torch.full((128,), float(self.comm_size), dtype=torch.float16)
+        expected_b = torch.full((128,), 3.0 * self.comm_size, dtype=torch.float16)
+
+        for iteration in range(4):
+            # Fresh tensors each iteration — allreduce mutates in-place.
+            a = torch.ones((128,), dtype=torch.float16, device=DEVICE)
+            b = torch.full((128,), 3.0, dtype=torch.float16, device=DEVICE)
+            r_a, r_b = compiled_module([a, b])
+            self.assertTrue(
+                torch.allclose(r_a.to("cpu"), expected_a),
+                f"Rank {self.comm_rank}: iteration {iteration}, "
+                f"tensor 0 incorrect. Expected {expected_a[0].item()}, "
+                f"got {r_a[0].to('cpu').item()}",
+            )
+            self.assertTrue(
+                torch.allclose(r_b.to("cpu"), expected_b),
+                f"Rank {self.comm_rank}: iteration {iteration}, "
+                f"tensor 1 incorrect. Expected {expected_b[0].item()}, "
+                f"got {r_b[0].to('cpu').item()}",
+            )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/distributed/test_reduce_scatter_compiled.py
+++ b/tests/distributed/test_reduce_scatter_compiled.py
@@ -1,0 +1,345 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for compiled reduce_scatter_tensor.
+
+Verifies that _c10d_functional.reduce_scatter_tensor is lowered into
+reducescatter_plan (compile-time) + reducescatter_run (runtime) calls
+and produces correct results.
+
+Usage:
+    torchrun --nproc-per-node 2 tests/distributed/test_reduce_scatter_compiled.py
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.distributed.distributed_c10d as c10d
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+import torch_spyre  # noqa: F401
+
+if "RANK" not in os.environ:
+    pytest.skip(
+        "RANK environment variable not defined, skipping distributed tests",
+        allow_module_level=True,
+    )
+
+if "WORLD_SIZE" not in os.environ:
+    pytest.skip(
+        "WORLD_SIZE environment variable not defined, skipping distributed tests",
+        allow_module_level=True,
+    )
+
+try:
+    world_size = int(os.environ.get("WORLD_SIZE", "0"))
+    if world_size < 2:
+        pytest.skip(
+            f"WORLD_SIZE is {world_size}, need at least 2 for distributed tests",
+            allow_module_level=True,
+        )
+except ValueError:
+    pytest.skip(
+        "WORLD_SIZE environment variable is not a valid integer, "
+        "skipping distributed tests",
+        allow_module_level=True,
+    )
+
+DEVICE = torch.device(f"spyre:{os.getenv('RANK', '0')}")
+C10D_BACKEND = "spyreccl"
+_GROUP_NAME = "default"
+
+
+class ReduceScatterModule(torch.nn.Module):
+    """Module that performs reduce_scatter_tensor on a single tensor."""
+
+    def __init__(self, group_size: int, group_name: str = _GROUP_NAME) -> None:
+        super().__init__()
+        self._group_size = group_size
+        self._group_name = group_name
+
+    def forward(self, tensor: torch.Tensor) -> torch.Tensor:
+        result = torch.ops._c10d_functional.reduce_scatter_tensor(
+            tensor, "sum", self._group_size, self._group_name
+        )
+        return torch.ops._c10d_functional.wait_tensor(result)
+
+
+class TestReduceScatterCompiled(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        torch.spyre._impl._lazy_init()
+
+        if not dist.distributed_c10d.is_backend_available(C10D_BACKEND):
+            raise RuntimeError(f"Error: Missing the C10 Backend {C10D_BACKEND}")
+        if C10D_BACKEND != dist.get_default_backend_for_device("spyre"):
+            raise RuntimeError(
+                f"Error: Missing a C10 Backend for 'spyre'! Expected {C10D_BACKEND}"
+            )
+
+        if not dist.is_initialized():
+            dist.init_process_group(f"cpu:gloo,spyre:{C10D_BACKEND}")
+
+        c10d._register_process_group(_GROUP_NAME, dist.group.WORLD)
+
+        cls.comm_size = dist.get_world_size()
+        cls.comm_rank = dist.get_rank()
+
+    @classmethod
+    def tearDownClass(cls):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def setUp(self):
+        super().setUp()
+        torch.compiler.reset()
+
+    def test_reduce_scatter_compiled_basic(self):
+        """Each rank contributes a full tensor; output is reduced scatter."""
+        # Input: each rank has a (128,) tensor filled with (rank + 1).
+        # With 2 ranks, reduce_scatter splits input into 2 chunks of 64 and
+        # sums corresponding chunks across ranks.
+        # Rank 0 input: [1,1,...,1] (128 elems)
+        # Rank 1 input: [2,2,...,2] (128 elems)
+        # After reduce_scatter with sum:
+        #   Rank 0 gets chunk 0: 1+2 = 3
+        #   Rank 1 gets chunk 1: 1+2 = 3
+        x = torch.full(
+            (128,), float(self.comm_rank + 1), dtype=torch.float16, device=DEVICE
+        )
+
+        module = ReduceScatterModule(group_size=self.comm_size)
+        compiled_module = torch.compile(module)
+        result = compiled_module(x)
+
+        self.assertEqual(result.shape[0], 128 // self.comm_size)
+
+        expected_val = self.comm_size * (self.comm_size + 1) / 2.0
+        expected = torch.full(
+            (128 // self.comm_size,), expected_val, dtype=torch.float16
+        )
+        self.assertTrue(
+            torch.allclose(result.to("cpu"), expected),
+            f"Rank {self.comm_rank}: reduce_scatter basic incorrect. "
+            f"Expected {expected_val}, got {result[0].to('cpu').item()}",
+        )
+
+    def test_reduce_scatter_compiled_fp16(self):
+        """Verify dtype and output shape preservation for fp16 inputs."""
+        x = torch.ones((128,), dtype=torch.float16, device=DEVICE)
+
+        module = ReduceScatterModule(group_size=self.comm_size)
+        compiled_module = torch.compile(module)
+        result = compiled_module(x)
+
+        self.assertEqual(result.dtype, torch.float16)
+        self.assertEqual(result.shape[0], 128 // self.comm_size)
+
+    def test_reduce_scatter_compiled_with_compute(self):
+        """Compute interleaved around reduce_scatter."""
+
+        class ComputeModule(torch.nn.Module):
+            def __init__(self, group_size: int, group_name: str = _GROUP_NAME):
+                super().__init__()
+                self._group_size = group_size
+                self._group_name = group_name
+
+            def forward(self, x, bias):
+                x_scaled = x * 2.0
+                result = torch.ops._c10d_functional.reduce_scatter_tensor(
+                    x_scaled, "sum", self._group_size, self._group_name
+                )
+                scattered = torch.ops._c10d_functional.wait_tensor(result)
+                return scattered + bias
+
+        x = torch.full(
+            (128,), float(self.comm_rank + 1), dtype=torch.float16, device=DEVICE
+        )
+        bias = torch.ones((128 // self.comm_size,), dtype=torch.float16, device=DEVICE)
+
+        module = ComputeModule(group_size=self.comm_size)
+        compiled_module = torch.compile(module)
+        result = compiled_module(x, bias)
+
+        # x_scaled = 2*(rank+1), reduce_scatter sum -> 2*sum(rank+1), + bias=1
+        rs_val = 2.0 * self.comm_size * (self.comm_size + 1) / 2.0
+        expected_val = rs_val + 1.0
+        expected = torch.full(
+            (128 // self.comm_size,), expected_val, dtype=torch.float16
+        )
+        self.assertTrue(
+            torch.allclose(result.to("cpu"), expected),
+            f"Rank {self.comm_rank}: reduce_scatter with compute incorrect. "
+            f"Expected {expected_val}, got {result[0].to('cpu').item()}",
+        )
+
+    def test_reduce_scatter_compiled_repeated_execution(self):
+        """WSI reuse: compiled reduce_scatter executed multiple times."""
+        module = ReduceScatterModule(group_size=self.comm_size)
+        compiled_module = torch.compile(module)
+
+        for iteration in range(4):
+            x = torch.full(
+                (128,),
+                float(self.comm_rank + 1),
+                dtype=torch.float16,
+                device=DEVICE,
+            )
+            result = compiled_module(x)
+
+            self.assertEqual(result.shape[0], 128 // self.comm_size)
+
+            expected_val = self.comm_size * (self.comm_size + 1) / 2.0
+            expected = torch.full(
+                (128 // self.comm_size,), expected_val, dtype=torch.float16
+            )
+            self.assertTrue(
+                torch.allclose(result.to("cpu"), expected),
+                f"Rank {self.comm_rank}: iteration {iteration}, "
+                f"reduce_scatter incorrect. "
+                f"Expected {expected_val}, got {result[0].to('cpu').item()}",
+            )
+
+    def test_reduce_scatter_coalesced_compiled(self):
+        """Coalesced reduce_scatter — multiple tensors in one call."""
+
+        class CoalescedModule(torch.nn.Module):
+            def __init__(self, group_size: int, group_name: str = _GROUP_NAME):
+                super().__init__()
+                self._group_size = group_size
+                self._group_name = group_name
+
+            def forward(self, tensors: list[torch.Tensor]) -> list[torch.Tensor]:
+                results = torch.ops._c10d_functional.reduce_scatter_tensor_coalesced(
+                    tensors, "sum", self._group_size, self._group_name
+                )
+                return [torch.ops._c10d_functional.wait_tensor(r) for r in results]
+
+        a = torch.full(
+            (128,),
+            float(self.comm_rank + 1),
+            dtype=torch.float16,
+            device=DEVICE,
+        )
+        b = torch.full(
+            (256,),
+            float(self.comm_rank + 1),
+            dtype=torch.float16,
+            device=DEVICE,
+        )
+
+        module = CoalescedModule(group_size=self.comm_size)
+        compiled_module = torch.compile(module)
+        r_a, r_b = compiled_module([a, b])
+
+        self.assertEqual(r_a.shape[0], 128 // self.comm_size)
+        self.assertEqual(r_b.shape[0], 256 // self.comm_size)
+
+        expected_val = self.comm_size * (self.comm_size + 1) / 2.0
+        expected_a = torch.full(
+            (128 // self.comm_size,), expected_val, dtype=torch.float16
+        )
+        expected_b = torch.full(
+            (256 // self.comm_size,), expected_val, dtype=torch.float16
+        )
+        self.assertTrue(
+            torch.allclose(r_a.to("cpu"), expected_a),
+            f"Rank {self.comm_rank}: coalesced tensor 0 incorrect. "
+            f"Expected {expected_val}, got {r_a[0].to('cpu').item()}",
+        )
+        self.assertTrue(
+            torch.allclose(r_b.to("cpu"), expected_b),
+            f"Rank {self.comm_rank}: coalesced tensor 1 incorrect. "
+            f"Expected {expected_val}, got {r_b[0].to('cpu').item()}",
+        )
+
+    def test_reduce_scatter_coalesced_compiled_multidim(self):
+        """Coalesced reduce_scatter with 2-D inputs — only dim 0 is split."""
+        # Two tensors of different 2-D shapes.  After reduce_scatter:
+        #   (128, 32) → (128 // group_size, 32)
+        #   (256, 16) → (256 // group_size, 16)
+        # Each rank fills with (rank + 1); sum across ranks = ws*(ws+1)/2.
+
+        class CoalescedMultidimModule(torch.nn.Module):
+            def __init__(self, group_size: int, group_name: str = _GROUP_NAME):
+                super().__init__()
+                self._group_size = group_size
+                self._group_name = group_name
+
+            def forward(self, tensors: list[torch.Tensor]) -> list[torch.Tensor]:
+                results = torch.ops._c10d_functional.reduce_scatter_tensor_coalesced(
+                    tensors, "sum", self._group_size, self._group_name
+                )
+                return [torch.ops._c10d_functional.wait_tensor(r) for r in results]
+
+        fill = float(self.comm_rank + 1)
+        a = torch.full((128, 32), fill, dtype=torch.float16, device=DEVICE)
+        b = torch.full((256, 16), fill, dtype=torch.float16, device=DEVICE)
+
+        module = CoalescedMultidimModule(group_size=self.comm_size)
+        compiled_module = torch.compile(module)
+        r_a, r_b = compiled_module([a, b])
+
+        self.assertEqual(r_a.shape, torch.Size([128 // self.comm_size, 32]))
+        self.assertEqual(r_b.shape, torch.Size([256 // self.comm_size, 16]))
+
+        expected_val = self.comm_size * (self.comm_size + 1) / 2.0
+        expected_a = torch.full(
+            (128 // self.comm_size, 32), expected_val, dtype=torch.float16
+        )
+        expected_b = torch.full(
+            (256 // self.comm_size, 16), expected_val, dtype=torch.float16
+        )
+        self.assertTrue(
+            torch.allclose(r_a.to("cpu"), expected_a),
+            f"Rank {self.comm_rank}: coalesced multidim tensor 0 incorrect. "
+            f"Expected {expected_val}, got {r_a[0, 0].to('cpu').item()}",
+        )
+        self.assertTrue(
+            torch.allclose(r_b.to("cpu"), expected_b),
+            f"Rank {self.comm_rank}: coalesced multidim tensor 1 incorrect. "
+            f"Expected {expected_val}, got {r_b[0, 0].to('cpu').item()}",
+        )
+
+    def test_reduce_scatter_compiled_multidim(self):
+        """reduce_scatter on a 2-D input — only dim 0 is split by group_size."""
+        # Input shape: (128, 64).  After reduce_scatter: (128 // group_size, 64).
+        # Each rank fills with (rank + 1), so the sum across ranks is ws*(ws+1)/2.
+        x = torch.full(
+            (128, 64),
+            float(self.comm_rank + 1),
+            dtype=torch.float16,
+            device=DEVICE,
+        )
+
+        module = ReduceScatterModule(group_size=self.comm_size)
+        compiled_module = torch.compile(module)
+        result = compiled_module(x)
+
+        expected_rows = 128 // self.comm_size
+        self.assertEqual(result.shape, torch.Size([expected_rows, 64]))
+
+        expected_val = self.comm_size * (self.comm_size + 1) / 2.0
+        expected = torch.full((expected_rows, 64), expected_val, dtype=torch.float16)
+        self.assertTrue(
+            torch.allclose(result.to("cpu"), expected),
+            f"Rank {self.comm_rank}: reduce_scatter multidim incorrect. "
+            f"Expected {expected_val}, got {result[0, 0].to('cpu').item()}",
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch_spyre/_inductor/distributed/spyre_library.py
+++ b/torch_spyre/_inductor/distributed/spyre_library.py
@@ -74,6 +74,12 @@ if torch._C._dispatch_has_kernel("spyre::broadcast_run"):
         output_size[0] *= group_size
         return torch.empty(output_size, dtype=x.dtype, device=x.device)
 
+    @torch.library.register_fake("spyre::reducescatter_run")
+    def _(x: torch.Tensor, plan_handle: int, group_size: int) -> torch.Tensor:
+        output_size = list(x.shape)
+        output_size[0] //= group_size
+        return torch.empty(output_size, dtype=x.dtype, device=x.device)
+
     @torch.library.register_fake("spyre::all_gather_async")
     def _(
         x: torch.Tensor, group_size: int = 1, group_name: str = "default"
@@ -81,4 +87,15 @@ if torch._C._dispatch_has_kernel("spyre::broadcast_run"):
         """Fake implementation for shape inference during compilation."""
         output_size = list(x.shape)
         output_size[0] *= group_size
+        return torch.empty(output_size, dtype=x.dtype, device=x.device)
+
+    @torch.library.register_fake("spyre::reduce_scatter_async")
+    def _(
+        x: torch.Tensor,
+        reduce_op: str = "sum",
+        group_size: int = 1,
+        group_name: str = "default",
+    ) -> torch.Tensor:
+        output_size = list(x.shape)
+        output_size[0] //= group_size
         return torch.empty(output_size, dtype=x.dtype, device=x.device)

--- a/torch_spyre/_inductor/ir.py
+++ b/torch_spyre/_inductor/ir.py
@@ -491,6 +491,28 @@ def _compute_device_num_elems(layout: "FixedLayout") -> int:
     return int(V.graph.sizevars.guarding_hint_or_throw(numel))
 
 
+def _emit_plan_once(wrapper: PythonWrapperCodegen, plan_line: str) -> None:
+    """Emit *plan_line* into the wrapper header exactly once per wrapper instance.
+
+    Each collective codegen method needs to write a plan call (e.g.
+    ``allreduce_plan(...)``) into the module-level header so it runs once at
+    graph load rather than on every forward pass.  Using ``wrapper._emitted_plans``
+    (a set attached to the wrapper object) ensures deduplication even when
+    multiple coalesced tensors share the same shape and would otherwise emit
+    identical plan lines.
+
+    Attaching state to the wrapper is fragile if Inductor ever reuses or clones
+    wrapper objects, but it mirrors the existing pattern established by the
+    broadcast/allgather/allreduce fallbacks.  Centralising the guard here means
+    only this one place needs updating if the approach changes.
+    """
+    if not hasattr(wrapper, "_emitted_plans"):
+        wrapper._emitted_plans = set()
+    if plan_line not in wrapper._emitted_plans:
+        wrapper.header.writeline(plan_line)
+        wrapper._emitted_plans.add(plan_line)
+
+
 class BroadcastAsyncFallback(ir.ExternKernel):
     """IR node for spyre.broadcast_async — emits a runtime call to async broadcast.
 
@@ -515,11 +537,7 @@ class BroadcastAsyncFallback(ir.ExternKernel):
             f"{plan_var} = torch.ops.spyre.broadcast_plan("
             f"{num_elems}, {dtype_code}, {src_rank}, '{group_name}')"
         )
-        if not hasattr(wrapper, "_emitted_plans"):
-            wrapper._emitted_plans = set()
-        if plan_line not in wrapper._emitted_plans:
-            wrapper.header.writeline(plan_line)
-            wrapper._emitted_plans.add(plan_line)
+        _emit_plan_once(wrapper, plan_line)
 
         # Emit run call in body (per-invocation)
         wrapper.writeline(
@@ -592,11 +610,7 @@ class AllGatherAsyncFallback(ir.ExternKernel):
             f"{plan_var} = torch.ops.spyre.allgather_plan("
             f"{num_elems}, {dtype_code}, {group_size}, '{group_name}')"
         )
-        if not hasattr(wrapper, "_emitted_plans"):
-            wrapper._emitted_plans = set()
-        if plan_line not in wrapper._emitted_plans:
-            wrapper.header.writeline(plan_line)
-            wrapper._emitted_plans.add(plan_line)
+        _emit_plan_once(wrapper, plan_line)
 
         # Emit run call in body (per-invocation)
         wrapper.writeline(
@@ -645,6 +659,82 @@ class AllGatherAsyncFallback(ir.ExternKernel):
         V.graph.register_operation(self)
 
 
+class ReduceScatterAsyncFallback(ir.ExternKernel):
+    """IR node for spyre.reduce_scatter_async.
+
+    Starts the reduce_scatter operation asynchronously and returns immediately.
+    Output tensor has shape[0] = input.shape[0] // group_size.
+    """
+
+    def codegen(self, wrapper: PythonWrapperCodegen) -> None:
+        """Emit plan call in header (compile-time) and run call in body (runtime)."""
+        input_tensor = self.inputs[0]
+        input_name = input_tensor.codegen_reference()
+        reduce_op, group_size, group_name = self.constant_args
+        output_name = self.get_name()
+
+        input_layout = input_tensor.get_layout()
+        dtype_code = _dtype_to_int(input_layout.dtype)
+        num_elems = _compute_device_num_elems(input_layout)
+
+        plan_var = f"_rs_plan_{output_name}"
+        plan_line = (
+            f"{plan_var} = torch.ops.spyre.reducescatter_plan("
+            f"{num_elems}, {dtype_code}, {group_size}, "
+            f"'{reduce_op}', '{group_name}')"
+        )
+        _emit_plan_once(wrapper, plan_line)
+
+        # Emit run call in body (per-invocation)
+        wrapper.writeline(
+            f"{output_name} = torch.ops.spyre.reducescatter_run("
+            f"{input_name}, {plan_var}, {group_size})"
+        )
+
+        logger.debug(
+            "Codegen reducescatter plan+run: %s -> %s "
+            "(reduce_op=%s, group_size=%s, group='%s')",
+            input_name,
+            output_name,
+            reduce_op,
+            group_size,
+            group_name,
+        )
+
+    def should_allocate(self) -> bool:
+        return False
+
+    def get_mutation_names(self) -> Sequence[str]:
+        return []
+
+    def get_unbacked_symbol_defs(self) -> OrderedSet[sympy.Symbol]:
+        return OrderedSet()
+
+    def __init__(
+        self,
+        op_overload: torch._ops.OpOverload,
+        x: IRNode,
+        reduce_op: str,
+        group_size: int,
+        group_name: str,
+    ) -> None:
+        in_layout = x.get_layout()
+        out_size = list(in_layout.size)
+        out_size[0] = out_size[0] // group_size
+        out_stride = ir.FlexibleLayout.contiguous_strides(out_size)
+        layout = FixedLayout(in_layout.device, in_layout.dtype, out_size, out_stride)
+        super().__init__(
+            None,
+            layout,
+            [x],
+            (reduce_op, group_size, group_name),
+            python_kernel_name="torch.ops.spyre.reducescatter_run",
+            op_overload=op_overload,
+        )
+        self.name = V.graph.register_buffer(self)
+        V.graph.register_operation(self)
+
+
 class AllReduceAsyncFallback(ir.ExternKernel):
     """IR node for spyre.all_reduce_async.
 
@@ -672,11 +762,7 @@ class AllReduceAsyncFallback(ir.ExternKernel):
             f"{plan_var} = torch.ops.spyre.allreduce_plan("
             f"{num_elems}, {dtype_code}, '{reduce_op}', '{group_name}')"
         )
-        if not hasattr(wrapper, "_emitted_plans"):
-            wrapper._emitted_plans = set()
-        if plan_line not in wrapper._emitted_plans:
-            wrapper.header.writeline(plan_line)
-            wrapper._emitted_plans.add(plan_line)
+        _emit_plan_once(wrapper, plan_line)
 
         # Emit run call in body
         wrapper.writeline(

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -54,6 +54,7 @@ from .ir import (
     SpyreEmptyFallback,
     SpyreReduction,
     WaitWorkFallback,
+    ReduceScatterAsyncFallback,
 )
 from .logging_utils import get_inductor_logger
 
@@ -2069,6 +2070,85 @@ def lower_c10d_all_gather_async(tensor, group_size, group_name):
     )
 
 
+@register_spyre_lowering(
+    torch.ops._c10d_functional.all_gather_into_tensor_coalesced.default
+)
+def lower_c10d_all_gather_coalesced(tensors, group_size, group_name):
+    """Decompose coalesced all_gather into per-tensor all_gather calls.
+
+    spyre-comms only supports single-tensor allgather WSIs, so we lower each
+    tensor in the list independently.  The C++ wsi_cache_ deduplicates plans
+    for same-shaped tensors automatically.
+    """
+    results = []
+    for tensor in tensors:
+        tensor.realize()
+        results.append(
+            ir.TensorBox.create(
+                AllGatherAsyncFallback(
+                    torch.ops.spyre.all_gather_async.default,
+                    tensor,
+                    group_size,
+                    group_name,
+                )
+            )
+        )
+    return results
+
+
+@register_spyre_lowering(torch.ops._c10d_functional.reduce_scatter_tensor.default)
+def lower_c10d_reduce_scatter_tensor(tensor, reduce_op, group_size, group_name):
+    """Lower reduce_scatter_tensor to ReduceScatterAsyncFallback.
+
+    Output tensor has shape[0] = input.shape[0] // group_size after reduction.
+    """
+    tensor.realize()
+    logger.debug(
+        "Lowering _c10d_functional.reduce_scatter_tensor to "
+        "ReduceScatterAsyncFallback (reduce_op=%s, group_size=%s, "
+        "group_name='%s')",
+        reduce_op,
+        group_size,
+        group_name,
+    )
+    return ir.TensorBox.create(
+        ReduceScatterAsyncFallback(
+            torch.ops.spyre.reduce_scatter_async.default,
+            tensor,
+            reduce_op,
+            group_size,
+            group_name,
+        )
+    )
+
+
+@register_spyre_lowering(
+    torch.ops._c10d_functional.reduce_scatter_tensor_coalesced.default
+)
+def lower_c10d_reduce_scatter_coalesced(tensors, reduce_op, group_size, group_name):
+    """Decompose coalesced reduce_scatter into per-tensor reduce_scatter calls.
+
+    spyre-comms only supports single-tensor reduce_scatter WSIs, so we lower
+    each tensor in the list independently.  The C++ wsi_cache_ deduplicates
+    plans for same-shaped tensors automatically.
+    """
+    results = []
+    for tensor in tensors:
+        tensor.realize()
+        results.append(
+            ir.TensorBox.create(
+                ReduceScatterAsyncFallback(
+                    torch.ops.spyre.reduce_scatter_async.default,
+                    tensor,
+                    reduce_op,
+                    group_size,
+                    group_name,
+                )
+            )
+        )
+    return results
+
+
 @register_spyre_lowering(torch.ops._c10d_functional.all_reduce.default)
 def lower_c10d_all_reduce_async(tensor, reduce_op, group_name):
     """
@@ -2118,3 +2198,46 @@ def lower_c10d_all_reduce_inplace(tensor, reduce_op, group_name):
             group_name,
         )
     )
+
+
+@register_spyre_lowering(torch.ops._c10d_functional.all_reduce_coalesced.default)
+def lower_c10d_all_reduce_coalesced(tensors, reduce_op, group_name):
+    """Decompose coalesced all_reduce into per-tensor all_reduce calls.
+
+    spyre-comms only supports single-tensor allreduce WSIs, so we lower each
+    tensor in the list independently.  The C++ wsi_cache_ deduplicates plans
+    for same-shaped tensors automatically.
+    """
+    results = []
+    for tensor in tensors:
+        tensor.realize()
+        results.append(
+            ir.TensorBox.create(
+                AllReduceAsyncFallback(
+                    torch.ops.spyre.all_reduce_async.default,
+                    tensor,
+                    reduce_op,
+                    group_name,
+                )
+            )
+        )
+    return results
+
+
+@register_spyre_lowering(torch.ops._c10d_functional.all_reduce_coalesced_.default)
+def lower_c10d_all_reduce_coalesced_inplace(tensors, reduce_op, group_name):
+    """In-place variant of the coalesced all_reduce decomposition."""
+    results = []
+    for tensor in tensors:
+        tensor.realize()
+        results.append(
+            ir.TensorBox.create(
+                AllReduceAsyncFallback(
+                    torch.ops.spyre.all_reduce_async.default,
+                    tensor,
+                    reduce_op,
+                    group_name,
+                )
+            )
+        )
+    return results

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -72,6 +72,7 @@ from .ir import (
     AllGatherAsyncFallback,
     AllReduceAsyncFallback,
     FixedTiledLayout,
+    ReduceScatterAsyncFallback,
     SpyreConstantFallback,
     SpyreEmptyFallback,
     BroadcastAsyncFallback,
@@ -2519,7 +2520,7 @@ def propagate_spyre_tensor_layouts(
             input_buf = V.graph.get_buffer(input_name)
             op.layouts = list(input_buf.layouts)
             op.restick_cost_fn = AnyInNode.from_args()
-        elif isinstance(op, AllGatherAsyncFallback):
+        elif isinstance(op, (AllGatherAsyncFallback, ReduceScatterAsyncFallback)):
             op.layouts = [generic_layout(op)]
             op.restick_cost_fn = AnyInNode.from_args()
         elif isinstance(op, ExternKernel):

--- a/torch_spyre/csrc/distributed/spyre_distributed.cpp
+++ b/torch_spyre/csrc/distributed/spyre_distributed.cpp
@@ -36,7 +36,7 @@
 
 namespace spyre {
 
-enum class CollectiveKind { Broadcast, AllGather, AllReduce };
+enum class CollectiveKind { Broadcast, AllGather, AllReduce, ReduceScatter };
 
 // Structure to hold pending async work
 struct PendingWork {
@@ -56,7 +56,7 @@ static std::unordered_map<spyre::SharedOwnerCtx*, PendingWork>
 static std::mutex work_map_mutex_;
 
 // Compile-time plan cache.
-enum class PlanKind { Broadcast, AllReduce, AllGather };
+enum class PlanKind { Broadcast, AllReduce, AllGather, ReduceScatter };
 
 struct CachedPlan {
   PlanKind kind;
@@ -68,9 +68,11 @@ struct CachedPlan {
   // tensor_info MUST outlive wsi — spyre_comms stores a non-owning reference
   // to it inside the WorkScheduleInfo's sentinel envelope.
   std::unique_ptr<spyre_comms::TensorInfo> tensor_info;
+  std::unique_ptr<spyre_comms::TensorInfo>
+      output_tensor_info;  // reduce_scatter
   std::unique_ptr<spyre_comms::WorkScheduleInfo> wsi;
   int64_t num_elems = 0;
-  int64_t group_size = 0;  // allgather only
+  int64_t group_size = 0;  // allgather / reduce_scatter
 };
 static std::vector<CachedPlan> wsi_cache_;
 static std::mutex wsi_cache_mutex_;
@@ -175,6 +177,15 @@ void ensure_wsi(CachedPlan& plan, int64_t num_elems,
       plan.wsi = context->allgather(output_infos, *plan.tensor_info);
       break;
     }
+    case PlanKind::ReduceScatter: {
+      int64_t out_elems = num_elems / plan.group_size;
+      spyre_comms::TensorShape out_shape({out_elems});
+      plan.output_tensor_info =
+          std::make_unique<spyre_comms::TensorInfo>(plan.dtype, out_shape);
+      plan.wsi = context->reduce_scatter(
+          *plan.tensor_info, *plan.output_tensor_info, plan.reduce_op);
+      break;
+    }
   }
   TORCH_CHECK(plan.wsi != nullptr, "Failed to create WSI");
 }
@@ -206,7 +217,7 @@ int64_t spyre_broadcast_plan_impl(int64_t num_elems, int64_t dtype_code,
   handle = static_cast<int64_t>(wsi_cache_.size());
   wsi_cache_.push_back(CachedPlan{PlanKind::Broadcast, dtype, src_rank,
                                   spyre_comms::SpyreReductionOpType::SUM,
-                                  nullptr, nullptr, 0, 0});
+                                  nullptr, nullptr, nullptr, 0, 0});
   auto& plan = wsi_cache_.back();
   ensure_wsi(plan, num_elems, context);
 
@@ -235,7 +246,7 @@ int64_t spyre_allreduce_plan_impl(int64_t num_elems, int64_t dtype_code,
 
   handle = static_cast<int64_t>(wsi_cache_.size());
   wsi_cache_.push_back(CachedPlan{PlanKind::AllReduce, dtype, 0, op_type,
-                                  nullptr, nullptr, 0, 0});
+                                  nullptr, nullptr, nullptr, 0, 0});
   auto& plan = wsi_cache_.back();
   ensure_wsi(plan, num_elems, context);
 
@@ -271,11 +282,51 @@ int64_t spyre_allgather_plan_impl(int64_t num_elems, int64_t dtype_code,
   handle = static_cast<int64_t>(wsi_cache_.size());
   wsi_cache_.push_back(CachedPlan{PlanKind::AllGather, dtype, 0,
                                   spyre_comms::SpyreReductionOpType::SUM,
-                                  nullptr, nullptr, 0, group_size});
+                                  nullptr, nullptr, nullptr, 0, group_size});
   auto& plan = wsi_cache_.back();
   ensure_wsi(plan, num_elems, context);
 
   DEBUGINFO("allgather_plan: created WSI at handle=", handle);
+  return handle;
+}
+
+int64_t spyre_reducescatter_plan_impl(int64_t num_elems, int64_t dtype_code,
+                                      int64_t group_size,
+                                      const std::string& reduce_op,
+                                      const std::string& group_name) {
+  DEBUGINFO("spyre::reducescatter_plan called with num_elems=", num_elems,
+            ", dtype=", dtype_code, ", group_size=", group_size,
+            ", reduce_op=", reduce_op);
+
+  auto context = ensure_context();
+  auto op_type = parse_reduce_op(reduce_op);
+
+  TORCH_CHECK(
+      group_size > 0 && group_size == static_cast<int64_t>(context->getSize()),
+      "group_size must equal world size: got ", group_size, " (world size is ",
+      context->getSize(), ")");
+  TORCH_CHECK(num_elems % group_size == 0,
+              "num_elems must be divisible by group_size: ", num_elems, " % ",
+              group_size, " != 0");
+
+  auto dtype =
+      torch_dtype_to_spyre_comms(static_cast<c10::ScalarType>(dtype_code));
+
+  std::lock_guard<std::mutex> lock(wsi_cache_mutex_);
+  int64_t handle = cache_lookup(PlanKind::ReduceScatter, dtype, num_elems, 0,
+                                op_type, group_size);
+  if (handle >= 0) {
+    DEBUGINFO("reducescatter_plan: cache hit at handle=", handle);
+    return handle;
+  }
+
+  handle = static_cast<int64_t>(wsi_cache_.size());
+  wsi_cache_.push_back(CachedPlan{PlanKind::ReduceScatter, dtype, 0, op_type,
+                                  nullptr, nullptr, nullptr, 0, group_size});
+  auto& plan = wsi_cache_.back();
+  ensure_wsi(plan, num_elems, context);
+
+  DEBUGINFO("reducescatter_plan: created WSI at handle=", handle);
   return handle;
 }
 
@@ -459,6 +510,78 @@ at::Tensor spyre_allgather_run_impl(const at::Tensor& input,
   return output;
 }
 
+at::Tensor spyre_reducescatter_run_impl(const at::Tensor& input,
+                                        int64_t plan_handle,
+                                        int64_t group_size) {
+  DEBUGINFO("spyre::reducescatter_run called with plan_handle=", plan_handle,
+            ", group_size=", group_size);
+
+  auto context = ensure_context();
+
+  std::lock_guard<std::mutex> cache_lock(wsi_cache_mutex_);
+  TORCH_CHECK(
+      plan_handle >= 0 && plan_handle < static_cast<int64_t>(wsi_cache_.size()),
+      "reducescatter_run: invalid plan_handle=", plan_handle);
+  auto& plan = wsi_cache_[static_cast<size_t>(plan_handle)];
+
+  TORCH_CHECK(input.is_privateuseone(),
+              "Tensor must be on Spyre device for reduce_scatter");
+  TORCH_CHECK(input.is_contiguous(),
+              "Tensor must be contiguous for reduce_scatter");
+  TORCH_CHECK(input.nbytes() > 0,
+              "Tensor must have non-zero size for reduce_scatter");
+
+  // Get SharedOwnerCtx for input
+  auto* input_ctx = static_cast<spyre::SharedOwnerCtx*>(
+      input.storage().data_ptr().get_context());
+  TORCH_CHECK(input_ctx != nullptr, "SharedOwnerCtx is null for input tensor");
+
+  spyre_comms::Tensor input_tensor(*plan.tensor_info,
+                                   input.storage().data_ptr().get());
+  input_tensor.SetSpyreDeviceAddressBorrowed(&input_ctx->composite_addr);
+
+  // Allocate output tensor with reduced size
+  auto output_sizes = input.sizes().vec();
+  TORCH_CHECK(output_sizes[0] % group_size == 0,
+              "reduce_scatter: input dim 0 (", output_sizes[0],
+              ") must be divisible by group_size (", group_size, ")");
+  output_sizes[0] /= group_size;
+  at::Tensor output = at::empty(output_sizes, input.options());
+
+  auto* output_ctx = static_cast<spyre::SharedOwnerCtx*>(
+      output.storage().data_ptr().get_context());
+  TORCH_CHECK(output_ctx != nullptr,
+              "SharedOwnerCtx is null for output tensor");
+
+  spyre_comms::Tensor output_tensor(*plan.output_tensor_info,
+                                    output.storage().data_ptr().get());
+  output_tensor.SetSpyreDeviceAddressBorrowed(&output_ctx->composite_addr);
+
+  auto work_schedule = context->reduce_scatter_applyTensors(
+      *plan.wsi, input_tensor, output_tensor);
+  TORCH_CHECK(
+      work_schedule != nullptr,
+      "reduce_scatter_applyTensors operation failed to create WorkSchedule");
+
+  work_schedule->start();
+
+  // Store pending work
+  {
+    std::lock_guard<std::mutex> lock(work_map_mutex_);
+    TORCH_CHECK(pending_work_map_.find(output_ctx) == pending_work_map_.end(),
+                "reducescatter_run called twice on the same allocation without "
+                "intervening wait_work");
+    pending_work_map_.emplace(output_ctx,
+                              PendingWork{CollectiveKind::ReduceScatter,
+                                          std::move(work_schedule),
+                                          {},
+                                          0,
+                                          {output, input}});
+  }
+
+  return output;
+}
+
 // Wait for async operation to complete
 at::Tensor spyre_wait_work_impl(const at::Tensor& tensor) {
   DEBUGINFO("spyre::wait_work called");
@@ -475,7 +598,8 @@ at::Tensor spyre_wait_work_impl(const at::Tensor& tensor) {
     TORCH_CHECK(it != pending_work_map_.end(),
                 "No pending async work found for tensor. "
                 "wait_work must be called on a tensor returned from "
-                "broadcast_run, allgather_run, or allreduce_run.");
+                "broadcast_run, allgather_run, allreduce_run, or "
+                "reducescatter_run.");
 
     pending = std::move(it->second);
     pending_work_map_.erase(it);
@@ -528,6 +652,9 @@ TORCH_LIBRARY(spyre, m) {
   m.def(
       "all_reduce_async(Tensor(a!) input, str reduce_op=\"sum\", "
       "str group_name=\"default\") -> Tensor(a)");
+  m.def(
+      "reduce_scatter_async(Tensor input, str reduce_op=\"sum\", "
+      "int group_size=1, str group_name=\"default\") -> Tensor");
   m.def("wait_work(Tensor(a!) tensor) -> Tensor(a)");
 
   // Compile-time plan ops — scalar-only, registered with impl directly
@@ -544,6 +671,10 @@ TORCH_LIBRARY(spyre, m) {
       "allgather_plan(int num_elems, int dtype, int group_size, "
       "str group_name) -> int",
       &spyre::spyre_allgather_plan_impl);
+  m.def(
+      "reducescatter_plan(int num_elems, int dtype, int group_size, "
+      "str reduce_op, str group_name) -> int",
+      &spyre::spyre_reducescatter_plan_impl);
 
   // Runtime run ops — bind cached WSI to a tensor and execute
   m.def(
@@ -552,6 +683,9 @@ TORCH_LIBRARY(spyre, m) {
   m.def("allreduce_run(Tensor(a!) input, int plan_handle) -> Tensor(a)");
   m.def(
       "allgather_run(Tensor input, int plan_handle, int group_size) "
+      "-> Tensor");
+  m.def(
+      "reducescatter_run(Tensor input, int plan_handle, int group_size) "
       "-> Tensor");
 }
 
@@ -562,4 +696,5 @@ TORCH_LIBRARY_IMPL(spyre, PrivateUse1, m) {
   m.impl("broadcast_run", &spyre::spyre_broadcast_run_impl);
   m.impl("allreduce_run", &spyre::spyre_allreduce_run_impl);
   m.impl("allgather_run", &spyre::spyre_allgather_run_impl);
+  m.impl("reducescatter_run", &spyre::spyre_reducescatter_run_impl);
 }


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Extends the compiled-path collective support with three new operations, completing the set of collectives needed for distributed inference with tensor parallelism:

- Coalesced all_reduce `_c10d_functional.all_reduce_coalesced / all_reduce_coalesced_`
- Coalesced all_gather `_c10d_functional.all_gather_into_tensor_coalesced`
- reduce_scatter `_c10d_functional.reduce_scatter_tensor / reduce_scatter_tensor_coalesced`

All three follow the established plan/run split: a *_plan(...) call is emitted once into the wrapper header at graph load, and a *_run(...) call is emitted per forward pass invocation. This means WSI compilation cost is paid once; subsequent calls reuse the cached plan.

#### Which issue(s) this PR is related to:

Related to #3644 

#### Special notes for your reviewer:

To test:
```bash
torchrun --nproc-per-node 2 tests/distributed/test_all_reduce_coalesced_compiled.py
torchrun --nproc-per-node 2 tests/distributed/test_all_gather_coalesced_compiled.py
torchrun --nproc-per-node 2 tests/distributed/test_reduce_scatter_compiled.py
```
Eg. with the `test_reduce_scatter_compiled.py`:

```bash
TORCH_SPYRE_DEBUG=1 torchrun --nproc-per-node 2 -m pytest tests/distributed/test_reduce_scatter_compiled.py -v 
```
We can see them passing and the APIs being called with `WorkScheduleInfo` (pasted only part of the logs for better readability):
```bash
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_plan_impl: spyre::reducescatter_plan called with num_elems=128, dtype=5, group_size=2, reduce_op=sum
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_plan_impl: spyre::reducescatter_plan called with num_elems=128, dtype=5, group_size=2, reduce_op=sum
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_plan_impl: reducescatter_plan: created WSI at handle=0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_plan_impl: spyre::reducescatter_plan called with num_elems=256, dtype=5, group_size=2, reduce_op=sum
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_plan_impl: reducescatter_plan: created WSI at handle=0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_plan_impl: spyre::reducescatter_plan called with num_elems=256, dtype=5, group_size=2, reduce_op=sum
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_plan_impl: reducescatter_plan: created WSI at handle=1
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_plan_impl: reducescatter_plan: created WSI at handle=1
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_run_impl: spyre::reducescatter_run called with plan_handle=0, group_size=2
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_run_impl: spyre::reducescatter_run called with plan_handle=0, group_size=2
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: shape=[64] on Spyre spyre:1
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: shape=[64] on Spyre spyre:0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocating 128 (bytes) on Spyrespyre:1
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocating 128 (bytes) on Spyrespyre:0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocated CompositeAddress{total_size=128, num_chunks=1, owns=true, chunks=[Chunk{addr=LogicalAddress{region_id=0x1000000080, offset=0x0}, size=128, domain_id=0}]}
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocated CompositeAddress{total_size=128, num_chunks=1, owns=true, chunks=[Chunk{addr=LogicalAddress{region_id=0x1000000080, offset=0x0}, size=128, domain_id=0}]}
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: SpyreTensorLayout: SpyreTensorLayout(device_size=[1, 64], stride_map =[64, 1], device_dtype=DataFormats.SEN169_FP16)
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: SpyreTensorLayout: SpyreTensorLayout(device_size=[1, 64], stride_map =[64, 1], device_dtype=DataFormats.SEN169_FP16)
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_wait_work_impl: spyre::wait_work called
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_wait_work_impl: Extracted and erased PendingWork, map size=0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_wait_work_impl: WorkSchedule wait completed
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_wait_work_impl: spyre::wait_work called
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_wait_work_impl: Extracted and erased PendingWork, map size=0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_wait_work_impl: WorkSchedule wait completed
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_run_impl: spyre::reducescatter_run called with plan_handle=1, group_size=2
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: shape=[128] on Spyre spyre:0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocating 256 (bytes) on Spyrespyre:0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocated CompositeAddress{total_size=256, num_chunks=1, owns=true, chunks=[Chunk{addr=LogicalAddress{region_id=0x1400000080, offset=0x0}, size=256, domain_id=0}]}
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: SpyreTensorLayout: SpyreTensorLayout(device_size=[2, 64], stride_map =[64, 1], device_dtype=DataFormats.SEN169_FP16)
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_run_impl: spyre::reducescatter_run called with plan_handle=1, group_size=2
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: shape=[128] on Spyre spyre:1
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocating 256 (bytes) on Spyrespyre:1
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocated CompositeAddress{total_size=256, num_chunks=1, owns=true, chunks=[Chunk{addr=LogicalAddress{region_id=0x1400000080, offset=0x0}, size=256, domain_id=0}]}
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: SpyreTensorLayout: SpyreTensorLayout(device_size=[2, 64], stride_map =[64, 1], device_dtype=DataFormats.SEN169_FP16)
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_wait_work_impl: spyre::wait_work called
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_wait_work_impl: Extracted and erased PendingWork, map size=0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_wait_work_impl: WorkSchedule wait completed
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_wait_work_impl: spyre::wait_work called
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_wait_work_impl: Extracted and erased PendingWork, map size=0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_wait_work_impl: WorkSchedule wait completed
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 copyAsync: src (Half) is on:spyre:0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 copyAsync: dst (Half) on:cpu

[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 synchronize: SpyreStream::synchronize() - stream 0 on device 0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 synchronize: SpyreStream::synchronize() - stream 0 on device 1
..[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: shape=[128] on Spyre spyre:0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: shape=[128] on Spyre spyre:1
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocating 256 (bytes) on Spyrespyre:0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocating 256 (bytes) on Spyrespyre:1
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocated CompositeAddress{total_size=256, num_chunks=1, owns=true, chunks=[Chunk{addr=LogicalAddress{region_id=0xc00000080, offset=0x0}, size=256, domain_id=0}]}
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: SpyreTensorLayout: SpyreTensorLayout(device_size=[2, 64], stride_map =[64, 1], device_dtype=DataFormats.SEN169_FP16)
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocated CompositeAddress{total_size=256, num_chunks=1, owns=true, chunks=[Chunk{addr=LogicalAddress{region_id=0xc00000080, offset=0x0}, size=256, domain_id=0}]}
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: SpyreTensorLayout: SpyreTensorLayout(device_size=[2, 64], stride_map =[64, 1], device_dtype=DataFormats.SEN169_FP16)
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_plan_impl: spyre::reducescatter_plan called with num_elems=128, dtype=5, group_size=2, reduce_op=sum
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_plan_impl: reducescatter_plan: cache hit at handle=0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_plan_impl: spyre::reducescatter_plan called with num_elems=128, dtype=5, group_size=2, reduce_op=sum
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_plan_impl: reducescatter_plan: cache hit at handle=0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_run_impl: spyre::reducescatter_run called with plan_handle=0, group_size=2
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: shape=[64] on Spyre spyre:0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocating 128 (bytes) on Spyrespyre:0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocated CompositeAddress{total_size=128, num_chunks=1, owns=true, chunks=[Chunk{addr=LogicalAddress{region_id=0x1400000080, offset=0x0}, size=128, domain_id=0}]}
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: SpyreTensorLayout: SpyreTensorLayout(device_size=[1, 64], stride_map =[64, 1], device_dtype=DataFormats.SEN169_FP16)
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_run_impl: spyre::reducescatter_run called with plan_handle=0, group_size=2
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: shape=[64] on Spyre spyre:1
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocating 128 (bytes) on Spyrespyre:1
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocated CompositeAddress{total_size=128, num_chunks=1, owns=true, chunks=[Chunk{addr=LogicalAddress{region_id=0x1400000080, offset=0x0}, size=128, domain_id=0}]}
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: SpyreTensorLayout: SpyreTensorLayout(device_size=[1, 64], stride_map =[64, 1], device_dtype=DataFormats.SEN169_FP16)
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_wait_work_impl: spyre::wait_work called
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_wait_work_impl: spyre::wait_work called
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_wait_work_impl: Extracted and erased PendingWork, map size=0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_wait_work_impl: Extracted and erased PendingWork, map size=0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_wait_work_impl: WorkSchedule wait completed
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_wait_work_impl: WorkSchedule wait completed
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 copyAsync: src (Half) is on:spyre:0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 copyAsync: dst (Half) on:cpu
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 copyAsync: src (Half) is on:spyre:1
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 copyAsync: dst (Half) on:cpu
[...]
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 synchronize: SpyreStream::synchronize() - stream 0 on device 0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 synchronize: SpyreStream::synchronize() - stream 0 on device 1
..[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: shape=[128] on Spyre spyre:0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocating 256 (bytes) on Spyrespyre:0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocated CompositeAddress{total_size=256, num_chunks=1, owns=true, chunks=[Chunk{addr=LogicalAddress{region_id=0xc00000080, offset=0x0}, size=256, domain_id=0}]}
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: SpyreTensorLayout: SpyreTensorLayout(device_size=[2, 64], stride_map =[64, 1], device_dtype=DataFormats.SEN169_FP16)
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: shape=[128] on Spyre spyre:1
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocating 256 (bytes) on Spyrespyre:1
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocated CompositeAddress{total_size=256, num_chunks=1, owns=true, chunks=[Chunk{addr=LogicalAddress{region_id=0xc00000080, offset=0x0}, size=256, domain_id=0}]}
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: SpyreTensorLayout: SpyreTensorLayout(device_size=[2, 64], stride_map =[64, 1], device_dtype=DataFormats.SEN169_FP16)
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: shape=[64] on Spyre spyre:0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocating 128 (bytes) on Spyrespyre:0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocated CompositeAddress{total_size=128, num_chunks=1, owns=true, chunks=[Chunk{addr=LogicalAddress{region_id=0x1400000080, offset=0x0}, size=128, domain_id=0}]}
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: SpyreTensorLayout: SpyreTensorLayout(device_size=[1, 64], stride_map =[64, 1], device_dtype=DataFormats.SEN169_FP16)
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: shape=[64] on Spyre spyre:1
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocating 128 (bytes) on Spyrespyre:1
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 allocate: allocated CompositeAddress{total_size=128, num_chunks=1, owns=true, chunks=[Chunk{addr=LogicalAddress{region_id=0x1400000080, offset=0x0}, size=128, domain_id=0}]}
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_empty: SpyreTensorLayout: SpyreTensorLayout(device_size=[1, 64], stride_map =[64, 1], device_dtype=DataFormats.SEN169_FP16)
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_plan_impl: spyre::reducescatter_plan called with num_elems=128, dtype=5, group_size=2, reduce_op=sum
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_plan_impl: reducescatter_plan: cache hit at handle=0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_plan_impl: spyre::reducescatter_plan called with num_elems=128, dtype=5, group_size=2, reduce_op=sum
[DEBUG] [spyre.runtime] 2026-09-04 20:10:09 spyre_reducescatter_plan_impl: reducescatter_plan: cache hit at handle=0
[INFO] [spyre.inductor.sdsc_compile] OP SPECS FOR BUNDLE GENERATION
OpSpec(op='mul', is_reduction=False, iteration_space={c0: (128, 2)})
  TensorArg(input, arg_index=0, device_size=[2, 64], device_coordinates=[floor(c0/64), Mod(c0, 64)], device_tile_advance_expr=None, allocation={'hbm': 0})
  TensorArg(input, arg_index=1, device_size=[1, 64], device_coordinates=[0, 0], device_tile_advance_expr=None, allocation={'hbm': 1})
  TensorArg(output, arg_index=2, device_size=[2, 64], device_coordinates=[floor(c0/64), Mod(c0, 64)], device_tile_advance_expr=None, allocation={'hbm': 2})
[DEBUG] [spyre.inductor.codegen.superdsc] symbol mapping: c0 -> out
[DEBUG] [spyre.inductor.codegen.superdsc] symbol mapping: c0 -> out
[INFO] [spyre.inductor.sdsc_compile] OP SPECS FOR BUNDLE GENERATION
OpSpec(op='mul', is_reduction=False, iteration_space={c0: (128, 2)})
  TensorArg(input, arg_index=0, device_size=[2, 64], device_coordinates=[floor(c0/64), Mod(c0, 64)], device_tile_advance_expr=None, allocation={'hbm': 0})
  TensorArg(input, arg_index=1, device_size=[1, 64], device_coordinates=[0, 0], device_tile_advance_expr=None, allocation={'hbm': 1})
  TensorArg(output, arg_index=2, device_size=[2, 64], device_coordinates=[floor(c0/64), Mod(c0, 64)], device_tile_advance_expr=None, allocation={'hbm': 2})
[DEBUG] [spyre.inductor.codegen.superdsc] symbol mapping: c0 -> out
[DEBUG] [spyre.inductor.codegen.superdsc] symbol mapping: c0 -> out
[...]
[DEBUG] [spyre.runtime] 2026-09-04 20:10:10 allocate: allocating 84096 (bytes) on Spyrespyre:1
[DEBUG] [spyre.runtime] 2026-09-04 20:10:10 allocate: allocated CompositeAddress{total_size=84096, num_chunks=1, owns=true, chunks=[Chunk{addr=LogicalAddress{region_id=0x80, offset=0x0}, size=84096, domain_id=0}]}
[DEBUG] [spyre.runtime] 2026-09-04 20:10:10 allocate: allocating 84096 (bytes) on Spyrespyre:0
[DEBUG] [spyre.runtime] 2026-09-04 20:10:10 allocate: allocated CompositeAddress{total_size=84096, num_chunks=1, owns=true, chunks=[Chunk{addr=LogicalAddress{region_id=0x80, offset=0x0}, size=84096, domain_id=0}]}
[DEBUG] [spyre.runtime] 2026-09-04 20:10:10 prepareKernel: JobPlan:
============ JobPlan =============
Total steps: 3
Job allocation: CompositeAddress{total_size=84096, num_chunks=1, owns=true, chunks=[Chunk{addr=LogicalAddress{region_id=0x80, offset=0x0}, size=84096, domain_id=0}]}
Program 0: CompositeAddress{total_size=76032, num_chunks=1, owns=false, chunks=[Chunk{addr=LogicalAddress{region_id=0x80, offset=0x1080}, size=76032, domain_id=0}]}
Pinned buffers: 1
  Buffer 0: ptr=0x558431fe8000, size=4224 bytes

Detailed Steps:
Step 0:   Host Compute
    Output buffer: 0x558431fe8000
    HCM metadata: present
    Fast path: enabled
    Fast plan: 6 patches, 3 input symbols, 4224 bytes output
    Pipeline barrier: enabled
Step 1:   H2D (Host-to-Device)
    Host address: 0x558431fe8000
    Device CompositeAddress: CompositeAddress{total_size=4224, num_chunks=1, owns=false, chunks=[Chunk{addr=LogicalAddress{region_id=0x80, offset=0x0}, size=4224, domain_id=0}]}
    Pipeline barrier: enabled
Step 2:   Device Compute
    Name: spyre_kernel_v1_fused_mul_ewlln7os2w3dfo2l#2
    Program CompositeAddress: CompositeAddress{total_size=84096, num_chunks=1, owns=false, chunks=[Chunk{addr=LogicalAddress{region_id=0x80, offset=0x0}, size=84096, domain_id=0}]}
    Bind I/O addresses: no
    Pipeline barrier: enabled
==================================

[DEBUG] [spyre.runtime] 2026-09-04 20:10:10 prepareKernel: JobPlan:
============ JobPlan =============
Total steps: 3
Job allocation: CompositeAddress{total_size=84096, num_chunks=1, owns=true, chunks=[Chunk{addr=LogicalAddress{region_id=0x80, offset=0x0}, size=84096, domain_id=0}]}
Program 0: CompositeAddress{total_size=76032, num_chunks=1, owns=false, chunks=[Chunk{addr=LogicalAddress{region_id=0x80, offset=0x1080}, size=76032, domain_id=0}]}
Pinned buffers: 1
  Buffer 0: ptr=0x558c02bab000, size=4224 bytes

Detailed Steps:
Step 0:   Host Compute
    Output buffer: 0x558c02bab000
    HCM metadata: present
    Fast path: enabled
    Fast plan: 6 patches, 3 input symbols, 4224 bytes output
    Pipeline barrier: enabled
Step 1:   H2D (Host-to-Device)
    Host address: 0x558c02bab000
    Device CompositeAddress: CompositeAddress{total_size=4224, num_chunks=1, owns=false, chunks=[Chunk{addr=LogicalAddress{region_id=0x80, offset=0x0}, size=4224, domain_id=0}]}
    Pipeline barrier: enabled
Step 2:   Device Compute
    Name: spyre_kernel_v1_fused_mul_ewlln7os2w3dfo2l#2
    Program CompositeAddress: CompositeAddress{total_size=84096, num_chunks=1, owns=false, chunks=[Chunk{addr=LogicalAddress{region_id=0x80, offset=0x0}, size=84096, domain_id=0}]}
    Bind I/O addresses: no
    Pipeline barrier: enabled
==================================

[...]
[DEBUG] [spyre.runtime] 2026-09-09 20:14:09 synchronize: SpyreStream::synchronize() - stream 0 on device 1
[DEBUG] [spyre.runtime] 2026-09-09 20:14:09 synchronize: SpyreStream::synchronize() - stream 0 on device 0
PASSEDPASSED[rank1]:[W909 20:14:09.528614593 ProcessGroup.hpp:1006] Warning: No backend of type 0 found for Process Group with name undefined. Assuming no hooks are registered. (function hasHooks)
[rank0]:[W909 20:14:09.528692407 ProcessGroup.hpp:1006] Warning: No backend of type 0 found for Process Group with name undefined. Assuming no hooks are registered. (function hasHooks)


================================================================================= warnings summary =================================================================================
torch_spyre/logging_config.py:318
  /home/flaviabeodebayser/dt-inductor/torch-spyre/torch_spyre/logging_config.py:318: DeprecationWarning: TORCH_SPYRE_DEBUG is deprecated. Use TORCH_LOGS='spyre:DEBUG' instead.
    _config = _resolve_config()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================== 6 passed, 1 warning in 11.16s ===========================================================================


================================================================================= warnings summary =================================================================================
torch_spyre/logging_config.py:318
  /home/flaviabeodebayser/dt-inductor/torch-spyre/torch_spyre/logging_config.py:318: DeprecationWarning: TORCH_SPYRE_DEBUG is deprecated. Use TORCH_LOGS='spyre:DEBUG' instead.
    _config = _resolve_config()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================== 6 passed, 1 warning in 11.06s ===========================================================================
```
**_Note:_**  This CI will fail, because it depends on spyre-comms API exposure change that is not merged yet; So we will see:
``` 
spyre_comms::Context’ {aka ‘class spyre_comms::Context’} has no member named ‘reduce_scatter_applyTensors’; did you mean ‘reduce_applyTensor’?
    560 |   auto work_schedule = context->reduce_scatter_applyTensors(
        |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~
        |                                 reduce_applyTensor
  ninja: build stopped: subcommand failed.
``` 
At the CI error logs until we get the spyre-comms API code merged.

#### Does this PR introduce a user-facing change?
Yes
