### PR TITLE
inductor: add native GQA attention lowering

### DIFF
--- a/tests/inductor/test_building_blocks.py
+++ b/tests/inductor/test_building_blocks.py
@@ -578,6 +578,17 @@ class TestBuildingBlocks(unittest.TestCase):
         self.assertEqual(num_head_tiles(16), 4)
         self.assertEqual(num_head_tiles(14), 7)
 
+    def test_granite_gqa_prefill_sequence_tiling(self):
+        """Native GQA remains unexpanded when Lq exceeds one sequence tile."""
+        self._run_granite_gqa_with_finite_broadcast_mask(
+            LQ=1024,
+            dtype=torch.bfloat16,
+            name_inputs=True,
+            LK=1024,
+            transposed_inputs=True,
+            reshape_output=True,
+        )
+
     @unittest.skip(
         "Test skipped solely because of runtime.  It passes but takes over 10 minutes."
     )

--- a/tests/inductor/test_codegen.py
+++ b/tests/inductor/test_codegen.py
@@ -487,6 +487,14 @@ class TestSdscJsonSymbolicDimSmoke(InductorTestCase):
 
 
 class TestTiledAwayPhysicalAxis(InductorTestCase):
+    def test_native_bmm_fake_broadcasts_gqa_axis(self):
+        query = torch.empty((1, 8, 4, 256, 128), device="meta")
+        key = torch.empty((1, 8, 1, 128, 256), device="meta")
+
+        result = torch.ops.spyre.batched_matmul(query, key)
+
+        self.assertEqual(result.shape, (1, 8, 4, 256, 256))
+
     def test_nonstick_role_uses_coordinate_axis_across_tiled_away_axis(self):
         """A constant GQA group slot must not collapse the Hkv stride."""
         d0, d1, d2, d3 = sympy.symbols("d0:4")

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -693,7 +693,8 @@ def batched_matmul(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:  # type: i
 
 @batched_matmul.register_fake
 def _(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-    output_shape = list(x.shape[:-1]) + [y.shape[-1]]
+    batch_shape = torch.broadcast_shapes(x.shape[:-2], y.shape[:-2])
+    output_shape = [*batch_shape, x.shape[-2], y.shape[-1]]
     return x.new_empty(output_shape)
 
 

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -491,14 +491,42 @@ def spyre__sdpa_overrideable(
     # that materializes a full [B, H, S_kv, D] copy that OOMs on long KV. K/V are
     # instead normalized PER BLOCK inside the loop (keys_T's .contiguous() and
     # the per-block v_blk.contiguous()), each a bounded [B, H, kv_block_size, D]
-    # copy (kv_block_size <= 2048, see below), never the full [B, H, S_kv, D].
+    # copy (bounded by _SDPA_MAX_SEQUENCE_TILE_SIZE), never the full
+    # [B, H, S_kv, D].
     original_query_strides = query.stride()
-    query = query.contiguous()
+    if num_heads % num_kvheads != 0:
+        raise Unsupported(
+            "GQA requires the number of KV heads to divide the number of query "
+            f"heads, got query={num_heads} and key/value={num_kvheads}"
+        )
+    gqa_group_size = num_heads // num_kvheads
+    use_gqa = gqa_group_size != 1
 
-    expansion = num_heads // num_kvheads
-    if expansion != 1:
-        key = key.unsqueeze(2).expand(-1, -1, expansion, -1, -1).flatten(1, 2)
-        value = value.unsqueeze(2).expand(-1, -1, expansion, -1, -1).flatten(1, 2)
+    # Keep the GQA relationship explicit instead of repeating K/V up to Hq.
+    # K/V receive only a unit view axis and broadcast over the within-group
+    # query-head dimension in the native batched-matmul lowering. Preserve the
+    # established rank-4 MHA path when there is no grouped-query expansion.
+    query = query.contiguous()
+    if use_gqa:
+        query = query.unflatten(1, (num_kvheads, gqa_group_size))
+
+    query_dim_names = (
+        [
+            "_b",
+            "num_kvheads",
+            "gqa_group_size",
+            "max_seqlen_q",
+            "head_dim",
+        ]
+        if use_gqa
+        else ["_b", "num_heads", "max_seqlen_q", "head_dim"]
+    )
+    accumulator_dim_names = query_dim_names[:-1]
+    accumulator_shape = (
+        (batch_size, num_kvheads, gqa_group_size, max_seqlen_q, 64)
+        if use_gqa
+        else (batch_size, num_heads, max_seqlen_q, 64)
+    )
 
     # Keep the original approximately four-way KV split for short sequences,
     # but cap each explicit online-softmax block at the max tile size. Round
@@ -524,29 +552,27 @@ def spyre__sdpa_overrideable(
         kv_blocks_per_loop_group,
     )
 
-    with spyre_hint(named_dims=["_b", "num_heads", "max_seqlen_q", "head_dim"]):
+    with spyre_hint(named_dims=query_dim_names):
         output = torch.zeros_like(query)
 
     # FIXME: create a sparse M tensor via reduction
     M_reduced = torch.full(
-        (batch_size, num_heads, max_seqlen_q, 64),
+        accumulator_shape,
         float("-inf"),
         device=query.device,
         dtype=query.dtype,
     )
-    with spyre_hint(named_dims=["_b", "num_heads", "max_seqlen_q"]):
-        M = M_reduced.amax(dim=-1)  # batch_size, num_heads, max_seqlen_q sparse
+    with spyre_hint(named_dims=accumulator_dim_names):
+        M = M_reduced.amax(dim=-1)
 
     # FIXME: create a sparse denominator tensor via reduction
     denominator_reduced = torch.zeros(
-        (batch_size, num_heads, max_seqlen_q, 64),
+        accumulator_shape,
         device=query.device,
         dtype=query.dtype,
     )
-    with spyre_hint(named_dims=["_b", "num_heads", "max_seqlen_q"]):
-        denominator = denominator_reduced.amax(
-            dim=-1
-        )  # batch_size, num_heads, max_seqlen_q sparse
+    with spyre_hint(named_dims=accumulator_dim_names):
+        denominator = denominator_reduced.amax(dim=-1)
 
     # Precompute the causal additive mask once before entering the tiled loops.
     # Shape [1, 1, max_seqlen_q, max_seqlen_kv]: 0.0 = keep, -inf = masked.
@@ -559,23 +585,29 @@ def spyre__sdpa_overrideable(
         causal_mask = torch.ops.spyre.causal_mask(
             max_seqlen_q, max_seqlen_kv, query.dtype, query.device
         )
+        if use_gqa:
+            causal_mask = causal_mask.unsqueeze(2)
 
-    # Seed named dimensions on the accumulators (above) and the scaled query so
-    # the max_seqlen_q tiling hint below has a propagated named dim to bind to.
-    # Without a seed the spyre_hint(tiles={"max_seqlen_q": ...}) scope is a
-    # no-op: assign_dim_hints drops any tile whose named dim never propagated.
-    # The names zip positionally to the query layout
-    # [batch_size, num_heads, max_seqlen_q, head_dim]; from this producer the
-    # names flow automatically to every downstream pointwise/reduction op.
-    #
-    # The head dim is named "num_heads" so it matches the
-    # tiles={"num_heads": ...} scope below and the head tile activates. The
-    # batch dim is still the placeholder "_b" -- it does NOT match
-    # tiles={"batch_size": ...}, so the batch tile stays inactive for now.
-    # Renaming "_b" -> "batch_size" is all it takes to light up the batch tile
-    # in a follow-up.
-    with spyre_hint(named_dims=["_b", "num_heads", "max_seqlen_q", "head_dim"]):
-        q_scaled = query * scaling_factor
+    if use_gqa and attn_bias is not None:
+        if attn_bias.dim() == 2:
+            attn_bias = attn_bias.unsqueeze(0).unsqueeze(0).unsqueeze(0)
+        elif attn_bias.dim() == 3:
+            attn_bias = attn_bias.unsqueeze(1).unsqueeze(2)
+        elif attn_bias.dim() == 4:
+            bias_heads = attn_bias.size(1)
+            if bias_heads == num_heads:
+                attn_bias = attn_bias.unflatten(1, (num_kvheads, gqa_group_size))
+            elif bias_heads in (1, num_kvheads):
+                attn_bias = attn_bias.unsqueeze(2)
+            else:
+                raise Unsupported(
+                    "GQA attention bias head dimension must be 1, Hkv, or Hq; "
+                    f"got {bias_heads} for Hkv={num_kvheads}, Hq={num_heads}"
+                )
+        elif attn_bias.dim() != 5:
+            raise Unsupported(
+                f"GQA attention bias must have rank 2-5, got rank {attn_bias.dim()}"
+            )
 
     # Bound each loop group's Lq-tile x unrolled-Lk-block product.  Keeping all
     # sixteen 32K blocks together creates a 322-SDSC bundle that crashes DXP;
@@ -590,18 +622,36 @@ def spyre__sdpa_overrideable(
             block_group_start + kv_blocks_per_loop_group, num_kv_blocks
         )
         with spyre_hint(tiles={"batch_size": max(1, batch_size // 2)}):
-            with spyre_hint(tiles={"num_heads": _sdpa_num_head_tiles(num_heads)}):
+            head_tiles = (
+                {} if use_gqa else {"num_heads": _sdpa_num_head_tiles(num_heads)}
+            )
+            with spyre_hint(tiles=head_tiles):
                 with spyre_hint(num_tiles_per_dim={"max_seqlen_q": num_q_tiles}):
+                    # Materialize scaled Q inside the sequence-tile scope. It is
+                    # loop-invariant across the unrolled KV blocks below.
+                    with spyre_hint(named_dims=query_dim_names):
+                        q_scaled = query * scaling_factor
                     for blk in range(block_group_start, block_group_end):
                         start = blk * kv_block_size
                         end = min(start + kv_block_size, max_seqlen_kv)
 
-                        k_blk = key[
-                            ..., start:end, :
-                        ]  # batch_size, num_heads, blk_len, head_dim
-                        v_blk = value[
-                            ..., start:end, :
-                        ]  # batch_size, num_heads, blk_len, head_dim
+                        k_blk = key[..., start:end, :]
+                        v_blk = value[..., start:end, :]
+                        if use_gqa:
+                            k_blk = k_blk.unsqueeze(2)
+                            v_blk = v_blk.unsqueeze(2)
+
+                        kv_dim_names = (
+                            [
+                                "_b",
+                                "num_kvheads",
+                                "_gqa_broadcast",
+                                "blk_len",
+                                "head_dim",
+                            ]
+                            if use_gqa
+                            else ["_b", "num_heads", "blk_len", "head_dim"]
+                        )
 
                         # The K/V slices are produced in-graph, so they carry no
                         # named dims and stay untiled -- forming a restickify
@@ -609,9 +659,7 @@ def spyre__sdpa_overrideable(
                         # Name each slice's first consuming op so the per-chunk
                         # key extent ("blk_len") propagates and the producers tile
                         # with their consumers.
-                        with spyre_hint(
-                            named_dims=["_b", "num_heads", "blk_len", "head_dim"]
-                        ):
+                        with spyre_hint(named_dims=kv_dim_names):
                             scaled_keys = k_blk * scaling_factor
                         # v_blk feeds the second matmul directly (line below), so
                         # unlike scaled_keys (re-normalized by keys_T.contiguous())
@@ -625,9 +673,7 @@ def spyre__sdpa_overrideable(
                         # block without a full-tensor value.contiguous() (an OOM on
                         # long KV). The named_dims seed lands on the resulting clone, so
                         # blk_len still propagates.
-                        with spyre_hint(
-                            named_dims=["_b", "num_heads", "blk_len", "head_dim"]
-                        ):
+                        with spyre_hint(named_dims=kv_dim_names):
                             v_blk = v_blk.contiguous()
                         # .contiguous() materializes the transposed keys so the
                         # scores matmul sees a clean single-contraction-dim input.
@@ -643,12 +689,23 @@ def spyre__sdpa_overrideable(
                         # max_seqlen_q tile region (otherwise it becomes an
                         # untiled restickify boundary). "blk_len" is the per-chunk
                         # key extent -- the scores' last axis.
-                        with spyre_hint(
-                            named_dims=["_b", "num_heads", "max_seqlen_q", "blk_len"]
-                        ):
-                            scores = torch.matmul(
-                                q_scaled, keys_T
-                            )  # batch_size, num_heads, max_seqlen_q, blk_len
+                        score_dim_names = (
+                            [
+                                "_b",
+                                "num_kvheads",
+                                "gqa_group_size",
+                                "max_seqlen_q",
+                                "blk_len",
+                            ]
+                            if use_gqa
+                            else ["_b", "num_heads", "max_seqlen_q", "blk_len"]
+                        )
+                        with spyre_hint(named_dims=score_dim_names):
+                            scores = (
+                                torch.ops.spyre.batched_matmul(q_scaled, keys_T)
+                                if use_gqa
+                                else torch.matmul(q_scaled, keys_T)
+                            )
 
                         if is_causal:
                             scores = scores + causal_mask[..., :, start:end]
@@ -685,10 +742,12 @@ def spyre__sdpa_overrideable(
                         # same reason as keys_T above -- a clean contiguous input
                         # keeps the matmul's contraction dim unambiguous.
                         exp_scores_c = exp_scores.contiguous()
-                        with spyre_hint(
-                            named_dims=["_b", "num_heads", "max_seqlen_q", "head_dim"]
-                        ):
-                            weighted = torch.matmul(exp_scores_c, v_blk)
+                        with spyre_hint(named_dims=query_dim_names):
+                            weighted = (
+                                torch.ops.spyre.batched_matmul(exp_scores_c, v_blk)
+                                if use_gqa
+                                else torch.matmul(exp_scores_c, v_blk)
+                            )
                         new_output = (
                             output * correction.unsqueeze(-1) + weighted
                         )  # batch_size, num_heads, max_seqlen_q, head_dim
@@ -701,17 +760,12 @@ def spyre__sdpa_overrideable(
                             # split-layout, so finalize_layouts hits
                             # restickify-infeasible. Fold it into the last KV
                             # block so it inherits the max_seqlen_q tile.
-                            with spyre_hint(
-                                named_dims=[
-                                    "_b",
-                                    "num_heads",
-                                    "max_seqlen_q",
-                                    "head_dim",
-                                ]
-                            ):
+                            with spyre_hint(named_dims=query_dim_names):
                                 output = new_output / new_denom.unsqueeze(-1)
                         else:
                             M, denominator, output = new_max, new_denom, new_output
+    if use_gqa:
+        output = output.flatten(1, 2)
     # The reference meta kernel for this op
     # (torch._meta_registrations.meta__scaled_dot_product_fused_attention_
     # overrideable -> alloc_with_matching_layout) declares the output layout to
@@ -722,7 +776,7 @@ def spyre__sdpa_overrideable(
     # (physical [B, S, H, D]) it is the swapped-dim layout. Reproduce the meta's
     # dim-order permutation so both cases match exactly.
     dim_order = sorted(
-        range(query.dim()), key=lambda i: original_query_strides[i], reverse=True
+        range(output.dim()), key=lambda i: original_query_strides[i], reverse=True
     )
     permuted = output.permute(dim_order).contiguous()
     inverse_permute = [dim_order.index(i) for i in range(len(dim_order))]

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -489,35 +489,57 @@ def lower_bmm(x, y):
 
     reduction_numel = x_size[-1]  # K
 
-    if x_ndim == 3 and y_ndim == 3:
-        ranges = [x_size[0], x_size[1], y_size[2]]  # B, M, N
-
-        def inner_fn(index, reduction_index):
-            i0, i1, i2 = index
-            (r0,) = reduction_index
-            tmp1 = x_loader([i0, i1, r0])
-            tmp2 = y_loader([i0, r0, i2])
-            return (tmp1, tmp2)
-    elif x_ndim == 4 and y_ndim == 4:
-        ranges = [x_size[0], x_size[1], x_size[2], y_size[-1]]
-
-        def inner_fn(index, reduction_index):
-            i0, i1, i2, i3 = index
-            (r0,) = reduction_index
-            tmp1 = x_loader([i0, i1, i2, r0])
-            tmp2 = y_loader([i0, i1, r0, i3])
-            return (tmp1, tmp2)
-    elif x_ndim == 3 and y_ndim == 2:
-        ranges = [x_size[0], x_size[1], y_size[1]]  # B, M, N
-
-        def inner_fn(index, reduction_index):
-            i0, i1, i2 = index
-            (r0,) = reduction_index
-            tmp1 = x_loader([i0, i1, r0])
-            tmp2 = y_loader([r0, i2])
-            return (tmp1, tmp2)
-    else:
+    if x_ndim < 2 or y_ndim < 2:
         raise Unsupported(f"BMM with input shapes {x.get_size()} and {y.get_size()}")
+
+    if sympy.simplify(x_size[-1] - y_size[-2]) != 0:
+        raise Unsupported(f"BMM with input shapes {x.get_size()} and {y.get_size()}")
+
+    x_batch = list(x_size[:-2])
+    y_batch = list(y_size[:-2])
+    batch_rank = max(len(x_batch), len(y_batch))
+    x_batch = [sympy.Integer(1)] * (batch_rank - len(x_batch)) + x_batch
+    y_batch = [sympy.Integer(1)] * (batch_rank - len(y_batch)) + y_batch
+    batch_ranges = []
+    x_broadcast = []
+    y_broadcast = []
+    for x_dim, y_dim in zip(x_batch, y_batch):
+        if sympy.simplify(x_dim - y_dim) == 0:
+            batch_ranges.append(x_dim)
+            x_broadcast.append(False)
+            y_broadcast.append(False)
+        elif sympy.simplify(x_dim - 1) == 0:
+            batch_ranges.append(y_dim)
+            x_broadcast.append(True)
+            y_broadcast.append(False)
+        elif sympy.simplify(y_dim - 1) == 0:
+            batch_ranges.append(x_dim)
+            x_broadcast.append(False)
+            y_broadcast.append(True)
+        else:
+            raise Unsupported(
+                f"BMM with incompatible batch shapes {x.get_size()} and {y.get_size()}"
+            )
+
+    ranges = [*batch_ranges, x_size[-2], y_size[-1]]
+    x_leading_pad = batch_rank - (x_ndim - 2)
+    y_leading_pad = batch_rank - (y_ndim - 2)
+
+    def inner_fn(index, reduction_index):
+        *batch_index, row, column = index
+        (contraction,) = reduction_index
+        x_indices = [
+            sympy.Integer(0) if is_broadcast else batch_index[dim]
+            for dim, is_broadcast in enumerate(x_broadcast)
+        ][x_leading_pad:]
+        y_indices = [
+            sympy.Integer(0) if is_broadcast else batch_index[dim]
+            for dim, is_broadcast in enumerate(y_broadcast)
+        ][y_leading_pad:]
+        return (
+            x_loader([*x_indices, row, contraction]),
+            y_loader([*y_indices, contraction, column]),
+        )
 
     if reduction_numel == 1:
         # Reduction degenerates to a pointwise mul


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds native grouped-query attention to the Spyre SDPA decomposition for all query lengths, without expanding K/V heads to the query-head count.

- Represents query heads as Hkv x G and broadcasts K/V over G in `spyre.batched_matmul`.
- Adds broadcast-aware batched-matmul fake and lowering support.
- Retains query/sequence tiling, including for Lq greater than 512.
- Deliberately leaves the GQA KV-head and group axes untiled.
- Recalibrates the SDPA cost model for native GQA: query-only work division for prefill, K/V traffic based on Hkv, and native-GQA decode block policies.
- Preserves the existing MHA path.

#### Which issue(s) this PR is related to:

Supports decode and chunked-prefill work in hf-adapters PR #414.

#### Special notes for your reviewer:

All prerequisite work, including #4421 and #4424, is now in main. Merge commit `f7585150` incorporates current main and the native-GQA cost-model recalibration.

There is no longer an Lq <= 512 limitation. That guard existed only because native GQA could not safely enter the sequence-tiled path without the infrastructure fixes. With those fixes in main, Lq=1024 runs natively and is sequence-tiled.

The GQA-axis tiling audit found neither Hkv nor G coarse tiling should be enabled here. Tiling G and then flattening it through a rank-changing consumer makes the remapping ambiguous and caused historical LX-planning reduction failures. Four-way Hkv tiling was also implemented and measured: depending on workload it increased synchronized kernel latency by 29% to 242%, while the untiled B=2, Lq=1024 case already fit. It additionally exposed three unsupported scalar-operand codegen paths in full CI. The experiment was therefore reverted.

The #4424 cost model was calibrated with expanded K/V and its logical-head work-division hint no longer represented the native GQA graph. New production-decomposition sweeps use the real Granite 3.3 8B and Gemma 4 layouts. They show that prefill is fastest with query-only work division, while decode is fastest with no explicit head/group work division. K/V traffic is now estimated from Hkv while score/live-set memory remains based on Hq.

At Lkv=8192, average Spyre kernel times changed as follows:

| Geometry | Lq | New policy | Before native recalibration | After | Change |
|---|---:|---|---:|---:|---:|
| Granite 32H/8KV/D128 | 512 | Q32, K512 | 7.182 ms | 3.690 ms | -48.6% |
| Gemma local 16H/8KV/D256 | 512 | Q32, K256 | 9.604 ms | 4.699 ms | -51.1% |
| Gemma 12B global 16H/1KV/D512 | 512 | Q32, K1024 | 10.308 ms | 3.078 ms | -70.1% |
| Gemma 26B global 16H/2KV/D512 | 512 | Q32, K1024 | 15.749 ms | 4.052 ms | -74.3% |
| Granite 32H/8KV/D128 | 1 | no work division, K8192 | 5.935 ms | 1.491 ms | -74.9% |
| Gemma local 16H/8KV/D256 | 1 | no work division, K8192 | 5.131 ms | 2.873 ms | -44.0% |
| Gemma 12B global 16H/1KV/D512 | 1 | no work division, K8192 | 1.311 ms | 0.347 ms | -73.5% |
| Gemma 26B global 16H/2KV/D512 | 1 | no work division, K8192 | 6.344 ms | 1.496 ms | -76.4% |

Gemma 26B global decode retains K256 through Lkv=2048 because that wins the measured short-context regime, then uses a full block at 4K/8K. Every selected production run passed correctness, applied its requested hints, and did not recompile.

Focused validation:

- Native decode, prefill, forced sequence tiling, and Lq=1024 GQA hardware coverage: 8 passed, 2 skipped.
- GQA codegen coverage: passed.
- SDPA tiling selector: 14 tests and 22 subtests passed.
- Production-selector checks for all four 8K model geometries plus the Gemma 26B 1K exception: passed correctness, hint placement, and no-recompile checks.
- Pre-commit, ruff, and mypy: passed.

#### Does this PR introduce a user-facing change?

Yes. `scaled_dot_product_attention(..., enable_gqa=True)` avoids materializing repeated K/V heads for both decode and prefill, including query lengths above 512.
