### PR TITLE
test(coarse_tile_e2e): remove two stale skip/xfail markers

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -4143,11 +4143,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             fn, x, y, run_compile=True, run_eager=False, atol=0.01, rtol=0.01
         )
 
-    @pytest.mark.skip(
-        reason="Compiles now, but produces a genuine numeric inf at runtime"
-        " (99.3% of elements mismatched, abs diff inf) -- distinct from the"
-        " compile-time layout-promotion issue this test previously hit"
-    )
     def test_hint_flash_attention_v2_divide_in_scope(self):
         """Flash attention v2 with the final divide INSIDE the scope.
 
@@ -4833,19 +4828,8 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             h_tiles=4, lq_tiles=None, B=4, H=8, Lq=1, Lk=8192, D=128, kv_block=2048
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "h_tiles == H gives a 1-element H tile, and a unit-size tiled dim is "
-            "squeezed out of _insert_one_read_copy's squeeze_pos map (built by "
-            "skipping ranges where int(r) == 1), so the subsequent "
-            "squeeze_pos[d] lookup raises KeyError. Reproduced at 2 and 4 chunks "
-            "on main; h_tiles of 2 and 4 are numerically exact. Compile-time "
-            "error only -- it does not leave the device in an error state."
-        ),
-    )
     def test_hint_flash_attention_kv_chunked_unit_h_tile(self):
-        """h_tiles == H (one head per tile) crashes in read-copy insertion."""
+        """h_tiles == H (one head per tile) is numerically exact."""
         self._run_kv_chunked_flash(h_tiles=8, lq_tiles=2)
 
     def test_hint_flash_attention_kv_chunked_8_chunks(self):


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Removes two stale skip/xfail markers from `test_coarse_tile_e2e.py`.
Both tests were disabled for bugs that no longer reproduce, most likely
because of #4270's `_propagate_read_copy_named_dims` fix (read-copy
staging buffers now correctly propagate named-dim metadata, where they
previously fell into layout/tracking paths that these two bugs depended
on).

- `test_hint_flash_attention_kv_chunked_unit_h_tile` was
  `xfail(strict=True)` for a `KeyError` in `_insert_one_read_copy`'s
  `squeeze_pos` map when a unit-size H tile got squeezed out of the map.
  Removing the decorator and running the test directly now produces a
  genuine pass (numeric `assert_close` against a CPU reference, plus a
  `LoopSpec(` count assertion — no early-exit paths), confirmed via a
  standalone run.
- `test_hint_flash_attention_v2_divide_in_scope` was
  `pytest.mark.skip` for a runtime numeric inf (99.3% of elements
  mismatched). Removing the skip and running it directly passes cleanly,
  confirmed twice in a row to rule out flakiness.

Not independently bisected against the exact commit that fixed each —
the causal link to #4270 is inferred from timing and from the read-copy
named-dim propagation fix being the most plausible mechanism, not proven
bug-by-bug.

#### Which issue(s) this PR is related to:

Follow-up to #4270.

#### Special notes for your reviewer:

Low risk — this only removes two decorators (and updates one now-stale
docstring line) with no production code changes. Both re-enabled tests
were run directly (the second one twice) and pass. Deferring the full
`test_coarse_tile_e2e.py` regression run and `pre-commit` verification
to CI given the small, low-risk diff (pre-commit was run locally and is
clean).

#### Does this PR introduce a user-facing change?

No. Test-suite cleanup only.

#### Additional note: