### PR TITLE
LX Relayouts: centralize physical ownership value semantics

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -6220,6 +6220,7 @@ class TestCoarseTileMoEBroadcastMatmulE2E(InductorTestCase):
     def test_unsqueeze_broadcast_matmul_keeps_copy_for_different_core_views(self):
         """A legal but different source ownership cannot replace the copy."""
         from torch_spyre._inductor import spyre_hint
+        from torch_spyre._inductor.pass_utils import PerCoreView
 
         E, T, H, F = 3, 64, 64, 64
         x = torch.randn(T, H, dtype=torch.float16).to("spyre")
@@ -6235,6 +6236,9 @@ class TestCoarseTileMoEBroadcastMatmulE2E(InductorTestCase):
             with spyre_hint(num_tiles_per_dim={"E": E}):
                 return torch.matmul(x.unsqueeze(0), w)
 
+        output_view = PerCoreView((), (), num_cores=1)
+        staged_view = PerCoreView((), (), num_cores=2)
+        direct_view = PerCoreView((), (), num_cores=4)
         with (
             mock_patch(_LAUNCH_JOBPLAN),
             mock_patch(_PREPARE_KERNEL),
@@ -6242,10 +6246,10 @@ class TestCoarseTileMoEBroadcastMatmulE2E(InductorTestCase):
             mock_patch(
                 "torch_spyre._inductor.read_copy_elision._per_core_view_on_buf",
                 side_effect=[
-                    ("output", None, True),
-                    ("output", None, True),
-                    ("staged-weight", None, True),
-                    ("direct-weight", None, True),
+                    (output_view, None, True),
+                    (output_view, None, True),
+                    (staged_view, None, True),
+                    (direct_view, None, True),
                 ],
             ),
         ):

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -21,6 +21,7 @@ import pytest
 import sympy
 
 import torch_spyre._inductor.codegen.superdsc as superdsc_module
+import torch_spyre._inductor.core_mapping as core_mapping_module
 import torch_spyre._inductor.pass_utils as pass_utils_module
 from torch_spyre._C import DataFormats, ElementArrangement
 from torch_spyre._inductor.codegen.superdsc import parse_op_spec
@@ -100,11 +101,48 @@ def test_owner_slots_must_be_concrete_integers(slot):
     with pytest.raises(ValueError, match="non-integral"):
         division.to_core_slices(2)
     assert not core_mappings_equal({dim: slot}, {dim: slot}, 2)
+    with pytest.raises(ValueError, match=f"non-integral owner slot {slot} on core 0"):
+        core_mapping_module.owner_slots({dim: slot}, {dim: 2}, 2)
     view = PerCoreView(((0, 2),), ((0, slot),), num_cores=2)
     from torch_spyre._inductor.scratchpad.lx_relayout import _core_slices
 
     with pytest.raises(ValueError, match="non-integral"):
         _core_slices(view, 2)
+
+
+def test_owner_evaluation_reuse_keeps_domain_and_range_checks():
+    dim = sympy.Symbol("dim")
+    direct = {dim: _CORE_ID}
+    wrapped = {dim: sympy.Mod(_CORE_ID, 4)}
+    evaluate = core_mapping_module._owner_at_core
+    evaluate.cache_clear()
+    assert core_mappings_equal(direct, wrapped, 4)
+    misses = evaluate.cache_info().misses
+    assert core_mapping_module.owner_slots(direct, {dim: 4}, 4) == tuple(
+        {dim: core} for core in range(4)
+    )
+    assert evaluate.cache_info().misses == misses
+    # Reusing earlier points must not hide a difference on a larger domain.
+    assert not core_mappings_equal(direct, wrapped, 8)
+    with pytest.raises(ValueError, match="outside split 2 on core 2"):
+        core_mapping_module.owner_slots(direct, {dim: 2}, 4)
+    assert not core_mappings_equal(direct, direct, 0)
+    evaluate.cache_clear()
+
+
+def test_owner_evaluation_keeps_short_circuit_order():
+    class FailsOnLaterCore(sympy.Function):
+        @classmethod
+        def eval(cls, value):
+            if value == 1:
+                raise NotImplementedError("later core must not be evaluated")
+            if value == 0:
+                return sympy.Integer(0)
+
+    dim = sympy.Symbol("dim")
+    assert not core_mappings_equal(
+        {dim: FailsOnLaterCore(_CORE_ID)}, {dim: sympy.Integer(1)}, 2
+    )
 
 
 def test_default_mapping_preserves_existing_core_order():

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -126,6 +126,8 @@ def test_owner_evaluation_reuse_keeps_domain_and_range_checks():
     assert not core_mappings_equal(direct, wrapped, 8)
     with pytest.raises(ValueError, match="outside split 2 on core 2"):
         core_mapping_module.owner_slots(direct, {dim: 2}, 4)
+    with pytest.raises(ValueError, match="owner slot -1 outside split 2 on core 0"):
+        core_mapping_module.owner_slots({dim: sympy.S.NegativeOne}, {dim: 2}, 4)
     assert not core_mappings_equal(direct, direct, 0)
     evaluate.cache_clear()
 
@@ -589,7 +591,10 @@ def _bmm_op_spec(op: str) -> OpSpec:
 
 @pytest.mark.parametrize("op", [BATCH_MATMUL_OP, BATCH_MATMUL_FP8_OP])
 @pytest.mark.parametrize("reduction_contiguous", [False, True])
-def test_planner_and_sdsc_use_the_same_mapping(monkeypatch, op, reduction_contiguous):
+@pytest.mark.parametrize("dim_splits", [(2, 4, 4), (1, 1, 4)])
+def test_planner_and_sdsc_use_the_same_mapping(
+    monkeypatch, op, reduction_contiguous, dim_splits
+):
     class FakeReduction:
         def __init__(self, reduction_type):
             self.reduction_type = reduction_type
@@ -613,7 +618,23 @@ def test_planner_and_sdsc_use_the_same_mapping(monkeypatch, op, reduction_contig
 
     op_spec = _bmm_op_spec(op)
     dims = tuple(op_spec.iteration_space)
-    splits = dict(zip(dims, (2, 4, 4)))
+    splits = dict(zip(dims, dim_splits))
+    op_spec.iteration_space = {
+        dim: (extent, splits[dim])
+        for dim, (extent, _) in op_spec.iteration_space.items()
+    }
+    monkeypatch.setattr(
+        pass_utils_module,
+        "iteration_space_from_op",
+        lambda _: {dim: extent for dim, (extent, _) in op_spec.iteration_space.items()},
+    )
+    ownership = pass_utils_module.make_iteration_space_ownership(
+        FakeComputedBuffer(op), splits
+    )
+    assert ownership.num_cores == math.prod(dim_splits)
+    assert dataclasses.replace(
+        ownership, num_cores=None
+    ).physical_core_count == math.prod(dim_splits)
     prep = pass_utils_module._ViewPrep(
         iter_space=op_spec.iteration_space,
         write_index=dims[0],
@@ -630,8 +651,8 @@ def test_planner_and_sdsc_use_the_same_mapping(monkeypatch, op, reduction_contig
         num_stick_stride=0,
         is_matmul=pass_utils_module._is_matmul_op(FakeComputedBuffer(op)),
     )
-    planner_view, _, representable = pass_utils_module._per_core_view_from_prep(
-        prep, splits, {dims[2]: 4}
+    planner_view, partial, representable = pass_utils_module._per_core_view_from_prep(
+        prep, ownership.work_slices, {dims[2]: dim_splits[2]}
     )
 
     op_spec.core_id_to_work_slice = derive_operation_mapping(
@@ -642,9 +663,15 @@ def test_planner_and_sdsc_use_the_same_mapping(monkeypatch, op, reduction_contig
     sdsc_output_mapping = {
         device_dim: sdsc_spec.core_id_to_work_slice[renamed[dim]]
         for device_dim, dim in enumerate(dims[:2])
+        if splits[dim] > 1
     }
     assert representable
+    assert partial
+    assert planner_view.num_cores == ownership.num_cores
     assert dict(planner_view.core_to_slot) == sdsc_output_mapping
+    if dim_splits[:2] == (1, 1):
+        assert planner_view.work_slice_dims == ()
+        assert not planner_view.same_partition(PerCoreView((), (), num_cores=1))
 
 
 def test_flattened_iteration_span_is_not_a_single_axis_view():

--- a/tests/inductor/test_core_mapping.py
+++ b/tests/inductor/test_core_mapping.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+import dataclasses
 import math
 from types import SimpleNamespace
 
@@ -34,8 +35,15 @@ from torch_spyre._inductor.core_mapping import (
     derive_operation_mapping,
     derive_partition_mapping,
     finalize_tensor_work_divisions,
+    remap_work_division,
 )
-from torch_spyre._inductor.op_spec import OpSpec, TensorArg, TensorWorkDivision
+from torch_spyre._inductor.op_spec import (
+    OpSpec,
+    TensorArg,
+    TensorWorkDivision,
+    is_lx_relayout_identity,
+)
+from torch_spyre._inductor.pass_utils import PerCoreView, per_core_views_equal
 from torch_spyre._inductor.spyre_kernel import simplify_op_spec
 from torch_spyre._inductor.views import (
     align_tensors,
@@ -51,6 +59,52 @@ def _coordinates(splits, num_cores, **kwargs):
         tuple(int(mapping[dim].subs(core_id, core)) for dim in dims)
         for core in range(num_cores)
     ]
+
+
+_CORE_ID = sympy.Symbol("core_id")
+
+
+def test_owner_maps_compare_physical_owners_not_sympy_spelling():
+    """Equivalent spellings compare equal; unsplit dimensions describe nothing."""
+
+    head, local = sympy.symbols("head local")
+    same = _CORE_ID - 4 * sympy.floor(_CORE_ID / 4)
+    reordered = sympy.floor(_CORE_ID / 2)
+    left = TensorWorkDivision(
+        {head: 4, local: 1}, {head: sympy.Mod(_CORE_ID, 4), local: sympy.S.Zero}
+    )
+    equivalent = TensorWorkDivision({head: 4}, {head: same}, num_cores=4)
+
+    assert left.physical_core_count == 4
+    assert left != equivalent and left.same_ownership(equivalent)
+    assert not left.same_ownership(
+        TensorWorkDivision({head: 4}, {head: reordered}, num_cores=4)
+    )
+
+    view = PerCoreView(((0, 4),), ((0, sympy.Mod(_CORE_ID, 4)),), num_cores=8)
+    equivalent_view = PerCoreView(
+        ((0, 4), (1, 1)), ((0, same), (1, sympy.S.Zero)), num_cores=8
+    )
+    assert view != equivalent_view and view.same_partition(equivalent_view)
+    assert per_core_views_equal(view, equivalent_view)
+    assert per_core_views_equal(None, None)
+    assert not view.same_partition(
+        PerCoreView(((0, 4),), ((0, reordered),), num_cores=8)
+    )
+
+
+@pytest.mark.parametrize("slot", [sympy.Rational(1, 2), sympy.Symbol("unresolved")])
+def test_owner_slots_must_be_concrete_integers(slot):
+    dim = sympy.Symbol("dim")
+    division = TensorWorkDivision({dim: 2}, {dim: slot}, num_cores=2)
+    with pytest.raises(ValueError, match="non-integral"):
+        division.to_core_slices(2)
+    assert not core_mappings_equal({dim: slot}, {dim: slot}, 2)
+    view = PerCoreView(((0, 2),), ((0, slot),), num_cores=2)
+    from torch_spyre._inductor.scratchpad.lx_relayout import _core_slices
+
+    with pytest.raises(ValueError, match="non-integral"):
+        _core_slices(view, 2)
 
 
 def test_default_mapping_preserves_existing_core_order():
@@ -168,6 +222,80 @@ def test_group_topology_does_not_follow_final_loop_reordering():
     )
 
 
+def test_remap_work_division_accepts_equivalent_merged_owner_slots():
+    first, second, merged = sympy.symbols("first second merged")
+    core_id = sympy.Symbol("core_id")
+    division = TensorWorkDivision(
+        {first: 4, second: 4},
+        {
+            first: sympy.Mod(core_id, 4),
+            second: core_id - 4 * sympy.floor(core_id / 4),
+        },
+        num_cores=8,
+    )
+
+    remapped = remap_work_division(
+        division,
+        {first: ((merged, 4),), second: ((merged, 4),)},
+    )
+
+    assert remapped.physical_core_count == 8
+    assert remapped.work_slices == {merged: 4}
+    assert core_mappings_equal(
+        {merged: remapped.core_id_to_work_slice[merged]},
+        {merged: sympy.Mod(core_id, 4)},
+        8,
+    )
+
+
+def test_remap_work_division_rejects_conflicting_merged_owner_slots():
+    first, second, merged = sympy.symbols("first second merged")
+    core_id = sympy.Symbol("core_id")
+    division = TensorWorkDivision(
+        {first: 4, second: 4},
+        {
+            first: sympy.Mod(core_id, 4),
+            second: sympy.floor(core_id / 2),
+        },
+        num_cores=8,
+    )
+
+    with pytest.raises(ValueError, match="conflicting normalized ownership"):
+        remap_work_division(
+            division,
+            {first: ((merged, 4),), second: ((merged, 4),)},
+        )
+
+
+def test_identity_with_equivalent_owner_spelling_is_not_a_relayout():
+    head = sympy.Symbol("head")
+    core_id = sympy.Symbol("core_id")
+    base = TensorArg(
+        True,
+        0,
+        DataFormats.SEN169_FP16,
+        [4, 64],
+        [head, head],
+        {"lx": 0},
+        work_division=TensorWorkDivision(
+            {head: 4},
+            {head: sympy.Mod(core_id, 4)},
+            num_cores=4,
+        ),
+    )
+    destination = dataclasses.replace(
+        base,
+        is_input=False,
+        work_division=TensorWorkDivision(
+            {head: 4},
+            {head: core_id - 4 * sympy.floor(core_id / 4)},
+            num_cores=4,
+        ),
+    )
+
+    assert not is_lx_relayout_identity("identity", (base, destination))
+
+
 def test_late_mapping_rejects_geometry_that_does_not_fill_groups():
     h, query = sympy.symbols("h query")
     with pytest.raises(ValueError, match="does not match operation split"):
@@ -281,6 +409,28 @@ def test_operation_mapping_rejects_conflicting_lx_tensor_owners():
         derive_operation_mapping(
             {shared: (8, 2), extra: (8, 2)},
             divisions,
+        )
+
+
+def test_operation_mapping_bounds_aligned_owner_dimension_permutations():
+    dims = sympy.symbols("d0:6")
+    core_id = sympy.Symbol("core_id")
+    division = TensorWorkDivision(
+        {dim: 2 for dim in dims},
+        {
+            dim: sympy.Mod(sympy.floor(core_id / (2**index)), 2)
+            for index, dim in enumerate(dims)
+        },
+        num_cores=64,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="too many aligned tensor-owned dimensions.*6 > 5",
+    ):
+        derive_operation_mapping(
+            {dim: (sympy.Integer(2), 2) for dim in dims},
+            [division],
         )
 
 

--- a/tests/inductor/test_hbm_pool_planning.py
+++ b/tests/inductor/test_hbm_pool_planning.py
@@ -119,7 +119,7 @@ class TestAllocator(unittest.TestCase):
         self.assertEqual(allocator.get_pool_end(), 80)
 
 
-def _make_ftl_buffer(name, host_size=(64,), dim_order=(0,)):
+def _make_ftl_buffer(name, host_size=(64,), dim_order=(0,), dtype=torch.float16):
     """Real ComputedBuffer with a FixedTiledLayout, for pool-eligibility tests.
 
     Mirrors _make_ftl_op in test_coarse_tiling.py:1187, trimmed to what
@@ -130,20 +130,20 @@ def _make_ftl_buffer(name, host_size=(64,), dim_order=(0,)):
     device_layout = SpyreTensorLayout(
         list(host_size),
         strides,
-        torch.float16,
+        dtype,
         list(dim_order),
         ElementArrangement.STANDARD,
     )
     layout = FixedTiledLayout(
         torch.device("cpu"),
-        torch.float16,
+        dtype,
         [Integer(s) for s in host_size],
         [Integer(s) for s in strides],
         device_layout,
     )
     pw = Pointwise(
         device=torch.device("cpu"),
-        dtype=torch.float16,
+        dtype=dtype,
         inner_fn=lambda index: Integer(1),
         ranges=[Integer(s) for s in host_size],
     )
@@ -208,6 +208,34 @@ class TestHbmPoolPlanningPerBundle(unittest.TestCase):
 
     def tearDown(self):
         self._graph_ctx.__exit__(None, None, None)
+
+    def test_storage_bytes_and_collective_units(self):
+        from torch_spyre._inductor.hbm_pool_planning import _compute_size_bytes
+        from torch_spyre._inductor.ir import _compute_device_num_elems
+
+        for dtype, expected in [
+            (torch.float16, 256),
+            (torch.float32, 384),
+            (torch.float8_e4m3fn, 128),
+            (torch.int64, 384),
+            (torch.bool, 256),
+            (torch.uint8, 384),
+        ]:
+            with self.subTest(dtype=dtype):
+                layout = _make_ftl_buffer("sized", (65,), dtype=dtype).get_layout()
+                self.assertEqual(_compute_size_bytes("sized"), expected)
+                # The collective plan receives this host dtype with the count.
+                self.assertEqual(
+                    _compute_device_num_elems(layout)
+                    * torch.empty((), dtype=dtype).element_size(),
+                    expected,
+                )
+
+        with patch(
+            "torch_spyre._inductor.hbm_pool_planning.get_device_size_in_bytes",
+            return_value=129,
+        ):
+            self.assertEqual(_compute_size_bytes("sized"), 256)
 
     def test_buffer_local_to_one_bundle_is_pool_eligible(self):
         """A buffer written and read within the same bundle gets an

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -571,6 +571,32 @@ def _relayout_plan(source="source", consumers="consumer"):
     return LXRelayoutPlan(source, consumers, _SOURCE_VIEW, _DESTINATION_VIEW, 8)
 
 
+@pytest.mark.parametrize(
+    ("view", "message"),
+    [
+        (
+            PerCoreView(((0, 2),), (), num_cores=2),
+            "split and owner-slot dimensions differ",
+        ),
+        (
+            PerCoreView(
+                ((0, 2),),
+                ((0, Symbol("unknown_owner")),),
+                num_cores=2,
+            ),
+            "non-concrete owner slot",
+        ),
+        (
+            PerCoreView(((0, 2),), ((0, Integer(2)),), num_cores=2),
+            "owner slot 2 outside split 2",
+        ),
+    ],
+)
+def test_lx_relayout_partition_validation_fails_closed(view, message):
+    with pytest.raises(ValueError, match=message):
+        lx_relayout_module._compatible_partitions(view, _DESTINATION_VIEW, 2)
+
+
 def test_lx_relayout_activation_policy_is_source_wide():
     dep = SimpleNamespace(name="input")
     producer = SimpleNamespace()

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -584,7 +584,7 @@ def _relayout_plan(source="source", consumers="consumer"):
                 ((0, Symbol("unknown_owner")),),
                 num_cores=2,
             ),
-            "non-concrete owner slot",
+            "non-integral owner slot",
         ),
         (
             PerCoreView(((0, 2),), ((0, Integer(2)),), num_cores=2),

--- a/tests/tensor/test_tensor_layout.py
+++ b/tests/tensor/test_tensor_layout.py
@@ -26,6 +26,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
 )
 from torch.spyre import SpyreTensorLayout, get_device_dtype
+from torch_spyre._C import DataFormats, ElementArrangement, get_device_size_in_bytes
 
 
 @instantiate_parametrized_tests
@@ -35,6 +36,59 @@ class TestSpyreTensorLayout(TestCase):
 
     def test_initializes(self):
         self.assertEqual(torch._C._get_privateuse1_backend_name(), "spyre")
+
+    @parametrize(
+        "df,eps,bits",
+        [
+            (DataFormats.SEN169_FP16, 64, 16),
+            (DataFormats.IEEE_FP32, 32, 32),
+            (DataFormats.SEN143_FP8, 128, 8),
+            (DataFormats.SENINT4, 256, 4),
+            (DataFormats.SENINT2, 512, 2),
+            (DataFormats.IEEE_INT32, 32, 32),
+            (DataFormats.IEEE_INT64, 16, 64),
+            (DataFormats.BOOL, 128, 8),
+            (DataFormats.BFLOAT16, 64, 16),
+        ],
+    )
+    def test_device_storage_size(self, df, eps, bits):
+        self.assertEqual(df.elems_per_stick(), eps)
+        for ea in ElementArrangement.__members__.values():
+            # Both normal and shortened/sparse trailing extents occupy full
+            # sticks. Empty outer geometry remains empty after FP8 rescaling.
+            for outer, inner in [(3, eps), (3, 1), (0, eps)]:
+                stl = SpyreTensorLayout([outer, inner], [eps, 1], df, ea)
+                expected = outer * eps * bits // 8
+                self.assertEqual(get_device_size_in_bytes(stl), expected)
+                self.assertEqual(
+                    get_device_size_in_bytes(stl.device_size, df), expected
+                )
+
+    @parametrize(
+        "df",
+        [
+            DataFormats.INVALID,
+            DataFormats.SEN153_FP9,
+            DataFormats.SENINT24,
+            DataFormats.SEN18F_FP24,
+        ],
+    )
+    def test_unmapped_compute_format_has_no_storage_size(self, df):
+        with self.assertRaisesRegex(RuntimeError, "No device stick geometry"):
+            get_device_size_in_bytes([1, 64], df)
+
+    @parametrize(
+        "df,dtype",
+        [(DataFormats.BFLOAT16, torch.float32), (DataFormats.IEEE_INT64, torch.int32)],
+    )
+    def test_explicit_transfer_storage_roundtrip(self, df, dtype):
+        # Explicit transfer encodings differ from default compute storage.
+        x = torch.arange(64, dtype=dtype)
+        eps = df.elems_per_stick()
+        stl = SpyreTensorLayout([64 // eps, eps], [eps, 1], df)
+        y = x.to("spyre", device_layout=stl)
+        self.assertEqual(y.device_tensor_layout().device_dtype, df)
+        self.assertEqual(y.cpu(), x)
 
     def test_default_layout(self):
         stl = SpyreTensorLayout([], torch.float16)

--- a/torch_spyre/_C.pyi
+++ b/torch_spyre/_C.pyi
@@ -37,6 +37,7 @@ __all__: list[str] = [
     "get_downcast_warning",
     "get_elem_in_stick",
     "get_spyre_tensor_layout",
+    "get_device_size_in_bytes",
     "kernel_provenance_registry_stats",
     "launch_jobplan",
     "lookup_kernel_provenance",
@@ -347,6 +348,12 @@ def get_downcast_warning() -> bool:
     """
 
 def get_elem_in_stick(arg0: torch.dtype) -> int: ...
+@typing.overload
+def get_device_size_in_bytes(layout: SpyreTensorLayout) -> int: ...
+@typing.overload
+def get_device_size_in_bytes(
+    device_size: typing.Sequence[int], device_dtype: DataFormats
+) -> int: ...
 def get_spyre_tensor_layout(arg0: torch.Tensor) -> SpyreTensorLayout: ...
 
 class SymbolicArgKind:

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -19,7 +19,11 @@ from typing import Any
 from sympy import Symbol
 
 from torch_spyre._C import DataFormats, encode_constant
-from torch_spyre._inductor.constants import CONV2D_DIM_LABELS, DEPTHWISE_CONV2D_OP
+from torch_spyre._inductor.constants import (
+    BYTES_PER_STICK,
+    CONV2D_DIM_LABELS,
+    DEPTHWISE_CONV2D_OP,
+)
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.op_spec import TensorWorkDivision
 from torch_spyre._inductor.pass_utils import coeff_through_floor
@@ -194,7 +198,7 @@ def num_bytes(df: DataFormats) -> int:
     num_elems = df.elems_per_stick()
     if num_elems > 128:
         raise RuntimeError(f"sub-byte dataformat {df}")
-    return 128 // num_elems
+    return BYTES_PER_STICK // num_elems
 
 
 def generate_constant_info(

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -20,7 +20,6 @@ from sympy import Symbol
 
 from torch_spyre._C import DataFormats, encode_constant
 from torch_spyre._inductor.constants import (
-    BYTES_PER_STICK,
     CONV2D_DIM_LABELS,
     DEPTHWISE_CONV2D_OP,
 )
@@ -198,7 +197,7 @@ def num_bytes(df: DataFormats) -> int:
     num_elems = df.elems_per_stick()
     if num_elems > 128:
         raise RuntimeError(f"sub-byte dataformat {df}")
-    return BYTES_PER_STICK // num_elems
+    return 128 // num_elems
 
 
 def generate_constant_info(

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -38,10 +38,6 @@ INT32TOFP32_OP = "int32tofp32"
 
 DEVICE_NAME = "spyre"
 
-# Spyre memory is addressed and allocated in 128-byte sticks. Keep every
-# frontend size and descriptor calculation on this single hardware constant.
-BYTES_PER_STICK = 128
-
 # The staggered EAs produced by the bidirectional fp16<->fp32 on-device
 # conversions, whose device coordinates are non-sequential and (unlike QFP8CH)
 # can be restored by the reverse conversion. propagate_layouts uses this set for

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -38,6 +38,10 @@ INT32TOFP32_OP = "int32tofp32"
 
 DEVICE_NAME = "spyre"
 
+# Spyre memory is addressed and allocated in 128-byte sticks. Keep every
+# frontend size and descriptor calculation on this single hardware constant.
+BYTES_PER_STICK = 128
+
 # The staggered EAs produced by the bidirectional fp16<->fp32 on-device
 # conversions, whose device coordinates are non-sequential and (unlike QFP8CH)
 # can be restored by the reverse conversion. propagate_layouts uses this set for

--- a/torch_spyre/_inductor/core_mapping.py
+++ b/torch_spyre/_inductor/core_mapping.py
@@ -27,6 +27,8 @@ from sympy import Expr, Integer, Mod, Symbol, floor, sympify
 from .op_spec import TensorWorkDivision
 
 
+# pass_utils imports this module; keep its PerCoreView type out of this layer.
+# TensorWorkDivision imports the comparator only when its method is called.
 _MAX_OWNER_PERMUTATION_DIMS = 5
 
 

--- a/torch_spyre/_inductor/core_mapping.py
+++ b/torch_spyre/_inductor/core_mapping.py
@@ -19,10 +19,77 @@ from __future__ import annotations
 import math
 from collections.abc import Mapping, Sequence
 from itertools import permutations
+from typing import Any
 
-from sympy import Expr, Integer, Mod, Symbol, floor
+from sympy import Expr, Integer, Mod, Symbol, floor, sympify
 
 from .op_spec import TensorWorkDivision
+
+
+_MAX_OWNER_PERMUTATION_DIMS = 5
+
+
+def owner_slots(
+    slots: Mapping[Any, Expr], splits: Mapping[Any, int], num_cores: int
+) -> tuple[dict[Any, int], ...]:
+    """Evaluate owner formulas on every core: one slot per split dimension.
+
+    This is the one place symbolic owners become per-core integers. A slot
+    that is not a concrete integer inside its split raises ``ValueError``.
+    """
+
+    if num_cores <= 0:
+        raise ValueError(f"physical core count must be positive, got {num_cores}")
+    if splits.keys() != slots.keys():
+        raise ValueError(
+            "ownership split and owner-slot dimensions differ: "
+            f"{sorted(map(str, splits))} != {sorted(map(str, slots))}"
+        )
+    core_id = Symbol("core_id")
+    rows = []
+    for core in range(num_cores):
+        row = {}
+        for dim, split in splits.items():
+            value = sympify(slots[dim]).subs(core_id, core)
+            if value.free_symbols or value.is_integer is not True:
+                raise ValueError(f"non-integral owner slot {value} on core {core}")
+            if not 0 <= int(value) < int(split):
+                raise ValueError(
+                    f"owner slot {int(value)} outside split {split} on core {core}"
+                )
+            row[dim] = int(value)
+        rows.append(row)
+    return tuple(rows)
+
+
+def same_owner_maps(
+    left_splits: Mapping[Any, int],
+    left_slots: Mapping[Any, Expr],
+    left_cores: int,
+    right_splits: Mapping[Any, int],
+    right_slots: Mapping[Any, Expr],
+    right_cores: int,
+) -> bool:
+    """Whether two owner maps give every physical core the same slice.
+
+    Unsplit dimensions describe no ownership and are ignored. Equivalent SymPy
+    spellings compare equal; a missing owner formula is a mismatch.
+    """
+
+    left = {dim: int(split) for dim, split in left_splits.items() if int(split) > 1}
+    right = {dim: int(split) for dim, split in right_splits.items() if int(split) > 1}
+    if left != right or left_cores != right_cores:
+        return False
+    if not left:
+        return True
+    try:
+        return core_mappings_equal(
+            {dim: left_slots[dim] for dim in left},
+            {dim: right_slots[dim] for dim in right},
+            left_cores,
+        )
+    except KeyError:
+        return False
 
 
 def core_to_slice_mapping(
@@ -194,6 +261,7 @@ def remap_work_division(
     physical partition does not change; only the symbols used to describe it do.
     """
 
+    num_cores = division.physical_core_count
     new_splits: dict[Symbol, int] = {}
     new_core_map: dict[Symbol, Expr] = {}
     for old_dim, split in division.work_slices.items():
@@ -218,8 +286,17 @@ def remap_work_division(
             if factor == 1:
                 continue
             new_slot = Mod(floor(slot / slot_stride), factor)
-            previous = (new_splits.get(new_dim), new_core_map.get(new_dim))
-            if previous[0] is not None and previous != (factor, new_slot):
+            previous_split = new_splits.get(new_dim)
+            previous_slot = new_core_map.get(new_dim)
+            if previous_split is not None and (
+                previous_split != factor
+                or previous_slot is None
+                or not core_mappings_equal(
+                    {new_dim: previous_slot},
+                    {new_dim: new_slot},
+                    num_cores,
+                )
+            ):
                 raise ValueError(f"conflicting normalized ownership on {new_dim}")
             new_splits[new_dim] = factor
             new_core_map[new_dim] = new_slot
@@ -227,7 +304,7 @@ def remap_work_division(
     return TensorWorkDivision(
         new_splits,
         new_core_map,
-        num_cores=division.num_cores,
+        num_cores=num_cores,
     )
 
 
@@ -287,12 +364,14 @@ def derive_operation_mapping(
     for division in tensor_divisions:
         if division is None:
             continue
-        if division.work_slices and division.num_cores not in (None, num_cores):
+        if division.work_slices and division.physical_core_count != num_cores:
             raise ValueError(
                 "LX tensor ownership and operation use different core domains: "
-                f"{division.num_cores} != {num_cores}"
+                f"{division.physical_core_count} != {num_cores}"
             )
         for dim, split in division.work_slices.items():
+            if int(split) <= 1:
+                continue
             if dim not in split_by_dim:
                 raise ValueError(f"LX tensor dimension {dim} is not in the operation")
             if split_by_dim[dim] != int(split):
@@ -315,6 +394,11 @@ def derive_operation_mapping(
 
     # Tensor-owned dimensions occupy the outer, contiguous groups. At most five
     # dimensions can be split on 32 cores, so trying their radix orders is small.
+    if len(constrained) > _MAX_OWNER_PERMUTATION_DIMS:
+        raise ValueError(
+            "too many aligned tensor-owned dimensions for bounded core-order "
+            f"search: {len(constrained)} > {_MAX_OWNER_PERMUTATION_DIMS}"
+        )
     for order in permutations(constrained):
         candidate = derive_core_mapping(
             dims,
@@ -333,17 +417,31 @@ def derive_operation_mapping(
 
 
 def core_mappings_equal(
-    left: Mapping[Symbol, Expr],
-    right: Mapping[Symbol, Expr],
+    left: Mapping[Any, Expr],
+    right: Mapping[Any, Expr],
     num_cores: int,
 ) -> bool:
     """Return whether two symbolic mappings assign every core identically."""
 
     if left.keys() != right.keys():
         return False
+    if num_cores <= 0:
+        return False
     core_id = Symbol("core_id")
-    return all(
-        int(left[dim].subs(core_id, core)) == int(right[dim].subs(core_id, core))
-        for dim in left
-        for core in range(num_cores)
-    )
+    try:
+        for dim in left:
+            for core in range(num_cores):
+                values = [
+                    sympify(mapping[dim]).subs(core_id, core)
+                    for mapping in (left, right)
+                ]
+                if any(
+                    value.free_symbols or value.is_integer is not True
+                    for value in values
+                ):
+                    return False
+                if values[0] != values[1]:
+                    return False
+        return True
+    except (TypeError, ValueError):
+        return False

--- a/torch_spyre/_inductor/core_mapping.py
+++ b/torch_spyre/_inductor/core_mapping.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Mapping, Sequence
+from functools import lru_cache
 from itertools import permutations
 from typing import Any
 
@@ -29,13 +30,23 @@ from .op_spec import TensorWorkDivision
 _MAX_OWNER_PERMUTATION_DIMS = 5
 
 
+# Room for 128 distinct formulas on a 32-core device; eviction only repeats work.
+@lru_cache(maxsize=4096)
+def _owner_at_core(expression: Expr, core: int) -> Expr:
+    """Reuse pure substitution, not a validity or ownership decision.
+
+    One core at a time preserves callers' short-circuit and error ordering.
+    No buffer, layout, split count or graph state participates in this result.
+    """
+    return expression.subs(Symbol("core_id"), core)
+
+
 def owner_slots(
     slots: Mapping[Any, Expr], splits: Mapping[Any, int], num_cores: int
 ) -> tuple[dict[Any, int], ...]:
     """Evaluate owner formulas on every core: one slot per split dimension.
 
-    This is the one place symbolic owners become per-core integers. A slot
-    that is not a concrete integer inside its split raises ``ValueError``.
+    A slot that is not a concrete integer inside its split raises ``ValueError``.
     """
 
     if num_cores <= 0:
@@ -45,12 +56,11 @@ def owner_slots(
             "ownership split and owner-slot dimensions differ: "
             f"{sorted(map(str, splits))} != {sorted(map(str, slots))}"
         )
-    core_id = Symbol("core_id")
     rows = []
     for core in range(num_cores):
         row = {}
         for dim, split in splits.items():
-            value = sympify(slots[dim]).subs(core_id, core)
+            value = _owner_at_core(sympify(slots[dim]), core)
             if value.free_symbols or value.is_integer is not True:
                 raise ValueError(f"non-integral owner slot {value} on core {core}")
             if not 0 <= int(value) < int(split):
@@ -427,12 +437,11 @@ def core_mappings_equal(
         return False
     if num_cores <= 0:
         return False
-    core_id = Symbol("core_id")
     try:
         for dim in left:
             for core in range(num_cores):
                 values = [
-                    sympify(mapping[dim]).subs(core_id, core)
+                    _owner_at_core(sympify(mapping[dim]), core)
                     for mapping in (left, right)
                 ]
                 if any(

--- a/torch_spyre/_inductor/hbm_pool_planning.py
+++ b/torch_spyre/_inductor/hbm_pool_planning.py
@@ -23,14 +23,13 @@ from torch._inductor.scheduler import (
 )
 from torch._inductor.ir import FallbackKernel
 from torch._inductor.virtualized import V
-from .constants import MAX_POOL_SIZE_BYTES, INTERMEDIATES_SEGMENT
+from .constants import BYTES_PER_STICK, MAX_POOL_SIZE_BYTES, INTERMEDIATES_SEGMENT
 from .ir import FixedTiledLayout, SpyreEmptyFallback
 from .logging_utils import get_inductor_logger
 from .scheduler import CountedLoopSchedulerNode
 from . import config
 
 logger = get_inductor_logger("HBM_POOL_PLANNING")
-_STICK_BYTES = 128
 _BYTES_PER_GB = 1024**3
 
 
@@ -117,8 +116,8 @@ def _compute_size_bytes(name: str) -> int:
     )
     dev_layout = layout.device_layout
     num_sticks = math.prod(dev_layout.device_size[:-1])
-    size_bytes = num_sticks * _STICK_BYTES
-    return _align_up(size_bytes, _STICK_BYTES)
+    size_bytes = num_sticks * BYTES_PER_STICK
+    return _align_up(size_bytes, BYTES_PER_STICK)
 
 
 def _compute_live_ranges(

--- a/torch_spyre/_inductor/hbm_pool_planning.py
+++ b/torch_spyre/_inductor/hbm_pool_planning.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
 from typing import Callable
 from sympy import Symbol
 from torch._inductor.scheduler import (
@@ -23,13 +22,17 @@ from torch._inductor.scheduler import (
 )
 from torch._inductor.ir import FallbackKernel
 from torch._inductor.virtualized import V
-from .constants import BYTES_PER_STICK, MAX_POOL_SIZE_BYTES, INTERMEDIATES_SEGMENT
+from torch_spyre._C import get_device_size_in_bytes
+from .constants import MAX_POOL_SIZE_BYTES, INTERMEDIATES_SEGMENT
 from .ir import FixedTiledLayout, SpyreEmptyFallback
 from .logging_utils import get_inductor_logger
 from .scheduler import CountedLoopSchedulerNode
 from . import config
 
 logger = get_inductor_logger("HBM_POOL_PLANNING")
+
+# Address alignment required by the native allocator, not a data-format size.
+_HBM_ALLOCATION_ALIGNMENT_BYTES = 128
 _BYTES_PER_GB = 1024**3
 
 
@@ -115,9 +118,8 @@ def _compute_size_bytes(name: str) -> int:
         f"hbm_pool_planning: expected FixedTiledLayout for {name}, got {type(layout)}"
     )
     dev_layout = layout.device_layout
-    num_sticks = math.prod(dev_layout.device_size[:-1])
-    size_bytes = num_sticks * BYTES_PER_STICK
-    return _align_up(size_bytes, BYTES_PER_STICK)
+    size_bytes = get_device_size_in_bytes(dev_layout)
+    return _align_up(size_bytes, _HBM_ALLOCATION_ALIGNMENT_BYTES)
 
 
 def _compute_live_ranges(

--- a/torch_spyre/_inductor/ir.py
+++ b/torch_spyre/_inductor/ir.py
@@ -39,6 +39,7 @@ import sympy
 from torch.utils._ordered_set import OrderedSet
 import torch._inductor.ir as ir
 from torch_spyre._inductor.logging_utils import get_inductor_logger
+from torch_spyre._inductor.constants import BYTES_PER_STICK
 
 logger = get_inductor_logger("ir")
 
@@ -476,9 +477,6 @@ def _dtype_to_int(dtype: torch.dtype) -> int:
     return code
 
 
-_STICK_BYTES = 128
-
-
 def _compute_device_num_elems(layout: "FixedLayout") -> int:
     """Compute flat 1D device element count from a layout.
 
@@ -488,7 +486,7 @@ def _compute_device_num_elems(layout: "FixedLayout") -> int:
     if isinstance(layout, FixedTiledLayout):
         stl = layout.device_layout
         num_sticks = math.prod(stl.device_size[:-1])
-        size_bytes = num_sticks * _STICK_BYTES
+        size_bytes = num_sticks * BYTES_PER_STICK
         element_size = torch.tensor([], dtype=layout.dtype).element_size()
         return size_bytes // element_size
     numel = sympy.prod(layout.size)

--- a/torch_spyre/_inductor/ir.py
+++ b/torch_spyre/_inductor/ir.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
 from typing import Any, Callable, Optional, Sequence, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -29,7 +28,7 @@ from torch._inductor.ir import (
     ReductionHint,
     TensorBox,
 )
-from torch_spyre._C import SpyreTensorLayout
+from torch_spyre._C import SpyreTensorLayout, get_device_size_in_bytes
 
 from torch._inductor.codegen.wrapper import (
     PythonWrapperCodegen,
@@ -39,7 +38,6 @@ import sympy
 from torch.utils._ordered_set import OrderedSet
 import torch._inductor.ir as ir
 from torch_spyre._inductor.logging_utils import get_inductor_logger
-from torch_spyre._inductor.constants import BYTES_PER_STICK
 
 logger = get_inductor_logger("ir")
 
@@ -478,15 +476,15 @@ def _dtype_to_int(dtype: torch.dtype) -> int:
 
 
 def _compute_device_num_elems(layout: "FixedLayout") -> int:
-    """Compute flat 1D device element count from a layout.
+    """Count storage in the scalar-type units passed to the collective planner.
 
     For FixedTiledLayout (has device_layout), uses the actual device size.
     For plain FixedLayout (intermediates), falls back to logical numel.
     """
     if isinstance(layout, FixedTiledLayout):
-        stl = layout.device_layout
-        num_sticks = math.prod(stl.device_size[:-1])
-        size_bytes = num_sticks * BYTES_PER_STICK
+        size_bytes = get_device_size_in_bytes(layout.device_layout)
+        # The plan receives layout.dtype too. Device element count alone would
+        # change byte coverage when host and device widths differ (e.g. int64).
         element_size = torch.tensor([], dtype=layout.dtype).element_size()
         return size_bytes // element_size
     numel = sympy.prod(layout.size)

--- a/torch_spyre/_inductor/op_spec.py
+++ b/torch_spyre/_inductor/op_spec.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 import dataclasses
+import math
 import threading
 from typing import Any, Literal, Sequence
 
@@ -153,6 +154,38 @@ class TensorWorkDivision:
     core_id_to_work_slice: dict[Symbol, Expr]
     num_cores: int | None = None
 
+    @property
+    def physical_core_count(self) -> int:
+        """Physical core domain over which the owner expressions are defined."""
+
+        return (
+            self.num_cores
+            if self.num_cores is not None
+            else math.prod(int(split) for split in self.work_slices.values())
+        )
+
+    def same_ownership(self, other: object) -> bool:
+        """Whether both values assign every physical core the same slice.
+
+        Structural equality remains the dataclass value-syntax comparison.
+        Ownership decisions use this evaluated comparison instead, so equivalent
+        SymPy spellings compare equal. Unsplit dimensions do not describe
+        ownership and are ignored.
+        """
+
+        if not isinstance(other, TensorWorkDivision):
+            return False
+        from .core_mapping import same_owner_maps
+
+        return same_owner_maps(
+            self.work_slices,
+            self.core_id_to_work_slice,
+            self.physical_core_count,
+            other.work_slices,
+            other.core_id_to_work_slice,
+            other.physical_core_count,
+        )
+
     def remap_symbols(self, symbol_mapping: dict[Symbol, Symbol]) -> TensorWorkDivision:
         """Return this ownership expressed in remapped loop symbols."""
 
@@ -171,12 +204,19 @@ class TensorWorkDivision:
     def to_core_slices(self, num_cores: int) -> dict[str, dict[str, int]]:
         """Expand symbolic ownership into DeepTools' per-core slice map."""
 
+        if num_cores <= 0:
+            raise ValueError(f"physical core count must be positive, got {num_cores}")
         core_id = Symbol("core_id")
         result = {}
         for core in range(num_cores):
             slots = {}
             for dim, expression in self.core_id_to_work_slice.items():
-                slot = int(sympify(expression).subs(core_id, core))
+                value = sympify(expression).subs(core_id, core)
+                if value.free_symbols or value.is_integer is not True:
+                    raise ValueError(
+                        f"core {core} owns non-integral {dim} slot {value}"
+                    )
+                slot = int(value)
                 split = self.work_slices[dim]
                 if not 0 <= slot < split:
                     raise ValueError(
@@ -247,7 +287,7 @@ def is_lx_relayout_identity(op: str, args: Sequence[TensorArg]) -> bool:
         and "lx" in destination.allocation
         and source.work_division is not None
         and destination.work_division is not None
-        and source.work_division != destination.work_division
+        and not source.work_division.same_ownership(destination.work_division)
     )
 
 

--- a/torch_spyre/_inductor/op_spec.py
+++ b/torch_spyre/_inductor/op_spec.py
@@ -175,6 +175,7 @@ class TensorWorkDivision:
 
         if not isinstance(other, TensorWorkDivision):
             return False
+        # core_mapping imports this module's TensorWorkDivision.
         from .core_mapping import same_owner_maps
 
         return same_owner_maps(

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -2763,6 +2763,35 @@ class PerCoreView:
     core_to_slot: tuple[tuple[int, Expr], ...]
     num_cores: int | None = None
 
+    def same_partition(self, other: object) -> bool:
+        """Whether both views assign every physical core the same buffer slice."""
+
+        if not isinstance(other, PerCoreView):
+            return False
+        from .core_mapping import same_owner_maps
+
+        def cores(view: PerCoreView) -> int:
+            if view.num_cores is not None:
+                return view.num_cores
+            return math.prod(split for _, split in view.work_slice_dims)
+
+        return same_owner_maps(
+            dict(self.work_slice_dims),
+            dict(self.core_to_slot),
+            cores(self),
+            dict(other.work_slice_dims),
+            dict(other.core_to_slot),
+            cores(other),
+        )
+
+
+def per_core_views_equal(left: PerCoreView | None, right: PerCoreView | None) -> bool:
+    """None-aware physical-partition comparison."""
+
+    if left is None or right is None:
+        return left is right
+    return left.same_partition(right)
+
 
 def _is_matmul_op(op: Operation) -> bool:
     return (

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -52,7 +52,7 @@ from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.op_spec import IndirectAccess, TensorWorkDivision
 
 from . import config
-from .core_mapping import core_to_slice_mapping
+from .core_mapping import core_to_slice_mapping, same_owner_maps
 from .constants import (
     ELIDED_COPY_BACK_ATTR,
     KEEP_BY_INDEX_OP,
@@ -1715,7 +1715,11 @@ def splits_by_index_coeff(
 def make_iteration_space_ownership(
     op: Operation, splits: dict[sympy.Symbol, int]
 ) -> TensorWorkDivision:
-    """Return complete symbol-keyed ownership for ``op``'s iteration space."""
+    """Return ownership of all iteration axes, including reduction axes.
+
+    Keep the physical core count explicit: an output view may omit an axis
+    being summed without reducing the number of participating cores.
+    """
     iter_space = iteration_space_from_op(op)
     work_slices = {sym: int(splits.get(sym, 1)) for sym in iter_space}
     dim_splits = tuple(work_slices.values())
@@ -2748,6 +2752,8 @@ class PerCoreView:
       pairs giving each core's position along that split dim.
     - num_cores: physical cores over which ``core_to_slot`` is defined. This
       can exceed the number of logical slices when data is replicated.
+      If omitted, the split product is used. Views that omit a reduction axis
+      or describe broadcast copies must retain the explicit physical count.
 
     The first two fields are keyed by the buffer's device-dim index — not by
     op-local iter symbols — so the value depends only on the buffer's physical
@@ -2768,7 +2774,6 @@ class PerCoreView:
 
         if not isinstance(other, PerCoreView):
             return False
-        from .core_mapping import same_owner_maps
 
         def cores(view: PerCoreView) -> int:
             if view.num_cores is not None:

--- a/torch_spyre/_inductor/read_copy_elision.py
+++ b/torch_spyre/_inductor/read_copy_elision.py
@@ -41,6 +41,7 @@ from .pass_utils import (
     device_coordinates,
     find_matmul_generated_var,
     identify_matmul_inputs,
+    per_core_views_equal,
     replace_computed_buffer_body,
 )
 from .wsr.coarse_tile import (
@@ -297,7 +298,7 @@ def _prove_matmul_direct_read(
     source_view, _, source_ok = _per_core_view_on_buf(
         direct_op, weight_dep, record.source_name
     )
-    if not old_ok or not new_ok or old_view != new_view:
+    if not old_ok or not new_ok or not per_core_views_equal(old_view, new_view):
         return None, "output core ownership changed"
     if not copy_ok or not source_ok:
         return None, "weight core ownership is not representable"
@@ -305,7 +306,7 @@ def _prove_matmul_direct_read(
     # assigning different source slices to the same core.  The staging copy
     # is the behavior being replaced, so the direct HBM read must preserve
     # its exact physical core-to-slice map.
-    if copy_view != source_view:
+    if not per_core_views_equal(copy_view, source_view):
         return None, (
             "direct source ownership does not match the staged copy: "
             f"{source_view} != {copy_view}"

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -524,7 +524,7 @@ def demote_incoherent_lx_buffers(
             if (
                 source_view is None
                 or destination_view is None
-                or source_view == destination_view
+                or source_view.same_partition(destination_view)
                 or len(reads) != 1
                 or len(writes) != 1
                 or reads[0].name != plan.source_name
@@ -576,7 +576,7 @@ def demote_incoherent_lx_buffers(
                 culprit = f"{node.get_name()} view unrepresentable"
                 break
             if expected is not None:
-                if view != expected:
+                if not view.same_partition(expected):
                     culprit = f"{node.get_name()} view {view} != {expected}"
                     break
                 if not _ownership_projectable(node, dep, name, expected):
@@ -585,7 +585,7 @@ def demote_incoherent_lx_buffers(
                 continue
             if ref is None:
                 ref = view
-            elif view != ref:
+            elif not view.same_partition(ref):
                 culprit = f"{node.get_name()} disagrees: {view} != {ref}"
                 break
         if culprit is None:
@@ -703,7 +703,7 @@ def verify_carried_reduction_ownership(
                 )
             if expected_view is None:
                 expected_view = view
-            elif view != expected_view:
+            elif not view.same_partition(expected_view):
                 raise Unsupported(
                     f"carried reduction {op_name} {access} ownership {view} "
                     f"does not match accumulator ownership {expected_view}"

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -2275,7 +2275,7 @@ class CoOptimizingAllocator(ScratchpadAllocator):
         finding the intersection of core divisions.
         """
         clone_divs: list[CoreDivision] = []
-        clone_views: list[tuple] = []  # parallel: the view each clone div reproduces
+        clone_views: list[PerCoreView] = []
         matches: dict[str, list[tuple[int, int]]] = {}
         for consumer in consumers:
             cname = consumer.get_name()
@@ -2296,7 +2296,14 @@ class CoOptimizingAllocator(ScratchpadAllocator):
             for j, (view, _, repr_ok) in enumerate(views):
                 if not repr_ok:
                     continue
-                k = next((idx for idx, v in enumerate(clone_views) if v == view), None)
+                k = next(
+                    (
+                        idx
+                        for idx, candidate in enumerate(clone_views)
+                        if candidate.same_partition(view)
+                    ),
+                    None,
+                )
                 if k is None:
                     cd = consumer_divs[j]
                     per_sym = _division_splits(consumer, cd)

--- a/torch_spyre/_inductor/scratchpad/lx_relayout.py
+++ b/torch_spyre/_inductor/scratchpad/lx_relayout.py
@@ -32,6 +32,7 @@ from torch._inductor.ir import (
 from .. import config
 from ..ir import FixedTiledLayout
 from ..logging_utils import get_inductor_logger
+from ..core_mapping import core_mappings_equal, owner_slots
 from ..op_spec import TensorWorkDivision
 from ..pass_utils import (
     PerCoreView,
@@ -91,7 +92,12 @@ def work_division_from_view(
             raise ValueError(f"cannot map device dimension {device_dim} to one loop")
         dim = next(iter(matches))
         slot = sympy.sympify(slots[device_dim])
-        if dim in splits and (splits[dim], core_map[dim]) != (split, slot):
+        if dim in splits and (
+            splits[dim] != split
+            or not core_mappings_equal(
+                {dim: core_map[dim]}, {dim: slot}, view.num_cores
+            )
+        ):
             raise ValueError(f"conflicting ownership for loop {dim}")
         splits[dim] = split
         core_map[dim] = slot
@@ -138,20 +144,15 @@ def demote_lx_relayout_group(
 
 
 def _core_slices(view: PerCoreView, num_cores: int) -> dict[int, dict[int, int]]:
-    core_id = sympy.Symbol("core_id")
-    splits = dict(view.work_slice_dims)
-    slots = dict(view.core_to_slot)
-    result = {}
-    for core in range(num_cores):
-        row = {}
-        for dim, split in splits.items():
-            value = sympy.sympify(slots[dim]).subs(core_id, core)
-            assert not value.free_symbols, f"non-concrete owner slot {value}"
-            slot = int(value)
-            assert 0 <= slot < split, f"owner slot {slot} outside split {split}"
-            row[dim] = slot
-        result[core] = row
-    return result
+    if view.num_cores is not None and view.num_cores <= 0:
+        raise ValueError(f"physical core count must be positive, got {view.num_cores}")
+    if view.num_cores is not None and view.num_cores != num_cores:
+        raise ValueError(
+            "ownership core count differs from the communication domain: "
+            f"{view.num_cores} != {num_cores}"
+        )
+    rows = owner_slots(dict(view.core_to_slot), dict(view.work_slice_dims), num_cores)
+    return dict(enumerate(rows))
 
 
 def _overlap(a: int, an: int, b: int, bn: int) -> bool:
@@ -231,7 +232,7 @@ def _unsupported_relayout_transition_reason(
     correctly addressed buffer.
     """
 
-    if source_work_division == destination_work_division:
+    if source_work_division.same_ownership(destination_work_division):
         return "distinct physical ownerships collapse to the same logical work division"
     return None
 
@@ -289,7 +290,7 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
         # Relayout copies sharing one source are allocated and materialized as
         # one atomic group. Any unsupported consumer therefore rejects the
         # group; supported consumers keep using the original buffer instead.
-        consumers_by_view: dict[PerCoreView, list[str]] = {}
+        consumers_by_view: list[tuple[PerCoreView, list[str]]] = []
         seen_consumers = set()
         rejection_reason = None
         for consumer, dep in consumer_reads:
@@ -338,7 +339,7 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                 rejection_reason = "source ownership cannot be projected to consumer"
                 break
             assert source_work_division is not None
-            if view == source_view:
+            if view.same_partition(source_view):
                 continue
             is_matmul = _is_matmul_op(consumer)
             if is_matmul and len(deps) != 2:
@@ -347,7 +348,12 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
             if not is_matmul and not isinstance(consumer.data, Pointwise):
                 rejection_reason = "consumer is neither pointwise nor matmul"
                 break
-            if not _compatible_partitions(source_view, view, num_cores):
+            try:
+                compatible = _compatible_partitions(source_view, view, num_cores)
+            except (TypeError, ValueError) as exc:
+                rejection_reason = f"invalid ownership partition: {exc}"
+                break
+            if not compatible:
                 rejection_reason = "source and destination partitions are incompatible"
                 break
             try:
@@ -365,8 +371,13 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
             ):
                 rejection_reason = reason
                 break
-            consumers_by_view.setdefault(view, []).append(consumer_name)
-        else:
+            for destination_view, consumer_names in consumers_by_view:
+                if destination_view.same_partition(view):
+                    consumer_names.append(consumer_name)
+                    break
+            else:
+                consumers_by_view.append((view, [consumer_name]))
+        if rejection_reason is None:
             result.extend(
                 LXRelayoutPlan(
                     source_name,
@@ -375,7 +386,7 @@ def collect_lx_relayout_plans(graph: GraphLowering) -> list[LXRelayoutPlan]:
                     destination_view,
                     num_cores,
                 )
-                for destination_view, consumer_names in consumers_by_view.items()
+                for destination_view, consumer_names in consumers_by_view
             )
         if rejection_reason is not None:
             logger.debug(
@@ -406,7 +417,8 @@ def materialize_lx_relayouts(graph: GraphLowering, plans: list[LXRelayoutPlan]) 
         copies[plan.edge] = (copy.get_name(), plan)
 
         assert plan.source_address is not None and plan.destination_address is not None
-        assert plan.source_view != plan.destination_view
+        if plan.source_view.same_partition(plan.destination_view):
+            raise RuntimeError("LX relayout plan has identical source and destination")
         source_layout = cast(FixedTiledLayout, source.layout)
         copy_layout = cast(FixedTiledLayout, copy.layout)
         source_layout.allocation["lx"] = plan.source_address

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -593,7 +593,7 @@ def get_ncores_for_buffers(
                             f"{view_cores} cores but op runs {_op_num_cores(op)}"
                         )
                         break
-                if view != ref_view:
+                if ref_view is not None and not view.same_partition(ref_view):
                     mismatch_reason = (
                         f"op '{ref_op_name}' ref {ref_view} != '{op.get_name()}' {view}"
                     )

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -397,7 +397,7 @@ PYBIND11_MODULE(_C, m) {
 
   m.def("get_spyre_tensor_layout", &spyre::get_spyre_tensor_layout);
   m.def("get_device_size_in_bytes",
-        py::overload_cast<spyre::SpyreTensorLayout>(
+        py::overload_cast<const spyre::SpyreTensorLayout&>(
             &spyre::get_device_size_in_bytes),
         py::arg("layout"),
         "Return padded storage bytes for a layout with known device geometry.");

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -396,6 +396,16 @@ PYBIND11_MODULE(_C, m) {
            [](const DataFormats& df) { return spyre::elems_per_stick(df); });
 
   m.def("get_spyre_tensor_layout", &spyre::get_spyre_tensor_layout);
+  m.def("get_device_size_in_bytes",
+        py::overload_cast<spyre::SpyreTensorLayout>(
+            &spyre::get_device_size_in_bytes),
+        py::arg("layout"),
+        "Return padded storage bytes for a layout with known device geometry.");
+  m.def("get_device_size_in_bytes",
+        py::overload_cast<const std::vector<int64_t>&, const DataFormats&>(
+            &spyre::get_device_size_in_bytes),
+        py::arg("device_size"), py::arg("device_dtype"),
+        "Return whole-stick storage bytes; reject undefined format geometry.");
   m.def("set_spyre_tensor_layout", &spyre::set_spyre_tensor_layout);
   m.def("get_downcast_warning", &spyre::get_downcast_warn_enabled,
         "Return whether downcast warnings are enabled.");

--- a/torch_spyre/csrc/spyre_tensor_impl.cpp
+++ b/torch_spyre/csrc/spyre_tensor_impl.cpp
@@ -18,6 +18,7 @@
 
 #include <c10/core/DispatchKey.h>
 #include <c10/core/DispatchKeySet.h>
+#include <util/sendefs/dataType.h>
 
 #include <string>
 #include <utility>
@@ -28,15 +29,19 @@
 
 namespace spyre {
 
-#define BYTES_IN_STICK 128
-
 int64_t elems_per_stick(const DataFormats& df) {
   // TODO(dgrove-oss): DeepTools dataFormatToStickSize map is incomplete!
-  if (df == DataFormats::IEEE_INT32) {
-    return 32;
+  auto it = dataFormatToStickSize.find(df);
+  if (it != dataFormatToStickSize.end() && it->second > 0) {
+    return static_cast<int64_t>(it->second);
   }
-  auto fp_elems = dataFormatToStickSize[df];
-  return static_cast<int64_t>(fp_elems);
+  // DCI already accepts these storage formats, missing from the map above.
+  // Complete their geometry without enabling unmapped compute formats.
+  if (df == DataFormats::IEEE_INT32 || df == DataFormats::IEEE_INT64 ||
+      df == DataFormats::BOOL || df == DataFormats::BFLOAT16) {
+    return getNumElemsInStick(df);
+  }
+  return 0;
 }
 
 /* Returns default tiling of tensor dimensions on the device.
@@ -296,9 +301,23 @@ void SpyreTensorImpl::shallow_copy_from(
 }
 
 uint64_t get_device_size_in_bytes(SpyreTensorLayout stl) {
-  uint64_t size_bytes = BYTES_IN_STICK;
-  for (int i = stl.device_size.size() - 2; i >= 0; i--) {
-    size_bytes *= stl.device_size[i];
+  return get_device_size_in_bytes(stl.device_size, stl.device_dtype);
+}
+
+uint64_t get_device_size_in_bytes(const std::vector<int64_t>& device_size,
+                                  const DataFormats& device_dtype) {
+  // Size complete device sticks, including padding and sparse positions. The
+  // trailing extent may expose fewer values, but does not shorten a stick.
+  // A compute format without storage geometry must not be sized by bit width.
+  const auto elems = elems_per_stick(device_dtype);
+  TORCH_CHECK(elems > 0, "No device stick geometry for data format ",
+              static_cast<int>(device_dtype));
+  const auto bits = getSizeInBits(device_dtype);
+  TORCH_CHECK(bits > 0, "No device element width for data format ",
+              static_cast<int>(device_dtype));
+  uint64_t size_bytes = (elems * bits + 7) / 8;
+  for (int i = static_cast<int>(device_size.size()) - 2; i >= 0; i--) {
+    size_bytes *= device_size[i];
   }
   return size_bytes;
 }

--- a/torch_spyre/csrc/spyre_tensor_impl.cpp
+++ b/torch_spyre/csrc/spyre_tensor_impl.cpp
@@ -41,6 +41,8 @@ int64_t elems_per_stick(const DataFormats& df) {
       df == DataFormats::BOOL || df == DataFormats::BFLOAT16) {
     return getNumElemsInStick(df);
   }
+  // Capability queries use zero for unsupported geometry; storage sizing below
+  // rejects it rather than allocating an unknown format.
   return 0;
 }
 
@@ -300,7 +302,7 @@ void SpyreTensorImpl::shallow_copy_from(
   this->spyre_layout = spyre_impl->spyre_layout;
 }
 
-uint64_t get_device_size_in_bytes(SpyreTensorLayout stl) {
+uint64_t get_device_size_in_bytes(const SpyreTensorLayout& stl) {
   return get_device_size_in_bytes(stl.device_size, stl.device_dtype);
 }
 

--- a/torch_spyre/csrc/spyre_tensor_impl.h
+++ b/torch_spyre/csrc/spyre_tensor_impl.h
@@ -150,7 +150,7 @@ class SpyreTensorLayout {
 
   std::string toString() const;
 
-  int64_t elems_per_stick() {
+  int64_t elems_per_stick() const {
     return spyre::elems_per_stick(this->device_dtype);
   }
 
@@ -203,7 +203,7 @@ class SpyreTensorImpl : public at::TensorImpl {
       const c10::intrusive_ptr<at::TensorImpl>& impl) override;
 };
 
-uint64_t get_device_size_in_bytes(SpyreTensorLayout stl);
+uint64_t get_device_size_in_bytes(const SpyreTensorLayout& stl);
 uint64_t get_device_size_in_bytes(const std::vector<int64_t>& device_size,
                                   const DataFormats& device_dtype);
 SpyreTensorLayout get_spyre_tensor_layout(const at::Tensor& tensor);

--- a/torch_spyre/csrc/spyre_tensor_impl.h
+++ b/torch_spyre/csrc/spyre_tensor_impl.h
@@ -204,6 +204,8 @@ class SpyreTensorImpl : public at::TensorImpl {
 };
 
 uint64_t get_device_size_in_bytes(SpyreTensorLayout stl);
+uint64_t get_device_size_in_bytes(const std::vector<int64_t>& device_size,
+                                  const DataFormats& device_dtype);
 SpyreTensorLayout get_spyre_tensor_layout(const at::Tensor& tensor);
 void set_spyre_tensor_layout(const at::Tensor& tensor,
                              const SpyreTensorLayout& stl);


### PR DESCRIPTION
Part of [Epic #3049](https://github.com/torch-spyre/torch-spyre/issues/3049).

Merged foundation; subsequent PRs now build on main containing #4283 and #4284. The original description below records the pre-merge review history.

---

## Summary

Give the existing ownership records one consistent way to answer whether each physical core owns the same values. For example, `core_id` and `core_id % 4` describe the same owners over four cores; their spelling must not change placement.

## Architecture and scope

- Add named `TensorWorkDivision.same_ownership` and `PerCoreView.same_partition` comparisons, without overriding dataclass equality.
- Centralize the physical-core-count fallback, raw symbolic-map comparison, and bytes-per-stick constant in existing modules.
- Keep malformed ownership validation at the value boundary. The standalone test now expects the actual `non-integral owner slot` diagnostic.

This prerequisite does not add movement or move compiler phases. It supplies the shared comparisons used by the ownership-flow rewrite.

## Review boundary and dependencies

Built on upstream main commit `e5ed9481f246dcee6720a2b3c7e38d1626d4c662` (not a claim that this is today's main tip). Head: `b5d37f2033e968d7be2f937dcf35eab58b1b23f7`.

No unmerged prerequisite; this PR is the start of the stack. [Review only this level's incremental changes](https://github.com/AdnanHoque/torch-spyre/compare/e5ed9481f246dcee6720a2b3c7e38d1626d4c662...b5d37f2033e968d7be2f937dcf35eab58b1b23f7).

All existing PR bases remain `main`; the dependency chain is explicit below. Merge prerequisites first, then rebase children. The cumulative GitHub diff includes prerequisites and is not the size of this level alone.

```text
main (e5ed9481)
└─ #4283 ownership values
   └─ #4284 physical ownership + prepare/emit
      └─ #3440 gathers and broadcasts
         ├─ #4152 exact fused-axis ownership
         │  └─ #4153 consumer order + local restickify
         └─ #3955 completed-reduction handoff
```

#3439 remains the original relayout foundation. #4177 is an independent clone-elision optimization, not a prerequisite of these compiler changes. #3955 is optional alongside the #4152/#4153 chain.

## Validation and remaining gates

Fresh focused host inventory on this exact head: **47 passed**, using the existing native stand-in and excluding real device/compile tests. The integrated local composition also passes its focused inventory. Signed commits and DCO, Ruff 0.14.5, and repository-isolated mypy 2.1.0 were checked; the full pre-commit suite passes on the integrated publication tree.

**Draft: source review is not device certification or code-owner approval.** The independent local adversarial review closed its two blockers; CI on the newly published commits and the relevant native/device/application checks are still required. Broader native-dependent host suites are not claimed green. Historical workload results name their own exact commits and must not be presented as measurements of this publication. No application source, cost-model policy, or SuperDSC contract is changed.
